### PR TITLE
StatePoolReleaser replaced by PoolItemsCallbacks in return from StatePool.Get

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -257,9 +257,9 @@ LXC_BRIDGE="ignored"`[1:])
 	// controller model.
 	statePool := state.NewStatePool(st)
 	defer statePool.Close()
-	hostedModelSt, release, err := statePool.Get(hostedModelUUID)
+	hostedModelSt, cb, err := statePool.Get(hostedModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	gotModelConstraints, err = hostedModelSt.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
@@ -331,7 +331,7 @@ LXC_BRIDGE="ignored"`[1:])
 		"Provider",
 		"Version",
 	)
-	// Those attritbutes are configured during initialization, after "Open".
+	// Those attributes are configured during initialization, after "Open".
 	expectedCalledCfg, err := hostedCfg.Apply(map[string]interface{}{"container-networking-method": ""})
 	c.Assert(err, jc.ErrorIsNil)
 	envProvider.CheckCall(c, 2, "Open", environs.OpenParams{

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -511,10 +511,10 @@ type migrationSuite struct {
 var _ = gc.Suite(&migrationSuite{})
 
 func (s *migrationSuite) startSync(c *gc.C, st *state.State) {
-	backingSt, releaser, err := s.BackingStatePool.Get(st.ModelUUID())
+	backingSt, cb, err := s.BackingStatePool.Get(st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	backingSt.StartSync()
-	releaser()
+	cb.Release()
 }
 
 func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -931,9 +931,9 @@ func (s *loginSuite) assertRemoteModel(c *gc.C, api api.Connection, expected nam
 	// the expected model. We make a change in state on that model, and
 	// then check that it is picked up by a call to the API.
 
-	st, release, err := s.StatePool.Get(tag.Id())
+	st, cb, err := s.StatePool.Get(tag.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 
 	expectedCons := constraints.MustParse("mem=8G")
 	err = st.SetModelConstraints(expectedCons)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -572,34 +572,34 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	)
 
 	add("/model/:modeluuid/applications/:application/resources/:resource", &ResourcesHandler{
-		StateAuthFunc: func(req *http.Request, tagKinds ...string) (ResourcesBackend, state.StatePoolReleaser, names.Tag, error) {
-			st, closer, entity, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)
+		StateAuthFunc: func(req *http.Request, tagKinds ...string) (ResourcesBackend, state.PoolItemCallbacks, names.Tag, error) {
+			st, cb, entity, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)
 			if err != nil {
-				return nil, nil, nil, errors.Trace(err)
+				return nil, cb, nil, errors.Trace(err)
 			}
 			rst, err := st.Resources()
 			if err != nil {
-				return nil, nil, nil, errors.Trace(err)
+				return nil, cb, nil, errors.Trace(err)
 			}
-			return rst, closer, entity.Tag(), nil
+			return rst, cb, entity.Tag(), nil
 		},
 	})
 	add("/model/:modeluuid/units/:unit/resources/:resource", &UnitResourcesHandler{
-		NewOpener: func(req *http.Request, tagKinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
-			st, closer, _, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)
+		NewOpener: func(req *http.Request, tagKinds ...string) (resource.Opener, state.PoolItemCallbacks, error) {
+			st, cb, _, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)
 			if err != nil {
-				return nil, nil, errors.Trace(err)
+				return nil, cb, errors.Trace(err)
 			}
 			tagStr := req.URL.Query().Get(":unit")
 			tag, err := names.ParseUnitTag(tagStr)
 			if err != nil {
-				return nil, nil, errors.Trace(err)
+				return nil, cb, errors.Trace(err)
 			}
 			opener, err := resourceadapters.NewResourceOpener(st, tag.Id())
 			if err != nil {
-				return nil, nil, errors.Trace(err)
+				return nil, cb, errors.Trace(err)
 			}
-			return opener, closer, nil
+			return opener, cb, nil
 		},
 	})
 
@@ -818,16 +818,16 @@ func (srv *Server) serveConn(
 		modelUUID: modelUUID,
 	})
 	var (
-		st       *state.State
-		h        *apiHandler
-		releaser state.StatePoolReleaser
+		st *state.State
+		h  *apiHandler
+		cb state.PoolItemCallbacks
 	)
 	if err == nil {
-		st, releaser, err = srv.statePool.Get(resolvedModelUUID)
+		st, cb, err = srv.statePool.Get(resolvedModelUUID)
 	}
 
 	if err == nil {
-		defer releaser()
+		defer cb.Release()
 		h, err = newAPIHandler(srv, st, conn, modelUUID, connectionID, host)
 	}
 

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -36,12 +36,12 @@ type backupHandler struct {
 func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, cb, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		h.sendError(resp, err)
 		return
 	}
-	defer releaser()
+	defer cb.Release()
 
 	m, err := st.Model()
 	if err != nil {

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -76,7 +76,7 @@ func (h *CharmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type charmsHandler struct {
 	ctxt          httpContext
 	dataDir       string
-	stateAuthFunc func(*http.Request) (*state.State, state.StatePoolReleaser, error)
+	stateAuthFunc func(*http.Request) (*state.State, state.PoolItemCallbacks, error)
 }
 
 // bundleContentSenderFunc functions are responsible for sending a
@@ -92,11 +92,11 @@ func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error 
 		return errors.Trace(emitUnsupportedMethodErr(r.Method))
 	}
 
-	st, releaser, err := h.stateAuthFunc(r)
+	st, cb, err := h.stateAuthFunc(r)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer releaser()
+	defer cb.Release()
 
 	// Add a charm to the store provider.
 	charmURL, err := h.processPost(r, st)
@@ -111,11 +111,11 @@ func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
 		return errors.Trace(emitUnsupportedMethodErr(r.Method))
 	}
 
-	st, releaser, _, err := h.ctxt.stateForRequestAuthenticated(r)
+	st, cb, _, err := h.ctxt.stateForRequestAuthenticated(r)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer releaser()
+	defer cb.Release()
 
 	// Retrieve or list charm files.
 	// Requires "url" (charm URL) and an optional "file" (the path to the

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -15,18 +15,18 @@ import (
 // Pool describes an interface for retrieving State instances from a
 // collection.
 type Pool interface {
-	Get(string) (*state.State, state.StatePoolReleaser, error)
+	Get(string) (*state.State, state.PoolItemCallbacks, error)
 }
 
 // MakeCloudSpecGetter returns a function which returns a CloudSpec
 // for a given model, using the given Pool.
 func MakeCloudSpecGetter(pool Pool) func(names.ModelTag) (environs.CloudSpec, error) {
 	return func(tag names.ModelTag) (environs.CloudSpec, error) {
-		st, release, err := pool.Get(tag.Id())
+		st, cb, err := pool.Get(tag.Id())
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
-		defer release()
+		defer cb.Release()
 
 		m, err := st.Model()
 		if err != nil {

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -22,12 +22,12 @@ type statePoolShim struct {
 }
 
 func (p *statePoolShim) Get(modelUUID string) (Backend, func(), error) {
-	st, releaser, err := p.StatePool.Get(modelUUID)
+	st, cb, err := p.StatePool.Get(modelUUID)
 	if err != nil {
 		return nil, func() {}, err
 	}
 	closer := func() {
-		releaser()
+		cb.Release()
 	}
 	model, err := st.Model()
 	if err != nil {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -141,24 +141,24 @@ func (st modelManagerStateShim) ControllerTag() names.ControllerTag {
 
 // GetBackend implements ModelManagerBackend.
 func (st modelManagerStateShim) GetBackend(modelUUID string) (ModelManagerBackend, func() bool, error) {
-	otherState, release, err := st.pool.Get(modelUUID)
+	otherState, cb, err := st.pool.Get(modelUUID)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, cb.Release, errors.Trace(err)
 	}
 	otherModel, err := otherState.Model()
 	if err != nil {
-		return nil, nil, err
+		return nil, cb.Release, err
 	}
-	return modelManagerStateShim{otherState, otherModel, st.pool}, release, nil
+	return modelManagerStateShim{otherState, otherModel, st.pool}, cb.Release, nil
 }
 
 // GetModel implements ModelManagerBackend.
 func (st modelManagerStateShim) GetModel(modelUUID string) (Model, func() bool, error) {
-	model, release, err := st.pool.GetModel(modelUUID)
+	model, cb, err := st.pool.GetModel(modelUUID)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, cb.Release, errors.Trace(err)
 	}
-	return modelShim{model}, release, nil
+	return modelShim{model}, cb.Release, nil
 }
 
 // Model implements ModelManagerBackend.

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -73,12 +73,12 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		socket := &debugLogSocketImpl{conn}
 		defer conn.Close()
 
-		st, releaser, _, err := h.ctxt.stateForRequestAuthenticatedTag(req, names.MachineTagKind, names.UserTagKind)
+		st, cb, _, err := h.ctxt.stateForRequestAuthenticatedTag(req, names.MachineTagKind, names.UserTagKind)
 		if err != nil {
 			socket.sendError(err)
 			return
 		}
-		defer releaser()
+		defer cb.Release()
 
 		params, err := readDebugLogParams(req.URL.Query())
 		if err != nil {

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -67,11 +67,11 @@ func createOffersAPI(
 // NewOffersAPI returns a new application offers OffersAPI facade.
 func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 	environFromModel := func(modelUUID string) (environs.Environ, error) {
-		st, releaser, err := ctx.StatePool().Get(modelUUID)
+		st, cb, err := ctx.StatePool().Get(modelUUID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		defer releaser()
+		defer cb.Release()
 		model, err := st.Model()
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -34,22 +34,22 @@ type statePoolShim struct {
 }
 
 func (pool statePoolShim) Get(modelUUID string) (Backend, func(), error) {
-	st, release, err := pool.StatePool.Get(modelUUID)
+	st, cb, err := pool.StatePool.Get(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
 	return &stateShim{
 		st:      st,
 		Backend: commoncrossmodel.GetBackend(st),
-	}, func() { release() }, nil
+	}, func() { cb.Release() }, nil
 }
 
 func (pool statePoolShim) GetModel(modelUUID string) (Model, func(), error) {
-	m, release, err := pool.StatePool.GetModel(modelUUID)
+	m, cb, err := pool.StatePool.GetModel(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return &modelShim{m}, func() { release() }, nil
+	return &modelShim{m}, func() { cb.Release() }, nil
 }
 
 // Backend provides selected methods off the state.State struct.

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -136,11 +136,11 @@ type poolShim struct {
 }
 
 func (p *poolShim) GetModel(uuid string) (*state.Model, func(), error) {
-	model, release, err := p.pool.GetModel(uuid)
+	model, cb, err := p.pool.GetModel(uuid)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return model, func() { release() }, nil
+	return model, func() { cb.Release() }, nil
 }
 
 func (s stateShim) ModelConfig() (*config.Config, error) {

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -151,7 +151,7 @@ func (s *ControllerAPI) AllModels() (params.UserModelList, error) {
 		return result, errors.Trace(err)
 	}
 	for _, modelUUID := range modelUUIDs {
-		st, release, err := s.statePool.Get(modelUUID)
+		st, cb, err := s.statePool.Get(modelUUID)
 		if err != nil {
 			// This model could have been removed.
 			if errors.IsNotFound(err) {
@@ -159,7 +159,7 @@ func (s *ControllerAPI) AllModels() (params.UserModelList, error) {
 			}
 			return result, errors.Trace(err)
 		}
-		defer release()
+		defer cb.Release()
 
 		model, err := st.Model()
 		if err != nil {
@@ -216,7 +216,7 @@ func (s *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 	}
 
 	for uuid, blocks := range modelBlocks {
-		model, release, err := s.statePool.GetModel(uuid)
+		model, cb, err := s.statePool.GetModel(uuid)
 		if err != nil {
 			logger.Debugf("unable to retrieve model %s: %v", uuid, err)
 			continue
@@ -227,7 +227,7 @@ func (s *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 			OwnerTag: model.Owner().String(),
 			Blocks:   blocks,
 		})
-		release()
+		cb.Release()
 	}
 
 	// Sort the resulting sequence by environment name, then owner.
@@ -282,7 +282,7 @@ func (s *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, 
 		if modelUUID == s.state.ControllerModelUUID() {
 			continue
 		}
-		st, release, err := s.statePool.Get(modelUUID)
+		st, cb, err := s.statePool.Get(modelUUID)
 		if err != nil {
 			// This model could have been removed.
 			if errors.IsNotFound(err) {
@@ -290,7 +290,7 @@ func (s *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, 
 			}
 			return result, errors.Trace(err)
 		}
-		defer release()
+		defer cb.Release()
 		model, err := st.Model()
 		if err != nil {
 			return result, errors.Trace(err)
@@ -413,11 +413,11 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 		return "", errors.NotFoundf("model")
 	}
 
-	hostedState, release, err := c.statePool.Get(modelTag.Id())
+	hostedState, cb, err := c.statePool.Get(modelTag.Id())
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	defer release()
+	defer cb.Release()
 
 	// Construct target info.
 	specTarget := spec.TargetInfo

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -121,9 +121,9 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	var obtained []string
 	for _, userModel := range response.UserModels {
 		obtained = append(obtained, userModel.Name)
-		stateModel, release, err := s.StatePool.GetModel(userModel.UUID)
+		stateModel, cb, err := s.StatePool.GetModel(userModel.UUID)
 		c.Assert(err, jc.ErrorIsNil)
-		defer release()
+		defer cb.Release()
 		s.checkEnvironmentMatches(c, userModel.Model, stateModel)
 	}
 	c.Assert(obtained, jc.DeepEquals, expected)

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -71,11 +71,11 @@ type poolShim struct {
 }
 
 func (p *poolShim) GetModel(uuid string) (Model, func(), error) {
-	m, release, err := p.pool.GetModel(uuid)
+	m, cb, err := p.pool.GetModel(uuid)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return m, func() { release() }, nil
+	return m, func() { cb.Release() }, nil
 }
 
 type machineShim struct {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -929,9 +929,9 @@ func (s *modelManagerStateSuite) TestAdminCanCreateModelForSomeoneElse(c *gc.C) 
 	c.Assert(model.Name, gc.Equals, "test-model")
 	// Make sure that the environment created does actually have the correct
 	// owner, and that owner is actually allowed to use the environment.
-	newState, release, err := s.StatePool.Get(model.UUID)
+	newState, cb, err := s.StatePool.Get(model.UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 
 	newModel, err := newState.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1093,9 +1093,9 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	m, err := s.modelmanager.CreateModel(createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, release, err := s.StatePool.Get(m.UUID)
+	st, cb, err := s.StatePool.Get(m.UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1129,9 +1129,9 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	m, err := s.modelmanager.CreateModel(createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, release, err := s.StatePool.Get(m.UUID)
+	st, cb, err := s.StatePool.Get(m.UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1165,9 +1165,9 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	m, err := s.modelmanager.CreateModel(createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, release, err := s.StatePool.Get(m.UUID)
+	st, cb, err := s.StatePool.Get(m.UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/controller/metricsmanager/metricsmanager.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager.go
@@ -129,14 +129,14 @@ func (api *MetricsManagerAPI) CleanupOldMetrics(args params.Entities) (params.Er
 		}
 		modelState := api.state
 		if tag != api.model.ModelTag() {
-			var release func() bool
-			modelState, release, err = api.pool.Get(tag.Id())
+			var cb state.PoolItemCallbacks
+			modelState, cb, err = api.pool.Get(tag.Id())
 			if err != nil {
 				err = errors.Annotatef(err, "failed to access state for %s", tag)
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
-			defer release()
+			defer cb.Release()
 		}
 
 		err = modelState.CleanupOldMetrics()
@@ -229,14 +229,14 @@ func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorRes
 		}
 		modelState := api.state
 		if tag != api.model.ModelTag() {
-			var release func() bool
-			modelState, release, err = api.pool.Get(tag.Id())
+			var cb state.PoolItemCallbacks
+			modelState, cb, err = api.pool.Get(tag.Id())
 			if err != nil {
 				err = errors.Annotatef(err, "failed to access state for %s", tag)
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
-			defer release()
+			defer cb.Release()
 		}
 		txVendorMetrics, err := transmitVendorMetrics(api.model)
 		if err != nil {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -111,11 +111,11 @@ func (api *API) getModel(modelTag string) (*state.Model, func(), error) {
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	model, release, err := api.pool.GetModel(tag.Id())
+	model, cb, err := api.pool.GetModel(tag.Id())
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return model, func() { release() }, nil
+	return model, func() { cb.Release() }, nil
 }
 
 func (api *API) getImportingModel(args params.ModelArgs) (*state.Model, func(), error) {
@@ -139,11 +139,11 @@ func (api *API) Abort(args params.ModelArgs) error {
 	}
 	defer releaseModel()
 
-	st, releaseSt, err := api.pool.Get(model.UUID())
+	st, cb, err := api.pool.Get(model.UUID())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer releaseSt()
+	defer cb.Release()
 	return st.RemoveImportingModelDocs()
 }
 
@@ -209,11 +209,11 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	st, release, err := api.pool.Get(tag.Id())
+	st, cb, err := api.pool.Get(tag.Id())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer release()
+	defer cb.Release()
 	env, err := api.getEnviron(st)
 	if err != nil {
 		return errors.Trace(err)
@@ -229,11 +229,11 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
-	st, release, err := api.pool.Get(tag.Id())
+	st, cb, err := api.pool.Get(tag.Id())
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
-	defer release()
+	defer cb.Release()
 
 	machines, err := st.AllMachines()
 	if err != nil {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -128,9 +128,9 @@ func (s *Suite) TestImport(c *gc.C) {
 	api := s.mustNewAPI(c)
 	tag := s.importModel(c, api)
 	// Check the model was imported.
-	model, release, err := s.StatePool.GetModel(tag.Id())
+	model, cb, err := s.StatePool.GetModel(tag.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	c.Assert(model.Name(), gc.Equals, "some-model")
 	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeImporting)
 }
@@ -179,9 +179,9 @@ func (s *Suite) TestActivate(c *gc.C) {
 	err := api.Activate(params.ModelArgs{ModelTag: tag.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
-	model, release, err := s.StatePool.GetModel(tag.Id())
+	model, cb, err := s.StatePool.GetModel(tag.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	c.Assert(model.MigrationMode(), gc.Equals, state.MigrationModeNone)
 }
 

--- a/apiserver/facades/controller/modelupgrader/backend.go
+++ b/apiserver/facades/controller/modelupgrader/backend.go
@@ -32,9 +32,9 @@ type statePool struct {
 }
 
 func (p *statePool) GetModel(uuid string) (Model, func(), error) {
-	m, release, err := p.pool.GetModel(uuid)
+	m, cb, err := p.pool.GetModel(uuid)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return m, func() { release() }, nil
+	return m, func() { cb.Release() }, nil
 }

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -403,11 +403,11 @@ func modelInfoFromPath(path string, st *state.State, pool *state.StatePool) (uui
 		return "", "", ""
 	}
 	for _, modelUUID := range modelUUIDs {
-		model, release, err := pool.GetModel(modelUUID)
+		model, cb, err := pool.GetModel(modelUUID)
 		if err != nil {
 			return "", "", ""
 		}
-		defer release()
+		defer cb.Release()
 		if model.Name() == modelName {
 			return modelUUID, user, modelName
 		}
@@ -499,11 +499,11 @@ func (h *guiArchiveHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 // handleGet returns information on Juju GUI archives in the controller.
 func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) error {
 	// Open the GUI archive storage.
-	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, cb, err := h.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer releaser()
+	defer cb.Release()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -567,11 +567,11 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Open the GUI archive storage.
-	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, cb, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer releaser()
+	defer cb.Release()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return errors.Annotate(err, "cannot open GUI storage")
@@ -643,11 +643,11 @@ func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) 
 	}
 
 	// Authenticate the request and retrieve the Juju state.
-	st, releaser, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	st, cb, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		return errors.Annotate(err, "cannot open state")
 	}
-	defer releaser()
+	defer cb.Release()
 
 	var selected params.GUIVersionRequest
 	decoder := json.NewDecoder(req.Body)

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -32,11 +32,11 @@ func (h introspectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h introspectionHandler) checkAuth(r *http.Request) error {
-	st, releaser, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
+	st, cb, entity, err := h.ctx.stateAndEntityForRequestAuthenticatedUser(r)
 	if err != nil {
 		return err
 	}
-	defer releaser()
+	defer cb.Release()
 
 	// Users with "superuser" access on the controller,
 	// or "read" access on the controller model, can

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -124,7 +124,7 @@ func newAgentLogWriteCloserFunc(
 }
 
 func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
-	st, releaseState, entity, err := ctxt.stateForRequestAuthenticatedAgent(req)
+	st, cb, entity, err := ctxt.stateForRequestAuthenticatedAgent(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -138,7 +138,7 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 	// address this caveat appropriately.
 	ver, err := logsink.JujuClientVersionFromRequest(req)
 	if err != nil {
-		releaseState()
+		cb.Release()
 		return errors.Trace(err)
 	}
 	s.version = ver
@@ -146,7 +146,7 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 	s.filePrefix = st.ModelUUID() + ":"
 	s.dblogger = s.dbloggers.get(st)
 	s.releaser = func() {
-		if removed := releaseState(); removed {
+		if removed := cb.Release(); removed {
 			s.dbloggers.remove(st)
 		}
 	}

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -30,16 +30,16 @@ type messageWriter interface {
 // logStreamEndpointHandler takes requests to stream logs from the DB.
 type logStreamEndpointHandler struct {
 	stopCh    <-chan struct{}
-	newSource func(*http.Request) (logStreamSource, state.StatePoolReleaser, error)
+	newSource func(*http.Request) (logStreamSource, state.PoolItemCallbacks, error)
 }
 
 func newLogStreamEndpointHandler(ctxt httpContext) *logStreamEndpointHandler {
-	newSource := func(req *http.Request) (logStreamSource, state.StatePoolReleaser, error) {
-		st, releaser, _, err := ctxt.stateForRequestAuthenticatedAgent(req)
+	newSource := func(req *http.Request) (logStreamSource, state.PoolItemCallbacks, error) {
+		st, cb, _, err := ctxt.stateForRequestAuthenticatedAgent(req)
 		if err != nil {
-			return nil, nil, errors.Trace(err)
+			return nil, cb, errors.Trace(err)
 		}
-		return &logStreamState{st}, releaser, nil
+		return &logStreamState{st}, cb, nil
 	}
 	return &logStreamEndpointHandler{
 		stopCh:    ctxt.stop(),
@@ -76,13 +76,13 @@ func (h *logStreamEndpointHandler) newLogStreamRequestHandler(conn messageWriter
 	// Validate before authenticate because the authentication is
 	// dependent on the state connection that is determined during the
 	// validation.
-	source, releaser, err := h.newSource(req)
+	source, cb, err := h.newSource(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	defer func() {
 		if err != nil {
-			releaser()
+			cb.Release()
 		}
 	}()
 
@@ -99,10 +99,10 @@ func (h *logStreamEndpointHandler) newLogStreamRequestHandler(conn messageWriter
 	}
 
 	reqHandler := &logStreamRequestHandler{
-		conn:     conn,
-		req:      req,
-		tailer:   tailer,
-		releaser: releaser,
+		conn:      conn,
+		req:       req,
+		tailer:    tailer,
+		callbacks: cb,
 	}
 	return reqHandler, nil
 }
@@ -182,10 +182,10 @@ func (st logStreamState) newTailer(args state.LogTailerParams) (state.LogTailer,
 }
 
 type logStreamRequestHandler struct {
-	conn     messageWriter
-	req      *http.Request
-	tailer   state.LogTailer
-	releaser state.StatePoolReleaser
+	conn      messageWriter
+	req       *http.Request
+	tailer    state.LogTailer
+	callbacks state.PoolItemCallbacks
 }
 
 func (h *logStreamRequestHandler) serveWebsocket(stop <-chan struct{}) {
@@ -215,7 +215,7 @@ func (h *logStreamRequestHandler) serveWebsocket(stop <-chan struct{}) {
 
 func (h *logStreamRequestHandler) close() {
 	h.tailer.Stop()
-	h.releaser()
+	h.callbacks.Release()
 }
 
 func (h *logStreamRequestHandler) sendRecords(rec []*state.LogRecord) error {

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -39,12 +39,12 @@ type pubsubHandler struct {
 func (h *pubsubHandler) authenticate(req *http.Request) error {
 	// We authenticate against the controller state instance that is held
 	// by Server.
-	_, releaser, entity, err := h.ctxt.stateForRequestAuthenticated(req)
+	_, cb, entity, err := h.ctxt.stateForRequestAuthenticated(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// We don't actually use the state for anything except authentication.
-	defer releaser()
+	defer cb.Release()
 
 	switch machine := entity.(type) {
 	case *state.Machine:

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -40,14 +40,14 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
-	st, releaser, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, cb, err := h.ctxt.stateForRequestUnauthenticated(req)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer releaser()
+	defer cb.Release()
 	userTag, response, err := h.processPost(req, st)
 	if err != nil {
 		if err := sendError(w, err); err != nil {

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -42,17 +42,17 @@ type ResourcesBackend interface {
 // ResourcesHandler is the HTTP handler for client downloads and
 // uploads of resources.
 type ResourcesHandler struct {
-	StateAuthFunc func(*http.Request, ...string) (ResourcesBackend, state.StatePoolReleaser, names.Tag, error)
+	StateAuthFunc func(*http.Request, ...string) (ResourcesBackend, state.PoolItemCallbacks, names.Tag, error)
 }
 
 // ServeHTTP implements http.Handler.
 func (h *ResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	backend, closer, tag, err := h.StateAuthFunc(req, names.UserTagKind, names.MachineTagKind)
+	backend, cb, tag, err := h.StateAuthFunc(req, names.UserTagKind, names.MachineTagKind)
 	if err != nil {
 		api.SendHTTPError(resp, err)
 		return
 	}
-	defer closer()
+	defer cb.Release()
 
 	switch req.Method {
 	case "GET":

--- a/apiserver/resources_mig.go
+++ b/apiserver/resources_mig.go
@@ -20,20 +20,20 @@ import (
 // resourcesMigrationUploadHandler handles resources uploads for model migrations.
 type resourcesMigrationUploadHandler struct {
 	ctxt          httpContext
-	stateAuthFunc func(*http.Request) (*state.State, state.StatePoolReleaser, error)
+	stateAuthFunc func(*http.Request) (*state.State, state.PoolItemCallbacks, error)
 }
 
 func (h *resourcesMigrationUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	st, releaser, err := h.stateAuthFunc(r)
+	st, cb, err := h.stateAuthFunc(r)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
 		}
 		return
 	}
-	defer releaser()
+	defer cb.Release()
 
 	switch r.Method {
 	case "POST":

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -62,13 +62,19 @@ func (s *ResourcesHandlerSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *ResourcesHandlerSuite) authState(req *http.Request, tagKinds ...string) (apiserver.ResourcesBackend, state.StatePoolReleaser, names.Tag, error) {
+func (s *ResourcesHandlerSuite) authState(req *http.Request, tagKinds ...string) (
+	apiserver.ResourcesBackend,
+	state.PoolItemCallbacks,
+	names.Tag,
+	error,
+) {
+	cb := state.PoolItemCallbacks{}
 	if s.stateAuthErr != nil {
-		return nil, nil, nil, errors.Trace(s.stateAuthErr)
+		return nil, cb, nil, errors.Trace(s.stateAuthErr)
 	}
-	closer := func() bool { return false }
+	cb.Release = func() bool { return false }
 	tag := names.NewUserTag(s.username)
-	return s.backend, closer, tag, nil
+	return s.backend, cb, tag, nil
 }
 
 func (s *ResourcesHandlerSuite) TestStateAuthFailure(c *gc.C) {

--- a/apiserver/resources_unit.go
+++ b/apiserver/resources_unit.go
@@ -20,19 +20,19 @@ import (
 // ResourcesHandler is the HTTP handler for unit agent downloads of
 // resources.
 type UnitResourcesHandler struct {
-	NewOpener func(*http.Request, ...string) (resource.Opener, state.StatePoolReleaser, error)
+	NewOpener func(*http.Request, ...string) (resource.Opener, state.PoolItemCallbacks, error)
 }
 
 // ServeHTTP implements http.Handler.
 func (h *UnitResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET":
-		opener, closer, err := h.NewOpener(req, names.UnitTagKind)
+		opener, cb, err := h.NewOpener(req, names.UnitTagKind)
 		if err != nil {
 			api.SendHTTPError(resp, err)
 			return
 		}
-		defer closer()
+		defer cb.Release()
 
 		name := req.URL.Query().Get(":resource")
 		opened, err := opener.OpenResource(name)

--- a/apiserver/resources_unit_test.go
+++ b/apiserver/resources_unit_test.go
@@ -62,8 +62,8 @@ func (s *UnitResourcesHandlerSuite) TestWrongMethod(c *gc.C) {
 func (s *UnitResourcesHandlerSuite) TestOpenerCreationError(c *gc.C) {
 	failure, expectedBody := apiFailure("boom", "")
 	handler := &apiserver.UnitResourcesHandler{
-		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
-			return nil, nil, failure
+		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.PoolItemCallbacks, error) {
+			return nil, state.PoolItemCallbacks{}, failure
 		},
 	}
 
@@ -86,9 +86,9 @@ func (s *UnitResourcesHandlerSuite) TestOpenResourceError(c *gc.C) {
 	failure, expectedBody := apiFailure("boom", "")
 	s.stub.SetErrors(failure)
 	handler := &apiserver.UnitResourcesHandler{
-		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
+		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.PoolItemCallbacks, error) {
 			s.stub.AddCall("NewOpener", kinds)
-			return opener, s.closer, nil
+			return opener, state.PoolItemCallbacks{Release: s.closer}, nil
 		},
 	}
 
@@ -113,9 +113,9 @@ func (s *UnitResourcesHandlerSuite) TestSuccess(c *gc.C) {
 		ReturnOpenResource: opened,
 	}
 	handler := &apiserver.UnitResourcesHandler{
-		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.StatePoolReleaser, error) {
+		NewOpener: func(_ *http.Request, kinds ...string) (resource.Opener, state.PoolItemCallbacks, error) {
 			s.stub.AddCall("NewOpener", kinds)
-			return opener, s.closer, nil
+			return opener, state.PoolItemCallbacks{Release: s.closer}, nil
 		},
 	}
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -556,9 +556,9 @@ func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the model's in the pool but not referenced.
-	st, releaser, err := s.StatePool.Get(otherState.ModelUUID())
+	st, cb, err := s.StatePool.Get(otherState.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
-	releaser()
+	cb.Release()
 
 	// Make a request for the model API to check it releases
 	// state back into the pool once the connection is closed.

--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -64,13 +64,13 @@ func validateModelUUID(args validateArgs) (string, error) {
 		return "", errors.Trace(common.UnknownModelError(args.modelUUID))
 	}
 
-	_, release, err := args.statePool.GetModel(args.modelUUID)
+	_, cb, err := args.statePool.GetModel(args.modelUUID)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return "", errors.Wrap(err, common.UnknownModelError(args.modelUUID))
 		}
 		return "", errors.Trace(err)
 	}
-	release()
+	cb.Release()
 	return args.modelUUID, nil
 }

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -160,7 +160,7 @@ func (c *dumpLogsCommand) findMachineId(dataDir string) (string, error) {
 }
 
 func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.StatePool, tag names.ModelTag) error {
-	st, release, err := statePool.Get(tag.Id())
+	st, cb, err := statePool.Get(tag.Id())
 	if err != nil {
 		if errors.IsNotFound(err) {
 			ctx.Infof("model with uuid %v has been removed", tag.Id())
@@ -168,7 +168,7 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.Stat
 		}
 		return errors.Annotate(err, "failed open model")
 	}
-	defer release()
+	defer cb.Release()
 
 	logName := ctx.AbsPath(filepath.Join(c.outDir, fmt.Sprintf("%s.log", tag.Id())))
 	ctx.Infof("writing to %s", logName)

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -139,9 +139,9 @@ current-model: controller
 
 func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	modelInfo := s.createModelAdminUser(c, "new-model", false)
-	st, release, err := s.StatePool.Get(modelInfo.UUID)
+	st, cb, err := s.StatePool.Get(modelInfo.UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.Destroy(state.DestroyModelParams{})

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -94,9 +94,9 @@ func (s *cmdUpgradeSuite) assertHostModelAgentVersion(c *gc.C, desiredAgentVersi
 
 	var desiredModel *state.Model
 	for _, modelUUID := range modelUUIDs {
-		model, release, err := s.StatePool.GetModel(modelUUID)
+		model, cb, err := s.StatePool.GetModel(modelUUID)
 		c.Assert(err, jc.ErrorIsNil)
-		defer release()
+		defer cb.Release()
 		if model.Name() == s.hostedModel {
 			desiredModel = model
 		}

--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -126,11 +126,11 @@ type poolShim struct {
 }
 
 func (p *poolShim) GetModel(uuid string) (PrecheckModel, func(), error) {
-	model, release, err := p.pool.GetModel(uuid)
+	model, cb, err := p.pool.GetModel(uuid)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return model, func() { release() }, nil
+	return model, func() { cb.Release() }, nil
 }
 
 // precheckAppShim implements PrecheckApplication.

--- a/scripts/juju-force-upgrade/main.go
+++ b/scripts/juju-force-upgrade/main.go
@@ -115,9 +115,9 @@ func main() {
 
 	statePool := state.NewStatePool(st)
 	defer statePool.Close()
-	modelSt, release, err := statePool.Get(modelUUID)
+	modelSt, cb, err := statePool.Get(modelUUID)
 	checkErr("open model", err)
-	defer release()
+	defer cb.Release()
 
 	checkErr("set model agent version", modelSt.SetModelAgentVersion(agentVersion, true))
 }

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -273,13 +273,13 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	machines := []machineModel{}
+	var machines []machineModel
 	for _, modelUUID := range modelUUIDs {
-		st, release, err := pool.Get(modelUUID)
+		st, cb, err := pool.Get(modelUUID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		defer release()
+		defer cb.Release()
 
 		model, err := st.Model()
 		if err != nil {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -222,7 +222,7 @@ func (st *State) cleanupModelsForDyingController(cleanupArgs []bson.Raw) (err er
 		return errors.Trace(err)
 	}
 	for _, modelUUID := range modelUUIDs {
-		st, release, err := pool.Get(modelUUID)
+		st, cb, err := pool.Get(modelUUID)
 		if err != nil {
 			// This model could have been removed.
 			if errors.IsNotFound(err) {
@@ -230,7 +230,7 @@ func (st *State) cleanupModelsForDyingController(cleanupArgs []bson.Raw) (err er
 			}
 			return errors.Trace(err)
 		}
-		defer release()
+		defer cb.Release()
 
 		model, err := st.Model()
 		if err != nil {

--- a/state/model.go
+++ b/state/model.go
@@ -1136,7 +1136,7 @@ func (m *Model) destroyOps(
 				continue
 			}
 
-			st, release, err := pool.Get(aModelUUID)
+			st, cb, err := pool.Get(aModelUUID)
 			if err != nil {
 				// This model could have been removed.
 				if errors.IsNotFound(err) {
@@ -1144,7 +1144,7 @@ func (m *Model) destroyOps(
 				}
 				return nil, errors.Trace(err)
 			}
-			defer release()
+			defer cb.Release()
 
 			model, err := st.Model()
 			if err != nil {

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -178,9 +178,9 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	}
 	assertModelMatches(model)
 
-	model, release, err := s.StatePool.GetModel(uuid)
+	model, cb, err := s.StatePool.GetModel(uuid)
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	assertModelMatches(model)
 
 	model, err = st.Model()
@@ -358,9 +358,9 @@ func (s *ModelSuite) TestConfigForOtherModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Obtain another instance of the model via the StatePool
-	model, release, err := s.StatePool.GetModel(otherModel.UUID())
+	model, cb, err := s.StatePool.GetModel(otherModel.UUID())
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 
 	conf, err := model.Config()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1143,9 +1143,9 @@ func (s *ModelSuite) TestListUsersTwoModels(c *gc.C) {
 	assertObtainedUsersMatchExpectedUsers(c, obtainedUsersOtherModel, expectedUsersOtherModel)
 
 	// It doesn't matter how you obtain the Model.
-	otherModel2, release, err := s.StatePool.GetModel(otherModel.UUID())
+	otherModel2, cb, err := s.StatePool.GetModel(otherModel.UUID())
 	c.Assert(err, jc.ErrorIsNil)
-	defer release()
+	defer cb.Release()
 	obtainedUsersOtherModel2, err := otherModel2.Users()
 	c.Assert(err, jc.ErrorIsNil)
 	assertObtainedUsersMatchExpectedUsers(c, obtainedUsersOtherModel2, expectedUsersOtherModel)

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -212,8 +212,8 @@ func (s *ModelSummariesSuite) TestContainsConfigInformation(c *gc.C) {
 	// We don't guarantee the order of the summaries, but the data for each model should match the same
 	// information you would get if you instantiate the model directly
 	summaryA := summaries[0]
-	model, closer, err := s.StatePool.GetModel(summaryA.UUID)
-	defer closer()
+	model, cb, err := s.StatePool.GetModel(summaryA.UUID)
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	conf, err := model.Config()
 	c.Assert(err, jc.ErrorIsNil)
@@ -234,8 +234,8 @@ func (s *ModelSummariesSuite) TestContainsProviderType(c *gc.C) {
 	c.Check(summaries, gc.HasLen, 2)
 	// We don't guarantee the order of the summaries, but both should have the same ProviderType
 	summaryA := summaries[0]
-	model, closer, err := s.StatePool.GetModel(summaryA.UUID)
-	defer closer()
+	model, cb, err := s.StatePool.GetModel(summaryA.UUID)
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	conf, err := model.Config()
 	c.Assert(err, jc.ErrorIsNil)
@@ -254,12 +254,12 @@ func (s *ModelSummariesSuite) TestContainsModelStatus(c *gc.C) {
 			Message: "human message",
 		},
 	}
-	shared, releaser, err := s.StatePool.GetModel(modelNameToUUID["shared"])
-	defer releaser()
+	shared, cb, err := s.StatePool.GetModel(modelNameToUUID["shared"])
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	err = shared.SetStatus(expectedStatus["shared"])
-	user1, releaser, err := s.StatePool.GetModel(modelNameToUUID["user1model"])
-	defer releaser()
+	user1, cb, err := s.StatePool.GetModel(modelNameToUUID["user1model"])
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	err = user1.SetStatus(expectedStatus["user1model"])
 	c.Assert(err, jc.ErrorIsNil)
@@ -280,8 +280,8 @@ func (s *ModelSummariesSuite) TestContainsModelStatus(c *gc.C) {
 
 func (s *ModelSummariesSuite) TestContainsAccessInformation(c *gc.C) {
 	modelNameToUUID := s.Setup4Models(c)
-	shared, releaser, err := s.StatePool.GetModel(modelNameToUUID["shared"])
-	defer releaser()
+	shared, cb, err := s.StatePool.GetModel(modelNameToUUID["shared"])
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	err = shared.UpdateLastModelConnection(names.NewUserTag("auser"))
 	s.Clock.Advance(time.Hour)
@@ -292,8 +292,8 @@ func (s *ModelSummariesSuite) TestContainsAccessInformation(c *gc.C) {
 	s.Clock.Advance(time.Hour) // give a different time for user2 accessing the shared model
 	err = shared.UpdateLastModelConnection(names.NewUserTag("user2read"))
 	c.Assert(err, jc.ErrorIsNil)
-	user1, releaser, err := s.StatePool.GetModel(modelNameToUUID["user1model"])
-	defer releaser()
+	user1, cb, err := s.StatePool.GetModel(modelNameToUUID["user1model"])
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	s.Clock.Advance(time.Hour)
 	timeUser1 := s.Clock.Now().Round(time.Second).UTC()
@@ -322,8 +322,8 @@ func (s *ModelSummariesSuite) TestContainsAccessInformation(c *gc.C) {
 
 func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	modelNameToUUID := s.Setup4Models(c)
-	shared, releaser, err := s.StatePool.Get(modelNameToUUID["shared"])
-	defer releaser()
+	shared, cb, err := s.StatePool.Get(modelNameToUUID["shared"])
+	defer cb.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	onecore := uint64(1)
 	twocores := uint64(2)
@@ -404,9 +404,9 @@ func (s *ModelSummariesSuite) TestModelsWithNoSettings(c *gc.C) {
 	modelNameToUUID := s.Setup4Models(c)
 	m2uuid := modelNameToUUID["user2model"]
 	// Mark the model as dying, and move to start tearing it down
-	model, releaser, err := s.StatePool.GetModel(m2uuid)
+	model, cb, err := s.StatePool.GetModel(m2uuid)
 	c.Assert(err, jc.ErrorIsNil)
-	defer releaser()
+	defer cb.Release()
 	err = model.SetStatus(status.StatusInfo{
 		Status:  status.Available,
 		Message: "running",

--- a/state/statemetrics/state.go
+++ b/state/statemetrics/state.go
@@ -14,8 +14,8 @@ import (
 // StatePool represents a pool of State objects.
 type StatePool interface {
 	SystemState() State
-	Get(modelUUID string) (State, state.StatePoolReleaser, error)
-	GetModel(modelUUID string) (Model, state.StatePoolReleaser, error)
+	Get(modelUUID string) (State, state.PoolItemCallbacks, error)
+	GetModel(modelUUID string) (Model, state.PoolItemCallbacks, error)
 }
 
 // State represents the global state managed by the Juju controller.
@@ -62,20 +62,20 @@ func (p statePoolShim) SystemState() State {
 	return stateShim{p.pool.SystemState()}
 }
 
-func (p statePoolShim) Get(modelUUID string) (State, state.StatePoolReleaser, error) {
-	st, releaser, err := p.pool.Get(modelUUID)
+func (p statePoolShim) Get(modelUUID string) (State, state.PoolItemCallbacks, error) {
+	st, cb, err := p.pool.Get(modelUUID)
 	if err != nil {
-		return nil, nil, err
+		return nil, cb, err
 	}
-	return stateShim{st}, releaser, nil
+	return stateShim{st}, cb, nil
 }
 
-func (p statePoolShim) GetModel(modelUUID string) (Model, state.StatePoolReleaser, error) {
-	model, releaser, err := p.pool.GetModel(modelUUID)
+func (p statePoolShim) GetModel(modelUUID string) (Model, state.PoolItemCallbacks, error) {
+	model, cb, err := p.pool.GetModel(modelUUID)
 	if err != nil {
-		return nil, nil, err
+		return nil, cb, err
 	}
-	return model, releaser, nil
+	return model, cb, nil
 }
 
 type stateShim struct {

--- a/state/statemetrics/statemetrics.go
+++ b/state/statemetrics/statemetrics.go
@@ -181,12 +181,12 @@ func (c *Collector) updateMetrics() {
 }
 
 func (c *Collector) updateModelMetrics(modelUUID string) {
-	model, release, err := c.pool.GetModel(modelUUID)
+	model, cb, err := c.pool.GetModel(modelUUID)
 	if err != nil {
 		logger.Debugf("error getting model: %v", err)
 		return
 	}
-	defer release()
+	defer cb.Release()
 
 	modelStatus, err := model.Status()
 	if err != nil {
@@ -199,7 +199,7 @@ func (c *Collector) updateModelMetrics(modelUUID string) {
 	}
 
 	modelTag := model.ModelTag()
-	st, releaseState, err := c.pool.Get(modelTag.Id())
+	st, cbState, err := c.pool.Get(modelTag.Id())
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return // Model removed
@@ -208,7 +208,7 @@ func (c *Collector) updateModelMetrics(modelUUID string) {
 		logger.Debugf("error getting model state: %v", err)
 		return
 	}
-	defer releaseState()
+	defer cbState.Release()
 
 	machines, err := st.AllMachines()
 	if err != nil {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -45,11 +45,11 @@ func runForAllModelStates(st *State, runner func(st *State) error) error {
 	defer pool.Close()
 	for _, modelDoc := range modelDocs {
 		modelUUID := modelDoc["_id"].(string)
-		envSt, release, err := pool.Get(modelUUID)
+		envSt, cb, err := pool.Get(modelUUID)
 		if err != nil {
 			return errors.Annotatef(err, "failed to open model %q", modelUUID)
 		}
-		defer release()
+		defer cb.Release()
 		if err := runner(envSt); err != nil {
 			return errors.Annotatef(err, "model UUID %q", modelUUID)
 		}

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -14,9 +14,9 @@ type StatePoolModelGetter struct {
 
 // Model is part of the ModelGetter interface.
 func (g StatePoolModelGetter) Model(modelUUID string) (Model, func(), error) {
-	model, release, err := g.StatePool.GetModel(modelUUID)
+	model, cb, err := g.StatePool.GetModel(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	return model, func() { release() }, nil
+	return model, func() { cb.Release() }, nil
 }

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -197,7 +197,7 @@ func (w *stateWorker) processModelLifeChange(
 		pool.Remove(modelUUID)
 	}
 
-	model, release, err := pool.GetModel(modelUUID)
+	model, cb, err := pool.GetModel(modelUUID)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Model has been removed from state.
@@ -207,7 +207,7 @@ func (w *stateWorker) processModelLifeChange(
 		}
 		return errors.Trace(err)
 	}
-	defer release()
+	defer cb.Release()
 
 	if model.Life() == state.Dead {
 		// Model is Dead, and will soon be removed from state.
@@ -267,11 +267,11 @@ func newModelStateWorker(
 }
 
 func (w *modelStateWorker) loop() error {
-	st, release, err := w.pool.Get(w.modelUUID)
+	st, cb, err := w.pool.Get(w.modelUUID)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer release()
+	defer cb.Release()
 	defer w.pool.Remove(w.modelUUID)
 
 	for {


### PR DESCRIPTION
## Description of change

This is a preparatory change for adding a new callback (or even callbacks) to the return of _StatePool.Get_.

This first change preserves current functionality, but replaces the _StatePoolReleaser_ func return with a new type, _PoolItemCallbacks_. This allows us to return additional callbacks in a single struct instance.

There are a couple of inconsequential changes included, but the intent is to introduce the new return type and ensure nothing is broken before adding the desired context reporting.

## QA steps

The full test suite is green.

## Documentation changes

None.

## Bug reference

TBC.
