### PR TITLE
Remove requirement for absolute path for credentials files.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -251,7 +251,7 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 		return errors.NotSupportedf("auth type %q for cloud %q", authType, c.CloudName)
 	}
 
-	attrs, err := c.promptCredentialAttributes(pollster, authType, schema, ctxt)
+	attrs, err := c.promptCredentialAttributes(pollster, authType, schema)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -326,7 +326,7 @@ func (c *addCredentialCommand) promptAuthType(p *interact.Pollster, authTypes []
 	return jujucloud.AuthType(authType), nil
 }
 
-func (c *addCredentialCommand) promptCredentialAttributes(p *interact.Pollster, authType jujucloud.AuthType, schema jujucloud.CredentialSchema, ctxt *cmd.Context) (attributes map[string]string, err error) {
+func (c *addCredentialCommand) promptCredentialAttributes(p *interact.Pollster, authType jujucloud.AuthType, schema jujucloud.CredentialSchema) (attributes map[string]string, err error) {
 	// Interactive add does not support adding multi-line values, which
 	// is what we typically get when the attribute can come from a file.
 	// For now we'll skip, and just get the user to enter the file path.
@@ -339,7 +339,7 @@ func (c *addCredentialCommand) promptCredentialAttributes(p *interact.Pollster, 
 		var err error
 
 		if currentAttr.FileAttr == "" {
-			value, err = c.promptFieldValue(p, ctxt, currentAttr)
+			value, err = c.promptFieldValue(p, currentAttr)
 			if err != nil {
 				return nil, err
 			}
@@ -347,7 +347,7 @@ func (c *addCredentialCommand) promptCredentialAttributes(p *interact.Pollster, 
 			currentAttr.Name = currentAttr.FileAttr
 			currentAttr.Hidden = false
 			currentAttr.FilePath = true
-			value, err = c.promptFieldValue(p, ctxt, currentAttr)
+			value, err = c.promptFieldValue(p, currentAttr)
 			if err != nil {
 				return nil, err
 			}
@@ -359,8 +359,7 @@ func (c *addCredentialCommand) promptCredentialAttributes(p *interact.Pollster, 
 	return attrs, nil
 }
 
-func (c *addCredentialCommand) promptFieldValue(
-	p *interact.Pollster, ctxt *cmd.Context, attr jujucloud.NamedCredentialAttr) (string, error) {
+func (c *addCredentialCommand) promptFieldValue(p *interact.Pollster, attr jujucloud.NamedCredentialAttr) (string, error) {
 	name := attr.Name
 
 	if len(attr.Options) > 0 {

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -461,6 +461,35 @@ func (s *addCredentialSuite) TestAddMAASCredential(c *gc.C) {
 	})
 }
 
+func (s *addCredentialSuite) TestAddGCEFileCredentials(c *gc.C) {
+	s.authTypes = []jujucloud.AuthType{jujucloud.JSONFileAuthType}
+	s.schema = map[jujucloud.AuthType]jujucloud.CredentialSchema{
+		jujucloud.JSONFileAuthType: {
+			{
+				"file",
+				jujucloud.CredentialAttr{
+					Description: "path to the credential file",
+					Optional:    false,
+					FilePath:    true,
+				},
+			},
+		},
+	}
+	sourceFile := s.createTestCredentialDataWithAuthType(c, fmt.Sprintf("%v", jujucloud.JSONFileAuthType))
+	stdin := strings.NewReader(fmt.Sprintf("blah\n%s\n", sourceFile))
+	ctx, err := s.run(c, stdin, "somecloud")
+	c.Assert(err, jc.ErrorIsNil)
+	expected := `
+Enter credential name: 
+Using auth-type "jsonfile".
+
+Enter path to the credential file: 
+Credential "blah" added locally for cloud "somecloud".
+
+`[1:]
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expected)
+}
+
 func (s *addCredentialSuite) TestShouldFinalizeCredentialWithEnvironProvider(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Why is this change needed?

As per bug [LP#1745031](https://bugs.launchpad.net/juju/+bug/1745031) it wasn't obvious that an absolute path was required, changing the verification to transform to an absolute path removed the need to specify.

Also now output  the Description for the file type attrs when requesting  the file path.

i.e. 
```
"file": path to the .json file containing your Google Compute Engine project credentials
Enter file:
```
## QA steps

Unit tests where included in they juju/utils change that allowed this.
Manually verified the description is outputted when using the add-credential command.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1745031
