### PR TITLE
audit-logging: Allow "ReadOnlyMethods" in exclude-methods

### DIFF
--- a/apiserver/observer/auditfilter_test.go
+++ b/apiserver/observer/auditfilter_test.go
@@ -81,3 +81,17 @@ func (s *auditFilterSuite) TestMakeFilter(c *gc.C) {
 	c.Assert(f1(auditlog.Request{Facade: "Helplessness", Method: "Blues"}), jc.IsFalse)
 	c.Assert(f1(auditlog.Request{Facade: "The", Method: "Shrine"}), jc.IsTrue)
 }
+
+func (s *auditFilterSuite) TestExpandsReadonlyMethods(c *gc.C) {
+	f1 := observer.MakeInterestingRequestFilter(set.NewStrings("ReadOnlyMethods", "Helplessness.Blues"))
+	c.Assert(f1(auditlog.Request{Facade: "Helplessness", Method: "Blues"}), jc.IsFalse)
+	c.Assert(f1(auditlog.Request{Facade: "Client", Method: "FullStatus"}), jc.IsFalse)
+	c.Assert(f1(auditlog.Request{Facade: "Falcon", Method: "Heavy"}), jc.IsTrue)
+}
+
+func (s *auditFilterSuite) TestOnlyExcludeReadonlyMethodsIfWeShould(c *gc.C) {
+	f1 := observer.MakeInterestingRequestFilter(set.NewStrings("Helplessness.Blues"))
+	c.Assert(f1(auditlog.Request{Facade: "Helplessness", Method: "Blues"}), jc.IsFalse)
+	// Doesn't allow the readonly methods unless they've included the special key.
+	c.Assert(f1(auditlog.Request{Facade: "Client", Method: "FullStatus"}), jc.IsTrue)
+}

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -148,9 +148,9 @@ var validateTests = []struct {
 	about: "invalid audit log exclude",
 	config: controller.Config{
 		controller.CACertKey:              testing.CACert,
-		controller.AuditLogExcludeMethods: []interface{}{"Dap.Kings", "Sharon Jones"},
+		controller.AuditLogExcludeMethods: []interface{}{"Dap.Kings", "ReadOnlyMethods", "Sharon Jones"},
 	},
-	expectError: `invalid audit log exclude methods: should be a list of "Facade.Method" names, got "Sharon Jones" at position 2`,
+	expectError: `invalid audit log exclude methods: should be a list of "Facade.Method" names \(or "ReadOnlyMethods"\), got "Sharon Jones" at position 3`,
 }}
 
 func (s *ConfigSuite) TestValidate(c *gc.C) {
@@ -224,7 +224,7 @@ func (s *ConfigSuite) TestAuditLogValues(c *gc.C) {
 			"audit-log-capture-args":    true,
 			"audit-log-max-size":        "100M",
 			"audit-log-max-backups":     10.0,
-			"audit-log-exclude-methods": []string{"Fleet.Foxes", "King.Gizzard"},
+			"audit-log-exclude-methods": []string{"Fleet.Foxes", "King.Gizzard", "ReadOnlyMethods"},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -235,6 +235,7 @@ func (s *ConfigSuite) TestAuditLogValues(c *gc.C) {
 	c.Assert(cfg.AuditLogExcludeMethods(), gc.DeepEquals, set.NewStrings(
 		"Fleet.Foxes",
 		"King.Gizzard",
+		"ReadOnlyMethods",
 	))
 }
 

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -126,7 +126,7 @@ func (s *ControllerSuite) TestUpdateControllerConfigValidates(c *gc.C) {
 	err := s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.AuditLogExcludeMethods: []string{"thing"},
 	}, nil)
-	c.Assert(err, gc.ErrorMatches, `invalid audit log exclude methods: should be a list of "Facade.Method" names, got "thing" at position 1`)
+	c.Assert(err, gc.ErrorMatches, `invalid audit log exclude methods: should be a list of "Facade.Method" names \(or "ReadOnlyMethods"\), got "thing" at position 1`)
 }
 
 func (s *ControllerSuite) TestUpdatingUnknownName(c *gc.C) {


### PR DESCRIPTION
## Description of change

By default the `audit-log-exclude-methods` value contained a list of 45 read-only API methods. This was unwieldy - it's replaced by a special value `ReadOnlyMethods` that will be interpreted as if the full list of read-only methods were included in audit-log-exclude-methods. It doesn't get expanded at the point of storing in the DB so that changes to the read-only method list will be honoured when Juju is upgraded.

## QA steps

* Bootstrap a controller with `auditing-enabled=true`
* See that the value of `audit-log-exclude-methods` is `ReadOnlyMethods` by default.
* Watch the audit log, update `audit-log-exclude-methods` to `[ReadOnlyMethods,Controller.ConfigSet]` and then in a separate command update `audit-log-capture-args` to true. The conversation to update `audit-log-exclude-methods` will be recorded in the log, but the one updating `capture-args` will be excluded.

## Documentation changes

Yes, the `ReadOnlyMethod` value (and the list of methods it represents) should be documented.
