### PR TITLE
Fixes lp#1747708: really mean status.since.

### DIFF
--- a/state/status.go
+++ b/state/status.go
@@ -286,7 +286,7 @@ func setStatus(db Database, params setStatusParams) (err error) {
 		// If this status is not new (i.e. it is exactly the same as
 		// our last status), there is no need to update the record.
 		// Update here will only reset the 'Since' field.
-		return
+		return err
 	}
 
 	// Set the authoritative status document, or fail trying.


### PR DESCRIPTION
## Description of change

Currently, <component>.status.since field reflects when this status was last set. It ignores whether the status is the same as the last call.

So if a unit has been active for an hour, unit.status.since will still say '5min ago' since we attempt to set status every 5 mins. So over time, instead of meaning 'since' this field started meaning 'last-time-called'. Historically, however,that function was performed by status history collection - we'd record each call to set status history regardless of the status value. We have recently changed this - status history collection in production system was growing out of control - to only record the first time the status was set to a new value and not record subsequent 'duplicates'.

This PR changes the meaning of 'since' in the status record back to mean 'this status has been the same since <original timestamp of the change>'. With this in place, we also change corresponding record in status history to have 'since' field mean 'last-time-setting-of-this-status-was-called'.

With this PR, show-status-log can yet again be used to find out when set-status hook was last called since record in history will have that timestamp.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1747708
