### PR TITLE
Occasionally sockets get wedged in Mgo.

### DIFF
--- a/patches/mgo_server_abended_255.diff
+++ b/patches/mgo_server_abended_255.diff
@@ -1,0 +1,15 @@
+diff --git a/cluster.go b/cluster.go
+index c3bf8b0..17a0261 100644
+--- a/gopkg.in/mgo.v2/cluster.go
++++ b/gopkg.in/mgo.v2/cluster.go
+@@ -646,6 +646,10 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout
+ 				cluster.syncServers()
+ 				time.Sleep(100 * time.Millisecond)
+ 				continue
++			} else {
++				server.Lock()
++				server.abended = false
++				server.Unlock()
+ 			}
+ 		}
+ 		return s, nil


### PR DESCRIPTION
## Description of change

If they ever go into an abended state, they end up in the socket pool to
be used again, but even when the connection is reset, they don't exit
the abended state. This causes us to recheck isMaster on every query,
and that also causes us to reauthenticate on every query. (the pattern
in mgo is that every connection is queued for logout after every query,
but the next query adds a login and it collapses a logout + login pair
into a no-op. But isMaster breaks that logic and causes logout and login
on every query.)

This is a patch taken from:
    https://github.com/go-mgo/mgo/pull/255/files

The symptom in production is that you'll see cpu consumption spike and when inspecting the calls being made, lots of isMaster and saslStart calls are happening. (The latter is the thing that actually costs the CPU time.)

## QA steps

The production issue of isMaster and saslStart storms should diminish. To QA this manually, you can try to run a heavily loaded system, such that a socket ends up in a bad state, and then you'll see a background load on the system that doesn't seem to ever go to idle. (I've seen the symptom in testing, but haven't been able to recreate it on demand.)

## Documentation changes

None.

## Bug reference

[lp:1747368](https://bugs.launchpad.net/juju/+bug/1747368)