### PR TITLE
Bug 1748283

### DIFF
--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -883,7 +883,7 @@ func (s *ConfigSuite) TestValidateCloudInitUserData(c *gc.C) {
 	}
 	s.FakeHomeSuite.Home.AddFiles(c, files...)
 	for i, test := range configValidateCloudInitUserDataTests {
-		c.Logf("test %d. %s", i, test.about)
+		c.Logf("test %d of %d. %s", i+1, len(configValidateCloudInitUserDataTests), test.about)
 		test.checkNew(c)
 	}
 }


### PR DESCRIPTION
## Description of change

Complicated YAML needs to be normalized for json/bson before passing via the apiserver.  Fix this for cloudinit-userdata.

## QA steps

1.  juju bootstrap localhost
2. setup config.yaml per https://gist.github.com/wwwtyro/6afde641c5c3db038b6b28106345251a (from bug)
3. juju model-config config.yaml
4. juju add-machine 
5. juju ssh <new machine>
6. cat /usr/share/ca-certificates/cloud-init-ca-certs.crt   <- should match data from config.yaml

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748283