### PR TITLE
Forward port PR8354 - fix lp:1748283

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -611,9 +611,9 @@ func Validate(cfg, old *Config) error {
 	}
 
 	if raw, ok := cfg.defined[CloudInitUserDataKey].(string); ok && raw != "" {
-		userDataMap := make(map[string]interface{})
-		if err := yaml.Unmarshal([]byte(raw), &userDataMap); err != nil {
-			return errors.Annotate(err, "cloudinit-userdata: must be valid YAML")
+		userDataMap, err := ensureStringMaps(raw)
+		if err != nil {
+			return errors.Annotate(err, "cloudinit-userdata")
 		}
 
 		// if there packages, ensure they are strings
@@ -676,6 +676,20 @@ func Validate(cfg, old *Config) error {
 
 	cfg.defined = ProcessDeprecatedAttributes(cfg.defined)
 	return nil
+}
+
+// ensureStringMaps takes in a string and returns YAML in a map
+// where all keys of any nested maps are strings.
+func ensureStringMaps(in string) (map[string]interface{}, error) {
+	userDataMap := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(in), &userDataMap); err != nil {
+		return nil, errors.Annotate(err, "must be valid YAML")
+	}
+	out, err := utils.ConformYAML(userDataMap)
+	if err != nil {
+		return nil, err
+	}
+	return out.(map[string]interface{}), nil
 }
 
 func isEmpty(val interface{}) bool {
@@ -1163,9 +1177,9 @@ func (c *Config) CloudInitUserData() map[string]interface{} {
 	if raw == "" {
 		return nil
 	}
-	userDataMap := make(map[string]interface{})
-	yaml.Unmarshal([]byte(raw), &userDataMap)
-	return userDataMap
+	// The raw data has already passed Validate()
+	conformingUserDataMap, _ := ensureStringMaps(raw)
+	return conformingUserDataMap
 }
 
 // ContainerInheritProperies returns a copy of the raw user data keys

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -900,7 +900,7 @@ func (s *ConfigSuite) TestValidateCloudInitUserData(c *gc.C) {
 	}
 	s.FakeHomeSuite.Home.AddFiles(c, files...)
 	for i, test := range configValidateCloudInitUserDataTests {
-		c.Logf("test %d. %s", i, test.about)
+		c.Logf("test %d of %d. %s", i+1, len(configValidateCloudInitUserDataTests), test.about)
 		test.checkNew(c)
 	}
 }


### PR DESCRIPTION
## Description of change

Complicated YAML needs to be normalized for json/bson before passing via the apiserver. Fix this for cloudinit-userdata.

## QA steps

1. juju bootstrap localhost
2. setup config.yaml per https://gist.github.com/wwwtyro/6afde641c5c3db038b6b28106345251a (from bug)
3. juju model-config config.yaml
4. juju add-machine
5. juju ssh
6. cat /usr/share/ca-certificates/cloud-init-ca-certs.crt <- should match data from config.yaml

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748283