### PR TITLE
Support upgrades from 2.1.x

### DIFF
--- a/state/iaasmodel.go
+++ b/state/iaasmodel.go
@@ -20,7 +20,8 @@ type IAASModel struct {
 
 // IAASModel returns an Infrastructure-As-A-Service (IAAS) model.
 func (m *Model) IAASModel() (*IAASModel, error) {
-	if m.Type() != ModelTypeIAAS {
+	// We keep a check against the missing modelType to handle upgrades.
+	if modelType := m.Type(); modelType != ModelTypeIAAS && modelType != modelTypeNone {
 		return nil, errors.NotSupportedf("called IAASModel() on a non-IAAS Model")
 	}
 	return &IAASModel{


### PR DESCRIPTION
An upgrade step to move to 2.2.0 now requires the IAAS model, which relied on the type being set in the model, which is an upgrade step for 2.3.0.

This broke upgrades from 2.1.x

## QA steps

Bootstrap a 2.1.2 environment.
Set logging to at least INFO for the controller model.
Then build this branch, followed by:
juju upgrade-juju -m controller --build-agent

Notice the logging line:
machine-0: 17:15:22 INFO juju.worker.upgradesteps upgrade to 2.3.3.1 completed successfully.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748294
