### PR TITLE
Add caas operator presence, and status fixes

### DIFF
--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -93,28 +93,29 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 		return status, errors.Trace(err)
 	}
 
-	volumes, err := st.AllVolumes()
-	if err != nil {
-		return status, errors.Trace(err)
-	}
-	modelVolumes := ModelVolumeInfo(volumes)
-
-	filesystems, err := st.AllFilesystems()
-	if err != nil {
-		return status, errors.Trace(err)
-	}
-	modelFilesystems := ModelFilesystemInfo(filesystems)
-
-	return params.ModelStatus{
+	result := params.ModelStatus{
 		ModelTag:           tag,
 		OwnerTag:           model.Owner().String(),
 		Life:               params.Life(model.Life().String()),
 		HostedMachineCount: len(hostedMachines),
 		ApplicationCount:   len(applications),
 		Machines:           modelMachines,
-		Volumes:            modelVolumes,
-		Filesystems:        modelFilesystems,
-	}, nil
+	}
+
+	if model.Type() == state.ModelTypeIAAS {
+		volumes, err := st.AllVolumes()
+		if err != nil {
+			return status, errors.Trace(err)
+		}
+		result.Volumes = ModelVolumeInfo(volumes)
+
+		filesystems, err := st.AllFilesystems()
+		if err != nil {
+			return status, errors.Trace(err)
+		}
+		result.Filesystems = ModelFilesystemInfo(filesystems)
+	}
+	return result, nil
 }
 
 // ModelFilesystemInfo returns information about filesystems in the model.

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -204,7 +204,7 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsNoTags(c *gc.C) {
 		{ProviderId: "another-uuid", Address: "another-address", Ports: []string{"another-port"},
 			Status: "running", Info: "another message"},
 		{ProviderId: "last-uuid", Address: "last-address", Ports: []string{"last-port"},
-			Status: "running", Info: "last message"},
+			Status: "error", Info: "last message"},
 	}
 	args := params.UpdateApplicationUnitArgs{
 		Args: []params.UpdateApplicationUnits{
@@ -224,13 +224,12 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsNoTags(c *gc.C) {
 	s.st.application.CheckCall(c, 0, "AddOperation", state.UnitUpdateProperties{
 		ProviderId: "last-uuid",
 		Address:    "last-address", Ports: []string{"last-port"},
-		Status: &status.StatusInfo{Status: status.Running, Message: "last message"},
+		Status: &status.StatusInfo{Status: status.Error, Message: "last message"},
 	})
 	s.st.application.units[0].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "uuid",
 		Address:    "address", Ports: []string{"port"},
-		Status: &status.StatusInfo{Status: status.Running, Message: "message"},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
@@ -252,7 +251,7 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithTags(c *gc.C) {
 		{ProviderId: "uuid", UnitTag: "unit-gitlab-0", Address: "address", Ports: []string{"port"},
 			Status: "running", Info: "message"},
 		{ProviderId: "another-uuid", UnitTag: "unit-gitlab-1", Address: "another-address", Ports: []string{"another-port"},
-			Status: "running", Info: "another message"},
+			Status: "error", Info: "another message"},
 	}
 	args := params.UpdateApplicationUnitArgs{
 		Args: []params.UpdateApplicationUnits{
@@ -272,13 +271,12 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithTags(c *gc.C) {
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "uuid",
 		Address:    "address", Ports: []string{"port"},
-		Status: &status.StatusInfo{Status: status.Running, Message: "message"},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "another-uuid",
 		Address:    "another-address", Ports: []string{"another-port"},
-		Status: &status.StatusInfo{Status: status.Running, Message: "another message"},
+		Status: &status.StatusInfo{Status: status.Error, Message: "another message"},
 	})
 	s.st.application.units[2].(*mockUnit).CheckCallNames(c, "Life")
 }

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -24,6 +24,8 @@ import (
 	"github.com/juju/juju/status"
 )
 
+const caasModelType = "caas"
+
 // FormatTabular writes a tabular summary of machines, applications, and
 // units. Any subordinate items are indented by two spaces beneath
 // their superior.
@@ -38,7 +40,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	maxVersionWidth := iaasMaxVersionWidth
-	if fs.Model.Type == "caas" {
+	if fs.Model.Type == caasModelType {
 		maxVersionWidth = caasMaxVersionWidth
 	}
 	truncatedWidth := maxVersionWidth - len(ellipsis)
@@ -112,7 +114,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		app := fs.Applications[appName]
 		version := app.Version
 		// CAAS versions may have repo prefix we don't care about.
-		if fs.Model.Type == "caas" {
+		if fs.Model.Type == caasModelType {
 			parts := strings.Split(version, "/")
 			if len(parts) == 2 {
 				version = parts[1]
@@ -149,8 +151,6 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		}
 	}
 
-	const caasModelType = "caas"
-
 	pUnit := func(name string, u unitStatus, level int) {
 		message := u.WorkloadStatusInfo.Message
 		agentDoing := agentDoing(u.JujuStatusInfo)
@@ -161,8 +161,9 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 			name += "*"
 		}
 		w.Print(indent("", level*2, name))
+		w.PrintStatus(u.WorkloadStatusInfo.Current)
+		w.PrintStatus(u.JujuStatusInfo.Current)
 		if fs.Model.Type == caasModelType {
-			w.PrintStatus(u.JujuStatusInfo.Current)
 			p(
 				u.Address,
 				strings.Join(u.OpenedPorts, ","),
@@ -170,8 +171,6 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 			)
 			return
 		}
-		w.PrintStatus(u.WorkloadStatusInfo.Current)
-		w.PrintStatus(u.JujuStatusInfo.Current)
 		p(
 			u.Machine,
 			u.PublicAddress,
@@ -181,7 +180,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	if fs.Model.Type == caasModelType {
-		outputHeaders("Unit", "Status", "Address", "Ports", "Message")
+		outputHeaders("Unit", "Workload", "Agent", "Address", "Ports", "Message")
 	} else {
 		outputHeaders("Unit", "Workload", "Agent", "Machine", "Public address", "Ports", "Message")
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4186,12 +4186,18 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 						JujuStatusInfo: statusInfoContents{
 							Current: status.Allocating,
 						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Active,
+						},
 					},
 					"foo/1": {
 						Address:     "10.0.0.1",
 						OpenedPorts: []string{"80/TCP"},
 						JujuStatusInfo: statusInfoContents{
 							Current: status.Running,
+						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Active,
 						},
 					},
 				},
@@ -4208,9 +4214,9 @@ Model  Controller  Cloud/Region  Version
 App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
 foo                     1/2                  0      
 
-Unit   Status      Address   Ports   Message
-foo/0  allocating                    
-foo/1  running     10.0.0.1  80/TCP  
+Unit   Workload  Agent       Address   Ports   Message
+foo/0  active    allocating                    
+foo/1  active    running     10.0.0.1  80/TCP  
 `[1:])
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -973,7 +973,7 @@ func (m *Machine) AgentPresence() (bool, error) {
 }
 
 // WaitAgentPresence blocks until the respective agent is alive.
-// These should really only be used in the test suite.
+// This should really only be used in the test suite.
 func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 	defer errors.DeferredAnnotatef(&err, "waiting for agent of machine %v", m)
 	ch := make(chan presence.Change)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1323,6 +1323,8 @@ func (u *Unit) AgentPresence() (bool, error) {
 	if u.ShouldBeAssigned() {
 		return pwatcher.Alive(u.globalAgentKey())
 	}
+	// Units in CAAS models rely on the operator pings.
+	// These are for the application itself.
 	app, err := u.Application()
 	if err != nil {
 		return false, errors.Trace(err)
@@ -1331,9 +1333,7 @@ func (u *Unit) AgentPresence() (bool, error) {
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	// TODO(caas) - record presence for application agent
-	// We return true so that the agent doesn't appwar as lost.
-	return true || appAlive, nil
+	return appAlive, nil
 }
 
 // Tag returns a name identifying the unit.
@@ -1350,7 +1350,7 @@ func (u *Unit) UnitTag() names.UnitTag {
 }
 
 // WaitAgentPresence blocks until the respective agent is alive.
-// These should really only be used in the test suite.
+// This should really only be used in the test suite.
 func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 	defer errors.DeferredAnnotatef(&err, "waiting for agent of unit %q", u)
 	ch := make(chan presence.Change)


### PR DESCRIPTION
## Description of change

A few small CAAS changes:
1. We add presence for the operator agent (copy/paste from machine/unit agents)
2. Fix ModelStatus() so that it can handle CAAS models (don't attempt get storage)
3. Tweak status updates so we don't spam status with unnecessary data
4. Adjust juju status output to show both agent and workload status again

## QA steps

Run up a CAAS model, deploy gitlab
Check that unit status doesn't show "lost"
Check status history
kill-controller and ensure no IAAS model errors
