### PR TITLE
Fixes Intermittent Test Failures Asserting Machine Provision Retries

### DIFF
--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1897,8 +1897,10 @@ func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {
 	c.Assert(e.retryCount[mSucceed[0].Id()], gc.Equals, 1)
 	c.Assert(e.retryCount[mSucceed[2].Id()], gc.Equals, 1)
 
-	// There is a potential race here where the provisioning has not yet been
-	// retried the specified number of times.
+	// This synchronisation addresses a potential race condition.
+	// It can happen that upon successful return from checkStartInstances
+	// The machine(s) arranged for provisioning failure have not yet been
+	// retried the specified number of times; so we wait.
 	id := mFail[1].Id()
 	for e.retryCount[id] < 3 {
 		select {


### PR DESCRIPTION
## Description of change

Rectifies a race condition in ProvisionerSuite.TestProvisioningMachinesDerivedAZ that causes intermittent failure.

Includes some drive-by cosmetic changes.

## QA steps

Prior failure can be reproduced in a loop in short time. Post change, the test failure could not be triggered within 1000 test runs.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748372
