### PR TITLE
Adjusts test callback expiry time for worker lease testing.

### DIFF
--- a/worker/lease/fixture_test.go
+++ b/worker/lease/fixture_test.go
@@ -43,13 +43,22 @@ func offset(d time.Duration) time.Time {
 	return defaultClockStart.Add(d)
 }
 
-// almostSeconds returns a duration smaller than the supplied number of
+// almostSeconds returns a duration shorter than the supplied number of
 // seconds by one nanosecond.
 func almostSeconds(seconds int) time.Duration {
 	if seconds < 1 {
-		panic("unexpected")
+		panic("expected positive time input")
 	}
 	return (time.Second * time.Duration(seconds)) - time.Nanosecond
+}
+
+// almostSeconds returns a duration longer than the supplied number of
+// seconds by one nanosecond.
+func justAfterSeconds(seconds int) time.Duration {
+	if seconds < 1 {
+		panic("expected positive time input")
+	}
+	return (time.Second * time.Duration(seconds)) + time.Nanosecond
 }
 
 // Fixture allows us to test a *lease.Manager with a usefully-mocked

--- a/worker/lease/manager_expire_test.go
+++ b/worker/lease/manager_expire_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&ExpireSuite{})
 func (s *ExpireSuite) TestStartup_ExpiryInPast(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{Expiry: offset(-time.Second)},
+			"redis": {Expiry: offset(-time.Second)},
 		},
 		expectCalls: []call{{
 			method: "Refresh",
@@ -42,7 +42,7 @@ func (s *ExpireSuite) TestStartup_ExpiryInPast(c *gc.C) {
 func (s *ExpireSuite) TestStartup_ExpiryInFuture(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 	}
 	fix.RunTest(c, func(_ *lease.Manager, clock *testing.Clock) {
@@ -53,7 +53,7 @@ func (s *ExpireSuite) TestStartup_ExpiryInFuture(c *gc.C) {
 func (s *ExpireSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "Refresh",
@@ -80,7 +80,7 @@ func (s *ExpireSuite) TestStartup_NoExpiry_NotLongEnough(c *gc.C) {
 func (s *ExpireSuite) TestStartup_NoExpiry_LongEnough(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"goose": corelease.Info{Expiry: offset(3 * time.Hour)},
+			"goose": {Expiry: offset(3 * time.Hour)},
 		},
 		expectCalls: []call{{
 			method: "Refresh",
@@ -105,7 +105,7 @@ func (s *ExpireSuite) TestStartup_NoExpiry_LongEnough(c *gc.C) {
 func (s *ExpireSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "Refresh",
@@ -126,7 +126,7 @@ func (s *ExpireSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
 func (s *ExpireSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "Refresh",
@@ -147,7 +147,7 @@ func (s *ExpireSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
 func (s *ExpireSuite) TestExpire_OtherError(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "Refresh",
@@ -218,7 +218,7 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -245,7 +245,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -256,7 +256,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 			callback: func(leases map[string]corelease.Info) {
 				leases["redis"] = corelease.Info{
 					Holder: "redis/0",
-					Expiry: offset(63 * time.Second),
+					Expiry: offset(time.Minute),
 				}
 			},
 		}, {
@@ -280,23 +280,23 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 func (s *ExpireSuite) TestExpire_Multiple(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
-			"redis": corelease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
-			"store": corelease.Info{
+			"store": {
 				Holder: "store/3",
 				Expiry: offset(5 * time.Second),
 			},
-			"tokumx": corelease.Info{
+			"tokumx": {
 				Holder: "tokumx/5",
 				Expiry: offset(10 * time.Second), // will not expire.
 			},
-			"ultron": corelease.Info{
+			"ultron": {
 				Holder: "ultron/7",
 				Expiry: offset(5 * time.Second),
 			},
-			"vvvvvv": corelease.Info{
+			"vvvvvv": {
 				Holder: "vvvvvv/2",
 				Expiry: offset(time.Second), // would expire, but errors first.
 			},

--- a/worker/lease/manager_expire_test.go
+++ b/worker/lease/manager_expire_test.go
@@ -166,6 +166,7 @@ func (s *ExpireSuite) TestExpire_OtherError(c *gc.C) {
 }
 
 func (s *ExpireSuite) TestClaim_ExpiryInFuture(c *gc.C) {
+	const newLeaseSecs = 63
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "ClaimLease",
@@ -173,7 +174,7 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture(c *gc.C) {
 			callback: func(leases map[string]corelease.Info) {
 				leases["redis"] = corelease.Info{
 					Holder: "redis/0",
-					Expiry: offset(63 * time.Second),
+					Expiry: offset(newLeaseSecs * time.Second),
 				}
 			},
 		}},
@@ -182,11 +183,12 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture(c *gc.C) {
 		// Ask for a minute, actually get 63s. Don't expire early.
 		err := manager.Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		clock.Advance(almostSeconds(63))
+		clock.Advance(almostSeconds(newLeaseSecs))
 	})
 }
 
 func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
+	const newLeaseSecs = 63
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "ClaimLease",
@@ -194,7 +196,7 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 			callback: func(leases map[string]corelease.Info) {
 				leases["redis"] = corelease.Info{
 					Holder: "redis/0",
-					Expiry: offset(63 * time.Second),
+					Expiry: offset(newLeaseSecs * time.Second),
 				}
 			},
 		}, {
@@ -211,11 +213,12 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 		// Ask for a minute, actually get 63s. Expire on time.
 		err := manager.Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		clock.Advance(63 * time.Second)
+		clock.Advance(justAfterSeconds(newLeaseSecs))
 	})
 }
 
 func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
+	const newLeaseSecs = 63
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
 			"redis": {
@@ -229,7 +232,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 			callback: func(leases map[string]corelease.Info) {
 				leases["redis"] = corelease.Info{
 					Holder: "redis/0",
-					Expiry: offset(63 * time.Second),
+					Expiry: offset(newLeaseSecs * time.Second),
 				}
 			},
 		}},
@@ -238,11 +241,12 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 		// Ask for a minute, actually get 63s. Don't expire early.
 		err := manager.Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		clock.Advance(almostSeconds(63))
+		clock.Advance(almostSeconds(newLeaseSecs))
 	})
 }
 
 func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
+	const newLeaseSecs = 63
 	fix := &Fixture{
 		leases: map[string]corelease.Info{
 			"redis": {
@@ -256,7 +260,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 			callback: func(leases map[string]corelease.Info) {
 				leases["redis"] = corelease.Info{
 					Holder: "redis/0",
-					Expiry: offset(time.Minute),
+					Expiry: offset(newLeaseSecs * time.Second),
 				}
 			},
 		}, {
@@ -273,7 +277,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 		// Ask for a minute, actually get 63s. Expire on time.
 		err := manager.Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		clock.Advance(63 * time.Second)
+		clock.Advance(justAfterSeconds(newLeaseSecs))
 	})
 }
 


### PR DESCRIPTION
## Description of change

Looks like an errant callback setting for the stub/mock in the test. The expiry is actually set to the wait time instead of the requested lease time, so it is a crapshot as to whether the time is up upon evaluation.

Setting it to the requested lease time seems to do the trick.

Includes some drive-by cosmetic changes.

## QA steps

Corrected unit test passes consistently.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748381
