### PR TITLE
port pr 8317: Adding container-inherit-properties to model-config

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -292,6 +292,7 @@ func (p *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.AptProxy = config.AptProxySettings()
 	result.AptMirror = config.AptMirror()
 	result.CloudInitUserData = config.CloudInitUserData()
+	result.ContainerInheritProperties = config.ContainerInheritProperies()
 	return result, nil
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1351,11 +1351,12 @@ func (s *withoutControllerSuite) TestContainerManagerConfig(c *gc.C) {
 
 func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	attrs := map[string]interface{}{
-		"http-proxy":            "http://proxy.example.com:9000",
-		"apt-https-proxy":       "https://proxy.example.com:9000",
-		"allow-lxd-loop-mounts": true,
-		"apt-mirror":            "http://example.mirror.com",
-		"cloudinit-userdata":    validCloudInitUserData,
+		"http-proxy":                   "http://proxy.example.com:9000",
+		"apt-https-proxy":              "https://proxy.example.com:9000",
+		"allow-lxd-loop-mounts":        true,
+		"apt-mirror":                   "http://example.mirror.com",
+		"cloudinit-userdata":           validCloudInitUserData,
+		"container-inherit-properties": "ca-certs,apt-primary",
 	}
 	err := s.Model.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1384,6 +1385,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
 		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
 		"package_upgrade": false})
+	c.Check(results.ContainerInheritProperties, gc.DeepEquals, "ca-certs,apt-primary")
 }
 
 func (s *withoutControllerSuite) TestSetSupportedContainers(c *gc.C) {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -669,13 +669,14 @@ type UpdateBehavior struct {
 // ContainerConfig contains information from the model config that is
 // needed for container cloud-init.
 type ContainerConfig struct {
-	ProviderType            string                 `json:"provider-type"`
-	AuthorizedKeys          string                 `json:"authorized-keys"`
-	SSLHostnameVerification bool                   `json:"ssl-hostname-verification"`
-	Proxy                   proxy.Settings         `json:"proxy"`
-	AptProxy                proxy.Settings         `json:"apt-proxy"`
-	AptMirror               string                 `json:"apt-mirror"`
-	CloudInitUserData       map[string]interface{} `json:"cloudinit-userdata,omitempty"`
+	ProviderType               string                 `json:"provider-type"`
+	AuthorizedKeys             string                 `json:"authorized-keys"`
+	SSLHostnameVerification    bool                   `json:"ssl-hostname-verification"`
+	Proxy                      proxy.Settings         `json:"proxy"`
+	AptProxy                   proxy.Settings         `json:"apt-proxy"`
+	AptMirror                  string                 `json:"apt-mirror"`
+	CloudInitUserData          map[string]interface{} `json:"cloudinit-userdata,omitempty"`
+	ContainerInheritProperties string                 `json:"container-inherit-properties,omitempty"`
 	*UpdateBehavior
 }
 

--- a/cloudconfig/export_test.go
+++ b/cloudconfig/export_test.go
@@ -3,4 +3,8 @@
 
 package cloudconfig
 
-var ToolsDownloadCommand = toolsDownloadCommand
+var (
+	ToolsDownloadCommand      = toolsDownloadCommand
+	GetMachineCloudCfgDirData = getMachineCloudCfgDirData
+	GetMachineData            = getMachineData
+)

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -1,0 +1,162 @@
+package cloudconfig
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	utilsos "github.com/juju/utils/os"
+	utilsseries "github.com/juju/utils/series"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/juju/paths"
+)
+
+// GetMachineCloudInitData returns a map of all cloud init data on the machine.
+func GetMachineCloudInitData(series string) (map[string]interface{}, error) {
+	operatingSystem, err := utilsseries.GetOSFromSeries(series)
+	if err != nil {
+		return nil, err
+	}
+
+	switch operatingSystem {
+	case utilsos.Ubuntu:
+	case utilsos.CentOS:
+	case utilsos.OpenSUSE:
+	default:
+		logger.Debugf("not attempting to get cloudinit data on %s", operatingSystem)
+		return nil, nil
+	}
+
+	machineCloudInitData, err := getMachineCloudCfgDirData(series)
+	if err != nil {
+		return nil, err
+	}
+	vendorData, err := getMachineVendorData(series)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range vendorData {
+		machineCloudInitData[k] = v
+	}
+	return machineCloudInitData, nil
+}
+
+type sortableFileInfos []os.FileInfo
+
+func (fil sortableFileInfos) Len() int {
+	return len(fil)
+}
+
+func (fil sortableFileInfos) Less(i, j int) bool {
+	return fil[i].Name() < fil[j].Name()
+}
+
+func (fil sortableFileInfos) Swap(i, j int) {
+	fil[i], fil[j] = fil[j], fil[i]
+}
+
+// CloudInitCfgDir is for testing purposes.
+var CloudInitCfgDir = paths.CloudInitCfgDir
+
+// getMachineCloudCfgDirData returns a map of the combined machine's cloud init
+// cloud.cfg.d config files.  Files are read in lexical order.
+func getMachineCloudCfgDirData(series string) (map[string]interface{}, error) {
+	dir, err := CloudInitCfgDir(series)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot determine CloudInitCfgDir for the machine")
+	}
+	fileInfo, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot determine files in CloudInitCfgDir for the machine")
+	}
+	sortedFileInfos := sortableFileInfos(fileInfo)
+	sort.Sort(sortedFileInfos)
+	cloudInit := make(map[string]interface{})
+	for _, file := range fileInfo {
+		name := file.Name()
+		if !strings.HasSuffix(name, ".cfg") {
+			continue
+		}
+		data, err := ioutil.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, errors.Annotatef(err, "cannot read %q from machine", name)
+		}
+		cloudCfgData, err := unmarshallContainerCloudInit(data)
+		if err != nil {
+			return nil, errors.Annotatef(err, "cannot unmarshall %q from machine", name)
+		}
+		for k, v := range cloudCfgData {
+			cloudInit[k] = v
+		}
+	}
+	return cloudInit, nil
+}
+
+// getMachineVendorData returns a map of machine's cloud init vendor-data.txt.
+func getMachineVendorData(series string) (map[string]interface{}, error) {
+	// vendor-data.txt may or may not be compressed.
+	return getMachineData(series, "vendor-data.txt")
+}
+
+// MachineCloudInitDir is for testing purposes.
+var MachineCloudInitDir = paths.MachineCloudInitDir
+
+func getMachineData(series, file string) (map[string]interface{}, error) {
+	dir, err := MachineCloudInitDir(series)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot determine MachineCloudInitDir for the machine")
+	}
+	data, err := ioutil.ReadFile(filepath.Join(dir, file))
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot read %q from machine (%s)", file)
+	}
+
+	if len(data) == 0 {
+		// vendor-data.txt is sometimes empty
+		return nil, nil
+	}
+	// The userdata maybe be gzip'd, base64 encoded, both, or neither.
+	// If both, it's been gzip'd, then base64 encoded.
+	rawBuf, err := unmarshallContainerCloudInit(data)
+	if err == nil {
+		return rawBuf, nil
+	}
+	logger.Tracef("unmarshal of %q failed (%s), maybe it is compressed", file, err)
+
+	zippedData, err := utils.Gunzip(data)
+	if err == nil {
+		return unmarshallContainerCloudInit(zippedData)
+	}
+	logger.Tracef("Gunzip of %q failed (%s), maybe it is encoded", file, err)
+
+	decodedData, err := base64.StdEncoding.DecodeString(string(data))
+	if err == nil {
+		// it could still be gzip'd.
+		buf, err := unmarshallContainerCloudInit(decodedData)
+		if err == nil {
+			return buf, nil
+		}
+	}
+	logger.Tracef("Decoding of %q failed (%s), maybe it is encoded and gzipped", file, err)
+
+	decodedZippedBuf, err := utils.Gunzip(decodedData)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot unmarshall or decompress %q", file)
+	}
+	return unmarshallContainerCloudInit(decodedZippedBuf)
+}
+
+func unmarshallContainerCloudInit(raw []byte) (map[string]interface{}, error) {
+	dataMap := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(raw), &dataMap)
+	if err != nil {
+		return nil, err
+	}
+	return dataMap, nil
+}

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -1,0 +1,244 @@
+package cloudconfig_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/juju/errors"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloudconfig"
+	"github.com/juju/juju/testing"
+)
+
+type fromHostSuite struct {
+	testing.BaseSuite
+
+	tempCloudCfgDir  string
+	tempCloudInitDir string
+}
+
+var _ = gc.Suite(&fromHostSuite{})
+
+func (s *fromHostSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+
+	// Pre-seed /etc/cloud/cloud.cfg.d replacement for testing
+	s.tempCloudCfgDir = c.MkDir() // will clean up
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg"), []byte(dpkg_local_cloud_config), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "50-curtin-networking.cfg"), []byte(curtin_networking), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "10_random.cfg"), []byte(other_config), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "Readme"), []byte(other_config), 0644)
+
+	// Pre-seed /var/lib/cloud/instance replacement for testing
+	s.tempCloudInitDir = c.MkDir()
+	ioutil.WriteFile(path.Join(s.tempCloudInitDir, "vendor-data.txt"), []byte(vendor_data), 0644)
+}
+
+func (s *fromHostSuite) SetUpTest(c *gc.C) {
+	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(_ string) (string, error) { return s.tempCloudCfgDir, nil })
+	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return s.tempCloudInitDir, nil })
+}
+
+func (s *fromHostSuite) TestGetMachineCloudInitData(c *gc.C) {
+	obtained, err := cloudconfig.GetMachineCloudInitData("xenial")
+	c.Assert(err, gc.IsNil)
+	c.Assert(obtained, gc.DeepEquals, expectedResult)
+}
+
+func (s *fromHostSuite) TestGetMachineCloudInitDataVerifySeries(c *gc.C) {
+	for _, series := range []string{"xenial", "opensuseleap", "centos7"} {
+		obtained, err := cloudconfig.GetMachineCloudInitData(series)
+		c.Assert(err, gc.IsNil)
+		c.Assert(obtained, gc.DeepEquals, expectedResult)
+	}
+
+	for _, series := range []string{"win2012", "highsierra"} {
+		obtained, err := cloudconfig.GetMachineCloudInitData(series)
+		c.Assert(err, gc.IsNil)
+		c.Assert(obtained, gc.IsNil)
+	}
+}
+
+func (s *fromHostSuite) TestMissingVendorDataFile(c *gc.C) {
+	dir := c.MkDir()
+	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return dir, nil })
+	obtained, err := cloudconfig.GetMachineData("xenial", "vendor-data.txt")
+	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine .*")
+	c.Assert(obtained, gc.IsNil)
+}
+
+func (s *fromHostSuite) TestGetMachineCloudCfgDirDataReadDirFailed(c *gc.C) {
+	dir := c.MkDir()
+	os.RemoveAll(dir)
+	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(string) (string, error) { return dir, nil })
+	obtained, err := cloudconfig.GetMachineCloudCfgDirData("xenial")
+	c.Assert(err, gc.ErrorMatches, "cannot determine files in CloudInitCfgDir for the machine: .* no such file or directory")
+	c.Assert(obtained, gc.IsNil)
+}
+
+func (s *fromHostSuite) TestGetMachineCloudCfgDirDataReadDirNotFound(c *gc.C) {
+	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(string) (string, error) { return "", errors.New("test failure") })
+	obtained, err := cloudconfig.GetMachineCloudCfgDirData("xenial")
+	c.Assert(err, gc.ErrorMatches, "cannot determine CloudInitCfgDir for the machine: test failure")
+	c.Assert(obtained, gc.IsNil)
+}
+
+func (s *fromHostSuite) TestGetMachineDataReadDirNotFound(c *gc.C) {
+	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return "", errors.New("test failure") })
+	obtained, err := cloudconfig.GetMachineData("xenial", "")
+	c.Assert(err, gc.ErrorMatches, "cannot determine MachineCloudInitDir for the machine: test failure")
+	c.Assert(obtained, gc.IsNil)
+}
+
+var dpkg_local_cloud_config = `
+# cloud-init/local-cloud-config
+apt:
+  preserve_sources_list: false
+  primary:
+  - arches: [default]
+    uri: http://archive.ubuntu.com/ubuntu
+  security:
+  - arches: [default]
+    uri: http://archive.ubuntu.com/ubuntu
+apt_preserve_sources_list: true
+reporting:
+  maas: {consumer_key: mpU9YZLWDG7ZQubksN, endpoint: 'http://10.10.101.2/MAAS/metadata/status/cmfcxx',
+    token_key: tgEn5v5TcakKwWKwCf, token_secret: jzLdPTuh7hHqHTG9kGEHSG7F25GMAmzJ,
+    type: webhook}
+system_info:
+  package_mirrors:
+  - arches: [i386, amd64]
+    failsafe: {primary: 'http://archive.ubuntu.com/ubuntu', security: 'http://security.ubuntu.com/ubuntu'}
+    search:
+      primary: ['http://archive.ubuntu.com/ubuntu']
+      security: ['http://archive.ubuntu.com/ubuntu']
+  - arches: [default]
+    failsafe: {primary: 'http://ports.ubuntu.com/ubuntu-ports', security: 'http://ports.ubuntu.com/ubuntu-ports'}
+    search:
+      primary: ['http://ports.ubuntu.com/ubuntu-ports']
+      security: ['http://ports.ubuntu.com/ubuntu-ports']
+`[1:]
+
+var curtin_networking = `
+network:
+  config:
+  - id: ens3
+    mac_address: 52:54:00:0c:xx:e0
+    mtu: 1500
+    name: ens3
+    subnets:
+    - address: 10.10.76.124/24
+      dns_nameservers:
+      - 10.10.76.45
+      gateway: 10.10.76.1
+      type: static
+    type: physical
+`[1:]
+
+var other_config = `
+#cloud-config
+packages:
+  - ‘python-novaclient’
+write_files:
+  - path: /tmp/juju-test
+    permissions: 0644
+    content: |
+      Hello World!
+apt_preserve_sources_list: false
+`[1:]
+
+var vendor_data = `
+#cloud-config
+ntp:
+  pools: []
+  servers: [10.10.76.2]
+`[1:]
+
+var readme_file = `
+# All files in this directory will be read by cloud-init
+# They are read in lexical order.  Later files overwrite values in
+# earlier files.
+`[1:]
+
+var expectedResult = map[string]interface{}{
+	"apt": map[interface{}]interface{}{
+		"preserve_sources_list": false,
+		"primary": []interface{}{
+			map[interface{}]interface{}{
+				"arches": []interface{}{"default"},
+				"uri":    "http://archive.ubuntu.com/ubuntu",
+			},
+		},
+		"security": []interface{}{
+			map[interface{}]interface{}{
+				"arches": []interface{}{"default"},
+				"uri":    "http://archive.ubuntu.com/ubuntu",
+			},
+		},
+	},
+	"reporting": map[interface{}]interface{}{
+		"maas": map[interface{}]interface{}{
+			"endpoint":     "http://10.10.101.2/MAAS/metadata/status/cmfcxx",
+			"token_key":    "tgEn5v5TcakKwWKwCf",
+			"token_secret": "jzLdPTuh7hHqHTG9kGEHSG7F25GMAmzJ",
+			"type":         "webhook",
+			"consumer_key": "mpU9YZLWDG7ZQubksN",
+		},
+	},
+	"system_info": map[interface{}]interface{}{
+		"package_mirrors": []interface{}{map[interface{}]interface{}{
+			"arches": []interface{}{"i386", "amd64"},
+			"failsafe": map[interface{}]interface{}{
+				"primary":  "http://archive.ubuntu.com/ubuntu",
+				"security": "http://security.ubuntu.com/ubuntu",
+			},
+			"search": map[interface{}]interface{}{
+				"primary":  []interface{}{"http://archive.ubuntu.com/ubuntu"},
+				"security": []interface{}{"http://archive.ubuntu.com/ubuntu"},
+			},
+		},
+			map[interface{}]interface{}{
+				"arches": []interface{}{"default"},
+				"failsafe": map[interface{}]interface{}{
+					"primary":  "http://ports.ubuntu.com/ubuntu-ports",
+					"security": "http://ports.ubuntu.com/ubuntu-ports",
+				},
+				"search": map[interface{}]interface{}{
+					"primary":  []interface{}{"http://ports.ubuntu.com/ubuntu-ports"},
+					"security": []interface{}{"http://ports.ubuntu.com/ubuntu-ports"},
+				},
+			},
+		},
+	},
+	"ntp": map[interface{}]interface{}{
+		"servers": []interface{}{"10.10.76.2"},
+		"pools":   []interface{}{},
+	},
+	"write_files": []interface{}{
+		map[interface{}]interface{}{
+			"path":        "/tmp/juju-test",
+			"permissions": 420,
+			"content":     "Hello World!\n",
+		}},
+	"apt_preserve_sources_list": true,
+	"packages":                  []interface{}{"‘python-novaclient’"},
+	"network": map[interface{}]interface{}{
+		"config": []interface{}{map[interface{}]interface{}{
+			"mtu":  1500,
+			"name": "ens3",
+			"subnets": []interface{}{
+				map[interface{}]interface{}{
+					"type":            "static",
+					"address":         "10.10.76.124/24",
+					"dns_nameservers": []interface{}{"10.10.76.45"},
+					"gateway":         "10.10.76.1",
+				},
+			},
+			"type":        "physical",
+			"id":          "ens3",
+			"mac_address": "52:54:00:0c:xx:e0"},
+		},
+	},
+}

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -6,6 +6,8 @@ import (
 	"path"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	utilsseries "github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig"
@@ -26,38 +28,89 @@ func (s *fromHostSuite) SetUpSuite(c *gc.C) {
 
 	// Pre-seed /etc/cloud/cloud.cfg.d replacement for testing
 	s.tempCloudCfgDir = c.MkDir() // will clean up
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg"), []byte(dpkg_local_cloud_config), 0644)
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "50-curtin-networking.cfg"), []byte(curtin_networking), 0644)
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "10_random.cfg"), []byte(other_config), 0644)
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "Readme"), []byte(other_config), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg"), []byte(dpkgLocalCloudConfig078), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "50-curtin-networking.cfg"), []byte(curtinNetworking), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "10_random.cfg"), []byte(otherConfig), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "Readme"), []byte(readmeFile), 0644)
 
 	// Pre-seed /var/lib/cloud/instance replacement for testing
 	s.tempCloudInitDir = c.MkDir()
-	ioutil.WriteFile(path.Join(s.tempCloudInitDir, "vendor-data.txt"), []byte(vendor_data), 0644)
+	ioutil.WriteFile(path.Join(s.tempCloudInitDir, "vendor-data.txt"), []byte(vendorData), 0644)
 }
 
 func (s *fromHostSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(_ string) (string, error) { return s.tempCloudCfgDir, nil })
 	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return s.tempCloudInitDir, nil })
+	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "xenial" })
 }
 
 func (s *fromHostSuite) TestGetMachineCloudInitData(c *gc.C) {
 	obtained, err := cloudconfig.GetMachineCloudInitData("xenial")
 	c.Assert(err, gc.IsNil)
-	c.Assert(obtained, gc.DeepEquals, expectedResult)
+	c.Assert(obtained, gc.DeepEquals, expectedResult078)
+}
+
+type cloudinitDataVerifyTest struct {
+	description     string
+	machineSeries   string
+	containerSeries string
+	err             string
+	result          map[string]interface{}
+}
+
+var cloudinitDataVerifyTests = []cloudinitDataVerifyTest{
+	{
+		description:     "xenial on xenial",
+		machineSeries:   "xenial",
+		containerSeries: "xenial",
+		result:          expectedResult078,
+	},
+	{
+		description:     "trusty on trusty",
+		machineSeries:   "trusty",
+		containerSeries: "trusty",
+		result:          expectedResult078,
+	},
+	{
+		description:     "xenial on trusty",
+		machineSeries:   "trusty",
+		containerSeries: "xenial",
+	},
+	{
+		description:     "opensuseleap on opensuseleap",
+		machineSeries:   "opensuseleap",
+		containerSeries: "opensuseleap",
+		result:          expectedResult078,
+	},
+	{
+		description:     "centos7 on centos7",
+		machineSeries:   "centos7",
+		containerSeries: "centos7",
+		result:          expectedResult078,
+	},
+	{
+		description:     "win2012 on win2012",
+		machineSeries:   "win2012",
+		containerSeries: "win2012",
+	},
+	{
+		description:     "highsierra on highsierra",
+		machineSeries:   "highsierra",
+		containerSeries: "highsierra",
+	},
 }
 
 func (s *fromHostSuite) TestGetMachineCloudInitDataVerifySeries(c *gc.C) {
-	for _, series := range []string{"xenial", "opensuseleap", "centos7"} {
-		obtained, err := cloudconfig.GetMachineCloudInitData(series)
+	for i, test := range cloudinitDataVerifyTests {
+		c.Logf("Test %d of %d: %s", i, len(cloudinitDataVerifyTests), test.description)
+		s.PatchValue(&utilsseries.MustHostSeries, func() string { return test.machineSeries })
+		obtained, err := cloudconfig.GetMachineCloudInitData(test.containerSeries)
 		c.Assert(err, gc.IsNil)
-		c.Assert(obtained, gc.DeepEquals, expectedResult)
-	}
-
-	for _, series := range []string{"win2012", "highsierra"} {
-		obtained, err := cloudconfig.GetMachineCloudInitData(series)
-		c.Assert(err, gc.IsNil)
-		c.Assert(obtained, gc.IsNil)
+		if test.result != nil {
+			c.Assert(obtained, gc.DeepEquals, expectedResult078)
+		} else {
+			c.Assert(obtained, gc.IsNil)
+		}
 	}
 }
 
@@ -66,6 +119,13 @@ func (s *fromHostSuite) TestMissingVendorDataFile(c *gc.C) {
 	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return dir, nil })
 	obtained, err := cloudconfig.GetMachineData("xenial", "vendor-data.txt")
 	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine .*")
+	c.Assert(obtained, gc.IsNil)
+}
+
+func (s *fromHostSuite) TestMissingVendorDataFileTrusty(c *gc.C) {
+	ioutil.WriteFile(path.Join(s.tempCloudInitDir, "vendor-data.txt"), []byte(vendorDataTrusty), 0644)
+	obtained, err := cloudconfig.GetMachineData("trusty", "vendor-data.txt")
+	c.Assert(err, gc.IsNil)
 	c.Assert(obtained, gc.IsNil)
 }
 
@@ -92,7 +152,110 @@ func (s *fromHostSuite) TestGetMachineDataReadDirNotFound(c *gc.C) {
 	c.Assert(obtained, gc.IsNil)
 }
 
-var dpkg_local_cloud_config = `
+func (s *fromHostSuite) TestCloudConfigVersionV078(c *gc.C) {
+	obtained, err := cloudconfig.GetMachineCloudInitData("xenial")
+	c.Assert(err, gc.IsNil)
+	c.Assert(obtained, gc.DeepEquals, expectedResult078)
+
+	resultMap := cloudconfig.CloudConfigByVersionFunc("xenial")("apt-primary,ca-certs,apt-security", obtained,
+		loggo.GetLogger("juju.machinecloudconfig"))
+	c.Assert(resultMap, gc.DeepEquals,
+		map[string]interface{}{
+			"apt": map[string]interface{}{
+				"primary": []interface{}{
+					map[interface{}]interface{}{
+						"arches": []interface{}{"default"},
+						"uri":    "http://archive.ubuntu.com/ubuntu",
+					},
+				},
+				"security": []interface{}{
+					map[interface{}]interface{}{
+						"arches": []interface{}{"default"},
+						"uri":    "http://archive.ubuntu.com/ubuntu",
+					},
+				},
+			},
+			"ca-certs": map[interface{}]interface{}{
+				"remove-defaults": true,
+				"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+			},
+		})
+}
+
+func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritPropertiesV078(c *gc.C) {
+	resultMap := cloudconfig.CloudConfigByVersionFunc("xenial")("", nil, loggo.GetLogger("juju.machinecloudconfig"))
+	c.Assert(resultMap, gc.IsNil)
+}
+
+func (s *fromHostSuite) TestCloudConfigVersionV077(c *gc.C) {
+	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "trusty" })
+	obtained, err := cloudconfig.GetMachineCloudInitData("trusty")
+	c.Assert(err, gc.IsNil)
+	c.Assert(obtained, gc.DeepEquals, expectedResult078)
+
+	resultMap := cloudconfig.CloudConfigByVersionFunc("xenial")("apt-primary,ca-certs,apt-security", obtained,
+		loggo.GetLogger("juju.machinecloudconfig"))
+	c.Assert(resultMap, gc.DeepEquals,
+		map[string]interface{}{
+			"apt": map[string]interface{}{
+				"primary": []interface{}{
+					map[interface{}]interface{}{
+						"arches": []interface{}{"default"},
+						"uri":    "http://archive.ubuntu.com/ubuntu",
+					},
+				},
+				"security": []interface{}{
+					map[interface{}]interface{}{
+						"arches": []interface{}{"default"},
+						"uri":    "http://archive.ubuntu.com/ubuntu",
+					},
+				},
+			},
+			"ca-certs": map[interface{}]interface{}{
+				"remove-defaults": true,
+				"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+			},
+		})
+}
+
+func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritPropertiesV077(c *gc.C) {
+	resultMap := cloudconfig.CloudConfigByVersionFunc("trusty")("", nil, loggo.GetLogger("juju.machinecloudconfig"))
+	c.Assert(resultMap, gc.IsNil)
+}
+
+var dpkgLocalCloudConfig077 = `
+# cloud-init/local-cloud-config
+apt_mirror: http://archive.ubuntu.com/ubuntu
+apt_mirror_search:
+ - http://local-mirror.mydomain
+ - http://archive.ubuntu.com
+apt_mirror_search_dns: False
+apt_sources:
+ - source: "deb http://apt.opscode.com/ $RELEASE-0.10 main"
+   key: |
+     -----BEGIN PGP PUBLIC KEY BLOCK-----
+     Version: GnuPG v1.4.9 (GNU/Linux)
+     -----END PGP PUBLIC KEY BLOCK-----
+apt_preserve_sources_list: true
+reporting:
+  maas: {consumer_key: mpU9YZLWDG7ZQubksN, endpoint: 'http://10.10.101.2/MAAS/metadata/status/cmfcxx',
+    token_key: tgEn5v5TcakKwWKwCf, token_secret: jzLdPTuh7hHqHTG9kGEHSG7F25GMAmzJ,
+    type: webhook}
+system_info:
+  package_mirrors:
+  - arches: [i386, amd64]
+    failsafe: {primary: 'http://archive.ubuntu.com/ubuntu', security: 'http://security.ubuntu.com/ubuntu'}
+    search:
+      primary: ['http://archive.ubuntu.com/ubuntu']
+      security: ['http://archive.ubuntu.com/ubuntu']
+  - arches: [default]
+    failsafe: {primary: 'http://ports.ubuntu.com/ubuntu-ports', security: 'http://ports.ubuntu.com/ubuntu-ports'}
+    search:
+      primary: ['http://ports.ubuntu.com/ubuntu-ports']
+      security: ['http://ports.ubuntu.com/ubuntu-ports']
+`[1:]
+
+var dpkgLocalCloudConfig078 = `
 # cloud-init/local-cloud-config
 apt:
   preserve_sources_list: false
@@ -121,7 +284,7 @@ system_info:
       security: ['http://ports.ubuntu.com/ubuntu-ports']
 `[1:]
 
-var curtin_networking = `
+var curtinNetworking = `
 network:
   config:
   - id: ens3
@@ -137,7 +300,7 @@ network:
     type: physical
 `[1:]
 
-var other_config = `
+var otherConfig = `
 #cloud-config
 packages:
   - ‘python-novaclient’
@@ -147,22 +310,33 @@ write_files:
     content: |
       Hello World!
 apt_preserve_sources_list: false
+ca-certs:
+  remove-defaults: true
+  trusted:
+  - |
+   -----BEGIN CERTIFICATE-----
+   YOUR-ORGS-TRUSTED-CA-CERT-HERE
+   -----END CERTIFICATE-----
 `[1:]
 
-var vendor_data = `
+var vendorData = `
 #cloud-config
 ntp:
   pools: []
   servers: [10.10.76.2]
 `[1:]
 
-var readme_file = `
+var vendorDataTrusty = `
+None
+`[1:]
+
+var readmeFile = `
 # All files in this directory will be read by cloud-init
 # They are read in lexical order.  Later files overwrite values in
 # earlier files.
 `[1:]
 
-var expectedResult = map[string]interface{}{
+var expectedResult078 = map[string]interface{}{
 	"apt": map[interface{}]interface{}{
 		"preserve_sources_list": false,
 		"primary": []interface{}{
@@ -224,6 +398,10 @@ var expectedResult = map[string]interface{}{
 		}},
 	"apt_preserve_sources_list": true,
 	"packages":                  []interface{}{"‘python-novaclient’"},
+	"ca-certs": map[interface{}]interface{}{
+		"remove-defaults": true,
+		"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+	},
 	"network": map[interface{}]interface{}{
 		"config": []interface{}{map[interface{}]interface{}{
 			"mtu":  1500,

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/series"
+	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charmrepo.v2"
 	"gopkg.in/juju/environschema.v1"
@@ -177,9 +178,15 @@ const (
 	// FanConfig defines the configuration for FAN network running in the model.
 	FanConfig = "fan-config"
 
-	// CloudInitUserDataKey is the key to specify cloud-init yaml the user wants to add
-	// into the cloud-config data produced by Juju when provisioning machines.
+	// CloudInitUserDataKey is the key to specify cloud-init yaml the user
+	// wants to add into the cloud-config data produced by Juju when
+	// provisioning machines.
 	CloudInitUserDataKey = "cloudinit-userdata"
+
+	// ContainerInheritProperiesKey is the key to specify a list of properties
+	// to be copied from a machine to a container during provisioning.  The
+	// list will be comma separated.
+	ContainerInheritProperiesKey = "container-inherit-properties"
 
 	//
 	// Deprecated Settings Attributes
@@ -374,20 +381,21 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":           series.LatestLts(),
-	ProvisionerHarvestModeKey:  HarvestDestroyed.String(),
-	ResourceTagsKey:            "",
-	"logging-config":           "",
-	AutomaticallyRetryHooks:    true,
-	"enable-os-refresh-update": true,
-	"enable-os-upgrade":        true,
-	"development":              false,
-	"test-mode":                false,
-	TransmitVendorMetricsKey:   true,
-	UpdateStatusHookInterval:   DefaultUpdateStatusHookInterval,
-	EgressSubnets:              "",
-	FanConfig:                  "",
-	CloudInitUserDataKey:       "",
+	"default-series":             series.LatestLts(),
+	ProvisionerHarvestModeKey:    HarvestDestroyed.String(),
+	ResourceTagsKey:              "",
+	"logging-config":             "",
+	AutomaticallyRetryHooks:      true,
+	"enable-os-refresh-update":   true,
+	"enable-os-upgrade":          true,
+	"development":                false,
+	"test-mode":                  false,
+	TransmitVendorMetricsKey:     true,
+	UpdateStatusHookInterval:     DefaultUpdateStatusHookInterval,
+	EgressSubnets:                "",
+	FanConfig:                    "",
+	CloudInitUserDataKey:         "",
+	ContainerInheritProperiesKey: "",
 
 	// Image and agent streams and URLs.
 	"image-stream":       "released",
@@ -631,6 +639,20 @@ func Validate(cfg, old *Config) error {
 		// error if bootcmd is specified
 		if _, ok := userDataMap["bootcmd"]; ok {
 			return errors.New("cloudinit-userdata: bootcmd not allowed")
+		}
+	}
+
+	if raw, ok := cfg.defined[ContainerInheritProperiesKey].(string); ok && raw != "" {
+		rawProperties := strings.Split(raw, ",")
+		propertySet := set.NewStrings()
+		for _, prop := range rawProperties {
+			propertySet.Add(strings.TrimSpace(prop))
+		}
+		whiteListSet := set.NewStrings("apt-primary", "apt-sources", "apt-security", "ca-certs")
+		diffSet := propertySet.Difference(whiteListSet)
+
+		if !diffSet.IsEmpty() {
+			return fmt.Errorf("container-inherit-properties: %s not allowed", strings.Join(diffSet.SortedValues(), ", "))
 		}
 	}
 
@@ -1146,6 +1168,12 @@ func (c *Config) CloudInitUserData() map[string]interface{} {
 	return userDataMap
 }
 
+// ContainerInheritProperies returns a copy of the raw user data keys
+// that were specified by the user.
+func (c *Config) ContainerInheritProperies() string {
+	return c.asString(ContainerInheritProperiesKey)
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1261,6 +1289,7 @@ var alwaysOptional = schema.Defaults{
 	EgressSubnets:                schema.Omit,
 	FanConfig:                    schema.Omit,
 	CloudInitUserDataKey:         schema.Omit,
+	ContainerInheritProperiesKey: schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -1688,6 +1717,11 @@ data of the store. (default false)`,
 	},
 	CloudInitUserDataKey: {
 		Description: "Cloud-init user-data (in yaml format) to be added to userdata for new machines created in this model",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	ContainerInheritProperiesKey: {
+		Description: "List of properties to be copied from the host machine to new containers created in this model (comma-separated)",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -550,6 +550,19 @@ var configTests = []configTest{
 			"syslog-client-cert": testing.ServerCert,
 			"syslog-client-key":  testing.ServerKey,
 		}),
+	}, {
+		about:       "Valid container-inherit-properties",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"container-inherit-properties": "apt-primary, ca-certs",
+		}),
+	}, {
+		about:       "Invalid container-inherit-properties",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"container-inherit-properties": "apt-security, write_files,users,apt-sources",
+		}),
+		err: `container-inherit-properties: users, write_files not allowed`,
 	},
 }
 
@@ -729,6 +742,10 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 
 	if val, ok := test.attrs[config.NetBondReconfigureDelayKey].(int); ok {
 		c.Assert(cfg.NetBondReconfigureDelay(), gc.Equals, val)
+	}
+
+	if val, ok := test.attrs[config.ContainerInheritProperiesKey].(string); ok && val != "" {
+		c.Assert(cfg.ContainerInheritProperies(), gc.Equals, val)
 	}
 }
 
@@ -1204,6 +1221,13 @@ func (s *ConfigSuite) TestCloudInitUserDataFromEnvironment(c *gc.C) {
 		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
 		"package_upgrade": false},
 	)
+}
+
+func (s *ConfigSuite) TestContainerInheritProperies(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{
+		"container-inherit-properties": "ca-certs,apt-primary",
+	})
+	c.Assert(cfg.ContainerInheritProperies(), gc.Equals, "ca-certs,apt-primary")
 }
 
 func (s *ConfigSuite) TestSchemaNoExtra(c *gc.C) {

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -23,20 +23,24 @@ const (
 	uniterStateDir
 	jujuDumpLogs
 	jujuIntrospect
+	instanceCloudInitDir
+	cloudInitCfgDir
 )
 
 var nixVals = map[osVarType]string{
-	tmpDir:          "/tmp",
-	logDir:          "/var/log",
-	dataDir:         "/var/lib/juju",
-	storageDir:      "/var/lib/juju/storage",
-	confDir:         "/etc/juju",
-	jujuRun:         "/usr/bin/juju-run",
-	jujuDumpLogs:    "/usr/bin/juju-dumplogs",
-	jujuIntrospect:  "/usr/bin/juju-introspect",
-	certDir:         "/etc/juju/certs.d",
-	metricsSpoolDir: "/var/lib/juju/metricspool",
-	uniterStateDir:  "/var/lib/juju/uniter/state",
+	tmpDir:               "/tmp",
+	logDir:               "/var/log",
+	dataDir:              "/var/lib/juju",
+	storageDir:           "/var/lib/juju/storage",
+	confDir:              "/etc/juju",
+	jujuRun:              "/usr/bin/juju-run",
+	jujuDumpLogs:         "/usr/bin/juju-dumplogs",
+	jujuIntrospect:       "/usr/bin/juju-introspect",
+	certDir:              "/etc/juju/certs.d",
+	metricsSpoolDir:      "/var/lib/juju/metricspool",
+	uniterStateDir:       "/var/lib/juju/uniter/state",
+	instanceCloudInitDir: "/var/lib/cloud/instance",
+	cloudInitCfgDir:      "/etc/cloud/cloud.cfg.d",
 }
 
 var winVals = map[osVarType]string{
@@ -129,6 +133,18 @@ func JujuDumpLogs(series string) (string, error) {
 // binary for a particular series.
 func JujuIntrospect(series string) (string, error) {
 	return osVal(series, jujuIntrospect)
+}
+
+// MachineCloudInitDir returns the absolute path to the instance
+// cloudinit directory for a particular series.
+func MachineCloudInitDir(series string) (string, error) {
+	return osVal(series, instanceCloudInitDir)
+}
+
+// CloudInitCfgDir returns the absolute path to the instance
+// cloud config directory for a particular series.
+func CloudInitCfgDir(series string) (string, error) {
+	return osVal(series, cloudInitCfgDir)
 }
 
 func MustSucceed(s string, e error) string {

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -39,6 +39,7 @@ var (
 	RetryStrategyDelay       = &retryStrategyDelay
 	RetryStrategyCount       = &retryStrategyCount
 	GetObservedNetworkConfig = &getObservedNetworkConfig
+	CombinedCloudInitData    = combinedCloudInitData
 )
 
 var ClassifyMachine = classifyMachine

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -114,6 +114,14 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.Trace(err)
 	}
 
+	cloudInitUserData, err := combinedCloudInitData(
+		config.CloudInitUserData,
+		config.ContainerInheritProperties,
+		series, kvmLogger)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
 		config.ProviderType,
@@ -124,7 +132,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.AptMirror,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
-		config.CloudInitUserData,
+		cloudInitUserData,
 	); err != nil {
 		kvmLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, err

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -282,15 +282,27 @@ func (s *kvmBrokerSuite) TestStartInstanceWithContainerInheritProperties(c *gc.C
 		return map[string]interface{}{
 			"packages":   []interface{}{"python-novaclient"},
 			"fake-entry": []interface{}{"testing-garbage"},
-			"write_files": []interface{}{
-				map[string]interface{}{
-					"path":        "/tmp/testfile",
-					"permissions": 438,
-					"content":     "Hello World!\nEOF",
-				}},
+			"apt": map[interface{}]interface{}{
+				"primary": []interface{}{
+					map[interface{}]interface{}{
+						"arches": []interface{}{"default"},
+						"uri":    "http://archive.ubuntu.com/ubuntu",
+					},
+				},
+				"security": []interface{}{
+					map[interface{}]interface{}{
+						"arches": []interface{}{"default"},
+						"uri":    "http://archive.ubuntu.com/ubuntu",
+					},
+				},
+			},
+			"ca-certs": map[interface{}]interface{}{
+				"remove-defaults": true,
+				"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+			},
 		}, nil
 	})
-	s.api.fakeContainerConfig.ContainerInheritProperties = "write_files,packages"
+	s.api.fakeContainerConfig.ContainerInheritProperties = "ca-certs,apt-security"
 
 	broker, brokerErr := s.newKVMBrokerFakeManager(c)
 	c.Assert(brokerErr, jc.ErrorIsNil)
@@ -303,16 +315,22 @@ func (s *kvmBrokerSuite) TestStartInstanceWithContainerInheritProperties(c *gc.C
 	c.Assert(call.Args[0], gc.FitsTypeOf, &instancecfg.InstanceConfig{})
 	instanceConfig := call.Args[0].(*instancecfg.InstanceConfig)
 	assertCloudInitUserData(instanceConfig.CloudInitUserData, map[string]interface{}{
-		"write_files": []interface{}{
-			map[string]interface{}{
-				"path":        "/tmp/testfile",
-				"permissions": 438,
-				"content":     "Hello World!\nEOF",
-			}},
-		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient", "python-novaclient"},
+		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
 		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
 		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
 		"package_upgrade": false,
+		"apt": map[string]interface{}{
+			"security": []interface{}{
+				map[interface{}]interface{}{
+					"arches": []interface{}{"default"},
+					"uri":    "http://archive.ubuntu.com/ubuntu",
+				},
+			},
+		},
+		"ca-certs": map[interface{}]interface{}{
+			"remove-defaults": true,
+			"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+		},
 	}, c)
 }
 

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -104,6 +104,14 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.Trace(err)
 	}
 
+	cloudInitUserData, err := combinedCloudInitData(
+		config.CloudInitUserData,
+		config.ContainerInheritProperties,
+		series, lxdLogger)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
 		config.ProviderType,
@@ -114,7 +122,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		config.AptMirror,
 		config.EnableOSRefreshUpdate,
 		config.EnableOSUpgrade,
-		config.CloudInitUserData,
+		cloudInitUserData,
 	); err != nil {
 		lxdLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, err

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -15,8 +15,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/common"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
@@ -43,6 +41,10 @@ func (s *lxdBrokerSuite) SetUpTest(c *gc.C) {
 
 	// To isolate the tests from the host's architecture, we override it here.
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	s.PatchValue(&provisioner.GetMachineCloudInitData, func(_ string) (map[string]interface{}, error) {
+		return nil, nil
+	})
 
 	var err error
 	s.agentConfig, err = agent.NewAgentConfig(
@@ -120,10 +122,6 @@ func (s *lxdBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) 
 	broker, brokerErr := s.newLXDBroker(c)
 	c.Assert(brokerErr, jc.ErrorIsNil)
 
-	s.PatchValue(provisioner.GetObservedNetworkConfig, func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
-		return nil, nil
-	})
-
 	patchResolvConf(s, c)
 
 	s.api.SetErrors(
@@ -161,10 +159,48 @@ func (s *lxdBrokerSuite) TestStartInstanceWithCloudInitUserData(c *gc.C) {
 	call := s.manager.Calls()[0]
 	c.Assert(call.Args[0], gc.FitsTypeOf, &instancecfg.InstanceConfig{})
 	instanceConfig := call.Args[0].(*instancecfg.InstanceConfig)
-	c.Assert(instanceConfig.CloudInitUserData, gc.DeepEquals, map[string]interface{}{
+	assertCloudInitUserData(instanceConfig.CloudInitUserData, map[string]interface{}{
 		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
 		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
 		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
 		"package_upgrade": false,
+	}, c)
+}
+
+func (s *lxdBrokerSuite) TestStartInstanceWithContainerInheritProperties(c *gc.C) {
+	s.PatchValue(&provisioner.GetMachineCloudInitData, func(_ string) (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"packages":   []interface{}{"python-novaclient"},
+			"fake-entry": []interface{}{"testing-garbage"},
+			"write_files": []interface{}{
+				map[string]interface{}{
+					"path":        "/tmp/testfile",
+					"permissions": 438,
+					"content":     "Hello World!\nEOF",
+				}},
+		}, nil
 	})
+	s.api.fakeContainerConfig.ContainerInheritProperties = "write_files,packages"
+
+	broker, brokerErr := s.newLXDBroker(c)
+	c.Assert(brokerErr, jc.ErrorIsNil)
+	_, err := s.startInstance(c, broker, "1/lxd/0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.manager.CheckCallNames(c, "CreateContainer")
+	call := s.manager.Calls()[0]
+	c.Assert(call.Args[0], gc.FitsTypeOf, &instancecfg.InstanceConfig{})
+	instanceConfig := call.Args[0].(*instancecfg.InstanceConfig)
+	assertCloudInitUserData(instanceConfig.CloudInitUserData, map[string]interface{}{
+		"write_files": []interface{}{
+			map[string]interface{}{
+				"path":        "/tmp/testfile",
+				"permissions": 438,
+				"content":     "Hello World!\nEOF",
+			}},
+		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient", "python-novaclient"},
+		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
+		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
+		"package_upgrade": false,
+	}, c)
 }


### PR DESCRIPTION
## Description of change

container-inherit-properties allows a user to specify cloudinit settings which should be replicated from a machine to a containers which juju has provisioned.

## QA steps

1. Configure MaaS to setup apt settings, mirror or proxy etc.
2. Bootstrap and provision a machine.
3. juju model-config container-inherit-properties="apt-primary"
4. add a container, lxd and kvm should be used.
5. verify the container picked up the apt cloud init properties
6. Try 2 series, one of them trusty, host and container with the same series.
7. Only ca-certs, apt-security, apt-sources and apt-primary allowed.

## Documentation changes

Documentation updates will be needed.

## Bug reference

n/a
