### PR TITLE
Corrects semantics for wait timeout in TestProvisioningMachinesDerivedAZ

### DIFF
--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1902,9 +1902,10 @@ func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {
 	// The machine(s) arranged for provisioning failure have not yet been
 	// retried the specified number of times; so we wait.
 	id := mFail[1].Id()
+	timeout := time.After(coretesting.LongWait)
 	for e.retryCount[id] < 3 {
 		select {
-		case <-time.After(coretesting.ShortWait):
+		case <-timeout:
 			c.Fatalf("Failed provision of %q did not retry 3 times", id)
 		default:
 		}


### PR DESCRIPTION
## Description of change

Prior change caused a new timeout duration to be generated on each pass of the loop, essentially delaying the reporting of failure condition until after the default test timeout.

Declaring the timeout outside of the loop rectifies this.

## QA steps

Proper red/green test verification.

## Documentation changes

None.

## Bug reference

Refines previous fix for:
https://bugs.launchpad.net/juju/+bug/1748372
