### PR TITLE
Clarify where 'credential' commands operate.

### DIFF
--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -13,13 +13,16 @@ import (
 )
 
 var usageSetDefaultCredentialSummary = `
-Sets the default credentials for a cloud.`[1:]
+Sets local default credentials for a cloud.`[1:]
 
 var usageSetDefaultCredentialDetails = `
-The default credentials are specified with a "credential name". A 
-credential name is created during the process of adding credentials either 
-via `[1:] + "`juju add-credential` or `juju autoload-credentials`" + `. Credential names 
-can be listed with ` + "`juju credentials`" + `.
+The default credentials are specified with a "credential name". 
+
+A credential name is created during the process of adding credentials either 
+via `[1:] + "`juju add-credential` or `juju autoload-credentials`" + `. 
+Credential names can be listed with ` + "`juju credentials`" + `.
+
+This command sets a locally stored credential to be used as a default.
 Default credentials avoid the need to specify a particular set of 
 credentials when more than one are available for a given cloud.
 
@@ -92,6 +95,6 @@ func (c *setDefaultCredentialCommand) Run(ctxt *cmd.Context) error {
 	if err := c.store.UpdateCredential(c.cloud, *cred); err != nil {
 		return err
 	}
-	ctxt.Infof("Default credential for %s set to %q.", c.cloud, c.credential)
+	ctxt.Infof("Local credential %q is set to be default for %q for this client.", c.credential, c.cloud)
 	return nil
 }

--- a/cmd/juju/cloud/defaultcredential_test.go
+++ b/cmd/juju/cloud/defaultcredential_test.go
@@ -55,7 +55,7 @@ func (s *defaultCredentialSuite) assertSetDefaultCredential(c *gc.C, cloudName s
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, fmt.Sprintf(`Default credential for %s set to "my-sekrets".`, cloudName))
+	c.Assert(output, gc.Equals, fmt.Sprintf(`Local credential "my-sekrets" is set to be default for %q for this client.`, cloudName))
 	c.Assert(store.Credentials[cloudName].DefaultCredential, gc.Equals, "my-sekrets")
 }
 

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -46,7 +46,7 @@ will be stored on the controller. It is considered to be controller default.
 Recall that when a controller is created a 'default' model is also 
 created. This model will use the controller default credential.
 
-When adding a new model, Juju will reuse controller default credential.
+When adding a new model, Juju will reuse the controller default credential.
 To add a model that uses a different credential, specify a locally
 stored credential using --credential option. See ` + "`juju help add-model`" + ` 
 for more information.

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -21,22 +21,37 @@ import (
 )
 
 var usageListCredentialsSummary = `
-Lists credentials for a cloud.`[1:]
+Lists locally stored credentials for a cloud.`[1:]
 
 var usageListCredentialsDetails = `
-Credentials are used with `[1:] + "`juju bootstrap`" + `  and ` + "`juju add-model`" + `.
+Locally stored credentials are used with `[1:] + "`juju bootstrap`" + `  
+and ` + "`juju add-model`" + `.
+
 An arbitrary "credential name" is used to represent credentials, which are 
 added either via ` + "`juju add-credential` or `juju autoload-credentials`" + `.
-Note that there can be multiple sets of credentials and thus multiple 
+Note that there can be multiple sets of credentials and, thus, multiple 
 names.
+
 Actual authentication material is exposed with the '--show-secrets' 
 option.
-A controller and subsequently created models can be created with a 
+
+A controller, and subsequently created models, can be created with a 
 different set of credentials but any action taken within the model (e.g.:
-` + "`juju deploy`; `juju add-unit`" + `) applies the set used to create the model. 
+` + "`juju deploy`; `juju add-unit`" + `) applies the credentail used 
+to create that model. This model credential is stored on the controller. 
+
+A credential for 'controller' model is determined at bootstrap time and
+will be stored on the controller. It is considered to be controller default.
+
 Recall that when a controller is created a 'default' model is also 
-created.
-Credentials denoted with an asterisk '*' are currently set as the default
+created. This model will use the controller default credential.
+
+When adding a new model, Juju will reuse controller default credential.
+To add a model that uses a different credential, specify a locally
+stored credential using --credential option. See ` + "`juju help add-model`" + ` 
+for more information.
+
+Credentials denoted with an asterisk '*' are currently set as the local default
 for the given cloud.
 
 Examples:
@@ -225,7 +240,7 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 	}
 
 	if len(credentials.Credentials) == 0 {
-		fmt.Fprintln(writer, "No credentials to display.")
+		fmt.Fprintln(writer, "No locally stored credentials to display.")
 		return nil
 	}
 

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -305,7 +305,7 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out := strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "No credentials to display.")
+	c.Assert(out, gc.Equals, "No locally stored credentials to display.")
 
 	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -19,7 +19,7 @@ type removeCredentialCommand struct {
 }
 
 var usageRemoveCredentialSummary = `
-Removes credentials for a cloud.`[1:]
+Removes locally stored credentials for a cloud.`[1:]
 
 var usageRemoveCredentialDetails = `
 The credentials to be removed are specified by a "credential name".
@@ -63,19 +63,19 @@ func (c *removeCredentialCommand) Init(args []string) (err error) {
 func (c *removeCredentialCommand) Run(ctxt *cmd.Context) error {
 	cred, err := c.store.CredentialForCloud(c.cloud)
 	if errors.IsNotFound(err) {
-		ctxt.Infof("No credentials exist for cloud %q", c.cloud)
+		ctxt.Infof("No locally stored credentials exist for cloud %q", c.cloud)
 		return nil
 	} else if err != nil {
 		return err
 	}
 	if _, ok := cred.AuthCredentials[c.credential]; !ok {
-		ctxt.Infof("No credential called %q exists for cloud %q", c.credential, c.cloud)
+		ctxt.Infof("No local credential called %q exists for cloud %q", c.credential, c.cloud)
 		return nil
 	}
 	delete(cred.AuthCredentials, c.credential)
 	if err := c.store.UpdateCredential(c.cloud, *cred); err != nil {
 		return err
 	}
-	ctxt.Infof("Credential %q for cloud %q has been deleted.", c.credential, c.cloud)
+	ctxt.Infof("Local credential %q for cloud %q has been deleted.", c.credential, c.cloud)
 	return nil
 }

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -45,7 +45,7 @@ func (s *removeCredentialSuite) TestMissingCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `No credential called "foo" exists for cloud "aws"`)
+	c.Assert(output, gc.Equals, `No local credential called "foo" exists for cloud "aws"`)
 }
 
 func (s *removeCredentialSuite) TestBadCloudName(c *gc.C) {
@@ -54,7 +54,7 @@ func (s *removeCredentialSuite) TestBadCloudName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `No credentials exist for cloud "somecloud"`)
+	c.Assert(output, gc.Equals, `No locally stored credentials exist for cloud "somecloud"`)
 }
 
 func (s *removeCredentialSuite) TestRemove(c *gc.C) {
@@ -73,7 +73,7 @@ func (s *removeCredentialSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `Credential "my-credential" for cloud "aws" has been deleted.`)
+	c.Assert(output, gc.Equals, `Local credential "my-credential" for cloud "aws" has been deleted.`)
 	_, stillThere := store.Credentials["aws"].AuthCredentials["my-credential"]
 	c.Assert(stillThere, jc.IsFalse)
 	c.Assert(store.Credentials["aws"].AuthCredentials, gc.HasLen, 1)


### PR DESCRIPTION
## Description of change

There is a fair bit of confusion around credential management in Juju.

One source of this confusion is the lack of clarity of where Juju credentials are stored.  Juju recognizes locally stored credentials and uses them to bootstrap or add models. However, for all other operations, Juju uses credentials stored on the controller.

The difference between these 2 types of credentials has not been clearly communicated to operators, partly because Juju commands do not make it clear what credential they operate on. Thus, when time comes to manage a credential, there is a confusion about what commands and in what sequence to use.

This PR is a Part 1 from the series that will clarify Juju messaging when dealing with credentials. This part only deals with messaging and prompting of commands that operate on locally stored credentials.

