### PR TITLE
Model credential visible to admin users only.

### DIFF
--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -224,6 +224,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"Cloud", nil},
 		{"CloudRegion", nil},
 		{"CloudCredential", nil},
+		{"ModelTag", nil},
 		{"SLALevel", nil},
 		{"SLAOwner", nil},
 		{"Life", nil},

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -245,6 +246,29 @@ func (s *modelInfoSuite) TestModelInfoOwner(c *gc.C) {
 	info := s.getModelInfo(c, s.st.model.cfg.UUID())
 	c.Assert(info.Users, gc.HasLen, 4)
 	c.Assert(info.Machines, gc.HasLen, 2)
+}
+
+func (s *modelInfoSuite) TestModelInfoHasCredentialForAdmin(c *gc.C) {
+	// Need to convince fake authorizer that this user has admin right on a test model;
+	// so user name is <desired permission><model tag>.
+	userName := fmt.Sprintf("%s%s", "admin", s.st.model.tag)
+	user := names.NewUserTag(userName)
+	s.st.model.users = append(s.st.model.users, &mockModelUser{
+		userName:       userName,
+		lastConnection: time.Time{},
+		access:         permission.AdminAccess,
+	})
+	s.setAPIUser(c, user)
+	info := s.getModelInfo(c, s.st.model.cfg.UUID())
+	c.Assert(info.CloudCredentialTag, gc.Equals, "cloudcred-some-cloud_bob_some-credential")
+}
+
+func (s *modelInfoSuite) TestModelInfoHasCredentialForNonAdmin(c *gc.C) {
+	mary := names.NewUserTag("mary@local")
+	s.authorizer.HasWriteTag = mary
+	s.setAPIUser(c, mary)
+	info := s.getModelInfo(c, s.st.model.cfg.UUID())
+	c.Assert(info.CloudCredentialTag, gc.Equals, "")
 }
 
 func (s *modelInfoSuite) TestModelInfoWriteAccess(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -884,6 +884,22 @@ func (m *ModelManagerAPI) ModelInfo(args params.Entities) (params.ModelInfoResul
 	return results, nil
 }
 
+// isModelAdmin reports if authorised user is either a controller admin
+// or has admin access to a given model.
+func (m *ModelManagerAPI) isModelAdmin(tag names.ModelTag) (bool, error) {
+	if m.isAdmin {
+		return true, nil
+	}
+	modelAdmin, err := m.authorizer.HasPermission(permission.AdminAccess, tag)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Trace(err)
+	}
+	return modelAdmin, nil
+}
+
 func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, error) {
 	st, release, err := m.state.GetBackend(tag.Id())
 	if errors.IsNotFound(err) {
@@ -912,7 +928,10 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 	}
 
 	if cloudCredentialTag, ok := model.CloudCredential(); ok {
-		info.CloudCredentialTag = cloudCredentialTag.String()
+		// Only model admins can see what credential model uses.
+		if modelAdmin, _ := m.isModelAdmin(model.ModelTag()); modelAdmin {
+			info.CloudCredentialTag = cloudCredentialTag.String()
+		}
 	}
 
 	// All users with access to the model can see the SLA information.


### PR DESCRIPTION
## Description of change

We want to show credential that a model uses as a result of show-model to model/controller admins.

Current api does not check whether requesting user has permission to see this. This PR includes this check.

I am proposing this as it has been discussed in the past and is in my current warpath. However, I am not entirely convinced that we need to be this restrictive - as long as users have any access, even read, to the model, we can show them what credential this model uses, including credential owner and its cloud name. This information may be useful and, unless the user has other privileges, they will not be able to do anything with this credential anyway - i.e. only the owner of the credential can update its content (and I am working on the patch where only model admin can upload/replace a credential that their model uses).  

## QA steps

Some existing unit tests in api and apiserver layer are broken as they all check for the presence of CloudCredentialTag. However, I do not want to address them until I get a buy-in on this implementation - it'll muddy the PR with bigger surface difference and will obscure the actual change I want.