### PR TITLE
2.3 dont prune oplog 1749078

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T14:24:45Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	c1418baa9f3df16f7a900af4e3f579333a8acd78	2018-01-15T06:36:48Z
+github.com/juju/testing	git	43f926548f91d55be6bae26ecb7d2386c64e887c	2018-02-13T13:46:16Z
 github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -118,7 +118,7 @@ type debugLogDbSuite struct {
 var _ = gc.Suite(&debugLogDbSuite{})
 
 func (s *debugLogDbSuite) SetUpSuite(c *gc.C) {
-	// Restart mongod with a the replicaset enabled.
+	// Restart mongod with the replicaset enabled.
 	mongod := jujutesting.MgoServer
 	mongod.Params = []string{"--replSet", "juju"}
 	mongod.Restart()
@@ -137,7 +137,7 @@ func (s *debugLogDbSuite) SetUpSuite(c *gc.C) {
 
 func (s *debugLogDbSuite) TearDownSuite(c *gc.C) {
 	// Restart mongod without the replicaset enabled so as not to
-	// affect other test that reply on this mongod instance in this
+	// affect other test that rely on this mongod instance in this
 	// package.
 	mongod := jujutesting.MgoServer
 	mongod.Params = []string{}

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -137,7 +137,7 @@ func (s *debugLogDbSuite) SetUpSuite(c *gc.C) {
 
 func (s *debugLogDbSuite) TearDownSuite(c *gc.C) {
 	// Restart mongod without the replicaset enabled so as not to
-	// affect other test that rely on this mongod instance in this
+	// affect other tests that rely on this mongod instance in this
 	// package.
 	mongod := jujutesting.MgoServer
 	mongod.Params = []string{}


### PR DESCRIPTION
## Description of change

As part of Mongo 3.4 support, it turns out mongo (correctly) now refuses to let us trim the local replicaset oplog while part of a replicaset. However, this broke the tear down which assumed we could delete all databases.
This just updates the testing package which now skips the local oplog collection.

## QA steps

Download Mongo 3.4
```
$ export JUJU_MONGOD=$PATH/TO/3.4/mongod
$ cd featuretests
$ go test --check.v --check.f debugLogDb
```

That test suite was using mongo with `--replSet` because it needs the oplog for how debug-log tracks what changes to display. Without this patch, the test suite fails, but with it, it should pass.

## Documentation changes

None

## Bug reference

https://github.com/juju/testing/pull/135
[lp:1749078](https://bugs.launchpad.net/juju/+bug/1749078)