### PR TITLE
Various fixes for caas relations

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -224,18 +224,21 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsNoTags(c *gc.C) {
 	s.st.application.CheckCall(c, 0, "AddOperation", state.UnitUpdateProperties{
 		ProviderId: "last-uuid",
 		Address:    "last-address", Ports: []string{"last-port"},
-		Status: &status.StatusInfo{Status: status.Error, Message: "last message"},
+		AgentStatus: &status.StatusInfo{Status: status.Error, Message: "last message"},
 	})
 	s.st.application.units[0].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "uuid",
 		Address:    "address", Ports: []string{"port"},
+		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "message"},
+		AgentStatus: &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "another-uuid",
 		Address:    "another-address", Ports: []string{"another-port"},
-		Status: &status.StatusInfo{Status: status.Running, Message: "another message"},
+		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "another message"},
+		AgentStatus: &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[2].(*mockUnit).CheckCallNames(c, "Life")
 }
@@ -271,12 +274,14 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithTags(c *gc.C) {
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "uuid",
 		Address:    "address", Ports: []string{"port"},
+		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "message"},
+		AgentStatus: &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: "another-uuid",
 		Address:    "another-address", Ports: []string{"another-port"},
-		Status: &status.StatusInfo{Status: status.Error, Message: "another message"},
+		AgentStatus: &status.StatusInfo{Status: status.Error, Message: "another message"},
 	})
 	s.st.application.units[2].(*mockUnit).CheckCallNames(c, "Life")
 }

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -156,9 +156,8 @@ var (
 		"hook-retry-strategy",
 		"operator",
 	}
-	notMigratingCAASWorkers = []string{
 	// TODO(caas)
-	}
+	notMigratingCAASWorkers = []string(nil)
 )
 
 func (s *CAASOperatorSuite) TestWorkers(c *gc.C) {


### PR DESCRIPTION
## Description of change

Fix some more places in the uniter facade where an application agent was connecting and we were assuming a unit agent.
When getting the network info for a relation, use the container address for caas units.
When recording status updates from the pods, update both agent and unit status if needed.

Also some test and go fmt fixes.

## QA steps

bootstrap and deploy a caas model

