### PR TITLE
Credential UX: show cred in 'show-model' and 'models' (non-tabular formats).

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -709,10 +709,6 @@ func (m *ModelManagerAPI) ListModelSummaries(req params.ModelSummariesRequest) (
 			CloudTag:    mi.CloudTag,
 			CloudRegion: mi.CloudRegion,
 
-			// Due to the nature of the query that gets this information,
-			// it is assumed that by the time we get here, only
-			// controller and model admins will have valid credential
-			// tag here.
 			CloudCredentialTag: mi.CloudCredentialTag,
 
 			SLA: &params.ModelSLAInfo{

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -706,8 +706,13 @@ func (m *ModelManagerAPI) ListModelSummaries(req params.ModelSummariesRequest) (
 			ControllerUUID: mi.ControllerUUID,
 			Life:           params.Life(mi.Life.String()),
 
-			CloudTag:           mi.CloudTag,
-			CloudRegion:        mi.CloudRegion,
+			CloudTag:    mi.CloudTag,
+			CloudRegion: mi.CloudRegion,
+
+			// Due to the nature of the query that gets this information,
+			// it is assumed that by the time we get here, only
+			// controller and model admins will have valid credential
+			// tag here.
 			CloudCredentialTag: mi.CloudCredentialTag,
 
 			SLA: &params.ModelSLAInfo{

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -36,6 +36,7 @@ type ModelInfo struct {
 	SLA            string                      `json:"sla,omitempty" yaml:"sla,omitempty"`
 	SLAOwner       string                      `json:"sla-owner,omitempty" yaml:"sla-owner,omitempty"`
 	AgentVersion   string                      `json:"agent-version,omitempty" yaml:"agent-version,omitempty"`
+	Credential     *ModelCredential            `json:"credential,omitempty" yaml:"credential,omitempty"`
 }
 
 // ModelMachineInfo contains information about a machine in a model.
@@ -70,6 +71,13 @@ func FriendlyDuration(when *time.Time, now time.Time) string {
 		return ""
 	}
 	return UserFriendlyDuration(*when, now)
+}
+
+// ModelCredential contains model credential basic details.
+type ModelCredential struct {
+	Name  string `json:"name" yaml:"name"`
+	Owner string `json:"owner" yaml:"owner"`
+	Cloud string `json:"cloud" yaml:"cloud"`
 }
 
 // ModelInfoFromParams translates a params.ModelInfo to ModelInfo.
@@ -130,6 +138,19 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		modelInfo.SLA = ModelSLAFromParams(info.SLA)
 		modelInfo.SLAOwner = ModelSLAOwnerFromParams(info.SLA)
 	}
+
+	if info.CloudCredentialTag != "" {
+		credTag, err := names.ParseCloudCredentialTag(info.CloudCredentialTag)
+		if err != nil {
+			return ModelInfo{}, errors.Trace(err)
+		}
+		modelInfo.Credential = &ModelCredential{
+			Name:  credTag.Name(),
+			Owner: credTag.Owner().Id(),
+			Cloud: credTag.Cloud().Id(),
+		}
+	}
+
 	return modelInfo, nil
 }
 

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -227,16 +227,17 @@ type ModelSummary struct {
 	ShortName string `json:"short-name" yaml:"short-name"`
 	UUID      string `json:"model-uuid" yaml:"model-uuid"`
 
-	ControllerUUID     string              `json:"controller-uuid" yaml:"controller-uuid"`
-	ControllerName     string              `json:"controller-name" yaml:"controller-name"`
-	Owner              string              `json:"owner" yaml:"owner"`
-	Cloud              string              `json:"cloud" yaml:"cloud"`
-	CloudRegion        string              `json:"region,omitempty" yaml:"region,omitempty"`
-	ProviderType       string              `json:"type,omitempty" yaml:"type,omitempty"`
-	Life               string              `json:"life" yaml:"life"`
-	Status             *common.ModelStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	UserAccess         string              `yaml:"access" json:"access"`
-	UserLastConnection string              `yaml:"last-connection" json:"last-connection"`
+	ControllerUUID     string                  `json:"controller-uuid" yaml:"controller-uuid"`
+	ControllerName     string                  `json:"controller-name" yaml:"controller-name"`
+	Owner              string                  `json:"owner" yaml:"owner"`
+	Cloud              string                  `json:"cloud" yaml:"cloud"`
+	CloudRegion        string                  `json:"region,omitempty" yaml:"region,omitempty"`
+	CloudCredential    *common.ModelCredential `json:"credential,omitempty" yaml:"credential,omitempty"`
+	ProviderType       string                  `json:"type,omitempty" yaml:"type,omitempty"`
+	Life               string                  `json:"life" yaml:"life"`
+	Status             *common.ModelStatus     `json:"status,omitempty" yaml:"status,omitempty"`
+	UserAccess         string                  `yaml:"access" json:"access"`
+	UserLastConnection string                  `yaml:"last-connection" json:"last-connection"`
 
 	// Counts is the map of different counts where key is the entity that was counted
 	// and value is the number, for e.g. {"machines":10,"cores":3}.
@@ -280,6 +281,14 @@ func (c *modelsCommand) modelSummaryFromParams(apiSummary base.UserModelSummary,
 	if apiSummary.ProviderType != "" {
 		summary.ProviderType = apiSummary.ProviderType
 
+	}
+	if apiSummary.CloudCredential != "" {
+		credTag := names.NewCloudCredentialTag(apiSummary.CloudCredential)
+		summary.CloudCredential = &common.ModelCredential{
+			Name:  credTag.Name(),
+			Owner: credTag.Owner().Id(),
+			Cloud: credTag.Cloud().Id(),
+		}
 	}
 	if apiSummary.UserLastConnection != nil {
 		summary.UserLastConnection = common.UserFriendlyDuration(*apiSummary.UserLastConnection, now)

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -265,6 +265,23 @@ func (s *BaseModelsSuite) TestModelsOwner(c *gc.C) {
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
 }
 
+// TestModelsForAdmin tests that a model admin user will get model credential.
+// Credential will only appear in non-tabular format - either yaml or json.
+func (s *BaseModelsSuite) TestModelsWithCredentials(c *gc.C) {
+	for i, infoResult := range s.api.infos {
+		// let's say only some models will have credentials returned from api...
+		if i%2 == 0 {
+			infoResult.Result.CloudCredentialTag = "cloudcred-some-cloud_some-owner_some-credential"
+		}
+	}
+
+	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format=yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(context), jc.Contains, "credential")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
+	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
+}
+
 func (s *BaseModelsSuite) TestModelsNonOwner(c *gc.C) {
 	// Ensure fake api caters to user 'bob'
 	for _, apiInfo := range s.api.infos {

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -655,7 +655,7 @@ func (s *ModelsSuiteV4) SetUpTest(c *gc.C) {
 func (s *ModelsSuiteV4) TestModelsJson(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"access":"read","last-connection":"2015-03-20","agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"access":"write","last-connection":"2015-03-01","agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"access":"","last-connection":"never connected","agent-version":"2.55.5"}],"current-model":"test-model1"}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"life":"","status":{"current":"active"},"access":"read","last-connection":"2015-03-20","agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"life":"","status":{"current":"active"},"access":"write","last-connection":"2015-03-01","agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"life":"","status":{"current":"destroying"},"access":"","last-connection":"never connected","agent-version":"2.55.5"}],"current-model":"test-model1"}
 `)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -673,6 +673,10 @@ models:
   controller-name: fake
   owner: admin
   cloud: dummy
+  credential:
+    name: one
+    owner: bob
+    cloud: foo
   life: ""
   status:
     current: active
@@ -686,6 +690,10 @@ models:
   controller-name: fake
   owner: carlotta
   cloud: dummy
+  credential:
+    name: one
+    owner: bob
+    cloud: foo
   life: ""
   status:
     current: active
@@ -699,6 +707,10 @@ models:
   controller-name: fake
   owner: daiwik@external
   cloud: dummy
+  credential:
+    name: one
+    owner: bob
+    cloud: foo
   life: ""
   status:
     current: destroying

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -18,12 +18,7 @@ import (
 	"github.com/juju/juju/cmd/output"
 )
 
-const showModelCommandDoc = `Show information about the current or specified 
-model.
-
-Additionally, users with controller- or model- admin access  to the shown model
-can see basic information about its cloud credential, stored on the controller. 
-`
+const showModelCommandDoc = `Show information about the current or specified model.`
 
 func NewShowCommand() cmd.Command {
 	showCmd := &showModelCommand{}

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -18,7 +18,12 @@ import (
 	"github.com/juju/juju/cmd/output"
 )
 
-const showModelCommandDoc = `Show information about the current or specified model`
+const showModelCommandDoc = `Show information about the current or specified 
+model.
+
+Additionally, users with controller- or model- admin access  to the shown model
+can see basic information about its cloud credential, stored on the controller. 
+`
 
 func NewShowCommand() cmd.Command {
 	showCmd := &showModelCommand{}
@@ -28,7 +33,6 @@ func NewShowCommand() cmd.Command {
 // showModelCommand shows all the users with access to the current model.
 type showModelCommand struct {
 	modelcmd.ModelCommandBase
-
 	out cmd.Output
 	api ShowModelAPI
 }

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -145,7 +145,32 @@ func (s *ShowCommandSuite) TestShowFormatYaml(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(ctx), jc.YAMLEquals, s.expectedOutput)
 }
 
+func (s *ShowCommandSuite) addCredentialToTestData() {
+	s.fake.info.CloudCredentialTag = "cloudcred-some-cloud_some-owner_some-credential"
+
+	modelOutput := s.expectedOutput["mymodel"].(attrs)
+	modelOutput["credential"] = attrs{
+		"name":  "some-credential",
+		"owner": "some-owner",
+		"cloud": "some-cloud",
+	}
+}
+
+func (s *ShowCommandSuite) TestShowWithCredentialFormatYaml(c *gc.C) {
+	s.addCredentialToTestData()
+	ctx, err := cmdtesting.RunCommand(c, s.newShowCommand(), "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), jc.YAMLEquals, s.expectedOutput)
+}
+
 func (s *ShowCommandSuite) TestShowFormatJson(c *gc.C) {
+	ctx, err := cmdtesting.RunCommand(c, s.newShowCommand(), "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), jc.JSONEquals, s.expectedOutput)
+}
+
+func (s *ShowCommandSuite) TestShowWithCredentialFormatJson(c *gc.C) {
+	s.addCredentialToTestData()
 	ctx, err := cmdtesting.RunCommand(c, s.newShowCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.JSONEquals, s.expectedOutput)

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -123,6 +123,10 @@ models:
   owner: admin
   cloud: dummy
   region: dummy-region
+  credential:
+    name: cred
+    owner: admin
+    cloud: dummy
   type: dummy
   life: alive
   status:


### PR DESCRIPTION
## Description of change

There is no means of discovering what cloud credential a model uses unless you look directly in the database.

This PR exposes this information as part of the 'show-model' and 'models' (non-tabular formats) outputs.

We only show basic credential information deduced from its name - credential name, its owner and what cloud it belongs to.

## QA steps

1. bootstrap
2. run 'show-model' or 'models --format=yaml/json'
You should be able to see the credential you've used.

## Documentation changes

Potentially, as part of the effort to improve user understanding around cloud credential management.

## Bug reference
Part of the solution to improve credential UX.
