### PR TITLE
Revert "Model credential visible to admin users only."

### DIFF
--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -4,7 +4,6 @@
 package modelmanager_test
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -224,7 +223,6 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"Cloud", nil},
 		{"CloudRegion", nil},
 		{"CloudCredential", nil},
-		{"ModelTag", nil},
 		{"SLALevel", nil},
 		{"SLAOwner", nil},
 		{"Life", nil},
@@ -247,29 +245,6 @@ func (s *modelInfoSuite) TestModelInfoOwner(c *gc.C) {
 	info := s.getModelInfo(c, s.st.model.cfg.UUID())
 	c.Assert(info.Users, gc.HasLen, 4)
 	c.Assert(info.Machines, gc.HasLen, 2)
-}
-
-func (s *modelInfoSuite) TestModelInfoHasCredentialForAdmin(c *gc.C) {
-	// Need to convince fake authorizer that this user has admin right on a test model;
-	// so user name is <desired permission><model tag>.
-	userName := fmt.Sprintf("%s%s", "admin", s.st.model.tag)
-	user := names.NewUserTag(userName)
-	s.st.model.users = append(s.st.model.users, &mockModelUser{
-		userName:       userName,
-		lastConnection: time.Time{},
-		access:         permission.AdminAccess,
-	})
-	s.setAPIUser(c, user)
-	info := s.getModelInfo(c, s.st.model.cfg.UUID())
-	c.Assert(info.CloudCredentialTag, gc.Equals, "cloudcred-some-cloud_bob_some-credential")
-}
-
-func (s *modelInfoSuite) TestModelInfoHasCredentialForNonAdmin(c *gc.C) {
-	mary := names.NewUserTag("mary@local")
-	s.authorizer.HasWriteTag = mary
-	s.setAPIUser(c, mary)
-	info := s.getModelInfo(c, s.st.model.cfg.UUID())
-	c.Assert(info.CloudCredentialTag, gc.Equals, "")
 }
 
 func (s *modelInfoSuite) TestModelInfoWriteAccess(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -884,22 +884,6 @@ func (m *ModelManagerAPI) ModelInfo(args params.Entities) (params.ModelInfoResul
 	return results, nil
 }
 
-// isModelAdmin reports if authorised user is either a controller admin
-// or has admin access to a given model.
-func (m *ModelManagerAPI) isModelAdmin(tag names.ModelTag) (bool, error) {
-	if m.isAdmin {
-		return true, nil
-	}
-	modelAdmin, err := m.authorizer.HasPermission(permission.AdminAccess, tag)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, errors.Trace(err)
-	}
-	return modelAdmin, nil
-}
-
 func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, error) {
 	st, release, err := m.state.GetBackend(tag.Id())
 	if errors.IsNotFound(err) {
@@ -928,10 +912,7 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 	}
 
 	if cloudCredentialTag, ok := model.CloudCredential(); ok {
-		// Only model admins can see what credential model uses.
-		if modelAdmin, _ := m.isModelAdmin(model.ModelTag()); modelAdmin {
-			info.CloudCredentialTag = cloudCredentialTag.String()
-		}
+		info.CloudCredentialTag = cloudCredentialTag.String()
 	}
 
 	// All users with access to the model can see the SLA information.


### PR DESCRIPTION
Reverts juju/juju#8364

This change is too restrictive. There is no reason to not return model cloud credential to a model user.