### PR TITLE
Handle the case where lease documents exist while migrating.

### DIFF
--- a/state/lease/client.go
+++ b/state/lease/client.go
@@ -292,9 +292,9 @@ func LookupLease(coll mongo.Collection, namespace, name string) (leaseDoc, error
 	var doc leaseDoc
 	err := coll.FindId(leaseDocId(namespace, name)).One(&doc)
 	if err != nil {
-		return doc, err
+		return leaseDoc{}, err
 	}
-	return doc, err
+	return doc, nil
 }
 
 // extendLeaseOps returns the []txn.Op necessary to extend the supplied lease

--- a/state/lease/client.go
+++ b/state/lease/client.go
@@ -286,6 +286,17 @@ func claimLeaseOps(
 	return []txn.Op{claimLeaseOp}, newEntry, nil
 }
 
+// LookupLease returns a lease claim if it exists.
+// If it doesn't exist, expect to get an mgo.NotFoundError, otherwise expect to get
+func LookupLease(coll mongo.Collection, namespace, name string) (leaseDoc, error) {
+	var doc leaseDoc
+	err := coll.FindId(leaseDocId(namespace, name)).One(&doc)
+	if err != nil {
+		return doc, err
+	}
+	return doc, err
+}
+
 // extendLeaseOps returns the []txn.Op necessary to extend the supplied lease
 // until duration in the future, and a cache entry corresponding to the values
 // that will be written if the transaction succeeds. If the supplied lease

--- a/state/lease/client_test.go
+++ b/state/lease/client_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+
+	corelease "github.com/juju/juju/core/lease"
+	statelease "github.com/juju/juju/state/lease"
+)
+
+// ClientAssertSuite tests that AssertOp does what it should.
+type ClientSuite struct {
+	FixtureSuite
+}
+
+var _ = gc.Suite(&ClientSuite{})
+
+func (s *ClientSuite) TestLookupLeaseNotThere(c *gc.C) {
+	db := NewMongo(s.db)
+	coll, closer := db.GetCollection("default-collection")
+	defer closer()
+	_, err := statelease.LookupLease(coll,"default-namespace", "bar")
+	c.Assert(err, gc.Equals, mgo.ErrNotFound)
+}
+
+func (s *ClientSuite) TestLookupLease(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("name", corelease.Request{"holder", time.Minute})
+	c.Assert(err, jc.ErrorIsNil)
+	db := NewMongo(s.db)
+	coll, closer := db.GetCollection("default-collection")
+	defer closer()
+	doc, err := statelease.LookupLease(coll,"default-namespace", "name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(doc.Name, gc.Equals, "name")
+	c.Check(doc.Holder, gc.Equals, "holder")
+	c.Check(doc.Namespace, gc.Equals, "default-namespace")
+}

--- a/state/lease/client_test.go
+++ b/state/lease/client_test.go
@@ -25,7 +25,7 @@ func (s *ClientSuite) TestLookupLeaseNotThere(c *gc.C) {
 	db := NewMongo(s.db)
 	coll, closer := db.GetCollection("default-collection")
 	defer closer()
-	_, err := statelease.LookupLease(coll,"default-namespace", "bar")
+	_, err := statelease.LookupLease(coll, "default-namespace", "bar")
 	c.Assert(err, gc.Equals, mgo.ErrNotFound)
 }
 
@@ -36,7 +36,7 @@ func (s *ClientSuite) TestLookupLease(c *gc.C) {
 	db := NewMongo(s.db)
 	coll, closer := db.GetCollection("default-collection")
 	defer closer()
-	doc, err := statelease.LookupLease(coll,"default-namespace", "name")
+	doc, err := statelease.LookupLease(coll, "default-namespace", "name")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(doc.Name, gc.Equals, "name")
 	c.Check(doc.Holder, gc.Equals, "holder")

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1272,6 +1272,15 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 			if doc.Type != "lease" {
 				continue
 			}
+			// Check if the target exists
+
+			if _, err := lease.LookupLease(coll, doc.Namespace, doc.Name); err == nil {
+				// target already exists, it takes precedence over an old doc, which we still want to delete
+				continue
+			} else if err != mgo.ErrNotFound {
+				// We got an unknown error looking up this doc, don't suppress it
+				return nil, err
+			}
 			claimOps, err := lease.ClaimLeaseOps(
 				doc.Namespace,
 				doc.Name,

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1270,17 +1270,20 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 				Remove: true,
 			})
 			if doc.Type != "lease" {
+				upgradesLogger.Tracef("deleting old lease doc %q", doc.DocID)
 				continue
 			}
 			// Check if the target exists
-
 			if _, err := lease.LookupLease(coll, doc.Namespace, doc.Name); err == nil {
 				// target already exists, it takes precedence over an old doc, which we still want to delete
+				upgradesLogger.Infof("new lease %q %q already exists, simply deleting old lease %q",
+					doc.Namespace, doc.Name, doc.DocID)
 				continue
 			} else if err != mgo.ErrNotFound {
 				// We got an unknown error looking up this doc, don't suppress it
 				return nil, err
 			}
+			upgradesLogger.Tracef("migrating lease %q to new lease structure", doc.DocID)
 			claimOps, err := lease.ClaimLeaseOps(
 				doc.Namespace,
 				doc.Name,


### PR DESCRIPTION
## Description of change

Under HA, it is possible to have the singleton lease document get created while
the upgrade steps are running. This would cause the migration code to fail,
because while the Create op was checking that the target didn't exist, we
weren't checking that the target didn't exist in the migration loop. Which
meant that we would try to delete the old and create the new, but fail the
assertion, and have no idea what was wrong.

Upon consideration, if we the lease we are 'migrating' already exists, then
someone has already taken the new lease, and it should win, and the old lease
just be discarded anyway. So that is what we do.

## QA steps

I believe Tim had a reproduction case where he bootstrapped an HA system with significant load, and then tried to upgrade it from 2.2 to 2.3 and found he got the 'state changing to quickly' failure.
There is also a similar case in the bug. I have not reproduced the specific error yet.

## Documentation changes

None.

## Bug reference

[lp:1746265](https://bugs.launchpad.net/juju/+bug/1746265)