### PR TITLE
[WIP] APICaller should connect to localhost only when a controller

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -785,19 +785,15 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 	}
 	servingInfo, isController := c.StateServingInfo()
 	addrs := c.apiDetails.addresses
+	// For controller we return only localhost - we should not connect
+	// to other controllers if we can talk locally.
 	if isController {
 		port := servingInfo.APIPort
 		// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4
 		// loopback, and when/if this changes localhost should resolve
 		// to IPv6 loopback in any case (lp:1644009). Review.
 		localAPIAddr := net.JoinHostPort("localhost", strconv.Itoa(port))
-		newAddrs := []string{localAPIAddr}
-		for _, addr := range addrs {
-			if addr != localAPIAddr {
-				newAddrs = append(newAddrs, addr)
-			}
-		}
-		addrs = newAddrs
+		addrs = []string{localAPIAddr}
 	}
 	return &api.Info{
 		Addrs:    addrs,
@@ -815,13 +811,27 @@ func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
 	if !ok {
 		return nil, false
 	}
+	// We return localhost first and then all addresses of known API
+	// endpoints - this lets us connect to other Mongo instances and start
+	// state even if our own Mongo has not started yet (see lp:1749383 #1).
 	// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4 loopback,
 	// and when/if this changes localhost should resolve to IPv6 loopback
 	// in any case (lp:1644009). Review.
-	addr := net.JoinHostPort("localhost", strconv.Itoa(ssi.StatePort))
+	local := net.JoinHostPort("localhost", strconv.Itoa(ssi.StatePort))
+	addrs := []string{local}
+
+	for _, addr := range c.apiDetails.addresses {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, false
+		}
+		if host := net.JoinHostPort(host, strconv.Itoa(ssi.StatePort)); host != local {
+			addrs = append(addrs, host)
+		}
+	}
 	return &mongo.MongoInfo{
 		Info: mongo.Info{
-			Addrs:  []string{addr},
+			Addrs:  addrs,
 			CACert: c.caCert,
 		},
 		Password: c.statePassword,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -418,42 +418,32 @@ func (*suite) TestAPIInfoMissingAddress(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
-func (*suite) TestAPIInfoPutsLocalhostFirstWhenServingInfoPresent(c *gc.C) {
+func (*suite) TestAPIInfoServesLocalhostOnlyWhenServingInfoPresent(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"localhost:1235", "localhost:1236"}
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	apiinfo, ok := conf.APIInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
-	c.Check(apiinfo.Addrs[0], gc.Equals, "localhost:47")
-}
-
-func (*suite) TestAPIInfoMovesLocalhostFirstWhenServingInfoPresent(c *gc.C) {
-	attrParams := attributeParams
-	attrParams.APIAddresses = []string{"localhost:1235", "localhost:47"}
-	servingInfo := stateServingInfo()
-	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
-	c.Assert(err, jc.ErrorIsNil)
-	apiinfo, ok := conf.APIInfo()
-	c.Assert(ok, jc.IsTrue)
-	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses))
-	c.Check(apiinfo.Addrs[0], gc.Equals, "localhost:47")
+	c.Check(apiinfo.Addrs, gc.DeepEquals, []string{"localhost:47"})
 }
 
 func (*suite) TestMongoInfo(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	mongoInfo, ok := conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69"})
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "foo.example:69", "bar.example:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 
 func (*suite) TestPromotedMongoInfo(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -468,7 +458,7 @@ func (*suite) TestPromotedMongoInfo(c *gc.C) {
 
 	mongoInfo, ok = conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69"})
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "foo.example:69", "bar.example:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 


### PR DESCRIPTION
## Description of change
When on a controller APICaller should only connect to itself

## QA steps
Verify that all calls from agents are done locally (with tcpdump?)

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1749383
