### PR TITLE
backport pr 8379 Fix lp:1748275

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -54,13 +54,16 @@ var defaultHTTPMethods = []string{"GET", "POST", "HEAD", "PUT", "DELETE", "OPTIO
 
 // Server holds the server side of the API.
 type Server struct {
-	tomb                   tomb.Tomb
-	clock                  clock.Clock
-	pingClock              clock.Clock
-	wg                     sync.WaitGroup
-	statePool              *state.StatePool
-	lis                    net.Listener
-	tag                    names.Tag
+	tomb      tomb.Tomb
+	clock     clock.Clock
+	pingClock clock.Clock
+	wg        sync.WaitGroup
+	statePool *state.StatePool
+	lis       net.Listener
+
+	// Tag of the machine where the API server is running.
+	tag names.Tag
+
 	dataDir                string
 	logDir                 string
 	limiter                utils.Limiter

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -916,7 +916,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 	setProvisioned("3")
 
 	// Add a few controllers, provision two of them.
-	_, err = s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	_, err = s.State.EnableHA(3, constraints.Value{}, "quantal", nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	setProvisioned("5")
 	setProvisioned("7")
@@ -1041,7 +1041,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 	setProvisioned("3")
 
 	// Add a few controllers, provision two of them.
-	_, err = s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	_, err = s.State.EnableHA(3, constraints.Value{}, "quantal", nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	setProvisioned("5")
 	setProvisioned("7")

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -180,7 +180,7 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 
 	// Create 3 controllers
 	machineA, _ := s.makeStateAgentVersion(c, s.oldVersion)
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(changes.Added), gc.Equals, 2)
 	machineB, _, _ := s.configureMachine(c, changes.Added[0], s.oldVersion)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -822,10 +822,16 @@ func (s *assignCleanSuite) TestAssignToMachineNoneAvailable(c *gc.C) {
 	c.Assert(m, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, eligibleMachinesInUse)
 
-	// Add two environ manager machines and check they are not chosen.
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	m0, err := s.State.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes.Added, gc.HasLen, 3)
+	err = m0.SetHasVote(true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add two environ manager machines and check they are not chosen.
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil, "0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(changes.Added, gc.HasLen, 2)
+	c.Assert(changes.Maintained, gc.HasLen, 1)
 
 	m, err = s.assignUnit(unit)
 	c.Assert(m, gc.IsNil)

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -44,7 +44,7 @@ func (s *UpgradeSuite) provision(c *gc.C, machineIds ...string) {
 }
 
 func (s *UpgradeSuite) addControllers(c *gc.C) (machineId1, machineId2 string) {
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil, s.serverIdA)
 	c.Assert(err, jc.ErrorIsNil)
 	return changes.Added[0], changes.Added[1]
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -489,7 +489,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 }
 
 func (s *CommonProvisionerSuite) enableHA(c *gc.C, n int) []*state.Machine {
-	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, series.LatestLts(), nil)
+	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, series.LatestLts(), nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	added := make([]*state.Machine, len(changes.Added))
 	for i, mid := range changes.Added {

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -450,7 +450,7 @@ func (s *UpgradeSuite) create3Controllers(c *gc.C) (machineIdA, machineIdB, mach
 	machineIdA = machine0.Id()
 	s.setMachineAlive(c, machineIdA)
 
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil, machineIdA)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(changes.Added), gc.Equals, 2)
 


### PR DESCRIPTION
## Description of change

If you run juju enable-ha very quickly, e.g. via script, after bootstrap has completed, there is a window of time where the controller hasn't sent a ping yet to agent presence. In this case, it's possible that
EnableHA will demote the server it's running on as part of the enablement process, causing another server to be provisioned.

## QA steps

Best bet is to find a cloud this is easily reproducible on to run. It can be difficult to reproduce.
$ juju bootstrap localhost test ; juju enable-ha -c test

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748275
