### PR TITLE
Handle an interesting race condition (bug #1747367)

### DIFF
--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -353,6 +353,11 @@ func (w *Watcher) flush() {
 				return
 			case req := <-w.request:
 				w.handle(req)
+				// handle may append to the w.pending array, and/or it may unwatch something that was previously pending
+				// thus changing e.ch to nil while we are waiting to send the request. We need to make sure we are using
+				// the correct 'e' object
+				// See TestRobustness which fails if this line doesn't exist
+				e = &w.pending[i]
 				continue
 			case e.ch <- Change{e.key, e.alive}:
 			}


### PR DESCRIPTION
## Description of change

The static analysis showed that this might be a problem, and we're able to set
up a case where it really does fail.

Essentially, we have one loop which waits to try and send a notification of an
event to users. While waiting for that event to be sent, it allows new requests
to be made. So if we start watching for an event, but never handle when it
triggers, and then queue up a bunch more watch events that cause us to
reallocate the event slice, and *then* unwatch the original event, we will
never notice that the original event is no longer watched because we'll be hung
on an object that doesn't get updated.

## QA steps

The test properly handles the error conditions. If you uncomment that one line in presence.go, it properly fails the test case (and fails after waiting LongWait).

## Documentation changes

None.

## Bug reference

[lp:1747367](https://bugs.launchpad.net/juju/+bug/1747367)