### PR TITLE
Handle removing unknown application from a bundle through overlay processing.

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1172,15 +1172,15 @@ func processSingleBundleOverlay(data *charm.BundleData, bundleOverlayFile string
 	// actually exist in the bundle data.
 	for appName, bc := range config.Applications {
 		app, found := data.Applications[appName]
-		if !found {
-			// Add it in.
-			data.Applications[appName] = bc
-			continue
-		}
 		// If bc is nil, that means to remove it from data.
 		if bc == nil {
 			delete(data.Applications, appName)
 			data.Relations = removeRelations(data.Relations, appName)
+			continue
+		}
+		if !found {
+			// Add it in.
+			data.Applications[appName] = bc
 			continue
 		}
 

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1883,6 +1883,20 @@ func (s *ProcessBundleOverlaySuite) TestRemoveApplication(c *gc.C) {
 	c.Assert(s.bundleData.Relations, gc.HasLen, 0)
 }
 
+func (s *ProcessBundleOverlaySuite) TestRemoveUnknownApplication(c *gc.C) {
+	config := `
+        applications:
+            unknown:
+    `
+	filename := s.writeFile(c, config)
+	err := processBundleOverlay(s.bundleData, filename)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertApplications(c, "django", "memcached")
+	c.Assert(s.bundleData.Relations, jc.DeepEquals, [][]string{
+		{"django", "memcached"},
+	})
+}
+
 func (s *ProcessBundleOverlaySuite) TestIncludes(c *gc.C) {
 	config := `
         applications:


### PR DESCRIPTION
## Description of change

There was a logic bug in the handling of the overlay where it would add in the unknown application with no details, rather than ignore.

## QA steps

Use juju deploy --dry-run with any bundle and on overlay that removes an unknown application.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1749761