### PR TITLE
2.3 into develop

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -433,42 +433,32 @@ func (*suite) TestAPIInfoMissingAddress(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
-func (*suite) TestAPIInfoPutsLocalhostFirstWhenServingInfoPresent(c *gc.C) {
+func (*suite) TestAPIInfoServesLocalhostOnlyWhenServingInfoPresent(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"localhost:1235", "localhost:1236"}
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	apiinfo, ok := conf.APIInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
-	c.Check(apiinfo.Addrs[0], gc.Equals, "localhost:47")
-}
-
-func (*suite) TestAPIInfoMovesLocalhostFirstWhenServingInfoPresent(c *gc.C) {
-	attrParams := attributeParams
-	attrParams.APIAddresses = []string{"localhost:1235", "localhost:47"}
-	servingInfo := stateServingInfo()
-	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
-	c.Assert(err, jc.ErrorIsNil)
-	apiinfo, ok := conf.APIInfo()
-	c.Assert(ok, jc.IsTrue)
-	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses))
-	c.Check(apiinfo.Addrs[0], gc.Equals, "localhost:47")
+	c.Check(apiinfo.Addrs, gc.DeepEquals, []string{"localhost:47"})
 }
 
 func (*suite) TestMongoInfo(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	mongoInfo, ok := conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69"})
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "foo.example:69", "bar.example:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 
 func (*suite) TestPromotedMongoInfo(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -483,7 +473,7 @@ func (*suite) TestPromotedMongoInfo(c *gc.C) {
 
 	mongoInfo, ok = conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69"})
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "foo.example:69", "bar.example:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1172,15 +1172,15 @@ func processSingleBundleOverlay(data *charm.BundleData, bundleOverlayFile string
 	// actually exist in the bundle data.
 	for appName, bc := range config.Applications {
 		app, found := data.Applications[appName]
-		if !found {
-			// Add it in.
-			data.Applications[appName] = bc
-			continue
-		}
 		// If bc is nil, that means to remove it from data.
 		if bc == nil {
 			delete(data.Applications, appName)
 			data.Relations = removeRelations(data.Relations, appName)
+			continue
+		}
+		if !found {
+			// Add it in.
+			data.Applications[appName] = bc
 			continue
 		}
 

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1956,6 +1956,20 @@ func (s *ProcessBundleOverlaySuite) TestRemoveApplication(c *gc.C) {
 	c.Assert(s.bundleData.Relations, gc.HasLen, 0)
 }
 
+func (s *ProcessBundleOverlaySuite) TestRemoveUnknownApplication(c *gc.C) {
+	config := `
+        applications:
+            unknown:
+    `
+	filename := s.writeFile(c, config)
+	err := processBundleOverlay(s.bundleData, filename)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertApplications(c, "django", "memcached")
+	c.Assert(s.bundleData.Relations, jc.DeepEquals, [][]string{
+		{"django", "memcached"},
+	})
+}
+
 func (s *ProcessBundleOverlaySuite) TestIncludes(c *gc.C) {
 	config := `
         applications:

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -353,6 +353,11 @@ func (w *Watcher) flush() {
 				return
 			case req := <-w.request:
 				w.handle(req)
+				// handle may append to the w.pending array, and/or it may unwatch something that was previously pending
+				// thus changing e.ch to nil while we are waiting to send the request. We need to make sure we are using
+				// the correct 'e' object
+				// See TestRobustness which fails if this line doesn't exist
+				e = &w.pending[i]
 				continue
 			case e.ch <- Change{e.key, e.alive}:
 			}


### PR DESCRIPTION
## Description of change

Sync changes from 2.3 into develop. Note that this reverts any changes from the CI acceptance tests, since they conflicted, and PR #8322 was flagged as being a sync of develop back into 2.3.

This includes:
 * Merge pull request #8388 from howbazaar/fix-bundle-missing-app
 * Merge pull request #8322 from Veebers/ci-sync-2.3
 * Merge pull request #8385 from jameinel/2.3-presence-1747367
 * Merge pull request #8386 from manadart/2.3-sketchy-test-fixes

## QA steps

See individual patches.

## Documentation changes

None.

## Bug reference

[lp:1749761](https://bugs.launchpad.net/juju/+bug/1749761)
[lp:1747367](https://bugs.launchpad.net/juju/+bug/1747367)
[lp:1748372](https://bugs.launchpad.net/juju/+bug/1748372)