### PR TITLE
Lock mutex on task.machines in provisioner when accessing it.

### DIFF
--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -47,8 +47,8 @@ var ClassifyMachine = classifyMachine
 // GetCopyAvailabilityZoneMachines returns a copy of p.(*provisionerTask).availabilityZoneMachines
 func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachine {
 	task := p.(*provisionerTask)
-	task.azMachinesMutex.RLock()
-	defer task.azMachinesMutex.RUnlock()
+	task.machinesMutex.RLock()
+	defer task.machinesMutex.RUnlock()
 	// sort to make comparisions in the tests easier.
 	sort.Sort(byPopulationThenNames(task.availabilityZoneMachines))
 	retvalues := make([]AvailabilityZoneMachine, len(task.availabilityZoneMachines))


### PR DESCRIPTION
## Description of change
There was a race condition in provisioner task, this fixes it.

## QA steps
Run race test on worker/provisioner

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1749003