### PR TITLE
Store caas container info in separate collection; optimise status reporting

### DIFF
--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4058,9 +4058,10 @@ func (s *uniterSuite) TestNetworkInfoCAASModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var updateUnits state.UpdateUnitsOperation
+	addr := "192.168.1.2"
 	updateUnits.Updates = []*state.UpdateUnitOperation{wpUnit.UpdateOperation(state.UnitUpdateProperties{
-		Address: "192.168.1.2",
-		Ports:   []string{"443"},
+		Address: &addr,
+		Ports:   &[]string{"443"},
 	})}
 	err = wp.UpdateUnits(&updateUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1110,11 +1110,15 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 	if leader := context.leaders[unit.ApplicationName()]; leader == unit.Name() {
 		result.Leader = true
 	}
-	result.ProviderId = unit.ProviderId()
-	containerInfo := unit.ContainerInfo()
-	result.Address = containerInfo.Address
-	if len(result.OpenedPorts) == 0 {
-		result.OpenedPorts = containerInfo.Ports
+	containerInfo, err := unit.ContainerInfo()
+	if err != nil && !errors.IsNotFound(err) {
+		logger.Debugf("error fetching container info: %v", err)
+	} else if err == nil {
+		result.ProviderId = containerInfo.ProviderId()
+		result.Address = containerInfo.Address()
+		if len(result.OpenedPorts) == 0 {
+			result.OpenedPorts = containerInfo.Ports()
+		}
 	}
 	return result
 }

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -125,11 +125,20 @@ func (m *mockApplication) AddOperation(props state.UnitUpdateProperties) *state.
 	return addOp
 }
 
+type mockContainerInfo struct {
+	state.CloudContainer
+	providerId string
+}
+
+func (m *mockContainerInfo) ProviderId() string {
+	return m.providerId
+}
+
 type mockUnit struct {
 	testing.Stub
-	name       string
-	life       state.Life
-	providerId string
+	name          string
+	life          state.Life
+	containerInfo *mockContainerInfo
 }
 
 func (*mockUnit) Tag() names.Tag {
@@ -149,8 +158,11 @@ func (m *mockUnit) Name() string {
 	return m.name
 }
 
-func (m *mockUnit) ProviderId() string {
-	return m.providerId
+func (m *mockUnit) ContainerInfo() (state.CloudContainer, error) {
+	if m.containerInfo == nil {
+		return nil, errors.NotFoundf("container info")
+	}
+	return m.containerInfo, nil
 }
 
 func (m *mockUnit) AgentStatus() (status.StatusInfo, error) {

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -78,7 +78,7 @@ type Unit interface {
 	Name() string
 	Life() state.Life
 	UnitTag() names.UnitTag
-	ProviderId() string
+	ContainerInfo() (state.CloudContainer, error)
 	AgentStatus() (status.StatusInfo, error)
 	UpdateOperation(props state.UnitUpdateProperties) *state.UpdateUnitOperation
 	DestroyOperation() *state.DestroyUnitOperation

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -111,8 +111,9 @@ var statusColors = map[status.Status]*ansiterm.Context{
 	status.Detaching:   WarningHighlight,
 	status.Detached:    WarningHighlight,
 	// bad
-	status.Blocked: ErrorHighlight,
-	status.Down:    ErrorHighlight,
-	status.Error:   ErrorHighlight,
-	status.Failed:  ErrorHighlight,
+	status.Blocked:    ErrorHighlight,
+	status.Down:       ErrorHighlight,
+	status.Error:      ErrorHighlight,
+	status.Failed:     ErrorHighlight,
+	status.Terminated: ErrorHighlight,
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -461,6 +461,10 @@ func allCollections() collectionSchema {
 		// for applications and units.
 		containerSpecsC: {},
 
+		// cloudContainersC holds the CAAS container (pod) information,
+		// for units, eg address, ports.
+		cloudContainersC: {},
+
 		// ----------------------
 
 		// Raw-access collections
@@ -490,6 +494,7 @@ const (
 	cleanupsC                = "cleanups"
 	cloudimagemetadataC      = "cloudimagemetadata"
 	cloudsC                  = "clouds"
+	cloudContainersC         = "containers"
 	cloudCredentialsC        = "cloudCredentials"
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -1,0 +1,118 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// CloudContainer represents the state of a CAAS container, eg pod.
+type CloudContainer interface {
+	// ProviderId returns the id assigned to the container/pod
+	// by the cloud.
+	ProviderId() string
+
+	// Address returns the container address.
+	Address() string
+
+	// Ports returns the open container ports.
+	Ports() []string
+}
+
+// cloudContainer is an implementation of CloudContainer.
+type cloudContainer struct {
+	doc cloudContainerDoc
+}
+
+type cloudContainerDoc struct {
+	// Id holds cloud container document key.
+	// It is the global key of the unit represented
+	// by this container.
+	Id string `bson:"_id"`
+
+	ProviderId string   `bson:"provider-id"`
+	Address    string   `bson:"address"`
+	Ports      []string `bson:"ports"`
+}
+
+// Id implements CloudContainer.
+func (c *cloudContainer) Id() string {
+	return c.doc.Id
+}
+
+// ProviderId implements CloudContainer.
+func (c *cloudContainer) ProviderId() string {
+	return c.doc.ProviderId
+}
+
+// Address implements CloudContainer.
+func (c *cloudContainer) Address() string {
+	return c.doc.Address
+}
+
+// Ports implements CloudContainer.
+func (c *cloudContainer) Ports() []string {
+	return c.doc.Ports
+}
+
+func (u *Unit) cloudContainer() (*cloudContainerDoc, error) {
+	coll, closer := u.st.db().GetCollection(cloudContainersC)
+	defer closer()
+
+	var doc cloudContainerDoc
+	err := coll.FindId(u.globalKey()).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("cloud container for unit %v", u.Name())
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &doc, nil
+}
+
+func (u *Unit) saveContainerOps(doc cloudContainerDoc) ([]txn.Op, error) {
+	existing, err := u.cloudContainer()
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	if err != nil {
+		return []txn.Op{{
+			C:      cloudContainersC,
+			Id:     doc.Id,
+			Assert: txn.DocMissing,
+			Insert: doc,
+		}}, nil
+	}
+	var asserts bson.D
+	providerValueAssert := bson.DocElem{"provider-id", existing.ProviderId}
+	if existing.ProviderId != "" {
+		asserts = bson.D{providerValueAssert}
+	} else {
+		asserts = bson.D{{"$or", []bson.D{{providerValueAssert}, {{"$exists", false}}}}}
+	}
+	return []txn.Op{{
+		C:      cloudContainersC,
+		Id:     existing.Id,
+		Assert: asserts,
+		Update: bson.D{
+			{"$set",
+				bson.D{{"provider-id", doc.ProviderId},
+					{"ports", doc.Ports},
+					{"address", doc.Address}},
+			},
+		},
+	}}, nil
+}
+
+func (u *Unit) removeCloudContainerOps() []txn.Op {
+	ops := []txn.Op{{
+		C:      cloudContainersC,
+		Id:     u.globalKey(),
+		Remove: true,
+	}}
+	return ops
+}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -198,6 +198,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// TODO(caas)
 		containerSpecsC,
+		cloudContainersC,
 	)
 
 	envCollections := set.NewStrings()
@@ -396,9 +397,6 @@ func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {
 		"Series",
 		"CharmURL",
 		"TxnRevno",
-		// TODO(caas)
-		"ProviderId",
-		"ContainerInfo",
 	)
 	migrated := set.NewStrings(
 		"Name",

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1048,7 +1048,9 @@ func (s *RelationUnitSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	// Add a container address.
 	unitUpdate := state.UpdateUnitsOperation{
 		Updates: []*state.UpdateUnitOperation{
-			prr.pu0.UpdateOperation(state.UnitUpdateProperties{ProviderId: "id", Address: "1.2.3.4"})},
+			prr.pu0.UpdateOperation(state.UnitUpdateProperties{
+				ProviderId: strPtr("id"),
+				Address:    strPtr("1.2.3.4")})},
 	}
 	err = mysql.UpdateUnits(&unitUpdate)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -52,9 +52,10 @@ func (m *mockServiceBroker) DeleteService(appName string) error {
 
 type mockContainerBroker struct {
 	testing.Stub
-	ensured      chan<- struct{}
-	unitDeleted  chan<- struct{}
-	unitsWatcher *watchertest.MockNotifyWatcher
+	ensured            chan<- struct{}
+	unitDeleted        chan<- struct{}
+	unitsWatcher       *watchertest.MockNotifyWatcher
+	reportedUnitStatus status.Status
 }
 
 func (m *mockContainerBroker) EnsureUnit(appName, unitName string, spec *caas.ContainerSpec) error {
@@ -80,7 +81,7 @@ func (m *mockContainerBroker) Units(appName string) ([]caas.Unit, error) {
 		{
 			Id:      "u1",
 			Address: "10.0.0.1",
-			Status:  status.StatusInfo{Status: status.Allocating},
+			Status:  status.StatusInfo{Status: m.reportedUnitStatus},
 		},
 	}, m.NextErr()
 }


### PR DESCRIPTION
## Description of change

CAAS container information is now stored in a separate collection instead of as attributes on the unit.
This is needed so that unit is less polluted and we can watch for container changes.
Also report in status when a pod is terminated by the caas substrate, and optimise status reporting by not sending a substrate reported status value unless it has changed.

## QA steps

Deploy a CAAS cloud and deploy the mysql charm, check status.
Wait for k8s to decide it wants to restart the pod and ensure this is reflected in juju status.