### PR TITLE
Show credential content - state layer.

### DIFF
--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -17,7 +17,7 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	Model() (Model, error)
 	ModelConfig() (*config.Config, error)
-	CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error)
+	CloudCredentials(user names.UserTag, cloudName string) (map[string]state.Credential, error)
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
 	RemoveCloudCredential(names.CloudCredentialTag) error
 	AddCloud(cloud.Cloud) error

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -357,10 +357,10 @@ func (api *CloudAPI) Credential(args params.Entities) (params.CloudCredentialRes
 			continue
 		}
 
-		attrs := cred.Attributes()
+		attrs := cred.Attributes
 		var redacted []string
 		// Mask out the secrets.
-		if s, ok := schemas[cred.AuthType()]; ok {
+		if s, ok := schemas[cloud.AuthType(cred.AuthType)]; ok {
 			for _, attr := range s {
 				if attr.Hidden {
 					delete(attrs, attr.Name)
@@ -369,7 +369,7 @@ func (api *CloudAPI) Credential(args params.Entities) (params.CloudCredentialRes
 			}
 		}
 		results.Results[i].Result = &params.CloudCredential{
-			AuthType:   string(cred.AuthType()),
+			AuthType:   cred.AuthType,
 			Attributes: attrs,
 			Redacted:   redacted,
 		}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -43,7 +43,7 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 		},
 		creds: map[string]state.Credential{
-			names.NewCloudCredentialTag("meep/bruce/one").Id(): statetesting.CloudCredential(cloud.EmptyAuthType, nil),
+			names.NewCloudCredentialTag("meep/bruce/one").Id(): statetesting.NewEmptyCredential(),
 			names.NewCloudCredentialTag("meep/bruce/two").Id(): statetesting.CloudCredential(cloud.UserPassAuthType, map[string]string{
 				"username": "admin",
 				"password": "adm1n",

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -15,6 +15,8 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
 	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 )
 
 type cloudSuite struct {
@@ -40,9 +42,9 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 		},
-		creds: map[string]cloud.Credential{
-			names.NewCloudCredentialTag("meep/bruce/one").Id(): cloud.NewEmptyCredential(),
-			names.NewCloudCredentialTag("meep/bruce/two").Id(): cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		creds: map[string]state.Credential{
+			names.NewCloudCredentialTag("meep/bruce/one").Id(): statetesting.CloudCredential(cloud.EmptyAuthType, nil),
+			names.NewCloudCredentialTag("meep/bruce/two").Id(): statetesting.CloudCredential(cloud.UserPassAuthType, map[string]string{
 				"username": "admin",
 				"password": "adm1n",
 			}),
@@ -331,7 +333,7 @@ func (s *cloudSuite) TestAddCredentialInV2(c *gc.C) {
 type mockBackend struct {
 	gitjujutesting.Stub
 	cloud cloud.Cloud
-	creds map[string]cloud.Credential
+	creds map[string]state.Credential
 }
 
 func (st *mockBackend) ControllerTag() names.ControllerTag {
@@ -358,7 +360,7 @@ func (st *mockBackend) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 	}, st.NextErr()
 }
 
-func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[string]cloud.Credential, error) {
+func (st *mockBackend) CloudCredentials(user names.UserTag, cloudName string) (map[string]state.Credential, error) {
 	st.MethodCall(st, "CloudCredentials", user, cloudName)
 	return st.creds, st.NextErr()
 }

--- a/apiserver/facades/client/cloud/instance_information_test.go
+++ b/apiserver/facades/client/cloud/instance_information_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/state"
 )
 
 type instanceTypesSuite struct{}
@@ -90,8 +91,8 @@ func (*mockBackend) ModelConfig() (*config.Config, error) {
 	return nil, nil
 }
 
-func (b *mockBackend) CloudCredential(tag names.CloudCredentialTag) (jujucloud.Credential, error) {
-	return jujucloud.Credential{}, nil
+func (b *mockBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+	return state.Credential{}, nil
 }
 
 type mockEnviron struct {

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
 )
 
 type instanceTypesSuite struct{}
@@ -102,8 +103,8 @@ func (b *mockBackend) Cloud(name string) (cloud.Cloud, error) {
 	return cloud.Cloud{}, nil
 }
 
-func (b *mockBackend) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
-	return cloud.Credential{}, nil
+func (b *mockBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+	return state.Credential{}, nil
 }
 
 type mockPool struct {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -346,8 +346,8 @@ func (st *mockState) Model() (machinemanager.Model, error) {
 	return &mockModel{}, nil
 }
 
-func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
-	return cloud.Credential{}, nil
+func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+	return state.Credential{}, nil
 }
 
 func (st *mockState) Cloud(string) (cloud.Cloud, error) {

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -551,7 +551,7 @@ type mockState struct {
 	model           *mockModel
 	controllerModel *mockModel
 	users           []permission.UserAccess
-	cred            cloud.Credential
+	cred            state.Credential
 	machines        []common.Machine
 	cfgDefaults     config.ModelDefaultAttributes
 	blockMsg        string
@@ -710,7 +710,7 @@ func (st *mockState) Cloud(name string) (cloud.Cloud, error) {
 	return st.cloud, st.NextErr()
 }
 
-func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
+func (st *mockState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
 	st.MethodCall(st, "CloudCredential", tag)
 	return st.cred, st.NextErr()
 }

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -395,7 +395,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 		if err != nil {
 			return result, errors.Annotate(err, "getting credential")
 		}
-		cloudCredential := jujucloud.CredentialFromProperties(
+		cloudCredential := jujucloud.NewNamedCredential(
 			credentialValue.Name,
 			jujucloud.AuthType(credentialValue.AuthType),
 			credentialValue.Attributes,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -395,7 +395,13 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 		if err != nil {
 			return result, errors.Annotate(err, "getting credential")
 		}
-		credential = &credentialValue
+		cloudCredential := jujucloud.CredentialFromProperties(
+			credentialValue.Name,
+			jujucloud.AuthType(credentialValue.AuthType),
+			credentialValue.Attributes,
+			credentialValue.Revoked,
+		)
+		credential = &cloudCredential
 	}
 
 	cloudSpec, err := environs.MakeCloudSpec(cloud, cloudRegionName, credential)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/juju/juju/provider/openstack"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -148,7 +149,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 						Value: "spam"}}},
 			},
 		},
-		cred: cloud.NewEmptyCredential(),
+		cred: statetesting.CloudCredential(cloud.EmptyAuthType, nil),
 		cfgDefaults: config.ModelDefaultAttributes{
 			"attr": config.AttributeDefaultValues{
 				Default:    "",
@@ -168,7 +169,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	s.ctlrSt = &mockState{
 		model:           controllerModel,
 		controllerModel: controllerModel,
-		cred:            cloud.NewEmptyCredential(),
+		cred:            statetesting.CloudCredential(cloud.EmptyAuthType, nil),
 		cloud:           dummyCloud,
 		clouds: map[names.CloudTag]cloud.Cloud{
 			names.NewCloudTag("some-cloud"): dummyCloud,
@@ -198,7 +199,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 				access:   permission.AdminAccess,
 			}},
 		},
-		cred:        cloud.NewEmptyCredential(),
+		cred:        statetesting.CloudCredential(cloud.EmptyAuthType, nil),
 		modelConfig: coretesting.ModelConfig(c),
 	}
 

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -149,7 +149,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 						Value: "spam"}}},
 			},
 		},
-		cred: statetesting.CloudCredential(cloud.EmptyAuthType, nil),
+		cred: statetesting.NewEmptyCredential(),
 		cfgDefaults: config.ModelDefaultAttributes{
 			"attr": config.AttributeDefaultValues{
 				Default:    "",
@@ -169,7 +169,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	s.ctlrSt = &mockState{
 		model:           controllerModel,
 		controllerModel: controllerModel,
-		cred:            statetesting.CloudCredential(cloud.EmptyAuthType, nil),
+		cred:            statetesting.NewEmptyCredential(),
 		cloud:           dummyCloud,
 		clouds: map[names.CloudTag]cloud.Cloud{
 			names.NewCloudTag("some-cloud"): dummyCloud,
@@ -199,7 +199,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 				access:   permission.AdminAccess,
 			}},
 		},
-		cred:        statetesting.CloudCredential(cloud.EmptyAuthType, nil),
+		cred:        statetesting.NewEmptyCredential(),
 		modelConfig: coretesting.ModelConfig(c),
 	}
 

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -87,6 +87,17 @@ func NewCredential(authType AuthType, attributes map[string]string) Credential {
 	return Credential{authType: authType, attributes: copyStringMap(attributes)}
 }
 
+// CredentialFromProperties returns an immutable, Credential with the supplied
+// name, auth-type, attributes and revoke flag.
+func CredentialFromProperties(name string, authType AuthType, attributes map[string]string, revoked bool) Credential {
+	return Credential{
+		Label:      name,
+		authType:   authType,
+		attributes: copyStringMap(attributes),
+		Revoked:    revoked,
+	}
+}
+
 // NewEmptyCredential returns a new Credential with the EmptyAuthType
 // auth-type.
 func NewEmptyCredential() Credential {

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -87,9 +87,8 @@ func NewCredential(authType AuthType, attributes map[string]string) Credential {
 	return Credential{authType: authType, attributes: copyStringMap(attributes)}
 }
 
-// CredentialFromProperties returns an immutable, Credential with the supplied
-// name, auth-type, attributes and revoke flag.
-func CredentialFromProperties(name string, authType AuthType, attributes map[string]string, revoked bool) Credential {
+// NewNamedCredential returns an immutable Credential with the supplied properties.
+func NewNamedCredential(name string, authType AuthType, attributes map[string]string, revoked bool) Credential {
 	return Credential{
 		Label:      name,
 		authType:   authType,

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/cloud"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
@@ -33,7 +32,7 @@ type PrecheckBackend interface {
 	AllApplications() ([]PrecheckApplication, error)
 	AllRelations() ([]PrecheckRelation, error)
 	ControllerBackend() (PrecheckBackend, error)
-	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
+	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
 	ListPendingResources(string) ([]resource.Resource, error)
 }
 

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/cloud"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/resource"
@@ -734,7 +733,7 @@ type fakeBackend struct {
 	relations  []migration.PrecheckRelation
 	allRelsErr error
 
-	credentials    cloud.Credential
+	credentials    state.Credential
 	credentialsErr error
 
 	pendingResources    []resource.Resource
@@ -767,7 +766,7 @@ func (b *fakeBackend) IsMigrationActive(string) (bool, error) {
 	return b.migrationActive, b.migrationActiveErr
 }
 
-func (b *fakeBackend) CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error) {
+func (b *fakeBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
 	return b.credentials, b.credentialsErr
 }
 

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -288,6 +288,9 @@ func (s *CloudCredentialsSuite) TestAllCloudCredentials(c *gc.C) {
 	_, one := s.createCloudCredential(c, "cirrus", "bob", "foobar")
 	_, two := s.createCloudCredential(c, "stratus", "bob", "foobar")
 
+	// Added to make sure it is not returned.
+	s.createCloudCredential(c, "cumulus", "mary", "foobar")
+
 	out, err := s.State.AllCloudCredentials(names.NewUserTag("bob"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, []state.Credential{one, two})

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -102,7 +102,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 
 	emptyCredential := cloud.NewEmptyCredential()
 	emptyCredential.Label = emptyCredentialTag.Name()
-	expectedEmptyCredential := statetesting.CloudCredential(cloud.EmptyAuthType, nil)
+	expectedEmptyCredential := statetesting.NewEmptyCredential()
 	expectedEmptyCredential.DocID = "dummy#initialize-admin#empty-credential"
 	expectedEmptyCredential.Owner = "initialize-admin"
 	expectedEmptyCredential.Cloud = "dummy"

--- a/state/interface.go
+++ b/state/interface.go
@@ -89,7 +89,7 @@ type AgentEntity interface {
 type CloudAccessor interface {
 	Cloud(cloud string) (cloud.Cloud, error)
 	Clouds() (map[names.CloudTag]cloud.Cloud, error)
-	CloudCredential(tag names.CloudCredentialTag) (cloud.Credential, error)
+	CloudCredential(tag names.CloudCredentialTag) (Credential, error)
 }
 
 // ModelAccessor defines the methods needed to watch for model

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -116,8 +116,8 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 			Owner:      credsTag.Owner(),
 			Cloud:      credsTag.Cloud(),
 			Name:       credsTag.Name(),
-			AuthType:   string(creds.AuthType()),
-			Attributes: creds.Attributes(),
+			AuthType:   creds.AuthType,
+			Attributes: creds.Attributes,
 		})
 	}
 	modelKey := dbModel.globalKey()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -111,11 +111,11 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 			return nil, nil, errors.Trace(err)
 		} else {
 			// ensure existing creds match
-			if string(existingCreds.AuthType()) != creds.AuthType() {
-				return nil, nil, errors.Errorf("credential auth type mismatch: %q != %q", existingCreds.AuthType(), creds.AuthType())
+			if existingCreds.AuthType != creds.AuthType() {
+				return nil, nil, errors.Errorf("credential auth type mismatch: %q != %q", existingCreds.AuthType, creds.AuthType())
 			}
-			if !reflect.DeepEqual(existingCreds.Attributes(), creds.Attributes()) {
-				return nil, nil, errors.Errorf("credential attribute mismatch: %v != %v", existingCreds.Attributes(), creds.Attributes())
+			if !reflect.DeepEqual(existingCreds.Attributes, creds.Attributes()) {
+				return nil, nil, errors.Errorf("credential attribute mismatch: %v != %v", existingCreds.Attributes, creds.Attributes())
 			}
 			if existingCreds.Revoked {
 				return nil, nil, errors.Errorf("credential %q is revoked", credID)

--- a/state/model.go
+++ b/state/model.go
@@ -356,9 +356,17 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	// specified, that the cloud supports the "empty" authentication
 	// type.
 	owner := args.Owner
-	cloudCredentials, err := st.CloudCredentials(owner, args.CloudName)
+	storedCredentials, err := st.CloudCredentials(owner, args.CloudName)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
+	}
+
+	cloudCredentials := make(map[string]jujucloud.Credential, len(storedCredentials))
+	for name, cred := range storedCredentials {
+		cloudCredentials[name] = jujucloud.CredentialFromProperties(cred.Name,
+			jujucloud.AuthType(cred.AuthType),
+			cred.Attributes,
+			cred.Revoked)
 	}
 	assertCloudCredentialOp, err := validateCloudCredential(
 		controllerCloud, cloudCredentials, args.CloudCredential,

--- a/state/model.go
+++ b/state/model.go
@@ -363,7 +363,7 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 
 	cloudCredentials := make(map[string]jujucloud.Credential, len(storedCredentials))
 	for name, cred := range storedCredentials {
-		cloudCredentials[name] = jujucloud.CredentialFromProperties(cred.Name,
+		cloudCredentials[name] = jujucloud.NewNamedCredential(cred.Name,
 			jujucloud.AuthType(cred.AuthType),
 			cred.Attributes,
 			cred.Revoked)

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -48,7 +48,7 @@ func CloudSpec(
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
-		cloudCredential := cloud.CredentialFromProperties(credentialValue.Name,
+		cloudCredential := cloud.NewNamedCredential(credentialValue.Name,
 			cloud.AuthType(credentialValue.AuthType),
 			credentialValue.Attributes,
 			credentialValue.Revoked,

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -48,7 +48,12 @@ func CloudSpec(
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
-		credential = &credentialValue
+		cloudCredential := cloud.CredentialFromProperties(credentialValue.Name,
+			cloud.AuthType(credentialValue.AuthType),
+			credentialValue.Attributes,
+			credentialValue.Revoked,
+		)
+		credential = &cloudCredential
 	}
 
 	return environs.MakeCloudSpec(modelCloud, regionName, credential)

--- a/state/testing/cloudcredentials.go
+++ b/state/testing/cloudcredentials.go
@@ -15,3 +15,11 @@ func CloudCredential(authType cloud.AuthType, attrs map[string]string) state.Cre
 	c.Attributes = attrs
 	return c
 }
+
+// NewEmptyCredential is a convenience method to create an empty state.Credential
+// with a cloud.EmptyAuthType as auth type to be used in unit tests.
+func NewEmptyCredential() state.Credential {
+	c := state.Credential{}
+	c.AuthType = string(cloud.EmptyAuthType)
+	return c
+}

--- a/state/testing/cloudcredentials.go
+++ b/state/testing/cloudcredentials.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+)
+
+// CloudCredential is a convenience method to create state.Credential to be used in unit tests.
+func CloudCredential(authType cloud.AuthType, attrs map[string]string) state.Credential {
+	c := state.Credential{}
+	c.AuthType = string(authType)
+	c.Attributes = attrs
+	return c
+}


### PR DESCRIPTION
## Description of change

There is a need for a credential owner to be able to view the content of their cloud credential(s) as it is stored on the controller.
A new command, 'show-credential' has been prototyped. It will allow users to view the contents of either:
* all their controller stored credentials; or
* all their controller stored credentials for a given cloud; or
* all their controller stored credential for concretely specified cloud and credential name.
Displayed output will also include models that use these listed credentials as well as what permission access the credential owner (i.e. currently logged on user) has on these models.
The output of the command will also be able to optionally show secrets.

Current implementation for reading cloud credential content is limited as it masks out secrets and is only suitable for non-owner views. This PR add the ability to view all cloud credential contents. It will be apiserver responsibility to ensure that only credential owners get the full content. That change will be proposed in a follow-up PR.

## Bug reference
This is part of the work to support improvements described in https://bugs.launchpad.net/juju/+bug/1735402
