### PR TITLE
Order-agnostic comparison in TestEnableHAControllerConfigConstraints

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -225,8 +225,8 @@ func (s *clientSuite) TestEnableHAControllerConfigConstraints(c *gc.C) {
 	c.Assert(machines, gc.HasLen, 3)
 	expectedCons := []constraints.Value{
 		controllerCons,
-		constraints.MustParse("spaces=random-space,ha-space"),
-		constraints.MustParse("spaces=random-space,ha-space"),
+		constraints.MustParse("spaces=ha-space,random-space"),
+		constraints.MustParse("spaces=ha-space,random-space"),
 	}
 	for i, m := range machines {
 		cons, err := m.Constraints()

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -585,9 +585,7 @@ func (s *BootstrapSuite) TestBootstrapAllSpacesAsConstraintsMerged(c *gc.C) {
 		"--constraints", "spaces=ha-space,random-space",
 	)
 
-	// Order is unimportant
 	got := *(bootstrap.args.BootstrapConstraints.Spaces)
-	sort.Strings(got)
 	c.Check(got, gc.DeepEquals, []string{"ha-space", "management-space", "random-space"})
 }
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -600,7 +600,7 @@ func (c Config) AsSpaceConstraints(spaces *[]string) *[]string {
 	if spaces == nil && len(newSpaces) == 0 {
 		return nil
 	}
-	ns := newSpaces.Values()
+	ns := newSpaces.SortedValues()
 	return &ns
 }
 

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -4,7 +4,6 @@
 package controller_test
 
 import (
-	"sort"
 	stdtesting "testing"
 	"time"
 
@@ -360,7 +359,6 @@ func (s *ConfigSuite) TestConfigAllSpacesAsMergedConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	got := *cfg.AsSpaceConstraints(&[]string{constraintSpace})
-	sort.Strings(got)
 	c.Check(got, gc.DeepEquals, []string{constraintSpace, haSpace, managementSpace})
 }
 


### PR DESCRIPTION
## Description of change

Fixes intermittent test failures due to ordering of space names inside constraints.Value instance.

## QA steps

Test consistently passes when run in a loop many times.

## Documentation changes

None.

## Bug reference

N/A
