### PR TITLE
Record k8s service info

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -200,3 +200,18 @@ func (c *Client) UpdateUnits(arg params.UpdateApplicationUnits) error {
 	}
 	return result.OneError()
 }
+
+// UpdateApplicationService updates the state model to reflect the state of the application's
+// service as reported by the cloud.
+func (c *Client) UpdateApplicationService(arg params.ApplicationServiceParams) error {
+	var result params.ErrorResults
+	args := params.UpdateApplicationServiceArgs{Args: []params.ApplicationServiceParams{arg}}
+	err := c.facade.FacadeCall("UpdateApplicationsService", args, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(result.Results) != len(args.Args) {
+		return errors.Errorf("expected %d result(s), got %d", len(args.Args), len(result.Results))
+	}
+	return result.OneError()
+}

--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -203,9 +203,9 @@ func (c *Client) UpdateUnits(arg params.UpdateApplicationUnits) error {
 
 // UpdateApplicationService updates the state model to reflect the state of the application's
 // service as reported by the cloud.
-func (c *Client) UpdateApplicationService(arg params.ApplicationServiceParams) error {
+func (c *Client) UpdateApplicationService(arg params.UpdateApplicationServiceArg) error {
 	var result params.ErrorResults
-	args := params.UpdateApplicationServiceArgs{Args: []params.ApplicationServiceParams{arg}}
+	args := params.UpdateApplicationServiceArgs{Args: []params.UpdateApplicationServiceArg{arg}}
 	err := c.facade.FacadeCall("UpdateApplicationsService", args, &result)
 	if err != nil {
 		return errors.Trace(err)

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -284,3 +284,52 @@ func (s *unitprovisionerSuite) TestUpdateUnitsCount(c *gc.C) {
 	})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
+
+func (s *unitprovisionerSuite) TestUpdateApplicationService(c *gc.C) {
+	var called bool
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		called = true
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "UpdateApplicationsService")
+		c.Assert(a, jc.DeepEquals, params.UpdateApplicationServiceArgs{
+			Args: []params.ApplicationServiceParams{
+				{
+					ApplicationTag: "application-app",
+					ProviderId:     "id",
+					Addresses:      []params.Address{{Value: "10.0.0.1"}},
+				},
+			},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{}},
+		}
+		return nil
+	})
+	err := client.UpdateApplicationService(params.ApplicationServiceParams{
+		ApplicationTag: names.NewApplicationTag("app").String(),
+		ProviderId:     "id",
+		Addresses:      []params.Address{{Value: "10.0.0.1"}},
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, jc.IsTrue)
+}
+
+func (s *unitprovisionerSuite) TestUpdateApplicationServiceCount(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	err := client.UpdateApplicationService(params.ApplicationServiceParams{
+		ApplicationTag: names.NewApplicationTag("app").String(),
+		ProviderId:     "id",
+		Addresses:      []params.Address{{Value: "10.0.0.1"}},
+	})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
+}

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -293,7 +293,7 @@ func (s *unitprovisionerSuite) TestUpdateApplicationService(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "UpdateApplicationsService")
 		c.Assert(a, jc.DeepEquals, params.UpdateApplicationServiceArgs{
-			Args: []params.ApplicationServiceParams{
+			Args: []params.UpdateApplicationServiceArg{
 				{
 					ApplicationTag: "application-app",
 					ProviderId:     "id",
@@ -307,7 +307,7 @@ func (s *unitprovisionerSuite) TestUpdateApplicationService(c *gc.C) {
 		}
 		return nil
 	})
-	err := client.UpdateApplicationService(params.ApplicationServiceParams{
+	err := client.UpdateApplicationService(params.UpdateApplicationServiceArg{
 		ApplicationTag: names.NewApplicationTag("app").String(),
 		ProviderId:     "id",
 		Addresses:      []params.Address{{Value: "10.0.0.1"}},
@@ -326,7 +326,7 @@ func (s *unitprovisionerSuite) TestUpdateApplicationServiceCount(c *gc.C) {
 		}
 		return nil
 	})
-	err := client.UpdateApplicationService(params.ApplicationServiceParams{
+	err := client.UpdateApplicationService(params.UpdateApplicationServiceArg{
 		ApplicationTag: names.NewApplicationTag("app").String(),
 		ProviderId:     "id",
 		Addresses:      []params.Address{{Value: "10.0.0.1"}},

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
@@ -85,9 +86,11 @@ type mockApplication struct {
 	life         state.Life
 	unitsWatcher *statetesting.MockStringsWatcher
 
-	tag   names.Tag
-	units []caasunitprovisioner.Unit
-	ops   *state.UpdateUnitsOperation
+	tag        names.Tag
+	units      []caasunitprovisioner.Unit
+	ops        *state.UpdateUnitsOperation
+	providerId string
+	addresses  []network.Address
 }
 
 func (*mockApplication) Tag() names.Tag {
@@ -115,6 +118,12 @@ func (m *mockApplication) AllUnits() (units []caasunitprovisioner.Unit, err erro
 
 func (m *mockApplication) UpdateUnits(ops *state.UpdateUnitsOperation) error {
 	m.ops = ops
+	return nil
+}
+
+func (m *mockApplication) UpdateCloudService(providerId string, addreses []network.Address) error {
+	m.providerId = providerId
+	m.addresses = addreses
 	return nil
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
@@ -296,4 +297,21 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithTags(c *gc.C) {
 		ProviderId: strPtr(""),
 		UnitStatus: &status.StatusInfo{Status: status.Terminated, Message: "unit stopped by the cloud"},
 	})
+}
+
+func (s *CAASProvisionerSuite) TestUpdateApplicationsService(c *gc.C) {
+	results, err := s.facade.UpdateApplicationsService(params.UpdateApplicationServiceArgs{
+		Args: []params.ApplicationServiceParams{
+			{ApplicationTag: "application-gitlab", ProviderId: "id", Addresses: []params.Address{{Value: "10.0.0.1"}}},
+			{ApplicationTag: "unit-gitlab-0"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	c.Assert(results.Results[1].Error, jc.DeepEquals, &params.Error{
+		Message: `"unit-gitlab-0" is not a valid application tag`,
+	})
+	c.Assert(s.st.application.providerId, gc.Equals, "id")
+	c.Assert(s.st.application.addresses, jc.DeepEquals, []network.Address{{Value: "10.0.0.1"}})
 }

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -301,7 +301,7 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithTags(c *gc.C) {
 
 func (s *CAASProvisionerSuite) TestUpdateApplicationsService(c *gc.C) {
 	results, err := s.facade.UpdateApplicationsService(params.UpdateApplicationServiceArgs{
-		Args: []params.ApplicationServiceParams{
+		Args: []params.UpdateApplicationServiceArg{
 			{ApplicationTag: "application-gitlab", ProviderId: "id", Addresses: []params.Address{{Value: "10.0.0.1"}}},
 			{ApplicationTag: "unit-gitlab-0"},
 		},

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 )
@@ -36,6 +37,7 @@ type Application interface {
 	AllUnits() (units []Unit, err error)
 	AddOperation(state.UnitUpdateProperties) *state.AddUnitOperation
 	UpdateUnits(*state.UpdateUnitsOperation) error
+	UpdateCloudService(providerId string, addreses []network.Address) error
 }
 
 type stateShim struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -498,6 +498,20 @@ type ApplicationUnitParams struct {
 	Data       map[string]interface{} `json:"data"`
 }
 
+// UpdateApplicationServiceArgs holds the parameters for
+// updating application services.
+type UpdateApplicationServiceArgs struct {
+	Args []ApplicationServiceParams `json:"args"`
+}
+
+// ApplicationServiceParams holds parameters used to update
+// an application's service definition for the cloud.
+type ApplicationServiceParams struct {
+	ApplicationTag string    `json:"application-tag"`
+	ProviderId     string    `json:"provider-id"`
+	Addresses      []Address `json:"addresses"`
+}
+
 // DestroyApplicationUnits holds parameters for the deprecated
 // Application.DestroyUnits call.
 type DestroyApplicationUnits struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -501,12 +501,12 @@ type ApplicationUnitParams struct {
 // UpdateApplicationServiceArgs holds the parameters for
 // updating application services.
 type UpdateApplicationServiceArgs struct {
-	Args []ApplicationServiceParams `json:"args"`
+	Args []UpdateApplicationServiceArg `json:"args"`
 }
 
-// ApplicationServiceParams holds parameters used to update
+// UpdateApplicationServiceArg holds parameters used to update
 // an application's service definition for the cloud.
-type ApplicationServiceParams struct {
+type UpdateApplicationServiceArg struct {
 	ApplicationTag string    `json:"application-tag"`
 	ProviderId     string    `json:"provider-id"`
 	Addresses      []Address `json:"addresses"`

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -6,6 +6,7 @@ package caas
 import (
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
@@ -21,6 +22,9 @@ type Broker interface {
 
 	// EnsureService creates or updates a service for pods with the given spec.
 	EnsureService(appName string, spec *ContainerSpec, numUnits int, config application.ConfigAttributes) error
+
+	// Service returns the service for the specified application.
+	Service(appName string) (*Service, error)
 
 	// DeleteService deletes the specified service.
 	DeleteService(appName string) error
@@ -43,6 +47,12 @@ type Broker interface {
 
 	// Units returns all units of the specified application.
 	Units(appName string) ([]Unit, error)
+}
+
+// Service represents information about the status of a caas service entity.
+type Service struct {
+	Id        string
+	Addresses []network.Address
 }
 
 // Unit represents information about the status of a "pod".

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -463,9 +463,13 @@ func allCollections() collectionSchema {
 		// for applications and units.
 		containerSpecsC: {},
 
-		// cloudContainersC holds the CAAS container (pod) information,
+		// cloudContainersC holds the CAAS container (pod) information
 		// for units, eg address, ports.
 		cloudContainersC: {},
+
+		// cloudServicesC holds the CAAS service information
+		// eg addresses.
+		cloudServicesC: {},
 
 		// ----------------------
 
@@ -496,7 +500,8 @@ const (
 	cleanupsC                = "cleanups"
 	cloudimagemetadataC      = "cloudimagemetadata"
 	cloudsC                  = "clouds"
-	cloudContainersC         = "containers"
+	cloudContainersC         = "cloudcontainers"
+	cloudServicesC           = "cloudservices"
 	cloudCredentialsC        = "cloudCredentials"
 	constraintsC             = "constraints"
 	containerRefsC           = "containerRefs"

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3469,14 +3469,29 @@ func (s *CAASApplicationSuite) TestAddUnitWithProviderId(c *gc.C) {
 }
 
 func (s *CAASApplicationSuite) TestServiceInfo(c *gc.C) {
-	err := s.app.UpdateCloudService("id", []network.Address{{Value: "10.0.0.1"}})
-	c.Assert(err, jc.ErrorIsNil)
-	app, err := s.caasSt.Application(s.app.Name())
-	c.Assert(err, jc.ErrorIsNil)
-	info, err := app.ServiceInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.ProviderId(), gc.Equals, "id")
-	c.Assert(info.Addresses(), jc.DeepEquals, []network.Address{{Value: "10.0.0.1"}})
+	for i := 0; i < 2; i++ {
+		err := s.app.UpdateCloudService("id", []network.Address{{Value: "10.0.0.1"}})
+		c.Assert(err, jc.ErrorIsNil)
+		app, err := s.caasSt.Application(s.app.Name())
+		c.Assert(err, jc.ErrorIsNil)
+		info, err := app.ServiceInfo()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.ProviderId(), gc.Equals, "id")
+		c.Assert(info.Addresses(), jc.DeepEquals, []network.Address{{Value: "10.0.0.1"}})
+	}
+}
+
+func (s *CAASApplicationSuite) TestServiceInfoEmptyProviderId(c *gc.C) {
+	for i := 0; i < 2; i++ {
+		err := s.app.UpdateCloudService("", []network.Address{{Value: "10.0.0.1"}})
+		c.Assert(err, jc.ErrorIsNil)
+		app, err := s.caasSt.Application(s.app.Name())
+		c.Assert(err, jc.ErrorIsNil)
+		info, err := app.ServiceInfo()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.ProviderId(), gc.Equals, "")
+		c.Assert(info.Addresses(), jc.DeepEquals, []network.Address{{Value: "10.0.0.1"}})
+	}
 }
 
 func (s *CAASApplicationSuite) TestRemoveUnitDeletesServiceInfo(c *gc.C) {

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -92,7 +92,8 @@ func (u *Unit) saveContainerOps(doc cloudContainerDoc) ([]txn.Op, error) {
 	if existing.ProviderId != "" {
 		asserts = bson.D{providerValueAssert}
 	} else {
-		asserts = bson.D{{"$or", []bson.D{{providerValueAssert}, {{"$exists", false}}}}}
+		asserts = bson.D{{"$or",
+			[]bson.D{{providerValueAssert}, {{"provider-id", bson.D{{"$exists", false}}}}}}}
 	}
 	return []txn.Op{{
 		C:      cloudContainersC,

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -1,0 +1,109 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/network"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// CloudService represents the state of a CAAS service.
+type CloudService interface {
+	// ProviderId returns the id assigned to the service
+	// by the cloud.
+	ProviderId() string
+
+	// Addresses returns the service addresses.
+	Addresses() []network.Address
+}
+
+// cloudService is an implementation of CloudService.
+type cloudService struct {
+	doc cloudServiceDoc
+}
+
+type cloudServiceDoc struct {
+	// Id holds cloud service document key.
+	// It is the global key of the application represented
+	// by this service.
+	Id string `bson:"_id"`
+
+	ProviderId string    `bson:"provider-id"`
+	Addresses  []address `bson:"addresses"`
+}
+
+// Id implements CloudService.
+func (c *cloudService) Id() string {
+	return c.doc.Id
+}
+
+// ProviderId implements CloudService.
+func (c *cloudService) ProviderId() string {
+	return c.doc.ProviderId
+}
+
+// Address implements CloudService.
+func (c *cloudService) Addresses() []network.Address {
+	return networkAddresses(c.doc.Addresses)
+}
+
+func (a *Application) cloudService() (*cloudServiceDoc, error) {
+	coll, closer := a.st.db().GetCollection(cloudServicesC)
+	defer closer()
+
+	var doc cloudServiceDoc
+	err := coll.FindId(a.globalKey()).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("cloud service for unit %v", a.Name())
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &doc, nil
+}
+
+func (a *Application) saveServiceOps(doc cloudServiceDoc) ([]txn.Op, error) {
+	existing, err := a.cloudService()
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	if err != nil {
+		return []txn.Op{{
+			C:      cloudServicesC,
+			Id:     doc.Id,
+			Assert: txn.DocMissing,
+			Insert: doc,
+		}}, nil
+	}
+	var asserts bson.D
+	providerValueAssert := bson.DocElem{"provider-id", existing.ProviderId}
+	if existing.ProviderId != "" {
+		asserts = bson.D{providerValueAssert}
+	} else {
+		asserts = bson.D{{"$or", []bson.D{{providerValueAssert}, {{"$exists", false}}}}}
+	}
+	return []txn.Op{{
+		C:      cloudServicesC,
+		Id:     existing.Id,
+		Assert: asserts,
+		Update: bson.D{
+			{"$set",
+				bson.D{{"provider-id", doc.ProviderId},
+					{"addresses", doc.Addresses}},
+			},
+		},
+	}}, nil
+}
+
+func (a *Application) removeCloudServiceOps() []txn.Op {
+	ops := []txn.Op{{
+		C:      cloudServicesC,
+		Id:     a.globalKey(),
+		Remove: true,
+	}}
+	return ops
+}

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -84,7 +84,8 @@ func (a *Application) saveServiceOps(doc cloudServiceDoc) ([]txn.Op, error) {
 	if existing.ProviderId != "" {
 		asserts = bson.D{providerValueAssert}
 	} else {
-		asserts = bson.D{{"$or", []bson.D{{providerValueAssert}, {{"$exists", false}}}}}
+		asserts = bson.D{{"$or",
+			[]bson.D{{providerValueAssert}, {{"provider-id", bson.D{{"$exists", false}}}}}}}
 	}
 	return []txn.Op{{
 		C:      cloudServicesC,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -199,6 +199,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// TODO(caas)
 		containerSpecsC,
 		cloudContainersC,
+		cloudServicesC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1989,6 +1989,26 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitProviderId(c *gc.C) {
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
+func (s *CAASUnitSuite) TestAddCAASUnitProviderId(c *gc.C) {
+	existingUnit, err := s.application.AddUnit(state.AddUnitParams{
+		Address: strPtr("192.168.1.1"),
+		Ports:   &[]string{"80"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	var updateUnits state.UpdateUnitsOperation
+	updateUnits.Updates = []*state.UpdateUnitOperation{
+		existingUnit.UpdateOperation(state.UnitUpdateProperties{
+			ProviderId: strPtr("another-uuid"),
+		})}
+	err = s.application.UpdateUnits(&updateUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := existingUnit.ContainerInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
+	c.Assert(info.Address(), gc.Equals, "192.168.1.1")
+	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
+}
+
 func (s *CAASUnitSuite) TestUpdateCAASUnitAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{
 		ProviderId: strPtr("unit-uuid"),

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -27,6 +27,7 @@ type applicationWorker struct {
 	containerSpecGetter ContainerSpecGetter
 	lifeGetter          LifeGetter
 	applicationGetter   ApplicationGetter
+	applicationUpdater  ApplicationUpdater
 	unitGetter          UnitGetter
 	unitUpdater         UnitUpdater
 
@@ -41,6 +42,7 @@ func newApplicationWorker(
 	containerSpecGetter ContainerSpecGetter,
 	lifeGetter LifeGetter,
 	applicationGetter ApplicationGetter,
+	applicationUpdater ApplicationUpdater,
 	unitGetter UnitGetter,
 	unitUpdater UnitUpdater,
 ) (worker.Worker, error) {
@@ -52,6 +54,7 @@ func newApplicationWorker(
 		containerSpecGetter: containerSpecGetter,
 		lifeGetter:          lifeGetter,
 		applicationGetter:   applicationGetter,
+		applicationUpdater:  applicationUpdater,
 		unitGetter:          unitGetter,
 		unitUpdater:         unitUpdater,
 		aliveUnitsChan:      make(chan []string),
@@ -96,6 +99,7 @@ func (aw *applicationWorker) loop() error {
 		aw.serviceBroker,
 		aw.containerSpecGetter,
 		aw.applicationGetter,
+		aw.applicationUpdater,
 		aw.aliveUnitsChan)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -18,5 +18,6 @@ type ContainerBroker interface {
 
 type ServiceBroker interface {
 	EnsureService(appName string, unitSpec *caas.ContainerSpec, numUnits int, config application.ConfigAttributes) error
+	Service(appName string) (*caas.Service, error)
 	DeleteService(appName string) error
 }

--- a/worker/caasunitprovisioner/client.go
+++ b/worker/caasunitprovisioner/client.go
@@ -15,6 +15,7 @@ import (
 // to the CAASUnitProvisioner worker.
 type Client interface {
 	ApplicationGetter
+	ApplicationUpdater
 	ContainerSpecGetter
 	LifeGetter
 	UnitGetter
@@ -28,6 +29,12 @@ type Client interface {
 type ApplicationGetter interface {
 	WatchApplications() (watcher.StringsWatcher, error)
 	ApplicationConfig(string) (application.ConfigAttributes, error)
+}
+
+// ApplicationUpdater provides an interface for updating
+// Juju applications from changes in the cloud.
+type ApplicationUpdater interface {
+	UpdateApplicationService(arg params.UpdateApplicationServiceArg) error
 }
 
 // ContainerSpecGetter provides an interface for

--- a/worker/caasunitprovisioner/manifold.go
+++ b/worker/caasunitprovisioner/manifold.go
@@ -55,7 +55,8 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	client := config.NewClient(apiCaller)
 	w, err := config.NewWorker(Config{
-		ApplicationGetter: client,
+		ApplicationGetter:  client,
+		ApplicationUpdater: client,
 
 		// TODO(caas) - get this based on the CAAS substrate
 		BrokerManagedUnits: false,

--- a/worker/caasunitprovisioner/manifold_test.go
+++ b/worker/caasunitprovisioner/manifold_test.go
@@ -129,6 +129,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(config, jc.DeepEquals, caasunitprovisioner.Config{
 		BrokerManagedUnits:  false,
 		ApplicationGetter:   &s.client,
+		ApplicationUpdater:  &s.client,
 		ServiceBroker:       &s.broker,
 		ContainerBroker:     &s.broker,
 		ContainerSpecGetter: &s.client,

--- a/worker/caasunitprovisioner/worker.go
+++ b/worker/caasunitprovisioner/worker.go
@@ -20,8 +20,9 @@ type Config struct {
 	// required number of units are running, rather than Juju having to do it.
 	BrokerManagedUnits bool
 
-	ApplicationGetter ApplicationGetter
-	ServiceBroker     ServiceBroker
+	ApplicationGetter  ApplicationGetter
+	ApplicationUpdater ApplicationUpdater
+	ServiceBroker      ServiceBroker
 
 	ContainerBroker     ContainerBroker
 	ContainerSpecGetter ContainerSpecGetter
@@ -34,6 +35,9 @@ type Config struct {
 func (config Config) Validate() error {
 	if config.ApplicationGetter == nil {
 		return errors.NotValidf("missing ApplicationGetter")
+	}
+	if config.ApplicationUpdater == nil {
+		return errors.NotValidf("missing ApplicationUpdater")
 	}
 	if config.ServiceBroker == nil {
 		return errors.NotValidf("missing ServiceBroker")
@@ -130,6 +134,7 @@ func (p *provisioner) loop() error {
 					p.config.ContainerSpecGetter,
 					p.config.LifeGetter,
 					p.config.ApplicationGetter,
+					p.config.ApplicationUpdater,
 					p.config.UnitGetter,
 					p.config.UnitUpdater,
 				)


### PR DESCRIPTION
## Description of change

When a k8s charm is deployed, a k8s service is created.
We record the details of that service against the application in state, so that the addresses can be used when the charm asks for network info.

Commit 1 is the state artefacts.
Commit 2 is the api layers
Commit 3 is the caas unit provisioner worker

## QA steps

Run up a caas model, deploy a charm, check mongo to ensure service details are stored.

