### PR TITLE
2.3 peergrouper test 1748385

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -270,8 +270,6 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 // address by selecting it from the given addresses. If no addresses are
 // available an empty string is returned.
 func SelectPeerAddress(addrs []network.Address) string {
-	logger.Debugf("selecting mongo peer address from %+v", addrs)
-
 	// ScopeMachineLocal addresses are never suitable for mongo peers,
 	// as each controller runs on a separate machine.
 	const allowMachineLocal = false
@@ -285,8 +283,6 @@ func SelectPeerAddress(addrs []network.Address) string {
 // SelectPeerHostPort returns the HostPort to use as the mongo replica set peer
 // by selecting it from the given hostPorts.
 func SelectPeerHostPort(hostPorts []network.HostPort) string {
-	logger.Debugf("selecting mongo peer hostPort by scope from %+v", hostPorts)
-
 	// ScopeMachineLocal addresses are never suitable for mongo peers,
 	// as each controller runs on a separate machine.
 	const allowMachineLocal = false
@@ -297,7 +293,6 @@ func SelectPeerHostPort(hostPorts []network.HostPort) string {
 // SelectPeerHostPortBySpace returns the HostPort to use as the mongo replica set peer
 // by selecting it from the given hostPorts.
 func SelectPeerHostPortBySpace(hostPorts []network.HostPort, space network.SpaceName) string {
-	logger.Debugf("selecting mongo peer hostPort in space %s from %+v", space, hostPorts)
 	// ScopeMachineLocal addresses are OK if we can't pick by space.
 	suitableHostPorts, foundHostPortsInSpaces := network.SelectMongoHostPortsBySpaces(hostPorts, []network.SpaceName{space})
 

--- a/network/address.go
+++ b/network/address.go
@@ -340,12 +340,6 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 // selection, otherwise just ScopeCloudLocal are.
 func SelectMongoHostPortsBySpaces(hostPorts []HostPort, spaces []SpaceName) ([]string, bool) {
 	filteredHostPorts, ok := SelectHostsPortBySpaces(hostPorts, spaces...)
-	if ok {
-		logger.Debugf(
-			"selected %q as controller host:port, using spaces %q",
-			filteredHostPorts, spaces,
-		)
-	}
 	return HostPortsToStrings(filteredHostPorts), ok
 }
 
@@ -367,10 +361,6 @@ func SelectMongoHostPortsByScope(hostPorts []HostPort, machineLocal bool) []stri
 	// Fallback to using the legacy and error-prone approach using scope
 	// selection instead.
 	internalHP := SelectInternalHostPort(hostPorts, machineLocal)
-	logger.Debugf(
-		"selected %q as controller host:port, using scope selection",
-		internalHP,
-	)
 	return []string{internalHP}
 }
 

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -6,6 +6,7 @@ package peergrouper
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/juju/replicaset"
 
@@ -35,18 +36,19 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTra
 	}
 	changed := false
 	members, extra, maxId := info.membersMap()
-	line := fmt.Sprintf("calculating desired peer group\ndesired voting members: (maxId: %d)", maxId)
+	lines := make([]string, 0)
+	lines = append(lines, fmt.Sprintf("calculated desired peer group\ndesired voting members: (maxId: %d)", maxId))
 	for tracker, replMem := range members {
-		line = fmt.Sprintf("%s\n   %#v: rs_id=%d, rs_addr=%s", line, tracker, replMem.Id, replMem.Address)
+		lines = append(lines, fmt.Sprintf("\n   %#v: rs_id=%d, rs_addr=%s", tracker, replMem.Id, replMem.Address))
 	}
 	if len(extra) > 0 {
-		line = line + "\nother members:"
+		lines = append(lines, "\nother members:")
 		for _, replMem := range extra {
 			vote := (replMem.Votes != nil && *replMem.Votes > 0)
-			line = fmt.Sprintf("%s\n   rs_id=%d, rs_addr=%s, tags=%v, vote=%t", line, replMem.Id, replMem.Address, replMem.Tags, vote)
+			lines = append(lines, fmt.Sprintf("\n   rs_id=%d, rs_addr=%s, tags=%v, vote=%t", replMem.Id, replMem.Address, replMem.Tags, vote))
 		}
 	}
-	logger.Debugf(line)
+	logger.Debugf(strings.Join(lines, ""))
 
 	// We may find extra peer group members if the machines
 	// have been removed or their controller status removed.

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -59,6 +59,8 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTra
 	// TODO There are some other possibilities
 	// for what to do in that case.
 	// 1) leave them untouched, but deal
+	// with others as usual "i didn't see that bit"
+	// 2) leave them untouched, deal with others,
 	// but make sure the extras aren't eligible to
 	// be primary.
 	// 3) remove them "get rid of bad rubbish"

--- a/worker/peergrouper/machinetracker.go
+++ b/worker/peergrouper/machinetracker.go
@@ -101,9 +101,13 @@ func (m *machineTracker) SelectMongoHostPort(mongoSpace network.SpaceName) strin
 	defer m.mu.Unlock()
 
 	if mongoSpace != "" {
-		return mongo.SelectPeerHostPortBySpace(m.mongoHostPorts, mongoSpace)
+		addr := mongo.SelectPeerHostPortBySpace(m.mongoHostPorts, mongoSpace)
+		logger.Debugf("machine %q selected address %q by space %q from %v", m.id, addr, mongoSpace, m.mongoHostPorts)
+		return addr
 	}
-	return mongo.SelectPeerHostPort(m.mongoHostPorts)
+	addr := mongo.SelectPeerHostPort(m.mongoHostPorts)
+	logger.Debugf("machine %q selected address %q by scope from %v", m.id, addr, m.mongoHostPorts)
+	return addr
 }
 
 func (m *machineTracker) String() string {

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -18,7 +18,6 @@ import (
 	worker "gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v1"
 
-	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -238,12 +237,7 @@ func (st *fakeState) WatchControllerStatusChanges() state.StringsWatcher {
 }
 
 func (st *fakeState) Space(name string) (SpaceReader, error) {
-	foo := []networkingcommon.BackingSpace{
-		&testing.FakeSpace{SpaceName: "Space" + name},
-		&testing.FakeSpace{SpaceName: "Space" + name},
-		&testing.FakeSpace{SpaceName: "Space" + name},
-	}
-	return foo[0].(SpaceReader), nil
+	return &testing.FakeSpace{SpaceName: "Space" + name}, nil
 }
 
 func (st *fakeState) SetOrGetMongoSpaceName(mongoSpaceName network.SpaceName) (network.SpaceName, error) {

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -137,194 +137,204 @@ func (s *workerSuite) waitAdvance(c *gc.C, d time.Duration) {
 	s.clock.Advance(d)
 }
 
-func (s *workerSuite) TestSetsAndUpdatesMembers(c *gc.C) {
-	logger.SetLogLevel(loggo.TRACE)
-	loggo.GetLogger("juju.mongo").SetLogLevel(loggo.INFO)
-	loggo.GetLogger("juju.network").SetLogLevel(loggo.INFO)
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		c.Logf("\n\nTestSetsAndUpdatesMembers: %s", ipVersion.version)
-		st := NewFakeState()
-		InitState(c, st, 3, ipVersion)
-		memberWatcher := st.session.members.Watch()
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0v", ipVersion))
-
-		logger.Infof("starting worker")
-		s.newNoPublishWorker(c, st)
-		// Due to the inherit complexity of the multiple goroutines running
-		// and listen do different watchers, there is no way to manually
-		// advance the testing clock in a controlled manner as the clock.After
-		// calls can be replaced in response to other watcher events. Hence
-		// using the standard testing clock wait / advance method does not
-		// work. So we use the real clock to advance the test clock for this
-		// test.
-		done := make(chan struct{})
-		clockAdvancerFinished := make(chan struct{})
-		defer func() {
-			close(done)
-			select {
-			case <-clockAdvancerFinished:
-				return
-			case <-time.After(coretesting.LongWait):
-				c.Error("advancing goroutine didn't finish")
-			}
-		}()
-		go func() {
-			defer close(clockAdvancerFinished)
-			for {
-				select {
-				case <-time.After(5 * time.Millisecond):
-					s.clock.Advance(pollInterval)
-				case <-done:
-					return
-				}
-			}
-		}()
-
-		// Wait for the worker to set the initial members.
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0v 1 2", ipVersion))
-
-		// Update the status of the new members
-		// and check that they become voting.
-		c.Logf("\nupdating new member status")
-		st.session.setStatus(mkStatuses("0p 1s 2s", ipVersion))
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v", ipVersion))
-
-		c.Logf("\nadding another machine")
-		m13 := st.addMachine("13", false)
-		m13.setStateHostPort(fmt.Sprintf(ipVersion.formatHostPort, 13, mongoPort))
-		st.setControllers("10", "11", "12", "13")
-
-		c.Logf("\nwaiting for new member to be added")
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v 3", ipVersion))
-
-		// Remove vote from an existing member; and give it to the new
-		// machine. Also set the status of the new machine to healthy.
-		c.Logf("\nremoving vote from machine 10 and adding it to machine 13")
-		st.machine("10").setWantsVote(false)
-		st.machine("13").setWantsVote(true)
-
-		st.session.setStatus(mkStatuses("0p 1s 2s 3s", ipVersion))
-
-		// Check that the new machine gets the vote and the
-		// old machine loses it.
-		c.Logf("\nwaiting for vote switch")
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0 1v 2v 3v", ipVersion))
-
-		c.Logf("\nremoving old machine")
-		// Remove the old machine.
-		st.removeMachine("10")
-		st.setControllers("11", "12", "13")
-
-		// Check that it's removed from the members.
-		c.Logf("\nwaiting for removal")
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("1v 2v 3v", ipVersion))
-	})
+func (s *workerSuite) TestSetsAndUpdatesMembersIPv4(c *gc.C) {
+	s.dotestSetAndUpdateMembers(c, testIPv4)
 }
 
-func (s *workerSuite) TestHasVoteMaintainedEvenWhenReplicaSetFails(c *gc.C) {
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st := NewFakeState()
+func (s *workerSuite) TestSetsAndUpdatesMembersIPv6(c *gc.C) {
+	s.dotestSetAndUpdateMembers(c, testIPv6)
+}
 
-		// Simulate a state where we have four controllers,
-		// one has gone down, and we're replacing it:
-		// 0 - hasvote true, wantsvote false, down
-		// 1 - hasvote true, wantsvote true
-		// 2 - hasvote true, wantsvote true
-		// 3 - hasvote false, wantsvote true
-		//
-		// When it starts, the worker should move the vote from
-		// 0 to 3. We'll arrange things so that it will succeed in
-		// setting the membership but fail setting the HasVote
-		// to false.
-		InitState(c, st, 4, ipVersion)
-		st.machine("10").SetHasVote(true)
-		st.machine("11").SetHasVote(true)
-		st.machine("12").SetHasVote(true)
-		st.machine("13").SetHasVote(false)
+func (s *workerSuite) dotestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion) {
+	c.Logf("\n\nTestSetsAndUpdatesMembers: %s", ipVersion.version)
+	st := NewFakeState()
+	InitState(c, st, 3, ipVersion)
+	memberWatcher := st.session.members.Watch()
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0v", ipVersion))
 
-		st.machine("10").setWantsVote(false)
-		st.machine("11").setWantsVote(true)
-		st.machine("12").setWantsVote(true)
-		st.machine("13").setWantsVote(true)
-
-		st.session.Set(mkMembers("0v 1v 2v 3", ipVersion))
-		st.session.setStatus(mkStatuses("0H 1p 2s 3s", ipVersion))
-
-		// Make the worker fail to set HasVote to false
-		// after changing the replica set membership.
-		st.errors.setErrorFor("Machine.SetHasVote * false", errors.New("frood"))
-
-		memberWatcher := st.session.members.Watch()
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v 3", ipVersion))
-
-		w, err := newNoPublishWorker(st, s.clock, &noOpHub{})
-		c.Assert(err, jc.ErrorIsNil)
-		done := make(chan error)
-		go func() {
-			done <- w.Wait()
-		}()
-
-		// Wait for the worker to set the initial members.
-		mustNext(c, memberWatcher)
-		assertMembers(c, memberWatcher.Value(), mkMembers("0 1v 2v 3v", ipVersion))
-
-		// The worker should encounter an error setting the
-		// has-vote status to false and exit.
+	logger.Infof("starting worker")
+	s.newNoPublishWorker(c, st)
+	// Due to the inherit complexity of the multiple goroutines running
+	// and listen do different watchers, there is no way to manually
+	// advance the testing clock in a controlled manner as the clock.After
+	// calls can be replaced in response to other watcher events. Hence
+	// using the standard testing clock wait / advance method does not
+	// work. So we use the real clock to advance the test clock for this
+	// test.
+	done := make(chan struct{})
+	clockAdvancerFinished := make(chan struct{})
+	defer func() {
+		close(done)
 		select {
-		case err := <-done:
-			c.Assert(err, gc.ErrorMatches, `cannot set HasVote removed: cannot set voting status of "[0-9]+" to false: frood`)
+		case <-clockAdvancerFinished:
+			return
 		case <-time.After(coretesting.LongWait):
-			c.Fatalf("timed out waiting for worker to exit")
+			c.Error("advancing goroutine didn't finish")
 		}
-
-		// Start the worker again - although the membership should
-		// not change, the HasVote status should be updated correctly.
-		st.errors.resetErrors()
-		w = s.newNoPublishWorker(c, st)
-
-		// Watch all the machines for changes, so we can check
-		// their has-vote status without polling.
-		changed := make(chan struct{}, 1)
-		for i := 10; i < 14; i++ {
-			watcher := st.machine(fmt.Sprint(i)).val.Watch()
-			defer watcher.Close()
-			go func() {
-				for watcher.Next() {
-					select {
-					case changed <- struct{}{}:
-					default:
-					}
-				}
-			}()
-		}
-		timeout := time.After(coretesting.LongWait)
-	loop:
+	}()
+	go func() {
+		defer close(clockAdvancerFinished)
 		for {
 			select {
-			case <-changed:
-				correct := true
-				for i := 10; i < 14; i++ {
-					hasVote := st.machine(fmt.Sprint(i)).HasVote()
-					expectHasVote := i != 10
-					if hasVote != expectHasVote {
-						correct = false
-					}
-				}
-				if correct {
-					break loop
-				}
-			case <-timeout:
-				c.Fatalf("timed out waiting for vote to be set")
+			case <-time.After(5 * time.Millisecond):
+				s.clock.Advance(pollInterval)
+			case <-done:
+				return
 			}
 		}
-	})
+	}()
+
+	// Wait for the worker to set the initial members.
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0v 1 2", ipVersion))
+
+	// Update the status of the new members
+	// and check that they become voting.
+	c.Logf("\nupdating new member status")
+	st.session.setStatus(mkStatuses("0p 1s 2s", ipVersion))
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v", ipVersion))
+
+	c.Logf("\nadding another machine")
+	m13 := st.addMachine("13", false)
+	m13.setStateHostPort(fmt.Sprintf(ipVersion.formatHostPort, 13, mongoPort))
+	st.setControllers("10", "11", "12", "13")
+
+	c.Logf("\nwaiting for new member to be added")
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v 3", ipVersion))
+
+	// Remove vote from an existing member; and give it to the new
+	// machine. Also set the status of the new machine to healthy.
+	c.Logf("\nremoving vote from machine 10 and adding it to machine 13")
+	st.machine("10").setWantsVote(false)
+	st.machine("13").setWantsVote(true)
+
+	st.session.setStatus(mkStatuses("0p 1s 2s 3s", ipVersion))
+
+	// Check that the new machine gets the vote and the
+	// old machine loses it.
+	c.Logf("\nwaiting for vote switch")
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0 1v 2v 3v", ipVersion))
+
+	c.Logf("\nremoving old machine")
+	// Remove the old machine.
+	st.removeMachine("10")
+	st.setControllers("11", "12", "13")
+
+	// Check that it's removed from the members.
+	c.Logf("\nwaiting for removal")
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("1v 2v 3v", ipVersion))
+
+}
+
+func (s *workerSuite) TestHasVoteMaintainedEvenWhenReplicaSetFailsIPv4(c *gc.C) {
+	s.dotestHasVoteMaintainsEvenWhenReplicaSetFails(c, testIPv4)
+}
+
+func (s *workerSuite) TestHasVoteMaintainedEvenWhenReplicaSetFailsIPv6(c *gc.C) {
+	s.dotestHasVoteMaintainsEvenWhenReplicaSetFails(c, testIPv6)
+}
+
+func (s *workerSuite) dotestHasVoteMaintainsEvenWhenReplicaSetFails(c *gc.C, ipVersion TestIPVersion) {
+	st := NewFakeState()
+
+	// Simulate a state where we have four controllers,
+	// one has gone down, and we're replacing it:
+	// 0 - hasvote true, wantsvote false, down
+	// 1 - hasvote true, wantsvote true
+	// 2 - hasvote true, wantsvote true
+	// 3 - hasvote false, wantsvote true
+	//
+	// When it starts, the worker should move the vote from
+	// 0 to 3. We'll arrange things so that it will succeed in
+	// setting the membership but fail setting the HasVote
+	// to false.
+	InitState(c, st, 4, ipVersion)
+	st.machine("10").SetHasVote(true)
+	st.machine("11").SetHasVote(true)
+	st.machine("12").SetHasVote(true)
+	st.machine("13").SetHasVote(false)
+
+	st.machine("10").setWantsVote(false)
+	st.machine("11").setWantsVote(true)
+	st.machine("12").setWantsVote(true)
+	st.machine("13").setWantsVote(true)
+
+	st.session.Set(mkMembers("0v 1v 2v 3", ipVersion))
+	st.session.setStatus(mkStatuses("0H 1p 2s 3s", ipVersion))
+
+	// Make the worker fail to set HasVote to false
+	// after changing the replica set membership.
+	st.errors.setErrorFor("Machine.SetHasVote * false", errors.New("frood"))
+
+	memberWatcher := st.session.members.Watch()
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v 3", ipVersion))
+
+	w, err := newNoPublishWorker(st, s.clock, &noOpHub{})
+	c.Assert(err, jc.ErrorIsNil)
+	done := make(chan error)
+	go func() {
+		done <- w.Wait()
+	}()
+
+	// Wait for the worker to set the initial members.
+	mustNext(c, memberWatcher)
+	assertMembers(c, memberWatcher.Value(), mkMembers("0 1v 2v 3v", ipVersion))
+
+	// The worker should encounter an error setting the
+	// has-vote status to false and exit.
+	select {
+	case err := <-done:
+		c.Assert(err, gc.ErrorMatches, `cannot set HasVote removed: cannot set voting status of "[0-9]+" to false: frood`)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for worker to exit")
+	}
+
+	// Start the worker again - although the membership should
+	// not change, the HasVote status should be updated correctly.
+	st.errors.resetErrors()
+	w = s.newNoPublishWorker(c, st)
+
+	// Watch all the machines for changes, so we can check
+	// their has-vote status without polling.
+	changed := make(chan struct{}, 1)
+	for i := 10; i < 14; i++ {
+		watcher := st.machine(fmt.Sprint(i)).val.Watch()
+		defer watcher.Close()
+		go func() {
+			for watcher.Next() {
+				select {
+				case changed <- struct{}{}:
+				default:
+				}
+			}
+		}()
+	}
+	timeout := time.After(coretesting.LongWait)
+loop:
+	for {
+		select {
+		case <-changed:
+			correct := true
+			for i := 10; i < 14; i++ {
+				hasVote := st.machine(fmt.Sprint(i)).HasVote()
+				expectHasVote := i != 10
+				if hasVote != expectHasVote {
+					correct = false
+				}
+			}
+			if correct {
+				break loop
+			}
+		case <-timeout:
+			c.Fatalf("timed out waiting for vote to be set")
+		}
+	}
 }
 
 func (s *workerSuite) TestAddressChange(c *gc.C) {

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -162,6 +162,7 @@ func (s *workerSuite) dotestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion
 	// using the standard testing clock wait / advance method does not
 	// work. So we use the real clock to advance the test clock for this
 	// test.
+	// Every 5ms we advance the testing clock by pollInterval (1min)
 	done := make(chan struct{})
 	clockAdvancerFinished := make(chan struct{})
 	defer func() {


### PR DESCRIPTION
## Description of change

The peergrouper spammed a lot of information to the log, but most of it wasn't in a form that was very easy to understand.

As an example, the output of
```
$ cd worker/peergrouper
$ go test -v --check.v --check.f SetsAndUpdates --check.vv
```
Used to look like:
```
removing old machine

waiting for removal
mustNext 0xc42048a5a0
[LOG] 0:00.010 DEBUG juju.worker.peergrouper controller machines in state: []string{"11", "12", "13"}
[LOG] 0:00.010 DEBUG juju.worker.peergrouper calculating desired peer group
[LOG] 0:00.010 DEBUG juju.worker.peergrouper members: ...
   &peergrouper.machine{id: "11", wantsVote: true, hostPorts: [[2001:DB8::11]:1234]}: rs_id=1, rs_addr=[2001:DB8::11]:1234
   &peergrouper.machine{id: "12", wantsVote: true, hostPorts: [[2001:DB8::12]:1234]}: rs_id=2, rs_addr=[2001:DB8::12]:1234
   &peergrouper.machine{id: "13", wantsVote: true, hostPorts: [[2001:DB8::13]:1234]}: rs_id=3, rs_addr=[2001:DB8::13]:1234
[LOG] 0:00.010 DEBUG juju.worker.peergrouper extra: []replicaset.Member{replicaset.Member{Id:0, Address:"[2001:DB8::10]:1234", Arbiter:(*bool)(nil), BuildIndexes:(*bool)(nil), Hidden:(*bool)(nil), Priority:(}
[LOG] 0:00.010 DEBUG juju.worker.peergrouper maxId: 3
[LOG] 0:00.010 DEBUG juju.worker.peergrouper assessing possible peer group changes:
[LOG] 0:00.010 DEBUG juju.worker.peergrouper machine "11" is already voting
[LOG] 0:00.010 DEBUG juju.worker.peergrouper machine "12" is already voting
[LOG] 0:00.010 DEBUG juju.worker.peergrouper machine "13" is already voting
[LOG] 0:00.010 DEBUG juju.worker.peergrouper assessed
[LOG] 0:00.010 DEBUG juju.mongo selecting mongo peer hostPort by scope from [[2001:DB8::11]:1234]
[LOG] 0:00.010 DEBUG juju.network selected "[2001:DB8::11]:1234" as controller host:port, using scope selection
[LOG] 0:00.010 DEBUG juju.mongo selecting mongo peer hostPort by scope from [[2001:DB8::12]:1234]
[LOG] 0:00.010 DEBUG juju.network selected "[2001:DB8::12]:1234" as controller host:port, using scope selection
[LOG] 0:00.010 DEBUG juju.mongo selecting mongo peer hostPort by scope from [[2001:DB8::13]:1234]
[LOG] 0:00.010 DEBUG juju.network selected "[2001:DB8::13]:1234" as controller host:port, using scope selection
[LOG] 0:00.010 DEBUG juju.mongo selecting mongo peer hostPort by scope from [[2001:DB8::11]:1234]
[LOG] 0:00.010 DEBUG juju.network selected "[2001:DB8::11]:1234" as controller host:port, using scope selection
[LOG] 0:00.010 DEBUG juju.mongo selecting mongo peer hostPort by scope from [[2001:DB8::12]:1234]
[LOG] 0:00.010 DEBUG juju.network selected "[2001:DB8::12]:1234" as controller host:port, using scope selection
[LOG] 0:00.010 DEBUG juju.mongo selecting mongo peer hostPort by scope from [[2001:DB8::13]:1234]
[LOG] 0:00.010 DEBUG juju.network selected "[2001:DB8::13]:1234" as controller host:port, using scope selection
[LOG] 0:00.010 DEBUG juju.worker.peergrouper desired peer group members:
    Id: 1, Tags: map[juju-machine-id:11], Vote: true
    Id: 2, Tags: map[juju-machine-id:12], Vote: true
    Id: 3, Tags: map[juju-machine-id:13], Vote: true
[LOG] 0:00.010 INFO juju.worker.peergrouper setting replicaset members to
    Id: 1, Tags: map[juju-machine-id:11], Vote: true
    Id: 2, Tags: map[juju-machine-id:12], Vote: true
    Id: 3, Tags: map[juju-machine-id:13], Vote: true
[LOG] 0:00.011 INFO juju.worker.peergrouper successfully updated replica set
[LOG] 0:00.011 DEBUG juju.worker.peergrouper controller machines in state: []string{"11", "12", "13"}
mustNext done 0xc42048a5a0, ok: true, val:
    Id: 1, Tags: map[juju-machine-id:11], Vote: true
    Id: 2, Tags: map[juju-machine-id:12], Vote: true
    Id: 3, Tags: map[juju-machine-id:13], Vote: true
```

It now looks like:
```
removing old machine

waiting for removal
mustNext 0xc420265560
[LOG] 0:00.008 DEBUG juju.worker.peergrouper controller machines in state: []string{"11", "12", "13"}
[LOG] 0:00.009 DEBUG juju.worker.peergrouper calculating desired peer group
desired members: (maxId: 3) ...
   &peergrouper.machine{id: "12", wantsVote: true, hostPorts: [[2001:DB8::12]:1234]}: rs_id=2, rs_addr=[2001:DB8::12]:1234
   &peergrouper.machine{id: "11", wantsVote: true, hostPorts: [[2001:DB8::11]:1234]}: rs_id=1, rs_addr=[2001:DB8::11]:1234
   &peergrouper.machine{id: "13", wantsVote: true, hostPorts: [[2001:DB8::13]:1234]}: rs_id=3, rs_addr=[2001:DB8::13]:1234
extra members:
   rs_id=0, rs_addr=[2001:DB8::10]:1234, tags=map[juju-machine-id:10], vote=false
[LOG] 0:00.009 DEBUG juju.worker.peergrouper assessing possible peer group changes:
[LOG] 0:00.009 DEBUG juju.worker.peergrouper machine "11" is already voting
[LOG] 0:00.009 DEBUG juju.worker.peergrouper machine "12" is already voting
[LOG] 0:00.009 DEBUG juju.worker.peergrouper machine "13" is already voting
[LOG] 0:00.009 DEBUG juju.worker.peergrouper assessed
[LOG] 0:00.009 DEBUG juju.worker.peergrouper machine "11" selected address "[2001:DB8::11]:1234" by scope from [[2001:DB8::11]:1234]
[LOG] 0:00.009 DEBUG juju.worker.peergrouper machine "12" selected address "[2001:DB8::12]:1234" by scope from [[2001:DB8::12]:1234]
[LOG] 0:00.009 DEBUG juju.worker.peergrouper machine "13" selected address "[2001:DB8::13]:1234" by scope from [[2001:DB8::13]:1234]
[LOG] 0:00.009 DEBUG juju.worker.peergrouper desired peer group members:
    Id: 3, Tags: map[juju-machine-id:13], Vote: true
    Id: 2, Tags: map[juju-machine-id:12], Vote: true
    Id: 1, Tags: map[juju-machine-id:11], Vote: true
[LOG] 0:00.009 INFO juju.worker.peergrouper setting replicaset members to
    Id: 3, Tags: map[juju-machine-id:13], Vote: true
    Id: 2, Tags: map[juju-machine-id:12], Vote: true
    Id: 1, Tags: map[juju-machine-id:11], Vote: true
[LOG] 0:00.009 INFO juju.worker.peergrouper successfully updated replica set
[LOG] 0:00.009 DEBUG juju.worker.peergrouper controller machines in state: []string{"11", "12", "13"}
mustNext done 0xc420265560, ok: true, val:
    Id: 3, Tags: map[juju-machine-id:13], Vote: true
    Id: 2, Tags: map[juju-machine-id:12], Vote: true
    Id: 1, Tags: map[juju-machine-id:11], Vote: true
```

Which I feel is more readable.

## QA steps

You can run the above section of the test suite. Or do:
```
$ juju bootstrap lxd --debug
$ juju enable-ha
$ juju debug-log -m controller --include-module juju.peergrouper --include-module juju.mongo --include-module juju.network
```
And see that in the new form, the logging is a lot clearer to understand what is going on.

## Documentation changes

None

## Bug reference

This is related to https://bugs.launchpad.net/juju/+bug/1748385 but the actual fix will be in develop.
