### PR TITLE
2.4 peergrouper test 1748385

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -270,8 +270,6 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 // address by selecting it from the given addresses. If no addresses are
 // available an empty string is returned.
 func SelectPeerAddress(addrs []network.Address) string {
-	logger.Debugf("selecting mongo peer address from %+v", addrs)
-
 	// ScopeMachineLocal addresses are never suitable for mongo peers,
 	// as each controller runs on a separate machine.
 	const allowMachineLocal = false
@@ -285,8 +283,6 @@ func SelectPeerAddress(addrs []network.Address) string {
 // SelectPeerHostPort returns the HostPort to use as the mongo replica set peer
 // by selecting it from the given hostPorts.
 func SelectPeerHostPort(hostPorts []network.HostPort) string {
-	logger.Debugf("selecting mongo peer hostPort by scope from %+v", hostPorts)
-
 	// ScopeMachineLocal addresses are never suitable for mongo peers,
 	// as each controller runs on a separate machine.
 	const allowMachineLocal = false
@@ -296,7 +292,6 @@ func SelectPeerHostPort(hostPorts []network.HostPort) string {
 // SelectPeerHostPortBySpace returns the HostPort to use as the mongo replica set peer
 // by selecting it from the given hostPorts.
 func SelectPeerHostPortBySpace(hostPorts []network.HostPort, space network.SpaceName) string {
-	logger.Debugf("selecting mongo peer hostPort in space %s from %+v", space, hostPorts)
 	// ScopeMachineLocal addresses are OK if we can't pick by space.
 	suitableHostPorts, foundHostPortsInSpaces :=
 		network.SelectMongoHostPortsBySpaceNames(hostPorts, []network.SpaceName{space})

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -292,15 +292,27 @@ func SelectPeerHostPort(hostPorts []network.HostPort) string {
 // SelectPeerHostPortBySpace returns the HostPort to use as the mongo replica set peer
 // by selecting it from the given hostPorts.
 func SelectPeerHostPortBySpace(hostPorts []network.HostPort, space network.SpaceName) string {
-	// ScopeMachineLocal addresses are OK if we can't pick by space.
-	suitableHostPorts, foundHostPortsInSpaces :=
-		network.SelectMongoHostPortsBySpaceNames(hostPorts, []network.SpaceName{space})
+	filteredHostPorts, foundHostPortsInSpaces :=
+		network.SelectHostPortsBySpaceNames(hostPorts, space)
 
+	var suitableAddr string
 	if !foundHostPortsInSpaces {
 		logger.Debugf("Failed to select hostPort by space - trying by scope from %+v", hostPorts)
-		suitableHostPorts = network.SelectHostPortsByScope(hostPorts, true)
+		// ScopeMachineLocal addresses are OK if we can't pick by space.
+		// XXX(jam): 2018-02-21 This doesn't seem right.
+		// peergrouper.MachineTracker.SelectMongoHostPort is the only place that calls this function.
+		// It first tries this iff we have a space name.
+		// It then falls back to calling SelectPeerHostPort which has an
+		// explicit "ScopeMachineLocal is never suitable for mongo peers".
+		// So why would it be necessary for a system that has a space declared,
+		// but can't find an address in that space to fall back to a local-only
+		// address.
+		suitableAddrs := network.SelectHostPortsByScope(hostPorts, true)
+		suitableAddr = suitableAddrs[0]
+	} else {
+		suitableAddr = filteredHostPorts[0].NetAddr()
 	}
-	return suitableHostPorts[0]
+	return suitableAddr
 }
 
 // GenerateSharedSecret generates a pseudo-random shared secret (keyfile)

--- a/network/address.go
+++ b/network/address.go
@@ -337,18 +337,11 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 	return internalAddress, ok
 }
 
-// SelectMongoHostPortsBySpaceNames returns the most suitable HostPort (as string) to
-// use as a Juju Controller (API/state server) endpoint given the list of
-// hostPorts. It first tries to find the first HostPort bound to the
-// spaces provided, then, if that fails, uses the older selection method based on scope.
-// When machineLocal is true and an address can't be selected by space both
-// ScopeCloudLocal and ScopeMachineLocal addresses are considered during the
-// selection, otherwise just ScopeCloudLocal are.
-func SelectMongoHostPortsBySpaceNames(hostPorts []HostPort, spaces []SpaceName) ([]string, bool) {
-	filteredHostPorts, ok := SelectHostPortsBySpaceNames(hostPorts, spaces...)
-	return HostPortsToStrings(filteredHostPorts), ok
-}
-
+// SelectHostPortsByScope looks through the HostPorts supplied and tries to
+// find one that is cloud-local. If necessary, passing machineLocal=true will
+// allow it to accept machine local addresses as well as cloud-local addresses,
+// but this is generally not recommended. (Once you are in HA you need
+// addresses that can be reached from another machine.)
 func SelectHostPortsByScope(hostPorts []HostPort, machineLocal bool) []string {
 	// Fallback to using the legacy and error-prone approach using scope
 	// selection instead.

--- a/network/address.go
+++ b/network/address.go
@@ -346,12 +346,6 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 // selection, otherwise just ScopeCloudLocal are.
 func SelectMongoHostPortsBySpaceNames(hostPorts []HostPort, spaces []SpaceName) ([]string, bool) {
 	filteredHostPorts, ok := SelectHostPortsBySpaceNames(hostPorts, spaces...)
-	if ok {
-		logger.Debugf(
-			"selected %q as controller host:port, using spaces %q",
-			filteredHostPorts, spaces,
-		)
-	}
 	return HostPortsToStrings(filteredHostPorts), ok
 }
 
@@ -359,7 +353,6 @@ func SelectHostPortsByScope(hostPorts []HostPort, machineLocal bool) []string {
 	// Fallback to using the legacy and error-prone approach using scope
 	// selection instead.
 	internalHP := SelectInternalHostPort(hostPorts, machineLocal)
-	logger.Debugf("selected %q as host:port, using scope selection", internalHP)
 	return []string{internalHP}
 }
 

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -60,10 +60,12 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTra
 	// TODO There are some other possibilities
 	// for what to do in that case.
 	// 1) leave them untouched, but deal
-	// with others as usual "i didn't see that bit".
-	// Make sure the extras aren't eligible to be primary.
-	// 2) remove them "get rid of bad rubbish"
-	// 3) do nothing "nothing to see here"
+	// with others as usual "i didn't see that bit"
+	// 2) leave them untouched, deal with others,
+	// but make sure the extras aren't eligible to
+	// be primary.
+	// 3) remove them "get rid of bad rubbish"
+	// 4) do nothing "nothing to see here"
 	for _, member := range extra {
 		if member.Votes == nil || *member.Votes > 0 {
 			return nil, nil, fmt.Errorf("voting non-machine member %#v found in peer group", member)

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -6,6 +6,7 @@ package peergrouper
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/juju/replicaset"
 
@@ -36,14 +37,19 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTra
 	}
 	changed := false
 	members, extra, maxId := info.membersMap()
-	logger.Debugf("calculating desired peer group")
-	line := "members: ..."
+	lines := make([]string, 0)
+	lines = append(lines, fmt.Sprintf("calculated desired peer group\ndesired voting members: (maxId: %d)", maxId))
 	for tracker, replMem := range members {
-		line = fmt.Sprintf("%s\n   %#v: rs_id=%d, rs_addr=%s", line, tracker, replMem.Id, replMem.Address)
+		lines = append(lines, fmt.Sprintf("\n   %#v: rs_id=%d, rs_addr=%s", tracker, replMem.Id, replMem.Address))
 	}
-	logger.Debugf(line)
-	logger.Debugf("extra: %#v", extra)
-	logger.Debugf("maxId: %v", maxId)
+	if len(extra) > 0 {
+		lines = append(lines, "\nother members:")
+		for _, replMem := range extra {
+			vote := (replMem.Votes != nil && *replMem.Votes > 0)
+			lines = append(lines, fmt.Sprintf("\n   rs_id=%d, rs_addr=%s, tags=%v, vote=%t", replMem.Id, replMem.Address, replMem.Tags, vote))
+		}
+	}
+	logger.Debugf(strings.Join(lines, ""))
 
 	// We may find extra peer group members if the machines
 	// have been removed or their controller status removed.
@@ -54,12 +60,10 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTra
 	// TODO There are some other possibilities
 	// for what to do in that case.
 	// 1) leave them untouched, but deal
-	// with others as usual "i didn't see that bit"
-	// 2) leave them untouched, deal with others,
-	// but make sure the extras aren't eligible to
-	// be primary.
-	// 3) remove them "get rid of bad rubbish"
-	// 4) do nothing "nothing to see here"
+	// with others as usual "i didn't see that bit".
+	// Make sure the extras aren't eligible to be primary.
+	// 2) remove them "get rid of bad rubbish"
+	// 3) do nothing "nothing to see here"
 	for _, member := range extra {
 		if member.Votes == nil || *member.Votes > 0 {
 			return nil, nil, fmt.Errorf("voting non-machine member %#v found in peer group", member)
@@ -223,23 +227,26 @@ func addNewMembers(
 	mongoSpace network.SpaceName,
 ) {
 	for _, m := range toKeep {
-		hasAddress := m.SelectMongoHostPort(mongoPort, mongoSpace) != ""
-		if members[m] == nil && hasAddress {
-			// This machine was not previously in the members list,
-			// so add it (as non-voting). We maintain the
-			// id manually to make it easier for tests.
-			maxId++
-			member := &replicaset.Member{
-				Tags: map[string]string{
-					jujuMachineKey: m.Id(),
-				},
-				Id: maxId,
-			}
-			members[m] = member
-			setVoting(m, false)
-		} else if !hasAddress {
-			logger.Debugf("ignoring machine %q with no address", m.Id())
+		if members[m] != nil {
+			continue
 		}
+		hasAddress := m.SelectMongoHostPort(mongoPort, mongoSpace) != ""
+		if !hasAddress {
+			logger.Debugf("ignoring machine %q with no address", m.Id())
+			continue
+		}
+		// This machine was not previously in the members list,
+		// so add it (as non-voting). We maintain the
+		// id manually to make it easier for tests.
+		maxId++
+		member := &replicaset.Member{
+			Tags: map[string]string{
+				jujuMachineKey: m.Id(),
+			},
+			Id: maxId,
+		}
+		members[m] = member
+		setVoting(m, false)
 	}
 }
 

--- a/worker/peergrouper/machinetracker.go
+++ b/worker/peergrouper/machinetracker.go
@@ -92,9 +92,13 @@ func (m *machineTracker) SelectMongoHostPort(port int, space network.SpaceName) 
 	m.mu.Unlock()
 
 	if space != "" {
-		return mongo.SelectPeerHostPortBySpace(hostPorts, space)
+		addr := mongo.SelectPeerHostPortBySpace(hostPorts, space)
+		logger.Debugf("machine %q selected address %q by space %q from %v", m.id, addr, space, hostPorts)
+		return addr
 	}
-	return mongo.SelectPeerHostPort(hostPorts)
+	addr := mongo.SelectPeerHostPort(hostPorts)
+	logger.Debugf("machine %q selected address %q by scope from %v", m.id, addr, hostPorts)
+	return addr
 }
 
 func (m *machineTracker) String() string {

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v1"
 
-	"github.com/juju/juju/apiserver/common/networkingcommon"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
@@ -234,12 +233,7 @@ func (st *fakeState) WatchControllerStatusChanges() state.StringsWatcher {
 }
 
 func (st *fakeState) Space(name string) (Space, error) {
-	foo := []networkingcommon.BackingSpace{
-		&apiservertesting.FakeSpace{SpaceName: "Space" + name},
-		&apiservertesting.FakeSpace{SpaceName: "Space" + name},
-		&apiservertesting.FakeSpace{SpaceName: "Space" + name},
-	}
-	return foo[0].(Space), nil
+	return &apiservertesting.FakeSpace{SpaceName: "Space" + name}, nil
 }
 
 func (st *fakeState) SetOrGetMongoSpaceName(mongoSpaceName network.SpaceName) (network.SpaceName, error) {


### PR DESCRIPTION
## Description of change

This is a merge of PR #8410 into develop which should actually fix bug #1748385. As well as bringing in the nicer formatting from PR #8410.
This also includes the tip of 2.3 => develop and fixes up the conflicts because of updates in develop.

## QA steps

We should no longer have timing related failures in develop for worker/peergrouper workerSuite.TestSetsAndUpdatesMembers

## Documentation changes

None.

## Bug reference

[lp:1748385](https://bugs.launchpad.net/juju/+bug/1748385)
