### PR TITLE
fix lp 1749201 Series upgrade doesn't start unit agents

### DIFF
--- a/agent/tools/export_test.go
+++ b/agent/tools/export_test.go
@@ -3,23 +3,8 @@
 
 package tools
 
-import (
-	"os"
-	"runtime"
-)
-
-func getDirPerm() os.FileMode {
-	// File permissions on windows yield diferent results then on Linux
-	// For example an os.FileMode of 0100 on a directory on Windows,
-	// will yield -r-xr-xr-x. os.FileMode of 0755 will yield -rwxrwxrwx
-	if runtime.GOOS == "windows" {
-		return os.FileMode(0777)
-	}
-	return os.FileMode(dirPerm)
-}
-
 var (
-	DirPerm        = getDirPerm()
+	DirPerm        = GetDirPerm()
 	MaybeReadTools = maybeReadTools
 )
 

--- a/agent/tools/export_test.go
+++ b/agent/tools/export_test.go
@@ -6,6 +6,7 @@ package tools
 var (
 	DirPerm        = GetDirPerm()
 	MaybeReadTools = maybeReadTools
+	HostSeries     = hostSeries
 )
 
 const (

--- a/agent/tools/export_test.go
+++ b/agent/tools/export_test.go
@@ -19,7 +19,8 @@ func getDirPerm() os.FileMode {
 }
 
 var (
-	DirPerm = getDirPerm()
+	DirPerm        = getDirPerm()
+	MaybeReadTools = maybeReadTools
 )
 
 const (

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -266,16 +265,17 @@ func (t *ToolsSuite) TestMaybeReadTools(c *gc.C) {
 	}
 	err := agenttools.UnpackTools(t.dataDir, testTools, bytes.NewReader(data))
 	c.Assert(err, jc.ErrorIsNil)
-	t.PatchValue(&series.MustHostSeries, func() string { return "xenial" })
+	t.PatchValue(&agenttools.HostSeries, func() (string, error) { return "xenial", nil })
 	gotTools, err := agenttools.MaybeReadTools(t.dataDir, version.MustParseBinary("1.2.3-xenial-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotTools, gc.NotNil)
 	testTools.Version = version.MustParseBinary("1.2.3-xenial-amd64")
-	c.Assert(*gotTools, gc.Equals, *testTools)
+	c.Assert(*gotTools, gc.DeepEquals, *testTools)
 	assertDirNames(c, t.toolsDir(), []string{"1.2.3-trusty-amd64", "1.2.3-xenial-amd64"})
 }
 
 func (t *ToolsSuite) TestMaybeReadToolsFail(c *gc.C) {
-	t.PatchValue(&series.MustHostSeries, func() string { return "xenial" })
+	t.PatchValue(&agenttools.HostSeries, func() (string, error) { return "xenial", nil })
 	gotTools, err := agenttools.MaybeReadTools(t.dataDir, version.MustParseBinary("1.2.3-trusty-amd64"))
 	c.Assert(err, gc.ErrorMatches, "cannot read agent binaries of current or other series.*")
 	c.Assert(gotTools, gc.IsNil)

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -269,6 +269,7 @@ func (t *ToolsSuite) TestMaybeReadTools(c *gc.C) {
 	t.PatchValue(&series.MustHostSeries, func() string { return "xenial" })
 	gotTools, err := agenttools.MaybeReadTools(t.dataDir, version.MustParseBinary("1.2.3-xenial-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
+	testTools.Version = version.MustParseBinary("1.2.3-xenial-amd64")
 	c.Assert(*gotTools, gc.Equals, *testTools)
 	assertDirNames(c, t.toolsDir(), []string{"1.2.3-trusty-amd64", "1.2.3-xenial-amd64"})
 }
@@ -276,7 +277,7 @@ func (t *ToolsSuite) TestMaybeReadTools(c *gc.C) {
 func (t *ToolsSuite) TestMaybeReadToolsFail(c *gc.C) {
 	t.PatchValue(&series.MustHostSeries, func() string { return "xenial" })
 	gotTools, err := agenttools.MaybeReadTools(t.dataDir, version.MustParseBinary("1.2.3-trusty-amd64"))
-	c.Assert(err, gc.ErrorMatches, "agent binaries of current or other series.*")
+	c.Assert(err, gc.ErrorMatches, "cannot read agent binaries of current or other series.*")
 	c.Assert(gotTools, gc.IsNil)
 }
 

--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -13,11 +13,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/fs"
-	utilsSeries "github.com/juju/utils/series"
+	utilsseries "github.com/juju/utils/series"
 	"github.com/juju/utils/symlink"
 	"github.com/juju/version"
 
@@ -29,6 +30,18 @@ const (
 	guiArchiveFile = "downloaded-gui.txt"
 	toolsFile      = "downloaded-tools.txt"
 )
+
+// GetDirPerm returns local var dirPerm based on OS for testing.
+//
+// File permissions on windows yield different results then on Linux
+// For example an os.FileMode of 0100 on a directory on Windows,
+// will yield -r-xr-xr-x. os.FileMode of 0755 will yield -rwxrwxrwx
+func GetDirPerm() os.FileMode {
+	if runtime.GOOS == "windows" {
+		return os.FileMode(0777)
+	}
+	return os.FileMode(dirPerm)
+}
 
 // SharedToolsDir returns the directory that is used to
 // store binaries for the given version of the juju tools
@@ -118,12 +131,7 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 			return errors.Annotatef(err, "tar extract %q failed", name)
 		}
 	}
-	toolsMetadataData, err := json.Marshal(tools)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(path.Join(dir, toolsFile), []byte(toolsMetadataData), 0644)
-	if err != nil {
+	if err = writeToolsMetadataData(dir, tools); err != nil {
 		return err
 	}
 
@@ -144,6 +152,14 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 		}
 	}
 	return err
+}
+
+func writeToolsMetadataData(dir string, tools *coretools.Tools) error {
+	toolsMetadataData, err := json.Marshal(tools)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path.Join(dir, toolsFile), []byte(toolsMetadataData), 0644)
 }
 
 func removeAll(dir string) {
@@ -227,29 +243,38 @@ func ChangeAgentTools(dataDir string, agentName string, vers version.Binary) (*c
 // TODO: (hml) 2018-02-22
 // Added for lp:bug1749201 - once agent binaries without the series in the name are
 // available, ReadTools() can move back to ChangeAgentTools()
-func maybeReadTools(dataDir string, currentVers version.Binary) (*coretools.Tools, error) {
-	tools, err := ReadTools(dataDir, currentVers)
+func maybeReadTools(dataDir string, currentVers version.Binary) (tools *coretools.Tools, err error) {
+	defer func() {
+		err = errors.Annotate(err, "cannot read agent binaries of current or other series")
+	}()
+
+	tools, err = ReadTools(dataDir, currentVers)
 	if err == nil {
-		return tools, err
+		return tools, nil
 	}
 	logger.Tracef("%s not found (%s)", SharedToolsDir(dataDir, currentVers), err)
 
-	hostOS := utilsSeries.MustOSFromSeries(utilsSeries.MustHostSeries())
-	potentialSeries := utilsSeries.OSSupportedSeries(hostOS)
+	hostOS := utilsseries.MustOSFromSeries(utilsseries.MustHostSeries())
+	potentialSeries := utilsseries.OSSupportedSeries(hostOS)
 
 	potentialVers := currentVers
 	for _, series := range potentialSeries {
 		potentialVers.Series = series
-		_, err := ReadTools(dataDir, potentialVers)
+		tools, err := ReadTools(dataDir, potentialVers)
 		if err == nil {
 			logger.Tracef("%s found", SharedToolsDir(dataDir, potentialVers))
-			err = fs.Copy(SharedToolsDir(dataDir, potentialVers), SharedToolsDir(dataDir, currentVers))
-			if err != nil {
-				return nil, err
+			if err = fs.Copy(SharedToolsDir(dataDir, potentialVers), SharedToolsDir(dataDir, currentVers)); err != nil {
+				return nil, errors.Trace(err)
 			}
-			return ReadTools(dataDir, potentialVers)
+			// Only changing the version in the copied downloaded-tools.txt, not the
+			// URL (which also contains the version string).
+			tools.Version = currentVers
+			if err = writeToolsMetadataData(SharedToolsDir(dataDir, currentVers), tools); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return ReadTools(dataDir, currentVers)
 		}
+		logger.Tracef("%s not found (%s)", SharedToolsDir(dataDir, potentialVers), err)
 	}
-
-	return nil, errors.Annotate(err, "agent binaries of current or other series")
+	return nil, errors.Trace(err)
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -487,7 +487,6 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 
 	createEngine := a.makeEngineCreator(agentConfig.UpgradedToVersion())
 	charmrepo.CacheDir = filepath.Join(agentConfig.DataDir(), "charmcache")
-
 	if err := a.ensureMachineAgentDir(agentConfig.DataDir()); err != nil {
 		return err
 	}
@@ -1660,7 +1659,7 @@ func (a *MachineAgent) ensureMachineAgentDir(dataDir string) error {
 		Series: series.MustHostSeries(),
 	}
 	_, err := tools.ChangeAgentTools(dataDir, a.Tag().String(), currentVersion)
-	return err
+	return errors.Trace(err)
 }
 
 func (a *MachineAgent) createSymlink(target, link string) error {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -915,12 +915,12 @@ func (s *MachineSuite) TestMachineAgentSymlinks(c *gc.C) {
 
 func (s *MachineSuite) TestEnsureMachineAgentDir(c *gc.C) {
 	stm, _, _ := s.primeAgent(c, state.JobManageModel)
-	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
+	s.PatchValue(&series.MustHostSeries, func() string { return "quantal" })
 	a := s.newAgent(c, stm)
 	defer a.Stop()
 	_, done := s.waitForOpenState(c, a)
 
-	for _, host := range []string{"trusty", series.MustHostSeries()} {
+	for _, host := range []string{"quantal", series.MustHostSeries()} {
 		dir := agenttools.SharedToolsDir(s.DataDir(), version.Binary{
 			Number: jujuversion.Current,
 			Arch:   arch.HostArch(),


### PR DESCRIPTION
## Description of change

During unit deployment, or redeployment, if the agents (tools) based on the current machine series can't be found, search for agents with the agent machine series from state.  This is necessary for getting units back up and running after the series is upgraded.  

## QA steps

How do we verify that the change works?

## Documentation changes

Follow instructions from the howto-upgradeseries juju doc.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1749201