### PR TITLE
Fix a couple of go fmt problems

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -93,8 +93,8 @@ var (
 	// be expressed as explicit dependencies, but nobody has yet had
 	// the intestinal fortitude to untangle this package. Be that
 	// person! Juju Needs You.
-	useMultipleCPUs    = utils.UseMultipleCPUs
-	reportOpenedState  = func(*state.State) {}
+	useMultipleCPUs   = utils.UseMultipleCPUs
+	reportOpenedState = func(*state.State) {}
 
 	caasModelManifolds = model.CAASManifolds
 	iaasModelManifolds = model.IAASManifolds

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -252,7 +252,6 @@ func (s *workerSuite) dotestHasVoteMaintainsEvenWhenReplicaSetFails(c *gc.C, ipV
 	mustNext(c, memberWatcher, "waiting for SetHasVote failure")
 	assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v 3", ipVersion))
 
-
 	w := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{})
 	defer workertest.DirtyKill(c, w)
 


### PR DESCRIPTION
## Description of change
Correct some go fmt errors that were preventing commits with the pre-commit hook. Do some devs not have it configured?

## QA steps
Running `go fmt` reports no errors.
