### PR TITLE
Ensure model type is filled in with old controllers

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/downloader"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
@@ -48,7 +49,7 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 	// Older servers don't fill out model type, but
 	// we know a missing type is an "iaas" model.
 	if result.Model.Type == "" {
-		result.Model.Type = "iaas"
+		result.Model.Type = model.IAAS.String()
 	}
 	return &result, nil
 }

--- a/api/modelmanager/modelinfo_test.go
+++ b/api/modelmanager/modelinfo_test.go
@@ -61,6 +61,18 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 	s.assertExpectedModelInfo(c, results)
 }
 
+func (s *modelInfoSuite) TestModelInfoOldController(c *gc.C) {
+	results := params.ModelInfoResults{
+		Results: []params.ModelInfoResult{{
+			Result: &params.ModelInfo{Name: "name", UUID: "etc."},
+		}, {
+			Error: &params.Error{Message: "woop"},
+		}},
+	}
+	s.assertExpectedModelInfo(c, results)
+	c.Assert(results.Results[0].Result.Type, gc.Equals, "iaas")
+}
+
 func (s *modelInfoSuite) TestModelInfoWithAgentVersion(c *gc.C) {
 	results := params.ModelInfoResults{
 		Results: []params.ModelInfoResult{{

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -292,6 +292,14 @@ func (c *Client) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, err
 	if len(results.Results) != len(tags) {
 		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
+	for i := range results.Results {
+		if results.Results[i].Error != nil {
+			continue
+		}
+		if results.Results[i].Result.Type == "" {
+			results.Results[i].Result.Type = model.IAAS.String()
+		}
+	}
 	return results.Results, nil
 }
 


### PR DESCRIPTION
## Description of change

A previous PR added model type and for older models, we needed to fill it in when processing api results. This PR fixes a case that was missed.

## QA steps

Run CLI against a JAAS controller.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1750833
