### PR TITLE
Use proper relation addresses for caas

### DIFF
--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -118,6 +118,10 @@ type ApplicationStatus struct {
 	MeterStatuses   map[string]MeterStatus `json:"meter-statuses"`
 	Status          DetailedStatus         `json:"status"`
 	WorkloadVersion string                 `json:"workload-version"`
+
+	// The following are for CAAS models.
+	ProviderId    string `json:"provider-id,omitempty"`
+	PublicAddress string `json:"public-address"`
 }
 
 // RemoteApplicationStatus holds status info about a remote application.
@@ -165,7 +169,6 @@ type UnitStatus struct {
 	Leader        bool                  `json:"leader,omitempty"`
 
 	// The following are for CAAS models.
-
 	ProviderId string `json:"provider-id,omitempty"`
 	Address    string `json:"address,omitempty"`
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -96,6 +96,8 @@ type applicationStatus struct {
 	CharmName     string                `json:"charm-name" yaml:"charm-name"`
 	CharmRev      int                   `json:"charm-rev" yaml:"charm-rev"`
 	CanUpgradeTo  string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
+	ProviderId    string                `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
+	Address       string                `json:"address,omitempty" yaml:"address,omitempty"`
 	Exposed       bool                  `json:"exposed" yaml:"exposed"`
 	Life          string                `json:"life,omitempty" yaml:"life,omitempty"`
 	StatusInfo    statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -200,6 +200,8 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		CharmRev:      charmRev,
 		Exposed:       application.Exposed,
 		Life:          application.Life,
+		ProviderId:    application.ProviderId,
+		Address:       application.PublicAddress,
 		Relations:     application.Relations,
 		CanUpgradeTo:  application.CanUpgradeTo,
 		SubordinateTo: application.SubordinateTo,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -107,7 +107,11 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	units := make(map[string]unitStatus)
-	outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
+	if fs.Model.Type == caasModelType {
+		outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
+	} else {
+		outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
+	}
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
 	for _, appName := range utils.SortStringsNaturally(stringKeysFromMap(fs.Applications)) {
@@ -137,12 +141,14 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		} else {
 			w.Print(scale)
 		}
-		p(app.CharmName,
+		w.Print(app.CharmName,
 			app.CharmOrigin,
 			app.CharmRev,
-			app.OS,
-			notes)
-
+			app.OS)
+		if fs.Model.Type == caasModelType {
+			w.Print(app.Address)
+		}
+		p(notes)
 		for un, u := range app.Units {
 			units[un] = u
 			if u.MeterStatus != nil {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4181,6 +4181,7 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 		},
 		Applications: map[string]applicationStatus{
 			"foo": {
+				Address: "54.32.1.2",
 				Units: map[string]unitStatus{
 					"foo/0": {
 						JujuStatusInfo: statusInfoContents{
@@ -4211,8 +4212,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-foo                     1/2                  0      
+App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Notes
+foo                     1/2                  0      54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -567,16 +567,18 @@ func NetworksForRelation(
 
 			}
 		} else {
-			addr, err := unit.PrivateAddress()
-			if err != nil && !network.IsNoAddressError(err) {
-				return "", nil, nil, errors.Trace(err)
-			}
-			if err == nil {
-				ingress = []string{addr.Value}
-			} else {
+			// Be be consistent with IAAS behaviour above, we'll return all
+			// addresses, including any container address.
+			addr, err := unit.AllAddresses()
+			if err != nil {
 				logger.Warningf(
-					"no container address for unit %q in relation %q",
+					"no service address for unit %q in relation %q",
 					unit.Name(), rel)
+			} else {
+				network.SortAddresses(addr)
+				for _, a := range addr {
+					ingress = append(ingress, a.Value)
+				}
 			}
 		}
 	}

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1045,14 +1045,10 @@ func (s *RelationUnitSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	c.Assert(ingress, gc.HasLen, 0)
 	c.Assert(egress, gc.HasLen, 0)
 
-	// Add a container address.
-	unitUpdate := state.UpdateUnitsOperation{
-		Updates: []*state.UpdateUnitOperation{
-			prr.pu0.UpdateOperation(state.UnitUpdateProperties{
-				ProviderId: strPtr("id"),
-				Address:    strPtr("1.2.3.4")})},
-	}
-	err = mysql.UpdateUnits(&unitUpdate)
+	// Add a service address.
+	err = mysql.UpdateCloudService("", []network.Address{
+		{Value: "1.2.3.4", Scope: network.ScopeCloudLocal},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

A previous PR recorded all relevant service address for caas services. We now use those for network-get and when setting up addresses for a relation. The change is really just making PublicAddress() and PrivateAddress() on unit do the right thing for CAAS. The behaviour for IAAS is unchanged.

As a small driveby, there was an existing inconsistency in how addresses were calculated when a relation was in play and without a relation - this has been fixed.

Finally, the service address (if any) is added to caas application status.

## QA steps

Run up a caas model and deploy and relate gitlab and mysql.
Run up an iaas model and deploy and cross model relate nagios and ubuntu/nrpe.