### PR TITLE
Goal State Hook Command 1/2

### DIFF
--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -433,6 +433,30 @@ func (st *State) SLALevel() (string, error) {
 	return result.Result, nil
 }
 
+// GoalState returns a GoalStateResult struct with the charm's
+// peers and related units information.
+func (c *State) GoalState() (string, error) {
+	var result params.StringResults
+
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: c.unitTag.String()},
+		},
+	}
+
+	err := c.facade.FacadeCall("GoalStates", args, &result)
+	if err != nil {
+		return "", err
+	}
+	if len(result.Results) != 1 {
+		return "", fmt.Errorf("expected 1 result, got %d", len(result.Results))
+	}
+	if err := result.Results[0].Error; err != nil {
+		return "", err
+	}
+	return result.Results[0].Result, nil
+}
+
 // SetContainerSpec sets the container spec of the specified application or unit.
 func (c *State) SetContainerSpec(entityName string, spec string) error {
 	var tag names.Tag

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2411,3 +2411,29 @@ func (u *UniterAPI) SetContainerSpec(args params.SetContainerSpecParams) (params
 	}
 	return results, nil
 }
+
+// GoalStates returns information of charm units and relations.
+func (u *UniterAPI) GoalStates(args params.Entities) (string, error) {
+	result := params.StringResults{
+		Results: make([]params.StringResult, len(args.Entities)),
+	}
+	canAccess, err := u.accessUnit()
+	if err != nil {
+		return "", err
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		if !canAccess(tag) {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		// TODO (agprado): get units and relations information from
+
+		result.Results[0].Result = "Hello World I'll be a yaml"
+	}
+	return result.Results[0].Result, nil
+}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4153,3 +4153,16 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Results["db"], jc.DeepEquals, expectedResult)
 }
+
+// TODO (agprado): Next PR diferenciate between Unit and App
+func (s *uniterSuite) TestGoalStates(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-wordpress-0"},
+	}}
+	results := "Hello World I'll be a yaml"
+
+	result, err := s.uniter.GoalStates(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, results)
+}
+

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -39,6 +39,7 @@ Currently available charm hook tools are:
     close-port               ensure a port or range is always closed
     config-get               print application configuration
     container-spec-set       set container spec information
+    goal-state               print the status of the charm's peers and related units
     is-leader                print application leadership status
     juju-log                 write a message to the juju log
     juju-reboot              Reboot the host machine
@@ -77,6 +78,7 @@ var expectedCommands = []string{
 	"close-port",
 	"config-get",
 	"container-spec-set",
+	"goal-state",
 	"is-leader",
 	"juju-log",
 	"juju-reboot",

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -125,6 +125,9 @@ type HookContext struct {
 	// configSettings holds the service configuration.
 	configSettings charm.Settings
 
+	// goalState holds the goal state struct
+	goalState string
+
 	// id identifies the context.
 	id string
 
@@ -481,6 +484,15 @@ func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
 		result[name] = value
 	}
 	return result, nil
+}
+
+func (ctx *HookContext) GoalState() (string, error) {
+	var err error
+	ctx.goalState, err = ctx.state.GoalState()
+	if err != nil {
+		return "", err
+	}
+	return ctx.goalState, nil
 }
 
 func (ctx *HookContext) SetContainerSpec(specYaml string, application bool) error {

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -94,6 +94,9 @@ type ContextUnit interface {
 	// Config returns the current service configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)
 
+	// GoalState returns the goal state for the current unit.
+	GoalState() (string, error)
+
 	// SetContainerSpec updates the yaml spec used to create a container.
 	SetContainerSpec(specYaml string, application bool) error
 }

--- a/worker/uniter/runner/jujuc/goal-state.go
+++ b/worker/uniter/runner/jujuc/goal-state.go
@@ -1,0 +1,55 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/gnuflag"
+)
+
+// GoalStateCommand implements the config-get command.
+type GoalStateCommand struct {
+	cmd.CommandBase
+	ctx Context
+	Key string // The key to show. If empty, show all.
+	out cmd.Output
+}
+
+func NewGoalStateCommand(ctx Context) (cmd.Command, error) {
+	return &GoalStateCommand{ctx: ctx}, nil
+}
+
+func (c *GoalStateCommand) Info() *cmd.Info {
+	doc := `
+'goal-state' command will list the charm units and relations, specifying their status and their relations to other units in different charms.
+`
+	return &cmd.Info{
+		Name:    "goal-state",
+		Purpose: "print the status of the charm's peers and related units",
+		Doc:     doc,
+	}
+}
+
+func (c *GoalStateCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+									"yaml":  cmd.FormatYaml,
+									"json":  cmd.FormatJson,})
+}
+
+func (c *GoalStateCommand) Init(args []string) error {
+	if args == nil {
+		return nil
+	}
+	c.Key = args[0]
+
+	return cmd.CheckEmpty(args[1:])
+}
+
+func (c *GoalStateCommand) Run(ctx *cmd.Context) error {
+	state, err := c.ctx.GoalState()
+	if err != nil {
+		return err
+	}
+	return c.out.Write(ctx, state)
+}

--- a/worker/uniter/runner/jujuc/goal-state_test.go
+++ b/worker/uniter/runner/jujuc/goal-state_test.go
@@ -1,0 +1,153 @@
+// Copyright 2018 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type GoalStateSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&GoalStateSuite{})
+
+func getGoalStateCommand(s *GoalStateSuite, c *gc.C, args []string) (*cmd.Context, int) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("goal-state"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(com, ctx, args)
+	return ctx, code
+}
+
+//var (
+//	goalStateYamlMap = map[string]interface{}{
+//		"tag":    "",
+//		"status": "error",
+//		"info":   "message foo",
+//		"data":   map[interface{}]interface{}{"foo": "bar"},
+//	}
+//	goalStateJsonMap = map[string]interface{}{
+//		"Tag":    "",
+//		"Status": "error",
+//		"Info":   "message foo",
+//		"Data":   map[string]interface{}{"foo": "bar"},
+//	}
+//	goalStateYamlMapAll = map[string]interface{}{
+//		"tag":    "",
+//		"status": "error",
+//		"info":   "message foo",
+//		"data":   map[interface{}]interface{}{"foo": "bar"},
+//	}
+//	goalStateJsonMapAll = map[string]interface{}{
+//		"Tag":    "",
+//		"Status": "error",
+//		"Info":   "message foo",
+//		"Data":   map[string]interface{}{"foo": "bar"},
+//	}
+//)
+
+//var goalStateAllTests = []struct {
+//	args   []string
+//	format int
+//	out    map[string]interface{}
+//}{
+//	{nil, formatYaml, goalStateYamlMap},
+//	{[]string{"--format", "yaml"}, formatYaml, goalStateYamlMap},
+//	{[]string{"--format", "json"}, formatJson, goalStateJsonMap},
+//	{[]string{"--all", "--format", "yaml"}, formatYaml, goalStateYamlMapAll},
+//	{[]string{"--all", "--format", "json"}, formatJson, goalStateJsonMapAll},
+//	{[]string{"-a", "--format", "yaml"}, formatYaml, goalStateYamlMapAll},
+//	{[]string{"-a", "--format", "json"}, formatJson, goalStateJsonMapAll},
+//}
+
+// TODO (agprado): Parse yaml and json in the next PR
+
+//var goalStateAllTests = []struct {
+//	args   []string
+//	format int
+//	out    string
+//}{
+//	{nil, formatYaml, "foo"},
+//	{[]string{"--format", "yaml"}, formatYaml, "bar"},
+//	{[]string{"--format", "json"}, formatJson, "foo"},
+//	{[]string{"--all", "--format", "yaml"}, formatYaml, "foo"},
+//	{[]string{"--all", "--format", "json"}, formatJson, "bar"},
+//	{[]string{"-a", "--format", "yaml"}, formatYaml, "foo"},
+//	{[]string{"-a", "--format", "json"}, formatJson, "bar"},
+//}
+//func (s *GoalStateSuite) TestOutputFormatAll(c *gc.C) {
+//	for i, t := range goalStateAllTests {
+//		c.Logf("test %d: %#v", i, t.args)
+//
+//		ctx, code := getGoalStateCommand(s, c, t.args)
+//
+//		c.Assert(code, gc.Equals, 0)
+//		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+//		out := ctx.Stdout
+//		//switch t.format {
+//		//case formatYaml:
+//		//	c.Assert(goyaml.Unmarshal(bufferBytes(ctx.Stdout), &out), gc.IsNil)
+//		//case formatJson:
+//		//	c.Assert(json.Unmarshal(bufferBytes(ctx.Stdout), &out), gc.IsNil)
+//		//}
+//		c.Assert(out, gc.DeepEquals, t.out)
+//	}
+//}
+
+func (s *GoalStateSuite) TestHelp(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("goal-state"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: goal-state [options]
+
+Summary:
+print the status of the charm's peers and related units
+
+Options:
+--format  (= yaml)
+    Specify output format (json|yaml)
+-o, --output (= "")
+    Specify an output file
+
+Details:
+'goal-state' command will list the charm units and relations, specifying their status and their relations to other units in different charms.
+`)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+}
+
+func (s *GoalStateSuite) TestOutputPath(c *gc.C) {
+
+	args := []string{"--output", "some-file", "monsters"}
+	ctx, code := getGoalStateCommand(s, c, args)
+
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+
+	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(content), gc.Equals, "test-goal-state\n")
+}
+
+func (s *GoalStateSuite) TestUnknownArg(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("goal-state"))
+	c.Assert(err, jc.ErrorIsNil)
+	cmdtesting.TestInit(c, com, []string{"multiple", "keys"}, `unrecognized args: \["keys"\]`)
+}
+

--- a/worker/uniter/runner/jujuc/jujuctesting/suite.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/suite.go
@@ -31,9 +31,10 @@ func (s *ContextSuite) NewInfo() *ContextInfo {
 		"title":               "My Title",
 		"username":            "admin001",
 	}
+	info.GoalState        = "test-goal-state"
 	info.AvailabilityZone = "us-east-1a"
-	info.PublicAddress = "gimli.minecraft.testing.invalid"
-	info.PrivateAddress = "192.168.0.99"
+	info.PublicAddress    = "gimli.minecraft.testing.invalid"
+	info.PrivateAddress   = "192.168.0.99"
 	return &info
 }
 

--- a/worker/uniter/runner/jujuc/jujuctesting/unit.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/unit.go
@@ -12,6 +12,7 @@ import (
 type Unit struct {
 	Name           string
 	ConfigSettings charm.Settings
+	GoalState      string
 	ContainerSpec  string
 	Application    bool
 }
@@ -38,6 +39,15 @@ func (c *ContextUnit) ConfigSettings() (charm.Settings, error) {
 	}
 
 	return c.info.ConfigSettings, nil
+}
+
+// GoalState implements jujuc.ContextUnit.
+func (c *ContextUnit) GoalState() (string, error) {
+	c.stub.AddCall("GoalState")
+	if err := c.stub.NextErr(); err != nil {
+		return "", errors.Trace(err)
+	}
+	return c.info.GoalState, nil
 }
 
 func (c *ContextUnit) SetContainerSpec(specYaml string, application bool) error {

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -25,6 +25,11 @@ type RestrictedContext struct{}
 // ConfigSettings implements hooks.Context.
 func (*RestrictedContext) ConfigSettings() (charm.Settings, error) { return nil, ErrRestrictedContext }
 
+// GoalState implements hooks.Context.
+func (*RestrictedContext) GoalState() (string, error) {
+	return "", ErrRestrictedContext
+}
+
 // UnitStatus implements hooks.Context.
 func (*RestrictedContext) UnitStatus() (*StatusInfo, error) {
 	return nil, ErrRestrictedContext

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -64,6 +64,7 @@ var baseCommands = map[string]creator{
 	"network-get" + cmdSuffix:             NewNetworkGetCommand,
 	"application-version-set" + cmdSuffix: NewApplicationVersionSetCommand,
 	"container-spec-set" + cmdSuffix:      NewContainerspecSetCommand,
+	"goal-state" + cmdSuffix:              NewGoalStateCommand,
 }
 
 var storageCommands = map[string]creator{


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

'goal-state' hook will provide the charms the ability to check the desired state defined by the user and compare it with the current state.

----

## Description of change

Implementation of new hook command `goal-state`.

## QA steps

After successful provisioning and deploying a charm. Run the hook `goal-state`. In this example I use a mysql charm.

     $ ./juju run --unit mysql/0 'goal-state'
     error: null
     result: Hello World I'll be a yaml

The hook is not completely implemented yet. But the command should return the fixed string `Hello World I'll be a yaml`. This string will be a yaml parsable object in the near future. I will implement this in the next PR.

## Documentation changes

To be implemented with the final implementation of the hook command

## Bug reference

N/A
