### PR TITLE
Handle missing relation egress networks

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -200,7 +200,7 @@ func (s *applicationOffersSuite) TestOfferError(c *gc.C) {
 	s.applicationOffers.CheckCallNames(c, addOffersBackendCall)
 }
 
-func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
+func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error, expectedCIDRS []string) {
 	s.setupOffers(c, "test", false)
 	s.mockState.users["mary"] = &mockUser{"mary"}
 	s.mockState.CreateOfferAccess(
@@ -253,7 +253,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 					Endpoint:       "db",
 					Username:       "fred",
 					Status:         params.EntityStatus{Status: "joined"},
-					IngressSubnets: []string{"192.168.1.0/32", "10.0.0.0/8"},
+					IngressSubnets: expectedCIDRS,
 				}},
 			},
 		},
@@ -273,11 +273,17 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error) {
 
 func (s *applicationOffersSuite) TestList(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("admin")
-	s.assertList(c, nil)
+	s.assertList(c, nil, []string{"192.168.1.0/32", "10.0.0.0/8"})
+}
+
+func (s *applicationOffersSuite) TestListNoRelationNetworks(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("admin")
+	s.mockState.relationNetworks = nil
+	s.assertList(c, nil, nil)
 }
 
 func (s *applicationOffersSuite) TestListPermission(c *gc.C) {
-	s.assertList(c, common.ErrPerm)
+	s.assertList(c, common.ErrPerm, nil)
 }
 
 func (s *applicationOffersSuite) TestListError(c *gc.C) {

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -208,10 +208,12 @@ func (api *BaseAPI) getOfferAdminDetails(backend Backend, app crossmodel.Applica
 			Since:  relStatus.Since,
 		}
 		relIngress, err := backend.IngressNetworks(oc.RelationKey())
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return errors.Trace(err)
 		}
-		connDetails.IngressSubnets = relIngress.CIDRS()
+		if err == nil {
+			connDetails.IngressSubnets = relIngress.CIDRS()
+		}
 		offer.Connections = append(offer.Connections, connDetails)
 	}
 

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -57,6 +57,7 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 		accessPerms:       make(map[offerAccess]permission.Access),
 		spaces:            make(map[string]applicationoffers.Space),
 		relations:         make(map[string]crossmodel.Relation),
+		relationNetworks:  &mockRelationNetworks{},
 	}
 	s.mockStatePool = &mockStatePool{map[string]applicationoffers.Backend{s.mockState.modelUUID: s.mockState}}
 }

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -332,6 +332,7 @@ type mockState struct {
 	relations         map[string]crossmodel.Relation
 	connections       []applicationoffers.OfferConnection
 	accessPerms       map[offerAccess]permission.Access
+	relationNetworks  state.RelationNetworks
 }
 
 func (m *mockState) GetAddressAndCertGetter() common.AddressAndCertGetter {
@@ -431,7 +432,10 @@ func (m *mockRelationNetworks) CIDRS() []string {
 }
 
 func (m *mockState) IngressNetworks(relationKey string) (state.RelationNetworks, error) {
-	return &mockRelationNetworks{}, nil
+	if m.relationNetworks == nil {
+		return nil, errors.NotFoundf("ingress networks")
+	}
+	return m.relationNetworks, nil
 }
 
 func (m *mockState) GetOfferAccess(offerUUID string, user names.UserTag) (permission.Access, error) {


### PR DESCRIPTION
## Description of change

A small fix for listing offers. If there are no relation egress networks recorded, handle that properly.
This happens if the offer is a "requires" endpoint.

## QA steps

Run up a CMR model with nagios/nrpe
Check output of juju offers to ensure it is complete

