### PR TITLE
Credential models and its owner's access to these models.

### DIFF
--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -286,6 +286,8 @@ func (st *State) AllCloudCredentials(user names.UserTag) ([]Credential, error) {
 	return credentials, nil
 }
 
+// CredentialOwnerModelAccess storescloud credntial model information for the credential owner
+// or an error retrieving it.
 type CredentialOwnerModelAccess struct {
 	ModelName   string
 	OwnerAccess permission.Access
@@ -312,9 +314,10 @@ func (st *State) CredentialModelsAndOwnerAccess(tag names.CloudCredentialTag) ([
 		results[i] = CredentialOwnerModelAccess{ModelName: model.Name}
 		ownerAccess, err := st.UserAccess(tag.Owner(), names.NewModelTag(model.UUID))
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				results[i].Error = errors.Trace(err)
+			if errors.IsNotFound(err) {
+				results[i].OwnerAccess = permission.NoAccess
 			}
+			results[i].Error = errors.Trace(err)
 			continue
 		}
 		results[i].OwnerAccess = ownerAccess.Access

--- a/state/credentialmodels_test.go
+++ b/state/credentialmodels_test.go
@@ -30,14 +30,14 @@ var _ = gc.Suite(&CredentialModelsSuite{})
 func (s *CredentialModelsSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 
-	// Cloud name is always "dummy" as deep within the testing infrastructure,
-	// we create a testing controller on a cloud "dummy".
-	// Test cloud "dummy" only allows credentials with an empty auth type.
 	s.credentialTag = s.createCloudCredential(c, "foobar")
 	s.addModel(c, "abcmodel", s.credentialTag)
 }
 
 func (s *CredentialModelsSuite) createCloudCredential(c *gc.C, credentialName string) names.CloudCredentialTag {
+	// Cloud name is always "dummy" as deep within the testing infrastructure,
+	// we create a testing controller on a cloud "dummy".
+	// Test cloud "dummy" only allows credentials with an empty auth type.
 	tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", "dummy", s.Owner.Id(), credentialName))
 	err := s.State.UpdateCloudCredential(tag, cloud.NewEmptyCredential())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/credentialmodels_test.go
+++ b/state/credentialmodels_test.go
@@ -1,0 +1,97 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+type CredentialModelsSuite struct {
+	ConnSuite
+
+	credentialTag names.CloudCredentialTag
+}
+
+var _ = gc.Suite(&CredentialModelsSuite{})
+
+func (s *CredentialModelsSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+
+	// Cloud name is always "dummy" as deep within the testing infrastructure,
+	// we create a testing controller on a cloud "dummy".
+	// Test cloud "dummy" only allows credentials with an empty auth type.
+	s.credentialTag = s.createCloudCredential(c, "foobar")
+	s.addModel(c, "abcmodel", s.credentialTag)
+}
+
+func (s *CredentialModelsSuite) createCloudCredential(c *gc.C, credentialName string) names.CloudCredentialTag {
+	tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", "dummy", s.Owner.Id(), credentialName))
+	err := s.State.UpdateCloudCredential(tag, cloud.NewEmptyCredential())
+	c.Assert(err, jc.ErrorIsNil)
+	return tag
+}
+
+func (s *CredentialModelsSuite) addModel(c *gc.C, modelName string, tag names.CloudCredentialTag) {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": modelName,
+		"uuid": uuid.String(),
+	})
+	_, st, err := s.State.NewModel(state.ModelArgs{
+		Type:                    state.ModelTypeIAAS,
+		CloudName:               "dummy",
+		CloudRegion:             "dummy-region",
+		Config:                  cfg,
+		Owner:                   tag.Owner(),
+		CloudCredential:         tag,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+}
+
+func (s *CredentialModelsSuite) TestCredentialModelsAndOwnerAccess(c *gc.C) {
+	out, err := s.State.CredentialModelsAndOwnerAccess(s.credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, []state.CredentialOwnerModelAccess{
+		{ModelName: "abcmodel", OwnerAccess: permission.AdminAccess},
+	})
+}
+
+func (s *CredentialModelsSuite) TestCredentialModelsAndOwnerAccessMany(c *gc.C) {
+	// add another model with the same credential
+	s.addModel(c, "xyzmodel", s.credentialTag)
+
+	// add another model with a different credential - should not be in the output.
+	anotherCredential := s.createCloudCredential(c, "another")
+	s.addModel(c, "dontshow", anotherCredential)
+
+	out, err := s.State.CredentialModelsAndOwnerAccess(s.credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, []state.CredentialOwnerModelAccess{
+		{ModelName: "abcmodel", OwnerAccess: permission.AdminAccess},
+		{ModelName: "xyzmodel", OwnerAccess: permission.AdminAccess},
+	})
+}
+
+func (s *CredentialModelsSuite) TestCredentialModelsAndOwnerAccessNoModels(c *gc.C) {
+	anotherCredential := s.createCloudCredential(c, "another")
+
+	out, err := s.State.CredentialModelsAndOwnerAccess(anotherCredential)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(out, gc.HasLen, 0)
+}


### PR DESCRIPTION
## Description of change

Soon-coming new 'show-credential' command will display credential content to the credential owner as well as models that use this credential and the credential owner's access to these models.

This PR introduces the state-level call that returns credential models and owner access.

I have pondered whether we do want to return {*state.Model, *state.UserAccess} from this call. However, considering Model objects could be big and we only want Access for the owner, I have decided to only return required information. 
