### PR TITLE
Wait for env.sh to be populated in RunHook.

### DIFF
--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -202,11 +202,16 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	timeout := time.After(testing.LongWait)
 	envsh := filepath.Join(debugDir, "env.sh")
 	for {
-		if _, err := os.Stat(envsh); err == nil {
-			break
+		// Wait for env.sh to show up, and have some content. If it exists and
+		// is size 0, we managed to see it at exactly the time it is being
+		// written.
+		if st, err := os.Stat(envsh); err == nil {
+			if st.Size() != 0 {
+				break
+			}
 		}
 		select {
-		case <-time.After(testing.ShortWait):
+		case <-time.After(time.Millisecond):
 		case <-timeout:
 			c.Fatal("timed out waiting for env.sh to be written")
 		}


### PR DESCRIPTION
## Description of change

One thing people often don't realize is that when doing:
```
 $ blah > foo.txt
```

foo.txt is opened by bash, and passed in. Which means it exists before
the command is run, and before the command completes. So the external
test was waiting for the file to show up, but it shows up first as a
0-length file, and then we happen to read the contents, which may not be
populated yet.

The heuristic is a bit weak (anything non-zero), but because the length
of the actual content we write is reasonably small, we can assume that
we'll see it all or see nothing. (If it was longer, we might see part of
the file written before the rest of the content.)

The easiest way to test for this is to change server.go
```
-export | grep -v $FILTER > $JUJU_DEBUG/env.sh
+(/bin/sleep 2; export) | grep -v $FILTER > $JUJU_DEBUG/env.sh
```

That forces a very large window from when the file is created, until it
is populated. And "RunHook" fails reliably without this patch, but
succeeds properly with it.

Also, drop the sleep time inside the loop from 50ms down to 1ms. We
really are just giving the other threads time to create the file, we
don't need to wait 50ms for it to finish.

## QA steps

See above, changing the line in server.go makes this fail reliably, which helps us make sure that it now passes reliably. :)

## Documentation changes

None.

## Bug reference

[lp:1749320](https://bugs.launchpad.net/juju/+bug/1749320)