### PR TITLE
Replace Mongo Space Name/Status with Config HA Space.

### DIFF
--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -700,35 +700,6 @@ func (s *MongoSuite) TestSelectPeerAddress(c *gc.C) {
 	c.Assert(address, gc.Equals, "10.0.0.1")
 }
 
-func (s *MongoSuite) TestSelectPeerHostPort(c *gc.C) {
-
-	hostPorts := []network.HostPort{{
-		Address: network.Address{
-			Value: "127.0.0.1",
-			Type:  network.IPv4Address,
-			Scope: network.ScopeMachineLocal,
-		},
-		Port: controller.DefaultStatePort,
-	}, {
-		Address: network.Address{
-			Value: "10.0.0.1",
-			Type:  network.IPv4Address,
-			Scope: network.ScopeCloudLocal,
-		},
-		Port: controller.DefaultStatePort,
-	}, {
-		Address: network.Address{
-			Value: "8.8.8.8",
-			Type:  network.IPv4Address,
-			Scope: network.ScopePublic,
-		},
-		Port: controller.DefaultStatePort,
-	}}
-
-	address := mongo.SelectPeerHostPort(hostPorts)
-	c.Assert(address, gc.Equals, "10.0.0.1:"+strconv.Itoa(controller.DefaultStatePort))
-}
-
 func (s *MongoSuite) TestGenerateSharedSecret(c *gc.C) {
 	secret, err := mongo.GenerateSharedSecret()
 	c.Assert(err, jc.ErrorIsNil)

--- a/network/address.go
+++ b/network/address.go
@@ -337,18 +337,6 @@ func SelectControllerAddress(addresses []Address, machineLocal bool) (Address, b
 	return internalAddress, ok
 }
 
-// SelectHostPortsByScope looks through the HostPorts supplied and tries to
-// find one that is cloud-local. If necessary, passing machineLocal=true will
-// allow it to accept machine local addresses as well as cloud-local addresses,
-// but this is generally not recommended. (Once you are in HA you need
-// addresses that can be reached from another machine.)
-func SelectHostPortsByScope(hostPorts []HostPort, machineLocal bool) []string {
-	// Fallback to using the legacy and error-prone approach using scope
-	// selection instead.
-	internalHP := SelectInternalHostPort(hostPorts, machineLocal)
-	return []string{internalHP}
-}
-
 // SelectPublicAddress picks one address from a slice that would be
 // appropriate to display as a publicly accessible endpoint. If there
 // are no suitable addresses, then ok is false (and an empty address is

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -128,11 +128,18 @@ func (info *peerGroupInfo) initNewReplicaSet() map[string]*replicaset.Member {
 	return rs
 }
 
-// desiredPeerGroup returns the mongo peer group according to the given
-// servers and a map with an element for each machine in info.machines
-// specifying whether that machine has been configured as voting. It will
-// return a nil member list and error if the current group is already
-// correct, though the voting map will be still be returned in that case.
+// desiredPeerGroup returns a new Mongo peer-group calculated from the input
+// peerGroupInfo.
+// Returned are the new members indexed by machine ID, and a map indicating
+// which machines are set as voters in the new new peer-group.
+// If the new peer-group is does not differ from that indicated by the input
+// peerGroupInfo, a nil member map is returned along with the correct voters
+// map.
+// An error is returned if:
+//   1) There are members unrecognised by machine association,
+//      and any of these are set as voters.
+//   2) There is no HA space configured and any machines have multiple
+//      cloud-local addresses.
 func desiredPeerGroup(info *peerGroupInfo) (map[string]*replicaset.Member, map[string]bool, error) {
 	logger.Debugf(info.getLogMessage())
 

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -189,7 +189,10 @@ func (s *desiredPeerGroupSuite) TestDesiredPeerGroup(c *gc.C) {
 				c.Assert(trackerMap[m.Id()], gc.IsNil)
 				trackerMap[m.Id()] = m
 			}
+
 			info, err := newPeerGroupInfo(trackerMap, test.statuses, test.members, mongoPort, network.SpaceName(""))
+			c.Assert(err, jc.ErrorIsNil)
+
 			newPeers, voting, err := desiredPeerGroup(info)
 			if test.expectErr != "" {
 				c.Assert(err, gc.ErrorMatches, test.expectErr)

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -84,3 +84,21 @@ func (s *machineTrackerSuite) TestSelectMongoAddressReturnsErrNoSpaceMultipleClo
 	c.Check(err, gc.ErrorMatches, `machine "3" has more than one non-local address and juju-ha-space is not set`)
 	c.Check(addr, gc.Equals, "")
 }
+
+func (s *machineTrackerSuite) TestSelectMongoAddressReturnsEmptyWhenNoAddressFound(c *gc.C) {
+	spaceName := network.SpaceName("")
+
+	m := &machineTracker{
+		id: "3",
+		addresses: []network.Address{
+			{
+				Value: "localhost",
+				Scope: network.ScopeMachineLocal,
+			},
+		},
+	}
+
+	addr, err := m.SelectMongoAddress(666, spaceName)
+	c.Assert(err, gc.IsNil)
+	c.Check(addr, gc.Equals, "")
+}

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package peergrouper
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type machineTrackerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&machineTrackerSuite{})
+
+func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithSpace(c *gc.C) {
+	spaceName := network.SpaceName("ha-space")
+
+	m := &machineTracker{
+		addresses: []network.Address{
+			{
+				Value:     "192.168.5.5",
+				Scope:     network.ScopeCloudLocal,
+				SpaceName: spaceName,
+			},
+			{
+				Value: "localhost",
+				Scope: network.ScopeMachineLocal,
+			},
+		},
+	}
+
+	addr, err := m.SelectMongoAddress(666, spaceName)
+	c.Assert(err, gc.IsNil)
+	c.Check(addr, gc.Equals, "192.168.5.5:666")
+}
+
+func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithoutSpace(c *gc.C) {
+	spaceName := network.SpaceName("")
+
+	m := &machineTracker{
+		addresses: []network.Address{
+			{
+				Value: "192.168.5.5",
+				Scope: network.ScopeCloudLocal,
+			},
+			{
+				Value: "localhost",
+				Scope: network.ScopeMachineLocal,
+			},
+		},
+	}
+
+	addr, err := m.SelectMongoAddress(666, spaceName)
+	c.Assert(err, gc.IsNil)
+	c.Check(addr, gc.Equals, "192.168.5.5:666")
+}
+
+func (s *machineTrackerSuite) TestSelectMongoAddressReturnsErrNoSpaceMultipleCloudLocal(c *gc.C) {
+	spaceName := network.SpaceName("")
+
+	m := &machineTracker{
+		id: "3",
+		addresses: []network.Address{
+			{
+				Value: "192.168.5.5",
+				Scope: network.ScopeCloudLocal,
+			},
+			{
+				Value: "10.0.0.1",
+				Scope: network.ScopeCloudLocal,
+			},
+			{
+				Value: "localhost",
+				Scope: network.ScopeMachineLocal,
+			},
+		},
+	}
+
+	addr, err := m.SelectMongoAddress(666, spaceName)
+	c.Check(err, gc.ErrorMatches, `machine "3" has more than one non-local address and juju-ha-space is not set`)
+	c.Check(addr, gc.Equals, "")
+}

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -27,6 +27,11 @@ func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithSpa
 				SpaceName: spaceName,
 			},
 			{
+				Value:     "192.168.10.5",
+				Scope:     network.ScopeCloudLocal,
+				SpaceName: network.SpaceName("another-space"),
+			},
+			{
 				Value: "localhost",
 				Scope: network.ScopeMachineLocal,
 			},

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/juju/errors"
@@ -429,10 +430,10 @@ func (session *fakeMongoSession) setStatus(members []replicaset.MemberStatus) {
 // Set implements mongoSession.Set
 func (session *fakeMongoSession) Set(members []replicaset.Member) error {
 	if err := session.errors.errorFor("Session.Set"); err != nil {
-		logger.Infof("NOT setting replicaset members to \n%s", prettyReplicaSetMembers(members))
+		logger.Infof("NOT setting replicaset members to \n%s", prettyReplicaSetMembersSlice(members))
 		return err
 	}
-	logger.Infof("setting replicaset members to \n%s", prettyReplicaSetMembers(members))
+	logger.Infof("setting replicaset members to \n%s", prettyReplicaSetMembersSlice(members))
 	session.members.Set(deepCopy(members))
 	if session.InstantlyReady {
 		statuses := make([]replicaset.MemberStatus, len(members))
@@ -451,6 +452,17 @@ func (session *fakeMongoSession) Set(members []replicaset.Member) error {
 	}
 	session.checker.checkInvariants()
 	return nil
+}
+
+// prettyReplicaSetMembersSlice wraps prettyReplicaSetMembers for testing
+// purposes only.
+func prettyReplicaSetMembersSlice(members []replicaset.Member) string {
+	vrm := make(map[string]*replicaset.Member, len(members))
+	for i := range members {
+		m := members[i]
+		vrm[strconv.Itoa(i)] = &m
+	}
+	return prettyReplicaSetMembers(vrm)
 }
 
 // deepCopy makes a deep copy of any type by marshalling

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/juju/replicaset"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/clock"
+	//"github.com/juju/utils/clock"
 	"github.com/juju/utils/voyeur"
 	gc "gopkg.in/check.v1"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/pubsub/apiserver"
-	"github.com/juju/juju/state"
+	//"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/workertest"
 )
@@ -116,14 +116,14 @@ func ExpectedAPIHostPorts(n int, ipVersion TestIPVersion) [][]network.HostPort {
 }
 
 func (s *workerSuite) TestSetsAndUpdatesMembersIPv4(c *gc.C) {
-	s.dotestSetAndUpdateMembers(c, testIPv4)
+	s.doTestSetAndUpdateMembers(c, testIPv4)
 }
 
 func (s *workerSuite) TestSetsAndUpdatesMembersIPv6(c *gc.C) {
-	s.dotestSetAndUpdateMembers(c, testIPv6)
+	s.doTestSetAndUpdateMembers(c, testIPv6)
 }
 
-func (s *workerSuite) dotestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion) {
+func (s *workerSuite) doTestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion) {
 	c.Logf("\n\nTestSetsAndUpdatesMembers: %s", ipVersion.version)
 	st := NewFakeState()
 	InitState(c, st, 3, ipVersion)
@@ -209,14 +209,14 @@ func (s *workerSuite) dotestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion
 }
 
 func (s *workerSuite) TestHasVoteMaintainedEvenWhenReplicaSetFailsIPv4(c *gc.C) {
-	s.dotestHasVoteMaintainsEvenWhenReplicaSetFails(c, testIPv4)
+	s.doTestHasVoteMaintainsEvenWhenReplicaSetFails(c, testIPv4)
 }
 
 func (s *workerSuite) TestHasVoteMaintainedEvenWhenReplicaSetFailsIPv6(c *gc.C) {
-	s.dotestHasVoteMaintainsEvenWhenReplicaSetFails(c, testIPv6)
+	s.doTestHasVoteMaintainsEvenWhenReplicaSetFails(c, testIPv6)
 }
 
-func (s *workerSuite) dotestHasVoteMaintainsEvenWhenReplicaSetFails(c *gc.C, ipVersion TestIPVersion) {
+func (s *workerSuite) doTestHasVoteMaintainsEvenWhenReplicaSetFails(c *gc.C, ipVersion TestIPVersion) {
 	st := NewFakeState()
 
 	// Simulate a state where we have four controllers,
@@ -493,7 +493,9 @@ func (s *workerSuite) TestControllersArePublishedOverHub(c *gc.C) {
 	}
 }
 
-func mongoSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, noSpaces bool) (*fakeState, []string, []network.Address) {
+func mongoSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, addSpaces bool) (
+	*fakeState, []string, []network.Address,
+) {
 	st := NewFakeState()
 	InitState(c, st, 3, ipVersion)
 
@@ -502,10 +504,13 @@ func mongoSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, noSpaces bool) 
 		fmt.Sprintf(ipVersion.formatHost, 2),
 		fmt.Sprintf(ipVersion.formatHost, 3),
 	)
-	if !noSpaces {
+	if addSpaces {
 		addrs[0].SpaceName = "one"
 		addrs[1].SpaceName = "two"
 		addrs[2].SpaceName = "three"
+	}
+	for i := range addrs {
+		addrs[i].Scope = network.ScopeCloudLocal
 	}
 
 	machines := []string{"10", "11", "12"}
@@ -519,33 +524,10 @@ func mongoSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, noSpaces bool) 
 	return st, machines, addrs
 }
 
-func startWorkerSupportingSpaces(c *gc.C, st *fakeState, ipVersion TestIPVersion) worker.Worker {
-	w, err := New(Config{
-		State:              st,
-		MongoSession:       st.session,
-		APIHostPortsSetter: nopAPIHostPortsSetter{},
-		Clock:              clock.WallClock,
-		SupportsSpaces:     true,
-		MongoPort:          mongoPort,
-		APIPort:            apiPort,
-		Hub:                nopHub{},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	return w
-}
-
-func runWorkerUntilMongoStateIs(c *gc.C, st *fakeState, w worker.Worker, mss state.MongoSpaceStates) {
-	changes := st.controllers.Watch()
-	changes.Next()
-	for st.getMongoSpaceState() != mss {
-		changes.Next()
-	}
-	workertest.CleanKill(c, w)
-}
-
-func (s *workerSuite) TestMongoFindAndUseSpace(c *gc.C) {
+func (s *workerSuite) TestUsesConfiguredHASpace(c *gc.C) {
 	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, false)
+		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, true)
+		st.setHASpace("one")
 
 		for i, machine := range machines {
 			// machine 10 gets an address in space one
@@ -554,11 +536,7 @@ func (s *workerSuite) TestMongoFindAndUseSpace(c *gc.C) {
 			st.machine(machine).setAddresses(addrs[:i+1]...)
 		}
 
-		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "one")
+		s.runUntilPublish(c, st, "")
 
 		// All machines have the same address in this test for simplicity. The
 		// space three address is 0.0.0.3 giving us the host port of 0.0.0.3:4711
@@ -573,53 +551,7 @@ func (s *workerSuite) TestMongoFindAndUseSpace(c *gc.C) {
 	})
 }
 
-func (s *workerSuite) TestMongoErrorNoCommonSpace(c *gc.C) {
-	c.Skip("dimitern: test disabled as it needs refactoring")
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, false)
-
-		for i, machine := range machines {
-			// machine 10 gets an address in space one
-			// machine 11 gets an address in space two
-			// machine 12 gets an address in space three
-			st.machine(machine).setAddresses(addrs[i])
-		}
-
-		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		done := make(chan error)
-		go func() {
-			done <- w.Wait()
-		}()
-		select {
-		case err := <-done:
-			c.Assert(err, gc.ErrorMatches, ".*couldn't find a space containing all peer group machines")
-		case <-time.After(coretesting.LongWait):
-			c.Fatalf("timed out waiting for worker to exit")
-		}
-
-		// Each machine is in a unique space, so the Mongo space should be empty
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "")
-		c.Assert(st.getMongoSpaceState(), gc.Equals, state.MongoSpaceInvalid)
-	})
-}
-
-func (s *workerSuite) TestMongoNoSpaces(c *gc.C) {
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, true)
-
-		for i, machine := range machines {
-			st.machine(machine).setAddresses(addrs[i])
-		}
-
-		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "")
-	})
-}
-
-func (s *workerSuite) TestMongoSpaceNotOverwritten(c *gc.C) {
+func (s *workerSuite) TestReturnsErrorWhenNoHASpaceAndMachinesWithMultiLocalAddr(c *gc.C) {
 	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
 		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, false)
 
@@ -630,65 +562,41 @@ func (s *workerSuite) TestMongoSpaceNotOverwritten(c *gc.C) {
 			st.machine(machine).setAddresses(addrs[:i+1]...)
 		}
 
-		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "one")
-
-		// Set st.mongoSpaceName to something different
-		st.SetMongoSpaceState(state.MongoSpaceUnknown)
-		st.SetOrGetMongoSpaceName("testing")
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
-
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "testing")
-		c.Assert(st.getMongoSpaceState(), gc.Equals, state.MongoSpaceValid)
+		err := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}).Wait()
+		errMsg := `cannot compute desired peer group: machine "11" has more than one non-local address and juju-ha-space is not set`
+		c.Assert(err, gc.ErrorMatches, errMsg)
 	})
 }
 
-func (s *workerSuite) TestMongoSpaceSetFromConfig(c *gc.C) {
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, false)
-		st.setHASpace("controller-ha-space")
-
-		// As in the prior test, this would auto-determine the Mongo space to
-		// be "one", had we no controller config set for HA space.
-		for i, machine := range machines {
-			st.machine(machine).setAddresses(addrs[:i+1]...)
-		}
-
-		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "controller-ha-space")
+// runUntilPublish runs a worker until addresses are published over the pub/sub
+// hub. Note that the replica-set is updated earlier than the publish,
+// so this sync can be used to check for those changes.
+// If errMsg is not empty, it is used to check for a matching error.
+func (s *workerSuite) runUntilPublish(c *gc.C, st *fakeState, errMsg string) {
+	hub := pubsub.NewStructuredHub(nil)
+	event := make(chan apiserver.Details)
+	_, err := hub.Subscribe(apiserver.DetailsTopic, func(topic string, data apiserver.Details, err error) {
+		c.Check(err, jc.ErrorIsNil)
+		event <- data
 	})
-}
+	c.Assert(err, jc.ErrorIsNil)
+	s.hub = hub
 
-func (s *workerSuite) TestMongoSpaceNotCalculatedWhenSpacesNotSupported(c *gc.C) {
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st, machines, addrs := mongoSpaceTestCommonSetup(c, ipVersion, false)
-
-		for i, machine := range machines {
-			// machine 10 gets an address in space one
-			// machine 11 gets addresses in spaces one and two
-			// machine 12 gets addresses in spaces one, two and three
-			st.machine(machine).setAddresses(addrs[:i+1]...)
+	w := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{})
+	defer func() {
+		if errMsg == "" {
+			workertest.CleanKill(c, w)
+		} else {
+			err := workertest.CheckKill(c, w)
+			c.Assert(err, gc.ErrorMatches, errMsg)
 		}
+	}()
 
-		// Set some garbage up to check that it isn't overwritten
-		st.SetOrGetMongoSpaceName("garbage")
-		st.SetMongoSpaceState(state.MongoSpaceUnknown)
-
-		// Start a worker that doesn't support spaces
-		w := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{})
-		defer workertest.CleanKill(c, w)
-		runWorkerUntilMongoStateIs(c, st, w.(*pgWorker), state.MongoSpaceUnsupported)
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "garbage")
-		c.Assert(st.getMongoSpaceState(), gc.Equals, state.MongoSpaceUnsupported)
-	})
+	select {
+	case <-event:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for event")
+	}
 }
 
 func (s *workerSuite) TestWorkerRetriesOnPublishError(c *gc.C) {


### PR DESCRIPTION
## Why is this change needed?

- Do not attempt to calculate a space based on potential peer group member addresses.
- Use the controller HA space when attempting to compute the peer group.
- If no space is configured, and any potential members have more than one suitable address, return an error.
- Removes superfluous calls involved in filtering addresses by space and scope.

## QA steps

Accompanying unit tests.
Subject to change after system testing in progress.

## Documentation changes

None, aside from those previously mentioned in this series regarding controller configuration values.

## Bug reference

Progresses https://bugs.launchpad.net/juju/+bug/1591962
