### PR TITLE
Handle some small failures on Windows.

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1413,7 +1413,11 @@ func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {
 
 	tmpFile, err := ioutil.TempFile("", "juju-bootstrap-test")
 	c.Assert(err, jc.ErrorIsNil)
-	defer func() { err := os.Remove(tmpFile.Name()); c.Assert(err, jc.ErrorIsNil) }()
+	defer func() {
+		tmpFile.Close()
+		err := os.Remove(tmpFile.Name())
+		c.Assert(err, jc.ErrorIsNil)
+	}()
 
 	contents := []byte("{something: special}\n")
 	err = ioutil.WriteFile(tmpFile.Name(), contents, 0644)
@@ -1435,8 +1439,8 @@ func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {
 	// that the state of the credential under test before finalization is
 	// indeed the file path itself and that the state of the credential
 	// after finalization is the contents of that file.
-	c.Assert(unfinalizedCredential.Attributes()["file"], gc.Matches, tmpFile.Name())
-	c.Assert(finalizedCredential.Attributes()["file"], gc.Matches, string(contents))
+	c.Assert(unfinalizedCredential.Attributes()["file"], gc.Equals, tmpFile.Name())
+	c.Assert(finalizedCredential.Attributes()["file"], gc.Equals, string(contents))
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegionsInvalid(c *gc.C) {

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -135,7 +135,7 @@ func (c *helpToolCommand) Run(ctx *cmd.Context) error {
 }
 
 var helpToolDoc = fmt.Sprintf(`
-Juju charms can access a series of built-in helpers called 'hook-tools'. 
+Juju charms can access a series of built-in helpers called 'hook-tools'.
 These are useful for the charm to be able to inspect its running environment.
 Currently available charm hook tools are:
 
@@ -145,7 +145,7 @@ Examples:
     For help on a specific tool, supply the name of that tool, for example:
 
         juju hook-tool unit-get
-        
+
 `, listHookTools())
 
 func listHookTools() string {
@@ -158,6 +158,8 @@ func listHookTools() string {
 	longest := 0
 	for _, name := range names {
 		if c, err := jujuc.NewCommand(dummyHookContext{}, name); err == nil {
+			// On Windows name has a '.exe' suffix, while Info().Name does not
+			name := c.Info().Name
 			if len(name) > longest {
 				longest = len(name)
 			}

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -27,7 +27,7 @@ Summary:
 Show help on a Juju charm hook tool.
 
 Details:
-Juju charms can access a series of built-in helpers called 'hook-tools'. 
+Juju charms can access a series of built-in helpers called 'hook-tools'.
 These are useful for the charm to be able to inspect its running environment.
 Currently available charm hook tools are:
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -565,7 +565,7 @@ var commandNames = []string{
 
 // devFeatures are feature flags that impact registration of commands.
 var devFeatures = []string{
-// Currently no feature flags.
+	// Currently no feature flags.
 }
 
 // These are the commands that are behind the `devFeatures`.


### PR DESCRIPTION
## Description of change

Mostly formatting issues that meant Windows improperly compared strings. One
test was using Matches when it wanted Equals, which didn't matter on Linux, but
on Windows the path section was interpreted as regex escapes. The other code
was improperly formatting code because of incorrect expectations about command
names. (On Windows they have a .exe extension.)

## QA steps

On a Windows machine:
```
$ cd cmd\juju\commands
$ go test
```

## Documentation changes

None

## Bug reference

[lp:1751774](https://bugs.launchpad.net/juju/+bug/1751774)