### PR TITLE
Let's Encrypt: use the HTTP challenge in place of DNS one.

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -586,7 +586,7 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer worker.Stop(srv)
 	apiInfo := s.APIInfo(c)
-	apiInfo.Addrs = []string{listener.Addr().String()}
+	apiInfo.Addrs = []string{srv.Addr().String()}
 	conn, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, gc.IsNil)
 	c.Assert(conn.PublicDNSName(), gc.Equals, "somewhere.example.com")

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -24,22 +24,15 @@ import (
 	proxyutils "github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api"
 	apitesting "github.com/juju/juju/api/testing"
-	"github.com/juju/juju/apiserver"
-	"github.com/juju/juju/apiserver/observer"
-	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/core/auditlog"
 	jjtesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
-	"github.com/juju/juju/state"
 	jtesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
@@ -560,36 +553,6 @@ func (s *apiclientSuite) TestOpenWithNoCACert(c *gc.C) {
 	if time.Since(t0) > 5*time.Second {
 		c.Errorf("looks like API is retrying on connection when there is an X509 error")
 	}
-}
-
-func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
-	// Start an API server with a (non-working) autocert hostname,
-	// so we can check that the PublicDNSName in the result goes
-	// all the way through the layers.
-	machineTag := names.NewMachineTag("0")
-	srv, err := apiserver.NewServer(s.StatePool, apiserver.ServerConfig{
-		ListenAddr:      "localhost:0",
-		Clock:           clock.WallClock,
-		GetCertificate:  func() *tls.Certificate { return jtesting.ServerTLSCert },
-		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{} },
-		Tag:             machineTag,
-		Hub:             centralhub.New(machineTag),
-		DataDir:         c.MkDir(),
-		LogDir:          c.MkDir(),
-		AutocertDNSName: "somewhere.example.com",
-		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
-		AutocertURL:     "https://0.1.2.3/no-autocert-here",
-		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
-		UpgradeComplete: func() bool { return true },
-		RestoreStatus:   func() state.RestoreStatus { return state.RestoreNotActive },
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	defer worker.Stop(srv)
-	apiInfo := s.APIInfo(c)
-	apiInfo.Addrs = []string{srv.Addr().String()}
-	conn, err := api.Open(apiInfo, api.DialOpts{})
-	c.Assert(err, gc.IsNil)
-	c.Assert(conn.PublicDNSName(), gc.Equals, "somewhere.example.com")
 }
 
 func (s *apiclientSuite) TestOpenWithRedirect(c *gc.C) {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -566,11 +566,9 @@ func (s *apiclientSuite) TestPublicDNSName(c *gc.C) {
 	// Start an API server with a (non-working) autocert hostname,
 	// so we can check that the PublicDNSName in the result goes
 	// all the way through the layers.
-	// Note that NewServer closes the listener when it stops.
-	listener, err := net.Listen("tcp", "localhost:0")
-	c.Assert(err, gc.IsNil)
 	machineTag := names.NewMachineTag("0")
-	srv, err := apiserver.NewServer(s.StatePool, listener, apiserver.ServerConfig{
+	srv, err := apiserver.NewServer(s.StatePool, apiserver.ServerConfig{
+		ListenAddr:      "localhost:0",
 		Clock:           clock.WallClock,
 		GetCertificate:  func() *tls.Certificate { return jtesting.ServerTLSCert },
 		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{} },

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -6,7 +6,6 @@ package controller_test
 import (
 	"crypto/tls"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/juju/pubsub"
@@ -215,11 +214,8 @@ func (s *legacySuite) TestWatchAllModels(c *gc.C) {
 }
 
 func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
-
-	lis, err := net.Listen("tcp", "localhost:0")
-	c.Assert(err, jc.ErrorIsNil)
-
-	srv, err := apiserver.NewServer(s.StatePool, lis, apiserver.ServerConfig{
+	srv, err := apiserver.NewServer(s.StatePool, apiserver.ServerConfig{
+		ListenAddr:      "localhost:0",
 		Clock:           clock.WallClock,
 		GetCertificate:  func() *tls.Certificate { return testing.ServerTLSCert },
 		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{} },
@@ -237,7 +233,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 
 	// Connect to the API server we've just started.
 	apiInfo := s.APIInfo(c)
-	apiInfo.Addrs = []string{lis.Addr().String()}
+	apiInfo.Addrs = []string{srv.Addr().String()}
 	apiInfo.ModelTag = names.ModelTag{}
 	apiState, err := api.Open(apiInfo, api.DialOpts{})
 	sysManager := controller.NewClient(apiState)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -51,6 +51,12 @@ var logger = loggo.GetLogger("juju.apiserver")
 
 var defaultHTTPMethods = []string{"GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS"}
 
+// enableAutocertChallengeHandler holds whether the autocert listener
+// may be started on port 80. It is defined so that tests can test some
+// of the autocert logic without failing because there's no way to listen
+// on port 80.
+var enableAutocertChallengeHandler = true
+
 // Server holds the server side of the API.
 type Server struct {
 	tomb      tomb.Tomb
@@ -335,7 +341,7 @@ func newServer(stPool *state.StatePool, lis net.Listener, cfg ServerConfig) (_ *
 	srv.lis = newThrottlingListener(
 		tls.NewListener(lis, srv.tlsConfig), cfg.RateLimitConfig, clock.WallClock)
 
-	if srv.challengeHandler != nil {
+	if srv.challengeHandler != nil && enableAutocertChallengeHandler {
 		srv.challengeLis, err = net.Listen("tcp", ":80")
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot listen for autocert challenges")

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -417,6 +417,11 @@ func (srv *Server) newTLSConfig(cfg ServerConfig) (*tls.Config, http.Handler) {
 	return tlsConfig, m.HTTPHandler(nil)
 }
 
+// Addr returns the address that the server is listening on.
+func (srv *Server) Addr() net.Addr {
+	return srv.lis.Addr()
+}
+
 // TotalConnections returns the total number of connections ever made.
 func (srv *Server) TotalConnections() int64 {
 	return atomic.LoadInt64(&srv.totalConn)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -67,7 +67,7 @@ type Server struct {
 	lis       net.Listener
 
 	// challengeLis holds the listener that listens for autocert challenges
-	// on port 80 (only set when autocert is enabled)
+	// on port 80 (only set when autocert is enabled).
 	challengeLis     net.Listener
 	challengeHandler http.Handler
 

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -359,6 +359,7 @@ func (srv *Server) newTLSConfig(cfg ServerConfig) *tls.Config {
 		Cache:      srv.statePool.SystemState().AutocertCache(),
 		HostPolicy: autocert.HostWhitelist(cfg.AutocertDNSName),
 	}
+	go http.ListenAndServe(":http", m.HTTPHandler(nil))
 	if cfg.AutocertURL != "" {
 		m.Client = &acme.Client{
 			DirectoryURL: cfg.AutocertURL,

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -5,8 +5,6 @@ package apiserver_test
 
 import (
 	"crypto/tls"
-	"fmt"
-	"net"
 
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -47,6 +45,7 @@ func (s *apiserverBaseSuite) SetUpTest(c *gc.C) {
 func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 	machineTag := names.NewMachineTag("0")
 	return apiserver.ServerConfig{
+		ListenAddr:      "localhost:0",
 		Clock:           clock.WallClock,
 		GetCertificate:  func() *tls.Certificate { return coretesting.ServerTLSCert },
 		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{} },
@@ -64,9 +63,7 @@ func (s *apiserverBaseSuite) sampleConfig(c *gc.C) apiserver.ServerConfig {
 }
 
 func (s *apiserverBaseSuite) newServerNoCleanup(c *gc.C, config apiserver.ServerConfig) *apiserver.Server {
-	listener, err := net.Listen("tcp", ":0")
-	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(s.StatePool, listener, config)
+	srv, err := apiserver.NewServer(s.StatePool, config)
 	c.Assert(err, jc.ErrorIsNil)
 	return srv
 }
@@ -90,9 +87,8 @@ func (s *apiserverBaseSuite) newServerDirtyKill(c *gc.C, config apiserver.Server
 // APIInfo returns an info struct that has the server's address and ca-cert
 // populated.
 func (s *apiserverBaseSuite) APIInfo(server *apiserver.Server) *api.Info {
-	address := fmt.Sprintf("localhost:%d", server.Addr().Port)
 	return &api.Info{
-		Addrs:  []string{address},
+		Addrs:  []string{server.Addr().String()},
 		CACert: coretesting.CACert,
 	}
 }

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -4,9 +4,6 @@
 package apiserver_test
 
 import (
-	"net"
-
-	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -45,11 +42,7 @@ func (s *auditConfigSuite) TestNewServerValidatesConfig(c *gc.C) {
 	config := s.sampleConfig(c)
 	config.GetAuditConfig = nil
 
-	listener, err := net.Listen("tcp", ":0")
-	c.Assert(err, jc.ErrorIsNil)
-	defer listener.Close()
-
-	srv, err := apiserver.NewServer(s.StatePool, listener, config)
+	srv, err := apiserver.NewServer(s.StatePool, config)
 	c.Assert(err, gc.ErrorMatches, "missing GetAuditConfig not valid")
 	c.Assert(srv, gc.IsNil)
 }

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -97,6 +97,7 @@ func (s *authHTTPSuite) baseURL(c *gc.C) *url.URL {
 }
 
 func dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
+	// TODO(rogpeppe) merge this with the very similar dialWebsocket function.
 	if header == nil {
 		header = http.Header{}
 	}
@@ -106,10 +107,8 @@ func dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket
 	tlsConfig := utils.SecureTLSConfig()
 	tlsConfig.RootCAs = caCerts
 	tlsConfig.ServerName = "anything"
-	c.Logf("dialing %v", server)
 
 	dialer := &websocket.Dialer{
-		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 	conn, _, err := dialer.Dial(server, header)

--- a/apiserver/cert_test.go
+++ b/apiserver/cert_test.go
@@ -157,6 +157,19 @@ func (s *certSuite) TestAutocertNoAutocertDNSName(c *gc.C) {
 	}})
 }
 
+func (s *certSuite) TestClientPublicDNSName(c *gc.C) {
+	s.PatchValue(apiserver.EnableAutocertChallengeHandler, false)
+	config := s.sampleConfig(c)
+	config.AutocertDNSName = "somewhere.example"
+	srv := s.newServer(c, config)
+	apiInfo := s.APIInfo(srv)
+	apiInfo.Tag = s.Owner
+	apiInfo.Password = ownerPassword
+	conn, err := api.Open(apiInfo, api.DialOpts{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(conn.PublicDNSName(), gc.Equals, "somewhere.example")
+}
+
 func gatherLog(f func()) []loggo.Entry {
 	var tw loggo.TestWriter
 	err := loggo.RegisterWriter("test", &tw)

--- a/apiserver/cert_test.go
+++ b/apiserver/cert_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/cert"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -65,6 +66,8 @@ func (s *certSuite) TestUpdateCert(c *gc.C) {
 }
 
 func (s *certSuite) TestAutocertFailure(c *gc.C) {
+	s.PatchValue(apiserver.EnableAutocertChallengeHandler, false)
+
 	// We don't have a fake autocert server, but we can at least
 	// smoke test that the autocert path is followed when we try
 	// to connect to a DNS name - the AutocertURL configured
@@ -97,6 +100,8 @@ func (s *certSuite) TestAutocertFailure(c *gc.C) {
 }
 
 func (s *certSuite) TestAutocertNameMismatch(c *gc.C) {
+	s.PatchValue(apiserver.EnableAutocertChallengeHandler, false)
+
 	config := s.sampleConfig(c)
 	config.AutocertDNSName = "somewhere.example"
 
@@ -125,6 +130,7 @@ func (s *certSuite) TestAutocertNameMismatch(c *gc.C) {
 }
 
 func (s *certSuite) TestAutocertNoAutocertDNSName(c *gc.C) {
+	s.PatchValue(apiserver.EnableAutocertChallengeHandler, false)
 	config := s.sampleConfig(c)
 	c.Assert(config.AutocertDNSName, gc.Equals, "") // sanity check
 	srv := s.newServer(c, config)

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -21,14 +21,13 @@ import (
 )
 
 var (
-	NewPingTimeout                 = newPingTimeout
-	MaxClientPingInterval          = maxClientPingInterval
-	NewBackups                     = &newBackups
-	BZMimeType                     = bzMimeType
-	JSMimeType                     = jsMimeType
-	GUIURLPathPrefix               = guiURLPathPrefix
-	SpritePath                     = spritePath
-	EnableAutocertChallengeHandler = &enableAutocertChallengeHandler
+	NewPingTimeout        = newPingTimeout
+	MaxClientPingInterval = maxClientPingInterval
+	NewBackups            = &newBackups
+	BZMimeType            = bzMimeType
+	JSMimeType            = jsMimeType
+	GUIURLPathPrefix      = guiURLPathPrefix
+	SpritePath            = spritePath
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -4,7 +4,6 @@
 package apiserver
 
 import (
-	"net"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -177,11 +176,6 @@ func TestingRestrictedRoot(check func(string, string) error) rpc.Root {
 func TestingAboutToRestoreRoot() rpc.Root {
 	r := TestingAPIRoot(AllFacades())
 	return restrictRoot(r, aboutToRestoreMethodsOnly)
-}
-
-// Addr returns the address that the server is listening on.
-func (srv *Server) Addr() *net.TCPAddr {
-	return srv.lis.Addr().(*net.TCPAddr) // cannot fail
 }
 
 // PatchGetMigrationBackend overrides the getMigrationBackend function

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -21,13 +21,14 @@ import (
 )
 
 var (
-	NewPingTimeout        = newPingTimeout
-	MaxClientPingInterval = maxClientPingInterval
-	NewBackups            = &newBackups
-	BZMimeType            = bzMimeType
-	JSMimeType            = jsMimeType
-	GUIURLPathPrefix      = guiURLPathPrefix
-	SpritePath            = spritePath
+	NewPingTimeout                 = newPingTimeout
+	MaxClientPingInterval          = maxClientPingInterval
+	NewBackups                     = &newBackups
+	BZMimeType                     = bzMimeType
+	JSMimeType                     = jsMimeType
+	GUIURLPathPrefix               = guiURLPathPrefix
+	SpritePath                     = spritePath
+	EnableAutocertChallengeHandler = &enableAutocertChallengeHandler
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -5,7 +5,6 @@ package apiserver_test
 
 import (
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -210,34 +209,30 @@ func (s *logsinkSuite) TestReceiveErrorBreaksConn(c *gc.C) {
 }
 
 func (s *logsinkSuite) TestNewServerValidatesLogSinkConfig(c *gc.C) {
-	type dummyListener struct {
-		net.Listener
-	}
-
 	cfg := defaultServerConfig(c)
 	cfg.LogSinkConfig = &apiserver.LogSinkConfig{}
 
-	_, err := apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
+	_, err := apiserver.NewServer(s.StatePool, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerBufferSize 0 <= 0 or > 1000 not valid")
 
 	cfg.LogSinkConfig.DBLoggerBufferSize = 1001
-	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerBufferSize 1001 <= 0 or > 1000 not valid")
 
 	cfg.LogSinkConfig.DBLoggerBufferSize = 1
-	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerFlushInterval 0s <= 0 or > 10 seconds not valid")
 
 	cfg.LogSinkConfig.DBLoggerFlushInterval = 30 * time.Second
-	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: DBLoggerFlushInterval 30s <= 0 or > 10 seconds not valid")
 
 	cfg.LogSinkConfig.DBLoggerFlushInterval = 10 * time.Second
-	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: RateLimitBurst 0 <= 0 not valid")
 
 	cfg.LogSinkConfig.RateLimitBurst = 1000
-	_, err = apiserver.NewServer(s.StatePool, dummyListener{}, cfg)
+	_, err = apiserver.NewServer(s.StatePool, cfg)
 	c.Assert(err, gc.ErrorMatches, "validating logsink configuration: RateLimitRefill 0s <= 0 not valid")
 }
 

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -52,11 +52,10 @@ func (s *pubsubSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { s.server.Stop() })
 
 	// A net.TCPAddr cannot be directly stringified into a valid hostname.
-	address := fmt.Sprintf("localhost:%d", s.server.Addr().Port)
 	path := fmt.Sprintf("/model/%s/pubsub", s.State.ModelUUID())
 	pubsubURL := &url.URL{
 		Scheme: "wss",
-		Host:   address,
+		Host:   s.server.Addr().String(),
 		Path:   path,
 	}
 	s.pubsubURL = pubsubURL.String()

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -63,15 +63,12 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	machine, password := s.Factory.MakeMachineReturningPassword(
 		c, &factory.MachineParams{Nonce: "fake_nonce"})
 
-	// A net.TCPAddr cannot be directly stringified into a valid hostname.
-	address := fmt.Sprintf("localhost:%d", srv.Addr().Port)
-
 	// Note we can't use openAs because we're not connecting to
 	apiInfo := &api.Info{
 		Tag:      machine.Tag(),
 		Password: password,
 		Nonce:    "fake_nonce",
-		Addrs:    []string{address},
+		Addrs:    []string{srv.Addr().String()},
 		CACert:   coretesting.CACert,
 		ModelTag: s.IAASModel.ModelTag(),
 	}
@@ -100,12 +97,18 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	err := s.State.SetAPIHostPorts(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Don't listen on "localhost:0" because that will only listen on either
+	// IPv4 or IPv6 but we want to listen on both.
+	cfg := defaultServerConfig(c)
+	cfg.ListenAddr = ":0"
+
 	// Start our own instance of the server listening on
 	// both IPv4 and IPv6 localhost addresses and an ephemeral port.
-	_, srv := newServer(c, s.StatePool)
+	srv, err := apiserver.NewServer(s.StatePool, cfg)
+	c.Assert(err, jc.ErrorIsNil)
 	defer assertStop(c, srv)
 
-	port := srv.Addr().Port
+	port := srv.Addr().(*net.TCPAddr).Port
 	portString := fmt.Sprintf("%d", port)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -300,11 +303,8 @@ func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
 	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
-	// We have to use 'localhost' because that is what the TLS cert says.
-	addr := fmt.Sprintf("localhost:%d", srv.Addr().Port)
-
 	// Specify an unsupported TLS version
-	conn, err := dialWebsocket(c, addr, "/", tls.VersionSSL30)
+	conn, err := dialWebsocket(c, srv.Addr().String(), "/", tls.VersionSSL30)
 	c.Assert(err, gc.ErrorMatches, ".*protocol version not supported")
 	c.Assert(conn, gc.IsNil)
 }
@@ -316,8 +316,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	_, srv := newServer(c, s.StatePool)
 	defer assertStop(c, srv)
 
-	// We have to use 'localhost' because that is what the TLS cert says.
-	addr := fmt.Sprintf("localhost:%d", srv.Addr().Port)
+	addr := srv.Addr().String()
 
 	// '/api' should be fine
 	conn, err := dialWebsocket(c, addr, "/api", 0)
@@ -563,8 +562,7 @@ func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 
 	// Make a request for the model API to check it releases
 	// state back into the pool once the connection is closed.
-	addr := fmt.Sprintf("localhost:%d", server.Addr().Port)
-	conn, err := dialWebsocket(c, addr, fmt.Sprintf("/model/%s/api", st.ModelUUID()), 0)
+	conn, err := dialWebsocket(c, server.Addr().String(), fmt.Sprintf("/model/%s/api", st.ModelUUID()), 0)
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
 
@@ -656,8 +654,6 @@ func newServerWithHub(c *gc.C, statePool *state.StatePool, hub *pubsub.Structure
 // server configuration may be specified (see defaultServerConfig
 // for a suitable starting point).
 func newServerWithConfig(c *gc.C, statePool *state.StatePool, cfg apiserver.ServerConfig) (*api.Info, *apiserver.Server) {
-	// Note that we can't listen on localhost here because TestAPIServerCanListenOnBothIPv4AndIPv6 assumes
-	// that we listen on IPv6 too, and listening on localhost does not do that.
 	srv, err := apiserver.NewServer(statePool, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	return &api.Info{

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -618,6 +618,7 @@ func defaultServerConfig(c *gc.C) apiserver.ServerConfig {
 	fakeOrigin := names.NewMachineTag("0")
 	hub := centralhub.New(fakeOrigin)
 	return apiserver.ServerConfig{
+		ListenAddr:      "localhost:0",
 		Clock:           clock.WallClock,
 		GetCertificate:  func() *tls.Certificate { return coretesting.ServerTLSCert },
 		Tag:             names.NewMachineTag("0"),
@@ -657,12 +658,10 @@ func newServerWithHub(c *gc.C, statePool *state.StatePool, hub *pubsub.Structure
 func newServerWithConfig(c *gc.C, statePool *state.StatePool, cfg apiserver.ServerConfig) (*api.Info, *apiserver.Server) {
 	// Note that we can't listen on localhost here because TestAPIServerCanListenOnBothIPv4AndIPv6 assumes
 	// that we listen on IPv6 too, and listening on localhost does not do that.
-	listener, err := net.Listen("tcp", ":0")
-	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(statePool, listener, cfg)
+	srv, err := apiserver.NewServer(statePool, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	return &api.Info{
-		Addrs:  []string{fmt.Sprintf("localhost:%d", srv.Addr().Port)},
+		Addrs:  []string{srv.Addr().String()},
 		CACert: coretesting.CACert,
 	}, srv
 }

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -113,7 +113,7 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Make 2 URLs to try - the old and the new.
-	addr := guiAddr(ctx, conn)
+	addr := guiAddr(conn)
 	rawURL := fmt.Sprintf("https://%s/gui/%s/", addr, details.ModelUUID)
 	qualifiedModelName, err := store.QualifiedModelName(controllerName, modelName)
 	if err != nil {
@@ -155,14 +155,8 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 }
 
 // guiAddr returns an address where the GUI is available.
-func guiAddr(ctx *cmd.Context, conn api.Connection) string {
-	client := controller.NewClient(conn)
-	config, err := client.ControllerConfig()
-	if err != nil {
-		ctx.Warningf("cannot get controller config: %s", err)
-		return conn.Addr()
-	}
-	if dnsName := config.AutocertDNSName(); dnsName != "" {
+func guiAddr(conn api.Connection) string {
+	if dnsName := conn.PublicDNSName(); dnsName != "" {
 		return dnsName
 	}
 	return conn.Addr()

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -99,7 +99,9 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 
 	store, ok := c.ClientStore().(modelcmd.QualifyingClientStore)
 	if !ok {
-		store = modelcmd.QualifyingClientStore{c.ClientStore()}
+		store = modelcmd.QualifyingClientStore{
+			ClientStore: c.ClientStore(),
+		}
 	}
 	controllerName, err := c.ControllerName()
 	if err != nil {
@@ -111,14 +113,15 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Make 2 URLs to try - the old and the new.
-	rawURL := fmt.Sprintf("https://%s/gui/%s/", conn.Addr(), details.ModelUUID)
+	addr := guiAddr(ctx, conn)
+	rawURL := fmt.Sprintf("https://%s/gui/%s/", addr, details.ModelUUID)
 	qualifiedModelName, err := store.QualifiedModelName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotate(err, "cannot construct model name")
 	}
 	// Do not include any possible "@external" fragment in the path.
 	qualifiedModelName = strings.Replace(qualifiedModelName, "@external/", "/", 1)
-	newRawURL := fmt.Sprintf("https://%s/gui/u/%s", conn.Addr(), qualifiedModelName)
+	newRawURL := fmt.Sprintf("https://%s/gui/u/%s", addr, qualifiedModelName)
 
 	// Check that the Juju GUI is available.
 	var guiURL string
@@ -149,6 +152,20 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// guiAddr returns an address where the GUI is available.
+func guiAddr(ctx *cmd.Context, conn api.Connection) string {
+	client := controller.NewClient(conn)
+	config, err := client.ControllerConfig()
+	if err != nil {
+		ctx.Warningf("cannot get controller config: %s", err)
+		return conn.Addr()
+	}
+	if dnsName := config.AutocertDNSName(); dnsName != "" {
+		return dnsName
+	}
+	return conn.Addr()
 }
 
 // checkAvailable ensures the Juju GUI is available on the controller at

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -35,7 +35,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	663f786f595ba1707f56f62f7f4f2284c47c0f1d	2017-12-05T01:02:50Z
+github.com/juju/gomaasapi	git	663f786f595ba1707f56f62f7f4f2284c47c0f1d	2017-12-05T12:16:38Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z
@@ -88,10 +88,10 @@ github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-0
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 github.com/satori/uuid	git	5bf94b69c6b68ee1b541973bb8e1144db23a194b	2017-03-21T23:07:31Z
 github.com/vmware/govmomi	git	17b8c9ccb7f8c7b015d44c4ea39305c970a7bf31	2017-09-05T23:36:42Z
-golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
+golang.org/x/crypto	git	650f4a345ab4e5b245a3034b110ebc7299e68186	2018-02-14T00:00:28Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
-golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:45Z
+golang.org/x/sys	git	37707fdb30a5b38865cfb95e5aab41707daec7fd	2018-02-02T13:58:01Z
 golang.org/x/text	git	2910a502d2bf9e43193af9d68ca516529614eed3	2016-07-26T16:48:57Z
 google.golang.org/api	git	ed10e890a8366167a7ce33fac2b12447987bcb1c	2017-08-17T20:34:27Z
 google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T22:36:35Z

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -70,7 +70,7 @@ func AssertStartControllerInstance(
 	instance.Instance, *instance.HardwareCharacteristics,
 ) {
 	params := environs.StartInstanceParams{ControllerUUID: controllerUUID}
-	err := fillinStartInstanceParams(env, machineId, true, &params)
+	err := FillInStartInstanceParams(env, machineId, true, &params)
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := env.StartInstance(params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -138,13 +138,15 @@ func StartInstanceWithParams(
 ) (
 	*environs.StartInstanceResult, error,
 ) {
-	if err := fillinStartInstanceParams(env, machineId, false, &params); err != nil {
+	if err := FillInStartInstanceParams(env, machineId, false, &params); err != nil {
 		return nil, err
 	}
 	return env.StartInstance(params)
 }
 
-func fillinStartInstanceParams(env environs.Environ, machineId string, isController bool, params *environs.StartInstanceParams) error {
+// FillInStartInstanceParams prepares the instance parameters for starting
+// the instance.
+func FillInStartInstanceParams(env environs.Environ, machineId string, isController bool, params *environs.StartInstanceParams) error {
 	if params.ControllerUUID == "" {
 		return errors.New("missing controller UUID in start instance parameters")
 	}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -780,6 +780,9 @@ func (s *environSuite) assertStartInstanceRequests(
 		},
 	}}
 	if args.autocert {
+		// Since a DNS name has been provided, Let's Encrypt is enabled.
+		// Therefore ports 443 (for the API server) and 80 (for the HTTP
+		// challenge) are accessible.
 		securityRules = append(securityRules, network.SecurityRule{
 			Name: to.StringPtr("JujuAPIInbound443"),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
@@ -808,15 +811,16 @@ func (s *environSuite) assertStartInstanceRequests(
 			},
 		})
 	} else {
+		port := fmt.Sprint(testing.FakeControllerConfig()["api-port"])
 		securityRules = append(securityRules, network.SecurityRule{
-			Name: to.StringPtr("JujuAPIInbound17777"),
+			Name: to.StringPtr("JujuAPIInbound" + port),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Description:              to.StringPtr("Allow API connections to controller machines"),
 				Protocol:                 network.SecurityRuleProtocolTCP,
 				SourceAddressPrefix:      to.StringPtr("*"),
 				SourcePortRange:          to.StringPtr("*"),
 				DestinationAddressPrefix: to.StringPtr("192.168.16.0/20"),
-				DestinationPortRange:     to.StringPtr("17777"),
+				DestinationPortRange:     to.StringPtr(port),
 				Access:                   network.SecurityRuleAccessAllow,
 				Priority:                 to.Int32Ptr(101),
 				Direction:                network.SecurityRuleDirectionInbound,

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -65,7 +65,7 @@ func (step commonDeploymentUpgradeStep) Run() error {
 	rules := make([]network.SecurityRule, 0, len(allRules))
 	for _, rule := range allRules {
 		name := to.String(rule.Name)
-		if name == to.String(sshSecurityRule.Name) || strings.HasPrefix(name, apiSecurityRulePrefix) {
+		if name == sshSecurityRuleName || strings.HasPrefix(name, apiSecurityRulePrefix) {
 			continue
 		}
 		rules = append(rules, rule)

--- a/provider/azure/upgrades.go
+++ b/provider/azure/upgrades.go
@@ -4,6 +4,8 @@
 package azure
 
 import (
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -51,21 +53,22 @@ func (step commonDeploymentUpgradeStep) Run() error {
 	// We will add these, excluding the SSH/API rules, to the
 	// network security group template created in the deployment
 	// below.
-	nsgClient := network.SecurityGroupsClient{env.network}
+	nsgClient := network.SecurityGroupsClient{
+		ManagementClient: env.network,
+	}
 	allRules, err := networkSecurityRules(nsgClient, env.resourceGroup)
 	if errors.IsNotFound(err) {
 		allRules = nil
 	} else if err != nil {
 		return errors.Trace(err)
 	}
-	var rules []network.SecurityRule
+	rules := make([]network.SecurityRule, 0, len(allRules))
 	for _, rule := range allRules {
-		switch to.String(rule.Name) {
-		case to.String(sshSecurityRule.Name):
-		case to.String(apiSecurityRule.Name):
-		default:
-			rules = append(rules, rule)
+		name := to.String(rule.Name)
+		if name == to.String(sshSecurityRule.Name) || strings.HasPrefix(name, apiSecurityRulePrefix) {
+			continue
 		}
+		rules = append(rules, rule)
 	}
 
 	env.mu.Lock()

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -850,7 +850,9 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				Hub:            centralhub.New(machineTag),
 				NewObserver:    func() observer.Observer { return &fakeobserver.Instance{} },
 				// Should never be used but prevent external access just in case.
-				AutocertURL: "https://0.1.2.3/no-autocert-here",
+				AutocertURL:                     "https://0.1.2.3/no-autocert-here",
+				AutocertDNSName:                 icfg.Controller.Config.AutocertDNSName(),
+				DisableAutocertChallengeHandler: true,
 				RegisterIntrospectionHandlers: func(f func(path string, h http.Handler)) {
 					f("navel", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						io.WriteString(w, "gazing")

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -839,7 +839,8 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 
 			statePool := state.NewStatePool(st)
 			machineTag := names.NewMachineTag("0")
-			estate.apiServer, err = apiserver.NewServer(statePool, estate.apiListener, apiserver.ServerConfig{
+			estate.apiServer, err = apiserver.NewServer(statePool, apiserver.ServerConfig{
+				Listener:       estate.apiListener,
 				Clock:          clock.WallClock,
 				GetCertificate: func() *tls.Certificate { return testing.ServerTLSCert },
 				GetAuditConfig: func() auditlog.Config { return auditlog.Config{} },

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -215,6 +215,13 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.Boo
 	if err := env.gce.OpenPorts(env.globalFirewallName(), rule); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if params.ControllerConfig.AutocertDNSName() != "" {
+		// Open port 80 as well as it handles Let's Encrypt HTTP challenge.
+		rule = network.NewOpenIngressRule("tcp", 80, 80)
+		if err := env.gce.OpenPorts(env.globalFirewallName(), rule); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
 	return bootstrap(ctx, env, params)
 }
 

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -4,8 +4,6 @@
 package apiserver_test
 
 import (
-	"net"
-
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
@@ -81,11 +79,10 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		return
 	}
 	args := s.stub.Calls()[0].Args
-	c.Assert(args, gc.HasLen, 3)
+	c.Assert(args, gc.HasLen, 2)
 	c.Assert(args[0], gc.FitsTypeOf, &state.StatePool{})
-	c.Assert(args[1], gc.Implements, new(net.Listener))
-	c.Assert(args[2], gc.FitsTypeOf, coreapiserver.ServerConfig{})
-	config := args[2].(coreapiserver.ServerConfig)
+	c.Assert(args[1], gc.FitsTypeOf, coreapiserver.ServerConfig{})
+	config := args[1].(coreapiserver.ServerConfig)
 
 	c.Assert(config.RegisterIntrospectionHandlers, gc.NotNil)
 	config.RegisterIntrospectionHandlers = nil
@@ -111,6 +108,7 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 	logSinkConfig := coreapiserver.DefaultLogSinkConfig()
 
 	c.Assert(config, jc.DeepEquals, coreapiserver.ServerConfig{
+		ListenAddr:           ":0",
 		Clock:                s.clock,
 		Tag:                  s.agentConfig.Tag(),
 		DataDir:              s.agentConfig.DataDir(),

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -5,7 +5,6 @@ package apiserver_test
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
 	"time"
 
@@ -62,12 +61,8 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *workerFixture) newServer(
-	statePool *state.StatePool,
-	listener net.Listener,
-	config coreapiserver.ServerConfig,
-) (worker.Worker, error) {
-	s.stub.MethodCall(s, "NewServer", statePool, listener, config)
+func (s *workerFixture) newServer(statePool *state.StatePool, config coreapiserver.ServerConfig) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewServer", statePool, config)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also update the "juju gui" command to use the dns name if provided.
The autocert functionality for now only works with the 3 main public clouds.
Opening port 80 on other providers will be implemented later when required.

This change is needed as Let's Encrypt disabled the DNS SNI challenge because it was demonstrated that it could be used improperly.

To QA:
1. bootstrap on google cloud normally;
2. ensure everything works and `juju gui` points to the ip address of the controller, and the GUI works; after accepting the self-signed cert;
3. bootstrap with `juju bootstrap google google --config autocert-dns-name=some.dns.name` where `some.dns.name` is a dns name that you own;
4. point the dns name to the resulting controller address;
5. when the dns change is propagated, run `juju gui`, and ensure that this time a proper dns name is suggested in the command output;
6. Open the GUI and make sure the cert is a proper cert this time, not a self-signed one;
7. Repeat 1..6 on azure and aws.
