### PR TITLE
Show-credential command and api.

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -136,7 +136,7 @@ func (c *Client) RevokeCredential(tag names.CloudCredentialTag) error {
 	return results.OneError()
 }
 
-// Credentials return a slice of credential values for the specified tags.
+// Credentials returns a slice of credential values for the specified tags.
 // Secrets are excluded from the credential attributes.
 func (c *Client) Credentials(tags ...names.CloudCredentialTag) ([]params.CloudCredentialResult, error) {
 	if len(tags) == 0 {
@@ -178,6 +178,7 @@ func (c *Client) AddCredential(tag string, credential jujucloud.Credential) erro
 	return results.OneError()
 }
 
+// AddCloud adds a new cloud to current controller.
 func (c *Client) AddCloud(cloud jujucloud.Cloud) error {
 	if bestVer := c.BestAPIVersion(); bestVer < 2 {
 		return errors.NotImplementedf("AddCloud() (need v2+, have v%d)", bestVer)
@@ -190,7 +191,7 @@ func (c *Client) AddCloud(cloud jujucloud.Cloud) error {
 	return nil
 }
 
-// CredentialContents return contents of the credential values for the specified
+// CredentialContents returns contents of the credential values for the specified
 // cloud and credential name. Secrets will be included if requested.
 func (c *Client) CredentialContents(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {
 	if bestVer := c.BestAPIVersion(); bestVer < 2 {

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -421,11 +421,12 @@ func (s *cloudSuite) TestCredentialContentsAll(c *gc.C) {
 		{
 			Result: &params.ControllerCredentialInfo{
 				Content: params.CredentialContent{
-					Cloud:      "cloud-name",
-					Name:       "credential-name",
-					AuthType:   "userpass",
-					Attributes: map[string]string{"username": "fred"},
-					Secrets:    map[string]string{"password": "sekret"},
+					Cloud:    "cloud-name",
+					Name:     "credential-name",
+					AuthType: "userpass",
+					Attributes: map[string]string{
+						"username": "fred",
+						"password": "sekret"},
 				},
 				Models: []params.ModelAccess{
 					{Model: "abcmodel", Access: "admin"},

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -4,6 +4,7 @@
 package cloud_test
 
 import (
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -11,6 +12,7 @@ import (
 
 	basetesting "github.com/juju/juju/api/base/testing"
 	cloudapi "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 )
@@ -397,4 +399,167 @@ func (s *cloudSuite) TestAddCredentialV2API(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestCredentialContentsArgumentCheck(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{BestVersion: 2}
+	client := cloudapi.NewClient(apiCaller)
+
+	// Check supplying cloud name without credential name is invalid.
+	result, err := client.CredentialContents("cloud", "", true)
+	c.Assert(result, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "credential name must be supplied")
+
+	// Check supplying credential name without cloud name is invalid.
+	result, err = client.CredentialContents("", "credential", true)
+	c.Assert(result, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "cloud name must be supplied")
+}
+
+func (s *cloudSuite) TestCredentialContentsAll(c *gc.C) {
+	expectedResults := []params.CredentialContentResult{
+		{
+			Result: &params.ControllerCredentialInfo{
+				Content: params.CredentialContent{
+					Cloud:      "cloud-name",
+					Name:       "credential-name",
+					AuthType:   "userpass",
+					Attributes: map[string]string{"username": "fred"},
+					Secrets:    map[string]string{"password": "sekret"},
+				},
+				Models: []params.ModelAccess{
+					{Model: "abcmodel", Access: "admin"},
+					{Model: "xyzmodel", Access: "read"},
+					{Model: "no-access-model"}, // no access
+				},
+			},
+		}, {
+			Error: common.ServerError(errors.New("boom")),
+		},
+	}
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "CredentialContents")
+				c.Assert(result, gc.FitsTypeOf, &params.CredentialContentResults{})
+				c.Assert(a, jc.DeepEquals, params.CloudCredentialArgs{
+					IncludeSecrets: true,
+				})
+				*result.(*params.CredentialContentResults) = params.CredentialContentResults{
+					Results: expectedResults,
+				}
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+
+	client := cloudapi.NewClient(apiCaller)
+	results, err := client.CredentialContents("", "", true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, expectedResults)
+}
+
+func (s *cloudSuite) TestCredentialContentsOne(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "CredentialContents")
+				c.Assert(result, gc.FitsTypeOf, &params.CredentialContentResults{})
+				c.Assert(a, jc.DeepEquals, params.CloudCredentialArgs{
+					IncludeSecrets: true,
+					Credentials: []params.CloudCredentialArg{
+						{CloudName: "cloud-name", CredentialName: "credential-name"},
+					},
+				})
+				*result.(*params.CredentialContentResults) = params.CredentialContentResults{
+					Results: []params.CredentialContentResult{
+						{},
+					},
+				}
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+
+	client := cloudapi.NewClient(apiCaller)
+	results, err := client.CredentialContents("cloud-name", "credential-name", true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+}
+
+func (s *cloudSuite) TestCredentialContentsGotMoreThanBargainedFor(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				*result.(*params.CredentialContentResults) = params.CredentialContentResults{
+					Results: []params.CredentialContentResult{
+						{},
+						{},
+					},
+				}
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+
+	client := cloudapi.NewClient(apiCaller)
+	results, err := client.CredentialContents("cloud-name", "credential-name", true)
+	c.Assert(results, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "expected 1 result for credential \"cloud-name\" on cloud \"credential-name\", got 2")
+}
+
+func (s *cloudSuite) TestCredentialContentsServerError(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				return errors.New("boom")
+			}),
+		BestVersion: 2,
+	}
+
+	client := cloudapi.NewClient(apiCaller)
+	results, err := client.CredentialContents("", "", true)
+	c.Assert(results, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *cloudSuite) TestCredentialContentsNotInV2API(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				return nil
+			},
+		),
+		BestVersion: 1,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	_, err := client.CredentialContents("", "", true)
+	c.Assert(err, gc.ErrorMatches, "CredentialContents\\(\\).* not implemented")
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -422,14 +422,12 @@ func (api *CloudAPIV2) CredentialContents(args params.CloudCredentialArgs) (para
 		if err != nil {
 			return params.CredentialContentResult{Error: common.ServerError(err)}
 		}
-		secrets := map[string]string{}
 		attrs := map[string]string{}
 		// Filter out the secrets.
 		if s, ok := schemas[cloud.AuthType(credential.AuthType)]; ok {
 			for _, attr := range s {
 				if value, exists := credential.Attributes[attr.Name]; exists {
-					if attr.Hidden {
-						secrets[attr.Name] = credential.Attributes[attr.Name]
+					if attr.Hidden && !includeSecrets {
 						continue
 					}
 					attrs[attr.Name] = value
@@ -443,9 +441,6 @@ func (api *CloudAPIV2) CredentialContents(args params.CloudCredentialArgs) (para
 				Attributes: attrs,
 				Cloud:      credential.Cloud,
 			},
-		}
-		if includeSecrets {
-			info.Content.Secrets = secrets
 		}
 
 		// get models

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -173,8 +173,6 @@ func (s *cloudSuiteV2) TestCredentialContentsNamedWithSecrets(c *gc.C) {
 					AuthType: "access-key",
 					Attributes: map[string]string{
 						"access-key": "BLAHB3445635BLAH",
-					},
-					Secrets: map[string]string{
 						"secret-key": "fffajdnjsdnnjd667gvd",
 					},
 				},

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -145,11 +145,8 @@ type CredentialContent struct {
 	// AuthType is the authentication type.
 	AuthType string `json:"auth-type"`
 
-	// Attributes contains non-secret credential values.
+	// Attributes contains credential values.
 	Attributes map[string]string `json:"attrs,omitempty"`
-
-	// Secrets contains secret credential values.
-	Secrets map[string]string `json:"secrets,omitempty"`
 }
 
 // ModelAccess contains information about user model access.

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -81,3 +81,10 @@ func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api cre
 	c.SetClientStore(testStore)
 	return modelcmd.WrapController(c)
 }
+
+func NewShowCredentialCommandForTest(api CredentialContentAPI) cmd.Command {
+	cmd := &showCredentialCommand{newAPIFunc: func() (CredentialContentAPI, error) {
+		return api, nil
+	}}
+	return modelcmd.WrapBase(cmd)
+}

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -108,7 +108,7 @@ type Credential struct {
 }
 
 type credentialsMap struct {
-	Credentials map[string]CloudCredential `yaml:"credentials" json:"credentials"`
+	Credentials map[string]CloudCredential `yaml:"local-credentials" json:"local-credentials"`
 }
 
 // NewListCredentialsCommand returns a command to list cloud credentials.

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -44,7 +44,8 @@ A credential for 'controller' model is determined at bootstrap time and
 will be stored on the controller. It is considered to be controller default.
 
 Recall that when a controller is created a 'default' model is also 
-created. This model will use the controller default credential.
+created. This model will use the controller default credential. To see all your
+credentials on the controller use "juju show-credentials" command.
 
 When adding a new model, Juju will reuse the controller default credential.
 To add a model that uses a different credential, specify a locally
@@ -63,7 +64,9 @@ See also:
     add-credential
     remove-credential
     set-default-credential
-    autoload-credentials`
+    autoload-credentials
+    show-credentials
+`
 
 type listCredentialsCommand struct {
 	cmd.CommandBase

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -162,7 +162,7 @@ func (s *listCredentialsSuite) TestListCredentialsYAMLWithSecrets(c *gc.C) {
 	}
 	out := s.listCredentials(c, "--format", "yaml", "--show-secrets")
 	c.Assert(out, gc.Equals, `
-credentials:
+local-credentials:
   aws:
     default-credential: down
     default-region: ap-southeast-2
@@ -214,7 +214,7 @@ func (s *listCredentialsSuite) TestListCredentialsYAMLNoSecrets(c *gc.C) {
 	}
 	out := s.listCredentials(c, "--format", "yaml")
 	c.Assert(out, gc.Equals, `
-credentials:
+local-credentials:
   aws:
     default-credential: down
     default-region: ap-southeast-2
@@ -245,7 +245,7 @@ credentials:
 func (s *listCredentialsSuite) TestListCredentialsYAMLFiltered(c *gc.C) {
 	out := s.listCredentials(c, "--format", "yaml", "azure")
 	c.Assert(out, gc.Equals, `
-credentials:
+local-credentials:
   azure:
     azhja:
       auth-type: userpass
@@ -258,21 +258,21 @@ credentials:
 func (s *listCredentialsSuite) TestListCredentialsJSONWithSecrets(c *gc.C) {
 	out := s.listCredentials(c, "--format", "json", "--show-secrets")
 	c.Assert(out, gc.Equals, `
-{"credentials":{"aws":{"default-credential":"down","default-region":"ap-southeast-2","cloud-credentials":{"bob":{"auth-type":"access-key","details":{"access-key":"key","secret-key":"secret"}},"down":{"auth-type":"userpass","details":{"password":"password","username":"user"}}}},"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","application-password":"app-secret","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}},"google":{"cloud-credentials":{"default":{"auth-type":"oauth2","details":{"client-email":"email","client-id":"id","private-key":"key"}}}},"mycloud":{"cloud-credentials":{"me":{"auth-type":"access-key","details":{"access-key":"key","secret-key":"secret"}}}}}}
+{"local-credentials":{"aws":{"default-credential":"down","default-region":"ap-southeast-2","cloud-credentials":{"bob":{"auth-type":"access-key","details":{"access-key":"key","secret-key":"secret"}},"down":{"auth-type":"userpass","details":{"password":"password","username":"user"}}}},"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","application-password":"app-secret","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}},"google":{"cloud-credentials":{"default":{"auth-type":"oauth2","details":{"client-email":"email","client-id":"id","private-key":"key"}}}},"mycloud":{"cloud-credentials":{"me":{"auth-type":"access-key","details":{"access-key":"key","secret-key":"secret"}}}}}}
 `[1:])
 }
 
 func (s *listCredentialsSuite) TestListCredentialsJSONNoSecrets(c *gc.C) {
 	out := s.listCredentials(c, "--format", "json")
 	c.Assert(out, gc.Equals, `
-{"credentials":{"aws":{"default-credential":"down","default-region":"ap-southeast-2","cloud-credentials":{"bob":{"auth-type":"access-key","details":{"access-key":"key"}},"down":{"auth-type":"userpass","details":{"username":"user"}}}},"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}},"google":{"cloud-credentials":{"default":{"auth-type":"oauth2","details":{"client-email":"email","client-id":"id"}}}},"mycloud":{"cloud-credentials":{"me":{"auth-type":"access-key","details":{"access-key":"key"}}}}}}
+{"local-credentials":{"aws":{"default-credential":"down","default-region":"ap-southeast-2","cloud-credentials":{"bob":{"auth-type":"access-key","details":{"access-key":"key"}},"down":{"auth-type":"userpass","details":{"username":"user"}}}},"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}},"google":{"cloud-credentials":{"default":{"auth-type":"oauth2","details":{"client-email":"email","client-id":"id"}}}},"mycloud":{"cloud-credentials":{"me":{"auth-type":"access-key","details":{"access-key":"key"}}}}}}
 `[1:])
 }
 
 func (s *listCredentialsSuite) TestListCredentialsJSONFiltered(c *gc.C) {
 	out := s.listCredentials(c, "--format", "json", "azure")
 	c.Assert(out, gc.Equals, `
-{"credentials":{"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}}}}
+{"local-credentials":{"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}}}}
 `[1:])
 }
 
@@ -293,10 +293,10 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 	c.Assert(out, gc.Equals, "Cloud  Credentialsaws    bob")
 
 	out = strings.Replace(s.listCredentials(c, "--format", "yaml"), "\n", "", -1)
-	c.Assert(out, gc.Equals, "credentials:  aws:    bob:      auth-type: oauth2")
+	c.Assert(out, gc.Equals, "local-credentials:  aws:    bob:      auth-type: oauth2")
 
 	out = strings.Replace(s.listCredentials(c, "--format", "json"), "\n", "", -1)
-	c.Assert(out, gc.Equals, `{"credentials":{"aws":{"cloud-credentials":{"bob":{"auth-type":"oauth2"}}}}}`)
+	c.Assert(out, gc.Equals, `{"local-credentials":{"aws":{"cloud-credentials":{"bob":{"auth-type":"oauth2"}}}}}`)
 }
 
 func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
@@ -311,13 +311,13 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out = strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "credentials: {}")
+	c.Assert(out, gc.Equals, "local-credentials: {}")
 
 	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out = strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, `{"credentials":{}}`)
+	c.Assert(out, gc.Equals, `{"local-credentials":{}}`)
 }
 
 func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -5,6 +5,7 @@ package cloud
 
 import (
 	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -83,7 +83,7 @@ func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
 	defer client.Close()
 
 	if client.BestAPIVersion() < 2 {
-		ctxt.Infof("Controller does not support credential content lookup")
+		ctxt.Infof("credential content lookup is not supported by this version of Juju")
 		return nil
 	}
 	contents, err := client.CredentialContents(c.CloudName, c.CredentialName, c.ShowSecrets)

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -1,0 +1,181 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+
+	apicloud "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+type showCredentialCommand struct {
+	modelcmd.CommandBase
+	store jujuclient.ClientStore
+
+	out cmd.Output
+
+	newAPIFunc func() (CredentialContentAPI, error)
+
+	CloudName      string
+	CredentialName string
+
+	ShowSecrets bool
+}
+
+// NewShowCredentialCommand returns a command to show information about
+// credentials stored on the controller.
+func NewShowCredentialCommand() cmd.Command {
+	cmd := &showCredentialCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	cmd.newAPIFunc = func() (CredentialContentAPI, error) {
+		return cmd.NewCredentialAPI()
+	}
+	return modelcmd.WrapBase(cmd)
+}
+
+func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	// We only support yaml for display purposes.
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+	})
+	f.BoolVar(&c.ShowSecrets, "show-secrets", false, "Display credential secret attributes")
+}
+
+func (c *showCredentialCommand) Init(args []string) error {
+	switch len(args) {
+	case 0:
+		// will get all credentials stored on the controller for this user.
+		break
+	case 1:
+		return errors.New("both cloud and credential name are needed")
+	case 2:
+		c.CloudName = args[0]
+		c.CredentialName = args[1]
+	default:
+		return errors.New("only cloud and credential names are supported")
+	}
+	return nil
+}
+
+func (c *showCredentialCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "show-credential",
+		Args:    "[<cloud name> <credential name>]",
+		Purpose: "Shows credential information on a controller.",
+		Doc:     showCredentialDoc,
+		Aliases: []string{"show-credentials"},
+	}
+}
+
+func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if client.BestAPIVersion() < 2 {
+		ctxt.Infof("Controller does not support credential content lookup")
+		return nil
+	}
+	contents, err := client.CredentialContents(c.CloudName, c.CredentialName, c.ShowSecrets)
+	if err != nil {
+		ctxt.Infof("Getting credential content failed with: %v", err)
+		return err
+	}
+	return c.parseContents(ctxt, contents)
+}
+
+type CredentialContentAPI interface {
+	CredentialContents(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error)
+	BestAPIVersion() int
+	Close() error
+}
+
+func (c *showCredentialCommand) NewCredentialAPI() (CredentialContentAPI, error) {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errors.New("there is no active controller")
+		}
+		return nil, errors.Trace(err)
+	}
+	api, err := c.NewAPIRoot(c.store, currentController, "")
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	return apicloud.NewClient(api), nil
+}
+
+type CredentialContent struct {
+	AuthType string `yaml:"auth-type" json:"auth-type"`
+	Cloud    string `yaml:"cloud" json:"cloud"`
+
+	// Attributes contains non-secret credential values.
+	Attributes map[string]string `yaml:"attributes,omitempty" json:"attributes,omitempty"`
+
+	// Secrets contains secret credential values.
+	Secrets map[string]string `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+
+	Models map[string]string `yaml:"models,omitempty" json:"models,omitempty"`
+}
+
+func (c *showCredentialCommand) parseContents(ctxt *cmd.Context, in []params.CredentialContentResult) error {
+	if len(in) == 0 {
+		ctxt.Infof("No credential to display")
+		return nil
+	}
+	out := map[string]CredentialContent{}
+	for _, result := range in {
+		if result.Error != nil {
+			ctxt.Infof("%v", result.Error)
+			continue
+		}
+		info := result.Result
+		credential := CredentialContent{
+			AuthType:   info.Content.AuthType,
+			Cloud:      info.Content.Cloud,
+			Attributes: info.Content.Attributes,
+			Secrets:    info.Content.Secrets,
+		}
+		credential.Models = make(map[string]string, len(info.Models))
+		for _, m := range info.Models {
+			ownerAccess := m.Access
+			if ownerAccess == "" {
+				ownerAccess = "-"
+			}
+			credential.Models[m.Model] = ownerAccess
+		}
+		out[info.Content.Name] = credential
+	}
+	return c.out.Write(ctxt, out)
+}
+
+var showCredentialDoc = `
+This command display information about credential(s) stored on the controller
+for this user.
+
+To see the contents of a credential, supply its cloud and name as arguments.
+To see all credentials stored for you, supply no arguments.
+
+To see secrets, content attributes marked as hidden, use --show-secrets option.
+
+To see locally stored credentials, use "juju credentials' command.
+
+Examples:
+
+    juju show-credential google my-admin-credential
+    juju show-credentials 
+    juju show-credentials --show-secrets
+
+See also: 
+    credentials
+`

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -1,0 +1,195 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/cloud"
+	_ "github.com/juju/juju/provider/all"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ShowCredentialSuite struct {
+	coretesting.BaseSuite
+
+	api *fakeCredentialContentAPI
+}
+
+var _ = gc.Suite(&ShowCredentialSuite{})
+
+func (s *ShowCredentialSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.api = &fakeCredentialContentAPI{v: 2}
+}
+
+func (s *ShowCredentialSuite) TestShowCredentialBadArgs(c *gc.C) {
+	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	_, err := cmdtesting.RunCommand(c, cmd, "cloud")
+	c.Assert(err, gc.ErrorMatches, "both cloud and credential name are needed")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "credential", "extra")
+	c.Assert(err, gc.ErrorMatches, `only cloud and credential names are supported`)
+}
+
+func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
+	s.api.v = 1
+	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Controller does not support credential content lookup\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
+	s.api.CheckCallNames(c, "BestAPIVersion", "Close")
+}
+
+func (s *ShowCredentialSuite) TestShowCredentialAPICallError(c *gc.C) {
+	s.api.SetErrors(errors.New("boom"), nil)
+	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Getting credential content failed with: boom\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
+	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
+}
+
+func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
+	s.api.contents = []params.CredentialContentResult{}
+	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No credential to display\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
+	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
+}
+
+func (s *ShowCredentialSuite) TestShowCredentialOne(c *gc.C) {
+	s.api.contents = []params.CredentialContentResult{
+		{
+			Result: &params.ControllerCredentialInfo{
+				Content: params.CredentialContent{
+					Cloud:      "cloud-name",
+					Name:       "credential-name",
+					AuthType:   "userpass",
+					Attributes: map[string]string{"username": "fred"},
+					Secrets:    map[string]string{"password": "sekret"},
+				},
+				Models: []params.ModelAccess{
+					{Model: "abcmodel", Access: "admin"},
+					{Model: "xyzmodel", Access: "read"},
+					{Model: "no-access-model"},
+				},
+			},
+		},
+	}
+	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+credential-name:
+  auth-type: userpass
+  cloud: cloud-name
+  attributes:
+    username: fred
+  secrets:
+    password: sekret
+  models:
+    abcmodel: admin
+    no-access-model: '-'
+    xyzmodel: read
+`[1:])
+	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
+}
+
+func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
+	s.api.contents = []params.CredentialContentResult{
+		{
+			Result: &params.ControllerCredentialInfo{
+				Content: params.CredentialContent{
+					Cloud:      "cloud-name",
+					Name:       "one",
+					AuthType:   "userpass",
+					Attributes: map[string]string{"username": "fred"},
+					// Don't have secrets here.
+				},
+				// Don't have models here.
+			},
+		}, {
+			Error: common.ServerError(errors.New("boom")),
+		}, {
+			Result: &params.ControllerCredentialInfo{
+				Content: params.CredentialContent{
+					Cloud:    "cloud-name",
+					Name:     "two",
+					AuthType: "userpass",
+					Attributes: map[string]string{
+						"username":  "fred",
+						"something": "visible-attr",
+					},
+					Secrets: map[string]string{
+						"password": "sekret",
+						"hidden":   "very-very-sekret",
+					},
+				},
+				Models: []params.ModelAccess{
+					{Model: "abcmodel", Access: "admin"},
+					{Model: "xyzmodel", Access: "read"},
+					{Model: "no-access-model"},
+				},
+			},
+		},
+	}
+	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "boom\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+one:
+  auth-type: userpass
+  cloud: cloud-name
+  attributes:
+    username: fred
+two:
+  auth-type: userpass
+  cloud: cloud-name
+  attributes:
+    something: visible-attr
+    username: fred
+  secrets:
+    hidden: very-very-sekret
+    password: sekret
+  models:
+    abcmodel: admin
+    no-access-model: '-'
+    xyzmodel: read
+`[1:])
+	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
+}
+
+type fakeCredentialContentAPI struct {
+	testing.Stub
+	v        int
+	contents []params.CredentialContentResult
+}
+
+func (f *fakeCredentialContentAPI) CredentialContents(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {
+	f.AddCall("CredentialContents", cloud, credential, withSecrets)
+	return f.contents, f.NextErr()
+}
+
+func (f *fakeCredentialContentAPI) Close() error {
+	f.AddCall("Close")
+	return f.NextErr()
+}
+
+func (f *fakeCredentialContentAPI) BestAPIVersion() int {
+	f.AddCall("BestAPIVersion")
+	return f.v
+}

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -44,7 +44,7 @@ func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
 	cmd := cloud.NewShowCredentialCommandForTest(s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Controller does not support credential content lookup\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "credential content lookup is not supported by this version of Juju\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "Close")
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -457,6 +457,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(cloud.NewAddCredentialCommand())
 	r.Register(cloud.NewRemoveCredentialCommand())
 	r.Register(cloud.NewUpdateCredentialCommand())
+	r.Register(cloud.NewShowCredentialCommand())
 
 	// CAAS commands
 	if featureflag.Enabled(feature.CAAS) {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -528,6 +528,8 @@ var commandNames = []string{
 	"show-backup",
 	"show-cloud",
 	"show-controller",
+	"show-credential",
+	"show-credentials",
 	"show-machine",
 	"show-model",
 	"show-offer",
@@ -565,7 +567,7 @@ var commandNames = []string{
 
 // devFeatures are feature flags that impact registration of commands.
 var devFeatures = []string{
-	// Currently no feature flags.
+// Currently no feature flags.
 }
 
 // These are the commands that are behind the `devFeatures`.

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -75,13 +75,14 @@ func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-cred:
-  auth-type: userpass
-  cloud: dummy
-  attributes:
-    username: dummy
-  models:
-    controller: admin
+controller-credentials:
+  dummy:
+    cred:
+      content:
+        auth-type: userpass
+        username: dummy
+      models:
+        controller: admin
 `[1:])
 }
 
@@ -90,14 +91,14 @@ func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-cred:
-  auth-type: userpass
-  cloud: dummy
-  attributes:
-    username: dummy
-  secrets:
-    password: secret
-  models:
-    controller: admin
+controller-credentials:
+  dummy:
+    cred:
+      content:
+        auth-type: userpass
+        password: secret
+        username: dummy
+      models:
+        controller: admin
 `[1:])
 }

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -39,7 +39,7 @@ func init() {
 	gc.Suite(&BakeryStorageSuite{})
 	gc.Suite(&blockSuite{})
 	gc.Suite(&cmdControllerSuite{})
-	gc.Suite(&cmdCredentialSuite{})
+	gc.Suite(&CmdCredentialSuite{})
 	gc.Suite(&cmdJujuSuite{})
 	gc.Suite(&cmdJujuSuiteNoCAAS{})
 	gc.Suite(&cmdLoginSuite{})


### PR DESCRIPTION
## Description of change

In the long running environment, there is a need for an operator to be able to view credential contents that are stored on the controller. 

This PR introduces a new command to inspect the content of the controller-stored credential(s) as well as listing the models that use it. Since this command can only be used to examine own credentials, we also display what access logged on user (i.e. credential owner) has for the listed models.

The user can display a specific, named credential. For that, they'd need to provide a cloud and credential name.

The user can also display all credentials that are stored for them on a controller. No cloud or credential name needs to be supplied then.

The command can also display hidden/secret attributes of the credential content. These are only displayed when asked for explicitly. Use --show-secrets option.

The PR also adds to help text on related commands to direct users to this new one.

## QA steps

1. bootstrap on a cloud that requires credential, say aws
2. run 'show-credential'

EXPECTED OUTPUT: The content of the credential that you have bootstrapped with. 

## Documentation changes

@juju/docs - New command in 2.4.x alert \o/

