### PR TITLE
Fixes lp#1751903: duplicate blocked warning.

### DIFF
--- a/cmd/juju/block/protection.go
+++ b/cmd/juju/block/protection.go
@@ -92,8 +92,7 @@ func ProcessBlockedError(err error, block Block) error {
 	}
 	if params.IsCodeOperationBlocked(err) {
 		msg := blockedMessages[block]
-		logger.Errorf("%v\n%v", err, msg)
-		return errors.New(msg)
+		return errors.Errorf("%v\n%v", err, msg)
 	}
 	return err
 }

--- a/cmd/juju/block/protection.go
+++ b/cmd/juju/block/protection.go
@@ -4,6 +4,8 @@
 package block
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -91,8 +93,9 @@ func ProcessBlockedError(err error, block Block) error {
 		return nil
 	}
 	if params.IsCodeOperationBlocked(err) {
-		msg := blockedMessages[block]
-		return errors.Errorf("%v\n%v", err, msg)
+		msg := fmt.Sprintf("%v\n%v", err, blockedMessages[block])
+		logger.Infof(msg)
+		return errors.Errorf(msg)
 	}
 	return err
 }


### PR DESCRIPTION
## Description of change

When users run a blocked operation in the environment, they get a warning message.

Warning message was repeated twice as we were both returning an error and logging it. Both outputs went to stderr.

This PR removes the logging of the error and just returns the error itself, with the correct and comprehensive message.
 
Added a feature test for sanity to ensure that we check the exact message to avoid accidental duplication in the future. 

## QA steps

1. bootstrap
2. block all changes 
3. run any command that would try to change current state

EXPECTED OUTPUT: Warning message about the block without stuttering or duplication of information.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1751903
