### PR TITLE
More logging for intermittent failing test.

### DIFF
--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
@@ -1502,6 +1503,9 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	task := s.newProvisionerTask(c, config.HarvestAll, e, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{})
 	defer workertest.CleanKill(c, task)
 
+	logger := loggo.GetLogger("juju.provisioner")
+	logger.SetLogLevel(loggo.TRACE)
+
 	// Provision some machines, some will be started first time,
 	// another will require retries.
 	m1, err := s.addMachine()
@@ -1532,8 +1536,9 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 					Data:    map[string]interface{}{"transient": true},
 					Since:   &now,
 				}
+				logger.Infof("setting instance status provisioning error as transient for m3")
 				err := m3.SetInstanceStatus(sInfo)
-				c.Assert(err, jc.ErrorIsNil)
+				c.Check(err, jc.ErrorIsNil)
 			}
 		}
 	}()


### PR DESCRIPTION
The test is a bit stupid, but it shouldn't be failing. This branch increases the logging level for the provisioner worker so we can see what is going on there more easily, and also logs when it sets the status in the goroutine.

A side tweak, you shouldn't use assert in any started goroutines.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1749709
