### PR TITLE
Fixes lp#1751849: Registration token used up, users needs guidance to resolve.

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -270,6 +270,12 @@ func (c *registerCommand) nonPublicControllerDetails(ctx *cmd.Context, registrat
 	}
 	resp, err := c.secretKeyLogin(registrationParams.controllerAddrs, req, controllerName)
 	if err != nil {
+		// If we got here and got an error, the registration token supplied
+		// will be expired.
+		// Log the error as it will be useful for debugging, but give user a
+		// suggestion for the way forward instead of error details.
+		logger.Infof("while validating secret key: %v", err)
+		err = errors.Errorf("Provided registration token may have been expired.\nA controller administrator must reset your user to issue a new token.\nSee %q for more information.", "juju help change-user-password")
 		return errRet(errors.Trace(err))
 	}
 

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -407,7 +407,11 @@ Enter a name for this controller: »foo
 	defer prompter.CheckDone()
 	s.apiOpenError = errors.New("open failed")
 	err := s.run(c, prompter, registrationData)
-	c.Assert(err, gc.ErrorMatches, `open failed`)
+	c.Assert(c.GetTestLog(), gc.Matches, "(.|\n)*open failed(.|\n)*")
+	c.Assert(err, gc.ErrorMatches, `
+Provided registration token may have been expired.
+A controller administrator must reset your user to issue a new token.
+See "juju help change-user-password" for more information.`[1:])
 }
 
 func (s *RegisterSuite) TestRegisterServerError(c *gc.C) {
@@ -434,7 +438,11 @@ Enter a name for this controller: »foo
 		SecretKey: mockSecretKey,
 	})
 	err = s.run(c, prompter, registrationData)
-	c.Assert(err, gc.ErrorMatches, "xyz")
+	c.Assert(c.GetTestLog(), gc.Matches, "(.|\n)* xyz(.|\n)*")
+	c.Assert(err, gc.ErrorMatches, `
+Provided registration token may have been expired.
+A controller administrator must reset your user to issue a new token.
+See "juju help change-user-password" for more information.`[1:])
 
 	// Check that the controller hasn't been added.
 	_, err = s.store.ControllerByName("controller-name")


### PR DESCRIPTION
## Description of change

'juju register' accepts a one-time registration token. Once used, re-running the same command will give users an obscure error message with no solution nor a way forward.

This PR changes the message we give the users when we suspect that the token was already used/expired.

## QA steps

1. bootstrap
2. add a user
3. run register command as provided by output from step 2
4. re-run 3

EXPECTED OUTPUT:
```
ERROR Provided registration token may have been expired.
A controller administrator must reset your user to issue a new token.
See "juju help change-user-password" for more information.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1751849
