### PR TITLE
Fixes lp#1638714: rephrase version check error.

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -690,7 +690,7 @@ func IsUpgradeInProgressError(err error) bool {
 // cannot be higher than the controller version.
 func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVersions bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
-		return errors.Errorf("hosted models cannot be a later version than the controller: %s > %s: upgrade 'controller' model first",
+		return errors.Errorf("hosted models cannot be upgraded to a later version than the controller: %s > %s: upgrade 'controller' model first",
 			newVersion.String(),
 			jujuversion.Current,
 		)

--- a/state/state.go
+++ b/state/state.go
@@ -690,7 +690,7 @@ func IsUpgradeInProgressError(err error) bool {
 // cannot be higher than the controller version.
 func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVersions bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
-		return errors.Errorf("a hosted model cannot have a higher version than the server model: %s > %s",
+		return errors.Errorf("hosted models cannot be a later version than the controller: %s > %s: upgrade 'controller' model first",
 			newVersion.String(),
 			jujuversion.Current,
 		)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3751,7 +3751,7 @@ func (s *StateSuite) TestSetModelAgentVersionOnOtherModel(c *gc.C) {
 
 	// Set other model version to > server version
 	err = otherSt.SetModelAgentVersion(higher.Number, false)
-	expected := fmt.Sprintf("hosted models cannot be a later version than the controller: %s > %s: upgrade 'controller' model first",
+	expected := fmt.Sprintf("hosted models cannot be upgraded to a later version than the controller: %s > %s: upgrade 'controller' model first",
 		higher.Number,
 		jujuversion.Current,
 	)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3751,7 +3751,7 @@ func (s *StateSuite) TestSetModelAgentVersionOnOtherModel(c *gc.C) {
 
 	// Set other model version to > server version
 	err = otherSt.SetModelAgentVersion(higher.Number, false)
-	expected := fmt.Sprintf("a hosted model cannot have a higher version than the server model: %s > %s",
+	expected := fmt.Sprintf("hosted models cannot be a later version than the controller: %s > %s: upgrade 'controller' model first",
 		higher.Number,
 		jujuversion.Current,
 	)


### PR DESCRIPTION
## Description of change

When trying to upgrade a hosted model to a version that is later than a controller, users get an error message that is hard to digest.

This PR re-phrases the message.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1638714
