### PR TITLE
Alias upgrade-juju / upgrade-model.

### DIFF
--- a/apiserver/restrict_upgrades.go
+++ b/apiserver/restrict_upgrades.go
@@ -33,8 +33,8 @@ func IsMethodAllowedDuringUpgrade(facadeName, methodName string) bool {
 var allowedMethodsDuringUpgrades = map[string]set.Strings{
 	"Client": set.NewStrings(
 		"FullStatus",          // for "juju status"
-		"FindTools",           // for "juju upgrade-juju", before we can reset upgrade to re-run
-		"AbortCurrentUpgrade", // for "juju upgrade-juju", so that we can reset upgrade to re-run
+		"FindTools",           // for "juju upgrade-model", before we can reset upgrade to re-run
+		"AbortCurrentUpgrade", // for "juju upgrade-model", so that we can reset upgrade to re-run
 
 	),
 	"SSHClient": set.NewStrings( // allow all SSH client related calls

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -47,5 +47,5 @@ Commands that can be disabled are grouped based on logical operations as follows
     sync-agents
     unexpose
     upgrade-charm
-    upgrade-juju
+    upgrade-model
 	`

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -558,6 +558,7 @@ var commandNames = []string{
 	"upgrade-charm",
 	"upgrade-gui",
 	"upgrade-juju",
+	"upgrade-model",
 	"upload-backup",
 	"users",
 	"version",

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -66,7 +66,7 @@ Examples:
     juju sync-agent-binaries --debug --source=/home/ubuntu/sync-agent-binaries
 
 See also:
-    upgrade-juju
+    upgrade-model
 
 `
 

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -56,8 +56,8 @@ used to allow the upgrade to proceed.
 Backups are recommended prior to upgrading.
 
 Examples:
-    juju upgrade-juju --dry-run
-    juju upgrade-juju --agent-version 2.0.1
+    juju upgrade-model --dry-run
+    juju upgrade-model --agent-version 2.0.1
     
 See also: 
     sync-agent-binaries`
@@ -92,9 +92,10 @@ type upgradeJujuCommand struct {
 
 func (c *upgradeJujuCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "upgrade-juju",
+		Name:    "upgrade-model",
 		Purpose: usageUpgradeJujuSummary,
 		Doc:     usageUpgradeJujuDetails,
+		Aliases: []string{"upgrade-juju"},
 	}
 }
 
@@ -140,19 +141,19 @@ var (
 
 // canUpgradeRunningVersion determines if the version of the running
 // environment can be upgraded using this version of the
-// upgrade-juju command.  Only versions with a minor version
+// upgrade-model command.  Only versions with a minor version
 // of 0 are expected to be able to upgrade environments running
 // the previous major version.
 //
 // This check is needed because we do not guarantee API
 // compatibility across major versions.  For example, a 3.3.0
-// version of the upgrade-juju command may not know how to upgrade
+// version of the upgrade-model command may not know how to upgrade
 // an environment running juju 4.0.0.
 //
 // The exception is that a N.0.* client must be able to upgrade
 // an environment one major version prior (N-1.*.*) so that
 // it can be used to upgrade the environment to N.0.*.  For
-// example, the 2.0.1 upgrade-juju command must be able to upgrade
+// example, the 2.0.1 upgrade-model command must be able to upgrade
 // environments running 1.* since it must be able to upgrade
 // environments from 1.25.4 -> 2.0.*.
 func canUpgradeRunningVersion(runningAgentVer version.Number) bool {
@@ -275,7 +276,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	// This logic seems to be overly complicated and it checks the same condition multiple times.
 	switch {
 	case !canUpgradeRunningVersion(agentVersion):
-		// This version of upgrade-juju cannot upgrade the running
+		// This version of upgrade-model cannot upgrade the running
 		// environment version (can't guarantee API compatibility).
 		return errors.Errorf("cannot upgrade a %s model with a %s client",
 			agentVersion, jujuversion.Current)
@@ -367,9 +368,9 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	if c.DryRun {
 		if c.BuildAgent {
-			fmt.Fprint(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-juju --build-agent\n")
+			fmt.Fprint(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-model --build-agent\n")
 		} else {
-			fmt.Fprintf(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-juju\n")
+			fmt.Fprintf(ctx.Stderr, "upgrade to this version by running\n    juju upgrade-model\n")
 		}
 	} else {
 		if c.ResetPrevious {
@@ -389,7 +390,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 				return errors.Errorf("%s\n\n"+
 					"Please wait for the upgrade to complete or if there was a problem with\n"+
 					"the last upgrade that has been resolved, consider running the\n"+
-					"upgrade-juju command with the --reset-previous-upgrade flag.", err,
+					"upgrade-model command with the --reset-previous-upgrade flag.", err,
 				)
 			} else {
 				return block.ProcessBlockedError(err, block.BlockChange)

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -603,7 +603,7 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			expectedCmdOutput: `best version:
     2.1.3.1
 upgrade to this version by running
-    juju upgrade-juju --build-agent
+    juju upgrade-model --build-agent
 `,
 		},
 		{
@@ -615,7 +615,7 @@ upgrade to this version by running
 			expectedCmdOutput: `best version:
     2.1.3
 upgrade to this version by running
-    juju upgrade-juju
+    juju upgrade-model
 `,
 		},
 		{
@@ -627,7 +627,7 @@ upgrade to this version by running
 			expectedCmdOutput: `best version:
     2.1.3
 upgrade to this version by running
-    juju upgrade-juju
+    juju upgrade-model
 `,
 		},
 	}
@@ -847,7 +847,7 @@ func (s *UpgradeJujuSuite) TestUpgradeInProgress(c *gc.C) {
 		"\n"+
 		"Please wait for the upgrade to complete or if there was a problem with\n"+
 		"the last upgrade that has been resolved, consider running the\n"+
-		"upgrade-juju command with the --reset-previous-upgrade flag.",
+		"upgrade-model command with the --reset-previous-upgrade flag.",
 	)
 }
 

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -279,7 +279,7 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 	values := make(attributes)
 	for k, v := range attrs {
 		if k == config.AgentVersionKey {
-			return errors.Errorf(`"agent-version"" must be set via "upgrade-juju"`)
+			return errors.Errorf(`"agent-version"" must be set via "upgrade-model"`)
 		}
 		values[k] = v
 		keys = append(keys, k)

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -173,7 +173,7 @@ func (s *ConfigCommandSuite) TestAllValuesTabular(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestSetAgentVersion(c *gc.C) {
 	_, err := s.run(c, "agent-version=2.0.0")
-	c.Assert(err, gc.ErrorMatches, `"agent-version"" must be set via "upgrade-juju"`)
+	c.Assert(err, gc.ErrorMatches, `"agent-version"" must be set via "upgrade-model"`)
 }
 
 func (s *ConfigCommandSuite) TestSetAndReset(c *gc.C) {

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -562,7 +562,7 @@ func (c *defaultsCommand) setDefaults(client defaultsCommandAPI, ctx *cmd.Contex
 	values := make(attributes)
 	for k, v := range attrs {
 		if k == config.AgentVersionKey {
-			return errors.Errorf(`"agent-version" must be set via "upgrade-juju"`)
+			return errors.Errorf(`"agent-version" must be set via "upgrade-model"`)
 		}
 		values[k] = v
 		keys = append(keys, k)

--- a/cmd/juju/model/defaultscommand_test.go
+++ b/cmd/juju/model/defaultscommand_test.go
@@ -48,7 +48,7 @@ func (s *DefaultsCommandSuite) TestDefaultsInit(c *gc.C) {
 		// Test set
 		description: "test cannot set agent-version",
 		args:        []string{"agent-version=2.0.0"},
-		errorMatch:  `"agent-version" must be set via "upgrade-juju"`,
+		errorMatch:  `"agent-version" must be set via "upgrade-model"`,
 	}, {
 		description: "test set multiple keys",
 		args:        []string{"foo=bar", "baz=eggs"},

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -66,7 +66,7 @@ func (s *cmdUpgradeSuite) TestControllerAdminCanUpgradeHostedModel(c *gc.C) {
 	// Upgrade hosted model.
 	v, _ := version.Parse(newVersion)
 	s.PatchValue(&coreversion.Current, v)
-	ctx = s.run(c, "upgrade-juju", "-m", fmt.Sprintf("%v/%v", s.hostedModelUser, s.hostedModel))
+	ctx = s.run(c, "upgrade-model", "-m", fmt.Sprintf("%v/%v", s.hostedModelUser, s.hostedModel))
 	expectedUpgradeMsg := fmt.Sprintf("started upgrade to %v", newVersion)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, expectedUpgradeMsg)
 	s.assertHostModelAgentVersion(c, newVersion)


### PR DESCRIPTION
## Description of change

In the long run, we want to move away from an unclear juju 1.x remnant of 'upgrade-juju' towards 'upgrade-controller' and 'upgrade-model' as these are Juju 2.x components and make more sense to the users.

This is an first step in that direction - current 'upgrade-juju' command is essentially an 'upgrade-model' command.

## QA steps

Both 'upgrade-model' and 'upgrade-juju' work.
