### PR TITLE
Support for caas namespaces

### DIFF
--- a/api/caasagent/client.go
+++ b/api/caasagent/client.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common/cloudspec"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
+)
+
+// Client provides access to an agent's view of state.
+type Client struct {
+	facade base.FacadeCaller
+	*cloudspec.CloudSpecAPI
+}
+
+// NewClient returns a version of an api client that provides functionality
+// required by caas agent code.
+func NewClient(caller base.APICaller) (*Client, error) {
+	modelTag, isModel := caller.ModelTag()
+	if !isModel {
+		return nil, errors.New("expected model specific API connection")
+	}
+	facadeCaller := base.NewFacadeCaller(caller, "CAASAgent")
+	return &Client{
+		facade:       facadeCaller,
+		CloudSpecAPI: cloudspec.NewCloudSpecAPI(facadeCaller, modelTag),
+	}, nil
+}
+
+// Model returns details of the api's model.
+func (st *Client) Model() (*model.Model, error) {
+	var result params.Model
+	err := st.facade.FacadeCall("Model", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	owner, err := names.ParseUserTag(result.OwnerTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &model.Model{
+		Name:  result.Name,
+		Type:  model.ModelType(result.Type),
+		UUID:  result.UUID,
+		Owner: owner,
+	}, nil
+}

--- a/api/caasagent/client_test.go
+++ b/api/caasagent/client_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/caasagent"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type agentSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&agentSuite{})
+
+func (s *agentSuite) TestModel(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASAgent")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "Model")
+		c.Check(arg, gc.IsNil)
+		c.Assert(result, gc.FitsTypeOf, &params.Model{})
+		*(result.(*params.Model)) = params.Model{
+			Name:     "mymodel",
+			UUID:     coretesting.ModelTag.Id(),
+			Type:     "iaas",
+			OwnerTag: "user-fred",
+		}
+		return nil
+	})
+
+	client, err := caasagent.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := client.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, &model.Model{
+		Name:  "mymodel",
+		UUID:  coretesting.ModelTag.Id(),
+		Type:  "iaas",
+		Owner: names.NewUserTag("fred"),
+	})
+}

--- a/api/caasagent/package_test.go
+++ b/api/caasagent/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -24,6 +24,7 @@ var facadeVersions = map[string]int{
 	"Backups":                      1,
 	"Block":                        2,
 	"Bundle":                       1,
+	"CAASAgent":                    1,
 	"CAASFirewaller":               1,
 	"CAASOperator":                 1,
 	"CAASOperatorProvisioner":      1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/agent" // ModelUser Write
+	"github.com/juju/juju/apiserver/facades/agent/caasagent"
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
 	"github.com/juju/juju/apiserver/facades/agent/deployer"
 	"github.com/juju/juju/apiserver/facades/agent/diskmanager"
@@ -154,6 +155,7 @@ func AllFacades() *facade.Registry {
 		reg("Application", 6, application.NewFacadeV6)
 		reg("CAASFirewaller", 1, caasfirewaller.NewStateFacade)
 		reg("CAASOperator", 1, caasoperator.NewStateFacade)
+		reg("CAASAgent", 1, caasagent.NewStateFacade)
 		reg("CAASOperatorProvisioner", 1, caasoperatorprovisioner.NewStateCAASOperatorProvisionerAPI)
 		reg("CAASUnitProvisioner", 1, caasunitprovisioner.NewStateFacade)
 	}

--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/cloudspec"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type Facade struct {
+	auth      facade.Authorizer
+	resources facade.Resources
+	state     CAASAgentState
+	cloudspec.CloudSpecAPI
+
+	model Model
+}
+
+// NewStateFacade provides the signature required for facade registration.
+func NewStateFacade(ctx facade.Context) (*Facade, error) {
+	authorizer := ctx.Auth()
+	resources := ctx.Resources()
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cloudSpecAPI := cloudspec.NewCloudSpec(
+		cloudspec.MakeCloudSpecGetterForModel(ctx.State()),
+		common.AuthFuncForTag(model.ModelTag()),
+	)
+	return NewFacade(resources, authorizer, stateShim{ctx.State()}, cloudSpecAPI, model)
+}
+
+// NewFacade returns a new CAASAgent facade.
+func NewFacade(
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+	st CAASAgentState,
+	cloudSpecAPI cloudspec.CloudSpecAPI,
+	model Model,
+) (*Facade, error) {
+	if !authorizer.AuthMachineAgent() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{
+		CloudSpecAPI: cloudSpecAPI,
+		auth:         authorizer,
+		resources:    resources,
+		state:        st,
+		model:        model,
+	}, nil
+}
+
+// Model returns the details about the model.
+func (f *Facade) Model() (params.Model, error) {
+	return params.Model{
+		Name:     f.model.Name(),
+		Type:     string(f.model.Type()),
+		UUID:     f.model.UUID(),
+		OwnerTag: f.model.Owner().String(),
+	}, nil
+}

--- a/apiserver/facades/agent/caasagent/caasagent_test.go
+++ b/apiserver/facades/agent/caasagent/caasagent_test.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/agent/caasagent"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&caasagentSuite{})
+
+type caasagentSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	facade     *caasagent.Facade
+	st         *mockState
+}
+
+func (s *caasagentSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("0"),
+	}
+
+	s.st = &mockState{}
+	model, err := s.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	facade, err := caasagent.NewFacade(s.resources, s.authorizer, s.st, nil, model)
+	c.Assert(err, jc.ErrorIsNil)
+	s.facade = facade
+}
+
+func (s *caasagentSuite) TestPermission(c *gc.C) {
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag: names.NewApplicationTag("someapp"),
+	}
+	_, err := caasagent.NewFacade(s.resources, s.authorizer, s.st, nil, nil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *caasagentSuite) TestModel(c *gc.C) {
+	result, err := s.facade.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.Model{
+		Name:     "some-model",
+		UUID:     coretesting.ModelTag.Id(),
+		Type:     "caas",
+		OwnerTag: "user-fred",
+	})
+
+	s.st.CheckCallNames(c, "Model")
+}

--- a/apiserver/facades/agent/caasagent/mock_test.go
+++ b/apiserver/facades/agent/caasagent/mock_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent_test
+
+import (
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/facades/agent/caasagent"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type mockState struct {
+	testing.Stub
+	model mockModel
+}
+
+func (st *mockState) Model() (caasagent.Model, error) {
+	st.MethodCall(st, "Model")
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	return &st.model, nil
+}
+
+type mockModel struct {
+	testing.Stub
+}
+
+func (st *mockModel) Name() string {
+	return "some-model"
+}
+
+func (st *mockModel) UUID() string {
+	return coretesting.ModelTag.Id()
+}
+
+func (st *mockModel) Type() state.ModelType {
+	return state.ModelTypeCAAS
+}
+
+func (st *mockModel) Owner() names.UserTag {
+	return names.NewUserTag("fred")
+}
+
+func (st *mockModel) ModelTag() names.ModelTag {
+	return coretesting.ModelTag
+}

--- a/apiserver/facades/agent/caasagent/package_test.go
+++ b/apiserver/facades/agent/caasagent/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facades/agent/caasagent/state.go
+++ b/apiserver/facades/agent/caasagent/state.go
@@ -1,0 +1,33 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasagent
+
+import (
+	"github.com/juju/juju/state"
+	"gopkg.in/juju/names.v2"
+)
+
+// CAASAgentState provides the subset of global state
+// required by the CAAS agent facade.
+type CAASAgentState interface {
+	Model() (Model, error)
+}
+
+// Model provides the subset of CAAS model state required
+// by the CAAS agent facade.
+type Model interface {
+	Name() string
+	UUID() string
+	Type() state.ModelType
+	Owner() names.UserTag
+	ModelTag() names.ModelTag
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (st stateShim) Model() (Model, error) {
+	return st.State.Model()
+}

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -44,6 +44,7 @@ var commonModelFacadeNames = set.NewStrings(
 // caasModelFacadeNames lists facades that are only used with CAAS
 // models.
 var caasModelFacadeNames = set.NewStrings(
+	"CAASAgent",
 	"CAASFirewaller",
 	"CAASOperator",
 	"CAASOperatorProvisioner",

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -12,10 +12,17 @@ import (
 )
 
 // NewContainerBrokerFunc returns a Container Broker.
-type NewContainerBrokerFunc func(environs.CloudSpec) (Broker, error)
+type NewContainerBrokerFunc func(spec environs.CloudSpec, namespace string) (Broker, error)
 
 // Broker instances interact with the CAAS substrate.
 type Broker interface {
+
+	// EnsureNamespace ensures this broker's namespace is created.
+	EnsureNamespace() error
+
+	// DeleteNamespace deletes this broker's namespace.
+	DeleteNamespace() error
+
 	// EnsureOperator creates or updates an operator pod for running
 	// a charm for the specified application.
 	EnsureOperator(appName, agentPath string, config *OperatorConfig) error

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -3,6 +3,8 @@
 
 package model
 
+import "gopkg.in/juju/names.v2"
+
 // ModelType indicates a model type.
 type ModelType string
 
@@ -17,4 +19,12 @@ const (
 // String returns m as a string.
 func (m ModelType) String() string {
 	return string(m)
+}
+
+// Model represents information about a model.
+type Model struct {
+	Name  string
+	Type  ModelType
+	UUID  string
+	Owner names.UserTag
 }

--- a/worker/caasbroker/broker.go
+++ b/worker/caasbroker/broker.go
@@ -8,16 +8,18 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker/catacomb"
 )
 
 var logger = loggo.GetLogger("juju.worker.caas")
 
-// ConfigObserver exposes a model configuration and a watch constructor
+// ConfigAPI exposes a model configuration and a watch constructor
 // that allows clients to be informed of changes to the configuration.
-type ConfigObserver interface {
+type ConfigAPI interface {
 	CloudSpec() (environs.CloudSpec, error)
+	Model() (*model.Model, error)
 }
 
 // Config describes the dependencies of a Tracker.
@@ -25,14 +27,14 @@ type ConfigObserver interface {
 // It's arguable that it should be called TrackerConfig, because of the heavy
 // use of model config in this package.
 type Config struct {
-	Observer               ConfigObserver
+	ConfigAPI              ConfigAPI
 	NewContainerBrokerFunc caas.NewContainerBrokerFunc
 }
 
 // Validate returns an error if the config cannot be used to start a Tracker.
 func (config Config) Validate() error {
-	if config.Observer == nil {
-		return errors.NotValidf("nil Observer")
+	if config.ConfigAPI == nil {
+		return errors.NotValidf("nil ConfigAPI")
 	}
 	if config.NewContainerBrokerFunc == nil {
 		return errors.NotValidf("nil NewContainerBrokerFunc")
@@ -57,11 +59,15 @@ func NewTracker(config Config) (*Tracker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	cloudSpec, err := config.Observer.CloudSpec()
+	cloudSpec, err := config.ConfigAPI.CloudSpec()
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get cloud information")
 	}
-	broker, err := config.NewContainerBrokerFunc(cloudSpec)
+	model, err := config.ConfigAPI.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := config.NewContainerBrokerFunc(cloudSpec, model.Name)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create caas broker")
 	}

--- a/worker/caasbroker/manifold.go
+++ b/worker/caasbroker/manifold.go
@@ -7,8 +7,8 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
 
-	"github.com/juju/juju/api/agent"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/caasagent"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/worker/dependency"
 )
@@ -32,13 +32,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, errors.Trace(err)
 			}
-			// TODO(caas) introduce a caasbroker API
-			apiSt, err := agent.NewState(apiCaller)
+			api, err := caasagent.NewClient(apiCaller)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 			w, err := NewTracker(Config{
-				Observer:               apiSt,
+				ConfigAPI:              api,
 				NewContainerBrokerFunc: config.NewContainerBrokerFunc,
 			})
 			if err != nil {

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -62,7 +62,9 @@ func (m *mockProvisionerFacade) SetPasswords(passwords []apicaasprovisioner.Appl
 	if err := m.stub.NextErr(); err != nil {
 		return params.ErrorResults{}, err
 	}
-	return params.ErrorResults{}, nil
+	return params.ErrorResults{
+		Results: make([]params.ErrorResult, len(passwords)),
+	}, nil
 }
 
 type mockAgentConfig struct {

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -82,6 +82,7 @@ func (s *CAASProvisionerSuite) TestWorkerStarts(c *gc.C) {
 }
 
 func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C) {
+	s.provisionerFacade.life = "alive"
 	s.provisionerFacade.applicationsWatcher.changes <- []string{"myapp"}
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
@@ -136,6 +137,7 @@ func (s *CAASProvisionerSuite) TestApplicationDeletedRemovesOperator(c *gc.C) {
 	s.assertOperatorCreated(c)
 	s.caasClient.ResetCalls()
 	s.provisionerFacade.stub.SetErrors(errors.NotFoundf("myapp"))
+	s.provisionerFacade.life = "dead"
 	s.provisionerFacade.applicationsWatcher.changes <- []string{"myapp"}
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {


### PR DESCRIPTION
## Description of change

Each CAAS model's k8s resources (pods, services, etc) are now created in a namespace named after the model. Because we don't have a model manager worker yet to react to model add/remove, we create and delete the namespace inside the k8s client when an operator is created/deleted. This is a workaround until the necessary model worker can be written.

To provide the model name to the k8s broker tracker, we implement an existing TODO which is to add a bespoke caas agent facade. There's also a driveby fix to clean up the caas operator provisioner worker logic a bit.

## QA steps

Run up a CAAS model and check that gitlab/mysql can be deployed and related, and that the expected namespace is used. Delete all model applications and check that the namespace is removed.