### PR TITLE
We iterate over the map, but then we mutate them.

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1009,8 +1009,8 @@ func (task *provisionerTask) populateExcludedMachines(machineId string, startIns
 	if len(derivedZones) == 0 {
 		return nil
 	}
-	task.machinesMutex.RLock()
-	defer task.machinesMutex.RUnlock()
+	task.machinesMutex.Lock()
+	defer task.machinesMutex.Unlock()
 	useZones := set.NewStrings(derivedZones...)
 	for _, zoneMachines := range task.availabilityZoneMachines {
 		if !useZones.Contains(zoneMachines.ZoneName) {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1208,12 +1208,12 @@ func (task *provisionerTask) addMachinetoAZMap(machine *apiprovisioner.Machine, 
 // It is assumed this is called when the machines are being deleted from state, or failed
 // provisioning.
 func (task *provisionerTask) removeMachineFromAZMap(machine *apiprovisioner.Machine) {
-	machineId := set.NewStrings(machine.Id())
+	machineId := machine.Id()
 	task.machinesMutex.Lock()
 	defer task.machinesMutex.Unlock()
 	for _, zoneMachines := range task.availabilityZoneMachines {
-		zoneMachines.MachineIds = zoneMachines.MachineIds.Difference(machineId)
-		zoneMachines.FailedMachineIds = zoneMachines.FailedMachineIds.Difference(machineId)
+		zoneMachines.MachineIds.Remove(machineId)
+		zoneMachines.FailedMachineIds.Remove(machineId)
 	}
 }
 


### PR DESCRIPTION
## Description of change

We had a Race condition because we were using just a Read Lock around something that was actually mutating the objects we were locking.

## QA steps

```
$ cd worker/provisioner
$ go test -race
```

## Documentation changes

None

## Bug reference

None