### PR TITLE
Add support for injecting secrets into pods

### DIFF
--- a/caas/containers.go
+++ b/caas/containers.go
@@ -4,6 +4,8 @@
 package caas
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -20,32 +22,59 @@ type ContainerPort struct {
 type FileSet struct {
 	Name      string            `yaml:"name"`
 	MountPath string            `yaml:"mount-path"`
-	Files     map[string]string `yaml:"files"`
+	Files     map[string]string `yaml:"files,omitempty"`
+	Secret    *FileSecret       `yaml:"secret,omitempty"`
+}
+
+// FileSecret defines a secret to use add to a mount point
+// for a container in the CAAS substrate.
+type FileSecret struct {
+	Name       string    `yaml:"name"`
+	SecretKeys []KeyPath `yaml:"keys,omitempty"`
+}
+
+// KeyPath defines a key and file path.
+type KeyPath struct {
+	Key  string `yaml:"key"`
+	Path string `yaml:"path"`
 }
 
 // ContainerSpec defines the data values used to configure
 // a container on the CAAS substrate.
 type ContainerSpec struct {
-	Name      string            `yaml:"name"`
-	ImageName string            `yaml:"image-name"`
-	Ports     []ContainerPort   `yaml:"ports,omitempty"`
-	Config    map[string]string `yaml:"config,omitempty"`
-	Files     []FileSet         `yaml:"files,omitempty"`
+	Name          string                  `yaml:"name"`
+	ImageName     string                  `yaml:"image-name"`
+	Ports         []ContainerPort         `yaml:"ports,omitempty"`
+	Files         []FileSet               `yaml:"files,omitempty"`
+	Config        map[string]string       `yaml:"-"`
+	ConfigSecrets map[string]ConfigSecret `yaml:"-"`
+}
+
+// ConfigSecret defines a secret to use when configuring a
+// container in the CAAS substrate.
+type ConfigSecret struct {
+	SecretName string `yaml:"secret"`
+	Key        string `yaml:"key"`
+}
+
+type containerYaml struct {
+	ContainerSpec `yaml:",inline"`
+	RawConfig     map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // ParseContainerSpec parses a YAML string into a ContainerSpec struct.
 func ParseContainerSpec(in string) (*ContainerSpec, error) {
-	var spec ContainerSpec
-	if err := yaml.Unmarshal([]byte(in), &spec); err != nil {
+	var rawSpec containerYaml
+	if err := yaml.Unmarshal([]byte(in), &rawSpec); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if spec.Name == "" {
+	if rawSpec.Name == "" {
 		return nil, errors.New("spec name is missing")
 	}
-	if spec.ImageName == "" {
+	if rawSpec.ImageName == "" {
 		return nil, errors.New("spec image name is missing")
 	}
-	for _, fs := range spec.Files {
+	for _, fs := range rawSpec.Files {
 		if fs.Name == "" {
 			return nil, errors.New("file set name is missing")
 		}
@@ -53,5 +82,35 @@ func ParseContainerSpec(in string) (*ContainerSpec, error) {
 			return nil, errors.Errorf("mount path is missing for file set %q", fs.Name)
 		}
 	}
-	return &spec, nil
+	for k, v := range rawSpec.RawConfig {
+		switch val := v.(type) {
+		case string:
+			if rawSpec.Config == nil {
+				rawSpec.Config = make(map[string]string)
+			}
+			rawSpec.Config[k] = val
+		case map[interface{}]interface{}:
+			if count := len(val); count != 2 {
+				return nil, errors.Errorf("expected 2 values in secret spec for %q, got %d", k, count)
+			}
+			secret, ok := val["secret"]
+			if !ok {
+				return nil, errors.Errorf("missing secret name for secret %q", k)
+			}
+			key, ok := val["key"]
+			if !ok {
+				return nil, errors.Errorf("missing key for secret %q", k)
+			}
+			if rawSpec.ConfigSecrets == nil {
+				rawSpec.ConfigSecrets = make(map[string]ConfigSecret)
+			}
+			rawSpec.ConfigSecrets[k] = ConfigSecret{
+				SecretName: fmt.Sprintf("%v", secret),
+				Key:        fmt.Sprintf("%v", key),
+			}
+		default:
+			return nil, errors.Errorf("unexpected config value type %T", val)
+		}
+	}
+	return &rawSpec.ContainerSpec, nil
 }

--- a/caas/containers_test.go
+++ b/caas/containers_test.go
@@ -29,6 +29,9 @@ ports:
 config:
   attr: foo=bar; fred=blogs
   foo: bar
+  mysecret:
+    secret: logincreds
+    key: password
 files:
   - name: configuration
     mount-path: /var/lib/foo
@@ -36,6 +39,17 @@ files:
       file1: |
         [config]
         foo: bar
+    secret:
+      name: anothersecret
+  - name: more-configuration
+    mount-path: /var/lib/foo
+    secret:
+      name: reallysecret
+      keys:
+        - key: password
+          path: password.txt
+        - key: rootpassword
+          path: rootpassword.txt
 `[1:]
 
 	expectedFileContent := `
@@ -56,12 +70,26 @@ foo: bar
 			"attr": "foo=bar; fred=blogs",
 			"foo":  "bar",
 		},
+		ConfigSecrets: map[string]caas.ConfigSecret{
+			"mysecret": {SecretName: "logincreds", Key: "password"},
+		},
 		Files: []caas.FileSet{
 			{
 				Name:      "configuration",
 				MountPath: "/var/lib/foo",
 				Files: map[string]string{
 					"file1": expectedFileContent,
+				},
+				Secret: &caas.FileSecret{Name: "anothersecret"},
+			}, {
+				Name:      "more-configuration",
+				MountPath: "/var/lib/foo",
+				Secret: &caas.FileSecret{
+					Name: "reallysecret",
+					SecretKeys: []caas.KeyPath{
+						{Key: "password", Path: "password.txt"},
+						{Key: "rootpassword", Path: "rootpassword.txt"},
+					},
 				},
 			},
 		},
@@ -119,4 +147,50 @@ files:
 
 	_, err := caas.ParseContainerSpec(specStr)
 	c.Assert(err, gc.ErrorMatches, `mount path is missing for file set "configuration"`)
+}
+
+func (s *ContainersSuite) TestParseTooManySecretAttributes(c *gc.C) {
+
+	specStr := `
+name: gitlab
+image-name: gitlab/latest
+config:
+  mysecret:
+    secret: logincreds
+    key: password
+    extra: bad
+`[1:]
+
+	_, err := caas.ParseContainerSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, `expected 2 values in secret spec for "mysecret", got 3`)
+}
+
+func (s *ContainersSuite) TestParseMissingSecretName(c *gc.C) {
+
+	specStr := `
+name: gitlab
+image-name: gitlab/latest
+config:
+  mysecret:
+    extra: value
+    key: password
+`[1:]
+
+	_, err := caas.ParseContainerSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, `missing secret name for secret "mysecret"`)
+}
+
+func (s *ContainersSuite) TestParseMissingSecretKey(c *gc.C) {
+
+	specStr := `
+name: gitlab
+image-name: gitlab/latest
+config:
+  mysecret:
+    secret: logincreds
+    extra: value
+`[1:]
+
+	_, err := caas.ParseContainerSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, `missing key for secret "mysecret"`)
 }

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import "k8s.io/client-go/pkg/api/v1"
+
+var (
+	MakeUnitSpec = makeUnitSpec
+)
+
+func PodSpec(u *unitSpec) v1.PodSpec {
+	return u.Pod
+}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -264,7 +264,7 @@ func (k *kubernetesClient) EnsureService(
 	// a deployment controller set to create that number of units is required.
 	if numUnits > 0 {
 		numPods := int32(numUnits)
-		if err := k.configureDeployment(appName, unitSpec, &numPods); err != nil {
+		if err := k.configureDeployment(appName, unitSpec, spec.Files, &numPods); err != nil {
 			return errors.Annotate(err, "creating or updating deployment controller")
 		}
 		cleanups = append(cleanups, func() { k.deleteDeployment(appName) })
@@ -285,8 +285,48 @@ func (k *kubernetesClient) EnsureService(
 	return nil
 }
 
-func (k *kubernetesClient) configureDeployment(appName string, unitSpec *unitSpec, replicas *int32) error {
+type configMapNameFunc func(fileSetName string) string
+
+func (k *kubernetesClient) configurePodFiles(podSpec *v1.PodSpec, files []caas.FileSet, cfgMapName configMapNameFunc) error {
+	for _, fileSet := range files {
+		cfgName := cfgMapName(fileSet.Name)
+		vol := v1.Volume{Name: cfgName}
+		if fileSet.Secret == nil {
+			if err := k.ensureConfigMap(filesetConfigMap(cfgName, &fileSet)); err != nil {
+				return errors.Annotatef(err, "creating or updating ConfigMap for file set %v", cfgName)
+			}
+			vol.ConfigMap = &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: cfgName,
+				},
+			}
+		} else {
+			vol.Secret = &v1.SecretVolumeSource{SecretName: fileSet.Secret.Name}
+			for _, kp := range fileSet.Secret.SecretKeys {
+				vol.Secret.Items = append(vol.Secret.Items, v1.KeyToPath{Key: kp.Key, Path: kp.Path})
+			}
+		}
+		podSpec.Volumes = []v1.Volume{vol}
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, v1.VolumeMount{
+			Name:      cfgName,
+			MountPath: fileSet.MountPath,
+			ReadOnly:  fileSet.Secret != nil,
+		})
+	}
+	return nil
+}
+
+func (k *kubernetesClient) configureDeployment(appName string, unitSpec *unitSpec, files []caas.FileSet, replicas *int32) error {
 	logger.Debugf("creating/updating deployment for %s", appName)
+
+	// Add the specified file to the pod spec.
+	cfgName := func(fileSetName string) string {
+		return applicationConfigMapName(appName, fileSetName)
+	}
+	podSpec := unitSpec.Pod
+	if err := k.configurePodFiles(&podSpec, files, cfgName); err != nil {
+		return errors.Trace(err)
+	}
 
 	namePrefix := resourceNamePrefix(appName)
 	deployment := &v1beta1.Deployment{
@@ -303,7 +343,7 @@ func (k *kubernetesClient) configureDeployment(appName string, unitSpec *unitSpe
 					GenerateName: namePrefix,
 					Labels:       map[string]string{labelApplication: appName},
 				},
-				Spec: unitSpec.Pod,
+				Spec: podSpec,
 			},
 		},
 	}
@@ -570,34 +610,20 @@ func (k *kubernetesClient) EnsureUnit(appName, unitName string, spec *caas.Conta
 				labelUnit:        podName}},
 		Spec: unitSpec.Pod,
 	}
-	for _, fileSet := range spec.Files {
-		cfgName := unitConfigMapName(unitName, fileSet.Name)
-		if err := k.ensureConfigMap(filesetConfigMap(unitName, fileSet.Name, &fileSet)); err != nil {
-			return errors.Annotatef(err, "creating or updating ConfigMap for file set %v", cfgName)
-		}
-		volumeSource := v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: cfgName,
-				},
-			},
-		}
-		pod.Spec.Volumes = []v1.Volume{{
-			Name:         cfgName,
-			VolumeSource: volumeSource,
-		}}
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-			Name:      cfgName,
-			MountPath: fileSet.MountPath,
-		})
+
+	// Add the specified file to the pod spec.
+	cfgName := func(fileSetName string) string {
+		return unitConfigMapName(unitName, fileSetName)
+	}
+	if err := k.configurePodFiles(&pod.Spec, spec.Files, cfgName); err != nil {
+		return errors.Trace(err)
 	}
 	return k.ensurePod(&pod)
 }
 
 // filesetConfigMap returns a *v1.ConfigMap for a pod
 // of the specified unit, with the specified files.
-func filesetConfigMap(unitName, fileSetName string, files *caas.FileSet) *v1.ConfigMap {
-	configMapName := unitConfigMapName(unitName, fileSetName)
+func filesetConfigMap(configMapName string, files *caas.FileSet) *v1.ConfigMap {
 	result := &v1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name: configMapName,
@@ -776,11 +802,18 @@ pod:
           {{if .Protocol}}protocol: {{.Protocol}}{{end}}
     {{- end}}
     {{end}}
-    {{if .Config}}
+    {{if or .Config .ConfigSecrets}}
     env:
     {{- range $k, $v := .Config }}
         - name: {{$k}}
           value: {{$v}}
+    {{- end}}
+    {{- range $k, $v := .ConfigSecrets }}
+        - name: {{$k}}
+          valueFrom:
+            secretKeyRef:
+              name: {{$v.SecretName}}
+              key: {{$v.Key}}
     {{- end}}
     {{end}}
 `[1:]
@@ -807,6 +840,10 @@ func operatorPodName(appName string) string {
 
 func operatorConfigMapName(appName string) string {
 	return operatorPodName(appName) + "-config"
+}
+
+func applicationConfigMapName(appName, fileSetName string) string {
+	return fmt.Sprintf("%v-%v-config", deploymentName(appName), fileSetName)
 }
 
 func unitConfigMapName(unitName, fileSetName string) string {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1,0 +1,96 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/testing"
+)
+
+type K8sSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&K8sSuite{})
+
+func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
+	containerSpec := caas.ContainerSpec{
+		Name:      "test",
+		Ports:     []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+		ImageName: "juju/image",
+	}
+	spec, err := provider.MakeUnitSpec(&containerSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.PodSpec(spec), jc.DeepEquals, v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "test",
+				Image: "juju/image",
+				Ports: []v1.ContainerPort{{ContainerPort: int32(80), Protocol: v1.ProtocolTCP}},
+			},
+		},
+	})
+}
+
+func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
+	containerSpec := caas.ContainerSpec{
+		Name:      "test",
+		Ports:     []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+		ImageName: "juju/image",
+		Config: map[string]string{
+			"foo": "bar",
+		},
+	}
+	spec, err := provider.MakeUnitSpec(&containerSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.PodSpec(spec), jc.DeepEquals, v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "test",
+				Image: "juju/image",
+				Ports: []v1.ContainerPort{{ContainerPort: int32(80), Protocol: v1.ProtocolTCP}},
+				Env: []v1.EnvVar{
+					{Name: "foo", Value: "bar"},
+				},
+			},
+		},
+	})
+}
+
+func (s *K8sSuite) TestMakeUnitSpecConfigPairsWithSecrets(c *gc.C) {
+	containerSpec := caas.ContainerSpec{
+		Name:      "test",
+		Ports:     []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+		ImageName: "juju/image",
+		Config: map[string]string{
+			"foo": "bar",
+		},
+		ConfigSecrets: map[string]caas.ConfigSecret{
+			"mysecret": {SecretName: "logincreds", Key: "password"},
+		},
+	}
+	spec, err := provider.MakeUnitSpec(&containerSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.PodSpec(spec), jc.DeepEquals, v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "test",
+				Image: "juju/image",
+				Ports: []v1.ContainerPort{{ContainerPort: int32(80), Protocol: v1.ProtocolTCP}},
+				Env: []v1.EnvVar{
+					{Name: "foo", Value: "bar"},
+					{Name: "mysecret", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{Name: "logincreds"},
+						Key:                  "password",
+					}}},
+				},
+			},
+		},
+	})
+}

--- a/caas/kubernetes/provider/package_test.go
+++ b/caas/kubernetes/provider/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

We add support for injecting secrets into pods. The secrets can be config values or mapped as files. We follow the k8s secret spec.

## QA steps

There's no charm yet which uses secrets, but a preliminary test can be done.
Add a secret k8s.
Deploy a sample charm which specifies secrets and ssh into to check that the secrets have been deployed.
