### PR TITLE
upgrademodel: Set tag to force sort to consider tagged releases

### DIFF
--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -590,6 +590,7 @@ func (context *upgradeContext) maybeChoosePackagedAgent() (err error) {
 		nextVersion := context.agent
 		nextVersion.Minor += 1
 		nextVersion.Patch = 0
+		nextVersion.Tag = " "
 
 		newestNextStable, found := context.tools.NewestCompatible(nextVersion)
 		if found {

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -590,6 +590,8 @@ func (context *upgradeContext) maybeChoosePackagedAgent() (err error) {
 		nextVersion := context.agent
 		nextVersion.Minor += 1
 		nextVersion.Patch = 0
+		// Set Tag to space so it will be considered lexicographically earlier
+		// than any tagged version.
 		nextVersion.Tag = " "
 
 		newestNextStable, found := context.tools.NewestCompatible(nextVersion)

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -130,6 +130,12 @@ var upgradeJujuTests = []struct {
 	agentVersion:   "2.0.0",
 	expectVersion:  "2.0.5",
 }, {
+	about:          "latest current release with tag",
+	tools:          []string{"2.2.0-quantal-amd64", "2.2.5-quantal-i386", "2.3.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
+	currentVersion: "2.0.0-quantal-amd64",
+	agentVersion:   "2.0.0",
+	expectVersion:  "2.1-dev1",
+}, {
 	about:          "latest current release matching CLI, major version, no matching major agent binaries",
 	tools:          []string{"2.8.2-quantal-amd64"},
 	currentVersion: "3.0.2-quantal-amd64",
@@ -141,12 +147,6 @@ var upgradeJujuTests = []struct {
 	currentVersion: "3.0.2-quantal-amd64",
 	agentVersion:   "2.8.2",
 	expectErr:      "no compatible agent binaries available",
-}, {
-	about:          "no next supported available",
-	tools:          []string{"2.2.0-quantal-amd64", "2.2.5-quantal-i386", "2.3.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
-	currentVersion: "2.0.0-quantal-amd64",
-	agentVersion:   "2.0.0",
-	expectErr:      "no more recent supported versions available",
 }, {
 	about:          "latest supported stable, when client is dev, explicit upload",
 	tools:          []string{"2.1-dev1-quantal-amd64", "2.1.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},


### PR DESCRIPTION
## Description of change

upgrade-juju would ignore a 'next release' agent version if it had a tag (e.g. beta1).

For instance 'upgrade-juju' would fail with a current agent version of 2.3.4 and a new version of 2.4-beta1 in the agent steam, one would have to provide --agent-version.

Now upgrade-juju will upgrade from 2.3.4 to 2.4-beta1 without the need for --agent-version.

The use of agents streams (devel, proposed, released etc.) are now used to provide the 'upgrade barrier'.

## QA steps

Unit tests updated to reflect this change.
The new upgrade functional test has been run with this change an now passes (the test failure in CI brought our attention to this issue).


