### PR TITLE
Fix intermittent failure in storage provisioner test.

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/watchers.go
+++ b/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/watchers.go
@@ -4,13 +4,13 @@
 package filesystemwatcher
 
 import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/utils/set"
 )
 
 // Watchers provides methods for watching filesystems. The watches aggregate

--- a/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/watchers_test.go
+++ b/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/watchers_test.go
@@ -157,6 +157,11 @@ func (s *WatchersSuite) TestWatchMachineManagedFilesystemsVolumeAttachmentDead(c
 	delete(s.backend.volumeAttachments, "2")
 	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2"}
 
+	// In order to not start the watcher until it has finished processing
+	// the previous event, we send another empty list through the channel
+	// which does nothing.
+	s.backend.modelVolumeAttachmentsW.C <- []string{}
+
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 	wc.AssertChangeInSingleEvent()
 	wc.AssertNoChange()
@@ -229,6 +234,11 @@ func (s *WatchersSuite) TestWatchMachineManagedFilesystemAttachmentsVolumeAttach
 	s.backend.volumeAttachments["1"].life = state.Dead
 	delete(s.backend.volumeAttachments, "2")
 	s.backend.modelVolumeAttachmentsW.C <- []string{"0:1", "0:2"}
+
+	// In order to not start the watcher until it has finished processing
+	// the previous event, we send another empty list through the channel
+	// which does nothing.
+	s.backend.modelVolumeAttachmentsW.C <- []string{}
 
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 	wc.AssertChangeInSingleEvent()


### PR DESCRIPTION
There was a race in the test between triggering a change and reading the result of the change out of the watcher. This test passed locally almost all the time unless you added the race detector, which changed the timing of the tests.

We fix this by adding a synchronisation point to the test to ensure that the event has been processed before we start the watcher.
## Bug reference

https://bugs.launchpad.net/juju/+bug/1753769