### PR TITLE
Update peer grouper.

### DIFF
--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -173,7 +173,7 @@ func (s *workerSuite) doTestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion
 	// Update the status of the new members
 	// and check that they become voting.
 	c.Logf("\nupdating new member status")
-	st.session.setStatus(mkStatuses("0p 1s 2s", ipVersion))
+	st.session.setStatus(mkStatuses("0s 1p 2s", ipVersion))
 	mustNext(c, memberWatcher, "new member status")
 	assertMembers(c, memberWatcher.Value(), mkMembers("0v 1v 2v", ipVersion))
 
@@ -189,9 +189,12 @@ func (s *workerSuite) doTestSetAndUpdateMembers(c *gc.C, ipVersion TestIPVersion
 	// machine. Also set the status of the new machine to healthy.
 	c.Logf("\nremoving vote from machine 10 and adding it to machine 13")
 	st.machine("10").setWantsVote(false)
+	mustNext(c, memberWatcher, "waiting for vote switch")
+	assertMembers(c, memberWatcher.Value(), mkMembers("0 1v 2 3", ipVersion))
+
 	st.machine("13").setWantsVote(true)
 
-	st.session.setStatus(mkStatuses("0p 1s 2s 3s", ipVersion))
+	st.session.setStatus(mkStatuses("0s 1p 2s 3s", ipVersion))
 
 	// Check that the new machine gets the vote and the
 	// old machine loses it.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

Update peer grouper logic to allow downgrading to an even number of machines while keeping an odd number of voters.

----

## Description of change

In order to forcibly remove a machine while HA is enabled, juju must keep an odd number of voters, while allowing an even number of machines.

## QA steps

Test have been updated.

## Documentation changes

N/A

## Bug reference

This PR is related but does NOT close the following Launchpad issues:
  - #[1703040](https://bugs.launchpad.net/juju/+bug/1703040)
  - #[1679926](https://bugs.launchpad.net/juju/+bug/1679926)
  - #[1658033](https://bugs.launchpad.net/juju/+bug/1658033)
  - #[1685883](https://bugs.launchpad.net/juju/+bug/1685883)
