### PR TITLE
Ensure charm files are created for deployments

### DIFF
--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import "k8s.io/client-go/pkg/api/v1"
+
+var (
+	MakeUnitSpec = makeUnitSpec
+)
+
+func PodSpec(u *unitSpec) v1.PodSpec {
+	return u.Pod
+}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/testing"
+)
+
+type K8sSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&K8sSuite{})
+
+func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
+	containerSpec := caas.ContainerSpec{
+		Name:      "test",
+		Ports:     []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+		ImageName: "juju/image",
+	}
+	spec, err := provider.MakeUnitSpec(&containerSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.PodSpec(spec), jc.DeepEquals, v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "test",
+				Image: "juju/image",
+				Ports: []v1.ContainerPort{{ContainerPort: int32(80), Protocol: v1.ProtocolTCP}},
+			},
+		},
+	})
+}
+
+func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
+	containerSpec := caas.ContainerSpec{
+		Name:      "test",
+		Ports:     []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+		ImageName: "juju/image",
+		Config: map[string]string{
+			"foo": "bar",
+		},
+	}
+	spec, err := provider.MakeUnitSpec(&containerSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.PodSpec(spec), jc.DeepEquals, v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "test",
+				Image: "juju/image",
+				Ports: []v1.ContainerPort{{ContainerPort: int32(80), Protocol: v1.ProtocolTCP}},
+				Env: []v1.EnvVar{
+					{Name: "foo", Value: "bar"},
+				},
+			},
+		},
+	})
+}

--- a/caas/kubernetes/provider/package_test.go
+++ b/caas/kubernetes/provider/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

When deploying a CAAS charm with a deployment controller, we weren't mounting any config files specified by the charm. We were only doing this for Juju managed units.
Refactor the common code to do this for both types and start adding unit tests for the k8s broker.

## QA steps

Deploy mysql caas charm
Exec a bash shell in the pod and check config files.