### PR TITLE
On VSphere, you can supply multiple VMX types.

### DIFF
--- a/provider/vsphere/internal/vsphereclient/ovf_ubuntu.go
+++ b/provider/vsphere/internal/vsphereclient/ovf_ubuntu.go
@@ -65,7 +65,7 @@ const UbuntuOVF = `<?xml version="1.0" encoding="UTF-8"?>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
         <vssd:VirtualSystemIdentifier>ubuntu-xenial-16.04-cloudimg-20170815</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>vmx-10 vmx-11 vmx-13</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>

--- a/provider/vsphere/internal/vsphereclient/ubuntu.ovf
+++ b/provider/vsphere/internal/vsphereclient/ubuntu.ovf
@@ -58,7 +58,7 @@
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
         <vssd:VirtualSystemIdentifier>ubuntu-xenial-16.04-cloudimg-20170815</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>vmx-10 vmx-11 vmx-13</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>


### PR DESCRIPTION
## Description of change

Tested on ESXi 6.0, it selected the highest level the controller
supported (vmx-11), rather than the old value of (vmx-10). And it simply
ignored the ESXi 6.5 value (vmx-13).

## QA steps

On VMWare, you can `juju add-machine` and then check the "Compatibility" field. With older Juju, it says: `ESXi 5.5 and later (VM version 10)`, and with this patch it says `ESXi 6.0 and later (VM version 11)`. (Presumably on ESXi 6.5, it would say `ESXi 6.0 and later (VM version 13)`)

Note that this has not been tested on ESXi 6.5 as we do not have that running in the lab.

## Documentation changes

None.

## Bug reference

[lp:1753968](https://bugs.launchpad.net/juju/+bug/1753968)