### PR TITLE
Skip bootstrap tests on non-bootstrap OS

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -5,7 +5,6 @@ package modelmanager_test
 
 import (
 	"regexp"
-	"runtime"
 	"time"
 
 	"github.com/juju/errors"
@@ -851,10 +850,7 @@ type modelManagerStateSuite struct {
 var _ = gc.Suite(&modelManagerStateSuite{})
 
 func (s *modelManagerStateSuite) SetUpSuite(c *gc.C) {
-	// TODO(anastasiamac 2016-07-19): Fix this on windows
-	if runtime.GOOS != "linux" {
-		c.Skip("bug 1603585: Skipping this on windows for now")
-	}
+	coretesting.SkipUnlessControllerOS(c)
 	s.JujuConnSuite.SetUpSuite(c)
 }
 

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -52,6 +52,7 @@ type cleaner interface {
 }
 
 func (s *BootstrapSuite) SetUpTest(c *gc.C) {
+	coretesting.SkipUnlessControllerOS(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(common.ConnectSSH, func(_ ssh.Client, host, checkHostScript string, opts *ssh.Options) error {
@@ -668,7 +669,6 @@ func (ac *addressesChange) Addresses() ([]network.Address, error) {
 }
 
 func (s *BootstrapSuite) TestWaitSSHRefreshAddresses(c *gc.C) {
-	coretesting.SkipIfWindowsBug(c, "lp:1604961")
 	ctx := cmdtesting.Context(c)
 	_, err := common.WaitSSH(ctx.Stderr, nil, ssh.DefaultClient, "", &addressesChange{addrs: [][]string{
 		nil,

--- a/testing/base.go
+++ b/testing/base.go
@@ -108,6 +108,14 @@ func SkipIfWindowsBug(c *gc.C, bugID string) {
 	}
 }
 
+// SkipUnlessControllerOS skips the test if the current OS is not a supported
+// controller OS.
+func SkipUnlessControllerOS(c *gc.C) {
+	if jujuos.HostOS() != jujuos.Ubuntu {
+		c.Skip("Test disabled for non-controller OS")
+	}
+}
+
 // SkipFlaky skips the test if there is an open bug for intermittent test failures
 func SkipFlaky(c *gc.C, bugID string) {
 	c.Skip(fmt.Sprintf("Test disabled until flakiness is fixed - see bug %s", bugID))


### PR DESCRIPTION
It is entirely pointless running tests for bootstrap on operating systems that are not supported as a bootstrap OS. 
