### PR TITLE
Use smaller certs for the cert updater.

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -85,7 +85,7 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	s.PatchValue(&cert.NewCA, coretesting.NewCA)
-	s.PatchValue(&cert.NewLeafKeyBits, 128)
+	s.PatchValue(&cert.NewLeafKeyBits, 512)
 }
 
 func (s *BootstrapSuite) SetUpTest(c *gc.C) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1077,39 +1077,6 @@ func (s *MachineSuite) TestMachineAgentDoesNotRunsCertificateUpdateWorkerForNonC
 	started.assertNotTriggered(c, startWorkerWait, "certificate was updated")
 }
 
-func (s *MachineSuite) TestCertificateUpdateWorkerUpdatesCertificate(c *gc.C) {
-	coretesting.SkipFlaky(c, "lp:1466514")
-	// Set up the machine agent.
-	m, _, _ := s.primeAgent(c, state.JobManageModel)
-	a := s.newAgent(c, m)
-	a.ReadConfig(names.NewMachineTag(m.Id()).String())
-
-	// Set up check that certificate has been updated.
-	updated := make(chan struct{})
-	go func() {
-		for {
-			stateInfo, _ := a.CurrentConfig().StateServingInfo()
-			srvCert, err := cert.ParseCert(stateInfo.Cert)
-			if !c.Check(err, jc.ErrorIsNil) {
-				break
-			}
-			sanIPs := make([]string, len(srvCert.IPAddresses))
-			for i, ip := range srvCert.IPAddresses {
-				sanIPs[i] = ip.String()
-			}
-			if len(sanIPs) == 1 && sanIPs[0] == "0.1.2.3" {
-				close(updated)
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-	}()
-
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
-	s.assertChannelActive(c, updated, "certificate to be updated")
-}
-
 func (s *MachineSuite) TestCertificateDNSUpdated(c *gc.C) {
 	m, _, _ := s.primeAgent(c, state.JobManageModel)
 	a := s.newAgent(c, m)

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	jujucert "github.com/juju/juju/cert"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -34,6 +35,7 @@ var _ = gc.Suite(&CertUpdaterSuite{})
 
 func (s *CertUpdaterSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.PatchValue(&jujucert.NewLeafKeyBits, 512)
 
 	s.stateServingInfo = params.StateServingInfo{
 		Cert:         coretesting.ServerCert,
@@ -133,7 +135,6 @@ func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 }
 
 func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
-	coretesting.SkipFlaky(c, "lp:1466514")
 	var srvCert *x509.Certificate
 	updated := make(chan struct{})
 	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {


### PR DESCRIPTION
The intermittent failures for the certupdater are almost certainly due to the time it takes to create the CA cert that it does when the worker starts to add the initial ip addresses.

The JujuConnSuite already patches the number of bits for cert creation, but this test is a standard BaseSuite, so didn't have this patch.

Also removed the currently skipped test that tests exactly the same behaviour as the worker test but by starting the entire machine agent.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1466514
https://bugs.launchpad.net/juju/+bug/1659036
