### PR TITLE
Make it so TestReachableNoPublicKeysPassed doesn't race.

### DIFF
--- a/network/ssh/reachable.go
+++ b/network/ssh/reachable.go
@@ -99,6 +99,7 @@ func (h *hostKeyChecker) hostKeyCallback(hostname string, remote net.Addr, key s
 		// first, still exit.
 		select {
 		case h.Accepted <- h.HostPort:
+			// We have accepted a host, we won't need to call Finished.
 			h.Finished = nil
 			return hostKeyAccepted
 		case <-h.Stop:
@@ -193,7 +194,7 @@ type reachableChecker struct {
 // and error will be returned.
 func (r *reachableChecker) FindHost(hostPorts []network.HostPort, publicKeys []string) (network.HostPort, error) {
 	uniqueHPs := network.UniqueHostPorts(hostPorts)
-	successful := make(chan network.HostPort, 1)
+	successful := make(chan network.HostPort)
 	stop := make(chan struct{})
 	// We use a channel instead of a sync.WaitGroup so that we can return as
 	// soon as we get one connected. We'll signal the rest to stop via the
@@ -213,6 +214,7 @@ func (r *reachableChecker) FindHost(hostPorts []network.HostPort, publicKeys []s
 		go checker.Check()
 	}
 
+	timeout := time.After(r.timeout)
 	for finishedCount := 0; finishedCount < len(uniqueHPs); {
 		select {
 		case result := <-successful:
@@ -221,7 +223,7 @@ func (r *reachableChecker) FindHost(hostPorts []network.HostPort, publicKeys []s
 			return result, nil
 		case <-finished:
 			finishedCount++
-		case <-time.After(r.timeout):
+		case <-timeout:
 			break
 		}
 	}

--- a/network/ssh/reachable.go
+++ b/network/ssh/reachable.go
@@ -99,6 +99,7 @@ func (h *hostKeyChecker) hostKeyCallback(hostname string, remote net.Addr, key s
 		// first, still exit.
 		select {
 		case h.Accepted <- h.HostPort:
+			h.Finished = nil
 			return hostKeyAccepted
 		case <-h.Stop:
 			return hostKeyAcceptedButStopped
@@ -132,9 +133,11 @@ func (h *hostKeyChecker) Check() {
 	defer func() {
 		// send a finished message unless we're already stopped and nobody
 		// is listening
-		select {
-		case h.Finished <- struct{}{}:
-		case <-h.Stop:
+		if h.Finished != nil {
+			select {
+			case h.Finished <- struct{}{}:
+			case <-h.Stop:
+			}
 		}
 	}()
 	// TODO(jam): 2017-01-24 One limitation of our algorithm, is that we don't


### PR DESCRIPTION
## Description of change

There was a race condition where we could return with 'finished' rather
than returning with 'accepted'.
This should change the logic so that if we are 'accepting' then we won't
try to return finished.

## QA steps

This diff will trigger the race reliably:
```
diff --git a/network/ssh/reachable.go b/network/ssh/reachable.go
index baff3d20b6..8631a043d0 100644
--- a/network/ssh/reachable.go
+++ b/network/ssh/reachable.go
@@ -213,6 +213,9 @@ func (r *reachableChecker) FindHost(hostPorts []network.HostPort, publicKeys []s
                go checker.Check()
        }

+       timeout := time.After(10 * time.Millisecond)
+       tmpSuccessful := successful
+       successful = nil
        for finishedCount := 0; finishedCount < len(uniqueHPs); {
                select {
                case result := <-successful:
@@ -223,6 +226,8 @@ func (r *reachableChecker) FindHost(hostPorts []network.HostPort, publicKeys []s
                        finishedCount++
                case <-time.After(r.timeout):
                        break
+               case <-timeout:
+                       successful = tmpSuccessful
                }
        }
        close(stop)
```
The original issue was that Accept is a buffered channel, so we could put the value in accept, return through the SSH code, and return from Check() and finally trigger Finished without the outer loop noticing that there is a value pending in Accepted.
With that patch, we won't look at Accepted for 10ms. With our code change, we reliably don't ever trigger a Finished call if we triggered an Accepted call.

## Documentation changes

None

## Bug reference

Race in the test suite, but I don't believe a bug was filed for it.