### PR TITLE
Cloud native charms uniter facade

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/facade"
 	leadershipapiserver "github.com/juju/juju/apiserver/facades/agent/leadership"
@@ -51,6 +52,8 @@ type UniterAPI struct {
 	accessUnit        common.GetAuthFunc
 	accessApplication common.GetAuthFunc
 	accessMachine     common.GetAuthFunc
+	accessCloudSpec   common.GetAuthFunc
+	cloudSpec         cloudspec.CloudSpecAPI
 	*StorageAPI
 }
 
@@ -156,6 +159,40 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
 		}
 	}
+	accessCloudSpec := func() (common.AuthFunc, error) {
+		switch tag := authorizer.GetAuthTag().(type) {
+		case names.ApplicationTag:
+			app, err := st.Application(tag.String())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			config, err := app.ApplicationConfig()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return func(tag names.Tag) bool {
+				return tag == app.Tag() && config.GetBool("trust", false)
+			}, nil
+		case names.UnitTag:
+			entity, err := st.Unit(tag.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			app, err := st.Application(entity.ApplicationName())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			config, err := app.ApplicationConfig()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return func(tag names.Tag) bool {
+				return tag == app.Tag() && config.GetBool("trust", false)
+			}, nil
+		default:
+			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
+		}
+	}
 
 	m, err := st.Model()
 	if err != nil {
@@ -183,6 +220,11 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 	}
 	accessUnitOrApplication := common.AuthAny(accessUnit, accessApplication)
 
+	cloudSpec := cloudspec.NewCloudSpec(
+		cloudspec.MakeCloudSpecGetterForModel(st),
+		common.AuthFuncForTag(m.ModelTag()),
+	)
+
 	return &UniterAPI{
 		LifeGetter:                 common.NewLifeGetter(st, accessUnitOrApplication),
 		DeadEnsurer:                common.NewDeadEnsurer(st, accessUnit),
@@ -203,6 +245,8 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		accessUnit:        accessUnit,
 		accessApplication: accessApplication,
 		accessMachine:     accessMachine,
+		accessCloudSpec:   accessCloudSpec,
+		cloudSpec:         cloudSpec,
 		StorageAPI:        storageAPI,
 	}, nil
 }
@@ -2427,4 +2471,31 @@ func (u *UniterAPI) GoalStates(args params.Entities) (string, error) {
 		result.Results[0].Result = "Hello World I'll be a yaml"
 	}
 	return result.Results[0].Result, nil
+}
+
+// GetCloudSpec returns the cloud spec used by the model in which the input
+// application resides.
+// A check is made beforehand to ensure that the requesting application has
+// been granted the appropriate trust.
+func (u *UniterAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, error) {
+	canAccess, err := u.accessCloudSpec()
+	if err != nil {
+		return params.CloudSpecResults{}, err
+	}
+
+	result := params.CloudSpecResults{Results: make([]params.CloudSpecResult, len(args.Entities))}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseApplicationTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		if !canAccess(tag) {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		result.Results[i] = u.cloudSpec.GetCloudSpec(u.m.Tag().(names.ModelTag))
+	}
+
+	return result, nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	leadershipapiserver "github.com/juju/juju/apiserver/facades/agent/leadership"
 	"github.com/juju/juju/apiserver/facades/agent/meterstatus"
+	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/leadership"
@@ -189,7 +190,7 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 			return nil, errors.Trace(err)
 		}
 		return func() bool {
-			return config.GetBool("trust", false)
+			return config.GetBool(application.TrustConfigOptionName, false)
 		}, nil
 	}
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -160,38 +160,33 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		}
 	}
 	accessCloudSpec := func() (common.AuthFunc, error) {
+		var appName string
+		var err error
+
 		switch tag := authorizer.GetAuthTag().(type) {
 		case names.ApplicationTag:
-			app, err := st.Application(tag.String())
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			config, err := app.ApplicationConfig()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return func(tag names.Tag) bool {
-				return tag == app.Tag() && config.GetBool("trust", false)
-			}, nil
+			appName = tag.String()
 		case names.UnitTag:
 			entity, err := st.Unit(tag.Id())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			app, err := st.Application(entity.ApplicationName())
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			config, err := app.ApplicationConfig()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return func(tag names.Tag) bool {
-				return tag == app.Tag() && config.GetBool("trust", false)
-			}, nil
+			appName = entity.ApplicationName()
 		default:
 			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
 		}
+
+		app, err := st.Application(appName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		config, err := app.ApplicationConfig()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return func(_ names.Tag) bool {
+			return config.GetBool("trust", false)
+		}, nil
 	}
 
 	m, err := st.Model()
@@ -2477,25 +2472,15 @@ func (u *UniterAPI) GoalStates(args params.Entities) (string, error) {
 // application resides.
 // A check is made beforehand to ensure that the requesting application has
 // been granted the appropriate trust.
-func (u *UniterAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, error) {
+func (u *UniterAPI) CloudSpec() (params.CloudSpecResult, error) {
 	canAccess, err := u.accessCloudSpec()
 	if err != nil {
-		return params.CloudSpecResults{}, err
+		return params.CloudSpecResult{}, err
 	}
 
-	result := params.CloudSpecResults{Results: make([]params.CloudSpecResult, len(args.Entities))}
-	for i, entity := range args.Entities {
-		tag, err := names.ParseApplicationTag(entity.Tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		if !canAccess(tag) {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		result.Results[i] = u.cloudSpec.GetCloudSpec(u.m.Tag().(names.ModelTag))
+	if !canAccess(nil) {
+		return params.CloudSpecResult{Error: common.ServerError(common.ErrPerm)}, nil
 	}
 
-	return result, nil
+	return u.cloudSpec.GetCloudSpec(u.m.Tag().(names.ModelTag)), nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -52,9 +52,13 @@ type UniterAPI struct {
 	accessUnit        common.GetAuthFunc
 	accessApplication common.GetAuthFunc
 	accessMachine     common.GetAuthFunc
-	accessCloudSpec   common.GetAuthFunc
-	cloudSpec         cloudspec.CloudSpecAPI
 	*StorageAPI
+
+	// A cloud spec can only be accessed for the model of the unit or
+	// application that is authorised for this API facade.
+	// We do not need to use an AuthFunc, because we do not need to pass a tag.
+	accessCloudSpec func() (func() bool, error)
+	cloudSpec       cloudspec.CloudSpecAPI
 }
 
 // UniterAPIV7 adds CMR support to NetworkInfo.
@@ -159,7 +163,7 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
 		}
 	}
-	accessCloudSpec := func() (common.AuthFunc, error) {
+	accessCloudSpec := func() (func() bool, error) {
 		var appName string
 		var err error
 
@@ -184,7 +188,7 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return func(_ names.Tag) bool {
+		return func() bool {
 			return config.GetBool("trust", false)
 		}, nil
 	}
@@ -2468,17 +2472,16 @@ func (u *UniterAPI) GoalStates(args params.Entities) (string, error) {
 	return result.Results[0].Result, nil
 }
 
-// GetCloudSpec returns the cloud spec used by the model in which the input
-// application resides.
-// A check is made beforehand to ensure that the requesting application has
-// been granted the appropriate trust.
+// GetCloudSpec returns the cloud spec used by the model in which the
+// authenticated unit or application resides.
+// A check is made beforehand to ensure that the request is made by an entity
+// that has been granted the appropriate trust.
 func (u *UniterAPI) CloudSpec() (params.CloudSpecResult, error) {
 	canAccess, err := u.accessCloudSpec()
 	if err != nil {
 		return params.CloudSpecResult{}, err
 	}
-
-	if !canAccess(nil) {
+	if !canAccess() {
 		return params.CloudSpecResult{Error: common.ServerError(common.ErrPerm)}, nil
 	}
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
+	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
@@ -4146,8 +4147,6 @@ func (s *uniterSuite) TestGetCloudSpecDeniesAccessWhenNotTrusted(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.CloudSpecResult{Error: apiservertesting.ErrUnauthorized})
 }
 
-const appConfigTrustKey = "trust"
-
 type cloudSpecUniterSuite struct {
 	uniterSuiteBase
 }
@@ -4159,15 +4158,15 @@ func (s *cloudSpecUniterSuite) SetUpTest(c *gc.C) {
 
 	// Update the application config for wordpress so that it is authorised to
 	// retrieve its cloud spec.
-	conf := map[string]interface{}{appConfigTrustKey: true}
-	fields := map[string]environschema.Attr{appConfigTrustKey: {Type: environschema.Tbool}}
-	defaults := map[string]interface{}{appConfigTrustKey: false}
+	conf := map[string]interface{}{application.TrustConfigOptionName: true}
+	fields := map[string]environschema.Attr{application.TrustConfigOptionName: {Type: environschema.Tbool}}
+	defaults := map[string]interface{}{application.TrustConfigOptionName: false}
 	err := s.wordpress.UpdateApplicationConfig(conf, nil, fields, defaults)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newConf, err := s.wordpress.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newConf.GetBool(appConfigTrustKey, false), jc.IsTrue)
+	c.Assert(newConf.GetBool(application.TrustConfigOptionName, false), jc.IsTrue)
 }
 
 func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -35,7 +36,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	jujufactory "github.com/juju/juju/testing/factory"
-	"gopkg.in/juju/environschema.v1"
 )
 
 // uniterSuite implements common testing suite for all API

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -38,10 +38,10 @@ import (
 	jujufactory "github.com/juju/juju/testing/factory"
 )
 
-// uniterSuite implements common testing suite for all API
-// versions. It's not intended to be used directly or registered as a
-// suite, but embedded.
-type uniterSuite struct {
+// uniterSuiteBase implements common testing suite for all API versions.
+// It is not intended to be used directly or registered as a suite,
+// but embedded.
+type uniterSuiteBase struct {
 	testing.JujuConnSuite
 
 	authorizer apiservertesting.FakeAuthorizer
@@ -61,9 +61,7 @@ type uniterSuite struct {
 	meteredUnit    *state.Unit
 }
 
-var _ = gc.Suite(&uniterSuite{})
-
-func (s *uniterSuite) SetUpTest(c *gc.C) {
+func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
 	factory := jujufactory.NewFactory(s.State)
@@ -131,6 +129,26 @@ func (s *uniterSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.uniter = uniterAPI
 }
+
+func (s *uniterSuiteBase) addRelation(c *gc.C, first, second string) *state.Relation {
+	eps, err := s.State.InferEndpoints(first, second)
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	return rel
+}
+
+func (s *uniterSuiteBase) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {
+	ok, err := relUnit.InScope()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, gc.Equals, inScope)
+}
+
+type uniterSuite struct {
+	uniterSuiteBase
+}
+
+var _ = gc.Suite(&uniterSuite{})
 
 func (s *uniterSuite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
 	anAuthorizer := s.authorizer
@@ -2463,20 +2481,6 @@ func (s *uniterSuite) TestGetMeterStatusBadTag(c *gc.C) {
 	}
 }
 
-func (s *uniterSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {
-	ok, err := relUnit.InScope()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ok, gc.Equals, inScope)
-}
-
-func (s *uniterSuite) addRelation(c *gc.C, first, second string) *state.Relation {
-	eps, err := s.State.InferEndpoints(first, second)
-	c.Assert(err, jc.ErrorIsNil)
-	rel, err := s.State.AddRelation(eps...)
-	c.Assert(err, jc.ErrorIsNil)
-	return rel
-}
-
 func (s *uniterSuite) addRelatedService(c *gc.C, firstSvc, relatedSvc string, unit *state.Unit) (*state.Relation, *state.Application, *state.Unit) {
 	relatedService := s.AddTestingApplication(c, relatedSvc, s.AddTestingCharm(c, relatedSvc))
 	rel := s.addRelation(c, firstSvc, relatedSvc)
@@ -3066,7 +3070,7 @@ func (s *uniterSuite) TestSetPodSpec(c *gc.C) {
 }
 
 type unitMetricBatchesSuite struct {
-	uniterSuite
+	uniterSuiteBase
 	*commontesting.ModelWatcherTest
 	uniter *uniter.UniterAPI
 }
@@ -3074,7 +3078,7 @@ type unitMetricBatchesSuite struct {
 var _ = gc.Suite(&unitMetricBatchesSuite{})
 
 func (s *unitMetricBatchesSuite) SetUpTest(c *gc.C) {
-	s.uniterSuite.SetUpTest(c)
+	s.uniterSuiteBase.SetUpTest(c)
 
 	meteredAuthorizer := apiservertesting.FakeAuthorizer{
 		Tag: s.meteredUnit.Tag(),
@@ -3204,22 +3208,14 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 }
 
 type uniterNetworkConfigSuite struct {
-	base     uniterSuite // not embedded so it doesn't run all tests.
+	uniterSuiteBase
 	uniterv4 *uniter.UniterAPIV4
 }
 
 var _ = gc.Suite(&uniterNetworkConfigSuite{})
 
-func (s *uniterNetworkConfigSuite) SetUpSuite(c *gc.C) {
-	s.base.SetUpSuite(c)
-}
-
-func (s *uniterNetworkConfigSuite) TearDownSuite(c *gc.C) {
-	s.base.TearDownSuite(c)
-}
-
 func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
-	s.base.JujuConnSuite.SetUpTest(c)
+	s.uniterSuiteBase.JujuConnSuite.SetUpTest(c)
 
 	// Add the spaces and subnets used by the test.
 	subnetInfos := []state.SubnetInfo{{
@@ -3230,69 +3226,68 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 		SpaceName: "internal",
 	}}
 	for _, info := range subnetInfos {
-		_, err := s.base.State.AddSpace(info.SpaceName, "", nil, false)
+		_, err := s.State.AddSpace(info.SpaceName, "", nil, false)
 		c.Assert(err, jc.ErrorIsNil)
-		_, err = s.base.State.AddSubnet(info)
+		_, err = s.State.AddSubnet(info)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	s.base.machine0 = s.addProvisionedMachineWithDevicesAndAddresses(c, 10)
+	s.machine0 = s.addProvisionedMachineWithDevicesAndAddresses(c, 10)
 
-	factory := jujufactory.NewFactory(s.base.State)
-	s.base.wpCharm = factory.MakeCharm(c, &jujufactory.CharmParams{
+	factory := jujufactory.NewFactory(s.State)
+	s.wpCharm = factory.MakeCharm(c, &jujufactory.CharmParams{
 		Name: "wordpress-extra-bindings",
 		URL:  "cs:quantal/wordpress-extra-bindings-4",
 	})
 	var err error
-	s.base.wordpress, err = s.base.State.AddApplication(state.AddApplicationArgs{
+	s.wordpress, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "wordpress",
-		Charm: s.base.wpCharm,
+		Charm: s.wpCharm,
 		EndpointBindings: map[string]string{
 			"db":        "internal", // relation name
 			"admin-api": "public",   // extra-binding name
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.wordpress,
-		Machine:     s.base.machine0,
+	s.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.wordpress,
+		Machine:     s.machine0,
 	})
 
-	s.base.machine1 = s.addProvisionedMachineWithDevicesAndAddresses(c, 20)
+	s.machine1 = s.addProvisionedMachineWithDevicesAndAddresses(c, 20)
 
 	mysqlCharm := factory.MakeCharm(c, &jujufactory.CharmParams{
 		Name: "mysql",
 	})
-	s.base.mysql = factory.MakeApplication(c, &jujufactory.ApplicationParams{
+	s.mysql = factory.MakeApplication(c, &jujufactory.ApplicationParams{
 		Name:  "mysql",
 		Charm: mysqlCharm,
 	})
-	s.base.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.wordpress,
-		Machine:     s.base.machine0,
+	s.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.wordpress,
+		Machine:     s.machine0,
 	})
-	s.base.mysqlUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.mysql,
-		Machine:     s.base.machine1,
+	s.mysqlUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.mysql,
+		Machine:     s.machine1,
 	})
 
-	// Create the resource registry separately to track invocations to
-	// Register.
-	s.base.resources = common.NewResources()
-	s.base.AddCleanup(func(_ *gc.C) { s.base.resources.StopAll() })
+	// Create the resource registry separately to track invocations to register.
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	s.setupUniterAPIForUnit(c, s.base.wordpressUnit)
+	s.setupUniterAPIForUnit(c, s.wordpressUnit)
 	uniterAPIV4, err := uniter.NewUniterAPIV4(
-		s.base.State,
-		s.base.resources,
-		s.base.authorizer,
+		s.State,
+		s.resources,
+		s.authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.uniterv4 = uniterAPIV4
 }
 
 func (s *uniterNetworkConfigSuite) addProvisionedMachineWithDevicesAndAddresses(c *gc.C, addrSuffix int) *state.Machine {
-	machine, err := s.base.State.AddMachine("quantal", state.JobHostUnits)
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	devicesArgs, devicesAddrs := s.makeMachineDevicesAndAddressesArgs(addrSuffix)
 	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil)
@@ -3346,22 +3341,18 @@ func (s *uniterNetworkConfigSuite) makeMachineDevicesAndAddressesArgs(addrSuffix
 		}}
 }
 
-func (s *uniterNetworkConfigSuite) TearDownTest(c *gc.C) {
-	s.base.JujuConnSuite.TearDownTest(c)
-}
-
 func (s *uniterNetworkConfigSuite) setupUniterAPIForUnit(c *gc.C, givenUnit *state.Unit) {
 	// Create a FakeAuthorizer so we can check permissions, set up assuming the
 	// given unit agent has logged in.
-	s.base.authorizer = apiservertesting.FakeAuthorizer{
+	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: givenUnit.Tag(),
 	}
 
 	var err error
 	s.uniterv4, err = uniter.NewUniterAPIV4(
-		s.base.State,
-		s.base.resources,
-		s.base.authorizer,
+		s.State,
+		s.resources,
+		s.authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -3373,8 +3364,8 @@ func (s *uniterNetworkConfigSuite) TestNetworkConfigPermissions(c *gc.C) {
 		{BindingName: "foo", UnitTag: "unit-foo-0"},
 		{BindingName: "db-client", UnitTag: "invalid"},
 		{BindingName: "juju-info", UnitTag: "unit-mysql-0"},
-		{BindingName: "", UnitTag: s.base.wordpressUnit.Tag().String()},
-		{BindingName: "unknown", UnitTag: s.base.wordpressUnit.Tag().String()},
+		{BindingName: "", UnitTag: s.wordpressUnit.Tag().String()},
+		{BindingName: "unknown", UnitTag: s.wordpressUnit.Tag().String()},
 	}}
 
 	result, err := s.uniterv4.NetworkConfig(args)
@@ -3393,20 +3384,20 @@ func (s *uniterNetworkConfigSuite) TestNetworkConfigPermissions(c *gc.C) {
 func (s *uniterNetworkConfigSuite) addRelationAndAssertInScope(c *gc.C) {
 	// Add a relation between wordpress and mysql and enter scope with
 	// mysqlUnit.
-	rel := s.base.addRelation(c, "wordpress", "mysql")
-	wpRelUnit, err := rel.Unit(s.base.wordpressUnit)
+	rel := s.addRelation(c, "wordpress", "mysql")
+	wpRelUnit, err := rel.Unit(s.wordpressUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = wpRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.assertInScope(c, wpRelUnit, true)
+	s.assertInScope(c, wpRelUnit, true)
 }
 
 func (s *uniterNetworkConfigSuite) TestNetworkConfigForExplicitlyBoundEndpoint(c *gc.C) {
 	s.addRelationAndAssertInScope(c)
 
 	args := params.UnitsNetworkConfig{Args: []params.UnitNetworkConfig{
-		{BindingName: "db", UnitTag: s.base.wordpressUnit.Tag().String()},
-		{BindingName: "admin-api", UnitTag: s.base.wordpressUnit.Tag().String()},
+		{BindingName: "db", UnitTag: s.wordpressUnit.Tag().String()},
+		{BindingName: "admin-api", UnitTag: s.wordpressUnit.Tag().String()},
 	}}
 
 	// For the relation "wordpress:db mysql:server" we expect to see only
@@ -3437,19 +3428,19 @@ func (s *uniterNetworkConfigSuite) TestNetworkConfigForImplicitlyBoundEndpoint(c
 	// Since wordpressUnit has explicit binding for "db", switch the API to
 	// mysqlUnit and check "mysql:server" uses the machine preferred private
 	// address.
-	s.setupUniterAPIForUnit(c, s.base.mysqlUnit)
-	rel := s.base.addRelation(c, "mysql", "wordpress")
-	mysqlRelUnit, err := rel.Unit(s.base.mysqlUnit)
+	s.setupUniterAPIForUnit(c, s.mysqlUnit)
+	rel := s.addRelation(c, "mysql", "wordpress")
+	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.assertInScope(c, mysqlRelUnit, true)
+	s.assertInScope(c, mysqlRelUnit, true)
 
 	args := params.UnitsNetworkConfig{Args: []params.UnitNetworkConfig{
-		{BindingName: "server", UnitTag: s.base.mysqlUnit.Tag().String()},
+		{BindingName: "server", UnitTag: s.mysqlUnit.Tag().String()},
 	}}
 
-	privateAddress, err := s.base.machine1.PrivateAddress()
+	privateAddress, err := s.machine1.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedConfig := []params.NetworkConfig{{Address: privateAddress.Value}}
@@ -3464,22 +3455,14 @@ func (s *uniterNetworkConfigSuite) TestNetworkConfigForImplicitlyBoundEndpoint(c
 }
 
 type uniterNetworkInfoSuite struct {
-	base       uniterSuite // not embedded so it doesn't run all tests.
+	uniterSuiteBase
 	mysqlCharm *state.Charm
 }
 
 var _ = gc.Suite(&uniterNetworkInfoSuite{})
 
-func (s *uniterNetworkInfoSuite) SetUpSuite(c *gc.C) {
-	s.base.SetUpSuite(c)
-}
-
-func (s *uniterNetworkInfoSuite) TearDownSuite(c *gc.C) {
-	s.base.TearDownSuite(c)
-}
-
 func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
-	s.base.JujuConnSuite.SetUpTest(c)
+	s.uniterSuiteBase.JujuConnSuite.SetUpTest(c)
 
 	// Add the spaces and subnets used by the test.
 	subnetInfos := []state.SubnetInfo{{
@@ -3498,25 +3481,25 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 		SpaceName: "layertwo",
 	}}
 	for _, info := range subnetInfos {
-		_, err := s.base.State.AddSpace(info.SpaceName, "", nil, false)
+		_, err := s.State.AddSpace(info.SpaceName, "", nil, false)
 		c.Assert(err, jc.ErrorIsNil)
 		if info.CIDR != "" {
-			_, err = s.base.State.AddSubnet(info)
+			_, err = s.State.AddSubnet(info)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 	}
 
-	s.base.machine0 = s.addProvisionedMachineWithDevicesAndAddresses(c, 10)
+	s.machine0 = s.addProvisionedMachineWithDevicesAndAddresses(c, 10)
 
-	factory := jujufactory.NewFactory(s.base.State)
-	s.base.wpCharm = factory.MakeCharm(c, &jujufactory.CharmParams{
+	factory := jujufactory.NewFactory(s.State)
+	s.wpCharm = factory.MakeCharm(c, &jujufactory.CharmParams{
 		Name: "wordpress-extra-bindings",
 		URL:  "cs:quantal/wordpress-extra-bindings-4",
 	})
 	var err error
-	s.base.wordpress, err = s.base.State.AddApplication(state.AddApplicationArgs{
+	s.wordpress, err = s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "wordpress",
-		Charm: s.base.wpCharm,
+		Charm: s.wpCharm,
 		EndpointBindings: map[string]string{
 			"db":        "internal",   // relation name
 			"admin-api": "public",     // extra-binding name
@@ -3525,42 +3508,42 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.wordpress,
-		Machine:     s.base.machine0,
+	s.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.wordpress,
+		Machine:     s.machine0,
 	})
 
-	s.base.machine1 = s.addProvisionedMachineWithDevicesAndAddresses(c, 20)
+	s.machine1 = s.addProvisionedMachineWithDevicesAndAddresses(c, 20)
 
 	s.mysqlCharm = factory.MakeCharm(c, &jujufactory.CharmParams{
 		Name: "mysql",
 	})
-	s.base.mysql = factory.MakeApplication(c, &jujufactory.ApplicationParams{
+	s.mysql = factory.MakeApplication(c, &jujufactory.ApplicationParams{
 		Name:  "mysql",
 		Charm: s.mysqlCharm,
 		EndpointBindings: map[string]string{
 			"server": "database",
 		},
 	})
-	s.base.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.wordpress,
-		Machine:     s.base.machine0,
+	s.wordpressUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.wordpress,
+		Machine:     s.machine0,
 	})
-	s.base.mysqlUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.mysql,
-		Machine:     s.base.machine1,
+	s.mysqlUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.mysql,
+		Machine:     s.machine1,
 	})
 
 	// Create the resource registry separately to track invocations to
 	// Register.
-	s.base.resources = common.NewResources()
-	s.base.AddCleanup(func(_ *gc.C) { s.base.resources.StopAll() })
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	s.setupUniterAPIForUnit(c, s.base.wordpressUnit)
+	s.setupUniterAPIForUnit(c, s.wordpressUnit)
 }
 
 func (s *uniterNetworkInfoSuite) addProvisionedMachineWithDevicesAndAddresses(c *gc.C, addrSuffix int) *state.Machine {
-	machine, err := s.base.State.AddMachine("quantal", state.JobHostUnits)
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	devicesArgs, devicesAddrs := s.makeMachineDevicesAndAddressesArgs(addrSuffix)
 	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil)
@@ -3642,22 +3625,18 @@ func (s *uniterNetworkInfoSuite) makeMachineDevicesAndAddressesArgs(addrSuffix i
 		}}
 }
 
-func (s *uniterNetworkInfoSuite) TearDownTest(c *gc.C) {
-	s.base.JujuConnSuite.TearDownTest(c)
-}
-
 func (s *uniterNetworkInfoSuite) setupUniterAPIForUnit(c *gc.C, givenUnit *state.Unit) {
 	// Create a FakeAuthorizer so we can check permissions, set up assuming the
 	// given unit agent has logged in.
-	s.base.authorizer = apiservertesting.FakeAuthorizer{
+	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: givenUnit.Tag(),
 	}
 
 	var err error
-	s.base.uniter, err = uniter.NewUniterAPI(
-		s.base.State,
-		s.base.resources,
-		s.base.authorizer,
+	s.uniter, err = uniter.NewUniterAPI(
+		s.State,
+		s.resources,
+		s.authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -3665,12 +3644,12 @@ func (s *uniterNetworkInfoSuite) setupUniterAPIForUnit(c *gc.C, givenUnit *state
 func (s *uniterNetworkInfoSuite) addRelationAndAssertInScope(c *gc.C) {
 	// Add a relation between wordpress and mysql and enter scope with
 	// mysqlUnit.
-	rel := s.base.addRelation(c, "wordpress", "mysql")
-	wpRelUnit, err := rel.Unit(s.base.wordpressUnit)
+	rel := s.addRelation(c, "wordpress", "mysql")
+	wpRelUnit, err := rel.Unit(s.wordpressUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = wpRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.assertInScope(c, wpRelUnit, true)
+	s.assertInScope(c, wpRelUnit, true)
 }
 
 func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
@@ -3701,7 +3680,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
 		},
 		{
 			"Unknown binding name",
-			params.NetworkInfoParams{Unit: s.base.wordpressUnit.Tag().String(), Bindings: []string{"unknown"}},
+			params.NetworkInfoParams{Unit: s.wordpressUnit.Tag().String(), Bindings: []string{"unknown"}},
 			params.NetworkInfoResults{
 				Results: map[string]params.NetworkInfoResult{
 					"unknown": {
@@ -3717,7 +3696,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
 
 	for _, test := range tests {
 		c.Logf("Testing %s", test.Name)
-		result, err := s.base.uniter.NetworkInfo(test.Arg)
+		result, err := s.uniter.NetworkInfo(test.Arg)
 		if test.Error != "" {
 			c.Check(err, gc.ErrorMatches, test.Error)
 		} else {
@@ -3731,7 +3710,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 	s.addRelationAndAssertInScope(c)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.base.wordpressUnit.Tag().String(),
+		Unit:     s.wordpressUnit.Tag().String(),
 		Bindings: []string{"db", "admin-api", "db-client"},
 	}
 	// For the relation "wordpress:db mysql:server" we expect to see only
@@ -3797,7 +3776,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 		IngressAddresses: []string{"100.64.0.10"},
 	}
 
-	result, err := s.base.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -3813,7 +3792,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoL2Binding(c *gc.C) {
 	s.addRelationAndAssertInScope(c)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.base.wordpressUnit.Tag().String(),
+		Unit:     s.wordpressUnit.Tag().String(),
 		Bindings: []string{"foo-bar"},
 	}
 
@@ -3826,7 +3805,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoL2Binding(c *gc.C) {
 		},
 	}
 
-	result, err := s.base.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -3839,16 +3818,16 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForImplicitlyBoundEndpoint(c *gc
 	// Since wordpressUnit has explicit binding for "db", switch the API to
 	// mysqlUnit and check "mysql:server" uses the machine preferred private
 	// address.
-	s.setupUniterAPIForUnit(c, s.base.mysqlUnit)
-	rel := s.base.addRelation(c, "mysql", "wordpress")
-	mysqlRelUnit, err := rel.Unit(s.base.mysqlUnit)
+	s.setupUniterAPIForUnit(c, s.mysqlUnit)
+	rel := s.addRelation(c, "mysql", "wordpress")
+	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.assertInScope(c, mysqlRelUnit, true)
+	s.assertInScope(c, mysqlRelUnit, true)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.base.mysqlUnit.Tag().String(),
+		Unit:     s.mysqlUnit.Tag().String(),
 		Bindings: []string{"server"},
 	}
 
@@ -3866,7 +3845,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForImplicitlyBoundEndpoint(c *gc
 		IngressAddresses: []string{"192.168.1.20"},
 	}
 
-	result, err := s.base.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -3879,30 +3858,30 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 	// If a network info call is made in the context of a relation, and the
 	// endpoint of that relation is bound to the non default space, we
 	// provide the ingress addresses as those belonging to the space.
-	s.setupUniterAPIForUnit(c, s.base.mysqlUnit)
-	_, err := s.base.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+	s.setupUniterAPIForUnit(c, s.mysqlUnit)
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		SourceModel: coretesting.ModelTag,
 		Name:        "wordpress-remote",
 		Endpoints:   []charm.Relation{{Name: "db", Interface: "mysql", Role: "requirer"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	rel := s.base.addRelation(c, "mysql", "wordpress-remote")
-	mysqlRelUnit, err := rel.Unit(s.base.mysqlUnit)
+	rel := s.addRelation(c, "mysql", "wordpress-remote")
+	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.assertInScope(c, mysqlRelUnit, true)
+	s.assertInScope(c, mysqlRelUnit, true)
 
 	// Relation specific egress subnets override model config.
-	err = s.base.JujuConnSuite.IAASModel.UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
+	err = s.JujuConnSuite.IAASModel.UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	relEgress := state.NewRelationEgressNetworks(s.base.State)
+	relEgress := state.NewRelationEgressNetworks(s.State)
 	_, err = relEgress.Save(rel.Tag().Id(), false, []string{"192.168.1.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	relId := rel.Id()
 	args := params.NetworkInfoParams{
-		Unit:       s.base.mysqlUnit.Tag().String(),
+		Unit:       s.mysqlUnit.Tag().String(),
 		Bindings:   []string{"server"},
 		RelationId: &relId,
 	}
@@ -3921,7 +3900,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 		IngressAddresses: []string{"192.168.1.20"},
 	}
 
-	result, err := s.base.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -3934,7 +3913,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 	// If a network info call is made in the context of a relation, and the
 	// endpoint of that relation is not bound, or bound to the default space, we
 	// provide the ingress address relevant to the relation: public for CMR.
-	_, err := s.base.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		SourceModel: coretesting.ModelTag,
 		Name:        "wordpress-remote",
 		Endpoints:   []charm.Relation{{Name: "db", Interface: "mysql", Role: "requirer"}},
@@ -3942,41 +3921,41 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Recreate mysql app without endpoint binding.
-	factory := jujufactory.NewFactory(s.base.State)
-	s.base.mysql = factory.MakeApplication(c, &jujufactory.ApplicationParams{
+	factory := jujufactory.NewFactory(s.State)
+	s.mysql = factory.MakeApplication(c, &jujufactory.ApplicationParams{
 		Name:  "mysql-default",
 		Charm: s.mysqlCharm,
 	})
-	s.base.mysqlUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.base.mysql,
-		Machine:     s.base.machine1,
+	s.mysqlUnit = factory.MakeUnit(c, &jujufactory.UnitParams{
+		Application: s.mysql,
+		Machine:     s.machine1,
 	})
-	s.setupUniterAPIForUnit(c, s.base.mysqlUnit)
+	s.setupUniterAPIForUnit(c, s.mysqlUnit)
 
-	rel := s.base.addRelation(c, "mysql-default", "wordpress-remote")
-	mysqlRelUnit, err := rel.Unit(s.base.mysqlUnit)
+	rel := s.addRelation(c, "mysql-default", "wordpress-remote")
+	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.base.assertInScope(c, mysqlRelUnit, true)
+	s.assertInScope(c, mysqlRelUnit, true)
 
 	// Relation specific egress subnets override model config.
-	err = s.base.JujuConnSuite.IAASModel.UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
+	err = s.JujuConnSuite.IAASModel.UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	relEgress := state.NewRelationEgressNetworks(s.base.State)
+	relEgress := state.NewRelationEgressNetworks(s.State)
 	_, err = relEgress.Save(rel.Tag().Id(), false, []string{"192.168.1.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	relId := rel.Id()
 	args := params.NetworkInfoParams{
-		Unit:       s.base.mysqlUnit.Tag().String(),
+		Unit:       s.mysqlUnit.Tag().String(),
 		Bindings:   []string{"server"},
 		RelationId: &relId,
 	}
 
 	// Since it is a remote relation, the expected ingress address is set to the
 	// machine's public address.
-	expectedIngressAddress, err := s.base.machine1.PublicAddress()
+	expectedIngressAddress, err := s.machine1.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedInfo := params.NetworkInfoResult{
@@ -3993,7 +3972,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 		IngressAddresses: []string{expectedIngressAddress.Value},
 	}
 
-	result, err := s.base.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4006,27 +3985,29 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoV6Results(c *gc.C) {
 	s.addRelationAndAssertInScope(c)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.base.wordpressUnit.Tag().String(),
+		Unit:     s.wordpressUnit.Tag().String(),
 		Bindings: []string{"db"},
 	}
 
 	expectedResult := params.NetworkInfoResultsV6{
 		Results: map[string]params.NetworkInfoResultV6{
-			"db": params.NetworkInfoResultV6{
+			"db": {
 				Info: []params.NetworkInfo{
-					params.NetworkInfo{
+					{
 						MACAddress:    "00:11:22:33:10:50",
 						InterfaceName: "eth0.100",
-						Addresses:     []params.InterfaceAddress{params.InterfaceAddress{Address: "10.0.0.10", CIDR: "10.0.0.0/24"}}},
-					params.NetworkInfo{
+						Addresses:     []params.InterfaceAddress{{Address: "10.0.0.10", CIDR: "10.0.0.0/24"}},
+					}, {
 						MACAddress:    "00:11:22:33:10:51",
 						InterfaceName: "eth1.100",
-						Addresses:     []params.InterfaceAddress{params.InterfaceAddress{Address: "10.0.0.11", CIDR: "10.0.0.0/24"}}},
+						Addresses:     []params.InterfaceAddress{{Address: "10.0.0.11", CIDR: "10.0.0.0/24"}},
+					},
 				},
-			}},
+			},
+		},
 	}
 
-	apiV6, err := uniter.NewUniterAPIV6(s.base.State, s.base.resources, s.base.authorizer)
+	apiV6, err := uniter.NewUniterAPIV6(s.State, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := apiV6.NetworkInfo(args)
@@ -4168,37 +4149,29 @@ func (s *uniterSuite) TestGetCloudSpecDeniesAccessWhenNotTrusted(c *gc.C) {
 const appConfigTrustKey = "trust"
 
 type cloudSpecUniterSuite struct {
-	base uniterSuite
+	uniterSuiteBase
 }
 
 var _ = gc.Suite(&cloudSpecUniterSuite{})
 
-func (s *cloudSpecUniterSuite) SetUpSuite(c *gc.C) {
-	s.base.SetUpSuite(c)
-}
-
-func (s *cloudSpecUniterSuite) TearDownSuite(c *gc.C) {
-	s.base.TearDownSuite(c)
-}
-
 func (s *cloudSpecUniterSuite) SetUpTest(c *gc.C) {
-	s.base.SetUpTest(c)
+	s.uniterSuiteBase.SetUpTest(c)
 
 	// Update the application config for wordpress so that it is authorised to
 	// retrieve its cloud spec.
 	conf := map[string]interface{}{appConfigTrustKey: true}
 	fields := map[string]environschema.Attr{appConfigTrustKey: {Type: environschema.Tbool}}
 	defaults := map[string]interface{}{appConfigTrustKey: false}
-	err := s.base.wordpress.UpdateApplicationConfig(conf, nil, fields, defaults)
+	err := s.wordpress.UpdateApplicationConfig(conf, nil, fields, defaults)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newConf, err := s.base.wordpress.ApplicationConfig()
+	newConf, err := s.wordpress.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newConf.GetBool(appConfigTrustKey, false), jc.IsTrue)
 }
 
 func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
-	result, err := s.base.uniter.CloudSpec()
+	result, err := s.uniter.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result.Name, gc.Equals, "dummy")

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -35,6 +35,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	jujufactory "github.com/juju/juju/testing/factory"
+	"gopkg.in/juju/environschema.v1"
 )
 
 // uniterSuite implements common testing suite for all API
@@ -129,6 +130,17 @@ func (s *uniterSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.uniter = uniterAPI
+
+	// Update the application config for wordpress so that it is authorised to
+	// retrieve its cloud spec.
+	conf := map[string]interface{}{"trust": true}
+	fields := map[string]environschema.Attr{
+		"trust": {Type: environschema.Tbool},
+	}
+	s.wordpress.UpdateApplicationConfig(conf, nil, fields, map[string]interface{}{"trust": false})
+	newConf, err := s.wordpress.ApplicationConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newConf.GetBool("trust", false), jc.IsTrue)
 }
 
 func (s *uniterSuite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
@@ -4156,4 +4168,36 @@ func (s *uniterSuite) TestGoalStates(c *gc.C) {
 	result, err := s.uniter.GoalStates(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, results)
+}
+
+func (s *uniterSuite) TestGetCloudSpecDeniesAccessWhenNotTrusted(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: names.NewApplicationTag("mysql").String()},
+	}}
+	result, err := s.uniter.CloudSpec(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.CloudSpecResults{
+		Results: []params.CloudSpecResult{
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (s *uniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: names.NewApplicationTag("wordpress").String()},
+	}}
+	ret, err := s.uniter.CloudSpec(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ret.Results, gc.HasLen, 1)
+
+	result := ret.Results[0]
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.Result.Name, gc.Equals, "dummy")
+
+	exp := map[string]string{
+		"username": "dummy",
+		"password": "secret",
+	}
+	c.Assert(result.Result.Credential.Attributes, gc.DeepEquals, exp)
 }


### PR DESCRIPTION
## Description of change

Adds a new API method to the uniter facade, for retrieving the running model's cloud spec.

Application config relevant to the caller must indicate that the application is authorised to retrieve its cloud spec. 

## QA steps

Accompanying unit tests.

## Documentation changes

Ultimately, yes.