### PR TITLE
Add upgrade steps to ensure all applications have config settings.

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1439,7 +1439,8 @@ func CreateMissingApplicationConfig(st *State) error {
 	var applicationConfigIDs []struct {
 		ID string `bson:"_id"`
 	}
-	settingsColl.Find(nil).All(&applicationConfigIDs)
+	settingsColl.Find(bson.M{
+		"_id": bson.M{"$regex": bson.RegEx{"#application$", ""}}}).All(&applicationConfigIDs)
 
 	allIDs := set.NewStrings()
 	for _, id := range applicationConfigIDs {
@@ -1449,24 +1450,25 @@ func CreateMissingApplicationConfig(st *State) error {
 	appsColl, appsCloser := st.db().GetRawCollection(applicationsC)
 	defer appsCloser()
 
-	var applicationIDs []struct {
+	var applicationNames []struct {
 		Name      string `bson:"name"`
 		ModelUUID string `bson:"model-uuid"`
 	}
-	appsColl.Find(nil).All(&applicationIDs)
+	appsColl.Find(nil).All(&applicationNames)
 
-	var newAppConfigs []txn.Op
+	var newAppConfigOps []txn.Op
 	emptySettings := make(map[string]interface{})
-	// var emptySettings map[string]interface{}
-	for _, app := range applicationIDs {
-		appConfID := fmt.Sprintf("%s:a#%s#application", app.ModelUUID, app.Name)
+	for _, app := range applicationNames {
+		appConfID := fmt.Sprintf("%s:%s", app.ModelUUID, applicationConfigKey(app.Name))
 		if !allIDs.Contains(appConfID) {
 			newOp := createSettingsOp(settingsC, appConfID, emptySettings)
+			// createSettingsOp assumes you're using a model-specific state, which will auto-inject the ModelUUID
+			// since we're doing this globally, cast it to the underlying type and add it.
 			newOp.Insert.(*settingsDoc).ModelUUID = app.ModelUUID
-			newAppConfigs = append(newAppConfigs, newOp)
+			newAppConfigOps = append(newAppConfigOps, newOp)
 		}
 	}
-	err := st.db().RunRawTransaction(newAppConfigs)
+	err := st.db().RunRawTransaction(newAppConfigOps)
 	if err != nil {
 		return errors.Annotate(err, "writing application configs")
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2297,7 +2297,7 @@ func (s *upgradesSuite) TestCreateMissingApplicationConfig(c *gc.C) {
 	}}
 
 	sort.Slice(expected, func(i, j int) bool {
-		return string(expected[i]["_id"].(string)) < string(expected[j]["_id"].(string))
+		return expected[i]["_id"].(string) < expected[j]["_id"].(string)
 	})
 
 	s.assertUpgradedData(c, CreateMissingApplicationConfig,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+	charm "gopkg.in/juju/charm.v6"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -332,6 +334,7 @@ type expectUpgradedData struct {
 func (s *upgradesSuite) assertUpgradedData(c *gc.C, upgrade func(*State) error, expect ...expectUpgradedData) {
 	// Two rounds to check idempotency.
 	for i := 0; i < 2; i++ {
+		c.Logf("Run: %d", i)
 		err := upgrade(s.state)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -2230,4 +2233,73 @@ func getHASpaceConfig(st *State, c *gc.C) string {
 	config, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	return config.JujuHASpace()
+}
+
+func (s *upgradesSuite) TestCreateMissingApplicationConfig(c *gc.C) {
+	// Setup models w/ applications that have setting configurations as if we've updated from <2.4-beta1 -> 2.4-beta1
+	// At least 2x models, one that was created before the update and one after (i.e. 1 missing the config and another that has that in place.)
+	// Ensure an update adds any missing applicationConfig entries.
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+
+	model1 := s.makeModel(c, "model-old", coretesting.Attrs{})
+	defer model1.Close()
+	model2 := s.makeModel(c, "model-new", coretesting.Attrs{})
+	defer model2.Close()
+
+	chDir := testcharms.Repo.CharmDir("dummy")
+	chInfo := CharmInfo{
+		Charm:       chDir,
+		ID:          charm.MustParseURL(fmt.Sprintf("cs:xenial/%s-%d", chDir.Meta().Name, chDir.Revision())),
+		StoragePath: "dummy-1",
+		SHA256:      "dummy-1-sha256",
+	}
+	ch, err := s.state.AddCharm(chInfo)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app1, err := model1.AddApplication(AddApplicationArgs{Name: "dummy", Charm: ch})
+	c.Assert(err, jc.ErrorIsNil)
+	// This one will be left alone to model a 2.4-beta1 created app.
+	_, err = model1.AddApplication(AddApplicationArgs{Name: "dummy2", Charm: ch})
+	c.Assert(err, jc.ErrorIsNil)
+	app2, err := model2.AddApplication(AddApplicationArgs{Name: "dummy", Charm: ch})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Remove any application config that has been added (to model a pre-2.4-beta1 collection)
+	err = settingsColl.Remove(bson.M{
+		"_id": fmt.Sprintf("%s:%s", model1.ModelUUID(), app1.applicationConfigKey()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = settingsColl.Remove(bson.M{
+		"_id": fmt.Sprintf("%s:%s", model2.ModelUUID(), app2.applicationConfigKey()),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Remove everything except the remaining application config.
+	_, err = settingsColl.RemoveAll(bson.M{
+		"_id": bson.M{"$not": bson.RegEx{"#application$", ""}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := []bson.M{{
+		"_id":        fmt.Sprintf("%s:a#dummy#application", model1.ModelUUID()),
+		"model-uuid": model1.ModelUUID(),
+		"settings":   bson.M{},
+	}, {
+		"_id":        fmt.Sprintf("%s:a#dummy2#application", model1.ModelUUID()),
+		"model-uuid": model1.ModelUUID(),
+		"settings":   bson.M{},
+	}, {
+		"_id":        fmt.Sprintf("%s:a#dummy#application", model2.ModelUUID()),
+		"model-uuid": model2.ModelUUID(),
+		"settings":   bson.M{},
+	}}
+
+	sort.Slice(expected, func(i, j int) bool {
+		return string(expected[i]["_id"].(string)) < string(expected[j]["_id"].(string))
+	})
+
+	s.assertUpgradedData(c, CreateMissingApplicationConfig,
+		expectUpgradedData{settingsColl, expected})
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -37,6 +37,7 @@ type StateBackend interface {
 	AddRelationStatus() error
 	DeleteCloudImageMetadata() error
 	CopyMongoSpaceToHASpaceConfig() error
+	CreateMissingApplicationConfig() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -141,6 +142,10 @@ func (s stateBackend) AddRelationStatus() error {
 
 func (s stateBackend) CopyMongoSpaceToHASpaceConfig() error {
 	return state.CopyMongoSpaceToHASpaceConfig(s.st)
+}
+
+func (s stateBackend) CreateMissingApplicationConfig() error {
+	return state.CreateMissingApplicationConfig(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -20,5 +20,12 @@ func stateStepsFor24() []Step {
 				return context.State().CopyMongoSpaceToHASpaceConfig()
 			},
 		},
+		&upgradeStep{
+			description: "create empty application settings for all applications",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().CreateMissingApplicationConfig()
+			},
+		},
 	}
 }

--- a/upgrades/steps_24_test.go
+++ b/upgrades/steps_24_test.go
@@ -32,7 +32,7 @@ func (s *steps24Suite) TestCopyMongoSpaceToHASpaceConfig(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
-func (s *steps24Suite) TestCreateMissingApplicatoinConfig(c *gc.C) {
+func (s *steps24Suite) TestCreateMissingApplicationConfig(c *gc.C) {
 	step := findStateStep(c, v24, "create empty application settings for all applications")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})

--- a/upgrades/steps_24_test.go
+++ b/upgrades/steps_24_test.go
@@ -31,3 +31,9 @@ func (s *steps24Suite) TestCopyMongoSpaceToHASpaceConfig(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps24Suite) TestCreateMissingApplicatoinConfig(c *gc.C) {
+	step := findStateStep(c, v24, "create empty application settings for all applications")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
## Description of change

The addition of storing the application config config in the state db broke upgrades from < 2.4-beta1 to 2.4-beta1 (symptom: Failure to tear down an application or unit of an upgraded unit).

This PR adds the upgrade step to ensure all applications have at least an empty application config in the DB.

## QA steps

The functional test assess_upgrade.py exercises this bug.

Manual steps:
  - bootstrap with current stable juju
  - deploy a workload (i.e. mediawiki)
  - upgrade to 2.4-beta1
  - destroy the environment
  - observe "state changing too quickly" errors on the controller logs
  - also observe juju failing to actually destroy the environment.

Which this fix this no longer happens.
