### PR TITLE
Goal State Hook Command 2/2

### DIFF
--- a/api/uniter/goal-state_test.go
+++ b/api/uniter/goal-state_test.go
@@ -1,0 +1,109 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"time"
+
+	coretesting "github.com/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/application"
+)
+
+type goalStateSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&goalStateSuite{})
+
+var (
+	timestamp = time.Date(2200, time.November, 5, 0, 0, 0, 0, time.UTC)
+
+	paramsBaseGoalStateStatus = params.GoalStateStatus{
+		Status: "active",
+		Since:  &timestamp,
+	}
+	apiBaseGoalStateStatus = application.GoalStateStatus{
+		Status: "active",
+		Since:  &timestamp,
+	}
+)
+
+func (s *goalStateSuite) TestGoalStateOneUnit(c *gc.C) {
+	paramsOneUnit := params.GoalStateResults{
+		Results: []params.GoalStateResult{
+			{Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					"mysql/0": paramsBaseGoalStateStatus,
+				},
+			},
+			},
+		},
+	}
+	apiOneUnit := application.GoalState{
+		Units: application.UnitsGoalState{
+			"mysql/0": apiBaseGoalStateStatus,
+		},
+	}
+	s.testGoalState(c, paramsOneUnit, apiOneUnit)
+
+}
+
+func (s *goalStateSuite) TestGoalStateTwoRelatedUnits(c *gc.C) {
+	paramsTwoRelatedUnits := params.GoalStateResults{
+		Results: []params.GoalStateResult{
+			{Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					"mysql/0": paramsBaseGoalStateStatus,
+				},
+				Relations: map[string]params.UnitsGoalState{
+					"db": params.UnitsGoalState{
+						"wordpress/0": paramsBaseGoalStateStatus,
+					},
+				},
+			},
+			},
+		},
+	}
+	apiTwoRelatedUnits := application.GoalState{
+		Units: application.UnitsGoalState{
+			"mysql/0": apiBaseGoalStateStatus,
+		},
+		Relations: map[string]application.UnitsGoalState{
+			"db": application.UnitsGoalState{
+				"wordpress/0": apiBaseGoalStateStatus,
+			},
+		},
+	}
+	s.testGoalState(c, paramsTwoRelatedUnits, apiTwoRelatedUnits)
+}
+
+func (s *goalStateSuite) testGoalState(c *gc.C, facadeResult params.GoalStateResults, apiResult application.GoalState) {
+
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Uniter")
+		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(request, gc.Equals, "GoalStates")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: "unit-mysql-0"}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.GoalStateResults{})
+		*(result.(*params.GoalStateResults)) = facadeResult
+		called = true
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	goalStateResult, err := st.GoalState()
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(goalStateResult, jc.DeepEquals, apiResult)
+}

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -1,0 +1,326 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/agent/uniter"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+// uniterSuite implements common testing suite for all API
+// versions. It's not intended to be used directly or registered as a
+// suite, but embedded.
+type uniterGoalStateSuite struct {
+	testing.JujuConnSuite
+
+	authorizer apiservertesting.FakeAuthorizer
+	resources  *common.Resources
+	uniter     *uniter.UniterAPI
+
+	machine0      *state.Machine
+	machine1      *state.Machine
+	machine2      *state.Machine
+	wordpress     *state.Application
+	wpCharm       *state.Charm
+	mysql         *state.Application
+	wordpressUnit *state.Unit
+	mysqlUnit     *state.Unit
+}
+
+var _ = gc.Suite(&uniterGoalStateSuite{})
+
+func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	newFactory := factory.NewFactory(s.State)
+	// Create two machines, two applications and add a unit to each service.
+	s.machine0 = newFactory.MakeMachine(c, &factory.MachineParams{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits, state.JobManageModel},
+	})
+	s.machine1 = newFactory.MakeMachine(c, &factory.MachineParams{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	})
+	s.machine2 = newFactory.MakeMachine(c, &factory.MachineParams{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	})
+
+	s.wpCharm = newFactory.MakeCharm(c, &factory.CharmParams{
+		Name: "wordpress",
+		URL:  "cs:quantal/wordpress-0",
+	})
+	s.wordpress = newFactory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "wordpress",
+		Charm: s.wpCharm,
+	})
+	s.wordpressUnit = newFactory.MakeUnit(c, &factory.UnitParams{
+		Application: s.wordpress,
+		Machine:     s.machine0,
+	})
+
+	mysqlCharm := newFactory.MakeCharm(c, &factory.CharmParams{
+		Name: "mysql",
+	})
+	s.mysql = newFactory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "mysql",
+		Charm: mysqlCharm,
+	})
+	s.mysqlUnit = newFactory.MakeUnit(c, &factory.UnitParams{
+		Application: s.mysql,
+		Machine:     s.machine1,
+	})
+
+	// Create a FakeAuthorizer so we can check permissions,
+	// set up assuming unit 0 has logged in.
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: s.mysqlUnit.Tag(),
+	}
+
+	// Create the resource registry separately to track invocations to
+	// Register.
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	uniterAPI, err := uniter.NewUniterAPI(
+		s.State,
+		s.resources,
+		s.authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.uniter = uniterAPI
+}
+
+var (
+	timestamp          = time.Date(2200, time.November, 5, 0, 0, 0, 0, time.UTC)
+	charmStatusWaiting = params.GoalStateStatus{
+		Status: "waiting",
+		Since:  &timestamp,
+	}
+	expectedUnitWordpress = params.UnitsGoalState{
+		"wordpress/0": charmStatusWaiting,
+	}
+	expectedUnitMysql = params.UnitsGoalState{
+		"mysql/0": charmStatusWaiting,
+	}
+	expected2UnitsMysql = params.UnitsGoalState{
+		"mysql/0": charmStatusWaiting,
+		"mysql/1": charmStatusWaiting,
+	}
+)
+
+// TestGoalStatesNoRelation tests single application with single unit.
+func (s *uniterGoalStateSuite) TestGoalStatesNoRelation(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+	}}
+	expected := params.GoalStateResults{
+		Results: []params.GoalStateResult{
+			{
+				Result: &params.GoalState{
+					Units: expectedUnitMysql,
+				},
+			}, {
+				Error: apiservertesting.ErrUnauthorized,
+			},
+		},
+	}
+	testGoalStates(c, s.uniter, args, expected)
+}
+
+// TestGoalStatesNoRelationTwoUnits adds a new unit to mysql application.
+func (s *uniterGoalStateSuite) TestPeerUnitsNoRelation(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+	}}
+
+	addApplicationUnitToMachine(c, s.mysql, s.machine1)
+
+	expected := params.GoalStateResults{
+		Results: []params.GoalStateResult{
+			{
+				Result: &params.GoalState{
+					Units: expected2UnitsMysql,
+				},
+			}, {
+				Error: apiservertesting.ErrUnauthorized,
+			},
+		},
+	}
+	testGoalStates(c, s.uniter, args, expected)
+}
+
+// TestGoalStatesSingleRelation tests structure with two different
+// application units and one relation between the units.
+func (s *uniterGoalStateSuite) TestGoalStatesSingleRelation(c *gc.C) {
+
+	err := s.addRelationToSuiteScope(c, s.wordpressUnit, s.mysqlUnit)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+	}}
+	expected := params.GoalStateResults{
+		Results: []params.GoalStateResult{
+			{
+				Result: &params.GoalState{
+					Units: expectedUnitMysql,
+					Relations: map[string]params.UnitsGoalState{
+						"db":     expectedUnitWordpress,
+						"server": expectedUnitMysql,
+					},
+				},
+			}, {
+				Error: apiservertesting.ErrUnauthorized,
+			},
+		},
+	}
+	testGoalStates(c, s.uniter, args, expected)
+}
+
+// TestGoalStatesMultipleRelations tests GoalStates with three
+// applications one application has two units and each unit is related
+// to a different application unit.
+func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
+
+	// Add another mysql unit on machine 1.
+	addApplicationUnitToMachine(c, s.mysql, s.machine1)
+
+	// new application needs: charm, app and unit instanciated in the new machine
+	newFactory := factory.NewFactory(s.State)
+	wpCharm1 := newFactory.MakeCharm(c, &factory.CharmParams{
+		Name: "wordpress",
+		URL:  "cs:quantal/wordpress-1",
+	})
+	wordpress1 := newFactory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "wordpress1",
+		Charm: wpCharm1,
+	})
+	wordpress1Unit := newFactory.MakeUnit(c, &factory.UnitParams{
+		Application: wordpress1,
+		Machine:     s.machine2,
+	})
+
+	var err error
+	err = s.addRelationToSuiteScope(c, wordpress1Unit, s.mysqlUnit)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.addRelationToSuiteScope(c, s.wordpressUnit, s.mysqlUnit)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+	}}
+
+	expected := params.GoalStateResults{
+		Results: []params.GoalStateResult{
+			{
+				Result: &params.GoalState{
+					Units: expected2UnitsMysql,
+					Relations: map[string]params.UnitsGoalState{
+						"db": params.UnitsGoalState{
+							"wordpress/0":  charmStatusWaiting,
+							"wordpress1/0": charmStatusWaiting,
+						},
+						"server": expected2UnitsMysql,
+					},
+				},
+			}, {
+				Error: apiservertesting.ErrUnauthorized,
+			},
+		},
+	}
+
+	testGoalStates(c, s.uniter, args, expected)
+}
+
+func (s *uniterGoalStateSuite) addRelationToSuiteScope(c *gc.C, unit1 *state.Unit, unit2 *state.Unit) error {
+	app1, err := unit1.Application()
+	c.Assert(err, jc.ErrorIsNil)
+
+	app2, err := unit2.Application()
+	c.Assert(err, jc.ErrorIsNil)
+
+	relation := s.addRelation(c, app1.Name(), app2.Name())
+	relationUnit, err := relation.Unit(unit1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	settings := map[string]interface{}{
+		"some": "settings",
+	}
+	err = relationUnit.EnterScope(settings)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, relationUnit, true)
+	return err
+}
+
+func (s *uniterGoalStateSuite) addRelation(c *gc.C, first, second string) *state.Relation {
+	eps, err := s.State.InferEndpoints(first, second)
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	return rel
+}
+
+func (s *uniterGoalStateSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {
+	ok, err := relUnit.InScope()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, gc.Equals, inScope)
+}
+
+// goalStates call untier.GoalStates API and compares the output with the
+// expected result
+func testGoalStates(c *gc.C, thisUniter *uniter.UniterAPI, args params.Entities, expected params.GoalStateResults) {
+	result, err := thisUniter.GoalStates(args)
+	c.Assert(err, jc.ErrorIsNil)
+	for i := range result.Results {
+		if result.Results[i].Error != nil {
+			break
+		}
+		setSinceToNil(c, result.Results[i].Result)
+	}
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, expected)
+}
+
+// setSinceToNil will set the field `since` to nil in order to
+// avoid a time check which otherwise would be impossible to pass
+func setSinceToNil(c *gc.C, goalState *params.GoalState) {
+
+	for i, u := range goalState.Units {
+		c.Assert(u.Since, gc.NotNil)
+		u.Since = &timestamp
+		goalState.Units[i] = u
+	}
+	for endPoint, gs := range goalState.Relations {
+		for key, m := range gs {
+			c.Assert(m.Since, gc.NotNil)
+			m.Since = &timestamp
+			gs[key] = m
+		}
+		goalState.Relations[endPoint] = gs
+	}
+}
+
+func addApplicationUnitToMachine(c *gc.C, app *state.Application, machine *state.Machine) {
+	mysqlUnit1, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = mysqlUnit1.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2458,33 +2458,7 @@ func (u *UniterAPI) SetPodSpec(args params.SetPodSpecParams) (params.ErrorResult
 	return results, nil
 }
 
-// GoalStates returns information of charm units and relations.
-func (u *UniterAPI) GoalStates(args params.Entities) (string, error) {
-	result := params.StringResults{
-		Results: make([]params.StringResult, len(args.Entities)),
-	}
-	canAccess, err := u.accessUnit()
-	if err != nil {
-		return "", err
-	}
-	for i, entity := range args.Entities {
-		tag, err := names.ParseUnitTag(entity.Tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		if !canAccess(tag) {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		// TODO (agprado): get units and relations information from
-
-		result.Results[0].Result = "Hello World I'll be a yaml"
-	}
-	return result.Results[0].Result, nil
-}
-
-// GetCloudSpec returns the cloud spec used by the model in which the
+// CloudSpec returns the cloud spec used by the model in which the
 // authenticated unit or application resides.
 // A check is made beforehand to ensure that the request is made by an entity
 // that has been granted the appropriate trust.
@@ -2498,4 +2472,125 @@ func (u *UniterAPI) CloudSpec() (params.CloudSpecResult, error) {
 	}
 
 	return u.cloudSpec.GetCloudSpec(u.m.Tag().(names.ModelTag)), nil
+}
+
+// GoalStates returns information of charm units and relations.
+func (u *UniterAPI) GoalStates(args params.Entities) (params.GoalStateResults, error) {
+	result := params.GoalStateResults{
+		Results: make([]params.GoalStateResult, len(args.Entities)),
+	}
+
+	canAccess, err := u.accessUnit()
+	if err != nil {
+		return params.GoalStateResults{}, err
+	}
+
+	for i, entity := range args.Entities {
+		tag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		if !canAccess(tag) {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		unit, err := u.getUnit(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		application, err := unit.Application()
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+		} else {
+			result.Results[i].Result, err = u.goalStateResult(application)
+			if err != nil {
+				result.Results[i].Error = common.ServerError(err)
+			}
+		}
+	}
+	return result, nil
+}
+
+// goalStateResult creates the structure with an application units and unit relations.
+func (u *UniterAPI) goalStateResult(application *state.Application) (*params.GoalState, error) {
+	gs := params.GoalState{}
+
+	var err error
+	gs.Units, err = u.goalStateUnits(application)
+	if err != nil {
+		return nil, err
+	}
+	allRelations, err := application.Relations()
+	if err != nil {
+		return nil, err
+	}
+	if allRelations != nil {
+		gs.Relations, err = u.goalStateRelations(allRelations)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &gs, nil
+}
+
+// goalStateRelations creates the structure with all the relations between endpoints in an application.
+func (u *UniterAPI) goalStateRelations(allRelations []*state.Relation) (map[string]params.UnitsGoalState, error) {
+
+	result := map[string]params.UnitsGoalState{}
+
+	for _, r := range allRelations {
+
+		endPoints := r.Endpoints()
+		for _, e := range endPoints {
+			if e.Relation.Role == "peer" {
+				continue
+			}
+			application, err := u.st.Application(e.ApplicationName)
+			if err != nil {
+				return nil, err
+			}
+			units, err := u.goalStateUnits(application)
+			if err != nil {
+				return nil, err
+			}
+			if len(units) == 0 {
+				continue
+			}
+			if result[e.Name] == nil {
+				result[e.Name] = params.UnitsGoalState{}
+			}
+			relation := result[e.Name]
+			for unitName, unitGS := range units {
+				relation[unitName] = unitGS
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// goalStateUnits loops through all application units, and stores the
+// application GoalStateStatus in UnitsGoalState.
+func (u *UniterAPI) goalStateUnits(application *state.Application) (params.UnitsGoalState, error) {
+
+	allUnits, err := application.AllUnits()
+	if err != nil {
+		return nil, err
+	}
+
+	unitsGoalState := params.UnitsGoalState{}
+	for _, u := range allUnits {
+		unit := params.GoalStateStatus{}
+		statusInfo, err := u.Status()
+		if err != nil {
+			return nil, errors.Errorf("Unit Status not accessible %q", err)
+		}
+		unit.Status = statusInfo.Status.String()
+		unit.Since = statusInfo.Since
+		unitsGoalState[u.Name()] = unit
+	}
+
+	return unitsGoalState, nil
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4130,17 +4130,6 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	c.Check(result.Results["db"], jc.DeepEquals, expectedResult)
 }
 
-// TODO (agprado): Next PR diferenciate between Unit and App
-func (s *uniterSuite) TestGoalStates(c *gc.C) {
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: "unit-wordpress-0"},
-	}}
-	results := "Hello World I'll be a yaml"
-
-	result, err := s.uniter.GoalStates(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, results)
-}
 
 func (s *uniterSuite) TestGetCloudSpecDeniesAccessWhenNotTrusted(c *gc.C) {
 	result, err := s.uniter.CloudSpec()

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -834,3 +834,29 @@ type EntityString struct {
 type SetPodSpecParams struct {
 	Specs []EntityString `json:"specs"`
 }
+
+// GoalStateResults holds the results of GoalStates API call
+type GoalStateResults struct {
+	Results []GoalStateResult `json:"results"`
+}
+
+// GoalStateResult the result of GoalStates per entity.
+type GoalStateResult struct {
+	Result *GoalState `json:"result"`
+	Error  *Error     `json:"error"`
+}
+
+// GoalStateStatus goal-state at unit level
+type GoalStateStatus struct {
+	Status string     `json:"status"`
+	Since  *time.Time `json:"since"`
+}
+
+// UnitsGoalState collection of GoalStatesStatus with unit name
+type UnitsGoalState map[string]GoalStateStatus
+
+// GoalState goal-state at application level, stores Units and Units-Relations
+type GoalState struct {
+	Units     UnitsGoalState            `json:"units"`
+	Relations map[string]UnitsGoalState `json:"relations"`
+}

--- a/core/application/goal-state.go
+++ b/core/application/goal-state.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"time"
+)
+
+// GoalStateStatus keeps the status and timestamp of a unit.
+type GoalStateStatus struct {
+	Status string
+	Since  *time.Time
+}
+
+// UnitsGoalState keeps the collection of units and their GoalStateStatus
+type UnitsGoalState map[string]GoalStateStatus
+
+// GoalState is responsible to organize the Units and Relations with a
+// specific unit, and transmit this information from the api to the worker.
+type GoalState struct {
+	Units     UnitsGoalState
+	Relations map[string]UnitsGoalState
+}

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/version"
@@ -126,7 +127,7 @@ type HookContext struct {
 	configSettings charm.Settings
 
 	// goalState holds the goal state struct
-	goalState string
+	goalState application.GoalState
 
 	// id identifies the context.
 	id string
@@ -486,13 +487,14 @@ func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
 	return result, nil
 }
 
-func (ctx *HookContext) GoalState() (string, error) {
+func (ctx *HookContext) GoalState() (*application.GoalState, error) {
 	var err error
 	ctx.goalState, err = ctx.state.GoalState()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return ctx.goalState, nil
+
+	return &ctx.goalState, nil
 }
 
 func (ctx *HookContext) SetPodSpec(specYaml string) error {

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
@@ -95,7 +96,7 @@ type ContextUnit interface {
 	ConfigSettings() (charm.Settings, error)
 
 	// GoalState returns the goal state for the current unit.
-	GoalState() (string, error)
+	GoalState() (*application.GoalState, error)
 
 	// SetPodSpec updates the yaml spec used to create a pod.
 	SetPodSpec(specYaml string) error

--- a/worker/uniter/runner/jujuc/goal-state_test.go
+++ b/worker/uniter/runner/jujuc/goal-state_test.go
@@ -1,5 +1,4 @@
 // Copyright 2018 Canonical Ltd.
-// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -21,90 +20,6 @@ type GoalStateSuite struct {
 }
 
 var _ = gc.Suite(&GoalStateSuite{})
-
-func getGoalStateCommand(s *GoalStateSuite, c *gc.C, args []string) (*cmd.Context, int) {
-	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, cmdString("goal-state"))
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := cmdtesting.Context(c)
-	code := cmd.Main(com, ctx, args)
-	return ctx, code
-}
-
-//var (
-//	goalStateYamlMap = map[string]interface{}{
-//		"tag":    "",
-//		"status": "error",
-//		"info":   "message foo",
-//		"data":   map[interface{}]interface{}{"foo": "bar"},
-//	}
-//	goalStateJsonMap = map[string]interface{}{
-//		"Tag":    "",
-//		"Status": "error",
-//		"Info":   "message foo",
-//		"Data":   map[string]interface{}{"foo": "bar"},
-//	}
-//	goalStateYamlMapAll = map[string]interface{}{
-//		"tag":    "",
-//		"status": "error",
-//		"info":   "message foo",
-//		"data":   map[interface{}]interface{}{"foo": "bar"},
-//	}
-//	goalStateJsonMapAll = map[string]interface{}{
-//		"Tag":    "",
-//		"Status": "error",
-//		"Info":   "message foo",
-//		"Data":   map[string]interface{}{"foo": "bar"},
-//	}
-//)
-
-//var goalStateAllTests = []struct {
-//	args   []string
-//	format int
-//	out    map[string]interface{}
-//}{
-//	{nil, formatYaml, goalStateYamlMap},
-//	{[]string{"--format", "yaml"}, formatYaml, goalStateYamlMap},
-//	{[]string{"--format", "json"}, formatJson, goalStateJsonMap},
-//	{[]string{"--all", "--format", "yaml"}, formatYaml, goalStateYamlMapAll},
-//	{[]string{"--all", "--format", "json"}, formatJson, goalStateJsonMapAll},
-//	{[]string{"-a", "--format", "yaml"}, formatYaml, goalStateYamlMapAll},
-//	{[]string{"-a", "--format", "json"}, formatJson, goalStateJsonMapAll},
-//}
-
-// TODO (agprado): Parse yaml and json in the next PR
-
-//var goalStateAllTests = []struct {
-//	args   []string
-//	format int
-//	out    string
-//}{
-//	{nil, formatYaml, "foo"},
-//	{[]string{"--format", "yaml"}, formatYaml, "bar"},
-//	{[]string{"--format", "json"}, formatJson, "foo"},
-//	{[]string{"--all", "--format", "yaml"}, formatYaml, "foo"},
-//	{[]string{"--all", "--format", "json"}, formatJson, "bar"},
-//	{[]string{"-a", "--format", "yaml"}, formatYaml, "foo"},
-//	{[]string{"-a", "--format", "json"}, formatJson, "bar"},
-//}
-//func (s *GoalStateSuite) TestOutputFormatAll(c *gc.C) {
-//	for i, t := range goalStateAllTests {
-//		c.Logf("test %d: %#v", i, t.args)
-//
-//		ctx, code := getGoalStateCommand(s, c, t.args)
-//
-//		c.Assert(code, gc.Equals, 0)
-//		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-//		out := ctx.Stdout
-//		//switch t.format {
-//		//case formatYaml:
-//		//	c.Assert(goyaml.Unmarshal(bufferBytes(ctx.Stdout), &out), gc.IsNil)
-//		//case formatJson:
-//		//	c.Assert(json.Unmarshal(bufferBytes(ctx.Stdout), &out), gc.IsNil)
-//		//}
-//		c.Assert(out, gc.DeepEquals, t.out)
-//	}
-//}
 
 func (s *GoalStateSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
@@ -130,23 +45,84 @@ Details:
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }
 
+var (
+	goalStateTestResultYaml = `units:
+  mysql/0:
+    status: active
+    since: 2200-11-05 15:29:12Z
+relations:
+  db:
+    mysql/0:
+      status: active
+      since: 2200-11-05 15:29:12Z
+  server:
+    wordpress/0:
+      status: active
+      since: 2200-11-05 15:29:12Z
+`
+	goalStateTestResultJson = `{"units":{"mysql/0":{"status":"active","since":"2200-11-05 15:29:12Z"}},"relations":{"db":{"mysql/0":{"status":"active","since":"2200-11-05 15:29:12Z"}},"server":{"wordpress/0":{"status":"active","since":"2200-11-05 15:29:12Z"}}}}
+`
+
+	goalStateAllTests = []struct {
+		args []string
+		out  string
+	}{
+		{nil, goalStateTestResultYaml},
+		{[]string{"--format", "yaml"}, goalStateTestResultYaml},
+		{[]string{"--format", "json"}, goalStateTestResultJson},
+	}
+
+	goalStateAllOutPutFileTests = []struct {
+		args []string
+		out  string
+	}{
+		{[]string{"--output", "some-file"}, goalStateTestResultYaml},
+		{[]string{"--format", "yaml", "--output", "some-file"}, goalStateTestResultYaml},
+		{[]string{"--format", "json", "--output", "some-file"}, goalStateTestResultJson},
+	}
+)
+
+func (s *GoalStateSuite) TestOutputFormatAll(c *gc.C) {
+	for i, t := range goalStateAllTests {
+		c.Logf("test %d: %#v", i, t.args)
+
+		ctx, code := s.getGoalStateCommand(c, t.args)
+
+		c.Assert(code, gc.Equals, 0)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+		c.Assert(bufferString(ctx.Stdout), gc.Equals, t.out)
+	}
+}
+
 func (s *GoalStateSuite) TestOutputPath(c *gc.C) {
 
-	args := []string{"--output", "some-file", "monsters"}
-	ctx, code := getGoalStateCommand(s, c, args)
+	for i, t := range goalStateAllOutPutFileTests {
+		c.Logf("test %d: %#v", i, t.args)
 
-	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+		ctx, code := s.getGoalStateCommand(c, t.args)
 
-	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+		c.Assert(code, gc.Equals, 0)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+
+		content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(content), gc.Equals, t.out)
+	}
+}
+
+func (s *GoalStateSuite) getGoalStateCommand(c *gc.C, args []string) (*cmd.Context, int) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("goal-state"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(content), gc.Equals, "test-goal-state\n")
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(com, ctx, args)
+	return ctx, code
 }
 
 func (s *GoalStateSuite) TestUnknownArg(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("goal-state"))
 	c.Assert(err, jc.ErrorIsNil)
-	cmdtesting.TestInit(c, com, []string{"multiple", "keys"}, `unrecognized args: \["keys"\]`)
+	cmdtesting.TestInit(c, com, []string{}, "")
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/suite.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/suite.go
@@ -4,9 +4,13 @@
 package jujuctesting
 
 import (
+	"time"
+
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/core/application"
 )
 
 // ContextSuite is the base suite for testing jujuc.Context-related code.
@@ -23,6 +27,13 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 // NewInfo builds a ContextInfo with basic default data.
 func (s *ContextSuite) NewInfo() *ContextInfo {
 	var info ContextInfo
+
+	timestamp := time.Date(2200, time.November, 05, 15, 29, 12, 30, time.UTC)
+	gsStatus := application.GoalStateStatus{
+		Status: "active",
+		Since:  &timestamp,
+	}
+
 	info.Unit.Name = s.Unit
 	info.ConfigSettings = charm.Settings{
 		"empty":               nil,
@@ -31,7 +42,19 @@ func (s *ContextSuite) NewInfo() *ContextInfo {
 		"title":               "My Title",
 		"username":            "admin001",
 	}
-	info.GoalState = "test-goal-state"
+	info.GoalState = application.GoalState{
+		Units: application.UnitsGoalState{
+			"mysql/0": gsStatus,
+		},
+		Relations: map[string]application.UnitsGoalState{
+			"db": application.UnitsGoalState{
+				"mysql/0": gsStatus,
+			},
+			"server": application.UnitsGoalState{
+				"wordpress/0": gsStatus,
+			},
+		},
+	}
 	info.AvailabilityZone = "us-east-1a"
 	info.PublicAddress = "gimli.minecraft.testing.invalid"
 	info.PrivateAddress = "192.168.0.99"

--- a/worker/uniter/runner/jujuc/jujuctesting/unit.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/unit.go
@@ -6,13 +6,15 @@ package jujuctesting
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/core/application"
 )
 
 // Unit holds the values for the hook context.
 type Unit struct {
 	Name           string
 	ConfigSettings charm.Settings
-	GoalState      string
+	GoalState      application.GoalState
 	ContainerSpec  string
 }
 
@@ -41,12 +43,12 @@ func (c *ContextUnit) ConfigSettings() (charm.Settings, error) {
 }
 
 // GoalState implements jujuc.ContextUnit.
-func (c *ContextUnit) GoalState() (string, error) {
+func (c *ContextUnit) GoalState() (*application.GoalState, error) {
 	c.stub.AddCall("GoalState")
 	if err := c.stub.NextErr(); err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return c.info.GoalState, nil
+	return &c.info.GoalState, nil
 }
 
 func (c *ContextUnit) SetPodSpec(specYaml string) error {

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/network"
 )
 
@@ -26,8 +27,8 @@ type RestrictedContext struct{}
 func (*RestrictedContext) ConfigSettings() (charm.Settings, error) { return nil, ErrRestrictedContext }
 
 // GoalState implements hooks.Context.
-func (*RestrictedContext) GoalState() (string, error) {
-	return "", ErrRestrictedContext
+func (*RestrictedContext) GoalState() (*application.GoalState, error) {
+	return &application.GoalState{}, ErrRestrictedContext
 }
 
 // UnitStatus implements hooks.Context.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

- Data structures for API and jujuc.
- Uniter API call
- goal-state hook command

----

## Description of change

Implementation of new hook command `goal-state`. This command returns a yaml-parsed string, with information about the charm units and their relations.

## QA steps

After provisioning a controller and create a model:

1. 
  - input

        $ juju deploy mysql
        $ juju run --unit mysql/0 'goal-state'

  - result
 parsed yaml string with information about the charm and its relations.

2 
  - input

        $ juju deploy wordpress
        $ juju add-relation mysql wordpress
        $ juju deploy mediawiki
        $ juju add-relation mysql:db mediawiki
        $ juju run --unit mysql/0 'goal-state'


  - result
   parsed yaml string with information about the charm and its relations.

Example:
After the preparing the model with the commands in step 2 
  - Juju status output: 
     [`$ ./juju status`](https://paste.ubuntu.com/p/dHrTP3ftmS/)
  - Juju goal state output: 
     [`$ ./juju run --unit mysql/0 'goal-state'`](https://paste.ubuntu.com/p/DwpzdHSWbs/)

## Documentation changes

Need to document hook `goal-state`

## Bug reference

N/A
