### PR TITLE
It is unsafe to close a channel someone else is writing to.

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -911,10 +911,10 @@ func (s *apiclientSuite) TestOpenDialTimeoutDoesNotAffectLogin(c *gc.C) {
 	err := clk.WaitAdvance(0, 0, 0)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// unblock the login by receiving from "unblocked", and then the
+	// unblock the login by sending to "unblocked", and then the
 	// api.Open should return the result of the login.
 	select {
-	case <-unblocked:
+	case unblocked <- struct{}{}:
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for login to be unblocked")
 	}
@@ -1304,7 +1304,7 @@ func (a *loginTimeoutAPIAdmin) Login(req params.LoginRequest) (params.LoginResul
 		return params.LoginResult{}, errors.New("timed out waiting to be unblocked")
 	}
 	select {
-	case unblocked <- struct{}{}:
+	case <-unblocked:
 	case <-time.After(jtesting.LongWait):
 		return params.LoginResult{}, errors.New("timed out sending on unblocked channel")
 	}


### PR DESCRIPTION
## Description of change

Instead of writing to the channel to signal the calling code that we
should unblock, instead read from the channel, so that the test code can
close it instead of reading from it.

## QA steps

```
$ cd api
$ go test -race -check.f Open.*Time
```
Before this it was triggering a Race condition, now it doesn't.

## Documentation changes

None.

## Bug reference

Related to bug #1755142, but only in that my fix for that bug caused this race.
