### PR TITLE
Update govmomi dep to version that supports go 1.10 properly

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -82,7 +82,7 @@ github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-0
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 github.com/satori/uuid	git	5bf94b69c6b68ee1b541973bb8e1144db23a194b	2017-03-21T23:07:31Z
-github.com/vmware/govmomi	git	17b8c9ccb7f8c7b015d44c4ea39305c970a7bf31	2017-09-05T23:36:42Z
+github.com/vmware/govmomi	git	05504416e95561e1478196d7058721c827a7bb8c	2018-03-06T20:02:55Z
 golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -335,8 +335,8 @@ func (c *Client) createImportSpec(
 	if args.Constraints.HasCpuPower() {
 		cpuPower := int64(*args.Constraints.CpuPower)
 		s.CpuAllocation = &types.ResourceAllocationInfo{
-			Limit:       cpuPower,
-			Reservation: cpuPower,
+			Limit:       &cpuPower,
+			Reservation: &cpuPower,
 		}
 	}
 	if err := c.addRootDisk(s, args, datastore, vmdkDatastorePath); err != nil {


### PR DESCRIPTION
## Description of change
Update govmomi dependency to fresh version, fixes issue with vsphere test hanging on go 1.10.

## QA steps
Use standard test suite.