### PR TITLE
Adds API client method for cloud spec retrieval.

### DIFF
--- a/api/uniter/cloud_native_test.go
+++ b/api/uniter/cloud_native_test.go
@@ -1,0 +1,56 @@
+package uniter_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/environschema.v1"
+
+	"github.com/juju/juju/apiserver/facades/client/application"
+)
+
+type cloudNativeUniterSuite struct {
+	uniterSuite
+}
+
+var _ = gc.Suite(&cloudNativeUniterSuite{})
+
+func (s *cloudNativeUniterSuite) SetUpTest(c *gc.C) {
+	s.uniterSuite.SetUpTest(c)
+
+	// Ensure the application is not trusted prior to tests.
+	s.setApplicationTrust(c, false)
+}
+
+// setApplicationTrust updates the configuration for the application unit to
+// allow or deny access for cloud spec retrieval.
+func (s *cloudNativeUniterSuite) setApplicationTrust(c *gc.C, trusted bool) {
+	conf := map[string]interface{}{application.TrustConfigOptionName: trusted}
+	fields := map[string]environschema.Attr{application.TrustConfigOptionName: {Type: environschema.Tbool}}
+	defaults := map[string]interface{}{application.TrustConfigOptionName: false}
+	err := s.wordpressApplication.UpdateApplicationConfig(conf, nil, fields, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newConf, err := s.wordpressApplication.ApplicationConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newConf.GetBool(application.TrustConfigOptionName, false), gc.Equals, trusted)
+}
+
+func (s *cloudNativeUniterSuite) TestCloudSpecErrorWhenUnauthorized(c *gc.C) {
+	result, err := s.uniter.CloudSpec()
+	c.Check(err, gc.ErrorMatches, "permission denied")
+	c.Check(result, gc.IsNil)
+}
+
+func (s *cloudNativeUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
+	s.setApplicationTrust(c, true)
+
+	result, err := s.uniter.CloudSpec()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result.Name, gc.Equals, "dummy")
+
+	exp := map[string]string{
+		"username": "dummy",
+		"password": "secret",
+	}
+	c.Check(result.Credential.Attributes, gc.DeepEquals, exp)
+}

--- a/api/uniter/cloud_native_test.go
+++ b/api/uniter/cloud_native_test.go
@@ -29,10 +29,6 @@ func (s *cloudNativeUniterSuite) setApplicationTrust(c *gc.C, trusted bool) {
 	defaults := map[string]interface{}{application.TrustConfigOptionName: false}
 	err := s.wordpressApplication.UpdateApplicationConfig(conf, nil, fields, defaults)
 	c.Assert(err, jc.ErrorIsNil)
-
-	newConf, err := s.wordpressApplication.ApplicationConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newConf.GetBool(application.TrustConfigOptionName, false), gc.Equals, trusted)
 }
 
 func (s *cloudNativeUniterSuite) TestCloudSpecErrorWhenUnauthorized(c *gc.C) {

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -435,16 +435,16 @@ func (st *State) SLALevel() (string, error) {
 
 // GoalState returns a GoalStateResult struct with the charm's
 // peers and related units information.
-func (c *State) GoalState() (string, error) {
+func (st *State) GoalState() (string, error) {
 	var result params.StringResults
 
 	args := params.Entities{
 		Entities: []params.Entity{
-			{Tag: c.unitTag.String()},
+			{Tag: st.unitTag.String()},
 		},
 	}
 
-	err := c.facade.FacadeCall("GoalStates", args, &result)
+	err := st.facade.FacadeCall("GoalStates", args, &result)
 	if err != nil {
 		return "", err
 	}
@@ -458,7 +458,7 @@ func (c *State) GoalState() (string, error) {
 }
 
 // SetPodSpec sets the pod spec of the specified application.
-func (c *State) SetPodSpec(appName string, spec string) error {
+func (st *State) SetPodSpec(appName string, spec string) error {
 	if !names.IsValidApplication(appName) {
 		return errors.NotValidf("application name %q", appName)
 	}
@@ -470,8 +470,25 @@ func (c *State) SetPodSpec(appName string, spec string) error {
 			Value: spec,
 		}},
 	}
-	if err := c.facade.FacadeCall("SetPodSpec", args, &result); err != nil {
+	if err := st.facade.FacadeCall("SetPodSpec", args, &result); err != nil {
 		return errors.Trace(err)
 	}
 	return result.OneError()
+}
+
+// CloudSpec returns the cloud spec for the model that calling unit or
+// application resides in.
+// If the application has not been authorised to access its cloud spec,
+// then an authorisation error will be returned.
+func (st *State) CloudSpec() (*params.CloudSpec, error) {
+	var result params.CloudSpecResult
+
+	err := st.facade.FacadeCall("CloudSpec", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	if err := result.Error; err != nil {
+		return nil, err
+	}
+	return result.Result, nil
 }

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -56,7 +56,8 @@ func (s *uniterSuite) setUpTest(c *gc.C, addController bool) {
 
 	// Create a machine, a application and add a unit so we can log in as
 	// its agent.
-	s.wordpressMachine, s.wordpressApplication, s.wordpressCharm, s.wordpressUnit = s.addMachineBoundAppCharmAndUnit(c, "wordpress", bindings)
+	s.wordpressMachine, s.wordpressApplication, s.wordpressCharm, s.wordpressUnit =
+		s.addMachineBoundAppCharmAndUnit(c, "wordpress", bindings)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.wordpressUnit.SetPassword(password)
@@ -69,7 +70,9 @@ func (s *uniterSuite) setUpTest(c *gc.C, addController bool) {
 	c.Assert(s.uniter, gc.NotNil)
 }
 
-func (s *uniterSuite) addMachineBoundAppCharmAndUnit(c *gc.C, appName string, bindings map[string]string) (*state.Machine, *state.Application, *state.Charm, *state.Unit) {
+func (s *uniterSuite) addMachineBoundAppCharmAndUnit(
+	c *gc.C, appName string, bindings map[string]string,
+) (*state.Machine, *state.Application, *state.Charm, *state.Unit) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	charm := s.AddTestingCharm(c, appName)
@@ -90,7 +93,8 @@ func (s *uniterSuite) addMachineBoundAppCharmAndUnit(c *gc.C, appName string, bi
 	return machine, app, charm, unit
 }
 
-func (s *uniterSuite) addMachineAppCharmAndUnit(c *gc.C, appName string) (*state.Machine, *state.Application, *state.Charm, *state.Unit) {
+func (s *uniterSuite) addMachineAppCharmAndUnit(c *gc.C, appName string,
+) (*state.Machine, *state.Application, *state.Charm, *state.Unit) {
 	return s.addMachineBoundAppCharmAndUnit(c, appName, nil)
 }
 
@@ -102,7 +106,8 @@ func (s *uniterSuite) addRelation(c *gc.C, first, second string) *state.Relation
 	return rel
 }
 
-func (s *uniterSuite) addRelatedApplication(c *gc.C, firstApp, relatedApp string, unit *state.Unit) (*state.Relation, *state.Application, *state.Unit) {
+func (s *uniterSuite) addRelatedApplication(c *gc.C, firstApp, relatedApp string, unit *state.Unit,
+) (*state.Relation, *state.Application, *state.Unit) {
 	relatedApplication := s.AddTestingApplication(c, relatedApp, s.AddTestingCharm(c, relatedApp))
 	rel := s.addRelation(c, firstApp, relatedApp)
 	relUnit, err := rel.Unit(unit)
@@ -126,13 +131,4 @@ func (s *uniterSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScop
 	ok, err := relUnit.InScope()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, gc.Equals, inScope)
-}
-
-func (s *uniterSuite) TestSLALevel(c *gc.C) {
-	err := s.State.SetSLA("essential", "bob", []byte("creds"))
-	c.Assert(err, jc.ErrorIsNil)
-
-	level, err := s.uniter.SLALevel()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(level, gc.Equals, "essential")
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4163,10 +4163,6 @@ func (s *cloudSpecUniterSuite) SetUpTest(c *gc.C) {
 	defaults := map[string]interface{}{application.TrustConfigOptionName: false}
 	err := s.wordpress.UpdateApplicationConfig(conf, nil, fields, defaults)
 	c.Assert(err, jc.ErrorIsNil)
-
-	newConf, err := s.wordpress.ApplicationConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newConf.GetBool(application.TrustConfigOptionName, false), jc.IsTrue)
 }
 
 func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {


### PR DESCRIPTION
## Description of change

Adds a new method to the uniter API client, for retrieving the running model's cloud spec.

Includes some fly-by cleanup - there was a redundant test for SLA level directly on the uniter base suite, which has been removed.

## QA steps

Accompanying unit tests.

## Documentation changes

Ultimately, yes.