### PR TITLE
At least log the original error.

### DIFF
--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -187,6 +187,7 @@ func ScaryConnect(a agent.Agent, apiOpen api.OpenFunc) (_ api.Connection, err er
 		default:
 			return
 		}
+		logger.Errorf("while trying to connect, got %v, treating as an unrecoverable error", err)
 		err = ErrConnectImpossible
 	}()
 


### PR DESCRIPTION
## Description of change

Something weird is happening in [lp:1751153](https://bugs.launchpad.net/juju-core/+bug/1751153) where deleting a directory is causing us to uninstall the Juju agent. However, the only logging we have says:
```
2018-02-22 17:28:22 DEBUG juju.worker.apicaller connect.go:152 failed to connect
2018-02-22 17:28:22 DEBUG juju.worker.dependency engine.go:504 "api-caller" manifold worker stopped: cannot open api: connection permanently impossible
```
If we are going to suppress an error, it helps when debugging failures
if we can at least get access to the original error.
It may be that this is actually redundant with the connect.go:152. But I have the feeling the actual failure is more like errAgentEntityDead or something like that, and it would be good to understand what it is.

## QA steps

Just a logging change.

## Documentation changes

None.

## Bug reference

Relates to [lp:1751153](https://bugs.launchpad.net/juju-core/+bug/1751153)  but not actually a fix for it.
