### PR TITLE
Add labels to metrics.

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -733,7 +733,11 @@ func (s *unitSuite) TestAddMetrics(c *gc.C) {
 			return nil
 		},
 	)
-	metrics := []params.Metric{{"A", "23", time.Now()}, {"B", "27.0", time.Now()}}
+	metrics := []params.Metric{{
+		Key: "A", Value: "23", Time: time.Now(),
+	}, {
+		Key: "B", Value: "27.0", Time: time.Now(), Labels: map[string]string{"foo": "bar"},
+	}}
 	err := s.apiUnit.AddMetrics(metrics)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -746,7 +750,11 @@ func (s *unitSuite) TestAddMetricsError(c *gc.C) {
 			return fmt.Errorf("test error")
 		},
 	)
-	metrics := []params.Metric{{"A", "23", time.Now()}, {"B", "27.0", time.Now()}}
+	metrics := []params.Metric{{
+		Key: "A", Value: "23", Time: time.Now(),
+	}, {
+		Key: "B", Value: "27.0", Time: time.Now(), Labels: map[string]string{"foo": "bar"},
+	}}
 	err := s.apiUnit.AddMetrics(metrics)
 	c.Assert(err, gc.ErrorMatches, "unable to add metric: test error")
 }
@@ -763,7 +771,11 @@ func (s *unitSuite) TestAddMetricsResultError(c *gc.C) {
 			return nil
 		},
 	)
-	metrics := []params.Metric{{"A", "23", time.Now()}, {"B", "27.0", time.Now()}}
+	metrics := []params.Metric{{
+		Key: "A", Value: "23", Time: time.Now(),
+	}, {
+		Key: "B", Value: "27.0", Time: time.Now(), Labels: map[string]string{"foo": "bar"},
+	}}
 	err := s.apiUnit.AddMetrics(metrics)
 	c.Assert(err, gc.ErrorMatches, "error adding metrics")
 }
@@ -890,7 +902,11 @@ func (s *unitMetricBatchesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *unitMetricBatchesSuite) TestSendMetricBatchPatch(c *gc.C) {
-	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	metrics := []params.Metric{{
+		Key: "pings", Value: "5", Time: time.Now().UTC(),
+	}, {
+		Key: "pongs", Value: "6", Time: time.Now().UTC(), Labels: map[string]string{"foo": "bar"},
+	}}
 	uuid := utils.MustNewUUID().String()
 	batch := params.MetricBatch{
 		UUID:     uuid,
@@ -925,7 +941,11 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchFail(c *gc.C) {
 			result.Results[0].Error = common.ServerError(common.ErrPerm)
 			return nil
 		})
-	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	metrics := []params.Metric{{
+		Key: "pings", Value: "5", Time: time.Now().UTC(),
+	}, {
+		Key: "pongs", Value: "6", Time: time.Now().UTC(), Labels: map[string]string{"foo": "bar"},
+	}}
 	uuid := utils.MustNewUUID().String()
 	batch := params.MetricBatch{
 		UUID:     uuid,
@@ -944,7 +964,11 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchFail(c *gc.C) {
 func (s *unitMetricBatchesSuite) TestSendMetricBatch(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	now := time.Now().Round(time.Second).UTC()
-	metrics := []params.Metric{{"pings", "5", now}}
+	metrics := []params.Metric{{
+		Key: "pings", Value: "5", Time: now,
+	}, {
+		Key: "pongs", Value: "6", Time: time.Now().UTC(), Labels: map[string]string{"foo": "bar"},
+	}}
 	batch := params.MetricBatch{
 		UUID:     uuid,
 		CharmURL: s.charm.URL().String(),
@@ -963,8 +987,11 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatch(c *gc.C) {
 	c.Assert(batches[0].UUID(), gc.Equals, uuid)
 	c.Assert(batches[0].Sent(), jc.IsFalse)
 	c.Assert(batches[0].CharmURL(), gc.Equals, s.charm.URL().String())
-	c.Assert(batches[0].Metrics(), gc.HasLen, 1)
-	c.Assert(batches[0].Metrics()[0].Key, gc.Equals, "pings")
+	c.Assert(batches[0].Metrics(), gc.HasLen, 2)
 	c.Assert(batches[0].Metrics()[0].Key, gc.Equals, "pings")
 	c.Assert(batches[0].Metrics()[0].Value, gc.Equals, "5")
+	c.Assert(batches[0].Metrics()[0].Labels, gc.HasLen, 0)
+	c.Assert(batches[0].Metrics()[1].Key, gc.Equals, "pongs")
+	c.Assert(batches[0].Metrics()[1].Value, gc.Equals, "6")
+	c.Assert(batches[0].Metrics()[1].Labels, gc.DeepEquals, map[string]string{"foo": "bar"})
 }

--- a/apiserver/facades/agent/metricsadder/metricsadder.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder.go
@@ -56,9 +56,10 @@ func (api *MetricsAdderAPI) AddMetricBatches(args params.MetricBatchParams) (par
 		metrics := make([]state.Metric, len(batch.Batch.Metrics))
 		for j, metric := range batch.Batch.Metrics {
 			metrics[j] = state.Metric{
-				Key:   metric.Key,
-				Value: metric.Value,
-				Time:  metric.Time,
+				Key:    metric.Key,
+				Value:  metric.Value,
+				Time:   metric.Time,
+				Labels: metric.Labels,
 			}
 		}
 		_, err = api.state.AddMetrics(

--- a/apiserver/facades/agent/metricsadder/metricsadder_test.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder_test.go
@@ -97,7 +97,11 @@ func (s *metricsAdderSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
-	metrics := []params.Metric{{Key: "pings", Value: "5", Time: time.Now().UTC()}}
+	metrics := []params.Metric{{
+		Key: "pings", Value: "5", Time: time.Now().UTC(),
+	}, {
+		Key: "pongs", Value: "6", Time: time.Now().UTC(), Labels: map[string]string{"foo": "bar"},
+	}}
 	uuid := utils.MustNewUUID().String()
 
 	result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
@@ -123,9 +127,13 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL().String())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
-	c.Assert(storedMetrics, gc.HasLen, 1)
+	c.Assert(storedMetrics, gc.HasLen, 2)
 	c.Assert(storedMetrics[0].Key, gc.Equals, metrics[0].Key)
 	c.Assert(storedMetrics[0].Value, gc.Equals, metrics[0].Value)
+	c.Assert(storedMetrics[0].Labels, gc.DeepEquals, metrics[0].Labels)
+	c.Assert(storedMetrics[1].Key, gc.Equals, metrics[1].Key)
+	c.Assert(storedMetrics[1].Value, gc.Equals, metrics[1].Value)
+	c.Assert(storedMetrics[1].Labels, gc.DeepEquals, metrics[1].Labels)
 }
 
 func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {

--- a/apiserver/facades/agent/metricsender/metricsender.go
+++ b/apiserver/facades/agent/metricsender/metricsender.go
@@ -184,9 +184,10 @@ func ToWire(mb *state.MetricBatch) *wireformat.MetricBatch {
 	metrics := make([]wireformat.Metric, len(mb.Metrics()))
 	for i, m := range mb.Metrics() {
 		metrics[i] = wireformat.Metric{
-			Key:   m.Key,
-			Value: m.Value,
-			Time:  m.Time.UTC(),
+			Key:    m.Key,
+			Value:  m.Value,
+			Time:   m.Time.UTC(),
+			Labels: m.Labels,
 		}
 	}
 	return &wireformat.MetricBatch{

--- a/apiserver/facades/agent/metricsender/metricsender_test.go
+++ b/apiserver/facades/agent/metricsender/metricsender_test.go
@@ -64,6 +64,9 @@ func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 			Key:   m.Key,
 			Value: m.Value,
 			Time:  m.Time.UTC(),
+			Labels: map[string]string{
+				"foo": "bar",
+			},
 		},
 	}
 	expected := &wireformat.MetricBatch{

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1914,9 +1914,10 @@ func (u *UniterAPI) AddMetricBatches(args params.MetricBatchParams) (params.Erro
 		metrics := make([]state.Metric, len(batch.Batch.Metrics))
 		for j, metric := range batch.Batch.Metrics {
 			metrics[j] = state.Metric{
-				Key:   metric.Key,
-				Value: metric.Value,
-				Time:  metric.Time,
+				Key:    metric.Key,
+				Value:  metric.Value,
+				Time:   metric.Time,
+				Labels: metric.Labels,
 			}
 		}
 		_, err = u.st.AddMetrics(state.BatchParam{

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -232,6 +232,9 @@ func (s *charmsSuite) TestMeteredCharmInfo(c *gc.C) {
 			"pings": params.CharmMetric{
 				Type:        "gauge",
 				Description: "Description of the metric."},
+			"pongs": params.CharmMetric{
+				Type:        "gauge",
+				Description: "Description of the metric."},
 			"juju-units": params.CharmMetric{
 				Type:        "",
 				Description: ""}}}

--- a/apiserver/facades/client/metricsdebug/metricsdebug_test.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug_test.go
@@ -175,8 +175,8 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
-	metricA := state.Metric{"pings", "5", t0}
-	metricB := state.Metric{"pings", "10.5", t1}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: t0}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: t1}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA, metricB}})
 	args := params.Entities{Entities: []params.Entity{
@@ -206,9 +206,9 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
-	metricA := state.Metric{"pings", "5", t1}
-	metricB := state.Metric{"pings", "10.5", t0}
-	metricC := state.Metric{"juju-units", "8", t1}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: t1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: t0}
+	metricC := state.Metric{Key: "juju-units", Value: "8", Time: t1}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB, metricC}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB, metricC}})
 	args := params.Entities{}
@@ -247,9 +247,9 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEac
 	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
-	metricA := state.Metric{"pings", "5", t1}
-	metricB := state.Metric{"pings", "10.5", t0}
-	metricC := state.Metric{"juju-units", "8", t1}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: t1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: t0}
+	metricC := state.Metric{Key: "juju-units", Value: "8", Time: t1}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB, metricC}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB}})
 	args := params.Entities{}
@@ -283,9 +283,9 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPer
 	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
-	metricA := state.Metric{"pings", "5", t1}
-	metricB := state.Metric{"pings", "10.5", t0}
-	metricC := state.Metric{"juju-units", "8", t1}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: t1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: t0}
+	metricC := state.Metric{Key: "juju-units", Value: "8", Time: t1}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricC}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB}})

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -703,9 +703,10 @@ type ProvisioningInfoResults struct {
 
 // Metric holds a single metric.
 type Metric struct {
-	Key   string    `json:"key"`
-	Value string    `json:"value"`
-	Time  time.Time `json:"time"`
+	Key    string            `json:"key"`
+	Value  string            `json:"value"`
+	Time   time.Time         `json:"time"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // MetricsParam contains the metrics for a single unit.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -49,7 +49,7 @@ github.com/juju/ratelimit	git	5b9ff866471762aa2ab2dced63c9fb6f53921342	2017-05-2
 github.com/juju/replicaset	git	0072546a972e6a32bdb2330809fdf7db6c755b85	2017-09-13T04:02:23Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T14:24:45Z
+github.com/juju/romulus	git	8bea892d0df70b89dbe7598167b4a643f06b2bc0	2018-03-15T23:01:00Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	43f926548f91d55be6bae26ecb7d2386c64e887c	2018-02-13T13:46:16Z

--- a/featuretests/cmd_juju_metrics.go
+++ b/featuretests/cmd_juju_metrics.go
@@ -54,8 +54,8 @@ func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
-	metricA := state.Metric{"pings", "5", newTime1}
-	metricB := state.Metric{"pings", "10.5", newTime2}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1")
@@ -88,8 +88,8 @@ func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
-	metricA := state.Metric{"pings", "5", newTime1}
-	metricB := state.Metric{"pings", "10.5", newTime2}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all")
@@ -116,8 +116,8 @@ func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
-	metricA := state.Metric{"pings", "5", newTime1}
-	metricB := state.Metric{"pings", "10.5", newTime2}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "json")
@@ -138,8 +138,8 @@ func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
-	metricA := state.Metric{"pings", "5", newTime1}
-	metricB := state.Metric{"pings", "10.5", newTime2}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "yaml")

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -57,16 +57,26 @@ type Metric struct {
 
 type byTime []Metric
 
-func (t byTime) Len() int      { return len(t) }
+// Len implements sort.Interface.
+func (t byTime) Len() int { return len(t) }
+
+// Swap implements sort.Interface.
 func (t byTime) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+
+// Less implements sort.Interface.
 func (t byTime) Less(i, j int) bool {
 	return t[i].Time.Before(t[j].Time)
 }
 
 type byKey []Metric
 
-func (t byKey) Len() int      { return len(t) }
+// Len implements sort.Interface.
+func (t byKey) Len() int { return len(t) }
+
+// Swap implements sort.Interface.
 func (t byKey) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+
+// Less implements sort.Interface.
 func (t byKey) Less(i, j int) bool {
 	return strings.Compare(t[i].Key, t[j].Key) < 0
 }

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -6,6 +6,7 @@ package state
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -48,9 +49,10 @@ type metricBatchDoc struct {
 
 // Metric represents a single Metric.
 type Metric struct {
-	Key   string    `bson:"key"`
-	Value string    `bson:"value"`
-	Time  time.Time `bson:"time"`
+	Key    string            `bson:"key"`
+	Value  string            `bson:"value"`
+	Time   time.Time         `bson:"time"`
+	Labels map[string]string `bson:"labels,omitempty"`
 }
 
 type byTime []Metric
@@ -59,6 +61,14 @@ func (t byTime) Len() int      { return len(t) }
 func (t byTime) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
 func (t byTime) Less(i, j int) bool {
 	return t[i].Time.Before(t[j].Time)
+}
+
+type byKey []Metric
+
+func (t byKey) Len() int      { return len(t) }
+func (t byKey) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t byKey) Less(i, j int) bool {
+	return strings.Compare(t[i].Key, t[j].Key) < 0
 }
 
 // validate checks that the MetricBatch contains valid metrics.
@@ -428,6 +438,7 @@ func (m *MetricBatch) UniqueMetrics() []Metric {
 		results[i] = m
 		i++
 	}
+	sort.Sort(byKey(results))
 	return results
 }
 

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -59,13 +59,17 @@ func ensureUnitDead(c *gc.C, unit *state.Unit) {
 func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	modelUUID := s.State.ModelUUID()
-	m := state.Metric{"pings", "5", now}
+	m := []state.Metric{{
+		Key: "pings", Value: "5", Time: now,
+	}, {
+		Key: "pongs", Value: "6", Time: now, Labels: map[string]string{"foo": "bar"},
+	}}
 	metricBatch, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
 			CharmURL: s.meteredCharm.URL().String(),
-			Metrics:  []state.Metric{m},
+			Metrics:  m,
 			Unit:     s.unit.UnitTag(),
 		},
 	)
@@ -75,34 +79,48 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
 	c.Assert(metricBatch.Sent(), jc.IsFalse)
 	c.Assert(metricBatch.Created(), gc.Equals, now)
-	c.Assert(metricBatch.Metrics(), gc.HasLen, 1)
+	c.Assert(metricBatch.Metrics(), gc.HasLen, 2)
 
 	metric := metricBatch.Metrics()[0]
 	c.Assert(metric.Key, gc.Equals, "pings")
 	c.Assert(metric.Value, gc.Equals, "5")
 	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	metric = metricBatch.Metrics()[1]
+	c.Assert(metric.Key, gc.Equals, "pongs")
+	c.Assert(metric.Value, gc.Equals, "6")
+	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	c.Assert(metric.Labels, gc.DeepEquals, map[string]string{"foo": "bar"})
 
 	saved, err := s.State.MetricBatch(metricBatch.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saved.Unit(), gc.Equals, "metered/0")
 	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
 	c.Assert(saved.Sent(), jc.IsFalse)
-	c.Assert(saved.Metrics(), gc.HasLen, 1)
+	c.Assert(saved.Metrics(), gc.HasLen, 2)
 	metric = saved.Metrics()[0]
 	c.Assert(metric.Key, gc.Equals, "pings")
 	c.Assert(metric.Value, gc.Equals, "5")
 	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	metric = saved.Metrics()[1]
+	c.Assert(metric.Key, gc.Equals, "pongs")
+	c.Assert(metric.Value, gc.Equals, "6")
+	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	c.Assert(metric.Labels, gc.DeepEquals, map[string]string{"foo": "bar"})
 }
 
 func (s *MetricSuite) TestAddModelMetricMetric(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	modelUUID := s.State.ModelUUID()
-	m := state.Metric{"pings", "5", now}
+	m := []state.Metric{{
+		Key: "pings", Value: "5", Time: now,
+	}, {
+		Key: "pongs", Value: "6", Time: now, Labels: map[string]string{"foo": "bar"},
+	}}
 	metricBatch, err := s.State.AddModelMetrics(
 		state.ModelBatchParam{
 			UUID:    utils.MustNewUUID().String(),
 			Created: now,
-			Metrics: []state.Metric{m},
+			Metrics: m,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -111,12 +129,17 @@ func (s *MetricSuite) TestAddModelMetricMetric(c *gc.C) {
 	c.Assert(metricBatch.CharmURL(), gc.Equals, "")
 	c.Assert(metricBatch.Sent(), jc.IsFalse)
 	c.Assert(metricBatch.Created(), gc.Equals, now)
-	c.Assert(metricBatch.Metrics(), gc.HasLen, 1)
+	c.Assert(metricBatch.Metrics(), gc.HasLen, 2)
 
 	metric := metricBatch.Metrics()[0]
 	c.Assert(metric.Key, gc.Equals, "pings")
 	c.Assert(metric.Value, gc.Equals, "5")
 	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	metric = metricBatch.Metrics()[1]
+	c.Assert(metric.Key, gc.Equals, "pongs")
+	c.Assert(metric.Value, gc.Equals, "6")
+	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	c.Assert(metric.Labels, gc.DeepEquals, map[string]string{"foo": "bar"})
 
 	tosend, err := s.State.MetricsToSend(1)
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,17 +148,22 @@ func (s *MetricSuite) TestAddModelMetricMetric(c *gc.C) {
 	c.Assert(saved.Unit(), gc.Equals, "")
 	c.Assert(metricBatch.CharmURL(), gc.Equals, "")
 	c.Assert(saved.Sent(), jc.IsFalse)
-	c.Assert(saved.Metrics(), gc.HasLen, 1)
+	c.Assert(saved.Metrics(), gc.HasLen, 2)
 	metric = saved.Metrics()[0]
 	c.Assert(metric.Key, gc.Equals, "pings")
 	c.Assert(metric.Value, gc.Equals, "5")
 	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	metric = saved.Metrics()[1]
+	c.Assert(metric.Key, gc.Equals, "pongs")
+	c.Assert(metric.Value, gc.Equals, "6")
+	c.Assert(metric.Time.Equal(now), jc.IsTrue)
+	c.Assert(metric.Labels, gc.DeepEquals, map[string]string{"foo": "bar"})
 }
 
 func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 	removeUnit(c, s.unit)
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	unitTag := names.NewUnitTag("test/0")
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
@@ -152,7 +180,7 @@ func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 	ensureUnitDead(c, s.unit)
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -167,7 +195,7 @@ func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 
 func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	added, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -191,7 +219,7 @@ func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 	oldTime := testing.NonZeroTime().Add(-(time.Hour * 25))
 	now := testing.NonZeroTime()
-	m := state.Metric{"pings", "5", oldTime}
+	m := state.Metric{Key: "pings", Value: "5", Time: oldTime}
 	oldMetric1, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -216,7 +244,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	oldMetric2.SetSent(testing.NonZeroTime().Add(-25 * time.Hour))
 
-	m = state.Metric{"pings", "5", now}
+	m = state.Metric{Key: "pings", Value: "5", Time: now}
 	newMetric, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -248,7 +276,7 @@ func (s *MetricSuite) TestCleanupNoMetrics(c *gc.C) {
 
 func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 	oldTime := testing.NonZeroTime().Add(-(time.Hour * 25))
-	m := state.Metric{"pings", "5", oldTime}
+	m := state.Metric{Key: "pings", Value: "5", Time: oldTime}
 	oldMetric, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -261,7 +289,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	now := testing.NonZeroTime()
-	m = state.Metric{"pings", "5", now}
+	m = state.Metric{Key: "pings", Value: "5", Time: now}
 	newMetric, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -285,7 +313,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 
 func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -307,7 +335,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 
 func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	uuid := utils.MustNewUUID().String()
 	charmURL := "cs:quantal/metered-1"
 	_, err := s.State.AddMetrics(
@@ -332,7 +360,7 @@ func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
 
 func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	err := s.application.SetMetricCredentials([]byte("hello there"))
 	c.Assert(err, gc.IsNil)
 	_, err = s.State.AddMetrics(
@@ -442,42 +470,42 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 		err     string
 	}{{
 		"assert non metered unit returns an error",
-		[]state.Metric{{"metric-key", "1", now}},
+		[]state.Metric{{Key: "metric-key", Value: "1", Time: now}},
 		nonMeteredUnit,
 		"charm doesn't implement metrics",
 	}, {
 		"assert metric with no errors and passes validation",
-		[]state.Metric{{"pings", "1", now}},
+		[]state.Metric{{Key: "pings", Value: "1", Time: now}},
 		meteredUnit,
 		"",
 	}, {
 		"assert valid metric fails on dying unit",
-		[]state.Metric{{"pings", "1", now}},
+		[]state.Metric{{Key: "pings", Value: "1", Time: now}},
 		dyingUnit,
 		"unit \"metered-application/1\" not found",
 	}, {
 		"assert charm doesn't implement key returns error",
-		[]state.Metric{{"not-implemented", "1", now}},
+		[]state.Metric{{Key: "not-implemented", Value: "1", Time: now}},
 		meteredUnit,
 		`metric "not-implemented" not defined`,
 	}, {
 		"assert invalid value returns error",
-		[]state.Metric{{"pings", "foobar", now}},
+		[]state.Metric{{Key: "pings", Value: "foobar", Time: now}},
 		meteredUnit,
 		`invalid value type: expected float, got "foobar"`,
 	}, {
 		"long value returns error",
-		[]state.Metric{{"pings", "3.141592653589793238462643383279", now}},
+		[]state.Metric{{Key: "pings", Value: "3.141592653589793238462643383279", Time: now}},
 		meteredUnit,
 		`metric value is too large`,
 	}, {
 		"negative value returns error",
-		[]state.Metric{{"pings", "-42.0", now}},
+		[]state.Metric{{Key: "pings", Value: "-42.0", Time: now}},
 		meteredUnit,
 		`invalid value: value must be greater or equal to zero, got -42.0`,
 	}, {
 		"non-float value returns an error",
-		[]state.Metric{{"pings", "abcd", now}},
+		[]state.Metric{{Key: "pings", Value: "abcd", Time: now}},
 		meteredUnit,
 		`invalid value type: expected float, got "abcd"`,
 	}}
@@ -510,7 +538,7 @@ func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
 			UUID:     mUUID,
 			Created:  now,
 			CharmURL: s.meteredCharm.URL().String(),
-			Metrics:  []state.Metric{{"pings", "5", now}},
+			Metrics:  []state.Metric{{Key: "pings", Value: "5", Time: now}},
 			Unit:     s.unit.UnitTag(),
 		},
 	)
@@ -521,7 +549,7 @@ func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
 			UUID:     mUUID,
 			Created:  now,
 			CharmURL: s.meteredCharm.URL().String(),
-			Metrics:  []state.Metric{{"pings", "10", now}},
+			Metrics:  []state.Metric{{Key: "pings", Value: "10", Time: now}},
 			Unit:     s.unit.UnitTag(),
 		},
 	)
@@ -554,7 +582,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 		c.Logf("running test: %v", test.about)
 		now := state.NowToTheSecond(s.State)
 		modelUUID := s.State.ModelUUID()
-		m := state.Metric{"juju-units", test.value, now}
+		m := state.Metric{Key: "juju-units", Value: test.value, Time: now}
 		metricBatch, err := s.State.AddMetrics(
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
@@ -596,7 +624,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 
 func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -655,8 +683,8 @@ func (s *MetricLocalCharmSuite) SetUpTest(c *gc.C) {
 
 func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
-	m2 := state.Metric{"pings", "10", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
+	m2 := state.Metric{Key: "pings", Value: "10", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -701,8 +729,8 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 
 func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
-	m2 := state.Metric{"pings", "10", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
+	m2 := state.Metric{Key: "pings", Value: "10", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -746,8 +774,8 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	// Add 2 metric batches to a single unit.
-	m := state.Metric{"pings", "5", now}
-	m2 := state.Metric{"pings", "10", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
+	m2 := state.Metric{Key: "pings", Value: "10", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -842,7 +870,7 @@ func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
 				UUID:     utils.MustNewUUID().String(),
 				Created:  t,
 				CharmURL: s.meteredCharm.URL().String(),
-				Metrics:  []state.Metric{{"pings", "5", t}},
+				Metrics:  []state.Metric{{Key: "pings", Value: "5", Time: t}},
 				Unit:     s.unit.UnitTag(),
 			},
 		)
@@ -853,7 +881,7 @@ func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
 				UUID:     utils.MustNewUUID().String(),
 				Created:  t,
 				CharmURL: s.meteredCharm.URL().String(),
-				Metrics:  []state.Metric{{"pings", "10", t}},
+				Metrics:  []state.Metric{{Key: "pings", Value: "10", Time: t}},
 				Unit:     newUnit.UnitTag(),
 			},
 		)
@@ -897,7 +925,7 @@ func assertMetricBatchesTimeAscending(c *gc.C, batches []state.MetricBatch) {
 
 func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -959,13 +987,13 @@ func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	metrics := batch.UniqueMetrics()
 	c.Assert(metrics, gc.HasLen, 2)
-	c.Assert(metrics, jc.SameContents, []state.Metric{{
-		Key:   "pings",
-		Value: "2",
-		Time:  t1,
-	}, {
+	c.Assert(metrics, jc.DeepEquals, []state.Metric{{
 		Key:   "juju-units",
 		Value: "1",
+		Time:  t1,
+	}, {
+		Key:   "pings",
+		Value: "2",
 		Time:  t1,
 	}})
 }
@@ -1013,7 +1041,7 @@ func mustCreateMeteredModel(c *gc.C, stateFactory *factory.Factory) (modelData, 
 
 func (s *CrossModelMetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
 	now := state.NowToTheSecond(s.State).Add(-48 * time.Hour)
-	m := state.Metric{"pings", "5", now}
+	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	m1, err := s.models[0].state.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),

--- a/testcharms/charm-repo/quantal/metered/metrics.yaml
+++ b/testcharms/charm-repo/quantal/metered/metrics.yaml
@@ -4,4 +4,7 @@ metrics:
   pings:
     type: gauge
     description: Description of the metric.
+  pongs:
+    type: gauge
+    description: Description of the metric.
   juju-units:

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -602,7 +602,12 @@ func (factory *Factory) MakeMetric(c *gc.C, params *MetricParams) *state.MetricB
 		params.Time = &now
 	}
 	if params.Metrics == nil {
-		params.Metrics = []state.Metric{{"pings", strconv.Itoa(uniqueInteger()), *params.Time}}
+		params.Metrics = []state.Metric{{
+			Key:    "pings",
+			Value:  strconv.Itoa(uniqueInteger()),
+			Time:   *params.Time,
+			Labels: map[string]string{"foo": "bar"},
+		}}
 	}
 
 	chURL, ok := params.Unit.CharmURL()

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -478,7 +478,7 @@ func (s *factorySuite) TestMakeMetric(c *gc.C) {
 		Unit:    unit,
 		Time:    &now,
 		Sent:    true,
-		Metrics: []state.Metric{{"pings", "1", now}},
+		Metrics: []state.Metric{{Key: "pings", Value: "1", Time: now}},
 	})
 	c.Assert(metric, gc.NotNil)
 

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -53,7 +53,12 @@ func (ctx *hookContext) Flush(process string, ctxErr error) (err error) {
 
 // AddMetric implements runner.Context.
 func (ctx *hookContext) AddMetric(key string, value string, created time.Time) error {
-	return ctx.recorder.AddMetric(key, value, created)
+	return ctx.recorder.AddMetric(key, value, created, nil)
+}
+
+// AddMetricLabels implements runner.Context.
+func (ctx *hookContext) AddMetricLabels(key string, value string, created time.Time, labels map[string]string) error {
+	return ctx.recorder.AddMetric(key, value, created, labels)
 }
 
 // addJujuUnitsMetric adds the juju-units built in metric if it
@@ -61,7 +66,7 @@ func (ctx *hookContext) AddMetric(key string, value string, created time.Time) e
 func (ctx *hookContext) addJujuUnitsMetric() error {
 	if ctx.recorder.IsDeclaredMetric("juju-units") {
 		// TODO(fwereade): 2016-03-17 lp:1558657
-		err := ctx.recorder.AddMetric("juju-units", "1", time.Now().UTC())
+		err := ctx.recorder.AddMetric("juju-units", "1", time.Now().UTC(), nil)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -135,8 +135,9 @@ type errorRecorder struct {
 	*spool.JSONMetricRecorder
 }
 
-func (e *errorRecorder) AddMetric(key, value string, created time.Time) (err error) {
-	return e.JSONMetricRecorder.AddMetric(key, "bad", created)
+func (e *errorRecorder) AddMetric(
+	key, value string, created time.Time, labels map[string]string) (err error) {
+	return e.JSONMetricRecorder.AddMetric(key, "bad", created, labels)
 }
 
 func (s *ManifoldSuite) TestRecordMetricsError(c *gc.C) {
@@ -317,7 +318,8 @@ type dummyRecorder struct {
 	batches []spool.MetricBatch
 }
 
-func (r *dummyRecorder) AddMetric(key, value string, created time.Time) error {
+func (r *dummyRecorder) AddMetric(
+	key, value string, created time.Time, labels map[string]string) error {
 	if r.err != "" {
 		return errors.New(r.err)
 	}
@@ -327,9 +329,10 @@ func (r *dummyRecorder) AddMetric(key, value string, created time.Time) error {
 		UUID:     utils.MustNewUUID().String(),
 		Created:  then,
 		Metrics: []jujuc.Metric{{
-			Key:   key,
-			Value: value,
-			Time:  then,
+			Key:    key,
+			Value:  value,
+			Time:   then,
+			Labels: labels,
 		}},
 		UnitTag: r.unitTag,
 	})

--- a/worker/metrics/spool/manifold.go
+++ b/worker/metrics/spool/manifold.go
@@ -23,9 +23,9 @@ import (
 
 // MetricRecorder records metrics to a spool directory.
 type MetricRecorder interface {
-	// AddMetric records a metric with the specified key, value and create time
-	// to a spool directory.
-	AddMetric(key, value string, created time.Time) error
+	// AddMetric records a metric with the specified key, value, create time
+	// and labels to a spool directory.
+	AddMetric(key, value string, created time.Time, labels map[string]string) error
 	// Close implements io.Closer.
 	Close() error
 	// IsDeclaredMetrics returns true if the metric recorder

--- a/worker/metrics/spool/metrics.go
+++ b/worker/metrics/spool/metrics.go
@@ -100,7 +100,12 @@ type MetricBatch struct {
 func APIMetricBatch(batch MetricBatch) params.MetricBatchParam {
 	metrics := make([]params.Metric, len(batch.Metrics))
 	for i, metric := range batch.Metrics {
-		metrics[i] = params.Metric{Key: metric.Key, Value: metric.Value, Time: metric.Time}
+		metrics[i] = params.Metric{
+			Key:    metric.Key,
+			Value:  metric.Value,
+			Time:   metric.Time,
+			Labels: metric.Labels,
+		}
 	}
 	return params.MetricBatchParam{
 		Tag: batch.UnitTag,
@@ -191,7 +196,8 @@ func (m *JSONMetricRecorder) Close() error {
 }
 
 // AddMetric implements the MetricsRecorder interface.
-func (m *JSONMetricRecorder) AddMetric(key, value string, created time.Time) (err error) {
+func (m *JSONMetricRecorder) AddMetric(
+	key, value string, created time.Time, labels map[string]string) (err error) {
 	defer func() {
 		if err != nil {
 			err = &errMetricsData{err}
@@ -203,7 +209,12 @@ func (m *JSONMetricRecorder) AddMetric(key, value string, created time.Time) (er
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return errors.Trace(m.enc.Encode(jujuc.Metric{Key: key, Value: value, Time: created}))
+	return errors.Trace(m.enc.Encode(jujuc.Metric{
+		Key:    key,
+		Value:  value,
+		Time:   created,
+		Labels: labels,
+	}))
 }
 
 func (m *JSONMetricRecorder) validateMetric(key, value string) error {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -590,6 +590,11 @@ func (ctx *HookContext) AddMetric(key, value string, created time.Time) error {
 	return errors.New("metrics not allowed in this context")
 }
 
+// AddMetricLabels adds metrics with labels to the hook context.
+func (ctx *HookContext) AddMetricLabels(key, value string, created time.Time, labels map[string]string) error {
+	return errors.New("metrics not allowed in this context")
+}
+
 // ActionData returns the context's internal action data. It's meant to be
 // transitory; it exists to allow uniter and runner code to keep working as
 // it did; it should be considered deprecated, and not used by new clients.

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -80,6 +80,8 @@ func (s *InterfaceSuite) TestAddingMetricsInWrongContext(c *gc.C) {
 	ctx := s.GetContext(c, 1, "u/123")
 	err := ctx.AddMetric("key", "123", time.Now())
 	c.Assert(err, gc.ErrorMatches, "metrics not allowed in this context")
+	err = ctx.AddMetricLabels("key", "123", time.Now(), map[string]string{"foo": "bar"})
+	c.Assert(err, gc.ErrorMatches, "metrics not allowed in this context")
 }
 
 func (s *InterfaceSuite) TestAvailabilityZone(c *gc.C) {

--- a/worker/uniter/runner/jujuc/add-metric_test.go
+++ b/worker/uniter/runner/jujuc/add-metric_test.go
@@ -248,6 +248,22 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 				Key: "b", Value: "2", Time: time.Now(),
 				Labels: map[string]string{"foo": "bar", "baz": "quux"},
 			}},
+		}, {
+			"can't add metrics with labels",
+			[]string{"add-metric", "--labels", "foo=bar", "key=60", "key2=50.4"},
+			false,
+			1,
+			"",
+			"ERROR cannot record metric: metrics disabled\n",
+			nil,
+		}, {
+			"cannot add builtin metric with labels",
+			[]string{"add-metric", "--labels", "foo=bar", "juju-key=50"},
+			true,
+			1,
+			"",
+			"ERROR juju-key uses a reserved prefix\n",
+			nil,
 		}}
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -181,6 +181,8 @@ type ContextLeadership interface {
 type ContextMetrics interface {
 	// AddMetric records a metric to return after hook execution.
 	AddMetric(string, string, time.Time) error
+	// AddMetricLabels records a metric with tags to return after hook execution.
+	AddMetricLabels(string, string, time.Time, map[string]string) error
 }
 
 // ContextStorage is the part of a hook context related to storage

--- a/worker/uniter/runner/jujuc/jujuctesting/metrics.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/metrics.go
@@ -25,6 +25,16 @@ func (m *Metrics) AddMetric(key, value string, created time.Time) {
 	})
 }
 
+// AddMetricLabels adds a Metric with labels for the provided data.
+func (m *Metrics) AddMetricLabels(key, value string, created time.Time, labels map[string]string) {
+	m.Metrics = append(m.Metrics, jujuc.Metric{
+		Key:    key,
+		Value:  value,
+		Time:   created,
+		Labels: labels,
+	})
+}
+
 // ContextMetrics is a test double for jujuc.ContextMetrics.
 type ContextMetrics struct {
 	contextBase
@@ -39,5 +49,16 @@ func (c *ContextMetrics) AddMetric(key, value string, created time.Time) error {
 	}
 
 	c.info.AddMetric(key, value, created)
+	return nil
+}
+
+// AddMetricLabels implements jujuc.ContextMetrics.
+func (c *ContextMetrics) AddMetricLabels(key, value string, created time.Time, labels map[string]string) error {
+	c.stub.AddCall("AddMetricLabels", key, value, created, labels)
+	if err := c.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	c.info.AddMetricLabels(key, value, created, labels)
 	return nil
 }

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -100,6 +100,11 @@ func (*RestrictedContext) WriteLeaderSettings(map[string]string) error { return 
 // AddMetric implements hooks.Context.
 func (*RestrictedContext) AddMetric(string, string, time.Time) error { return ErrRestrictedContext }
 
+// AddMetricLabels implements hooks.Context.
+func (*RestrictedContext) AddMetricLabels(string, string, time.Time, map[string]string) error {
+	return ErrRestrictedContext
+}
+
 // StorageTags implements hooks.Context.
 func (*RestrictedContext) StorageTags() ([]names.StorageTag, error) { return nil, ErrRestrictedContext }
 

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -85,6 +85,19 @@ func (c *Context) AddMetric(key, value string, created time.Time) error {
 	return c.Context.AddMetric(key, value, created)
 }
 
+func (c *Context) AddMetricLabels(key, value string, created time.Time, labels map[string]string) error {
+	if !c.canAddMetrics {
+		return fmt.Errorf("metrics disabled")
+	}
+	c.metrics = append(c.metrics, jujuc.Metric{
+		Key:    key,
+		Value:  value,
+		Time:   created,
+		Labels: labels,
+	})
+	return c.Context.AddMetricLabels(key, value, created, labels)
+}
+
 func (c *Context) RequestReboot(priority jujuc.RebootPriority) error {
 	c.rebootPriority = priority
 	if c.shouldError {


### PR DESCRIPTION
## Description of change

> Why is this change needed?

Labels will enable aggregating KPI metrics by application-specific
criteria.

## QA steps

> How do we verify that the change works?

Deploy a charm that uses the new `add-metric --labels` option in its collect-metrics hook. Verify that metrics are collected with labels.

## Documentation changes

> Does it affect current user workflow? CLI? API?

Yes, the `add-metric --labels` option will be added to the Juju metrics documentation.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A