### PR TITLE
Adds check to enable-ha for when no juju-ha-space is set.

### DIFF
--- a/api/highavailability/client_test.go
+++ b/api/highavailability/client_test.go
@@ -4,7 +4,6 @@
 package highavailability_test
 
 import (
-	"fmt"
 	stdtesting "testing"
 
 	jc "github.com/juju/testing/checkers"

--- a/api/highavailability/client_test.go
+++ b/api/highavailability/client_test.go
@@ -4,6 +4,7 @@
 package highavailability_test
 
 import (
+	"fmt"
 	stdtesting "testing"
 
 	jc "github.com/juju/testing/checkers"
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/juju/api/highavailability"
 	"github.com/juju/juju/constraints"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/presence"
 	coretesting "github.com/juju/juju/testing"
@@ -47,12 +49,19 @@ func setAgentPresence(c *gc.C, s *jujutesting.JujuConnSuite, machineId string) *
 }
 
 func assertEnableHA(c *gc.C, s *jujutesting.JujuConnSuite) {
-	_, err := s.State.AddMachine("quantal", state.JobManageModel)
+	m, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
 	// We have to ensure the agents are alive, or EnableHA will
 	// create more to replace them.
 	pingerA := setAgentPresence(c, s, "0")
 	defer assertKill(c, pingerA)
+
+	err = m.SetMachineAddresses(
+		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
+		network.NewScopedAddress("cloud-local0.internal", network.ScopeCloudLocal),
+		network.NewScopedAddress("fc00::1", network.ScopePublic),
+	)
+	c.Assert(err, jc.ErrorIsNil)
 
 	emptyCons := constraints.Value{}
 	client := highavailability.NewClient(s.APIState)

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -6,6 +6,7 @@ package highavailability
 import (
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -165,6 +166,8 @@ func (api *HighAvailabilityAPI) enableHASingle(st *state.State, spec params.Cont
 // validateCurrentControllers checks for a scenario where there is no HA space
 // in controller configuration and more than one machine-local address on any
 // of the controller machines. An error is returned if it is detected.
+// When HA space is set, there are other code paths that ensure controllers
+// have at least one address in the space.
 func validateCurrentControllers(st *state.State, cfg controller.Config, machineIds []string) error {
 	if cfg.JujuHASpace() != "" {
 		return nil
@@ -183,7 +186,9 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 	}
 	if len(badIds) > 0 {
 		return errors.Errorf(
-			"juju-ha-space is not set and a unique cloud-local address was not found for machines: %v", badIds)
+			"juju-ha-space is not set and a unique cloud-local address was not found for machines: %s",
+			strings.Join(badIds, ", "),
+		)
 	}
 	return nil
 }

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -208,7 +208,7 @@ func getBootstrapConstraints(st *state.State, machineIds []string) (constraints.
 		controllerIds = append(controllerIds, idNum)
 	}
 	if len(controllerIds) == 0 {
-		errors.Errorf("internal error, failed to find any controllers")
+		return constraints.Value{}, errors.Errorf("internal error; failed to find any controllers")
 	}
 	sort.Ints(controllerIds)
 	controllerId := controllerIds[0]

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -179,8 +179,8 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 		if err != nil {
 			return errors.Annotatef(err, "reading controller id %v", id)
 		}
-		internal, ok := network.SelectInternalAddresses(controller.Addresses(), false)
-		if !ok || len(internal) > 1 {
+		internal := network.SelectInternalAddresses(controller.Addresses(), false)
+		if len(internal) != 1 {
 			badIds = append(badIds, id)
 		}
 	}

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -347,6 +347,7 @@ func (s *clientSuite) TestEnableHAPlacementTo(c *gc.C) {
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: machine1Cons,
 	})
+	c.Assert(err, jc.ErrorIsNil)
 	s.setAgentPresence(c, "1")
 
 	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
@@ -389,6 +390,7 @@ func (s *clientSuite) TestEnableHA0Preserves(c *gc.C) {
 	c.Assert(enableHAResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
 
 	s.setAgentPresence(c, "1")
@@ -419,6 +421,7 @@ func (s *clientSuite) TestEnableHA0Preserves5(c *gc.C) {
 	c.Assert(enableHAResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 5)
 	s.setAgentPresence(c, "1")
 	s.setAgentPresence(c, "2")

--- a/network/address.go
+++ b/network/address.go
@@ -378,23 +378,22 @@ func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, boo
 	return addresses[index], true
 }
 
-// SelectInternalAddresses picks one address from a slice that can be used as
-// an endpoint for juju internal communication. If there are no suitable
-// addresses, then ok is false (and a nil slice is returned).
-// If any suitable addresses are found then ok is true.
-func SelectInternalAddresses(addresses []Address, machineLocal bool) ([]Address, bool) {
+// SelectInternalAddresses picks the best addresses from a slice that can be
+// used as an endpoint for juju internal communication.
+// I nil slice is returned if there are no suitable addresses identified.
+func SelectInternalAddresses(addresses []Address, machineLocal bool) []Address {
 	indexes := bestAddressIndexes(len(addresses), func(i int) Address {
 		return addresses[i]
 	}, internalAddressMatcher(machineLocal))
 	if len(indexes) == 0 {
-		return nil, false
+		return nil
 	}
 
 	out := make([]Address, 0, len(indexes))
 	for _, index := range indexes {
 		out = append(out, addresses[index])
 	}
-	return out, true
+	return out
 }
 
 // SelectInternalHostPort picks one HostPort from a slice that can be

--- a/network/address.go
+++ b/network/address.go
@@ -366,7 +366,7 @@ func SelectPublicHostPort(hps []HostPort) string {
 
 // SelectInternalAddress picks one address from a slice that can be
 // used as an endpoint for juju internal communication. If there are
-// are no suitable addresses, then ok is false (and an empty address is
+// no suitable addresses, then ok is false (and an empty address is
 // returned). If a suitable address was found then ok is true.
 func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, bool) {
 	index := bestAddressIndex(len(addresses), func(i int) Address {
@@ -376,6 +376,25 @@ func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, boo
 		return Address{}, false
 	}
 	return addresses[index], true
+}
+
+// SelectInternalAddresses picks one address from a slice that can be used as
+// an endpoint for juju internal communication. If there are no suitable
+// addresses, then ok is false (and a nil slice is returned).
+// If any suitable addresses are found then ok is true.
+func SelectInternalAddresses(addresses []Address, machineLocal bool) ([]Address, bool) {
+	indexes := bestAddressIndexes(len(addresses), func(i int) Address {
+		return addresses[i]
+	}, internalAddressMatcher(machineLocal))
+	if len(indexes) == 0 {
+		return nil, false
+	}
+
+	out := make([]Address, 0, len(indexes))
+	for _, index := range indexes {
+		out = append(out, addresses[index])
+	}
+	return out, true
 }
 
 // SelectInternalHostPort picks one HostPort from a slice that can be

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -574,7 +574,7 @@ var selectInternalAddressesTests = []selectInternalAddressesTest{
 		},
 	},
 	{
-		about: "ok is false when no cloud-local addresses are found",
+		about: "nil is returned when no cloud-local addresses are found",
 		addresses: []network.Address{
 			network.NewScopedAddress("169.254.1.1", network.ScopeLinkLocal),
 			network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),


### PR DESCRIPTION
## Description of change

Recent changes to controller config and the peergrouper have instituted the following behaviour:
- Configurations for HA and management spaces are supplied as constraints to _bootstrap_ and _enable-ha_.
- The peergrouper will fail to elect a peer group if there is no HA space configured and if any of the candidate machines have more than one cloud-local address available for Mongo peer-group communication.

This patch introduces a smoke test upon issuing the _enable-ha_ command, prior to actioning it, that checks the *current* controller machines to ensure they have a unique communication address when no HA space is configured. 

## QA steps

Accompanying unit tests.

## Documentation changes

This behaviour should be noted in the _enable-ha_ docs.

## Bug reference

N/A
