### PR TITLE
Never write/read from s.lastStack without the mutex.

### DIFF
--- a/apiserver/logsink/logsink_test.go
+++ b/apiserver/logsink/logsink_test.go
@@ -60,7 +60,9 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 	s.abort = make(chan struct{})
 	s.written = make(chan params.LogRecord, 1)
 	s.stub.ResetCalls()
+	s.stackMu.Lock()
 	s.lastStack = nil
+	s.stackMu.Unlock()
 
 	recordStack := func() {
 		s.stackMu.Lock()


### PR DESCRIPTION
## Description of change

We were initializing it to nil at the start of the test without using the mutex.

## QA steps

Theoretically this is
```
$ cd apiserver/logsink
$ go test -race
```
However, I wasn't able to actually trigger it (maybe it only races if you actually have a failing test and it wants to print the traceback.)

## Documentation changes

None.

## Bug reference

[lp:1755796](https://bugs.launchpad.net/juju/+bug/1755796)