### PR TITLE
Fix TestProvisionerRetriesTransientErrors

### DIFF
--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1524,17 +1524,6 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	// instance has started.
 	runSetStatusGoroutine := make(chan struct{})
 	setStatusGoroutineDone := make(chan struct{})
-	defer func() {
-		if runSetStatusGoroutine != nil {
-			close(runSetStatusGoroutine)
-			runSetStatusGoroutine = nil
-		}
-		select {
-		case <-setStatusGoroutineDone:
-		case <-time.After(coretesting.LongWait):
-			c.Errorf("SetInstanceStatus goroutine failed to stop")
-		}
-	}()
 	go func() {
 		defer close(setStatusGoroutineDone)
 		for {
@@ -1557,7 +1546,6 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	}()
 	s.checkStartInstance(c, m3)
 	close(runSetStatusGoroutine)
-	runSetStatusGoroutine = nil
 
 	select {
 	case <-setStatusGoroutineDone:


### PR DESCRIPTION
The original fix using channels had a race in it. The additional fix didn't fix that race, but duplicated it.

When closing the channel to signal to the goroutine that it needs to finish, the caller *must* not then set it to nil. This is the race. The nil is being set before the other goroutine reads it. One of two things will happen, the other goroutine notices and stops, or it reads the nil value, doesn't stop and keeps trying to set the status eventually panicing as it uses the closed session.

The fix is to not set the channel to nil.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1754021