### PR TITLE
Add version tag to caas operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ check-deps:
 DOCKER_USERNAME?=jujusolutions
 JUJUD_STAGING_DIR=/tmp/jujud-operator
 JUJUD_BIN_DIR=${GOPATH}/bin
+OPERATOR_IMAGE_TAG = $(shell jujud version | cut -d- -f1,2)
 
 operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requirements.txt
 	rm -rf ${JUJUD_STAGING_DIR}
@@ -149,7 +150,7 @@ operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requi
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
-	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator ${JUJUD_STAGING_DIR}
+	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
 	docker push ${DOCKER_USERNAME}/caas-jujud-operator

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	MakeUnitSpec = makeUnitSpec
+	OperatorPod  = operatorPod
 )
 
 func PodSpec(u *unitSpec) v1.PodSpec {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -731,6 +731,9 @@ func operatorPod(appName, agentPath string) *v1.Pod {
 	configVolName := configMapName + "-volume"
 
 	appTag := names.NewApplicationTag(appName)
+	vers := version.Current
+	vers.Build = 0
+	operatorImage := fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", vers.String())
 	return &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   podName,
@@ -740,7 +743,7 @@ func operatorPod(appName, agentPath string) *v1.Pod {
 			Containers: []v1.Container{{
 				Name:            "juju-operator",
 				ImagePullPolicy: v1.PullIfNotPresent,
-				Image:           "jujusolutions/caas-jujud-operator:latest",
+				Image:           operatorImage,
 				Env: []v1.EnvVar{
 					{Name: "JUJU_APPLICATION", Value: appName},
 				},

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -4,6 +4,8 @@
 package provider_test
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"k8s.io/client-go/pkg/api/v1"
@@ -11,6 +13,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type K8sSuite struct {
@@ -81,4 +84,15 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
+	pod := provider.OperatorPod("gitlab", "/var/lib/juju")
+	vers := version.Current
+	vers.Build = 0
+	c.Assert(pod.Name, gc.Equals, "juju-operator-gitlab")
+	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
+	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", vers.String()))
+	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 1)
+	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/agent.conf")
 }


### PR DESCRIPTION
## Description of change

The make target to build a caas operator image is modified to include a tag representing the jujud version. The operator pod will pull the image corresponding with its version.

## QA steps

Deploy k8s
Deploy a CAAS charm
Check the version of the operator image to see that it matches the jujud agent version
