### PR TITLE
Fix intermittent logsink test failure.

### DIFF
--- a/apiserver/logsink/logsink_test.go
+++ b/apiserver/logsink/logsink_test.go
@@ -44,7 +44,7 @@ type logsinkSuite struct {
 	mu      sync.Mutex
 	opened  int
 	closed  int
-	stub    testing.Stub
+	stub    *testing.Stub
 	written chan params.LogRecord
 
 	logs loggo.TestWriter
@@ -59,7 +59,7 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.abort = make(chan struct{})
 	s.written = make(chan params.LogRecord, 1)
-	s.stub.ResetCalls()
+	s.stub = &testing.Stub{}
 	s.stackMu.Lock()
 	s.lastStack = nil
 	s.stackMu.Unlock()
@@ -74,7 +74,7 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 		func(req *http.Request) (logsink.LogWriteCloser, error) {
 			s.stub.AddCall("Open")
 			return &mockLogWriteCloser{
-				&s.stub,
+				s.stub,
 				s.written,
 				recordStack,
 			}, s.stub.NextErr()
@@ -197,7 +197,7 @@ func (s *logsinkSuite) TestRateLimit(c *gc.C) {
 		func(req *http.Request) (logsink.LogWriteCloser, error) {
 			s.stub.AddCall("Open")
 			return &mockLogWriteCloser{
-				&s.stub,
+				s.stub,
 				s.written,
 				nil,
 			}, s.stub.NextErr()
@@ -209,6 +209,7 @@ func (s *logsinkSuite) TestRateLimit(c *gc.C) {
 			Clock:  testClock,
 		},
 	))
+	defer s.srv.Close()
 
 	conn := s.dialWebsocket(c)
 	websockettest.AssertJSONInitialErrorNil(c, conn)


### PR DESCRIPTION
It seemed that the Close call being recorded was from a different test. To isolate each test, instead of using the same testing stub, a new instance is created for each test.

While fixing that, I think I found the cause of the extra Close. It came from TestRateLimit, which replaced the srv instance variable. I *think* that the closure for the cleanup ends up referring to the first instance of the httptest.Server rather than the one created in TestRateLimit.

This branch also makes sure that the httptest.Server created in TestRateLimit is closed at the end of the test.

https://bugs.launchpad.net/juju/+bug/1737765