### PR TITLE
CAAS models support meter status and workload version

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -199,11 +199,8 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		return nil, errors.Trace(err)
 	}
 
-	// // Only IAAS models support storage and meter status (for now).
-	var (
-		storageAPI *StorageAPI
-		msAPI      *meterstatus.MeterStatusAPI
-	)
+	// // Only IAAS models support storage (for now).
+	var storageAPI *StorageAPI
 	if m.Type() == state.ModelTypeIAAS {
 		ss, err := getStorageState(st)
 		if err != nil {
@@ -213,10 +210,10 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		if err != nil {
 			return nil, err
 		}
-		msAPI, err = meterstatus.NewMeterStatusAPI(st, resources, authorizer)
-		if err != nil {
-			return nil, errors.Annotate(err, "could not create meter status API handler")
-		}
+	}
+	msAPI, err := meterstatus.NewMeterStatusAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Annotate(err, "could not create meter status API handler")
 	}
 	accessUnitOrApplication := common.AuthAny(accessUnit, accessApplication)
 

--- a/state/application.go
+++ b/state/application.go
@@ -1333,28 +1333,24 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		Status:  status.Allocating,
 		Updated: now.UnixNano(),
 	}
-	var (
-		unitStatusDoc      *statusDoc
-		workloadVersionDoc *statusDoc
-		meterStatus        *meterStatusDoc
-	)
 
 	model, err := a.st.Model()
 	if err != nil {
 		return "", nil, errors.Trace(err)
 	}
-	unitStatusDoc = &statusDoc{
+	unitStatusDoc := &statusDoc{
 		Status:     status.Waiting,
 		StatusInfo: status.MessageWaitForContainer,
 		Updated:    now.UnixNano(),
 	}
+	meterStatus := &meterStatusDoc{Code: MeterNotSet.String()}
+
+	workloadVersionDoc := &statusDoc{
+		Status:  status.Unknown,
+		Updated: now.UnixNano(),
+	}
 	if model.Type() != ModelTypeCAAS {
 		unitStatusDoc.StatusInfo = status.MessageWaitForMachine
-		workloadVersionDoc = &statusDoc{
-			Status:  status.Unknown,
-			Updated: now.UnixNano(),
-		}
-		meterStatus = &meterStatusDoc{Code: MeterNotSet.String()}
 	}
 	var containerDoc *cloudContainerDoc
 	if model.Type() == ModelTypeCAAS {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1873,13 +1873,18 @@ func (s *ApplicationSuite) TestAddCAASUnit(c *gc.C) {
 	c.Assert(unitZero.SubordinateNames(), gc.HasLen, 0)
 	c.Assert(state.GetUnitModelUUID(unitZero), gc.Equals, st.ModelUUID())
 
-	// CAAS units have no workload version, nor meter status.
-	vers, err := unitZero.WorkloadVersion()
+	err = unitZero.SetWorkloadVersion("3.combined")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(vers, gc.Equals, "")
+	version, err := unitZero.WorkloadVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(version, gc.Equals, "3.combined")
+
+	err = unitZero.SetMeterStatus(state.MeterGreen.String(), "all good")
+	c.Assert(err, jc.ErrorIsNil)
 	ms, err := unitZero.GetMeterStatus()
-	c.Assert(err, gc.NotNil)
-	c.Assert(ms.Code, gc.Equals, state.MeterNotAvailable)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ms.Code, gc.Equals, state.MeterGreen)
+	c.Assert(ms.Info, gc.Equals, "all good")
 
 	// But they do have status.
 	us, err := unitZero.Status()

--- a/state/unit.go
+++ b/state/unit.go
@@ -2798,15 +2798,6 @@ func addUnitOps(st *State, args addUnitOpsArgs) ([]txn.Op, error) {
 	// TODO: consider the constraints op
 	// TODO: consider storageOps
 	var prereqOps []txn.Op
-	if args.workloadStatusDoc != nil {
-		prereqOps = append(prereqOps, createStatusOp(st, unitGlobalKey(name), *args.workloadStatusDoc))
-	}
-	if args.meterStatusDoc != nil {
-		prereqOps = append(prereqOps, createMeterStatusOp(st, agentGlobalKey, args.meterStatusDoc))
-	}
-	if args.workloadVersionDoc != nil {
-		prereqOps = append(prereqOps, createStatusOp(st, globalWorkloadVersionKey(name), *args.workloadVersionDoc))
-	}
 	if args.containerDoc != nil {
 		prereqOps = append(prereqOps, txn.Op{
 			C:      cloudContainersC,
@@ -2817,6 +2808,9 @@ func addUnitOps(st *State, args addUnitOpsArgs) ([]txn.Op, error) {
 	}
 	prereqOps = append(prereqOps,
 		createStatusOp(st, agentGlobalKey, args.agentStatusDoc),
+		createStatusOp(st, unitGlobalKey(name), *args.workloadStatusDoc),
+		createMeterStatusOp(st, agentGlobalKey, args.meterStatusDoc),
+		createStatusOp(st, globalWorkloadVersionKey(name), *args.workloadVersionDoc),
 	)
 
 	// Freshly-created units will not have a charm URL set; migrated


### PR DESCRIPTION
## Description of change

CAAS models used to arbitrarily disallow meter status and workload version for units.
Remove that restriction. 

## QA steps

Run unit tests. Upstream K8s is currently broken.
https://github.com/kubernetes/kubernetes/issues/61076