### PR TITLE
Peergrouper Watches Controller Config

### DIFF
--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -156,10 +156,10 @@ func desiredPeerGroup(info *peerGroupInfo) (map[string]*replicaset.Member, map[s
 	logger.Debugf(info.getLogMessage())
 
 	peerChanges := peerGroupChanges{
-		isChanged:                   false,
-		machineVoting:               map[string]bool{},
-		addrs:                       map[string]string{},
-		members:                     map[string]*replicaset.Member{},
+		isChanged:     false,
+		machineVoting: map[string]bool{},
+		addrs:         map[string]string{},
+		members:       map[string]*replicaset.Member{},
 	}
 
 	// We may find extra peer group members if the machines have been removed
@@ -327,10 +327,12 @@ func (p *peerGroupChanges) possiblePeerGroupChanges(info *peerGroupInfo) {
 				logger.Debugf("machine %q is a potential voter", id)
 				p.toAddVote = append(p.toAddVote, id)
 			} else if member != nil {
-				logger.Debugf("machine %q exists but is not ready (status: %v, healthy: %v)", id, status.State, status.Healthy)
+				logger.Debugf("machine %q exists but is not ready (status: %v, healthy: %v)",
+					id, status.State, status.Healthy)
 				p.toKeepNonVoting = append(p.toKeepNonVoting, id)
 			} else {
-				logger.Debugf("machine %q doesn't exists and is not ready (status: %v, healthy: %v)", id, status.State, status.Healthy)
+				logger.Debugf("machine %q doesn't exists and is not ready (status: %v, healthy: %v)",
+					id, status.State, status.Healthy)
 				p.toKeepCreateNonVotingMember = append(p.toKeepCreateNonVotingMember, id)
 			}
 		case !wantsVote && isVoting:
@@ -358,7 +360,6 @@ func setMemberVoting(member *replicaset.Member, voting bool) {
 
 // adjustVotes removes and adds votes to the members via setVoting.
 func (p *peerGroupChanges) adjustVotes() {
-
 	setVoting := func(memberIds []string, voting bool) {
 		for _, id := range memberIds {
 			setMemberVoting(p.members[id], voting)
@@ -429,17 +430,9 @@ func (p *peerGroupChanges) updateAddresses() {
 			p.isChanged = true
 		}
 	}
-	//return p.isChanged
 }
 
 func isReady(status replicaset.MemberStatus) bool {
 	return status.Healthy && (status.State == replicaset.PrimaryState ||
 		status.State == replicaset.SecondaryState)
-}
-
-func min(i, j int) int {
-	if i < j {
-		return i
-	}
-	return j
 }

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -312,7 +312,7 @@ func (p *peerGroupChanges) possiblePeerGroupChanges(info *peerGroupInfo) {
 		machineIds = append(machineIds, id)
 	}
 	sort.Strings(machineIds)
-	logger.Debugf("assessing possible peer group changes:")
+	logger.Debugf("assessing possible peer group changes:")1
 	for _, id := range machineIds {
 		m := info.machines[id]
 		member := p.members[id]
@@ -331,7 +331,7 @@ func (p *peerGroupChanges) possiblePeerGroupChanges(info *peerGroupInfo) {
 					id, status.State, status.Healthy)
 				p.toKeepNonVoting = append(p.toKeepNonVoting, id)
 			} else {
-				logger.Debugf("machine %q doesn't exists and is not ready (status: %v, healthy: %v)",
+				logger.Debugf("machine %q does not exist and is not ready (status: %v, healthy: %v)",
 					id, status.State, status.Healthy)
 				p.toKeepCreateNonVotingMember = append(p.toKeepCreateNonVotingMember, id)
 			}

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -312,7 +312,7 @@ func (p *peerGroupChanges) possiblePeerGroupChanges(info *peerGroupInfo) {
 		machineIds = append(machineIds, id)
 	}
 	sort.Strings(machineIds)
-	logger.Debugf("assessing possible peer group changes:")1
+	logger.Debugf("assessing possible peer group changes:")
 	for _, id := range machineIds {
 		m := info.machines[id]
 		member := p.members[id]

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -226,6 +226,7 @@ func (w *pgWorker) loop() error {
 			// Continuing is OK because subsequent invocations of the loop will
 			// pick up the most recent config from state anyway.
 			if len(w.machineTrackers) == 0 {
+				logger.Tracef("no controller information, ignoring config change")
 				continue
 			}
 		case <-updateChan:

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -446,6 +446,13 @@ func (s *workerSuite) TestControllersArePublished(c *gc.C) {
 			c.Fatalf("timed out waiting for publish")
 		}
 
+		// If a config change wakes up the loop *after* the controller topology
+		// is published, then we will get another call to setAPIHostPorts.
+		select {
+		case <-publishCh:
+		case <-time.After(coretesting.ShortWait):
+		}
+
 		// Change one of the server API addresses and check that it is
 		// published.
 		newMachine10Addresses := network.NewAddresses(ipVersion.extraHost)

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -99,7 +99,7 @@ func InitState(c *gc.C, st *fakeState, numMachines int, ipVersion TestIPVersion)
 	st.session.Set(mkMembers("0v", ipVersion))
 	st.session.setStatus(mkStatuses("0p", ipVersion))
 	st.check = checkInvariants
-	st.controllerConfig = controller.Config{}
+	st.controllerConfig.Set(controller.Config{})
 }
 
 // ExpectedAPIHostPorts returns the expected addresses
@@ -512,7 +512,7 @@ func (s *workerSuite) TestControllersArePublishedOverHubWithNewVoters(c *gc.C) {
 	st.session.Set(mkMembers("0v 1 2", testIPv4))
 	st.session.setStatus(mkStatuses("0p 1s 2s", testIPv4))
 	st.check = checkInvariants
-	st.controllerConfig = controller.Config{}
+	st.controllerConfig.Set(controller.Config{})
 
 	hub := pubsub.NewStructuredHub(nil)
 	event := make(chan apiserver.Details)


### PR DESCRIPTION
## Description of change

When controller configuration is updated (in particular HA and management spaces), we want to wake up the peergrouper worker loop immediately.

## QA steps

- Configure MAAS to ensure that there are 3 nodes, each with addresses in 2 spaces common to all.
- Bootstrap with one of the spaces as HA space in controller config.
- Enable HA.
- Update the controller config HA space to the other common space.
- Ensure that everything is still working and that the Mongo rs.status() looks OK.

## Documentation changes

Ultimately, yes.

## Bug reference

N/A
