### PR TITLE
Add support for destroying caas models

### DIFF
--- a/api/undertaker/undertaker.go
+++ b/api/undertaker/undertaker.go
@@ -43,7 +43,7 @@ func (c *Client) ModelInfo() (params.UndertakerModelInfoResult, error) {
 	return result, errors.Trace(err)
 }
 
-// ProcessDyingModel checks if a dying model has any machines or services.
+// ProcessDyingModel checks if a dying model has any machines or applications.
 // If there are none, the model's life is changed from dying to dead.
 func (c *Client) ProcessDyingModel() error {
 	return c.entityFacadeCall("ProcessDyingModel", nil)
@@ -82,7 +82,7 @@ func (c *Client) entityFacadeCall(name string, results interface{}) error {
 }
 
 // WatchModelResources starts a watcher for changes to the model's
-// machines and services.
+// machines and applications.
 func (c *Client) WatchModelResources() (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	err := c.entityFacadeCall("WatchModelResources", &results)

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -38,6 +38,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Singular",
 	"StatusHistory",
 	"StringsWatcher",
+	"Undertaker",
 	"Uniter",
 )
 

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -56,11 +56,11 @@ type Broker interface {
 	// Provider returns the ContainerEnvironProvider that created this Broker.
 	Provider() ContainerEnvironProvider
 
+	// Destroy terminates all containers and other resources in this broker's namespace.
+	Destroy() error
+
 	// EnsureNamespace ensures this broker's namespace is created.
 	EnsureNamespace() error
-
-	// DeleteNamespace deletes this broker's namespace.
-	DeleteNamespace() error
 
 	// EnsureOperator creates or updates an operator pod for running
 	// a charm for the specified application.

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -223,15 +223,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// that it happens sometimes, even when we try to avoid
 		// it.
 
-		// The undertaker is currently the only ifNotAlive worker.
-		undertakerName: ifNotUpgrading(ifNotAlive(undertaker.Manifold(undertaker.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-
-			NewFacade: undertaker.NewFacade,
-			NewWorker: undertaker.NewWorker,
-		}))),
-
 		charmRevisionUpdaterName: ifNotMigrating(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
 			APICallerName: apiCallerName,
 			ClockName:     clockName,
@@ -327,6 +318,15 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// that it happens sometimes, even when we try to avoid
 		// it.
 
+		// The undertaker is currently the only ifNotAlive worker.
+		undertakerName: ifNotUpgrading(ifNotAlive(undertaker.Manifold(undertaker.ManifoldConfig{
+			APICallerName:      apiCallerName,
+			CloudDestroyerName: environTrackerName,
+
+			NewFacade: undertaker.NewFacade,
+			NewWorker: undertaker.NewWorker,
+		}))),
+
 		// All the rest depend on ifNotMigrating.
 		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
 			AgentName:          agentName,
@@ -395,6 +395,16 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	agentConfig := config.Agent.CurrentConfig()
 	modelTag := agentConfig.Model()
 	manifolds := dependency.Manifolds{
+
+		// The undertaker is currently the only ifNotAlive worker.
+		undertakerName: ifNotUpgrading(ifNotAlive(undertaker.Manifold(undertaker.ManifoldConfig{
+			APICallerName:      apiCallerName,
+			CloudDestroyerName: caasBrokerTrackerName,
+
+			NewFacade: undertaker.NewFacade,
+			NewWorker: undertaker.NewWorker,
+		}))),
+
 		caasBrokerTrackerName: ifResponsible(caasbroker.Manifold(caasbroker.ManifoldConfig{
 			APICallerName:          apiCallerName,
 			NewContainerBrokerFunc: config.NewContainerBrokerFunc,

--- a/cmd/modelcmd/clientstore.go
+++ b/cmd/modelcmd/clientstore.go
@@ -43,20 +43,20 @@ func (s QualifyingClientStore) QualifiedModelName(controllerName, modelName stri
 
 // Implements jujuclient.ModelGetter.
 func (s QualifyingClientStore) ModelByName(controllerName, modelName string) (*jujuclient.ModelDetails, error) {
-	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	qualifiedModelName, err := s.QualifiedModelName(controllerName, modelName)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting model %q", modelName)
 	}
-	return s.ClientStore.ModelByName(controllerName, modelName)
+	return s.ClientStore.ModelByName(controllerName, qualifiedModelName)
 }
 
 // Implements jujuclient.ModelUpdater.
 func (s QualifyingClientStore) UpdateModel(controllerName, modelName string, details jujuclient.ModelDetails) error {
-	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	qualifiedModelName, err := s.QualifiedModelName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotatef(err, "updating model %q", modelName)
 	}
-	return s.ClientStore.UpdateModel(controllerName, modelName, details)
+	return s.ClientStore.UpdateModel(controllerName, qualifiedModelName, details)
 }
 
 // Implements jujuclient.ModelUpdater.
@@ -74,18 +74,18 @@ func (s QualifyingClientStore) SetModels(controllerName string, models map[strin
 
 // Implements jujuclient.ModelUpdater.
 func (s QualifyingClientStore) SetCurrentModel(controllerName, modelName string) error {
-	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	qualifiedModelName, err := s.QualifiedModelName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotatef(err, "setting current model to %q", modelName)
 	}
-	return s.ClientStore.SetCurrentModel(controllerName, modelName)
+	return s.ClientStore.SetCurrentModel(controllerName, qualifiedModelName)
 }
 
 // Implements jujuclient.ModelRemover.
 func (s QualifyingClientStore) RemoveModel(controllerName, modelName string) error {
-	modelName, err := s.QualifiedModelName(controllerName, modelName)
+	qualifiedModelName, err := s.QualifiedModelName(controllerName, modelName)
 	if err != nil {
 		return errors.Annotatef(err, "removing model %q", modelName)
 	}
-	return s.ClientStore.RemoveModel(controllerName, modelName)
+	return s.ClientStore.RemoveModel(controllerName, qualifiedModelName)
 }

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -1,6 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package modelcmd
 
-import "github.com/juju/cmd"
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/jujuclient"
+)
 
 var NewAPIContext = newAPIContext
 
@@ -14,4 +21,10 @@ func InitContexts(c *cmd.Context, b interface {
 	initContexts(*cmd.Context)
 }) {
 	b.initContexts(c)
+}
+
+func SetModelRefresh(refresh func(jujuclient.ClientStore, string) error, b interface {
+	SetModelRefresh(refresh func(jujuclient.ClientStore, string) error)
+}) {
+	b.SetModelRefresh(refresh)
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -228,6 +228,18 @@ type ConfigGetter interface {
 	Config() *config.Config
 }
 
+// CloudDestroyer provides the API to cleanup cloud resources.
+type CloudDestroyer interface {
+	// Destroy shuts down all known machines and destroys the
+	// rest of the environment. Note that on some providers,
+	// very recently started instances may not be destroyed
+	// because they are not yet visible.
+	//
+	// When Destroy has been called, any Environ referring to the
+	// same remote environment may become invalid.
+	Destroy() error
+}
+
 // An Environ represents a Juju environment.
 //
 // Due to the limitations of some providers (for example ec2), the
@@ -247,6 +259,9 @@ type Environ interface {
 	// StorageProviders returned from Environ.StorageProvider will
 	// be scoped specifically to that Environ.
 	storage.ProviderRegistry
+
+	// CloudDestroyer provides the API to cleanup cloud resources.
+	CloudDestroyer
 
 	// PrepareForBootstrap prepares an environment for bootstrapping.
 	//
@@ -324,15 +339,6 @@ type Environ interface {
 	// If it can be determined that the environment has not been bootstrapped,
 	// then ErrNotBootstrapped should be returned instead.
 	ControllerInstances(controllerUUID string) ([]instance.Id, error)
-
-	// Destroy shuts down all known machines and destroys the
-	// rest of the environment. Note that on some providers,
-	// very recently started instances may not be destroyed
-	// because they are not yet visible.
-	//
-	// When Destroy has been called, any Environ referring to the
-	// same remote environment may become invalid.
-	Destroy() error
 
 	// DestroyController is similar to Destroy() in that it destroys
 	// the model, which in this case will be the controller model.

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -264,10 +264,10 @@ func (st *State) modelQueryForUser(user names.UserTag, isSuperuser bool) (mongo.
 }
 
 type ModelAccessInfo struct {
-	Name           string `bson:"name"`
-	UUID           string `bson:"_id"`
-	Owner          string `bson:"owner"`
-	Type           ModelType
+	Name           string    `bson:"name"`
+	UUID           string    `bson:"_id"`
+	Owner          string    `bson:"owner"`
+	Type           ModelType `bson:"type"`
 	LastConnection time.Time
 }
 
@@ -283,7 +283,7 @@ func (st *State) ModelBasicInfoForUser(user names.UserTag) ([]ModelAccessInfo, e
 		return nil, errors.Trace(err)
 	}
 	defer closer1()
-	modelQuery.Select(bson.M{"_id": 1, "name": 1, "owner": 1})
+	modelQuery.Select(bson.M{"_id": 1, "name": 1, "owner": 1, "type": 1})
 	var accessInfo []ModelAccessInfo
 	if err := modelQuery.All(&accessInfo); err != nil {
 		return nil, errors.Trace(err)
@@ -308,14 +308,9 @@ func (st *State) ModelBasicInfoForUser(user names.UserTag) ([]ModelAccessInfo, e
 	if err := iter.Close(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	for i := range accessInfo {
 		uuid := accessInfo[i].UUID
 		accessInfo[i].LastConnection = lastConns[uuid]
-		accessInfo[i].Type = model.Type()
 	}
 	return accessInfo, nil
 }

--- a/worker/caasbroker/manifold.go
+++ b/worker/caasbroker/manifold.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/caasagent"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -55,10 +56,13 @@ func manifoldOutput(in worker.Worker, out interface{}) error {
 	if !ok {
 		return errors.Errorf("expected *broker.Tracker, got %T", in)
 	}
-	outBroker, ok := out.(*caas.Broker)
-	if !ok {
-		return errors.Errorf("expected *caas.Broker, got %T", out)
+	switch result := out.(type) {
+	case *caas.Broker:
+		*result = inTracker.Broker()
+	case *environs.CloudDestroyer:
+		*result = inTracker.Broker()
+	default:
+		return errors.Errorf("expected *caas.Broker or *environs.CloudDestroyer, got %T", out)
 	}
-	*outBroker = inTracker.Broker()
 	return nil
 }

--- a/worker/environ/manifold.go
+++ b/worker/environ/manifold.go
@@ -55,10 +55,13 @@ func manifoldOutput(in worker.Worker, out interface{}) error {
 	if !ok {
 		return errors.Errorf("expected *environ.Tracker, got %T", in)
 	}
-	outEnviron, ok := out.(*environs.Environ)
-	if !ok {
-		return errors.Errorf("expected *environs.Environ, got %T", out)
+	switch result := out.(type) {
+	case *environs.Environ:
+		*result = inTracker.Environ()
+	case *environs.CloudDestroyer:
+		*result = inTracker.Environ()
+	default:
+		return errors.Errorf("expected *environs.Environ or *environs.CloudDestroyer, got %T", out)
 	}
-	*outEnviron = inTracker.Environ()
 	return nil
 }

--- a/worker/undertaker/manifold_test.go
+++ b/worker/undertaker/manifold_test.go
@@ -5,10 +5,11 @@ package undertaker_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/environs"
@@ -17,45 +18,83 @@ import (
 	"github.com/juju/juju/worker/undertaker"
 )
 
-type ManifoldSuite struct {
+type manifoldSuite struct {
 	testing.IsolationSuite
+	modelType string
 }
 
-var _ = gc.Suite(&ManifoldSuite{})
+type CAASManifoldSuite struct {
+	manifoldSuite
+}
 
-func (*ManifoldSuite) TestInputs(c *gc.C) {
-	manifold := undertaker.Manifold(namesConfig())
+type IAASManifoldSuite struct {
+	manifoldSuite
+}
+
+var (
+	_ = gc.Suite(&IAASManifoldSuite{})
+	_ = gc.Suite(&CAASManifoldSuite{})
+)
+
+func (s *CAASManifoldSuite) SetUpTest(c *gc.C) {
+	s.modelType = "caas"
+}
+
+func (s *IAASManifoldSuite) SetUpTest(c *gc.C) {
+	s.modelType = "iaas"
+}
+
+func (s *manifoldSuite) destroyerName() string {
+	if s.modelType == "iaas" {
+		return "environ"
+	}
+	return "broker"
+}
+
+func (s *manifoldSuite) namesConfig() undertaker.ManifoldConfig {
+	destroyerName := "environ"
+	if s.modelType == "caas" {
+		destroyerName = "broker"
+	}
+	return undertaker.ManifoldConfig{
+		APICallerName:      "api-caller",
+		CloudDestroyerName: destroyerName,
+	}
+}
+
+func (s *manifoldSuite) TestInputs(c *gc.C) {
+	manifold := undertaker.Manifold(s.namesConfig())
 	c.Check(manifold.Inputs, jc.DeepEquals, []string{
-		"api-caller", "environ",
+		"api-caller", s.destroyerName(),
 	})
 }
 
-func (*ManifoldSuite) TestOutput(c *gc.C) {
-	manifold := undertaker.Manifold(namesConfig())
+func (s *manifoldSuite) TestOutput(c *gc.C) {
+	manifold := undertaker.Manifold(s.namesConfig())
 	c.Check(manifold.Output, gc.IsNil)
 }
 
-func (*ManifoldSuite) TestAPICallerMissing(c *gc.C) {
+func (s *manifoldSuite) TestAPICallerMissing(c *gc.C) {
 	resources := resourcesMissing("api-caller")
-	manifold := undertaker.Manifold(namesConfig())
+	manifold := undertaker.Manifold(s.namesConfig())
 
 	worker, err := manifold.Start(resources.Context())
 	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
 	c.Check(worker, gc.IsNil)
 }
 
-func (*ManifoldSuite) TestEnvironMissing(c *gc.C) {
-	resources := resourcesMissing("environ")
-	manifold := undertaker.Manifold(namesConfig())
+func (s *manifoldSuite) TestEnvironMissing(c *gc.C) {
+	resources := resourcesMissing("environ", "broker")
+	manifold := undertaker.Manifold(s.namesConfig())
 
 	worker, err := manifold.Start(resources.Context())
 	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
 	c.Check(worker, gc.IsNil)
 }
 
-func (*ManifoldSuite) TestNewFacadeError(c *gc.C) {
+func (s *manifoldSuite) TestNewFacadeError(c *gc.C) {
 	resources := resourcesMissing()
-	config := namesConfig()
+	config := s.namesConfig()
 	config.NewFacade = func(apiCaller base.APICaller) (undertaker.Facade, error) {
 		checkResource(c, apiCaller, resources, "api-caller")
 		return nil, errors.New("blort")
@@ -67,16 +106,16 @@ func (*ManifoldSuite) TestNewFacadeError(c *gc.C) {
 	c.Check(worker, gc.IsNil)
 }
 
-func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
+func (s *manifoldSuite) TestNewWorkerError(c *gc.C) {
 	resources := resourcesMissing()
 	expectFacade := &fakeFacade{}
-	config := namesConfig()
+	config := s.namesConfig()
 	config.NewFacade = func(_ base.APICaller) (undertaker.Facade, error) {
 		return expectFacade, nil
 	}
 	config.NewWorker = func(cfg undertaker.Config) (worker.Worker, error) {
 		c.Check(cfg.Facade, gc.Equals, expectFacade)
-		checkResource(c, cfg.Environ, resources, "environ")
+		checkResource(c, cfg.Destroyer, resources, s.destroyerName())
 		return nil, errors.New("lhiis")
 	}
 	manifold := undertaker.Manifold(config)
@@ -86,9 +125,9 @@ func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
 	c.Check(worker, gc.IsNil)
 }
 
-func (*ManifoldSuite) TestNewWorkerSuccess(c *gc.C) {
+func (s *manifoldSuite) TestNewWorkerSuccess(c *gc.C) {
 	expectWorker := &fakeWorker{}
-	config := namesConfig()
+	config := s.namesConfig()
 	config.NewFacade = func(_ base.APICaller) (undertaker.Facade, error) {
 		return &fakeFacade{}, nil
 	}
@@ -103,17 +142,11 @@ func (*ManifoldSuite) TestNewWorkerSuccess(c *gc.C) {
 	c.Check(worker, gc.Equals, expectWorker)
 }
 
-func namesConfig() undertaker.ManifoldConfig {
-	return undertaker.ManifoldConfig{
-		APICallerName: "api-caller",
-		EnvironName:   "environ",
-	}
-}
-
 func resourcesMissing(missing ...string) dt.StubResources {
 	resources := dt.StubResources{
 		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
 		"environ":    dt.StubResource{Output: &fakeEnviron{}},
+		"broker":     dt.StubResource{Output: &fakeBroker{}},
 	}
 	for _, name := range missing {
 		resources[name] = dt.StubResource{Error: dependency.ErrMissing}
@@ -131,6 +164,10 @@ type fakeAPICaller struct {
 
 type fakeEnviron struct {
 	environs.Environ
+}
+
+type fakeBroker struct {
+	caas.Broker
 }
 
 type fakeFacade struct {

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -28,8 +28,8 @@ type Facade interface {
 // Config holds the resources and configuration necessary to run an
 // undertaker worker.
 type Config struct {
-	Facade  Facade
-	Environ environs.Environ
+	Facade    Facade
+	Destroyer environs.CloudDestroyer
 }
 
 // Validate returns an error if the config cannot be expected to drive
@@ -38,8 +38,8 @@ func (config Config) Validate() error {
 	if config.Facade == nil {
 		return errors.NotValidf("nil Facade")
 	}
-	if config.Environ == nil {
-		return errors.NotValidf("nil Environ")
+	if config.Destroyer == nil {
+		return errors.NotValidf("nil Destroyer")
 	}
 	return nil
 }
@@ -131,7 +131,7 @@ func (u *Undertaker) run() error {
 	); err != nil {
 		return errors.Trace(err)
 	}
-	if err := u.config.Environ.Destroy(); err != nil {
+	if err := u.config.Destroyer.Destroy(); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/worker/undertaker/validate_test.go
+++ b/worker/undertaker/validate_test.go
@@ -24,16 +24,16 @@ func (*ValidateSuite) TestNilFacade(c *gc.C) {
 	checkInvalid(c, config, "nil Facade not valid")
 }
 
-func (*ValidateSuite) TestNilEnviron(c *gc.C) {
+func (*ValidateSuite) TestNilDestroyer(c *gc.C) {
 	config := validConfig()
-	config.Environ = nil
-	checkInvalid(c, config, "nil Environ not valid")
+	config.Destroyer = nil
+	checkInvalid(c, config, "nil Destroyer not valid")
 }
 
 func validConfig() undertaker.Config {
 	return undertaker.Config{
-		Facade:  &fakeFacade{},
-		Environ: &fakeEnviron{},
+		Facade:    &fakeFacade{},
+		Destroyer: &fakeEnviron{},
 	}
 }
 


### PR DESCRIPTION
## Description of change

juju destroy-model now works for k8s models
The main implementation step was to introduce a common CloudDestroyer interface satisfied by both a traditional cloud Environ plus a CAAS broker instance. The existing model undertaker worker is constructed using the relevant dependency.

Also fix an existing bug in state method ModelBasicInfoForUser() which was setting the incorrect model type.

As a drive by, a little cleanup of ModelCommandBase was done to fix some error messages.

## QA steps

Deploy a k8s model
juju destory-model
ensure prompts are correct and model is fully deleted and k8s resources terminated

