### PR TITLE
Remove the testing stipple by using IsolationSuite.

### DIFF
--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 type environSuite struct {
+	gitjujutesting.IsolationSuite
 	env *oracle.OracleEnviron
 }
 

--- a/provider/oracle/images_test.go
+++ b/provider/oracle/images_test.go
@@ -6,6 +6,7 @@ package oracle_test
 import (
 	"errors"
 
+	gitjujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/imagemetadata"
@@ -14,7 +15,9 @@ import (
 	oracletesting "github.com/juju/juju/provider/oracle/testing"
 )
 
-type imageSuite struct{}
+type imageSuite struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&imageSuite{})
 

--- a/provider/oracle/instance_test.go
+++ b/provider/oracle/instance_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/juju/go-oracle-cloud/response"
+	gitjujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -20,6 +21,7 @@ import (
 )
 
 type instanceSuite struct {
+	gitjujutesting.IsolationSuite
 	env   *oracle.OracleEnviron
 	mutex *sync.Mutex
 }

--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type firewallSuite struct{}
+type firewallSuite struct{
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&firewallSuite{})
 var clk = gitjujutesting.NewClock(time.Time{})

--- a/provider/oracle/networking_test.go
+++ b/provider/oracle/networking_test.go
@@ -4,6 +4,7 @@
 package oracle_test
 
 import (
+	gitjujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -12,7 +13,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type networkingSuite struct{}
+type networkingSuite struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&networkingSuite{})
 

--- a/provider/oracle/provider_test.go
+++ b/provider/oracle/provider_test.go
@@ -5,6 +5,7 @@ package oracle_test
 
 import (
 	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,7 +15,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type environProviderSuite struct{}
+type environProviderSuite struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&environProviderSuite{})
 

--- a/provider/oracle/storage_provider_test.go
+++ b/provider/oracle/storage_provider_test.go
@@ -5,6 +5,7 @@ package oracle_test
 
 import (
 	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,7 +16,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type storageProviderSuite struct{}
+type storageProviderSuite struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&storageProviderSuite{})
 

--- a/provider/oracle/storage_test.go
+++ b/provider/oracle/storage_test.go
@@ -4,6 +4,7 @@
 package oracle_test
 
 import (
+	gitjujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -13,7 +14,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type storageSuite struct{}
+type storageSuite struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&storageSuite{})
 

--- a/provider/oracle/userdata_test.go
+++ b/provider/oracle/userdata_test.go
@@ -4,6 +4,7 @@
 package oracle_test
 
 import (
+	gitjujutesting "github.com/juju/testing"
 	jujuos "github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
@@ -11,7 +12,9 @@ import (
 	"github.com/juju/juju/provider/oracle"
 )
 
-type userdataSuite struct{}
+type userdataSuite struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&userdataSuite{})
 


### PR DESCRIPTION
## Description of change

Just cleans up lots of tests. Both ensures the tests don't accidentally
do anything with $HOME, but also makes sure when there is a failure it
ends up in the right log output, but when there isn't, we don't see
testing stipple.

## QA steps

```
$ cd provider/oracle
$ go test
```

Without this change, you'll see a lot of WARNING issued. With this change, the test run should run quietly.

## Documentation changes

None.

## Bug reference

[lp:1750094](https://bugs.launchpad.net/juju/+bug/1750094)