### PR TITLE
Repair bad logic in caas unit provisioner worker

### DIFF
--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -48,7 +48,7 @@ func newApplicationWorker(
 	applicationUpdater ApplicationUpdater,
 	unitGetter UnitGetter,
 	unitUpdater UnitUpdater,
-) (worker.Worker, error) {
+) (*applicationWorker, error) {
 	w := &applicationWorker{
 		application:        application,
 		jujuManagedUnits:   jujuManagedUnits,
@@ -73,13 +73,13 @@ func newApplicationWorker(
 }
 
 // Kill is part of the worker.Worker interface.
-func (w *applicationWorker) Kill() {
-	w.catacomb.Kill(nil)
+func (aw *applicationWorker) Kill() {
+	aw.catacomb.Kill(nil)
 }
 
 // Wait is part of the worker.Worker interface.
-func (w *applicationWorker) Wait() error {
-	return w.catacomb.Wait()
+func (aw *applicationWorker) Wait() error {
+	return aw.catacomb.Wait()
 }
 
 func (aw *applicationWorker) loop() error {

--- a/worker/caasunitprovisioner/export_test.go
+++ b/worker/caasunitprovisioner/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitprovisioner
+
+import "gopkg.in/juju/worker.v1"
+
+func AppWorker(parent worker.Worker, appName string) (*applicationWorker, bool) {
+	p := parent.(*provisioner)
+	return p.getApplicationWorker(appName)
+}
+
+func NewAppWorker(parent worker.Worker, appName string) {
+	p := parent.(*provisioner)
+	p.saveApplicationWorker(appName, &applicationWorker{})
+}


### PR DESCRIPTION
## Description of change

As described in the bug, the caas unit provisioner used a naked channel send and had a fundamental logic error. John's fix is applied plus some additional testing. 

## QA steps

Run test --race

## Bug reference

https://bugs.launchpad.net/bugs/1756685