### PR TITLE
Check All Addresses When Validating Space Config

### DIFF
--- a/state/controller.go
+++ b/state/controller.go
@@ -166,7 +166,7 @@ func (st *State) checkSpaceIsAvailableToAllControllers(configSpace string) error
 		if err != nil {
 			return errors.Annotate(err, "cannot get machine")
 		}
-		if _, ok := network.SelectAddressesBySpaceNames(m.MachineAddresses(), spaceName); !ok {
+		if _, ok := network.SelectAddressesBySpaceNames(m.Addresses(), spaceName); !ok {
 			missing = append(missing, id)
 		}
 	}

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -144,7 +144,7 @@ func (s *ControllerSuite) TestRemovingUnknownName(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown controller config setting "dr-worm"`)
 }
 
-func (s *ControllerSuite) TestUpdateControllerConfigChecksSpace(c *gc.C) {
+func (s *ControllerSuite) TestUpdateControllerConfigRejectsSpaceWithoutAddresses(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.SetMachineAddresses(network.NewAddress("192.168.9.9")), jc.ErrorIsNil)
@@ -154,4 +154,15 @@ func (s *ControllerSuite) TestUpdateControllerConfigChecksSpace(c *gc.C) {
 	}, nil)
 	c.Assert(err, gc.ErrorMatches,
 		`invalid config value for "juju-mgmt-space": machines with no addresses in space "mgmt-space": "0"`)
+}
+
+func (s *ControllerSuite) TestUpdateControllerConfigAcceptsSpaceWithAddresses(c *gc.C) {
+	m, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.SetMachineAddresses(network.NewAddressOnSpace("mgmt-space", "192.168.9.9")), jc.ErrorIsNil)
+
+	err = s.State.UpdateControllerConfig(map[string]interface{}{
+		controller.JujuManagementSpace: "mgmt-space",
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -159,7 +159,7 @@ func (s *ControllerSuite) TestUpdateControllerConfigRejectsSpaceWithoutAddresses
 func (s *ControllerSuite) TestUpdateControllerConfigAcceptsSpaceWithAddresses(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.SetMachineAddresses(network.NewAddressOnSpace("mgmt-space", "192.168.9.9")), jc.ErrorIsNil)
+	c.Assert(m.SetProviderAddresses(network.NewAddressOnSpace("mgmt-space", "192.168.9.9")), jc.ErrorIsNil)
 
 	err = s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.JujuManagementSpace: "mgmt-space",


### PR DESCRIPTION
## Description of change

Controller config validation was previously only checking machine addresses, which incorrectly reported that machines had no access to supplied space names.

We now use all addresses

## QA steps

- Bootstrap onto MAAS machine with known space.
- Update controller config to set either HA or management space name to the known space.
- Changes should be validated.

## Documentation changes

No.

## Bug reference

N/A
