### PR TITLE
Provider invalid credential error.

### DIFF
--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -25,3 +25,28 @@ type zoneIndependentError struct {
 func (zoneIndependentError) AvailabilityZoneIndependent() bool {
 	return true
 }
+
+// credentialNotValid represents an error when a provider credential is not valid.
+// Realistically, this is not a transient error. Without a valid credential we
+// cannot do much on the provider. This is fatal.
+type credentialNotValid struct {
+	error
+}
+
+// CredentialNotValid returns an error which wraps err and satisfies
+// IsCredentialNotValid().
+func CredentialNotValid(err error) error {
+	if err == nil {
+		return nil
+	}
+	wrapped := errors.Wrap(err, &credentialNotValid{err})
+	wrapped.(*errors.Err).SetLocation(1)
+	return wrapped
+}
+
+// IsCredentialNotValid reports whether err was created with CredentialNotValid().
+func IsCredentialNotValid(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*credentialNotValid)
+	return ok
+}

--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -44,6 +44,23 @@ func CredentialNotValid(err error) error {
 	return wrapped
 }
 
+// NewCredentialNotValid returns an error with given message and satisfies
+// IsCredentialNotValid().
+func NewCredentialNotValid(message string) error {
+	err := errors.New("credential not valid: " + message)
+	wrapped := errors.Wrap(err, &credentialNotValid{err})
+	wrapped.(*errors.Err).SetLocation(1)
+	return wrapped
+}
+
+// CredentialNotValidf returns a wrapped error with given message and satisfies
+// IsCredentialNotValid().
+func CredentialNotValidf(err error, message string) error {
+	wrapped := errors.Wrapf(err, &credentialNotValid{err}, message)
+	wrapped.(*errors.Err).SetLocation(1)
+	return wrapped
+}
+
 // IsCredentialNotValid reports whether err was created with CredentialNotValid().
 func IsCredentialNotValid(err error) bool {
 	err = errors.Cause(err)

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -38,6 +38,8 @@ func (s *ErrorsSuite) TestNewInvalidCredential(c *gc.C) {
 	err2 := errors.Annotate(err1, "bar")
 	err := common.CredentialNotValid(err2)
 
+	// This is to confirm that IsCredentialNotValid is correct.
+	c.Assert(err2, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Assert(err, gc.ErrorMatches, "bar: foo")
 

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -33,7 +33,7 @@ github.com/juju/juju/provider/common/errors_test.go:.*: bar
 github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
-func (s *ErrorsSuite) TestNewInvalidCredential(c *gc.C) {
+func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
 	err1 := errors.New("foo")
 	err2 := errors.Annotate(err1, "bar")
 	err := common.CredentialNotValid(err2)
@@ -48,4 +48,17 @@ func (s *ErrorsSuite) TestNewInvalidCredential(c *gc.C) {
 github.com/juju/juju/provider/common/errors_test.go:.*: foo
 github.com/juju/juju/provider/common/errors_test.go:.*: bar
 github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+}
+
+func (s *ErrorsSuite) TestInvalidCredentialNew(c *gc.C) {
+	err := common.NewCredentialNotValid("Your account is blocked.")
+	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
+	c.Assert(err, gc.ErrorMatches, "credential not valid: Your account is blocked.")
+}
+
+func (s *ErrorsSuite) TestInvalidCredentialf(c *gc.C) {
+	err1 := errors.New("foo")
+	err := common.CredentialNotValidf(err1, "bar")
+	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
+	c.Assert(err, gc.ErrorMatches, "bar: foo")
 }

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -32,3 +32,18 @@ github.com/juju/juju/provider/common/errors_test.go:.*: foo
 github.com/juju/juju/provider/common/errors_test.go:.*: bar
 github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
+
+func (s *ErrorsSuite) TestNewInvalidCredential(c *gc.C) {
+	err1 := errors.New("foo")
+	err2 := errors.Annotate(err1, "bar")
+	err := common.CredentialNotValid(err2)
+
+	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
+	c.Assert(err, gc.ErrorMatches, "bar: foo")
+
+	stack := errors.ErrorStack(err)
+	c.Assert(stack, gc.Matches, `
+github.com/juju/juju/provider/common/errors_test.go:.*: foo
+github.com/juju/juju/provider/common/errors_test.go:.*: bar
+github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+}


### PR DESCRIPTION
## Description of change

This PR adds a catch-all credential validity error. This will be initially used for situations where cloud credentials expire, say on a running production environment.

