### PR TITLE
2.3 storage provisioner nopanic

### DIFF
--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -44,7 +44,7 @@ func (st *State) WatchBlockDevices(m names.MachineTag) (watcher.NotifyWatcher, e
 		return nil, err
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -65,7 +65,7 @@ func (st *State) WatchMachine(m names.MachineTag) (watcher.NotifyWatcher, error)
 		return nil, err
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -97,7 +97,7 @@ func (st *State) watchStorageEntities(method string) (watcher.StringsWatcher, er
 		return nil, err
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -132,7 +132,7 @@ func (st *State) watchAttachments(
 		return nil, err
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -156,7 +156,7 @@ func (st *State) Volumes(tags []names.VolumeTag) ([]params.VolumeResult, error) 
 		return nil, err
 	}
 	if len(results.Results) != len(tags) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -175,7 +175,7 @@ func (st *State) Filesystems(tags []names.FilesystemTag) ([]params.FilesystemRes
 		return nil, err
 	}
 	if len(results.Results) != len(tags) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -189,7 +189,7 @@ func (st *State) VolumeAttachments(ids []params.MachineStorageId) ([]params.Volu
 		return nil, err
 	}
 	if len(results.Results) != len(ids) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -204,7 +204,7 @@ func (st *State) VolumeBlockDevices(ids []params.MachineStorageId) ([]params.Blo
 		return nil, err
 	}
 	if len(results.Results) != len(ids) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -218,7 +218,7 @@ func (st *State) FilesystemAttachments(ids []params.MachineStorageId) ([]params.
 		return nil, err
 	}
 	if len(results.Results) != len(ids) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -238,7 +238,7 @@ func (st *State) VolumeParams(tags []names.VolumeTag) ([]params.VolumeParamsResu
 		return nil, err
 	}
 	if len(results.Results) != len(tags) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -258,7 +258,7 @@ func (st *State) RemoveVolumeParams(tags []names.VolumeTag) ([]params.RemoveVolu
 		return nil, err
 	}
 	if len(results.Results) != len(tags) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -278,7 +278,7 @@ func (st *State) FilesystemParams(tags []names.FilesystemTag) ([]params.Filesyst
 		return nil, err
 	}
 	if len(results.Results) != len(tags) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -298,7 +298,7 @@ func (st *State) RemoveFilesystemParams(tags []names.FilesystemTag) ([]params.Re
 		return nil, err
 	}
 	if len(results.Results) != len(tags) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -313,7 +313,7 @@ func (st *State) VolumeAttachmentParams(ids []params.MachineStorageId) ([]params
 		return nil, err
 	}
 	if len(results.Results) != len(ids) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -328,7 +328,7 @@ func (st *State) FilesystemAttachmentParams(ids []params.MachineStorageId) ([]pa
 		return nil, err
 	}
 	if len(results.Results) != len(ids) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(ids), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -342,7 +342,7 @@ func (st *State) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, e
 		return nil, err
 	}
 	if len(results.Results) != len(volumes) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(volumes), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(volumes), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -356,7 +356,7 @@ func (st *State) SetFilesystemInfo(filesystems []params.Filesystem) ([]params.Er
 		return nil, err
 	}
 	if len(results.Results) != len(filesystems) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(filesystems), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(filesystems), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -370,7 +370,7 @@ func (st *State) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttach
 		return nil, err
 	}
 	if len(results.Results) != len(volumeAttachments) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(volumeAttachments), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(volumeAttachments), len(results.Results))
 	}
 	return results.Results, nil
 }
@@ -384,7 +384,7 @@ func (st *State) SetFilesystemAttachmentInfo(filesystemAttachments []params.File
 		return nil, err
 	}
 	if len(results.Results) != len(filesystemAttachments) {
-		panic(errors.Errorf("expected %d result(s), got %d", len(filesystemAttachments), len(results.Results)))
+		return nil, errors.Errorf("expected %d result(s), got %d", len(filesystemAttachments), len(results.Results))
 	}
 	return results.Results, nil
 }

--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -37,7 +37,7 @@ func (sa *StorageAccessor) UnitStorageAttachments(unitTag names.UnitTag) ([]para
 		return nil, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -61,7 +61,7 @@ func (sa *StorageAccessor) DestroyUnitStorageAttachments(unitTag names.UnitTag) 
 		return errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -111,7 +111,7 @@ func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTa
 		return params.StorageAttachment{}, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return params.StorageAttachment{}, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -133,7 +133,7 @@ func (sa *StorageAccessor) StorageAttachmentLife(ids []params.StorageAttachmentI
 		return nil, errors.Trace(err)
 	}
 	if len(results.Results) != len(ids) {
-		panic(errors.Errorf("expected %d results, got %d", len(ids), len(results.Results)))
+		return nil, errors.Errorf("expected %d results, got %d", len(ids), len(results.Results))
 	}
 	return results.Results, nil
 }

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -87,9 +87,8 @@ func (s *storageSuite) TestStorageAttachmentResultCountMismatch(c *gc.C) {
 		return nil
 	})
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	c.Assert(func() {
-		st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
-	}, gc.PanicMatches, "expected 1 result, got 2")
+	_, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
 func (s *storageSuite) TestAPIErrors(c *gc.C) {

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -67,7 +67,7 @@ func (u *Unit) Refresh() error {
 		return errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -111,7 +111,7 @@ func (u *Unit) UnitStatus() (params.StatusResult, error) {
 		return params.StatusResult{}, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+		return params.StatusResult{}, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -61,7 +61,7 @@ func makeWatcherAPICaller(caller base.APICaller, facadeName, watcherId string) w
 func (w *commonWatcher) init() {
 	w.in = make(chan interface{})
 	if w.newResult == nil {
-		panic("newResult must me set")
+		panic("newResult must be set")
 	}
 	if w.call == nil {
 		panic("call must be set")

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -1378,8 +1378,8 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 		url:        "cs:no-such",
 		resolveErr: `cannot resolve URL "cs:no-such": charm or bundle not found`,
 	}, {
-		about:    "invalid charm name",
-		url:      "cs:",
+		about: "invalid charm name",
+		url:   "cs:",
 		// go-1.9 replaces 'cs:' with 'cs://', but not go-1.10
 		parseErr: `cannot parse URL "cs:/*": name "" not valid`,
 	}, {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1014,7 +1014,7 @@ type ResumeReplicationParams struct {
 type MeterStatusParam struct {
 	Tag  string `json:"tag"`
 	Code string `json:"code"`
-	Info string `json:"info, omitempty"`
+	Info string `json:"info,omitempty"`
 }
 
 // MeterStatusParams holds parameters for making SetMeterStatus calls.

--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type firewallSuite struct{
+type firewallSuite struct {
 	gitjujutesting.IsolationSuite
 }
 


### PR DESCRIPTION
## Description of change

General code cleanup.
 * don't use panic() when you don't have to (`api/storageprovisioner`, 'api/uniter`)
 * 2 places where `go fmt` is unhappy that I didn't touch. (why?)
 * 1 place where `go vet` caught that we have an invalid formatting string.

## QA steps

Test suite should pass clean.

## Documentation changes

None.

## Bug reference

None.
