### PR TITLE
Fix retry logic in maas instance status check.

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1183,10 +1183,13 @@ func (environ *maasEnviron) waitForNodeDeployment2(id instance.Id, timeout time.
 		Total: timeout,
 	}
 
+	retryCount := 1
 	for a := longAttempt.Start(); a.Next(); {
 		machine, err := environ.getInstance(id)
 		if err != nil {
-			return errors.Trace(err)
+			logger.Warningf("failed to get instance from provider attempt %d", retryCount)
+			retryCount++
+			continue
 		}
 		stat := machine.Status()
 		if stat.Status == status.Running {


### PR DESCRIPTION
## Description of change

Juju doesn't retry when failing to collect information from a MAAS provider.

## QA steps

Bootstrap a MAAS controller wait a few seconds then kill the connection to the MAAS.
You should see logger warnings for the retry attempts.
