### PR TITLE
`juju metrics` command displays labels.

### DIFF
--- a/api/metricsdebug/client_test.go
+++ b/api/metricsdebug/client_test.go
@@ -40,9 +40,10 @@ func (s *metricsdebugSuiteMock) TestGetMetrics(c *gc.C) {
 			result := response.(*params.MetricResults)
 			result.Results = []params.EntityMetrics{{
 				Metrics: []params.MetricResult{{
-					Key:   "pings",
-					Value: "5",
-					Time:  now,
+					Key:    "pings",
+					Value:  "5",
+					Time:   now,
+					Labels: map[string]string{"foo": "bar"},
 				}},
 				Error: nil,
 			}}
@@ -57,6 +58,8 @@ func (s *metricsdebugSuiteMock) TestGetMetrics(c *gc.C) {
 	c.Assert(metrics[0].Key, gc.Equals, "pings")
 	c.Assert(metrics[0].Value, gc.Equals, "5")
 	c.Assert(metrics[0].Time, gc.Equals, now)
+	c.Assert(metrics[0].Labels, gc.HasLen, 1)
+	c.Assert(metrics[0].Labels, gc.DeepEquals, map[string]string{"foo": "bar"})
 }
 
 func (s *metricsdebugSuiteMock) TestGetMetricsFails(c *gc.C) {

--- a/apiserver/facades/client/metricsdebug/metricsdebug_test.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug_test.go
@@ -216,12 +216,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 4)
-	c.Assert(result.Results[0].Metrics, jc.SameContents, []params.MetricResult{{
-		Key:   "pings",
-		Value: "5",
-		Time:  t1,
-		Unit:  "metered/0",
-	}, {
+	c.Assert(result.Results[0].Metrics, gc.DeepEquals, []params.MetricResult{{
 		Key:   "juju-units",
 		Value: "8",
 		Time:  t1,
@@ -229,11 +224,16 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 	}, {
 		Key:   "pings",
 		Value: "5",
+		Time:  t1,
+		Unit:  "metered/0",
+	}, {
+		Key:   "juju-units",
+		Value: "8",
 		Time:  t1,
 		Unit:  "metered/1",
 	}, {
-		Key:   "juju-units",
-		Value: "8",
+		Key:   "pings",
+		Value: "5",
 		Time:  t1,
 		Unit:  "metered/1",
 	}},
@@ -257,14 +257,14 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEac
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
-	c.Assert(result.Results[0].Metrics, jc.SameContents, []params.MetricResult{{
-		Key:   "pings",
-		Value: "5",
+	c.Assert(result.Results[0].Metrics, gc.DeepEquals, []params.MetricResult{{
+		Key:   "juju-units",
+		Value: "8",
 		Time:  t1,
 		Unit:  "metered/0",
 	}, {
-		Key:   "juju-units",
-		Value: "8",
+		Key:   "pings",
+		Value: "5",
 		Time:  t1,
 		Unit:  "metered/0",
 	}, {
@@ -294,14 +294,14 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPer
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
-	c.Assert(result.Results[0].Metrics, jc.SameContents, []params.MetricResult{{
-		Key:   "pings",
-		Value: "5",
+	c.Assert(result.Results[0].Metrics, jc.DeepEquals, []params.MetricResult{{
+		Key:   "juju-units",
+		Value: "8",
 		Time:  t1,
 		Unit:  "metered/0",
 	}, {
-		Key:   "juju-units",
-		Value: "8",
+		Key:   "pings",
+		Value: "5",
 		Time:  t1,
 		Unit:  "metered/0",
 	}, {

--- a/apiserver/facades/client/metricsdebug/metricsdebug_test.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug_test.go
@@ -199,6 +199,41 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 	})
 }
 
+func (s *metricsDebugSuite) TestGetMetricsLabelOrdering(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
+	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	t0 := time.Now().Round(time.Second)
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{{
+		Key: "pings", Value: "6", Time: t0,
+	}, {
+		Key: "pings", Value: "2", Time: t0, Labels: map[string]string{"quux": "baz"},
+	}, {
+		Key: "pings", Value: "3", Time: t0, Labels: map[string]string{"foo": "bar"},
+	}, {
+		Key: "pings", Value: "1", Time: t0, Labels: map[string]string{"abc": "123"},
+	}}})
+	args := params.Entities{Entities: []params.Entity{
+		{"unit-metered/0"},
+	}}
+	result, err := s.metricsdebug.GetMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Metrics, gc.HasLen, 4)
+	c.Assert(result.Results[0], jc.DeepEquals, params.EntityMetrics{
+		Metrics: []params.MetricResult{{
+			Unit: "metered/0", Key: "pings", Value: "6", Time: t0,
+		}, {
+			Unit: "metered/0", Key: "pings", Value: "1", Time: t0, Labels: map[string]string{"abc": "123"},
+		}, {
+			Unit: "metered/0", Key: "pings", Value: "3", Time: t0, Labels: map[string]string{"foo": "bar"},
+		}, {
+			Unit: "metered/0", Key: "pings", Value: "2", Time: t0, Labels: map[string]string{"quux": "baz"},
+		}},
+		Error: nil,
+	})
+}
+
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
 	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})

--- a/apiserver/params/metrics.go
+++ b/apiserver/params/metrics.go
@@ -32,8 +32,9 @@ type EntityMetrics struct {
 
 // MetricResult contains a single metric.
 type MetricResult struct {
-	Time  time.Time `json:"time"`
-	Key   string    `json:"key"`
-	Value string    `json:"value"`
-	Unit  string    `json:"unit"`
+	Time   time.Time         `json:"time"`
+	Key    string            `json:"key"`
+	Value  string            `json:"value"`
+	Unit   string            `json:"unit"`
+	Labels map[string]string `json:"labels"`
 }

--- a/cmd/juju/metricsdebug/metrics_test.go
+++ b/cmd/juju/metricsdebug/metrics_test.go
@@ -70,18 +70,32 @@ func (s *metricsSuite) TestSort(c *gc.C) {
 		Key:   "a-s",
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}, {
+		Unit:   "unit-metered-0",
+		Key:    "a-s",
+		Value:  "5.0",
+		Labels: map[string]string{"quux": "baz"},
+		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}, {
+		Unit:   "unit-metered-0",
+		Key:    "a-s",
+		Value:  "10.0",
+		Labels: map[string]string{"foo": "bar"},
+		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 	}}
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE
-unit-metered-0	2016-08-22T12:02:04Z	   a-s	 15.0
-unit-metered-0	2016-08-22T12:02:04Z	   b-s	 10.0
-unit-metered-0	2016-08-22T12:02:04Z	   c-s	  5.0
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE	  LABELS
+unit-metered-0	2016-08-22T12:02:04Z	   a-s	 15.0	        
+unit-metered-0	2016-08-22T12:02:04Z	   a-s	 10.0	 foo=bar
+unit-metered-0	2016-08-22T12:02:04Z	   a-s	  5.0	quux=baz
+unit-metered-0	2016-08-22T12:02:04Z	   b-s	 10.0	        
+unit-metered-0	2016-08-22T12:02:04Z	   c-s	  5.0	        
 `)
 }
 
-func (s *metricsSuite) TestDefaultTabulatFormat(c *gc.C) {
+func (s *metricsSuite) TestDefaultTabularFormat(c *gc.C) {
 	s.client.metrics = []params.MetricResult{{
 		Unit:  "unit-metered-0",
 		Key:   "pongs",
@@ -96,9 +110,9 @@ func (s *metricsSuite) TestDefaultTabulatFormat(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE
-unit-metered-0	2016-08-22T12:02:03Z	 pings	  5.0
-unit-metered-0	2016-08-22T12:02:04Z	 pongs	 15.0
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE	LABELS
+unit-metered-0	2016-08-22T12:02:03Z	 pings	  5.0	      
+unit-metered-0	2016-08-22T12:02:04Z	 pongs	 15.0	      
 `)
 }
 
@@ -113,11 +127,17 @@ func (s *metricsSuite) TestJSONFormat(c *gc.C) {
 		Key:   "pongs",
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}, {
+		Unit:   "unit-metered-0",
+		Key:    "pongs",
+		Value:  "10.0",
+		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+		Labels: map[string]string{"foo": "bar"},
 	}}
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"application-metered"})
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:03Z","metric":"pings","value":"5.0"},{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:04Z","metric":"pongs","value":"15.0"}]
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:03Z","metric":"pings","value":"5.0"},{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:04Z","metric":"pongs","value":"15.0"},{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:04Z","metric":"pongs","value":"10.0","labels":{"foo":"bar"}}]
 `)
 }
 
@@ -132,6 +152,12 @@ func (s *metricsSuite) TestYAMLFormat(c *gc.C) {
 		Key:   "pongs",
 		Value: "15.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+	}, {
+		Unit:   "unit-metered-0",
+		Key:    "pongs",
+		Value:  "10.0",
+		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
+		Labels: map[string]string{"foo": "bar"},
 	}}
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
@@ -144,6 +170,12 @@ func (s *metricsSuite) TestYAMLFormat(c *gc.C) {
   timestamp: 2016-08-22T12:02:04Z
   metric: pongs
   value: "15.0"
+- unit: unit-metered-0
+  timestamp: 2016-08-22T12:02:04Z
+  metric: pongs
+  value: "10.0"
+  labels:
+    foo: bar
 `)
 }
 

--- a/featuretests/cmd_juju_metrics.go
+++ b/featuretests/cmd_juju_metrics.go
@@ -26,23 +26,32 @@ func (s *cmdMetricsCommandSuite) TestDebugNoArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "you need to specify at least one unit or application")
 }
 
-type metric struct {
-	Unit      string    `json:"unit" yaml:"unit"`
-	Timestamp time.Time `json:"timestamp" yaml:"timestamp"`
-	Metric    string    `json:"metric" yaml:"metric"`
-	Value     string    `json:"value" yaml:"value"`
+type tabularMetric struct {
+	Unit      string
+	Timestamp time.Time
+	Metric    string
+	Value     string
+	Labels    string
 }
 
-func formatTabular(metrics ...metric) string {
+type structuredMetric struct {
+	Unit      string            `json:"unit" yaml:"unit"`
+	Timestamp time.Time         `json:"timestamp" yaml:"timestamp"`
+	Metric    string            `json:"metric" yaml:"metric"`
+	Value     string            `json:"value" yaml:"value"`
+	Labels    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+func formatTabular(metrics ...tabularMetric) string {
 	table := uitable.New()
 	table.MaxColWidth = 50
 	table.Wrap = true
 	for _, col := range []int{1, 2, 3, 4} {
 		table.RightAlign(col)
 	}
-	table.AddRow("UNIT", "TIMESTAMP", "METRIC", "VALUE")
+	table.AddRow("UNIT", "TIMESTAMP", "METRIC", "VALUE", "LABELS")
 	for _, m := range metrics {
-		table.AddRow(m.Unit, m.Timestamp.Format(time.RFC3339), m.Metric, m.Value)
+		table.AddRow(m.Unit, m.Timestamp.Format(time.RFC3339), m.Metric, m.Value, m.Labels)
 	}
 	return table.String() + "\n"
 }
@@ -54,29 +63,35 @@ func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
-	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
-	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1, Labels: map[string]string{"foo": "bar"}}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2, Labels: map[string]string{"baz": "quux"}}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
-		formatTabular(metric{
-			Unit:      unit2.Name(),
-			Timestamp: newTime2,
-			Metric:    "pings",
-			Value:     "10.5",
-		}),
-	)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, formatTabular([]tabularMetric{{
+		Unit:      unit2.Name(),
+		Timestamp: newTime2,
+		Metric:    "pings",
+		Value:     "10.5",
+		Labels:    "baz=quux",
+	}, {
+		Unit:      unit2.Name(),
+		Timestamp: newTime1,
+		Metric:    "pings",
+		Value:     "5",
+		Labels:    "foo=bar",
+	}}...))
 	ctx, err = cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
-		formatTabular(metric{
+		formatTabular(tabularMetric{
 			Unit:      unit.Name(),
 			Timestamp: newTime1,
 			Metric:    "pings",
 			Value:     "5",
+			Labels:    "foo=bar",
 		}),
 	)
 }
@@ -89,14 +104,19 @@ func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
-	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
+	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2, Labels: map[string]string{"foo": "bar", "baz": "quux"}}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
-		formatTabular([]metric{{
+		formatTabular([]tabularMetric{{
 			Unit:      unit.Name(),
+			Timestamp: newTime1,
+			Metric:    "pings",
+			Value:     "5",
+		}, {
+			Unit:      unit2.Name(),
 			Timestamp: newTime1,
 			Metric:    "pings",
 			Value:     "5",
@@ -105,6 +125,7 @@ func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 			Timestamp: newTime2,
 			Metric:    "pings",
 			Value:     "10.5",
+			Labels:    "baz=quux,foo=bar",
 		}}...),
 	)
 }
@@ -116,17 +137,33 @@ func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
 	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
-	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
+	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1, Labels: map[string]string{"abc": "123"}}
 	metricB := state.Metric{Key: "pings", Value: "10.5", Time: newTime2}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{metricA}})
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	expectedOutput := []metric{{
+	expectedOutput := []structuredMetric{{
 		Unit:      unit2.Name(),
 		Timestamp: newTime2,
 		Metric:    "pings",
 		Value:     "10.5",
+	}, {
+		Unit:      unit2.Name(),
+		Timestamp: newTime1,
+		Metric:    "pings",
+		Value:     "5",
+		Labels:    map[string]string{"abc": "123"},
+	}}
+	c.Assert(cmdtesting.Stdout(ctx), jc.JSONEquals, expectedOutput)
+	ctx, err = cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0", "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	expectedOutput = []structuredMetric{{
+		Unit:      unit.Name(),
+		Timestamp: newTime1,
+		Metric:    "pings",
+		Value:     "5",
+		Labels:    map[string]string{"abc": "123"},
 	}}
 	c.Assert(cmdtesting.Stdout(ctx), jc.JSONEquals, expectedOutput)
 }
@@ -144,7 +181,7 @@ func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit2, Metrics: []state.Metric{metricA, metricB}})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/1", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	expectedOutput := []metric{{
+	expectedOutput := []structuredMetric{{
 		Unit:      unit2.Name(),
 		Timestamp: newTime2,
 		Metric:    "pings",


### PR DESCRIPTION
## Description of change

> Why is this change needed?

To display metrics with labels properly when the `juju metrics` command is used.

## QA steps

> How do we verify that the change works?

Deploy a charm that collects metrics with labels. Observe that the last value collected for each distinct combination of label key-values, per metric key, per unit is displayed.

## Documentation changes

> Does it affect current user workflow? CLI? API?

Yes, juju metrics documentation will be updated with examples and guidance on usage.

## Bug reference

> Does this change fix a bug? Please add a link to it.

N/A