### PR TITLE
run config-change hook when caas pod address changes

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -581,9 +581,12 @@ func (u *Unit) WatchConfigSettings() (watcher.NotifyWatcher, error) {
 }
 
 // WatchAddresses returns a watcher for observing changes to the
-// unit's addresses. The unit must be assigned to a machine before
-// this method is called, and the returned watcher will be valid only
-// while the unit's assigned machine is not changed.
+// unit's addresses.
+// For IAAS models, the unit must be assigned to a machine before
+// this method is called, and the returned watcher will be valid
+// only while the unit's assigned machine is not changed.
+// For CAAS models, the watcher observes changes to the address
+// of the pod associated with the unit.
 func (u *Unit) WatchAddresses() (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1750,15 +1750,20 @@ func (u *UniterAPI) watchOneUnitAddresses(tag names.UnitTag) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	machineId, err := unit.AssignedMachineId()
-	if err != nil {
-		return "", err
+	var watch state.NotifyWatcher
+	if unit.ShouldBeAssigned() {
+		machineId, err := unit.AssignedMachineId()
+		if err != nil {
+			return "", err
+		}
+		machine, err := u.st.Machine(machineId)
+		if err != nil {
+			return "", err
+		}
+		watch = machine.WatchAddresses()
+	} else {
+		watch = unit.WatchContainerAddresses()
 	}
-	machine, err := u.st.Machine(machineId)
-	if err != nil {
-		return "", err
-	}
-	watch := machine.WatchAddresses()
 	// Consume the initial event. Technically, API
 	// calls to Watch 'transmit' the initial event
 	// in the Watch response. But NotifyWatchers

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -23,6 +23,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Cloud",
 	"LeadershipService",
 	"LifeFlag",
+	"MeterStatus",
 	"MigrationFlag",
 	"MigrationMaster",
 	"MigrationMinion",

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -225,23 +225,22 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 	}
 	requiredEvents++
 
+	var seenAddressesChange bool
+	addressesw, err := w.unit.WatchAddresses()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	addressesChanges := addressesw.Changes()
+	if err := w.catacomb.Add(addressesw); err != nil {
+		return errors.Trace(err)
+	}
+	requiredEvents++
+
 	var (
-		seenAddressesChange bool
-		addressesChanges    watcher.NotifyChannel
-		seenStorageChange   bool
-		storageChanges      watcher.StringsChannel
+		seenStorageChange bool
+		storageChanges    watcher.StringsChannel
 	)
 	if w.modelType == model.IAAS {
-		addressesw, err := w.unit.WatchAddresses()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		addressesChanges = addressesw.Changes()
-		if err := w.catacomb.Add(addressesw); err != nil {
-			return errors.Trace(err)
-		}
-		requiredEvents++
-
 		storagew, err := w.unit.WatchStorage()
 		if err != nil {
 			return errors.Trace(err)

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -306,19 +306,19 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 	}
 	ctx.proxySettings = modelConfig.ProxySettings()
 
+	statusCode, statusInfo, err := f.unit.MeterStatus()
+	if err != nil {
+		return errors.Annotate(err, "could not retrieve meter status for unit")
+	}
+	ctx.meterStatus = &meterStatus{
+		code: statusCode,
+		info: statusInfo,
+	}
+
 	if f.modelType == model.IAAS {
 		ctx.machinePorts, err = f.state.AllMachinePorts(f.machineTag)
 		if err != nil {
 			return errors.Trace(err)
-		}
-
-		statusCode, statusInfo, err := f.unit.MeterStatus()
-		if err != nil {
-			return errors.Annotate(err, "could not retrieve meter status for unit")
-		}
-		ctx.meterStatus = &meterStatus{
-			code: statusCode,
-			info: statusInfo,
 		}
 
 		// Calling these last, because there's a potential race: they're not guaranteed


### PR DESCRIPTION
## Description of change

When a caas pod address changes, we run the config-change hook for the unit.
Add a new container address watcher based on the existing machine address watcher and its tests.
Also, there's now no longer a need in the uniter remote state to only use address watcher with IAAS models.
Also do a drive by fix for CAAS meterstatus which was unable to be tested live previously due to an upstream k8s bug.

## QA steps

deploy a caas charm
stop a pod and let it restart
check the config-changed hook is run