### PR TITLE
Handle Adding Addresses to Machines in working HA with no HA Space Config

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -186,7 +186,8 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 	}
 	if len(badIds) > 0 {
 		return errors.Errorf(
-			"juju-ha-space is not set and a unique cloud-local address was not found for machines: %s",
+			"juju-ha-space is not set and a unique usable address was not found for machines: %s"+
+				"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication",
 			strings.Join(badIds, ", "),
 		)
 	}

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -201,7 +201,8 @@ func (s *clientSuite) TestEnableHAErrorForMultiCloudLocal(c *gc.C) {
 
 	_, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
-		"juju-ha-space is not set and a unique cloud-local address was not found for machines: 0")
+		"juju-ha-space is not set and a unique usable address was not found for machines: 0"+
+			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHAAddMachinesErrorForMultiCloudLocal(c *gc.C) {
@@ -226,7 +227,8 @@ func (s *clientSuite) TestEnableHAAddMachinesErrorForMultiCloudLocal(c *gc.C) {
 
 	_, err = s.enableHA(c, 5, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
-		"juju-ha-space is not set and a unique cloud-local address was not found for machines: 2")
+		"juju-ha-space is not set and a unique usable address was not found for machines: 2"+
+			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHAConstraints(c *gc.C) {

--- a/state/controller.go
+++ b/state/controller.go
@@ -128,8 +128,9 @@ func (st *State) checkValidControllerConfig(updateAttrs map[string]interface{}, 
 		}
 
 		if k == jujucontroller.JujuHASpace || k == jujucontroller.JujuManagementSpace {
-			if err := st.checkSpaceIsAvailableToAllControllers(updateAttrs[k].(string)); err != nil {
-				return errors.Annotatef(err, "invalid config value for %q", k)
+			cVal := updateAttrs[k].(string)
+			if err := st.checkSpaceIsAvailableToAllControllers(cVal); err != nil {
+				return errors.Annotatef(err, "invalid config %q=%q", k, cVal)
 			}
 		}
 	}
@@ -172,8 +173,7 @@ func (st *State) checkSpaceIsAvailableToAllControllers(configSpace string) error
 	}
 
 	if len(missing) > 0 {
-		mStr := strings.Trim(fmt.Sprintf("%q", missing), "[]")
-		return errors.Errorf("machines with no addresses in space %q: %s", configSpace, mStr)
+		return errors.Errorf("machines with no addresses in this space: %s", strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -153,7 +153,7 @@ func (s *ControllerSuite) TestUpdateControllerConfigRejectsSpaceWithoutAddresses
 		controller.JujuManagementSpace: "mgmt-space",
 	}, nil)
 	c.Assert(err, gc.ErrorMatches,
-		`invalid config value for "juju-mgmt-space": machines with no addresses in space "mgmt-space": "0"`)
+		`invalid config "juju-mgmt-space"="mgmt-space": machines with no addresses in this space: 0`)
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigAcceptsSpaceWithAddresses(c *gc.C) {

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -462,7 +462,7 @@ func (p *peerGroupChanges) updateAddressFromInternal(id string, info *peerGroupI
 
 	msg := fmt.Sprintf(
 		"machine %q has more than one usable address and juju-ha-space is not set"+
-			"\n run \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication", id)
+			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication", id)
 
 	// If this would-be member is new, we enforce the policy of having a
 	// configured HA space when there are multiple cloud-local addresses.

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -460,7 +460,9 @@ func (p *peerGroupChanges) updateAddressFromInternal(id string, info *peerGroupI
 		return nil
 	}
 
-	msg := fmt.Sprintf("machine %q has more than one non-local address and juju-ha-space is not set", id)
+	msg := fmt.Sprintf(
+		"machine %q has more than one usable address and juju-ha-space is not set"+
+			"\n run \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication", id)
 
 	// If this would-be member is new, we enforce the policy of having a
 	// configured HA space when there are multiple cloud-local addresses.

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -219,7 +219,6 @@ func (p *peerGroupChanges) checkExtraMembers(extra []replicaset.Member) error {
 // toKeep holds machines with no desired change to their voting status
 // (this includes machines that are not yet represented in the peer group).
 func (p *peerGroupChanges) possiblePeerGroupChanges(info *peerGroupInfo) {
-
 	machineIds := make([]string, 0, len(info.machines))
 	for id := range info.machines {
 		machineIds = append(machineIds, id)
@@ -411,7 +410,7 @@ func (p *peerGroupChanges) updateAddresses(info *peerGroupInfo) error {
 	return nil
 }
 
-// updateAddressUsingSpace sets the member address based on the configured
+// updateAddressFromSpace sets the member address based on the configured
 // HA space. If no addresses are available for the machine and space,
 // then an error is returned.
 func (p *peerGroupChanges) updateAddressFromSpace(id string, info *peerGroupInfo) error {
@@ -471,10 +470,9 @@ func (p *peerGroupChanges) updateAddressFromInternal(id string, info *peerGroupI
 
 	// If the prior address is still available, we allow preservation of the
 	// status quo rather than throwing out with an error.
-	// TODO (manadart 2018-03-21) Should we also check the voting status?
 	for _, addr := range addrs {
 		if member.Address == addr {
-			logger.Warningf(msg + "\npreserving member with unchanged address")
+			logger.Warningf("%s\npreserving member with unchanged address %q", msg, addr)
 			return nil
 		}
 	}

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -398,63 +398,6 @@ func (s *desiredPeerGroupSuite) TestCheckExtraMembersReturnsFalseWhenEmpty(c *gc
 	c.Check(err, jc.ErrorIsNil)
 }
 
-func (s *desiredPeerGroupSuite) TestGetMongoAddressesReturnsCorrectAddressForEachMachine(c *gc.C) {
-	spaceName := network.SpaceName("ha-space")
-
-	m1 := &machineTracker{
-		addresses: []network.Address{
-			{
-				Value:     "192.168.5.5",
-				Scope:     network.ScopeCloudLocal,
-				SpaceName: spaceName,
-			},
-			{
-				Value: "localhost",
-				Scope: network.ScopeMachineLocal,
-			},
-		},
-	}
-	m2 := &machineTracker{
-		addresses: []network.Address{
-			{
-				Value: "192.168.5.6",
-				Scope: network.ScopeCloudLocal,
-			},
-			{
-				Value: "localhost",
-				Scope: network.ScopeMachineLocal,
-			},
-		},
-	}
-	m3 := &machineTracker{
-		addresses: []network.Address{
-			{
-				Value: "localhost",
-				Scope: network.ScopeMachineLocal,
-			},
-		},
-	}
-	info := &peerGroupInfo{
-		machines: map[string]*machineTracker{
-			"1": m1,
-			"2": m2,
-			"3": m3,
-		},
-		haSpace:   spaceName,
-		mongoPort: 666,
-	}
-
-	peerChanges := peerGroupChanges{
-		addrs: map[string]string{},
-	}
-	err := peerChanges.getMongoAddresses(info)
-	c.Assert(err, gc.IsNil)
-	c.Assert(len(peerChanges.addrs), gc.Equals, 3)
-	c.Check(peerChanges.addrs["1"], gc.Equals, "192.168.5.5:666")
-	c.Check(peerChanges.addrs["2"], gc.Equals, "192.168.5.6:666")
-	c.Check(peerChanges.addrs["3"], gc.Equals, "")
-}
-
 func countVotes(members []replicaset.Member) int {
 	tot := 0
 	for _, m := range members {

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -4,11 +4,12 @@
 package peergrouper
 
 import (
+	"sort"
+
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
-	"sort"
 )
 
 type machineTrackerSuite struct {

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
+	"sort"
 )
 
 type machineTrackerSuite struct {
@@ -16,7 +17,7 @@ type machineTrackerSuite struct {
 
 var _ = gc.Suite(&machineTrackerSuite{})
 
-func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithSpace(c *gc.C) {
+func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddress(c *gc.C) {
 	spaceName := network.SpaceName("ha-space")
 
 	m := &machineTracker{
@@ -38,20 +39,15 @@ func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithSpa
 		},
 	}
 
-	addr, err := m.SelectMongoAddress(666, spaceName)
+	addr, err := m.SelectMongoAddressFromSpace(666, spaceName)
 	c.Assert(err, gc.IsNil)
 	c.Check(addr, gc.Equals, "192.168.5.5:666")
 }
 
-func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithoutSpace(c *gc.C) {
-	spaceName := network.SpaceName("")
-
+func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorWhenNoAddressFound(c *gc.C) {
 	m := &machineTracker{
+		id: "3",
 		addresses: []network.Address{
-			{
-				Value: "192.168.5.5",
-				Scope: network.ScopeCloudLocal,
-			},
 			{
 				Value: "localhost",
 				Scope: network.ScopeMachineLocal,
@@ -59,14 +55,22 @@ func (s *machineTrackerSuite) TestSelectMongoAddressReturnsCorrectAddressWithout
 		},
 	}
 
-	addr, err := m.SelectMongoAddress(666, spaceName)
-	c.Assert(err, gc.IsNil)
-	c.Check(addr, gc.Equals, "192.168.5.5:666")
+	_, err := m.SelectMongoAddressFromSpace(666, "bad-space")
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, `no addresses found for machine "3" in space "bad-space"`)
 }
 
-func (s *machineTrackerSuite) TestSelectMongoAddressReturnsErrNoSpaceMultipleCloudLocal(c *gc.C) {
-	spaceName := network.SpaceName("")
+func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorForEmptySpace(c *gc.C) {
+	m := &machineTracker{
+		id: "3",
+	}
 
+	_, err := m.SelectMongoAddressFromSpace(666, "")
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, `empty space supplied as an argument for selecting Mongo address for machine "3"`)
+}
+
+func (s *machineTrackerSuite) TestGetPotentialMongoHostPortsReturnsAllAddresses(c *gc.C) {
 	m := &machineTracker{
 		id: "3",
 		addresses: []network.Address{
@@ -85,25 +89,7 @@ func (s *machineTrackerSuite) TestSelectMongoAddressReturnsErrNoSpaceMultipleClo
 		},
 	}
 
-	addr, err := m.SelectMongoAddress(666, spaceName)
-	c.Check(err, gc.ErrorMatches, `machine "3" has more than one non-local address and juju-ha-space is not set`)
-	c.Check(addr, gc.Equals, "")
-}
-
-func (s *machineTrackerSuite) TestSelectMongoAddressReturnsEmptyWhenNoAddressFound(c *gc.C) {
-	spaceName := network.SpaceName("")
-
-	m := &machineTracker{
-		id: "3",
-		addresses: []network.Address{
-			{
-				Value: "localhost",
-				Scope: network.ScopeMachineLocal,
-			},
-		},
-	}
-
-	addr, err := m.SelectMongoAddress(666, spaceName)
-	c.Assert(err, gc.IsNil)
-	c.Check(addr, gc.Equals, "")
+	addrs := network.HostPortsToStrings(m.GetPotentialMongoHostPorts(666))
+	sort.Strings(addrs)
+	c.Check(addrs, gc.DeepEquals, []string{"10.0.0.1:666", "192.168.5.5:666", "localhost:666"})
 }

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -83,13 +83,13 @@ func (s *machineTrackerSuite) TestGetPotentialMongoHostPortsReturnsAllAddresses(
 				Scope: network.ScopeCloudLocal,
 			},
 			{
-				Value: "localhost",
-				Scope: network.ScopeMachineLocal,
+				Value: "185.159.16.82",
+				Scope: network.ScopePublic,
 			},
 		},
 	}
 
 	addrs := network.HostPortsToStrings(m.GetPotentialMongoHostPorts(666))
 	sort.Strings(addrs)
-	c.Check(addrs, gc.DeepEquals, []string{"10.0.0.1:666", "192.168.5.5:666", "localhost:666"})
+	c.Check(addrs, gc.DeepEquals, []string{"10.0.0.1:666", "192.168.5.5:666", "185.159.16.82:666"})
 }

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -91,5 +91,5 @@ func (s *machineTrackerSuite) TestGetPotentialMongoHostPortsReturnsAllAddresses(
 
 	addrs := network.HostPortsToStrings(m.GetPotentialMongoHostPorts(666))
 	sort.Strings(addrs)
-	c.Check(addrs, gc.DeepEquals, []string{"10.0.0.1:666", "192.168.5.5:666", "185.159.16.82:666"})
+	c.Check(addrs, gc.DeepEquals, []string{"10.0.0.1:666", "185.159.16.82:666", "192.168.5.5:666"})
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -701,7 +701,8 @@ func (s *workerSuite) doTestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMu
 	st := haSpaceTestCommonSetup(c, ipVersion, "0v")
 	err := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}).Wait()
 	errMsg := `computing desired peer group: updating member address: ` +
-		`machine "1[12]" has more than one non-local address and juju-ha-space is not set`
+		`machine "1[12]" has more than one usable address and juju-ha-space is not set` +
+		"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication"
 	c.Check(err, gc.ErrorMatches, errMsg)
 }
 

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -546,7 +546,7 @@ func (s *workerSuite) TestControllersArePublishedOverHubWithNewVoters(c *gc.C) {
 	}
 }
 
-func haSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion) *fakeState {
+func haSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, members string) *fakeState {
 	st := NewFakeState()
 	InitState(c, st, 3, ipVersion)
 
@@ -582,13 +582,13 @@ func haSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion) *fakeState {
 		machine.setAddresses(addrs...)
 	}
 
-	st.session.Set(mkMembers("0v 1v 2v", ipVersion))
+	st.session.Set(mkMembers(members, ipVersion))
 	return st
 }
 
 func (s *workerSuite) TestUsesConfiguredHASpace(c *gc.C) {
 	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st := haSpaceTestCommonSetup(c, ipVersion)
+		st := haSpaceTestCommonSetup(c, ipVersion, "0v 1v 2v")
 		st.setHASpace("one")
 		s.runUntilPublish(c, st, "")
 		assertMemberAddresses(c, st, ipVersion.formatHost, 1)
@@ -635,7 +635,7 @@ func (s *workerSuite) TestDetectsAndUsesHASpaceChangeIPv6(c *gc.C) {
 }
 
 func (s *workerSuite) doTestDetectsAndUsesHASpaceChange(c *gc.C, ipVersion TestIPVersion) {
-	st := haSpaceTestCommonSetup(c, ipVersion)
+	st := haSpaceTestCommonSetup(c, ipVersion, "0v 1v 2v")
 	st.setHASpace("one")
 
 	// Set up a hub and channel on which to receive notifications.
@@ -687,13 +687,36 @@ func assertMemberAddresses(c *gc.C, st *fakeState, addrTemplate string, addrDesi
 	c.Check(obtained, gc.DeepEquals, expected)
 }
 
-func (s *workerSuite) TestReturnsErrorWhenNoHASpaceAndMachinesWithMultiLocalAddr(c *gc.C) {
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st := haSpaceTestCommonSetup(c, ipVersion)
-		err := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}).Wait()
-		errMsg := `computing desired peer group: machine "1[012]" has more than one non-local address and juju-ha-space is not set`
-		c.Check(err, gc.ErrorMatches, errMsg)
-	})
+func (s *workerSuite) TestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddrIPv4(c *gc.C) {
+	s.doTestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddr(c, testIPv4)
+}
+
+func (s *workerSuite) TestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddrIPv6(c *gc.C) {
+	s.doTestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddr(c, testIPv6)
+}
+
+func (s *workerSuite) doTestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddr(
+	c *gc.C, ipVersion TestIPVersion,
+) {
+	st := haSpaceTestCommonSetup(c, ipVersion, "0v")
+	err := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}).Wait()
+	errMsg := `computing desired peer group: updating member address: ` +
+		`machine "1[12]" has more than one non-local address and juju-ha-space is not set`
+	c.Check(err, gc.ErrorMatches, errMsg)
+}
+
+func (s *workerSuite) TestSamePeersAndNoHASpaceAndMachinesWithMultiAddrIPv4(c *gc.C) {
+	s.doTestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddr(c, testIPv4)
+}
+
+func (s *workerSuite) TestSamePeersAndNoHASpaceAndMachinesWithMultiAddrIPv6(c *gc.C) {
+	s.doTestReturnsErrorForNewPeersAndNoHASpaceAndMachinesWithMultiAddr(c, testIPv6)
+}
+
+func (s *workerSuite) doTestSamePeersAndNoHASpaceAndMachinesWithMultiAddr(c *gc.C, ipVersion TestIPVersion) {
+	st := haSpaceTestCommonSetup(c, ipVersion, "0v 1v 2v")
+	s.runUntilPublish(c, st, "")
+	assertMemberAddresses(c, st, ipVersion.formatHost, 1)
 }
 
 func (s *workerSuite) TestWorkerRetriesOnSetAPIHostPortsErrorIPv4(c *gc.C) {


### PR DESCRIPTION
## Description of change

The recent changes for HA space turn up an undesirable scenario for when HA is enabled, no HA space is configured, and the machines each have a single cloud local address each.

Adding an address to one of the machines will cause the peergrouper loop to throw an error because of the rule that the HA space must be configured where there are multiple potential Mongo addresses.

This change ensures that if a machine with multiple addresses was already a replica-set member, and its address can remain unchanged, then we do not return an error, opting instead to retain the status-quo.

First commit in this PR is code/comment movement and can be disregarded for review purposes.

## QA steps

Unit tests cover the new scenarios.
Feature tests for HA space configuration are forthcoming.

## Documentation changes

Prior to release, the various behaviours should be documented under the _enable-ha_ command.

## Bug reference

N/A
