### PR TITLE
Provider detects when credential is invalid: aws.

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -331,10 +331,15 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 	instances := make(instanceCache)
 	if instanceIds.Size() > 1 {
 		if err := instances.update(v.env.ec2, instanceIds.Values()...); err != nil {
+			err := maybeConvertCredentialError(err)
 			logger.Debugf("querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
 			// the creation of another volume.
+			// Except if it is a credential error...
+			if common.IsCredentialNotValid(err) {
+				return nil, errors.Trace(err)
+			}
 		}
 	}
 
@@ -360,7 +365,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 			return
 		}
 		if _, err := v.env.ec2.DeleteVolume(volumeId); err != nil {
-			logger.Errorf("error cleaning up volume %v: %v", volumeId, err)
+			logger.Errorf("error cleaning up volume %v: %v", volumeId, maybeConvertCredentialError(err))
 		}
 	}()
 
@@ -372,19 +377,19 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 	// Create.
 	instId := string(p.Attachment.InstanceId)
 	if err := instances.update(v.env.ec2, instId); err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Trace(maybeConvertCredentialError(err))
 	}
 	inst, err := instances.get(instId)
 	if err != nil {
 		// Can't create the volume without the instance,
 		// because we need to know what its AZ is.
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Trace(maybeConvertCredentialError(err))
 	}
 	vol, _ := parseVolumeOptions(p.Size, p.Attributes)
 	vol.AvailZone = inst.AvailZone
 	resp, err := v.env.ec2.CreateVolume(vol)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Trace(maybeConvertCredentialError(err))
 	}
 	volumeId = resp.Id
 
@@ -419,7 +424,7 @@ func (v *ebsVolumeSource) ListVolumes() ([]string, error) {
 func listVolumes(client *ec2.EC2, filter *ec2.Filter, includeRootDisks bool) ([]string, error) {
 	resp, err := client.Volumes(nil, filter)
 	if err != nil {
-		return nil, err
+		return nil, maybeConvertCredentialError(err)
 	}
 	volumeIds := make([]string, 0, len(resp.Volumes))
 	for _, vol := range resp.Volumes {
@@ -450,7 +455,7 @@ func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVo
 	// be rare.
 	resp, err := v.env.ec2.Volumes(volIds, nil)
 	if err != nil {
-		return nil, err
+		return nil, maybeConvertCredentialError(err)
 	}
 	byId := make(map[string]ec2.Volume)
 	for _, vol := range resp.Volumes {
@@ -517,6 +522,8 @@ func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
 				// be destroyed.
 				logger.Tracef("Ignoring error destroying volume %q: %v", volumeId, err)
 				err = nil
+			} else {
+				err = maybeConvertCredentialError(err)
 			}
 		}
 	}()
@@ -611,7 +618,7 @@ func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
 		return nil
 	}
 	_, err = client.DeleteVolume(volumeId)
-	return errors.Annotatef(err, "destroying %q", volumeId)
+	return errors.Annotatef(maybeConvertCredentialError(err), "destroying %q", volumeId)
 }
 
 func releaseVolume(client *ec2.EC2, volumeId string) error {
@@ -635,7 +642,7 @@ func releaseVolume(client *ec2.EC2, volumeId string) error {
 		if err == errWaitVolumeTimeout {
 			return errors.Errorf("timed out waiting for volume %v to become available", volumeId)
 		}
-		return errors.Annotatef(err, "cannot release volume %q", volumeId)
+		return errors.Annotatef(maybeConvertCredentialError(err), "cannot release volume %q", volumeId)
 	}
 	// Releasing the volume just means dropping the
 	// tags that associate it with the model and
@@ -697,10 +704,15 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 	}
 	instances := make(instanceCache)
 	if err := instances.update(v.env.ec2, instIds.Values()...); err != nil {
+		err := maybeConvertCredentialError(err)
 		logger.Debugf("querying running instances: %v", err)
 		// We ignore the error, because we don't want an invalid
 		// InstanceId reference from one VolumeParams to prevent
 		// the creation of another volume.
+		// Except if it is a credential error...
+		if common.IsCredentialNotValid(err) {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	results := make([]storage.AttachVolumesResult, len(attachParams))
@@ -708,7 +720,7 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 		instId := string(params.InstanceId)
 		inst, err := instances.get(instId)
 		if err != nil {
-			results[i].Error = err
+			results[i].Error = maybeConvertCredentialError(err)
 			continue
 		}
 
@@ -724,7 +736,7 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 		nextDeviceName := blockDeviceNamer(numbers)
 		_, deviceName, err := v.attachOneVolume(nextDeviceName, params.VolumeId, instId)
 		if err != nil {
-			results[i].Error = err
+			results[i].Error = maybeConvertCredentialError(err)
 			continue
 		}
 
@@ -766,7 +778,7 @@ func (v *ebsVolumeSource) attachOneVolume(
 	// Wait for the volume to move out of "creating".
 	volume, err := v.waitVolumeCreated(volumeId)
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Trace(maybeConvertCredentialError(err))
 	}
 
 	// Possible statuses:
@@ -819,7 +831,7 @@ func (v *ebsVolumeSource) attachOneVolume(
 			}
 		}
 		if err != nil {
-			return "", "", errors.Annotate(err, "attaching volume")
+			return "", "", errors.Annotate(maybeConvertCredentialError(err), "attaching volume")
 		}
 		return requestDeviceName, actualDeviceName, nil
 	}
@@ -841,7 +853,7 @@ func (v *ebsVolumeSource) waitVolumeCreated(volumeId string) (*ec2.Volume, error
 			volumeId, lastStatus,
 		)
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(maybeConvertCredentialError(err))
 	}
 	return volume, nil
 }
@@ -873,7 +885,7 @@ func waitVolume(
 func describeVolume(client *ec2.EC2, volumeId string) (*ec2.Volume, error) {
 	resp, err := client.Volumes([]string{volumeId}, nil)
 	if err != nil {
-		return nil, errors.Annotate(err, "querying volume")
+		return nil, errors.Annotate(maybeConvertCredentialError(err), "querying volume")
 	}
 	if len(resp.Volumes) == 0 {
 		return nil, errors.NotFoundf("%v", volumeId)
@@ -895,7 +907,7 @@ func (c instanceCache) update(ec2client *ec2.EC2, ids ...string) error {
 	filter.Add("instance-state-name", "running")
 	resp, err := ec2client.Instances(ids, filter)
 	if err != nil {
-		return errors.Annotate(err, "querying instance details")
+		return errors.Annotate(maybeConvertCredentialError(err), "querying instance details")
 	}
 	for j := range resp.Reservations {
 		r := &resp.Reservations[j]
@@ -939,7 +951,7 @@ func detachVolumes(client *ec2.EC2, attachParams []storage.VolumeAttachmentParam
 		}
 		if err != nil {
 			results[i] = errors.Annotatef(
-				err, "detaching %s from %s",
+				maybeConvertCredentialError(err), "detaching %s from %s",
 				names.ReadableString(params.Volume),
 				names.ReadableString(params.Machine),
 			)
@@ -953,7 +965,7 @@ func (v *ebsVolumeSource) ImportVolume(volumeId string, tags map[string]string) 
 	resp, err := v.env.ec2.Volumes([]string{volumeId}, nil)
 	if err != nil {
 		// TODO(axw) check for "not found" response, massage error message?
-		return storage.VolumeInfo{}, err
+		return storage.VolumeInfo{}, maybeConvertCredentialError(err)
 	}
 	if len(resp.Volumes) != 1 {
 		return storage.VolumeInfo{}, errors.Errorf("expected 1 volume result, got %d", len(resp.Volumes))

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -54,12 +54,17 @@ func AllModelGroups(e environs.Environ) ([]string, error) {
 }
 
 var (
-	EC2AvailabilityZones     = &ec2AvailabilityZones
-	RunInstances             = &runInstances
-	BlockDeviceNamer         = blockDeviceNamer
-	GetBlockDeviceMappings   = getBlockDeviceMappings
-	IsVPCNotUsableError      = isVPCNotUsableError
-	IsVPCNotRecommendedError = isVPCNotRecommendedError
+	EC2AvailabilityZones           = &ec2AvailabilityZones
+	RunInstances                   = &runInstances
+	BlockDeviceNamer               = blockDeviceNamer
+	GetBlockDeviceMappings         = getBlockDeviceMappings
+	IsVPCNotUsableError            = isVPCNotUsableError
+	IsVPCNotRecommendedError       = isVPCNotRecommendedError
+	ShortAttempt                   = &shortAttempt
+	DestroyVolumeAttempt           = &destroyVolumeAttempt
+	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
+	TerminateInstancesById         = &terminateInstancesById
+	MaybeConvertCredentialError    = maybeConvertCredentialError
 )
 
 const VPCIDNone = vpcIDNone
@@ -75,13 +80,6 @@ func UseTestImageData(c *gc.C, files map[string]string) {
 		sstesting.SetRoundTripperFiles(nil, nil)
 	}
 }
-
-var (
-	ShortAttempt                   = &shortAttempt
-	DestroyVolumeAttempt           = &destroyVolumeAttempt
-	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
-	TerminateInstancesById         = &terminateInstancesById
-)
 
 // FabricateInstance creates a new fictitious instance
 // given an existing instance and a new id.
@@ -359,3 +357,7 @@ const testImageMetadataProduct = `
  "format": "products:1.0"
 }
 `
+
+func VerifyCredentials(env environs.Environ) error {
+	return verifyCredentials(env.(*environ))
+}

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/provider/common"
 )
 
 var logger = loggo.GetLogger("juju.provider.ec2")
@@ -52,7 +53,7 @@ func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error
 	var err error
 	e.ec2, err = awsClient(e.cloud)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(maybeConvertCredentialError(err))
 	}
 
 	if err := e.SetConfig(args.Config); err != nil {
@@ -168,15 +169,20 @@ func (p environProvider) MetadataLookupParams(region string) (*simplestreams.Met
 	}, nil
 }
 
-const badAccessKey = `
-Please ensure the Access Key ID you have specified is correct.
-You can obtain the Access Key ID via the "Security Credentials"
-page in the AWS console.`
+const badKeys = `
+The provided credentials could not be validated and 
+may not be authorized to carry out the request.
+Ensure that your account is authorized to use the Amazon EC2 service and 
+that you are using the correct access keys. 
+These keys are obtained via the "Security Credentials"
+page in the AWS console.
+`
 
-const badSecretKey = `
-Please ensure the Secret Access Key you have specified is correct.
-You can obtain the Secret Access Key via the "Security Credentials"
-page in the AWS console.`
+const unauthorised = `
+Please subscribe to the requested Amazon service. 
+You are currently not authorized to use it.
+New Amazon accounts might take some time to be activated while 
+your details are being verified.`
 
 // verifyCredentials issues a cheap, non-modifying/idempotent request to EC2 to
 // verify the configured credentials. If verification fails, a user-friendly
@@ -184,19 +190,44 @@ page in the AWS console.`
 // level.
 var verifyCredentials = func(e *environ) error {
 	_, err := e.ec2.AccountAttributes()
-	if err != nil {
-		logger.Debugf("ec2 request failed: %v", err)
-		if err, ok := err.(*ec2.Error); ok {
-			switch err.Code {
-			case "AuthFailure":
-				return errors.New("authentication failed.\n" + badAccessKey)
-			case "SignatureDoesNotMatch":
-				return errors.New("authentication failed.\n" + badSecretKey)
-			default:
-				return err
-			}
-		}
-		return err
+	return maybeConvertCredentialError(err)
+}
+
+// maybeConvertCredentialError examines the error received from the provider.
+// Authentication related errors are wrapped in common.CredentialNotValid.
+// Authorisation related errors are annotated with an additional
+// user-friendly explanation.
+// All other errors are returned un-wrapped and not annotated.
+var maybeConvertCredentialError = func(err error) error {
+	if err == nil {
+		return nil
 	}
-	return nil
+
+	if err, ok := err.(*ec2.Error); ok {
+		// EC2 error codes are from https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.
+		switch err.Code {
+		case "AuthFailure":
+			return common.CredentialNotValidf(err, badKeys)
+		case "InvalidClientTokenId":
+			return common.CredentialNotValidf(err, badKeys)
+		case "MissingAuthenticationToken":
+			return common.CredentialNotValidf(err, badKeys)
+		case "Blocked":
+			return common.CredentialNotValidf(err, "\nYour Amazon account is currently blocked.")
+		case "CustomerKeyHasBeenRevoked":
+			return common.CredentialNotValidf(err, "\nYour Amazon keys have been revoked.")
+		case "PendingVerification":
+			return common.CredentialNotValidf(err, "\nYou account is pending verification by Amazon.")
+		case "SignatureDoesNotMatch":
+			return common.CredentialNotValidf(err, badKeys)
+		case "OptInRequired":
+			return errors.Annotate(err, unauthorised)
+		case "UnauthorizedOperation":
+			return errors.Annotate(err, unauthorised)
+		default:
+			// This error is unrelated to access keys, account or credentials...
+			return err
+		}
+	}
+	return err
 }

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -178,7 +178,7 @@ These keys are obtained via the "Security Credentials"
 page in the AWS console.
 `
 
-const unauthorised = `
+const unauthorized = `
 Please subscribe to the requested Amazon service. 
 You are currently not authorized to use it.
 New Amazon accounts might take some time to be activated while 
@@ -217,13 +217,13 @@ var maybeConvertCredentialError = func(err error) error {
 		case "CustomerKeyHasBeenRevoked":
 			return common.CredentialNotValidf(err, "\nYour Amazon keys have been revoked.")
 		case "PendingVerification":
-			return common.CredentialNotValidf(err, "\nYou account is pending verification by Amazon.")
+			return common.CredentialNotValidf(err, "\nYour account is pending verification by Amazon.")
 		case "SignatureDoesNotMatch":
 			return common.CredentialNotValidf(err, badKeys)
 		case "OptInRequired":
-			return errors.Annotate(err, unauthorised)
+			return errors.Annotate(err, unauthorized)
 		case "UnauthorizedOperation":
-			return errors.Annotate(err, unauthorised)
+			return errors.Annotate(err, unauthorized)
 		default:
 			// This error is unrelated to access keys, account or credentials...
 			return err

--- a/provider/ec2/provider_test.go
+++ b/provider/ec2/provider_test.go
@@ -4,13 +4,18 @@
 package ec2_test
 
 import (
+	"fmt"
+
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/amz.v3/aws"
+	ec2cloud "gopkg.in/amz.v3/ec2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/ec2"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -123,4 +128,85 @@ func (s *ProviderSuite) testOpenError(c *gc.C, spec environs.CloudSpec, expect s
 		Config: coretesting.ModelConfig(c),
 	})
 	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+func (s *ProviderSuite) TestVerifyCredentialsErrs(c *gc.C) {
+	env, err := environs.Open(s.provider, environs.OpenParams{
+		Cloud:  s.spec,
+		Config: coretesting.ModelConfig(c),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.NotNil)
+
+	err = ec2.VerifyCredentials(env)
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
+	c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
+}
+
+func (s *ProviderSuite) TestMaybeConvertCredentialErrorIgnoresNil(c *gc.C) {
+	err := ec2.MaybeConvertCredentialError(nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ProviderSuite) TestMaybeConvertCredentialErrorConvertsCredentialRelatedFailures(c *gc.C) {
+	for _, code := range []string{
+		"AuthFailure",
+		"InvalidClientTokenId",
+		"MissingAuthenticationToken",
+		"Blocked",
+		"CustomerKeyHasBeenRevoked",
+		"PendingVerification",
+		"SignatureDoesNotMatch",
+	} {
+		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code})
+		c.Assert(err, gc.NotNil)
+		c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
+	}
+}
+
+func (s *ProviderSuite) TestMaybeConvertCredentialErrorAppendsAuthorisationFailureMessage(c *gc.C) {
+	for _, code := range []string{
+		"OptInRequired",
+		"UnauthorizedOperation",
+	} {
+		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code})
+		c.Assert(err, gc.NotNil)
+		c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
+		c.Assert(err.Error(), jc.Contains, fmt.Sprintf("\nPlease subscribe to the requested Amazon service. \n"+
+			"You are currently not authorized to use it.\n"+
+			"New Amazon accounts might take some time to be activated while \n"+
+			"your details are being verified.:  (%v)", code))
+	}
+}
+
+func (s *ProviderSuite) TestMaybeConvertCredentialErrorHandlesOtherProviderErrors(c *gc.C) {
+	// Any other ec2.Error is returned unwrapped.
+	err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: "DryRunOperation"})
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
+	c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
+}
+
+func (s *ProviderSuite) TestConvertedCredentialError(c *gc.C) {
+	// Trace() will keep error type
+	inner := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: "Blocked"})
+	traced := errors.Trace(inner)
+	c.Assert(traced, gc.NotNil)
+	c.Assert(traced, jc.Satisfies, common.IsCredentialNotValid)
+
+	// Annotate() will keep error type
+	annotated := errors.Annotate(inner, "annotation")
+	c.Assert(annotated, gc.NotNil)
+	c.Assert(annotated, jc.Satisfies, common.IsCredentialNotValid)
+
+	// Running a CredentialNotValid through conversion call again is a no-op.
+	again := ec2.MaybeConvertCredentialError(inner)
+	c.Assert(again, gc.NotNil)
+	c.Assert(again, jc.Satisfies, common.IsCredentialNotValid)
+	c.Assert(again.Error(), jc.Contains, "\nYour Amazon account is currently blocked.:  (Blocked)")
+
+	// Running an annotated CredentialNotValid through conversion call again is a no-op too.
+	againAnotated := ec2.MaybeConvertCredentialError(annotated)
+	c.Assert(againAnotated, gc.NotNil)
+	c.Assert(againAnotated, jc.Satisfies, common.IsCredentialNotValid)
+	c.Assert(againAnotated.Error(), jc.Contains, "\nYour Amazon account is currently blocked.:  (Blocked)")
 }


### PR DESCRIPTION
## Description of change

This is the first PR in a series that allows providers to throw 'credential not valid" error when the situation calls for it.

Initial commit contains the logic for examining provider specific error codes to determine which are related to credentials. We are wrapping desired errors in needed "credential not valid".

Following commit ensures that all provider calls that could have erred out because a credential was deemed invalid, do go through the logic from the 1st commit and  throw correctly typed error.

## QA steps

Existing unit tests pass and I have added more unit tests to test for the errors specifically.

I have bootstrapped and deployed on aws, so I know that the success path still passes.

However, since I could not figure out how to invalidate my aws credential once bootstrapped (without impacting my long-term productivity), I have not tested the scenario where credentials become invalid in flight.
