### PR TITLE
apiserver/facades/agent/metricsender: Adding model names to metrics.

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -46,6 +46,7 @@ type ModelManagerBackend interface {
 	ModelConfigDefaultValues() (config.ModelDefaultAttributes, error)
 	UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string, regionSpec *environs.RegionSpec) error
 	Unit(name string) (*state.Unit, error)
+	Name() string
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)
 	AddControllerUser(state.UserAccessSpec) (permission.UserAccess, error)
@@ -164,6 +165,11 @@ func (st modelManagerStateShim) GetModel(modelUUID string) (Model, func() bool, 
 // Model implements ModelManagerBackend.
 func (st modelManagerStateShim) Model() (Model, error) {
 	return modelShim{st.model}, nil
+}
+
+// Name implements ModelManagerBackend.
+func (st modelManagerStateShim) Name() string {
+	return st.model.Name()
 }
 
 var _ Model = (*modelShim)(nil)

--- a/apiserver/facades/agent/metricsender/metricsender.go
+++ b/apiserver/facades/agent/metricsender/metricsender.go
@@ -85,6 +85,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 		if err != nil {
 			return errors.Trace(err)
 		}
+		modelName := st.Name()
 		lenM := len(metrics)
 		if lenM == 0 {
 			if sent == 0 {
@@ -103,7 +104,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 				heldBatches = append(heldBatches, m.UUID())
 				heldBatchUnits[m.Unit()] = true
 			} else {
-				wireData = append(wireData, ToWire(m))
+				wireData = append(wireData, ToWire(m, modelName))
 			}
 		}
 		response, err := sender.Send(wireData)
@@ -180,7 +181,7 @@ func DefaultMetricSender() MetricSender {
 
 // ToWire converts the state.MetricBatch into a type
 // that can be sent over the wire to the collector.
-func ToWire(mb *state.MetricBatch) *wireformat.MetricBatch {
+func ToWire(mb *state.MetricBatch, modelName string) *wireformat.MetricBatch {
 	metrics := make([]wireformat.Metric, len(mb.Metrics()))
 	for i, m := range mb.Metrics() {
 		metrics[i] = wireformat.Metric{
@@ -193,6 +194,7 @@ func ToWire(mb *state.MetricBatch) *wireformat.MetricBatch {
 	return &wireformat.MetricBatch{
 		UUID:           mb.UUID(),
 		ModelUUID:      mb.ModelUUID(),
+		ModelName:      modelName,
 		UnitName:       mb.Unit(),
 		CharmUrl:       mb.CharmURL(),
 		Created:        mb.Created().UTC(),

--- a/apiserver/facades/agent/metricsender/metricsender_test.go
+++ b/apiserver/facades/agent/metricsender/metricsender_test.go
@@ -43,6 +43,7 @@ var _ metricsender.MetricSender = (*metricsender.NopSender)(nil)
 
 func (s *MetricSenderSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
 	// Application with metrics credentials set.
 	credApp := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm, Name: "cred"})
@@ -57,7 +58,7 @@ func (s *MetricSenderSuite) SetUpTest(c *gc.C) {
 func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 	now := time.Now().Round(time.Second)
 	metric := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: false, Time: &now})
-	result := metricsender.ToWire(metric)
+	result := metricsender.ToWire(metric, s.Model.Name())
 	m := metric.Metrics()[0]
 	metrics := []wireformat.Metric{
 		{
@@ -72,6 +73,7 @@ func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 	expected := &wireformat.MetricBatch{
 		UUID:           metric.UUID(),
 		ModelUUID:      metric.ModelUUID(),
+		ModelName:      "controller",
 		UnitName:       metric.Unit(),
 		CharmUrl:       metric.CharmURL(),
 		Created:        metric.Created().UTC(),
@@ -80,6 +82,39 @@ func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 		SLACredentials: metric.SLACredentials(),
 	}
 	c.Assert(result, gc.DeepEquals, expected)
+}
+
+func (s *MetricSenderSuite) TestSendMetricsFromNewModel(c *gc.C) {
+	var sender testing.MockSender
+	now := time.Now()
+	clock := jujutesting.NewClock(time.Now())
+
+	state := s.Factory.MakeModel(c, &factory.ModelParams{Name: "test-model"})
+	defer state.Close()
+	f := factory.NewFactory(state)
+	model, err := state.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	modelName := model.Name()
+	c.Assert(modelName, gc.Equals, "test-model")
+
+	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	// Application with metrics credentials set.
+	credApp := f.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm, Name: "cred"})
+	err = credApp.SetMetricCredentials([]byte("something here"))
+	c.Assert(err, jc.ErrorIsNil)
+	meteredApp := f.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	meteredUnit := f.MakeUnit(c, &factory.UnitParams{Application: meteredApp, SetCharmURL: true})
+	credUnit := f.MakeUnit(c, &factory.UnitParams{Application: credApp, SetCharmURL: true})
+
+	f.MakeMetric(c, &factory.MetricParams{Unit: credUnit, Time: &now})
+	f.MakeMetric(c, &factory.MetricParams{Unit: meteredUnit, Time: &now})
+	f.MakeMetric(c, &factory.MetricParams{Unit: credUnit, Sent: true, Time: &now})
+	err = metricsender.SendMetrics(TestSenderBackend{state, model}, &sender, clock, 10, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sender.Data, gc.HasLen, 1)
+	c.Assert(sender.Data[0], gc.HasLen, 2)
+	c.Assert(sender.Data[0][0].ModelName, gc.Equals, "test-model")
+	c.Assert(sender.Data[0][1].ModelName, gc.Equals, "test-model")
 }
 
 // TestSendMetrics creates 2 unsent metrics and a sent metric

--- a/apiserver/facades/agent/metricsender/stateinterface.go
+++ b/apiserver/facades/agent/metricsender/stateinterface.go
@@ -21,6 +21,7 @@ type ModelBackend interface {
 	CountOfSentMetrics() (int, error)
 	CleanupOldMetrics() error
 
+	Name() string
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -576,6 +576,11 @@ func (st *mockState) ModelUUID() string {
 	return st.model.UUID()
 }
 
+func (st *mockState) Name() string {
+	st.MethodCall(st, "Name")
+	return "test-model"
+}
+
 func (st *mockState) ControllerModelUUID() string {
 	st.MethodCall(st, "ControllerModelUUID")
 	return st.controllerModel.tag.Id()

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -49,7 +49,7 @@ github.com/juju/ratelimit	git	5b9ff866471762aa2ab2dced63c9fb6f53921342	2017-05-2
 github.com/juju/replicaset	git	0072546a972e6a32bdb2330809fdf7db6c755b85	2017-09-13T04:02:23Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:42:13Z
-github.com/juju/romulus	git	8bea892d0df70b89dbe7598167b4a643f06b2bc0	2018-03-15T23:01:00Z
+github.com/juju/romulus	git	4a5dc86d19ad82bc77607b535c9da447ddaafac9	2018-03-22T16:17:33Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	43f926548f91d55be6bae26ecb7d2386c64e887c	2018-02-13T13:46:16Z


### PR DESCRIPTION
## Description of change

We need to send the model name in the metric batches.

## QA steps

1. bootstrap 
2. add a model
3. deploy metered application
4. set SLA
5. make sure metrics are sent with the model's name

one relevant changes are made:
6. get user statement, make sure model name is filled in

## Documentation changes

None

## Bug reference

N/A