### PR TITLE
update goose dependency for bug 1756135

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -94,7 +94,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	8c3190dff075bf5442c9eedbf8f8ed6144a099e7	2016-12-15T13:08:49Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
-gopkg.in/goose.v2	git	4dc44b23a313a8a3e4051e7ee568a954a8cb3385	2018-02-08T12:05:40Z
+gopkg.in/goose.v2	git	36df5d12fc6d0ef1c102e1c18a22ddf345b18821	2018-03-22T12:54:45Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6	git	d93cf8b75cf4017ace4b3bf6af3bd03003e11cfa	2017-11-14T08:46:58Z


### PR DESCRIPTION
## Description of change

Resolves issues determining urls for OpenStack API.

## QA steps

Bootstrap in the customer environment.  Bootstrap in know OpenStack and Rackspace configs should not change.

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1756135
