### PR TITLE
Reinstate the pre-push commit hooks

### DIFF
--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type firewallSuite struct{
+type firewallSuite struct {
 	gitjujutesting.IsolationSuite
 }
 

--- a/scripts/pre-push.bash
+++ b/scripts/pre-push.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2013 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+set -e
+
+z40=0000000000000000000000000000000000000000
+
+IFS=' '
+while read local_ref local_sha remote_ref remote_sha
+do
+    if [ "$local_sha" = $z40 ]; then
+        # delete remote branch, no check
+        exit 0
+    else
+        git diff --quiet || (echo "unstaged changes"; exit 1)
+        git diff --cached --quiet || (echo "uncommitted changes"; exit 1)
+
+        if [ "$remote_sha" = $z40 ]
+        then
+            # New branch, examine all commits not on master
+            range="$local_sha...master"
+        else
+            # Update to existing branch, examine new commits
+            range="$remote_sha...$local_sha"
+        fi
+
+        FILECOUNT=`git log --name-only '--pretty=format:' $range | grep '.go$' | wc -l`
+        if [ $FILECOUNT -eq 0 ]; then
+            # no go files changed, skip go validation
+            exit 0
+        fi
+
+        ./scripts/verify.bash
+
+    fi
+done
+

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright 2014 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+# This is called from pre-push.bash to do some verification checks on 
+# the Go code.  The script will exit non-zero if any of these tests
+# fail. However if environment variable IGNORE_VET_WARNINGS is a non-zero
+# length string, go vet warnings will not exit non-zero.
+
+set -e 
+
+VERSION=`go version | awk '{print $3}'`
+echo "go version $VERSION"
+
+echo "checking: go fmt ..."
+BADFMT=`find * -name '*.go' -not -name '.#*' | xargs gofmt -l`
+if [ -n "$BADFMT" ]; then
+    BADFMT=`echo "$BADFMT" | sed "s/^/  /"`
+    echo -e "gofmt is sad:\n\n$BADFMT"
+    exit 1
+fi
+
+
+echo "checking: go vet ..."
+
+# Define additional Printf style functions to check. These add to the
+# default list of standard library functions that go vet already has.
+logging_prints="\
+Tracef
+Debugf
+Infof
+Warningf
+Errorf
+Criticalf
+"
+
+error_prints="\
+AlreadyExistsf
+BadRequestf
+MethodNotAllowedf
+NotAssignedf
+NotFoundf
+NotImplementedf
+NotProvisionedf
+NotSupportedf
+NotValidf
+Unauthorizedf
+UserNotFoundf
+"
+
+# Under Go 1.6, the vet docs say that -printfuncs takes each print
+# function in "name:N" format. This has changed in Go 1.7 and doesn't
+# actually seem to make a difference under 1.6 either don't bother.
+all_prints=`echo $logging_prints $error_prints | tr " " ,`
+
+go tool vet \
+   -all \
+   -composites=false \
+   -copylocks=false \
+   -printfuncs=$all_prints \
+    . || [ -n "$IGNORE_VET_WARNINGS" ]
+
+
+echo "checking: go build ..."
+go build github.com/juju/juju/...
+
+echo "checking: tests are wired up ..."
+./scripts/checktesting.bash


### PR DESCRIPTION
@nskaggs is intending to replace them with something better, but until
then we should still use them.

With bonus gofmt fix (hoist by my own petard, really).

## QA steps

While I was pushing this change I saw the fmt/vet/build/test checks running (and in fact had to fix some bad formatting).