### PR TITLE
Add --force flag to remove-offers

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -286,11 +286,12 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 }
 
 // DestroyOffers removes the specified application offers.
-func (c *Client) DestroyOffers(offerURLs ...string) error {
+func (c *Client) DestroyOffers(force bool, offerURLs ...string) error {
 	if len(offerURLs) == 0 {
 		return nil
 	}
 	args := params.DestroyApplicationOffers{
+		Force:     force,
 		OfferURLs: make([]string, len(offerURLs)),
 	}
 	for i, url := range offerURLs {

--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -290,6 +290,11 @@ func (c *Client) DestroyOffers(force bool, offerURLs ...string) error {
 	if len(offerURLs) == 0 {
 		return nil
 	}
+	if force {
+		if bestVer := c.BestAPIVersion(); bestVer < 2 {
+			return errors.NotImplementedf("DestroyOffers() with force (need v2+, have v%d)", bestVer)
+		}
+	}
 	args := params.DestroyApplicationOffers{
 		Force:     force,
 		OfferURLs: make([]string, len(offerURLs)),

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -659,6 +659,7 @@ func (s *crossmodelMockSuite) TestDestroyOffers(c *gc.C) {
 			c.Assert(request, gc.Equals, "DestroyOffers")
 			args, ok := a.(params.DestroyApplicationOffers)
 			c.Assert(ok, jc.IsTrue)
+			c.Assert(args.Force, jc.IsTrue)
 			c.Assert(args.OfferURLs, jc.DeepEquals, []string{"me/prod.app"})
 			if results, ok := result.(*params.ErrorResults); ok {
 				results.Results = []params.ErrorResult{{
@@ -668,7 +669,7 @@ func (s *crossmodelMockSuite) TestDestroyOffers(c *gc.C) {
 			return nil
 		})
 	client := applicationoffers.NewClient(apiCaller)
-	err := client.DestroyOffers("me/prod.app")
+	err := client.DestroyOffers(true, "me/prod.app")
 	c.Assert(err, gc.ErrorMatches, "fail")
 	c.Assert(called, jc.IsTrue)
 }

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -649,27 +649,51 @@ func (s *crossmodelMockSuite) TestGetConsumeDetailsBadURL(c *gc.C) {
 
 func (s *crossmodelMockSuite) TestDestroyOffers(c *gc.C) {
 	var called bool
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Assert(request, gc.Equals, "DestroyOffers")
-			args, ok := a.(params.DestroyApplicationOffers)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Force, jc.IsTrue)
-			c.Assert(args.OfferURLs, jc.DeepEquals, []string{"me/prod.app"})
-			if results, ok := result.(*params.ErrorResults); ok {
-				results.Results = []params.ErrorResult{{
-					Error: &params.Error{Message: "fail"},
-				}}
-			}
-			return nil
-		})
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				called = true
+				c.Assert(request, gc.Equals, "DestroyOffers")
+				args, ok := a.(params.DestroyApplicationOffers)
+				c.Assert(ok, jc.IsTrue)
+				c.Assert(args.Force, jc.IsTrue)
+				c.Assert(args.OfferURLs, jc.DeepEquals, []string{"me/prod.app"})
+				if results, ok := result.(*params.ErrorResults); ok {
+					results.Results = []params.ErrorResult{{
+						Error: &params.Error{Message: "fail"},
+					}}
+				}
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
 	client := applicationoffers.NewClient(apiCaller)
 	err := client.DestroyOffers(true, "me/prod.app")
 	c.Assert(err, gc.ErrorMatches, "fail")
 	c.Assert(called, jc.IsTrue)
+}
+
+func (s *crossmodelMockSuite) TestDestroyOffersForce(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Fail()
+				return nil
+			},
+		),
+		BestVersion: 1,
+	}
+	client := applicationoffers.NewClient(apiCaller)
+	err := client.DestroyOffers(true, "offer-url")
+
+	c.Assert(err, gc.ErrorMatches, "DestroyOffers\\(\\).* not implemented")
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -19,7 +19,7 @@ var facadeVersions = map[string]int{
 	"AllWatcher":                   1,
 	"Annotations":                  2,
 	"Application":                  5,
-	"ApplicationOffers":            1,
+	"ApplicationOffers":            2,
 	"ApplicationScaler":            1,
 	"Backups":                      1,
 	"Block":                        2,

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -497,7 +497,7 @@ func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 
 	// Deleting the offer results in an empty change set.
 	offers := state.NewApplicationOffers(s.State)
-	err = offers.Remove("hosted-mysql")
+	err = offers.Remove("hosted-mysql", false)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -134,6 +134,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 5, application.NewFacade) // adds AttachStorage & UpdateApplicationSeries & SetRelationStatus
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
+	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)
 	reg("Block", 2, block.NewAPI)

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -21,7 +21,7 @@ import (
 
 type offerAccessSuite struct {
 	baseSuite
-	api *applicationoffers.OffersAPI
+	api *applicationoffers.OffersAPIV2
 }
 
 var _ = gc.Suite(&offerAccessSuite{})

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -38,10 +38,11 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api, err = applicationoffers.CreateOffersAPI(
+	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, nil, s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
 	)
 	c.Assert(err, jc.ErrorIsNil)
+	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}
 }
 
 func (s *offerAccessSuite) modifyAccess(

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -48,29 +48,28 @@ func createOffersAPI(
 	authorizer facade.Authorizer,
 	resources facade.Resources,
 	authContext *commoncrossmodel.AuthContext,
-) (*OffersAPIV2, error) {
+) (*OffersAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
 
 	dataDir := resources.Get("dataDir").(common.StringResource)
-	api := &OffersAPIV2{
-		OffersAPI: &OffersAPI{
-			dataDir:      dataDir.String(),
-			authContext:  authContext,
-			APIAddresser: common.NewAPIAddresser(backend.GetAddressAndCertGetter(), resources),
-			BaseAPI: BaseAPI{
-				Authorizer:           authorizer,
-				GetApplicationOffers: getApplicationOffers,
-				ControllerModel:      backend,
-				StatePool:            statePool,
-				getEnviron:           getEnviron,
-			}}}
+	api := &OffersAPI{
+		dataDir:      dataDir.String(),
+		authContext:  authContext,
+		APIAddresser: common.NewAPIAddresser(backend.GetAddressAndCertGetter(), resources),
+		BaseAPI: BaseAPI{
+			Authorizer:           authorizer,
+			GetApplicationOffers: getApplicationOffers,
+			ControllerModel:      backend,
+			StatePool:            statePool,
+			getEnviron:           getEnviron,
+		}}
 	return api, nil
 }
 
 // NewOffersAPIV2 returns a new application offers OffersAPIV2 facade.
-func NewOffersAPIV2(ctx facade.Context) (*OffersAPIV2, error) {
+func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 	environFromModel := func(modelUUID string) (environs.Environ, error) {
 		st, releaser, err := ctx.StatePool().Get(modelUUID)
 		if err != nil {
@@ -101,9 +100,13 @@ func NewOffersAPIV2(ctx facade.Context) (*OffersAPIV2, error) {
 	)
 }
 
-// NewOffersAPI returns a new application offers OffersAPI facade.
-func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
-	return NewOffersAPI(ctx)
+// NewOffersAPIV2 returns a new application offers OffersAPIV2 facade.
+func NewOffersAPIV2(ctx facade.Context) (*OffersAPIV2, error) {
+	apiV1, err := NewOffersAPI(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &OffersAPIV2{OffersAPI: apiV1}, nil
 }
 
 // Offer makes application endpoints available for consumption at a specified URL.

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -34,6 +34,11 @@ type OffersAPI struct {
 	authContext *commoncrossmodel.AuthContext
 }
 
+// OffersAPIV2 implements the cross model interface V2.
+type OffersAPIV2 struct {
+	*OffersAPI
+}
+
 // createAPI returns a new application offers OffersAPI facade.
 func createOffersAPI(
 	getApplicationOffers func(interface{}) jujucrossmodel.ApplicationOffers,
@@ -43,28 +48,29 @@ func createOffersAPI(
 	authorizer facade.Authorizer,
 	resources facade.Resources,
 	authContext *commoncrossmodel.AuthContext,
-) (*OffersAPI, error) {
+) (*OffersAPIV2, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
 
 	dataDir := resources.Get("dataDir").(common.StringResource)
-	api := &OffersAPI{
-		dataDir:      dataDir.String(),
-		authContext:  authContext,
-		APIAddresser: common.NewAPIAddresser(backend.GetAddressAndCertGetter(), resources),
-		BaseAPI: BaseAPI{
-			Authorizer:           authorizer,
-			GetApplicationOffers: getApplicationOffers,
-			ControllerModel:      backend,
-			StatePool:            statePool,
-			getEnviron:           getEnviron,
-		}}
+	api := &OffersAPIV2{
+		OffersAPI: &OffersAPI{
+			dataDir:      dataDir.String(),
+			authContext:  authContext,
+			APIAddresser: common.NewAPIAddresser(backend.GetAddressAndCertGetter(), resources),
+			BaseAPI: BaseAPI{
+				Authorizer:           authorizer,
+				GetApplicationOffers: getApplicationOffers,
+				ControllerModel:      backend,
+				StatePool:            statePool,
+				getEnviron:           getEnviron,
+			}}}
 	return api, nil
 }
 
-// NewOffersAPI returns a new application offers OffersAPI facade.
-func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
+// NewOffersAPIV2 returns a new application offers OffersAPIV2 facade.
+func NewOffersAPIV2(ctx facade.Context) (*OffersAPIV2, error) {
 	environFromModel := func(modelUUID string) (environs.Environ, error) {
 		st, releaser, err := ctx.StatePool().Get(modelUUID)
 		if err != nil {
@@ -93,6 +99,11 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		ctx.Resources(),
 		authContext.(*commoncrossmodel.AuthContext),
 	)
+}
+
+// NewOffersAPI returns a new application offers OffersAPI facade.
+func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
+	return NewOffersAPI(ctx)
 }
 
 // Offer makes application endpoints available for consumption at a specified URL.
@@ -516,14 +527,23 @@ func (api *OffersAPI) oneRemoteApplicationInfo(urlStr string) (*params.RemoteApp
 
 // DestroyOffers removes the offers specified by the given URLs.
 func (api *OffersAPI) DestroyOffers(args params.DestroyApplicationOffers) (params.ErrorResults, error) {
-	result := make([]params.ErrorResult, len(args.OfferURLs))
+	return destroyOffers(api, args.OfferURLs, false)
+}
 
-	models, err := api.getModelsFromOffers(args.OfferURLs...)
+// DestroyOffers removes the offers specified by the given URLs, forcing if necessary.
+func (api *OffersAPIV2) DestroyOffers(args params.DestroyApplicationOffers) (params.ErrorResults, error) {
+	return destroyOffers(api.OffersAPI, args.OfferURLs, args.Force)
+}
+
+func destroyOffers(api *OffersAPI, offerURLs []string, force bool) (params.ErrorResults, error) {
+	result := make([]params.ErrorResult, len(offerURLs))
+
+	models, err := api.getModelsFromOffers(offerURLs...)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
-	for i, one := range args.OfferURLs {
+	for i, one := range offerURLs {
 		url, err := jujucrossmodel.ParseOfferURL(one)
 		if err != nil {
 			result[i].Error = common.ServerError(err)
@@ -544,7 +564,7 @@ func (api *OffersAPI) DestroyOffers(args params.DestroyApplicationOffers) (param
 			result[i].Error = common.ServerError(err)
 			continue
 		}
-		err = api.GetApplicationOffers(backend).Remove(url.ApplicationName)
+		err = api.GetApplicationOffers(backend).Remove(url.ApplicationName, force)
 		result[i].Error = common.ServerError(err)
 	}
 	return params.ErrorResults{Results: result}, nil

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -59,7 +59,7 @@ func (m *stubApplicationOffers) UpdateOffer(offer jujucrossmodel.AddApplicationO
 	panic("not implemented")
 }
 
-func (m *stubApplicationOffers) Remove(url string) error {
+func (m *stubApplicationOffers) Remove(url string, force bool) error {
 	m.AddCall(removeOfferCall)
 	panic("not implemented")
 }
@@ -305,7 +305,10 @@ func (m *mockApplicationOffers) ListOffers(filters ...jujucrossmodel.Application
 	return result, nil
 }
 
-func (m *mockApplicationOffers) Remove(name string) error {
+func (m *mockApplicationOffers) Remove(name string, force bool) error {
+	if len(m.st.connections) > 0 && !force {
+		return errors.Errorf("offer has %d relations", len(m.st.connections))
+	}
 	_, ok := m.st.applicationOffers[name]
 	if !ok {
 		return errors.NotFoundf("application offer %q", name)

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -71,6 +71,7 @@ func (c *removeCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ControllerCommandBase.SetFlags(f)
 	f.BoolVar(&c.force, "force", false, "remove the offer as well as any relations to the offer")
 	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
@@ -168,7 +169,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	}
 	defer api.Close()
 
-	if api.BestAPIVersion() < 2 {
+	if c.force && api.BestAPIVersion() < 2 {
 		return errors.NotSupportedf("on this juju controller, remove-offer --force")
 	}
 

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&removeSuite{})
 
 func (s *removeSuite) SetUpTest(c *gc.C) {
 	s.BaseCrossModelSuite.SetUpTest(c)
-	s.mockAPI = &mockRemoveAPI{}
+	s.mockAPI = &mockRemoveAPI{version: 2}
 }
 
 func (s *removeSuite) runRemove(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -43,28 +43,50 @@ func (s *removeSuite) TestRemoveInconsistentControllers(c *gc.C) {
 
 func (s *removeSuite) TestRemoveApiError(c *gc.C) {
 	s.mockAPI.msg = "fail"
-	_, err := s.runRemove(c, "fred/model.db2")
+	_, err := s.runRemove(c, "fred/model.db2", "-y")
 	c.Assert(err, gc.ErrorMatches, ".*fail.*")
 }
 
 func (s *removeSuite) TestRemove(c *gc.C) {
 	s.mockAPI.expectedURLs = []string{"fred/model.db2", "mary/model.db2"}
-	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2")
+	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *removeSuite) TestRemoveForce(c *gc.C) {
+	s.mockAPI.expectedURLs = []string{"fred/model.db2", "mary/model.db2"}
+	s.mockAPI.expectedForce = true
+	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y", "--force")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *removeSuite) TestOldAPI(c *gc.C) {
+	s.mockAPI.version = 1
+	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y")
+	c.Assert(err, gc.ErrorMatches, "on this juju controller, remove-offer --force not supported")
+}
+
 type mockRemoveAPI struct {
-	msg          string
-	expectedURLs []string
+	version       int
+	msg           string
+	expectedForce bool
+	expectedURLs  []string
 }
 
 func (s mockRemoveAPI) Close() error {
 	return nil
 }
 
-func (s mockRemoveAPI) DestroyOffers(offerURLs ...string) error {
+func (s mockRemoveAPI) BestAPIVersion() int {
+	return s.version
+}
+
+func (s mockRemoveAPI) DestroyOffers(force bool, offerURLs ...string) error {
 	if s.msg != "" {
 		return errors.New(s.msg)
+	}
+	if s.expectedForce != force {
+		return errors.New("mismatched force arg")
 	}
 	if strings.Join(s.expectedURLs, ",") != strings.Join(offerURLs, ",") {
 		return errors.New("mismatched URLs")

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -31,6 +31,11 @@ func (s *removeSuite) runRemove(c *gc.C, args ...string) (*cmd.Context, error) {
 	return cmdtesting.RunCommand(c, crossmodel.NewRemoveCommandForTest(s.store, s.mockAPI), args...)
 }
 
+func (s *removeSuite) TestNonExistentController(c *gc.C) {
+	_, err := s.runRemove(c, "", "-c", "bad")
+	c.Assert(err, gc.ErrorMatches, `controller bad not found`)
+}
+
 func (s *removeSuite) TestRemoveURLError(c *gc.C) {
 	_, err := s.runRemove(c, "fred/model.foo/db2")
 	c.Assert(err, gc.ErrorMatches, "application offer URL has invalid form.*")
@@ -68,8 +73,15 @@ func (s *removeSuite) TestRemoveNameOnly(c *gc.C) {
 
 func (s *removeSuite) TestOldAPI(c *gc.C) {
 	s.mockAPI.version = 1
-	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y")
+	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y", "--force")
 	c.Assert(err, gc.ErrorMatches, "on this juju controller, remove-offer --force not supported")
+}
+
+func (s *removeSuite) TestOldAPINoForce(c *gc.C) {
+	s.mockAPI.expectedURLs = []string{"fred/model.db2", "mary/model.db2"}
+	s.mockAPI.version = 1
+	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 type mockRemoveAPI struct {

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -60,6 +60,12 @@ func (s *removeSuite) TestRemoveForce(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *removeSuite) TestRemoveNameOnly(c *gc.C) {
+	s.mockAPI.expectedURLs = []string{"fred/test.db2"}
+	_, err := s.runRemove(c, "db2")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *removeSuite) TestOldAPI(c *gc.C) {
 	s.mockAPI.version = 1
 	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y")
@@ -89,7 +95,7 @@ func (s mockRemoveAPI) DestroyOffers(force bool, offerURLs ...string) error {
 		return errors.New("mismatched force arg")
 	}
 	if strings.Join(s.expectedURLs, ",") != strings.Join(offerURLs, ",") {
-		return errors.New("mismatched URLs")
+		return errors.Errorf("mismatched URLs: %v != %v", s.expectedURLs, offerURLs)
 	}
 	return nil
 }

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -47,10 +47,18 @@ func (s *showSuite) TestShowURLError(c *gc.C) {
 	s.assertShowError(c, []string{"fred/model.foo/db2"}, "application offer URL has invalid form.*")
 }
 
+func (s *showSuite) TestShowNameOnly(c *gc.C) {
+	s.assertShowYaml(c, "db2")
+}
+
 func (s *showSuite) TestShowYaml(c *gc.C) {
+	s.assertShowYaml(c, "fred/model.db2")
+}
+
+func (s *showSuite) assertShowYaml(c *gc.C, arg string) {
 	s.assertShow(
 		c,
-		[]string{"fred/model.db2", "--format", "yaml"},
+		[]string{arg, "--format", "yaml"},
 		`
 test-master:fred/model.db2:
   description: IBM DB2 Express Server Edition is an entry level database system

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -139,7 +139,7 @@ type ApplicationOffers interface {
 	ListOffers(filter ...ApplicationOfferFilter) ([]ApplicationOffer, error)
 
 	// Remove removes the application offer at the specified URL.
-	Remove(offerName string) error
+	Remove(offerName string, force bool) error
 
 	// AllApplicationOffers returns all application offers in the model.
 	AllApplicationOffers() (offers []*ApplicationOffer, _ error)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1378,7 +1378,7 @@ func (s *ApplicationSuite) TestOffersRefCountWorks(c *gc.C) {
 	assertOffersRef(c, s.State, "mysql", 2)
 
 	// Once the offer is removed, refcount is decremented.
-	err = ao.Remove("hosted-mysql")
+	err = ao.Remove("hosted-mysql", false)
 	c.Assert(err, jc.ErrorIsNil)
 	assertOffersRef(c, s.State, "mysql", 1)
 
@@ -1388,7 +1388,7 @@ func (s *ApplicationSuite) TestOffersRefCountWorks(c *gc.C) {
 	assertOffersRef(c, s.State, "mysql", 1)
 
 	// Remove the last offer and the app can be destroyed.
-	err = ao.Remove("mysql-offer")
+	err = ao.Remove("mysql-offer", false)
 	c.Assert(err, jc.ErrorIsNil)
 	assertNoOffersRef(c, s.State, "mysql")
 


### PR DESCRIPTION
## Description of change

This PR allows people to remove offers which have connections by adding a --force arg to remove-offers command.

## QA steps

Deploy a cross model scenario.
Remove an offer which has connections.
Ensure it fails without --force
With --force, ensure it works and also deletes the relations
Check relation departed hooks run etc

## Documentation changes

Need to document the new --force arg for remove-offers

## Bug reference

https://bugs.launchpad.net/juju/+bug/1757926
https://bugs.launchpad.net/juju/+bug/1757944