### PR TITLE
2.3 Disregard Addresses in the Empty Space During Mongo Space Name Determination

### DIFF
--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -645,9 +645,9 @@ func (s *workerSuite) TestMongoNoSpaces(c *gc.C) {
 		}
 
 		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
+		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceInvalid)
 
-		// Only space one has all three servers in it
+		// No space was set.
 		c.Assert(st.getMongoSpaceName(), gc.Equals, "")
 	})
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -652,34 +652,6 @@ func (s *workerSuite) TestMongoNoSpaces(c *gc.C) {
 	})
 }
 
-func (s *workerSuite) TestMongoSpaceNotOverwritten(c *gc.C) {
-	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
-		st, machines, hostPorts := mongoSpaceTestCommonSetup(c, ipVersion, false)
-
-		for i, machine := range machines {
-			// machine 10 gets a host port in space one
-			// machine 11 gets host ports in spaces one and two
-			// machine 12 gets host ports in spaces one, two and three
-			st.machine(machine).setMongoHostPorts(hostPorts[0 : i+1])
-		}
-
-		w := startWorkerSupportingSpaces(c, st, ipVersion)
-		runWorkerUntilMongoStateIs(c, st, w, state.MongoSpaceValid)
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "one")
-
-		// Set st.mongoSpaceName to something different
-
-		st.SetMongoSpaceState(state.MongoSpaceUnknown)
-		st.SetOrGetMongoSpaceName("testing")
-
-		// Only space one has all three servers in it
-		c.Assert(st.getMongoSpaceName(), gc.Equals, "testing")
-		c.Assert(st.getMongoSpaceState(), gc.Equals, state.MongoSpaceValid)
-	})
-}
-
 func (s *workerSuite) TestMongoSpaceNotCalculatedWhenSpacesNotSupported(c *gc.C) {
 	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
 		st, machines, hostPorts := mongoSpaceTestCommonSetup(c, ipVersion, false)


### PR DESCRIPTION
## Description of change

Allowing the empty space to be factored into the auto-determination of the Mongo space name is error-prone, as it brings machine-local addresses into the potential calculation.

Such addresses are now ignored.

Ignoring addresses in the empty space has the side-effect of the empty space never being a valid space. _MongoSpaceState_ is always invalid if no non-empty space can be determined.

## QA steps

Accompanying unit test changes.

## Documentation changes

None.

## Bug reference

N/A
