### PR TITLE
Reintroduce snap wrapper to force PATH to include snap path.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ grade: devel
 
 apps:
   juju:
-    command: bin/juju
+    command: wrappers/juju
 
 parts:
   wrappers:

--- a/snap/wrappers/juju
+++ b/snap/wrappers/juju
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
+export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
+
+exec $SNAP/bin/juju "$@"
+


### PR DESCRIPTION
This will fix LP:1759013 as it adds the snap build bin path so that juju-metadata can be found.