### PR TITLE
Make sure we sort slices we are comparing.

### DIFF
--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -306,9 +306,15 @@ func (s *ipAddressesStateSuite) TestMachineAllNetworkAddresses(c *gc.C) {
 	for i := range addedAddresses {
 		expected[i] = addedAddresses[i].NetworkAddress()
 	}
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i].Value < expected[j].Value
+	})
 
 	networkAddresses, err := s.machine.AllNetworkAddresses()
 	c.Assert(err, jc.ErrorIsNil)
+	sort.Slice(networkAddresses, func(i, j int) bool {
+		return networkAddresses[i].Value < networkAddresses[j].Value
+	})
 	c.Assert(networkAddresses, jc.DeepEquals, expected)
 }
 


### PR DESCRIPTION
## Description of change

The ordering of NetworkAddresses is not guaranteed. The other Addresses
tests were already sorting, it seems we just missed this one because it
was a different object type. I don't know why it usually passes, but on
my machine using Mongo 3.4 I see it fail about every other run.

## QA steps

```
$ cd state
$ git test -check.v -check.f TestMachineAll
```

## Documentation changes

None.

## Bug reference

None. (Intermittent test that didn't seem to trip on CI)