### PR TITLE
Model owner not special

### DIFF
--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -87,9 +87,10 @@ func GetPermission(accessGetter userAccessFunc, userTag names.UserTag, target na
 	return userAccess, nil
 }
 
-// HasModelAdmin reports whether or not a user has admin access to the specified model.
-// A user has model access if they are the model owner, if they are a controller superuser,
-// or if they have been explicitly granted admin access to the model.
+// HasModelAdmin reports whether or not a user has admin access to the
+// specified model. A user has model access if they are a controller
+// superuser, or if they have been explicitly granted admin access to the
+// model.
 func HasModelAdmin(
 	authorizer facade.Authorizer,
 	user names.UserTag,
@@ -99,10 +100,6 @@ func HasModelAdmin(
 	// superusers have admin for all models.
 	if isSuperUser, err := authorizer.HasPermission(permission.SuperuserAccess, controllerTag); err != nil || isSuperUser {
 		return isSuperUser, err
-	}
-	// model owners have admin.
-	if user.Id() == model.Owner().Id() {
-		return true, nil
 	}
 	return authorizer.HasPermission(permission.AdminAccess, model.ModelTag())
 }

--- a/apiserver/facades/client/keymanager/keymanager_test.go
+++ b/apiserver/facades/client/keymanager/keymanager_test.go
@@ -228,13 +228,6 @@ func (s *keyManagerSuite) TestAddKeysModelAdmin(c *gc.C) {
 	s.assertAddKeys(c, otherState, user.UserTag(), true)
 }
 
-func (s *keyManagerSuite) TestAddKeysModelOwner(c *gc.C) {
-	user := s.Factory.MakeUser(c, nil)
-	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
-	defer otherModel.Close()
-	s.assertAddKeys(c, otherModel, user.UserTag(), true)
-}
-
 func (s *keyManagerSuite) TestAddKeysNonAuthorised(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	s.assertAddKeys(c, s.State, user.UserTag(), false)
@@ -330,13 +323,6 @@ func (s *keyManagerSuite) TestDeleteKeysModelAdmin(c *gc.C) {
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
 	s.assertDeleteKeys(c, otherState, user.UserTag(), true)
-}
-
-func (s *keyManagerSuite) TestDeleteKeysModelOwner(c *gc.C) {
-	user := s.Factory.MakeUser(c, nil)
-	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
-	defer otherModel.Close()
-	s.assertDeleteKeys(c, otherModel, user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestDeleteKeysNonAuthorised(c *gc.C) {
@@ -517,13 +503,6 @@ func (s *keyManagerSuite) TestImportKeysModelAdmin(c *gc.C) {
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "admin" + otherModel.ModelTag().String()})
 	s.assertImportKeys(c, otherState, user.UserTag(), true)
-}
-
-func (s *keyManagerSuite) TestImportKeysModelOwner(c *gc.C) {
-	user := s.Factory.MakeUser(c, nil)
-	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Owner: user.UserTag()})
-	defer otherModel.Close()
-	s.assertImportKeys(c, otherModel, user.UserTag(), true)
 }
 
 func (s *keyManagerSuite) TestImportKeysNonAuthorised(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -216,11 +216,11 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 	})
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"UUID", nil},
-		{"Owner", nil},
 		{"Name", nil},
 		{"Type", nil},
 		{"UUID", nil},
 		{"ControllerUUID", nil},
+		{"Owner", nil},
 		{"Life", nil},
 		{"Cloud", nil},
 		{"CloudRegion", nil},
@@ -241,13 +241,6 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"LastModelConnection", []interface{}{names.NewLocalUserTag("mary")}},
 		{"Type", nil},
 	})
-}
-
-func (s *modelInfoSuite) TestModelInfoOwner(c *gc.C) {
-	s.setAPIUser(c, names.NewUserTag("bob@local"))
-	info := s.getModelInfo(c, s.st.model.cfg.UUID())
-	c.Assert(info.Users, gc.HasLen, 4)
-	c.Assert(info.Machines, gc.HasLen, 2)
 }
 
 func (s *modelInfoSuite) TestModelInfoWriteAccess(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -832,7 +832,6 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	destroyStorage := true
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"UUID", nil},
-		{"Owner", nil},
 		{"Destroy", []interface{}{state.DestroyModelParams{
 			DestroyStorage: &destroyStorage,
 		}}},

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -320,12 +320,6 @@ func (st *State) CredentialModelsAndOwnerAccess(tag names.CloudCredentialTag) ([
 		ownerAccess, err := st.UserAccess(tag.Owner(), names.NewModelTag(model.UUID))
 		if err != nil {
 			if errors.IsNotFound(err) {
-				// Model owner is one of the model admins.
-				modelOwnerTag, _ := names.ParseUserTag(model.Owner)
-				if modelOwnerTag == tag.Owner() {
-					results[i].OwnerAccess = permission.AdminAccess
-					continue
-				}
 				results[i].OwnerAccess = permission.NoAccess
 				continue
 			}


### PR DESCRIPTION
When we first had multiple models we did not have permissions, so model owners were special. 

Since we now have model admins, the owner should no longer be special.

While cleaning this up, I found that the check to destroy model was just wrong, and was only checking against the model owner rather than model admins for permission to destroy.
