### PR TITLE
Adding invalid flag and reason to stored credentials.

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -38,6 +38,13 @@ type Credential struct {
 
 	// Label is optionally set to describe the credentials to a user.
 	Label string
+
+	// Invalid is true if the credential is invalid.
+	Invalid bool
+
+	// InvalidReason contains the reason why a credential was flagged as invalid.
+	// It is expected that this string will be empty when a credential is valid.
+	InvalidReason string
 }
 
 // AuthType returns the authentication type.

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -115,7 +115,7 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 	credentials := map[names.CloudCredentialTag]Credential{
 		tag: convertCloudCredentialToState(tag, credential),
 	}
-	annotationMsg := "updating cloud credential"
+	annotationMsg := "updating cloud credentials"
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		cloudName := tag.Cloud().Id()
 		cloud, err := st.Cloud(cloudName)

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -29,6 +29,11 @@ func (c Credential) CloudCredentialTag() (names.CloudCredentialTag, error) {
 	return c.cloudCredentialDoc.cloudCredentialTag()
 }
 
+// IsValid indicates whether the credential is valid.
+func (c Credential) IsValid() bool {
+	return !c.cloudCredentialDoc.Invalid
+}
+
 // cloudCredentialDoc records information about a user's cloud credentials.
 type cloudCredentialDoc struct {
 	DocID      string            `bson:"_id"`
@@ -38,6 +43,22 @@ type cloudCredentialDoc struct {
 	Revoked    bool              `bson:"revoked"`
 	AuthType   string            `bson:"auth-type"`
 	Attributes map[string]string `bson:"attributes,omitempty"`
+
+	// Invalid stores flag that indicates if a credential is invalid.
+	// Note that the credential is valid:
+	//  * if the flag is explicitly set to 'false'; or
+	//  * if the flag is not set at all, as will be the case for
+	//    new inserts or credentials created with previous Juju versions. In
+	//    this case, we'd still read it as 'false' and the credential validity
+	//    will be interpreted correctly.
+	// This flag will need to be explicitly set to 'true' for a credential
+	// to be considered invalid.
+	Invalid bool `bson:"invalid"`
+
+	// InvalidReason contains the reason why the credential was marked as invalid.
+	// This can range from cloud messages such as an expired credential to
+	// commercial reasons set via CLI or api calls.
+	InvalidReason string `bson:"invalid-reason,omitempty"`
 }
 
 // CloudCredential returns the cloud credential for the given tag.
@@ -57,7 +78,6 @@ func (st *State) CloudCredential(tag names.CloudCredentialTag) (Credential, erro
 		)
 	}
 	return Credential{doc}, nil
-
 }
 
 // CloudCredentials returns the user's cloud credentials for a given cloud,
@@ -169,6 +189,8 @@ func updateCloudCredentialOp(tag names.CloudCredentialTag, cred cloud.Credential
 			{"auth-type", string(cred.AuthType())},
 			{"attributes", cred.Attributes()},
 			{"revoked", cred.Revoked},
+			{"invalid", cred.Invalid},
+			{"invalid-reason", cred.InvalidReason},
 		}}},
 	}
 }

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -135,7 +135,7 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 		} else {
 			annotationMsg = "creating cloud credential"
 			if credential.Invalid || credential.InvalidReason != "" {
-				return nil, errors.NotValidf("adding invalid credential")
+				return nil, errors.NotSupportedf("adding invalid credential")
 			}
 			ops = append(ops, createCloudCredentialOp(tag, credential))
 		}

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -68,7 +68,7 @@ func (s *CloudCredentialsSuite) TestCreateInvalidCredential(c *gc.C) {
 	cred.InvalidReason = "because am testing you"
 	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
 	err = s.State.UpdateCloudCredential(tag, cred)
-	c.Assert(err, gc.ErrorMatches, "creating cloud credential: adding invalid credential not valid")
+	c.Assert(err, gc.ErrorMatches, "creating cloud credential: adding invalid credential not supported")
 }
 
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -51,6 +51,38 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, expected)
 }
 
+func (s *CloudCredentialsSuite) TesCreateInvalidCredential(c *gc.C) {
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	// Setting of these properties should have no effect when creating a new credential.
+	cred.Invalid = true
+	cred.InvalidReason = "because am testing you"
+	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+
+	out, err := s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := statetesting.CloudCredential(cloud.AccessKeyAuthType,
+		map[string]string{"bar": "bar val", "foo": "foo val"},
+	)
+	expected.DocID = "stratus#bob#foobar"
+	expected.Owner = "bob"
+	expected.Cloud = "stratus"
+	expected.Name = "foobar"
+	c.Assert(out, jc.DeepEquals, expected)
+}
+
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 	err := s.State.AddCloud(cloud.Cloud{
 		Name:      "stratus",
@@ -88,6 +120,62 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 	expected.Name = "foobar"
 	expected.Revoked = true
 
+	c.Assert(out, jc.DeepEquals, expected)
+}
+
+func (s *CloudCredentialsSuite) TestInvalidateCredential(c *gc.C) {
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred = cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"user":     "bob's nephew",
+		"password": "simple",
+	})
+	cred.Invalid = true
+	cred.InvalidReason = "because it is really really invalid"
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+
+	out, err := s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := statetesting.CloudCredential(cloud.UserPassAuthType, map[string]string{
+		"user":     "bob's nephew",
+		"password": "simple",
+	})
+	expected.DocID = "stratus#bob#foobar"
+	expected.Owner = "bob"
+	expected.Cloud = "stratus"
+	expected.Name = "foobar"
+	expected.Invalid = true
+	expected.InvalidReason = "because it is really really invalid"
+
+	c.Assert(out, jc.DeepEquals, expected)
+
+	// and now flip back to indicate credential is valid
+	cred.Invalid = false
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+
+	out, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected.Invalid = false
+	// InvalidReason has not been emptied (it will be a responsibility of
+	// api/apiserver layers to construct correct requests that remove the reason when credential is valid).
+	// Here we do expect that the reason is still present.
 	c.Assert(out, jc.DeepEquals, expected)
 }
 

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -51,7 +51,7 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, expected)
 }
 
-func (s *CloudCredentialsSuite) TesCreateInvalidCredential(c *gc.C) {
+func (s *CloudCredentialsSuite) TestCreateInvalidCredential(c *gc.C) {
 	err := s.State.AddCloud(cloud.Cloud{
 		Name:      "stratus",
 		Type:      "low",
@@ -68,19 +68,7 @@ func (s *CloudCredentialsSuite) TesCreateInvalidCredential(c *gc.C) {
 	cred.InvalidReason = "because am testing you"
 	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
 	err = s.State.UpdateCloudCredential(tag, cred)
-	c.Assert(err, jc.ErrorIsNil)
-
-	out, err := s.State.CloudCredential(tag)
-	c.Assert(err, jc.ErrorIsNil)
-
-	expected := statetesting.CloudCredential(cloud.AccessKeyAuthType,
-		map[string]string{"bar": "bar val", "foo": "foo val"},
-	)
-	expected.DocID = "stratus#bob#foobar"
-	expected.Owner = "bob"
-	expected.Cloud = "stratus"
-	expected.Name = "foobar"
-	c.Assert(out, jc.DeepEquals, expected)
+	c.Assert(err, gc.ErrorMatches, "creating cloud credential: adding invalid credential not valid")
 }
 
 func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -123,6 +123,8 @@ func convertCloudCredentialToState(tag names.CloudCredentialTag, cloudCredential
 	credential.Owner = tag.Owner().Id()
 	credential.Cloud = tag.Cloud().Id()
 	credential.DocID = cloudCredentialDocID(tag)
+	credential.Invalid = cloudCredential.Invalid
+	credential.InvalidReason = cloudCredential.InvalidReason
 	return credential
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -65,6 +65,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainCredentials(c *gc.C) {
 		"cloud":      "cloud-aws",
 		"name":       "default",
 		"revoked":    false,
+		"invalid":    false,
 		"auth-type":  "userpass",
 		"attributes": bson.M{"user": "fred"},
 	}, {
@@ -73,6 +74,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainCredentials(c *gc.C) {
 		"cloud":      "cloud-aws",
 		"name":       "default",
 		"revoked":    false,
+		"invalid":    false,
 		"auth-type":  "userpass",
 		"attributes": bson.M{"user": "fred"},
 	}}
@@ -554,12 +556,14 @@ func (s *upgradesSuite) TestUpdateLegacyLXDCloud(c *gc.C) {
 	}}
 
 	expectedCloudCreds := []bson.M{{
-		"_id":       "localhost#admin#streetcred",
-		"owner":     "admin",
-		"cloud":     "localhost",
-		"name":      "streetcred",
-		"revoked":   false,
-		"auth-type": "certificate",
+		"_id":            "localhost#admin#streetcred",
+		"owner":          "admin",
+		"cloud":          "localhost",
+		"name":           "streetcred",
+		"revoked":        false,
+		"invalid":        false,
+		"invalid-reason": "",
+		"auth-type":      "certificate",
 		"attributes": bson.M{
 			"foo": "bar",
 			"baz": "qux",


### PR DESCRIPTION
## Description of change

We need the ability to invalidate cloud credentials. This PR adds a flag and a reason property at state layer.

