### PR TITLE
Run config-changed hook on application config update.

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -569,7 +569,7 @@ func (u *Unit) WatchConfigSettings() (watcher.NotifyWatcher, error) {
 // configuration settings watchers which are created with WatchConfigSettings
 // and do not monitor for application configuration settings such as "trust".
 func (u *Unit) WatchTrustConfigSettings() (watcher.NotifyWatcher, error) {
-	return getSettingsWatcher(u, "WatchApplicationConfigSettings")
+	return getSettingsWatcher(u, "WatchTrustConfigSettings")
 }
 
 func getSettingsWatcher(u *Unit, facadeName string) (watcher.NotifyWatcher, error) {

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -561,11 +561,23 @@ func (u *Unit) ClearResolved() error {
 // set before this method is called, and the returned watcher will be
 // valid only while the unit's charm URL is not changed.
 func (u *Unit) WatchConfigSettings() (watcher.NotifyWatcher, error) {
+	return getSettingsWatcher(u, "WatchConfigSettings")
+}
+
+// WatchTrustConfigSettings will return a watcher to monitor at least the trust
+// application configuration settings. This is in contrast to Charm
+// configuration settings watchers which are created with WatchConfigSettings
+// and do not monitor for application configuration settings such as "trust".
+func (u *Unit) WatchTrustConfigSettings() (watcher.NotifyWatcher, error) {
+	return getSettingsWatcher(u, "WatchApplicationConfigSettings")
+}
+
+func getSettingsWatcher(u *Unit, facadeName string) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.st.facade.FacadeCall("WatchConfigSettings", args, &results)
+	err := u.st.facade.FacadeCall(facadeName, args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -565,29 +565,40 @@ func (s *unitSuite) TestWatchConfigSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
-	// Update application config and see if it is reported
-	field := "applicationConfigField"
-	s.wordpressApplication.UpdateApplicationConfig(application.ConfigAttributes{
-		field: true,
-	},
-		[]string{},
-		environschema.Fields{field: {
-			Description: "Does this application have access to trusted credentials",
-			Type:        environschema.Tbool,
-			Group:       environschema.JujuGroup,
-		}},
-		schema.Defaults{
-			field: false,
-		},
-	)
-	wc.AssertOneChange()
-
 	// Non-change is not reported.
 	err = s.wordpressApplication.UpdateCharmConfig(charm.Settings{
 		"blog-title": "sauceror central",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
+}
+
+func (s *unitSuite) TestWatchTrustConfigSettings(c *gc.C) {
+	watcher, err := s.apiUnit.WatchTrustConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	notifyWatcher := watchertest.NewNotifyWatcherC(c, watcher, s.BackingState.StartSync)
+	defer notifyWatcher.AssertStops()
+
+	// Initial event.
+	notifyWatcher.AssertOneChange()
+
+	// Update application config and see if it is reported
+	trustFieldKey := "trust"
+	s.wordpressApplication.UpdateApplicationConfig(application.ConfigAttributes{
+		trustFieldKey: true,
+	},
+		[]string{},
+		environschema.Fields{trustFieldKey: {
+			Description: "Does this application have access to trusted credentials",
+			Type:        environschema.Tbool,
+			Group:       environschema.JujuGroup,
+		}},
+		schema.Defaults{
+			trustFieldKey: false,
+		},
+	)
+	notifyWatcher.AssertOneChange()
 }
 
 func (s *unitSuite) TestWatchActionNotifications(c *gc.C) {

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
@@ -19,6 +21,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/application"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -560,6 +563,23 @@ func (s *unitSuite) TestWatchConfigSettings(c *gc.C) {
 		"blog-title": "sauceror central",
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Update application config and see if it is reported
+	field := "applicationConfigField"
+	s.wordpressApplication.UpdateApplicationConfig(application.ConfigAttributes{
+		field: true,
+	},
+		[]string{},
+		environschema.Fields{field: {
+			Description: "Does this application have access to trusted credentials",
+			Type:        environschema.Tbool,
+			Group:       environschema.JujuGroup,
+		}},
+		schema.Defaults{
+			field: false,
+		},
+	)
 	wc.AssertOneChange()
 
 	// Non-change is not reported.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -939,7 +939,7 @@ func (u *UniterAPI) WatchConfigSettings(args params.Entities) (params.NotifyWatc
 	return result, nil
 }
 
-func (u *UniterAPI) WatchApplicationConfigSettings(args params.Entities) (params.NotifyWatchResults, error) {
+func (u *UniterAPI) WatchTrustConfigSettings(args params.Entities) (params.NotifyWatchResults, error) {
 	watcherFn := func(u *state.Unit) (state.NotifyWatcher, error) {
 		return u.WatchApplicationConfigSettings()
 	}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -928,6 +928,30 @@ func (u *UniterAPI) ClosePorts(args params.EntitiesPortRanges) (params.ErrorResu
 // to each unit's application configuration settings. See also
 // state/watcher.go:Unit.WatchConfigSettings().
 func (u *UniterAPI) WatchConfigSettings(args params.Entities) (params.NotifyWatchResults, error) {
+	watcherFn := func(u *state.Unit) (state.NotifyWatcher, error) {
+		return u.WatchConfigSettings()
+	}
+	result, err := u.WatchSettings(args, watcherFn)
+	if err != nil {
+		return params.NotifyWatchResults{}, errors.Trace(err)
+	}
+
+	return result, nil
+}
+
+func (u *UniterAPI) WatchApplicationConfigSettings(args params.Entities) (params.NotifyWatchResults, error) {
+	watcherFn := func(u *state.Unit) (state.NotifyWatcher, error) {
+		return u.WatchApplicationConfigSettings()
+	}
+	result, err := u.WatchSettings(args, watcherFn)
+	if err != nil {
+		return params.NotifyWatchResults{}, errors.Trace(err)
+	}
+
+	return result, nil
+}
+
+func (u *UniterAPI) WatchSettings(args params.Entities, configWatcherFn func(u *state.Unit) (state.NotifyWatcher, error)) (params.NotifyWatchResults, error) {
 	result := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -944,7 +968,7 @@ func (u *UniterAPI) WatchConfigSettings(args params.Entities) (params.NotifyWatc
 		err = common.ErrPerm
 		watcherId := ""
 		if canAccess(tag) {
-			watcherId, err = u.watchOneUnitConfigSettings(tag)
+			watcherId, err = u.watchOneUnitConfigSettings(tag, configWatcherFn)
 		}
 		result.Results[i].NotifyWatcherId = watcherId
 		result.Results[i].Error = common.ServerError(err)
@@ -1726,23 +1750,23 @@ func (u *UniterAPI) destroySubordinates(principal *state.Unit) error {
 	return nil
 }
 
-func (u *UniterAPI) watchOneUnitConfigSettings(tag names.UnitTag) (string, error) {
+func (u *UniterAPI) watchOneUnitConfigSettings(tag names.UnitTag, configWatcherFn func(u *state.Unit) (state.NotifyWatcher, error)) (string, error) {
 	unit, err := u.getUnit(tag)
 	if err != nil {
 		return "", err
 	}
-	watch, err := unit.WatchConfigSettings()
+	configWatcher, err := configWatcherFn(unit)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(err)
 	}
 	// Consume the initial event. Technically, API
 	// calls to Watch 'transmit' the initial event
 	// in the Watch response. But NotifyWatchers
 	// have no state to transmit.
-	if _, ok := <-watch.Changes(); ok {
-		return u.resources.Register(watch), nil
+	if _, ok := <-configWatcher.Changes(); ok {
+		return u.resources.Register(configWatcher), nil
 	}
-	return "", watcher.EnsureErr(watch)
+	return "", watcher.EnsureErr(configWatcher)
 }
 
 func (u *UniterAPI) watchOneUnitAddresses(tag names.UnitTag) (string, error) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1616,8 +1616,18 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit charm not set")
 	}
-	settingsKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
-	return newEntityWatcher(u.st, settingsC, u.st.docID(settingsKey)), nil
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+	applicationConfigKey := applicationConfigKey(u.ApplicationName())
+	watcher := newDocWatcher(u.st, []docKey{
+		{
+			settingsC,
+			u.st.docID(charmConfigKey),
+		}, {
+			settingsC,
+			u.st.docID(applicationConfigKey),
+		},
+	})
+	return watcher, nil
 }
 
 // WatchMeterStatus returns a watcher observing changes that affect the meter status

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1617,17 +1617,14 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 		return nil, fmt.Errorf("unit charm not set")
 	}
 	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
+}
+
+// WatchApplicationConfigSettings is the same as WatchConfigSettings but
+// notifies on changes to application configuration not charm configuration.
+func (u *Unit) WatchApplicationConfigSettings() (NotifyWatcher, error) {
 	applicationConfigKey := applicationConfigKey(u.ApplicationName())
-	watcher := newDocWatcher(u.st, []docKey{
-		{
-			settingsC,
-			u.st.docID(charmConfigKey),
-		}, {
-			settingsC,
-			u.st.docID(applicationConfigKey),
-		},
-	})
-	return watcher, nil
+	return newEntityWatcher(u.st, settingsC, u.st.docID(applicationConfigKey)), nil
 }
 
 // WatchMeterStatus returns a watcher observing changes that affect the meter status

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -195,17 +195,18 @@ func (st *mockState) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, err
 }
 
 type mockUnit struct {
-	tag                   names.UnitTag
-	life                  params.Life
-	resolved              params.ResolvedMode
-	series                string
-	application           mockApplication
-	unitWatcher           *mockNotifyWatcher
-	addressesWatcher      *mockNotifyWatcher
-	configSettingsWatcher *mockNotifyWatcher
-	storageWatcher        *mockStringsWatcher
-	actionWatcher         *mockStringsWatcher
-	relationsWatcher      *mockStringsWatcher
+	tag                              names.UnitTag
+	life                             params.Life
+	resolved                         params.ResolvedMode
+	series                           string
+	application                      mockApplication
+	unitWatcher                      *mockNotifyWatcher
+	addressesWatcher                 *mockNotifyWatcher
+	configSettingsWatcher            *mockNotifyWatcher
+	applicationConfigSettingsWatcher *mockNotifyWatcher
+	storageWatcher                   *mockStringsWatcher
+	actionWatcher                    *mockStringsWatcher
+	relationsWatcher                 *mockStringsWatcher
 }
 
 func (u *mockUnit) Life() params.Life {
@@ -242,6 +243,10 @@ func (u *mockUnit) WatchAddresses() (watcher.NotifyWatcher, error) {
 
 func (u *mockUnit) WatchConfigSettings() (watcher.NotifyWatcher, error) {
 	return u.configSettingsWatcher, nil
+}
+
+func (u *mockUnit) WatchTrustConfigSettings() (watcher.NotifyWatcher, error) {
+	return u.applicationConfigSettingsWatcher, nil
 }
 
 func (u *mockUnit) WatchStorage() (watcher.StringsWatcher, error) {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -41,6 +41,7 @@ type Unit interface {
 	Watch() (watcher.NotifyWatcher, error)
 	WatchAddresses() (watcher.NotifyWatcher, error)
 	WatchConfigSettings() (watcher.NotifyWatcher, error)
+	WatchTrustConfigSettings() (watcher.NotifyWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)
 	WatchActionNotifications() (watcher.StringsWatcher, error)
 	// WatchRelation returns a watcher that fires when relations

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -196,11 +196,12 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 	requiredEvents++
 
 	var seenConfigChange bool
-	configw, err := w.unit.WatchConfigSettings()
+	charmConfigw, err := w.unit.WatchConfigSettings()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := w.catacomb.Add(configw); err != nil {
+	trustConfigw, err := w.unit.WatchTrustConfigSettings()
+	if err != nil {
 		return errors.Trace(err)
 	}
 	requiredEvents++
@@ -334,6 +335,17 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 	resetUpdateStatusTimer := func() {
 		updateStatusTimer = w.updateStatusChannel(updateStatusInterval).After()
 	}
+	configChanged := func(changeOccured bool) error {
+		logger.Debugf("got config change: ok=%t", changeOccured)
+		if !changeOccured {
+			return errors.New("config watcher closed")
+		}
+		if err := w.configChanged(); err != nil {
+			return errors.Trace(err)
+		}
+		observedEvent(&seenConfigChange)
+		return nil
+	}
 
 	for {
 		select {
@@ -360,16 +372,16 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			}
 			observedEvent(&seenApplicationChange)
 
-		case _, ok := <-configw.Changes():
-			logger.Debugf("got config change: ok=%t", ok)
-			if !ok {
-				return errors.New("config watcher closed")
+		case _, ok := <-charmConfigw.Changes():
+			err = configChanged(ok)
+			if err != nil {
+				return err
 			}
-			if err := w.configChanged(); err != nil {
-				return errors.Trace(err)
+		case _, ok := <-trustConfigw.Changes():
+			err = configChanged(ok)
+			if err != nil {
+				return err
 			}
-			observedEvent(&seenConfigChange)
-
 		case _, ok := <-addressesChanges:
 			logger.Debugf("got address change: ok=%t", ok)
 			if !ok {


### PR DESCRIPTION
## Description of change

Run config changed hook on "application configuration" update.

Why is this change needed?

Config changed hook would run on charm config changes but not application config changes.

## QA steps

Deploy an Ubuntu charm, trust the application, it should trigger config changed.

