### PR TITLE
Add support for caas upgrade-charm

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	1a6490253bea4ce78594db114d787ca97ee9f527	2018-01-09T11:21:21Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
-github.com/juju/description	git	7ee30d2bc01ef20938adea2efeb991eb817c1f2a	2018-02-21T00:58:49Z
+github.com/juju/description	git	83beb4e3593c52f6145454291e019f58a5897e47	2018-04-09T06:23:21Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65	2017-11-13T08:59:48Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/worker/caasoperator/localstate.go
+++ b/worker/caasoperator/localstate.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import "gopkg.in/juju/charm.v6"
+
+// LocalState is a cache of the state of the operator
+// It is generally compared to the remote state of the
+// the application as stored in the controller.
+type LocalState struct {
+	// CharmModifiedVersion increases any time the charm,
+	// or any part of it, is changed in some way.
+	CharmModifiedVersion int
+
+	// CharmURL reports the currently installed charm URL. This is set
+	// by the committing of deploy (install/upgrade) ops.
+	CharmURL *charm.URL
+}

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -65,8 +65,9 @@ type fakeAPICaller struct {
 type fakeClient struct {
 	testing.Stub
 	caasoperator.Client
-	unitsWatcher *watchertest.MockStringsWatcher
-	watcher      *watchertest.MockNotifyWatcher
+	unitsWatcher       *watchertest.MockStringsWatcher
+	watcher            *watchertest.MockNotifyWatcher
+	applicationWatched chan struct{}
 }
 
 func (c *fakeClient) SetStatus(application string, status status.Status, message string, data map[string]interface{}) error {
@@ -112,6 +113,7 @@ func (c *fakeClient) Watch(application string) (watcher.NotifyWatcher, error) {
 	if err := c.NextErr(); err != nil {
 		return nil, err
 	}
+	c.applicationWatched <- struct{}{}
 	return c.watcher, nil
 }
 

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -62,6 +62,11 @@ func (f *factory) NewUpgrade(charmURL *corecharm.URL) (Operation, error) {
 	return f.newDeploy(Upgrade, charmURL, false, false)
 }
 
+// NewNoOpUpgrade is part of the Factory interface.
+func (f *factory) NewNoOpUpgrade(charmURL *corecharm.URL) (Operation, error) {
+	return &skipOperation{&noOpUpgrade{charmURL: charmURL}}, nil
+}
+
 // NewRevertUpgrade is part of the Factory interface.
 func (f *factory) NewRevertUpgrade(charmURL *corecharm.URL) (Operation, error) {
 	return f.newDeploy(Upgrade, charmURL, true, false)

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -67,6 +67,10 @@ func (s *FactorySuite) TestNewUpgradeString(c *gc.C) {
 	s.testNewDeployString(c, (operation.Factory).NewUpgrade, "upgrade to")
 }
 
+func (s *FactorySuite) TestNOOpUpgradeString(c *gc.C) {
+	s.testNewDeployString(c, (operation.Factory).NewNoOpUpgrade, "skip no-op upgrade operation to")
+}
+
 func (s *FactorySuite) TestNewRevertUpgradeString(c *gc.C) {
 	s.testNewDeployString(c,
 		(operation.Factory).NewRevertUpgrade,

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -70,6 +70,14 @@ type Factory interface {
 	// NewUpgrade creates an upgrade operation for the supplied charm.
 	NewUpgrade(charmURL *corecharm.URL) (Operation, error)
 
+	// NewNoOpUpgrade creates a noop upgrade operation for the supplied charm.
+	// The purpose is to go through the machinations so that in the commit phase,
+	// the uniter records the current charm url and modified version in local state
+	// so it knows the upgraded charm has been unpacked and it can run the upgrade-charm hook.
+	// For a caas uniter, the operator is the thing that does the charm upgrade,
+	// so we just plug in a no op into the uniter state machine.
+	NewNoOpUpgrade(charmURL *corecharm.URL) (Operation, error)
+
 	// NewRevertUpgrade creates an operation to clear the unit's resolved flag,
 	// and execute an upgrade to the supplied charm that is careful to excise
 	// remnants of a previously failed upgrade to a different charm.

--- a/worker/uniter/operation/noopupgrade.go
+++ b/worker/uniter/operation/noopupgrade.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation
+
+import (
+	"fmt"
+
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+type noOpUpgrade struct {
+	Operation
+
+	charmURL *charm.URL
+}
+
+// String is part of the Operation interface.
+func (op *noOpUpgrade) String() string {
+	return fmt.Sprintf("no-op upgrade operation to %v", op.charmURL.String())
+}
+
+// Commit is part of the Operation interface.
+func (op *noOpUpgrade) Commit(state State) (*State, error) {
+	change := stateChange{
+		Kind: RunHook,
+		Step: Queued,
+		Hook: &hook.Info{Kind: hooks.UpgradeCharm},
+	}
+	newState := change.apply(state)
+	return newState, nil
+}

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -269,7 +269,7 @@ func (s *uniterResolver) nextOp(
 		if s.config.ModelType == model.IAAS {
 			return opFactory.NewUpgrade(remoteState.CharmURL)
 		} else {
-			return opFactory.NewRunHook(hook.Info{Kind: hooks.UpgradeCharm})
+			return opFactory.NewNoOpUpgrade(remoteState.CharmURL)
 		}
 	}
 

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -38,6 +38,11 @@ func (f *mockOpFactory) NewUpgrade(charmURL *charm.URL) (operation.Operation, er
 	return f.op, f.NextErr()
 }
 
+func (f *mockOpFactory) NewNoOpUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+	f.MethodCall(f, "NewNoOpUpgrade", charmURL)
+	return f.op, f.NextErr()
+}
+
 func (f *mockOpFactory) NewRevertUpgrade(charmURL *charm.URL) (operation.Operation, error) {
 	f.MethodCall(f, "NewRevertUpgrade", charmURL)
 	return f.op, f.NextErr()

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -56,6 +56,14 @@ func (s *resolverOpFactory) NewUpgrade(charmURL *charm.URL) (operation.Operation
 	return s.wrapUpgradeOp(op, charmURL), nil
 }
 
+func (s *resolverOpFactory) NewNoOpUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+	op, err := s.Factory.NewNoOpUpgrade(charmURL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return s.wrapUpgradeOp(op, charmURL), nil
+}
+
 func (s *resolverOpFactory) NewRevertUpgrade(charmURL *charm.URL) (operation.Operation, error) {
 	op, err := s.Factory.NewRevertUpgrade(charmURL)
 	if err != nil {

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -133,6 +133,7 @@ func (s *ResolverOpFactorySuite) TestUpgrade(c *gc.C) {
 	s.testUpgrade(c, resolver.ResolverOpFactory.NewUpgrade)
 	s.testUpgrade(c, resolver.ResolverOpFactory.NewRevertUpgrade)
 	s.testUpgrade(c, resolver.ResolverOpFactory.NewResolvedUpgrade)
+	s.testUpgrade(c, resolver.ResolverOpFactory.NewNoOpUpgrade)
 }
 
 func (s *ResolverOpFactorySuite) testUpgrade(


### PR DESCRIPTION
## Description of change

Wire up the CAAS operator so it informs each of its uniter workers when a charm upgrade is available. The uniters will run the upgrade-charm hook. The operator will first have reacted to the charm upgrade by downloading and unpacking the charm.

Also a drive by fix for an intermittent caas operator test failure.

## QA steps

Deploy and upgrade a charm on both caas and iaas models.

## Bug reference

https://bugs.launchpad.net/bugs/1758828
