### PR TITLE
Test tweak.

### DIFF
--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -127,7 +127,8 @@ timing:
 		withAPIDelay:      2 * time.Second,
 		withClientWait:    "6s",
 		withClientQueryID: validActionId,
-		withAPITimeout:    4 * time.Second,
+		// Wait just slightly less than the 2s tick time, to make sure it times out first
+		withAPITimeout:    3900 * time.Millisecond,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status: "running",


### PR DESCRIPTION
## Description of change

It seems the API Timeout was too close to the client wait timeout. So
occassionaly the test would fail (see bug #1759461).
Changing the timeout to 4.01 seconds was sufficient to reliably fail the
test, so we moved it to 3.9s which seems to make it reliably pass.

## QA steps

Perturb the timeout time, and see that
```
$ cd cmd/juju/action
$ go test --check.v --check.f ShowOutput
```
doesn't fail.

## Documentation changes

None.

## Bug reference

[lp:1759461](https://bugs.launchpad.net/juju/+bug/1759461)