### PR TITLE
2.3 into develop

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ grade: devel
 
 apps:
   juju:
-    command: bin/juju
+    command: wrappers/juju
 
 parts:
   wrappers:

--- a/snap/wrappers/juju
+++ b/snap/wrappers/juju
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
+export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
+
+exec $SNAP/bin/juju "$@"
+

--- a/state/presence/pruner_test.go
+++ b/state/presence/pruner_test.go
@@ -234,7 +234,7 @@ func assertStopped(c *gc.C, w worker.Worker) {
 
 func (s *prunerSuite) TestDeepStressStaysSane(c *gc.C) {
 	FakePeriod(2)
-	keys := make([]string, 500)
+	keys := make([]string, 50)
 	for i := 0; i < len(keys); i++ {
 		keys[i] = fmt.Sprintf("being-%04d", i)
 	}
@@ -242,8 +242,7 @@ func (s *prunerSuite) TestDeepStressStaysSane(c *gc.C) {
 	// key. We then keep creating new pingers for each one, and rotate them
 	// into old, and stop them when they rotate out. So we potentially have
 	// 3 active pingers for each key. We should never see any key go
-	// inactive, because there is always at least 1 active pinger for each
-	// one
+	// inactive, because we ping when we start a Pinger.
 	oldPingers := make([]*Pinger, len(keys))
 	newPingers := make([]*Pinger, len(keys))
 	ch := make(chan Change)


### PR DESCRIPTION
## Description of change

Merge 2.3 into develop.

Resolve several changes which shouldn't be in develop
 * version update for 2.3.6
 * peergrouper changes to handle the space-name ""
 * actions test that was broken in 2.3 but fixed already in develop

Does include the changes to restore
 * test fix for pruner TestDeepStressStaysSane
 * Wrapper for 'juju' that updates PATH to include snap locations to
 * allow bundled plugins

Included patches:
 * https://github.com/juju/juju/pull/8547
 * https://github.com/juju/juju/pull/8545
 * https://github.com/juju/juju/pull/8531
 * https://github.com/juju/juju/pull/8528
 * https://github.com/juju/juju/pull/8533

## QA steps

See individual patches.

## Documentation changes

None.

## Bug reference

 * https://bugs.launchpad.net/juju/+bug/1759461
 * https://bugs.launchpad.net/juju/+bug/1687531
 * https://bugs.launchpad.net/juju/+bug/1759013