### PR TITLE
Peergrouper Sets Status When Mongo Peer Address Cannot be Determined

### DIFF
--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 // jujuMachineKey is the key for the tag where we save a member's machine id.
@@ -397,88 +399,128 @@ func (p *peerGroupChanges) getMachinesVoting() {
 // updateAddresses updates the member addresses in the new replica-set, using
 // the HA space if one is configured.
 func (p *peerGroupChanges) updateAddresses(info *peerGroupInfo) error {
-	update := p.updateAddressFromSpace
+	var err error
 	if info.haSpace == "" {
-		update = p.updateAddressFromInternal
+		err = p.updateAddressesFromInternal(info)
+	} else {
+		err = p.updateAddressesFromSpace(info)
 	}
-
-	for id := range p.members {
-		if err := update(id, info); err != nil {
-			return errors.Annotate(err, "updating member address")
-		}
-	}
-	return nil
+	return errors.Annotate(err, "updating member addresses")
 }
 
-// updateAddressFromSpace sets the member address based on the configured
-// HA space. If no addresses are available for the machine and space,
-// then an error is returned.
-func (p *peerGroupChanges) updateAddressFromSpace(id string, info *peerGroupInfo) error {
-	m := info.machines[id]
-	addr, err := m.SelectMongoAddressFromSpace(info.mongoPort, info.haSpace)
-	if err != nil {
-		return errors.Trace(err)
-	}
+const multiAddressMessage = "multiple usable addresses found" +
+	"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication"
 
-	if addr != p.members[id].Address {
-		p.members[id].Address = addr
-		p.isChanged = true
-	}
-	return nil
-}
-
-// updateAddressFromInternal attempts to update the member with a cloud-local
-// address from the machine.
+// updateAddressesFromInternal attempts to update each member with a
+// cloud-local address from the machine.
 // If there is a single cloud local address available, it is used.
 // If there are multiple addresses, then a check is made to ensure that:
 //   - the member was previously in the replica-set and;
 //   - the previous address used for replication is still available.
 // If the check is satisfied, then a warning is logged and no change is made.
 // Otherwise an error is returned to indicate that a HA space must be
-// configured in order to proceed.
-func (p *peerGroupChanges) updateAddressFromInternal(id string, info *peerGroupInfo) error {
-	member := p.members[id]
-	hostPorts := info.machines[id].GetPotentialMongoHostPorts(info.mongoPort)
-	addrs := network.SelectInternalHostPorts(hostPorts, false)
+// configured in order to proceed. Such machines have their status set to
+// indicate that they require intervention.
+func (p *peerGroupChanges) updateAddressesFromInternal(info *peerGroupInfo) error {
+	var multipleAddresses []string
 
-	// This should not happen because SelectInternalHostPorts will choose a
-	// public address when there are no cloud-local addresses.
-	// Zero addresses would mean the machine would not be accessible at all.
-	// We ignore this outcome and leave the address alone.
-	if len(addrs) == 0 {
-		return nil
+	for id := range p.members {
+		m := info.machines[id]
+		hostPorts := m.GetPotentialMongoHostPorts(info.mongoPort)
+		addrs := network.SelectInternalHostPorts(hostPorts, false)
+
+		// This should not happen because SelectInternalHostPorts will choose a
+		// public address when there are no cloud-local addresses.
+		// Zero addresses would mean the machine is completely inaccessible.
+		// We ignore this outcome and leave the address alone.
+		if len(addrs) == 0 {
+			continue
+		}
+
+		// Unique address; we can use this for Mongo peer communication.
+		member := p.members[id]
+		if len(addrs) == 1 {
+			addr := addrs[0]
+			logger.Debugf("machine %q selected address %q by scope from %v", id, addr, hostPorts)
+
+			if member.Address != addr {
+				member.Address = addr
+				p.isChanged = true
+			}
+			continue
+		}
+
+		// Multiple potential Mongo addresses.
+		// Checks are required in order to use it as a peer.
+		unchanged := false
+		if _, ok := info.recognised[id]; ok {
+			for _, addr := range addrs {
+				if member.Address == addr {
+					logger.Warningf("%s\npreserving member with unchanged address %q", multiAddressMessage, addr)
+					unchanged = true
+					break
+				}
+			}
+		}
+
+		// If this member was not previously in the replica-set, or if its
+		// address has changed, we enforce the policy of requiring a
+		// configured HA space when there are multiple cloud-local addresses.
+		if !unchanged {
+			multipleAddresses = append(multipleAddresses, id)
+			if err := m.stm.SetStatus(getStatusInfo(multiAddressMessage)); err != nil {
+				return errors.Trace(err)
+			}
+		}
 	}
 
-	if len(addrs) == 1 {
-		addr := addrs[0]
-		logger.Debugf("machine %q selected address %q by scope from %v", id, addr, hostPorts)
+	if len(multipleAddresses) > 0 {
+		ids := strings.Join(multipleAddresses, ", ")
+		return fmt.Errorf("juju-ha-space is not set and these machines have more than one usable address: %s"+
+			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication", ids)
+	}
+	return nil
+}
 
-		if member.Address != addr {
-			member.Address = addr
+// updateAddressesFromSpace updates the member addresses based on the
+// configured HA space.
+// If no addresses are available for any of the machines, then such machines
+// have their status set and are included in the detail of the returned error.
+func (p *peerGroupChanges) updateAddressesFromSpace(info *peerGroupInfo) error {
+	space := info.haSpace
+	var noAddresses []string
+
+	for id := range p.members {
+		m := info.machines[id]
+		addr, err := m.SelectMongoAddressFromSpace(info.mongoPort, space)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if addr == "" {
+			noAddresses = append(noAddresses, id)
+			if err := m.stm.SetStatus(getStatusInfo(fmt.Sprintf("no addresses in space %q", space))); err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+		if addr != p.members[id].Address {
+			p.members[id].Address = addr
 			p.isChanged = true
 		}
-		return nil
 	}
 
-	msg := fmt.Sprintf(
-		"machine %q has more than one usable address and juju-ha-space is not set"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication", id)
-
-	// If this would-be member is new, we enforce the policy of having a
-	// configured HA space when there are multiple cloud-local addresses.
-	if _, ok := info.recognised[id]; !ok {
-		return errors.New(msg)
+	if len(noAddresses) > 0 {
+		ids := strings.Join(noAddresses, ", ")
+		return fmt.Errorf("no usable Mongo addresses found in space %q for machines: %s", space, ids)
 	}
+	return nil
+}
 
-	// If the prior address is still available, we allow preservation of the
-	// status quo rather than throwing out with an error.
-	for _, addr := range addrs {
-		if member.Address == addr {
-			logger.Warningf("%s\npreserving member with unchanged address %q", msg, addr)
-			return nil
-		}
+func getStatusInfo(msg string) status.StatusInfo {
+	now := time.Now()
+	return status.StatusInfo{
+		Status:  status.Blocked,
+		Message: msg,
+		Since:   &now,
 	}
-
-	// The member address needs to change. We enforce the HA space requirement.
-	return errors.New(msg)
 }

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -308,7 +308,6 @@ func (s *desiredPeerGroupSuite) TestDesiredPeerGroupIPv6(c *gc.C) {
 }
 
 func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIPVersion) {
-
 	for ti, test := range desiredPeerGroupTests(ipVersion) {
 		c.Logf("\ntest %d: %s", ti, test.about)
 		trackerMap := make(map[string]*machineTracker)

--- a/worker/peergrouper/machinetracker.go
+++ b/worker/peergrouper/machinetracker.go
@@ -84,8 +84,8 @@ func (m *machineTracker) Addresses() []network.Address {
 }
 
 // SelectMongoAddress returns the best address on the machine for MongoDB peer
-// use, using the input space. An error is return if the empty space is
-// supplied, or if no addresses are found.
+// use, using the input space.
+// An error is return if the empty space is supplied.
 func (m *machineTracker) SelectMongoAddressFromSpace(port int, space network.SpaceName) (string, error) {
 	if space == "" {
 		return "", fmt.Errorf("empty space supplied as an argument for selecting Mongo address for machine %q", m.id)
@@ -105,7 +105,7 @@ func (m *machineTracker) SelectMongoAddressFromSpace(port int, space network.Spa
 	// If we end up here, then there are no addresses available in the
 	// specified space. This should not happen, because the configured
 	// space is used as a constraint when first enabling HA.
-	return "", fmt.Errorf("no addresses found for machine %q in space %q", m.id, space)
+	return "", nil
 }
 
 // GetPotentialMongoHostPorts simply returns all the available addresses

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -45,7 +45,7 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddre
 	c.Check(addr, gc.Equals, "192.168.5.5:666")
 }
 
-func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorWhenNoAddressFound(c *gc.C) {
+func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceEmptyWhenNoAddressFound(c *gc.C) {
 	m := &machineTracker{
 		id: "3",
 		addresses: []network.Address{
@@ -56,9 +56,9 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorWhenNoAddressF
 		},
 	}
 
-	_, err := m.SelectMongoAddressFromSpace(666, "bad-space")
-	c.Assert(err, gc.NotNil)
-	c.Check(err, gc.ErrorMatches, `no addresses found for machine "3" in space "bad-space"`)
+	addrs, err := m.SelectMongoAddressFromSpace(666, "bad-space")
+	c.Assert(err, gc.IsNil)
+	c.Check(addrs, gc.Equals, "")
 }
 
 func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorForEmptySpace(c *gc.C) {

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -193,8 +193,9 @@ func (st *fakeState) addMachine(id string, wantsVote bool) *fakeMachine {
 		errors:  &st.errors,
 		checker: st,
 		doc: machineDoc{
-			id:        id,
-			wantsVote: wantsVote,
+			id:         id,
+			wantsVote:  wantsVote,
+			statusInfo: status.StatusInfo{Status: status.Started},
 		},
 	}
 	st.machines[id] = m
@@ -275,6 +276,7 @@ type machineDoc struct {
 	hasVote    bool
 	instanceId instance.Id
 	addresses  []network.Address
+	statusInfo status.StatusInfo
 }
 
 func (m *fakeMachine) Refresh() error {
@@ -324,9 +326,12 @@ func (m *fakeMachine) Addresses() []network.Address {
 }
 
 func (m *fakeMachine) Status() (status.StatusInfo, error) {
-	return status.StatusInfo{
-		Status: status.Started,
-	}, nil
+	return m.doc.statusInfo, nil
+}
+
+func (m *fakeMachine) SetStatus(sInfo status.StatusInfo) error {
+	m.doc.statusInfo = sInfo
+	return nil
 }
 
 // mutate atomically changes the machineDoc of

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -44,6 +44,7 @@ type Space interface {
 type Machine interface {
 	Id() string
 	Status() (status.StatusInfo, error)
+	SetStatus(status.StatusInfo) error
 	Refresh() error
 	Watch() state.NotifyWatcher
 	WantsVote() bool


### PR DESCRIPTION
## Description of change

- All machines now go through Mongo address determination with error conditions aggregated, instead of throwing out upon the first encounter.
- All machines failing address determination have their status set to _blocked_. The specific status to be used will be subject to review.

## QA steps

Accompanying unit tests.

## Documentation changes

Upon finalisation of the HA space behaviour, this logic should be documented against the _enable-ha_ command.

## Bug reference

N/A
