### PR TITLE
Includes deletion of mongo space name/status in 2.4 Upgrade Step.

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -2064,12 +2064,6 @@ type controllersDoc struct {
 	CloudName  string `bson:"cloud"`
 	ModelUUID  string `bson:"model-uuid"`
 	MachineIds []string
-
-	// These are replaced by juju-ha-space in controller config.
-	// Deprecated.
-	MongoSpaceName string `bson:"mongo-space-name"`
-	// Deprecated.
-	MongoSpaceState string `bson:"mongo-space-state"`
 }
 
 // ControllerInfo holds information about currently

--- a/state/state.go
+++ b/state/state.go
@@ -2060,11 +2060,15 @@ func (st *State) SetAdminMongoPassword(password string) error {
 }
 
 type controllersDoc struct {
-	Id              string `bson:"_id"`
-	CloudName       string `bson:"cloud"`
-	ModelUUID       string `bson:"model-uuid"`
-	MachineIds      []string
-	MongoSpaceName  string `bson:"mongo-space-name"`
+	Id         string `bson:"_id"`
+	CloudName  string `bson:"cloud"`
+	ModelUUID  string `bson:"model-uuid"`
+	MachineIds []string
+
+	// These are replaced by juju-ha-space in controller config.
+	// Deprecated.
+	MongoSpaceName string `bson:"mongo-space-name"`
+	// Deprecated.
 	MongoSpaceState string `bson:"mongo-space-state"`
 }
 
@@ -2082,33 +2086,14 @@ type ControllerInfo struct {
 	// MachineIds holds the ids of all machines configured to run a controller.
 	// Check the individual machine docs to know if a given machine wants to vote and/or has the vote.
 	MachineIds []string
-
-	// MongoSpaceName is the space that contains all Mongo servers.
-	MongoSpaceName string
-
-	// MongoSpaceState records the state of the mongo space selection state machine. Valid states are:
-	// * We haven't looked for a Mongo space yet (MongoSpaceUnknown)
-	// * We have looked for a Mongo space, but we didn't find one (MongoSpaceInvalid)
-	// * We have looked for and found a Mongo space (MongoSpaceValid)
-	// * We didn't try to find a Mongo space because the provider doesn't support spaces (MongoSpaceUnsupported)
-	MongoSpaceState MongoSpaceStates
 }
-
-type MongoSpaceStates string
-
-const (
-	MongoSpaceUnknown     MongoSpaceStates = ""
-	MongoSpaceValid       MongoSpaceStates = "valid"
-	MongoSpaceInvalid     MongoSpaceStates = "invalid"
-	MongoSpaceUnsupported MongoSpaceStates = "unsupported"
-)
 
 // ControllerInfo returns information about
 // the currently configured controller machines.
 func (st *State) ControllerInfo() (*ControllerInfo, error) {
 	session := st.session.Copy()
 	defer session.Close()
-	return readRawControllerInfo(st.session)
+	return readRawControllerInfo(session)
 }
 
 // readRawControllerInfo reads ControllerInfo direct from the supplied session,
@@ -2127,11 +2112,9 @@ func readRawControllerInfo(session *mgo.Session) (*ControllerInfo, error) {
 		return nil, errors.Annotatef(err, "cannot get controllers document")
 	}
 	return &ControllerInfo{
-		CloudName:       doc.CloudName,
-		ModelTag:        names.NewModelTag(doc.ModelUUID),
-		MachineIds:      doc.MachineIds,
-		MongoSpaceName:  doc.MongoSpaceName,
-		MongoSpaceState: MongoSpaceStates(doc.MongoSpaceState),
+		CloudName:  doc.CloudName,
+		ModelTag:   names.NewModelTag(doc.ModelUUID),
+		MachineIds: doc.MachineIds,
 	}, nil
 }
 
@@ -2176,69 +2159,6 @@ func (st *State) SetStateServingInfo(info StateServingInfo) error {
 		return errors.Annotatef(err, "cannot set state serving info")
 	}
 	return nil
-}
-
-// SetOrGetMongoSpaceName attempts to set the Mongo space or, if that fails, look
-// up the current Mongo space. Either way, it always returns what is in the
-// database by the end of the call.
-func (st *State) SetOrGetMongoSpaceName(mongoSpaceName network.SpaceName) (network.SpaceName, error) {
-	err := st.setMongoSpaceName(mongoSpaceName)
-	if err == txn.ErrAborted {
-		// Failed to set the new space name. Return what is already stored in state.
-		controllerInfo, err := st.ControllerInfo()
-		if err != nil {
-			return network.SpaceName(""), errors.Trace(err)
-		}
-		return network.SpaceName(controllerInfo.MongoSpaceName), nil
-	} else if err != nil {
-		return network.SpaceName(""), errors.Trace(err)
-	}
-	return mongoSpaceName, nil
-}
-
-// SetMongoSpaceState attempts to set the Mongo space state or, if that fails, look
-// up the current Mongo state. Either way, it always returns what is in the
-// database by the end of the call.
-func (st *State) SetMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
-	if mongoSpaceState != MongoSpaceUnknown &&
-		mongoSpaceState != MongoSpaceValid &&
-		mongoSpaceState != MongoSpaceInvalid &&
-		mongoSpaceState != MongoSpaceUnsupported {
-		return errors.NotValidf("mongoSpaceState: %s", mongoSpaceState)
-	}
-
-	err := st.setMongoSpaceState(mongoSpaceState)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
-func (st *State) setMongoSpaceName(mongoSpaceName network.SpaceName) error {
-	ops := []txn.Op{{
-		C:      controllersC,
-		Id:     modelGlobalKey,
-		Assert: bson.D{{"mongo-space-state", string(MongoSpaceUnknown)}},
-		Update: bson.D{{
-			"$set",
-			bson.D{
-				{"mongo-space-name", string(mongoSpaceName)},
-				{"mongo-space-state", MongoSpaceValid},
-			},
-		}},
-	}}
-
-	return st.db().RunTransaction(ops)
-}
-
-func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
-	ops := []txn.Op{{
-		C:      controllersC,
-		Id:     modelGlobalKey,
-		Update: bson.D{{"$set", bson.D{{"mongo-space-state", mongoSpaceState}}}},
-	}}
-
-	return st.db().RunTransaction(ops)
 }
 
 func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4402,64 +4402,6 @@ func (s *StateSuite) TestUnitsForInvalidId(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `"invalid-id" is not a valid machine id`)
 }
 
-func (s *StateSuite) TestSetOrGetMongoSpaceNameSets(c *gc.C) {
-	info, err := s.State.ControllerInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.MongoSpaceName, gc.Equals, "")
-	c.Assert(info.MongoSpaceState, gc.Equals, state.MongoSpaceUnknown)
-
-	spaceName := network.SpaceName("foo")
-
-	name, err := s.State.SetOrGetMongoSpaceName(spaceName)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(name, gc.Equals, spaceName)
-
-	info, err = s.State.ControllerInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.MongoSpaceName, gc.Equals, string(spaceName))
-	c.Assert(info.MongoSpaceState, gc.Equals, state.MongoSpaceValid)
-}
-
-func (s *StateSuite) TestSetOrGetMongoSpaceNameDoesNotReplaceValidSpace(c *gc.C) {
-	spaceName := network.SpaceName("foo")
-	name, err := s.State.SetOrGetMongoSpaceName(spaceName)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(name, gc.Equals, spaceName)
-
-	name, err = s.State.SetOrGetMongoSpaceName(network.SpaceName("bar"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(name, gc.Equals, spaceName)
-
-	info, err := s.State.ControllerInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.MongoSpaceName, gc.Equals, string(spaceName))
-	c.Assert(info.MongoSpaceState, gc.Equals, state.MongoSpaceValid)
-}
-
-func (s *StateSuite) TestSetMongoSpaceStateSetsValidStates(c *gc.C) {
-	mongoStates := []state.MongoSpaceStates{
-		state.MongoSpaceUnknown,
-		state.MongoSpaceValid,
-		state.MongoSpaceInvalid,
-		state.MongoSpaceUnsupported,
-	}
-	for _, st := range mongoStates {
-		err := s.State.SetMongoSpaceState(st)
-		c.Assert(err, jc.ErrorIsNil)
-		info, err := s.State.ControllerInfo()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(info.MongoSpaceState, gc.Equals, st)
-	}
-}
-
-func (s *StateSuite) TestSetMongoSpaceStateErrorOnInvalidStates(c *gc.C) {
-	err := s.State.SetMongoSpaceState(state.MongoSpaceStates("bad"))
-	c.Assert(err, gc.ErrorMatches, "mongoSpaceState: bad not valid")
-	info, err := s.State.ControllerInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.MongoSpaceState, gc.Equals, state.MongoSpaceUnknown)
-}
-
 func (s *StateSuite) TestRunTransactionObserver(c *gc.C) {
 	type args struct {
 		dbName    string
@@ -4497,7 +4439,7 @@ func (s *StateSuite) TestRunTransactionObserver(c *gc.C) {
 
 	calls := getCalls()
 	// There may be some leadership txns in the call list.
-	// We onlt care about the constraints call.
+	// We only care about the constraints call.
 	found := false
 	for _, call := range calls {
 		if call.ops[0].C != "constraints" {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1430,7 +1430,8 @@ func MoveMongoSpaceToHASpaceConfig(st *State) error {
 		}
 
 		// In the unlikely event that there is already a juju-ha-space
-		// configuration setting, we skip the
+		// configuration setting, we do not copy over it with the old Mongo
+		// space name.
 		if haSpace, ok := settings.Get(controller.JujuHASpace); ok {
 			upgradesLogger.Debugf("not copying mongo-space-name %q to juju-ha-space - already set to %q",
 				mongoSpace, haSpace)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1408,9 +1408,15 @@ func DeleteCloudImageMetadata(st *State) error {
 // and if there is no value already set for the HA space name.
 // The old keys are then deleted from ControllerInfo.
 func MoveMongoSpaceToHASpaceConfig(st *State) error {
+	// Holds Mongo space fields removed from controllersDoc.
+	type controllersUpgradeDoc struct {
+		MongoSpaceName  string `bson:"mongo-space-name"`
+		MongoSpaceState string `bson:"mongo-space-state"`
+	}
+	var doc controllersUpgradeDoc
+
 	controllerColl, controllerCloser := st.db().GetRawCollection(controllersC)
 	defer controllerCloser()
-	var doc controllersDoc
 	err := controllerColl.Find(bson.D{{"_id", modelGlobalKey}}).One(&doc)
 	if err != nil {
 		return errors.Annotate(err, "retrieving controller info doc")

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1411,7 +1411,7 @@ func MoveMongoSpaceToHASpaceConfig(st *State) error {
 	controllerColl, controllerCloser := st.db().GetRawCollection(controllersC)
 	defer controllerCloser()
 	var doc controllersDoc
-	err := controllerColl.FindId(bson.D{{"_id", modelGlobalKey}}).One(&doc)
+	err := controllerColl.Find(bson.D{{"_id", modelGlobalKey}}).One(&doc)
 	if err != nil {
 		return errors.Annotate(err, "retrieving controller info doc")
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2179,7 +2179,7 @@ func (s *upgradesSuite) TestCopyMongoSpaceToHASpaceConfigWhenValid(c *gc.C) {
 	err = MoveMongoSpaceToHASpaceConfig(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(getHASpaceConfig(s.state, c), gc.Equals, "mongo-space")
+	c.Check(getHASpaceConfig(s.state, c), gc.Equals, sn)
 }
 
 func (s *upgradesSuite) TestNoCopyMongoSpaceToHASpaceConfigWhenNotValid(c *gc.C) {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2233,7 +2233,12 @@ func (s *upgradesSuite) TestMoveMongoSpaceToHASpaceConfigDeletesOldKeys(c *gc.C)
 	err = MoveMongoSpaceToHASpaceConfig(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var doc controllersDoc
+	// Holds Mongo space fields removed from controllersDoc.
+	type controllersUpgradeDoc struct {
+		MongoSpaceName  string `bson:"mongo-space-name"`
+		MongoSpaceState string `bson:"mongo-space-state"`
+	}
+	var doc controllersUpgradeDoc
 	err = controllerColl.Find(bson.D{{"_id", modelGlobalKey}}).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(doc.MongoSpaceName, gc.Equals, "")

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -36,7 +36,7 @@ type StateBackend interface {
 	MoveOldAuditLog() error
 	AddRelationStatus() error
 	DeleteCloudImageMetadata() error
-	CopyMongoSpaceToHASpaceConfig() error
+	MoveMongoSpaceToHASpaceConfig() error
 	CreateMissingApplicationConfig() error
 	RemoveVotingMachineIds() error
 }
@@ -141,8 +141,8 @@ func (s stateBackend) AddRelationStatus() error {
 	return state.AddRelationStatus(s.st)
 }
 
-func (s stateBackend) CopyMongoSpaceToHASpaceConfig() error {
-	return state.CopyMongoSpaceToHASpaceConfig(s.st)
+func (s stateBackend) MoveMongoSpaceToHASpaceConfig() error {
+	return state.MoveMongoSpaceToHASpaceConfig(s.st)
 }
 
 func (s stateBackend) CreateMissingApplicationConfig() error {

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -14,10 +14,10 @@ func stateStepsFor24() []Step {
 			},
 		},
 		&upgradeStep{
-			description: "copy controller info Mongo space to controller config HA space if valid",
+			description: "move controller info Mongo space to controller config HA space if valid",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
-				return context.State().CopyMongoSpaceToHASpaceConfig()
+				return context.State().MoveMongoSpaceToHASpaceConfig()
 			},
 		},
 		&upgradeStep{
@@ -31,7 +31,7 @@ func stateStepsFor24() []Step {
 			description: "remove votingmachineids",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
-				return context.State().CreateMissingApplicationConfig()
+				return context.State().RemoveVotingMachineIds()
 			},
 		},
 	}

--- a/upgrades/steps_24_test.go
+++ b/upgrades/steps_24_test.go
@@ -27,7 +27,7 @@ func (s *steps24Suite) TestMoveOldAuditLog(c *gc.C) {
 }
 
 func (s *steps24Suite) TestCopyMongoSpaceToHASpaceConfig(c *gc.C) {
-	step := findStateStep(c, v24, "copy controller info Mongo space to controller config HA space if valid")
+	step := findStateStep(c, v24, "move controller info Mongo space to controller config HA space if valid")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }


### PR DESCRIPTION
## Description of change

- Keys for Mongo space name/state deleted from controller info doc.
- State methods for manipulating Mongo space name/state are removed.
- Mongo space name/state removed from ControllerInfo type.
- Fixes method call in upgrade step for removing voting member IDs.
- Doc level mongo space name/state marked deprecated.

## QA steps

Accompanying unit tests.
