### PR TITLE
add juju-updateseries command to assist restarting juju agents after series upgrade

### DIFF
--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	dirPerm        = 0755
+	filePerm       = 0644
 	guiArchiveFile = "downloaded-gui.txt"
 	toolsFile      = "downloaded-tools.txt"
 )
@@ -116,12 +117,7 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 			return errors.Annotatef(err, "tar extract %q failed", name)
 		}
 	}
-	toolsMetadataData, err := json.Marshal(tools)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(path.Join(dir, toolsFile), []byte(toolsMetadataData), 0644)
-	if err != nil {
+	if err = WriteToolsMetadataData(dir, tools); err != nil {
 		return err
 	}
 
@@ -215,4 +211,13 @@ func ChangeAgentTools(dataDir string, agentName string, vers version.Binary) (*c
 		return nil, fmt.Errorf("cannot replace tools directory: %s", err)
 	}
 	return tools, nil
+}
+
+// WriteToolsMetadataData writes the tools metadata file to the given directory.
+func WriteToolsMetadataData(dir string, tools *coretools.Tools) error {
+	toolsMetadataData, err := json.Marshal(tools)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path.Join(dir, toolsFile), []byte(toolsMetadataData), filePerm)
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -82,11 +82,12 @@ import (
 )
 
 var (
-	logger         = loggo.GetLogger("juju.cmd.jujud")
-	jujuRun        = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
-	jujuDumpLogs   = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
-	jujuIntrospect = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
-	jujudSymlinks  = []string{jujuRun, jujuDumpLogs, jujuIntrospect}
+	logger           = loggo.GetLogger("juju.cmd.jujud")
+	jujuRun          = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
+	jujuDumpLogs     = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
+	jujuIntrospect   = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
+	jujuUpdateSeries = paths.MustSucceed(paths.JujuUpdateSeries(series.MustHostSeries()))
+	jujudSymlinks    = []string{jujuRun, jujuDumpLogs, jujuIntrospect, jujuUpdateSeries}
 
 	// The following are defined as variables to allow the tests to
 	// intercept calls to the functions. In every case, they should

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -24,6 +24,7 @@ import (
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/cmd/jujud/dumplogs"
 	"github.com/juju/juju/cmd/jujud/introspect"
+	"github.com/juju/juju/cmd/jujud/updateseries"
 	components "github.com/juju/juju/component/all"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
@@ -232,6 +233,8 @@ func Main(args []string) int {
 		code = cmd.Main(dumplogs.NewCommand(), ctx, args[1:])
 	case names.JujuIntrospect:
 		code = cmd.Main(&introspect.IntrospectCommand{}, ctx, args[1:])
+	case names.JujuUpdateSeries:
+		code = cmd.Main(&updateseries.UpdateSeriesCommand{}, ctx, args[1:])
 	default:
 		code, err = hookToolMain(commandName, ctx, args)
 	}

--- a/cmd/jujud/updateseries/package_test.go
+++ b/cmd/jujud/updateseries/package_test.go
@@ -1,0 +1,15 @@
+package updateseries
+
+import (
+	"runtime"
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("updateseries only runs on Linux")
+	}
+	gc.TestingT(t)
+}

--- a/cmd/jujud/updateseries/updateseries.go
+++ b/cmd/jujud/updateseries/updateseries.go
@@ -1,0 +1,415 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package updateseries
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/fs"
+	jujuos "github.com/juju/utils/os"
+	"github.com/juju/utils/series"
+	"github.com/juju/utils/shell"
+	"github.com/juju/utils/symlink"
+	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/cmd/jujud/agent"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/service/systemd"
+)
+
+var logger = loggo.GetLogger("juju.cmd.jujud.updateseries")
+
+const updateSeriesCommandDoc = `
+Update Juju agents on this machine to start after series upgrade.
+`
+
+type UpdateSeriesCommand struct {
+	cmd.CommandBase
+
+	machineAgent string
+	unitAgents   []string
+	dataDir      string
+	toSeries     string
+	fromSeries   string
+	startAgents  bool
+}
+
+func (c *UpdateSeriesCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "juju-updateseries",
+		Args:    "--to-series <series> --from-series <series> [--data-dir <dir>|--start-agents]",
+		Purpose: "Update Juju agents on this machine to start after series upgrade",
+		Doc:     updateSeriesCommandDoc,
+	}
+}
+
+func (c *UpdateSeriesCommand) Init(args []string) error {
+	switch {
+	case c.toSeries == "" && c.fromSeries == "":
+		return errors.Errorf("both --to-series and --from-series must be specified")
+	case c.toSeries == "":
+		return errors.Errorf("--to-series must be specified")
+	case c.fromSeries == "":
+		return errors.Errorf("--from-series must be specified")
+	case c.toSeries == c.fromSeries:
+		return errors.Errorf("--to-series and --from-series cannot be the same")
+	}
+
+	fromOS, err1 := series.GetOSFromSeries(c.toSeries)
+	toOS, err2 := series.GetOSFromSeries(c.fromSeries)
+	switch {
+	case err1 != nil:
+		return err1
+	case err2 != nil:
+		return err2
+	case fromOS != toOS:
+		return errors.Errorf("series from two different operating systems specified")
+	case fromOS == jujuos.Windows:
+		return errors.NewNotSupported(nil, "windows not supported")
+	}
+
+	ctlr, err := isController()
+	switch {
+	case err != nil:
+		return err
+	case ctlr:
+		return errors.Errorf("cannot run on a controller machine")
+	}
+
+	return c.CommandBase.Init(args)
+}
+
+func (c *UpdateSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.dataDir, "data-dir", cmdutil.DataDir, "Juju base data directory")
+	f.StringVar(&c.toSeries, "to-series", "", "Series updating to")
+	f.StringVar(&c.fromSeries, "from-series", "", "Series updating from")
+	f.BoolVar(&c.startAgents, "start-agents", false, "start agents if successful with update")
+}
+
+func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
+	if err := c.findAgents(ctx); err != nil {
+		return err
+	}
+
+	fromInitSys, err := service.VersionInitSystem(c.fromSeries)
+	if err != nil {
+		return err
+	}
+
+	toInitSys, err := service.VersionInitSystem(c.toSeries)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case toInitSys == service.InitSystemUpstart:
+		return errors.NewNotSupported(nil, "downgrade to series using upstart not supported")
+	case toInitSys == fromInitSys && toInitSys == service.InitSystemSystemd:
+		if err = c.copyTools(); err != nil {
+			return err
+		} else {
+			ctx.Infof("successfully copied tools and relinked agent tools")
+		}
+		if !c.startAgents {
+			break
+		}
+		if err = c.startAllAgents(ctx); err != nil {
+			return err
+		}
+		ctx.Infof("all agents successfully restarted")
+	case toInitSys == service.InitSystemSystemd:
+		errorHappened := false
+		if err = c.writeSystemdAgents(ctx); err != nil {
+			ctx.Warningf("%s", err)
+			errorHappened = true
+		}
+		if err = c.copyTools(); err != nil {
+			ctx.Warningf("%s", err)
+			errorHappened = true
+		} else {
+			ctx.Infof("successfully copied tools and relinked agent tools")
+		}
+		switch {
+		case !errorHappened && c.startAgents:
+			if err = c.startAllAgents(ctx); err != nil {
+				return err
+			}
+			ctx.Infof("all agents successfully restarted")
+		case errorHappened && c.startAgents:
+			return errors.Errorf("unable to start agents due to previous errors")
+		}
+	default:
+		return errors.Errorf("Failed to migrate from %s to %s", fromInitSys, toInitSys)
+	}
+	return nil
+}
+
+func (c *UpdateSeriesCommand) findAgents(ctx *cmd.Context) error {
+	agentsDir := filepath.Join(c.dataDir, "agents")
+	dir, err := os.Open(agentsDir)
+	if err != nil {
+		return errors.Annotate(err, "opening agents dir")
+	}
+	defer dir.Close()
+
+	entries, err := dir.Readdir(-1)
+	if err != nil {
+		return errors.Annotate(err, "reading agents dir")
+	}
+	for _, info := range entries {
+		name := info.Name()
+		tag, err := names.ParseTag(name)
+		if err != nil {
+			continue
+		}
+		switch tag.Kind() {
+		case names.MachineTagKind:
+			c.machineAgent = name
+		case names.UnitTagKind:
+			c.unitAgents = append(c.unitAgents, name)
+		default:
+			ctx.Warningf("%s is not of type Machine nor Unit, ignoring", name)
+		}
+	}
+	return nil
+}
+
+var isController = func() (bool, error) {
+	services, err := service.ListServices()
+	if err != nil {
+		return true, err
+	}
+	for _, service := range services {
+		if strings.HasPrefix(service, mongo.ServiceName) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+var (
+	systemdDir          = "/etc/systemd/system"
+	systemdMultiUserDir = systemdDir + "/multi-user.target.wants"
+)
+
+// For testing
+var sysdIsRunning = systemd.IsRunning
+
+func (c *UpdateSeriesCommand) writeSystemdAgents(ctx *cmd.Context) error {
+	var lastError error
+	for _, agentName := range append(c.unitAgents, c.machineAgent) {
+		conf, err := c.createAgentConf(agentName)
+		if err != nil {
+			ctx.Warningf("%s", err)
+			lastError = err
+			continue
+		}
+		svcName := "jujud-" + agentName
+		svc, err := service.NewService(svcName, conf, c.toSeries)
+
+		upgradableSvc, ok := svc.(service.UpgradableService)
+		if !ok {
+			initName, err := service.VersionInitSystem(c.toSeries)
+			if err != nil {
+				return errors.Trace(errors.Annotate(err, "nor is service an UpgradableService"))
+			}
+			return errors.Errorf("%s service not of type UpgradableService", initName)
+		}
+		if err = upgradableSvc.WriteService(); err != nil {
+			ctx.Warningf("failed to write service for %s: %s", agentName, err)
+			lastError = err
+			continue
+		}
+
+		running, err := sysdIsRunning()
+		switch {
+		case err != nil:
+			return errors.Errorf("failure attempting to determine if systemd is running: %#v\n", err)
+		case running:
+			// Links for manual and automatic use of the service
+			// have been written, move to the next.
+			ctx.Infof("wrote %s agent, enabled and linked by systemd", svcName)
+			continue
+		}
+
+		svcFileName := svcName + ".service"
+		if err = os.Symlink(path.Join(c.dataDir, "init", svcName, svcFileName),
+			path.Join(systemdDir, svcFileName)); err != nil && !os.IsExist(err) {
+			return errors.Errorf("failed to link service file (%s) in systemd dir: %s\n", svcFileName, err)
+		}
+		if err = os.Symlink(path.Join(c.dataDir, "init", svcName, svcFileName),
+			path.Join(systemdMultiUserDir, svcFileName)); err != nil && !os.IsExist(err) {
+			return errors.Errorf("failed to link service file (%s) in multi-user.target.wants dir: %s\n", svcFileName, err)
+		}
+		ctx.Infof("wrote %s agent, enabled and linked by symlink", svcName)
+	}
+	return lastError
+}
+
+func (c *UpdateSeriesCommand) createAgentConf(agentName string) (_ common.Conf, err error) {
+	defer func() {
+		if err != nil {
+			logger.Infof("Failed create agent conf for %s: %s", agentName, err)
+		}
+	}()
+
+	renderer, err := shell.NewRenderer("")
+	if err != nil {
+		return common.Conf{}, err
+	}
+
+	tag, err := names.ParseTag(agentName)
+	if err != nil {
+		return common.Conf{}, err
+	}
+	name := tag.Id()
+
+	var kind service.AgentKind
+	switch tag.Kind() {
+	case names.MachineTagKind:
+		kind = service.AgentKindMachine
+	case names.UnitTagKind:
+		kind = service.AgentKindUnit
+	default:
+		return common.Conf{}, errors.NewNotValid(nil, fmt.Sprintf("agent %q is neither a machine nor a unit", agentName))
+	}
+
+	info := service.NewAgentInfo(
+		kind,
+		name,
+		c.dataDir,
+		paths.MustSucceed(paths.LogDir(c.toSeries)),
+	)
+	return service.AgentConf(info, renderer), nil
+}
+
+func (c *UpdateSeriesCommand) startAllAgents(ctx *cmd.Context) error {
+	running, err := sysdIsRunning()
+	switch {
+	case err != nil:
+		return err
+	case !running:
+		return errors.Errorf("systemd is not fully running, please reboot to start agents")
+	}
+
+	for _, unit := range c.unitAgents {
+		if err = c.startAgent(unit, service.AgentKindUnit); err != nil {
+			return errors.Annotatef(err, "failed to start %s service", "jujud-"+unit)
+		}
+		ctx.Infof("started %s service", "jujud-"+unit)
+	}
+
+	err = c.startAgent(c.machineAgent, service.AgentKindMachine)
+	if err == nil {
+		ctx.Infof("started %s service", "jujud-"+c.machineAgent)
+	}
+	return errors.Annotatef(err, "failed to start %s service", "jujud-"+c.machineAgent)
+}
+
+func (c *UpdateSeriesCommand) startAgent(name string, kind service.AgentKind) (err error) {
+	renderer, err := shell.NewRenderer("")
+	if err != nil {
+		return err
+	}
+	info := service.NewAgentInfo(
+		kind,
+		name,
+		c.dataDir,
+		paths.MustSucceed(paths.LogDir(c.toSeries)),
+	)
+	conf := service.AgentConf(info, renderer)
+	svcName := "jujud-" + name
+	svc, err := service.NewService(svcName, conf, c.toSeries)
+	if err = svc.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UpdateSeriesCommand) copyTools() (err error) {
+	defer func() {
+		if err != nil {
+			errors.Annotate(err, "failed to copy tools")
+		}
+	}()
+
+	// Get the current juju version from the machine agent
+	// conf file.
+	agentConf := agent.NewAgentConf(c.dataDir)
+	if err = agentConf.ReadConfig(c.machineAgent); err != nil {
+		return err
+	}
+	config := agentConf.CurrentConfig()
+	if config == nil {
+		return errors.Errorf("%s agent conf is not found", c.machineAgent)
+	}
+	jujuVersion := config.UpgradedToVersion()
+
+	// Setup new and old version.Binarys with only the series
+	// different.
+	fromVers := version.Binary{
+		Number: jujuVersion,
+		Arch:   arch.HostArch(),
+		Series: c.fromSeries,
+	}
+	toVers := version.Binary{
+		Number: jujuVersion,
+		Arch:   arch.HostArch(),
+		Series: c.toSeries,
+	}
+
+	// If tools with the new series don't already exist, copy
+	// current tools to new directory with correct series.
+	if _, err = os.Stat(tools.SharedToolsDir(c.dataDir, toVers)); err != nil {
+		// Copy tools to new directory with correct series.
+		if err = fs.Copy(tools.SharedToolsDir(c.dataDir, fromVers), tools.SharedToolsDir(c.dataDir, toVers)); err != nil {
+			return err
+		}
+	}
+
+	// Write tools metadata with new version, however don't change
+	// the URL, so we know where it came from.
+	jujuTools, err := tools.ReadTools(c.dataDir, toVers)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Only write once
+	if jujuTools.Version != toVers {
+		jujuTools.Version = toVers
+		if err = tools.WriteToolsMetadataData(tools.ToolsDir(c.dataDir, toVers.String()), jujuTools); err != nil {
+			return err
+		}
+	}
+
+	// Update Agent Tool links
+	var lastError error
+	for _, agentName := range append(c.unitAgents, c.machineAgent) {
+		toolPath := tools.ToolsDir(c.dataDir, toVers.String())
+		toolsDir := tools.ToolsDir(c.dataDir, agentName)
+
+		err = symlink.Replace(toolsDir, toolPath)
+		if err != nil {
+			lastError = err
+		}
+	}
+
+	return lastError
+}

--- a/cmd/jujud/updateseries/updateseries_test.go
+++ b/cmd/jujud/updateseries/updateseries_test.go
@@ -1,0 +1,510 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package updateseries
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"runtime"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	agenttools "github.com/juju/juju/agent/tools"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/service/common"
+	svctesting "github.com/juju/juju/service/common/testing"
+	"github.com/juju/juju/testing"
+	coretest "github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type updateSeriesCmdSuite struct {
+	testing.BaseSuite
+
+	acfg        agent.Config
+	dataDir     string
+	machineName string
+	unitNames   []string
+
+	services    []*svctesting.FakeService
+	serviceData *svctesting.FakeServiceData
+}
+
+func (s *updateSeriesCmdSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("jujud-updateseries doesn't work on Windows")
+	}
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *updateSeriesCmdSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.dataDir = c.MkDir()
+	s.PatchValue(&cmdutil.DataDir, s.dataDir)
+
+	tmpSystemdDir := path.Join(s.dataDir, "etc", "systemd", "system")
+	tmpSystemdMultiUserDir := path.Join(tmpSystemdDir, "multi-user.target.wants")
+	os.MkdirAll(tmpSystemdMultiUserDir, os.ModeDir|os.ModePerm)
+	s.PatchValue(&systemdDir, tmpSystemdDir)
+	s.PatchValue(&systemdMultiUserDir, tmpSystemdMultiUserDir)
+
+	s.PatchValue(&isController, func() (bool, error) { return false, nil })
+
+	s.machineName = "machine-0"
+	s.unitNames = []string{"unit-ubuntu-0", "unit-mysql-0"}
+
+	// Equalivent to reboot after upgrade
+	s.PatchValue(&sysdIsRunning, func() (bool, error) { return true, nil })
+
+	s.assertSetupAgentsForTest(c)
+	s.setUpAgentConf(c)
+	s.setUpServices(c)
+	s.services[0].ResetCalls()
+	s.setupTools(c, "trusty")
+}
+
+func (s *updateSeriesCmdSuite) TearDownTest(c *gc.C) {
+	s.serviceData = nil
+	s.services = nil
+	s.BaseSuite.TearDownTest(c)
+}
+
+var _ = gc.Suite(&updateSeriesCmdSuite{})
+
+func (s *updateSeriesCmdSuite) setUpAgentConf(c *gc.C) {
+	// Read in copyTools()
+	configParams := agent.AgentConfigParams{
+		Paths:             agent.Paths{DataDir: s.dataDir},
+		Tag:               names.NewMachineTag("0"),
+		UpgradedToVersion: jujuversion.Current,
+		APIAddresses:      []string{"localhost:17070"},
+		CACert:            testing.CACert,
+		Password:          "fake",
+		Controller:        testing.ControllerTag,
+		Model:             testing.ModelTag,
+		MongoVersion:      mongo.Mongo32wt,
+	}
+
+	acfg, err := agent.NewAgentConfig(configParams)
+	c.Assert(err, jc.ErrorIsNil)
+	err = acfg.Write()
+	c.Assert(err, jc.ErrorIsNil)
+	s.acfg = acfg
+}
+
+func (s *updateSeriesCmdSuite) setUpServices(c *gc.C) {
+	for _, fake := range append(s.unitNames, s.machineName) {
+		s.addService("jujud-" + fake)
+	}
+	s.PatchValue(&service.NewService, s.newService)
+	s.PatchValue(&service.ListServices, s.listServices)
+}
+
+func (s *updateSeriesCmdSuite) addService(name string) {
+	svc, _ := s.newService(name, common.Conf{}, "")
+	svc.Install()
+	svc.Start()
+}
+
+func (s *updateSeriesCmdSuite) listServices() ([]string, error) {
+	return s.serviceData.InstalledNames(), nil
+}
+
+func (s *updateSeriesCmdSuite) newService(name string, conf common.Conf, series string) (service.Service, error) {
+	for _, svc := range s.services {
+		if svc.Name() == name {
+			return svc, nil
+		}
+	}
+	if s.serviceData == nil {
+		s.serviceData = svctesting.NewFakeServiceData()
+	}
+	svc := &svctesting.FakeService{
+		FakeServiceData: s.serviceData,
+		Service: common.Service{
+			Name: name,
+			Conf: common.Conf{},
+		},
+		DataDir: s.dataDir,
+	}
+	s.services = append(s.services, svc)
+	return svc, nil
+}
+
+func (s *updateSeriesCmdSuite) setupTools(c *gc.C, series string) {
+	files := []*testing.TarFile{
+		testing.NewTarFile("jujud", 0755, "jujuc executable"),
+	}
+	data, checksum := testing.TarGz(files...)
+	testTools := &coretest.Tools{
+		URL: "http://foo/bar1",
+		Version: version.Binary{
+			Number: jujuversion.Current,
+			Arch:   arch.HostArch(),
+			Series: series,
+		},
+		Size:   int64(len(data)),
+		SHA256: checksum,
+	}
+	err := agenttools.UnpackTools(s.dataDir, testTools, bytes.NewReader(data))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type updateSeriesArgParsing struct {
+	title      string
+	args       []string
+	errMatch   string
+	dataDir    string
+	toSeries   string
+	fromSeries string
+	controller bool
+}
+
+func (s *updateSeriesCmdSuite) TestArgValidationInInit(c *gc.C) {
+	for i, test := range []updateSeriesArgParsing{
+		{
+			title:      "no args",
+			errMatch:   "both --to-series and --from-series must be specified",
+			controller: false,
+		}, {
+			title:      "to-series only",
+			args:       []string{"--to-series", "trusty"},
+			errMatch:   "--from-series must be specified",
+			controller: false,
+		}, {
+			title:      "from-series only",
+			args:       []string{"--from-series", "trusty"},
+			errMatch:   "--to-series must be specified",
+			controller: false,
+		}, {
+			title:      "to-series == from-series",
+			args:       []string{"--to-series", "trusty", "--from-series", "trusty"},
+			controller: false,
+			errMatch:   "--to-series and --from-series cannot be the same",
+		}, {
+			title:      "controller machine",
+			args:       []string{"--to-series", "xenial", "--from-series", "trusty"},
+			controller: true,
+			errMatch:   "cannot run on a controller machine",
+		}, {
+			title:      "success specifying series",
+			args:       []string{"--to-series", "xenial", "--from-series", "trusty"},
+			toSeries:   "xenial",
+			fromSeries: "trusty",
+			dataDir:    s.dataDir,
+			controller: false,
+		}, {
+			title:      "unsupported: windows",
+			args:       []string{"--to-series", "win10", "--from-series", "win8"},
+			toSeries:   "xenial",
+			fromSeries: "trusty",
+			errMatch:   "windows not supported",
+		}, {
+			title:      "different operating systems",
+			args:       []string{"--to-series", "win10", "--from-series", "xenial"},
+			toSeries:   "xenial",
+			fromSeries: "trusty",
+			errMatch:   "series from two different operating systems specified",
+		}, {
+			title:      "success specifying series & datadir",
+			args:       []string{"--to-series", "xenial", "--from-series", "trusty", "--data-dir", "/tmp/testme"},
+			toSeries:   "xenial",
+			fromSeries: "trusty",
+			dataDir:    "/tmp/testme",
+			controller: false,
+		},
+	} {
+		c.Logf("%d: %s", i, test.title)
+		s.PatchValue(&isController, func() (bool, error) { return test.controller, nil })
+		cmd := &UpdateSeriesCommand{}
+		err := cmdtesting.InitCommand(cmd, test.args)
+		if test.errMatch == "" {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(cmd.dataDir, gc.Equals, test.dataDir)
+			c.Assert(cmd.toSeries, gc.Equals, test.toSeries)
+			c.Assert(cmd.fromSeries, gc.Equals, test.fromSeries)
+		} else {
+			c.Assert(err, gc.ErrorMatches, test.errMatch)
+		}
+	}
+}
+
+func (s *updateSeriesCmdSuite) TestArgValidationInRun(c *gc.C) {
+	for i, test := range []updateSeriesArgParsing{
+		{
+			title:    "unsupported: down grade",
+			args:     []string{"--to-series", "trusty", "--from-series", "xenial"},
+			errMatch: "downgrade to series using upstart not supported",
+		},
+	} {
+		c.Logf("%d: %s", i, test.title)
+		_, err := s.run(c, test.args...)
+		c.Assert(err, gc.ErrorMatches, test.errMatch)
+	}
+}
+
+func (s *updateSeriesCmdSuite) assertSetupAgentsForTest(c *gc.C) {
+	agentsDir := path.Join(s.dataDir, "agents")
+	err := os.MkdirAll(path.Join(agentsDir, s.machineName), os.ModeDir|os.ModePerm)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, unit := range s.unitNames {
+		err = os.Mkdir(path.Join(agentsDir, unit), os.ModeDir|os.ModePerm)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *updateSeriesCmdSuite) TestFindAgents(c *gc.C) {
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	err := cmd.findAgents(cmdtesting.Context(c))
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmd.machineAgent, gc.Equals, s.machineName)
+	c.Assert(cmd.unitAgents, jc.SameContents, s.unitNames)
+}
+
+func (s *updateSeriesCmdSuite) TestFindAgentsFail(c *gc.C) {
+	agentsDir := path.Join(s.dataDir, "agents")
+	err := os.MkdirAll(path.Join(agentsDir, names.ApplicationTagKind+"-failme-0"), os.ModeDir|os.ModePerm)
+
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	err = cmd.findAgents(cmdtesting.Context(c))
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmd.machineAgent, gc.Equals, s.machineName)
+	c.Assert(cmd.unitAgents, jc.SameContents, s.unitNames)
+}
+
+func (s *updateSeriesCmdSuite) TestCreateAgentConf(c *gc.C) {
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	conf, err := cmd.createAgentConf("machine-2")
+	c.Assert(err, jc.ErrorIsNil)
+	// Spot check Conf
+	c.Assert(conf.Desc, gc.Equals, "juju agent for machine-2")
+}
+
+func (s *updateSeriesCmdSuite) TestCreateAgentConfFailAgentKind(c *gc.C) {
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	_, err := cmd.createAgentConf("application-fail")
+	c.Assert(err, gc.ErrorMatches, `agent "application-fail" is neither a machine nor a unit`)
+}
+
+func (s *updateSeriesCmdSuite) TestStartAllAgents(c *gc.C) {
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	ctx := cmdtesting.Context(c)
+	err := cmd.findAgents(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmd.startAllAgents(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertServicesCalls(c, "Start", len(s.services))
+}
+
+func (s *updateSeriesCmdSuite) TestStartAllAgentsFailPreReboot(c *gc.C) {
+	s.PatchValue(&sysdIsRunning, func() (bool, error) { return false, nil })
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	err := cmd.startAllAgents(cmdtesting.Context(c))
+	c.Assert(err, gc.ErrorMatches, "systemd is not fully running, please reboot to start agents")
+}
+
+func (s *updateSeriesCmdSuite) TestStartAllAgentsFailUnit(c *gc.C) {
+	s.services[0].SetErrors(
+		errors.New("fail me"),
+	)
+
+	cmd := &UpdateSeriesCommand{toSeries: "xenial", fromSeries: "trusty", dataDir: s.dataDir}
+	ctx := cmdtesting.Context(c)
+	err := cmd.findAgents(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmd.startAllAgents(ctx)
+	c.Assert(err, gc.ErrorMatches, "failed to start .* service: fail me")
+
+	s.assertServicesCalls(c, "Start", 1)
+}
+
+func (s *updateSeriesCmdSuite) TestRunPreUpstartToSystemdUpgradeReboot(c *gc.C) {
+	s.PatchValue(&sysdIsRunning, func() (bool, error) { return false, nil })
+	s.assertRunTest(c)
+	s.assertServiceSymLinks(c)
+	// Check idempotence
+	s.services[0].ResetCalls()
+	ctx := s.assertRunTest(c)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by symlink\n"+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by symlink\n"+
+		"wrote jujud-machine-0 agent, enabled and linked by symlink\n"+
+		"successfully copied tools and relinked agent tools\n")
+	s.assertServiceSymLinks(c)
+}
+
+func (s *updateSeriesCmdSuite) TestRunPostUpstartToSystemdUpgradeReboot(c *gc.C) {
+	s.assertRunTest(c)
+	// Check idempotence
+	s.services[0].ResetCalls()
+	ctx := s.assertRunTest(c)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by systemd\n"+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by systemd\n"+
+		"wrote jujud-machine-0 agent, enabled and linked by systemd\n"+
+		"successfully copied tools and relinked agent tools\n")
+}
+
+func (s *updateSeriesCmdSuite) TestRunPostUpstartToSystemdUpgradeStartAllAgents(c *gc.C) {
+	args := []string{"--to-series", "xenial", "--from-series", "trusty", "--start-agents"}
+	ctx, err := s.run(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	s.assertVerifyCmdResults(c)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by systemd\n"+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by systemd\n"+
+		"wrote jujud-machine-0 agent, enabled and linked by systemd\n"+
+		"successfully copied tools and relinked agent tools\n"+
+		"started jujud-unit-.*-0 service\n"+
+		"started jujud-unit-.*-0 service\n"+
+		"started jujud-machine-0 service\n"+
+		"all agents successfully restarted\n")
+}
+
+func (s *updateSeriesCmdSuite) TestSystemdToSystemdUpgrade(c *gc.C) {
+	s.setupTools(c, "xenial")
+	args := []string{"--to-series", "yakkety", "--from-series", "xenial"}
+	ctx, err := s.run(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	s.assertToolsCopySymlink(c, "yakkety")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"successfully copied tools and relinked agent tools\n")
+}
+
+func (s *updateSeriesCmdSuite) TestSystemdToSystemdUpgradeStartAllAgents(c *gc.C) {
+	s.setupTools(c, "xenial")
+	args := []string{"--to-series", "yakkety", "--from-series", "xenial", "--start-agents"}
+	ctx, err := s.run(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	s.assertToolsCopySymlink(c, "yakkety")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"successfully copied tools and relinked agent tools\n"+
+		"started jujud-unit-.*-0 service\n"+
+		"started jujud-unit-.*-0 service\n"+
+		"started jujud-machine-0 service\n"+
+		"all agents successfully restarted\n")
+}
+
+func (s *updateSeriesCmdSuite) TestRunTwiceFailFirstWriteService(c *gc.C) {
+	s.PatchValue(&sysdIsRunning, func() (bool, error) { return false, nil })
+	s.services[0].SetErrors(
+		errors.New("fail me"),
+	)
+
+	args := []string{"--to-series", "xenial", "--from-series", "trusty"}
+	ctx, err := s.run(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertServicesCalls(c, "WriteService", len(s.services))
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by symlink\n"+
+		"wrote jujud-machine-0 agent, enabled and linked by symlink\n"+
+		"successfully copied tools and relinked agent tools\n")
+
+	// Check idempotence
+	s.services[0].ResetCalls()
+	ctx = s.assertRunTest(c)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, ""+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by symlink\n"+
+		"wrote jujud-unit-.*-0 agent, enabled and linked by symlink\n"+
+		"wrote jujud-machine-0 agent, enabled and linked by symlink\n"+
+		"successfully copied tools and relinked agent tools\n")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *updateSeriesCmdSuite) TestRunTwiceRewriteToolsLink(c *gc.C) {
+	s.PatchValue(&sysdIsRunning, func() (bool, error) { return false, nil })
+	s.assertRunTest(c)
+	s.assertServiceSymLinks(c)
+
+	ver := version.Binary{
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		Series: "xenial",
+	}
+	os.RemoveAll(path.Join(s.dataDir, "tools", ver.String()))
+	name := s.services[0].Service.Name
+	os.RemoveAll(path.Join(s.dataDir, "init", name, name+".service"))
+
+	s.services[0].ResetCalls()
+	s.assertRunTest(c)
+	s.assertServiceSymLinks(c)
+}
+
+func (s *updateSeriesCmdSuite) assertRunTest(c *gc.C) *cmd.Context {
+	args := []string{"--to-series", "xenial", "--from-series", "trusty"}
+	ctx, err := s.run(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	s.assertVerifyCmdResults(c)
+	return ctx
+}
+
+func (s *updateSeriesCmdSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, &UpdateSeriesCommand{}, args...)
+}
+
+func (s *updateSeriesCmdSuite) assertVerifyCmdResults(c *gc.C) {
+	s.assertServicesCalls(c, "WriteService", len(s.services))
+	s.assertToolsCopySymlink(c, "xenial")
+}
+
+func (s *updateSeriesCmdSuite) assertToolsCopySymlink(c *gc.C, series string) {
+	// Check tools changes
+	ver := version.Binary{
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		Series: series,
+	}
+	jujuTools, err := agenttools.ReadTools(s.dataDir, ver)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(jujuTools.Version, gc.DeepEquals, ver)
+
+	for _, name := range append(s.unitNames, s.machineName) {
+		link := path.Join(s.dataDir, "tools", name)
+		linkResult, err := os.Readlink(link)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(linkResult, gc.Equals, path.Join(s.dataDir, "tools", ver.String()))
+	}
+}
+
+func (s *updateSeriesCmdSuite) assertServiceSymLinks(c *gc.C) {
+	for _, agent := range append(s.unitNames, s.machineName) {
+		svcName := "jujud-" + agent
+		svcFileName := svcName + ".service"
+		result, err := os.Readlink(path.Join(systemdDir, svcFileName))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.Equals, path.Join(s.dataDir, "init", svcName, svcFileName))
+	}
+}
+
+func (s *updateSeriesCmdSuite) assertServicesCalls(c *gc.C, svc string, expectedCnt int) {
+	// Call list shared by the services
+	calls := s.services[0].Calls()
+	serviceCount := 0
+	for _, call := range calls {
+		if call.FuncName == svc {
+			serviceCount += 1
+		}
+	}
+	c.Assert(serviceCount, gc.Equals, expectedCnt)
+}

--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -6,10 +6,11 @@
 package names
 
 const (
-	Juju           = "juju"
-	Jujud          = "jujud"
-	JujudVersions  = "jujud-versions.yaml"
-	JujuRun        = "juju-run"
-	JujuDumpLogs   = "juju-dumplogs"
-	JujuIntrospect = "juju-introspect"
+	Juju             = "juju"
+	Jujud            = "jujud"
+	JujudVersions    = "jujud-versions.yaml"
+	JujuRun          = "juju-run"
+	JujuDumpLogs     = "juju-dumplogs"
+	JujuIntrospect   = "juju-introspect"
+	JujuUpdateSeries = "juju-updateseries"
 )

--- a/juju/names/names_windows.go
+++ b/juju/names/names_windows.go
@@ -5,10 +5,11 @@
 package names
 
 const (
-	Juju           = "juju.exe"
-	Jujud          = "jujud.exe"
-	JujudVersions  = "jujud-versions.yaml"
-	JujuRun        = "juju-run.exe"
-	JujuDumpLogs   = "juju-dumplogs.exe"
-	JujuIntrospect = "juju-introspect.exe"
+	Juju             = "juju.exe"
+	Jujud            = "jujud.exe"
+	JujudVersions    = "jujud-versions.yaml"
+	JujuRun          = "juju-run.exe"
+	JujuDumpLogs     = "juju-dumplogs.exe"
+	JujuIntrospect   = "juju-introspect.exe"
+	JujuUpdateSeries = "juju-updateseries.exe"
 )

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -23,6 +23,7 @@ const (
 	uniterStateDir
 	jujuDumpLogs
 	jujuIntrospect
+	jujuUpdateSeries
 	instanceCloudInitDir
 	cloudInitCfgDir
 )
@@ -36,6 +37,7 @@ var nixVals = map[osVarType]string{
 	jujuRun:              "/usr/bin/juju-run",
 	jujuDumpLogs:         "/usr/bin/juju-dumplogs",
 	jujuIntrospect:       "/usr/bin/juju-introspect",
+	jujuUpdateSeries:     "/usr/bin/juju-updateseries",
 	certDir:              "/etc/juju/certs.d",
 	metricsSpoolDir:      "/var/lib/juju/metricspool",
 	uniterStateDir:       "/var/lib/juju/uniter/state",
@@ -44,17 +46,18 @@ var nixVals = map[osVarType]string{
 }
 
 var winVals = map[osVarType]string{
-	tmpDir:          "C:/Juju/tmp",
-	logDir:          "C:/Juju/log",
-	dataDir:         "C:/Juju/lib/juju",
-	storageDir:      "C:/Juju/lib/juju/storage",
-	confDir:         "C:/Juju/etc",
-	jujuRun:         "C:/Juju/bin/juju-run.exe",
-	jujuDumpLogs:    "C:/Juju/bin/juju-dumplogs.exe",
-	jujuIntrospect:  "C:/Juju/bin/juju-introspect.exe",
-	certDir:         "C:/Juju/certs",
-	metricsSpoolDir: "C:/Juju/lib/juju/metricspool",
-	uniterStateDir:  "C:/Juju/lib/juju/uniter/state",
+	tmpDir:           "C:/Juju/tmp",
+	logDir:           "C:/Juju/log",
+	dataDir:          "C:/Juju/lib/juju",
+	storageDir:       "C:/Juju/lib/juju/storage",
+	confDir:          "C:/Juju/etc",
+	jujuRun:          "C:/Juju/bin/juju-run.exe",
+	jujuDumpLogs:     "C:/Juju/bin/juju-dumplogs.exe",
+	jujuIntrospect:   "C:/Juju/bin/juju-introspect.exe",
+	jujuUpdateSeries: "C:/Juju/bin/juju-updateseries.exe",
+	certDir:          "C:/Juju/certs",
+	metricsSpoolDir:  "C:/Juju/lib/juju/metricspool",
+	uniterStateDir:   "C:/Juju/lib/juju/uniter/state",
 }
 
 // osVal will lookup the value of the key valname
@@ -145,6 +148,12 @@ func MachineCloudInitDir(series string) (string, error) {
 // cloud config directory for a particular series.
 func CloudInitCfgDir(series string) (string, error) {
 	return osVal(series, cloudInitCfgDir)
+}
+
+// JujuUpdateSeries returns the absolute path to the juju-updateseries
+// binary for a particular series.
+func JujuUpdateSeries(series string) (string, error) {
+	return osVal(series, jujuUpdateSeries)
 }
 
 func MustSucceed(s string, e error) string {

--- a/service/service.go
+++ b/service/service.go
@@ -93,6 +93,13 @@ type RestartableService interface {
 	Restart() error
 }
 
+type UpgradableService interface {
+	// WriteService write the service conf data, if the service is
+	// running add links to allow for manual and automatic start
+	// of the service.
+	WriteService() error
+}
+
 // TODO(ericsnow) bug #1426458
 // Eliminate the need to pass an empty conf for most service methods
 // and several helper functions.

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -454,32 +454,7 @@ func (s *Service) install() error {
 		}
 	}
 
-	filename, err := s.writeConf()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	conn, err := s.newConn()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer conn.Close()
-
-	runtime, force := false, true
-	_, err = conn.LinkUnitFiles([]string{filename}, runtime, force)
-	if err != nil {
-		return s.errorf(err, "dbus link request failed")
-	}
-
-	if err := conn.Reload(); err != nil {
-		return s.errorf(err, "dbus post-link daemon reload request failed")
-	}
-
-	_, _, err = conn.EnableUnitFiles([]string{filename}, runtime, force)
-	if err != nil {
-		return s.errorf(err, "dbus enable request failed")
-	}
-	return nil
+	return s.WriteService()
 }
 
 func (s *Service) writeConf() (string, error) {
@@ -561,4 +536,40 @@ func (s *Service) StartCommands() ([]string, error) {
 		cmds.start(name),
 	}
 	return cmdList, nil
+}
+
+// WriteService implements UpgradableService.WriteService
+func (s *Service) WriteService() error {
+	filename, err := s.writeConf()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if running, err := IsRunning(); err != nil {
+		return errors.Trace(err)
+	} else if !running {
+		return nil
+	}
+
+	conn, err := s.newConn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer conn.Close()
+
+	runtime, force := false, true
+	if _, err = conn.LinkUnitFiles([]string{filename}, runtime, force); err != nil {
+		return s.errorf(err, "dbus link request failed")
+	}
+
+	err = conn.Reload()
+	if err != nil {
+		return s.errorf(err, "dbus post-link daemon reload request failed")
+	}
+
+	if _, _, err = conn.EnableUnitFiles([]string{filename}, runtime, force); err != nil {
+		return s.errorf(err, "dbus enable request failed")
+
+	}
+	return nil
 }


### PR DESCRIPTION
## Description of change

Add a juju command available on each unit to assist with restarting juju agents after a series upgrade from trusty to xenial.  This requires writing systemd service files for the agents, link and enable them, and copying tools to a correctly named directory and relinking agent tools.  Optional is to restart the agents, if systemd is really running.

## QA steps

1. bootstrap juju localhost
2. juju deploy ubuntu -n 2 --series trusty
3. juju ssh 0 -- sudo do-release-upgrade -f DistUpgradeViewNonInteractive
4. juju ssh 1 -- sudo do-release-upgrade -f DistUpgradeViewNonInteractive
4. juju ssh 0 -- sudo rm /var/lib/juju/agents/unit-ubuntu-0/charm/wheelhouse/.bootstrapped
4. juju ssh 1 -- sudo rm /var/lib/juju/agents/unit-ubuntu-0/charm/wheelhouse/.bootstrapped
5. juju ssh 0 -- sudo shutdown -r now
6. juju ssh 0 -- sudo juju-updateseries --to-series xenial --from-series trusty
6. juju ssh 0 -- sudo juju-updateseries --to-series xenial --from-series trusty  --start-agents
6. juju ssh 1 -- sudo juju-updateseries --to-series xenial --from-series trusty  --start-agents  <-- won't start agents
7. juju ssh 1 -- sudo shutdown -r now

Once juju and the agents settle... juju status should show good results for the two units

## Documentation changes

The current instructions will need to be updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1749201