### PR TITLE
Update dependencies to newer github.com/juju/testing

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T14:24:45Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	43f926548f91d55be6bae26ecb7d2386c64e887c	2018-02-13T13:46:16Z
+github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
 github.com/juju/txn	git	dbb63c620814d1a0f96260f4cad3e2cca14f702b	2017-06-13T23:44:54Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z


### PR DESCRIPTION
## Description of change

This brings in a testing package that supports mongo 3.6.

This is essentially just bringing in:
 https://github.com/juju/testing/pull/136

## QA steps

Install mongo 3.6 into $PATH and make sure you don't have juju-mongodb3.2 installed.
You should then be able to do something like:
```
$ cd state
$ go test -check.v
```

Without this patch, testing should fail because of passing commandline parameters to mongo that it no longer supports, etc.

## Documentation changes

None.

## Bug reference

[lp:1760390](https://bugs.launchpad.net/juju/+bug/1760390)