### PR TITLE
maas 1.9 <-> 2.0 instanceid migration script.

### DIFF
--- a/scripts/migrate_maas_instance_ids.sh
+++ b/scripts/migrate_maas_instance_ids.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+#This script script is intended to run only against controller machines that
+#have upgraded from a MAAS 1.9 provider to a MAAS 2.x provider. Do not use this
+#script otherwise. The javascript below is horrible. It is designed to run
+#operations in bulk targeting a minimum version of mongo 3.2 which has little
+#functionality in the way of aggregation.
+
+while getopts 'r' flag; do
+    case "${flag}" in
+        r) rollback_flag=true
+	   ;;
+        *) echo "This script is dangerous use it carefully" $>2
+	   ;;
+    esac
+done
+
+if [ $rollback_flag ]
+then
+    #This script warps a MAAS 1.9 style URL around the instance_id. You can
+    #run this script with the -r flag for convenience but you should really just reload the
+    #backup that you have created with mongoexport or otherwise if you run into trouble.
+    mongo_script='db.instanceData.aggregate([{"$project":{instanceid:{"$cond":{if:{"$ne":[{"$substr":["$instanceid",0,20]},"/MAAS/api/1.0/nodes/"]},then:{"$concat":["/MAAS/api/1.0/nodes/","$instanceid","/"]},else:"$instanceid"}},document:"$$ROOT"}},{"$out":"tmp"}]);ops=db.instanceData.find().map(function(item){newid=db.tmp.findOne({"document.instanceid":item.instanceid});return{"updateOne":{"filter":{instanceid:newid.document.instanceid},"update":{"$set":{instanceid:newid.instanceid}}}}});db.instanceData.bulkWrite(ops);'
+else
+    #This script drops the URL wrapping the instance which coerces the data into MAAS 2.0 format
+    mongo_script='db.instanceData.aggregate([{"$project":{instanceid:{"$cond":{if:{"$eq":[{"$substr":["$instanceid",0,20]},"/MAAS/api/1.0/nodes/"]},then:{"$substr":["$instanceid",20,-1]},else:"$instanceid"}},document:"$$ROOT"}},{"$out":"tmp"}]);ops=db.instanceData.find().map(function(item){newid=db.tmp.findOne({"document.instanceid":item.instanceid});if(item.instanceid.slice(-1)==="/"){return{"updateOne":{"filter":{instanceid:newid.document.instanceid},"update":{"$set":{instanceid:newid.instanceid.slice(0,-1)}}}}}else{return{}}});db.instanceData.bulkWrite(ops);'
+fi
+
+agent=$(cd /var/lib/juju/agents; echo machine-*)
+pw=$(sudo grep statepassword /var/lib/juju/agents/${agent}/agent.conf | cut '-d ' -sf2)
+/usr/lib/juju/mongo3.2/bin/mongo --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates localhost:37017/juju --eval $mongo_script > /dev/null

--- a/scripts/migrate_maas_instance_ids.sh
+++ b/scripts/migrate_maas_instance_ids.sh
@@ -123,4 +123,4 @@ script=$(echo $mongo_script | tr -d ' ' | tr -d '[:blank:]' | tr -d '[:space:]')
 
 agent=$(cd /var/lib/juju/agents; echo machine-*)
 pw=$(sudo grep statepassword /var/lib/juju/agents/${agent}/agent.conf | cut '-d ' -sf2)
-/usr/lib/juju/mongo3.2/bin/mongo --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates localhost:37017/juju --eval $script
+/usr/lib/juju/mongo3.2/bin/mongo --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates localhost:37017/juju --eval "$script"

--- a/scripts/migrate_maas_instance_ids.sh
+++ b/scripts/migrate_maas_instance_ids.sh
@@ -8,26 +8,119 @@ set -e
 #operations in bulk targeting a minimum version of mongo 3.2 which has little
 #functionality in the way of aggregation.
 
-while getopts 'r' flag; do
+usage() { echo "usage: $0 [-rh]" 1>&2; exit 1; }
+
+while getopts 'rh' flag; do
     case "${flag}" in
         r) rollback_flag=true
-	   ;;
-        *) echo "This script is dangerous use it carefully" $>2
-	   ;;
+           ;;
+        h) usage
+           ;;
+        *) usage
+           ;;
     esac
 done
 
 if [ $rollback_flag ]
 then
-    #This script warps a MAAS 1.9 style URL around the instance_id. You can
-    #run this script with the -r flag for convenience but you should really just reload the
-    #backup that you have created with mongoexport or otherwise if you run into trouble.
-    mongo_script='db.instanceData.aggregate([{"$project":{instanceid:{"$cond":{if:{"$ne":[{"$substr":["$instanceid",0,20]},"/MAAS/api/1.0/nodes/"]},then:{"$concat":["/MAAS/api/1.0/nodes/","$instanceid","/"]},else:"$instanceid"}},document:"$$ROOT"}},{"$out":"tmp"}]);ops=db.instanceData.find().map(function(item){newid=db.tmp.findOne({"document.instanceid":item.instanceid});return{"updateOne":{"filter":{instanceid:newid.document.instanceid},"update":{"$set":{instanceid:newid.instanceid}}}}});db.instanceData.bulkWrite(ops);'
+    #This script warps a MAAS 1.9 style URL around the instance_id. You can run
+    #this script with the -r flag for convenience but you should really just
+    #reload the backup that you have created with mongoexport or otherwise if
+    #you run into trouble.
+    mongo_script=$(cat <<'JAVASCRIPT'
+db.instanceData.aggregate([{
+    "$project": {
+        instanceid: {
+            "$cond": {
+                if: {
+                    "$ne": [{
+                        "$substr": ["$instanceid", 0, 20]
+                    }, "/MAAS/api/1.0/nodes/"]
+                }
+                , then: {
+                    "$concat": ["/MAAS/api/1.0/nodes/", "$instanceid", "/"]
+                }
+                , else: "$instanceid"
+            }
+        }
+        , document: "$$ROOT"
+    }
+}, {
+    "$out": "tmp"
+}]);
+ops = db.instanceData.find().map(function (item) {
+    newid = db.tmp.findOne({
+        "document.instanceid": item.instanceid
+    });
+    return {
+        "updateOne": {
+            "filter": {
+                instanceid: newid.document.instanceid
+            }
+            , "update": {
+                "$set": {
+                    instanceid: newid.instanceid
+                }
+            }
+        }
+    }
+});
+db.instanceData.bulkWrite(ops);
+JAVASCRIPT
+)
 else
-    #This script drops the URL wrapping the instance which coerces the data into MAAS 2.0 format
-    mongo_script='db.instanceData.aggregate([{"$project":{instanceid:{"$cond":{if:{"$eq":[{"$substr":["$instanceid",0,20]},"/MAAS/api/1.0/nodes/"]},then:{"$substr":["$instanceid",20,-1]},else:"$instanceid"}},document:"$$ROOT"}},{"$out":"tmp"}]);ops=db.instanceData.find().map(function(item){newid=db.tmp.findOne({"document.instanceid":item.instanceid});if(item.instanceid.slice(-1)==="/"){return{"updateOne":{"filter":{instanceid:newid.document.instanceid},"update":{"$set":{instanceid:newid.instanceid.slice(0,-1)}}}}}else{return{}}});db.instanceData.bulkWrite(ops);'
+    #This script drops the URL wrapping the instance which coerces the data into
+    #MAAS 2.0 format
+    mongo_script=$(cat <<'JAVASCRIPT'
+db.instanceData.aggregate([{
+    "$project": {
+        instanceid: {
+            "$cond": {
+                if: {
+                    "$eq": [{
+                        "$substr": ["$instanceid", 0, 20]
+                    }, "/MAAS/api/1.0/nodes/"]
+                }
+                , then: {
+                    "$substr": ["$instanceid", 20, -1]
+                }
+                , else: "$instanceid"
+            }
+        }
+        , document: "$$ROOT"
+    }
+}, {
+    "$out": "tmp"
+}]);
+ops = db.instanceData.find().map(function (item) {
+    newid = db.tmp.findOne({
+        "document.instanceid": item.instanceid
+    });
+    if (item.instanceid.slice(-1) === "/") {
+        return {
+            "updateOne": {
+                "filter": {
+                    instanceid: newid.document.instanceid
+                }
+                , "update": {
+                    "$set": {
+                        instanceid: newid.instanceid.slice(0, -1)
+                    }
+                }
+            }
+        }
+    } else {
+        return {}
+    }
+});
+db.instanceData.bulkWrite(ops);
+JAVASCRIPT
+)
 fi
+
+#prepare mongoscript for evaluation
+script=$(echo $mongo_script | tr -d ' ' | tr -d '[:blank:]' | tr -d '[:space:]')
 
 agent=$(cd /var/lib/juju/agents; echo machine-*)
 pw=$(sudo grep statepassword /var/lib/juju/agents/${agent}/agent.conf | cut '-d ' -sf2)
-/usr/lib/juju/mongo3.2/bin/mongo --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates localhost:37017/juju --eval $mongo_script > /dev/null
+/usr/lib/juju/mongo3.2/bin/mongo --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates localhost:37017/juju --eval $script


### PR DESCRIPTION
## Description of change

maas 1.9 <-> 2.x instanceid migration script.

Why is this change needed?

When upgrading a MAAS from 1.9 to 2.x instance ids can remain in the old MAAS 1.9 format.

## QA steps

TBA

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1731108
