### PR TITLE
RFC: Add a Tracef for all transactions.

### DIFF
--- a/state/txns.go
+++ b/state/txns.go
@@ -152,7 +152,6 @@ func (r *multiModelRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 		}
 		outOps = append(outOps, outOp)
 	}
-	logger.Tracef("rewrote transaction: %#v", outOps)
 	return outOps, nil
 }
 


### PR DESCRIPTION
## Description of change

Rather than tracing just the transactions that we rewrite, trace all
changes to the database. And do so using "pretty" which makes it easier
to understand the actual transactions.

We write it to a specific logger so that people can enable/disable just
the transaction logging.

## QA steps

```
$ juju model-config -m controller logging-config="<root>=DEBUG;juju.state.txn=TRACE"
$ juju debug-log -m controller
```

That should show you all of the transactions that are being run, pretty printed along with whether there was an error trying to run the transactions.
We used to have *some* transactions being printed if you did 'juju.state=TRACE'. However, only the multiModelRunner, (so only if we were auto-adding model-uuid, etc). They also weren't pretty printed which takes less vertical space, but makes them much harder to understand.

They get logged as something like:
```
machine-0: 10:30:06 TRACE juju.state.txn ran transaction []txn.Op{
    {
        C:      "leases",
        Id:     "a51056e5-96a1-40dc-88d3-8f18a932ce4c:application-leadership#ul#",
        Assert: bson.M{
            "holder":   "ul/0",
            "start":    int64(988297707995),
            "duration": time.Duration(60000000000),
            "writer":   "machine-0",
        },
        Insert: nil,
        Update: bson.M{
            "$set": bson.D{
                {
                    Name:  "start",
                    Value: int64(1017307120518),
                },
                {
                    Name:  "duration",
                    Value: int64(60000000000),
                },
                {
                    Name:  "writer",
                    Value: "machine-0",
                },
            },
        },
        Remove: false,
    },
}
err: <nil>
```

Ideally we would have a more custom format that would be a little bit tighter, such as:
```
machine-0: 10:30:06 TRACE juju.state.txn ran transaction []txn.Op{{
        C:      "leases",
        Id:     "a51056e5-96a1-40dc-88d3-8f18a932ce4c:application-leadership#ul#",
        Assert: bson.M{
            "holder":   "ul/0",
            "start":    int64(988297707995),
            "duration": time.Duration(60000000000),
            "writer":   "machine-0",
        },
        Insert: nil,
        Update: bson.M{
            "$set": bson.D{{
                    Name:  "start",
                    Value: int64(1017307120518),
                }, {
                    Name:  "duration",
                    Value: int64(60000000000),
                }, {
                    Name:  "writer",
                    Value: "machine-0",
                }},
        },
        Remove: false,
    }}
err: <nil>
```

But IMO it isn't quite enough to be worth the effort. (You could even format the bson.D as:
```
        Update: bson.M{
            "$set": bson.D{
		{"start", int64(1017307120518)},
	 	{"duration", int64(60000000000)},
		{"writer", "machine-0"},
	}},
```
## Documentation changes

We could potentially document something like:
  To see all transactions that are being run, it is possible to set `juju.state.txn=TRACE` as part of logging-config. I don't think we currently document the various things that are possible to get out of logging.

## Bug reference

None.
