### PR TITLE
apiserver: tidying up from the big API server/HTTP server split

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -406,33 +406,8 @@ func (st *state) connectStream(path string, attrs url.Values, extraHeaders http.
 		}
 	}
 
-	connection, resp, err := websocketDial(dialer, target.String(), requestHeader)
+	connection, err := websocketDial(dialer, target.String(), requestHeader)
 	if err != nil {
-		// TODO(http): move this into websocketDial
-		if err == websocket.ErrBadHandshake {
-			// If ErrBadHandshake is returned, a non-nil response
-			// is returned so the client can react to auth errors
-			// (for example).
-			defer resp.Body.Close()
-			body, readErr := ioutil.ReadAll(resp.Body)
-			if readErr != nil {
-				return nil, err
-			}
-			if resp.Header.Get("Content-Type") == "application/json" {
-				var result params.ErrorResult
-				jsonErr := json.Unmarshal(body, &result)
-				if jsonErr != nil {
-					return nil, errors.Annotate(jsonErr, "reading error response")
-				}
-				return nil, result.Error
-			}
-
-			err = errors.Errorf(
-				"%s (%s)",
-				strings.TrimSpace(string(body)),
-				http.StatusText(resp.StatusCode),
-			)
-		}
 		return nil, err
 	}
 	if err := readInitialStreamError(connection); err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -554,14 +555,47 @@ func (c *Client) AgentVersion() (version.Number, error) {
 
 // websocketDial is called instead of dialer.Dial so we can override it in
 // tests.
-var websocketDial = func(dialer *websocket.Dialer, urlStr string, requestHeader http.Header) (base.Stream, *http.Response, error) {
+var websocketDial = websocketDialWithErrors
+
+// WebsocketDialer is something that can make a websocket connection. Enables
+// testing the error unpacking in websocketDialWithErrors.
+type WebsocketDialer interface {
+	Dial(string, http.Header) (*websocket.Conn, *http.Response, error)
+}
+
+// websocketDialWithErrors dials the websocket and extracts any error
+// from the response if there's a handshake error setting up the
+// socket. Any other errors are returned normally.
+func websocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeader http.Header) (base.Stream, error) {
 	c, resp, err := dialer.Dial(urlStr, requestHeader)
 	if err != nil {
-		// In websocket handshake errors the response is returned to
-		// enable reading error details.
-		return nil, resp, err
+		if err == websocket.ErrBadHandshake {
+			// If ErrBadHandshake is returned, a non-nil response
+			// is returned so the client can react to auth errors
+			// (for example).
+			defer resp.Body.Close()
+			body, readErr := ioutil.ReadAll(resp.Body)
+			if readErr != nil {
+				return nil, err
+			}
+			if resp.Header.Get("Content-Type") == "application/json" {
+				var result params.ErrorResult
+				jsonErr := json.Unmarshal(body, &result)
+				if jsonErr != nil {
+					return nil, errors.Annotate(jsonErr, "reading error response")
+				}
+				return nil, result.Error
+			}
+
+			err = errors.Errorf(
+				"%s (%s)",
+				strings.TrimSpace(string(body)),
+				http.StatusText(resp.StatusCode),
+			)
+		}
+		return nil, err
 	}
-	return c, nil, nil
+	return c, nil
 }
 
 // WatchDebugLog returns a channel of structured Log Messages. Only log entries

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -19,11 +19,12 @@ import (
 )
 
 var (
-	CertDir             = &certDir
-	WebsocketDial       = &websocketDial
-	SlideAddressToFront = slideAddressToFront
-	BestVersion         = bestVersion
-	FacadeVersions      = &facadeVersions
+	CertDir                 = &certDir
+	WebsocketDial           = &websocketDial
+	WebsocketDialWithErrors = websocketDialWithErrors
+	SlideAddressToFront     = slideAddressToFront
+	BestVersion             = bestVersion
+	FacadeVersions          = &facadeVersions
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {

--- a/api/pubsub/pubsub_test.go
+++ b/api/pubsub/pubsub_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apipubsub "github.com/juju/juju/api/pubsub"
-	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testserver"
 	"github.com/juju/juju/state"
@@ -133,7 +132,6 @@ type PubSubIntegrationSuite struct {
 	password   string
 	nonce      string
 	hub        *pubsub.StructuredHub
-	server     *apiserver.Server
 	info       *api.Info
 }
 
@@ -155,13 +153,10 @@ func (s *PubSubIntegrationSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { statePool.Close() })
 	config := testserver.DefaultServerConfig(c)
 	config.Hub = s.hub
-	info, server, httpServer := testserver.NewServerWithConfig(c, statePool, config)
-	httpServer.StartTLS()
-	s.AddCleanup(func(*gc.C) { httpServer.Close() })
-	s.server = server
-	s.AddCleanup(func(*gc.C) { s.server.Stop() })
+	server := testserver.NewServerWithConfig(c, statePool, config)
+	s.AddCleanup(func(c *gc.C) { c.Assert(server.Stop(), jc.ErrorIsNil) })
 
-	s.info = info
+	s.info = server.Info
 	s.info.ModelTag = s.IAASModel.ModelTag()
 	s.info.Tag = s.machineTag
 	s.info.Password = s.password

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/apiserver/testserver"
 	"github.com/juju/juju/apiserver/websocket/websockettest"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -194,7 +193,7 @@ func (s *logsinkSuite) TestReceiveErrorBreaksConn(c *gc.C) {
 }
 
 func (s *logsinkSuite) TestNewServerValidatesLogSinkConfig(c *gc.C) {
-	cfg := testserver.DefaultServerConfig(c)
+	cfg := s.config
 	// Make a fake-ish state pool.
 	cfg.StatePool = &state.StatePool{}
 	cfg.Mux = apiserverhttp.NewMux()

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -121,9 +121,6 @@ func (w *Worker) loop() error {
 	}
 	go server.Serve(listener)
 	defer func() {
-		// TODO(axw) we need to provide mux clients a means
-		// of registering for graceful shutdown, and wait
-		// for them also.
 		logger.Infof("shutting down HTTP server")
 		// Shutting down the server will also close listener.
 		err := server.Shutdown(context.Background())


### PR DESCRIPTION
## Description of change

During the review of #8518 there were some changes requested that we decided it would be better to do in a separate PR (rather than holding that one up). This change has some of them:

* Simplifying the usage of apiserver/testserver by wrapping the returned API server and HTTP server into a struct to close them both at once.
* Moving the websocket error response parsing in the API client into websocket

There are some other changes that I want to discuss more with @wallyworld (throttling and prometheus stats in the http server), so I'll hold off on those until he comes back.

## QA steps

Bootstrap a controller and deploy some applications - smoke test.
