### PR TITLE
Have the debuglog handler return auth errors over websocket.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -573,6 +573,11 @@ func websocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeade
 			// If ErrBadHandshake is returned, a non-nil response
 			// is returned so the client can react to auth errors
 			// (for example).
+			//
+			// The problem here is that there is a response, but the response
+			// body is truncated to 1024 bytes for debugging information, not
+			// for a true response. While this may work for small bodies, it
+			// isn't guaranteed to work for all messages.
 			defer resp.Body.Close()
 			body, readErr := ioutil.ReadAll(resp.Body)
 			if readErr != nil {

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/websocket"
 	"github.com/juju/juju/state"
@@ -26,8 +27,10 @@ import (
 // variants. The supplied handle func allows for varied handling of
 // requests.
 type debugLogHandler struct {
-	ctxt   httpContext
-	handle debugLogHandlerFunc
+	ctxt          httpContext
+	authenticator httpcontext.Authenticator
+	authorizer    httpcontext.Authorizer
+	handle        debugLogHandlerFunc
 }
 
 type debugLogHandlerFunc func(
@@ -39,16 +42,28 @@ type debugLogHandlerFunc func(
 
 func newDebugLogHandler(
 	ctxt httpContext,
+	authenticator httpcontext.Authenticator,
+	authorizer httpcontext.Authorizer,
 	handle debugLogHandlerFunc,
 ) *debugLogHandler {
 	return &debugLogHandler{
-		ctxt:   ctxt,
-		handle: handle,
+		ctxt:          ctxt,
+		authenticator: authenticator,
+		authorizer:    authorizer,
+		handle:        handle,
 	}
 }
 
 // ServeHTTP will serve up connections as a websocket for the
 // debug-log API.
+//
+// The authentication and authorization have to be done after the http request
+// has been upgraded to a websocket as we may be sending back a discharge
+// required error. This error contains the macaroon that needs to be
+// discharged by the user. In order for this error to be deserialized
+// correctly any auth failure will come back in the initial error that is
+// returned over the websocket. This is consumed by the ConnectStream function
+// on the apiclient.
 //
 // Args for the HTTP request are as follows:
 //   includeEntity -> []string - lists entity tags to include in the response
@@ -71,8 +86,20 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	handler := func(conn *websocket.Conn) {
 		socket := &debugLogSocketImpl{conn}
 		defer conn.Close()
+		// Authentication and authorization has to be done after the http
+		// connection has been upgraded to a websocket.
 
-		st, _, err := h.ctxt.stateForRequestAuthenticated(req)
+		authInfo, err := h.authenticator.Authenticate(req)
+		if err != nil {
+			socket.sendError(errors.Annotate(err, "authentication failed"))
+			return
+		}
+		if err := h.authorizer.Authorize(authInfo); err != nil {
+			socket.sendError(errors.Annotate(err, "authorization failed"))
+			return
+		}
+
+		st, err := h.ctxt.stateForRequestUnauthenticated(req)
 		if err != nil {
 			socket.sendError(err)
 			return

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -8,12 +8,17 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
 
-func newDebugLogDBHandler(ctxt httpContext) http.Handler {
-	return newDebugLogHandler(ctxt, handleDebugLogDBRequest)
+func newDebugLogDBHandler(
+	ctxt httpContext,
+	authenticator httpcontext.Authenticator,
+	authorizer httpcontext.Authorizer,
+) http.Handler {
+	return newDebugLogHandler(ctxt, authenticator, authorizer, handleDebugLogDBRequest)
 }
 
 func handleDebugLogDBRequest(


### PR DESCRIPTION
The discharge required macaroon error for debug-log is working by accident.

The http response on failure to upgrade the websocket doesn't have a complete body, so we can't rely on it to have a well formed JSON document.

This branch changes the authorisation and authentication aspects of debug-log to happen after the connection has been upgraded to a websocket.

We keep the old mechanism in the client code for talking to old servers, and old clients talking to new servers will still get the error correctly due to the expected first error on ConnectStream.

## QA steps

Bootstrap and debug-log

## Documentation changes

None
