### PR TITLE
Cloud credential validator, api for agent worker.

### DIFF
--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -81,6 +81,10 @@ func (st *State) IsMaster() (bool, error) {
 
 // WatchCredential returns a watcher which reports when the specified
 // credential has changed.
+// TODO (anastasiamac 2018-04-06) I think that this is wrong and it does not
+// look to be used and should be removed:
+// * why are we ignoring the tag argument?;
+// * what is actually being called since there is no equivalent apiserver.*.WatchCredential?...
 func (c *State) WatchCredential(tag names.CloudCredentialTag) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.facade.FacadeCall("WatchCredential", nil, &result)

--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -12,11 +12,9 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/common/cloudspec"
-	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/watcher"
 )
 
 // State provides access to an agent's view of the state.
@@ -77,24 +75,6 @@ func (st *State) IsMaster() (bool, error) {
 	var results params.IsMasterResult
 	err := st.facade.FacadeCall("IsMaster", nil, &results)
 	return results.Master, err
-}
-
-// WatchCredential returns a watcher which reports when the specified
-// credential has changed.
-// TODO (anastasiamac 2018-04-06) I think that this is wrong and it does not
-// look to be used and should be removed:
-// * why are we ignoring the tag argument?;
-// * what is actually being called since there is no equivalent apiserver.*.WatchCredential?...
-func (c *State) WatchCredential(tag names.CloudCredentialTag) (watcher.NotifyWatcher, error) {
-	var result params.NotifyWatchResult
-	err := c.facade.FacadeCall("WatchCredential", nil, &result)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	return apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result), nil
 }
 
 type Entity struct {

--- a/api/base/types.go
+++ b/api/base/types.go
@@ -146,7 +146,8 @@ type SLASummary struct {
 // StoredCredential contains information about the cloud credential stored on the controller
 // and used by models.
 type StoredCredential struct {
-	// CloudCredential is a cloud credential that identifies cloud credential on the controller.
+	// CloudCredential is a cloud credential id that identifies cloud credential on the controller.
+	// The value is what CloudCredentialTag.Id() returns.
 	CloudCredential string
 
 	// Valid is a flag that indicates whether the credential is valid.

--- a/api/base/types.go
+++ b/api/base/types.go
@@ -142,3 +142,13 @@ type SLASummary struct {
 	Level string
 	Owner string
 }
+
+// StoredCredential contains information about the cloud credential stored on the controller
+// and used by models.
+type StoredCredential struct {
+	// CloudCredential is a cloud credential that identifies cloud credential on the controller.
+	CloudCredential string
+
+	// Valid is a flag that indicates whether the credential is valid.
+	Valid bool
+}

--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -1,0 +1,106 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+)
+
+var logger = loggo.GetLogger("juju.api.credentialvalidator")
+
+// Facade provides methods that the Juju client command uses to interact
+// with the Juju backend.
+type Facade struct {
+	facade base.FacadeCaller
+}
+
+// NewFacade creates a new `Facade` based on an existing authenticated API
+// connection.
+func NewFacade(caller base.APICaller) *Facade {
+	return &Facade{base.NewFacadeCaller(caller, "CredentialValidator")}
+}
+
+// ModelCredential get cloud credential that a given model uses, including
+// useful data such as "is this credential valid"...
+// Some clouds do not require a credential and support the "empty" authentication
+// type. Models on these clouds will have no credentials set, and thus, will return
+// a false as 2nd argument.
+func (c *Facade) ModelCredential(modelUUID string) (base.StoredCredential, bool, error) {
+	// Construct model tag from model uuid.
+	in := params.Entities{
+		Entities: []params.Entity{{Tag: names.NewModelTag(modelUUID).String()}},
+	}
+
+	// Call apiserver to get credential for this model.
+	out := params.ModelCredentialResults{}
+	emptyResult := base.StoredCredential{}
+	if err := c.facade.FacadeCall("ModelCredentials", in, &out); err != nil {
+		return emptyResult, false, errors.Trace(err)
+	}
+
+	// There should be just 1.
+	if count := len(out.Results); count != 1 {
+		return emptyResult, false, errors.Errorf("expected 1 model credential for model %q, got %d", modelUUID, count)
+	}
+	if err := out.Results[0].Error; err != nil {
+		return emptyResult, false, errors.Trace(err)
+	}
+
+	result := out.Results[0].Result
+
+	modelTag, err := names.ParseModelTag(result.Model)
+	if err != nil {
+		return emptyResult, false, errors.Trace(err)
+	}
+	if modelTag.Id() != modelUUID {
+		return emptyResult, false, errors.Errorf("unexpected credential for model %q, expected credential for model %q", modelTag.Id(), modelUUID)
+	}
+
+	if !result.Exists {
+		return emptyResult, false, nil
+	}
+
+	credentialTag, err := names.ParseCloudCredentialTag(result.CloudCredential)
+	if err != nil {
+		return emptyResult, false, errors.Trace(err)
+	}
+	return base.StoredCredential{
+		CloudCredential: credentialTag.Id(),
+		Valid:           result.Valid,
+	}, true, nil
+}
+
+// WatchCredential provides notify watcher that is responsive to changes
+// to a given cloud credential.
+func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, error) {
+	// Construct credential tag from given id.
+	in := params.Entities{
+		Entities: []params.Entity{{Tag: names.NewCloudCredentialTag(credentialID).String()}},
+	}
+
+	// Call apiserver to get the watcher for this credential.
+	var results params.NotifyWatchResults
+	err := c.facade.FacadeCall("WatchCredential", in, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// There should be just 1.
+	if count := len(results.Results); count != 1 {
+		return nil, errors.Errorf("expected 1 watcher for credential %q, got %d", credentialID, count)
+	}
+
+	if err := results.Results[0].Error; err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), results.Results[0])
+	return w, nil
+}

--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -28,7 +28,7 @@ func NewFacade(caller base.APICaller) *Facade {
 	return &Facade{base.NewFacadeCaller(caller, "CredentialValidator")}
 }
 
-// ModelCredential get cloud credential that a given model uses, including
+// ModelCredential gets the cloud credential that a given model uses, including
 // useful data such as "is this credential valid"...
 // Some clouds do not require a credential and support the "empty" authentication
 // type. Models on these clouds will have no credentials set, and thus, will return

--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -33,74 +33,40 @@ func NewFacade(caller base.APICaller) *Facade {
 // Some clouds do not require a credential and support the "empty" authentication
 // type. Models on these clouds will have no credentials set, and thus, will return
 // a false as 2nd argument.
-func (c *Facade) ModelCredential(modelUUID string) (base.StoredCredential, bool, error) {
-	// Construct model tag from model uuid.
-	in := params.Entities{
-		Entities: []params.Entity{{Tag: names.NewModelTag(modelUUID).String()}},
-	}
-
-	// Call apiserver to get credential for this model.
-	out := params.ModelCredentialResults{}
+func (c *Facade) ModelCredential() (base.StoredCredential, bool, error) {
+	out := params.ModelCredential{}
 	emptyResult := base.StoredCredential{}
-	if err := c.facade.FacadeCall("ModelCredentials", in, &out); err != nil {
+	if err := c.facade.FacadeCall("ModelCredential", nil, &out); err != nil {
 		return emptyResult, false, errors.Trace(err)
 	}
 
-	// There should be just 1.
-	if count := len(out.Results); count != 1 {
-		return emptyResult, false, errors.Errorf("expected 1 model credential for model %q, got %d", modelUUID, count)
-	}
-	if err := out.Results[0].Error; err != nil {
-		return emptyResult, false, errors.Trace(err)
-	}
-
-	result := out.Results[0].Result
-
-	modelTag, err := names.ParseModelTag(result.Model)
-	if err != nil {
-		return emptyResult, false, errors.Trace(err)
-	}
-	if modelTag.Id() != modelUUID {
-		return emptyResult, false, errors.Errorf("unexpected credential for model %q, expected credential for model %q", modelTag.Id(), modelUUID)
-	}
-
-	if !result.Exists {
+	if !out.Exists {
 		return emptyResult, false, nil
 	}
 
-	credentialTag, err := names.ParseCloudCredentialTag(result.CloudCredential)
+	credentialTag, err := names.ParseCloudCredentialTag(out.CloudCredential)
 	if err != nil {
 		return emptyResult, false, errors.Trace(err)
 	}
 	return base.StoredCredential{
 		CloudCredential: credentialTag.Id(),
-		Valid:           result.Valid,
+		Valid:           out.Valid,
 	}, true, nil
 }
 
 // WatchCredential provides a notify watcher that is responsive to changes
 // to a given cloud credential.
 func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, error) {
-	// Construct credential tag from given id.
-	in := params.Entities{
-		Entities: []params.Entity{{Tag: names.NewCloudCredentialTag(credentialID).String()}},
-	}
-
-	// Call apiserver to get the watcher for this credential.
-	var results params.NotifyWatchResults
-	err := c.facade.FacadeCall("WatchCredential", in, &results)
+	in := names.NewCloudCredentialTag(credentialID).String()
+	var result params.NotifyWatchResult
+	err := c.facade.FacadeCall("WatchCredential", in, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	// There should be just 1.
-	if count := len(results.Results); count != 1 {
-		return nil, errors.Errorf("expected 1 watcher for credential %q, got %d", credentialID, count)
-	}
-
-	if err := results.Results[0].Error; err != nil {
+	if err := result.Error; err != nil {
 		return nil, errors.Trace(err)
 	}
-	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), results.Results[0])
+	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }

--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -78,7 +78,7 @@ func (c *Facade) ModelCredential(modelUUID string) (base.StoredCredential, bool,
 	}, true, nil
 }
 
-// WatchCredential provides notify watcher that is responsive to changes
+// WatchCredential provides a notify watcher that is responsive to changes
 // to a given cloud credential.
 func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, error) {
 	// Construct credential tag from given id.

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -4,8 +4,6 @@
 package credentialvalidator_test
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -27,26 +25,20 @@ type CredentialValidatorSuite struct {
 func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
-		c.Check(request, gc.Equals, "ModelCredentials")
-		c.Check(arg, jc.DeepEquals, params.Entities{
-			Entities: []params.Entity{{Tag: modelTag.String()}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ModelCredentialResults{})
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Result: &params.ModelCredential{
-					Model:           modelTag.String(),
-					CloudCredential: credentialTag.String(),
-					Exists:          true,
-					Valid:           true,
-				}},
-			},
+		c.Check(request, gc.Equals, "ModelCredential")
+		c.Check(arg, gc.IsNil)
+		c.Assert(result, gc.FitsTypeOf, &params.ModelCredential{})
+		*(result.(*params.ModelCredential)) = params.ModelCredential{
+			Model:           modelTag.String(),
+			CloudCredential: credentialTag.String(),
+			Exists:          true,
+			Valid:           true,
 		}
 		return nil
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	found, exists, err := client.ModelCredential(modelUUID)
+	found, exists, err := client.ModelCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsTrue)
 	c.Assert(found, gc.DeepEquals, base.StoredCredential{CloudCredential: "cloud/user/credential", Valid: true})
@@ -54,111 +46,32 @@ func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
 
 func (s *CredentialValidatorSuite) TestModelCredentialIsNotNeeded(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Result: &params.ModelCredential{
-					Model:  modelTag.String(),
-					Exists: false,
-				}},
-			},
+		*(result.(*params.ModelCredential)) = params.ModelCredential{
+			Model:  modelTag.String(),
+			Exists: false,
 		}
 		return nil
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential(modelUUID)
+	_, exists, err := client.ModelCredential()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(exists, jc.IsFalse)
-}
-
-func (s *CredentialValidatorSuite) TestModelCredentialManyResults(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Result: &params.ModelCredential{}},
-				{Result: &params.ModelCredential{}},
-			},
-		}
-		return nil
-	})
-
-	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential(modelUUID)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`expected 1 model credential for model %q, got 2`, modelUUID))
-	c.Assert(exists, jc.IsFalse)
-}
-
-func (s *CredentialValidatorSuite) TestModelCredentialForWrongModel(c *gc.C) {
-	diffUUID := "d5757ef7-c86a-4835-84bc-7174af535e25"
-
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Result: &params.ModelCredential{
-					// different model UUID than the one supplied to the call
-					Model: names.NewModelTag(diffUUID).String(),
-				}},
-			},
-		}
-		return nil
-	})
-
-	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential(modelUUID)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`unexpected credential for model %q, expected credential for model %q`, diffUUID, modelUUID))
-	c.Assert(exists, jc.IsFalse)
-}
-
-func (s *CredentialValidatorSuite) TestModelCredentialInvalidModelTag(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Result: &params.ModelCredential{
-					Model: "some-invalid-string-for-uuid",
-				}},
-			},
-		}
-		return nil
-	})
-
-	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential(modelUUID)
-	c.Assert(err, gc.ErrorMatches, `"some-invalid-string-for-uuid" is not a valid tag`)
 	c.Assert(exists, jc.IsFalse)
 }
 
 func (s *CredentialValidatorSuite) TestModelCredentialInvalidCredentialTag(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Result: &params.ModelCredential{
-					Model:           modelTag.String(),
-					Exists:          true,
-					CloudCredential: "some-invalid-cloud-credential-tag-as-string",
-				}},
-			},
+		*(result.(*params.ModelCredential)) = params.ModelCredential{
+			Model:           modelTag.String(),
+			Exists:          true,
+			CloudCredential: "some-invalid-cloud-credential-tag-as-string",
 		}
 		return nil
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential(modelUUID)
+	_, exists, err := client.ModelCredential()
 	c.Assert(err, gc.ErrorMatches, `"some-invalid-cloud-credential-tag-as-string" is not a valid tag`)
-	c.Assert(exists, jc.IsFalse)
-}
-
-func (s *CredentialValidatorSuite) TestModelCredentialError(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
-			Results: []params.ModelCredentialResult{
-				{Error: &params.Error{Message: "foo"}}},
-		}
-		return nil
-	})
-
-	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential(modelUUID)
-	c.Assert(err, gc.ErrorMatches, "foo")
 	c.Assert(exists, jc.IsFalse)
 }
 
@@ -168,7 +81,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialCallError(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, _, err := client.ModelCredential(modelUUID)
+	_, _, err := client.ModelCredential()
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
@@ -176,15 +89,9 @@ func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
 		c.Check(request, gc.Equals, "WatchCredential")
-		c.Check(arg, jc.DeepEquals, params.Entities{
-			Entities: []params.Entity{{Tag: credentialTag.String()}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResults{})
-		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
-			Results: []params.NotifyWatchResult{
-				{NotifyWatcherId: "notify-watcher-id"},
-			},
-		}
+		c.Check(arg, jc.DeepEquals, credentialTag.String())
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResult{})
+		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{NotifyWatcherId: "notify-watcher-id"}
 		return nil
 	})
 
@@ -194,28 +101,9 @@ func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
 	c.Assert(found, gc.NotNil)
 }
 
-func (s *CredentialValidatorSuite) TestWatchCredentialTooMany(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
-			Results: []params.NotifyWatchResult{
-				{},
-				{},
-			},
-		}
-		return nil
-	})
-
-	client := credentialvalidator.NewFacade(apiCaller)
-	_, err := client.WatchCredential(credentialID)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("expected 1 watcher for credential %q, got 2", credentialID))
-}
-
 func (s *CredentialValidatorSuite) TestWatchCredentialError(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
-			Results: []params.NotifyWatchResult{
-				{Error: &params.Error{Message: "foo"}}},
-		}
+		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{Error: &params.Error{Message: "foo"}}
 		return nil
 	})
 

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -85,22 +85,6 @@ func (s *CredentialValidatorSuite) TestModelCredentialCallError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
-func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
-	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "CredentialValidator")
-		c.Check(request, gc.Equals, "WatchCredential")
-		c.Check(arg, jc.DeepEquals, credentialTag.String())
-		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResult{})
-		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{NotifyWatcherId: "notify-watcher-id"}
-		return nil
-	})
-
-	client := credentialvalidator.NewFacade(apiCaller)
-	found, err := client.WatchCredential(credentialID)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found, gc.NotNil)
-}
-
 func (s *CredentialValidatorSuite) TestWatchCredentialError(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{Error: &params.Error{Message: "foo"}}

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -49,7 +49,7 @@ func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
 	found, exists, err := client.ModelCredential(modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsTrue)
-	c.Assert(found, gc.Equals, base.StoredCredential{CloudCredential: "cloud/user/credential", Valid: true})
+	c.Assert(found, gc.DeepEquals, base.StoredCredential{CloudCredential: "cloud/user/credential", Valid: true})
 }
 
 func (s *CredentialValidatorSuite) TestModelCredentialIsNotNeeded(c *gc.C) {

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -1,0 +1,243 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/credentialvalidator"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&CredentialValidatorSuite{})
+
+type CredentialValidatorSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CredentialValidator")
+		c.Check(request, gc.Equals, "ModelCredentials")
+		c.Check(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: modelTag.String()}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ModelCredentialResults{})
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Result: &params.ModelCredential{
+					Model:           modelTag.String(),
+					CloudCredential: credentialTag.String(),
+					Exists:          true,
+					Valid:           true,
+				}},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	found, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(found, gc.Equals, base.StoredCredential{CloudCredential: "cloud/user/credential", Valid: true})
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialIsNotNeeded(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Result: &params.ModelCredential{
+					Model:  modelTag.String(),
+					Exists: false,
+				}},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialManyResults(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Result: &params.ModelCredential{}},
+				{Result: &params.ModelCredential{}},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`expected 1 model credential for model %q, got 2`, modelUUID))
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialForWrongModel(c *gc.C) {
+	diffUUID := "d5757ef7-c86a-4835-84bc-7174af535e25"
+
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Result: &params.ModelCredential{
+					// different model UUID than the one supplied to the call
+					Model: names.NewModelTag(diffUUID).String(),
+				}},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`unexpected credential for model %q, expected credential for model %q`, diffUUID, modelUUID))
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialInvalidModelTag(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Result: &params.ModelCredential{
+					Model: "some-invalid-string-for-uuid",
+				}},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, gc.ErrorMatches, `"some-invalid-string-for-uuid" is not a valid tag`)
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialInvalidCredentialTag(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Result: &params.ModelCredential{
+					Model:           modelTag.String(),
+					Exists:          true,
+					CloudCredential: "some-invalid-cloud-credential-tag-as-string",
+				}},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, gc.ErrorMatches, `"some-invalid-cloud-credential-tag-as-string" is not a valid tag`)
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ModelCredentialResults)) = params.ModelCredentialResults{
+			Results: []params.ModelCredentialResult{
+				{Error: &params.Error{Message: "foo"}}},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, exists, err := client.ModelCredential(modelUUID)
+	c.Assert(err, gc.ErrorMatches, "foo")
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialCallError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("foo")
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, _, err := client.ModelCredential(modelUUID)
+	c.Assert(err, gc.ErrorMatches, "foo")
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CredentialValidator")
+		c.Check(request, gc.Equals, "WatchCredential")
+		c.Check(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: credentialTag.String()}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResults{})
+		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{
+				{NotifyWatcherId: "notify-watcher-id"},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	found, err := client.WatchCredential(credentialID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.NotNil)
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredentialTooMany(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{
+				{},
+				{},
+			},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, err := client.WatchCredential(credentialID)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("expected 1 watcher for credential %q, got 2", credentialID))
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredentialError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{
+				{Error: &params.Error{Message: "foo"}}},
+		}
+		return nil
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, err := client.WatchCredential(credentialID)
+	c.Assert(err, gc.ErrorMatches, "foo")
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredentialCallError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("foo")
+	})
+
+	client := credentialvalidator.NewFacade(apiCaller)
+	_, err := client.WatchCredential(credentialID)
+	c.Assert(err, gc.ErrorMatches, "foo")
+}
+
+var (
+	modelUUID = "e5757df7-c86a-4835-84bc-7174af535d25"
+	modelTag  = names.NewModelTag(modelUUID)
+
+	credentialID  = "cloud/user/credential"
+	credentialTag = names.NewCloudCredentialTag(credentialID)
+)

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -5,25 +5,25 @@ package credentialvalidator_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	names "gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/base/testing"
+	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/credentialvalidator"
 	"github.com/juju/juju/apiserver/params"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&CredentialValidatorSuite{})
 
 type CredentialValidatorSuite struct {
-	coretesting.BaseSuite
+	testing.IsolationSuite
 }
 
 func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
 		c.Check(request, gc.Equals, "ModelCredential")
 		c.Check(arg, gc.IsNil)
@@ -45,7 +45,7 @@ func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestModelCredentialIsNotNeeded(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ModelCredential)) = params.ModelCredential{
 			Model:  modelTag.String(),
 			Exists: false,
@@ -60,7 +60,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialIsNotNeeded(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestModelCredentialInvalidCredentialTag(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ModelCredential)) = params.ModelCredential{
 			Model:           modelTag.String(),
 			Exists:          true,
@@ -76,7 +76,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialInvalidCredentialTag(c *gc
 }
 
 func (s *CredentialValidatorSuite) TestModelCredentialCallError(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("foo")
 	})
 
@@ -86,7 +86,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialCallError(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
 		c.Check(request, gc.Equals, "WatchCredential")
 		c.Check(arg, jc.DeepEquals, credentialTag.String())
@@ -102,7 +102,7 @@ func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestWatchCredentialError(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{Error: &params.Error{Message: "foo"}}
 		return nil
 	})
@@ -113,7 +113,7 @@ func (s *CredentialValidatorSuite) TestWatchCredentialError(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestWatchCredentialCallError(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("foo")
 	})
 

--- a/api/credentialvalidator/package_test.go
+++ b/api/credentialvalidator/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -35,6 +35,7 @@ var facadeVersions = map[string]int{
 	"Client":                       1,
 	"Cloud":                        2,
 	"Controller":                   5,
+	"CredentialValidator":          1,
 	"CrossController":              1,
 	"CrossModelRelations":          1,
 	"Deployer":                     1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/agent" // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/agent/caasagent"
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
+	"github.com/juju/juju/apiserver/facades/agent/credentialvalidator"
 	"github.com/juju/juju/apiserver/facades/agent/deployer"
 	"github.com/juju/juju/apiserver/facades/agent/diskmanager"
 	"github.com/juju/juju/apiserver/facades/agent/fanconfigurer"
@@ -165,6 +166,7 @@ func AllFacades() *facade.Registry {
 	reg("Controller", 5, controller.NewControllerAPIv5)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
+	reg("CredentialValidator", 1, credentialvalidator.NewCredentialValidatorAPI)
 	reg("ExternalControllerUpdater", 1, externalcontrollerupdater.NewStateAPI)
 
 	reg("Deployer", 1, deployer.NewDeployerAPI)

--- a/apiserver/facades/agent/credentialvalidator/backend.go
+++ b/apiserver/facades/agent/credentialvalidator/backend.go
@@ -1,0 +1,93 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+// Backend exposes information about any current model migrations.
+type Backend interface {
+	ModelUUID() string
+	ModelCredential() (*ModelCredential, error)
+	ModelUsesCredential(tag names.CloudCredentialTag) (bool, error)
+	WatchCredential(names.CloudCredentialTag) state.NotifyWatcher
+}
+
+type stateShim struct {
+	*state.State
+}
+
+// NewStateBackend creates new backend to be used by credential validator Facade.
+func NewStateBackend(st *state.State) Backend {
+	return &stateShim{st}
+}
+
+// ModelUsesCredential determines if the model for this backend
+// uses given credential.
+func (s *stateShim) ModelUsesCredential(tag names.CloudCredentialTag) (bool, error) {
+	m, err := s.Model()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	currentModelName := m.Name()
+	models, err := s.CredentialModelsAndOwnerAccess(tag)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	for _, credentialModel := range models {
+		if credentialModel.ModelName == currentModelName {
+			return true, nil
+			break
+		}
+	}
+	return false, nil
+}
+
+// ModelCredential implements Backend interface.
+func (s *stateShim) ModelCredential() (*ModelCredential, error) {
+	model, err := s.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	result := &ModelCredential{Model: model.ModelTag()}
+	tag, exists := model.CloudCredential()
+	result.Exists = exists
+	if !exists {
+		// Model is on the cloud with "empty" auth and, hence,
+		// model credential is not set.
+		return result, nil
+	}
+
+	result.Credential = tag
+	c, err := s.CloudCredential(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result.Valid = c.IsValid()
+
+	return result, nil
+}
+
+// ModelCredential stores model's cloud credential information.
+type ModelCredential struct {
+	// Model is a model tag.
+	Model names.ModelTag
+
+	// Exists indicates whether the model has  a cloud credential.
+	// On some clouds, that only require "empty" auth, cloud credential
+	// is not needed for the models to function properly.
+	Exists bool
+
+	// Credential is a cloud credential tag.
+	Credential names.CloudCredentialTag
+
+	// Valid indicates that Juju considers this cloud credential to be valid.
+	Valid bool
+}

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -3,14 +3,12 @@
 package credentialvalidator
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -18,8 +16,8 @@ var logger = loggo.GetLogger("juju.api.credentialvalidator")
 
 // CredentialValidator defines the methods on credentialvalidator API endpoint.
 type CredentialValidator interface {
-	ModelCredentials(params.Entities) (params.ModelCredentialResults, error)
-	WatchCredential(params.Entities) (params.NotifyWatchResults, error)
+	ModelCredential() (params.ModelCredential, error)
+	WatchCredential(string) (params.NotifyWatchResult, error)
 }
 
 type CredentialValidatorAPI struct {
@@ -30,8 +28,8 @@ type CredentialValidatorAPI struct {
 var _ CredentialValidator = (*CredentialValidatorAPI)(nil)
 
 // NewCredentialValidatorAPI creates a new CredentialValidator API endpoint on server-side.
-func NewCredentialValidatorAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*CredentialValidatorAPI, error) {
-	return internalNewCredentialValidatorAPI(NewStateBackend(st), resources, authorizer)
+func NewCredentialValidatorAPI(ctx facade.Context) (*CredentialValidatorAPI, error) {
+	return internalNewCredentialValidatorAPI(NewBackend(ctx.State()), ctx.Resources(), ctx.Auth())
 }
 
 func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*CredentialValidatorAPI, error) {
@@ -46,97 +44,54 @@ func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resourc
 	}, nil
 }
 
-// auth only accepts the model tag reported by the backend.
-func (api *CredentialValidatorAPI) auth(tagString string) error {
-	tag, err := names.ParseModelTag(tagString)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if tag.Id() != api.backend.ModelUUID() {
-		return common.ErrPerm
-	}
-	return nil
-}
-
 // WatchCredential returns a collection of NotifyWatchers that observe
 // changes to the given cloud credentials.
 // The order of returned watchers is important and corresponds directly to the
 // order of supplied cloud credentials collection.
-func (api *CredentialValidatorAPI) WatchCredential(args params.Entities) (params.NotifyWatchResults, error) {
-	results := params.NotifyWatchResults{
-		Results: make([]params.NotifyWatchResult, len(args.Entities)),
+func (api *CredentialValidatorAPI) WatchCredential(tag string) (params.NotifyWatchResult, error) {
+	fail := func(failure error) (params.NotifyWatchResult, error) {
+		return params.NotifyWatchResult{}, common.ServerError(failure)
 	}
 
-	for i, entity := range args.Entities {
-		credentialTag, err := names.ParseCloudCredentialTag(entity.Tag)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		// Is credential used by the model that has created this backend?
-		// Technically just as with above, this will mean that only 1 credential will ever
-		// be ok in this collection...
-		isUsed, err := api.backend.ModelUsesCredential(credentialTag)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		if !isUsed {
-			results.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-
-		watch := api.backend.WatchCredential(credentialTag)
-		// Consume the initial event. Technically, API calls to Watch
-		// 'transmit' the initial event in the Watch response. But
-		// NotifyWatchers have no state to transmit.
-		if _, ok := <-watch.Changes(); ok {
-			results.Results[i].NotifyWatcherId = api.resources.Register(watch)
-		} else {
-			err = watcher.EnsureErr(watch)
-			results.Results[i].Error = common.ServerError(err)
-		}
+	credentialTag, err := names.ParseCloudCredentialTag(tag)
+	if err != nil {
+		return fail(err)
 	}
-	return results, nil
+
+	// Is credential used by the model that has created this backend?
+	isUsed, err := api.backend.ModelUsesCredential(credentialTag)
+	if err != nil {
+		return fail(err)
+	}
+	if !isUsed {
+		return fail(common.ErrPerm)
+	}
+
+	result := params.NotifyWatchResult{}
+	watch := api.backend.WatchCredential(credentialTag)
+	// Consume the initial event. Technically, API calls to Watch
+	// 'transmit' the initial event in the Watch response. But
+	// NotifyWatchers have no state to transmit.
+	if _, ok := <-watch.Changes(); ok {
+		result.NotifyWatcherId = api.resources.Register(watch)
+	} else {
+		err = watcher.EnsureErr(watch)
+		result.Error = common.ServerError(err)
+	}
+	return result, nil
 }
 
-// ModelCredentials returns cloud credential information for each
-// given model. For models that are on the clouds that do not require cloud
-// credentials, the result will have Exists set to false.
-// It is also possible to encounter some processing errors for a model in a collection.
-// This can be returned instead of its cloud credential.
-// The order of returned cloud credential information is important and
-// corresponds directly to the order of supplied models collection.
-func (api *CredentialValidatorAPI) ModelCredentials(args params.Entities) (params.ModelCredentialResults, error) {
-	results := params.ModelCredentialResults{
-		Results: make([]params.ModelCredentialResult, len(args.Entities)),
-	}
-	for i, entity := range args.Entities {
-		mc, err := api.modelCredential(entity.Tag)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		results.Results[i].Result = mc
-	}
-	return results, nil
-}
-
-// modelCredential does auth and lookup for a single entity.
-func (api *CredentialValidatorAPI) modelCredential(tagString string) (*params.ModelCredential, error) {
-	if err := api.auth(tagString); err != nil {
-		return nil, errors.Trace(err)
-	}
+// ModelCredential returns cloud credential information for a  model.
+func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, error) {
 	c, err := api.backend.ModelCredential()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return params.ModelCredential{}, common.ServerError(err)
 	}
 
-	return &params.ModelCredential{
+	return params.ModelCredential{
 		Model:           c.Model.String(),
 		CloudCredential: c.Credential.String(),
 		Exists:          c.Exists,
-		// TODO (anastasiamac 2018-04-06) Expand this to mean "valid for this model"...
-		Valid: c.Valid,
+		Valid:           c.Valid,
 	}, nil
 }

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -1,0 +1,142 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package credentialvalidator
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+var logger = loggo.GetLogger("juju.api.credentialvalidator")
+
+// CredentialValidator defines the methods on credentialvalidator API endpoint.
+type CredentialValidator interface {
+	ModelCredentials(params.Entities) (params.ModelCredentialResults, error)
+	WatchCredential(params.Entities) (params.NotifyWatchResults, error)
+}
+
+type CredentialValidatorAPI struct {
+	backend   Backend
+	resources facade.Resources
+}
+
+var _ CredentialValidator = (*CredentialValidatorAPI)(nil)
+
+// NewCredentialValidatorAPI creates a new CredentialValidator API endpoint on server-side.
+func NewCredentialValidatorAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*CredentialValidatorAPI, error) {
+	return internalNewCredentialValidatorAPI(NewStateBackend(st), resources, authorizer)
+}
+
+func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*CredentialValidatorAPI, error) {
+	hostAuthTag := authorizer.GetAuthTag()
+	if hostAuthTag == nil {
+		return nil, common.ErrPerm
+	}
+
+	return &CredentialValidatorAPI{
+		resources: resources,
+		backend:   backend,
+	}, nil
+}
+
+// auth only accepts the model tag reported by the backend.
+func (api *CredentialValidatorAPI) auth(tagString string) error {
+	tag, err := names.ParseModelTag(tagString)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if tag.Id() != api.backend.ModelUUID() {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+// WatchCredential returns a collection of NotifyWatchers that observe
+// changes to the given cloud credentials.
+// The order of returned watchers is important and corresponds directly to the
+// order of supplied cloud credentials collection.
+func (api *CredentialValidatorAPI) WatchCredential(args params.Entities) (params.NotifyWatchResults, error) {
+	results := params.NotifyWatchResults{
+		Results: make([]params.NotifyWatchResult, len(args.Entities)),
+	}
+
+	for i, entity := range args.Entities {
+		credentialTag, err := names.ParseCloudCredentialTag(entity.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		// Is credential used by the model that has created this backend?
+		// Technically just as with above, this will mean that only 1 credential will ever
+		// be ok in this collection...
+		isUsed, err := api.backend.ModelUsesCredential(credentialTag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		if !isUsed {
+			results.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+
+		watch := api.backend.WatchCredential(credentialTag)
+		// Consume the initial event. Technically, API calls to Watch
+		// 'transmit' the initial event in the Watch response. But
+		// NotifyWatchers have no state to transmit.
+		if _, ok := <-watch.Changes(); ok {
+			results.Results[i].NotifyWatcherId = api.resources.Register(watch)
+		} else {
+			err = watcher.EnsureErr(watch)
+			results.Results[i].Error = common.ServerError(err)
+		}
+	}
+	return results, nil
+}
+
+// ModelCredentials returns cloud credential information for each
+// given model. For models that are on the clouds that do not require cloud
+// credentials, the result will have Exists set to false.
+// It is also possible to encounter some processing errors for a model in a collection.
+// This can be returned instead of its cloud credential.
+// The order of returned cloud credential information is important and
+// corresponds directly to the order of supplied models collection.
+func (api *CredentialValidatorAPI) ModelCredentials(args params.Entities) (params.ModelCredentialResults, error) {
+	results := params.ModelCredentialResults{
+		Results: make([]params.ModelCredentialResult, len(args.Entities)),
+	}
+	for i, entity := range args.Entities {
+		mc, err := api.modelCredential(entity.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].Result = mc
+	}
+	return results, nil
+}
+
+// modelCredential does auth and lookup for a single entity.
+func (api *CredentialValidatorAPI) modelCredential(tagString string) (*params.ModelCredential, error) {
+	if err := api.auth(tagString); err != nil {
+		return nil, errors.Trace(err)
+	}
+	c, err := api.backend.ModelCredential()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &params.ModelCredential{
+		Model:           c.Model.String(),
+		CloudCredential: c.Credential.String(),
+		Exists:          c.Exists,
+		// TODO (anastasiamac 2018-04-06) Expand this to mean "valid for this model"...
+		Valid: c.Valid,
+	}, nil
+}

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -1,0 +1,187 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/agent/credentialvalidator"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type CredentialValidatorSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+	backend    *testBackend
+
+	api *credentialvalidator.CredentialValidatorAPI
+}
+
+var _ = gc.Suite(&CredentialValidatorSuite{})
+
+func (s *CredentialValidatorSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.backend = newMockBackend()
+
+	s.resources = common.NewResources()
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("0"),
+	}
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	api, err := credentialvalidator.NewCredentialValidatorAPIForTest(s.backend, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
+	diffUUID := "d5757ef7-c86a-4835-84bc-7174af535e25"
+	result, err := s.api.ModelCredentials(params.Entities{
+		Entities: []params.Entity{
+			{Tag: names.NewModelTag(diffUUID).String()},
+			{Tag: names.NewModelTag(modelUUID).String()},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ModelCredentialResults{
+		Results: []params.ModelCredentialResult{
+			{nil, common.ServerError(common.ErrPerm)},
+			{&params.ModelCredential{
+				Model:           names.NewModelTag(modelUUID).String(),
+				Exists:          true,
+				CloudCredential: credentialTag.String(),
+				Valid:           true,
+			}, nil},
+		},
+	})
+}
+
+func (s *CredentialValidatorSuite) TestModelCredentialNotNeeded(c *gc.C) {
+	s.backend.mc.Exists = false
+	// In real life, these properties will not be set if Exists is false, so
+	// doing the same in test.
+	s.backend.mc.Credential = names.CloudCredentialTag{}
+	s.backend.mc.Valid = false
+	result, err := s.api.ModelCredentials(params.Entities{
+		Entities: []params.Entity{
+			{Tag: names.NewModelTag(modelUUID).String()},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ModelCredentialResults{
+		Results: []params.ModelCredentialResult{
+			{&params.ModelCredential{
+				Model:  names.NewModelTag(modelUUID).String(),
+				Exists: false,
+			}, nil},
+		},
+	})
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
+	result, err := s.api.WatchCredential(params.Entities{
+		Entities: []params.Entity{{Tag: credentialTag.String()}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{"1", nil},
+		},
+	})
+
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredentialNotUsedInThisModel(c *gc.C) {
+	s.backend.isUsed = false
+	result, err := s.api.WatchCredential(params.Entities{
+		Entities: []params.Entity{{Tag: credentialTag.String()}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{"", common.ServerError(common.ErrPerm)},
+		},
+	})
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+}
+
+func (s *CredentialValidatorSuite) TestWatchCredentialInvalidTag(c *gc.C) {
+	result, err := s.api.WatchCredential(params.Entities{
+		Entities: []params.Entity{{Tag: "my-tag"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{"", common.ServerError(errors.New(`"my-tag" is not a valid tag`))},
+		},
+	})
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+}
+
+// modelUUID is the model tag we're using in the tests.
+var modelUUID = "01234567-89ab-cdef-0123-456789abcdef"
+
+// credentialTag is the credential tag we're using in the tests.
+// needs to fit fmt.Sprintf("%s/%s/%s", cloudName, userName, credentialName)
+var credentialTag = names.NewCloudCredentialTag("cloud/user/credential")
+
+func newMockBackend() *testBackend {
+	b := &testBackend{
+		Stub:      &testing.Stub{},
+		modelUUID: modelUUID,
+		isUsed:    true,
+		mc: &credentialvalidator.ModelCredential{
+			Model:      names.NewModelTag(modelUUID),
+			Exists:     true,
+			Credential: credentialTag,
+			Valid:      true,
+		},
+	}
+	return b
+}
+
+type testBackend struct {
+	*testing.Stub
+
+	modelUUID string
+	mc        *credentialvalidator.ModelCredential
+	isUsed    bool
+}
+
+func (b *testBackend) ModelUUID() string {
+	b.AddCall("ModelUUID")
+	return b.modelUUID
+}
+
+func (b *testBackend) ModelCredential() (*credentialvalidator.ModelCredential, error) {
+	b.AddCall("ModelCredential")
+	if err := b.NextErr(); err != nil {
+		return nil, err
+	}
+	return b.mc, nil
+}
+
+func (b *testBackend) ModelUsesCredential(tag names.CloudCredentialTag) (bool, error) {
+	b.AddCall("ModelUsesCredential", tag)
+	if err := b.NextErr(); err != nil {
+		return false, err
+	}
+	return b.isUsed, nil
+}
+
+func (b *testBackend) WatchCredential(t names.CloudCredentialTag) state.NotifyWatcher {
+	b.AddCall("WatchCredential", t)
+	return apiservertesting.NewFakeNotifyWatcher()
+}

--- a/apiserver/facades/agent/credentialvalidator/export_test.go
+++ b/apiserver/facades/agent/credentialvalidator/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator
+
+import (
+	"github.com/juju/juju/apiserver/facade"
+)
+
+func NewCredentialValidatorAPIForTest(b Backend, resources facade.Resources, authorizer facade.Authorizer) (*CredentialValidatorAPI, error) {
+	return internalNewCredentialValidatorAPI(b, resources, authorizer)
+}

--- a/apiserver/facades/agent/credentialvalidator/package_test.go
+++ b/apiserver/facades/agent/credentialvalidator/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+)
+
+// StateAccessor exposes State methods needed by credential validator.
+type StateAccessor interface {
+	Model() (*state.Model, error)
+	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
+	WatchCredential(names.CloudCredentialTag) state.NotifyWatcher
+}
+
+type stateShim struct {
+	*state.State
+}
+
+// NewStateShim creates new state shim to be used by credential validator Facade.
+func NewStateShim(st *state.State) StateAccessor {
+	return &stateShim{st}
+}

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -381,3 +381,34 @@ type DestroyModelParams struct {
 	// params.CodeHasPersistentStorage will be returned.
 	DestroyStorage *bool `json:"destroy-storage,omitempty"`
 }
+
+// ModelCredential stores information about cloud credential that a model uses:
+// what credential is being used, is it valid for this model, etc.
+type ModelCredential struct {
+	// Model is a tag for the model.
+	Model string `json:"model-tag"`
+
+	// Exists indicates whether credential was set on the model.
+	// It is valid for model not to have a credential if it is on the
+	// cloud that does not require auth.
+	Exists bool `json:"exists,omitempty"`
+
+	// CloudCredential is the tag for the cloud credential that the model uses.
+	CloudCredential string `json:"credential-tag"`
+
+	// Valid stores whether this credential is valid, for example, not expired,
+	// and whether this credential works for this model, i.e. all model
+	// machines can be accessed with this credential.
+	Valid bool `json:"valid,omitempty"`
+}
+
+// ModelCredentialResult holds the result of a ModelCredential call.
+type ModelCredentialResult struct {
+	Result *ModelCredential `json:"result,omitempty"`
+	Error  *Error           `json:"error,omitempty"`
+}
+
+// ModelCredentialResults holds the result of a bulk ModelCredential API call.
+type ModelCredentialResults struct {
+	Results []ModelCredentialResult `json:"results"`
+}

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -401,14 +401,3 @@ type ModelCredential struct {
 	// machines can be accessed with this credential.
 	Valid bool `json:"valid,omitempty"`
 }
-
-// ModelCredentialResult holds the result of a ModelCredential call.
-type ModelCredentialResult struct {
-	Result *ModelCredential `json:"result,omitempty"`
-	Error  *Error           `json:"error,omitempty"`
-}
-
-// ModelCredentialResults holds the result of a bulk ModelCredential API call.
-type ModelCredentialResults struct {
-	Results []ModelCredentialResult `json:"results"`
-}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -178,7 +178,7 @@ func newAPIRoot(st *state.State, pool *state.StatePool, facades *facade.Registry
 }
 
 // restrictAPIRoot calls restrictAPIRootDuringMaintenance, and
-// then restricts the result further to the contoller or model
+// then restricts the result further to the controller or model
 // facades, depending on the type of login.
 func restrictAPIRoot(
 	srv *Server,

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -318,7 +318,7 @@ func (st *State) AllCloudCredentials(user names.UserTag) ([]Credential, error) {
 	return credentials, nil
 }
 
-// CredentialOwnerModelAccess storescloud credntial model information for the credential owner
+// CredentialOwnerModelAccess stores cloud credential model information for the credential owner
 // or an error retrieving it.
 type CredentialOwnerModelAccess struct {
 	ModelName   string

--- a/worker/environ/environ.go
+++ b/worker/environ/environ.go
@@ -6,7 +6,6 @@ package environ
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/watcher"
@@ -20,7 +19,6 @@ var logger = loggo.GetLogger("juju.worker.environ")
 type ConfigObserver interface {
 	environs.EnvironConfigGetter
 	WatchForModelConfigChanges() (watcher.NotifyWatcher, error)
-	WatchCredential(tag names.CloudCredentialTag) (watcher.NotifyWatcher, error)
 }
 
 // Config describes the dependencies of a Tracker.


### PR DESCRIPTION
## Description of change

Cloud credential may become invalid on a longer-running models.

Juju needs to react to this - dependency engine will need to manage workers that depend on credential validity, user needs to have the ability to update credential content or replace the credential that the model uses altogether.

To support this, we need to have a worker that is able to "flag" changes in the validity of the credential. The worker and its manifold will be proposed as part of the follow-up. This PR contains the api and apiserver that the worker is calling. Here we are providing functionality to the worker (at agent-scope) to determine what cloud credential the model uses and to watch it.  

Some typo fixes were added as a drive-by.
