### PR TITLE
Use mutate method to set status on mocked machine docs.

### DIFF
--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -332,9 +332,6 @@ func (m *fakeMachine) Status() (status.StatusInfo, error) {
 }
 
 func (m *fakeMachine) SetStatus(sInfo status.StatusInfo) error {
-	if err := m.errors.errorFor("Machine.SetStatus", m.doc.id, sInfo); err != nil {
-		return err
-	}
 	m.mutate(func(doc *machineDoc) {
 		doc.statusInfo = sInfo
 	})

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -326,13 +326,18 @@ func (m *fakeMachine) Addresses() []network.Address {
 }
 
 func (m *fakeMachine) Status() (status.StatusInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.doc.statusInfo, nil
 }
 
 func (m *fakeMachine) SetStatus(sInfo status.StatusInfo) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.doc.statusInfo = sInfo
+	if err := m.errors.errorFor("Machine.SetStatus", m.doc.id, sInfo); err != nil {
+		return err
+	}
+	m.mutate(func(doc *machineDoc) {
+		doc.statusInfo = sInfo
+	})
 	return nil
 }
 

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -608,9 +608,9 @@ func (s *workerSuite) doTestUsesConfiguredHASpace(c *gc.C, ipVersion TestIPVersi
 	})
 	c.Assert(err, gc.IsNil)
 
-	st.setHASpace("one")
+	st.setHASpace("two")
 	s.runUntilPublish(c, st, "")
-	assertMemberAddresses(c, st, ipVersion.formatHost, 1)
+	assertMemberAddresses(c, st, ipVersion.formatHost, 2)
 
 	sInfo, err := st.machine("11").Status()
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
## Description of change

Attempts to fix intermittent failures in the workerSuite for setting machine status upon failed peer-group determination.

## QA steps

Verify tests green; observe that the merge bot passes the tests.
