### PR TITLE
Added SupportedLts()

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
@@ -1017,7 +1016,7 @@ func (s *clientSuite) TestClientAddMachinesDefaultSeries(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1033,7 +1032,7 @@ func (s *clientSuite) assertAddMachines(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1109,7 +1108,7 @@ func (s *clientSuite) TestClientAddMachinesWithConstraints(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1199,7 +1198,7 @@ func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 			c.Assert(machineResult.Error, gc.ErrorMatches, "cannot add a new machine: cannot add a machine with an instance id and no nonce")
 		} else {
 			c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-			s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
+			s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
 			instanceId := fmt.Sprintf("1234-%d", i)
 			s.checkInstance(c, machineResult.Machine, instanceId, "foo", hc, addrs)
 		}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/instance"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/rpc"
@@ -1016,7 +1017,7 @@ func (s *clientSuite) TestClientAddMachinesDefaultSeries(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1032,7 +1033,7 @@ func (s *clientSuite) assertAddMachines(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1108,7 +1109,7 @@ func (s *clientSuite) TestClientAddMachinesWithConstraints(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1198,7 +1199,7 @@ func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 			c.Assert(machineResult.Error, gc.ErrorMatches, "cannot add a new machine: cannot add a machine with an instance id and no nonce")
 		} else {
 			c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-			s.checkMachine(c, machineResult.Machine, jujuversion.SupportedLts(), apiParams[i].Constraints.String())
+			s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
 			instanceId := fmt.Sprintf("1234-%d", i)
 			s.checkInstance(c, machineResult.Machine, instanceId, "foo", hc, addrs)
 		}

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type modelInfoSuite struct {
@@ -167,7 +167,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		CloudTag:           "cloud-some-cloud",
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
-		DefaultSeries:      series.LatestLts(),
+		DefaultSeries:      version.SupportedLts(),
 		Life:               params.Dying,
 		Status: params.EntityStatus{
 			Status: status.Destroying,

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type modelInfoSuite struct {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type DeploySuite struct {
@@ -200,7 +201,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c 
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
 	err := runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", version.SupportedLts()))
 	s.AssertService(c, "dummy", curl, 1, 0)
 }
 
@@ -408,7 +409,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 func (s *DeploySuite) TestPlacement(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
 	// Add a machine that will be ignored due to placement directive.
-	machine, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = runDeploy(c, ch, "-n", "1", "--to", "valid", "--series", "quantal")
@@ -472,9 +473,9 @@ func (s *DeploySuite) assertForceMachine(c *gc.C, machineId string) {
 
 func (s *DeploySuite) TestForceMachine(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	machine, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runDeploy(c, "--to", machine.Id(), ch, "portlandia", "--series", series.LatestLts())
+	err = runDeploy(c, "--to", machine.Id(), ch, "portlandia", "--series", version.SupportedLts())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, machine.Id())
 }
@@ -482,12 +483,12 @@ func (s *DeploySuite) TestForceMachine(c *gc.C) {
 func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
 	template := state.MachineTemplate{
-		Series: series.LatestLts(),
+		Series: version.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideNewMachine(template, template, instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runDeploy(c, "--to", container.Id(), ch, "portlandia", "--series", series.LatestLts())
+	err = runDeploy(c, "--to", container.Id(), ch, "portlandia", "--series", version.SupportedLts())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, container.Id())
 	machines, err := s.State.AllMachines()
@@ -497,9 +498,9 @@ func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
 
 func (s *DeploySuite) TestForceMachineNewContainer(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	machine, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runDeploy(c, "--to", "lxd:"+machine.Id(), ch, "portlandia", "--series", series.LatestLts())
+	err = runDeploy(c, "--to", "lxd:"+machine.Id(), ch, "portlandia", "--series", version.SupportedLts())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, machine.Id()+"/lxd/0")
 
@@ -525,7 +526,7 @@ func (s *DeploySuite) TestForceMachineNotFound(c *gc.C) {
 }
 
 func (s *DeploySuite) TestForceMachineSubordinate(c *gc.C) {
-	machine, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "logging")
 	err = runDeploy(c, "--to", machine.Id(), ch, "--series", "quantal")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -23,7 +23,6 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charmrepo.v2"

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -47,10 +47,10 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type DeploySuite struct {

--- a/cmd/juju/application/series_selector.go
+++ b/cmd/juju/application/series_selector.go
@@ -6,7 +6,7 @@ package application
 import (
 	"gopkg.in/juju/charm.v6"
 
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/version"
 )
 
 const (

--- a/cmd/juju/application/series_selector.go
+++ b/cmd/juju/application/series_selector.go
@@ -4,8 +4,9 @@
 package application
 
 import (
-	"github.com/juju/utils/series"
 	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/version"
 )
 
 const (
@@ -91,7 +92,7 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 		return "", err
 	}
 
-	latestLTS := series.LatestLts()
+	latestLTS := version.SupportedLts()
 	logger.Infof(msgLatestLTSSeries, latestLTS)
 	return latestLTS, nil
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -222,7 +222,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	}
 	bootstrapVersion := v100p64
 	if test.version != "" {
-		useVersion := strings.Replace(test.version, "%LTS%", series.LatestLts(), 1)
+		useVersion := strings.Replace(test.version, "%LTS%", jujuversion.SupportedLts(), 1)
 		bootstrapVersion = version.MustParseBinary(useVersion)
 		restore = restore.Add(testing.PatchValue(&jujuversion.Current, bootstrapVersion.Number))
 		restore = restore.Add(testing.PatchValue(&arch.HostArch, func() string { return bootstrapVersion.Arch }))
@@ -1212,7 +1212,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 }
 
 func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
-	s.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
@@ -222,7 +223,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	}
 	bootstrapVersion := v100p64
 	if test.version != "" {
-		useVersion := strings.Replace(test.version, "%LTS%", jujuversion.SupportedLts(), 1)
+		useVersion := strings.Replace(test.version, "%LTS%", supportedversion.SupportedLts(), 1)
 		bootstrapVersion = version.MustParseBinary(useVersion)
 		restore = restore.Add(testing.PatchValue(&jujuversion.Current, bootstrapVersion.Number))
 		restore = restore.Add(testing.PatchValue(&arch.HostArch, func() string { return bootstrapVersion.Arch }))
@@ -1212,7 +1213,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 }
 
 func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
-	s.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -369,7 +370,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 
 		for _, uploaded := range test.expectUploaded {
 			// Substitute latest LTS for placeholder in expected series for uploaded tools
-			uploaded = strings.Replace(uploaded, "%LTS%", jujuversion.SupportedLts(), 1)
+			uploaded = strings.Replace(uploaded, "%LTS%", supportedversion.SupportedLts(), 1)
 			vers := version.MustParseBinary(uploaded)
 			s.checkToolsUploaded(c, vers, agentVersion)
 		}

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -369,7 +369,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 
 		for _, uploaded := range test.expectUploaded {
 			// Substitute latest LTS for placeholder in expected series for uploaded tools
-			uploaded = strings.Replace(uploaded, "%LTS%", series.LatestLts(), 1)
+			uploaded = strings.Replace(uploaded, "%LTS%", jujuversion.SupportedLts(), 1)
 			vers := version.MustParseBinary(uploaded)
 			s.checkToolsUploaded(c, vers, agentVersion)
 		}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/version"
 )
 
 type imageMetadataCommandBase struct {

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
@@ -21,6 +20,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/version"
 )
 
 type imageMetadataCommandBase struct {
@@ -149,7 +149,7 @@ func (c *imageMetadataCommand) setParams(context *cmd.Context) error {
 		logger.Infof("no model found, creating image metadata using user supplied data")
 	}
 	if c.Series == "" {
-		c.Series = series.LatestLts()
+		c.Series = version.SupportedLts()
 	}
 	if c.ImageId == "" {
 		return errors.Errorf("image id must be specified")

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type ImageMetadataSuite struct {
@@ -169,7 +169,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
-		series: series.LatestLts(),
+		series: version.SupportedLts(),
 		arch:   "arch",
 	}
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type ImageMetadataSuite struct {

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -25,9 +25,9 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/juju/osenv"
+	jujuversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/logfwd/syslog"
 	"github.com/juju/juju/network"
-	jujuversion "github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.environs.config")

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/logfwd/syslog"
 	"github.com/juju/juju/network"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.environs.config")
@@ -272,7 +273,7 @@ func PreferredSeries(cfg HasDefaultSeries) string {
 	if series, ok := cfg.DefaultSeries(); ok {
 		return series
 	}
-	return series.LatestLts()
+	return jujuversion.SupportedLts()
 }
 
 // Config holds an immutable environment configuration.
@@ -381,7 +382,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":             series.LatestLts(),
+	"default-series":             jujuversion.SupportedLts(),
 	ProvisionerHarvestModeKey:    HarvestDestroyed.String(),
 	ResourceTagsKey:              "",
 	"logging-config":             "",

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	"github.com/juju/utils/proxy"
-	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charmrepo.v2"

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
+	jujuversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
 )
 
 func Test(t *stdtesting.T) {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -14,7 +14,6 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
-	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charmrepo.v2"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 func Test(t *stdtesting.T) {
@@ -55,7 +55,7 @@ var sampleConfig = testing.Attrs{
 	"unknown":                    "my-unknown",
 	"ssl-hostname-verification":  true,
 	"development":                false,
-	"default-series":             series.LatestLts(),
+	"default-series":             jujuversion.SupportedLts(),
 	"disable-network-management": false,
 	"ignore-machine-addresses":   false,
 	"automatically-retry-hooks":  true,
@@ -628,7 +628,7 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	if seriesAttr != "" {
 		c.Assert(defaultSeries, gc.Equals, seriesAttr)
 	} else {
-		c.Assert(defaultSeries, gc.Equals, series.LatestLts())
+		c.Assert(defaultSeries, gc.Equals, jujuversion.SupportedLts())
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
@@ -760,7 +760,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"firewall-mode":              config.FwInstance,
 		"unknown":                    "my-unknown",
 		"ssl-hostname-verification":  true,
-		"default-series":             series.LatestLts(),
+		"default-series":             jujuversion.SupportedLts(),
 		"disable-network-management": false,
 		"ignore-machine-addresses":   false,
 		"automatically-retry-hooks":  true,

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
 	jujutesting "github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
@@ -209,7 +210,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	// we could connect to (actual live tests, rather than local-only)
 	cons := constraints.MustParse("mem=2G")
 	if t.CanOpenState {
-		_, err := sync.Upload(t.toolsStorage, "released", nil, jujuversion.SupportedLts())
+		_, err := sync.Upload(t.toolsStorage, "released", nil, supportedversion.SupportedLts())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	args := t.bootstrapParams()
@@ -659,7 +660,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	expectedVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: jujuversion.SupportedLts(),
+		Series: supportedversion.SupportedLts(),
 	}
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -209,7 +209,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	// we could connect to (actual live tests, rather than local-only)
 	cons := constraints.MustParse("mem=2G")
 	if t.CanOpenState {
-		_, err := sync.Upload(t.toolsStorage, "released", nil, series.LatestLts())
+		_, err := sync.Upload(t.toolsStorage, "released", nil, jujuversion.SupportedLts())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	args := t.bootstrapParams()
@@ -659,7 +659,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	expectedVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.LatestLts(),
+		Series: jujuversion.SupportedLts(),
 	}
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -24,7 +24,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
+	jujuversion "github.com/juju/juju/juju/version"
 )
 
 type provisionerSuite struct {

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	"github.com/juju/utils/shell"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -25,6 +24,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type provisionerSuite struct {
@@ -46,7 +46,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 }
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
-	var series = series.LatestLts()
+	var series = jujuversion.SupportedLts()
 	const arch = "amd64"
 
 	args := s.getArgs(c)
@@ -128,7 +128,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
-	var series = series.LatestLts()
+	var series = jujuversion.SupportedLts()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,
@@ -150,7 +150,7 @@ func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
-	var series = series.LatestLts()
+	var series = jujuversion.SupportedLts()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/names"
+	supportedversion "github.com/juju/juju/juju/version"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -311,7 +312,7 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := jujuversion.SupportedLts()
+	defaultSeries := supportedversion.SupportedLts()
 	if series.MustHostSeries() != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -286,7 +286,7 @@ func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 
 // UploadFakeTools puts fake tools into the supplied storage with a binary
 // version matching jujuversion.Current; if jujuversion.Current's series is different
-// to series.LatestLts(), matching fake tools will be uploaded for that
+// to  juju/juju/version.SupportedLts(), matching fake tools will be uploaded for that
 // series.  This is useful for tests that are kinda casual about specifying
 // their environment.
 func UploadFakeTools(c *gc.C, stor storage.Storage, toolsDir, stream string) {
@@ -311,7 +311,7 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := series.LatestLts()
+	defaultSeries := jujuversion.SupportedLts()
 	if series.MustHostSeries() != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -12,9 +12,9 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
-	"github.com/juju/juju/version"
 )
 
 type RepoSuite struct {

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -8,13 +8,13 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
+	"github.com/juju/juju/version"
 )
 
 type RepoSuite struct {
@@ -26,7 +26,7 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.CharmsPath = c.MkDir()
 	// Change the environ's config to ensure we're using the one in state.
-	updateAttrs := map[string]interface{}{"default-series": series.LatestLts()}
+	updateAttrs := map[string]interface{}{"default-series": version.SupportedLts()}
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/juju/version/version.go
+++ b/juju/version/version.go
@@ -1,0 +1,12 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package version contains versioning information about packages that juju supports.
+package version
+
+// SupportedLts returns the latest LTS that Juju supports and is compatible with.
+// For example, Juju 2.3.x series cannot be run on "bionic"
+// as mongo version that it depends on (3.2 and less) is not packaged for bionic.
+func SupportedLts() string {
+	return "xenial"
+}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -55,6 +55,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	jujuversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
@@ -67,7 +68,6 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.provider.dummy")

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -39,7 +39,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
-	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
@@ -68,6 +67,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.provider.dummy")
@@ -104,7 +104,7 @@ func SampleConfig() testing.Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            series.LatestLts(),
+		"default-series":            jujuversion.SupportedLts(),
 
 		"secret":     "pork",
 		"controller": true,

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/ec2/internal/ec2instancetypes"
 	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&specSuite{})
@@ -170,7 +171,7 @@ func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.
 
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Constraints: constraints.MustParse("instance-type=t2.medium"),
 	}
 
@@ -192,16 +193,16 @@ var findInstanceSpecErrorTests = []struct {
 	err    string
 }{
 	{
-		series: series.LatestLts(),
+		series: jujuversion.SupportedLts(),
 		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, series.LatestLts()),
+		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, jujuversion.SupportedLts()),
 	}, {
 		series: "raring",
 		arches: []string{"amd64", "i386"},
 		cons:   "mem=4G",
 		err:    `no "raring" images in test matching instance types \[.*\]`,
 	}, {
-		series: series.LatestLts(),
+		series: jujuversion.SupportedLts(),
 		arches: []string{"amd64"},
 		cons:   "instance-type=m1.small mem=4G",
 		err:    `no instance types in test matching constraints "instance-type=m1.small mem=4096M"`,

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/provider/ec2/internal/ec2instancetypes"
 	"github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&specSuite{})
@@ -171,7 +171,7 @@ func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.
 
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
-		Series:      jujuversion.SupportedLts(),
+		Series:      version.SupportedLts(),
 		Constraints: constraints.MustParse("instance-type=t2.medium"),
 	}
 
@@ -193,16 +193,16 @@ var findInstanceSpecErrorTests = []struct {
 	err    string
 }{
 	{
-		series: jujuversion.SupportedLts(),
+		series: version.SupportedLts(),
 		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, jujuversion.SupportedLts()),
+		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, version.SupportedLts()),
 	}, {
 		series: "raring",
 		arches: []string{"amd64", "i386"},
 		cons:   "mem=4G",
 		err:    `no "raring" images in test matching instance types \[.*\]`,
 	}, {
-		series: jujuversion.SupportedLts(),
+		series: version.SupportedLts(),
 		arches: []string{"amd64"},
 		cons:   "instance-type=m1.small mem=4G",
 		err:    `no instance types in test matching constraints "instance-type=m1.small mem=4096M"`,

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/provider/ec2"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -79,7 +80,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.LiveTests.SetUpSuite(c)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -79,7 +79,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.LiveTests.SetUpSuite(c)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -234,7 +235,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
@@ -1428,7 +1429,7 @@ func (t *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.small root-disk=1G")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1438,7 +1439,7 @@ func (t *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.invalid")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "m1.invalid" specified`)
@@ -1448,7 +1449,7 @@ func (t *localServerSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=i386")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "i386" specified`)
@@ -1458,7 +1459,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-available"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    jujuversion.SupportedLts(),
+		Series:    supportedversion.SupportedLts(),
 		Placement: placement,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1468,7 +1469,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unavailable"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    jujuversion.SupportedLts(),
+		Series:    supportedversion.SupportedLts(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is "unavailable"`)
@@ -1478,7 +1479,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    jujuversion.SupportedLts(),
+		Series:    supportedversion.SupportedLts(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
@@ -1502,7 +1503,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placemen
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    jujuversion.SupportedLts(),
+		Series:    supportedversion.SupportedLts(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1525,7 +1526,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneVolumeConflict(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    jujuversion.SupportedLts(),
+		Series:    supportedversion.SupportedLts(),
 		Placement: "zone=test-available",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1546,7 +1547,7 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	env := t.Prepare(c)
 	params, err := env.(simplestreams.MetadataValidator).MetadataLookupParams("test")
 	c.Assert(err, jc.ErrorIsNil)
-	params.Series = jujuversion.SupportedLts()
+	params.Series = supportedversion.SupportedLts()
 	params.Endpoint = region.EC2Endpoint
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -234,7 +234,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
@@ -1428,7 +1428,7 @@ func (t *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.small root-disk=1G")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1438,7 +1438,7 @@ func (t *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.invalid")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "m1.invalid" specified`)
@@ -1448,7 +1448,7 @@ func (t *localServerSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=i386")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "i386" specified`)
@@ -1458,7 +1458,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-available"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    jujuversion.SupportedLts(),
 		Placement: placement,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1468,7 +1468,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unavailable"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    jujuversion.SupportedLts(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is "unavailable"`)
@@ -1478,7 +1478,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    jujuversion.SupportedLts(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
@@ -1502,7 +1502,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placemen
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    jujuversion.SupportedLts(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1525,7 +1525,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneVolumeConflict(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    jujuversion.SupportedLts(),
 		Placement: "zone=test-available",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1546,7 +1546,7 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	env := t.Prepare(c)
 	params, err := env.(simplestreams.MetadataValidator).MetadataLookupParams("test")
 	c.Assert(err, jc.ErrorIsNil)
-	params.Series = series.LatestLts()
+	params.Series = jujuversion.SupportedLts()
 	params.Endpoint = region.EC2Endpoint
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -6,7 +6,6 @@ package gce_test
 import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
@@ -14,6 +13,7 @@ import (
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/version"
 )
 
 type environPolSuite struct {
@@ -23,7 +23,7 @@ type environPolSuite struct {
 var _ = gc.Suite(&environPolSuite{})
 
 func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts()})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 0)
@@ -36,7 +36,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=amd64 root-disk=1G")
 	placement := "zone=home-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons, Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons, Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
@@ -46,14 +46,14 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1.invalid")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
 
 	c.Check(err, gc.ErrorMatches, `.*invalid GCE instance type.*`)
 }
@@ -61,14 +61,14 @@ func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 root-disk=1G")
 	placement := ""
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons, Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons, Placement: placement})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=i386")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -79,7 +79,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -90,7 +90,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `.*availability zone "a-zone" is DOWN`)
 }
@@ -101,7 +101,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
 
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
@@ -120,7 +120,7 @@ func (s *environPolSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placement
 	}
 
 	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    version.SupportedLts(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			VolumeId: "away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
@@ -135,7 +135,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneConflictsVolume(c *gc.C) 
 	}
 
 	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    series.LatestLts(),
+		Series:    version.SupportedLts(),
 		Placement: "zone=away-zone",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/storage"
-	"github.com/juju/juju/version"
 )
 
 type environPolSuite struct {

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -10,12 +10,12 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/lxd"
+	"github.com/juju/juju/version"
 )
 
 type environPolSuite struct {
@@ -25,7 +25,7 @@ type environPolSuite struct {
 var _ = gc.Suite(&environPolSuite{})
 
 func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts()})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.CheckNoAPI(c)
@@ -33,14 +33,14 @@ func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
 
 func (s *environPolSuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=some-instance-type")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
 
 	c.Check(err, gc.ErrorMatches, `LXD does not support instance types.*`)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("root-disk=1G")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -49,14 +49,14 @@ func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	cons := constraints.MustParse("arch=i386")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `unknown placement directive: .*`)
 }

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/provider/lxd"
-	"github.com/juju/juju/version"
 )
 
 type environPolSuite struct {

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -10,10 +10,10 @@ import (
 	"path"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/cloud"
 	jujupaths "github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/version"
 )
 
 // ReadLegacyCloudCredentials reads cloud credentials off disk for an old
@@ -24,7 +24,7 @@ import (
 // satisfying errors.IsNotFound will be returned.
 func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
 	var (
-		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(series.LatestLts()))
+		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(version.SupportedLts()))
 		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
 		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
 		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	jujupaths "github.com/juju/juju/juju/paths"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/version"
 )
 
 // ReadLegacyCloudCredentials reads cloud credentials off disk for an old

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -16,7 +16,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -32,11 +31,11 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	jujuversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
 )
 
 // ensure we conform to the right interfaces

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // ensure we conform to the right interfaces
@@ -671,32 +672,32 @@ func (suite *environSuite) TestSubnetsMissingSubnet(c *gc.C) {
 func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "zone=zone1"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "zone=zone1"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "zone=zone2"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "zone=zone2"})
 	c.Assert(err, gc.ErrorMatches, `availability zone "zone2" not valid`)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "zone=test-unknown"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "zone=test-unknown"})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
 func (s *environSuite) TestPrecheckInvalidPlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "notzone=anything"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "notzone=anything"})
 	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
 }
 
 func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: "assumed_node_name"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "assumed_node_name"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -27,6 +27,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -63,7 +64,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
 }
 
 func (s *baseProviderSuite) TearDownTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -63,7 +63,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.MustHostSeries, func() string { return series.LatestLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return jujuversion.SupportedLts() })
 }
 
 func (s *baseProviderSuite) TearDownTest(c *gc.C) {

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-	"github.com/juju/utils/series"
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/version"
 )
 
 // extractSystemId extracts the 'system_id' part from an InstanceId.
@@ -48,7 +48,7 @@ type machineInfo struct {
 	Hostname string `yaml:",omitempty"`
 }
 
-var maasDataDir = paths.MustSucceed(paths.DataDir(series.LatestLts()))
+var maasDataDir = paths.MustSucceed(paths.DataDir(version.SupportedLts()))
 var _MAASInstanceFilename = path.Join(maasDataDir, "MAASmachine.txt")
 
 // cloudinitRunCmd returns the shell command that, when run, will create the

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/paths"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/version"
 )
 
 // extractSystemId extracts the 'system_id' part from an InstanceId.

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1244,7 +1244,7 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.LatestLts(), "amd64", "instance-type=m1.tiny",
+		env, jujuversion.SupportedLts(), "amd64", "instance-type=m1.tiny",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1261,7 +1261,7 @@ func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.LatestLts(), "amd64", "virt-type="+testVirtType,
+		env, jujuversion.SupportedLts(), "amd64", "virt-type="+testVirtType,
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1280,7 +1280,7 @@ func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.LatestLts(), "amd64", "",
+		env, jujuversion.SupportedLts(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1297,7 +1297,7 @@ func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.LatestLts(), "amd64", "",
+		env, jujuversion.SupportedLts(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1312,7 +1312,7 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 		Arch: "amd64",
 	}}
 	_, err := openstack.FindInstanceSpec(
-		env, series.LatestLts(), "amd64", "instance-type=m1.large",
+		env, jujuversion.SupportedLts(), "amd64", "instance-type=m1.large",
 		imageMetadata,
 	)
 	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
@@ -1321,39 +1321,39 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small")
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.large")
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Constraints: cons})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unknown" not valid`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	t.srv.Nova.SetAvailabilityZones() // no availability zone support
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: series.LatestLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
@@ -1387,7 +1387,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZones(c *gc.C, placeme
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:            series.LatestLts(),
+		Series:            jujuversion.SupportedLts(),
 		Placement:         placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})
@@ -1422,7 +1422,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZonesConflictsVolume(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:            series.LatestLts(),
+		Series:            jujuversion.SupportedLts(),
 		Placement:         "zone=az2",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -1244,7 +1245,7 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, jujuversion.SupportedLts(), "amd64", "instance-type=m1.tiny",
+		env, supportedversion.SupportedLts(), "amd64", "instance-type=m1.tiny",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1261,7 +1262,7 @@ func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, jujuversion.SupportedLts(), "amd64", "virt-type="+testVirtType,
+		env, supportedversion.SupportedLts(), "amd64", "virt-type="+testVirtType,
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1280,7 +1281,7 @@ func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, jujuversion.SupportedLts(), "amd64", "",
+		env, supportedversion.SupportedLts(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1297,7 +1298,7 @@ func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, jujuversion.SupportedLts(), "amd64", "",
+		env, supportedversion.SupportedLts(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1312,7 +1313,7 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 		Arch: "amd64",
 	}}
 	_, err := openstack.FindInstanceSpec(
-		env, jujuversion.SupportedLts(), "amd64", "instance-type=m1.large",
+		env, supportedversion.SupportedLts(), "amd64", "instance-type=m1.large",
 		imageMetadata,
 	)
 	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
@@ -1321,39 +1322,39 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small")
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Constraints: cons})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.large")
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Constraints: cons})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unknown" not valid`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	t.srv.Nova.SetAvailabilityZones() // no availability zone support
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
@@ -1387,7 +1388,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZones(c *gc.C, placeme
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:            jujuversion.SupportedLts(),
+		Series:            supportedversion.SupportedLts(),
 		Placement:         placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})
@@ -1422,7 +1423,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZonesConflictsVolume(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:            jujuversion.SupportedLts(),
+		Series:            supportedversion.SupportedLts(),
 		Placement:         "zone=az2",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
-	jujuversion "github.com/juju/juju/version"
+	jujuversion "github.com/juju/juju/juju/version"
 )
 
 // FakeAuthKeys holds the authorized key used for testing

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -7,7 +7,6 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/series"
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // FakeAuthKeys holds the authorized key used for testing
@@ -68,7 +68,7 @@ func FakeConfig() Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            series.LatestLts(),
+		"default-series":            jujuversion.SupportedLts(),
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,13 +21,6 @@ import (
 // number of the release package.
 const version = "2.3.6"
 
-// SupportedLts returns the latest LTS that Juju supports and is compatible with.
-// For example, Juju 2.3.x series cannot be run on "bionic"
-// as mongo version that it depends on (3.2 and less) is not packaged for bionic.
-func SupportedLts() string {
-	return "xenial"
-}
-
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,6 +21,14 @@ import (
 // number of the release package.
 const version = "2.3.6"
 
+// SupportedLts returns the latest LTS that Juju supports and
+// // is compatible with.
+// For example, Juju 2.3.x series cannot be run on "bionic"
+// as mongo version that it depends on (3.2 and less) is not packaged for bionic.
+func SupportedLts() string {
+	return "xenial"
+}
+
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,8 +21,7 @@ import (
 // number of the release package.
 const version = "2.3.6"
 
-// SupportedLts returns the latest LTS that Juju supports and
-// // is compatible with.
+// SupportedLts returns the latest LTS that Juju supports and is compatible with.
 // For example, Juju 2.3.x series cannot be run on "bionic"
 // as mongo version that it depends on (3.2 and less) is not packaged for bionic.
 func SupportedLts() string {

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -132,7 +133,7 @@ func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctyp
 
 	// make a container on the host machine
 	template := state.MachineTemplate{
-		Series: jujuversion.SupportedLts(),
+		Series: supportedversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, host.Id(), ctype)
@@ -182,7 +183,7 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	for _, ctype := range containerTypes {
 		// create a machine to host the container.
 		m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-			Series:      jujuversion.SupportedLts(),
+			Series:      supportedversion.SupportedLts(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		})
@@ -243,7 +244,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -356,7 +357,7 @@ func (s *ContainerSetupSuite) TestContainerInitInstDataError(c *gc.C) {
 	defer releaser.Release()
 
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -132,7 +132,7 @@ func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctyp
 
 	// make a container on the host machine
 	template := state.MachineTemplate{
-		Series: series.LatestLts(),
+		Series: jujuversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, host.Id(), ctype)
@@ -182,7 +182,7 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	for _, ctype := range containerTypes {
 		// create a machine to host the container.
 		m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-			Series:      series.LatestLts(),
+			Series:      jujuversion.SupportedLts(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		})
@@ -243,7 +243,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -356,7 +356,7 @@ func (s *ContainerSetupSuite) TestContainerInitInstDataError(c *gc.C) {
 	defer releaser.Release()
 
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -14,7 +14,6 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -431,7 +430,7 @@ func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	defer workertest.CleanKill(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
-	_, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
+	_, err := s.State.AddMachine(jujuversion.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectNoEvents(c)
@@ -448,7 +447,7 @@ func (s *kvmProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 
 func (s *kvmProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	template := state.MachineTemplate{
-		Series: series.LatestLts(),
+		Series: jujuversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, "0", instance.KVM)

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -27,6 +27,7 @@ import (
 	kvmtesting "github.com/juju/juju/container/kvm/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -430,7 +431,7 @@ func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	defer workertest.CleanKill(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
-	_, err := s.State.AddMachine(jujuversion.SupportedLts(), state.JobHostUnits)
+	_, err := s.State.AddMachine(supportedversion.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectNoEvents(c)
@@ -447,7 +448,7 @@ func (s *kvmProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 
 func (s *kvmProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	template := state.MachineTemplate{
-		Series: jujuversion.SupportedLts(),
+		Series: supportedversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, "0", instance.KVM)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -471,7 +471,7 @@ func (s *CommonProvisionerSuite) addMachine() (*state.Machine, error) {
 
 func (s *CommonProvisionerSuite) addMachineWithConstraints(cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 	})
@@ -481,7 +481,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 	templates := make([]state.MachineTemplate, number)
 	for i, _ := range templates {
 		templates[i] = state.MachineTemplate{
-			Series:      series.LatestLts(),
+			Series:      jujuversion.SupportedLts(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		}
@@ -490,7 +490,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 }
 
 func (s *CommonProvisionerSuite) enableHA(c *gc.C, n int) []*state.Machine {
-	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, series.LatestLts(), nil, "")
+	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, jujuversion.SupportedLts(), nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	added := make([]*state.Machine, len(changes.Added))
 	for i, mid := range changes.Added {
@@ -799,7 +799,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXD(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: series.LatestLts(),
+		Series: jujuversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.LXD)
@@ -827,7 +827,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: series.LatestLts(),
+		Series: jujuversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.KVM)
@@ -1106,7 +1106,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 
 func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.MachineVolumeParams, cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series.LatestLts(),
+		Series:      jujuversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 		Volumes:     volumes,

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/dummy"
@@ -471,7 +472,7 @@ func (s *CommonProvisionerSuite) addMachine() (*state.Machine, error) {
 
 func (s *CommonProvisionerSuite) addMachineWithConstraints(cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 	})
@@ -481,7 +482,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 	templates := make([]state.MachineTemplate, number)
 	for i, _ := range templates {
 		templates[i] = state.MachineTemplate{
-			Series:      jujuversion.SupportedLts(),
+			Series:      supportedversion.SupportedLts(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		}
@@ -490,7 +491,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 }
 
 func (s *CommonProvisionerSuite) enableHA(c *gc.C, n int) []*state.Machine {
-	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, jujuversion.SupportedLts(), nil, "")
+	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, supportedversion.SupportedLts(), nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	added := make([]*state.Machine, len(changes.Added))
 	for i, mid := range changes.Added {
@@ -799,7 +800,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXD(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: jujuversion.SupportedLts(),
+		Series: supportedversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.LXD)
@@ -827,7 +828,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: jujuversion.SupportedLts(),
+		Series: supportedversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.KVM)
@@ -1106,7 +1107,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 
 func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.MachineVolumeParams, cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      jujuversion.SupportedLts(),
+		Series:      supportedversion.SupportedLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 		Volumes:     volumes,

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
-	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/reboot"
 )
@@ -39,7 +39,7 @@ var _ = gc.Suite(&rebootSuite{})
 func (s *rebootSuite) SetUpTest(c *gc.C) {
 	var err error
 	template := state.MachineTemplate{
-		Series: series.LatestLts(),
+		Series: version.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	s.JujuConnSuite.SetUpTest(c)

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -15,8 +15,8 @@ import (
 	apireboot "github.com/juju/juju/api/reboot"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/reboot"
 )


### PR DESCRIPTION
## Description of change

Juju has some strong dependencies on the software versions that are packaged with series.

For example, mongo 3.2 is not in bionic (and is not likely to be forward-ported). Consequently, Juju 2.3 cannot bootstrap in bionic, only 2.4+ can.

In other words, we have a need to be explicit about what latest LTS a Juju version supports.

