### PR TITLE
raft: Enable raft workers in the machine agent

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -258,6 +258,7 @@ func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) st
 func initRaft(agentConfig agent.Config) error {
 	raftDir := filepath.Join(agentConfig.DataDir(), "raft")
 	return raft.Bootstrap(raft.Config{
+		Clock:      clock.WallClock,
 		StorageDir: raftDir,
 		Logger:     logger,
 		Tag:        agentConfig.Tag(),

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -64,7 +64,6 @@ import (
 	"github.com/juju/juju/worker/raft"
 	"github.com/juju/juju/worker/raft/raftclusterer"
 	"github.com/juju/juju/worker/raft/raftflag"
-	"github.com/juju/juju/worker/raft/rafttest"
 	"github.com/juju/juju/worker/raft/rafttransport"
 	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/restorewatcher"
@@ -725,7 +724,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			ClockName:     clockName,
 			AgentName:     agentName,
 			TransportName: raftTransportName,
-			FSM:           &rafttest.FSM{},
+			FSM:           &raft.SimpleFSM{},
 			Logger:        loggo.GetLogger("juju.worker.raft"),
 			NewWorker:     raft.NewWorker,
 		}),

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -721,6 +721,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// TODO(babbageclunk): not sure what gates should be around this.
 		raftName: raft.Manifold(raft.ManifoldConfig{
+			ClockName:     clockName,
 			AgentName:     agentName,
 			TransportName: raftTransportName,
 			FSM:           &rafttest.FSM{},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -710,6 +710,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		raftTransportName: ifController(rafttransport.Manifold(rafttransport.ManifoldConfig{
+			ClockName:         clockName,
 			AgentName:         agentName,
 			AuthenticatorName: httpServerName,
 			HubName:           centralHubName,

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -719,7 +719,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			Path:              "/raft",
 		})),
 
-		// TODO(babbageclunk): not sure what gates should be around this.
 		raftName: raft.Manifold(raft.ManifoldConfig{
 			ClockName:     clockName,
 			AgentName:     agentName,

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -74,6 +74,10 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"peer-grouper",
 		"proxy-config-updater",
 		"pubsub-forwarder",
+		"raft",
+		"raft-clusterer",
+		"raft-flag",
+		"raft-transport",
 		"reboot-executor",
 		"restore-watcher",
 		"serving-info-setter",
@@ -140,6 +144,10 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"upgrade-steps-gate",
 		"upgrade-steps-runner",
 		"upgrader",
+		"raft",
+		"raft-clusterer",
+		"raft-flag",
+		"raft-transport",
 	)
 	manifolds := machine.Manifolds(machine.ManifoldsConfig{
 		Agent: &mockAgent{},
@@ -157,13 +165,24 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 	manifolds := machine.Manifolds(machine.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
+	controllerWorkers := set.NewStrings(
+		"certificate-watcher",
+		"audit-config-updater",
+		"is-primary-controller-flag",
+		"raft-transport",
+	)
+	primaryControllerWorkers := set.NewStrings(
+		"external-controller-updater",
+		"log-pruner",
+		"transaction-pruner",
+	)
 	for name, manifold := range manifolds {
 		c.Logf(name)
-		switch name {
-		case "certificate-watcher", "audit-config-updater", "is-primary-controller-flag":
+		switch {
+		case controllerWorkers.Contains(name):
 			checkContains(c, manifold.Inputs, "is-controller-flag")
 			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
-		case "external-controller-updater", "log-pruner", "transaction-pruner":
+		case primaryControllerWorkers.Contains(name):
 			checkNotContains(c, manifold.Inputs, "is-controller-flag")
 			checkContains(c, manifold.Inputs, "is-primary-controller-flag")
 		default:

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -37,12 +37,13 @@ type Details struct {
 }
 
 // DetailsRequestTopic is the topic that details requests are
-// published on. In response to those requests, the current details
-// will be published on the DetailsTopic.
+// published on. The peergrouper responds those requests, publishing
+// the current details on the DetailsTopic.
 const DetailsRequestTopic = "apiserver.details-request"
 
 // DetailsRequest indicates the worker who is asking for the details
-// to be sent.
+// to be sent. It should always be LocalOnly - we only want to ask our
+// local PeerGrouper for details.
 type DetailsRequest struct {
 	Requester string `yaml:"requester"`
 	LocalOnly bool   `yaml:"local-only"`

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -45,6 +45,7 @@ const DetailsRequestTopic = "apiserver.details-request"
 // to be sent.
 type DetailsRequest struct {
 	Requester string `yaml:"requester"`
+	LocalOnly bool   `yaml:"local-only"`
 }
 
 // ConnectTopic is the topic name for the published message

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -36,6 +36,17 @@ type Details struct {
 	LocalOnly bool                 `yaml:"local-only"`
 }
 
+// DetailsRequestTopic is the topic that details requests are
+// published on. In response to those requests, the current details
+// will be published on the DetailsTopic.
+const DetailsRequestTopic = "apiserver.details-request"
+
+// DetailsRequest indicates the worker who is asking for the details
+// to be sent.
+type DetailsRequest struct {
+	Requester string `yaml:"requester"`
+}
+
 // ConnectTopic is the topic name for the published message
 // whenever an agent conntects to the API server.
 const ConnectTopic = "apiserver.agent-connect"

--- a/tools/lxdtools/lxdtools.go
+++ b/tools/lxdtools/lxdtools.go
@@ -101,7 +101,7 @@ func GetImageWithServer(
 		target = entry.Target
 		image, _, err := server.GetImage(target)
 		if err == nil {
-			logger.Debugf("Found image locally - %q %q", image, target)
+			logger.Debugf("Found image locally - %q %q", image.Filename, target)
 			return server, image, target, nil
 		}
 	}
@@ -130,7 +130,7 @@ func GetImageWithServer(
 		if target != "" {
 			image, _, err := source.GetImage(target)
 			if err == nil {
-				logger.Debugf("Found image remotely - %q %q %q", source, image, target)
+				logger.Debugf("Found image remotely - %q %q %q", remote.Name, image.Filename, target)
 				return source, image, target, nil
 			} else {
 				lastErr = err

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -153,7 +153,7 @@ func (info *peerGroupInfo) initNewReplicaSet() map[string]*replicaset.Member {
 //      and any of these are set as voters.
 //   2) There is no HA space configured and any machines have multiple
 //      cloud-local addresses.
-func desiredPeerGroup(info *peerGroupInfo) (map[string]*replicaset.Member, map[string]bool, error) {
+func desiredPeerGroup(info *peerGroupInfo) (bool, map[string]*replicaset.Member, map[string]bool, error) {
 	logger.Debugf(info.getLogMessage())
 
 	peerChanges := peerGroupChanges{
@@ -175,7 +175,7 @@ func desiredPeerGroup(info *peerGroupInfo) (map[string]*replicaset.Member, map[s
 	// 4) Do nothing.
 	err := peerChanges.checkExtraMembers(info.extra)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return false, nil, nil, errors.Trace(err)
 	}
 
 	peerChanges.members = info.initNewReplicaSet()
@@ -189,13 +189,10 @@ func desiredPeerGroup(info *peerGroupInfo) (map[string]*replicaset.Member, map[s
 	peerChanges.adjustVotes()
 
 	if err := peerChanges.updateAddresses(info); err != nil {
-		return nil, nil, errors.Trace(err)
+		return false, nil, nil, errors.Trace(err)
 	}
 
-	if !peerChanges.isChanged {
-		return nil, peerChanges.machineVoting, nil
-	}
-	return peerChanges.members, peerChanges.machineVoting, nil
+	return peerChanges.isChanged, peerChanges.members, peerChanges.machineVoting, nil
 }
 
 // checkExtraMembers checks to see if any of the input members, identified as

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -467,12 +467,12 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "creating peer group info")
 	}
-	members, voting, err := desiredPeerGroup(info)
+	membersChanged, members, voting, err := desiredPeerGroup(info)
 	if err != nil {
 		return nil, errors.Annotate(err, "computing desired peer group")
 	}
 	if logger.IsDebugEnabled() {
-		if members != nil {
+		if membersChanged {
 			logger.Debugf("desired peer group members: \n%s", prettyReplicaSetMembers(members))
 		} else {
 			var output []string
@@ -518,7 +518,7 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 	if err := setHasVote(added, true); err != nil {
 		return nil, errors.Annotate(err, "adding new voters")
 	}
-	if members != nil {
+	if membersChanged {
 		ms := make([]replicaset.Member, 0, len(members))
 		for _, m := range members {
 			ms = append(ms, *m)

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -546,6 +546,16 @@ func (s *workerSuite) TestControllersArePublishedOverHubWithNewVoters(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for event")
 	}
+
+	// And check that they can be republished on request.
+	_, err = hub.Publish(apiserver.DetailsRequestTopic, apiserver.DetailsRequest{"dad"})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case obtained := <-event:
+		c.Assert(obtained, jc.DeepEquals, expected)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for event")
+	}
 }
 
 func haSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, members string) *fakeState {
@@ -903,6 +913,10 @@ type nopHub struct{}
 
 func (nopHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
 	return nil, nil
+}
+
+func (nopHub) Subscribe(topic string, handler interface{}) (func(), error) {
+	return func() {}, nil
 }
 
 func (s *workerSuite) newWorker(

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -548,7 +548,10 @@ func (s *workerSuite) TestControllersArePublishedOverHubWithNewVoters(c *gc.C) {
 	}
 
 	// And check that they can be republished on request.
-	_, err = hub.Publish(apiserver.DetailsRequestTopic, apiserver.DetailsRequest{"dad"})
+	_, err = hub.Publish(apiserver.DetailsRequestTopic, apiserver.DetailsRequest{
+		Requester: "dad",
+		LocalOnly: true,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
 	case obtained := <-event:

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -101,7 +101,10 @@ func newSubscriber(config WorkerConfig) (*subscriber, error) {
 	sub.unsubServerDetails = unsub
 
 	// Ask for the current server details now that we're subscribed.
-	detailsRequest := apiserver.DetailsRequest{Requester: "pubsub-forwarder"}
+	detailsRequest := apiserver.DetailsRequest{
+		Requester: "pubsub-forwarder",
+		LocalOnly: true,
+	}
 	if _, err := config.Hub.Publish(apiserver.DetailsRequestTopic, detailsRequest); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -100,6 +100,12 @@ func newSubscriber(config WorkerConfig) (*subscriber, error) {
 	}
 	sub.unsubServerDetails = unsub
 
+	// Ask for the current server details now that we're subscribed.
+	detailsRequest := apiserver.DetailsRequest{Requester: "pubsub-forwarder"}
+	if _, err := config.Hub.Publish(apiserver.DetailsRequestTopic, detailsRequest); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	err = catacomb.Invoke(catacomb.Plan{
 		Site: &sub.catacomb,
 		Work: sub.waitForDeath,

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -326,6 +326,25 @@ func (s *SubscriberSuite) TestIntrospectionReport(c *gc.C) {
 		"  Addresses: [10.1.2.5]\n")
 }
 
+func (s *SubscriberSuite) TestRequestsDetailsOnceSubscribed(c *gc.C) {
+	subscribed := make(chan apiserver.DetailsRequest)
+	s.config.Hub.Subscribe(apiserver.DetailsRequestTopic,
+		func(_ string, req apiserver.DetailsRequest, err error) {
+			c.Assert(err, jc.ErrorIsNil)
+			subscribed <- req
+		},
+	)
+
+	s.newHAWorker(c)
+
+	select {
+	case req := <-subscribed:
+		c.Assert(req, gc.Equals, apiserver.DetailsRequest{Requester: "pubsub-forwarder"})
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for details request")
+	}
+}
+
 var logger = loggo.GetLogger("workertest")
 
 type fakeRemoteTracker struct {

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -330,7 +330,7 @@ func (s *SubscriberSuite) TestRequestsDetailsOnceSubscribed(c *gc.C) {
 	subscribed := make(chan apiserver.DetailsRequest)
 	s.config.Hub.Subscribe(apiserver.DetailsRequestTopic,
 		func(_ string, req apiserver.DetailsRequest, err error) {
-			c.Assert(err, jc.ErrorIsNil)
+			c.Check(err, jc.ErrorIsNil)
 			subscribed <- req
 		},
 	)
@@ -339,7 +339,7 @@ func (s *SubscriberSuite) TestRequestsDetailsOnceSubscribed(c *gc.C) {
 
 	select {
 	case req := <-subscribed:
-		c.Assert(req, gc.Equals, apiserver.DetailsRequest{Requester: "pubsub-forwarder"})
+		c.Assert(req, gc.Equals, apiserver.DetailsRequest{Requester: "pubsub-forwarder", LocalOnly: true})
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for details request")
 	}

--- a/worker/raft/manifold_test.go
+++ b/worker/raft/manifold_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/raft"
-	"github.com/juju/juju/worker/raft/rafttest"
 )
 
 type ManifoldSuite struct {
@@ -30,7 +29,7 @@ type ManifoldSuite struct {
 	agent     *mockAgent
 	transport *coreraft.InmemTransport
 	clock     *testing.Clock
-	fsm       *rafttest.FSM
+	fsm       *raft.SimpleFSM
 	logger    loggo.Logger
 	worker    *mockRaftWorker
 	stub      testing.Stub
@@ -47,7 +46,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 			dataDir: filepath.Join("data", "dir"),
 		},
 	}
-	s.fsm = &rafttest.FSM{}
+	s.fsm = &raft.SimpleFSM{}
 	s.logger = loggo.GetLogger("juju.worker.raft_test")
 	s.worker = &mockRaftWorker{
 		r: &coreraft.Raft{},

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -57,6 +57,12 @@ func NewWorker(config Config) (worker.Worker, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "subscribing to apiserver details")
 	}
+	// Now that we're subscribed, request the current API server details.
+	req := apiserver.DetailsRequest{Requester: "raft-clusterer"}
+	if _, err := config.Hub.Publish(apiserver.DetailsRequestTopic, req); err != nil {
+		return nil, errors.Annotate(err, "requesting current apiserver details")
+	}
+
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
 		Work: func() error {

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -58,7 +58,10 @@ func NewWorker(config Config) (worker.Worker, error) {
 		return nil, errors.Annotate(err, "subscribing to apiserver details")
 	}
 	// Now that we're subscribed, request the current API server details.
-	req := apiserver.DetailsRequest{Requester: "raft-clusterer"}
+	req := apiserver.DetailsRequest{
+		Requester: "raft-clusterer",
+		LocalOnly: true,
+	}
 	if _, err := config.Hub.Publish(apiserver.DetailsRequestTopic, req); err != nil {
 		return nil, errors.Annotate(err, "requesting current apiserver details")
 	}

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/pubsub/apiserver"
 	"github.com/juju/juju/pubsub/centralhub"
 	coretesting "github.com/juju/juju/testing"
+	jujuraft "github.com/juju/juju/worker/raft"
 	"github.com/juju/juju/worker/raft/raftclusterer"
 	"github.com/juju/juju/worker/raft/rafttest"
 	"github.com/juju/juju/worker/workertest"
@@ -28,7 +29,7 @@ type workerFixture struct {
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
-	s.FSM = &rafttest.FSM{}
+	s.FSM = &jujuraft.SimpleFSM{}
 	s.RaftFixture.SetUpTest(c)
 	s.hub = centralhub.New(names.NewMachineTag("0"))
 	s.config = raftclusterer.Config{
@@ -109,9 +110,9 @@ func (s *WorkerSuite) TestAddRemoveServers(c *gc.C) {
 	// Create 4 servers: machine-0, machine-1, machine-2,
 	// and machine-3, where all servers can connect
 	// bidirectionally.
-	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &rafttest.FSM{})
-	_, _, transport2, _, _ := s.NewRaft(c, "machine-2", &rafttest.FSM{})
-	_, _, transport3, _, _ := s.NewRaft(c, "machine-3", &rafttest.FSM{})
+	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &jujuraft.SimpleFSM{})
+	_, _, transport2, _, _ := s.NewRaft(c, "machine-2", &jujuraft.SimpleFSM{})
+	_, _, transport3, _, _ := s.NewRaft(c, "machine-3", &jujuraft.SimpleFSM{})
 	connectTransports(s.Transport, transport1, transport2, transport3)
 
 	machine0Address := string(s.Transport.LocalAddr())
@@ -208,8 +209,8 @@ func (s *WorkerSuite) TestChangeLocalServer(c *gc.C) {
 	// We add machine-1 and machine-2, and change machine-0's
 	// address. Changing machine-0's address should not affect
 	// its leadership.
-	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &rafttest.FSM{})
-	_, _, transport2, _, _ := s.NewRaft(c, "machine-2", &rafttest.FSM{})
+	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &jujuraft.SimpleFSM{})
+	_, _, transport2, _, _ := s.NewRaft(c, "machine-2", &jujuraft.SimpleFSM{})
 	connectTransports(s.Transport, transport1, transport2)
 	machine1Address := string(transport1.LocalAddr())
 	machine2Address := string(transport2.LocalAddr())

--- a/worker/raft/rafttransport/streamlayer.go
+++ b/worker/raft/rafttransport/streamlayer.go
@@ -41,6 +41,18 @@ func newStreamLayer(
 		l.tomb.Done()
 		return l
 	}
+
+	// Ask for the current details to be sent.
+	req := apiserver.DetailsRequest{
+		Requester: "raft-transport-stream-layer",
+		LocalOnly: true,
+	}
+	if _, err := hub.Publish(apiserver.DetailsRequestTopic, req); err != nil {
+		l.tomb.Kill(err)
+		l.tomb.Done()
+		return l
+	}
+
 	go func() {
 		defer unsubscribe()
 		defer l.tomb.Done()

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -127,7 +127,7 @@ func Bootstrap(config Config) error {
 	// During bootstrap, we do not require an FSM.
 	config.FSM = bootstrapFSM{}
 
-	w, err := NewWorker(config)
+	w, err := newWorker(config)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -150,7 +150,11 @@ func Bootstrap(config Config) error {
 }
 
 // NewWorker returns a new raft worker, with the given configuration.
-func NewWorker(config Config) (*Worker, error) {
+func NewWorker(config Config) (worker.Worker, error) {
+	return newWorker(config)
+}
+
+func newWorker(config Config) (*Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -16,19 +16,18 @@ import (
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/raft"
-	"github.com/juju/juju/worker/raft/rafttest"
 	"github.com/juju/juju/worker/workertest"
 )
 
 type workerFixture struct {
 	testing.IsolationSuite
-	fsm    *rafttest.FSM
+	fsm    *raft.SimpleFSM
 	config raft.Config
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.fsm = &rafttest.FSM{}
+	s.fsm = &raft.SimpleFSM{}
 	_, transport := coreraft.NewInmemTransport("machine-123")
 	s.AddCleanup(func(c *gc.C) {
 		c.Assert(transport.Close(), jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

This runs the raft workers in the machine agent, as a step towards managing leases and leadership with raft. The new workers are:

raft-transport: manages connections between the raft nodes (runs in all controller agents).
raft: runs the raft node and provides it to other workers (all controllers).
raft-flag: bounces whenever the raft leadership of this node changes and exposes a .Check method that returns whether this is the leader (all controllers).
raft-clusterer: watches for changes to the set of controller machines and updates raft as needed (only runs on the leader node).

At the moment the payload the raft cluster manages is rudimentary - it just maintains a log of entries. In the future this will be replaced with an FSM that manages leases.

## QA steps

* Bootstrap a controller, deploy some applications and run `juju enable-ha`. 
* Watch the debug logging for juju.worker.raft (and modules under that) to see the controller machines get added to the cluster and elect a leader.
* SSH to the controller machines and use `juju-engine-report` to check the raft cluster is as expected.
* Upgrade juju and see the raft workers come back up and resume normal interaction.
* Stop jujud on the leader machine and see that the raft cluster elects a new leader.
* Restart jujud on the old leader and see that the raft workers catch up.
