### PR TITLE
Publish api connections

### DIFF
--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -10,14 +10,22 @@ import (
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/pubsub/apiserver"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 )
+
+// Hub defines the only method of the apiserver centralhub that
+// the observer uses.
+type Hub interface {
+	Publish(topic string, data interface{}) (<-chan struct{}, error)
+}
 
 // RequestObserver serves as a sink for API server requests and
 // responses.
 type RequestObserver struct {
 	clock              clock.Clock
+	hub                Hub
 	logger             loggo.Logger
 	connLogger         loggo.Logger
 	pingLogger         loggo.Logger
@@ -34,6 +42,7 @@ type RequestObserver struct {
 		tag                string
 		model              string
 		agent              bool
+		fromController     bool
 	}
 }
 
@@ -43,6 +52,10 @@ type RequestObserverContext struct {
 
 	// Clock is the clock to use for all time operations on this type.
 	Clock clock.Clock
+
+	// Hub refers to the pubsub Hub which will have connection
+	// and disconnection events published.
+	Hub Hub
 
 	// Logger is the log to use to write log statements.
 	Logger loggo.Logger
@@ -55,6 +68,7 @@ func NewRequestObserver(ctx RequestObserverContext) *RequestObserver {
 	module := ctx.Logger.Name()
 	return &RequestObserver{
 		clock:      ctx.Clock,
+		hub:        ctx.Hub,
 		logger:     ctx.Logger,
 		connLogger: loggo.GetLogger(module + ".connection"),
 		pingLogger: loggo.GetLogger(module + ".ping"),
@@ -71,13 +85,23 @@ func (n *RequestObserver) isAgent(entity names.Tag) bool {
 }
 
 // Login implements Observer.
-func (n *RequestObserver) Login(entity names.Tag, model names.ModelTag, fromController bool, _ string) {
+func (n *RequestObserver) Login(entity names.Tag, model names.ModelTag, fromController bool, userData string) {
 	n.state.tag = entity.String()
-	// Don't log connections from the controller to the model.
-	if n.isAgent(entity) && !fromController {
+	n.state.fromController = fromController
+	if n.isAgent(entity) {
 		n.state.agent = true
 		n.state.model = model.Id()
-		n.connLogger.Infof("agent login: %s for %s", n.state.tag, n.state.model)
+		// Don't log connections from the controller to the model.
+		if !n.state.fromController {
+			n.connLogger.Infof("agent login: %s for %s", n.state.tag, n.state.model)
+		}
+		n.hub.Publish(apiserver.ConnectTopic, apiserver.APIConnection{
+			AgentTag:        n.state.tag,
+			ControllerAgent: fromController,
+			ModelUUID:       model.Id(),
+			ConnectionID:    n.state.id,
+			UserData:        userData,
+		})
 	}
 }
 
@@ -96,7 +120,16 @@ func (n *RequestObserver) Join(req *http.Request, connectionID uint64) {
 // Leave implements Observer.
 func (n *RequestObserver) Leave() {
 	if n.state.agent {
-		n.connLogger.Infof("agent disconnected: %s for %s", n.state.tag, n.state.model)
+		// Don't log disconnections from the controller to the model.
+		if !n.state.fromController {
+			n.connLogger.Infof("agent disconnected: %s for %s", n.state.tag, n.state.model)
+		}
+		n.hub.Publish(apiserver.DisconnectTopic, apiserver.APIConnection{
+			AgentTag:        n.state.tag,
+			ControllerAgent: n.state.fromController,
+			ModelUUID:       n.state.model,
+			ConnectionID:    n.state.id,
+		})
 	}
 	n.logger.Debugf(
 		"[%X] %s API connection terminated after %v",

--- a/apiserver/observer/request_notifier_test.go
+++ b/apiserver/observer/request_notifier_test.go
@@ -1,0 +1,140 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package observer_test
+
+import (
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/observer"
+	"github.com/juju/juju/pubsub/apiserver"
+)
+
+type RequestObserverSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&RequestObserverSuite{})
+
+func (*RequestObserverSuite) makeNotifier(c *gc.C) (*observer.RequestObserver, *connectionHub) {
+	hub := &connectionHub{c: c}
+	return observer.NewRequestObserver(observer.RequestObserverContext{
+		Clock:  testing.NewClock(time.Now()),
+		Hub:    hub,
+		Logger: loggo.GetLogger("test"),
+	}), hub
+}
+
+func (s *RequestObserverSuite) TestAgentConnectionPublished(c *gc.C) {
+	notifier, hub := s.makeNotifier(c)
+
+	agent := names.NewMachineTag("42")
+	model := names.NewModelTag("fake-uuid")
+	notifier.Login(agent, model, false, "user data")
+
+	c.Assert(hub.called, gc.Equals, 1)
+	c.Assert(hub.topic, gc.Equals, apiserver.ConnectTopic)
+	c.Assert(hub.details, jc.DeepEquals, apiserver.APIConnection{
+		AgentTag:     "machine-42",
+		ModelUUID:    "fake-uuid",
+		UserData:     "user data",
+		ConnectionID: 0,
+	})
+}
+
+func (s *RequestObserverSuite) TestControllerAgentConnectionPublished(c *gc.C) {
+	notifier, hub := s.makeNotifier(c)
+
+	agent := names.NewMachineTag("2")
+	model := names.NewModelTag("fake-uuid")
+	notifier.Login(agent, model, true, "user data")
+
+	c.Assert(hub.called, gc.Equals, 1)
+	c.Assert(hub.topic, gc.Equals, apiserver.ConnectTopic)
+	c.Assert(hub.details, jc.DeepEquals, apiserver.APIConnection{
+		AgentTag:        "machine-2",
+		ModelUUID:       "fake-uuid",
+		ControllerAgent: true,
+		UserData:        "user data",
+		ConnectionID:    0,
+	})
+}
+
+func (s *RequestObserverSuite) TestUserConnectionsNotPublished(c *gc.C) {
+	notifier, hub := s.makeNotifier(c)
+
+	user := names.NewUserTag("bob")
+	model := names.NewModelTag("fake-uuid")
+	notifier.Login(user, model, false, "user data")
+
+	c.Assert(hub.called, gc.Equals, 0)
+}
+
+func (s *RequestObserverSuite) TestAgentDisconnectionPublished(c *gc.C) {
+	notifier, hub := s.makeNotifier(c)
+
+	agent := names.NewMachineTag("42")
+	model := names.NewModelTag("fake-uuid")
+	// All details are saved from Login.
+	notifier.Login(agent, model, false, "user data")
+	notifier.Leave()
+
+	c.Assert(hub.called, gc.Equals, 2)
+	c.Assert(hub.topic, gc.Equals, apiserver.DisconnectTopic)
+	c.Assert(hub.details, jc.DeepEquals, apiserver.APIConnection{
+		AgentTag:     "machine-42",
+		ModelUUID:    "fake-uuid",
+		ConnectionID: 0,
+	})
+}
+
+func (s *RequestObserverSuite) TestControllerAgentDisconnectionPublished(c *gc.C) {
+	notifier, hub := s.makeNotifier(c)
+
+	agent := names.NewMachineTag("2")
+	model := names.NewModelTag("fake-uuid")
+	// All details are saved from Login.
+	notifier.Login(agent, model, true, "user data")
+	notifier.Leave()
+
+	c.Assert(hub.called, gc.Equals, 2)
+	c.Assert(hub.topic, gc.Equals, apiserver.DisconnectTopic)
+	c.Assert(hub.details, jc.DeepEquals, apiserver.APIConnection{
+		AgentTag:        "machine-2",
+		ModelUUID:       "fake-uuid",
+		ControllerAgent: true,
+		ConnectionID:    0,
+	})
+}
+
+func (s *RequestObserverSuite) TestUserDisconnectionsNotPublished(c *gc.C) {
+	notifier, hub := s.makeNotifier(c)
+
+	user := names.NewUserTag("bob")
+	model := names.NewModelTag("fake-uuid")
+	// All details are saved from Login.
+	notifier.Login(user, model, false, "user data")
+	notifier.Leave()
+
+	c.Assert(hub.called, gc.Equals, 0)
+}
+
+type connectionHub struct {
+	c       *gc.C
+	called  int
+	topic   string
+	details apiserver.APIConnection
+}
+
+func (hub *connectionHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
+	hub.called++
+	hub.topic = topic
+	hub.details = data.(apiserver.APIConnection)
+	return nil, nil
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	1fe2a4bf0a3a2c10881501233ff7c6aed7790082	2017-11-10T02:00:13Z
 github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7dd	2017-04-28T16:15:59Z
-github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T03:24:24Z
+github.com/juju/pubsub	git	091412f84753115324ce870066ffbb6bb55c4ef4	2017-11-22T01:43:26Z
 github.com/juju/ratelimit	git	5b9ff866471762aa2ab2dced63c9fb6f53921342	2017-05-23T01:21:41Z
 github.com/juju/replicaset	git	0072546a972e6a32bdb2330809fdf7db6c755b85	2017-09-13T04:02:23Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -3,6 +3,8 @@
 
 package apiserver
 
+import "github.com/juju/juju/pubsub/common"
+
 // DetailsTopic is the topic name for the published message when the details
 // of the api servers change. This message is normally published by the
 // peergrouper when the set of API servers changes.
@@ -33,3 +35,26 @@ type Details struct {
 	Servers   map[string]APIServer `yaml:"servers"`
 	LocalOnly bool                 `yaml:"local-only"`
 }
+
+// ConnectTopic is the topic name for the published message
+// whenever an agent conntects to the API server.
+const ConnectTopic = "apiserver.agent-connect"
+
+// DisconnectTopic is the topic name for the published message
+// whenever an agent disconntects to the API server.
+const DisconnectTopic = "apiserver.agent-disconnect"
+
+// APIConnection holds all the salient pieces of information that are
+// available when an agent connects to the API server.
+type APIConnection struct {
+	AgentTag        string `yaml:"agent-tag"`
+	ControllerAgent bool   `yaml:"controller-agent,omitempty"`
+	ModelUUID       string `yaml:"model-uuid"`
+	ConnectionID    uint64 `yaml:"connection-id"`
+	Origin          string `yaml:"origin"`
+	UserData        string `yaml:"user-data,omitempty"`
+}
+
+// OriginTarget represents the data for the connect and disconnect
+// topics.
+type OriginTarget common.OriginTarget

--- a/pubsub/common/messages.go
+++ b/pubsub/common/messages.go
@@ -1,0 +1,15 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+// OriginTarget represents the commonly used message structure
+// where the publisher generally just specifies the Target and the
+// Origin is filled in by the hub.
+type OriginTarget struct {
+	// Origin represents this API server.
+	Origin string `yaml:"origin"`
+	// Target represents the other API server that this one is forwarding
+	// messages to.
+	Target string `yaml:"target"`
+}

--- a/pubsub/forwarder/messages.go
+++ b/pubsub/forwarder/messages.go
@@ -3,6 +3,8 @@
 
 package forwarder
 
+import "github.com/juju/juju/pubsub/common"
+
 const (
 	// ConnectTopic is published when a connection is established between
 	// the forwarding worker and another API server.
@@ -15,10 +17,4 @@ const (
 
 // OriginTarget represents the data for the connect and disconnect
 // topics.
-type OriginTarget struct {
-	// Origin represents this API server.
-	Origin string `yaml:"origin"`
-	// Target represents the other API server that this one is forwarding
-	// messages to.
-	Target string `yaml:"target"`
-}
+type OriginTarget common.OriginTarget

--- a/worker/apiserver/observers.go
+++ b/worker/apiserver/observers.go
@@ -6,6 +6,7 @@ package apiserver
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
 	"github.com/juju/utils/clock"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -20,6 +21,7 @@ func newObserverFn(
 	controllerConfig controller.Config,
 	clock clock.Clock,
 	prometheusRegisterer prometheus.Registerer,
+	hub *pubsub.StructuredHub,
 ) (observer.ObserverFactory, error) {
 
 	var observerFactories []observer.ObserverFactory
@@ -30,6 +32,7 @@ func newObserverFn(
 		ctx := observer.RequestObserverContext{
 			Clock:  clock,
 			Logger: logger,
+			Hub:    hub,
 		}
 		return observer.NewRequestObserver(ctx)
 	})

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -107,6 +107,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		controllerConfig,
 		config.Clock,
 		config.PrometheusRegisterer,
+		config.Hub,
 	)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create RPC observer factory")


### PR DESCRIPTION
This is the of the branches for the new presence implementation.

The idea is to base agent presence on whether or not there is a current API connection alive for that agent. The implementation is entirely in memory, using published messages for connection and disconnection to drive the recording of who is connected.

This work hooks into the current API server connection notifier to send the connect and disconnect events.

## QA steps

There is no real way to QA this yet.
