### PR TITLE
Removed "xenial" hard-coding in tests where supported lts was needed.

### DIFF
--- a/api/backups/download_test.go
+++ b/api/backups/download_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 	"github.com/juju/juju/testing"
@@ -32,7 +33,7 @@ func (s *downloadSuite) TestSuccessfulRequest(c *gc.C) {
 	backupsState := backups.NewBackups(store)
 
 	r := strings.NewReader("<compressed archive data>")
-	meta, err := backups.NewMetadataState(db, "0", "xenial")
+	meta, err := backups.NewMetadataState(db, "0", version.SupportedLts())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta.CACert, gc.Equals, testing.CACert)
 	c.Assert(meta.CAPrivateKey, gc.Equals, testing.CAKey)

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -411,7 +412,7 @@ func createModelSummary() *params.ModelSummary {
 		UUID:               "uuid",
 		ControllerUUID:     "controllerUUID",
 		ProviderType:       "aws",
-		DefaultSeries:      "xenial",
+		DefaultSeries:      version.SupportedLts(),
 		CloudTag:           "cloud-aws",
 		CloudRegion:        "us-east-1",
 		CloudCredentialTag: "cloudcred-foo_bob_one",

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	supportedversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -221,7 +222,7 @@ func (s *provisionerSuite) TestEnsureDeadAndRemove(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestMarkForRemoval(c *gc.C) {
-	machine, err := s.State.AddMachine("xenial", state.JobHostUnits)
+	machine, err := s.State.AddMachine(supportedversion.SupportedLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiMachine := s.assertGetOneMachine(c, machine.MachineTag())
@@ -358,7 +359,7 @@ func (s *provisionerSuite) TestSeries(c *gc.C) {
 func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 	// Create a fresh machine, since machine 0 is already provisioned.
 	template := state.MachineTemplate{
-		Series: "xenial",
+		Series: supportedversion.SupportedLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	notProvisionedMachine, err := s.State.AddOneMachine(template)

--- a/cmd/juju/application/series_selector_test.go
+++ b/cmd/juju/application/series_selector_test.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"github.com/juju/juju/juju/version"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
@@ -63,7 +64,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			force: true,
 			conf:  defaultSeries{},
 		},
-		expectedSeries: "xenial",
+		expectedSeries: version.SupportedLts(),
 	}, {
 		// Now charms with supported series.
 
@@ -150,8 +151,8 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 		expectedSeries: "precise",
 	}}
 
-	// Use xenial for LTS for all calls.
-	previous := series.SetLatestLtsForTesting("xenial")
+	// Use juju/juju/juju/version.SupportedLts() for LTS for all calls.
+	previous := series.SetLatestLtsForTesting(version.SupportedLts())
 	defer series.SetLatestLtsForTesting(previous)
 
 	for i, test := range deploySeriesTests {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -361,10 +361,9 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
 		ControllerConfig: coretesting.FakeControllerConfig(),
-		// TODO(redir): BBB: When we no longer support upstart based systems this can change to series.LatestLts()
-		BootstrapSeries: "xenial",
-		AdminSecret:     testing.AdminSecret,
-		CAPrivateKey:    coretesting.CAKey,
+		BootstrapSeries:  supportedversion.SupportedLts(),
+		AdminSecret:      testing.AdminSecret,
+		CAPrivateKey:     coretesting.CAKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

Some unit tests were testing functionality for latest lts hardcoding 'xenial'.
What was actually needed by these tests was the latest lts that juju supported. This PR changes these tests to go through newest method that defines what lts version a juju version supports.

