### PR TITLE
Fixes lp#1762600: mark an option as deprecated.

### DIFF
--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -99,6 +99,8 @@ func (c *statusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.backlogSizeDays, "days", 0, "Returns the logs for the past <days> days (cannot be combined with -n or --date)")
 	f.StringVar(&c.backlogDate, "from-date", "", "Returns logs for any date after the passed one, the expected date format is YYYY-MM-DD (cannot be combined with -n or --days)")
 	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
+	// TODO (anastasiamac 2018-04-11) Remove at the next major release, say Juju 2.5+ or Juju 3.x.
+	// the functionality is no longer there since a fix for lp#1530840
 	f.BoolVar(&c.includeStatusUpdates, "include-status-updates", false, "Deprecated, has no effect for 2.3+ controllers: Include update status hook messages in the returned logs")
 }
 

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -99,7 +99,7 @@ func (c *statusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.backlogSizeDays, "days", 0, "Returns the logs for the past <days> days (cannot be combined with -n or --date)")
 	f.StringVar(&c.backlogDate, "from-date", "", "Returns logs for any date after the passed one, the expected date format is YYYY-MM-DD (cannot be combined with -n or --days)")
 	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
-	f.BoolVar(&c.includeStatusUpdates, "include-status-updates", false, "Inlcude update status hook messages in the returned logs")
+	f.BoolVar(&c.includeStatusUpdates, "include-status-updates", false, "Deprecated, has no effect for 2.3+ controllers: Include update status hook messages in the returned logs")
 }
 
 func (c *statusHistoryCommand) Init(args []string) error {


### PR DESCRIPTION
## Description of change

We have changed the way status updates are being recorded as part of the fix for lp#1530840.

This PR marks the option that was used on show-status-log to filter status-update messages as deprected.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1762600
