### PR TITLE
2.3 Image Metadata for Containers on Other Providers

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -659,7 +660,8 @@ func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType)
 func (s *provisionerSuite) TestContainerManagerConfigKVM(c *gc.C) {
 	cfg := s.getManagerConfig(c, instance.KVM)
 	c.Assert(cfg, jc.DeepEquals, map[string]string{
-		container.ConfigModelUUID: coretesting.ModelTag.Id(),
+		container.ConfigModelUUID:      coretesting.ModelTag.Id(),
+		config.ContainerImageStreamKey: "released",
 	})
 }
 
@@ -668,7 +670,8 @@ func (s *provisionerSuite) TestContainerManagerConfigPermissive(c *gc.C) {
 	// will just return the basic type-independent configuration.
 	cfg := s.getManagerConfig(c, "invalid")
 	c.Assert(cfg, jc.DeepEquals, map[string]string{
-		container.ConfigModelUUID: coretesting.ModelTag.Id(),
+		container.ConfigModelUUID:      coretesting.ModelTag.Id(),
+		config.ContainerImageStreamKey: "released",
 	})
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/network/containerizer"
@@ -263,10 +264,16 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 	switch args.Type {
 	case instance.LXD:
 		// TODO(jam): DefaultMTU needs to be handled here
-		// TODO(jam): Do we want to handle ImageStream here, or do we
-		// hide it from them? (all cached images must come from the
-		// same image stream?)
 	}
+
+	mConfig, err := p.m.ModelConfig()
+	if err != nil {
+		return result, err
+	}
+	if url, set := mConfig.ContainerImageMetadataURL(); set {
+		cfg[config.ContainerImageMetadataURLKey] = url
+	}
+	cfg[config.ContainerImageStreamKey] = mConfig.ContainerImageStream()
 
 	result.ManagerConfig = cfg
 	return result, nil

--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -50,10 +50,11 @@ func (c *kvmContainer) Start(params StartParams) error {
 	sp := syncParams{
 		arch:    params.Arch,
 		series:  params.Series,
+		stream:  params.Stream,
 		ftype:   ftype,
 		srcFunc: srcFunc,
 	}
-	logger.Debugf("synchronise images for %s %s %s", sp.arch, sp.series, params.ImageDownloadURL)
+	logger.Debugf("synchronise images for %s %s %s %s", sp.arch, sp.series, sp.stream, params.ImageDownloadURL)
 	var callback ProgressCallback
 	if params.StatusCallback != nil {
 		callback = func(msg string) {

--- a/container/kvm/interface.go
+++ b/container/kvm/interface.go
@@ -12,6 +12,7 @@ import (
 type StartParams struct {
 	Series            string
 	Arch              string
+	Stream            string
 	UserDataFile      string
 	NetworkConfigData string
 	Network           *container.NetworkConfig

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/status"
@@ -27,7 +28,7 @@ import (
 var (
 	logger = loggo.GetLogger("juju.container.kvm")
 
-	// KvmObjectFactory imlements the container factory interface for kvm
+	// KvmObjectFactory implements the container factory interface for kvm
 	// containers.
 	KvmObjectFactory ContainerFactory = &containerFactory{}
 
@@ -57,7 +58,7 @@ var (
 var kvmPath = "/usr/sbin"
 
 // IsKVMSupported calls into the kvm-ok executable from the cpu-checkers package.
-// It is a variable to allow us to overrid behaviour in the tests.
+// It is a variable to allow us to override behaviour in the tests.
 var IsKVMSupported = func() (bool, error) {
 
 	// Prefer the user's $PATH first, but check /usr/sbin if we can't
@@ -103,17 +104,29 @@ func NewContainerManager(conf container.ManagerConfig) (container.Manager, error
 		logger.Infof("Availability zone will be empty for this container manager")
 	}
 
+	imageMetaDataURL := conf.PopValue(config.ContainerImageMetadataURLKey)
+	imageStream := conf.PopValue(config.ContainerImageStreamKey)
+
 	conf.WarnAboutUnused()
-	return &containerManager{namespace: namespace, logdir: logDir, availabilityZone: availabilityZone}, nil
+	return &containerManager{
+		namespace:        namespace,
+		logdir:           logDir,
+		availabilityZone: availabilityZone,
+		imageMetadataURL: imageMetaDataURL,
+		imageStream:      imageStream,
+	}, nil
 }
 
 // containerManager handles all of the business logic at the juju specific
 // level. It makes sure that the necessary directories are in place, that the
-// user-data is written out in the right place.
+// user-data is written out in the right place, and that OS images are sourced
+// from the correct location.
 type containerManager struct {
 	namespace        instance.Namespace
 	logdir           string
 	availabilityZone string
+	imageMetadataURL string
+	imageStream      string
 }
 
 var _ container.Manager = (*containerManager)(nil)
@@ -178,11 +191,17 @@ func (manager *containerManager) CreateContainer(
 	startParams.NetworkConfigData = containerinit.CloudInitNetworkConfigDisabled
 	startParams.StatusCallback = callback
 
-	// If the Simplestream requested is anything but released, update
-	// our StartParams to request it.
-	if instanceConfig.ImageStream != imagemetadata.ReleasedStream {
-		startParams.ImageDownloadURL = imagemetadata.UbuntuCloudImagesURL + "/" + instanceConfig.ImageStream
+	// Check whether a container image metadata URL was configured.
+	// Default to Ubuntu cloud images if configured stream is not "released".
+	imURL := manager.imageMetadataURL
+	if manager.imageMetadataURL == "" && manager.imageStream != imagemetadata.ReleasedStream {
+		imURL = imagemetadata.UbuntuCloudImagesURL
+		imURL, err = imagemetadata.ImageMetadataURL(imURL, manager.imageStream)
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "generating image metadata source")
+		}
 	}
+	startParams.ImageDownloadURL = imURL
 
 	var hardware instance.HardwareCharacteristics
 	hardware, err = instance.ParseHardware(
@@ -246,7 +265,7 @@ func (manager *containerManager) ListContainers() (result []instance.Instance, e
 	return
 }
 
-// ParseConstraintsToStartParams takes a constrants object and returns a bare
+// ParseConstraintsToStartParams takes a constraints object and returns a bare
 // StartParams object that has Memory, Cpu, and Disk populated.  If there are
 // no defined values in the constraints for those fields, default values are
 // used.  Other constrains cause a warning to be emitted.

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -190,6 +190,7 @@ func (manager *containerManager) CreateContainer(
 	startParams.UserDataFile = userDataFilename
 	startParams.NetworkConfigData = containerinit.CloudInitNetworkConfigDisabled
 	startParams.StatusCallback = callback
+	startParams.Stream = manager.imageStream
 
 	// Check whether a container image metadata URL was configured.
 	// Default to Ubuntu cloud images if configured stream is not "released".

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -127,6 +127,7 @@ func (s *KVMSuite) TestCreateContainerUtilizesReleaseSimpleStream(c *gc.C) {
 	containertesting.CreateContainerWithMachineConfig(c, s.manager, instanceConfig)
 
 	c.Assert(kvm.TestStartParams.ImageDownloadURL, gc.Equals, "")
+	c.Assert(kvm.TestStartParams.Stream, gc.Equals, "released")
 }
 
 // Test that CreateContainer creates proper startParams.
@@ -147,6 +148,7 @@ func (s *KVMSuite) TestCreateContainerUtilizesDailySimpleStream(c *gc.C) {
 	containertesting.CreateContainerWithMachineConfig(c, s.manager, instanceConfig)
 
 	c.Assert(kvm.TestStartParams.ImageDownloadURL, gc.Equals, "http://cloud-images.ubuntu.com/daily")
+	c.Assert(kvm.TestStartParams.Stream, gc.Equals, "daily")
 }
 
 func (s *KVMSuite) TestCreateContainerUtilizesSetImageMetadataURL(c *gc.C) {
@@ -173,15 +175,17 @@ func (s *KVMSuite) TestStartContainerUtilizesSimpleStream(c *gc.C) {
 	startParams := kvm.StartParams{
 		Series:           "mocked-series",
 		Arch:             "mocked-arch",
+		Stream:           "released",
 		ImageDownloadURL: "mocked-url",
 	}
 	mockedContainer := kvm.NewEmptyKvmContainer()
 	mockedContainer.Start(startParams)
 
 	expectedArgs := fmt.Sprintf(
-		"synchronise images for %s %s %s",
+		"synchronise images for %s %s %s %s",
 		startParams.Arch,
 		startParams.Series,
+		startParams.Stream,
 		startParams.ImageDownloadURL,
 	)
 	c.Assert(c.GetTestLog(), jc.Contains, expectedArgs)

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -39,8 +39,8 @@ type Oner interface {
 
 // syncParams conveys the information necessary for calling imagedownloads.One.
 type syncParams struct {
-	arch, series, ftype string
-	srcFunc             func() simplestreams.DataSource
+	arch, series, stream, ftype string
+	srcFunc                     func() simplestreams.DataSource
 }
 
 // One implements Oner.
@@ -48,7 +48,7 @@ func (p syncParams) One() (*imagedownloads.Metadata, error) {
 	if err := p.exists(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return imagedownloads.One(p.arch, p.series, p.ftype, p.srcFunc)
+	return imagedownloads.One(p.arch, p.series, p.stream, p.ftype, p.srcFunc)
 }
 
 func (p syncParams) exists() error {

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -5,7 +5,15 @@
 
 package lxd
 
+import (
+	"github.com/juju/juju/container"
+	"github.com/juju/juju/tools/lxdclient"
+)
+
 var (
-	NICDevice      = nicDevice
-	NetworkDevices = networkDevices
+	NICDevice       = nicDevice
+	NetworkDevices  = networkDevices
+	GetImageSources = func(mgr container.Manager) ([]lxdclient.Remote, error) {
+		return mgr.(*containerManager).getImageSources()
+	}
 )

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -80,6 +80,14 @@ const (
 	// AgentMetadataURLKey stores the key for this setting.
 	AgentMetadataURLKey = "agent-metadata-url"
 
+	// ContainerImageStreamKey is the key used to specify the stream
+	// to for container OS images.
+	ContainerImageStreamKey = "container-image-stream"
+
+	// ContainerImageMetadataURLKey is the key used to specify the location
+	// of OS image metadata for containers.
+	ContainerImageMetadataURLKey = "container-image-metadata-url"
+
 	// HTTPProxyKey stores the key for this setting.
 	HTTPProxyKey = "http-proxy"
 
@@ -184,7 +192,7 @@ const (
 	CloudInitUserDataKey = "cloudinit-userdata"
 
 	// ContainerInheritProperiesKey is the key to specify a list of properties
-	// to be copied from a machine to a container during provisioning.  The
+	// to be copied from a machine to a container during provisioning. The
 	// list will be comma separated.
 	ContainerInheritProperiesKey = "container-inherit-properties"
 
@@ -398,10 +406,12 @@ var defaultConfigValues = map[string]interface{}{
 	ContainerInheritProperiesKey: "",
 
 	// Image and agent streams and URLs.
-	"image-stream":       "released",
-	"image-metadata-url": "",
-	AgentStreamKey:       "released",
-	AgentMetadataURLKey:  "",
+	"image-stream":               "released",
+	"image-metadata-url":         "",
+	AgentStreamKey:               "released",
+	AgentMetadataURLKey:          "",
+	ContainerImageStreamKey:      "released",
+	ContainerImageMetadataURLKey: "",
 
 	// Log forward settings.
 	LogForwardEnabled: false,
@@ -939,10 +949,19 @@ func (c *Config) AgentMetadataURL() (string, bool) {
 	return "", false
 }
 
-// ImageMetadataURL returns the URL at which the metadata used to locate image ids is located,
-// and wether it has been set.
+// ImageMetadataURL returns the URL at which the metadata used to locate image
+// ids is located, and whether it has been set.
 func (c *Config) ImageMetadataURL() (string, bool) {
 	if url, ok := c.defined["image-metadata-url"]; ok && url != "" {
+		return url.(string), true
+	}
+	return "", false
+}
+
+// ContainerImageMetadataURL returns the URL at which the metadata used to
+// locate container OS image ids is located, and whether it has been set.
+func (c *Config) ContainerImageMetadataURL() (string, bool) {
+	if url, ok := c.defined[ContainerImageMetadataURLKey]; ok && url != "" {
 		return url.(string), true
 	}
 	return "", false
@@ -1037,6 +1056,16 @@ func (c *Config) ImageStream() string {
 // when bootstrapping or upgrading an environment.
 func (c *Config) AgentStream() string {
 	v, _ := c.defined[AgentStreamKey].(string)
+	if v != "" {
+		return v
+	}
+	return "released"
+}
+
+// ContainerImageStream returns the simplestreams stream used to identify which
+// image ids to search when starting a container.
+func (c *Config) ContainerImageStream() string {
+	v, _ := c.defined[ContainerImageStreamKey].(string)
 	if v != "" {
 		return v
 	}
@@ -1284,6 +1313,8 @@ var alwaysOptional = schema.Defaults{
 	"image-stream":               schema.Omit,
 	"image-metadata-url":         schema.Omit,
 	AgentMetadataURLKey:          schema.Omit,
+	ContainerImageStreamKey:      schema.Omit,
+	ContainerImageMetadataURLKey: schema.Omit,
 	"default-series":             schema.Omit,
 	"development":                schema.Omit,
 	"ssl-hostname-verification":  schema.Omit,
@@ -1576,6 +1607,16 @@ global or per instance security groups.`,
 	},
 	"image-stream": {
 		Description: `The simplestreams stream used to identify which image ids to search when starting an instance.`,
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	ContainerImageMetadataURLKey: {
+		Description: "The URL at which the metadata used to locate container OS image ids is located",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	ContainerImageStreamKey: {
+		Description: `The simplestreams stream used to identify which image ids to search when starting a container.`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -90,18 +90,20 @@ var configTests = []configTest{
 		useDefaults: config.UseDefaults,
 		attrs:       minimalConfigAttrs,
 	}, {
-		about:       "Agent Stream",
+		about:       "Streams",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"image-metadata-url": "image-url",
-			"agent-stream":       "released",
+			"image-stream":           "released",
+			"agent-stream":           "released",
+			"container-image-stream": "daily",
 		}),
 	}, {
 		about:       "Metadata URLs",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"image-metadata-url": "image-url",
-			"agent-metadata-url": "agent-metadata-url-value",
+			"image-metadata-url":           "image-url",
+			"agent-metadata-url":           "agent-metadata-url-value",
+			"container-image-metadata-url": "container-image-metadata-url-value",
 		}),
 	}, {
 		about:       "Explicit series",
@@ -714,6 +716,20 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 		}
 	}
 	c.Assert(agentStreamValue, gc.Equals, expectedAgentStreamAttr)
+
+	containerURL, urlPresent := cfg.ContainerImageMetadataURL()
+	if v, _ := test.attrs["container-image-metadata-url"].(string); v != "" {
+		c.Assert(containerURL, gc.Equals, v)
+		c.Assert(urlPresent, jc.IsTrue)
+	} else {
+		c.Assert(urlPresent, jc.IsFalse)
+	}
+
+	if v, ok := test.attrs["container-image-stream"]; ok {
+		c.Assert(cfg.ContainerImageStream(), gc.Equals, v)
+	} else {
+		c.Assert(cfg.ContainerImageStream(), gc.Equals, "released")
+	}
 
 	resourceTags, cfgHasResourceTags := cfg.ResourceTags()
 	c.Assert(cfgHasResourceTags, jc.IsTrue)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1396,3 +1396,44 @@ func DeleteCloudImageMetadata(st *State) error {
 	_, err := bulk.Run()
 	return errors.Annotate(err, "deleting cloud image metadata records")
 }
+
+// UpgradeDefaultContainerImageStreamConfig ensures that the config value for
+// container-image-stream is set to its default value, "released".
+func UpgradeContainerImageStreamDefault(st *State) error {
+	coll, closer := st.db().GetRawCollection(settingsC)
+	defer closer()
+	iter := coll.Find(bson.D{}).Iter()
+	defer iter.Close()
+
+	var ops []txn.Op
+	var doc settingsDoc
+	for iter.Next(&doc) {
+		needsWrite := false
+		ciStreamVal, keySet := doc.Settings[config.ContainerImageStreamKey]
+		if !keySet {
+			needsWrite = true
+		} else {
+			if ciStream, _ := ciStreamVal.(string); ciStream == "" {
+				needsWrite = true
+			}
+		}
+		if !needsWrite {
+			continue
+		}
+
+		doc.Settings[config.ContainerImageStreamKey] = "released"
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     doc.DocID,
+			Assert: txn.DocExists,
+			Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
+		})
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runRawTransaction(ops))
+	}
+	return nil
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2153,3 +2153,44 @@ func (s *upgradesSuite) TestDeleteCloudImageMetadata(c *gc.C) {
 	defer closer()
 	s.assertUpgradedData(c, DeleteCloudImageMetadata, expectUpgradedData{coll, expected})
 }
+
+func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = settingsColl.Insert(
+		bson.M{
+			"_id":      "foo",
+			"settings": bson.M{"other-setting": "val"},
+		},
+		bson.M{
+			"_id":      "bar",
+			"settings": bson.M{"container-image-stream": "", "other-setting": "val"},
+		},
+		bson.M{
+			"_id":      "baz",
+			"settings": bson.M{"container-image-stream": "daily"},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSettings := []bson.M{
+		{
+			"_id":      "bar",
+			"settings": bson.M{"container-image-stream": "released", "other-setting": "val"},
+		},
+		{
+			"_id":      "baz",
+			"settings": bson.M{"container-image-stream": "daily"},
+		},
+		{
+			"_id":      "foo",
+			"settings": bson.M{"container-image-stream": "released", "other-setting": "val"},
+		},
+	}
+
+	s.assertUpgradedData(c, UpgradeContainerImageStreamDefault,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}

--- a/tools/lxdclient/remote.go
+++ b/tools/lxdclient/remote.go
@@ -61,7 +61,6 @@ var CloudImagesDailyRemote = Remote{
 }
 
 var generateCertificate = func() ([]byte, []byte, error) { return lxdshared.GenerateMemCert(true) }
-var DefaultImageSources = []Remote{CloudImagesRemote, CloudImagesDailyRemote}
 
 // Remote describes a LXD "remote" server for a client. In
 // particular it holds the information needed for the client

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -35,6 +35,7 @@ type StateBackend interface {
 	AddRelationStatus() error
 	MoveOldAuditLog() error
 	DeleteCloudImageMetadata() error
+	EnsureContainerImageStreamDefault() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -139,4 +140,8 @@ func (s stateBackend) MoveOldAuditLog() error {
 
 func (s stateBackend) DeleteCloudImageMetadata() error {
 	return state.DeleteCloudImageMetadata(s.st)
+}
+
+func (s stateBackend) EnsureContainerImageStreamDefault() error {
+	return state.UpgradeContainerImageStreamDefault(s.st)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -29,6 +29,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.3.1"), stateStepsFor231()},
 		upgradeToVersion{version.MustParse("2.3.2"), stateStepsFor232()},
 		upgradeToVersion{version.MustParse("2.3.4"), stateStepsFor234()},
+		upgradeToVersion{version.MustParse("2.3.6"), stateStepsFor236()},
 	}
 	return steps
 }

--- a/upgrades/steps_236.go
+++ b/upgrades/steps_236.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor236 returns upgrade steps for Juju 2.3.6 that manipulate state directly.
+func stateStepsFor236() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "ensure container-image-stream config defaults to released",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureContainerImageStreamDefault()
+			},
+		},
+	}
+}

--- a/upgrades/steps_236_test.go
+++ b/upgrades/steps_236_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v236 = version.MustParse("2.3.6")
+
+type steps236Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps236Suite{})
+
+func (s *steps236Suite) TestEnsureContainerImageStreamDefault(c *gc.C) {
+	step := findStateStep(c, v236, "ensure container-image-stream config defaults to released")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -645,6 +645,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.3.1",
 		"2.3.2",
 		"2.3.4",
+		"2.3.6",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Linked bug reports that the LXD provider honours the image-metadata-url, but LXD containers deployed on other providers do not.

This change introduces new configuration options specifically for use by container managers:
- container-image-metadata-url
- container-image-stream

The simplestreams searching did not work previously for KVM using a non-default stream. Changes to the KVM container manager and simplestreams meta-data filtering now rectify this.

An upgrade step has been added to ensure that the default value of "released" is set for the new _container-image-stream_ configuration value.

## QA steps

- New unit tests
- Tested adding LXD container machines; verified that images are searched for based on configuration and that default Ubuntu cloud image sources are used as a fall-back.
- Tested adding LXD container machines; verified that images are searched for based on configuration and that using the daily stream works.
- Tested bootstrapping and adding machines with 2.3.5, upgrading to 2.3.6 and ensuring that machines can still be added, honouring the new configuration settings.

## Documentation changes

New configuration options will need documentation.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1606617
