### PR TITLE
Inverted unit resolve

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -563,7 +563,7 @@ func (s *clientSuite) TestForceDestroyMachines(c *gc.C) {
 	s.assertForceDestroyMachines(c)
 }
 
-func (s *clientSuite) testClientUnitResolved(c *gc.C, noretry bool, expectedResolvedMode state.ResolvedMode) {
+func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolvedMode state.ResolvedMode) {
 	// Setup:
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
@@ -577,7 +577,7 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, noretry bool, expectedReso
 	err = u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	// Code under test:
-	err = s.APIState.Client().Resolved("wordpress/0", noretry)
+	err = s.APIState.Client().Resolved("wordpress/0", retry)
 	c.Assert(err, jc.ErrorIsNil)
 	// Freshen the unit's state.
 	err = u.Refresh()
@@ -589,11 +589,11 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, noretry bool, expectedReso
 }
 
 func (s *clientSuite) TestClientUnitResolved(c *gc.C) {
-	s.testClientUnitResolved(c, true, state.ResolvedNoHooks)
+	s.testClientUnitResolved(c, false, state.ResolvedNoHooks)
 }
 
 func (s *clientSuite) TestClientUnitResolvedRetry(c *gc.C) {
-	s.testClientUnitResolved(c, false, state.ResolvedRetryHooks)
+	s.testClientUnitResolved(c, true, state.ResolvedRetryHooks)
 }
 
 func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
@@ -612,7 +612,7 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 }
 
 func (s *clientSuite) assertResolved(c *gc.C, u *state.Unit) {
-	err := s.APIState.Client().Resolved("wordpress/0", false)
+	err := s.APIState.Client().Resolved("wordpress/0", true)
 	c.Assert(err, jc.ErrorIsNil)
 	// Freshen the unit's state.
 	err = u.Refresh()

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -128,8 +128,8 @@ timing:
 		withClientWait:    "6s",
 		withClientQueryID: validActionId,
 		// Wait just slightly less than the 2s tick time, to make sure it times out first
-		withAPITimeout:    3900 * time.Millisecond,
-		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
+		withAPITimeout: 3900 * time.Millisecond,
+		withTags:       tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status: "running",
 			Output: map[string]interface{}{

--- a/cmd/juju/commands/resolved.go
+++ b/cmd/juju/commands/resolved.go
@@ -57,5 +57,5 @@ func (c *resolvedCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	return block.ProcessBlockedError(client.Resolved(c.UnitName, c.NoRetry), block.BlockChange)
+	return block.ProcessBlockedError(client.Resolved(c.UnitName, !c.NoRetry), block.BlockChange)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -2445,7 +2445,7 @@ func (u *Unit) RunningActions() ([]Action, error) {
 // reestablish normal workflow. The retryHooks parameter informs
 // whether to attempt to reexecute previous failed hooks or to continue
 // as if they had succeeded before.
-func (u *Unit) Resolve(noretryHooks bool) error {
+func (u *Unit) Resolve(retryHooks bool) error {
 	// We currently check agent status to see if a unit is
 	// in error state. As the new Juju Health work is completed,
 	// this will change to checking the unit status.
@@ -2456,9 +2456,9 @@ func (u *Unit) Resolve(noretryHooks bool) error {
 	if statusInfo.Status != status.Error {
 		return errors.Errorf("unit %q is not in an error state", u)
 	}
-	mode := ResolvedRetryHooks
-	if noretryHooks {
-		mode = ResolvedNoHooks
+	mode := ResolvedNoHooks
+	if retryHooks {
+		mode = ResolvedRetryHooks
 	}
 	return u.SetResolved(mode)
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1040,9 +1040,9 @@ func (s *UnitSuite) TestUnitWaitAgentPresence(c *gc.C) {
 }
 
 func (s *UnitSuite) TestResolve(c *gc.C) {
-	err := s.unit.Resolve(false)
+	err := s.unit.Resolve(true)
 	c.Assert(err, gc.ErrorMatches, `unit "wordpress/0" is not in an error state`)
-	err = s.unit.Resolve(true)
+	err = s.unit.Resolve(false)
 	c.Assert(err, gc.ErrorMatches, `unit "wordpress/0" is not in an error state`)
 
 	now := coretesting.NonZeroTime()
@@ -1053,17 +1053,17 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 	}
 	err = s.unit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.unit.Resolve(false)
-	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(true)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.Resolve(false)
 	c.Assert(err, gc.ErrorMatches, `cannot set resolved mode for unit "wordpress/0": already resolved`)
 	c.Assert(s.unit.Resolved(), gc.Equals, state.ResolvedRetryHooks)
 
 	err = s.unit.ClearResolved()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.unit.Resolve(true)
-	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(false)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.Resolve(true)
 	c.Assert(err, gc.ErrorMatches, `cannot set resolved mode for unit "wordpress/0": already resolved`)
 	c.Assert(s.unit.Resolved(), gc.Equals, state.ResolvedNoHooks)
 }


### PR DESCRIPTION
## Description of change

The resolve --no-retry behaviour is inverted.
This is because state.Unit.Resolve() is incorrect. The default behaviour was changed but the state method wasn't changed to match.

## QA steps

Deploy a charm with a deliberate error in the install hook
juju resolve will re-run the install hook and the unit will stay in error.
juju resolve --no-retry will move onto the start hook and unit will have the error cleared

## Documentation changes

We should check the doc is correct

## Bug reference

https://bugs.launchpad.net/juju/+bug/1762979