### PR TITLE
Fixes lp#1638714: Clarify upgrade message further.

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -690,7 +690,7 @@ func IsUpgradeInProgressError(err error) bool {
 // cannot be higher than the controller version.
 func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVersions bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
-		return errors.Errorf("model (%s) cannot be upgraded to a later version than the controller (%s): upgrade 'controller' model first",
+		return errors.Errorf("model cannot be upgraded to %s while the controller is %s: upgrade 'controller' model first",
 			newVersion.String(),
 			jujuversion.Current,
 		)

--- a/state/state.go
+++ b/state/state.go
@@ -690,7 +690,7 @@ func IsUpgradeInProgressError(err error) bool {
 // cannot be higher than the controller version.
 func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVersions bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
-		return errors.Errorf("hosted models cannot be upgraded to a later version than the controller: %s > %s: upgrade 'controller' model first",
+		return errors.Errorf("model (%s) cannot be upgraded to a later version than the controller (%s): upgrade 'controller' model first",
 			newVersion.String(),
 			jujuversion.Current,
 		)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3751,7 +3751,7 @@ func (s *StateSuite) TestSetModelAgentVersionOnOtherModel(c *gc.C) {
 
 	// Set other model version to > server version
 	err = otherSt.SetModelAgentVersion(higher.Number, false)
-	expected := fmt.Sprintf("hosted models cannot be upgraded to a later version than the controller: %s > %s: upgrade 'controller' model first",
+	expected := fmt.Sprintf("model (%s) cannot be upgraded to a later version than the controller (%s): upgrade 'controller' model first",
 		higher.Number,
 		jujuversion.Current,
 	)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3751,7 +3751,7 @@ func (s *StateSuite) TestSetModelAgentVersionOnOtherModel(c *gc.C) {
 
 	// Set other model version to > server version
 	err = otherSt.SetModelAgentVersion(higher.Number, false)
-	expected := fmt.Sprintf("model (%s) cannot be upgraded to a later version than the controller (%s): upgrade 'controller' model first",
+	expected := fmt.Sprintf("model cannot be upgraded to %s while the controller is %s: upgrade 'controller' model first",
 		higher.Number,
 		jujuversion.Current,
 	)


### PR DESCRIPTION
## Description of change

We have already clarified an upgrade message sent to users to clear up the confusion around model's vs controller's version (see linked bug).

However, a great recent suggestion made us circle back and clear the message further.

With this PR, if users are trying to upgrade their models before upgrading the controller, they will get a message similar to this one:

```model cannot be upgraded to 2.3.5 while the controller is 2.3.3: upgrade 'controller' model first```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1638714
