### PR TITLE
re-enable skipped test for lp 1466514

### DIFF
--- a/cmd/jujud/agent/machine_charms_test.go
+++ b/cmd/jujud/agent/machine_charms_test.go
@@ -45,7 +45,6 @@ func (s *MachineWithCharmsSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *MachineWithCharmsSuite) TestManageModelRunsCharmRevisionUpdater(c *gc.C) {
-	coretesting.SkipFlaky(c, "lp:1466514")
 	m, _, _ := s.primeAgent(c, state.JobManageModel)
 
 	s.SetupScenario(c)


### PR DESCRIPTION
## Description of change

This PR re-enables the test that was skipped due to the flaky implementation. Implementation was fixed as part of the fix for the linked bug.

## Bug reference
Related to https://bugs.launchpad.net/juju/+bug/1466514
