### PR TITLE
Fix CAAS data model for container addresses and add base import/export

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1113,7 +1113,10 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 		// For CAAS units we want to provide the container address.
 		container, err := unit.ContainerInfo()
 		if err == nil {
-			result.Address = container.Address()
+			addr := container.Address()
+			if addr != nil {
+				result.Address = addr.Value
+			}
 		} else {
 			logger.Debugf("error fetching container address: %v", err)
 		}
@@ -1156,7 +1159,11 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 		logger.Debugf("error fetching container info: %v", err)
 	} else if err == nil {
 		result.ProviderId = containerInfo.ProviderId()
-		result.Address = containerInfo.Address()
+		addr := containerInfo.Address()
+		if addr != nil {
+			result.Address = addr.Value
+		}
+
 		if len(result.OpenedPorts) == 0 {
 			result.OpenedPorts = containerInfo.Ports()
 		}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,9 +13,9 @@ github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
 github.com/ghodss/yaml	git	73d445a93680fa1a78ae23a5839bad48f32ba1ee	2015-09-09T03:16:57Z
 github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T22:25:50Z
-github.com/golang/mock	git	69521b3833175dfcfb1cc1fdb0c9be92e66faa81	2018-04-03T23:54:22Z
 github.com/gogo/protobuf	git	c0656edd0d9eab7c66d1eb0c568f9039345796f7	2017-03-30T07:10:51Z
 github.com/golang/glog	git	23def4e6c14b4da8ac2ed8007337bc5eb5007998	2016-01-26T23:53:08Z
+github.com/golang/mock	git	69521b3833175dfcfb1cc1fdb0c9be92e66faa81	2018-04-03T23:54:22Z
 github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-09T07:27:36Z
 github.com/google/go-querystring	git	9235644dd9e52eeae6fa48efd539fdc351a0af53	2016-04-01T23:30:42Z
 github.com/google/gofuzz	git	24818f796faf91cd76ec7bddd72458fbced7a6c1	2017-06-12T17:47:53Z
@@ -36,7 +36,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	1a6490253bea4ce78594db114d787ca97ee9f527	2018-01-09T11:21:21Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
-github.com/juju/description	git	83beb4e3593c52f6145454291e019f58a5897e47	2018-04-09T06:23:21Z
+github.com/juju/description	git	4005001e8e767301af5abd1768b2f934347f1db3	2018-04-13T05:19:25Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65	2017-11-13T08:59:48Z
 github.com/juju/go-oracle-cloud	git	932a8cea00a1cd5cba3829a672c823955db674ae	2017-04-21T13:45:47Z

--- a/state/application.go
+++ b/state/application.go
@@ -1386,7 +1386,9 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 				containerDoc.ProviderId = *args.providerId
 			}
 			if args.address != nil {
-				containerDoc.Address = *args.address
+				networkAddr := network.NewScopedAddress(*args.address, network.ScopeMachineLocal)
+				addr := fromNetworkAddress(networkAddr, OriginProvider)
+				containerDoc.Address = &addr
 			}
 			if args.ports != nil {
 				containerDoc.Ports = *args.ports

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3424,7 +3424,8 @@ func (s *CAASApplicationSuite) TestUpdateCAASUnits(c *gc.C) {
 	info, ok := containerInfoById["unit-uuid"]
 	c.Assert(ok, jc.IsTrue)
 	c.Check(u.Name(), gc.Equals, existingUnit.Name())
-	c.Check(info.Address(), gc.Equals, "192.168.1.2")
+	c.Check(info.Address(), gc.NotNil)
+	c.Check(*info.Address(), gc.DeepEquals, network.NewScopedAddress("192.168.1.2", network.ScopeMachineLocal))
 	c.Check(info.Ports(), jc.DeepEquals, []string{"443"})
 	statusInfo, err := u.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3452,7 +3453,8 @@ func (s *CAASApplicationSuite) TestUpdateCAASUnits(c *gc.C) {
 	info, ok = containerInfoById["new-unit-uuid"]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(u.Name(), gc.Equals, "wordpress/2")
-	c.Assert(info.Address(), gc.Equals, "192.168.1.1")
+	c.Check(info.Address(), gc.NotNil)
+	c.Check(*info.Address(), gc.DeepEquals, network.NewScopedAddress("192.168.1.1", network.ScopeMachineLocal))
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 	addr, err := u.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -8,6 +8,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/network"
 )
 
 // CloudContainer represents the state of a CAAS container, eg pod.
@@ -17,7 +19,7 @@ type CloudContainer interface {
 	ProviderId() string
 
 	// Address returns the container address.
-	Address() string
+	Address() *network.Address
 
 	// Ports returns the open container ports.
 	Ports() []string
@@ -35,7 +37,7 @@ type cloudContainerDoc struct {
 	Id string `bson:"_id"`
 
 	ProviderId string   `bson:"provider-id"`
-	Address    string   `bson:"address"`
+	Address    *address `bson:"address"`
 	Ports      []string `bson:"ports"`
 }
 
@@ -50,8 +52,12 @@ func (c *cloudContainer) ProviderId() string {
 }
 
 // Address implements CloudContainer.
-func (c *cloudContainer) Address() string {
-	return c.doc.Address
+func (c *cloudContainer) Address() *network.Address {
+	if c.doc.Address == nil {
+		return nil
+	}
+	addr := c.doc.Address.networkAddress()
+	return &addr
 }
 
 // Ports implements CloudContainer.

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -58,7 +58,7 @@ func (a *Application) cloudService() (*cloudServiceDoc, error) {
 	var doc cloudServiceDoc
 	err := coll.FindId(a.globalKey()).One(&doc)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("cloud service for unit %v", a.Name())
+		return nil, errors.NotFoundf("cloud service for application %v", a.Name())
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -71,6 +71,11 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		storageInstancesC,
 		volumesC,
 		volumeAttachmentsC,
+
+		// caas
+		podSpecsC,
+		cloudContainersC,
+		cloudServicesC,
 	)
 
 	ignoredCollections := set.NewStrings(
@@ -195,11 +200,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		externalControllersC,
 		relationNetworksC,
 		firewallRulesC,
-
-		// TODO(caas)
-		podSpecsC,
-		cloudContainersC,
-		cloudServicesC,
 	)
 
 	envCollections := set.NewStrings()

--- a/state/podspec.go
+++ b/state/podspec.go
@@ -13,9 +13,12 @@ import (
 )
 
 type containerSpecDoc struct {
-	Tag       string `bson:"_id"`
-	ModelUUID string `bson:"model-uuid"`
-	Spec      string `bson:"spec"`
+	// Id holds container spec document key.
+	// It is the global key of the application represented
+	// by this container.
+	Id string `bson:"_id"`
+
+	Spec string `bson:"spec"`
 }
 
 // SetPodSpec sets the pod spec for the given application tag.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2025,7 +2025,8 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitProviderId(c *gc.C) {
 	info, err := existingUnit.ContainerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
-	c.Assert(info.Address(), gc.Equals, "192.168.1.1")
+	addr := network.NewScopedAddress("192.168.1.1", network.ScopeMachineLocal)
+	c.Assert(info.Address(), gc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
@@ -2045,7 +2046,8 @@ func (s *CAASUnitSuite) TestAddCAASUnitProviderId(c *gc.C) {
 	info, err := existingUnit.ContainerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
-	c.Assert(info.Address(), gc.Equals, "192.168.1.1")
+	c.Check(info.Address(), gc.NotNil)
+	c.Check(*info.Address(), jc.DeepEquals, network.NewScopedAddress("192.168.1.1", network.ScopeMachineLocal))
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
@@ -2066,7 +2068,8 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitAddress(c *gc.C) {
 	info, err := existingUnit.ContainerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	c.Assert(info.Address(), gc.Equals, "192.168.1.2")
+	addr := network.NewScopedAddress("192.168.1.2", network.ScopeMachineLocal)
+	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
@@ -2087,7 +2090,8 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitPorts(c *gc.C) {
 	info, err := existingUnit.ContainerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	c.Assert(info.Address(), gc.Equals, "192.168.1.1")
+	addr := network.NewScopedAddress("192.168.1.1", network.ScopeMachineLocal)
+	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"443"})
 }
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -3218,12 +3218,12 @@ func (w *containerAddressesWatcher) loop() error {
 	w.watcher.Watch(cloudContainersC, id, revno, containerCh)
 	defer w.watcher.Unwatch(cloudContainersC, id, containerCh)
 
-	var address string
+	var currentAddress *address
 	container, err := w.unit.cloudContainer()
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	} else if err == nil {
-		address = container.Address
+		currentAddress = container.Address
 	}
 	out := w.out
 	for {
@@ -3237,9 +3237,15 @@ func (w *containerAddressesWatcher) loop() error {
 			if err != nil {
 				return err
 			}
+			addressValue := func(addr *address) string {
+				if addr == nil {
+					return ""
+				}
+				return addr.Value
+			}
 			newAddress := container.Address
-			if newAddress != address {
-				address = newAddress
+			if addressValue(newAddress) != addressValue(currentAddress) {
+				currentAddress = newAddress
 				out = w.out
 			}
 		case out <- struct{}{}:

--- a/worker/presence/presence.go
+++ b/worker/presence/presence.go
@@ -164,7 +164,7 @@ func (w *wrapper) agentDisconnect(topic string, data apiserver.APIConnection, er
 		w.logger.Errorf("agentDisconnect error %v", err)
 		return
 	}
-	w.logger.Tracef("api disconnect %s (%s)", data.Origin, data.ConnectionID)
+	w.logger.Tracef("api disconnect %s (%v)", data.Origin, data.ConnectionID)
 	w.recorder.Disconnect(data.Origin, data.ConnectionID)
 }
 


### PR DESCRIPTION
## Description of change

We want to migrate caas models. This PR adds the base model export / import.
It also fixes the container address model to use a proper network address struct instead of a string.

The next PR will fix migration pre-checks etc to be caas compatible.

As a drive by, fix a dependencies.tsv ordering issue.

## QA steps

Basic smoke test of migrating iaas model.

