### PR TITLE
Better tests for credential validator worker.

### DIFF
--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -34,7 +34,6 @@ var (
 		"action-pruner",
 		"charm-revision-updater",
 		"compute-provisioner",
-		"credential-validator-flag",
 		"environ-tracker",
 		"firewaller",
 		"instance-poller",


### PR DESCRIPTION
## Description of change

Based on review comments in PR #8586, this PR improves credential validator worker tests:
 * in worker pkg itself - watcher is constructed deterministically and sends definitive changes; added compliant StartStop test;
* in cmd/jujud/agent pkg - only models with cloud credential are expected to have a credential validator worker.   

## QA steps

Internal change so all unit tests are expected to pass.

