### PR TITLE
Juju 1751321 runoptions

### DIFF
--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -53,13 +53,13 @@ are able to use this command.
 Targets are specified using either machine ids, application names or unit
 names.  At least one target specifier is needed.
 
-Multiple values can be set for --machine, --application and --unit by using
+Multiple values can be set for --machine, --application, and --unit by using
 comma separated values.
 
 If the target is a machine, the command is run as the "root" user on
 the remote machine.
 
-Few options are shorted for usabilty purpose in CLI
+Some options are shortened for usabilty purpose in CLI
 --application can also be specified as --app and -a
 --unit can also be specified as -u
 --timeout can also be specified as -t
@@ -106,16 +106,14 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 		"default": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
-	for _, flag := range[]string{"timeout", "t"} {
-		f.DurationVar(&c.timeout, flag, 5*time.Minute, "How long to wait before the remote command is considered to have failed")
-	}
+	f.DurationVar(&c.timeout, "t", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
+	f.DurationVar(&c.timeout, "timeout", 0, "")
 	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
-	for _, flag := range[]string{"application", "app", "a"} {
-		f.Var(cmd.NewStringsValue(nil, &c.services), flag, "One or more application names")
-	}
-	for _, flag := range[]string{"unit", "u"} {
-		f.Var(cmd.NewStringsValue(nil, &c.units), flag, "One or more unit ids")
-	}
+	f.Var(cmd.NewStringsValue(nil, &c.services), "a", "One or more application names")
+	f.Var(cmd.NewStringsValue(nil, &c.services), "app", "")
+	f.Var(cmd.NewStringsValue(nil, &c.services), "application", "")
+	f.Var(cmd.NewStringsValue(nil, &c.units), "u", "One or more unit ids")
+	f.Var(cmd.NewStringsValue(nil, &c.units), "unit", "")
 }
 
 func (c *runCommand) Init(args []string) error {

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -53,21 +53,23 @@ are able to use this command.
 Targets are specified using either machine ids, application names or unit
 names.  At least one target specifier is needed.
 
-Multiple values can be set for --machine, --application/--app/-a, and --unit/-u by using
+Multiple values can be set for --machine, --application and --unit by using
 comma separated values.
 
 If the target is a machine, the command is run as the "root" user on
 the remote machine.
 
+Few options are shorted for usabilty purpose in CLI
+--application can also be specified as --app and -a
+--unit can also be specified as -u
+--timeout can also be specified as -t
+
 If the target is an application, the command is run on all units for that
 application. For example, if there was an application "mysql" and that application
 had two units, "mysql/0" and "mysql/1", then
   --application mysql
-  --app mysql
-   -a mysql
 is equivalent to
   --unit mysql/0,mysql/1
-   -u mysql/0,mysql/1
 
 Commands run for applications or units are executed in a 'hook context' for
 the unit.
@@ -104,14 +106,16 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 		"default": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
-	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
-	f.DurationVar(&c.timeout, "t", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
+	for _, flag := range[]string{"timeout", "t"} {
+		f.DurationVar(&c.timeout, flag, 5*time.Minute, "How long to wait before the remote command is considered to have failed")
+	}
 	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
-	f.Var(cmd.NewStringsValue(nil, &c.services), "application", "One or more application names")
-	f.Var(cmd.NewStringsValue(nil, &c.services), "app", "One or more application names")
-	f.Var(cmd.NewStringsValue(nil, &c.services), "a", "One or more application names")
-	f.Var(cmd.NewStringsValue(nil, &c.units), "unit", "One or more unit ids")
-	f.Var(cmd.NewStringsValue(nil, &c.units), "u", "One or more unit ids")
+	for _, flag := range[]string{"application", "app", "a"} {
+		f.Var(cmd.NewStringsValue(nil, &c.services), flag, "One or more application names")
+	}
+	for _, flag := range[]string{"unit", "u"} {
+		f.Var(cmd.NewStringsValue(nil, &c.units), flag, "One or more unit ids")
+	}
 }
 
 func (c *runCommand) Init(args []string) error {
@@ -141,7 +145,7 @@ func (c *runCommand) Init(args []string) error {
 		}
 	} else {
 		if len(c.machines) == 0 && len(c.services) == 0 && len(c.units) == 0 {
-			return errors.Errorf("You must specify a target, either through --all, --machine, --application/--app/-a or --unit/-u")
+			return errors.Errorf("You must specify a target, either through --all, --machine, --application or --unit")
 		}
 	}
 

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -53,7 +53,7 @@ are able to use this command.
 Targets are specified using either machine ids, application names or unit
 names.  At least one target specifier is needed.
 
-Multiple values can be set for --machine, --application, and --unit by using
+Multiple values can be set for --machine, --application/--app/-a, and --unit/-u by using
 comma separated values.
 
 If the target is a machine, the command is run as the "root" user on
@@ -63,8 +63,11 @@ If the target is an application, the command is run on all units for that
 application. For example, if there was an application "mysql" and that application
 had two units, "mysql/0" and "mysql/1", then
   --application mysql
+  --app mysql
+   -a mysql
 is equivalent to
   --unit mysql/0,mysql/1
+   -u mysql/0,mysql/1
 
 Commands run for applications or units are executed in a 'hook context' for
 the unit.
@@ -80,7 +83,7 @@ If you need to pass flags to the command being run, you must precede the
 command and its arguments with "--", to tell "juju run" to stop processing
 those arguments. For example:
 
-    juju run --all -- hostname -f
+    juju run --all --hostname -f
 `
 
 func (c *runCommand) Info() *cmd.Info {
@@ -102,9 +105,13 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
 	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
+	f.DurationVar(&c.timeout, "t", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
 	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
 	f.Var(cmd.NewStringsValue(nil, &c.services), "application", "One or more application names")
+	f.Var(cmd.NewStringsValue(nil, &c.services), "app", "One or more application names")
+	f.Var(cmd.NewStringsValue(nil, &c.services), "a", "One or more application names")
 	f.Var(cmd.NewStringsValue(nil, &c.units), "unit", "One or more unit ids")
+	f.Var(cmd.NewStringsValue(nil, &c.units), "u", "One or more unit ids")
 }
 
 func (c *runCommand) Init(args []string) error {
@@ -134,7 +141,7 @@ func (c *runCommand) Init(args []string) error {
 		}
 	} else {
 		if len(c.machines) == 0 && len(c.services) == 0 && len(c.units) == 0 {
-			return errors.Errorf("You must specify a target, either through --all, --machine, --application or --unit")
+			return errors.Errorf("You must specify a target, either through --all, --machine, --application/--app/-a or --unit/-u")
 		}
 	}
 

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -52,7 +52,7 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 	}, {
 		message:  "no target",
 		args:     []string{"sudo reboot"},
-		errMatch: "You must specify a target, either through --all, --machine, --application/--app/-a or --unit/-u",
+		errMatch: "You must specify a target, either through --all, --machine, --application or --unit",
 	}, {
 		message:  "command to all machines",
 		args:     []string{"--all", "sudo reboot"},

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -52,7 +52,7 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 	}, {
 		message:  "no target",
 		args:     []string{"sudo reboot"},
-		errMatch: "You must specify a target, either through --all, --machine, --application or --unit",
+		errMatch: "You must specify a target, either through --all, --machine, --application/--app/-a or --unit/-u",
 	}, {
 		message:  "command to all machines",
 		args:     []string{"--all", "sudo reboot"},
@@ -89,6 +89,11 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 		commands: "sudo reboot",
 		services: []string{"wordpress", "mysql"},
 	}, {
+		message:  "command to application mysql",
+                args:     []string{"--app=mysql", "uname -a"},
+		commands: "uname -a",
+		services: []string{"mysql"}
+	}, {
 		message: "bad application names",
 		args:    []string{"--application", "foo,2,foo/0", "sudo reboot"},
 		errMatch: "" +
@@ -96,9 +101,24 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 			"  \"2\" is not a valid application name\n" +
 			"  \"foo/0\" is not a valid application name",
 	}, {
+		message: "command to application mysql",
+		args:     []string{"--app=mysql", "sudo reboot"},
+		commands: "sudo reboot",
+		services: []string{"mysql"},
+	}, {
+		message: "command to application wordpress",
+		args:     []string{"-a","wordpress", "sudo reboot"},
+		commands: "sudo reboot",
+		services: []string{"wordpress"},
+	}, {
 		message:  "all and defined units",
 		args:     []string{"--all", "--unit=wordpress/0,mysql/1", "sudo reboot"},
 		errMatch: `You cannot specify --all and individual units`,
+	}, {
+		message:  "command to valid unit",
+		args:     []string{"-u","mysql/0", "sudo reboot"},
+		commands: "sudo reboot",
+		units:    []string{"mysql/0"},
 	}, {
 		message:  "command to valid units",
 		args:     []string{"--unit=wordpress/0,wordpress/1,mysql/0", "sudo reboot"},
@@ -151,6 +171,10 @@ func (*RunSuite) TestTimeoutArgParsing(c *gc.C) {
 		message: "two hours",
 		args:    []string{"--timeout=2h", "--all", "sudo reboot"},
 		timeout: 2 * time.Hour,
+	}, {
+		message: "5 minutes",
+		args:    []string{"-t","5m", "--all", "sudo reboot"},
+		timeout: 5 * time.Minute,
 	}, {
 		message: "3 minutes 30 seconds",
 		args:    []string{"--timeout=3m30s", "--all", "sudo reboot"},


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

## Description of change
Why is this change needed?
For usability convenience in CLI, few options are shorten.
At the same time existing option names are not changed.
## QA steps
How do we verify that the change works?
Create a LXD configuration locally, deploy a simple media wiki application.
execute juju run command with with option like 
--app , -a  for application
-u for unit
-t for timeout

## Documentation changes
Does it affect current user workflow? CLI? API?
YES. 
For the juju command "run" the usage section needs update. with the addition 
options added for
appillation : --app , -a
unit : -u
timeout : -t
## Bug reference
Does this change fix a bug? Please add a link to it.
https://bugs.launchpad.net/juju/+bug/1751321