### PR TITLE
2.4 supported LTS is 'bionic'

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -1021,7 +1021,7 @@ func (s *clientSuite) TestClientAddMachinesDefaultSeries(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLTS(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1037,7 +1037,7 @@ func (s *clientSuite) assertAddMachines(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLTS(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1113,7 +1113,7 @@ func (s *clientSuite) TestClientAddMachinesWithConstraints(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLTS(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1203,7 +1203,7 @@ func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 			c.Assert(machineResult.Error, gc.ErrorMatches, "cannot add a new machine: cannot add a machine with an instance id and no nonce")
 		} else {
 			c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-			s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLts(), apiParams[i].Constraints.String())
+			s.checkMachine(c, machineResult.Machine, supportedversion.SupportedLTS(), apiParams[i].Constraints.String())
 			instanceId := fmt.Sprintf("1234-%d", i)
 			s.checkInstance(c, machineResult.Machine, instanceId, "foo", hc, addrs)
 		}

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -168,7 +168,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		CloudTag:           "cloud-some-cloud",
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
-		DefaultSeries:      version.SupportedLts(),
+		DefaultSeries:      version.SupportedLTS(),
 		Life:               params.Dying,
 		Status: params.EntityStatus{
 			Status: status.Destroying,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -200,7 +200,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c 
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
 	err := runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", version.SupportedLts()))
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", version.SupportedLTS()))
 	s.AssertService(c, "dummy", curl, 1, 0)
 }
 
@@ -423,7 +423,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 func (s *DeploySuite) TestPlacement(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
 	// Add a machine that will be ignored due to placement directive.
-	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = runDeploy(c, ch, "-n", "1", "--to", "valid", "--series", "quantal")
@@ -487,9 +487,9 @@ func (s *DeploySuite) assertForceMachine(c *gc.C, machineId string) {
 
 func (s *DeploySuite) TestForceMachine(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runDeploy(c, "--to", machine.Id(), ch, "portlandia", "--series", version.SupportedLts())
+	err = runDeploy(c, "--to", machine.Id(), ch, "portlandia", "--series", version.SupportedLTS())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, machine.Id())
 }
@@ -497,12 +497,12 @@ func (s *DeploySuite) TestForceMachine(c *gc.C) {
 func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
 	template := state.MachineTemplate{
-		Series: version.SupportedLts(),
+		Series: version.SupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideNewMachine(template, template, instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runDeploy(c, "--to", container.Id(), ch, "portlandia", "--series", version.SupportedLts())
+	err = runDeploy(c, "--to", container.Id(), ch, "portlandia", "--series", version.SupportedLTS())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, container.Id())
 	machines, err := s.State.AllMachines()
@@ -512,9 +512,9 @@ func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
 
 func (s *DeploySuite) TestForceMachineNewContainer(c *gc.C) {
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "dummy")
-	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runDeploy(c, "--to", "lxd:"+machine.Id(), ch, "portlandia", "--series", version.SupportedLts())
+	err = runDeploy(c, "--to", "lxd:"+machine.Id(), ch, "portlandia", "--series", version.SupportedLTS())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, machine.Id()+"/lxd/0")
 
@@ -540,7 +540,7 @@ func (s *DeploySuite) TestForceMachineNotFound(c *gc.C) {
 }
 
 func (s *DeploySuite) TestForceMachineSubordinate(c *gc.C) {
-	machine, err := s.State.AddMachine(version.SupportedLts(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(version.SupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "logging")
 	err = runDeploy(c, "--to", machine.Id(), ch, "--series", "quantal")

--- a/cmd/juju/application/series_selector.go
+++ b/cmd/juju/application/series_selector.go
@@ -92,7 +92,7 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 		return "", err
 	}
 
-	latestLTS := version.SupportedLts()
+	latestLTS := version.SupportedLTS()
 	logger.Infof(msgLatestLTSSeries, latestLTS)
 	return latestLTS, nil
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -226,7 +226,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	}
 	bootstrapVersion := v100p64
 	if test.version != "" {
-		useVersion := strings.Replace(test.version, "%LTS%", supportedversion.SupportedLts(), 1)
+		useVersion := strings.Replace(test.version, "%LTS%", supportedversion.SupportedLTS(), 1)
 		bootstrapVersion = version.MustParseBinary(useVersion)
 		restore = restore.Add(testing.PatchValue(&jujuversion.Current, bootstrapVersion.Number))
 		restore = restore.Add(testing.PatchValue(&arch.HostArch, func() string { return bootstrapVersion.Arch }))
@@ -1237,7 +1237,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 }
 
 func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
-	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLTS() })
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -370,7 +370,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 
 		for _, uploaded := range test.expectUploaded {
 			// Substitute latest LTS for placeholder in expected series for uploaded tools
-			uploaded = strings.Replace(uploaded, "%LTS%", supportedversion.SupportedLts(), 1)
+			uploaded = strings.Replace(uploaded, "%LTS%", supportedversion.SupportedLTS(), 1)
 			vers := version.MustParseBinary(uploaded)
 			s.checkToolsUploaded(c, vers, agentVersion)
 		}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -149,7 +149,7 @@ func (c *imageMetadataCommand) setParams(context *cmd.Context) error {
 		logger.Infof("no model found, creating image metadata using user supplied data")
 	}
 	if c.Series == "" {
-		c.Series = version.SupportedLts()
+		c.Series = version.SupportedLTS()
 	}
 	if c.ImageId == "" {
 		return errors.Errorf("image id must be specified")

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -169,7 +169,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
-		series: version.SupportedLts(),
+		series: version.SupportedLTS(),
 		arch:   "arch",
 	}
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -64,7 +64,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
 github.com/juju/txn	git	f50b17d1ff3c31b7ea1c70e0d38a83f19af6d334	2018-04-06T04:58:51Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	1d3aa4661175bbdb5ded53d2b86b6106bbdc0a4f	2018-02-07T01:23:44Z
+github.com/juju/utils	git	81099fe346680b173c8707b3bae933ea2fd7d326	2018-04-16T01:54:08Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -275,7 +275,7 @@ func PreferredSeries(cfg HasDefaultSeries) string {
 	if series, ok := cfg.DefaultSeries(); ok {
 		return series
 	}
-	return jujuversion.SupportedLts()
+	return jujuversion.SupportedLTS()
 }
 
 // Config holds an immutable environment configuration.
@@ -384,7 +384,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":             jujuversion.SupportedLts(),
+	"default-series":             jujuversion.SupportedLTS(),
 	ProvisionerHarvestModeKey:    HarvestDestroyed.String(),
 	ResourceTagsKey:              "",
 	"logging-config":             "",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -55,7 +55,7 @@ var sampleConfig = testing.Attrs{
 	"unknown":                    "my-unknown",
 	"ssl-hostname-verification":  true,
 	"development":                false,
-	"default-series":             jujuversion.SupportedLts(),
+	"default-series":             jujuversion.SupportedLTS(),
 	"disable-network-management": false,
 	"ignore-machine-addresses":   false,
 	"automatically-retry-hooks":  true,
@@ -634,7 +634,7 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	if seriesAttr != "" {
 		c.Assert(defaultSeries, gc.Equals, seriesAttr)
 	} else {
-		c.Assert(defaultSeries, gc.Equals, jujuversion.SupportedLts())
+		c.Assert(defaultSeries, gc.Equals, jujuversion.SupportedLTS())
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
@@ -766,7 +766,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"firewall-mode":              config.FwInstance,
 		"unknown":                    "my-unknown",
 		"ssl-hostname-verification":  true,
-		"default-series":             jujuversion.SupportedLts(),
+		"default-series":             jujuversion.SupportedLTS(),
 		"disable-network-management": false,
 		"ignore-machine-addresses":   false,
 		"automatically-retry-hooks":  true,

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -210,7 +210,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	// we could connect to (actual live tests, rather than local-only)
 	cons := constraints.MustParse("mem=2G")
 	if t.CanOpenState {
-		_, err := sync.Upload(t.toolsStorage, "released", nil, supportedversion.SupportedLts())
+		_, err := sync.Upload(t.toolsStorage, "released", nil, supportedversion.SupportedLTS())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	args := t.bootstrapParams()
@@ -660,7 +660,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	expectedVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: supportedversion.SupportedLts(),
+		Series: supportedversion.SupportedLTS(),
 	}
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -46,7 +46,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 }
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
-	var series = jujuversion.SupportedLts()
+	var series = jujuversion.SupportedLTS()
 	const arch = "amd64"
 
 	args := s.getArgs(c)
@@ -128,7 +128,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
-	var series = jujuversion.SupportedLts()
+	var series = jujuversion.SupportedLTS()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,
@@ -150,7 +150,7 @@ func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
-	var series = jujuversion.SupportedLts()
+	var series = jujuversion.SupportedLTS()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -285,7 +285,7 @@ func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 
 // UploadFakeTools puts fake tools into the supplied storage with a binary
 // version matching jujuversion.Current; if jujuversion.Current's series is different
-// to  juju/juju/version.SupportedLts(), matching fake tools will be uploaded for that
+// to  juju/juju/version.SupportedLTS(), matching fake tools will be uploaded for that
 // series.  This is useful for tests that are kinda casual about specifying
 // their environment.
 func UploadFakeTools(c *gc.C, stor storage.Storage, toolsDir, stream string) {
@@ -310,7 +310,7 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := supportedversion.SupportedLts()
+	defaultSeries := supportedversion.SupportedLTS()
 	if series.MustHostSeries() != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -26,7 +26,7 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.CharmsPath = c.MkDir()
 	// Change the environ's config to ensure we're using the one in state.
-	updateAttrs := map[string]interface{}{"default-series": version.SupportedLts()}
+	updateAttrs := map[string]interface{}{"default-series": version.SupportedLTS()}
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/juju/version/version.go
+++ b/juju/version/version.go
@@ -4,9 +4,13 @@
 // Package version contains versioning information about packages that juju supports.
 package version
 
-// SupportedLts returns the latest LTS that Juju supports and is compatible with.
+// SupportedLTS returns the latest LTS that Juju supports and is compatible with.
 // For example, Juju 2.3.x series cannot be run on "bionic"
 // as mongo version that it depends on (3.2 and less) is not packaged for bionic.
-func SupportedLts() string {
-	return "xenial"
+//
+// Current default for Juju versions:
+// * 2.3 - 'xenial'
+// * 2.4- 'bionic'
+func SupportedLTS() string {
+	return "bionic"
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -107,7 +107,7 @@ func SampleConfig() testing.Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            jujuversion.SupportedLts(),
+		"default-series":            jujuversion.SupportedLTS(),
 
 		"secret":     "pork",
 		"controller": true,

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -171,7 +171,7 @@ func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.
 
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
-		Series:      version.SupportedLts(),
+		Series:      version.SupportedLTS(),
 		Constraints: constraints.MustParse("instance-type=t2.medium"),
 	}
 
@@ -193,16 +193,16 @@ var findInstanceSpecErrorTests = []struct {
 	err    string
 }{
 	{
-		series: version.SupportedLts(),
+		series: version.SupportedLTS(),
 		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, version.SupportedLts()),
+		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, version.SupportedLTS()),
 	}, {
 		series: "raring",
 		arches: []string{"amd64", "i386"},
 		cons:   "mem=4G",
 		err:    `no "raring" images in test matching instance types \[.*\]`,
 	}, {
-		series: version.SupportedLts(),
+		series: version.SupportedLTS(),
 		arches: []string{"amd64"},
 		cons:   "instance-type=m1.small mem=4G",
 		err:    `no instance types in test matching constraints "instance-type=m1.small mem=4096M"`,

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -80,7 +80,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.LiveTests.SetUpSuite(c)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLTS() })
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -235,7 +235,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLTS() })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
@@ -1429,7 +1429,7 @@ func (t *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.small root-disk=1G")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1439,7 +1439,7 @@ func (t *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.invalid")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "m1.invalid" specified`)
@@ -1449,7 +1449,7 @@ func (t *localServerSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=i386")
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "i386" specified`)
@@ -1459,7 +1459,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-available"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    supportedversion.SupportedLts(),
+		Series:    supportedversion.SupportedLTS(),
 		Placement: placement,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1469,7 +1469,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unavailable"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    supportedversion.SupportedLts(),
+		Series:    supportedversion.SupportedLTS(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is "unavailable"`)
@@ -1479,7 +1479,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
 	err := env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    supportedversion.SupportedLts(),
+		Series:    supportedversion.SupportedLTS(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
@@ -1503,7 +1503,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placemen
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    supportedversion.SupportedLts(),
+		Series:    supportedversion.SupportedLTS(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1526,7 +1526,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneVolumeConflict(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    supportedversion.SupportedLts(),
+		Series:    supportedversion.SupportedLTS(),
 		Placement: "zone=test-available",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1547,7 +1547,7 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	env := t.Prepare(c)
 	params, err := env.(simplestreams.MetadataValidator).MetadataLookupParams("test")
 	c.Assert(err, jc.ErrorIsNil)
-	params.Series = supportedversion.SupportedLts()
+	params.Series = supportedversion.SupportedLTS()
 	params.Endpoint = region.EC2Endpoint
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -23,7 +23,7 @@ type environPolSuite struct {
 var _ = gc.Suite(&environPolSuite{})
 
 func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts()})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 0)
@@ -36,7 +36,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=amd64 root-disk=1G")
 	placement := "zone=home-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons, Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons, Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
@@ -46,14 +46,14 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1.invalid")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
 	c.Check(err, gc.ErrorMatches, `.*invalid GCE instance type.*`)
 }
@@ -61,14 +61,14 @@ func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 root-disk=1G")
 	placement := ""
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons, Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons, Placement: placement})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=i386")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -79,7 +79,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Placement: placement})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -90,7 +90,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `.*availability zone "a-zone" is DOWN`)
 }
@@ -101,7 +101,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Placement: placement})
 
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
@@ -120,7 +120,7 @@ func (s *environPolSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placement
 	}
 
 	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    version.SupportedLts(),
+		Series:    version.SupportedLTS(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			VolumeId: "away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
@@ -135,7 +135,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneConflictsVolume(c *gc.C) 
 	}
 
 	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:    version.SupportedLts(),
+		Series:    version.SupportedLTS(),
 		Placement: "zone=away-zone",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -25,7 +25,7 @@ type environPolSuite struct {
 var _ = gc.Suite(&environPolSuite{})
 
 func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts()})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.CheckNoAPI(c)
@@ -33,14 +33,14 @@ func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
 
 func (s *environPolSuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=some-instance-type")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
 	c.Check(err, gc.ErrorMatches, `LXD does not support instance types.*`)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("root-disk=1G")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -49,14 +49,14 @@ func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	cons := constraints.MustParse("arch=i386")
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Constraints: cons})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLts(), Placement: placement})
+	err := s.Env.PrecheckInstance(environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `unknown placement directive: .*`)
 }

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -24,7 +24,7 @@ import (
 // satisfying errors.IsNotFound will be returned.
 func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
 	var (
-		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(version.SupportedLts()))
+		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(version.SupportedLTS()))
 		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
 		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
 		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -671,32 +671,32 @@ func (suite *environSuite) TestSubnetsMissingSubnet(c *gc.C) {
 func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "zone=zone1"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLTS(), Placement: "zone=zone1"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "zone=zone2"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLTS(), Placement: "zone=zone2"})
 	c.Assert(err, gc.ErrorMatches, `availability zone "zone2" not valid`)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "zone=test-unknown"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLTS(), Placement: "zone=test-unknown"})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
 func (s *environSuite) TestPrecheckInvalidPlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "notzone=anything"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLTS(), Placement: "notzone=anything"})
 	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
 }
 
 func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLts(), Placement: "assumed_node_name"})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: jujuversion.SupportedLTS(), Placement: "assumed_node_name"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -64,7 +64,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLts() })
+	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLTS() })
 }
 
 func (s *baseProviderSuite) TearDownTest(c *gc.C) {

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -48,7 +48,7 @@ type machineInfo struct {
 	Hostname string `yaml:",omitempty"`
 }
 
-var maasDataDir = paths.MustSucceed(paths.DataDir(version.SupportedLts()))
+var maasDataDir = paths.MustSucceed(paths.DataDir(version.SupportedLTS()))
 var _MAASInstanceFilename = path.Join(maasDataDir, "MAASmachine.txt")
 
 // cloudinitRunCmd returns the shell command that, when run, will create the

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1245,7 +1245,7 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, supportedversion.SupportedLts(), "amd64", "instance-type=m1.tiny",
+		env, supportedversion.SupportedLTS(), "amd64", "instance-type=m1.tiny",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1262,7 +1262,7 @@ func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, supportedversion.SupportedLts(), "amd64", "virt-type="+testVirtType,
+		env, supportedversion.SupportedLTS(), "amd64", "virt-type="+testVirtType,
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1281,7 +1281,7 @@ func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, supportedversion.SupportedLts(), "amd64", "",
+		env, supportedversion.SupportedLTS(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1298,7 +1298,7 @@ func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, supportedversion.SupportedLts(), "amd64", "",
+		env, supportedversion.SupportedLTS(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1313,7 +1313,7 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 		Arch: "amd64",
 	}}
 	_, err := openstack.FindInstanceSpec(
-		env, supportedversion.SupportedLts(), "amd64", "instance-type=m1.large",
+		env, supportedversion.SupportedLTS(), "amd64", "instance-type=m1.large",
 		imageMetadata,
 	)
 	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
@@ -1322,39 +1322,39 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small")
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Constraints: cons})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.large")
-	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Constraints: cons})
+	err := env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unknown" not valid`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	t.srv.Nova.SetAvailabilityZones() // no availability zone support
 	placement := "zone=test-unknown"
-	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLts(), Placement: placement})
+	err := t.env.PrecheckInstance(environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Placement: placement})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
@@ -1388,7 +1388,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZones(c *gc.C, placeme
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:            supportedversion.SupportedLts(),
+		Series:            supportedversion.SupportedLTS(),
 		Placement:         placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})
@@ -1423,7 +1423,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZonesConflictsVolume(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = t.env.PrecheckInstance(environs.PrecheckInstanceParams{
-		Series:            supportedversion.SupportedLts(),
+		Series:            supportedversion.SupportedLTS(),
 		Placement:         "zone=az2",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -68,7 +68,7 @@ func FakeConfig() Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            jujuversion.SupportedLts(),
+		"default-series":            jujuversion.SupportedLTS(),
 	}
 }
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -133,7 +133,7 @@ func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctyp
 
 	// make a container on the host machine
 	template := state.MachineTemplate{
-		Series: supportedversion.SupportedLts(),
+		Series: supportedversion.SupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, host.Id(), ctype)
@@ -183,7 +183,7 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	for _, ctype := range containerTypes {
 		// create a machine to host the container.
 		m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-			Series:      supportedversion.SupportedLts(),
+			Series:      supportedversion.SupportedLTS(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		})
@@ -244,7 +244,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -357,7 +357,7 @@ func (s *ContainerSetupSuite) TestContainerInitInstDataError(c *gc.C) {
 	defer releaser.Release()
 
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -431,7 +431,7 @@ func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	defer workertest.CleanKill(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
-	_, err := s.State.AddMachine(supportedversion.SupportedLts(), state.JobHostUnits)
+	_, err := s.State.AddMachine(supportedversion.SupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectNoEvents(c)
@@ -448,7 +448,7 @@ func (s *kvmProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 
 func (s *kvmProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	template := state.MachineTemplate{
-		Series: supportedversion.SupportedLts(),
+		Series: supportedversion.SupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, "0", instance.KVM)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -472,7 +472,7 @@ func (s *CommonProvisionerSuite) addMachine() (*state.Machine, error) {
 
 func (s *CommonProvisionerSuite) addMachineWithConstraints(cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 	})
@@ -482,7 +482,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 	templates := make([]state.MachineTemplate, number)
 	for i, _ := range templates {
 		templates[i] = state.MachineTemplate{
-			Series:      supportedversion.SupportedLts(),
+			Series:      supportedversion.SupportedLTS(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		}
@@ -491,7 +491,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 }
 
 func (s *CommonProvisionerSuite) enableHA(c *gc.C, n int) []*state.Machine {
-	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, supportedversion.SupportedLts(), nil, "")
+	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, supportedversion.SupportedLTS(), nil, "")
 	c.Assert(err, jc.ErrorIsNil)
 	added := make([]*state.Machine, len(changes.Added))
 	for i, mid := range changes.Added {
@@ -800,7 +800,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXD(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: supportedversion.SupportedLts(),
+		Series: supportedversion.SupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.LXD)
@@ -828,7 +828,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: supportedversion.SupportedLts(),
+		Series: supportedversion.SupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.KVM)
@@ -1107,7 +1107,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 
 func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.MachineVolumeParams, cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      supportedversion.SupportedLts(),
+		Series:      supportedversion.SupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 		Volumes:     volumes,

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -39,7 +39,7 @@ var _ = gc.Suite(&rebootSuite{})
 func (s *rebootSuite) SetUpTest(c *gc.C) {
 	var err error
 	template := state.MachineTemplate{
-		Series: version.SupportedLts(),
+		Series: version.SupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	s.JujuConnSuite.SetUpTest(c)


### PR DESCRIPTION
## Description of change

Changed the value of supported LTS for 2.4 to be 'bionic' instead of previous 'xenial' (default LTS for 2.3).

The only worthy change in this PR is /juju/juju/juju/version.SupportedLTS() value.
The rest is mechanic case change that has already been done on 2.3 branch and has not been forward-ported.

## Documentation changes

@juju/docs, Probably worthwhile having a page where we do describe supported versions (including LTS) by each Juju release. 

## Bug reference
https://bugs.launchpad.net/juju/+bug/1762741
