### PR TITLE
Allow absolute path for credentials file.

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -6,7 +6,6 @@ package cloud
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
@@ -144,7 +143,7 @@ func (s CredentialSchema) Attribute(name string) (*CredentialAttr, bool) {
 // provided credential schemas, and reading any file attributes into their
 // corresponding non-file attributes. This will also validate the credential.
 //
-// If there is no schema with the matching auth-type, and error satisfying
+// If there is no schema with the matching auth-type, an error satisfying
 // errors.IsNotSupported will be returned.
 func FinalizeCredential(
 	credential Credential,
@@ -225,10 +224,7 @@ func (s CredentialSchema) Finalize(
 // ValidateFileAttrValue returns the normalised file path, so
 // long as the specified path is valid and not a directory.
 func ValidateFileAttrValue(path string) (string, error) {
-	if !filepath.IsAbs(path) && !strings.HasPrefix(path, "~") {
-		return "", errors.Errorf("file path must be an absolute path: %s", path)
-	}
-	absPath, err := utils.NormalizePath(path)
+	absPath, err := utils.ExpandPath(path)
 	if err != nil {
 		return "", err
 	}

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -587,23 +587,19 @@ func (s *credentialsSuite) TestFinalizeCredentialRelativeFilePath(c *gc.C) {
 	err := ioutil.WriteFile(absFilename, []byte{}, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	filename := "~/filename"
-
 	cred := cloud.NewCredential(
 		cloud.JSONFileAuthType,
 		map[string]string{
-			"file": filename,
+			"file": "~/filename",
 		},
 	)
 	schema := cloud.CredentialSchema{{
 		"file", cloud.CredentialAttr{FilePath: true},
 	}}
-
 	readFile := func(path string) ([]byte, error) {
 		c.Assert(path, gc.Equals, absFilename)
 		return []byte("file-contents"), nil
 	}
-
 	newCred, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.JSONFileAuthType: schema,
 	}, readFile)

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -4,12 +4,14 @@
 package cloud_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
@@ -580,6 +582,37 @@ func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 	})
 }
 
+func (s *credentialsSuite) TestFinalizeCredentialRelativeFilePath(c *gc.C) {
+	absFilename := filepath.Join(utils.Home(), "filename")
+	err := ioutil.WriteFile(absFilename, []byte{}, 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	filename := "~/filename"
+
+	cred := cloud.NewCredential(
+		cloud.JSONFileAuthType,
+		map[string]string{
+			"file": filename,
+		},
+	)
+	schema := cloud.CredentialSchema{{
+		"file", cloud.CredentialAttr{FilePath: true},
+	}}
+
+	readFile := func(path string) ([]byte, error) {
+		c.Assert(path, gc.Equals, absFilename)
+		return []byte("file-contents"), nil
+	}
+
+	newCred, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.JSONFileAuthType: schema,
+	}, readFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newCred.Attributes(), jc.DeepEquals, map[string]string{
+		"file": "file-contents",
+	})
+}
+
 func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
 	cred := cloud.NewCredential(
 		cloud.JSONFileAuthType,
@@ -594,22 +627,6 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
 		cloud.JSONFileAuthType: schema,
 	}, nil)
 	c.Assert(err, gc.ErrorMatches, "invalid file path: .*")
-}
-
-func (s *credentialsSuite) TestFinalizeCredentialRelativeFilePath(c *gc.C) {
-	cred := cloud.NewCredential(
-		cloud.JSONFileAuthType,
-		map[string]string{
-			"file": "file",
-		},
-	)
-	schema := cloud.CredentialSchema{{
-		"file", cloud.CredentialAttr{FilePath: true},
-	}}
-	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
-		cloud.JSONFileAuthType: schema,
-	}, nil)
-	c.Assert(err, gc.ErrorMatches, "file path must be an absolute path: file")
 }
 
 func (s *credentialsSuite) TestRemoveSecrets(c *gc.C) {
@@ -633,4 +650,20 @@ func (s *credentialsSuite) TestRemoveSecrets(c *gc.C) {
 	c.Assert(sanitisedCred.Attributes(), jc.DeepEquals, map[string]string{
 		"username": "user",
 	})
+}
+
+func (s *credentialsSuite) TestValidateFileAttrValue(c *gc.C) {
+	_, err := cloud.ValidateFileAttrValue("/xyz/nothing.blah")
+	c.Assert(err, gc.ErrorMatches, "invalid file path: /xyz/nothing.blah")
+
+	absPathNewFile := filepath.Join(utils.Home(), "new-creds.json")
+	err = ioutil.WriteFile(absPathNewFile, []byte("abc"), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	absPath, err := cloud.ValidateFileAttrValue("~/new-creds.json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(absPath, gc.Equals, absPathNewFile)
+
+	_, err = cloud.ValidateFileAttrValue(utils.Home())
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("file path must be a file: %s", utils.Home()))
 }


### PR DESCRIPTION
## Description of change

As per bug LP:1745031 add-credentials asks for a path then errors afterwards if the path is not absolute.
This change removes that constraint by determining the absolute path of the file path provided.

## QA steps

There are unit tests.

Functional tests:
 - $ juju add-credential google
 - (enter any credential name) <enter>
 - (select default jsonfile) <enter>
 - Enter a relative path to an empty json file that exists

For previous versions this will error with "file path must be an absolute path: "
This version will accept the path.

## Bug reference

This fixes  bug: https://bugs.launchpad.net/juju/+bug/1745031
