### PR TITLE
"Default controller name verification"

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -227,6 +227,11 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		return errors.NotValidf("series %q", c.BootstrapSeries)
 	}
 
+	/* controller is the name of controller created for internal juju management */
+	if c.hostedModelName == "controller" {
+		return errors.New(" 'controller' name is already assigned to juju internal management controller ")
+	}
+
 	// Parse the placement directive. Bootstrap currently only
 	// supports provider-specific placement directives.
 	if c.Placement != "" {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -229,7 +229,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 
 	/* controller is the name of controller created for internal juju management */
 	if c.hostedModelName == "controller" {
-		return errors.New(" 'controller' name is already assigned to juju internal management controller ")
+		return errors.New(" 'controller' name is already assigned to juju internal management model")
 	}
 
 	// Parse the placement directive. Bootstrap currently only


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:
## Description of change
Why is this change needed?
This PR addresses the issue in bootstrap process.
when a default model name is provided as 'controller' which is the name of juju internal management model, the verification of the parameters values provided wasn't done initially for this option. Instead only after the image get downloaded and machine is up, this error is captured.
This option value is evaluated in the beginning and displays an error message to make it efficiently interactive.

## QA steps
How do we verify that the change works?
Create a controller with juju bootstrap command by supplying cloud type(localhost for lxd is enough) and with option -d and value as controller -- this if for the name of default model user can specify.

## Documentation changes
Does it affect current user workflow? CLI? API?
N/A
## Bug reference
Does this change fix a bug? Please add a link to it.
https://bugs.launchpad.net/juju/+bug/1596496