### PR TITLE
caas operator makes a legacy jujud dir pending upstream updates

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -189,6 +189,18 @@ func (op *caasOperator) makeAgentSymlinks(unitTag names.UnitTag) error {
 		return errors.Trace(err)
 	}
 
+	// TODO(caas) - remove this when upstream charmhelpers are fixed
+	// Charmhelpers expect to see a jujud in a machine-X directory.
+	legacyMachineDir := filepath.Join(agentBinaryDir, "machine-0")
+	err = os.Mkdir(legacyMachineDir, 0600)
+	if err != nil && !os.IsExist(err) {
+		return errors.Trace(err)
+	}
+	err = symlink.New(jujudPath, filepath.Join(legacyMachineDir, jujunames.Jujud))
+	if err != nil && !os.IsExist(err) && !os.IsPermission(err) {
+		return errors.Trace(err)
+	}
+
 	// Second the charm directory.
 	unitAgentDir := filepath.Join(op.config.DataDir, "agents", unitTag.String())
 	err = os.MkdirAll(unitAgentDir, 0600)


### PR DESCRIPTION
## Description of change

In CAAS charms, certain charm helper functions were failing, eg juju_version().
This is because upstream charm helpers code expects jujud to be in a directory /var/lib/tools/machine-X/
However, CAAS operators don'r use those same directories. So we add a symlink for now until we can get upstream charm helpers updated and into the distro.

## QA steps

Deploy CAAS mysql and gitlab and relate them.
Check the relation succeeds. It would fail with a relation joined hook error previously.

