### PR TITLE
add-apt-repository has been provided elsewhere for a long time.

### DIFF
--- a/acceptancetests/repository/trusty/haproxy/README.md
+++ b/acceptancetests/repository/trusty/haproxy/README.md
@@ -149,7 +149,7 @@ wish to use.
 The following steps are needed for testing and development of the charm,
 but **not** for deployment:
 
-    sudo apt-get install python-software-properties
+    sudo apt-get install software-properties-common
     sudo add-apt-repository ppa:cjohnston/flake8
     sudo apt-get update
     sudo apt-get install python-mock python-flake8 python-nose python-nosexcover python-testtools charm-tools

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -161,7 +161,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 	if len(cfg.PackageSources()) > 0 {
 		// Ensure add-apt-repository is available.
 		cmds = append(cmds, LogProgressCmd("Installing add-apt-repository"))
-		cmds = append(cmds, cfg.paccmder.InstallCmd("python-software-properties"))
+		cmds = append(cmds, cfg.paccmder.InstallCmd("software-properties-common"))
 	}
 	for _, src := range cfg.PackageSources() {
 		// PPA keys are obtained by add-apt-repository, from launchpad.

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -156,12 +156,12 @@ func (s *configureSuite) TestAptSources(c *gc.C) {
 			"(.|\n)*install -D -m 644 /dev/null '/etc/apt/preferences.d/50-cloud-tools'(.|\n)*",
 		)
 
-		// Only install python-software-properties (add-apt-repository)
+		// Only install software-properties-common (add-apt-repository)
 		// if we need to.
 		c.Assert(
 			script,
 			checkIff(gc.Matches, needsCloudTools),
-			aptgetRegexp+"install.*python-software-properties(.|\n)*",
+			aptgetRegexp+"install.*software-properties-common(.|\n)*",
 		)
 	}
 }


### PR DESCRIPTION
## Description of change

As near as I can tell, since Trusty we should have been installing
software-properties-common instead of python-software-properties. We
just didn't notice because add-apt-repository is actually always
available (cloud-init depends on it in Trusty, ubuntu-server depends on
it in Xenial).

Bionic has removed the python-software-properties package last week, so
we shouldn't be trying to install it.

## QA steps

Bootstrapping started failing on Bionic, so one test is:
```
$ juju bootstrap --bootstrap-series=bionic --config image-stream=daily lxd
```

We should also see no regression in bootstrapping any of Trusty or Xenial even when custom archives are being used.

## Documentation changes

None.

## Bug reference

[lp:1764267](https://bugs.launchpad.net/juju/+bug/1764267)