### PR TITLE
"Fix for run-timeout should not be set to 0"

### DIFF
--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -62,7 +62,6 @@ the remote machine.
 Some options are shortened for usabilty purpose in CLI
 --application can also be specified as --app and -a
 --unit can also be specified as -u
---timeout can also be specified as -t
 
 If the target is an application, the command is run on all units for that
 application. For example, if there was an application "mysql" and that application
@@ -106,8 +105,7 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 		"default": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
-	f.DurationVar(&c.timeout, "t", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
-	f.DurationVar(&c.timeout, "timeout", 0, "")
+	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
 	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
 	f.Var(cmd.NewStringsValue(nil, &c.services), "a", "One or more application names")
 	f.Var(cmd.NewStringsValue(nil, &c.services), "app", "")

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -92,7 +92,7 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 		message:  "command to application mysql",
                 args:     []string{"--app=mysql", "uname -a"},
 		commands: "uname -a",
-		services: []string{"mysql"}
+		services: []string{"mysql"},
 	}, {
 		message: "bad application names",
 		args:    []string{"--application", "foo,2,foo/0", "sudo reboot"},
@@ -171,10 +171,6 @@ func (*RunSuite) TestTimeoutArgParsing(c *gc.C) {
 		message: "two hours",
 		args:    []string{"--timeout=2h", "--all", "sudo reboot"},
 		timeout: 2 * time.Hour,
-	}, {
-		message: "5 minutes",
-		args:    []string{"-t","5m", "--all", "sudo reboot"},
-		timeout: 5 * time.Minute,
 	}, {
 		message: "3 minutes 30 seconds",
 		args:    []string{"--timeout=3m30s", "--all", "sudo reboot"},


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:
## Description of change
Why is this change needed?
This PR addresses issue with run command.
The previous commit related to run commando shorten option, contain changes for 'timeout' option as well and sets 0 as value.
This made run command required to be passed with timeout option with value >0 explicitly.
This is not required and we decided not to shorten the the timeout option for run command.
## QA steps
How do we verify that the change works?
execute run command without/with timeout option in combination with other options
## Documentation changes
Does it affect current user workflow? CLI? API?
Yes.
## Bug reference

Does this change fix a bug? Please add a link to it.