### PR TITLE
Weave new presence through apiserver

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -118,6 +118,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		a.srv.facades,
 		a.root.resources,
 		a.root,
+		a.root.presence,
 	)
 	apiRoot, err = restrictAPIRoot(
 		a.srv,

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/websocket"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/rpc"
@@ -66,6 +67,7 @@ type Server struct {
 	offerAuthCtxt          *crossmodel.AuthContext
 	lastConnectionID       uint64
 	centralHub             *pubsub.StructuredHub
+	presence               presence.Recorder
 	newObserver            observer.ObserverFactory
 	connCount              int64
 	totalConn              int64
@@ -104,6 +106,7 @@ type ServerConfig struct {
 	DataDir       string
 	LogDir        string
 	Hub           *pubsub.StructuredHub
+	Presence      presence.Recorder
 	Mux           *apiserverhttp.Mux
 	Authenticator httpcontext.LocalMacaroonAuthenticator
 
@@ -169,6 +172,9 @@ func (c ServerConfig) Validate() error {
 	}
 	if c.Hub == nil {
 		return errors.NotValidf("missing Hub")
+	}
+	if c.Presence == nil {
+		return errors.NotValidf("missing Presence")
 	}
 	if c.Mux == nil {
 		return errors.NotValidf("missing Mux")
@@ -246,6 +252,7 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		restoreStatus:                 cfg.RestoreStatus,
 		facades:                       AllFacades(),
 		centralHub:                    cfg.Hub,
+		presence:                      cfg.Presence,
 		mux:                           cfg.Mux,
 		authenticator:                 cfg.Authenticator,
 		allowModelAccess:              cfg.AllowModelAccess,

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/apiserver/stateauthenticator"
 	apitesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -79,6 +80,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 		DataDir:         c.MkDir(),
 		LogDir:          c.MkDir(),
 		Hub:             centralhub.New(machineTag),
+		Presence:        presence.New(clock.WallClock),
 		Mux:             s.mux,
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -107,7 +107,9 @@ func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachine
 			continue
 		}
 		var status string
-		statusInfo, err := MachineStatus(m)
+		// This is suboptimal as if there are many machines,
+		// we are making many calls into the DB for each machine.
+		statusInfo, err := m.Status()
 		if err == nil {
 			status = string(statusInfo.Status)
 		} else {

--- a/apiserver/common/machinestatus.go
+++ b/apiserver/common/machinestatus.go
@@ -19,7 +19,7 @@ type MachineStatusGetter interface {
 
 // MachineStatus returns the machine agent status for a given
 // machine, with special handling for agent presence.
-func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
+func (c *ModelPresenceContext) MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
 	machineStatus, err := machine.Status()
 	if err != nil {
 		return status.StatusInfo{}, err
@@ -31,7 +31,7 @@ func MachineStatus(machine MachineStatusGetter) (status.StatusInfo, error) {
 		return machineStatus, nil
 	}
 
-	agentAlive, err := machine.AgentPresence()
+	agentAlive, err := c.machinePresence(machine)
 	if err != nil {
 		// We don't want any presence errors affecting status.
 		logger.Debugf("error determining presence for machine %s: %v", machine.Id(), err)

--- a/apiserver/common/presence.go
+++ b/apiserver/common/presence.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/presence"
+)
+
+// ModelPresence represents the API server connections for a model.
+type ModelPresence interface {
+	// For a given non controller agent, return the Status for that agent.
+	AgentStatus(agent string) (presence.Status, error)
+}
+
+// ModelPresenceContext represents the known agent presence state for the
+// entire model.
+type ModelPresenceContext struct {
+	// Presence represents the API server connections for a model.
+	// If this is non-nil it is used in preference to the state AgentPresence method.
+	Presence ModelPresence
+}
+
+func (c *ModelPresenceContext) machinePresence(machine MachineStatusGetter) (bool, error) {
+	if c.Presence == nil {
+		return machine.AgentPresence()
+	}
+	agent := names.NewMachineTag(machine.Id())
+	status, err := c.Presence.AgentStatus(agent.String())
+	return status == presence.Alive, err
+}
+
+func (c *ModelPresenceContext) unitPresence(unit UnitStatusGetter) (bool, error) {
+	if c.Presence == nil {
+		return unit.AgentPresence()
+	}
+	agent := names.NewUnitTag(unit.Name())
+	status, err := c.Presence.AgentStatus(agent.String())
+	return status == presence.Alive, err
+}

--- a/apiserver/common/presence_test.go
+++ b/apiserver/common/presence_test.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/presence"
+)
+
+func allAlive() common.ModelPresence {
+	return &fakeModelPresence{status: presence.Alive}
+}
+
+func agentsDown() common.ModelPresence {
+	return &fakeModelPresence{status: presence.Missing}
+}
+
+func presenceError() common.ModelPresence {
+	return &fakeModelPresence{err: errors.New("boom")}
+}
+
+type fakeModelPresence struct {
+	status presence.Status
+	err    error
+}
+
+func (f *fakeModelPresence) AgentStatus(agent string) (presence.Status, error) {
+	return f.status, f.err
+}

--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -32,7 +32,7 @@ type UnitStatusGetter interface {
 
 // UnitStatus returns the unit agent and workload status for a given
 // unit, with special handling for agent presence.
-func UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndErr) {
+func (c *ModelPresenceContext) UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndErr) {
 	agent.Status, agent.Err = unit.AgentStatus()
 	workload.Status, workload.Err = unit.Status()
 
@@ -42,7 +42,7 @@ func UnitStatus(unit UnitStatusGetter) (agent StatusAndErr, workload StatusAndEr
 		return
 	}
 
-	agentAlive, err := unit.AgentPresence()
+	agentAlive, err := c.unitPresence(unit)
 	if err != nil {
 		return
 	}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -44,7 +44,7 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	return newAPIRoot(nil, state.NewStatePool(nil), facades, common.NewResources(), nil)
+	return newAPIRoot(nil, state.NewStatePool(nil), facades, common.NewResources(), nil, nil)
 }
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -50,3 +50,14 @@ func (context Context) StatePool() *state.StatePool {
 func (context Context) ID() string {
 	return context.ID_
 }
+
+// Presence implements facade.Context.
+func (context Context) Presence() facade.Presence {
+	return context
+}
+
+// ModelPresence implements facade.Presence.
+func (context Context) ModelPresence(modelUUID string) facade.ModelPresence {
+	// Potentially may need to add stuff here at some stage.
+	return nil
+}

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -6,6 +6,7 @@ package facade
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
@@ -60,6 +61,10 @@ type Context interface {
 	// StatePool returns the state pool used by the apiserver to minimise the
 	// creation of the expensive *State instances.
 	StatePool() *state.StatePool
+
+	// Presence returns an instance that is able to be asked for
+	// the current model presence.
+	Presence() Presence
 
 	// ID returns a string that should almost always be "", unless
 	// this is a watcher facade, in which case it exists in lieu of
@@ -131,4 +136,16 @@ type Resources interface {
 // all those things to finish.)
 type Resource interface {
 	Stop() error
+}
+
+// Presence represents the current known state of API connections from agents
+// to any of the API servers.
+type Presence interface {
+	ModelPresence(modelUUID string) ModelPresence
+}
+
+// ModelPresence represents the API server connections for a model.
+type ModelPresence interface {
+	// For a given non controller agent, return the Status for that agent.
+	AgentStatus(agent string) (presence.Status, error)
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -36,6 +36,7 @@ func (ctx *charmsSuiteContext) Resources() facade.Resources { return common.NewR
 func (ctx *charmsSuiteContext) State() *state.State         { return ctx.cs.State }
 func (ctx *charmsSuiteContext) StatePool() *state.StatePool { return nil }
 func (ctx *charmsSuiteContext) ID() string                  { return "" }
+func (ctx *charmsSuiteContext) Presence() facade.Presence   { return nil }
 
 func (s *charmsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -388,6 +388,8 @@ type statusContext struct {
 	providerType string
 	model        *state.Model
 	status       *state.ModelStatus
+	presence     common.ModelPresenceContext
+
 	// machines: top-level machine id -> list of machines nested in
 	// this machine.
 	machines map[string][]*state.Machine
@@ -1253,7 +1255,7 @@ func (c *contextUnit) Status() (status.StatusInfo, error) {
 // processUnitAndAgentStatus retrieves status information for both unit and unitAgents.
 func (c *statusContext) processUnitAndAgentStatus(unit *state.Unit) (agentStatus, workloadStatus params.DetailedStatus) {
 	wrapped := &contextUnit{unit, c}
-	agent, workload := common.UnitStatus(wrapped)
+	agent, workload := c.presence.UnitStatus(wrapped)
 	populateStatusFromStatusInfoAndErr(&agentStatus, agent.Status, agent.Err)
 	populateStatusFromStatusInfoAndErr(&workloadStatus, workload.Status, workload.Err)
 
@@ -1293,7 +1295,7 @@ func (c *contextMachine) Status() (status.StatusInfo, error) {
 // It also returns deprecated legacy status information.
 func (c *statusContext) processMachine(machine *state.Machine) (out params.DetailedStatus) {
 	wrapped := &contextMachine{machine, c}
-	statusInfo, err := common.MachineStatus(wrapped)
+	statusInfo, err := c.presence.MachineStatus(wrapped)
 	populateStatusFromStatusInfoAndErr(&out, statusInfo, err)
 
 	out.Life = processLife(machine)

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 )
@@ -13,7 +14,7 @@ type patcher interface {
 }
 
 func SetPrecheckResult(p patcher, err error) {
-	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.State, *migration.TargetInfo) error {
+	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.State, *migration.TargetInfo, facade.Presence) error {
 		return err
 	})
 }

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -18,10 +18,12 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/controller/migrationmaster"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -402,6 +404,7 @@ func (s *Suite) makeAPI() (*migrationmaster.API, error) {
 		nil, // pool
 		s.resources,
 		s.authorizer,
+		&fakePresence{},
 	)
 }
 
@@ -542,4 +545,15 @@ type failingPrecheckBackend struct {
 
 func (b *failingPrecheckBackend) Model() (migration.PrecheckModel, error) {
 	return nil, errors.New("boom")
+}
+
+type fakePresence struct {
+}
+
+func (f *fakePresence) ModelPresence(modelUUID string) facade.ModelPresence {
+	return f
+}
+
+func (f *fakePresence) AgentStatus(agent string) (presence.Status, error) {
+	return presence.Alive, nil
 }

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -27,6 +27,7 @@ func NewFacade(ctx facade.Context) (*API, error) {
 		migration.PoolShim(ctx.StatePool()),
 		ctx.Resources(),
 		ctx.Auth(),
+		ctx.Presence(),
 	)
 }
 

--- a/apiserver/testserver/server.go
+++ b/apiserver/testserver/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/stateauthenticator"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -36,6 +37,7 @@ func DefaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		Tag:             names.NewMachineTag("0"),
 		LogDir:          c.MkDir(),
 		Hub:             hub,
+		Presence:        presence.New(clock.WallClock),
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{Enabled: false} },

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -689,6 +689,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			PrometheusRegisterer:              config.PrometheusRegisterer,
 			RegisterIntrospectionHTTPHandlers: config.RegisterIntrospectionHTTPHandlers,
 			Hub:       config.CentralHub,
+			Presence:  config.PresenceRecorder,
 			NewWorker: apiserver.NewWorker,
 		}),
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -55,6 +55,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -864,6 +865,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 				LogDir:          LogDir,
 				Mux:             estate.mux,
 				Hub:             centralhub.New(machineTag),
+				Presence:        presence.New(clock.WallClock),
 				NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 				RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 				PublicDNSName:   icfg.Controller.Config.AutocertDNSName(),

--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/dependency"
@@ -38,6 +39,7 @@ type ManifoldConfig struct {
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
 	Hub                               *pubsub.StructuredHub
+	Presence                          presence.Recorder
 
 	NewWorker func(Config) (worker.Worker, error)
 }
@@ -76,6 +78,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.Hub == nil {
 		return errors.NotValidf("nil Hub")
+	}
+	if config.Presence == nil {
+		return errors.NotValidf("nil Presence")
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
@@ -164,6 +169,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		RestoreStatus:                     restoreStatus,
 		UpgradeComplete:                   upgradeLock.IsUnlocked,
 		Hub:                               config.Hub,
+		Presence:                          config.Presence,
 		Authenticator:                     authenticator,
 		GetAuditConfig:                    getAuditConfig,
 		NewServer:                         newServerShim,

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/apiserver"
@@ -76,6 +77,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		PrometheusRegisterer:              &s.prometheusRegisterer,
 		RegisterIntrospectionHTTPHandlers: func(func(string, http.Handler)) {},
 		Hub:       &s.hub,
+		Presence:  presence.New(s.clock),
 		NewWorker: s.newWorker,
 	})
 }
@@ -160,6 +162,9 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 
 	c.Assert(config.RegisterIntrospectionHTTPHandlers, gc.NotNil)
 	config.RegisterIntrospectionHTTPHandlers = nil
+
+	c.Assert(config.Presence, gc.NotNil)
+	config.Presence = nil
 
 	// NewServer is hard-coded by the manifold to an internal shim.
 	c.Assert(config.NewServer, gc.NotNil)

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 )
 
@@ -28,6 +29,7 @@ type Config struct {
 	AgentConfig                       agent.Config
 	Clock                             clock.Clock
 	Hub                               *pubsub.StructuredHub
+	Presence                          presence.Recorder
 	Mux                               *apiserverhttp.Mux
 	Authenticator                     httpcontext.LocalMacaroonAuthenticator
 	StatePool                         *state.StatePool
@@ -53,6 +55,9 @@ func (config Config) Validate() error {
 	}
 	if config.Hub == nil {
 		return errors.NotValidf("nil Hub")
+	}
+	if config.Presence == nil {
+		return errors.NotValidf("nil Presence")
 	}
 	if config.StatePool == nil {
 		return errors.NotValidf("nil StatePool")
@@ -120,6 +125,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		DataDir:                       config.AgentConfig.DataDir(),
 		LogDir:                        config.AgentConfig.LogDir(),
 		Hub:                           config.Hub,
+		Presence:                      config.Presence,
 		Mux:                           config.Mux,
 		Authenticator:                 config.Authenticator,
 		RestoreStatus:                 config.RestoreStatus,

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -99,6 +99,9 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 	// compare it.
 	config.GetAuditConfig = nil
 
+	c.Assert(config.Presence, gc.NotNil)
+	config.Presence = nil
+
 	rateLimitConfig := coreapiserver.DefaultRateLimitConfig()
 	logSinkConfig := coreapiserver.DefaultLogSinkConfig()
 

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -16,6 +16,7 @@ import (
 	coreapiserver "github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/apiserver"
 	"github.com/juju/juju/worker/workertest"
@@ -54,6 +55,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		Authenticator:                     s.authenticator,
 		Clock:                             s.clock,
 		Hub:                               &s.hub,
+		Presence:                          presence.New(s.clock),
 		Mux:                               s.mux,
 		StatePool:                         &state.StatePool{},
 		PrometheusRegisterer:              &s.prometheusRegisterer,


### PR DESCRIPTION
This is the penultimate branch for enabling the new presence code in the API server.

It ended up being much bigger than I thought as the code that determins agent presence in the API server was also used by the migration code. This required a bit of thought and rework around how to have the API server control the switch for using the existing presence code or the new presence code in order to determin agent status.

This branch takes the approach of writing the interfaces close to the place where they are needed. This made mocking out the interfaces much easier.

The current implementation still uses the current presence implementation as outlined by the TODO in apiserver/root.go.

## QA steps

Nothing to see here. Everything should be as before.
