### PR TITLE
Container Image Config Changes for LXD

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -5,7 +5,15 @@
 
 package lxd
 
+import (
+	"github.com/juju/juju/container"
+	"github.com/juju/juju/tools/lxdtools"
+)
+
 var (
-	NICDevice      = nicDevice
-	NetworkDevices = networkDevices
+	NICDevice       = nicDevice
+	NetworkDevices  = networkDevices
+	GetImageSources = func(mgr container.Manager) ([]lxdtools.RemoteServer, error) {
+		return mgr.(*containerManager).getImageSources()
+	}
 )


### PR DESCRIPTION
## Description of change

This is a forward port of changes from the 2.3 branch that affects the LXD container manager in develop.

These were applied separately as they were deliberately omitted from a prior 2.3->develop merge. The code bases are divergent around recent changes to the LXD client.

## QA steps

- Additional unit tests.
- Manually tested adding LXD machines using both the released and daily streams.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1606617
