### PR TITLE
Don't update caas units if app is not alive

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -98,6 +98,11 @@ func (*mockApplication) Tag() names.Tag {
 	panic("should not be called")
 }
 
+func (a *mockApplication) Name() string {
+	a.MethodCall(a, "Name")
+	return a.tag.Id()
+}
+
 func (a *mockApplication) Life() state.Life {
 	a.MethodCall(a, "Life")
 	return a.life

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -594,7 +594,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 	}
 	err := app.UpdateUnits(&unitUpdate)
 	// We ignore any updates for dying applications.
-	if errors.Cause(err) == state.NotAliveError {
+	if state.IsNotAlive(err) {
 		return nil
 	}
 	return err

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -38,6 +38,8 @@ type Application interface {
 	AddOperation(state.UnitUpdateProperties) *state.AddUnitOperation
 	UpdateUnits(*state.UpdateUnitsOperation) error
 	UpdateCloudService(providerId string, addreses []network.Address) error
+	Life() state.Life
+	Name() string
 }
 
 type stateShim struct {

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -21,6 +21,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Cleaner",
 	"Client",
 	"Cloud",
+	"CredentialValidator",
 	"LeadershipService",
 	"LifeFlag",
 	"MeterStatus",

--- a/state/application.go
+++ b/state/application.go
@@ -2387,6 +2387,12 @@ type AddUnitOperation struct {
 
 // Build is part of the ModelOperation interface.
 func (op *AddUnitOperation) Build(attempt int) ([]txn.Op, error) {
+	if alive, err := isAlive(op.application.st, applicationsC, op.application.doc.DocID); err != nil {
+		return nil, err
+	} else if !alive {
+		return nil, NotAliveError
+	}
+
 	var ops []txn.Op
 
 	addUnitArgs := AddUnitParams{

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1870,7 +1870,7 @@ func (s *ApplicationSuite) TestAddUnitWhenNotAlive(c *gc.C) {
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.mysql.AddUnit(state.AddUnitParams{})
-	c.Assert(err, gc.ErrorMatches, `cannot add unit to application "mysql": application is not alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot add unit to application "mysql": application is not found or not alive`)
 	err = u.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Remove()
@@ -2387,7 +2387,7 @@ func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cons1 := constraints.MustParse("mem=1G")
 	err = s.mysql.SetConstraints(cons1)
-	c.Assert(err, gc.ErrorMatches, `cannot set constraints: not found or not alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot set constraints: application is not found or not alive`)
 	scons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&scons, jc.Satisfies, constraints.IsEmpty)
@@ -2398,7 +2398,7 @@ func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 	err = unit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysql.SetConstraints(cons1)
-	c.Assert(err, gc.ErrorMatches, `cannot set constraints: not found or not alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot set constraints: application is not found or not alive`)
 	_, err = s.mysql.Constraints()
 	c.Assert(err, gc.ErrorMatches, `constraints not found`)
 }
@@ -2672,7 +2672,7 @@ func (s *ApplicationSuite) TestMetricCredentialsOnDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, s.mysql, state.Dying)
 	err = s.mysql.SetMetricCredentials([]byte("set after dying"))
-	c.Assert(err, gc.ErrorMatches, "cannot update metric credentials: application not found or not alive")
+	c.Assert(err, gc.ErrorMatches, "cannot update metric credentials: application is not found or not alive")
 }
 
 func (s *ApplicationSuite) testStatus(c *gc.C, status1, status2, expected status.Status) {
@@ -3416,7 +3416,7 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	})}
 	err = s.app.UpdateUnits(&updateUnits)
 	if !aliveApp {
-		c.Assert(errors.Cause(err), jc.DeepEquals, state.NotAliveError)
+		c.Assert(err, jc.Satisfies, state.IsNotAlive)
 		return
 	}
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -272,10 +272,10 @@ func (s *AssignSuite) TestAssignMachineWhenDying(c *gc.C) {
 		}
 		return err
 	}
-	expect := ".*: unit is not alive"
+	expect := ".*: unit is not found or not alive"
 	testWhenDying(c, unit, expect, expect, assignTest)
 
-	expect = ".*: machine is not alive"
+	expect = ".*: machine is not found or not alive"
 	unit, err = s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	testWhenDying(c, machine, expect, expect, assignTest)
@@ -477,7 +477,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineUnitNotAlive(c *gc.C) {
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToNewMachine()
-	c.Assert(err, gc.ErrorMatches, `cannot assign unit "wordpress/0" to new machine: unit is not alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit "wordpress/0" to new machine: unit is not found or not alive`)
 
 	// ...and a dead one.
 	err = subUnit.EnsureDead()
@@ -487,7 +487,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineUnitNotAlive(c *gc.C) {
 	err = unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToNewMachine()
-	c.Assert(err, gc.ErrorMatches, `cannot assign unit "wordpress/0" to new machine: unit is not alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit "wordpress/0" to new machine: unit is not found or not alive`)
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachineUnitRemoved(c *gc.C) {

--- a/state/charm.go
+++ b/state/charm.go
@@ -358,11 +358,9 @@ func (c *Charm) Refresh() error {
 func (c *Charm) Destroy() error {
 	buildTxn := func(_ int) ([]txn.Op, error) {
 		ops, err := charmDestroyOps(c.st, c.doc.URL)
-		switch errors.Cause(err) {
-		case nil:
-		case errNotAlive:
+		if IsNotAlive(err) {
 			return nil, jujutxn.ErrNoOperations
-		default:
+		} else if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return ops, nil

--- a/state/errors.go
+++ b/state/errors.go
@@ -47,7 +47,32 @@ func IsCharmAlreadyUploadedError(err interface{}) bool {
 var ErrCharmRevisionAlreadyModified = fmt.Errorf("charm revision already modified")
 
 var ErrDead = fmt.Errorf("not found or dead")
-var errNotAlive = fmt.Errorf("not found or not alive")
+
+type notAliveError struct {
+	entity string
+}
+
+func (e notAliveError) Error() string {
+	if e.entity == "" {
+		return "not found or not alive"
+	}
+	return fmt.Sprintf("%v is not found or not alive", e.entity)
+}
+
+// IsNotAlive returns true if err is cause by a not alive error.
+func IsNotAlive(err error) bool {
+	_, ok := errors.Cause(err).(notAliveError)
+	return ok
+}
+
+var (
+	machineNotAliveErr     = notAliveError{"machine"}
+	applicationNotAliveErr = notAliveError{"application"}
+	unitNotAliveErr        = notAliveError{"unit"}
+	spaceNotAliveErr       = notAliveError{"space"}
+	subnetNotAliveErr      = notAliveError{"subnet"}
+	notAliveErr            = notAliveError{""}
+)
 
 func onAbort(txnErr, err error) error {
 	if txnErr == txn.ErrAborted ||

--- a/state/life.go
+++ b/state/life.go
@@ -10,9 +10,6 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
-// NotAliveError is used to indicate an entity is not alive.
-var NotAliveError = errors.New("not alive")
-
 // Life represents the lifecycle state of the entities
 // Relation, Unit, Service and Machine.
 type Life int8

--- a/state/life.go
+++ b/state/life.go
@@ -10,6 +10,9 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
+// NotAliveError is used to indicate an entity is not alive.
+var NotAliveError = errors.New("not alive")
+
 // Life represents the lifecycle state of the entities
 // Relation, Unit, Service and Machine.
 type Life int8

--- a/state/life_ns.go
+++ b/state/life_ns.go
@@ -71,7 +71,7 @@ func (nsLife_) aliveOp(entities mongo.Collection, docID string) (txn.Op, error) 
 	switch errors.Cause(err) {
 	case nil:
 	case errCheckFailed:
-		return txn.Op{}, errNotAlive
+		return txn.Op{}, notAliveErr
 	default:
 		return txn.Op{}, errors.Trace(err)
 	}

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -179,7 +179,7 @@ func (s *LifeSuite) TestLifeString(c *gc.C) {
 }
 
 const (
-	notAliveErr = ".*: not found or not alive"
+	notAliveErr = ".*: .* is not found or not alive"
 	deadErr     = ".*: not found or dead"
 	noErr       = ""
 )

--- a/state/machine.go
+++ b/state/machine.go
@@ -1323,7 +1323,7 @@ func (m *Machine) SetProvisioned(
 	} else if alive, err := isAlive(m.st, machinesC, m.doc.DocID); err != nil {
 		return err
 	} else if !alive {
-		return errNotAlive
+		return machineNotAliveErr
 	}
 	return fmt.Errorf("already set")
 }
@@ -1725,7 +1725,7 @@ func (m *Machine) setConstraintsOps(cons constraints.Value) ([]txn.Op, error) {
 	}
 
 	if m.doc.Life != Alive {
-		return nil, errNotAlive
+		return nil, machineNotAliveErr
 	}
 	if _, err := m.InstanceId(); err == nil {
 		return nil, fmt.Errorf("machine is already provisioned")

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1582,7 +1582,7 @@ func (s *MachineSuite) TestSetUnsupportedConstraintsWarning(c *gc.C) {
 
 func (s *MachineSuite) TestConstraintsLifecycle(c *gc.C) {
 	cons := constraints.MustParse("mem=1G")
-	cannotSet := `updating machine "1": cannot set constraints: not found or not alive`
+	cannotSet := `updating machine "1": cannot set constraints: machine is not found or not alive`
 	testWhenDying(c, s.machine, cannotSet, cannotSet, func() error {
 		err := s.machine.SetConstraints(cons)
 		mcons, err1 := s.machine.Constraints()

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -201,7 +201,7 @@ func (s *Space) EnsureDead() (err error) {
 		s.doc.Life = Dead
 		return nil
 	}
-	return onAbort(txnErr, errNotAlive)
+	return onAbort(txnErr, spaceNotAliveErr)
 }
 
 // Remove removes a Dead space. If the space is not Dead or it is already

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -208,7 +208,7 @@ func (s *storageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
 	}).Check()
 
 	_, err := s.IAASModel.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
-	c.Assert(err, gc.ErrorMatches, `adding "multi1to10" storage to storage-block2/0: unit is not alive`)
+	c.Assert(err, gc.ErrorMatches, `adding "multi1to10" storage to storage-block2/0: unit is not found or not alive`)
 
 	s.assertStorageCount(c, s.originalStorageCount)
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -120,7 +120,7 @@ func (s *Subnet) EnsureDead() (err error) {
 		s.doc.Life = Dead
 		return nil
 	}
-	return onAbort(txnErr, errNotAlive)
+	return onAbort(txnErr, subnetNotAliveErr)
 }
 
 // Remove removes a Dead subnet. If the subnet is not Dead or it is already

--- a/state/unit.go
+++ b/state/unit.go
@@ -1543,9 +1543,7 @@ func (u *Unit) AssignedMachineId() (id string, err error) {
 }
 
 var (
-	machineNotAliveErr = errors.New("machine is not alive")
 	machineNotCleanErr = errors.New("machine is dirty")
-	unitNotAliveErr    = errors.New("unit is not alive")
 	alreadyAssignedErr = errors.New("unit is already assigned to a machine")
 	inUseErr           = errors.New("machine is not unused")
 )


### PR DESCRIPTION
## Description of change

CAAS unit provisioner uses a bulk model update operation to updates units when an event arrives from the k8s cloud. If the application is dying, the operation fails with a txn contention error. We need to change state code to return a different error. The facade can simply ignore this error as any events from k8s are irrelevant at this point.

Also driveby fix - add CreddentialValidator facade to the allowed caas list.

## QA steps

Deploy caas model.
Deploy app, add units, destroy.
Ensure in juju logs that we no longer get a bunch of repeated txn contention errors.

