### PR TITLE
Hook up new presence to apiserver and status.

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -44,7 +44,7 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	return newAPIRoot(nil, state.NewStatePool(nil), facades, common.NewResources(), nil, nil)
+	return newAPIRoot(nil, nil, facades, common.NewResources(), nil)
 }
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to
@@ -57,7 +57,7 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHan
 	srv := &Server{
 		authenticator: authenticator,
 		offerAuthCtxt: offerAuthCtxt,
-		statePool:     pool,
+		shared:        &sharedServerContext{statePool: pool},
 		tag:           names.NewMachineTag("0"),
 	}
 	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), 6543, "testing.invalid:1234")

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -12,6 +12,7 @@ import (
 type Context struct {
 	Auth_      facade.Authorizer
 	Dispose_   func()
+	Hub_       facade.Hub
 	Resources_ facade.Resources
 	State_     *state.State
 	StatePool_ *state.StatePool
@@ -29,6 +30,11 @@ func (context Context) Auth() facade.Authorizer {
 // Dispose is part of the facade.Context interface.
 func (context Context) Dispose() {
 	context.Dispose_()
+}
+
+// Hub is part of the facade.Context interface.
+func (context Context) Hub() facade.Hub {
+	return context.Hub_
 }
 
 // Resources is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -66,6 +66,10 @@ type Context interface {
 	// the current model presence.
 	Presence() Presence
 
+	// Hub returns the central hub that the API server holds.
+	// At least at this stage, facades only need to publish events.
+	Hub() Hub
+
 	// ID returns a string that should almost always be "", unless
 	// this is a watcher facade, in which case it exists in lieu of
 	// actual arguments in the Next() call, and is used as a key
@@ -148,4 +152,9 @@ type Presence interface {
 type ModelPresence interface {
 	// For a given non controller agent, return the Status for that agent.
 	AgentStatus(agent string) (presence.Status, error)
+}
+
+// Hub represents the central hub that the API server has.
+type Hub interface {
+	Publish(topic string, data interface{}) (<-chan struct{}, error)
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -37,6 +37,7 @@ func (ctx *charmsSuiteContext) State() *state.State         { return ctx.cs.Stat
 func (ctx *charmsSuiteContext) StatePool() *state.StatePool { return nil }
 func (ctx *charmsSuiteContext) ID() string                  { return "" }
 func (ctx *charmsSuiteContext) Presence() facade.Presence   { return nil }
+func (ctx *charmsSuiteContext) Hub() facade.Hub             { return nil }
 
 func (s *charmsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -36,7 +36,9 @@ type API struct {
 	pool          Pool
 	auth          facade.Authorizer
 	resources     facade.Resources
-	client        *Client
+	presence      facade.Presence
+
+	client *Client
 	// statusSetter provides common methods for updating an entity's provisioning status.
 	statusSetter *common.StatusSetter
 	toolsFinder  *common.ToolsFinder
@@ -114,6 +116,7 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	st := ctx.State()
 	resources := ctx.Resources()
 	authorizer := ctx.Auth()
+	presence := ctx.Presence()
 
 	model, err := st.Model()
 	if err != nil {
@@ -139,6 +142,7 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 		modelConfigAPI,
 		resources,
 		authorizer,
+		presence,
 		statusSetter,
 		toolsFinder,
 		newEnviron,
@@ -153,6 +157,7 @@ func NewClient(
 	modelConfigAPI *modelconfig.ModelConfigAPI,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
+	presence facade.Presence,
 	statusSetter *common.StatusSetter,
 	toolsFinder *common.ToolsFinder,
 	newEnviron func() (environs.Environ, error),
@@ -168,6 +173,7 @@ func NewClient(
 			pool:          pool,
 			auth:          authorizer,
 			resources:     resources,
+			presence:      presence,
 			statusSetter:  statusSetter,
 			toolsFinder:   toolsFinder,
 		},

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -177,6 +177,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	if err != nil {
 		return noStatus, errors.Annotate(err, "cannot get model")
 	}
+	context.presence.Presence = c.api.presence.ModelPresence(m.UUID())
 	cfg, err := m.Config()
 	if err != nil {
 		return noStatus, errors.Annotate(err, "cannot obtain current model config")

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -37,6 +37,7 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // modelconfig API
 		nil, // resources
 		authorizer,
+		nil, // presence
 		nil, // statusSetter
 		nil, // toolsFinder
 		nil, // newEnviron

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -137,7 +137,7 @@ func (gr *guiRouter) ensureFileHandler(h func(gh *guiHandler, w http.ResponseWri
 // and archive hash.
 func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string, err error) {
 	// Retrieve the Juju GUI info from the GUI storage.
-	st := gr.ctxt.srv.statePool.SystemState()
+	st := gr.ctxt.srv.shared.statePool.SystemState()
 	storage, err := st.GUIStorage()
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
@@ -361,7 +361,7 @@ func getConfigPath(path string, ctxt httpContext) string {
 	if uuid != "" {
 		return fmt.Sprintf("%[1]s?model-uuid=%[2]s&base-postfix=%[2]s/", configPath, uuid)
 	}
-	st := ctxt.srv.statePool.SystemState()
+	st := ctxt.srv.shared.statePool.SystemState()
 	if isNewGUI(st) {
 		// This is the proper case in which a new GUI is being served from a
 		// new URL. No query must be included in the config path.
@@ -370,7 +370,7 @@ func getConfigPath(path string, ctxt httpContext) string {
 	// Possibly handle requests to the new "/u/{user}/{model}" path, but
 	// made from an old version of the GUI, which didn't connect to the
 	// model based on the path.
-	uuid, user, model := modelInfoFromPath(path, st, ctxt.srv.statePool)
+	uuid, user, model := modelInfoFromPath(path, st, ctxt.srv.shared.statePool)
 	if uuid != "" {
 		return fmt.Sprintf("%s?model-uuid=%s&base-postfix=u/%s/%s/", configPath, uuid, user, model)
 	}

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -28,7 +28,7 @@ type httpContext struct {
 // without checking any authentication information.
 func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state.PooledState, error) {
 	modelUUID := httpcontext.RequestModelUUID(r)
-	st, err := ctxt.srv.statePool.Get(modelUUID)
+	st, err := ctxt.srv.shared.statePool.Get(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -82,7 +82,7 @@ func (ctxt *httpContext) stateForMigration(
 	requiredMode state.MigrationMode,
 ) (_ *state.PooledState, err error) {
 	modelUUID := r.Header.Get(params.MigrationModelHTTPHeader)
-	migrationSt, err := ctxt.srv.statePool.Get(modelUUID)
+	migrationSt, err := ctxt.srv.shared.statePool.Get(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -92,7 +92,7 @@ func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.Resp
 	// Get the backend state for the source model so we can lookup the app in that model to get the charm details.
 	offerUUID := remoteApp.OfferUUID()
 	sourceModelUUID := remoteApp.SourceModel().Id()
-	sourceSt, err := h.ctxt.srv.statePool.Get(sourceModelUUID)
+	sourceSt, err := h.ctxt.srv.shared.statePool.Get(sourceModelUUID)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/pubsub/controller"
+	"github.com/juju/juju/state"
+)
+
+// sharedServerContext contains a number of components that are unchangable in the API server.
+// These components need to be exposed through the facade.Context. Instead of having the methods
+// of newAPIHandler and newAPIRoot take ever increasing numbers of parameters, they will instead
+// have a pointer to the sharedServerContext.
+//
+// All attributes in the context should be goroutine aware themselves, like the state pool, hub, and
+// presence, or protected and only accessed through methods on this context object.
+type sharedServerContext struct {
+	statePool  *state.StatePool
+	centralHub *pubsub.StructuredHub
+	presence   presence.Recorder
+	logger     loggo.Logger
+
+	featuresMutex sync.RWMutex
+	features      set.Strings
+
+	unsubscribe func()
+}
+
+type sharedServerConfig struct {
+	statePool  *state.StatePool
+	centralHub *pubsub.StructuredHub
+	presence   presence.Recorder
+	logger     loggo.Logger
+}
+
+func (c *sharedServerConfig) validate() error {
+	if c.statePool == nil {
+		return errors.NotValidf("nil statePool")
+	}
+	if c.centralHub == nil {
+		return errors.NotValidf("nil centralHub")
+	}
+	if c.presence == nil {
+		return errors.NotValidf("nil presence")
+	}
+	return nil
+}
+
+func newSharedServerContex(config sharedServerConfig) (*sharedServerContext, error) {
+	if err := config.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	ctx := &sharedServerContext{
+		statePool:  config.statePool,
+		centralHub: config.centralHub,
+		presence:   config.presence,
+		logger:     config.logger,
+	}
+	controllerConfig, err := ctx.statePool.SystemState().ControllerConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get controller config")
+	}
+	ctx.features = controllerConfig.Features()
+	// We are able to get the current controller config before subscribing to changes
+	// because the changes are only ever published in response to an API call, and
+	// this function is called in the newServer call to create the API server,
+	// and we know that we can't make any API calls until the server has started.
+	ctx.unsubscribe, err = ctx.centralHub.Subscribe(controller.ConfigChanged, ctx.onConfigChanged)
+	if err != nil {
+		ctx.logger.Criticalf("programming error in subscribe function: %v", err)
+		return nil, errors.Trace(err)
+	}
+	return ctx, nil
+}
+
+func (c *sharedServerContext) Close() {
+	c.unsubscribe()
+}
+
+func (c *sharedServerContext) onConfigChanged(topic string, data controller.ConfigChangedMessage, err error) {
+	if err != nil {
+		c.logger.Criticalf("programming error in %s message data: %v", topic, err)
+		return
+	}
+
+	features := data.Config.Features()
+
+	c.featuresMutex.Lock()
+	removed := c.features.Difference(features)
+	added := features.Difference(c.features)
+	c.features = features
+	values := features.SortedValues()
+	c.featuresMutex.Unlock()
+
+	if removed.Size() != 0 || added.Size() != 0 {
+		c.logger.Infof("updating features to %v", values)
+	}
+}
+
+func (c *sharedServerContext) featureEnabled(flag string) bool {
+	c.featuresMutex.RLock()
+	defer c.featuresMutex.RUnlock()
+	return c.features.Contains(flag)
+}

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -1,0 +1,109 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	corecontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/pubsub/controller"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
+)
+
+type sharedServerContextSuite struct {
+	statetesting.StateSuite
+
+	hub    *pubsub.StructuredHub
+	config sharedServerConfig
+}
+
+var _ = gc.Suite(&sharedServerContextSuite{})
+
+func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.config = sharedServerConfig{
+		statePool:  s.StatePool,
+		centralHub: s.hub,
+		presence:   presence.New(clock.WallClock),
+		logger:     loggo.GetLogger("test"),
+	}
+}
+
+func (s *sharedServerContextSuite) TestConfigNoStatePool(c *gc.C) {
+	s.config.statePool = nil
+	err := s.config.validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "nil statePool not valid")
+}
+
+func (s *sharedServerContextSuite) TestConfigNoHub(c *gc.C) {
+	s.config.centralHub = nil
+	err := s.config.validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "nil centralHub not valid")
+}
+
+func (s *sharedServerContextSuite) TestConfigNoPresence(c *gc.C) {
+	s.config.presence = nil
+	err := s.config.validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "nil presence not valid")
+}
+
+func (s *sharedServerContextSuite) TestNewCallsConfigValidate(c *gc.C) {
+	s.config.statePool = nil
+	ctx, err := newSharedServerContex(s.config)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "nil statePool not valid")
+	c.Check(ctx, gc.IsNil)
+}
+
+func (s *sharedServerContextSuite) TestValidConfig(c *gc.C) {
+	ctx, err := newSharedServerContex(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	// Normally you wouldn't directly access features.
+	c.Assert(ctx.features, gc.HasLen, 0)
+	ctx.Close()
+}
+
+func (s *sharedServerContextSuite) newContext(c *gc.C) *sharedServerContext {
+	ctx, err := newSharedServerContex(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { ctx.Close() })
+	return ctx
+}
+
+func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
+	ctx := s.newContext(c)
+
+	msg := controller.ConfigChangedMessage{
+		corecontroller.Config{
+			corecontroller.Features: []string{"foo", "bar"},
+		},
+	}
+
+	done, err := s.hub.Publish(controller.ConfigChanged, msg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("handler didn't")
+	}
+
+	c.Check(ctx.featureEnabled("foo"), jc.IsTrue)
+	c.Check(ctx.featureEnabled("bar"), jc.IsTrue)
+	c.Check(ctx.featureEnabled("baz"), jc.IsFalse)
+}

--- a/controller/config.go
+++ b/controller/config.go
@@ -160,6 +160,9 @@ const (
 	// JujuManagementSpace is the network space that agents should use to
 	// communicate with controllers.
 	JujuManagementSpace = "juju-mgmt-space"
+
+	// Features allows a list of runtime changable features to be updated.
+	Features = "features"
 )
 
 var (
@@ -187,6 +190,7 @@ var (
 		AuditLogMaxSize,
 		AuditLogMaxBackups,
 		AuditLogExcludeMethods,
+		Features,
 	}
 
 	// AllowedUpdateConfigAttributes contains all of the controller
@@ -201,6 +205,7 @@ var (
 		AuditLogExcludeMethods,
 		JujuHASpace,
 		JujuManagementSpace,
+		Features,
 	)
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to
@@ -346,6 +351,18 @@ func (c Config) AuditLogExcludeMethods() set.Strings {
 		return items
 	}
 	return set.NewStrings(DefaultAuditLogExcludeMethods...)
+}
+
+// Features returns the controller config set features flags.
+func (c Config) Features() set.Strings {
+	features := set.NewStrings()
+	if value, ok := c[Features]; ok {
+		value := value.([]interface{})
+		for _, item := range value {
+			features.Add(item.(string))
+		}
+	}
+	return features
 }
 
 // ControllerUUID returns the uuid for the model's controller.
@@ -632,6 +649,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxTxnLogSize:           schema.String(),
 	JujuHASpace:             schema.String(),
 	JujuManagementSpace:     schema.String(),
+	Features:                schema.List(schema.String()),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -652,4 +670,5 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxTxnLogSize:           fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
 	JujuHASpace:             schema.Omit,
 	JujuManagementSpace:     schema.Omit,
+	Features:                schema.Omit,
 })

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -40,3 +40,8 @@ const StrictMigration = "strict-migration"
 
 // CAAS enables creating models on CAAS infrastructure (k8s, etc)
 const CAAS = "caas"
+
+// NewPresence indicates that the new in-memory presence implementation
+// should be used by the API server to determine agent presence.
+// This value is only checked using the controller config "features" attrubite.
+const NewPresence = "new-presence"

--- a/pubsub/controller/messages.go
+++ b/pubsub/controller/messages.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import "github.com/juju/juju/controller"
+
+// ConfigChanged messages are published by the apiserver client controller
+// facade whenever the controller config is updated.
+// data: `ConfigChangedMessage`
+const ConfigChanged = "controller.config-changed"
+
+// ConfigChangedMessage contains the controller.Config as it is after
+// the update. Despite the controller.Config being a map[string]interface{},
+// which also happens to be the default pubsub message payload, we wrap it
+// in a structure because the central hub annotates the serialised data structure
+// with, at least, the origin of the message.
+type ConfigChangedMessage struct {
+	Config controller.Config
+	// TODO(thumper): add a version int to allow out of order messages.
+	// Out of order could occur if two events happen simultaneously on two
+	// different machines, and the forwarding of those messages cross each other.
+	// Adding a version could allow subscribers to ignore lower versioned messages.
+}

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -36,6 +36,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.JujuHASpace,
 		controller.JujuManagementSpace,
 		controller.AuditLogExcludeMethods,
+		controller.Features,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
This branch adds two new logical pieces, and hooks up a third.

Features are added to controller config, and when config is updated, a pubsub message is sent for controller.ConfigChanged.

Added a new apiserver struct for shared server data. This is for server attributes that don't change from connection to connection, and need to be threaded through to the facade context. The state pool, presence, and now the central hub are all part of this context. This shared context also knows what controller feature flags have been set.

The last piece is to hook up the status code to the new presence. This means setting the ModelPresence when calling status. There was a logic bug in the controller connections in that all were considered controller connections which meant that AgentStatus always showed unknown. The controller connection flag is supposed to be for non-controller models for controller machine connections. This has now been updated.

## QA steps
```
juju bootstrap lxd test
juju enable-ha
watch -c juju status -m controller
juju ssh -m controller 2
# in there, do this
sudo service jujud-machine-2 stop
# observe the slow status updating showing machine 2 down
# in another terminal
juju controller-config features=[new-presence]
# now stop and start machine 2 and observe faster status.
```

## Documentation changes

This isn't a user observable change, although we may want to document the controller feature flags options.
