### PR TITLE
Guard configObserver Channel send with Provisioner's Catacomb

### DIFF
--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -18,9 +18,11 @@ func SetObserver(p Provisioner, observer chan<- *config.Config) {
 	var configObserver *configObserver
 	if ep, ok := p.(*environProvisioner); ok {
 		configObserver = &ep.configObserver
+		configObserver.catacomb = &ep.catacomb
 	} else {
 		cp := p.(*containerProvisioner)
 		configObserver = &cp.configObserver
+		configObserver.catacomb = &cp.catacomb
 	}
 	configObserver.Lock()
 	configObserver.observer = observer

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -484,8 +484,3 @@ func (s *kvmProvisionerSuite) TestKVMProvisionerObservesConfigChanges(c *gc.C) {
 	defer workertest.CleanKill(c, p)
 	s.assertProvisionerObservesConfigChanges(c, p)
 }
-
-type kvmFakeBridger struct {
-	brokerSuite      *kvmBrokerSuite
-	provisionerSuite *kvmProvisionerSuite
-}

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -88,9 +88,9 @@ func NewRetryStrategy(delay time.Duration, count int) RetryStrategy {
 
 // configObserver is implemented so that tests can see when the environment
 // configuration changes.
-// The dying function should be set by the outer provider to return its
-// catacomb. This is used to prevent notify from blocking a provisioner
-// that has had its Kill method invoked.
+// The catacomb is set in export_test to the provider's member.
+// This is used to prevent notify from blocking a provisioner that has had its
+// Kill method invoked.
 type configObserver struct {
 	sync.Mutex
 	observer chan<- *config.Config

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -67,7 +67,7 @@ type CommonProvisionerSuite struct {
 
 func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChanges(c *gc.C, p provisioner.Provisioner) {
 	// Inject our observer into the provisioner
-	cfgObserver := make(chan *config.Config, 1)
+	cfgObserver := make(chan *config.Config)
 	provisioner.SetObserver(p, cfgObserver)
 
 	// Switch to reaping on All machines.


### PR DESCRIPTION
## Description of change

Intermittent test failures have been observed coming from ```kvmProvisionerSuite.TestKVMProvisionerObservesConfigChanges```.

This turned out to be caused by ```configObserver```, used by tests to detect config changes. The sends on this channel were unguarded and under certain circumstances could block the worker from being killed.

There were a couple of approaches that I entertained for the fix. This simplest is to pad out the channel buffer. I think what I settled on provides reasonable safety, without imposing too much more "test concern" on to the affected workers.

## QA steps

Test failures can be repeated by removing the channel buffer in ```CommonProvisionerSuite.assertProvisionerObservesConfigChanges```

Tests always pass after the fix.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1753418
