### PR TITLE
Introduce functional test for resolve command.

### DIFF
--- a/acceptancetests/assess_cross_model_relations.py
+++ b/acceptancetests/assess_cross_model_relations.py
@@ -42,7 +42,7 @@ from jujupy.client import (
     )
 from jujupy.models import (
     temporary_model
-)
+    )
 from jujucharm import local_charm_path
 from utility import (
     add_basic_testing_arguments,

--- a/acceptancetests/assess_cross_model_relations.py
+++ b/acceptancetests/assess_cross_model_relations.py
@@ -31,8 +31,6 @@ import argparse
 import logging
 import sys
 import yaml
-from contextlib import contextmanager
-from subprocess import CalledProcessError
 from textwrap import dedent
 
 from deploy_stack import (
@@ -42,6 +40,9 @@ from jujupy.client import (
     Controller,
     register_user_interactively,
     )
+from jujupy.models import (
+    temporary_model
+)
 from jujucharm import local_charm_path
 from utility import (
     add_basic_testing_arguments,
@@ -288,20 +289,6 @@ def deploy_local_charm(client, app_name):
         charm=app_name, juju_ver=client.version)
     client.deploy(charm_path)
     client.wait_for_started()
-
-
-@contextmanager
-def temporary_model(client, model_name):
-    """Create a new model that is cleaned up once it's done with."""
-    try:
-        new_client = client.add_model(model_name)
-        yield new_client
-    finally:
-        try:
-            log.info('Destroying temp model "{}"'.format(model_name))
-            new_client.destroy_model()
-        except CalledProcessError:
-            log.info('Failed to cleanup model.')
 
 
 def extract_second_provider_details(args):

--- a/acceptancetests/assess_resolve.py
+++ b/acceptancetests/assess_resolve.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+""" Ensure resolve command resolves hook issues.
+
+This test covers the resolve command (and the option --no-retry)
+
+The test:
+  - Uses a simple custom charm that instruments failure in the install hook
+  - Ensures that 'resolve' retries the failed install hook and that the
+    followup 'start' hook is fired.
+  - Ensures that 'resolve --no-retry' does NOT re-run the failed install hook
+    and instead goes ahead and runs the follow up 'started' hook.
+"""
+
+from __future__ import print_function
+
+import argparse
+import logging
+import sys
+
+from deploy_stack import (
+    BootstrapManager,
+    )
+from jujupy.models import (
+    temporary_model,
+)
+from jujupy.wait_condition import (
+    UnitInstallCondition,
+)
+from jujucharm import local_charm_path
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
+
+
+__metaclass__ = type
+
+
+log = logging.getLogger('assess_resolve')
+
+
+class ResolveCharmMessage:
+    """Workload active message differs if the install hook completed."""
+    ACTIVE_NO_INSTALL_HOOK = 'No install hook'
+    ACTIVE_INSTALL_HOOK = 'Install hook succeeded'
+    INSTALL_FAIL = 'hook failed: "install"'
+
+
+def assess_resolve(client, local_charm='simple-resolve'):
+    local_resolve_charm = local_charm_path(
+        charm=local_charm, juju_ver=client.version)
+    ensure_retry_does_not_rerun_failed_hook(client, local_resolve_charm)
+
+
+def ensure_retry_does_not_rerun_failed_hook(client, resolve_charm):
+        with temporary_model(client, "no-retry") as temp_client:
+            unit_name = 'simple-resolve/0'
+            temp_client.deploy(resolve_charm)
+            temp_client.wait_for(UnitInstallError(unit_name))
+            temp_client.juju('resolve', ('--no-retry', unit_name))
+            temp_client.wait_for(
+                UnitInstallActive(
+                    unit_name, ResolveCharmMessage.ACTIVE_NO_INSTALL_HOOK))
+
+
+class UnitInstallError(UnitInstallCondition):
+
+    def __init__(self, unit, *args, **kwargs):
+        super(UnitInstallError, self).__init__(
+            unit, 'error', ResolveCharmMessage.INSTALL_FAIL, *args, **kwargs)
+
+
+class UnitInstallActive(UnitInstallCondition):
+
+    def __init__(self, unit, message, *args, **kwargs):
+        super(UnitInstallActive, self).__init__(
+            unit, 'active', message, *args, **kwargs)
+
+
+def parse_args(argv):
+    """Parse all arguments."""
+    parser = argparse.ArgumentParser(
+        description='Ensure the resolve command operates to spec.')
+    add_basic_testing_arguments(parser)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    configure_logging(args.verbose)
+    bs_manager = BootstrapManager.from_args(args)
+    with bs_manager.booted_context(args.upload_tools):
+        assess_resolve(bs_manager.client)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/acceptancetests/assess_resolve.py
+++ b/acceptancetests/assess_resolve.py
@@ -22,10 +22,10 @@ from deploy_stack import (
     )
 from jujupy.models import (
     temporary_model,
-)
+    )
 from jujupy.wait_condition import (
     UnitInstallCondition,
-)
+    )
 from jujucharm import local_charm_path
 from utility import (
     add_basic_testing_arguments,
@@ -58,19 +58,31 @@ def ensure_retry_does_not_rerun_failed_hook(client, resolve_charm):
             temp_client.deploy(resolve_charm)
             temp_client.wait_for(UnitInstallError(unit_name))
             temp_client.juju('resolve', ('--no-retry', unit_name))
+            # simple-resolve start hook sets a message when active to indicate
+            # it ran and if the install hook ran successfully or not.
+            # Here we make sure it's active and no install hook success.
             temp_client.wait_for(
                 UnitInstallActive(
                     unit_name, ResolveCharmMessage.ACTIVE_NO_INSTALL_HOOK))
 
 
 class UnitInstallError(UnitInstallCondition):
+    """Wait until `unit` is in error state with message status `message`.
 
+    Useful to determine when a unit is in an expected error state (the message
+    check allows further confirmation the error reason is the one we're looking
+    for)
+    """
     def __init__(self, unit, *args, **kwargs):
         super(UnitInstallError, self).__init__(
             unit, 'error', ResolveCharmMessage.INSTALL_FAIL, *args, **kwargs)
 
 
 class UnitInstallActive(UnitInstallCondition):
+    """Wait until `unit` is in active state with message status `message`
+
+    Useful to determine when a unit is active for a specific reason.
+    """
 
     def __init__(self, unit, message, *args, **kwargs):
         super(UnitInstallActive, self).__init__(

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -873,6 +873,7 @@ class ModelClient:
             'audit-log-max-size',
             'audit-log-max-backups',
             'auditing-enabled',
+            'audit-log-exclude-methods',
             'auth-url',
             'bootstrap-host',
             'client-email',

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -335,8 +335,8 @@ class UnitInstallCondition(BaseCondition):
         try:
             unit = status.get_unit(self.unit)
             unit_status = unit['workload-status']
-            cond_met = unit_status['current'] == self.current \
-                and unit_status['message'] == self.message
+            cond_met = (unit_status['current'] == self.current
+                        and unit_status['message'] == self.message)
         except KeyError:
             cond_met = False
         if not cond_met:

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -21,13 +21,14 @@ from subprocess import CalledProcessError
 from jujupy.exceptions import (
     VersionsNotUpdated,
     AgentsNotStarted,
+    StatusNotMet,
     )
 from jujupy.status import (
     Status,
     )
 from utility import (
     until_timeout,
-)
+    )
 
 
 log = logging.getLogger(__name__)
@@ -340,12 +341,11 @@ class UnitInstallCondition(BaseCondition):
         except KeyError:
             cond_met = False
         if not cond_met:
-            yield 'unit-workload', 'not-{}'.format(self.current)
+            yield ('unit-workload ({})'.format(self.unit),
+                   'not-{}'.format(self.current))
 
     def do_raise(self, model_name, status):
-        raise Exception(
-            'Model {} never reached {{ workload: {}, message: {} }}'.format(
-                model_name, self.current, self.message))
+        raise StatusNotMet('{} ({})'.format(model_name, self.unit), status)
 
 
 class CommandComplete(BaseCondition):

--- a/acceptancetests/repository/charms/simple-resolve/README
+++ b/acceptancetests/repository/charms/simple-resolve/README
@@ -1,0 +1,3 @@
+Simple charm that errors once on the install hook, but works the next time run.
+
+Used to test juju resolve command.

--- a/acceptancetests/repository/charms/simple-resolve/copyright
+++ b/acceptancetests/repository/charms/simple-resolve/copyright
@@ -1,0 +1,1 @@
+Copyright 2018 Canonical Ltd.

--- a/acceptancetests/repository/charms/simple-resolve/hooks/install
+++ b/acceptancetests/repository/charms/simple-resolve/hooks/install
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Simple install hook that errors the first time it is run, on any subsequent 
+# run the hook will succeed (unless the canary file is removed).
+
+canary_file=/tmp/resolver.canary
+success_file=/tmp/resolver.success
+
+function exit_error() {
+    status-set blocked "Install hook failed on: $1 attempts." || true
+    exit 1
+}
+
+if [ ! -e ${canary_file} ]; then
+    echo "No canary file, exiting error."
+    echo 1 > ${canary_file}
+    exit_error 1
+fi
+
+# Need to error for x amount of times before juju stops trying automatically.
+run_count=$(cat ${canary_file})
+
+# For now juju is always re-trying. Need to just exit regardless.
+echo $((${run_count}+1)) > ${canary_file}
+exit_error ${run_count}
+
+# if [ ${run_count} -le 3 ]; then
+#     echo "Incrementing and erroring"
+#     echo $((${run_count}+1)) > ${canary_file}
+#     exit_error ${run_count}
+# else
+#     echo "Canary file found, exit success."
+#     touch ${success_file}
+#     status-set maintenance "Install hook succeeded." || true
+#     exit 0
+# fi
+

--- a/acceptancetests/repository/charms/simple-resolve/hooks/install
+++ b/acceptancetests/repository/charms/simple-resolve/hooks/install
@@ -24,6 +24,8 @@ run_count=$(cat ${canary_file})
 echo $((${run_count}+1)) > ${canary_file}
 exit_error ${run_count}
 
+# This will be useful when install error retries are limited to n-times. For 
+# now it retries forever and thus there is no exit condition.
 # if [ ${run_count} -le 3 ]; then
 #     echo "Incrementing and erroring"
 #     echo $((${run_count}+1)) > ${canary_file}

--- a/acceptancetests/repository/charms/simple-resolve/hooks/start
+++ b/acceptancetests/repository/charms/simple-resolve/hooks/start
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+install_success_file=/tmp/resolver.success
+
+status_message="No install hook"
+if [ -e ${install_success_file} ]; then
+    status_message="Install hook succeeded"
+fi
+
+echo "${status_message}"
+status-set active "${status_message}" || true

--- a/acceptancetests/repository/charms/simple-resolve/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resolve/metadata.yaml
@@ -1,0 +1,12 @@
+name: simple-resolve
+maintainer: Christopher Lee <chris.mclachlan-lee@canonical.com>
+summary: Purposfully error on install hook for testing resolve command.
+description: |
+  A testing charm that errors once on install hook then succeeds on the next run.
+categories:
+  - misc
+series:
+  - trusty
+  - xenial
+  - artful
+  - bionic

--- a/acceptancetests/repository/charms/simple-resolve/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resolve/metadata.yaml
@@ -6,7 +6,7 @@ description: |
 categories:
   - misc
 series:
-  - trusty
   - xenial
-  - artful
   - bionic
+  - trusty
+  - artful


### PR DESCRIPTION
This test ensures that failed hooks are not retried when the argument
'--no-retry' is provided.


## Description of change
As per bug LP:1762979 add a test to ensure the behaviour of "resolve --no-retry" works as expected. (i.e. does not re-try failed hooks).

## Bug reference

https://bugs.launchpad.net/juju/+bug/1762979
