### PR TITLE
Add pre-check make target to run go fmt, go vet etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,11 @@ release-build: godeps add-patches go-build
 
 release-install: godeps add-patches go-install remove-patches
 
-check: godeps
+pre-check:
+	@echo running pre-test checks
+	@$(PROJECT_DIR)/scripts/verify.bash
+
+check: godeps pre-check
 	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT)/...
 
 install: godeps go-install


### PR DESCRIPTION
## Description of change

make check now depends on a pre-check target to run the git pre-commit script.
This ensures a landing run will fail if go fmt or go vet etc are unhappy.

## QA steps

make check
ensure it runs the pre-check target
