### PR TITLE
2.4 peergrouper remove master

### DIFF
--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -47,3 +47,11 @@ func (s MongoSessionShim) CurrentMembers() ([]replicaset.Member, error) {
 func (s MongoSessionShim) Set(members []replicaset.Member) error {
 	return replicaset.Set(s.Session, members)
 }
+
+func (s MongoSessionShim) StepDownPrimary() error {
+	return replicaset.StepDownPrimary(s.Session)
+}
+
+func (s MongoSessionShim) Refresh() {
+	s.Session.Refresh()
+}


### PR DESCRIPTION
## Description of change

This allows us to cleanly remove the controller machine who is currently voted the Primary Mongo node. Mongo will refuse to allow a replicaset config that doesn't have Priority for the current master. So you first have to ask the master to step down if you want to remove it.

I've tested that it works correctly in LXD, and does seem to cleanly tear down. (caveat bugs like
  https://bugs.launchpad.net/bugs/1765109
  https://bugs.launchpad.net/bugs/1761237
)

This also cleans up a couple of cases that I ran into where the log messages end up telling us about machines out of order, which makes it harder than it needs to be to understand what is going on.

## QA steps

```
$ juju bootstrap --debug lxd
$ juju switch controller
$ juju remove-machine 0
... failed: machine 0 is the only controller machine
$ juju enable-ha
$ watch "juju status && juju show-controller"
# Wait for them to all be happy
$ juju remove-machine 0
# Continue watching, and consider running 'juju debug-log'
# everything fairly quickly shuts down and is happy
```
Without this patch, removing machine 1 and 2 worked, but removing machine 0 would get stuck trying to apply the replicaset that didn't have machine 0 voting, and would continually fail.

Note, there is likely a case where this is non-optimal, if you are removing 2 machines at the same time, it is possible that you're  removing machine 0, which causes us to change the vote to 1, but then we're also trying to remove machine 1, which will only then trigger us to switch the vote to 2. And that only works if all of this happens within 60s before machine 0 will put its hat back into the ring to be primary again. The main problem is every stepDown can cause a revote.

One option would be to rework the logic, and note that machine 0 wants to not be the primary, see that other machines also want to be removed, remove them first, then step down, then reevaluate to remove machine 0.

I went with this because it was straightforward and easy. And still somewhat necessary. If we have HA=3, and we are removing the master, we want whoever *becomes* the new master to be the only one with a vote. But we don't want to force whether that is machine 1 or machine 2 (IMO).

## Documentation changes

Other than the general update that 2.4 should support being able to `juju remove-machine` for controller machines, there should be nothing of special note for this patch.

## Bug reference

This is one step along the general bug of being able to remove controller machines:
[lp:1658033](https://bugs.launchpad.net/bugs/1658033)