### PR TITLE
Make sure enable-ha always wants 3/5/7 voters.

### DIFF
--- a/state/enableha.go
+++ b/state/enableha.go
@@ -117,7 +117,7 @@ func (st *State) EnableHA(
 		}
 		if desiredControllerCount == 0 {
 			// Make sure we go to add odd number of desired voters. Even if HA was currently at 2 desired voters
-			desiredControllerCount = votingCount + (votingCount+1)%1
+			desiredControllerCount = votingCount + (votingCount+1)%2
 			if desiredControllerCount <= 1 {
 				desiredControllerCount = 3
 			}

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -116,7 +116,8 @@ func (st *State) EnableHA(
 			return nil, errors.Trace(err)
 		}
 		if desiredControllerCount == 0 {
-			desiredControllerCount = votingCount
+			// Make sure we go to add odd number of desired voters. Even if HA was currently at 2 desired voters
+			desiredControllerCount = votingCount + (votingCount+1)%1
 			if desiredControllerCount <= 1 {
 				desiredControllerCount = 3
 			}
@@ -410,17 +411,44 @@ func removeControllerOps(m *Machine) []txn.Op {
 	}}
 }
 
-// RemoveControllerMachine will remove Machine from being part of the set of Controllers for this
+// RemoveControllerMachine will remove Machine from being part of the set of Controllers.
+// It must not have or want to vote, and it must not be the last controller.
 func (st *State) RemoveControllerMachine(m *Machine) error {
-	if m.WantsVote() {
-		return errors.Errorf("machine %s cannot be removed as a controller as it still wants to vote", m.Id())
+	logger.Infof("removing controller machine %q", m.doc.Id)
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt != 0 {
+			// Something changed, make sure we're still up to date
+			m.Refresh()
+		}
+		if m.WantsVote() {
+			return nil, errors.Errorf("machine %s cannot be removed as a controller as it still wants to vote", m.Id())
+		}
+		if m.HasVote() {
+			return nil, errors.Errorf("machine %s cannot be removed as a controller as it still has a vote", m.Id())
+		}
+		controllerInfo, err := st.ControllerInfo()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(controllerInfo.MachineIds) <= 1 {
+			return nil, errors.Errorf("machine %s cannot be removed as it is the last controller", m.Id())
+		}
+		txnLogger.Debugf("txn for removing controller machine %q", m.doc.Id)
+		return []txn.Op{{
+			C:      machinesC,
+			Id:     m.doc.DocID,
+			Assert: bson.D{{"novote", true}, {"hasvote", false}},
+			Update: bson.D{
+				{"$pull", bson.D{{"jobs", JobManageModel}}},
+			},
+		}, {
+			C:      controllersC,
+			Id:     modelGlobalKey,
+			Assert: bson.D{{"machineids", controllerInfo.MachineIds}},
+			Update: bson.D{{"$pull", bson.D{{"machineids", m.doc.Id}}}},
+		}}, nil
 	}
-	if m.HasVote() {
-		return errors.Errorf("machine %s cannot be removed as a controller as it still has a vote", m.Id())
-	}
-	// TODO: Ensure that there are other controllers
-	// Note: we treat removing a machine that is not there as 'convergence' rather than illegal.
-	if err := st.runRawTransaction(removeControllerOps(m)); err != nil {
+	if err := st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -16,6 +16,7 @@ import (
 	jujutxn "github.com/juju/txn"
 	txntesting "github.com/juju/txn/testing"
 	jutils "github.com/juju/utils"
+	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
@@ -112,6 +113,10 @@ func newRunnerForHooks(st *State) jujutxn.Runner {
 	runner := jujutxn.NewRunner(jujutxn.RunnerParams{
 		Database: db.raw,
 		Clock:    st.stateClock,
+		RunTransactionObserver: func(t jujutxn.ObservedTransaction) {
+			txnLogger.Tracef("ran transaction in %.3fs %# v\nerr: %v",
+				t.Duration.Seconds(), pretty.Formatter(t.Ops), t.Error)
+		},
 	})
 	db.runner = runner
 	return runner

--- a/state/machine.go
+++ b/state/machine.go
@@ -811,6 +811,7 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 				}
 				ops[0].Assert = append(asserts, checkUnits)
 				ops = append(ops, cleanupOp)
+				txnLogger.Debugf("txn moving machine %q to %s", m.Id(), life)
 				return ops, nil
 			}
 		}


### PR DESCRIPTION
## Description of change

When we made it possible to remove a machine, that meant we could get a
'current' number of machines that want to vote to an even number (even
if the numebr of actual voters is kept to an odd number).

However, that meant that doing:
```
 $ juju enable-ha # gives you 3
 $ juju remove-machine 1
 # now have 1 voter (the primary), and another
 # that wants to vote
 $ juju enable-ha # should get you back to 3
```

However, with the old code the check would say "set the number to the
current number" which was 2. This changes it to always roll up to the
next odd number.

The other change in this patch are:

1. RemoveControllerMachine now properly makes sure it isn't removing the
   last controller. And we add 'race' tests that ensure we notice and give
   an error as to *why* we are unable to do what you asked (rather than
   just 'transaction aborted').

2. Machine.Destroy() also gets race tests that ensure we refuse to
   remove the last controller machine if another machine is also being
   removed.

3. While debugging with `TEST_LOGGING_CONFIG="<root>=DEBUG;juju.state.txn=TRACE"`,
   I eventually noticed that transactions being run by the "BeforeHooks"
   functionality were not getting logged. This fixes that runner to also
   log to the txnLogger.
   Also, as an RFC, I put a summary of the transaction that is about to
   be run into juju.state.txn DEBUG. For these, I'm pretty sure that
   logging level is ok, because these are not frequent transactions.
   I'd like to give more 'rationale' for transactions, but that probably
   needs to be a different rework.

## QA steps

```
$ juju bootstrap lxd
$ juju enable-ha
$ watch --color juju status --color -m controller
# should see 3 machines become happy
$ juju remove-machine 1
# should see machine 1 get removed
$ juju enable-ha
$ watch --color juju status --color -m controller
# should see a machine 3 get created to replace machine 1
```

You can also do that test with 5 instead of 3 controllers.

## Documentation changes

No. Enable-ha used to be the only way to remove controllers, so this is more preserving the "odd" number of controllers behavior.

## Bug reference

Part of the bigger series of changes around: [lp:1658033](https://bugs.launchpad.net/bugs/1658033)