### PR TITLE
Port catacomb to use tomb v2

### DIFF
--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
-	"gopkg.in/tomb.v1"
+	"gopkg.in/tomb.v2"
 )
 
 // Catacomb is a variant of tomb.Tomb with its own internal goroutine, designed
@@ -110,11 +110,11 @@ func Invoke(plan Plan) (err error) {
 	// This goroutine runs the work func and stops the catacomb with its error;
 	// and waits for for the listen goroutine and all added workers to complete
 	// before marking the catacomb's tomb Dead.
-	go func() {
-		defer catacomb.tomb.Done()
+	catacomb.tomb.Go(func() error {
 		defer catacomb.wg.Wait()
 		catacomb.Kill(runSafely(plan.Work))
-	}()
+		return nil
+	})
 	return nil
 }
 

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	worker "gopkg.in/juju/worker.v1"
-	"gopkg.in/tomb.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/worker/catacomb"
 )

--- a/worker/catacomb/fixture_test.go
+++ b/worker/catacomb/fixture_test.go
@@ -8,8 +8,8 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	worker "gopkg.in/juju/worker.v1"
-	"gopkg.in/tomb.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/tomb.v2"
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/catacomb"
@@ -88,11 +88,11 @@ func (fix *fixture) assertAddAlive(c *gc.C, w *errorWorker) {
 
 func (fix *fixture) startErrorWorker(c *gc.C, err error) *errorWorker {
 	ew := &errorWorker{}
-	go func() {
-		defer ew.tomb.Done()
+	ew.tomb.Go(func() error {
 		defer ew.tomb.Kill(err)
 		<-ew.tomb.Dying()
-	}()
+		return nil
+	})
 	fix.cleaner.AddCleanup(func(_ *gc.C) {
 		ew.stop()
 	})


### PR DESCRIPTION
## Description of change

As part of the effort to update our dependencies, catacomb is ported to use tomb.v2

## QA steps

Run the tests
bootstrap juju