### PR TITLE
Merge pull request #8605 from ExternalReality/bug#1761706

### DIFF
--- a/network/fan.go
+++ b/network/fan.go
@@ -70,6 +70,9 @@ func CalculateOverlaySegment(underlayCIDR string, fan FanConfigEntry) (*net.IPNe
 		newOverlaySize := overlaySize + (subnetSize - underlaySize)
 		fanSize := uint(underlaySize - overlaySize)
 		newFanIP := underlayNet.IP.To4()
+		if newFanIP == nil {
+			return nil, errors.New("fan address is not an IPv4 address.")
+		}
 		for i := 0; i < 4; i++ {
 			newFanIP[i] &^= fan.Underlay.Mask[i]
 		}

--- a/network/fan_test.go
+++ b/network/fan_test.go
@@ -105,3 +105,12 @@ func (*FanConfigSuite) TestCalculateOverlaySegment(c *gc.C) {
 	c.Assert(net, gc.NotNil)
 	c.Check(net.String(), gc.Equals, "252.92.0.0/14")
 }
+
+func (*FanConfigSuite) TestCalculateOverlaySegmentNonIPv4FanAddress(c *gc.C) {
+	// Use mapping from smaller IPv6 subnet to larger overlay.
+	config, err := network.ParseFanConfig("2001:db8::/16=2001:db7::/8")
+
+	// CalculateOverlaySegment does not support IPv6 addresses.
+	_, err = network.CalculateOverlaySegment("2001:db8::/16", config[0])
+	c.Assert(err, gc.ErrorMatches, "fan address is not an IPv4 address.")
+}

--- a/state/spacesdiscovery.go
+++ b/state/spacesdiscovery.go
@@ -121,6 +121,10 @@ func (st *State) SaveSubnetsFromProvider(subnets []network.SubnetInfo, spaceName
 			if modelSubnetIds.Contains(id) {
 				continue
 			}
+			if subnetNet.IP.To4() == nil {
+				logger.Debugf("%s address is not an IPv4 address.", subnetNet.IP)
+				continue
+			}
 			overlaySegment, err := network.CalculateOverlaySegment(subnet.CIDR, fan)
 			if err != nil {
 				return errors.Trace(err)

--- a/state/spacesdiscovery_test.go
+++ b/state/spacesdiscovery_test.go
@@ -429,6 +429,27 @@ func (s *SpacesDiscoverySuite) TestReloadSubnetsWithFAN(c *gc.C) {
 	checkSubnetsEqual(c, subnets, twoSubnetsAfterFAN)
 }
 
+func (s *SpacesDiscoverySuite) TestReloadSubnetsIgnoredWithFAN(c *gc.C) {
+	s.environ = networkedEnviron{
+		stub:           &testing.Stub{},
+		spaceDiscovery: false,
+		subnets:        twoSubnetsAndIgnored,
+	}
+	s.usedEnviron = &s.environ
+
+	// This is just a test configuration. This configuration may be
+	// considered invalid in the future. Here we show that this
+	// configuration is ignored.
+	s.IAASModel.UpdateModelConfig(map[string]interface{}{"fan-config": "fe80:dead:beef::/48=fe80:dead:beef::/24"}, nil)
+	err := s.State.ReloadSpaces(s.usedEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets, err := s.State.AllSubnets()
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkSubnetsEqual(c, subnets, twoSubnets)
+}
+
 func (s *SpacesDiscoverySuite) TestReloadSpacesWithFAN(c *gc.C) {
 	s.environ = networkedEnviron{
 		stub:           &testing.Stub{},


### PR DESCRIPTION
https://github.com/juju/juju/pull/8605

## Description of change

Calculating Overlay segments from fan configuration and UnderlayCIDR does not work for non IPV4 addresses. This is a backport (see above link).

## QA steps

N/A

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1761706
