### PR TITLE
Don't assume the only Dying machines are currently losing votes.

### DIFF
--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -891,6 +891,12 @@ func (s *workerSuite) TestDyingMachinesAreRemoved(c *gc.C) {
 	// And once we don't have the vote, and we see the machine is Dying we should remove it
 	mustNext(c, memberWatcher, "remove dying machine")
 	assertMembers(c, memberWatcher.Value(), mkMembers("0v 2", testIPv4))
+
+	// Now, machine 2 no longer has the vote, but if we now flag it as dying,
+	// then it should also get progressed to dead as well.
+	st.machine("12").advanceLifecycle(state.Dying, false)
+	mustNext(c, memberWatcher, "removing dying machine")
+	assertMembers(c, memberWatcher.Value(), mkMembers("0v", testIPv4))
 }
 
 func (s *workerSuite) TestRemovePrimaryValidSecondaries(c *gc.C) {


### PR DESCRIPTION
## Description of change

If you:

```
  $ juju bootstrap
  $ juju enable-ha
  $ juju remove-machine 2
```

At this point, assuming machine 0 is the primary, then machine 1 will
also have lost its vote to preserve the odd-number of voters.
However, if you then
```
  $ juju remove-machine 1
```

Then that machine will go into Dying, and *should* lose `JobManageModel`
but it wouldn't, because it was not losing its vote.
Instead we just check all machines, see if they are not Alive, and flag
anything that has finally lost its vote as no longer managing the model.

## QA steps
```
$ juju bootstrap lxd --debug
$ juju enable-ha -n3
$ juju remove-machine 2
# wait for a while, notice in
$ juju show-controller
# that machine 1 has also gone into "ha-pending".
$ juju remove-machine 1
```

Without this patch, machine 1 will fail to get cleaned up. (Never go to Dead), because it never loses `JobManageModel`. With this patch it cleans up correctly.

## Documentation changes

None.

## Bug reference

[lp:1765387](https://bugs.launchpad.net/juju/+bug/1765387)