### PR TITLE
New controller config to allow operator image path to be set

### DIFF
--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -98,3 +98,19 @@ func (c *Client) Life(appName string) (life.Value, error) {
 	}
 	return life.Value(results.Results[0].Life), nil
 }
+
+// OperatorProvisioningInfo holds the info needed to provision an operator.
+type OperatorProvisioningInfo struct {
+	ImagePath string
+}
+
+// OperatorProvisioningInfo returns the info needed to provision an operator.
+func (c *Client) OperatorProvisioningInfo() (OperatorProvisioningInfo, error) {
+	var result params.OperatorProvisioningInfo
+	if err := c.facade.FacadeCall("OperatorProvisioningInfo", nil, &result); err != nil {
+		return OperatorProvisioningInfo{}, err
+	}
+	return OperatorProvisioningInfo{
+		ImagePath: result.ImagePath,
+	}, nil
+}

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -152,3 +152,22 @@ func (s *provisionerSuite) TestLifeCount(c *gc.C) {
 	_, err := client.Life("gitlab")
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
+
+func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASOperatorProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "OperatorProvisioningInfo")
+		c.Assert(a, gc.IsNil)
+		c.Assert(result, gc.FitsTypeOf, &params.OperatorProvisioningInfo{})
+		*(result.(*params.OperatorProvisioningInfo)) = params.OperatorProvisioningInfo{
+			ImagePath: "juju-operator-image",
+		}
+		return nil
+	})
+	info, err := client.OperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, caasoperatorprovisioner.OperatorProvisioningInfo{
+		ImagePath: "juju-operator-image",
+	})
+}

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -9,13 +9,16 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type mockState struct {
 	testing.Stub
 	applicationWatcher *mockStringsWatcher
 	app                *mockApplication
+	operatorImage      string
 }
 
 func newMockState() *mockState {
@@ -34,6 +37,12 @@ func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
 		return st.app, nil
 	}
 	return nil, errors.NotFoundf("entity %v", tag)
+}
+
+func (st *mockState) ControllerConfig() (controller.Config, error) {
+	cfg := coretesting.FakeControllerConfig()
+	cfg[controller.CAASOperatorImagePath] = st.operatorImage
+	return cfg, nil
 }
 
 type mockApplication struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -4,12 +4,15 @@
 package caasoperatorprovisioner
 
 import (
+	"fmt"
+
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/version"
 )
 
 type API struct {
@@ -60,4 +63,23 @@ func (a *API) WatchApplications() (params.StringsWatchResult, error) {
 		}, nil
 	}
 	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}
+
+// OperatorProvisioningInfo returns the info needed to provision an operator.
+func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error) {
+	cfg, err := a.state.ControllerConfig()
+	if err != nil {
+		return params.OperatorProvisioningInfo{}, err
+	}
+
+	imagePath := cfg.CAASOperatorImagePath()
+	if imagePath == "" {
+		vers := version.Current
+		vers.Build = 0
+		imagePath = fmt.Sprintf("%s/caas-jujud-operator:%s", "jujusolutions", vers.String())
+	}
+
+	return params.OperatorProvisioningInfo{
+		ImagePath: imagePath,
+	}, nil
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -4,6 +4,8 @@
 package caasoperatorprovisioner_test
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -14,6 +16,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&CAASProvisionerSuite{})
@@ -110,5 +113,22 @@ func (s *CAASProvisionerSuite) TestLife(c *gc.C) {
 				Message: "permission denied",
 			},
 		}},
+	})
+}
+
+func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
+	result, err := s.api.OperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
+		ImagePath: fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
+	})
+}
+
+func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
+	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	result, err := s.api.OperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
+		ImagePath: s.st.operatorImage,
 	})
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -6,12 +6,14 @@ package caasoperatorprovisioner
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 )
 
 // CAASOperatorProvisionerState provides the subset of global state
 // required by the CAAS operator provisioner facade.
 type CAASOperatorProvisionerState interface {
+	ControllerConfig() (controller.Config, error)
 	WatchApplications() state.StringsWatcher
 	FindEntity(tag names.Tag) (state.Entity, error)
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -428,6 +428,11 @@ type ConfigResult struct {
 	Error  *Error                 `json:"error,omitempty"`
 }
 
+// OperatorProvisioningInfo holds info need to provision an operator.
+type OperatorProvisioningInfo struct {
+	ImagePath string `json:"image-path"`
+}
+
 // PublicAddress holds parameters for the PublicAddress call.
 type PublicAddress struct {
 	Target string `json:"target"`

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -116,6 +116,9 @@ type Unit struct {
 
 // OperatorConfig is the config to use when creating an operator.
 type OperatorConfig struct {
+	// OperatorImagePath is the docker registry URL for the image.
+	OperatorImagePath string
+
 	// AgentConf is the contents of the agent.conf file.
 	AgentConf []byte
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -4,8 +4,6 @@
 package provider_test
 
 import (
-	"fmt"
-
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -115,12 +113,12 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 }
 
 func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
-	pod := provider.OperatorPod("gitlab", "/var/lib/juju")
+	pod := provider.OperatorPod("gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator")
 	vers := version.Current
 	vers.Build = 0
 	c.Assert(pod.Name, gc.Equals, "juju-operator-gitlab")
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
-	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", vers.String()))
+	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/caas-jujud-operator")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 1)
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/agent.conf")
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -36,6 +36,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.JujuHASpace,
 		controller.JujuManagementSpace,
 		controller.AuditLogExcludeMethods,
+		controller.CAASOperatorImagePath,
 		controller.Features,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -45,6 +45,18 @@ func (m *mockProvisionerFacade) WatchApplications() (watcher.StringsWatcher, err
 	return m.applicationsWatcher, nil
 }
 
+func (m *mockProvisionerFacade) OperatorProvisioningInfo() (apicaasprovisioner.OperatorProvisioningInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "OperatorProvisioningInfo")
+	if err := m.stub.NextErr(); err != nil {
+		return apicaasprovisioner.OperatorProvisioningInfo{}, err
+	}
+	return apicaasprovisioner.OperatorProvisioningInfo{
+		ImagePath: "juju-operator-image",
+	}, nil
+}
+
 func (m *mockProvisionerFacade) Life(entityName string) (life.Value, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -26,6 +26,7 @@ var logger = loggo.GetLogger("juju.workers.caasprovisioner")
 
 // CAASProvisionerFacade exposes CAAS provisioning functionality to a worker.
 type CAASProvisionerFacade interface {
+	OperatorProvisioningInfo() (apicaasprovisioner.OperatorProvisioningInfo, error)
 	WatchApplications() (watcher.StringsWatcher, error)
 	SetPasswords([]apicaasprovisioner.ApplicationPassword) (params.ErrorResults, error)
 	Life(string) (life.Value, error)
@@ -185,5 +186,11 @@ func (p *provisioner) newOperatorConfig(appName string, password string) (*caas.
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &caas.OperatorConfig{AgentConf: confBytes}, nil
+
+	info, err := p.provisionerFacade.OperatorProvisioningInfo()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("using caas operator info %+v", info)
+	return &caas.OperatorConfig{AgentConf: confBytes, OperatorImagePath: info.ImagePath}, nil
 }

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -98,6 +98,7 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C) {
 	c.Assert(args[1], gc.Equals, "/var/lib/juju")
 	c.Assert(args[2], gc.FitsTypeOf, &caas.OperatorConfig{})
 	config := args[2].(*caas.OperatorConfig)
+	c.Assert(config.OperatorImagePath, gc.Equals, "juju-operator-image")
 
 	agentFile := filepath.Join(c.MkDir(), "agent.config")
 	err := ioutil.WriteFile(agentFile, []byte(config.AgentConf), 0644)
@@ -114,7 +115,7 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C) {
 			break
 		}
 	}
-	s.provisionerFacade.stub.CheckCallNames(c, "Life", "SetPasswords")
+	s.provisionerFacade.stub.CheckCallNames(c, "Life", "SetPasswords", "OperatorProvisioningInfo")
 	c.Assert(s.provisionerFacade.stub.Calls()[0].Args[0], gc.Equals, "myapp")
 	passwords := s.provisionerFacade.stub.Calls()[1].Args[0].([]apicaasprovisioner.ApplicationPassword)
 


### PR DESCRIPTION
## Description of change

There is a new controller config setting to allowthe default CAAS operator image path to be set.
"caas-operator-image-path" (defaults to jujusolutions/caas-jujud-operator:<juju version>)

You can bootstrap like so:
$ juju bootstrap lxd --config caas-operator-image-path=`<mypath>`
or after bootstrap
$ juju controller-config caas-operator-image-path=<mypath>

This allows the operator image to be overridden for testing etc

## QA steps

bootstrap as per the description and deploy a caas charm

## Documentation changes

@juju/docs 
This is something for advanced users. I wouldn't recommend exposing it in general doc.

