### PR TITLE
First phase of proxy rework - new hook vars, and a feature flag

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -45,3 +45,7 @@ const CAAS = "caas"
 // should be used by the API server to determine agent presence.
 // This value is only checked using the controller config "features" attrubite.
 const NewPresence = "new-presence"
+
+// NewProxyOnly is a temporary traditional feature flag that will disable writing
+// the proxy information into the /etc locations (for users and systemd).
+const NewProxyOnly = "new-proxy-only"

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/os"
 	"github.com/juju/utils/packaging/commands"
 	"github.com/juju/utils/packaging/config"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/utils/series"
 	worker "gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/watcher"
 )
 
@@ -139,6 +141,9 @@ func (w *proxyWorker) handleProxyValues(proxySettings proxyutils.Settings) {
 	proxySettings.SetEnvironmentValues()
 	if err := w.config.InProcessUpdate(proxySettings); err != nil {
 		logger.Errorf("error updating in-process proxy settings: %v", err)
+	}
+	if featureflag.Enabled(feature.NewProxyOnly) {
+		return
 	}
 	if proxySettings != w.proxy || w.first {
 		logger.Debugf("new proxy settings %#v", proxySettings)

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -23,6 +23,7 @@ import (
 	gc "gopkg.in/check.v1"
 	worker "gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/proxyupdater"
@@ -171,6 +172,25 @@ func (s *ProxyUpdaterSuite) waitForFile(c *gc.C, filename, expected string) {
 	}
 }
 
+func (s *ProxyUpdaterSuite) assertNoFile(c *gc.C, filename string) {
+	//TODO(bogdanteleaga): Find a way to test this on windows
+	if runtime.GOOS == "windows" {
+		c.Skip("Proxy settings are written to the registry on windows")
+	}
+	maxWait := time.After(coretesting.ShortWait)
+	for {
+		select {
+		case <-maxWait:
+			return
+		case <-time.After(10 * time.Millisecond):
+			_, err := os.Stat(filename)
+			if err == nil {
+				c.Fatalf("file %s exists", filename)
+			}
+		}
+	}
+}
+
 func (s *ProxyUpdaterSuite) TestRunStop(c *gc.C) {
 	updater, err := proxyupdater.NewWorker(s.config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -221,6 +241,24 @@ func (s *ProxyUpdaterSuite) TestWriteSystemFiles(c *gc.C) {
 	s.waitForFile(c, s.proxyEnvFile, proxySettings.AsScriptEnvironment())
 	s.waitForFile(c, s.proxySystemdFile, proxySettings.AsSystemdDefaultEnv())
 
+	paccmder, err := commands.NewPackageCommander(series.MustHostSeries())
+	c.Assert(err, jc.ErrorIsNil)
+	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
+}
+
+func (s *ProxyUpdaterSuite) TestWriteSystemFilesNewProxyOnly(c *gc.C) {
+	s.SetFeatureFlags(feature.NewProxyOnly)
+	proxySettings, aptProxySettings := s.updateConfig(c)
+
+	updater, err := proxyupdater.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer worker.Stop(updater)
+
+	s.waitProxySettings(c, proxySettings)
+	s.assertNoFile(c, s.proxyEnvFile)
+	s.assertNoFile(c, s.proxySystemdFile)
+
+	// apt settings still written out.
 	paccmder, err := commands.NewPackageCommander(series.MustHostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")


### PR DESCRIPTION
New environment variables for hook executions for proxies.

Expose the settings for http_proxy, https_proxy, and ftp_proxy as env vars prefixed by JUJU_CHARM_. The intent is that charms will be able to set proxies for actions that may need a proxy, but not having to have global settings that hit NO_PROXY size limits.

Add a feature flag "new-proxy-only" which will stop the proxy updater worker from writing the proxy files to disk, and stops the setting of the normal proxy environment settings in the hook execution environment.

## Documentation changes

We will need to document the new proxy expectations, but not worth starting yet as we may well change.