### PR TITLE
2.3 upgrade escaping 1765722

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,6 +9,7 @@ github.com/coreos/go-systemd	git	7b2428fec40033549c68f54e26e89e7ca9a9ce31	2016-0
 github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07-05T20:30:06Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
 github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T22:25:50Z
+github.com/golang/mock	git	69521b3833175dfcfb1cc1fdb0c9be92e66faa81	2018-04-03T23:54:22Z
 github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-09T07:27:36Z
 github.com/google/go-querystring	git	9235644dd9e52eeae6fa48efd539fdc351a0af53	2016-04-01T23:30:42Z
 github.com/gorilla/handlers	git	13d73096a474cac93275c679c7b8a2dc17ddba82	2017-02-24T19:39:55Z

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2163,7 +2163,7 @@ func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
 	// Value set to the empty string
 	m2 := s.makeModel(c, "m2", coretesting.Attrs{
 		"container-image-stream": "",
-		"other-setting": "val",
+		"other-setting":          "val",
 	})
 	defer m2.Close()
 	// Value set to something other that default
@@ -2201,7 +2201,7 @@ func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
 		m1.ModelUUID() + ":e": bson.M{"container-image-stream": "released", "other-setting": "val"},
 		m2.ModelUUID() + ":e": bson.M{"container-image-stream": "released", "other-setting": "val"},
 		m3.ModelUUID() + ":e": bson.M{"container-image-stream": "daily"},
-		"not-a-model": bson.M{"other-setting": "val"},
+		"not-a-model":         bson.M{"other-setting": "val"},
 	}
 	for iter.Next(&rawSettings) {
 		expSettings := copyMap(rawSettings, nil)
@@ -2227,6 +2227,95 @@ func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
 	c.Assert(iter.Close(), jc.ErrorIsNil)
 
 	s.assertUpgradedData(c, UpgradeContainerImageStreamDefault,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}
+
+func (s *upgradesSuite) TestRemoveContainerImageStreamFromNonModelSettings(c *gc.C) {
+	// a model with a valid setting
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
+		"other-setting":          "val",
+		"container-image-stream": "released",
+	})
+	defer m1.Close()
+	// a model with a custom setting
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{
+		"container-image-stream": "daily",
+		"other-setting":          "val",
+	})
+	defer m2.Close()
+
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	// A document that isn't a model with an accidental setting
+	err := settingsColl.Insert(
+		bson.M{
+			"_id": "not-a-model",
+			"settings": bson.M{
+				"container-image-stream":                   "released",
+				"other-setting":                            "val",
+				unescapeReplacer.Replace("dotted.setting"): "value",
+				unescapeReplacer.Replace("dollar$setting"): "value",
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// A document that doesn't have the setting
+	err = settingsColl.Insert(
+		bson.M{
+			"_id": "applicationsetting",
+			"settings": bson.M{
+				"other-setting": "val",
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// A document that has the setting, but it shouldn't be touched because it is a custom value.
+	err = settingsColl.Insert(
+		bson.M{
+			"_id": "otherapplication",
+			"settings": bson.M{
+				"container-image-stream": "custom",
+				"other-setting":          "val",
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Read all the settings from the database, and change the 'not-a-model'
+	// content which has 'container-image-stream' that needs to be removed.
+	// documents we think we're changing, and the rest should go through
+	// unchanged.
+	var rawSettings bson.M
+	iter := settingsColl.Find(nil).Sort("_id").Iter()
+	defer iter.Close()
+
+	expectedSettings := []bson.M{}
+
+	for iter.Next(&rawSettings) {
+		expSettings := copyMap(rawSettings, nil)
+		delete(expSettings, "txn-queue")
+		delete(expSettings, "txn-revno")
+		delete(expSettings, "version")
+		id, ok := expSettings["_id"]
+		idStr, ok := id.(string)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(idStr, gc.Not(gc.Equals), "")
+		if idStr == "not-a-model" {
+			raw, ok := expSettings["settings"]
+			c.Assert(ok, jc.IsTrue)
+			settings, ok := raw.(bson.M)
+			c.Assert(ok, jc.IsTrue)
+			delete(settings, "container-image-stream")
+		}
+		expectedSettings = append(expectedSettings, expSettings)
+	}
+	c.Assert(iter.Close(), jc.ErrorIsNil)
+
+	// Note that the assertions on this are very hard to read for humans,
+	// because Settings documents have a ton of keys and nested sub documents.
+	// But it is a more accurate depiction of what is in that table.
+	s.assertUpgradedData(c, RemoveContainerImageStreamFromNonModelSettings,
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -36,7 +36,7 @@ type StateBackend interface {
 	MoveOldAuditLog() error
 	DeleteCloudImageMetadata() error
 	EnsureContainerImageStreamDefault() error
-	RemoveContainerImageStreamFromNonModelSettings()
+	RemoveContainerImageStreamFromNonModelSettings() error
 }
 
 // Model is an interface providing access to the details of a model within the

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -36,6 +36,7 @@ type StateBackend interface {
 	MoveOldAuditLog() error
 	DeleteCloudImageMetadata() error
 	EnsureContainerImageStreamDefault() error
+	RemoveContainerImageStreamFromNonModelSettings()
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -144,4 +145,8 @@ func (s stateBackend) DeleteCloudImageMetadata() error {
 
 func (s stateBackend) EnsureContainerImageStreamDefault() error {
 	return state.UpgradeContainerImageStreamDefault(s.st)
+}
+
+func (s stateBackend) RemoveContainerImageStreamFromNonModelSettings() error {
+	return state.RemoveContainerImageStreamFromNonModelSettings(s.st)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -30,6 +30,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.3.2"), stateStepsFor232()},
 		upgradeToVersion{version.MustParse("2.3.4"), stateStepsFor234()},
 		upgradeToVersion{version.MustParse("2.3.6"), stateStepsFor236()},
+		upgradeToVersion{version.MustParse("2.3.7"), stateStepsFor237()},
 	}
 	return steps
 }

--- a/upgrades/steps_237.go
+++ b/upgrades/steps_237.go
@@ -7,10 +7,10 @@ package upgrades
 func stateStepsFor237() []Step {
 	return []Step{
 		&upgradeStep{
-			description: "ensure container-image-stream config defaults to released",
+			description: "ensure container-image-stream isn't set in applications",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
-				return context.State().EnsureContainerImageStreamDefault()
+				return context.State().RemoveContainerImageStreamFromNonModelSettings()
 			},
 		},
 	}

--- a/upgrades/steps_237.go
+++ b/upgrades/steps_237.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor237 returns upgrade steps for Juju 2.3.7 that manipulate state directly.
+func stateStepsFor237() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "ensure container-image-stream config defaults to released",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureContainerImageStreamDefault()
+			},
+		},
+	}
+}

--- a/upgrades/steps_237_test.go
+++ b/upgrades/steps_237_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v237 = version.MustParse("2.3.7")
+
+type steps237Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps237Suite{})
+
+func (s *steps236Suite) TestEnsureContainerImageStreamDefault237(c *gc.C) {
+	step := findStateStep(c, v237, "ensure container-image-stream config defaults to released")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/steps_237_test.go
+++ b/upgrades/steps_237_test.go
@@ -20,8 +20,8 @@ type steps237Suite struct {
 
 var _ = gc.Suite(&steps237Suite{})
 
-func (s *steps236Suite) TestEnsureContainerImageStreamDefault237(c *gc.C) {
-	step := findStateStep(c, v237, "ensure container-image-stream config defaults to released")
+func (s *steps236Suite) TestRemoveContainerImageStreamFromNonModelSettings(c *gc.C) {
+	step := findStateStep(c, v237, "ensure container-image-stream isn't set in applications")
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -646,6 +646,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.3.2",
 		"2.3.4",
 		"2.3.6",
+		"2.3.7",
 	})
 }
 


### PR DESCRIPTION
## Description of change

The upgrade step to add "container-image-series" to model config was accidentally adding it to *all* settings documents, including application config. We only noticed because some charm documents have "." in their keys so we have to encode/decode the keys to map it to keys that Mongo will accept.

This changes it so that we only touch the model documents. It also refactors the upgrade steps that touch model documents so all the steps that find the model docs are shared, and just the modification of the docs is unique code.

## QA steps

You can see the reproduction steps in the bug but:
```
$ juju bootstrap lxd --agent-version=2.3.5
$ juju switch controller
$ juju deploy --to 0 percona-cluster
$ juju run --unit percona-cluster/0 leader-get
# see that it has mysql.password in it
$ juju upgrade-juju --build-agent
$ juju status
```
With the existing 2.3.6 release, it will be stuck in an upgrade loop because the upgrade step will be trying to rewrite documents incorrectly.

As a further test, you could deploy any other change, and upgrading to 2.3.6 would show that
```
> db.settings.find().pretty()
```
Would have added `"container-image-stream": "released"` to the settings. Then upgrading to 2.3.7 should show that value being removed. A test for that would be:

```
$ juju bootstrap --agent-version=2.3.5
$ juju switch controller
$ juju deploy cs:~jameinel/ubuntu-lite --to 0
$ juju upgrade-juju --agent-version=2.3.6
> db.settings.find().pretty()
# will include something like:
{
        "_id" : "c96ad806-372e-4c1c-83b0-f3ef1b2bdb8b:a#ubuntu-lite#cs:~jameinel/ubuntu-lite-7",
        "model-uuid" : "c96ad806-372e-4c1c-83b0-f3ef1b2bdb8b",
        "settings" : {
                "container-image-stream" : "released"
        },
        "version" : NumberLong(0),
        "txn-revno" : NumberLong(4),
        "txn-queue" : [
                "5adc977cf96e93066e4ebf33_38c97e68"
        ]
}
# this should upgrade happily, albeit slightly incorrectly
$ juju upgrade-juju --build-agent
> db.settings.find().pretty()
# new value:
{
        "_id" : "c96ad806-372e-4c1c-83b0-f3ef1b2bdb8b:a#ubuntu-lite#cs:~jameinel/ubuntu-lite-7",
        "model-uuid" : "c96ad806-372e-4c1c-83b0-f3ef1b2bdb8b",
        "settings" : {

        },
        "version" : NumberLong(0),
        "txn-revno" : NumberLong(5),
        "txn-queue" : [
                "5adc9a15f96e9309c6ce4ec6_46cc5b83"
        ]
}
```

Note that this doesn't work with 'lxd' because it has:
```
{
        "_id" : "c96ad806-372e-4c1c-83b0-f3ef1b2bdb8b:pool#lxd-zfs",
        "model-uuid" : "c96ad806-372e-4c1c-83b0-f3ef1b2bdb8b",
        "settings" : {
                "type" : "lxd",
                "driver" : "zfs",
                "lxd-pool" : "juju-zfs",
                "zfs．pool_name" : "juju-lxd",
                "name" : "lxd-zfs"
        },
        "version" : NumberLong(0),
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5adc9566f96e93037cb50555_26c7bcb5",
                "5adc95cbf96e930546fb0af9_dfa5c61c",
                "5adc9643f96e930546fb0b02_834567ce"
        ]
}
```

## Documentation changes

None.

## Bug reference

[lp:1765722](https://bugs.launchpad.net/juju/+bug/1765722)