### PR TITLE
2.4 upgrade step 1765722

### DIFF
--- a/api/hostkeyreporter/package_test.go
+++ b/api/hostkeyreporter/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package hostkeyreporter_test
 

--- a/api/migrationflag/facade.go
+++ b/api/migrationflag/facade.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag
 

--- a/api/migrationflag/package_test.go
+++ b/api/migrationflag/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/apiserver/facades/agent/hostkeyreporter/shim.go
+++ b/apiserver/facades/agent/hostkeyreporter/shim.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package hostkeyreporter
 

--- a/apiserver/facades/agent/migrationflag/facade.go
+++ b/apiserver/facades/agent/migrationflag/facade.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag
 

--- a/apiserver/facades/agent/migrationflag/facade_test.go
+++ b/apiserver/facades/agent/migrationflag/facade_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/apiserver/facades/agent/migrationflag/package_test.go
+++ b/apiserver/facades/agent/migrationflag/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/apiserver/facades/agent/migrationflag/shim.go
+++ b/apiserver/facades/agent/migrationflag/shim.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag
 

--- a/apiserver/facades/agent/migrationflag/util_test.go
+++ b/apiserver/facades/agent/migrationflag/util_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package sshclient
 

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package application
 

--- a/core/crossmodel/offerurl_test.go
+++ b/core/crossmodel/offerurl_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package crossmodel_test
 

--- a/core/crossmodel/package_test.go
+++ b/core/crossmodel/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the LGPLv3, see COPYING and COPYING.LESSER file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package crossmodel_test
 

--- a/resource/sort.go
+++ b/resource/sort.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package resource
 

--- a/state/settings.go
+++ b/state/settings.go
@@ -60,6 +60,11 @@ func (m *settingsMap) SetBSON(raw bson.Raw) error {
 	return nil
 }
 
+func (m settingsMap) GetBSON() (interface{}, error) {
+	escapedMap := copyMap(m, escapeReplacer.Replace)
+	return escapedMap, nil
+}
+
 // ItemChange represents the change of an item in a settings.
 type ItemChange struct {
 	Type     int

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -214,7 +214,7 @@ func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
 
 func (s *SettingsSuite) TestRawSettingsMapEncodeDecode(c *gc.C) {
 	smap := &settingsMap{
-		"$dollar": 1,
+		"$dollar":    1,
 		"dotted.key": 2,
 	}
 	asBSON, err := bson.Marshal(smap)
@@ -224,7 +224,7 @@ func (s *SettingsSuite) TestRawSettingsMapEncodeDecode(c *gc.C) {
 	err = bson.Unmarshal(asBSON, &asMap)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(asMap, gc.DeepEquals, map[string]interface{}{
-		"\uff04dollar": 1,
+		"\uff04dollar":    1,
 		"dotted\uff0ekey": 2,
 	})
 	// unmarshalling into a settingsMap will give us the right decoded keys
@@ -232,7 +232,7 @@ func (s *SettingsSuite) TestRawSettingsMapEncodeDecode(c *gc.C) {
 	err = bson.Unmarshal(asBSON, &asSettingsMap)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(map[string]interface{}(asSettingsMap), gc.DeepEquals, map[string]interface{}{
-		"$dollar": 1,
+		"$dollar":    1,
 		"dotted.key": 2,
 	})
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -681,16 +681,21 @@ func maybeUpdateSettings(settings map[string]interface{}, key string, value inte
 	return false
 }
 
-// AddStatusHistoryPruneSettings adds the model settings
-// to control log pruning if they are missing.
-func AddStatusHistoryPruneSettings(st *State) error {
-	coll, closer := st.db().GetRawCollection(settingsC)
-	defer closer()
-
+// applyToAllModelSettings iterates the model settings documents and applys the
+// passed in function to them.  If the function returns 'true' it indicates the
+// settings have been modified, and they should be written back to the
+// database.
+// Note that if there are any problems with updating settings, then none of the
+// changes will be applied, as they are all updated in a single transaction.
+func applyToAllModelSettings(st *State, change func(*settingsDoc) (bool, error)) error {
 	uuids, err := st.AllModelUUIDs()
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	coll, closer := st.db().GetRawCollection(settingsC)
+	defer closer()
+
 	var ids []string
 	for _, uuid := range uuids {
 		ids = append(ids, uuid+":e")
@@ -702,11 +707,15 @@ func AddStatusHistoryPruneSettings(st *State) error {
 	var ops []txn.Op
 	var doc settingsDoc
 	for iter.Next(&doc) {
-		settingsChanged :=
-			maybeUpdateSettings(doc.Settings, config.MaxStatusHistoryAge, config.DefaultStatusHistoryAge)
-		settingsChanged =
-			maybeUpdateSettings(doc.Settings, config.MaxStatusHistorySize, config.DefaultStatusHistorySize) || settingsChanged
+		settingsChanged, err := change(&doc)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		if settingsChanged {
+			// Note: some settings contain embedded '.' or '$' characters and
+			// need to be encoded to save back to the database. We don't need
+			// to do that here, only because we don't use those keys in our
+			// Model and Controller settings documents.
 			ops = append(ops, txn.Op{
 				C:      settingsC,
 				Id:     doc.DocID,
@@ -724,44 +733,34 @@ func AddStatusHistoryPruneSettings(st *State) error {
 	return nil
 }
 
-// AddActionPruneSettings adds the model settings
+// AddStatusHistoryPruneSettings adds the model settings
 // to control log pruning if they are missing.
-func AddActionPruneSettings(st *State) error {
-	coll, closer := st.db().GetRawCollection(settingsC)
-	defer closer()
-
-	uuids, err := st.AllModelUUIDs()
+func AddStatusHistoryPruneSettings(st *State) error {
+	err := applyToAllModelSettings(st, func(doc *settingsDoc) (bool, error) {
+		settingsChanged :=
+			maybeUpdateSettings(doc.Settings, config.MaxStatusHistoryAge, config.DefaultStatusHistoryAge)
+		settingsChanged =
+			maybeUpdateSettings(doc.Settings, config.MaxStatusHistorySize, config.DefaultStatusHistorySize) || settingsChanged
+		return settingsChanged, nil
+	})
 	if err != nil {
 		return errors.Trace(err)
 	}
-	var ids []string
-	for _, uuid := range uuids {
-		ids = append(ids, uuid+":e")
-	}
+	return nil
+}
 
-	iter := coll.Find(bson.M{"_id": bson.M{"$in": ids}}).Iter()
-	defer iter.Close()
-	var ops []txn.Op
-	var doc settingsDoc
-	for iter.Next(&doc) {
+// AddActionPruneSettings adds the model settings
+// to control log pruning if they are missing.
+func AddActionPruneSettings(st *State) error {
+	err := applyToAllModelSettings(st, func(doc *settingsDoc) (bool, error) {
 		settingsChanged :=
 			maybeUpdateSettings(doc.Settings, config.MaxActionResultsAge, config.DefaultActionResultsAge)
 		settingsChanged =
 			maybeUpdateSettings(doc.Settings, config.MaxActionResultsSize, config.DefaultActionResultsSize) || settingsChanged
-		if settingsChanged {
-			ops = append(ops, txn.Op{
-				C:      settingsC,
-				Id:     doc.DocID,
-				Assert: txn.DocExists,
-				Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
-			})
-		}
-	}
-	if err := iter.Close(); err != nil {
+		return settingsChanged, nil
+	})
+	if err != nil {
 		return errors.Trace(err)
-	}
-	if len(ops) > 0 {
-		return errors.Trace(st.runRawTransaction(ops))
 	}
 	return nil
 }
@@ -770,39 +769,13 @@ func AddActionPruneSettings(st *State) error {
 // to control how often to run the update-status hook
 // if they are missing.
 func AddUpdateStatusHookSettings(st *State) error {
-	coll, closer := st.db().GetRawCollection(settingsC)
-	defer closer()
-
-	uuids, err := st.AllModelUUIDs()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	var ids []string
-	for _, uuid := range uuids {
-		ids = append(ids, uuid+":e")
-	}
-
-	iter := coll.Find(bson.M{"_id": bson.M{"$in": ids}}).Iter()
-	defer iter.Close()
-	var ops []txn.Op
-	var doc settingsDoc
-	for iter.Next(&doc) {
+	err := applyToAllModelSettings(st, func(doc *settingsDoc) (bool, error) {
 		settingsChanged :=
 			maybeUpdateSettings(doc.Settings, config.UpdateStatusHookInterval, config.DefaultUpdateStatusHookInterval)
-		if settingsChanged {
-			ops = append(ops, txn.Op{
-				C:      settingsC,
-				Id:     doc.DocID,
-				Assert: txn.DocExists,
-				Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
-			})
-		}
-	}
-	if err := iter.Close(); err != nil {
+		return settingsChanged, nil
+	})
+	if err != nil {
 		return errors.Trace(err)
-	}
-	if len(ops) > 0 {
-		return errors.Trace(st.runRawTransaction(ops))
 	}
 	return nil
 }
@@ -1510,33 +1483,70 @@ func RemoveVotingMachineIds(st *State) error {
 // UpgradeDefaultContainerImageStreamConfig ensures that the config value for
 // container-image-stream is set to its default value, "released".
 func UpgradeContainerImageStreamDefault(st *State) error {
+	err := applyToAllModelSettings(st, func(doc *settingsDoc) (bool, error) {
+		ciStreamVal, keySet := doc.Settings[config.ContainerImageStreamKey]
+		if keySet {
+			if ciStream, _ := ciStreamVal.(string); ciStream != "" {
+				return false, nil
+			}
+		}
+		doc.Settings[config.ContainerImageStreamKey] = "released"
+		return true, nil
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// RemoveContainerImageStreamFromNonModelSettings
+// In 2.3.6 we accidentally had an upgrade step that added
+// "container-image-stream": "released" to all settings documents, not just the
+// ones relating to Model data.
+// This removes it from all the ones that aren't model docs if it is exactly
+// what we would have added in 2.3.6
+func RemoveContainerImageStreamFromNonModelSettings(st *State) error {
+	uuids, err := st.AllModelUUIDs()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	modelDocIDs := set.NewStrings()
+	for _, uuid := range uuids {
+		modelDocIDs.Add(uuid + ":e")
+	}
 	coll, closer := st.db().GetRawCollection(settingsC)
 	defer closer()
-	iter := coll.Find(bson.D{}).Iter()
+
+	iter := coll.Find(nil).Iter()
 	defer iter.Close()
+
+	// This is the key for the field that was accidentally added in 2.3.6
+	// settings.container-image-stream
+	const dbSettingsKey = "settings." + config.ContainerImageStreamKey
 
 	var ops []txn.Op
 	var doc settingsDoc
 	for iter.Next(&doc) {
-		needsWrite := false
-		ciStreamVal, keySet := doc.Settings[config.ContainerImageStreamKey]
-		if !keySet {
-			needsWrite = true
-		} else {
-			if ciStream, _ := ciStreamVal.(string); ciStream == "" {
-				needsWrite = true
-			}
-		}
-		if !needsWrite {
+		if modelDocIDs.Contains(doc.DocID) {
+			// this is a model document, whatever was set here should stay
 			continue
 		}
-
-		doc.Settings[config.ContainerImageStreamKey] = "released"
+		if stream, ok := doc.Settings[config.ContainerImageStreamKey]; !ok {
+			// doesn't contain ContainerImageStreamKey
+			continue
+		} else if stream != "released" {
+			// definitely wasn't set by the 2.3.6 upgrade step
+			continue
+		}
+		// We just unset the one field that we accidentally set before, so we
+		// don't have to worry about serialization of the other keys in the
+		// document.
 		ops = append(ops, txn.Op{
 			C:      settingsC,
 			Id:     doc.DocID,
 			Assert: txn.DocExists,
-			Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
+			Update: bson.M{"$unset": bson.M{dbSettingsKey: 1}},
 		})
 	}
 	if err := iter.Close(); err != nil {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -712,10 +712,6 @@ func applyToAllModelSettings(st *State, change func(*settingsDoc) (bool, error))
 			return errors.Trace(err)
 		}
 		if settingsChanged {
-			// Note: some settings contain embedded '.' or '$' characters and
-			// need to be encoded to save back to the database. We don't need
-			// to do that here, only because we don't use those keys in our
-			// Model and Controller settings documents.
 			ops = append(ops, txn.Op{
 				C:      settingsC,
 				Id:     doc.DocID,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2345,7 +2345,7 @@ func (s *upgradesSuite) TestRemoveVotingMachineIds(c *gc.C) {
 func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
 	// Value not set
 	m1 := s.makeModel(c, "m1", coretesting.Attrs{
-		"other-setting": "val",
+		"other-setting":                            "val",
 		unescapeReplacer.Replace("dotted.setting"): "value",
 		unescapeReplacer.Replace("dollar$setting"): "value",
 	})

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2343,42 +2343,167 @@ func (s *upgradesSuite) TestRemoveVotingMachineIds(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
+	// Value not set
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
+		"other-setting": "val",
+	})
+	defer m1.Close()
+	// Value set to the empty string
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{
+		"container-image-stream": "",
+		"other-setting":          "val",
+	})
+	defer m2.Close()
+	// Value set to something other that default
+	m3 := s.makeModel(c, "m3", coretesting.Attrs{
+		"container-image-stream": "daily",
+	})
+	defer m3.Close()
+
 	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
-	_, err := settingsColl.RemoveAll(nil)
+	// To simulate a 2.3.5 without any setting, delete the record from it.
+	err := settingsColl.UpdateId(m1.ModelUUID()+":e",
+		bson.M{"$unset": bson.M{"settings.container-image-stream": 1}},
+	)
 	c.Assert(err, jc.ErrorIsNil)
+	// And an extra document from somewhere else that we shouldn't touch
 	err = settingsColl.Insert(
 		bson.M{
-			"_id":      "foo",
+			"_id":      "not-a-model",
 			"settings": bson.M{"other-setting": "val"},
-		},
-		bson.M{
-			"_id":      "bar",
-			"settings": bson.M{"container-image-stream": "", "other-setting": "val"},
-		},
-		bson.M{
-			"_id":      "baz",
-			"settings": bson.M{"container-image-stream": "daily"},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedSettings := []bson.M{
-		{
-			"_id":      "bar",
-			"settings": bson.M{"container-image-stream": "released", "other-setting": "val"},
-		},
-		{
-			"_id":      "baz",
-			"settings": bson.M{"container-image-stream": "daily"},
-		},
-		{
-			"_id":      "foo",
-			"settings": bson.M{"container-image-stream": "released", "other-setting": "val"},
-		},
+	// Read all the settings from the database, but make sure to change the
+	// documents we think we're changing, and the rest should go through
+	// unchanged.
+	var rawSettings bson.M
+	iter := settingsColl.Find(nil).Sort("_id").Iter()
+	defer iter.Close()
+
+	expectedSettings := []bson.M{}
+
+	expectedChanges := map[string]bson.M{
+		m1.ModelUUID() + ":e": bson.M{"container-image-stream": "released", "other-setting": "val"},
+		m2.ModelUUID() + ":e": bson.M{"container-image-stream": "released", "other-setting": "val"},
+		m3.ModelUUID() + ":e": bson.M{"container-image-stream": "daily"},
+		"not-a-model":         bson.M{"other-setting": "val"},
 	}
+	for iter.Next(&rawSettings) {
+		expSettings := copyMap(rawSettings, nil)
+		delete(expSettings, "txn-queue")
+		delete(expSettings, "txn-revno")
+		delete(expSettings, "version")
+		id, ok := expSettings["_id"]
+		c.Assert(ok, jc.IsTrue)
+		idStr, ok := id.(string)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(idStr, gc.Not(gc.Equals), "")
+		if changes, ok := expectedChanges[idStr]; ok {
+			raw, ok := expSettings["settings"]
+			c.Assert(ok, jc.IsTrue)
+			settings, ok := raw.(bson.M)
+			c.Assert(ok, jc.IsTrue)
+			for k, v := range changes {
+				settings[k] = v
+			}
+		}
+		expectedSettings = append(expectedSettings, expSettings)
+	}
+	c.Assert(iter.Close(), jc.ErrorIsNil)
 
 	s.assertUpgradedData(c, UpgradeContainerImageStreamDefault,
+		expectUpgradedData{settingsColl, expectedSettings},
+	)
+}
+
+func (s *upgradesSuite) TestRemoveContainerImageStreamFromNonModelSettings(c *gc.C) {
+	// a model with a valid setting
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
+		"other-setting":          "val",
+		"container-image-stream": "released",
+	})
+	defer m1.Close()
+	// a model with a custom setting
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{
+		"container-image-stream": "daily",
+		"other-setting":          "val",
+	})
+	defer m2.Close()
+
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	// A document that isn't a model with an accidental setting
+	err := settingsColl.Insert(
+		bson.M{
+			"_id": "not-a-model",
+			"settings": bson.M{
+				"container-image-stream":                   "released",
+				"other-setting":                            "val",
+				unescapeReplacer.Replace("dotted.setting"): "value",
+				unescapeReplacer.Replace("dollar$setting"): "value",
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// A document that doesn't have the setting
+	err = settingsColl.Insert(
+		bson.M{
+			"_id": "applicationsetting",
+			"settings": bson.M{
+				"other-setting": "val",
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// A document that has the setting, but it shouldn't be touched because it is a custom value.
+	err = settingsColl.Insert(
+		bson.M{
+			"_id": "otherapplication",
+			"settings": bson.M{
+				"container-image-stream": "custom",
+				"other-setting":          "val",
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Read all the settings from the database, and change the 'not-a-model'
+	// content which has 'container-image-stream' that needs to be removed.
+	// documents we think we're changing, and the rest should go through
+	// unchanged.
+	var rawSettings bson.M
+	iter := settingsColl.Find(nil).Sort("_id").Iter()
+	defer iter.Close()
+
+	expectedSettings := []bson.M{}
+
+	for iter.Next(&rawSettings) {
+		expSettings := copyMap(rawSettings, nil)
+		delete(expSettings, "txn-queue")
+		delete(expSettings, "txn-revno")
+		delete(expSettings, "version")
+		id, ok := expSettings["_id"]
+		idStr, ok := id.(string)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(idStr, gc.Not(gc.Equals), "")
+		if idStr == "not-a-model" {
+			raw, ok := expSettings["settings"]
+			c.Assert(ok, jc.IsTrue)
+			settings, ok := raw.(bson.M)
+			c.Assert(ok, jc.IsTrue)
+			delete(settings, "container-image-stream")
+		}
+		expectedSettings = append(expectedSettings, expSettings)
+	}
+	c.Assert(iter.Close(), jc.ErrorIsNil)
+
+	// Note that the assertions on this are very hard to read for humans,
+	// because Settings documents have a ton of keys and nested sub documents.
+	// But it is a more accurate depiction of what is in that table.
+	s.assertUpgradedData(c, RemoveContainerImageStreamFromNonModelSettings,
 		expectUpgradedData{settingsColl, expectedSettings},
 	)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2346,6 +2346,8 @@ func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
 	// Value not set
 	m1 := s.makeModel(c, "m1", coretesting.Attrs{
 		"other-setting": "val",
+		unescapeReplacer.Replace("dotted.setting"): "value",
+		unescapeReplacer.Replace("dollar$setting"): "value",
 	})
 	defer m1.Close()
 	// Value set to the empty string

--- a/state/watcher/logger.go
+++ b/state/watcher/logger.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package watcher
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -37,6 +37,7 @@ type StateBackend interface {
 	AddRelationStatus() error
 	DeleteCloudImageMetadata() error
 	EnsureContainerImageStreamDefault() error
+	RemoveContainerImageStreamFromNonModelSettings() error
 	MoveMongoSpaceToHASpaceConfig() error
 	CreateMissingApplicationConfig() error
 	RemoveVotingMachineIds() error
@@ -176,4 +177,8 @@ func (s stateBackend) DeleteCloudImageMetadata() error {
 
 func (s stateBackend) EnsureContainerImageStreamDefault() error {
 	return state.UpgradeContainerImageStreamDefault(s.st)
+}
+
+func (s stateBackend) RemoveContainerImageStreamFromNonModelSettings() error {
+	return state.RemoveContainerImageStreamFromNonModelSettings(s.st)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -30,6 +30,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.3.2"), stateStepsFor232()},
 		upgradeToVersion{version.MustParse("2.3.4"), stateStepsFor234()},
 		upgradeToVersion{version.MustParse("2.3.6"), stateStepsFor236()},
+		upgradeToVersion{version.MustParse("2.3.7"), stateStepsFor237()},
 		upgradeToVersion{version.MustParse("2.4.0"), stateStepsFor24()},
 	}
 	return steps

--- a/upgrades/steps_237.go
+++ b/upgrades/steps_237.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor237 returns upgrade steps for Juju 2.3.7 that manipulate state directly.
+func stateStepsFor237() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "ensure container-image-stream isn't set in applications",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveContainerImageStreamFromNonModelSettings()
+			},
+		},
+	}
+}

--- a/upgrades/steps_237_test.go
+++ b/upgrades/steps_237_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v237 = version.MustParse("2.3.7")
+
+type steps237Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps237Suite{})
+
+func (s *steps236Suite) TestRemoveContainerImageStreamFromNonModelSettings(c *gc.C) {
+	step := findStateStep(c, v237, "ensure container-image-stream isn't set in applications")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -646,6 +646,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.3.2",
 		"2.3.4",
 		"2.3.6",
+		"2.3.7",
 		"2.4.0",
 	})
 }

--- a/worker/centralhub/manifold_test.go
+++ b/worker/centralhub/manifold_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package centralhub_test
 

--- a/worker/centralhub/package_test.go
+++ b/worker/centralhub/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package centralhub_test
 

--- a/worker/migrationflag/manifold_test.go
+++ b/worker/migrationflag/manifold_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/worker/migrationflag/package_test.go
+++ b/worker/migrationflag/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/worker/migrationflag/util_test.go
+++ b/worker/migrationflag/util_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/worker/migrationflag/validate_test.go
+++ b/worker/migrationflag/validate_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/worker/migrationflag/worker_test.go
+++ b/worker/migrationflag/worker_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationflag_test
 

--- a/worker/migrationmaster/package_test.go
+++ b/worker/migrationmaster/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package migrationmaster_test
 

--- a/worker/pubsub/manifold_test.go
+++ b/worker/pubsub/manifold_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package pubsub_test
 

--- a/worker/pubsub/package_test.go
+++ b/worker/pubsub/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Canonical Ltd.
-// Licensed under the LGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package pubsub_test
 


### PR DESCRIPTION
## Description of change

This brings in the fix for the 2.3.6 upgrade step and also fixes the raw settingsMap so that it always escapes on write and unescapes on read.

We could probably do less escaping in the Settings structure, but we applying an escaping or decoding 2x is safe, because we are replacing with characters that don't get used.

## QA steps

See the steps for the general 2.3.6 upgrade issue (associated bug).
But also just running
```
$ cd state
$ go test -check.v -check.f upgrades
```
They would fail without the patch to settings.go


## Documentation changes

None.

## Bug reference

[lp:1765722](https://bugs.launchpad.net/juju/+bug/1765722)