### PR TITLE
Extract common agent related functionality from juju-updateseries

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
@@ -139,4 +140,18 @@ func setupAgentLogging(config agent.Config) {
 	if flags := featureflag.String(); flags != "" {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
+}
+
+// GetJujuVersion gets the version of the agent from agent's config file
+func GetJujuVersion(machineAgent string, dataDir string) (version.Number, error) {
+	agentConf := NewAgentConf(dataDir)
+	if err := agentConf.ReadConfig(machineAgent); err != nil {
+		err = errors.Annotate(err, "failed to read agent config file.")
+		return version.Number{}, err
+	}
+	config := agentConf.CurrentConfig()
+	if config == nil {
+		return version.Number{}, errors.Errorf("%s agent conf is not found", machineAgent)
+	}
+	return config.UpgradedToVersion(), nil
 }

--- a/cmd/jujud/updateseries/updateseries.go
+++ b/cmd/jujud/updateseries/updateseries.go
@@ -4,32 +4,19 @@
 package updateseries
 
 import (
-	"fmt"
-	"os"
-	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/arch"
-	"github.com/juju/utils/fs"
 	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
-	"github.com/juju/utils/shell"
-	"github.com/juju/utils/symlink"
-	"github.com/juju/version"
-	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/systemd"
 )
 
@@ -48,7 +35,13 @@ type UpdateSeriesCommand struct {
 	toSeries     string
 	fromSeries   string
 	startAgents  bool
+	manager      service.SystemdServiceManager
 }
+
+var (
+	systemdDir          = "/etc/systemd/system"
+	systemdMultiUserDir = systemdDir + "/multi-user.target.wants"
+)
 
 func (c *UpdateSeriesCommand) Info() *cmd.Info {
 	return &cmd.Info{
@@ -92,6 +85,9 @@ func (c *UpdateSeriesCommand) Init(args []string) error {
 		return errors.Errorf("cannot run on a controller machine")
 	}
 
+	if c.manager == nil {
+		c.manager = service.NewSystemdServiceManager(systemd.IsRunning)
+	}
 	return c.CommandBase.Init(args)
 }
 
@@ -104,8 +100,18 @@ func (c *UpdateSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
-	if err := c.findAgents(ctx); err != nil {
+
+	var (
+		err              error
+		failedAgentNames []string
+	)
+
+	if c.machineAgent, c.unitAgents, failedAgentNames, err = c.manager.FindAgents(c.dataDir); err != nil {
 		return err
+	} else {
+		for _, name := range failedAgentNames {
+			ctx.Warningf("%s is not of type Machine nor Unit, ignoring", name)
+		}
 	}
 
 	fromInitSys, err := service.VersionInitSystem(c.fromSeries)
@@ -118,38 +124,97 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
+	jujuVersion, err := agent.GetJujuVersion(c.machineAgent, c.dataDir)
+	if err != nil {
+		return err
+	}
+
 	switch {
 	case toInitSys == service.InitSystemUpstart:
 		return errors.NewNotSupported(nil, "downgrade to series using upstart not supported")
 	case toInitSys == fromInitSys && toInitSys == service.InitSystemSystemd:
-		if err = c.copyTools(); err != nil {
+		if err := c.manager.CopyAgentBinary(c.machineAgent, c.unitAgents, c.dataDir, c.toSeries, c.fromSeries, jujuVersion); err != nil {
 			return err
 		} else {
-			ctx.Infof("successfully copied tools and relinked agent tools")
+			ctx.Infof("successfully copied and relinked agent binaries")
 		}
 		if !c.startAgents {
 			break
 		}
-		if err = c.startAllAgents(ctx); err != nil {
+
+		startedMachineName, startedUnitNames, err := c.manager.StartAllAgents(
+			c.machineAgent,
+			c.unitAgents,
+			c.dataDir,
+			c.toSeries,
+		)
+		if err != nil {
 			return err
+		} else {
+			for _, unitName := range startedUnitNames {
+				ctx.Infof("started %s service", unitName)
+			}
+			ctx.Infof("started %s service", startedMachineName)
 		}
 		ctx.Infof("all agents successfully restarted")
 	case toInitSys == service.InitSystemSystemd:
 		errorHappened := false
-		if err = c.writeSystemdAgents(ctx); err != nil {
+		failedAgentNames = failedAgentNames[:0]
+		startedSysdServiceNames, startedSymServiceNames, failedAgentNames, err := c.manager.WriteSystemdAgents(
+			c.machineAgent,
+			c.unitAgents,
+			c.dataDir,
+			systemdDir,
+			systemdMultiUserDir,
+			c.toSeries,
+		)
+		if err != nil {
+			for _, agentName := range failedAgentNames {
+				ctx.Warningf("failed to write service for %s: %s", agentName, err)
+			}
 			ctx.Warningf("%s", err)
 			errorHappened = true
 		}
-		if err = c.copyTools(); err != nil {
+		for _, sysSvcName := range startedSysdServiceNames {
+			ctx.Infof("wrote %s agent, enabled and linked by systemd", sysSvcName)
+		}
+		for _, symSvcName := range startedSymServiceNames {
+			ctx.Infof("wrote %s agent, enabled and linked by symlink", symSvcName)
+		}
+		err = c.manager.CopyAgentBinary(
+			c.machineAgent,
+			c.unitAgents,
+			c.dataDir,
+			c.toSeries,
+			c.fromSeries,
+			jujuVersion,
+		)
+		if err != nil {
 			ctx.Warningf("%s", err)
 			errorHappened = true
 		} else {
-			ctx.Infof("successfully copied tools and relinked agent tools")
+			ctx.Infof("successfully copied and relinked agent binaries")
 		}
 		switch {
 		case !errorHappened && c.startAgents:
-			if err = c.startAllAgents(ctx); err != nil {
+			startedMachineName, startedUnitNames, err := c.manager.StartAllAgents(
+				c.machineAgent,
+				c.unitAgents,
+				c.dataDir,
+				c.toSeries,
+			)
+			if err != nil {
 				return err
+			} else {
+				for _, unitName := range startedUnitNames {
+					ctx.Infof("started %s service", unitName)
+				}
+				if startedMachineName != "" {
+					ctx.Infof("started %s service", startedMachineName)
+				}
+				if err != nil {
+					return nil
+				}
 			}
 			ctx.Infof("all agents successfully restarted")
 		case errorHappened && c.startAgents:
@@ -157,36 +222,6 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 		}
 	default:
 		return errors.Errorf("Failed to migrate from %s to %s", fromInitSys, toInitSys)
-	}
-	return nil
-}
-
-func (c *UpdateSeriesCommand) findAgents(ctx *cmd.Context) error {
-	agentsDir := filepath.Join(c.dataDir, "agents")
-	dir, err := os.Open(agentsDir)
-	if err != nil {
-		return errors.Annotate(err, "opening agents dir")
-	}
-	defer dir.Close()
-
-	entries, err := dir.Readdir(-1)
-	if err != nil {
-		return errors.Annotate(err, "reading agents dir")
-	}
-	for _, info := range entries {
-		name := info.Name()
-		tag, err := names.ParseTag(name)
-		if err != nil {
-			continue
-		}
-		switch tag.Kind() {
-		case names.MachineTagKind:
-			c.machineAgent = name
-		case names.UnitTagKind:
-			c.unitAgents = append(c.unitAgents, name)
-		default:
-			ctx.Warningf("%s is not of type Machine nor Unit, ignoring", name)
-		}
 	}
 	return nil
 }
@@ -202,214 +237,4 @@ var isController = func() (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-var (
-	systemdDir          = "/etc/systemd/system"
-	systemdMultiUserDir = systemdDir + "/multi-user.target.wants"
-)
-
-// For testing
-var sysdIsRunning = systemd.IsRunning
-
-func (c *UpdateSeriesCommand) writeSystemdAgents(ctx *cmd.Context) error {
-	var lastError error
-	for _, agentName := range append(c.unitAgents, c.machineAgent) {
-		conf, err := c.createAgentConf(agentName)
-		if err != nil {
-			ctx.Warningf("%s", err)
-			lastError = err
-			continue
-		}
-		svcName := "jujud-" + agentName
-		svc, err := service.NewService(svcName, conf, c.toSeries)
-
-		upgradableSvc, ok := svc.(service.UpgradableService)
-		if !ok {
-			initName, err := service.VersionInitSystem(c.toSeries)
-			if err != nil {
-				return errors.Trace(errors.Annotate(err, "nor is service an UpgradableService"))
-			}
-			return errors.Errorf("%s service not of type UpgradableService", initName)
-		}
-		if err = upgradableSvc.WriteService(); err != nil {
-			ctx.Warningf("failed to write service for %s: %s", agentName, err)
-			lastError = err
-			continue
-		}
-
-		running, err := sysdIsRunning()
-		switch {
-		case err != nil:
-			return errors.Errorf("failure attempting to determine if systemd is running: %#v\n", err)
-		case running:
-			// Links for manual and automatic use of the service
-			// have been written, move to the next.
-			ctx.Infof("wrote %s agent, enabled and linked by systemd", svcName)
-			continue
-		}
-
-		svcFileName := svcName + ".service"
-		if err = os.Symlink(path.Join(c.dataDir, "init", svcName, svcFileName),
-			path.Join(systemdDir, svcFileName)); err != nil && !os.IsExist(err) {
-			return errors.Errorf("failed to link service file (%s) in systemd dir: %s\n", svcFileName, err)
-		}
-		if err = os.Symlink(path.Join(c.dataDir, "init", svcName, svcFileName),
-			path.Join(systemdMultiUserDir, svcFileName)); err != nil && !os.IsExist(err) {
-			return errors.Errorf("failed to link service file (%s) in multi-user.target.wants dir: %s\n", svcFileName, err)
-		}
-		ctx.Infof("wrote %s agent, enabled and linked by symlink", svcName)
-	}
-	return lastError
-}
-
-func (c *UpdateSeriesCommand) createAgentConf(agentName string) (_ common.Conf, err error) {
-	defer func() {
-		if err != nil {
-			logger.Infof("Failed create agent conf for %s: %s", agentName, err)
-		}
-	}()
-
-	renderer, err := shell.NewRenderer("")
-	if err != nil {
-		return common.Conf{}, err
-	}
-
-	tag, err := names.ParseTag(agentName)
-	if err != nil {
-		return common.Conf{}, err
-	}
-	name := tag.Id()
-
-	var kind service.AgentKind
-	switch tag.Kind() {
-	case names.MachineTagKind:
-		kind = service.AgentKindMachine
-	case names.UnitTagKind:
-		kind = service.AgentKindUnit
-	default:
-		return common.Conf{}, errors.NewNotValid(nil, fmt.Sprintf("agent %q is neither a machine nor a unit", agentName))
-	}
-
-	info := service.NewAgentInfo(
-		kind,
-		name,
-		c.dataDir,
-		paths.MustSucceed(paths.LogDir(c.toSeries)),
-	)
-	return service.AgentConf(info, renderer), nil
-}
-
-func (c *UpdateSeriesCommand) startAllAgents(ctx *cmd.Context) error {
-	running, err := sysdIsRunning()
-	switch {
-	case err != nil:
-		return err
-	case !running:
-		return errors.Errorf("systemd is not fully running, please reboot to start agents")
-	}
-
-	for _, unit := range c.unitAgents {
-		if err = c.startAgent(unit, service.AgentKindUnit); err != nil {
-			return errors.Annotatef(err, "failed to start %s service", "jujud-"+unit)
-		}
-		ctx.Infof("started %s service", "jujud-"+unit)
-	}
-
-	err = c.startAgent(c.machineAgent, service.AgentKindMachine)
-	if err == nil {
-		ctx.Infof("started %s service", "jujud-"+c.machineAgent)
-	}
-	return errors.Annotatef(err, "failed to start %s service", "jujud-"+c.machineAgent)
-}
-
-func (c *UpdateSeriesCommand) startAgent(name string, kind service.AgentKind) (err error) {
-	renderer, err := shell.NewRenderer("")
-	if err != nil {
-		return err
-	}
-	info := service.NewAgentInfo(
-		kind,
-		name,
-		c.dataDir,
-		paths.MustSucceed(paths.LogDir(c.toSeries)),
-	)
-	conf := service.AgentConf(info, renderer)
-	svcName := "jujud-" + name
-	svc, err := service.NewService(svcName, conf, c.toSeries)
-	if err = svc.Start(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *UpdateSeriesCommand) copyTools() (err error) {
-	defer func() {
-		if err != nil {
-			errors.Annotate(err, "failed to copy tools")
-		}
-	}()
-
-	// Get the current juju version from the machine agent
-	// conf file.
-	agentConf := agent.NewAgentConf(c.dataDir)
-	if err = agentConf.ReadConfig(c.machineAgent); err != nil {
-		return err
-	}
-	config := agentConf.CurrentConfig()
-	if config == nil {
-		return errors.Errorf("%s agent conf is not found", c.machineAgent)
-	}
-	jujuVersion := config.UpgradedToVersion()
-
-	// Setup new and old version.Binarys with only the series
-	// different.
-	fromVers := version.Binary{
-		Number: jujuVersion,
-		Arch:   arch.HostArch(),
-		Series: c.fromSeries,
-	}
-	toVers := version.Binary{
-		Number: jujuVersion,
-		Arch:   arch.HostArch(),
-		Series: c.toSeries,
-	}
-
-	// If tools with the new series don't already exist, copy
-	// current tools to new directory with correct series.
-	if _, err = os.Stat(tools.SharedToolsDir(c.dataDir, toVers)); err != nil {
-		// Copy tools to new directory with correct series.
-		if err = fs.Copy(tools.SharedToolsDir(c.dataDir, fromVers), tools.SharedToolsDir(c.dataDir, toVers)); err != nil {
-			return err
-		}
-	}
-
-	// Write tools metadata with new version, however don't change
-	// the URL, so we know where it came from.
-	jujuTools, err := tools.ReadTools(c.dataDir, toVers)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Only write once
-	if jujuTools.Version != toVers {
-		jujuTools.Version = toVers
-		if err = tools.WriteToolsMetadataData(tools.ToolsDir(c.dataDir, toVers.String()), jujuTools); err != nil {
-			return err
-		}
-	}
-
-	// Update Agent Tool links
-	var lastError error
-	for _, agentName := range append(c.unitAgents, c.machineAgent) {
-		toolPath := tools.ToolsDir(c.dataDir, toVers.String())
-		toolsDir := tools.ToolsDir(c.dataDir, agentName)
-
-		err = symlink.Replace(toolsDir, toolPath)
-		if err != nil {
-			lastError = err
-		}
-	}
-
-	return lastError
 }

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -1,0 +1,325 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This file has routines which can be used for agent specific functionalities related to service files:
+//	- finding all agents in the machine
+//	- create conf file using the machine details
+// 	- write systemd service file and setting links
+// 	- copy all tools and related to agents and setup the links
+// 	- start all the agents
+// These routines can be used by any tools/cmds trying to implement the above functionality as part of the process, eg. juju-updateseries command.
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/fs"
+	"github.com/juju/utils/shell"
+	"github.com/juju/utils/symlink"
+	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/service/common"
+	//	"github.com/juju/juju/service/systemd"
+)
+
+type SystemdServiceManager interface {
+	// FindAgents finds all the agents available in the machine.
+	FindAgents(dataDir string) (string, []string, []string, error)
+
+	// WriteSystemdAgents creates systemd files and create symlinks for the list of machine and units passed in the standard filepath.
+	WriteSystemdAgents(machineAgent string, unitAgents []string, dataDir string, symLinkSystemdDir string, symLinkSystemdMultiUserDir string, series string) ([]string, []string, []string, error)
+
+	//CreateAgentConf creates the configfile for specified agent running on a host with specified series.
+	CreateAgentConf(agentName string, dataDir string, series string) (common.Conf, error)
+
+	// CopyAgentBinary copies all the tools into the path specified for each agent.
+	CopyAgentBinary(machineAgent string, unitAgents []string, dataDir string, toSeries string, fromSeries string, jujuVersion version.Number) error
+
+	// StartAllAgents starts all the agents in the machine with specified series.
+	StartAllAgents(machineAgent string, unitAgents []string, dataDir string, series string) (string, []string, error)
+}
+
+type systemdServiceManager struct {
+	isRunning func() (bool, error)
+}
+
+// NewSystemdServiceManager returns object of systemServiceManager interface.
+func NewSystemdServiceManager(isRunning func() (bool, error)) SystemdServiceManager {
+	return &systemdServiceManager{isRunning: isRunning}
+}
+
+// FindAgents finds all the agents available in the machine.
+func (s *systemdServiceManager) FindAgents(dataDir string) (string, []string, []string, error) {
+
+	var (
+		machineAgent  string
+		unitAgents    []string
+		errAgentNames []string
+	)
+
+	agentDir := filepath.Join(dataDir, "agents")
+	dir, err := os.Open(agentDir)
+	if err != nil {
+		return "", nil, nil, errors.Annotate(err, "opening agents dir")
+	}
+	defer dir.Close()
+
+	entries, err := dir.Readdir(-1)
+	if err != nil {
+		return "", nil, nil, errors.Annotate(err, "reading agents dir")
+	}
+	for _, info := range entries {
+		name := info.Name()
+		tag, err := names.ParseTag(name)
+		if err != nil {
+			continue
+		}
+		switch tag.Kind() {
+		case names.MachineTagKind:
+			machineAgent = name
+		case names.UnitTagKind:
+			unitAgents = append(unitAgents, name)
+		default:
+			errAgentNames = append(errAgentNames, name)
+			logger.Infof("%s is not of type Machine nor Unit, ignoring", name)
+		}
+	}
+	return machineAgent, unitAgents, errAgentNames, nil
+}
+
+// WriteSystemdAgents creates systemd files and create symlinks for the list of machine and units passed in the standard filepath '/var/lib/juju' during the upgrade process.
+func (s *systemdServiceManager) WriteSystemdAgents(machineAgent string, unitAgents []string, dataDir string, symLinkSystemdDir string, symLinkSystemdMultiUserDir string, series string) ([]string, []string, []string, error) {
+
+	var (
+		startedSysServiceNames []string
+		startedSymServiceNames []string
+		errAgentNames          []string
+		lastError              error
+	)
+
+	for _, agentName := range append(unitAgents, machineAgent) {
+		conf, err := s.CreateAgentConf(agentName, dataDir, series)
+		if err != nil {
+			logger.Infof("%s", err)
+			lastError = err
+			continue
+		}
+
+		svcName := serviceName(agentName)
+		svc, err := NewService(svcName, conf, series)
+		if err != nil {
+			logger.Infof("Failed to create new service %s: ", err)
+			continue
+		}
+
+		upSvc, ok := svc.(UpgradableService)
+		if !ok {
+			initName, err := VersionInitSystem(series)
+			if err != nil {
+				return nil, nil, nil, errors.Trace(errors.Annotate(err, "nor is service an UpgradableService"))
+			}
+			return nil, nil, nil, errors.Errorf("%s service not of type UpgradableService", initName)
+		}
+
+		if err = upSvc.WriteService(); err != nil {
+			logger.Infof("failed to write service for %s: %s", agentName, err)
+			errAgentNames = append(errAgentNames, agentName)
+			lastError = err
+			continue
+		} else {
+			logger.Infof("successfully wrote service for %s:", agentName)
+		}
+
+		running, err := s.isRunning()
+		switch {
+		case err != nil:
+			return nil, nil, nil, errors.Errorf("failure attempting to determine if systemd is running: %#v\n", err)
+		case running:
+			// Links for manual and automatic use of the service
+			// have been written, move to the next.
+			startedSysServiceNames = append(startedSysServiceNames, svcName)
+			logger.Infof("wrote %s agent, enabled and linked by systemd", svcName)
+			continue
+		}
+
+		svcFileName := svcName + ".service"
+		if err = os.Symlink(path.Join(dataDir, "init", svcName, svcFileName),
+			path.Join(symLinkSystemdDir, svcFileName)); err != nil && !os.IsExist(err) {
+			return nil, nil, nil, errors.Errorf("failed to link service file (%s) in systemd dir: %s\n", svcFileName, err)
+		}
+
+		if err = os.Symlink(path.Join(dataDir, "init", svcName, svcFileName),
+			path.Join(symLinkSystemdMultiUserDir, svcFileName)); err != nil && !os.IsExist(err) {
+			return nil, nil, nil, errors.Errorf("failed to link service file (%s) in multi-user.target.wants dir: %s\n", svcFileName, err)
+		}
+
+		startedSymServiceNames = append(startedSymServiceNames, svcName)
+		logger.Infof("wrote %s agent, enabled and linked by symlink", svcName)
+	}
+	return startedSysServiceNames, startedSymServiceNames, errAgentNames, lastError
+}
+
+// CreateAgentConf creates the configfile for specified agent running on a host with specified series.
+func (s *systemdServiceManager) CreateAgentConf(agentName string, dataDir string, series string) (_ common.Conf, err error) {
+	defer func() {
+		if err != nil {
+			logger.Infof("failed create agent conf for %s: %s", agentName, err)
+		}
+	}()
+
+	renderer, err := shell.NewRenderer("")
+	if err != nil {
+		return common.Conf{}, err
+	}
+
+	tag, err := names.ParseTag(agentName)
+	if err != nil {
+		return common.Conf{}, err
+	}
+	name := tag.Id()
+
+	var kind AgentKind
+	switch tag.Kind() {
+	case names.MachineTagKind:
+		kind = AgentKindMachine
+	case names.UnitTagKind:
+		kind = AgentKindUnit
+	default:
+		return common.Conf{}, errors.NewNotValid(nil, fmt.Sprintf("agent %q is neither a machine nor a unit", agentName))
+	}
+
+	info := NewAgentInfo(
+		kind,
+		name,
+		dataDir,
+		paths.MustSucceed(paths.LogDir(series)),
+	)
+	return AgentConf(info, renderer), nil
+}
+
+// CopyAgentBinary copies all the tools into the path specified for each agent.
+func (s *systemdServiceManager) CopyAgentBinary(machineAgent string, unitAgents []string, dataDir string, toSeries string, fromSeries string, jujuVersion version.Number) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Annotate(err, "failed to copy tools")
+		}
+	}()
+
+	// Setup new and old version.Binarys with only the series
+	// different.
+	fromVers := version.Binary{
+		Number: jujuVersion,
+		Arch:   arch.HostArch(),
+		Series: fromSeries,
+	}
+	toVers := version.Binary{
+		Number: jujuVersion,
+		Arch:   arch.HostArch(),
+		Series: toSeries,
+	}
+
+	// If tools with the new series don't already exist, copy
+	// current tools to new directory with correct series.
+	if _, err = os.Stat(tools.SharedToolsDir(dataDir, toVers)); err != nil {
+		// Copy tools to new directory with correct series.
+		if err = fs.Copy(tools.SharedToolsDir(dataDir, fromVers), tools.SharedToolsDir(dataDir, toVers)); err != nil {
+			return err
+		}
+	}
+
+	// Write tools metadata with new version, however don't change
+	// the URL, so we know where it came from.
+	jujuTools, err := tools.ReadTools(dataDir, toVers)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Only write once
+	if jujuTools.Version != toVers {
+		jujuTools.Version = toVers
+		if err = tools.WriteToolsMetadataData(tools.ToolsDir(dataDir, toVers.String()), jujuTools); err != nil {
+			return err
+		}
+	}
+
+	// Update Agent Tool links
+	var lastError error
+	for _, agentName := range append(unitAgents, machineAgent) {
+		toolPath := tools.ToolsDir(dataDir, toVers.String())
+		toolsDir := tools.ToolsDir(dataDir, agentName)
+
+		err = symlink.Replace(toolsDir, toolPath)
+		if err != nil {
+			lastError = err
+		}
+	}
+
+	return lastError
+}
+
+// StartAllAgents starts all the agents in the machine with specified series.
+func (s *systemdServiceManager) StartAllAgents(machineAgent string, unitAgents []string, dataDir string, series string) (string, []string, error) {
+
+	var (
+		startedMachineName string
+		startedUnitNames   []string
+		err                error
+	)
+
+	running, err := s.isRunning()
+
+	switch {
+	case err != nil:
+		return "", nil, err
+	case !running:
+		return "", nil, errors.Errorf("systemd is not fully running, please reboot to start agents")
+	}
+
+	for _, unit := range unitAgents {
+		if err = startAgent(unit, AgentKindUnit, dataDir, series); err != nil {
+			return "", nil, errors.Annotatef(err, "failed to start %s service", serviceName(unit))
+		}
+		startedUnitNames = append(startedUnitNames, serviceName(unit))
+		logger.Infof("started %s service", serviceName(unit))
+	}
+
+	err = startAgent(machineAgent, AgentKindMachine, dataDir, series)
+	if err == nil {
+		startedMachineName = serviceName(machineAgent)
+		logger.Infof("started %s service", serviceName(machineAgent))
+	}
+	return startedMachineName, startedUnitNames, errors.Annotatef(err, "failed to start %s service", serviceName(machineAgent))
+}
+
+func startAgent(name string, kind AgentKind, dataDir string, series string) (err error) {
+	renderer, err := shell.NewRenderer("")
+	if err != nil {
+		return err
+	}
+	info := NewAgentInfo(
+		kind,
+		name,
+		dataDir,
+		paths.MustSucceed(paths.LogDir(series)),
+	)
+	conf := AgentConf(info, renderer)
+	svcName := serviceName(name)
+	svc, err := NewService(svcName, conf, series)
+	if err = svc.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func serviceName(agent string) string {
+	return "jujud-" + agent
+}

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -1,0 +1,323 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//The unit testcases in this file do not pertain to an specific command.
+
+package service_test
+
+import (
+	"bytes"
+	"os"
+	"path"
+
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	agenttools "github.com/juju/juju/agent/tools"
+	agentcmd "github.com/juju/juju/cmd/jujud/agent"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/service/common"
+	svctesting "github.com/juju/juju/service/common/testing"
+	"github.com/juju/juju/testing"
+	coretest "github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type agentConfSuite struct {
+	testing.BaseSuite
+
+	acfg                agent.Config
+	dataDir             string
+	machineName         string
+	unitNames           []string
+	systemdDir          string
+	systemdMultiUserDir string
+	sysdIsRunning       bool
+	manager             service.SystemdServiceManager
+
+	services    []*svctesting.FakeService
+	serviceData *svctesting.FakeServiceData
+}
+
+func (s *agentConfSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *agentConfSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.dataDir = c.MkDir()
+	s.PatchValue(&cmdutil.DataDir, s.dataDir)
+
+	tmpSystemdDir := path.Join(s.dataDir, "etc", "systemd", "system")
+	tmpSystemdMultiUserDir := path.Join(tmpSystemdDir, "multi-user.target.wants")
+	os.MkdirAll(tmpSystemdMultiUserDir, os.ModeDir|os.ModePerm)
+	s.PatchValue(&s.systemdDir, tmpSystemdDir)
+	s.PatchValue(&s.systemdMultiUserDir, tmpSystemdMultiUserDir)
+
+	s.machineName = "machine-0"
+	s.unitNames = []string{"unit-ubuntu-0", "unit-mysql-0"}
+
+	s.manager = service.NewSystemdServiceManager(func() (bool, error) { return true, nil })
+
+	s.assertSetupAgentsForTest(c)
+	s.setUpAgentConf(c)
+	s.setUpServices(c)
+	s.services[0].ResetCalls()
+	s.setupTools(c, "trusty")
+}
+
+func (s *agentConfSuite) TearDownTest(c *gc.C) {
+	s.serviceData = nil
+	s.services = nil
+	s.BaseSuite.TearDownTest(c)
+}
+
+var _ = gc.Suite(&agentConfSuite{})
+
+func (s *agentConfSuite) setUpAgentConf(c *gc.C) {
+	// Required for CopyAgentBinaries to evaluate the version of the agent.
+	configParams := agent.AgentConfigParams{
+		Paths:             agent.Paths{DataDir: s.dataDir},
+		Tag:               names.NewMachineTag("0"),
+		UpgradedToVersion: jujuversion.Current,
+		APIAddresses:      []string{"localhost:17070"},
+		CACert:            testing.CACert,
+		Password:          "fake",
+		Controller:        testing.ControllerTag,
+		Model:             testing.ModelTag,
+		MongoVersion:      mongo.Mongo32wt,
+	}
+
+	acfg, err := agent.NewAgentConfig(configParams)
+	c.Assert(err, jc.ErrorIsNil)
+	err = acfg.Write()
+	c.Assert(err, jc.ErrorIsNil)
+	s.acfg = acfg
+}
+
+func (s *agentConfSuite) setUpServices(c *gc.C) {
+	for _, fake := range append(s.unitNames, s.machineName) {
+		s.addService("jujud-" + fake)
+	}
+	s.PatchValue(&service.NewService, s.newService)
+	s.PatchValue(&service.ListServices, s.listServices)
+}
+
+func (s *agentConfSuite) addService(name string) {
+	svc, _ := s.newService(name, common.Conf{}, "")
+	svc.Install()
+	svc.Start()
+}
+
+func (s *agentConfSuite) listServices() ([]string, error) {
+	return s.serviceData.InstalledNames(), nil
+}
+
+func (s *agentConfSuite) newService(name string, conf common.Conf, series string) (service.Service, error) {
+	for _, svc := range s.services {
+		if svc.Name() == name {
+			return svc, nil
+		}
+	}
+	if s.serviceData == nil {
+		s.serviceData = svctesting.NewFakeServiceData()
+	}
+	svc := &svctesting.FakeService{
+		FakeServiceData: s.serviceData,
+		Service: common.Service{
+			Name: name,
+			Conf: common.Conf{},
+		},
+		DataDir: s.dataDir,
+	}
+	s.services = append(s.services, svc)
+	return svc, nil
+}
+
+func (s *agentConfSuite) setupTools(c *gc.C, series string) {
+	files := []*testing.TarFile{
+		testing.NewTarFile("jujud", 0755, "jujuc executable"),
+	}
+	data, checksum := testing.TarGz(files...)
+	testTools := &coretest.Tools{
+		URL: "http://foo/bar1",
+		Version: version.Binary{
+			Number: jujuversion.Current,
+			Arch:   arch.HostArch(),
+			Series: series,
+		},
+		Size:   int64(len(data)),
+		SHA256: checksum,
+	}
+	err := agenttools.UnpackTools(s.dataDir, testTools, bytes.NewReader(data))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *agentConfSuite) assertSetupAgentsForTest(c *gc.C) {
+	agentsDir := path.Join(s.dataDir, "agents")
+	err := os.MkdirAll(path.Join(agentsDir, s.machineName), os.ModeDir|os.ModePerm)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, unit := range s.unitNames {
+		err = os.Mkdir(path.Join(agentsDir, unit), os.ModeDir|os.ModePerm)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *agentConfSuite) TestFindAgents(c *gc.C) {
+	var err error
+	var machineAgent string
+	var unitAgents []string
+	machineAgent, unitAgents, _, err = s.manager.FindAgents(s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(machineAgent, gc.Equals, s.machineName)
+	c.Assert(unitAgents, jc.SameContents, s.unitNames)
+}
+
+func (s *agentConfSuite) TestFindAgentsFail(c *gc.C) {
+	agentsDir := path.Join(s.dataDir, "agents")
+	err := os.MkdirAll(path.Join(agentsDir, names.ApplicationTagKind+"-failme-0"), os.ModeDir|os.ModePerm)
+	var machineAgent string
+	var unitAgents []string
+	machineAgent, unitAgents, _, err = s.manager.FindAgents(s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(machineAgent, gc.Equals, s.machineName)
+	c.Assert(unitAgents, jc.SameContents, s.unitNames)
+}
+
+func (s *agentConfSuite) TestCreateAgentConf(c *gc.C) {
+	conf, err := s.manager.CreateAgentConf("machine-2", s.dataDir, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	// Spot check Conf
+	c.Assert(conf.Desc, gc.Equals, "juju agent for machine-2")
+}
+
+func (s *agentConfSuite) TestCreateAgentConfFailAgentKind(c *gc.C) {
+	_, err := s.manager.CreateAgentConf("application-fail", s.dataDir, "xenial")
+	c.Assert(err, gc.ErrorMatches, `agent "application-fail" is neither a machine nor a unit`)
+}
+
+func (s *agentConfSuite) TestStartAllAgents(c *gc.C) {
+	_ = cmdtesting.Context(c)
+	var err error
+	var machineAgent string
+	var unitAgents []string
+	machineAgent, unitAgents, _, err = s.manager.FindAgents(s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+	_, _, err = s.manager.StartAllAgents(machineAgent, unitAgents, s.dataDir, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertServicesCalls(c, "Start", len(s.services))
+}
+
+func (s *agentConfSuite) TestStartAllAgentsFailUnit(c *gc.C) {
+	s.services[0].SetErrors(
+		errors.New("fail me"),
+	)
+
+	var err error
+	var machineAgent string
+	var unitAgents []string
+	machineAgent, unitAgents, _, err = s.manager.FindAgents(s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+	_, _, err = s.manager.StartAllAgents(machineAgent, unitAgents, s.dataDir, "xenial")
+	c.Assert(err, gc.ErrorMatches, "failed to start .* service: fail me")
+
+	s.assertServicesCalls(c, "Start", 1)
+}
+
+func (s *agentConfSuite) TestWriteServiceCopyStartAllAgents(c *gc.C) {
+	var err error
+	var machineAgent string
+	var unitAgents []string
+	machineAgent, unitAgents, _, err = s.manager.FindAgents(s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, _, err = s.manager.WriteSystemdAgents(machineAgent, unitAgents, s.dataDir, s.systemdDir, s.systemdMultiUserDir, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertServicesCalls(c, "WriteService", len(s.services))
+
+	jujuVersion, err := agentcmd.GetJujuVersion(machineAgent, s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.manager.CopyAgentBinary(machineAgent, unitAgents, s.dataDir, "xenial", "trusty", jujuVersion)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.manager.StartAllAgents(machineAgent, unitAgents, s.dataDir, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertServicesCalls(c, "Start", len(s.services))
+	s.assertToolsCopySymlink(c, "xenial")
+}
+
+func (s *agentConfSuite) TestPreRebootWriteServiceCopyStartAllAgents(c *gc.C) {
+	s.manager = service.NewSystemdServiceManager(func() (bool, error) { return false, nil })
+	var err error
+	var machineAgent string
+	var unitAgents []string
+	machineAgent, unitAgents, _, err = s.manager.FindAgents(s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, _, err = s.manager.WriteSystemdAgents(machineAgent, unitAgents, s.dataDir, s.systemdDir, s.systemdMultiUserDir, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertServicesCalls(c, "WriteService", len(s.services))
+
+	jujuVersion, err := agentcmd.GetJujuVersion(machineAgent, s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.manager.CopyAgentBinary(machineAgent, unitAgents, s.dataDir, "xenial", "trusty", jujuVersion)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.manager.StartAllAgents(machineAgent, unitAgents, s.dataDir, "xenial")
+	c.Assert(err, gc.ErrorMatches, "systemd is not fully running, please reboot to start agents")
+}
+
+func (s *agentConfSuite) assertToolsCopySymlink(c *gc.C, series string) {
+	// Check tools changes
+	ver := version.Binary{
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		Series: series,
+	}
+	jujuTools, err := agenttools.ReadTools(s.dataDir, ver)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(jujuTools.Version, gc.DeepEquals, ver)
+
+	for _, name := range append(s.unitNames, s.machineName) {
+		link := path.Join(s.dataDir, "tools", name)
+		linkResult, err := os.Readlink(link)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(linkResult, gc.Equals, path.Join(s.dataDir, "tools", ver.String()))
+	}
+}
+
+func (s *agentConfSuite) assertServiceSymLinks(c *gc.C) {
+	for _, agent := range append(s.unitNames, s.machineName) {
+		svcName := "jujud-" + agent
+		svcFileName := svcName + ".service"
+		result, err := os.Readlink(path.Join(s.systemdDir, svcFileName))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.Equals, path.Join(s.dataDir, "init", svcName, svcFileName))
+	}
+}
+
+func (s *agentConfSuite) assertServicesCalls(c *gc.C, svc string, expectedCnt int) {
+	// Call list shared by the services
+	calls := s.services[0].Calls()
+	serviceCount := 0
+	for _, call := range calls {
+		if call.FuncName == svc {
+			serviceCount += 1
+		}
+	}
+	c.Assert(serviceCount, gc.Equals, expectedCnt)
+}

--- a/service/agentinfo.go
+++ b/service/agentinfo.go
@@ -12,8 +12,6 @@ import (
 	"github.com/juju/juju/agent/tools"
 )
 
-// TODO(ericsnow) Move this file to the agent package.
-
 // AgentKind identifies the kind of agent.
 type AgentKind string
 


### PR DESCRIPTION
## Description of change
This PR address relocation of functions which are common in update series and also agent specific functions from service folder.
## QA steps
This change is required to make the code more compact and reduce redundant code.
verify the execution of bootstrap, deploy and update series command as well.
## Documentation changes
N/A
## Bug reference
https://bugs.launchpad.net/juju/+bug/1634390
