### PR TITLE
peergrouper + raft: Handle blank API addresses

### DIFF
--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -604,14 +604,9 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 	// Reset machine status for members of the changed peer-group.
 	// Any previous peer-group determination errors result in status
 	// warning messages.
-	// Remove members from the return that are not voters.
 	for id := range desired.members {
 		if err := w.machineTrackers[id].stm.SetStatus(getStatusInfo("")); err != nil {
 			return nil, errors.Trace(err)
-		}
-
-		if !desired.machineVoting[id] {
-			delete(desired.members, id)
 		}
 	}
 	for _, tracker := range info.machines {

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -490,8 +490,8 @@ func (s *workerSuite) TestControllersArePublishedOverHub(c *gc.C) {
 	expected := apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
 			"10": {ID: "10", Addresses: []string{"0.1.2.10:5678"}, InternalAddress: "0.1.2.10:5678"},
-			"11": {ID: "11", Addresses: []string{"0.1.2.11:5678"}},
-			"12": {ID: "12", Addresses: []string{"0.1.2.12:5678"}},
+			"11": {ID: "11", Addresses: []string{"0.1.2.11:5678"}, InternalAddress: "0.1.2.11:5678"},
+			"12": {ID: "12", Addresses: []string{"0.1.2.12:5678"}, InternalAddress: "0.1.2.12:5678"},
 		},
 		LocalOnly: true,
 	}


### PR DESCRIPTION
## Description of change

When the (mongo & raft) leader machine of a 3-machine controller was removed it would prevent the raft worker on one of the remaining machines from coming back up, so the raft worker on the other machine wouldn't be able to become the leader and continue working.

It turned out that this was because the peer grouper has been changed to make one of the remaining machines non-voting (to avoid problems from even numbers of voters), and this in turn meant that the API server details for that machine would have a blank internal address. The raft worker on a machine can't start without knowing it's own address.

Change the peer grouper to publish the internal address of API servers even if they aren't voting.

(This change doesn't do any of the trickier work of handling going from two to one controller in the cluster, removing the leader - that will come later once we've sorted out how it should work.)

## QA steps
Spin up a 3-machine controller. Run `juju remove-machine 0` (assuming 0 is the leader) on the controller model. The raft workers on the remaining machines should elect a new leader and stay healthy.

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1765109
