### PR TITLE
Cloud credential validity: apiserver call to set value.

### DIFF
--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -12,8 +12,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// CloudCredentialInterface is an interface for manipulating cloud credential.
-type CloudCredentialInterface interface {
+// Backend is an interface for manipulating cloud credential.
+type Backend interface {
 
 	// CloudCredential returns the cloud credential for the given tag.
 	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
@@ -24,7 +24,7 @@ type CloudCredentialInterface interface {
 
 // ChangeCloudCredentialsValidity marks given cloud credentials as valid/invalid according
 // to supplied validity indicators using given persistence interface.
-func ChangeCloudCredentialsValidity(st CloudCredentialInterface, creds params.ValidateCredentialArgs) ([]params.ErrorResult, error) {
+func ChangeCloudCredentialsValidity(b Backend, creds params.ValidateCredentialArgs) ([]params.ErrorResult, error) {
 	if len(creds.All) == 0 {
 		return nil, nil
 	}
@@ -35,7 +35,7 @@ func ChangeCloudCredentialsValidity(st CloudCredentialInterface, creds params.Va
 			all[i].Error = common.ServerError(err)
 			continue
 		}
-		storedCredential, err := st.CloudCredential(tag)
+		storedCredential, err := b.CloudCredential(tag)
 		if err != nil {
 			all[i].Error = common.ServerError(err)
 			continue
@@ -50,7 +50,7 @@ func ChangeCloudCredentialsValidity(st CloudCredentialInterface, creds params.Va
 		cloudCredential.Invalid = !one.Valid
 		cloudCredential.InvalidReason = one.Reason
 
-		err = st.UpdateCloudCredential(tag, cloudCredential)
+		err = b.UpdateCloudCredential(tag, cloudCredential)
 		if err != nil {
 			all[i].Error = common.ServerError(err)
 		}

--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -1,0 +1,59 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialcommon
+
+import (
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+)
+
+// CloudCredentialInterface is an interface for manipulating cloud credential.
+type CloudCredentialInterface interface {
+
+	// CloudCredential returns the cloud credential for the given tag.
+	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
+
+	// UpdateCloudCredential adds or updates a cloud credential with the given tag.
+	UpdateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error
+}
+
+// ChangeCloudCredentialsValidity marks given cloud credentials as valid/invalid according
+// to supplied validity indicators using given persistence interface.
+func ChangeCloudCredentialsValidity(st CloudCredentialInterface, creds params.ValidateCredentialArgs) ([]params.ErrorResult, error) {
+	if len(creds.All) == 0 {
+		return nil, nil
+	}
+	all := make([]params.ErrorResult, len(creds.All))
+	for i, one := range creds.All {
+		tag, err := names.ParseCloudCredentialTag(one.CredentialTag)
+		if err != nil {
+			all[i].Error = common.ServerError(err)
+			continue
+		}
+		storedCredential, err := st.CloudCredential(tag)
+		if err != nil {
+			all[i].Error = common.ServerError(err)
+			continue
+		}
+		cloudCredential := cloud.NewNamedCredential(
+			storedCredential.Name,
+			cloud.AuthType(storedCredential.AuthType),
+			storedCredential.Attributes,
+			storedCredential.Revoked,
+		)
+
+		cloudCredential.Invalid = !one.Valid
+		cloudCredential.InvalidReason = one.Reason
+
+		err = st.UpdateCloudCredential(tag, cloudCredential)
+		if err != nil {
+			all[i].Error = common.ServerError(err)
+		}
+	}
+	return all, nil
+}

--- a/apiserver/common/credentialcommon/cloudcredential_test.go
+++ b/apiserver/common/credentialcommon/cloudcredential_test.go
@@ -1,0 +1,156 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialcommon_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/credentialcommon"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+type CredentialValiditySuite struct {
+	testing.IsolationSuite
+
+	st *mockState
+}
+
+var _ = gc.Suite(&CredentialValiditySuite{})
+
+func (s *CredentialValiditySuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.st = &mockState{
+		Stub:        &testing.Stub{},
+		credentials: map[names.CloudCredentialTag]state.Credential{},
+		updated:     map[names.CloudCredentialTag]cloud.Credential{},
+	}
+}
+
+func (s *CredentialValiditySuite) TestEmptyArgs(c *gc.C) {
+	errs, err := credentialcommon.ChangeCloudCredentialsValidity(s.st, params.ValidateCredentialArgs{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.HasLen, 0)
+	s.st.CheckCallNames(c, []string{}...) // Nothing was called
+}
+
+func (s *CredentialValiditySuite) TestInvalidFlag(c *gc.C) {
+	args := []params.ValidateCredentialArg{{CredentialTag: "def-invalid"}}
+	errs, err := credentialcommon.ChangeCloudCredentialsValidity(s.st, params.ValidateCredentialArgs{args})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.DeepEquals, []params.ErrorResult{
+		{common.ServerError(errors.Errorf("%q is not a valid tag", "def-invalid"))},
+	})
+	s.st.CheckCallNames(c, []string{}...) // Nothing was called
+}
+
+func (s *CredentialValiditySuite) TestGetCredentialError(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("boom"),
+	)
+	args := []params.ValidateCredentialArg{
+		{CredentialTag: names.NewCloudCredentialTag("cloud/user/credential").String()},
+	}
+	errs, err := credentialcommon.ChangeCloudCredentialsValidity(s.st, params.ValidateCredentialArgs{args})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.DeepEquals, []params.ErrorResult{
+		{common.ServerError(errors.New("boom"))},
+	})
+	s.st.CheckCallNames(c, "CloudCredential")
+}
+
+func (s *CredentialValiditySuite) TestChangeCloudCredentialsValidityToValid(c *gc.C) {
+	tag := names.NewCloudCredentialTag("cloud/user/credential")
+	credOne := statetesting.NewEmptyCredential()
+	credOne.Invalid = true
+	credOne.InvalidReason = "all for testing"
+	c.Assert(credOne.IsValid(), jc.IsFalse)
+
+	s.st.credentials = map[names.CloudCredentialTag]state.Credential{
+		tag: credOne,
+	}
+
+	errs, err := credentialcommon.ChangeCloudCredentialsValidity(s.st,
+		params.ValidateCredentialArgs{
+			[]params.ValidateCredentialArg{
+				{CredentialTag: tag.String(), Valid: true},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.DeepEquals, []params.ErrorResult{{}})
+	s.st.CheckCallNames(c, "CloudCredential", "UpdateCloudCredential")
+	c.Assert(s.st.updated, gc.HasLen, 1)
+
+	sentToState := s.st.updated[tag]
+	c.Assert(sentToState.Invalid, jc.IsFalse)
+	c.Assert(sentToState.InvalidReason, gc.Equals, "")
+}
+
+// TestChangeCloudCredentialsValidityFromValid also tests bulk call.
+func (s *CredentialValiditySuite) TestChangeCloudCredentialsValidityFromValid(c *gc.C) {
+	tagOne := names.NewCloudCredentialTag("cloud/user/credential")
+	credOne := statetesting.NewEmptyCredential()
+	c.Assert(credOne.IsValid(), jc.IsTrue)
+
+	tagTwo := names.NewCloudCredentialTag("cloud/user/credentialTwo")
+	credTwo := statetesting.NewEmptyCredential()
+	c.Assert(credTwo.IsValid(), jc.IsTrue)
+
+	s.st.credentials = map[names.CloudCredentialTag]state.Credential{
+		tagOne: credOne,
+		tagTwo: credTwo,
+	}
+
+	errs, err := credentialcommon.ChangeCloudCredentialsValidity(s.st,
+		params.ValidateCredentialArgs{
+			[]params.ValidateCredentialArg{
+				// valid to start with but invalidate with no reason
+				{CredentialTag: tagOne.String(), Valid: false},
+				// valid to start with but invalidate with a reason
+				{CredentialTag: tagTwo.String(), Valid: false, Reason: "affirmative"},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.DeepEquals, []params.ErrorResult{{}, {}})
+	s.st.CheckCallNames(c, "CloudCredential", "UpdateCloudCredential", "CloudCredential", "UpdateCloudCredential")
+
+	oneSentToState := s.st.updated[tagOne]
+	c.Assert(oneSentToState.Invalid, jc.IsTrue)
+	c.Assert(oneSentToState.InvalidReason, gc.Equals, "")
+
+	twoSentToState := s.st.updated[tagTwo]
+	c.Assert(twoSentToState.Invalid, jc.IsTrue)
+	c.Assert(twoSentToState.InvalidReason, gc.Equals, "affirmative")
+}
+
+type mockState struct {
+	*testing.Stub
+	credentials map[names.CloudCredentialTag]state.Credential
+	updated     map[names.CloudCredentialTag]cloud.Credential
+}
+
+func (s *mockState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+	s.MethodCall(s, "CloudCredential", tag)
+	if err := s.NextErr(); err != nil {
+		return state.Credential{}, err
+	}
+	return s.credentials[tag], nil
+}
+
+func (s *mockState) UpdateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
+	s.MethodCall(s, "UpdateCloudCredential", tag, credential)
+	if err := s.NextErr(); err != nil {
+		return err
+	}
+	s.updated[tag] = credential
+	return nil
+}

--- a/apiserver/common/credentialcommon/package_test.go
+++ b/apiserver/common/credentialcommon/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialcommon_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -176,3 +176,16 @@ type CredentialContentResult struct {
 type CredentialContentResults struct {
 	Results []CredentialContentResult `json:"results,omitempty"`
 }
+
+// ValidateCredentialArg contains collection of cloud credentials
+// identified by their tags to mark as valid or not.
+type ValidateCredentialArg struct {
+	CredentialTag string `json:"tag"`
+	Valid         bool   `json:"valid"`
+	Reason        string `json:"reason,omitempty"`
+}
+
+// ValidateCredentialArgs contains a set of ValidateCredentialArg.
+type ValidateCredentialArgs struct {
+	All []ValidateCredentialArg `json:"credentials,omitempty"`
+}


### PR DESCRIPTION
## Description of change

Juju needs the ability to mark cloud credentials as invalid or valid based on the circumstance. This PR has apiserver call to do that.

