### PR TITLE
Fixes lp#1765688: key-value optional for create-storage-pool.

### DIFF
--- a/cmd/juju/storage/poolcreate.go
+++ b/cmd/juju/storage/poolcreate.go
@@ -62,7 +62,7 @@ type poolCreateCommand struct {
 // Init implements Command.Init.
 func (c *poolCreateCommand) Init(args []string) (err error) {
 	if len(args) < 2 {
-		return errors.New("pool creation requires names, provider type and optional attrs for configuration")
+		return errors.New("pool creation requires names, provider type and optional attributes for configuration")
 	}
 
 	c.poolName = args[0]
@@ -77,7 +77,7 @@ func (c *poolCreateCommand) Init(args []string) (err error) {
 	// as either a provider or a pool name are missing.
 
 	if strings.Contains(c.poolName, "=") || strings.Contains(c.provider, "=") {
-		return errors.New("pool creation requires names and provider type before optional attrs for configuration")
+		return errors.New("pool creation requires names and provider type before optional attributes for configuration")
 	}
 
 	options, err := keyvalues.Parse(args[2:], false)

--- a/cmd/juju/storage/poolcreate.go
+++ b/cmd/juju/storage/poolcreate.go
@@ -60,8 +60,8 @@ type poolCreateCommand struct {
 
 // Init implements Command.Init.
 func (c *poolCreateCommand) Init(args []string) (err error) {
-	if len(args) < 3 {
-		return errors.New("pool creation requires names, provider type and attrs for configuration")
+	if len(args) < 2 {
+		return errors.New("pool creation requires names, provider type and optional attrs for configuration")
 	}
 
 	c.poolName = args[0]
@@ -72,10 +72,10 @@ func (c *poolCreateCommand) Init(args []string) (err error) {
 		return err
 	}
 
-	if len(options) == 0 {
-		return errors.New("pool creation requires attrs for configuration")
-	}
 	c.attrs = make(map[string]interface{})
+	if len(options) == 0 {
+		return nil
+	}
 	for key, value := range options {
 		c.attrs[key] = value
 	}

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -50,6 +50,16 @@ func (s *PoolCreateSuite) TestPoolCreateAttrMissingKey(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `expected "key=value", got "=too"`)
 }
 
+func (s *PoolCreateSuite) TestPoolCreateAttrMissingPoolName(c *gc.C) {
+	_, err := s.runPoolCreate(c, []string{"sunshine=again", "lollypop"})
+	c.Check(err, gc.ErrorMatches, `pool creation requires names and provider type before optional attrs for configuration`)
+}
+
+func (s *PoolCreateSuite) TestPoolCreateAttrMissingProvider(c *gc.C) {
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop=again"})
+	c.Check(err, gc.ErrorMatches, `pool creation requires names and provider type before optional attrs for configuration`)
+}
+
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingValue(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", "something="})
 	c.Check(err, gc.ErrorMatches, `expected "key=value", got "something="`)

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -32,12 +32,12 @@ func (s *PoolCreateSuite) runPoolCreate(c *gc.C, args []string) (*cmd.Context, e
 
 func (s *PoolCreateSuite) TestPoolCreateOneArg(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{"sunshine"})
-	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and optional attrs for configuration")
+	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and optional attributes for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateNoArgs(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{""})
-	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and optional attrs for configuration")
+	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and optional attributes for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateTwoArgs(c *gc.C) {
@@ -52,12 +52,12 @@ func (s *PoolCreateSuite) TestPoolCreateAttrMissingKey(c *gc.C) {
 
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingPoolName(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{"sunshine=again", "lollypop"})
-	c.Check(err, gc.ErrorMatches, `pool creation requires names and provider type before optional attrs for configuration`)
+	c.Check(err, gc.ErrorMatches, `pool creation requires names and provider type before optional attributes for configuration`)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingProvider(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop=again"})
-	c.Check(err, gc.ErrorMatches, `pool creation requires names and provider type before optional attrs for configuration`)
+	c.Check(err, gc.ErrorMatches, `pool creation requires names and provider type before optional attributes for configuration`)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingValue(c *gc.C) {

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -32,17 +32,17 @@ func (s *PoolCreateSuite) runPoolCreate(c *gc.C, args []string) (*cmd.Context, e
 
 func (s *PoolCreateSuite) TestPoolCreateOneArg(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{"sunshine"})
-	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and attrs for configuration")
+	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and optional attrs for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateNoArgs(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{""})
-	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and attrs for configuration")
+	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and optional attrs for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateTwoArgs(c *gc.C) {
 	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop"})
-	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and attrs for configuration")
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingKey(c *gc.C) {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -406,7 +406,7 @@ func (s *cmdStorageSuite) TestCreatePoolNoAttrs(c *gc.C) {
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorNoProvider(c *gc.C) {
-	s.assertCreatePoolError(c, "pool creation requires names and provider type before optional attrs for configuration", "", "oops provider", "smth=one")
+	s.assertCreatePoolError(c, "pool creation requires names and provider type before optional attributes for configuration", "", "oops provider", "smth=one")
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorProviderType(c *gc.C) {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -397,12 +397,16 @@ func (s *cmdStorageSuite) assertCreatePoolError(c *gc.C, errString, expected str
 	c.Assert(stderr, jc.Contains, expected)
 }
 
-func (s *cmdStorageSuite) TestCreatePoolErrorNoAttrs(c *gc.C) {
-	s.assertCreatePoolError(c, "pool creation requires names, provider type and attrs for configuration", "", "loop", "ftPool")
+func (s *cmdStorageSuite) TestCreatePoolNoAttrs(c *gc.C) {
+	pname := "ftPool"
+	stdout, _, err := runPoolCreate(c, pname, "loop")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
+	assertPoolExists(c, s.State, pname, "loop", "")
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorNoProvider(c *gc.C) {
-	s.assertCreatePoolError(c, "pool creation requires names, provider type and attrs for configuration", "", "oops provider", "smth=one")
+	s.assertCreatePoolError(c, "pool creation requires names and provider type before optional attrs for configuration", "", "oops provider", "smth=one")
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorProviderType(c *gc.C) {
@@ -434,6 +438,10 @@ func assertPoolExists(c *gc.C, st *state.State, pname, providerType, attr string
 		if one.Name() == pname {
 			exists = true
 			c.Assert(string(one.Provider()), gc.Equals, providerType)
+			if attr == "" {
+				c.Check(one.Attrs(), gc.HasLen, 0)
+				continue
+			}
 			// At this stage, only 1 attr is expected and checked
 			expectedAttrs := strings.Split(attr, "=")
 			value, ok := one.Attrs()[expectedAttrs[0]]


### PR DESCRIPTION
## Description of change

As per linked bug, some storage pools do not require additional attributes and, thus, the command to create them will not have any key-value pairs specified.

This PR removes the check from command.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1765688
