### PR TITLE
More accurate bundle changes output

### DIFF
--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -90,3 +90,13 @@ func (c *Client) SLALevel() (string, error) {
 	}
 	return result.Result, nil
 }
+
+// Sequences returns all sequence names and next values.
+func (c *Client) Sequences() (map[string]int, error) {
+	var result params.ModelSequencesResult
+	err := c.facade.FacadeCall("Sequences", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result.Sequences, nil
+}

--- a/api/modelconfig/modelconfig.go
+++ b/api/modelconfig/modelconfig.go
@@ -93,6 +93,9 @@ func (c *Client) SLALevel() (string, error) {
 
 // Sequences returns all sequence names and next values.
 func (c *Client) Sequences() (map[string]int, error) {
+	if c.BestAPIVersion() < 2 {
+		return nil, errors.NotSupportedf("Sequences on v1 facade")
+	}
 	var result params.ModelSequencesResult
 	err := c.facade.FacadeCall("Sequences", nil, &result)
 	if err != nil {

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -181,24 +181,39 @@ func (s *modelconfigSuite) TestGetSupport(c *gc.C) {
 	c.Assert(level, gc.Equals, "level")
 }
 
+func (s *modelconfigSuite) TestSequencesV1(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		basetesting.APICallerFunc(
+			func(_ string, _ int, _, _ string, _, _ interface{}) error {
+				c.Errorf("shoulnd't be called")
+				return nil
+			},
+		), 1} // facade version one
+	client := modelconfig.NewClient(apiCaller)
+	sequences, err := client.Sequences()
+	c.Assert(err, gc.ErrorMatches, "Sequences on v1 facade not supported")
+	c.Assert(sequences, gc.IsNil)
+}
+
 func (s *modelconfigSuite) TestSequences(c *gc.C) {
 	called := false
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "ModelConfig")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "Sequences")
-			c.Check(a, jc.DeepEquals, nil)
-			results := result.(*params.ModelSequencesResult)
-			results.Sequences = map[string]int{"foo": 5, "bar": 2}
-			called = true
-			return nil
-		},
-	)
+	apiCaller := basetesting.BestVersionCaller{
+		basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "ModelConfig")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "Sequences")
+				c.Check(a, jc.DeepEquals, nil)
+				results := result.(*params.ModelSequencesResult)
+				results.Sequences = map[string]int{"foo": 5, "bar": 2}
+				called = true
+				return nil
+			},
+		), 2}
 	client := modelconfig.NewClient(apiCaller)
 	sequences, err := client.Sequences()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/modelconfig/modelconfig_test.go
+++ b/api/modelconfig/modelconfig_test.go
@@ -180,3 +180,28 @@ func (s *modelconfigSuite) TestGetSupport(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(level, gc.Equals, "level")
 }
+
+func (s *modelconfigSuite) TestSequences(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "ModelConfig")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "Sequences")
+			c.Check(a, jc.DeepEquals, nil)
+			results := result.(*params.ModelSequencesResult)
+			results.Sequences = map[string]int{"foo": 5, "bar": 2}
+			called = true
+			return nil
+		},
+	)
+	client := modelconfig.NewClient(apiCaller)
+	sequences, err := client.Sequences()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(sequences, jc.DeepEquals, map[string]int{"foo": 5, "bar": 2})
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -197,7 +197,8 @@ func AllFacades() *facade.Registry {
 	reg("MigrationMinion", 1, migrationminion.NewFacade)
 	reg("MigrationTarget", 1, migrationtarget.NewFacade)
 
-	reg("ModelConfig", 1, modelconfig.NewFacade)
+	reg("ModelConfig", 1, modelconfig.NewFacadeV1)
+	reg("ModelConfig", 2, modelconfig.NewFacadeV2)
 	reg("ModelManager", 2, modelmanager.NewFacadeV2)
 	reg("ModelManager", 3, modelmanager.NewFacadeV3)
 	reg("ModelManager", 4, modelmanager.NewFacadeV4)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -60,7 +60,7 @@ type caCerter interface {
 type Client struct {
 	// TODO(wallyworld) - we'll retain model config facade methods
 	// on the client facade until GUI and Python client library are updated.
-	*modelconfig.ModelConfigAPI
+	*modelconfig.ModelConfigAPIV1
 	caCerter
 
 	api        *API
@@ -136,6 +136,7 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	}
 	blockChecker := common.NewBlockChecker(st)
 	backend := modelconfig.NewStateBackend(model)
+	// The modelConfigAPI exposed here is V1.
 	modelConfigAPI, err := modelconfig.NewModelConfigAPI(backend, authorizer)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -144,7 +145,7 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	return NewClient(
 		&stateShim{st, model},
 		&poolShim{ctx.StatePool()},
-		modelConfigAPI,
+		&modelconfig.ModelConfigAPIV1{modelConfigAPI},
 		resources,
 		authorizer,
 		statusSetter,
@@ -159,7 +160,7 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 func NewClient(
 	backend Backend,
 	pool Pool,
-	modelConfigAPI *modelconfig.ModelConfigAPI,
+	modelConfigAPI *modelconfig.ModelConfigAPIV1,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 	statusSetter *common.StatusSetter,
@@ -172,8 +173,8 @@ func NewClient(
 		return nil, common.ErrPerm
 	}
 	client := &Client{
-		ModelConfigAPI: modelConfigAPI,
-		caCerter:       caCerter,
+		ModelConfigAPIV1: modelConfigAPI,
+		caCerter:         caCerter,
 		api: &API{
 			stateAccessor: backend,
 			pool:          pool,

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -19,6 +19,7 @@ type Backend interface {
 	ModelTag() names.ModelTag
 	ModelConfigValues() (config.ConfigValues, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
+	Sequences() (map[string]int, error)
 	SetSLA(level, owner string, credentials []byte) error
 	SLALevel() (string, error)
 }

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -197,3 +197,19 @@ func (c *ModelConfigAPI) SLALevel() (params.StringResult, error) {
 	result.Result = level
 	return result, nil
 }
+
+// Sequences returns the model's sequence names and next values.
+func (c *ModelConfigAPI) Sequences() (params.ModelSequencesResult, error) {
+	result := params.ModelSequencesResult{}
+	if err := c.canReadModel(); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	values, err := c.backend.Sequences()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	result.Sequences = values
+	return result, nil
+}

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -24,7 +24,7 @@ type modelconfigSuite struct {
 	gitjujutesting.IsolationSuite
 	backend    *mockBackend
 	authorizer apiservertesting.FakeAuthorizer
-	api        *modelconfig.ModelConfigAPI
+	api        *modelconfig.ModelConfigAPIV2
 }
 
 var _ = gc.Suite(&modelconfigSuite{})

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -218,6 +218,10 @@ func (m *mockBackend) ModelConfigValues() (config.ConfigValues, error) {
 	return m.cfg, nil
 }
 
+func (m *mockBackend) Sequences() (map[string]int, error) {
+	return nil, nil
+}
+
 func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string, validate ...state.ValidateConfigFunc) error {
 	for _, validateFunc := range validate {
 		if err := validateFunc(update, remove, m.old); err != nil {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -46,6 +46,11 @@ type ModelDefaultsResult struct {
 	Config map[string]ModelDefaults `json:"config"`
 }
 
+// ModelSequencesResult holds the map of sequence names to next value.
+type ModelSequencesResult struct {
+	Sequences map[string]int `json:"sequences"`
+}
+
 // ModelDefaults holds the settings for a given ModelDefaultsResult config
 // attribute.
 type ModelDefaults struct {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1393,14 +1393,9 @@ func buildModelRepresentation(
 	// Add in the model sequences.
 	sequences, err := apiRoot.Sequences()
 	if err == nil {
-		// Sequences are only supported by version 2.3.8 or later.
-		// If sequences isn't implemented, we get an error response, in which
-		// case we just use the default, which is an empty map. This means
-		// that the bundlechanges library just uses its inference to determine
-		// the next values based on what is in the model. If sequences are there, they
-		// are used in addition to what is deployed.
-		// There is no down side here to ignoring the error.
 		model.Sequence = sequences
+	} else if !errors.IsNotSupported(err) {
+		return nil, errors.Annotate(err, "getting model sequences")
 	}
 	// Now get all the application config.
 	configValues, err := apiRoot.GetConfig(appNames...)

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1390,6 +1390,18 @@ func buildModelRepresentation(
 			return nil, errors.Errorf("unexpected tag kind for annotations: %q", kind)
 		}
 	}
+	// Add in the model sequences.
+	sequences, err := apiRoot.Sequences()
+	if err == nil {
+		// Sequences are only supported by version 2.3.8 or later.
+		// If sequences isn't implemented, we get an error response, in which
+		// case we just use the default, which is an empty map. This means
+		// that the bundlechanges library just uses its inference to determine
+		// the next values based on what is in the model. If sequences are there, they
+		// are used in addition to what is deployed.
+		// There is no down side here to ignoring the error.
+		model.Sequence = sequences
+	}
 	// Now get all the application config.
 	configValues, err := apiRoot.GetConfig(appNames...)
 	if err != nil {

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -2081,7 +2081,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundlePassesSequences(c *gc.C) {
 		machines = append(machines, m)
 		c.Assert(m.ForceDestroy(), jc.ErrorIsNil)
 	}
-	// Tear them down again. This is somewhat convoluted, but it is what we need
+	// Tear them down. This is somewhat convoluted, but it is what we need
 	// to do to properly cleanly tear down machines.
 	c.Assert(app.Destroy(), jc.ErrorIsNil)
 	destroyUnitsMachine(u1)

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -66,6 +66,7 @@ type ApplicationAPI interface {
 type ModelAPI interface {
 	ModelUUID() (string, bool)
 	ModelGet() (map[string]interface{}, error)
+	Sequences() (map[string]int, error)
 }
 
 // MeteredDeployAPI represents the methods of the API the deploy

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1608,6 +1608,10 @@ func (f *fakeDeployAPI) Close() error {
 	return jujutesting.TypeAssertError(results[0])
 }
 
+func (f *fakeDeployAPI) Sequences() (map[string]int, error) {
+	return nil, nil
+}
+
 func (f *fakeDeployAPI) ModelGet() (map[string]interface{}, error) {
 	results := f.MethodCall(f, "ModelGet")
 	return results[0].(map[string]interface{}), jujutesting.TypeAssertError(results[1])

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -219,16 +219,13 @@ type exporter struct {
 }
 
 func (e *exporter) sequences() error {
-	sequences, closer := e.st.db().GetCollection(sequenceC)
-	defer closer()
-
-	var docs []sequenceDoc
-	if err := sequences.Find(nil).All(&docs); err != nil {
+	sequences, err := e.st.Sequences()
+	if err != nil {
 		return errors.Trace(err)
 	}
 
-	for _, doc := range docs {
-		e.model.SetSequence(doc.Name, doc.Counter)
+	for name, value := range sequences {
+		e.model.SetSequence(name, value)
 	}
 	return nil
 }

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -84,6 +84,23 @@ type seqUpdater interface {
 	set(expected, next int) (bool, error)
 }
 
+// Sequences returns the model's sequence names and their next values.
+func (st *State) Sequences() (map[string]int, error) {
+	sequences, closer := st.db().GetCollection(sequenceC)
+	defer closer()
+
+	var docs []sequenceDoc
+	if err := sequences.Find(nil).All(&docs); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	result := make(map[string]int)
+	for _, doc := range docs {
+		result[doc.Name] = doc.Counter
+	}
+	return result, nil
+}
+
 const maxSeqRetries = 20
 
 // updateSeqWithMin implements the abstract logic for incrementing a

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -57,6 +57,26 @@ func (s *sequenceSuite) TestSequenceWithMultipleEnvs(c *gc.C) {
 	s.checkDoc(c, state2.ModelUUID(), "foo", 2)
 }
 
+func (s *sequenceSuite) TestSequences(c *gc.C) {
+	state1 := s.State
+	state2 := s.Factory.MakeModel(c, nil)
+	defer state2.Close()
+
+	s.incAndCheck(c, state1, "foo", 0)
+	s.incAndCheck(c, state2, "foo", 0)
+	s.incAndCheck(c, state1, "foo", 1)
+	s.incAndCheck(c, state2, "foo", 1)
+	s.incAndCheck(c, state1, "foo", 2)
+	s.incAndCheck(c, state1, "bar", 0)
+	s.incAndCheck(c, state2, "baz", 0)
+
+	sequences, err := state1.Sequences()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sequences, jc.DeepEquals, map[string]int{
+		"foo": 3, "bar": 1,
+	})
+}
+
 func (s *sequenceSuite) TestSequenceWithMin(c *gc.C) {
 	st := s.State
 	modelUUID := st.ModelUUID()


### PR DESCRIPTION
Juju does not allow reusing machine or unit numbers. The bundlechanges library now determines what needs to be done and what the machine numbers and unit numbers are based on the current model deployment. However without also knowing the sequences, the bundlechanges library is not able to create the same numbers that Juju will allow.

This change exposes the Sequences for a model, and adds that to the model description used to determine the bundlechanges.

## QA steps

Deploy a unit of an application, then remove the app, its units, and the machines it was  deployed on. Then deploy a bundle that uses the same app name.

You should see the machines numbers created, and the units put on them reflect reality, rather than starting at zero. Will work with both --dry-run and real deploy.

