### PR TITLE
Update bundlechanges to bring in machine sorting.

### DIFF
--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -5,6 +5,7 @@ package common_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -155,7 +156,7 @@ func (st *mockState) AllMachines() (machines []common.Machine, _ error) {
 	for id := range st.machines {
 		ids = append(ids, id)
 	}
-	utils.SortStringsNaturally(ids)
+	naturalsort.Sort(ids)
 	for _, id := range ids {
 		machines = append(machines, st.machines[id])
 	}

--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/description"
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
-	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/description"
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
@@ -258,7 +259,7 @@ func (api *API) MinionReports() (params.MinionReports, error) {
 	for i := 0; i < len(out.Failed); i++ {
 		out.Failed[i] = reports.Failed[i].String()
 	}
-	utils.SortStringsNaturally(out.Failed)
+	naturalsort.Sort(out.Failed)
 
 	out.UnknownCount = len(reports.Unknown)
 
@@ -266,7 +267,7 @@ func (api *API) MinionReports() (params.MinionReports, error) {
 	for i := 0; i < len(unknown); i++ {
 		unknown[i] = reports.Unknown[i].String()
 	}
-	utils.SortStringsNaturally(unknown)
+	naturalsort.Sort(unknown)
 
 	// Limit the number of unknowns reported
 	numSamples := out.UnknownCount

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/naturalsort"
-	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
 
@@ -127,7 +128,7 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		}
 		sortedNames = append(sortedNames, name)
 	}
-	utils.SortStringsNaturally(sortedNames)
+	naturalsort.Sort(sortedNames)
 
 	var output interface{}
 	switch c.out.Name() {

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils"
 )
 
@@ -47,9 +48,9 @@ func formatOneline(writer io.Writer, value interface{}, printf onelinePrintf) er
 		printf(writer, format, uName, u, level)
 	}
 
-	for _, svcName := range utils.SortStringsNaturally(stringKeysFromMap(fs.Applications)) {
+	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
 		svc := fs.Applications[svcName]
-		for _, uName := range utils.SortStringsNaturally(stringKeysFromMap(svc.Units)) {
+		for _, uName := range naturalsort.Sort(stringKeysFromMap(svc.Units)) {
 			unit := svc.Units[uName]
 			pprint(uName, unit, 0)
 			recurseUnits(unit, 1, pprint)

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
-	"github.com/juju/utils"
 )
 
 // FormatOneline writes a brief list of units and their subordinates.

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/ansiterm"
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 
@@ -58,14 +59,14 @@ func FormatSummary(writer io.Writer, value interface{}) error {
 	p(" ")
 
 	p("# Applications:", fmt.Sprintf("(%d)", len(fs.Applications)))
-	for _, svcName := range utils.SortStringsNaturally(stringKeysFromMap(svcExposure)) {
+	for _, svcName := range naturalsort.Sort(stringKeysFromMap(svcExposure)) {
 		s := svcExposure[svcName]
 		p(svcName, fmt.Sprintf("%d/%d\texposed", s[true], s[true]+s[false]))
 	}
 	p(" ")
 
 	p("# Remote:", fmt.Sprintf("(%d)", len(fs.RemoteApplications)))
-	for _, svcName := range utils.SortStringsNaturally(stringKeysFromMap(fs.RemoteApplications)) {
+	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.RemoteApplications)) {
 		s := fs.RemoteApplications[svcName]
 		p(svcName, "", s.OfferURL)
 	}
@@ -132,7 +133,7 @@ func (f *summaryFormatter) trackUnit(name string, status unitStatus, indentLevel
 }
 
 func (f *summaryFormatter) printStateToCount(m map[status.Status]int) {
-	for _, stateToCount := range utils.SortStringsNaturally(stringKeysFromMap(m)) {
+	for _, stateToCount := range naturalsort.Sort(stringKeysFromMap(m)) {
 		numInStatus := m[status.Status(stateToCount)]
 		f.delimitValuesWithTabs(stateToCount+":", fmt.Sprintf(" %d ", numInStatus))
 	}
@@ -166,7 +167,7 @@ func (f *summaryFormatter) resolveAndTrackIp(publicDns string) {
 
 func (f *summaryFormatter) aggregateMachineStates(machines map[string]machineStatus) map[status.Status]int {
 	stateToMachine := make(map[status.Status]int)
-	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(machines)) {
+	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		m := machines[name]
 		f.resolveAndTrackIp(m.DNSName)
 
@@ -181,10 +182,10 @@ func (f *summaryFormatter) aggregateMachineStates(machines map[string]machineSta
 
 func (f *summaryFormatter) aggregateServiceAndUnitStates(services map[string]applicationStatus) map[string]map[bool]int {
 	svcExposure := make(map[string]map[bool]int)
-	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(services)) {
+	for _, name := range naturalsort.Sort(stringKeysFromMap(services)) {
 		s := services[name]
 		// Grab unit states
-		for _, un := range utils.SortStringsNaturally(stringKeysFromMap(s.Units)) {
+		for _, un := range naturalsort.Sort(stringKeysFromMap(s.Units)) {
 			u := s.Units[un]
 			f.trackUnit(un, u, 0)
 			recurseUnits(u, 1, f.trackUnit)

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
-	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/cmd/output"

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charm.v6/hooks"
 

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charm.v6/hooks"
@@ -73,7 +74,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 
 	if len(fs.RemoteApplications) > 0 {
 		outputHeaders("SAAS", "Status", "Store", "URL")
-		for _, appName := range utils.SortStringsNaturally(stringKeysFromMap(fs.RemoteApplications)) {
+		for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.RemoteApplications)) {
 			app := fs.RemoteApplications[appName]
 			var store, urlPath string
 			url, err := crossmodel.ParseOfferURL(app.OfferURL)
@@ -101,7 +102,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
-	for _, appName := range utils.SortStringsNaturally(stringKeysFromMap(fs.Applications)) {
+	for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
 		app := fs.Applications[appName]
 		version := app.Version
 		// Don't let a long version push out the version column.
@@ -156,7 +157,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	outputHeaders("Unit", "Workload", "Agent", "Machine", "Public address", "Ports", "Message")
-	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
+	for _, name := range naturalsort.Sort(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)
 		const indentationLevel = 1
@@ -172,7 +173,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 			w.PrintColor(outputColor, fs.Model.MeterStatus.Message)
 			w.Println()
 		}
-		for _, name := range utils.SortStringsNaturally(stringKeysFromMap(units)) {
+		for _, name := range naturalsort.Sort(stringKeysFromMap(units)) {
 			u := units[name]
 			if u.MeterStatus != nil {
 				w.Print(name)
@@ -227,7 +228,7 @@ func printOffers(tw *ansiterm.TabWriter, offers map[string]offerStatus) error {
 	w.Println()
 
 	w.Println("Offer", "Application", "Charm", "Rev", "Connected", "Endpoint", "Interface", "Role")
-	for _, offerName := range utils.SortStringsNaturally(stringKeysFromMap(offers)) {
+	for _, offerName := range naturalsort.Sort(stringKeysFromMap(offers)) {
 		offer := offers[offerName]
 		// Sort endpoints alphabetically.
 		endpoints := []string{}
@@ -287,7 +288,7 @@ func getModelMessage(model modelStatus) string {
 func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
 	w := output.Wrapper{tw}
 	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
-	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(machines)) {
+	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])
 	}
 }
@@ -305,7 +306,7 @@ func printMachine(w output.Wrapper, m machineStatus) {
 	w.Print(m.Id)
 	w.PrintStatus(m.JujuStatus.Current)
 	w.Println(m.DNSName, m.InstanceId, m.Series, az, m.MachineStatus.Message)
-	for _, name := range utils.SortStringsNaturally(stringKeysFromMap(m.Containers)) {
+	for _, name := range naturalsort.Sort(stringKeysFromMap(m.Containers)) {
 		printMachine(w, m.Containers[name])
 	}
 }

--- a/cmd/juju/status/utils.go
+++ b/cmd/juju/status/utils.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/juju/utils"
+	"github.com/juju/naturalsort"
 )
 
 // stringKeysFromMap takes a map with keys which are strings and returns
@@ -25,7 +25,7 @@ func recurseUnits(u unitStatus, il int, recurseMap func(string, unitStatus, int)
 	if len(u.Subordinates) == 0 {
 		return
 	}
-	for _, uName := range utils.SortStringsNaturally(stringKeysFromMap(u.Subordinates)) {
+	for _, uName := range naturalsort.Sort(stringKeysFromMap(u.Subordinates)) {
 		unit := u.Subordinates[uName]
 		recurseMap(uName, unit, il)
 		recurseUnits(unit, il+1, recurseMap)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
-github.com/juju/bundlechanges	git	1a6490253bea4ce78594db114d787ca97ee9f527	2018-01-09T11:21:21Z
+github.com/juju/bundlechanges  git     6e161783b56db0f558218579fa6a76fec55eacc8        2018-04-23T05:15:47Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
 github.com/juju/description	git	7ee30d2bc01ef20938adea2efeb991eb817c1f2a	2018-02-21T00:58:49Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
@@ -38,6 +38,7 @@ github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	1fe2a4bf0a3a2c10881501233ff7c6aed7790082	2017-11-10T02:00:13Z
+github.com/juju/naturalsort    git     5b81707e882b8293e6cf77854b4cd49f29776e11        2018-04-23T03:48:42Z
 github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7dd	2017-04-28T16:15:59Z
 github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T03:24:24Z
 github.com/juju/ratelimit	git	5b9ff866471762aa2ab2dced63c9fb6f53921342	2017-05-23T01:21:41Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
-github.com/juju/bundlechanges  git     6e161783b56db0f558218579fa6a76fec55eacc8        2018-04-23T05:15:47Z
+github.com/juju/bundlechanges	git	6e161783b56db0f558218579fa6a76fec55eacc8	2018-04-23T05:15:47Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
 github.com/juju/description	git	7ee30d2bc01ef20938adea2efeb991eb817c1f2a	2018-02-21T00:58:49Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
@@ -38,7 +38,7 @@ github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	1fe2a4bf0a3a2c10881501233ff7c6aed7790082	2017-11-10T02:00:13Z
-github.com/juju/naturalsort    git     5b81707e882b8293e6cf77854b4cd49f29776e11        2018-04-23T03:48:42Z
+github.com/juju/naturalsort	git	5b81707e882b8293e6cf77854b4cd49f29776e11	2018-04-23T03:48:42Z
 github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7dd	2017-04-28T16:15:59Z
 github.com/juju/pubsub	git	f4dfa62f30adc6955341b3dd73dde7c8d9b23b9e	2017-03-31T03:24:24Z
 github.com/juju/ratelimit	git	5b9ff866471762aa2ab2dced63c9fb6f53921342	2017-05-23T01:21:41Z

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/description"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
@@ -187,7 +188,7 @@ func uploadCharms(config UploadBinariesConfig) error {
 	// It is critical that charms are uploaded in ascending charm URL
 	// order so that charm revisions end up the same in the target as
 	// they were in the source.
-	utils.SortStringsNaturally(config.Charms)
+	naturalsort.Sort(config.Charms)
 
 	for _, charmURL := range config.Charms {
 		logger.Debugf("sending charm %s to target", charmURL)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/naturalsort"
-	"github.com/juju/utils"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 


### PR DESCRIPTION
When there were many machines defined in a bundle, they would be processed alphabetically, so machine 10 was before machine 2. The new bundlechanges library fixes this.

As part of this fix, update all call sites for the SortStringsNaturally to use the new naturalsort repo.

## QA steps

Deploy a bundle, even --dry-run, that specifies more than 10 machines.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1762309
