### PR TITLE
If a machine has no addresses, treat it as not started.

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -184,7 +184,12 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 		if err != nil {
 			return errors.Annotatef(err, "reading controller id %v", id)
 		}
-		internal := network.SelectInternalAddresses(controller.Addresses(), false)
+		addresses := controller.Addresses()
+		if len(addresses) == 0 {
+			// machines without any address are essentially not started yet
+			continue
+		}
+		internal := network.SelectInternalAddresses(addresses, false)
 		if len(internal) != 1 {
 			badIds = append(badIds, id)
 		}


### PR DESCRIPTION
## Description of change

If you run `juju enable-ha` twice quickly it shouldn't complain that
there is no available address for the machine that is still starting.

## QA steps

```
$ juju bootstrap lxd
$ juju enable-ha; juju enable-ha
...
ERROR juju-ha-space is not set and a unique usable address was not found for machines: 1, 2
run "juju config juju-ha-space=<name>" to set a space for Mongo peer communication
```
That error should go away with this patch. The error is because a machine that hasn't started yet doesn't have any addresses. But this shouldn't be treated as an error condition. Especially because if 1 machine hasn't started, and you had to kill the other machine, then you couldn't ever get another machine started.

## Documentation changes

Polish on the new enable-ha workflow, but it shouldn't need separate documentation.

## Bug reference

[lp:1765342](https://bugs.launchpad.net/juju/+bug/1765342)