### PR TITLE
Worker Test Race condition

### DIFF
--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -143,10 +142,9 @@ func (s *WorkerValidationSuite) testValidateError(c *gc.C, f func(*rafttransport
 
 type WorkerSuite struct {
 	workerFixture
-	server  *httptest.Server
-	worker  *rafttransport.Worker
-	reqsMtx sync.Mutex
-	reqs    chan apiserver.DetailsRequest
+	server *httptest.Server
+	worker *rafttransport.Worker
+	reqs   chan apiserver.DetailsRequest
 }
 
 var _ = gc.Suite(&WorkerSuite{})
@@ -161,16 +159,19 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	clientTransport := s.server.Client().Transport.(*http.Transport)
 	s.config.TLSConfig = clientTransport.TLSClientConfig
 
-	s.reqsMtx.Lock()
 	s.reqs = make(chan apiserver.DetailsRequest, 10)
-	s.reqsMtx.Unlock()
-
-	s.config.Hub.Subscribe(apiserver.DetailsRequestTopic,
-		func(_ string, req apiserver.DetailsRequest, err error) {
-			c.Check(err, jc.ErrorIsNil)
-			s.detailsRequest() <- req
-		},
+	unsubscribe, _ := s.config.Hub.Subscribe(apiserver.DetailsRequestTopic,
+		func(reqs chan apiserver.DetailsRequest) func(_ string, req apiserver.DetailsRequest, err error) {
+			return func(_ string, req apiserver.DetailsRequest, err error) {
+				c.Check(err, jc.ErrorIsNil)
+				reqs <- req
+			}
+		}(s.reqs),
 	)
+	s.AddCleanup(func(c *gc.C) {
+		unsubscribe()
+	})
+
 	s.worker = s.newWorker(c, s.config)
 	s.config.Hub.Publish(apiserver.DetailsTopic, apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
@@ -282,7 +283,7 @@ func (s *WorkerSuite) TestRoundTrip(c *gc.C) {
 func (s *WorkerSuite) TestRequestsDetails(c *gc.C) {
 	// The worker gets started in SetUpTest.
 	select {
-	case req := <-s.detailsRequest():
+	case req := <-s.reqs:
 		c.Assert(req, gc.Equals, apiserver.DetailsRequest{
 			Requester: "raft-transport-stream-layer",
 			LocalOnly: true,
@@ -290,15 +291,6 @@ func (s *WorkerSuite) TestRequestsDetails(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for details request")
 	}
-}
-
-// detailsRequest getter is required as the underlying channel is swapped when
-// WorkerSuite.SetupTest is called, causing a race condition to triggered.
-func (s *WorkerSuite) detailsRequest() chan apiserver.DetailsRequest {
-	s.reqsMtx.Lock()
-	defer s.reqsMtx.Unlock()
-
-	return s.reqs
 }
 
 type WorkerTimeoutSuite struct {


### PR DESCRIPTION
## Description of change

The following PR introduces a mutex to guard against the underlying changing of the `reqs` channel during `SetUpTest`.

We introduce a new getting called `detailsRequest` that provides better encapsulation around the mutex.

Running `go test -race -count=10 ./worker/raft/rafttransport/...` no longer shows the race condition.

> Why is this change needed?

To improve confidence in our tests, so we no that failures will be legitimate ones and not false positives. 

## QA steps

> How do we verify that the change works?

Running the tests with `-race` enabled. Improve the confidence with this using `-count`.

## Documentation changes

> Does it affect current user workflow? CLI? API?

No

## Bug reference

> Does this change fix a bug? Please add a link to it.

Not that I'm aware of.
