### PR TITLE
state: supply SLA information in AllWatcher output

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -142,6 +142,10 @@ func (e *backingModel) updated(st *State, store *multiwatcherStore, id string) e
 		Owner:          e.Owner,
 		ControllerUUID: e.ControllerUUID,
 		Config:         cfg.AllAttrs(),
+		SLA: multiwatcher.ModelSLAInfo{
+			Level: e.SLA.Level.String(),
+			Owner: e.SLA.Owner,
+		},
 	}
 	c, err := readConstraints(st, modelGlobalKey)
 	// Treat it as if the model is removed.

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1443,6 +1443,8 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 		func(c *gc.C, st *State) changeTestCase {
 			model, err := st.Model()
 			c.Assert(err, jc.ErrorIsNil)
+			err = model.SetSLA("essential", "test-sla-owner", nil)
+			c.Assert(err, jc.ErrorIsNil)
 			cfg, err := model.Config()
 			c.Assert(err, jc.ErrorIsNil)
 			status, err := model.Status()
@@ -1471,6 +1473,10 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 							Data:    status.Data,
 							Since:   status.Since,
 						},
+						SLA: multiwatcher.ModelSLAInfo{
+							Level: "essential",
+							Owner: "test-sla-owner",
+						},
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
@@ -1496,6 +1502,9 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 							Data:    status.Data,
 							Since:   status.Since,
 						},
+						SLA: multiwatcher.ModelSLAInfo{
+							Level: "unsupported",
+						},
 					},
 				},
 				change: watcher.Change{
@@ -1515,6 +1524,9 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 							Message: status.Message,
 							Data:    status.Data,
 							Since:   status.Since,
+						},
+						SLA: multiwatcher.ModelSLAInfo{
+							Level: "unsupported",
 						},
 					}}}
 		},
@@ -1605,6 +1617,9 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 				Data:    status.Data,
 				Since:   status.Since,
 			},
+			SLA: multiwatcher.ModelSLAInfo{
+				Level: "unsupported",
+			},
 		},
 		&multiwatcher.ModelInfo{
 			ModelUUID:      model1.UUID(),
@@ -1618,6 +1633,9 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 				Message: status1.Message,
 				Data:    status1.Data,
 				Since:   status1.Since,
+			},
+			SLA: multiwatcher.ModelSLAInfo{
+				Level: "unsupported",
 			},
 		},
 	)
@@ -1756,6 +1774,9 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    status0.Data,
 				Since:   status0.Since,
 			},
+			SLA: multiwatcher.ModelSLAInfo{
+				Level: "unsupported",
+			},
 		},
 	}, {
 		Entity: &multiwatcher.ModelInfo{
@@ -1770,6 +1791,9 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Message: status1.Message,
 				Data:    status1.Data,
 				Since:   status1.Since,
+			},
+			SLA: multiwatcher.ModelSLAInfo{
+				Level: "unsupported",
 			},
 		},
 	}, {
@@ -1985,6 +2009,9 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Current: "available",
 				Message: "",
 				Data:    map[string]interface{}{},
+			},
+			SLA: multiwatcher.ModelSLAInfo{
+				Level: "unsupported",
 			},
 		},
 	}, {

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -1,6 +1,11 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// TODO(rogpeppe) move everything in this package to apiserver/params
+// because all the types are part of the public API server interface.
+// Then params would not need to import this package and we would
+// not need to duplicate types like Life and ModelSLAInfo.
+
 package multiwatcher
 
 import (
@@ -436,6 +441,13 @@ const (
 	BlockChange BlockType = "BlockChange"
 )
 
+// ModelSLAInfo describes the SLA info for a model.
+// Note: this replicates the type of the same name in the params package.
+type ModelSLAInfo struct {
+	Level string `json:"level"`
+	Owner string `json:"owner"`
+}
+
 // ModelInfo holds the information about an model that is
 // tracked by multiwatcherStore.
 type ModelInfo struct {
@@ -447,6 +459,7 @@ type ModelInfo struct {
 	Config         map[string]interface{} `json:"config,omitempty"`
 	Status         StatusInfo             `json:"status"`
 	Constraints    constraints.Value      `json:"constraints"`
+	SLA            ModelSLAInfo           `json:"sla"`
 }
 
 // EntityId returns a unique identifier for an model.


### PR DESCRIPTION
The JIMM service needs to be kept informed of SLA changes.
This enables that.

## QA steps

- Bootstrap a controller.
- Use the [juju-watchall command](https://godoc.org/github.com/rogpeppe/misc/cmd/juju-watchall) to watch events on the model:

    juju-watchall -a

- Change the SLA level on a model with the `juju sla` command.

- Verify that you see the SLA level change in the watcher output.
