### PR TITLE
Support removing a primary when in N=2 mode.

### DIFF
--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -135,7 +135,13 @@ func (info *peerGroupInfo) getLogMessage() string {
 	}
 
 	template := "\n   %#v: rs_id=%d, rs_addr=%s"
-	for id, rm := range info.recognised {
+	ids := make([]string, 0, len(info.recognised))
+	for id := range info.recognised {
+		ids = append(ids, id)
+	}
+	sortAsInts(ids)
+	for _, id := range ids {
+		rm := info.recognised[id]
 		lines = append(lines, fmt.Sprintf(template, info.machines[id], rm.Id, rm.Address))
 	}
 
@@ -345,7 +351,24 @@ func (p *peerGroupChanges) reviewPeerGroupChanges() {
 		}
 	}
 	keptVoters := currVoters - len(p.toRemoveVote)
-	if (keptVoters+len(p.toAddVote))%2 == 1 {
+	if keptVoters == 0 {
+		// to keep no voters means to step down the primary without a replacement, which is not possible.
+		// So restore the current primary. Once there is another member to work with after reconfiguring, we will then
+		// be able to ask the current primary to step down, and then we can finally remove it.
+		var tempToRemove []string
+		for _, id := range p.toRemoveVote {
+			isPrimary := isPrimaryMember(p.info, id)
+			if !isPrimary {
+				tempToRemove = append(tempToRemove, id)
+			} else {
+				logger.Debugf("asked to remove all voters, preserving primary voter %q", id)
+				p.desired.stepDownPrimary = false
+			}
+		}
+		p.toRemoveVote = tempToRemove
+	}
+	newCount := keptVoters + len(p.toAddVote)
+	if (newCount)%2 == 1 {
 		logger.Debugf("number of voters is odd")
 		// if this is true we will create an odd number of voters
 		return
@@ -358,33 +381,16 @@ func (p *peerGroupChanges) reviewPeerGroupChanges() {
 	}
 	// we must remove an extra peer
 	// make sure we don't pick the primary to be removed.
-	if keptVoters == 0 {
-		// we are asking to remove all voters, a clear 'odd' number of voters
-		// to preserve is to just keep the current primary.
-		logger.Debugf("remove all voters, preserve primary voter")
-		var tempToRemove []string
-		for _, id := range p.toRemoveVote {
-			isPrimary := isPrimaryMember(p.info, id)
-			if !isPrimary {
-				tempToRemove = append(tempToRemove, id)
+	for i, id := range p.toKeepVoting {
+		if !isPrimaryMember(p.info, id) {
+			p.toRemoveVote = append(p.toRemoveVote, id)
+			logger.Debugf("removing vote from %q to maintain odd number of voters", id)
+			if i == len(p.toKeepVoting)-1 {
+				p.toKeepVoting = p.toKeepVoting[:i]
 			} else {
-				logger.Debugf("preserving primary %q as the last voter", id)
-				p.desired.stepDownPrimary = false
+				p.toKeepVoting = append(p.toKeepVoting[:i], p.toKeepVoting[i+1:]...)
 			}
-		}
-		p.toRemoveVote = tempToRemove
-	} else {
-		for i, id := range p.toKeepVoting {
-			if !isPrimaryMember(p.info, id) {
-				p.toRemoveVote = append(p.toRemoveVote, id)
-				logger.Debugf("removing vote from %q to maintain odd number of voters", id)
-				if i == len(p.toKeepVoting)-1 {
-					p.toKeepVoting = p.toKeepVoting[:i]
-				} else {
-					p.toKeepVoting = append(p.toKeepVoting[:i], p.toKeepVoting[i+1:]...)
-				}
-				break
-			}
+			break
 		}
 	}
 }
@@ -392,6 +398,11 @@ func (p *peerGroupChanges) reviewPeerGroupChanges() {
 func isVotingMember(m *replicaset.Member) bool {
 	v := m.Votes
 	return v == nil || *v > 0
+}
+
+func hasPriority(m *replicaset.Member) bool {
+	p := m.Priority
+	return p == nil || *p > 0
 }
 
 func isPrimaryMember(info *peerGroupInfo, id string) bool {

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -400,11 +400,6 @@ func isVotingMember(m *replicaset.Member) bool {
 	return v == nil || *v > 0
 }
 
-func hasPriority(m *replicaset.Member) bool {
-	p := m.Priority
-	return p == nil || *p > 0
-}
-
 func isPrimaryMember(info *peerGroupInfo, id string) bool {
 	return info.statuses[id].State == replicaset.PrimaryState
 }

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -479,21 +479,34 @@ func (session *fakeMongoSession) Set(members []replicaset.Member) error {
 }
 
 func (session *fakeMongoSession) StepDownPrimary() error {
-	logger.Debugf("StepDownPrimary")
 	if err := session.errors.errorFor("Session.StepDownPrimary"); err != nil {
+		logger.Debugf("StepDownPrimary error: %v", err)
 		return err
 	}
+	logger.Debugf("StepDownPrimary")
 	status := session.status.Get().(*replicaset.Status)
 	members := session.members.Get().([]replicaset.Member)
+	membersById := make(map[int]replicaset.Member, len(members))
+	for _, member := range members {
+		membersById[member.Id] = member
+	}
 	// We use a simple algorithm, find the primary, and all the secondaries that don't have 0 priority. And then pick a
 	// random secondary and swap their states
 	primaryIndex := -1
 	secondaryIndexes := []int{}
-	for i, member := range status.Members {
-		if member.State == replicaset.PrimaryState {
+	var info []string
+	for i, statusMember := range status.Members {
+		if statusMember.State == replicaset.PrimaryState {
 			primaryIndex = i
-		} else if member.State == replicaset.SecondaryState && (members[i].Priority == nil || *members[i].Priority > 0) {
-			secondaryIndexes = append(secondaryIndexes, i)
+			info = append(info, fmt.Sprintf("%d: current primary", statusMember.Id))
+		} else if statusMember.State == replicaset.SecondaryState {
+			confMember := membersById[statusMember.Id]
+			if confMember.Priority == nil || *confMember.Priority > 0 {
+				secondaryIndexes = append(secondaryIndexes, i)
+				info = append(info, fmt.Sprintf("%d: eligible secondary", statusMember.Id))
+			} else {
+				info = append(info, fmt.Sprintf("%d: ineligible secondary", statusMember.Id))
+			}
 		}
 	}
 	if primaryIndex == -1 {
@@ -505,6 +518,8 @@ func (session *fakeMongoSession) StepDownPrimary() error {
 	secondaryIndex := secondaryIndexes[rand.Intn(len(secondaryIndexes))]
 	status.Members[primaryIndex].State = replicaset.SecondaryState
 	status.Members[secondaryIndex].State = replicaset.PrimaryState
+	logger.Debugf("StepDownPrimary nominated %d to be the new primary from: %v",
+		status.Members[secondaryIndex].Id, info)
 	session.setStatus(status.Members)
 	return nil
 }
@@ -519,7 +534,7 @@ func prettyReplicaSetMembersSlice(members []replicaset.Member) string {
 	vrm := make(map[string]*replicaset.Member, len(members))
 	for i := range members {
 		m := members[i]
-		vrm[strconv.Itoa(i)] = &m
+		vrm[strconv.Itoa(m.Id)] = &m
 	}
 	return prettyReplicaSetMembers(vrm)
 }

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -644,11 +644,7 @@ func prettyReplicaSetMembers(members map[string]*replicaset.Member) string {
 		if isVotingMember(m) {
 			voting = "voting"
 		}
-		priority := "<nil>"
-		if m.Priority != nil {
-			priority = fmt.Sprintf("%f", *m.Priority)
-		}
-		result = append(result, fmt.Sprintf("    Id: %d, Tags: %v, %s, Priority: %v", m.Id, m.Tags, voting, priority))
+		result = append(result, fmt.Sprintf("    Id: %d, Tags: %v, %s", m.Id, m.Tags, voting))
 	}
 	return strings.Join(result, "\n")
 }

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -640,7 +640,15 @@ func prettyReplicaSetMembers(members map[string]*replicaset.Member) string {
 	sort.Strings(keys)
 	for _, key := range keys {
 		m := members[key]
-		result = append(result, fmt.Sprintf("    Id: %d, Tags: %v, Vote: %v", m.Id, m.Tags, isVotingMember(m)))
+		voting := "not-voting"
+		if isVotingMember(m) {
+			voting = "voting"
+		}
+		priority := "<nil>"
+		if m.Priority != nil {
+			priority = fmt.Sprintf("%f", *m.Priority)
+		}
+		result = append(result, fmt.Sprintf("    Id: %d, Tags: %v, %s, Priority: %v", m.Id, m.Tags, voting, priority))
 	}
 	return strings.Join(result, "\n")
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -99,7 +99,7 @@ func InitState(c *gc.C, st *fakeState, numMachines int, ipVersion TestIPVersion)
 	st.session.Set(mkMembers("0v", ipVersion))
 	st.session.setStatus(mkStatuses("0p", ipVersion))
 	st.machine("10").SetHasVote(true)
-	st.check = checkInvariants
+	st.setCheck(checkInvariants)
 }
 
 // ExpectedAPIHostPorts returns the expected addresses
@@ -518,7 +518,7 @@ func (s *workerSuite) TestControllersArePublishedOverHubWithNewVoters(c *gc.C) {
 	st.setControllers(ids...)
 	st.session.Set(mkMembers("0v 1 2", testIPv4))
 	st.session.setStatus(mkStatuses("0p 1s 2s", testIPv4))
-	st.check = checkInvariants
+	st.setCheck(checkInvariants)
 
 	hub := pubsub.NewStructuredHub(nil)
 	event := make(chan apiserver.Details)
@@ -943,7 +943,7 @@ func (s *workerSuite) TestRemovePrimaryValidSecondaries(c *gc.C) {
 	// Now we ask the primary to step down again, and we should first reconfigure the group to include
 	// the other secondary. We first unset the invariant checker, because we are intentionally going to an even number
 	// of voters, but this is not the normal condition
-	st.check = nil
+	st.setCheck(nil)
 	if primaryMemberIndex == 1 {
 		st.machine("11").setWantsVote(false)
 	} else {


### PR DESCRIPTION
## Description of change

If we are down to N=2, we need to restore the secondary as a voter
before we can ask the current primary to step down.
Given how long it will take us to re-evaluate the loop, we might want a
faster polling when we are in these transitionary phases.
But this should at least be the correct transition steps.

## QA steps

```
$ juju bootstrap lxd
$ juju enable-ha
$ watch juju status
# wait for 3 controllers to be up and happy
$ juju remove-machine 2
$ watch --color "juju status --color && juju show-controller"
# Should show machine 0 staying as the primary and machine 2 being
# removed, and thus machine 1 being flagged as a secondary with no vote.
# show-controller will show it as 'ha-pending'.
$ juju remove-machine 0
```

Without this patch, the controller goes into a dead spin, trying to demote the current primary, even though it never gave machine 1 the right to become a primary.
Instead we transition via a step where both 0 and 1 become 'ha-enabled' and have the right to vote, and then we will ask machine 0 to step down, and *then* we will finally be able to remove machine 0.

## Documentation changes

None.

## Bug reference

[lp:1766571](https://bugs.launchpad.net/juju/+bug/1766571)