### PR TITLE
Search more files to find DNS config.

### DIFF
--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -38,9 +38,9 @@ func (h hostArchToolsFinder) FindTools(v version.Number, series, _ string) (tool
 	return h.f.FindTools(v, series, arch.HostArch())
 }
 
-// resolvConf is the full path to the resolv.conf file on the local
+// resolvConf contains the full path to common resolv.conf files on the local
 // system. Defined here so it can be overriden for testing.
-var resolvConf = "/etc/resolv.conf"
+var resolvConfFiles = []string{"/etc/resolv.conf", "/etc/systemd/resolved.conf", "/run/systemd/resolve/resolv.conf"}
 
 func prepareOrGetContainerInterfaceInfo(
 	api APICalls,
@@ -100,7 +100,7 @@ func finishNetworkConfig(bridgeDevice string, interfaces []network.InterfaceInfo
 
 	if !haveNameservers || !haveSearchDomains {
 		logger.Warningf("incomplete DNS config found, discovering host's DNS config")
-		dnsConfig, err := network.ParseResolvConf(resolvConf)
+		dnsConfig, err := findDNSServerConfig()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -116,6 +116,26 @@ func finishNetworkConfig(bridgeDevice string, interfaces []network.InterfaceInfo
 	}
 
 	return results, nil
+}
+
+// findDNSServerConfig is a heuristic method to find an adequate DNS
+// configuration. Currently the only rule that is implemented is that common
+// configuration files are parsed until a configuration is found that is not a
+// loopback address (i.e systemd/resolved stub address).
+func findDNSServerConfig() (*network.DNSConfig, error) {
+	for _, dnsConfigFile := range resolvConfFiles {
+		dnsConfig, err := network.ParseResolvConf(dnsConfigFile)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, nameServer := range dnsConfig.Nameservers {
+			if nameServer.Scope != network.ScopeMachineLocal {
+				logger.Debugf("The DNS configuration from %s has been selected for use", dnsConfigFile)
+				return dnsConfig, nil
+			}
+		}
+	}
+	return nil, errors.New("A DNS configuration could not be found.")
 }
 
 func releaseContainerAddresses(

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -294,7 +294,7 @@ nameserver ns2.dummy
 	fakeResolvConf := filepath.Join(c.MkDir(), "fakeresolv.conf")
 	err := ioutil.WriteFile(fakeResolvConf, []byte(fakeConf), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(provisioner.ResolvConf, fakeResolvConf)
+	s.PatchValue(provisioner.ResolvConfFiles, []string{fakeResolvConf})
 }
 
 func instancesFromResults(results ...*environs.StartInstanceResult) []instance.Instance {

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -37,7 +37,7 @@ var (
 	ContainerManagerConfig   = containerManagerConfig
 	GetContainerInitialiser  = &getContainerInitialiser
 	GetToolsFinder           = &getToolsFinder
-	ResolvConf               = &resolvConf
+	ResolvConfFiles          = &resolvConfFiles
 	RetryStrategyDelay       = &retryStrategyDelay
 	RetryStrategyCount       = &retryStrategyCount
 	GetObservedNetworkConfig = &getObservedNetworkConfig


### PR DESCRIPTION
## Description of change

When a provider cannot determine the DNS config settings for a container it reads /etc/resolv.conf. On bionic hosts this does not work. Here we search several files in accordance with what systemd resolved.  

## QA steps

1) Boot maas 2.3 controller using bionic as the series 
2) deploy a charm to a lxd container
3) Check to see if the container can resolve names (if it can't you will see errors in the log).

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1764317