### PR TITLE
fix 1749300: don't save backup to db by default

### DIFF
--- a/api/backups/create.go
+++ b/api/backups/create.go
@@ -10,8 +10,30 @@ import (
 )
 
 // Create sends a request to create a backup of juju's state.  It
+// returns the metadata associated with the resulting backup and a
+// filename for download.
+func (c *Client) Create(notes string, keepCopy, noDownload bool) (*params.BackupsCreateResult, error) {
+	var result params.BackupsCreateResult
+	args := params.BackupsCreateArgs{
+		Notes:      notes,
+		KeepCopy:   keepCopy,
+		NoDownload: noDownload,
+	}
+	if err := c.facade.FacadeCall("CreateBackup", args, &result); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &result, nil
+}
+
+// CreateDeprecated sends a request to create a backup of juju's state.  It
 // returns the metadata associated with the resulting backup.
-func (c *Client) Create(notes string) (*params.BackupsMetadataResult, error) {
+//
+// NOTE(hml) this exists only for backwards compatibility, for API facade
+// versions 1; clients should prefer its successor, Create, above.
+//
+// TODO(hml) 2018-05-02
+// Drop this in Juju 3.0.
+func (c *Client) CreateDeprecated(notes string) (*params.BackupsMetadataResult, error) {
 	var result params.BackupsMetadataResult
 	args := params.BackupsCreateArgs{Notes: notes}
 	if err := c.facade.FacadeCall("Create", args, &result); err != nil {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -21,7 +21,7 @@ var facadeVersions = map[string]int{
 	"Application":                  6,
 	"ApplicationOffers":            2,
 	"ApplicationScaler":            1,
-	"Backups":                      1,
+	"Backups":                      2,
 	"Block":                        2,
 	"Bundle":                       1,
 	"CAASAgent":                    1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -144,6 +144,7 @@ func AllFacades() *facade.Registry {
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)
+	reg("Backups", 2, backups.NewFacadeV2)
 	reg("Block", 2, block.NewAPI)
 	reg("Bundle", 1, bundle.NewFacade)
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -26,7 +26,7 @@ type backupsSuite struct {
 	testing.JujuConnSuite
 	resources  *common.Resources
 	authorizer *apiservertesting.FakeAuthorizer
-	api        *backupsAPI.API
+	api        *backupsAPI.APIv2
 	meta       *backups.Metadata
 	machineTag names.MachineTag
 }
@@ -57,14 +57,15 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 
 	tag := names.NewLocalUserTag("admin")
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
-	s.api, err = backupsAPI.NewAPI(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
+	s.api, err = backupsAPI.NewAPIv2(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.meta = backupstesting.NewMetadataStarted()
 }
 
 func (s *backupsSuite) setBackups(c *gc.C, meta *backups.Metadata, err string) *backupstesting.FakeBackups {
 	fake := backupstesting.FakeBackups{
-		Meta: meta,
+		Meta:     meta,
+		Filename: "test-filename",
 	}
 	if meta != nil {
 		fake.MetaList = append(fake.MetaList, meta)

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -17,12 +17,15 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 		func(*mgo.Session, int) error { return nil },
 	)
 	s.setBackups(c, s.meta, "")
+	//apiv2 := &backups.APIv2{s.api}
 	var args params.BackupsCreateArgs
+	//result, err := apiv2.Create(args)
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := backups.ResultFromMetadata(s.meta)
 
-	c.Check(result, gc.DeepEquals, expected)
+	c.Check(result.Metadata, gc.DeepEquals, expected)
+	c.Check(result.Filename, jc.Contains, "test-filename")
 }
 
 func (s *backupsSuite) TestCreateNotes(c *gc.C) {
@@ -34,12 +37,15 @@ func (s *backupsSuite) TestCreateNotes(c *gc.C) {
 	args := params.BackupsCreateArgs{
 		Notes: "this backup is important",
 	}
+	//apiv2 := &backups.APIv2{s.api}
+	//result, err := apiv2.Create(args)
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := backups.ResultFromMetadata(s.meta)
 	expected.Notes = "this backup is important"
 
-	c.Check(result, gc.DeepEquals, expected)
+	c.Check(result.Metadata, gc.DeepEquals, expected)
+	c.Check(result.Filename, jc.Contains, "test-filename")
 }
 
 func (s *backupsSuite) TestCreateError(c *gc.C) {
@@ -47,7 +53,9 @@ func (s *backupsSuite) TestCreateError(c *gc.C) {
 	s.PatchValue(backups.WaitUntilReady,
 		func(*mgo.Session, int) error { return nil },
 	)
+	//apiv2 := &backups.APIv2{s.api}
 	var args params.BackupsCreateArgs
+	//_, err := apiv2.Create(args)
 	_, err := s.api.Create(args)
 
 	c.Logf("%v", err)

--- a/apiserver/facades/client/backups/info.go
+++ b/apiserver/facades/client/backups/info.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Info provides the implementation of the API method.
-func (a *API) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult, error) {
+func (a *APIv2) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult, error) {
 	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 

--- a/apiserver/facades/client/backups/list.go
+++ b/apiserver/facades/client/backups/list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // List provides the implementation of the API method.
-func (a *API) List(args params.BackupsListArgs) (params.BackupsListResult, error) {
+func (a *APIv2) List(args params.BackupsListArgs) (params.BackupsListResult, error) {
 	var result params.BackupsListResult
 
 	backups, closer := newBackups(a.backend)

--- a/apiserver/facades/client/backups/remove.go
+++ b/apiserver/facades/client/backups/remove.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-func (a *API) Remove(args params.BackupsRemoveArgs) error {
+func (a *APIv2) Remove(args params.BackupsRemoveArgs) error {
 	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 

--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -20,7 +20,7 @@ import (
 var bootstrapNode = names.NewMachineTag("0")
 
 // Restore implements the server side of Backups.Restore.
-func (a *API) Restore(p params.RestoreArgs) error {
+func (a *APIv2) Restore(p params.RestoreArgs) error {
 	logger.Infof("Starting server side restore")
 
 	// Get hold of a backup file Reader

--- a/apiserver/facades/client/backups/shim.go
+++ b/apiserver/facades/client/backups/shim.go
@@ -41,6 +41,15 @@ func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Au
 	return NewAPI(&stateShim{st, model}, resources, authorizer)
 }
 
+// NewFacadeV2 provides the required signature for version 2 facade registration.
+func NewFacadeV2(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*APIv2, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return NewAPIv2(&stateShim{st, model}, resources, authorizer)
+}
+
 // ControllerTag disambiguates the ControllerTag method pending further
 // refactoring to separate model functionality from state functionality.
 func (s *stateShim) ControllerTag() names.ControllerTag {

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -11,7 +11,9 @@ import (
 
 // BackupsCreateArgs holds the args for the API Create method.
 type BackupsCreateArgs struct {
-	Notes string `json:"notes"`
+	Notes      string `json:"notes"`
+	KeepCopy   bool   `json:"keep-copy"`
+	NoDownload bool   `json:"no-download"`
 }
 
 // BackupsInfoArgs holds the args for the API Info method.
@@ -76,4 +78,9 @@ type BackupsMetadataResult struct {
 type RestoreArgs struct {
 	// BackupId holds the id of the backup in server if any
 	BackupId string `json:"backup-id"`
+}
+
+type BackupsCreateResult struct {
+	Metadata BackupsMetadataResult `json:"metadata"`
+	Filename string                `json:"filename"`
 }

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -5,6 +5,7 @@ package backups_test
 
 import (
 	"bytes"
+	"io/ioutil"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -31,30 +32,41 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 	s.defaultFilename = "juju-backup-<date>-<time>.tar.gz"
 }
 
+func (s *createSuite) setSuccess() *fakeAPIClient {
+	client := &fakeAPIClient{metaresult: s.metaresult}
+	s.patchGetAPI(client)
+	return client
+}
+
+func (s *createSuite) setFailure(failure string) *fakeAPIClient {
+	client := &fakeAPIClient{err: errors.New(failure)}
+	s.patchGetAPI(client)
+	return client
+}
+
 func (s *createSuite) setDownload() *fakeAPIClient {
-	client := s.BaseBackupsSuite.setDownload()
+	client := s.setSuccess()
+	client.archive = ioutil.NopCloser(bytes.NewBufferString(s.data))
 	return client
 }
 
 func (s *createSuite) checkDownloadStd(c *gc.C, ctx *cmd.Context) {
-	c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+	c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, MetaResultString)
 
-	out := ctx.Stdout.(*bytes.Buffer).String()
-	if !s.command.Log.Quiet {
-		parts := strings.Split(out, MetaResultString)
-		c.Assert(parts, gc.HasLen, 2)
-		c.Assert(parts[0], gc.Equals, "")
-		out = parts[1]
-	}
+	out := ctx.Stderr.(*bytes.Buffer).String()
 
 	parts := strings.Split(out, "\n")
-	c.Assert(parts, gc.HasLen, 3)
-	c.Assert(parts[2], gc.Equals, "")
-
-	c.Check(parts[0], gc.Equals, s.metaresult.ID)
+	i := 0
+	if s.command.KeepCopy {
+		c.Assert(parts, gc.HasLen, 3)
+		c.Check(parts[0], gc.Equals, s.metaresult.ID)
+		i = 1
+	} else {
+		c.Assert(parts, gc.HasLen, 2)
+	}
 
 	// Check the download message.
-	parts = strings.Split(parts[1], "downloading to ")
+	parts = strings.Split(parts[i], "downloading to ")
 	c.Assert(parts, gc.HasLen, 2)
 	c.Assert(parts[0], gc.Equals, "")
 	s.filename = parts[1]
@@ -65,52 +77,140 @@ func (s *createSuite) checkDownload(c *gc.C, ctx *cmd.Context) {
 	s.checkArchive(c)
 }
 
-func (s *createSuite) TestNoArgs(c *gc.C) {
-	client := s.BaseBackupsSuite.setDownload()
-	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--quiet")
-	c.Assert(err, jc.ErrorIsNil)
-
-	client.Check(c, s.metaresult.ID, "", "Create", "Download")
+type createBackupArgParsing struct {
+	title      string
+	args       []string
+	errMatch   string
+	filename   string
+	keepCopy   bool
+	noDownload bool
+	notes      string
 }
 
-func (s *createSuite) TestDefaultDownload(c *gc.C) {
-	s.setDownload()
-	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--quiet", "--filename", s.defaultFilename)
+var testCreateBackupArgParsing = []createBackupArgParsing{
+	{
+		title:      "no args",
+		args:       []string{},
+		filename:   backups.NotSet,
+		keepCopy:   false,
+		noDownload: false,
+		notes:      "",
+	},
+	{
+		title:      "filename",
+		args:       []string{"--filename", "testname"},
+		filename:   "testname",
+		keepCopy:   false,
+		noDownload: false,
+		notes:      "",
+	},
+	{
+		title:      "filename flag, no name",
+		args:       []string{"--filename"},
+		errMatch:   "flag needs an argument: --filename",
+		filename:   backups.NotSet,
+		keepCopy:   false,
+		noDownload: false,
+		notes:      "",
+	},
+	{
+		title:      "filename && no-download",
+		args:       []string{"--filename", "testname", "--no-download"},
+		errMatch:   "cannot mix --no-download and --filename",
+		filename:   backups.NotSet,
+		keepCopy:   false,
+		noDownload: false,
+		notes:      "",
+	},
+	{
+		title:      "keep-copy",
+		args:       []string{"--keep-copy"},
+		errMatch:   "",
+		filename:   backups.NotSet,
+		keepCopy:   true,
+		noDownload: false,
+		notes:      "",
+	},
+	{
+		title:      "notes",
+		args:       []string{"note for the backup"},
+		errMatch:   "",
+		filename:   backups.NotSet,
+		keepCopy:   false,
+		noDownload: false,
+		notes:      "note for the backup",
+	},
+}
+
+func (s *createSuite) TestArgParsing(c *gc.C) {
+	for i, test := range testCreateBackupArgParsing {
+		c.Logf("%d: %s", i, test.title)
+		err := cmdtesting.InitCommand(s.wrappedCommand, test.args)
+		if test.errMatch == "" {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(s.command.Filename, gc.Equals, test.filename)
+			c.Assert(s.command.KeepCopy, gc.Equals, test.keepCopy)
+			c.Assert(s.command.NoDownload, gc.Equals, test.noDownload)
+			c.Assert(s.command.Notes, gc.Equals, test.notes)
+		} else {
+			c.Assert(err, gc.ErrorMatches, test.errMatch)
+		}
+	}
+}
+
+func (s *createSuite) TestDefault(c *gc.C) {
+	client := s.setDownload()
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand)
 	c.Assert(err, jc.ErrorIsNil)
 
+	client.CheckCalls(c, "Create", "Download")
+	client.CheckArgs(c, "", "false", "false", "filename")
 	s.checkDownload(c, ctx)
-	c.Check(s.command.Filename, gc.Not(gc.Equals), "")
 	c.Check(s.command.Filename, gc.Equals, backups.NotSet)
 }
 
-func (s *createSuite) TestQuiet(c *gc.C) {
-	client := s.BaseBackupsSuite.setDownload()
+func (s *createSuite) TestDefaultV1(c *gc.C) {
+	s.apiVersion = 1
+	client := s.setDownload()
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand)
+	c.Assert(err, jc.ErrorIsNil)
+
+	client.CheckCalls(c, "CreateDeprecated", "Download")
+	client.CheckArgs(c, "", "spam")
+	c.Assert(s.command.KeepCopy, jc.IsTrue)
+	s.checkDownload(c, ctx)
+	c.Check(s.command.Filename, gc.Equals, backups.NotSet)
+}
+
+func (s *createSuite) TestDefaultQuiet(c *gc.C) {
+	client := s.setDownload()
 	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.Check(c, s.metaresult.ID, "", "Create", "Download")
+	client.CheckCalls(c, "Create", "Download")
+	client.CheckArgs(c, "", "false", "false", "filename")
 
 	c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
-	out := ctx.Stdout.(*bytes.Buffer).String()
-	c.Check(out, gc.Not(jc.Contains), MetaResultString)
-	c.Check(out, jc.HasPrefix, s.metaresult.ID+"\n")
-	s.checkDownloadStd(c, ctx)
+	c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "")
 }
 
 func (s *createSuite) TestNotes(c *gc.C) {
-	client := s.BaseBackupsSuite.setDownload()
-	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "spam", "--quiet")
+	client := s.setDownload()
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "test notes")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.Check(c, s.metaresult.ID, "spam", "Create", "Download")
+	client.CheckCalls(c, "Create", "Download")
+	client.CheckArgs(c, "test notes", "false", "false", "filename")
+	s.checkDownload(c, ctx)
 }
 
 func (s *createSuite) TestFilename(c *gc.C) {
 	client := s.setDownload()
-	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--filename", "backup.tgz", "--quiet")
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--filename", "backup.tgz")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.Check(c, s.metaresult.ID, "", "Create", "Download")
+	client.CheckCalls(c, "Create", "Download")
+	client.CheckArgs(c, "", "false", "false", "filename")
 	s.checkDownload(c, ctx)
 	c.Check(s.command.Filename, gc.Equals, "backup.tgz")
 }
@@ -120,10 +220,30 @@ func (s *createSuite) TestNoDownload(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--no-download")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.Check(c, "", "", "Create")
-	out := MetaResultString + s.metaresult.ID + "\n"
-	s.checkStd(c, ctx, out, backups.DownloadWarning+"\n")
+	client.CheckCalls(c, "Create")
+	client.CheckArgs(c, "", "true", "true")
+	out := MetaResultString
+	s.checkStd(c, ctx, out, "WARNING "+backups.DownloadWarning+"\n"+s.metaresult.ID+"\n")
 	c.Check(s.command.Filename, gc.Equals, backups.NotSet)
+}
+
+func (s *createSuite) TestKeepCopy(c *gc.C) {
+	client := s.setDownload()
+	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--keep-copy")
+	c.Assert(err, jc.ErrorIsNil)
+
+	client.CheckCalls(c, "Create", "Download")
+	client.CheckArgs(c, "", "true", "false", "filename")
+
+	s.checkDownload(c, ctx)
+}
+
+func (s *createSuite) TestKeepCopyV1Fail(c *gc.C) {
+	s.apiVersion = 1
+	s.setDownload()
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--keep-copy")
+
+	c.Assert(err, gc.ErrorMatches, "--keep-copy is not supported by this controller")
 }
 
 func (s *createSuite) TestFilenameAndNoDownload(c *gc.C) {

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -97,7 +97,7 @@ func (c *downloadCommand) Run(ctx *cmd.Context) error {
 	// Write out the archive.
 	_, err = io.Copy(archive, resultArchive)
 	if err != nil {
-		return errors.Annotate(err, "while creating local archive file")
+		return errors.Annotate(err, "while copying local archive file")
 	}
 
 	// Print the local filename.

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -21,6 +21,7 @@ const (
 
 var (
 	NewAPIClient = &newAPIClient
+	NewGetAPI    = &getAPI
 )
 
 type CreateCommand struct {

--- a/cmd/juju/backups/list.go
+++ b/cmd/juju/backups/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -35,6 +36,11 @@ func (c *listCommand) Info() *cmd.Info {
 		Doc:     listDoc,
 		Aliases: []string{"list-backups"},
 	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
 }
 
 // Init implements Command.Init.

--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -13,10 +13,13 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
+	"fmt"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/backups"
 	backupstesting "github.com/juju/juju/state/backups/testing"
 	"github.com/juju/juju/testing"
+	"os"
+	"path"
 )
 
 type backupsSuite struct {
@@ -58,8 +61,8 @@ func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 	dbInfo := backups.DBInfo{"a", "b", "c", targets, mongo.Mongo32wt}
 	meta := backupstesting.NewMetadataStarted()
 	meta.Notes = "some notes"
-	err := s.api.Create(meta, &paths, &dbInfo)
 
+	_, err := s.api.Create(meta, &paths, &dbInfo, true, true)
 	c.Check(err, gc.ErrorMatches, expected)
 }
 
@@ -69,11 +72,28 @@ func (s *backupsSuite) TestNewBackups(c *gc.C) {
 	c.Check(api, gc.NotNil)
 }
 
-func (s *backupsSuite) TestCreateOkay(c *gc.C) {
+func (s *backupsSuite) TestCreateOkayKeepCopyNoDownload(c *gc.C) {
+	s.testCreateOkay(c, true, true)
+}
 
+func (s *backupsSuite) TestCreateOkayKeepCopyFalse(c *gc.C) {
+	s.testCreateOkay(c, false, true)
+}
+
+func (s *backupsSuite) TestCreateOkayNoDownloadFalse(c *gc.C) {
+	s.testCreateOkay(c, true, false)
+}
+
+func (s *backupsSuite) testCreateOkay(c *gc.C, keepCopy, noDownload bool) {
+	dataDir := c.MkDir()
+	backupDir := c.MkDir()
 	// Patch the internals.
 	archiveFile := ioutil.NopCloser(bytes.NewBufferString("<compressed tarball>"))
-	result := backups.NewTestCreateResult(archiveFile, 10, "<checksum>")
+	result := backups.NewTestCreateResult(
+		archiveFile,
+		10,
+		"<checksum>",
+		path.Join(backupDir, backups.TempFilename))
 	received, testCreate := backups.NewTestCreate(result)
 	s.PatchValue(backups.RunCreate, testCreate)
 
@@ -92,18 +112,24 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	stored := s.setStored("spam")
 
 	// Run the backup.
-	paths := backups.Paths{BackupDir: "/path/to/dir", DataDir: "/var/lib/juju"}
+	paths := backups.Paths{BackupDir: backupDir, DataDir: dataDir}
 	targets := set.NewStrings("juju", "admin")
 	dbInfo := backups.DBInfo{"a", "b", "c", targets, mongo.Mongo32wt}
 	meta := backupstesting.NewMetadataStarted()
 	backupstesting.SetOrigin(meta, "<model ID>", "<machine ID>", "<hostname>")
 	meta.Notes = "some notes"
-	err := s.api.Create(meta, &paths, &dbInfo)
+	resultFilename, err := s.api.Create(meta, &paths, &dbInfo, keepCopy, noDownload)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resultFilename, gc.Equals, path.Join(backupDir, backups.TempFilename))
 
 	// Test the call values.
-	s.Storage.CheckCalled(c, "spam", meta, archiveFile, "Add", "Metadata")
-	backupDir, filesToBackUp, _ := backups.ExposeCreateArgs(received)
-	c.Check(backupDir, gc.Equals, "/path/to/dir")
+	if keepCopy {
+		s.Storage.CheckCalled(c, "spam", meta, archiveFile, "Add", "Metadata")
+	} else {
+		c.Assert(s.Storage.Calls, jc.SameContents, []string{})
+	}
+	resultBackupDir, filesToBackUp, _ := backups.ExposeCreateArgs(received)
+	c.Check(resultBackupDir, gc.Equals, backupDir)
 	c.Check(filesToBackUp, jc.SameContents, []string{"<some file>"})
 
 	c.Check(receivedDBInfo.Address, gc.Equals, "a")
@@ -114,25 +140,29 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	c.Check(rootDir, gc.Equals, "")
 
 	// Check the resulting metadata.
-	c.Check(meta, gc.Equals, s.Storage.MetaArg)
-	c.Check(meta.ID(), gc.Equals, "spam")
+	if keepCopy {
+		c.Check(meta, gc.Equals, s.Storage.MetaArg)
+		c.Check(meta.ID(), gc.Equals, "spam")
+		c.Check(meta.Stored().Unix(), gc.Equals, stored.Unix())
+	}
 	c.Check(meta.Size(), gc.Equals, int64(10))
 	c.Check(meta.Checksum(), gc.Equals, "<checksum>")
-	c.Check(meta.Stored().Unix(), gc.Equals, stored.Unix())
 	c.Check(meta.Origin.Model, gc.Equals, "<model ID>")
 	c.Check(meta.Origin.Machine, gc.Equals, "<machine ID>")
 	c.Check(meta.Origin.Hostname, gc.Equals, "<hostname>")
 	c.Check(meta.Notes, gc.Equals, "some notes")
 
 	// Check the file storage.
-	s.Storage.Meta = meta
-	s.Storage.File = archiveFile
-	storedMeta, storedFile, err := s.Storage.Get(meta.ID())
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(storedMeta, gc.DeepEquals, meta)
-	data, err := ioutil.ReadAll(storedFile)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(string(data), gc.Equals, "<compressed tarball>")
+	if keepCopy {
+		s.Storage.Meta = meta
+		s.Storage.File = archiveFile
+		storedMeta, storedFile, err := s.Storage.Get(meta.ID())
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(storedMeta, gc.DeepEquals, meta)
+		data, err := ioutil.ReadAll(storedFile)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(string(data), gc.Equals, "<compressed tarball>")
+	}
 }
 
 func (s *backupsSuite) TestCreateFailToListFiles(c *gc.C) {
@@ -188,4 +218,28 @@ func (s *backupsSuite) TestStoreArchive(c *gc.C) {
 	s.Storage.CheckCalled(c, "spam", meta, archive, "Add", "Metadata")
 	c.Assert(meta.ID(), gc.Equals, "spam")
 	c.Assert(meta.Stored(), jc.DeepEquals, stored)
+}
+
+func (s *backupsSuite) TestGetFileName(c *gc.C) {
+	backupDir := c.MkDir()
+	os.MkdirAll(backupDir, 0644)
+	backupFilename := path.Join(backupDir, backups.TempFilename)
+	backupFile, err := os.Create(backupFilename)
+	c.Assert(err, jc.ErrorIsNil)
+	backupFile.Write([]byte("archive file testing"))
+
+	resultMeta, resultArchive, err := s.api.Get(backupFilename)
+	c.Assert(err, jc.ErrorIsNil)
+	defer resultArchive.Close()
+	resultMeta.FileMetadata.Checksum()
+
+	// Purpose for metadata here is for the checksum to be used by the
+	// caller, so check it here.
+	c.Assert(resultMeta.FileMetadata.Checksum(), gc.NotNil)
+	b, err := ioutil.ReadAll(resultArchive)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(b), gc.Equals, "archive file testing")
+
+	_, err = ioutil.ReadDir(backupDir)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("open %s: no such file or directory", backupDir))
 }

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -89,17 +89,18 @@ func SetBackupStoredTime(st *state.State, id string, stored time.Time) error {
 }
 
 // ExposeCreateResult extracts the values in a create() result.
-func ExposeCreateResult(result *createResult) (io.ReadCloser, int64, string) {
-	return result.archiveFile, result.size, result.checksum
+func ExposeCreateResult(result *createResult) (io.ReadCloser, int64, string, string) {
+	return result.archiveFile, result.size, result.checksum, result.filename
 }
 
 // NewTestCreateArgs builds a new args value for create() calls.
-func NewTestCreateArgs(backupDir string, filesToBackUp []string, db DBDumper, metar io.Reader) *createArgs {
+func NewTestCreateArgs(backupDir string, filesToBackUp []string, db DBDumper, metar io.Reader, noDownload bool) *createArgs {
 	args := createArgs{
 		backupDir:      backupDir,
 		filesToBackUp:  filesToBackUp,
 		db:             db,
 		metadataReader: metar,
+		noDownload:     noDownload,
 	}
 	return &args
 }
@@ -110,11 +111,12 @@ func ExposeCreateArgs(args *createArgs) (string, []string, DBDumper) {
 }
 
 // NewTestCreateResult builds a new create() result.
-func NewTestCreateResult(file io.ReadCloser, size int64, checksum string) *createResult {
+func NewTestCreateResult(file io.ReadCloser, size int64, checksum, filename string) *createResult {
 	result := createResult{
 		archiveFile: file,
 		size:        size,
 		checksum:    checksum,
+		filename:    filename,
 	}
 	return &result
 }
@@ -125,7 +127,7 @@ func NewTestCreate(result *createResult) (*createArgs, func(*createArgs) (*creat
 
 	if result == nil {
 		archiveFile := ioutil.NopCloser(bytes.NewBufferString("<archive>"))
-		result = NewTestCreateResult(archiveFile, 10, "<checksum>")
+		result = NewTestCreateResult(archiveFile, 10, "<checksum>", "")
 	}
 
 	testCreate := func(args *createArgs) (*createResult, error) {

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -17,6 +17,9 @@ import (
 )
 
 // FakeBackups is an implementation of Backups to use for testing.
+// TODO: (hml) 2018-04-25
+// Let's change FakeBackups to using gomock or base.APICaller.
+// Checking calls made and arguments is a pain.
 type FakeBackups struct {
 	// Calls contains the order in which methods were called.
 	Calls []string
@@ -29,6 +32,8 @@ type FakeBackups struct {
 	Archive io.ReadCloser
 	// Error holds the error to return.
 	Error error
+	// Filename holds the name of the file to return.
+	Filename string
 
 	// IDArg holds the ID that was passed in.
 	IDArg string
@@ -40,28 +45,39 @@ type FakeBackups struct {
 	MetaArg *backups.Metadata
 	// PrivateAddr Holds the address for the internal network of the machine.
 	PrivateAddr string
-	// InstanceId Is the id of the machine to be restored.
+	// InstanceId is the id of the machine to be restored.
 	InstanceId instance.Id
 	// ArchiveArg holds the backup archive that was passed in.
 	ArchiveArg io.Reader
+	// KeepCopy holds the keepCopy bool that was passed in.
+	KeepCopy bool
+	// NoDownload holds the noDownload bool that was passed in.
+	NoDownload bool
 }
 
 var _ backups.Backups = (*FakeBackups)(nil)
 
 // Create creates and stores a new juju backup archive and returns
 // its associated metadata.
-func (b *FakeBackups) Create(meta *backups.Metadata, paths *backups.Paths, dbInfo *backups.DBInfo) error {
+func (b *FakeBackups) Create(
+	meta *backups.Metadata,
+	paths *backups.Paths,
+	dbInfo *backups.DBInfo,
+	keepCopy, noDownload bool,
+) (string, error) {
 	b.Calls = append(b.Calls, "Create")
 
 	b.PathsArg = paths
 	b.DBInfoArg = dbInfo
 	b.MetaArg = meta
+	b.KeepCopy = keepCopy
+	b.NoDownload = noDownload
 
 	if b.Meta != nil {
 		*meta = *b.Meta
 	}
 
-	return b.Error
+	return b.Filename, b.Error
 }
 
 // Add stores the backup and returns its new ID.


### PR DESCRIPTION
## Description of change

juju create-backup should only download a backup by default, not save a copy to the db also.  Added a new flag, --keep-copy, to allow for a copy to be saved to the db at creation time.  Since there is a 
no-download flag currently, it will now imply keep-copy, as you must do one or the other.  

## QA steps

1. juju bootstrap localhost testme
2. juju switch controller
3. juju create-backup
3. verify compressed download file downloaded.
4. juju backups, 
4. results should show no backup ids.
6. on controller, verify there are no /tmp/juju-backups directories
7. juju create-backup --keep-copy
8. verify compressed file downloaded.
4. juju backups
5. one backup id should be listed, same as printed during create-backup
6. juju create-backup --no-download
4. verify no new compressed backup file downloaded.
5. juju backups
4. results should show another backup id

## Documentation changes

Yes, 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1749300