### PR TITLE
Iaas only commands

### DIFF
--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -61,6 +61,7 @@ type APIClient interface {
 // ActionCommandBase is the base type for action sub-commands.
 type ActionCommandBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 }
 
 // NewActionAPIClient returns a client for the action api endpoint.

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -52,6 +52,9 @@ func (s *BaseActionSuite) SetUpTest(c *gc.C) {
 
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
+	s.store.Controllers["ctrl"] = jujuclient.ControllerDetails{}
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/admin": {ModelType: "iaas"}}}
 	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{
 		User: "admin",
 	}

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jtesting "github.com/juju/juju/testing"
 )
 
@@ -37,7 +38,7 @@ var _ = gc.Suite(&AddRelationSuite{})
 
 func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
 	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	return err
 }
@@ -86,7 +87,7 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Code:    params.CodeUnauthorized,
 	})
 	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	ctx, _ := cmdtesting.RunCommand(c, cmd, "application1", "application2")
 	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -107,13 +108,13 @@ var initAddUnitErrorTests = []struct {
 func (s *AddUnitSuite) TestInitErrors(c *gc.C) {
 	for i, t := range initAddUnitErrorTests {
 		c.Logf("test %d", i)
-		err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake), t.args)
+		err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, jujuclienttesting.MinimalStore()), t.args)
 		c.Check(err, gc.ErrorMatches, t.err)
 	}
 }
 
 func (s *AddUnitSuite) runAddUnit(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), args...)
+	_, err := cmdtesting.RunCommand(c, application.NewAddUnitCommandForTest(s.fake, jujuclienttesting.MinimalStore()), args...)
 	return err
 }
 
@@ -176,7 +177,8 @@ func (s *AddUnitSuite) TestUnauthorizedMentionsJujuGrant(c *gc.C) {
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	}
-	ctx, _ := cmdtesting.RunCommand(c, application.NewAddUnitCommandForTest(s.fake), "some-application-name")
+	ctx, _ := cmdtesting.RunCommand(c, application.NewAddUnitCommandForTest(
+		s.fake, jujuclienttesting.MinimalStore()), "some-application-name")
 	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
 	c.Assert(errString, gc.Matches, `.*juju grant.*`)
 }

--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -77,7 +77,7 @@ func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 	for i, t := range deployTests {
 		c.Logf("\ntest %d: %s", i, t.about)
 		wrappedDeployCmd := NewDeployCommandForTest(nil, nil)
-		wrappedDeployCmd.SetClientStore(jujuclient.NewMemStore())
+		wrappedDeployCmd.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(wrappedDeployCmd, t.args)
 		if t.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, t.expectError)
@@ -100,7 +100,7 @@ func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 
 func (*CmdSuite) TestExposeCommandInitWithMissingArgs(c *gc.C) {
 	cmd := NewExposeCommand()
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	err := cmdtesting.InitCommand(cmd, nil)
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 
@@ -109,34 +109,21 @@ func (*CmdSuite) TestExposeCommandInitWithMissingArgs(c *gc.C) {
 
 func (*CmdSuite) TestUnexposeCommandInitWithMissingArgs(c *gc.C) {
 	cmd := NewUnexposeCommand()
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	err := cmdtesting.InitCommand(cmd, nil)
 	c.Assert(err, gc.ErrorMatches, "no application name specified")
 }
 
 func (*CmdSuite) TestRemoveUnitCommandInitMissingArgs(c *gc.C) {
 	cmd := NewRemoveUnitCommand()
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	err := cmdtesting.InitCommand(cmd, nil)
 	c.Assert(err, gc.ErrorMatches, "no units specified")
 }
 
 func (*CmdSuite) TestRemoveUnitCommandInitInvalidUnit(c *gc.C) {
 	cmd := NewRemoveUnitCommand()
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	err := cmdtesting.InitCommand(cmd, []string{"seven/nine"})
 	c.Assert(err, gc.ErrorMatches, `invalid unit name "seven/nine"`)
-}
-
-func NewMockStore() *jujuclient.MemStore {
-	store := jujuclient.NewMemStore()
-	store.CurrentControllerName = "foo"
-	store.Controllers["foo"] = jujuclient.ControllerDetails{
-		APIEndpoints: []string{"0.1.2.3:1234"},
-	}
-	store.Models["foo"] = &jujuclient.ControllerModels{
-		CurrentModel: "admin/bar",
-		Models:       map[string]jujuclient.ModelDetails{"admin/bar": {}},
-	}
-	return store
 }

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/jujuclient"
 )
 
 const maxValueSize = 5242880 // Max size for a config file.
@@ -55,10 +56,12 @@ func NewConfigCommand() cmd.Command {
 }
 
 // NewConfigCommandForTest returns a SetCommand with the api provided as specified.
-func NewConfigCommandForTest(api applicationAPI) modelcmd.ModelCommand {
-	return modelcmd.Wrap(&configCommand{
+func NewConfigCommandForTest(api applicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	cmd := modelcmd.Wrap(&configCommand{
 		api: api,
 	})
+	cmd.SetClientStore(store)
+	return cmd
 }
 
 type attributes map[string]string

--- a/cmd/juju/application/constraints_test.go
+++ b/cmd/juju/application/constraints_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -41,7 +42,7 @@ func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 		args: []string{"mysql", "cpu-power=250"},
 	}} {
 		cmd := application.NewServiceSetConstraintsCommand()
-		cmd.SetClientStore(application.NewMockStore())
+		cmd.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
@@ -73,7 +74,7 @@ func (s *ServiceConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 		},
 	} {
 		cmd := application.NewServiceGetConstraintsCommand()
-		cmd.SetClientStore(application.NewMockStore())
+		cmd.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -39,7 +39,7 @@ func (s *ConsumeSuite) SetUpTest(c *gc.C) {
 	s.store.CurrentControllerName = controllerName
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{}
 	s.store.Models[controllerName] = &jujuclient.ControllerModels{
-		CurrentModel: "fred/test",
+		CurrentModel: "bob/test",
 		Models: map[string]jujuclient.ModelDetails{
 			"bob/test": {ModelUUID: "test-uuid", ModelType: model.IAAS},
 			"bob/prod": {ModelUUID: "prod-uuid", ModelType: model.IAAS},

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/juju/version"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -1418,7 +1419,7 @@ func (s *DeployUnitTestSuite) runDeploy(c *gc.C, fakeAPI *fakeDeployAPI, args ..
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return cmdtesting.RunCommand(c, cmd, args...)
 }
 
@@ -1447,7 +1448,7 @@ func (s *DeployUnitTestSuite) TestDeployApplicationConfig(c *gc.C) {
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, dummyURL.String(),
 		"--config", "foo=bar",
 	)
@@ -1570,7 +1571,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)
-	deployCmd.SetClientStore(NewMockStore())
+	deployCmd.SetClientStore(jujuclienttesting.MinimalStore())
 	context, err := cmdtesting.RunCommand(c, deployCmd, "cs:bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1610,7 +1611,7 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorage(c *gc.C) {
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, dummyURL.String(),
 		"--attach-storage", "foo/0",
 		"--attach-storage", "bar/1,baz/2",
@@ -1635,7 +1636,7 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorageNotSupported(c *gc.C) {
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
-	cmd.SetClientStore(NewMockStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, dummyURL.String(), "--attach-storage", "foo/0")
 	c.Assert(err, gc.ErrorMatches, "this juju controller does not support --attach-storage")
 }

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -40,16 +40,17 @@ func NewUpgradeCharmCommandForTest(
 }
 
 // NewResolvedCommandForTest returns a ResolvedCommand with the api provided as specified.
-func NewResolvedCommandForTest(applicationResolveAPI applicationResolveAPI, clientAPI clientAPI) modelcmd.ModelCommand {
+func NewResolvedCommandForTest(applicationResolveAPI applicationResolveAPI, clientAPI clientAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &resolvedCommand{applicationResolveAPI: applicationResolveAPI, clientAPI: clientAPI}
+	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
 
 // NewAddUnitCommandForTest returns an AddUnitCommand with the api provided as specified.
-func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
-	return modelcmd.Wrap(&addUnitCommand{
-		api: api,
-	})
+func NewAddUnitCommandForTest(api serviceAddUnitAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	cmd := &addUnitCommand{api: api}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
 }
 
 // NewAddRelationCommandForTest returns an AddRelationCommand with the api provided as specified.
@@ -59,10 +60,11 @@ func NewAddRelationCommandForTest(addAPI applicationAddRelationAPI, consumeAPI a
 }
 
 // NewRemoveRelationCommandForTest returns an RemoveRelationCommand with the api provided as specified.
-func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI) modelcmd.ModelCommand {
+func NewRemoveRelationCommandForTest(api ApplicationDestroyRelationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &removeRelationCommand{newAPIFunc: func() (ApplicationDestroyRelationAPI, error) {
 		return api, nil
 	}}
+	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
 
@@ -80,35 +82,40 @@ func NewConsumeCommandForTest(
 func NewUpdateSeriesCommandForTest(
 	appAPI updateApplicationSeriesAPI,
 	machAPI updateMachineSeriesAPI,
+	store jujuclient.ClientStore,
 ) modelcmd.ModelCommand {
 	cmd := &updateSeriesCommand{
 		updateApplicationSeriesClient: appAPI,
 		updateMachineSeriesClient:     machAPI,
 	}
+	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
 
 // NewSuspendRelationCommandForTest returns a SuspendRelationCommand with the api provided as specified.
-func NewSuspendRelationCommandForTest(api SetRelationSuspendedAPI) modelcmd.ModelCommand {
+func NewSuspendRelationCommandForTest(api SetRelationSuspendedAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &suspendRelationCommand{newAPIFunc: func() (SetRelationSuspendedAPI, error) {
 		return api, nil
 	}}
+	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
 
 // NewResumeRelationCommandForTest returns a ResumeRelationCommand with the api provided as specified.
-func NewResumeRelationCommandForTest(api SetRelationSuspendedAPI) modelcmd.ModelCommand {
+func NewResumeRelationCommandForTest(api SetRelationSuspendedAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &resumeRelationCommand{newAPIFunc: func() (SetRelationSuspendedAPI, error) {
 		return api, nil
 	}}
+	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
 
 // NewRemoveSaasCommandForTest returns a RemoveSaasCommand with the api provided as specified.
-func NewRemoveSaasCommandForTest(api RemoveSaasAPI) modelcmd.ModelCommand {
+func NewRemoveSaasCommandForTest(api RemoveSaasAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &removeSaasCommand{newAPIFunc: func() (RemoveSaasAPI, error) {
 		return api, nil
 	}}
+	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
 

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -30,7 +31,8 @@ func (s *RemoveRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&RemoveRelationSuite{})
 
 func (s *RemoveRelationSuite) runRemoveRelation(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, NewRemoveRelationCommandForTest(s.mockAPI), args...)
+	store := jujuclienttesting.MinimalStore()
+	_, err := cmdtesting.RunCommand(c, NewRemoveRelationCommandForTest(s.mockAPI, store), args...)
 	return err
 }
 

--- a/cmd/juju/application/removesaas_test.go
+++ b/cmd/juju/application/removesaas_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -30,7 +31,8 @@ func (s *RemoveSaasSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *RemoveSaasSuite) runRemoveSaas(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, NewRemoveSaasCommandForTest(s.mockAPI), args...)
+	store := jujuclienttesting.MinimalStore()
+	return cmdtesting.RunCommand(c, NewRemoveSaasCommandForTest(s.mockAPI, store), args...)
 }
 
 func (s *RemoveSaasSuite) TestRemove(c *gc.C) {

--- a/cmd/juju/application/resolved_test.go
+++ b/cmd/juju/application/resolved_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type ResolvedSuite struct {
@@ -27,7 +28,8 @@ func (s *ResolvedSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&ResolvedSuite{})
 
 func (s *ResolvedSuite) runResolved(c *gc.C, args []string) error {
-	cmd := application.NewResolvedCommandForTest(s.mockAPI, s.mockAPI)
+	store := jujuclienttesting.MinimalStore()
+	cmd := application.NewResolvedCommandForTest(s.mockAPI, s.mockAPI, store)
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	return err
 }

--- a/cmd/juju/application/resumerelation_test.go
+++ b/cmd/juju/application/resumerelation_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -30,7 +31,8 @@ func (s *ResumeRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&ResumeRelationSuite{})
 
 func (s *ResumeRelationSuite) runResumeRelation(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, NewResumeRelationCommandForTest(s.mockAPI), args...)
+	store := jujuclienttesting.MinimalStore()
+	_, err := cmdtesting.RunCommand(c, NewResumeRelationCommandForTest(s.mockAPI, store), args...)
 	return err
 }
 

--- a/cmd/juju/application/suspendrelation_test.go
+++ b/cmd/juju/application/suspendrelation_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -30,7 +31,8 @@ func (s *SuspendRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&SuspendRelationSuite{})
 
 func (s *SuspendRelationSuite) runSuspendRelation(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, NewSuspendRelationCommandForTest(s.mockAPI), args...)
+	store := jujuclienttesting.MinimalStore()
+	_, err := cmdtesting.RunCommand(c, NewSuspendRelationCommandForTest(s.mockAPI, store), args...)
 	return err
 }
 

--- a/cmd/juju/application/updateseries.go
+++ b/cmd/juju/application/updateseries.go
@@ -40,6 +40,7 @@ type updateMachineSeriesAPI interface {
 // updateSeriesCommand is responsible for updating the series of an application or machine.
 type updateSeriesCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 
 	updateApplicationSeriesClient updateApplicationSeriesAPI
 	updateMachineSeriesClient     updateMachineSeriesAPI

--- a/cmd/juju/application/updateseries_test.go
+++ b/cmd/juju/application/updateseries_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/testing"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type updateSeriesSuite struct {
@@ -28,7 +29,8 @@ func (s *updateSeriesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *updateSeriesSuite) runUpdateSeries(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, NewUpdateSeriesCommandForTest(s.mockApplicationAPI, s.mockMachineAPI), args...)
+	store := jujuclienttesting.MinimalStore()
+	return cmdtesting.RunCommand(c, NewUpdateSeriesCommandForTest(s.mockApplicationAPI, s.mockMachineAPI, store), args...)
 }
 
 func (s *updateSeriesSuite) TestUpdateSeriesApplicationGoodPath(c *gc.C) {

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type createSuite struct {
@@ -27,7 +28,7 @@ var _ = gc.Suite(&createSuite{})
 
 func (s *createSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.wrappedCommand, s.command = backups.NewCreateCommandForTest()
+	s.wrappedCommand, s.command = backups.NewCreateCommandForTest(jujuclienttesting.MinimalStore())
 	s.defaultFilename = "juju-backup-<date>-<time>.tar.gz"
 }
 

--- a/cmd/juju/backups/download_test.go
+++ b/cmd/juju/backups/download_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type downloadSuite struct {
@@ -23,7 +24,7 @@ var _ = gc.Suite(&downloadSuite{})
 
 func (s *downloadSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.wrappedCommand, s.command = backups.NewDownloadCommandForTest()
+	s.wrappedCommand, s.command = backups.NewDownloadCommandForTest(jujuclienttesting.MinimalStore())
 }
 
 func (s *downloadSuite) TearDownTest(c *gc.C) {

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -31,39 +31,45 @@ type DownloadCommand struct {
 	*downloadCommand
 }
 
-func NewCreateCommandForTest() (cmd.Command, *CreateCommand) {
+func NewCreateCommandForTest(store jujuclient.ClientStore) (cmd.Command, *CreateCommand) {
 	c := &createCommand{}
+	c.SetClientStore(store)
 	c.Log = &cmd.Log{}
 	return modelcmd.Wrap(c), &CreateCommand{c}
 }
 
-func NewDownloadCommandForTest() (cmd.Command, *DownloadCommand) {
+func NewDownloadCommandForTest(store jujuclient.ClientStore) (cmd.Command, *DownloadCommand) {
 	c := &downloadCommand{}
 	c.Log = &cmd.Log{}
+	c.SetClientStore(store)
 	return modelcmd.Wrap(c), &DownloadCommand{c}
 }
 
-func NewListCommandForTest() cmd.Command {
+func NewListCommandForTest(store jujuclient.ClientStore) cmd.Command {
 	c := &listCommand{}
 	c.Log = &cmd.Log{}
+	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }
 
-func NewShowCommandForTest() cmd.Command {
+func NewShowCommandForTest(store jujuclient.ClientStore) cmd.Command {
 	c := &showCommand{}
 	c.Log = &cmd.Log{}
+	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }
 
-func NewUploadCommandForTest() cmd.Command {
+func NewUploadCommandForTest(store jujuclient.ClientStore) cmd.Command {
 	c := &uploadCommand{}
 	c.Log = &cmd.Log{}
+	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }
 
-func NewRemoveCommandForTest() cmd.Command {
+func NewRemoveCommandForTest(store jujuclient.ClientStore) cmd.Command {
 	c := &removeCommand{}
 	c.Log = &cmd.Log{}
+	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }
 

--- a/cmd/juju/backups/list_test.go
+++ b/cmd/juju/backups/list_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type listSuite struct {
@@ -22,7 +23,7 @@ var _ = gc.Suite(&listSuite{})
 
 func (s *listSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = backups.NewListCommandForTest()
+	s.subcommand = backups.NewListCommandForTest(jujuclienttesting.MinimalStore())
 }
 
 func (s *listSuite) TestOkay(c *gc.C) {

--- a/cmd/juju/backups/remove_test.go
+++ b/cmd/juju/backups/remove_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type removeSuite struct {
@@ -22,7 +23,7 @@ var _ = gc.Suite(&removeSuite{})
 
 func (s *removeSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.command = backups.NewRemoveCommandForTest()
+	s.command = backups.NewRemoveCommandForTest(jujuclienttesting.MinimalStore())
 }
 
 func (s *removeSuite) TestOkay(c *gc.C) {

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -62,9 +62,9 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 	s.store.CurrentControllerName = "testing"
 	s.store.Models["testing"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
-			"admin": {ModelUUID: "test1-uuid", ModelType: model.IAAS},
+			"current-user/test1": {ModelUUID: "test1-uuid", ModelType: model.IAAS},
 		},
-		CurrentModel: "admin",
+		CurrentModel: "test1",
 	}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{
 		User:     "current-user",

--- a/cmd/juju/backups/show_test.go
+++ b/cmd/juju/backups/show_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type showSuite struct {
@@ -22,7 +23,7 @@ var _ = gc.Suite(&showSuite{})
 
 func (s *showSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = backups.NewShowCommandForTest()
+	s.subcommand = backups.NewShowCommandForTest(jujuclienttesting.MinimalStore())
 }
 
 func (s *showSuite) TestOkay(c *gc.C) {

--- a/cmd/juju/backups/upload_test.go
+++ b/cmd/juju/backups/upload_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type uploadSuite struct {
@@ -28,7 +29,7 @@ var _ = gc.Suite(&uploadSuite{})
 func (s *uploadSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
 
-	s.command = backups.NewUploadCommandForTest()
+	s.command = backups.NewUploadCommandForTest(jujuclienttesting.MinimalStore())
 	s.filename = "juju-backup-20140912-130755.abcd-spam-deadbeef-eggs.tar.gz"
 }
 

--- a/cmd/juju/block/export_test.go
+++ b/cmd/juju/block/export_test.go
@@ -5,6 +5,7 @@ package block
 
 import (
 	"github.com/juju/cmd"
+	"github.com/juju/juju/jujuclient"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -12,22 +13,26 @@ import (
 
 // NewDisableCommandForTest returns a new disable command with the
 // apiFunc specified to return the args.
-func NewDisableCommandForTest(api blockClientAPI, err error) cmd.Command {
-	return modelcmd.Wrap(&disableCommand{
+func NewDisableCommandForTest(store jujuclient.ClientStore, api blockClientAPI, err error) cmd.Command {
+	cmd := &disableCommand{
 		apiFunc: func(_ newAPIRoot) (blockClientAPI, error) {
 			return api, err
 		},
-	})
+	}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
 }
 
 // NewEnableCommandForTest returns a new enable command with the
 // apiFunc specified to return the args.
-func NewEnableCommandForTest(api unblockClientAPI, err error) cmd.Command {
-	return modelcmd.Wrap(&enableCommand{
+func NewEnableCommandForTest(store jujuclient.ClientStore, api unblockClientAPI, err error) cmd.Command {
+	cmd := &enableCommand{
 		apiFunc: func(_ newAPIRoot) (unblockClientAPI, error) {
 			return api, err
 		},
-	})
+	}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
 }
 
 type listMockAPI interface {
@@ -38,13 +43,15 @@ type listMockAPI interface {
 
 // NewListCommandForTest returns a new list command with the
 // apiFunc specified to return the args.
-func NewListCommandForTest(api listMockAPI, err error) cmd.Command {
-	return modelcmd.Wrap(&listCommand{
+func NewListCommandForTest(store jujuclient.ClientStore, api listMockAPI, err error) cmd.Command {
+	cmd := &listCommand{
 		apiFunc: func(_ newAPIRoot) (blockListAPI, error) {
 			return api, err
 		},
 		controllerAPIFunc: func(_ newControllerAPIRoot) (controllerListAPI, error) {
 			return api, err
 		},
-	})
+	}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
 }

--- a/cmd/juju/cachedimages/cachedimages.go
+++ b/cmd/juju/cachedimages/cachedimages.go
@@ -12,6 +12,7 @@ import (
 // image manager client.
 type CachedImagesCommandBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 }
 
 // NewImagesManagerClient returns a imagemanager client for the root api endpoint

--- a/cmd/juju/cachedimages/export_test.go
+++ b/cmd/juju/cachedimages/export_test.go
@@ -3,10 +3,26 @@
 
 package cachedimages
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
 var (
 	GetListImagesAPI  = &getListImagesAPI
 	GetRemoveImageAPI = &getRemoveImageAPI
-
-	NewRemoveCommandForTest = NewRemoveCommand
-	NewListCommandForTest   = NewListCommand
 )
+
+func NewListCommandForTest(store jujuclient.ClientStore) cmd.Command {
+	cmd := &listCommand{}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
+func NewRemoveCommandForTest(store jujuclient.ClientStore) cmd.Command {
+	cmd := &removeCommand{}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}

--- a/cmd/juju/cachedimages/list_test.go
+++ b/cmd/juju/cachedimages/list_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/cachedimages"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -54,7 +55,7 @@ func (s *listImagesCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func runListCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, cachedimages.NewListCommandForTest(), args...)
+	return cmdtesting.RunCommand(c, cachedimages.NewListCommandForTest(jujuclienttesting.MinimalStore()), args...)
 }
 
 func (*listImagesCommandSuite) TestListImagesNone(c *gc.C) {

--- a/cmd/juju/cachedimages/remove_test.go
+++ b/cmd/juju/cachedimages/remove_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/cachedimages"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -46,7 +47,7 @@ func (s *removeImageCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func runRemoveCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, cachedimages.NewRemoveCommandForTest(), args...)
+	return cmdtesting.RunCommand(c, cachedimages.NewRemoveCommandForTest(jujuclienttesting.MinimalStore()), args...)
 }
 
 func (s *removeImageCommandSuite) TestRemoveImage(c *gc.C) {

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/loggo"
 	"github.com/juju/loggo/loggocolor"
 	"github.com/mattn/go-isatty"
@@ -105,12 +106,14 @@ func (c *debugLogCommand) Info() *cmd.Info {
 	}
 }
 
-func newDebugLogCommand() cmd.Command {
-	return newDebugLogCommandTZ(time.Local)
+func newDebugLogCommand(store jujuclient.ClientStore) cmd.Command {
+	return newDebugLogCommandTZ(store, time.Local)
 }
 
-func newDebugLogCommandTZ(tz *time.Location) cmd.Command {
-	return modelcmd.Wrap(&debugLogCommand{tz: tz})
+func newDebugLogCommandTZ(store jujuclient.ClientStore, tz *time.Location) cmd.Command {
+	cmd := &debugLogCommand{tz: tz}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
 }
 
 type debugLogCommand struct {

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -107,6 +108,7 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 	} {
 		c.Logf("test %v", i)
 		command := &debugLogCommand{}
+		command.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(modelcmd.Wrap(command), test.args)
 		if test.errMatch == "" {
 			c.Check(err, jc.ErrorIsNil)
@@ -122,7 +124,7 @@ func (s *DebugLogSuite) TestParamsPassed(c *gc.C) {
 	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
 		return fake, nil
 	})
-	_, err := cmdtesting.RunCommand(c, newDebugLogCommand(),
+	_, err := cmdtesting.RunCommand(c, newDebugLogCommand(jujuclienttesting.MinimalStore()),
 		"-i", "machine-1*", "-x", "machine-1-lxd-1",
 		"--include-module=juju.provisioner",
 		"--lines=500",
@@ -158,7 +160,7 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 	checkOutput := func(args ...string) {
 		count := len(args)
 		args, expected := args[:count-1], args[count-1]
-		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(tz), args...)
+		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(jujuclienttesting.MinimalStore(), tz), args...)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -300,18 +300,18 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(status.NewStatusHistoryCommand())
 
 	// Error resolution and debugging commands.
-	r.Register(newDefaultRunCommand())
+	r.Register(newDefaultRunCommand(nil))
 	r.Register(newSCPCommand(nil))
 	r.Register(newSSHCommand(nil, nil))
 	r.Register(application.NewResolvedCommand())
-	r.Register(newDebugLogCommand())
+	r.Register(newDebugLogCommand(nil))
 	r.Register(newDebugHooksCommand(nil))
 
 	// Configuration commands.
 	r.Register(model.NewModelGetConstraintsCommand())
 	r.Register(model.NewModelSetConstraintsCommand())
 	r.Register(newSyncToolsCommand())
-	r.Register(newUpgradeJujuCommand(nil))
+	r.Register(newUpgradeJujuCommand(nil, nil))
 	r.Register(application.NewUpgradeCharmCommand())
 	r.Register(application.NewUpdateSeriesCommand())
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
@@ -51,6 +52,8 @@ func syncToolsHelpText() string {
 }
 
 func (s *MainSuite) TestRunMain(c *gc.C) {
+	jujuclienttesting.SetupMinimalFileStore(c)
+
 	// The test array structure needs to be inline here as some of the
 	// expected values below use deployHelpText().  This constructs the deploy
 	// command and runs gets the help for it.  When the deploy command is

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -24,6 +24,7 @@ func newMigrateCommand() modelcmd.ModelCommand {
 // migrateCommand initiates a model migration.
 type migrateCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	newAPIRoot       func(jujuclient.ClientStore, string, string) (api.Connection, error)
 	api              migrateAPI
 	targetController string

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -37,6 +38,7 @@ func (suite *PluginSuite) SetUpTest(c *gc.C) {
 	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	suite.oldPath = os.Getenv("PATH")
 	os.Setenv("PATH", "/bin:"+gitjujutesting.HomePath())
+	jujuclienttesting.SetupMinimalFileStore(c)
 }
 
 func (suite *PluginSuite) TearDownTest(c *gc.C) {

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -21,21 +21,25 @@ import (
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
-func newDefaultRunCommand() cmd.Command {
-	return newRunCommand(time.After)
+func newDefaultRunCommand(store jujuclient.ClientStore) cmd.Command {
+	return newRunCommand(store, time.After)
 }
 
-func newRunCommand(timeAfter func(time.Duration) <-chan time.Time) cmd.Command {
-	return modelcmd.Wrap(&runCommand{
+func newRunCommand(store jujuclient.ClientStore, timeAfter func(time.Duration) <-chan time.Time) cmd.Command {
+	cmd := modelcmd.Wrap(&runCommand{
 		timeAfter: timeAfter,
 	})
+	cmd.SetClientStore(store)
+	return cmd
 }
 
 // runCommand is responsible for running arbitrary commands on remote machines.
 type runCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	out       cmd.Output
 	all       bool
 	timeout   time.Duration

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -33,7 +34,7 @@ type RunSuite struct {
 var _ = gc.Suite(&RunSuite{})
 
 func newTestRunCommand(clock clock.Clock) cmd.Command {
-	return newRunCommand(clock.After)
+	return newRunCommand(jujuclienttesting.MinimalStore(), clock.After)
 }
 
 func (*RunSuite) TestTargetArgParsing(c *gc.C) {
@@ -141,6 +142,7 @@ func (*RunSuite) TestTargetArgParsing(c *gc.C) {
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		cmd := &runCommand{}
+		cmd.SetClientStore(jujuclienttesting.MinimalStore())
 		runCmd := modelcmd.Wrap(cmd)
 		cmdtesting.TestInit(c, runCmd, test.args, test.errMatch)
 		if test.errMatch == "" {
@@ -178,6 +180,7 @@ func (*RunSuite) TestTimeoutArgParsing(c *gc.C) {
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		cmd := &runCommand{}
+		cmd.SetClientStore(jujuclienttesting.MinimalStore())
 		runCmd := modelcmd.Wrap(cmd)
 		cmdtesting.TestInit(c, runCmd, test.args, test.errMatch)
 		if test.errMatch == "" {

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -31,6 +31,7 @@ import (
 // and DebugHooksCommand.
 type SSHCommon struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	proxy           bool
 	noHostKeyChecks bool
 	Target          string

--- a/cmd/juju/commands/sshkeys.go
+++ b/cmd/juju/commands/sshkeys.go
@@ -10,6 +10,7 @@ import (
 
 type SSHKeysBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 }
 
 // NewKeyManagerClient returns a keymanager client for the root api endpoint

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -31,6 +31,7 @@ func newSyncToolsCommand() cmd.Command {
 // bucket.
 type syncToolsCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	allVersions  bool
 	versionStr   string
 	majorVersion int

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -45,6 +45,8 @@ func (s *syncToolsSuite) SetUpTest(c *gc.C) {
 	})
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/test-target": {ModelType: "iaas"}}}
 	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{
 		User: "admin",
 	}

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/jujuclient"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -62,11 +63,13 @@ Examples:
 See also: 
     sync-agent-binaries`
 
-func newUpgradeJujuCommand(minUpgradeVers map[int]version.Number, options ...modelcmd.WrapOption) cmd.Command {
+func newUpgradeJujuCommand(store jujuclient.ClientStore, minUpgradeVers map[int]version.Number, options ...modelcmd.WrapOption) cmd.Command {
 	if minUpgradeVers == nil {
 		minUpgradeVers = minMajorUpgradeVersion
 	}
-	return modelcmd.Wrap(&upgradeJujuCommand{minMajorUpgradeVersion: minUpgradeVers}, options...)
+	cmd := &upgradeJujuCommand{minMajorUpgradeVersion: minUpgradeVers}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd, options...)
 }
 
 // upgradeJujuCommand upgrades the agents in a juju installation.

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/sync"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -30,6 +32,7 @@ import (
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	supportedversion "github.com/juju/juju/juju/version"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -50,6 +53,11 @@ type UpgradeJujuSuite struct {
 
 func (s *UpgradeJujuSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	err := s.ControllerStore.UpdateModel(jujutesting.ControllerName, "admin/dummy-model", jujuclient.ModelDetails{
+		ModelType: model.IAAS,
+		ModelUUID: coretesting.ModelTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	s.resources = common.NewResources()
 	s.authoriser = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
@@ -314,6 +322,10 @@ var upgradeJujuTests = []struct {
 	expectVersion:  "1.21.3",
 }}
 
+func (s *UpgradeJujuSuite) upgradeJujuCommand(minUpgradeVers map[int]version.Number, options ...modelcmd.WrapOption) cmd.Command {
+	return newUpgradeJujuCommand(s.ControllerStore, minUpgradeVers, options...)
+}
+
 func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 	for i, test := range upgradeJujuTests {
 		c.Logf("\ntest %d: %s", i, test.about)
@@ -325,7 +337,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 		s.PatchValue(&jujuversion.Current, current.Number)
 		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
 		s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
-		com := newUpgradeJujuCommand(test.upgradeMap)
+		com := s.upgradeJujuCommand(test.upgradeMap)
 		if err := cmdtesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
 				c.Check(err, gc.ErrorMatches, test.expectInitErr)
@@ -452,7 +464,7 @@ func (s *UpgradeJujuSuite) Reset(c *gc.C) {
 func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	cmd := newUpgradeJujuCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
+	cmd := s.upgradeJujuCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
 	vers := version.Binary{
@@ -479,7 +491,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadDevAgent(c *gc.C) {
 		return fakeAPI, nil
 	})
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	cmd := newUpgradeJujuCommand(nil)
+	cmd := s.upgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
@@ -501,7 +513,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNewerClient(c *gc.C)
 		return fakeAPI, nil
 	})
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.100.0"))
-	cmd := newUpgradeJujuCommand(nil)
+	cmd := s.upgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
@@ -525,7 +537,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNonController(c *gc.
 		return fakeAPI, nil
 	})
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	cmd := newUpgradeJujuCommand(nil)
+	cmd := s.upgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, gc.ErrorMatches, "no more recent supported versions available")
 	c.Assert(fakeAPI.ignoreAgentVersions, jc.IsFalse)
@@ -534,7 +546,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNonController(c *gc.
 func (s *UpgradeJujuSuite) TestBlockUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	cmd := newUpgradeJujuCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
+	cmd := s.upgradeJujuCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockUpgradeJujuWithRealUpload")
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
@@ -554,7 +566,7 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 	s.PatchValue(&getModelConfigAPI, func(*upgradeJujuCommand) (modelConfigAPI, error) {
 		return fakeAPI, nil
 	})
-	cmd := newUpgradeJujuCommand(nil)
+	cmd := s.upgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent", "-m", "dummy-model")
 	c.Assert(err, gc.ErrorMatches, "--build-agent can only be used with the controller model")
 }
@@ -574,7 +586,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithIgnoreAgentVersions(c *gc.C) {
 		return fakeAPI, nil
 	})
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.100.0"))
-	cmd := newUpgradeJujuCommand(nil)
+	cmd := s.upgradeJujuCommand(nil)
 	_, err := cmdtesting.RunCommand(c, cmd, "--ignore-agent-versions")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
@@ -640,7 +652,7 @@ upgrade to this version by running
 
 		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
 
-		com := newUpgradeJujuCommand(nil)
+		com := s.upgradeJujuCommand(nil)
 		err := cmdtesting.InitCommand(com, test.cmdArgs)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -784,12 +796,12 @@ func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
 
 		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
 
-		com := newUpgradeJujuCommand(test.upgradeMap)
-		err := cmdtesting.InitCommand(com, test.cmdArgs)
+		cmd := s.upgradeJujuCommand(test.upgradeMap)
+		err := cmdtesting.InitCommand(cmd, test.cmdArgs)
 		c.Assert(err, jc.ErrorIsNil)
 
 		ctx := cmdtesting.Context(c)
-		err = com.Run(ctx)
+		err = cmd.Run(ctx)
 		if test.expectedErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectedErr)
 		} else if !c.Check(err, jc.ErrorIsNil) {

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -148,7 +148,7 @@ func runInCommand(c *gc.C, run func(ctx *cmd.Context, base *modelcmd.ModelComman
 	cmd := &testCommand{
 		run: run,
 	}
-	cmd.SetClientStore(jujuclient.NewMemStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	cmd.SetAPIOpen(func(*api.Info, api.DialOpts) (api.Connection, error) {
 		return nil, errors.New("no API available")
 	})
@@ -168,5 +168,7 @@ func (c *testCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *testCommand) Info() *cmd.Info {
-	panic("unexpected call to Info")
+	return &cmd.Info{
+		Name: "test",
+	}
 }

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -29,7 +30,7 @@ func (s *baseControllerSuite) SetUpTest(c *gc.C) {
 	s.controllersYaml = testControllersYaml
 	s.modelsYaml = testModelsYaml
 	s.accountsYaml = testAccountsYaml
-	s.store = nil
+	s.store = jujuclienttesting.MinimalStore()
 }
 
 func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclient.MemStore {

--- a/cmd/juju/firewall/export_test.go
+++ b/cmd/juju/firewall/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 func NewListRulesCommandForTest(
@@ -17,6 +18,7 @@ func NewListRulesCommandForTest(
 			return api, nil
 		},
 	}
+	aCmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(aCmd)
 }
 
@@ -28,5 +30,6 @@ func NewSetRulesCommandForTest(
 			return api, nil
 		},
 	}
+	aCmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(aCmd)
 }

--- a/cmd/juju/firewall/listrules.go
+++ b/cmd/juju/firewall/listrules.go
@@ -43,6 +43,7 @@ func NewListFirewallRulesCommand() cmd.Command {
 
 type listFirewallRulesCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	out cmd.Output
 
 	newAPIFunc func() (ListFirewallRulesAPI, error)

--- a/cmd/juju/firewall/setrule.go
+++ b/cmd/juju/firewall/setrule.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 
 	"fmt"
+
 	"github.com/juju/juju/api/firewallrules"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
@@ -52,6 +53,7 @@ func NewSetFirewallRuleCommand() cmd.Command {
 
 type setFirewallRuleCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	service        string
 	whitelistValue string
 

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -98,7 +98,7 @@ func NewAddCommand() cmd.Command {
 
 // addCommand starts a new machine and registers it in the model.
 type addCommand struct {
-	modelcmd.ModelCommandBase
+	baseMachinesCommand
 	api               AddMachineAPI
 	modelConfigAPI    ModelConfigAPI
 	machineManagerAPI MachineManagerAPI

--- a/cmd/juju/machine/base.go
+++ b/cmd/juju/machine/base.go
@@ -22,9 +22,14 @@ type statusAPI interface {
 	Close() error
 }
 
+type baseMachinesCommand struct {
+	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
+}
+
 // baseMachineCommand provides access to information about machines in a model.
 type baselistMachinesCommand struct {
-	modelcmd.ModelCommandBase
+	baseMachinesCommand
 	out           cmd.Output
 	isoTime       bool
 	api           statusAPI
@@ -35,7 +40,7 @@ type baselistMachinesCommand struct {
 
 // SetFlags sets utc and format flags based on user specified options.
 func (c *baselistMachinesCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
+	c.baseMachinesCommand.SetFlags(f)
 	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
 	f.BoolVar(&c.color, "color", false, "Force use of ANSI color codes")
 	c.out.AddFlags(f, c.defaultFormat, map[string]cmd.Formatter{

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/storage"
 )
 
@@ -26,18 +27,21 @@ func NewAddCommandForTest(api AddMachineAPI, mcAPI ModelConfigAPI, mmAPI Machine
 		machineManagerAPI: mmAPI,
 		modelConfigAPI:    mcAPI,
 	}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd), &AddCommand{cmd}
 }
 
 // NewListCommandForTest returns a listMachineCommand with specified api
 func NewListCommandForTest(api statusAPI) cmd.Command {
 	cmd := newListMachinesCommand(api)
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd)
 }
 
 // NewShowCommandForTest returns a showMachineCommand with specified api
 func NewShowCommandForTest(api statusAPI) cmd.Command {
 	cmd := newShowMachineCommand(api)
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd)
 }
 
@@ -51,6 +55,7 @@ func NewRemoveCommandForTest(apiRoot api.Connection, machineAPI RemoveMachineAPI
 		apiRoot:    apiRoot,
 		machineAPI: machineAPI,
 	}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd), &RemoveCommand{cmd}
 }
 

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -23,7 +23,7 @@ func NewRemoveCommand() cmd.Command {
 
 // removeCommand causes an existing machine to be destroyed.
 type removeCommand struct {
-	modelcmd.ModelCommandBase
+	baseMachinesCommand
 	apiRoot      api.Connection
 	machineAPI   RemoveMachineAPI
 	MachineIds   []string

--- a/cmd/juju/metricsdebug/collectmetrics_test.go
+++ b/cmd/juju/metricsdebug/collectmetrics_test.go
@@ -310,7 +310,7 @@ func (s *collectMetricsSuite) TestCollectMetrics(c *gc.C) {
 			runClient.results = test.results
 		}
 		metricsdebug.PatchGetActionResult(s.PatchValue, test.actionMap)
-		ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommand(), test.args...)
+		ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommandForTest(), test.args...)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		} else {
@@ -327,7 +327,7 @@ func (s *collectMetricsSuite) TestCollectMetricsFailsOnNonLocalCharm(c *gc.C) {
 	s.PatchValue(metricsdebug.NewAPIConn, noConn)
 	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
 	s.PatchValue(metricsdebug.NewServiceClient, metricsdebug.NewServiceClientFnc(serviceClient))
-	_, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommand(), "foobar")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommandForTest(), "foobar")
 	c.Assert(err, gc.ErrorMatches, `"foobar" is not a local charm`)
 	runClient.CheckCallNames(c, "Close")
 }

--- a/cmd/juju/metricsdebug/export_test.go
+++ b/cmd/juju/metricsdebug/export_test.go
@@ -7,8 +7,12 @@ import (
 	"errors"
 	"time"
 
+	"github.com/juju/cmd"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 var (
@@ -43,4 +47,16 @@ func PatchGetActionResult(patchValue func(interface{}, interface{}), actions map
 		}
 		return params.ActionResult{}, errors.New("plm")
 	})
+}
+
+func NewCollectMetricsCommandForTest() cmd.Command {
+	cmd := &collectMetricsCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(cmd)
+}
+
+func NewMetricsCommandForTest() cmd.Command {
+	cmd := &MetricsCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(cmd)
 }

--- a/cmd/juju/metricsdebug/metrics_test.go
+++ b/cmd/juju/metricsdebug/metrics_test.go
@@ -83,7 +83,7 @@ func (s *metricsSuite) TestSort(c *gc.C) {
 		Labels: map[string]string{"foo": "bar"},
 		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 	}}
-	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE	  LABELS
@@ -107,7 +107,7 @@ func (s *metricsSuite) TestDefaultTabularFormat(c *gc.C) {
 		Value: "5.0",
 		Time:  time.Date(2016, 8, 22, 12, 02, 03, 0, time.UTC),
 	}}
-	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "metered/0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"unit-metered-0"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `UNIT          	           TIMESTAMP	METRIC	VALUE	LABELS
@@ -134,7 +134,7 @@ func (s *metricsSuite) TestJSONFormat(c *gc.C) {
 		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 		Labels: map[string]string{"foo": "bar"},
 	}}
-	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "json")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "metered", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"application-metered"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:03Z","metric":"pings","value":"5.0"},{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:04Z","metric":"pongs","value":"15.0"},{"unit":"unit-metered-0","timestamp":"2016-08-22T12:02:04Z","metric":"pongs","value":"10.0","labels":{"foo":"bar"}}]
@@ -159,7 +159,7 @@ func (s *metricsSuite) TestYAMLFormat(c *gc.C) {
 		Time:   time.Date(2016, 8, 22, 12, 02, 04, 0, time.UTC),
 		Labels: map[string]string{"foo": "bar"},
 	}}
-	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "metered", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string{"application-metered"})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `- unit: unit-metered-0
@@ -180,28 +180,28 @@ func (s *metricsSuite) TestYAMLFormat(c *gc.C) {
 }
 
 func (s *metricsSuite) TestAll(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.CheckCall(c, 0, "GetMetrics", []string(nil))
 }
 
 func (s *metricsSuite) TestAllWithExtraArgs(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "--all", "metered")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "--all", "metered")
 	c.Assert(err, gc.ErrorMatches, "cannot use --all with additional entities")
 }
 
 func (s *metricsSuite) TestInvalidUnitName(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered-/0")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "metered-/0")
 	c.Assert(err, gc.ErrorMatches, `"metered-/0" is not a valid unit or application`)
 }
 
 func (s *metricsSuite) TestAPIClientError(c *gc.C) {
 	s.client.SetErrors(errors.New("a silly error"))
-	_, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered/0")
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest(), "metered/0")
 	c.Assert(err, gc.ErrorMatches, `a silly error`)
 }
 
 func (s *metricsSuite) TestNoArgs(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, metricsdebug.New())
+	_, err := cmdtesting.RunCommand(c, metricsdebug.NewMetricsCommandForTest())
 	c.Assert(err, gc.ErrorMatches, "you need to specify at least one unit or application")
 }

--- a/cmd/juju/model/constraints.go
+++ b/cmd/juju/model/constraints.go
@@ -80,6 +80,7 @@ func NewModelGetConstraintsCommand() cmd.Command {
 // modelGetConstraintsCommand shows the constraints for a model.
 type modelGetConstraintsCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	out cmd.Output
 	api ConstraintsAPI
 }
@@ -139,6 +140,7 @@ func NewModelSetConstraintsCommand() cmd.Command {
 // modelSetConstraintsCommand sets the constraints for a model.
 type modelSetConstraintsCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	api         ConstraintsAPI
 	Constraints constraints.Value
 }

--- a/cmd/juju/model/constraints_test.go
+++ b/cmd/juju/model/constraints_test.go
@@ -33,7 +33,7 @@ func (s *ModelConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 			args: []string{"cpu-power=250"},
 		},
 	} {
-		err := cmdtesting.InitCommand(model.NewModelSetConstraintsCommand(), test.args)
+		err := cmdtesting.InitCommand(model.NewModelSetConstraintsCommandForTest(), test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -57,7 +57,7 @@ func (s *ModelConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 			args: []string{},
 		},
 	} {
-		err := cmdtesting.InitCommand(model.NewModelGetConstraintsCommand(), test.args)
+		err := cmdtesting.InitCommand(model.NewModelGetConstraintsCommandForTest(), test.args)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 // NewConfigCommandForTest returns a configCommand with the api
@@ -20,6 +21,7 @@ func NewConfigCommandForTest(api configCommandAPI) cmd.Command {
 	cmd := &configCommand{
 		api: api,
 	}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd)
 }
 
@@ -39,6 +41,7 @@ func NewRetryProvisioningCommandForTest(api RetryProvisioningAPI) cmd.Command {
 	cmd := &retryProvisioningCommand{
 		api: api,
 	}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd)
 }
 
@@ -113,6 +116,18 @@ func NewRevokeCommandForTest(modelsApi RevokeModelAPI, offersAPI RevokeOfferAPI,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(cmd), &RevokeCommand{cmd}
+}
+
+func NewModelSetConstraintsCommandForTest() cmd.Command {
+	cmd := &modelSetConstraintsCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(cmd)
+}
+
+func NewModelGetConstraintsCommandForTest() cmd.Command {
+	cmd := &modelGetConstraintsCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(cmd)
 }
 
 var GetBudgetAPIClient = &getBudgetAPIClient

--- a/cmd/juju/model/retryprovisioning.go
+++ b/cmd/juju/model/retryprovisioning.go
@@ -23,6 +23,7 @@ func NewRetryProvisioningCommand() cmd.Command {
 // the provisoner that it should try to re-provision the machine.
 type retryProvisioningCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	Machines []names.MachineTag
 	api      RetryProvisioningAPI
 }

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -69,7 +69,7 @@ func (s *CharmResourcesSuite) TestOkay(c *gc.C) {
 	resources[0].Revision = 2
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
-	command := resourcecmd.NewCharmResourcesCommand(s.client)
+	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -94,7 +94,7 @@ website   2
 func (s *CharmResourcesSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
-	command := resourcecmd.NewCharmResourcesCommand(s.client)
+	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -165,7 +165,7 @@ website   1
 	}
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
-		command := resourcecmd.NewCharmResourcesCommand(s.client)
+		command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
 		args := []string{
 			"--format", format,
 			"cs:a-charm",
@@ -188,7 +188,7 @@ func (s *CharmResourcesSuite) TestChannelFlag(c *gc.C) {
 		charmRes(c, "music", ".mp3", "mp3 of your backing vocals", string(fp2.Bytes())),
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
-	command := resourcecmd.NewCharmResourcesCommand(s.client)
+	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",

--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -5,6 +5,7 @@ package resource
 
 import (
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 func ListCharmResourcesCommandChannel(c modelcmd.Command) string {
@@ -30,3 +31,29 @@ func UploadCommandService(c *UploadCommand) string {
 }
 
 var FormatApplicationResources = formatApplicationResources
+
+func NewCharmResourcesCommandForTest(resourceLister ResourceLister) modelcmd.ModelCommand {
+	var c CharmResourcesCommand
+	c.setResourceLister(resourceLister)
+	c.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(&c)
+}
+
+func NewListCharmResourcesCommandForTest(resourceLister ResourceLister) modelcmd.ModelCommand {
+	var c ListCharmResourcesCommand
+	c.setResourceLister(resourceLister)
+	c.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(&c)
+}
+
+func NewUploadCommandForTest(deps UploadDeps) *UploadCommand {
+	cmd := &UploadCommand{deps: deps}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return cmd
+}
+
+func NewListCommandForTest(deps ListDeps) *ListCommand {
+	cmd := &ListCommand{deps: deps}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return cmd
+}

--- a/cmd/juju/resource/list_charm_resources_test.go
+++ b/cmd/juju/resource/list_charm_resources_test.go
@@ -70,7 +70,7 @@ func (s *ListCharmSuite) TestOkay(c *gc.C) {
 	resources[0].Revision = 2
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
-	command := resourcecmd.NewListCharmResourcesCommand(s.client)
+	command := resourcecmd.NewListCharmResourcesCommandForTest(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -95,7 +95,7 @@ website   2
 func (s *ListCharmSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
-	command := resourcecmd.NewListCharmResourcesCommand(s.client)
+	command := resourcecmd.NewListCharmResourcesCommandForTest(s.client)
 	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
 	c.Check(code, gc.Equals, 0)
 
@@ -166,7 +166,7 @@ website   1
 	}
 	for format, expected := range formats {
 		c.Logf("checking format %q", format)
-		command := resourcecmd.NewListCharmResourcesCommand(s.client)
+		command := resourcecmd.NewListCharmResourcesCommandForTest(s.client)
 		args := []string{
 			"--format", format,
 			"cs:a-charm",
@@ -189,7 +189,7 @@ func (s *ListCharmSuite) TestChannelFlag(c *gc.C) {
 		charmRes(c, "music", ".mp3", "mp3 of your backing vocals", string(fp2.Bytes())),
 	}
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
-	command := resourcecmd.NewListCharmResourcesCommand(s.client)
+	command := resourcecmd.NewListCharmResourcesCommandForTest(s.client)
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",

--- a/cmd/juju/resource/list_test.go
+++ b/cmd/juju/resource/list_test.go
@@ -37,21 +37,21 @@ func (s *ShowServiceSuite) SetUpTest(c *gc.C) {
 }
 
 func (*ShowServiceSuite) TestInitEmpty(c *gc.C) {
-	s := resourcecmd.ListCommand{}
+	s := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{})
 
 	err := s.Init([]string{})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*ShowServiceSuite) TestInitGood(c *gc.C) {
-	s := resourcecmd.ListCommand{}
+	s := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{})
 	err := s.Init([]string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resourcecmd.ListCommandTarget(&s), gc.Equals, "foo")
+	c.Assert(resourcecmd.ListCommandTarget(s), gc.Equals, "foo")
 }
 
 func (*ShowServiceSuite) TestInitTooManyArgs(c *gc.C) {
-	s := resourcecmd.ListCommand{}
+	s := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{})
 
 	err := s.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
@@ -78,7 +78,7 @@ func (s *ShowServiceSuite) TestRunNoResourcesForService(c *gc.C) {
 	data := []resource.ServiceResources{resource.ServiceResources{}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 
@@ -179,7 +179,7 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 	}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 
@@ -207,7 +207,7 @@ func (s *ShowServiceSuite) TestRunNoResourcesForUnit(c *gc.C) {
 	data := []resource.ServiceResources{resource.ServiceResources{}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 
@@ -256,7 +256,7 @@ func (s *ShowServiceSuite) TestRunResourcesForAppButNoResourcesForUnit(c *gc.C) 
 	}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 
@@ -337,7 +337,7 @@ func (s *ShowServiceSuite) TestRunUnit(c *gc.C) {
 		}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 
@@ -498,7 +498,7 @@ func (s *ShowServiceSuite) TestRunDetails(c *gc.C) {
 	}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 
@@ -635,7 +635,7 @@ func (s *ShowServiceSuite) TestRunUnitDetails(c *gc.C) {
 	}}
 	s.stubDeps.client.ReturnResources = data
 
-	cmd := resourcecmd.NewListCommand(resourcecmd.ListDeps{
+	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
 		NewClient: s.stubDeps.NewClient,
 	})
 

--- a/cmd/juju/resource/upload_test.go
+++ b/cmd/juju/resource/upload_test.go
@@ -40,46 +40,46 @@ func (*UploadSuite) TestInitEmpty(c *gc.C) {
 }
 
 func (*UploadSuite) TestInitOneArg(c *gc.C) {
-	var u resourcecmd.UploadCommand
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{})
 	err := u.Init([]string{"foo"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitJustName(c *gc.C) {
-	var u resourcecmd.UploadCommand
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{})
 
 	err := u.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitNoName(c *gc.C) {
-	var u resourcecmd.UploadCommand
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{})
 
 	err := u.Init([]string{"foo", "=foobar"})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitNoPath(c *gc.C) {
-	var u resourcecmd.UploadCommand
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{})
 
 	err := u.Init([]string{"foo", "foobar="})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitGood(c *gc.C) {
-	var u resourcecmd.UploadCommand
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{})
 
 	err := u.Init([]string{"foo", "bar=baz"})
 	c.Assert(err, jc.ErrorIsNil)
-	svc, name, filename := resourcecmd.UploadCommandResourceFile(&u)
+	svc, name, filename := resourcecmd.UploadCommandResourceFile(u)
 	c.Assert(svc, gc.Equals, "foo")
 	c.Assert(name, gc.Equals, "bar")
 	c.Assert(filename, gc.Equals, "baz")
-	c.Assert(resourcecmd.UploadCommandService(&u), gc.Equals, "foo")
+	c.Assert(resourcecmd.UploadCommandService(u), gc.Equals, "foo")
 }
 
 func (*UploadSuite) TestInitTwoResources(c *gc.C) {
-	var u resourcecmd.UploadCommand
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{})
 
 	err := u.Init([]string{"foo", "bar=baz", "fizz=buzz"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
@@ -104,7 +104,7 @@ used as a resource for an application.
 func (s *UploadSuite) TestRun(c *gc.C) {
 	file := &stubFile{stub: s.stub}
 	s.stubDeps.file = file
-	u := resourcecmd.NewUploadCommand(resourcecmd.UploadDeps{
+	u := resourcecmd.NewUploadCommandForTest(resourcecmd.UploadDeps{
 		NewClient:    s.stubDeps.NewClient,
 		OpenResource: s.stubDeps.OpenResource,
 	},

--- a/cmd/juju/setmeterstatus/export_test.go
+++ b/cmd/juju/setmeterstatus/export_test.go
@@ -3,4 +3,17 @@
 
 package setmeterstatus
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
 var NewClient = &newClient
+
+func NewCommandForTest(store jujuclient.ClientStore) cmd.Command {
+	cmd := &SetMeterStatusCommand{}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -91,7 +91,7 @@ func (s *BaseSpaceSuite) newCommandForTest() modelcmd.ModelCommand {
 	cmd := s.newCommand()
 	// The client store shouldn't be used, but mock it
 	// out to make sure.
-	cmd.SetClientStore(jujuclient.NewMemStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	cmd1 := modelcmd.InnerCommand(cmd).(interface {
 		SetAPI(space.SpaceAPI)
 	})

--- a/cmd/juju/space/space.go
+++ b/cmd/juju/space/space.go
@@ -58,6 +58,7 @@ var logger = loggo.GetLogger("juju.cmd.juju.space")
 // subcommands.
 type SpaceCommandBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	api SpaceAPI
 }
 

--- a/cmd/juju/storage/attach_test.go
+++ b/cmd/juju/storage/attach_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type AttachStorageSuite struct {
@@ -25,7 +26,7 @@ func (s *AttachStorageSuite) TestAttach(c *gc.C) {
 		{},
 		{},
 	}}
-	cmd := storage.NewAttachStorageCommand(fake.new)
+	cmd := storage.NewAttachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1", "baz/2")
 	c.Assert(err, jc.ErrorIsNil)
 	fake.CheckCallNames(c, "NewEntityAttacherCloser", "Attach", "Close")
@@ -41,7 +42,7 @@ func (s *AttachStorageSuite) TestAttachError(c *gc.C) {
 		{Error: &params.Error{Message: "foo"}},
 		{Error: &params.Error{Message: "bar"}},
 	}}
-	attachCmd := storage.NewAttachStorageCommand(fake.new)
+	attachCmd := storage.NewAttachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, attachCmd, "baz/0", "qux/1", "quux/2")
 	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `failed to attach qux/1 to baz/0: foo
@@ -53,7 +54,7 @@ failed to attach quux/2 to baz/0: bar
 func (s *AttachStorageSuite) TestAttachUnauthorizedError(c *gc.C) {
 	var fake fakeEntityAttacher
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
-	cmd := storage.NewAttachStorageCommand(fake.new)
+	cmd := storage.NewAttachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1")
 	c.Assert(err, gc.ErrorMatches, "nope")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
@@ -69,7 +70,7 @@ func (s *AttachStorageSuite) TestAttachInitErrors(c *gc.C) {
 }
 
 func (s *AttachStorageSuite) testAttachInitError(c *gc.C, args []string, expect string) {
-	cmd := storage.NewAttachStorageCommand(nil)
+	cmd := storage.NewAttachStorageCommandForTest(nil, jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/cmd/juju/storage/detach_test.go
+++ b/cmd/juju/storage/detach_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type DetachStorageSuite struct {
@@ -25,7 +26,7 @@ func (s *DetachStorageSuite) TestDetach(c *gc.C) {
 		{},
 		{},
 	}}
-	cmd := storage.NewDetachStorageCommand(fake.new)
+	cmd := storage.NewDetachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1")
 	c.Assert(err, jc.ErrorIsNil)
 	fake.CheckCallNames(c, "NewEntityDetacherCloser", "Detach", "Close")
@@ -41,7 +42,7 @@ func (s *DetachStorageSuite) TestDetachError(c *gc.C) {
 		{Error: &params.Error{Message: "foo"}},
 		{Error: &params.Error{Message: "bar"}},
 	}}
-	detachCmd := storage.NewDetachStorageCommand(fake.new)
+	detachCmd := storage.NewDetachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, detachCmd, "baz/0", "qux/1")
 	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `failed to detach baz/0: foo
@@ -53,7 +54,7 @@ failed to detach qux/1: bar
 func (s *DetachStorageSuite) TestDetachUnauthorizedError(c *gc.C) {
 	var fake fakeEntityDetacher
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
-	cmd := storage.NewDetachStorageCommand(fake.new)
+	cmd := storage.NewDetachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0")
 	c.Assert(err, gc.ErrorMatches, "nope")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
@@ -68,7 +69,7 @@ func (s *DetachStorageSuite) TestDetachInitErrors(c *gc.C) {
 }
 
 func (s *DetachStorageSuite) testDetachInitError(c *gc.C, args []string, expect string) {
-	cmd := storage.NewDetachStorageCommand(nil)
+	cmd := storage.NewDetachStorageCommandForTest(nil, jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/cmd/juju/storage/export_test.go
+++ b/cmd/juju/storage/export_test.go
@@ -54,3 +54,24 @@ func NewAddCommandForTest(api StorageAddAPI, store jujuclient.ClientStore) cmd.C
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
+
+func NewRemoveStorageCommandForTest(new NewStorageRemoverCloserFunc, store jujuclient.ClientStore) cmd.Command {
+	cmd := &removeStorageCommand{}
+	cmd.SetClientStore(store)
+	cmd.newStorageRemoverCloser = new
+	return modelcmd.Wrap(cmd)
+}
+
+func NewAttachStorageCommandForTest(new NewEntityAttacherCloserFunc, store jujuclient.ClientStore) cmd.Command {
+	cmd := &attachStorageCommand{}
+	cmd.SetClientStore(store)
+	cmd.newEntityAttacherCloser = new
+	return modelcmd.Wrap(cmd)
+}
+
+func NewDetachStorageCommandForTest(new NewEntityDetacherCloserFunc, store jujuclient.ClientStore) cmd.Command {
+	cmd := &detachStorageCommand{}
+	cmd.SetClientStore(store)
+	cmd.newEntityDetacherCloser = new
+	return modelcmd.Wrap(cmd)
+}

--- a/cmd/juju/storage/package_test.go
+++ b/cmd/juju/storage/package_test.go
@@ -42,6 +42,12 @@ func (s *SubStorageSuite) SetUpTest(c *gc.C) {
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Models["testing"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/controller": {},
+		},
+		CurrentModel: "admin/controller",
+	}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{
 		User: "admin",
 	}

--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -35,7 +35,7 @@ func (s *poolListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *poolListSuite) runPoolList(c *gc.C, args []string) (*cmd.Context, error) {
-	args = append(args, []string{"-m", "admin"}...)
+	args = append(args, []string{"-m", "controller"}...)
 	return cmdtesting.RunCommand(c, storage.NewPoolListCommandForTest(s.mockAPI, s.store), args...)
 }
 

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -23,14 +23,6 @@ func NewRemoveStorageCommandWithAPI() cmd.Command {
 	return modelcmd.Wrap(cmd)
 }
 
-// NewRemoveStorageCommand returns a command
-// used to remove storage from the model.
-func NewRemoveStorageCommand(new NewStorageRemoverCloserFunc) cmd.Command {
-	cmd := &removeStorageCommand{}
-	cmd.newStorageRemoverCloser = new
-	return modelcmd.Wrap(cmd)
-}
-
 const (
 	removeStorageCommandDoc = `
 Removes storage from the model. Specify one or more

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -20,6 +20,7 @@ import (
 // storage managing client.
 type StorageCommandBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 }
 
 // NewStorageAPI returns a storage api for the root api endpoint

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -85,9 +85,7 @@ func (s *BaseSubnetSuite) RunCommand(c *gc.C, args ...string) (string, string, e
 
 func (s *BaseSubnetSuite) newCommandForTest() modelcmd.ModelCommand {
 	cmd := s.newCommand()
-	// The client store shouldn't be used, but mock it
-	// out to make sure.
-	cmd.SetClientStore(jujuclient.NewMemStore())
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	cmd1 := modelcmd.InnerCommand(cmd).(interface {
 		SetAPI(subnet.SubnetAPI)
 	})

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -74,6 +74,7 @@ var logger = loggo.GetLogger("juju.cmd.juju.subnet")
 // subcommands.
 type SubnetCommandBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	api SubnetAPI
 }
 

--- a/cmd/plugins/juju-metadata/addimage_test.go
+++ b/cmd/plugins/juju-metadata/addimage_test.go
@@ -14,6 +14,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type addImageSuite struct {
@@ -132,7 +134,9 @@ func (s *addImageSuite) assertValidAddImageMetadata(c *gc.C, m params.CloudImage
 }
 
 func runAddImageMetadata(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, newAddImageMetadataCommand(), args...)
+	cmd := &addImageMetadataCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
 }
 
 func (s *addImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMetadata, msg string) {

--- a/cmd/plugins/juju-metadata/deleteimage_test.go
+++ b/cmd/plugins/juju-metadata/deleteimage_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 const deleteTestId = "tst12345"
@@ -61,6 +62,7 @@ func (s *deleteImageSuite) TestDeleteImageMetadataFailed(c *gc.C) {
 
 func (s *deleteImageSuite) runDeleteImageMetadata(c *gc.C, args ...string) error {
 	tstDelete := &deleteImageMetadataCommand{}
+	tstDelete.SetClientStore(jujuclienttesting.MinimalStore())
 	tstDelete.newAPIFunc = func() (MetadataDeleteAPI, error) {
 		return s.mockAPI, nil
 	}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -25,6 +25,7 @@ import (
 
 type imageMetadataCommandBase struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 }
 
 func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Environ, error) {

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -42,7 +43,7 @@ func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.dir = c.MkDir()
 
-	s.store = jujuclient.NewMemStore()
+	s.store = jujuclienttesting.MinimalStore()
 	cacheTestEnvConfig(c, s.store)
 
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "access")

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -14,7 +14,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -33,6 +36,14 @@ func (s *BaseCloudImageMetadataSuite) setupBaseSuite(c *gc.C) {
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Models["testing"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/controller": {
+				ModelType: model.IAAS,
+			},
+		},
+		CurrentModel: "admin/controller",
+	}
 	s.store.Accounts["testing"] = jujuclient.AccountDetails{
 		User: "admin",
 	}
@@ -58,7 +69,9 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 }
 
 func runList(c *gc.C, args []string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, newListImagesCommand(), args...)
+	cmd := &listImagesCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), args...)
 }
 
 func (s *ListSuite) TestListDefault(c *gc.C) {

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -29,6 +29,7 @@ func newToolsMetadataCommand() cmd.Command {
 // toolsMetadataCommand is used to generate simplestreams metadata for juju agents.
 type toolsMetadataCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	fetch       bool
 	metadataDir string
 	stream      string

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -99,7 +100,7 @@ func (s *ValidateToolsMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.metadataDir = c.MkDir()
 
-	s.store = jujuclient.NewMemStore()
+	s.store = jujuclienttesting.MinimalStore()
 	cacheTestEnvConfig(c, s.store)
 
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "access")

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -547,7 +547,7 @@ func (s *crossmodelSuite) TestConsumeWithPermission(c *gc.C) {
 	s.createTestUser(c)
 	s.loginTestUser(c)
 	ctx, err := cmdtesting.RunCommand(c, application.NewConsumeCommand(),
-		"otheruser/othermodel.hosted-mysql")
+		"-m", "admin/controller", "otheruser/othermodel.hosted-mysql")
 	c.Assert(err, gc.ErrorMatches, `application offer "otheruser/othermodel.hosted-mysql" not found`)
 
 	s.loginAdminUser(c)
@@ -569,6 +569,7 @@ func (s *crossmodelSuite) TestRemoveSaas(c *gc.C) {
 	s.addOtherModelApplication(c)
 	_, err := cmdtesting.RunCommand(c, application.NewConsumeCommand(),
 		"otheruser/othermodel.hosted-mysql")
+	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = cmdtesting.RunCommand(c, application.NewRemoveSaasCommand(),
 		"-m", "admin/controller", "hosted-mysql")

--- a/jujuclient/jujuclienttesting/simple.go
+++ b/jujuclient/jujuclienttesting/simple.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclienttesting
+
+import (
+	"github.com/juju/juju/core/model"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/jujuclient"
+)
+
+// MinimalStore returns a simple store that can be used
+// with CLI commands under test.
+func MinimalStore() *jujuclient.MemStore {
+	store := jujuclient.NewMemStore()
+	store.CurrentControllerName = "arthur"
+	store.Controllers["arthur"] = jujuclient.ControllerDetails{}
+	store.Models["arthur"] = &jujuclient.ControllerModels{
+		CurrentModel: "king/sword",
+		Models: map[string]jujuclient.ModelDetails{"king/sword": {
+			ModelType: model.IAAS,
+		}},
+	}
+	store.Accounts["arthur"] = jujuclient.AccountDetails{
+		User: "king",
+	}
+	return store
+}
+
+// SetupMinimalFileStore creates a minimal file backed Juju
+// ClientStore in the current XDG Juju directory.
+func SetupMinimalFileStore(c *gc.C) {
+	store := MinimalStore()
+	err := jujuclient.WriteControllersFile(&jujuclient.Controllers{
+		Controllers:       store.Controllers,
+		CurrentController: store.CurrentControllerName,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = jujuclient.WriteModelsFile(store.Models)
+	c.Assert(err, jc.ErrorIsNil)
+	err = jujuclient.WriteAccountsFile(store.Accounts)
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
## Description of change

We need to gracefully reject IAAS only commands run on a CAAS model.
There's 2 commits here owing to the testing fallout caused by the change.
Commit 1: introduce a marker interface which is embedded in IAAS only commands. The base model command determines the model type and rejects IAAS only commands on CAAS models. The lookup of model type is done as early as possible, starting with during Init(). This allows the user to get feedback ASAP that the command isn;t suitable, even if they haven't supplied all required args etc This resulted in some refactoring of how client store etc was obtained. There was a large test fallout.
Commit 2: fix all the failing tests. The main requirement was to ensure a valid client store was available for all commands, even for tests which only called Init().

## QA steps

Run up both a CAAS and IAAS model. Ensure common commands work across both models, and IAAS only commands fail on the CAAS model. Use combinations of -m <model> and switch etc to test different model selection scenarios.

