### PR TITLE
Allow passing agent stream to upgrade-model.

### DIFF
--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 
 import argparse
 import logging
+import re
 import sys
 
 from collections import (
@@ -26,6 +27,9 @@ from utility import (
     )
 from textwrap import (
     dedent,
+)
+from deploy_stack import (
+    BootstrapManager
 )
 from jujupy.binaries import (
     get_stable_juju
@@ -74,22 +78,60 @@ def assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client):
                 'agent-stream': 'released'
             })
             with stable_bsm.booted_context(False):
-                assert_stable_model_is_correct(stable_client)
-
-                deploy_mediawiki_with_db(stable_client)
-                assert_mediawiki_is_responding(stable_client)
-                upgrade_stable_to_devel_version(devel_client)
-                assert_mediawiki_is_responding(devel_client)
+                assert_upgrade_is_successful(stable_client, devel_client)
 
 
-def upgrade_stable_to_devel_version(client):
+def assess_upgrade_passing_agent_stream(args, devel_client):
+    # Use the same devel juju to ensure this feature is supported.
+    stable_bsm = BootstrapManager.from_client(args, devel_client)
+    stable_client = stable_bsm.client
+    devel_version_parts = get_version_parts(devel_client.version)
+    forced_devel_client = devel_client.clone(
+        version='{vers}-{series}-{arch}'.format(
+            vers=increment_version(devel_client.version),
+            series=devel_version_parts.series,
+            arch=devel_version_parts.arch))
+    with temp_dir() as base_dir:
+        stream_server = StreamServer(base_dir)
+        setup_agent_metadata(
+            stream_server, args.devel_juju_agent,
+            stable_client, base_dir, 'released')
+        setup_agent_metadata(
+            stream_server, args.devel_juju_agent,
+            forced_devel_client, base_dir, 'proposed',
+            force_version=True)
+        with stream_server.server() as url:
+            stable_client.env.update_config({
+                'agent-metadata-url': url,
+                'agent-stream': 'released'
+            })
+            with stable_bsm.booted_context(False):
+                assert_upgrade_is_successful(
+                    stable_client,
+                    forced_devel_client,
+                    ('--agent-stream', 'proposed'))
+
+
+def assert_upgrade_is_successful(
+        stable_client, devel_client, extra_upgrade_args=()):
+    if not isinstance(extra_upgrade_args, tuple):
+        raise ValueError("extra_upgrade_args must be a tuple")
+    assert_stable_model_is_correct(stable_client)
+
+    deploy_mediawiki_with_db(stable_client)
+    assert_mediawiki_is_responding(stable_client)
+    upgrade_stable_to_devel_version(devel_client, extra_upgrade_args)
+    assert_mediawiki_is_responding(devel_client)
+
+
+def upgrade_stable_to_devel_version(client, extra_args):
     devel_version = get_stripped_version_number(client.version)
     client.get_controller_client().juju(
-        'upgrade-juju', ('-m', 'controller', '--debug'))
+        'upgrade-juju', ('-m', 'controller', '--debug') + extra_args)
     assert_model_is_version(client.get_controller_client(), devel_version)
     wait_until_model_upgrades(client)
 
-    client.juju('upgrade-juju', ('--debug'))
+    client.juju('upgrade-juju', ('--debug',) + extra_args)
     assert_model_is_version(client, devel_version)
     wait_until_model_upgrades(client)
 
@@ -110,11 +152,15 @@ def assert_model_is_version(client, expected_version, timeout=600):
     client.wait_for(WaitModelVersion(expected_version, timeout))
 
 
-def setup_agent_metadata(stream_server, agent, client, tmp_dir, stream):
+def setup_agent_metadata(
+        stream_server, agent, client, tmp_dir, stream, force_version=False):
     version_parts = get_version_parts(client.version)
 
     if agent is None:
-        agent_details = agent_tgz_from_juju_binary(client.full_path, tmp_dir)
+        agent_details = agent_tgz_from_juju_binary(
+            client.full_path,
+            tmp_dir,
+            force_version=version_parts.version if force_version else None)
     else:
         agent_details = agent
 
@@ -136,6 +182,42 @@ def setup_agent_metadata(stream_server, agent, client, tmp_dir, stream):
 def get_version_parts(version_string):
     parts = get_version_string_parts(version_string)
     return VersionParts(parts[0], parts[1], parts[2])
+
+
+def increment_version(version_string):
+    """Increment the patch version of the given version.
+
+    example:
+        2.3.7 -> 2.3.8
+        2.4-beta1 -> 2.4-beta2
+    """
+    juju_version = get_stripped_version_number(version_string)
+    try:
+        major, minor, patch = juju_version.split('.')
+        return '{}.{}.{}'.format(major, minor, increment_patch_version(patch))
+    except ValueError:
+        # Named patch version
+        major, minor_patch = juju_version.split('.')
+        minor, patch = minor_patch.split('-')
+        return '{}.{}-{}'.format(major, minor, increment_patch_version(patch))
+
+
+def increment_patch_version(patch_version):
+    """Increment the patch version of the given version.
+
+    example:
+        7 -> 8
+        beta1 -> beta2
+    """
+    try:
+        return int(patch_version) + 1
+    except ValueError:
+        # Named patch version (alpha/beta etc.)
+        name, num = re.search('(\D+)(\d+)', patch_version).groups()
+        return "{name}{num}".format(
+            name=name,
+            num=int(num) + 1,
+        )
 
 
 def parse_args(argv):
@@ -172,6 +254,7 @@ def main(argv=None):
     )
 
     assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client)
+    assess_upgrade_passing_agent_stream(args, devel_client)
     return 0
 
 

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -529,6 +529,7 @@ def get_version_string_parts(version_string):
     # strip the series and arch from the built version.
     version_parts = version_string.split('-')
     if len(version_parts) == 4:
+        # Version contains "-<patchname>", reconstruct it after the split.
         return '-'.join(version_parts[0:2]), version_parts[2], version_parts[3]
     else:
         try:

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -145,7 +145,8 @@ class StreamServer:
             server_process.join()
 
 
-def agent_tgz_from_juju_binary(juju_bin_path, tmp_dir, series=None):
+def agent_tgz_from_juju_binary(
+        juju_bin_path, tmp_dir, series=None, force_version=None):
     """
     Create agent tarball with jujud found with provided juju binary.
 
@@ -189,17 +190,27 @@ def agent_tgz_from_juju_binary(juju_bin_path, tmp_dir, series=None):
             'Unable to determine version, series and arch from version '
             'string: {}'.format(version_output))
 
+    version = force_version or version
     agent_tgz_name = 'juju-{version}-{series}-{arch}.tgz'.format(
         version=version,
         series=series if series else bin_agent_series,
         arch=arch
     )
 
-    log.debug('Creating agent file: {}'.format(agent_tgz_name))
+    # It's possible we're re-generating a file.
     tgz_path = os.path.join(tmp_dir, agent_tgz_name)
+    if os.path.exists(tgz_path):
+        log.debug('Reusing agent file: {}'.format(agent_tgz_name))
+        return tgz_path
+
+    log.debug('Creating agent file: {}'.format(agent_tgz_name))
     with tarfile.open(tgz_path, 'w:gz') as tar:
         tar.add(jujud_path, arcname='jujud')
-
+        if force_version is not None:
+            force_version_file = os.path.join(tmp_dir, 'FORCE-VERSION')
+            with open(force_version_file, 'wt') as f:
+                f.write(version)
+            tar.add(force_version_file, arcname='FORCE-VERSION')
     return tgz_path
 
 

--- a/api/client.go
+++ b/api/client.go
@@ -281,12 +281,13 @@ func (c *Client) AbortCurrentUpgrade() error {
 }
 
 // FindTools returns a List containing all tools matching the specified parameters.
-func (c *Client) FindTools(majorVersion, minorVersion int, series, arch string) (result params.FindToolsResult, err error) {
+func (c *Client) FindTools(majorVersion, minorVersion int, series, arch, agentStream string) (result params.FindToolsResult, err error) {
 	args := params.FindToolsParams{
 		MajorVersion: majorVersion,
 		MinorVersion: minorVersion,
 		Arch:         arch,
 		Series:       series,
+		AgentStream:  agentStream,
 	}
 	err = c.facade.FacadeCall("FindTools", args, &result)
 	return result, err

--- a/api/client.go
+++ b/api/client.go
@@ -282,6 +282,10 @@ func (c *Client) AbortCurrentUpgrade() error {
 
 // FindTools returns a List containing all tools matching the specified parameters.
 func (c *Client) FindTools(majorVersion, minorVersion int, series, arch, agentStream string) (result params.FindToolsResult, err error) {
+	if c.facade.BestAPIVersion() == 1 && agentStream != "" {
+		return params.FindToolsResult{}, errors.New(
+			"passing agent-stream not supported by target model")
+	}
 	args := params.FindToolsParams{
 		MajorVersion: majorVersion,
 		MinorVersion: minorVersion,

--- a/api/client.go
+++ b/api/client.go
@@ -284,7 +284,7 @@ func (c *Client) AbortCurrentUpgrade() error {
 func (c *Client) FindTools(majorVersion, minorVersion int, series, arch, agentStream string) (result params.FindToolsResult, err error) {
 	if c.facade.BestAPIVersion() == 1 && agentStream != "" {
 		return params.FindToolsResult{}, errors.New(
-			"passing agent-stream not supported by target model")
+			"passing agent-stream not supported by the controller")
 	}
 	args := params.FindToolsParams{
 		MajorVersion: majorVersion,

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/common"
 	servercommon "github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -673,4 +674,17 @@ type closeWatcher struct {
 func (c *closeWatcher) Close() error {
 	c.closed = true
 	return nil
+}
+
+type IsolatedClientSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&IsolatedClientSuite{})
+
+func (s *IsolatedClientSuite) TestFindAllErrorsOnOlderController(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{BestVersion: 1}
+	client := api.APIClient(apiCaller)
+	_, err := client.FindTools(0, 0, "", "", "proposed")
+	c.Assert(err, gc.ErrorMatches, "passing agent-stream not supported by the controller")
 }

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -101,6 +101,13 @@ func NewTestingState(params TestingStateParams) Connection {
 	return st
 }
 
+// APIClient returns a 'barebones' api.Client suitable for calling FindTools in
+// an error state (anything else is likely to panic.)
+func APIClient(apiCaller base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(apiCaller, "Client")
+	return &Client{ClientFacade: frontend, facade: backend, st: &state{}}
+}
+
 // PatchClientFacadeCall changes the internal FacadeCaller to one that lets
 // you mock out the FacadeCall method. The function returned by
 // PatchClientFacadeCall is a cleanup function that returns the client to its

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -32,7 +32,7 @@ var facadeVersions = map[string]int{
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,
 	"Cleaner":                      2,
-	"Client":                       1,
+	"Client":                       2,
 	"Cloud":                        2,
 	"Controller":                   5,
 	"CredentialValidator":          1,

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -172,7 +172,7 @@ func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
 }
 
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
-	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 1)
+	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 2)
 }
 
 func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -149,7 +149,8 @@ func AllFacades() *facade.Registry {
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)
 	reg("Charms", 2, charms.NewFacade)
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)
-	reg("Client", 1, client.NewFacade)
+	reg("Client", 1, client.NewFacadeV1)
+	reg("Client", 2, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacade)
 	reg("Cloud", 2, cloud.NewFacadeV2) // adds CredentialContents
 

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -262,7 +262,11 @@ func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (coretools.
 	}
 	filter := toolsFilter(args)
 	cfg := env.Config()
-	streams := envtools.PreferredStreams(&args.Number, cfg.Development(), cfg.AgentStream())
+	requestedStream := cfg.AgentStream()
+	if args.AgentStream != "" {
+		requestedStream = args.AgentStream
+	}
+	streams := envtools.PreferredStreams(&args.Number, cfg.Development(), requestedStream)
 	simplestreamsList, err := envtoolsFindTools(
 		env, args.MajorVersion, args.MinorVersion, streams, filter,
 	)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -116,12 +116,12 @@ func (c *Client) checkIsAdmin() error {
 	return nil
 }
 
-// NewFacade provides the required signature for facade registration.
+// NewFacade creates a version 1 Client facade to handle API requests.
 func NewFacade(ctx facade.Context) (*Client, error) {
 	return newFacade(ctx)
 }
 
-// NewFacadeV1 provides the required signature for facade registration.
+// NewFacadeV1 creates a version 1 Client facade to handle API requests.
 func NewFacadeV1(ctx facade.Context) (*ClientV1, error) {
 	client, err := newFacade(ctx)
 	if err != nil {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -63,6 +63,11 @@ type Client struct {
 	check      *common.BlockChecker
 }
 
+// ClientV1 serves the (v1) client-specific API methods.
+type ClientV1 struct {
+	*Client
+}
+
 func (c *Client) checkCanRead() error {
 	isAdmin, err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
 	if err != nil {
@@ -113,6 +118,19 @@ func (c *Client) checkIsAdmin() error {
 
 // NewFacade provides the required signature for facade registration.
 func NewFacade(ctx facade.Context) (*Client, error) {
+	return newFacade(ctx)
+}
+
+// NewFacadeV1 provides the required signature for facade registration.
+func NewFacadeV1(ctx facade.Context) (*ClientV1, error) {
+	client, err := newFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ClientV1{client}, nil
+}
+
+func newFacade(ctx facade.Context) (*Client, error) {
 	st := ctx.State()
 	resources := ctx.Resources()
 	authorizer := ctx.Auth()
@@ -710,4 +728,16 @@ func (c *Client) CACert() (params.BytesResult, error) {
 	}
 	caCert, _ := cfg.CACert()
 	return params.BytesResult{Result: []byte(caCert)}, nil
+}
+
+// FindTools returns a List containing all tools matching the given parameters.
+func (c *ClientV1) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+	if err := c.checkCanWrite(); err != nil {
+		return params.FindToolsResult{}, err
+	}
+
+	if args.AgentStream != "" {
+		return params.FindToolsResult{}, errors.New("requesting agent-stream not supported by model")
+	}
+	return c.api.toolsFinder.FindTools(args)
 }

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -984,16 +984,26 @@ func (s *clientSuite) TestClientPrivateAddressUnit(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientFindTools(c *gc.C) {
-	result, err := s.APIState.Client().FindTools(99, -1, "", "")
+	result, err := s.APIState.Client().FindTools(99, -1, "", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, jc.Satisfies, params.IsCodeNotFound)
 	toolstesting.UploadToStorage(c, s.DefaultToolsStorage, "released", version.MustParseBinary("2.99.0-precise-amd64"))
-	result, err = s.APIState.Client().FindTools(2, 99, "precise", "amd64")
+	result, err = s.APIState.Client().FindTools(2, 99, "precise", "amd64", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.List, gc.HasLen, 1)
 	c.Assert(result.List[0].Version, gc.Equals, version.MustParseBinary("2.99.0-precise-amd64"))
 	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
+		s.APIState.Addr(), coretesting.ModelTag.Id(), result.List[0].Version)
+	c.Assert(result.List[0].URL, gc.Equals, url)
+
+	toolstesting.UploadToStorage(c, s.DefaultToolsStorage, "pretend", version.MustParseBinary("3.0.1-precise-amd64"))
+	result, err = s.APIState.Client().FindTools(3, 0, "precise", "amd64", "pretend")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.List, gc.HasLen, 1)
+	c.Assert(result.List[0].Version, gc.Equals, version.MustParseBinary("3.0.1-precise-amd64"))
+	url = fmt.Sprintf("https://%s/model/%s/tools/%s",
 		s.APIState.Addr(), coretesting.ModelTag.Id(), result.List[0].Version)
 	c.Assert(result.List[0].URL, gc.Equals, url)
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -950,6 +950,9 @@ type FindToolsParams struct {
 
 	// Series will be used to match tools by series if non-empty.
 	Series string `json:"series"`
+
+	// AgentStream will be used to set agent stream to search
+	AgentStream string `json:"agentstream"`
 }
 
 // FindToolsResult holds a list of tools from FindTools and any error.

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -114,7 +114,7 @@ func (c *syncToolsCommand) Init(args []string) error {
 // syncToolsAPI provides an interface with a subset of the
 // api.Client API. This exists to enable mocking.
 type syncToolsAPI interface {
-	FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error)
+	FindTools(majorVersion, minorVersion int, series, arch, agentStream string) (params.FindToolsResult, error)
 	UploadTools(r io.ReadSeeker, v version.Binary, series ...string) (coretools.List, error)
 	Close() error
 }
@@ -180,7 +180,7 @@ type syncToolsAPIAdapter struct {
 }
 
 func (s syncToolsAPIAdapter) FindTools(majorVersion int, stream string) (coretools.List, error) {
-	result, err := s.syncToolsAPI.FindTools(majorVersion, -1, "", "")
+	result, err := s.syncToolsAPI.FindTools(majorVersion, -1, "", "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -218,12 +218,13 @@ func (s *syncToolsSuite) TestAPIAdapterFindTools(c *gc.C) {
 	var called bool
 	result := coretools.List{&coretools.Tools{}}
 	fake := fakeSyncToolsAPI{
-		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
+		findTools: func(majorVersion, minorVersion int, series, arch, stream string) (params.FindToolsResult, error) {
 			called = true
 			c.Assert(majorVersion, gc.Equals, 2)
 			c.Assert(minorVersion, gc.Equals, -1)
 			c.Assert(series, gc.Equals, "")
 			c.Assert(arch, gc.Equals, "")
+			c.Assert(stream, gc.Equals, "")
 			return params.FindToolsResult{List: result}, nil
 		},
 	}
@@ -236,7 +237,7 @@ func (s *syncToolsSuite) TestAPIAdapterFindTools(c *gc.C) {
 
 func (s *syncToolsSuite) TestAPIAdapterFindToolsNotFound(c *gc.C) {
 	fake := fakeSyncToolsAPI{
-		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
+		findTools: func(majorVersion, minorVersion int, series, arch, stream string) (params.FindToolsResult, error) {
 			err := common.ServerError(errors.NotFoundf("tools"))
 			return params.FindToolsResult{Error: err}, nil
 		},
@@ -250,7 +251,7 @@ func (s *syncToolsSuite) TestAPIAdapterFindToolsNotFound(c *gc.C) {
 func (s *syncToolsSuite) TestAPIAdapterFindToolsAPIError(c *gc.C) {
 	findToolsErr := common.ServerError(errors.NotFoundf("tools"))
 	fake := fakeSyncToolsAPI{
-		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
+		findTools: func(majorVersion, minorVersion int, series, arch, stream string) (params.FindToolsResult, error) {
 			return params.FindToolsResult{Error: findToolsErr}, findToolsErr
 		},
 	}
@@ -291,12 +292,12 @@ func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 }
 
 type fakeSyncToolsAPI struct {
-	findTools   func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error)
+	findTools   func(majorVersion, minorVersion int, series, arch, stream string) (params.FindToolsResult, error)
 	uploadTools func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error)
 }
 
-func (f *fakeSyncToolsAPI) FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
-	return f.findTools(majorVersion, minorVersion, series, arch)
+func (f *fakeSyncToolsAPI) FindTools(majorVersion, minorVersion int, series, arch, stream string) (params.FindToolsResult, error) {
+	return f.findTools(majorVersion, minorVersion, series, arch, stream)
 }
 
 func (f *fakeSyncToolsAPI) UploadTools(r io.ReadSeeker, v version.Binary, additionalSeries ...string) (coretools.List, error) {

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -52,6 +52,9 @@ the software to the controller's cache via the ` + "`juju sync-agent-binaries`" 
 The command will abort if an upgrade is in progress. It will also abort if
 a previous upgrade was not fully completed (e.g.: if one of the
 controllers in a high availability model failed to upgrade).
+When looking for an agent to upgrade to Juju will check the currently
+configured agent stream for that model. It's possible to overwrite this for
+the lifetime of this upgrade using --agent-stream
 If a failed upgrade has been resolved, '--reset-previous-upgrade' can be
 used to allow the upgrade to proceed.
 Backups are recommended prior to upgrading.
@@ -59,6 +62,7 @@ Backups are recommended prior to upgrading.
 Examples:
     juju upgrade-model --dry-run
     juju upgrade-model --agent-version 2.0.1
+    juju upgrade-model --agent-version proposed
     
 See also: 
     sync-agent-binaries`
@@ -81,6 +85,7 @@ type upgradeJujuCommand struct {
 	DryRun        bool
 	ResetPrevious bool
 	AssumeYes     bool
+	AgentStream   string
 
 	// IgnoreAgentVersions is used to allow an admin to request an agent version without waiting for all agents to be at the right
 	// version.
@@ -105,6 +110,7 @@ func (c *upgradeJujuCommand) Info() *cmd.Info {
 func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.StringVar(&c.vers, "agent-version", "", "Upgrade to specific version")
+	f.StringVar(&c.AgentStream, "agent-stream", "", "Check this agent stream for upgrades")
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build a local version of the agent binary; for development use only")
 	f.BoolVar(&c.DryRun, "dry-run", false, "Don't change anything, just report what would be changed")
 	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
@@ -178,7 +184,7 @@ func formatTools(tools coretools.List) string {
 }
 
 type upgradeJujuAPI interface {
-	FindTools(majorVersion, minorVersion int, series, arch string) (result params.FindToolsResult, err error)
+	FindTools(majorVersion, minorVersion int, series, arch, agentStream string) (result params.FindToolsResult, err error)
 	UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error)
 	AbortCurrentUpgrade() error
 	SetModelAgentVersion(version version.Number, ignoreAgentVersion bool) error
@@ -468,7 +474,7 @@ func (c *upgradeJujuCommand) initVersions(
 		return nil, false, err
 	}
 	logger.Debugf("searching for agent binaries with major: %d", filterVersion.Major)
-	findResult, err := client.FindTools(filterVersion.Major, -1, "", "")
+	findResult, err := client.FindTools(filterVersion.Major, -1, "", "", c.AgentStream)
 	if err != nil {
 		return nil, false, err
 	}

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -1010,7 +1010,7 @@ func (a *fakeUpgradeJujuAPI) ModelGet() (map[string]interface{}, error) {
 	return config.AllAttrs(), nil
 }
 
-func (a *fakeUpgradeJujuAPI) FindTools(majorVersion, minorVersion int, series, arch string) (
+func (a *fakeUpgradeJujuAPI) FindTools(majorVersion, minorVersion int, series, arch, stream string) (
 	result params.FindToolsResult, err error,
 ) {
 	a.findToolsCalled = true
@@ -1057,7 +1057,7 @@ func (a *fakeUpgradeJujuAPINoState) Close() error {
 	return nil
 }
 
-func (a *fakeUpgradeJujuAPINoState) FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
+func (a *fakeUpgradeJujuAPINoState) FindTools(majorVersion, minorVersion int, series, arch, stream string) (params.FindToolsResult, error) {
 	var result params.FindToolsResult
 	if len(a.tools) == 0 {
 		result.Error = common.ServerError(errors.NotFoundf("tools"))


### PR DESCRIPTION
## Description of change

Enable the --agent-stream argument for upgrade-model. This allows one to upgrade a model from a different stream then what's configured in the model config (also, without having to change the model config.)

## QA steps

There will be a functional test as part of this PR exercising this new command argument.

## Documentation changes

There is an additional argument to 'upgrade-model' or 'upgrade-juju'. The help description has been updated.
