### PR TITLE
Code changes for 1634390 - systemd Install/Upgrade modification

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -525,6 +525,7 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 			if err != nil {
 				return errors.Trace(err)
 			}
+
 			if !running {
 				return svc.Start()
 			}

--- a/service/service.go
+++ b/service/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"github.com/juju/utils/series"
+	"github.com/juju/utils/shell"
 
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service/common"
@@ -20,7 +21,8 @@ import (
 )
 
 var (
-	logger = loggo.GetLogger("juju.service")
+	logger   = loggo.GetLogger("juju.service")
+	renderer = shell.BashRenderer{}
 )
 
 // These are the names of the init systems regognized by juju.
@@ -131,10 +133,15 @@ func newService(name string, conf common.Conf, initSystem, series string) (Servi
 	case InitSystemSystemd:
 		dataDir, err := paths.DataDir(series)
 		if err != nil {
-			return nil, errors.Annotatef(err, "failed to find juju data dir for application %q", name)
+			return nil, err
 		}
-
-		svc, err := systemd.NewService(name, conf, dataDir, systemd.NewDBusAPI)
+		svc, err := systemd.NewService(
+			name,
+			conf,
+			"/lib/systemd/system",
+			systemd.NewDBusAPI,
+			renderer.Join(dataDir, "init"),
+		)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to wrap service %q", name)
 		}

--- a/service/systemd/cmdline.go
+++ b/service/systemd/cmdline.go
@@ -131,6 +131,18 @@ func (cl Cmdline) conf(name, dirname string) ([]byte, error) {
 	return []byte(out), nil
 }
 
+func (cl Cmdline) reload() error {
+	cmd := cl.commands.reload()
+
+	_, err := cl.runCommand(cmd, "")
+	if err != nil {
+		err = errors.Trace(err)
+		return err
+	}
+
+	return err
+}
+
 const runCommandMsg = "%s failed (%s)"
 
 func (Cmdline) runCommand(cmd, label string) (string, error) {

--- a/service/systemd/testing/writeconf.go
+++ b/service/systemd/testing/writeconf.go
@@ -24,15 +24,15 @@ type WriteConfTest struct {
 }
 
 func (wct WriteConfTest) dirname() string {
-	return fmt.Sprintf("'%s/init/%s'", wct.DataDir, wct.Service)
+	return fmt.Sprintf("'%s/%s'", wct.DataDir, wct.Service)
 }
 
 func (wct WriteConfTest) filename() string {
-	return fmt.Sprintf("'%[1]s/init/%[2]s/%[2]s.service'", wct.DataDir, wct.Service)
+	return fmt.Sprintf("'%[1]s/%[2]s/%[2]s.service'", wct.DataDir, wct.Service)
 }
 
 func (wct WriteConfTest) scriptname() string {
-	return fmt.Sprintf("'%s/init/%s/exec-start.sh'", wct.DataDir, wct.Service)
+	return fmt.Sprintf("'%s/%s/exec-start.sh'", wct.DataDir, wct.Service)
 }
 
 // CheckCommands checks the given commands against the test's expectations.

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -43,6 +43,7 @@ var upgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("2.0.0"), stepsFor20()},
 		upgradeToVersion{version.MustParse("2.2.0"), stepsFor22()},
+		upgradeToVersion{version.MustParse("2.4.0"), stepsFor24()},
 	}
 	return steps
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -654,7 +654,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"2.0.0", "2.2.0",
+		"2.0.0", "2.2.0", "2.4.0",
 	})
 }
 


### PR DESCRIPTION
## Description of change
The PR addresses the code changes to install the service files in systemd path during fresh installation and also during upgrade step to 2.4.0

## QA steps
Bootstrap lxd container and deploy applications and verify if the controller and other unit has service in '/lib/systemd/' path.
Upgrade to 2.4 from any old version of juju and verify the service file installed path.

## Documentation changes
N/A

## Bug reference
https://mail.google.com/mail/u/0/#inbox/162cbf9b65f380b6
