### PR TITLE
Resolve primary address hostnames for network-get output.

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -671,8 +671,9 @@ type ProxyConfigResults struct {
 
 // InterfaceAddress represents a single address attached to the interface.
 type InterfaceAddress struct {
-	Address string `json:"value"`
-	CIDR    string `json:"cidr"`
+	Hostname string `json:"hostname"`
+	Address  string `json:"value"`
+	CIDR     string `json:"cidr"`
 }
 
 // NetworkInfo describes one interface with IP addresses.

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -35,11 +35,9 @@ type NetworkGetCommand struct {
 	out cmd.Output
 }
 
-// Type alias for Domain resolution function for testing
 type resolver = func(host string) (addrs []string, err error)
 
-var lookupFunc = net.LookupHost
-var LookupHost = &lookupFunc
+var LookupHost resolver = net.LookupHost
 
 func NewNetworkGetCommand(ctx Context) (_ cmd.Command, err error) {
 	cmd := &NetworkGetCommand{ctx: ctx}
@@ -127,7 +125,7 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
-	ni = resolveNetworkInfoAddresses(ni, *LookupHost)
+	ni = resolveNetworkInfoAddresses(ni, LookupHost)
 
 	// If no specific attributes asked for,
 	// print everything we know.

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -35,6 +35,12 @@ type NetworkGetCommand struct {
 	out cmd.Output
 }
 
+// Type alias for Domain resolution function for testing
+type resolver = func(host string) (addrs []string, err error)
+
+var lookupFunc = net.LookupHost
+var LookupHost = &lookupFunc
+
 func NewNetworkGetCommand(ctx Context) (_ cmd.Command, err error) {
 	cmd := &NetworkGetCommand{ctx: ctx}
 	cmd.relationIdProxy, err = NewRelationIdValue(ctx, &cmd.RelationId)
@@ -121,7 +127,7 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
-	ni = resolveNetworkInfoAddresses(ni)
+	ni = resolveNetworkInfoAddresses(ni, *LookupHost)
 
 	// If no specific attributes asked for,
 	// print everything we know.
@@ -167,23 +173,24 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 	return c.out.Write(ctx, keyValues)
 }
 
-// This addresses the immediate problem of
+// TODO(externalreality) This addresses the immediate problem of
 // https://bugs.launchpad.net/juju/+bug/1721368, but the hostname can populate
 // both the egress subnet cidr and the ingress addreses. These too should be
 // resolved. In addition these values probably should not be stored as hostnames
 // but rather the IP, that is, it might be better to do the resolution on input
 // rather than output (network-get) as we do here.
-func resolveNetworkInfoAddresses(networkInfoResult params.NetworkInfoResult) params.NetworkInfoResult {
+func resolveNetworkInfoAddresses(networkInfoResult params.NetworkInfoResult, lookupHost resolver) params.NetworkInfoResult {
 	logger.Debugf("Resolving Addresses")
 	for i, networkInfo := range networkInfoResult.Info {
 		for j, interfaceAddress := range networkInfo.Addresses {
 			if ip := net.ParseIP(interfaceAddress.Address); ip != nil {
 				continue
 			}
-			resolvedAddress, err := net.LookupHost(interfaceAddress.Address)
+			resolvedAddress, err := lookupHost(interfaceAddress.Address)
 			if err != nil {
 				logger.Warningf("The address %q is neither an IP address or a resolvable hostname", interfaceAddress.Address)
 			} else {
+				networkInfoResult.Info[i].Addresses[j].Hostname = interfaceAddress.Address
 				networkInfoResult.Info[i].Addresses[j].Address = resolvedAddress[0]
 			}
 		}

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -5,10 +5,13 @@ package jujuc
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
 // NetworkGetCommand implements the network-get command.
@@ -118,6 +121,8 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
+	ni = resolveNetworkInfoAddresses(ni)
+
 	// If no specific attributes asked for,
 	// print everything we know.
 	if !c.primaryAddress && len(c.keys) == 0 {
@@ -160,4 +165,28 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return c.out.Write(ctx, keyValues[c.keys[0]])
 	}
 	return c.out.Write(ctx, keyValues)
+}
+
+// This addresses the immediate problem of
+// https://bugs.launchpad.net/juju/+bug/1721368, but the hostname can populate
+// both the egress subnet cidr and the ingress addreses. These too should be
+// resolved. In addition these values probably should not be stored as hostnames
+// but rather the IP, that is, it might be better to do the resolution on input
+// rather than output (network-get) as we do here.
+func resolveNetworkInfoAddresses(networkInfoResult params.NetworkInfoResult) params.NetworkInfoResult {
+	logger.Debugf("Resolving Addresses")
+	for i, networkInfo := range networkInfoResult.Info {
+		for j, interfaceAddress := range networkInfo.Addresses {
+			if ip := net.ParseIP(interfaceAddress.Address); ip != nil {
+				continue
+			}
+			resolvedAddress, err := net.LookupHost(interfaceAddress.Address)
+			if err != nil {
+				logger.Warningf("The address %q is neither an IP address or a resolvable hostname", interfaceAddress.Address)
+			} else {
+				networkInfoResult.Info[i].Addresses[j].Address = resolvedAddress[0]
+			}
+		}
+	}
+	return networkInfoResult
 }

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -28,7 +28,7 @@ func (s *NetworkGetSuite) SetUpSuite(c *gc.C) {
 	lookupHost := func(host string) (addrs []string, err error) {
 		return []string{"10.3.3.3"}, nil
 	}
-	testing.PatchValue(jujuc.LookupHost, lookupHost)
+	testing.PatchValue(&jujuc.LookupHost, lookupHost)
 }
 
 func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,6 +22,14 @@ type NetworkGetSuite struct {
 }
 
 var _ = gc.Suite(&NetworkGetSuite{})
+
+func (s *NetworkGetSuite) SetUpSuite(c *gc.C) {
+	s.ContextSuite.SetUpSuite(c)
+	lookupHost := func(host string) (addrs []string, err error) {
+		return []string{"10.3.3.3"}, nil
+	}
+	testing.PatchValue(jujuc.LookupHost, lookupHost)
+}
 
 func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 	hctx := s.GetHookContext(c, -1, "")
@@ -104,6 +113,29 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 		IngressAddresses: []string{"100.1.2.3", "100.4.3.2"},
 		EgressSubnets:    []string{"192.168.1.0/8", "10.0.0.0/8"},
 	}
+
+	// This should not happen. A hostname should never populate the address
+	// field. However, until the code is updated to prevent addresses from
+	// being populated by Hostnames (e.g. Change the Address field type from
+	// `string` to `net.IP` which will ensure all code paths exclude string
+	// population) we will have this check in place to ensure that hostnames
+	// are resolved to IPs and that hostnames populate a distinct field.
+	// `network-get --primary-address` and the like should only ever return
+	// IPs.
+	presetBindings["resolvable-hostname"] = params.NetworkInfoResult{
+		Info: []params.NetworkInfo{
+			{MACAddress: "00:11:22:33:44:33",
+				InterfaceName: "eth3",
+				Addresses: []params.InterfaceAddress{
+					{
+						Address: "resolvable-hostname",
+						CIDR:    "10.33.1.8/24",
+					},
+				},
+			},
+		},
+	}
+
 	hctx.info.NetworkInterface.NetworkInfoResults = presetBindings
 
 	com, err := jujuc.NewCommand(hctx, cmdString("network-get"))
@@ -165,9 +197,11 @@ bind-addresses:
 - macaddress: "00:11:22:33:44:22"
   interfacename: eth2
   addresses:
-  - address: 10.20.1.42
+  - hostname: ""
+    address: 10.20.1.42
     cidr: 10.20.1.42/24
-  - address: fc00::1
+  - hostname: ""
+    address: fc00::1
     cidr: fc00::/64`[1:],
 	}, {
 		summary: "explicitly bound relation name given with single flag arg",
@@ -181,16 +215,20 @@ bind-addresses:
 - macaddress: "00:11:22:33:44:00"
   interfacename: eth0
   addresses:
-  - address: 10.10.0.23
+  - hostname: ""
+    address: 10.10.0.23
     cidr: 10.10.0.0/24
-  - address: 192.168.1.111
+  - hostname: ""
+    address: 192.168.1.111
     cidr: 192.168.1.0/24
 - macaddress: "00:11:22:33:44:11"
   interfacename: eth1
   addresses:
-  - address: 10.10.1.23
+  - hostname: ""
+    address: 10.10.1.23
     cidr: 10.10.1.0/24
-  - address: 192.168.2.111
+  - hostname: ""
+    address: 192.168.2.111
     cidr: 192.168.2.0/24`[1:],
 	}, {
 		summary: "no user requested binding falls back to binding address, with ingress-address arg",
@@ -204,7 +242,8 @@ bind-addresses:
 - macaddress: "00:11:22:33:44:33"
   interfacename: eth3
   addresses:
-  - address: 10.33.1.8
+  - hostname: ""
+    address: 10.33.1.8
     cidr: 10.33.1.8/24`[1:],
 	}, {
 		summary: "explicit ingress and egress information",
@@ -223,7 +262,8 @@ bind-addresses:
 - macaddress: "00:11:22:33:44:33"
   interfacename: eth3
   addresses:
-  - address: 10.33.1.8
+  - hostname: ""
+    address: 10.33.1.8
     cidr: 10.33.1.8/24
 egress-subnets:
 - 192.168.1.0/8
@@ -231,6 +271,17 @@ egress-subnets:
 ingress-addresses:
 - 100.1.2.3
 - 100.4.3.2`[1:],
+	}, {
+		summary: "a resolvable hostname as addresss, no args",
+		args:    []string{"resolvable-hostname"},
+		out: `
+bind-addresses:
+- macaddress: "00:11:22:33:44:33"
+  interfacename: eth3
+  addresses:
+  - hostname: resolvable-hostname
+    address: 10.3.3.3
+    cidr: 10.33.1.8/24`[1:],
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		com := s.createCommand(c)


### PR DESCRIPTION
## Description of change

Juju can store unresolved hostnames in network info Address fields. These hostnames can show up in network-get output which should always be IP addresses and not hostnames. To solve the issue simply, we resolve the hostnames on network get output.  

## QA steps

On a local provider you may:

1. Bootstrap 
2. Launch a lxd instance
3. Ensure that you can ssh into the machine
4. Assign the machine a resolvable hostname (e.g. add an entry to /etc/hosts)
5. manually provision machine using `ssh:<user>@<hostname>` placement directive format 
6. deploy mysql to manually provisioned machine
7. `juju run mysql/0 -- network-get --primary-address --format yaml db 

You should see an IP Address and not a hostname 

## Documentation changes

N/A

## Does it affect current user workflow? CLI? API?

If a user is depending on hostnames, for whatever reason, they might be in for a surprise.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721368
