### PR TITLE
Modifies version check so that lxd init is run on "bionic" hosts.

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -68,8 +68,8 @@ func (ci *containerInitialiser) Initialise() error {
 		return errors.Trace(err)
 	}
 
-	switch ci.series {
-	case "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily":
+	// LXD init is only run on Xenial and later.
+	if ci.series == "trusty" {
 		return nil
 	}
 

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -68,9 +68,8 @@ func (ci *containerInitialiser) Initialise() error {
 		return errors.Trace(err)
 	}
 
-	// Well... this will need to change soon once we are passed 17.04 as who
-	// knows what the series name will be.
-	if ci.series < "xenial" {
+	switch ci.series {
+	case "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily":
 		return nil
 	}
 

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -8,7 +8,9 @@ package lxd
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os/exec"
 	"runtime"
 
 	"github.com/juju/testing"
@@ -130,26 +132,32 @@ func (s *InitialiserSuite) TestNoSeriesPackages(c *gc.C) {
 	})
 }
 
-func (s *InitialiserSuite) TestLXDInit(c *gc.C) {
-	// Patch df so it always returns 100GB
-	df100 := func(path string) (uint64, error) {
-		return 100 * 1024 * 1024 * 1024, nil
-	}
-	s.PatchValue(&df, df100)
+func (s *InitialiserSuite) TestLXDInitBionic(c *gc.C) {
+	s.patchDF100GB()
 
-	container := NewContainerInitialiser("xenial")
+	container := NewContainerInitialiser("bionic")
 	err := container.Initialise()
 	c.Assert(err, jc.ErrorIsNil)
 
 	testing.AssertEchoArgs(c, "lxd", "init", "--auto")
 }
 
+func (s *InitialiserSuite) TestLXDInitTrusty(c *gc.C) {
+	s.patchDF100GB()
+
+	container := NewContainerInitialiser("trusty")
+	err := container.Initialise()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that our patched call has no recorded args.
+	execPath, err := exec.LookPath("lxd")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = ioutil.ReadFile(execPath + ".out")
+	c.Assert(err, gc.ErrorMatches, "*. no such file or directory$")
+}
+
 func (s *InitialiserSuite) TestLXDAlreadyInitialized(c *gc.C) {
-	// Patch df so it always returns 100GB
-	df100 := func(path string) (uint64, error) {
-		return 100 * 1024 * 1024 * 1024, nil
-	}
-	s.PatchValue(&df, df100)
+	s.patchDF100GB()
 
 	container := NewContainerInitialiser("xenial")
 	cont, ok := container.(*containerInitialiser)
@@ -168,6 +176,14 @@ error: You have existing containers or images. lxd init requires an empty LXD.`,
 	// the above error should be ignored by the code that calls lxd init.
 	err := container.Initialise()
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+// patchDF100GB ensures that df always returns 100GB.
+func (s *InitialiserSuite) patchDF100GB() {
+	df100 := func(path string) (uint64, error) {
+		return 100 * 1024 * 1024 * 1024, nil
+	}
+	s.PatchValue(&df, df100)
 }
 
 type mockServerUpdater struct {


### PR DESCRIPTION
## Description of change

Fixes a bug whereby "lxd init" is not run on Bionic hosts, due to a version check that is outdated since the series names rolled around to "A".

## QA steps

Unit tests, red/green system testing.

## Documentation changes

No.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1765571
