### PR TITLE
Provider call context implementation when coming from state or apiserver layer.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -206,7 +206,7 @@ func InitializeState(
 	}
 
 	if err := hostedModelEnv.Create(
-		state.CreateCallContext(st),
+		state.CallContext(st),
 		environs.CreateParams{
 			ControllerUUID: controllerUUID,
 		}); err != nil {

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -207,7 +206,7 @@ func InitializeState(
 	}
 
 	if err := hostedModelEnv.Create(
-		context.NewCloudCallContext(),
+		state.CreateCallContext(st),
 		environs.CreateParams{
 			ControllerUUID: controllerUUID,
 		}); err != nil {

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -52,7 +52,7 @@ func NewMachinerAPI(st *state.State, resources facade.Resources, authorizer faca
 		DeadEnsurer:        common.NewDeadEnsurer(st, getCanModify),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, resources, getCanRead),
 		APIAddresser:       common.NewAPIAddresser(st, resources),
-		NetworkConfigAPI:   networkingcommon.NewNetworkConfigAPI(st, state.CreateCallContext(st), getCanModify),
+		NetworkConfigAPI:   networkingcommon.NewNetworkConfigAPI(st, state.CallContext(st), getCanModify),
 		st:                 st,
 		auth:               authorizer,
 		getCanModify:       getCanModify,

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 )
@@ -53,7 +52,7 @@ func NewMachinerAPI(st *state.State, resources facade.Resources, authorizer faca
 		DeadEnsurer:        common.NewDeadEnsurer(st, getCanModify),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, resources, getCanRead),
 		APIAddresser:       common.NewAPIAddresser(st, resources),
-		NetworkConfigAPI:   networkingcommon.NewNetworkConfigAPI(st, context.NewCloudCallContext(), getCanModify),
+		NetworkConfigAPI:   networkingcommon.NewNetworkConfigAPI(st, state.CreateCallContext(st), getCanModify),
 		st:                 st,
 		auth:               authorizer,
 		getCanModify:       getCanModify,

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -116,7 +116,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
 	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(env)
 
-	callCtx := state.CreateCallContext(st)
+	callCtx := state.CallContext(st)
 	return &ProvisionerAPI{
 		Remover:                 common.NewRemover(st, false, getAuthFunc),
 		StatusSetter:            common.NewStatusSetter(st, getAuthFunc),

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -116,7 +116,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
 	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(env)
 
-	callCtx := context.NewCloudCallContext()
+	callCtx := state.CreateCallContext(st)
 	return &ProvisionerAPI{
 		Remover:                 common.NewRemover(st, false, getAuthFunc),
 		StatusSetter:            common.NewStatusSetter(st, getAuthFunc),

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 )
 
@@ -41,6 +42,7 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, nil, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		context.NewCloudCallContext(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -17,7 +17,9 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -48,6 +50,7 @@ func createOffersAPI(
 	authorizer facade.Authorizer,
 	resources facade.Resources,
 	authContext *commoncrossmodel.AuthContext,
+	callCtx context.ProviderCallContext,
 ) (*OffersAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
@@ -64,6 +67,7 @@ func createOffersAPI(
 			StatePool:            statePool,
 			getEnviron:           getEnviron,
 			getControllerInfo:    getControllerInfo,
+			callContext:          callCtx,
 		},
 	}
 	return api, nil
@@ -94,6 +98,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		return common.StateControllerInfo(st)
 	}
 
+	callCtx := state.CreateCallContext(st)
 	authContext := ctx.Resources().Get("offerAccessAuthContext").(common.ValueResource).Value
 	return createOffersAPI(
 		GetApplicationOffers,
@@ -104,6 +109,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		ctx.Auth(),
 		ctx.Resources(),
 		authContext.(*commoncrossmodel.AuthContext),
+		callCtx,
 	)
 }
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -98,7 +98,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		return common.StateControllerInfo(st)
 	}
 
-	callCtx := state.CreateCallContext(st)
+	callCtx := state.CallContext(st)
 	authContext := ctx.Resources().Get("offerAccessAuthContext").(common.ValueResource).Value
 	return createOffersAPI(
 		GetApplicationOffers,

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -53,6 +54,7 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		context.NewCloudCallContext(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}
@@ -1053,6 +1055,7 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		context.NewCloudCallContext(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -29,6 +29,7 @@ type BaseAPI struct {
 	StatePool            StatePool
 	getEnviron           environFromModelFunc
 	getControllerInfo    func() (apiAddrs []string, caCert string, _ error)
+	callContext          context.ProviderCallContext
 }
 
 // checkPermission ensures that the logged in user holds the given permission on an entity.
@@ -498,8 +499,6 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceNames []string) (m
 		return nil, errors.Trace(err)
 	}
 
-	ctx := context.NewCloudCallContext()
-
 	netEnv, ok := environs.SupportsNetworking(env)
 	if !ok {
 		logger.Debugf("cloud provider doesn't support networking, not getting space info")
@@ -519,7 +518,7 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceNames []string) (m
 				return nil, errors.Trace(err)
 			}
 		}
-		providerSpace, err := netEnv.ProviderSpaceInfo(ctx, space)
+		providerSpace, err := netEnv.ProviderSpaceInfo(api.callContext, space)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -59,9 +59,10 @@ type Client struct {
 	// on the client facade until GUI and Python client library are updated.
 	*modelconfig.ModelConfigAPI
 
-	api        *API
-	newEnviron func() (environs.Environ, error)
-	check      *common.BlockChecker
+	api         *API
+	newEnviron  func() (environs.Environ, error)
+	check       *common.BlockChecker
+	callContext context.ProviderCallContext
 }
 
 // ClientV1 serves the (v1) client-specific API methods.
@@ -155,6 +156,7 @@ func newFacade(ctx facade.Context) (*Client, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	return NewClient(
 		&stateShim{st, model},
 		&poolShim{ctx.StatePool()},
@@ -166,6 +168,7 @@ func newFacade(ctx facade.Context) (*Client, error) {
 		toolsFinder,
 		newEnviron,
 		blockChecker,
+		state.CreateCallContext(st),
 	)
 }
 
@@ -181,6 +184,7 @@ func NewClient(
 	toolsFinder *common.ToolsFinder,
 	newEnviron func() (environs.Environ, error),
 	blockChecker *common.BlockChecker,
+	callCtx context.ProviderCallContext,
 ) (*Client, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
@@ -196,8 +200,9 @@ func NewClient(
 			statusSetter:  statusSetter,
 			toolsFinder:   toolsFinder,
 		},
-		newEnviron: newEnviron,
-		check:      blockChecker,
+		newEnviron:  newEnviron,
+		check:       blockChecker,
+		callContext: callCtx,
 	}
 	return client, nil
 }
@@ -606,7 +611,7 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 		return errors.Trace(err)
 	}
 
-	if err := environs.CheckProviderAPI(env, context.NewCloudCallContext()); err != nil {
+	if err := environs.CheckProviderAPI(env, c.callContext); err != nil {
 		return err
 	}
 	// If this is the controller model, also check to make sure that there are

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -168,7 +168,7 @@ func newFacade(ctx facade.Context) (*Client, error) {
 		toolsFinder,
 		newEnviron,
 		blockChecker,
-		state.CreateCallContext(st),
+		state.CallContext(st),
 	)
 }
 

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/client"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
@@ -42,6 +43,7 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // toolsFinder
 		nil, // newEnviron
 		nil, // blockChecker
+		context.NewCloudCallContext(), // ProviderCallContext
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
@@ -42,6 +43,7 @@ type CloudAPI struct {
 	authorizer             facade.Authorizer
 	apiUser                names.UserTag
 	getCredentialsAuthFunc common.GetAuthFunc
+	callContext            environscontext.ProviderCallContext
 }
 
 type CloudAPIV2 struct {
@@ -57,18 +59,18 @@ var (
 func NewFacade(context facade.Context) (*CloudAPI, error) {
 	st := NewStateBackend(context.State())
 	ctlrSt := NewStateBackend(context.StatePool().SystemState())
-	return NewCloudAPI(st, ctlrSt, context.Auth())
+	return NewCloudAPI(st, ctlrSt, context.Auth(), state.CreateCallContext(context.State()))
 }
 
 func NewFacadeV2(context facade.Context) (*CloudAPIV2, error) {
 	st := NewStateBackend(context.State())
 	ctlrSt := NewStateBackend(context.StatePool().SystemState())
-	return NewCloudAPIV2(st, ctlrSt, context.Auth())
+	return NewCloudAPIV2(st, ctlrSt, context.Auth(), state.CreateCallContext(context.State()))
 }
 
 // NewCloudAPI creates a new API server endpoint for managing the controller's
 // cloud definition and cloud credentials.
-func NewCloudAPI(backend, ctlrBackend Backend, authorizer facade.Authorizer) (*CloudAPI, error) {
+func NewCloudAPI(backend, ctlrBackend Backend, authorizer facade.Authorizer, callCtx environscontext.ProviderCallContext) (*CloudAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
@@ -93,11 +95,12 @@ func NewCloudAPI(backend, ctlrBackend Backend, authorizer facade.Authorizer) (*C
 		authorizer:             authorizer,
 		getCredentialsAuthFunc: getUserAuthFunc,
 		apiUser:                authUser,
+		callContext:            callCtx,
 	}, nil
 }
 
-func NewCloudAPIV2(backend, ctlrBackend Backend, authorizer facade.Authorizer) (*CloudAPIV2, error) {
-	cloudAPI, err := NewCloudAPI(backend, ctlrBackend, authorizer)
+func NewCloudAPIV2(backend, ctlrBackend Backend, authorizer facade.Authorizer, callCtx environscontext.ProviderCallContext) (*CloudAPIV2, error) {
+	cloudAPI, err := NewCloudAPI(backend, ctlrBackend, authorizer, callCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -59,13 +59,13 @@ var (
 func NewFacade(context facade.Context) (*CloudAPI, error) {
 	st := NewStateBackend(context.State())
 	ctlrSt := NewStateBackend(context.StatePool().SystemState())
-	return NewCloudAPI(st, ctlrSt, context.Auth(), state.CreateCallContext(context.State()))
+	return NewCloudAPI(st, ctlrSt, context.Auth(), state.CallContext(context.State()))
 }
 
 func NewFacadeV2(context facade.Context) (*CloudAPIV2, error) {
 	st := NewStateBackend(context.State())
 	ctlrSt := NewStateBackend(context.StatePool().SystemState())
-	return NewCloudAPIV2(st, ctlrSt, context.Auth(), state.CreateCallContext(context.State()))
+	return NewCloudAPIV2(st, ctlrSt, context.Auth(), state.CallContext(context.State()))
 }
 
 // NewCloudAPI creates a new API server endpoint for managing the controller's

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -15,6 +15,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 	_ "github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/ec2"
@@ -86,7 +87,7 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 		},
 	}
 
-	client, err := cloudfacade.NewCloudAPIV2(s.backend, s.backend, s.authorizer)
+	client, err := cloudfacade.NewCloudAPIV2(s.backend, s.backend, s.authorizer, context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	s.apiv2 = client
 }

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs/context"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -62,7 +63,7 @@ func (s *cloudSuite) setTestAPIForUser(c *gc.C, user names.UserTag) {
 		Tag: user,
 	}
 	var err error
-	s.api, err = cloudfacade.NewCloudAPI(s.backend, s.ctlrBackend, s.authorizer)
+	s.api, err = cloudfacade.NewCloudAPI(s.backend, s.ctlrBackend, s.authorizer, context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -80,7 +79,7 @@ func instanceTypes(api *CloudAPI,
 
 		itCons := common.NewInstanceTypeConstraints(
 			env,
-			context.NewCloudCallContext(),
+			api.callContext,
 			value,
 		)
 		it, err := common.InstanceTypes(itCons)

--- a/apiserver/facades/client/machinemanager/instance_information.go
+++ b/apiserver/facades/client/machinemanager/instance_information.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -52,7 +51,7 @@ func instanceTypes(mm *MachineManagerAPI,
 		}
 		itCons := common.NewInstanceTypeConstraints(
 			env,
-			context.NewCloudCallContext(),
+			mm.callContext,
 			value,
 		)
 		it, err := common.InstanceTypes(itCons)

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -49,7 +49,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 			},
 		},
 	}
-	api, err := machinemanager.NewMachineManagerAPI(backend, pool, authorizer)
+	api, err := machinemanager.NewMachineManagerAPI(backend, pool, authorizer, context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := params.ModelInstanceTypesConstraints{

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -29,6 +30,8 @@ type MachineManagerAPI struct {
 	pool       Pool
 	authorizer facade.Authorizer
 	check      *common.BlockChecker
+
+	callContext context.ProviderCallContext
 }
 
 // NewFacade create a new server-side MachineManager API facade. This
@@ -41,7 +44,7 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 	}
 	backend := &stateShim{State: st, IAASModel: im}
 	pool := &poolShim{ctx.StatePool()}
-	return NewMachineManagerAPI(backend, pool, ctx.Auth())
+	return NewMachineManagerAPI(backend, pool, ctx.Auth(), state.CreateCallContext(st))
 }
 
 type MachineManagerAPIV4 struct {
@@ -58,15 +61,16 @@ func NewFacadeV4(ctx facade.Context) (*MachineManagerAPIV4, error) {
 }
 
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
-func NewMachineManagerAPI(backend Backend, pool Pool, auth facade.Authorizer) (*MachineManagerAPI, error) {
+func NewMachineManagerAPI(backend Backend, pool Pool, auth facade.Authorizer, callCtx context.ProviderCallContext) (*MachineManagerAPI, error) {
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
 	return &MachineManagerAPI{
-		st:         backend,
-		pool:       pool,
-		authorizer: auth,
-		check:      common.NewBlockChecker(backend),
+		st:          backend,
+		pool:        pool,
+		authorizer:  auth,
+		check:       common.NewBlockChecker(backend),
+		callContext: callCtx,
 	}, nil
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -44,7 +44,7 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 	}
 	backend := &stateShim{State: st, IAASModel: im}
 	pool := &poolShim{ctx.StatePool()}
-	return NewMachineManagerAPI(backend, pool, ctx.Auth(), state.CreateCallContext(st))
+	return NewMachineManagerAPI(backend, pool, ctx.Auth(), state.CallContext(st))
 }
 
 type MachineManagerAPIV4 struct {

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 	_ "github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/dummy"
@@ -35,7 +36,8 @@ type ListModelsWithInfoSuite struct {
 	authoriser apiservertesting.FakeAuthorizer
 	adminUser  names.UserTag
 
-	api *modelmanager.ModelManagerAPI
+	api         *modelmanager.ModelManagerAPI
+	callContext context.ProviderCallContext
 }
 
 var _ = gc.Suite(&ListModelsWithInfoSuite{})
@@ -56,7 +58,9 @@ func (s *ListModelsWithInfoSuite) SetUpTest(c *gc.C) {
 	s.authoriser = apiservertesting.FakeAuthorizer{
 		Tag: s.adminUser,
 	}
-	api, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, s.authoriser, s.st.model)
+
+	s.callContext = context.NewCloudCallContext()
+	api, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, s.authoriser, s.st.model, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -74,7 +78,7 @@ func (s *ListModelsWithInfoSuite) createModel(c *gc.C, user names.UserTag) *mock
 
 func (s *ListModelsWithInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
-	modelmanager, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, s.authoriser, s.st.model)
+	modelmanager, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, s.authoriser, s.st.model, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = modelmanager
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/permission"
@@ -36,6 +37,8 @@ type modelInfoSuite struct {
 	st           *mockState
 	ctlrSt       *mockState
 	modelmanager *modelmanager.ModelManagerAPI
+
+	callContext context.ProviderCallContext
 }
 
 func pUint64(v uint64) *uint64 {
@@ -142,15 +145,17 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
+	s.callContext = context.NewCloudCallContext()
+
 	var err error
-	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, &s.authorizer, s.st.model)
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, &s.authorizer, s.st.model, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
 	var err error
-	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, s.authorizer, s.st.model)
+	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, s.authorizer, s.st.model, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -86,6 +86,7 @@ type ModelManagerAPI struct {
 	apiUser     names.UserTag
 	isAdmin     bool
 	model       common.Model
+	callContext context.ProviderCallContext
 }
 
 // ModelManagerAPIV2 provides a way to wrap the different calls between
@@ -132,6 +133,7 @@ func NewFacadeV4(ctx facade.Context) (*ModelManagerAPI, error) {
 		configGetter,
 		auth,
 		model,
+		state.CreateCallContext(st),
 	)
 }
 
@@ -161,6 +163,7 @@ func NewModelManagerAPI(
 	configGetter environs.EnvironConfigGetter,
 	authorizer facade.Authorizer,
 	m common.Model,
+	callCtx context.ProviderCallContext,
 ) (*ModelManagerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
@@ -185,6 +188,7 @@ func NewModelManagerAPI(
 		apiUser:        apiUser,
 		isAdmin:        isAdmin,
 		model:          m,
+		callContext:    callCtx,
 	}, nil
 }
 
@@ -490,7 +494,7 @@ func (m *ModelManagerAPI) newIAASModel(
 	}
 
 	err = env.Create(
-		context.NewCloudCallContext(),
+		m.callContext,
 		environs.CreateParams{
 			ControllerUUID: controllerCfg.ControllerUUID(),
 		},

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -133,7 +133,7 @@ func NewFacadeV4(ctx facade.Context) (*ModelManagerAPI, error) {
 		configGetter,
 		auth,
 		model,
-		state.CreateCallContext(st),
+		state.CallContext(st),
 	)
 }
 

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -44,7 +44,7 @@ func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (API,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newAPIWithBacking(stateShim, context.NewCloudCallContext(), res, auth)
+	return newAPIWithBacking(stateShim, state.CreateCallContext(st), res, auth)
 }
 
 // newAPIWithBacking creates a new server-side Spaces API facade with

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -44,7 +44,7 @@ func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (API,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newAPIWithBacking(stateShim, state.CreateCallContext(st), res, auth)
+	return newAPIWithBacking(stateShim, state.CallContext(st), res, auth)
 }
 
 // newAPIWithBacking creates a new server-side Spaces API facade with

--- a/apiserver/facades/client/sshclient/export_test.go
+++ b/apiserver/facades/client/sshclient/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshclient
+
+var InternalFacade = internalFacade

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -36,7 +36,7 @@ func NewFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{st, m}}, ctx.Auth(), state.CreateCallContext(st))
+	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{st, m}}, ctx.Auth(), state.CallContext(st))
 }
 
 func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -16,22 +16,35 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.sshclient")
 
 // Facade implements the API required by the sshclient worker.
 type Facade struct {
-	backend    Backend
-	authorizer facade.Authorizer
+	backend     Backend
+	authorizer  facade.Authorizer
+	callContext context.ProviderCallContext
 }
 
-// New returns a new API facade for the sshclient worker.
-func New(backend Backend, _ facade.Resources, authorizer facade.Authorizer) (*Facade, error) {
-	if !authorizer.AuthClient() {
+// NewFacade is used for API registration.
+func NewFacade(ctx facade.Context) (*Facade, error) {
+	st := ctx.State()
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{st, m}}, ctx.Auth(), state.CreateCallContext(st))
+}
+
+func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {
+	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	return &Facade{backend: backend, authorizer: authorizer}, nil
+
+	return &Facade{backend: backend, authorizer: auth, callContext: callCtx}, nil
 }
 
 func (facade *Facade) checkIsModelAdmin() error {
@@ -82,7 +95,6 @@ func (facade *Facade) AllAddresses(args params.Entities) (params.SSHAddressesRes
 	}
 
 	environ, supportsNetworking := environs.SupportsNetworking(env)
-	ctx := context.NewCloudCallContext()
 	getter := func(m SSHMachine) ([]network.Address, error) {
 		devicesAddresses, err := m.AllNetworkAddresses()
 		if err != nil {
@@ -100,7 +112,7 @@ func (facade *Facade) AllAddresses(args params.Entities) (params.SSHAddressesRes
 			}
 		}
 		if supportsNetworking {
-			return environ.SSHAddresses(ctx, uniqueAddresses)
+			return environ.SSHAddresses(facade.callContext, uniqueAddresses)
 		} else {
 			return uniqueAddresses, nil
 		}

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
@@ -32,15 +31,6 @@ type SSHMachine interface {
 	PrivateAddress() (network.Address, error)
 	Addresses() []network.Address
 	AllNetworkAddresses() ([]network.Address, error)
-}
-
-// NewFacade wraps New to express the supplied *state.State as a Backend.
-func NewFacade(st *state.State, res facade.Resources, auth facade.Authorizer) (*Facade, error) {
-	m, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return New(&backend{stateenvirons.EnvironConfigGetter{st, m}}, res, auth)
 }
 
 type backend struct {

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -49,7 +49,7 @@ func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (Subn
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newAPIWithBacking(stateshim, context.NewCloudCallContext(), res, auth)
+	return newAPIWithBacking(stateshim, state.CreateCallContext(st), res, auth)
 }
 
 func (api *subnetsAPI) checkCanRead() error {

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -49,7 +49,7 @@ func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (Subn
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newAPIWithBacking(stateshim, state.CreateCallContext(st), res, auth)
+	return newAPIWithBacking(stateshim, state.CallContext(st), res, auth)
 }
 
 func (api *subnetsAPI) checkCanRead() error {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -37,7 +37,7 @@ type API struct {
 
 // NewFacade is used for API registration.
 func NewFacade(ctx facade.Context) (*API, error) {
-	return NewAPI(ctx, stateenvirons.GetNewEnvironFunc(environs.New), context.NewCloudCallContext())
+	return NewAPI(ctx, stateenvirons.GetNewEnvironFunc(environs.New), state.CreateCallContext(ctx.State()))
 }
 
 // NewAPI returns a new API. Accepts a NewEnvironFunc and context.ProviderCallContext

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -37,7 +37,7 @@ type API struct {
 
 // NewFacade is used for API registration.
 func NewFacade(ctx facade.Context) (*API, error) {
-	return NewAPI(ctx, stateenvirons.GetNewEnvironFunc(environs.New), state.CreateCallContext(ctx.State()))
+	return NewAPI(ctx, stateenvirons.GetNewEnvironFunc(environs.New), state.CallContext(ctx.State()))
 }
 
 // NewAPI returns a new API. Accepts a NewEnvironFunc and context.ProviderCallContext

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -524,7 +524,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			if err != nil {
 				return false, errors.Annotate(err, "getting environ from state")
 			}
-			return environs.SupportsSpaces(state.CreateCallContext(st), env), nil
+			return environs.SupportsSpaces(state.CallContext(st), env), nil
 		}
 
 		manifolds := machineManifolds(machine.ManifoldsConfig{

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -53,7 +53,6 @@ import (
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/paths"
@@ -525,7 +524,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			if err != nil {
 				return false, errors.Annotate(err, "getting environ from state")
 			}
-			return environs.SupportsSpaces(context.NewCloudCallContext(), env), nil
+			return environs.SupportsSpaces(state.CreateCallContext(st), env), nil
 		}
 
 		manifolds := machineManifolds(machine.ManifoldsConfig{

--- a/environs/context/callcontext.go
+++ b/environs/context/callcontext.go
@@ -11,12 +11,12 @@ type ProviderCallContext interface {
 
 	// InvalidateCredential provides means to invalidate a credential
 	// that is used to make a call.
-	InvalidateCredential() error
+	InvalidateCredential(string) error
 }
 
 func NewCloudCallContext() *CloudCallContext {
 	return &CloudCallContext{
-		InvalidateCredentialF: func() error {
+		InvalidateCredentialF: func(string) error {
 			return errors.NotImplementedf("InvalidateCredentialCallback")
 		},
 	}
@@ -35,10 +35,10 @@ func NewCloudCallContext() *CloudCallContext {
 // as this knowledge is specific to where the call was made *from* not on what object
 // it was made.
 type CloudCallContext struct {
-	InvalidateCredentialF func() error
+	InvalidateCredentialF func(string) error
 }
 
 // InvalidateCredentialCallback implements context.InvalidateCredentialCallback.
-func (c *CloudCallContext) InvalidateCredential() error {
-	return c.InvalidateCredentialF()
+func (c *CloudCallContext) InvalidateCredential(reason string) error {
+	return c.InvalidateCredentialF(reason)
 }

--- a/state/callcontext.go
+++ b/state/callcontext.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "github.com/juju/juju/environs/context"
+
+func CreateCallContext(st *State) context.ProviderCallContext {
+	callCtx := context.NewCloudCallContext()
+	callCtx.InvalidateCredentialF = func(reason string) error {
+		return st.InvalidateModelCredential(reason)
+	}
+	return callCtx
+}

--- a/state/callcontext.go
+++ b/state/callcontext.go
@@ -5,10 +5,8 @@ package state
 
 import "github.com/juju/juju/environs/context"
 
-func CreateCallContext(st *State) context.ProviderCallContext {
+func CallContext(st *State) context.ProviderCallContext {
 	callCtx := context.NewCloudCallContext()
-	callCtx.InvalidateCredentialF = func(reason string) error {
-		return st.InvalidateModelCredential(reason)
-	}
+	callCtx.InvalidateCredentialF = st.InvalidateModelCredential
 	return callCtx
 }

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -395,3 +395,23 @@ func (s *CloudCredentialsSuite) TestAllCloudCredentials(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, []state.Credential{one, two})
 }
+
+func (s *CloudCredentialsSuite) TestInvalidateCloudCredential(c *gc.C) {
+	oneTag, one := s.createCloudCredential(c, "cirrus", "bob", "foobar")
+	c.Assert(one.IsValid(), jc.IsTrue)
+
+	reason := "testing, testing 1,2,3"
+	err := s.State.InvalidateCloudCredential(oneTag, reason)
+	c.Assert(err, jc.ErrorIsNil)
+
+	updated, err := s.State.CloudCredential(oneTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(updated.IsValid(), jc.IsFalse)
+	c.Assert(updated.InvalidReason, gc.DeepEquals, reason)
+}
+
+func (s *CloudCredentialsSuite) TestInvalidateCloudCredentialNotFound(c *gc.C) {
+	tag := names.NewCloudCredentialTag("cloud/user/credential")
+	err := s.State.InvalidateCloudCredential(tag, "just does not matter")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/containernetworking.go
+++ b/state/containernetworking.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
 )
 
 // AutoConfigureContainerNetworking tries to set up best container networking available
@@ -30,7 +29,7 @@ func (m *Model) AutoConfigureContainerNetworking(environ environs.Environ) error
 
 	if modelConfig.ContainerNetworkingMethod() != "" {
 		// Do nothing, user has decided what to do
-	} else if environs.SupportsContainerAddresses(createEnvironCallContext(m.st), environ) {
+	} else if environs.SupportsContainerAddresses(CreateCallContext(m.st), environ) {
 		updateAttrs["container-networking-method"] = "provider"
 	} else if fanConfigured {
 		updateAttrs["container-networking-method"] = "fan"
@@ -39,10 +38,6 @@ func (m *Model) AutoConfigureContainerNetworking(environ environs.Environ) error
 	}
 	err = m.UpdateModelConfig(updateAttrs, nil)
 	return err
-}
-
-func createEnvironCallContext(st *State) context.ProviderCallContext {
-	return context.NewCloudCallContext()
 }
 
 func (m *Model) discoverFan(environ environs.Environ, modelConfig *config.Config, updateAttrs map[string]interface{}) (bool, error) {
@@ -59,7 +54,7 @@ func (m *Model) discoverFan(environ environs.Environ, modelConfig *config.Config
 		logger.Debugf("Not trying to autoconfigure FAN - configured already")
 		return false, nil
 	}
-	subnets, err := netEnviron.SuperSubnets(createEnvironCallContext(m.st))
+	subnets, err := netEnviron.SuperSubnets(CreateCallContext(m.st))
 	if errors.IsNotSupported(err) || (err == nil && len(subnets) == 0) {
 		logger.Debugf("Not trying to autoconfigure FAN - SuperSubnets not supported or empty")
 		return false, nil

--- a/state/containernetworking.go
+++ b/state/containernetworking.go
@@ -29,7 +29,7 @@ func (m *Model) AutoConfigureContainerNetworking(environ environs.Environ) error
 
 	if modelConfig.ContainerNetworkingMethod() != "" {
 		// Do nothing, user has decided what to do
-	} else if environs.SupportsContainerAddresses(CreateCallContext(m.st), environ) {
+	} else if environs.SupportsContainerAddresses(CallContext(m.st), environ) {
 		updateAttrs["container-networking-method"] = "provider"
 	} else if fanConfigured {
 		updateAttrs["container-networking-method"] = "fan"
@@ -54,7 +54,7 @@ func (m *Model) discoverFan(environ environs.Environ, modelConfig *config.Config
 		logger.Debugf("Not trying to autoconfigure FAN - configured already")
 		return false, nil
 	}
-	subnets, err := netEnviron.SuperSubnets(CreateCallContext(m.st))
+	subnets, err := netEnviron.SuperSubnets(CallContext(m.st))
 	if errors.IsNotSupported(err) || (err == nil && len(subnets) == 0) {
 		logger.Debugf("Not trying to autoconfigure FAN - SuperSubnets not supported or empty")
 		return false, nil

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -39,7 +39,7 @@ func distributeUnit(u *Unit, candidates []instance.Id) ([]instance.Id, error) {
 	if len(distributionGroup) == 0 {
 		return candidates, nil
 	}
-	return distributor.DistributeInstances(createEnvironCallContext(u.st), candidates, distributionGroup)
+	return distributor.DistributeInstances(CreateCallContext(u.st), candidates, distributionGroup)
 }
 
 // ServiceInstances returns the instance IDs of provisioned

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -39,7 +39,7 @@ func distributeUnit(u *Unit, candidates []instance.Id) ([]instance.Id, error) {
 	if len(distributionGroup) == 0 {
 		return candidates, nil
 	}
-	return distributor.DistributeInstances(CreateCallContext(u.st), candidates, distributionGroup)
+	return distributor.DistributeInstances(CallContext(u.st), candidates, distributionGroup)
 }
 
 // ServiceInstances returns the instance IDs of provisioned

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -1,0 +1,25 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+)
+
+// InvalidateModelCredential invalidate cloud credential for the model
+// of the given state.
+func (st *State) InvalidateModelCredential(reason string) error {
+	m, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	tag, exists := m.CloudCredential()
+	if !exists {
+		// Model is on the cloud that does not require auth - nothing to do.
+		return nil
+	}
+
+	return errors.Trace(st.InvalidateCloudCredential(tag, reason))
+}

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+type ModelCredentialSuite struct {
+	ConnSuite
+
+	credentialTag names.CloudCredentialTag
+}
+
+var _ = gc.Suite(&ModelCredentialSuite{})
+
+func (s *ModelCredentialSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+
+	s.credentialTag = s.createCloudCredential(c, "foobar")
+}
+
+func (s *ModelCredentialSuite) TestInvalidateModelCredentialNone(c *gc.C) {
+	// The model created in ConnSuite does not have a credential.
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	_, exists := m.CloudCredential()
+	c.Assert(exists, jc.IsFalse)
+
+	reason := "special invalidation"
+	err = s.State.InvalidateModelCredential(reason)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ModelCredentialSuite) TestInvalidateModelCredential(c *gc.C) {
+	s.addModel(c, "abcmodel", s.credentialTag)
+	credential, err := s.State.CloudCredential(s.credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credential.IsValid(), jc.IsTrue)
+
+	reason := "special invalidation"
+	err = s.State.InvalidateModelCredential(reason)
+	c.Assert(err, jc.ErrorIsNil)
+
+	invalidated, err := s.State.CloudCredential(s.credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(invalidated.IsValid(), jc.IsFalse)
+	c.Assert(invalidated.InvalidReason, gc.DeepEquals, reason)
+}
+
+func (s *ModelCredentialSuite) createCloudCredential(c *gc.C, credentialName string) names.CloudCredentialTag {
+	// Cloud name is always "dummy" as deep within the testing infrastructure,
+	// we create a testing controller on a cloud "dummy".
+	// Test cloud "dummy" only allows credentials with an empty auth type.
+	tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", "dummy", s.Owner.Id(), credentialName))
+	err := s.State.UpdateCloudCredential(tag, cloud.NewEmptyCredential())
+	c.Assert(err, jc.ErrorIsNil)
+	return tag
+}
+
+func (s *ModelCredentialSuite) addModel(c *gc.C, modelName string, tag names.CloudCredentialTag) {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": modelName,
+		"uuid": uuid.String(),
+	})
+	_, st, err := s.State.NewModel(state.ModelArgs{
+		Type:                    state.ModelTypeIAAS,
+		CloudName:               "dummy",
+		CloudRegion:             "dummy-region",
+		Config:                  cfg,
+		Owner:                   tag.Owner(),
+		CloudCredential:         tag,
+		StorageProviderRegistry: storage.StaticProviderRegistry{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.Close()
+	s.State = st
+}

--- a/state/policy.go
+++ b/state/policy.go
@@ -69,7 +69,7 @@ func (st *State) precheckInstance(
 		return errors.New("policy returned nil prechecker without an error")
 	}
 	return prechecker.PrecheckInstance(
-		createEnvironCallContext(st),
+		CreateCallContext(st),
 		environs.PrecheckInstanceParams{
 			Series:            series,
 			Constraints:       cons,

--- a/state/policy.go
+++ b/state/policy.go
@@ -69,7 +69,7 @@ func (st *State) precheckInstance(
 		return errors.New("policy returned nil prechecker without an error")
 	}
 	return prechecker.PrecheckInstance(
-		CreateCallContext(st),
+		CallContext(st),
 		environs.PrecheckInstanceParams{
 			Series:            series,
 			Constraints:       cons,

--- a/state/spacesdiscovery.go
+++ b/state/spacesdiscovery.go
@@ -37,7 +37,7 @@ func (st *State) ReloadSpaces(environ environs.Environ) error {
 		return errors.NotSupportedf("spaces discovery in a non-networking environ")
 	}
 
-	ctx := CreateCallContext(st)
+	ctx := CallContext(st)
 	canDiscoverSpaces, err := netEnviron.SupportsSpaceDiscovery(ctx)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/spacesdiscovery.go
+++ b/state/spacesdiscovery.go
@@ -37,7 +37,7 @@ func (st *State) ReloadSpaces(environ environs.Environ) error {
 		return errors.NotSupportedf("spaces discovery in a non-networking environ")
 	}
 
-	ctx := createEnvironCallContext(st)
+	ctx := CreateCallContext(st)
 	canDiscoverSpaces, err := netEnviron.SupportsSpaceDiscovery(ctx)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
## Description of change

When calling a substrate API, we might want to have Juju react based on where the call is made from and what substrate response was given. The most recent example of this, for substrates that require credentials, we want to react to a rejection of a provided credential.

This PR shows how a credential needs to be invalidated when a substrate call is done from state or an apiserver layer.
