### PR TITLE
2.3 Runs LXD Init on Bionic Hosts

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -68,9 +68,8 @@ func (ci *containerInitialiser) Initialise() error {
 		return err
 	}
 
-	// Well... this will need to change soon once we are passed 17.04 as who
-	// knows what the series name will be.
-	if ci.series < "xenial" {
+	switch ci.series {
+	case "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily":
 		return nil
 	}
 

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -68,8 +68,8 @@ func (ci *containerInitialiser) Initialise() error {
 		return err
 	}
 
-	switch ci.series {
-	case "quantal", "raring", "saucy", "trusty", "utopic", "vivid", "wily":
+	// LXD init is only run on Xenial and later.
+	if ci.series == "trusty" {
 		return nil
 	}
 

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -8,7 +8,9 @@ package lxd
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os/exec"
 	"runtime"
 
 	"github.com/juju/testing"
@@ -129,26 +131,32 @@ func (s *InitialiserSuite) TestNoSeriesPackages(c *gc.C) {
 	})
 }
 
-func (s *InitialiserSuite) TestLXDInit(c *gc.C) {
-	// Patch df so it always returns 100GB
-	df100 := func(path string) (uint64, error) {
-		return 100 * 1024 * 1024 * 1024, nil
-	}
-	s.PatchValue(&df, df100)
+func (s *InitialiserSuite) TestLXDInitBionic(c *gc.C) {
+	s.patchDF100GB()
 
-	container := NewContainerInitialiser("xenial")
+	container := NewContainerInitialiser("bionic")
 	err := container.Initialise()
 	c.Assert(err, jc.ErrorIsNil)
 
 	testing.AssertEchoArgs(c, "lxd", "init", "--auto")
 }
 
+func (s *InitialiserSuite) TestLXDInitTrusty(c *gc.C) {
+	s.patchDF100GB()
+
+	container := NewContainerInitialiser("trusty")
+	err := container.Initialise()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that our patched call has no recorded args.
+	execPath, err := exec.LookPath("lxd")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = ioutil.ReadFile(execPath + ".out")
+	c.Assert(err, gc.ErrorMatches, "*. no such file or directory$")
+}
+
 func (s *InitialiserSuite) TestLXDAlreadyInitialized(c *gc.C) {
-	// Patch df so it always returns 100GB
-	df100 := func(path string) (uint64, error) {
-		return 100 * 1024 * 1024 * 1024, nil
-	}
-	s.PatchValue(&df, df100)
+	s.patchDF100GB()
 
 	container := NewContainerInitialiser("xenial")
 	cont, ok := container.(*containerInitialiser)
@@ -167,6 +175,14 @@ error: You have existing containers or images. lxd init requires an empty LXD.`,
 	// the above error should be ignored by the code that calls lxd init.
 	err := container.Initialise()
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+// patchDF100GB ensures that df always returns 100GB.
+func (s *InitialiserSuite) patchDF100GB() {
+	df100 := func(path string) (uint64, error) {
+		return 100 * 1024 * 1024 * 1024, nil
+	}
+	s.PatchValue(&df, df100)
 }
 
 type mockConfigSetter struct {


### PR DESCRIPTION
## Description of change

Backport of changes in the develop branch to ensure that _lxd init_ is run by _bionic_ container managers. 

## QA steps

Unit and system tests.

## Documentation changes

No.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1765571
