### PR TITLE
Merge pull request #8672 from ExternalReality/develop

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -671,8 +671,9 @@ type ProxyConfigResults struct {
 
 // InterfaceAddress represents a single address attached to the interface.
 type InterfaceAddress struct {
-	Address string `json:"value"`
-	CIDR    string `json:"cidr"`
+	Hostname string `json:"hostname"`
+	Address  string `json:"value"`
+	CIDR     string `json:"cidr"`
 }
 
 // NetworkInfo describes one interface with IP addresses.

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -5,10 +5,13 @@ package jujuc
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
 // NetworkGetCommand implements the network-get command.
@@ -31,6 +34,10 @@ type NetworkGetCommand struct {
 
 	out cmd.Output
 }
+
+type resolver = func(host string) (addrs []string, err error)
+
+var LookupHost resolver = net.LookupHost
 
 func NewNetworkGetCommand(ctx Context) (_ cmd.Command, err error) {
 	cmd := &NetworkGetCommand{ctx: ctx}
@@ -118,6 +125,8 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
+	ni = resolveNetworkInfoAddresses(ni, LookupHost)
+
 	// If no specific attributes asked for,
 	// print everything we know.
 	if !c.primaryAddress && len(c.keys) == 0 {
@@ -160,4 +169,29 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return c.out.Write(ctx, keyValues[c.keys[0]])
 	}
 	return c.out.Write(ctx, keyValues)
+}
+
+// TODO(externalreality) This addresses the immediate problem of
+// https://bugs.launchpad.net/juju/+bug/1721368, but the hostname can populate
+// both the egress subnet cidr and the ingress addreses. These too should be
+// resolved. In addition these values probably should not be stored as hostnames
+// but rather the IP, that is, it might be better to do the resolution on input
+// rather than output (network-get) as we do here.
+func resolveNetworkInfoAddresses(networkInfoResult params.NetworkInfoResult, lookupHost resolver) params.NetworkInfoResult {
+	logger.Debugf("Resolving Addresses")
+	for i, networkInfo := range networkInfoResult.Info {
+		for j, interfaceAddress := range networkInfo.Addresses {
+			if ip := net.ParseIP(interfaceAddress.Address); ip != nil {
+				continue
+			}
+			resolvedAddress, err := lookupHost(interfaceAddress.Address)
+			if err != nil {
+				logger.Warningf("The address %q is neither an IP address or a resolvable hostname", interfaceAddress.Address)
+			} else {
+				networkInfoResult.Info[i].Addresses[j].Hostname = interfaceAddress.Address
+				networkInfoResult.Info[i].Addresses[j].Address = resolvedAddress[0]
+			}
+		}
+	}
+	return networkInfoResult
 }


### PR DESCRIPTION
https://github.com/juju/juju/pull/8672

## Description of change

Juju can store unresolved hostnames in network info Address fields. These hostnames can show up in network-get output which should always be IP addresses and not hostnames. To solve the issue simply, we resolve the hostnames on network get output. 

## QA steps

On a local provider you may:

1. Bootstrap 
2. Launch a lxd instance
3. Ensure that you can ssh into the machine
4. Assign the machine a resolvable hostname (e.g. add an entry to /etc/hosts)
5. manually provision machine using `ssh:<user>@<hostname>` placement directive format 
6. deploy mysql to manually provisioned machine
7. `juju run mysql/0 -- network-get --primary-address --format yaml db 

You should see an IP Address and not a hostname 

## Documentation changes

N/A

## Does it affect current user workflow? CLI? API?

If a user is depending on hostnames, for whatever reason, they might be in for a surprise.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721368

