### PR TITLE
Add policy to deploy and add unit API calls.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -350,6 +350,10 @@ type AddUnitsParams struct {
 	// created.
 	Placement []*instance.Placement
 
+	// Policy represents how a machine for the unit is determined.
+	// This value is ignored on any Juju server before 2.4.
+	Policy string
+
 	// AttachStorage contains IDs of existing storage that should be
 	// attached to the application unit that will be deployed. This
 	// may be non-empty only if NumUnits is 1.
@@ -379,6 +383,7 @@ func (c *Client) AddUnits(args AddUnitsParams) ([]string, error) {
 		ApplicationName: args.ApplicationName,
 		NumUnits:        args.NumUnits,
 		Placement:       args.Placement,
+		Policy:          args.Policy,
 		AttachStorage:   attachStorage,
 	}, results)
 	return results.Units, err

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -46,16 +46,21 @@ type APIv4 struct {
 	*APIv5
 }
 
-// APIv6 provides the Application API facade for version 6.
-type APIv6 struct {
-	*APIv5
+// APIv5 provides the Application API facade for version 5.
+type APIv5 struct {
+	*APIv6
 }
 
-// API implements the application interface and is the concrete
+// APIv6 provides the Application API facade for version 6.
+type APIv6 struct {
+	*APIBase
+}
+
+// APIBase implements the shared application interface and is the concrete
 // implementation of the api end point.
 //
 // API provides the Application API facade for version 5.
-type APIv5 struct {
+type APIBase struct {
 	backend    Backend
 	authorizer facade.Authorizer
 	check      BlockChecker
@@ -80,25 +85,33 @@ func NewFacadeV4(ctx facade.Context) (*APIv4, error) {
 	return &APIv4{api}, nil
 }
 
-// NewFacadeV6 provides the signature required for facade registration
-// for versions 6.
-func NewFacadeV6(ctx facade.Context) (*APIv6, error) {
-	apiV5, err := NewFacadeV5(ctx)
+// NewFacade provides the signature required for facade registration.
+func NewFacadeV5(ctx facade.Context) (*APIv5, error) {
+	api, err := NewFacadeV6(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &APIv6{apiV5}, nil
+	return &APIv5{api}, nil
 }
 
-// NewFacade provides the signature required for facade registration.
-func NewFacadeV5(ctx facade.Context) (*APIv5, error) {
+// NewFacadeV6 provides the signature required for facade registration
+// for versions 6.
+func NewFacadeV6(ctx facade.Context) (*APIv6, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv6{api}, nil
+}
+
+func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 	backend, err := NewStateBackend(ctx.State())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting state")
 	}
 	blockChecker := common.NewBlockChecker(ctx.State())
 	stateCharm := CharmToStateCharm
-	return NewAPIV5(
+	return NewAPIBase(
 		backend,
 		ctx.Auth(),
 		blockChecker,
@@ -107,18 +120,18 @@ func NewFacadeV5(ctx facade.Context) (*APIv5, error) {
 	)
 }
 
-// NewAPI returns a new application API facade.
-func NewAPIV5(
+// NewAPIBase returns a new application API facade.
+func NewAPIBase(
 	backend Backend,
 	authorizer facade.Authorizer,
 	blockChecker BlockChecker,
 	stateCharm func(Charm) *state.Charm,
 	deployApplication func(ApplicationDeployer, DeployApplicationParams) (Application, error),
-) (*APIv5, error) {
+) (*APIBase, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	return &APIv5{
+	return &APIBase{
 		backend:               backend,
 		authorizer:            authorizer,
 		check:                 blockChecker,
@@ -127,7 +140,7 @@ func NewAPIV5(
 	}, nil
 }
 
-func (api *APIv5) checkPermission(tag names.Tag, perm permission.Access) error {
+func (api *APIBase) checkPermission(tag names.Tag, perm permission.Access) error {
 	allowed, err := api.authorizer.HasPermission(perm, tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -138,16 +151,16 @@ func (api *APIv5) checkPermission(tag names.Tag, perm permission.Access) error {
 	return nil
 }
 
-func (api *APIv5) checkCanRead() error {
+func (api *APIBase) checkCanRead() error {
 	return api.checkPermission(api.backend.ModelTag(), permission.ReadAccess)
 }
 
-func (api *APIv5) checkCanWrite() error {
+func (api *APIBase) checkCanWrite() error {
 	return api.checkPermission(api.backend.ModelTag(), permission.WriteAccess)
 }
 
 // SetMetricCredentials sets credentials on the application.
-func (api *APIv5) SetMetricCredentials(args params.ApplicationMetricCredentials) (params.ErrorResults, error) {
+func (api *APIBase) SetMetricCredentials(args params.ApplicationMetricCredentials) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -173,7 +186,7 @@ func (api *APIv5) SetMetricCredentials(args params.ApplicationMetricCredentials)
 
 // Deploy fetches the charms from the charm store and deploys them
 // using the specified placement directives.
-func (api *APIv5) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, error) {
+func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -415,7 +428,7 @@ func parseSettingsCompatible(charmConfig *charm.Config, settings map[string]stri
 // Update updates the application attributes, including charm URL,
 // minimum number of units, charm config and constraints.
 // All parameters in params.ApplicationUpdate except the application name are optional.
-func (api *APIv5) Update(args params.ApplicationUpdate) error {
+func (api *APIBase) Update(args params.ApplicationUpdate) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -473,7 +486,7 @@ func (api *APIv5) Update(args params.ApplicationUpdate) error {
 
 // UpdateApplicationSeries updates the application series. Series for
 // subordinates updated too.
-func (api *APIv5) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.ErrorResults, error) {
+func (api *APIBase) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -490,7 +503,7 @@ func (api *APIv5) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.
 	return results, nil
 }
 
-func (api *APIv5) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
+func (api *APIBase) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
 	if arg.Series == "" {
 		return &params.Error{
 			Message: "series missing from args",
@@ -518,7 +531,7 @@ func (api *APIv5) updateOneApplicationSeries(arg params.UpdateSeriesArg) error {
 }
 
 // SetCharm sets the charm for a given for the application.
-func (api *APIv5) SetCharm(args params.ApplicationSetCharm) error {
+func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -549,7 +562,7 @@ func (api *APIv5) SetCharm(args params.ApplicationSetCharm) error {
 
 // GetConfig returns the charm config for each of the
 // applications asked for.
-func (api *APIv5) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConfigResults{}, err
 	}
@@ -564,7 +577,7 @@ func (api *APIv5) GetConfig(args params.Entities) (params.ApplicationGetConfigRe
 	return results, nil
 }
 
-func (api *APIv5) getCharmConfig(entity string) (map[string]interface{}, error) {
+func (api *APIBase) getCharmConfig(entity string) (map[string]interface{}, error) {
 	tag, err := names.ParseTag(entity)
 	if err != nil {
 		return nil, err
@@ -590,7 +603,7 @@ func (api *APIv5) getCharmConfig(entity string) (map[string]interface{}, error) 
 }
 
 // applicationSetCharm sets the charm for the given for the application.
-func (api *APIv5) applicationSetCharm(
+func (api *APIBase) applicationSetCharm(
 	appName string,
 	application Application,
 	url string,
@@ -704,7 +717,7 @@ func applicationSetCharmConfigYAML(appName string, application Application, sett
 
 // GetCharmURL returns the charm URL the given application is
 // running at present.
-func (api *APIv5) GetCharmURL(args params.ApplicationGet) (params.StringResult, error) {
+func (api *APIBase) GetCharmURL(args params.ApplicationGet) (params.StringResult, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.StringResult{}, errors.Trace(err)
 	}
@@ -719,7 +732,7 @@ func (api *APIv5) GetCharmURL(args params.ApplicationGet) (params.StringResult, 
 // Set implements the server side of Application.Set.
 // It does not unset values that are set to an empty string.
 // Unset should be used for that.
-func (api *APIv5) Set(p params.ApplicationSet) error {
+func (api *APIBase) Set(p params.ApplicationSet) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -745,7 +758,7 @@ func (api *APIv5) Set(p params.ApplicationSet) error {
 }
 
 // Unset implements the server side of Client.Unset.
-func (api *APIv5) Unset(p params.ApplicationUnset) error {
+func (api *APIBase) Unset(p params.ApplicationUnset) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -764,7 +777,7 @@ func (api *APIv5) Unset(p params.ApplicationUnset) error {
 }
 
 // CharmRelations implements the server side of Application.CharmRelations.
-func (api *APIv5) CharmRelations(p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
+func (api *APIBase) CharmRelations(p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
 	var results params.ApplicationCharmRelationsResults
 	if err := api.checkCanRead(); err != nil {
 		return results, errors.Trace(err)
@@ -787,7 +800,7 @@ func (api *APIv5) CharmRelations(p params.ApplicationCharmRelations) (params.App
 
 // Expose changes the juju-managed firewall to expose any ports that
 // were also explicitly marked by units as open.
-func (api *APIv5) Expose(args params.ApplicationExpose) error {
+func (api *APIBase) Expose(args params.ApplicationExpose) error {
 	if err := api.checkCanWrite(); err != nil {
 		return errors.Trace(err)
 	}
@@ -814,7 +827,7 @@ func (api *APIv5) Expose(args params.ApplicationExpose) error {
 
 // Unexpose changes the juju-managed firewall to unexpose any ports that
 // were also explicitly marked by units as open.
-func (api *APIv5) Unexpose(args params.ApplicationUnexpose) error {
+func (api *APIBase) Unexpose(args params.ApplicationUnexpose) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -829,7 +842,7 @@ func (api *APIv5) Unexpose(args params.ApplicationUnexpose) error {
 }
 
 // AddUnits adds a given number of units to an application.
-func (api *APIv5) AddUnits(args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
+func (api *APIBase) AddUnits(args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)
 	}
@@ -908,7 +921,7 @@ func addApplicationUnits(backend Backend, args params.AddApplicationUnits) ([]Un
 //
 // TODO(axw) 2017-03-16 #1673323
 // Drop this in Juju 3.0.
-func (api *APIv5) DestroyUnits(args params.DestroyApplicationUnits) error {
+func (api *APIBase) DestroyUnits(args params.DestroyApplicationUnits) error {
 	var errs []error
 	entities := params.DestroyUnitsParams{
 		Units: make([]params.DestroyUnitParams, 0, len(args.UnitNames)),
@@ -944,11 +957,11 @@ func (api *APIv4) DestroyUnit(args params.Entities) (params.DestroyUnitResults, 
 	for i, arg := range args.Entities {
 		v5args.Units[i].UnitTag = arg.Tag
 	}
-	return api.APIv5.DestroyUnit(v5args)
+	return api.APIBase.DestroyUnit(v5args)
 }
 
 // DestroyUnit removes a given set of application units.
-func (api *APIv5) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
+func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.DestroyUnitResults{}, errors.Trace(err)
 	}
@@ -1021,7 +1034,7 @@ func (api *APIv5) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUni
 //
 // TODO(axw) 2017-03-16 #1673323
 // Drop this in Juju 3.0.
-func (api *APIv5) Destroy(in params.ApplicationDestroy) error {
+func (api *APIBase) Destroy(in params.ApplicationDestroy) error {
 	if !names.IsValidApplication(in.ApplicationName) {
 		return errors.NotValidf("application name %q", in.ApplicationName)
 	}
@@ -1050,11 +1063,11 @@ func (api *APIv4) DestroyApplication(args params.Entities) (params.DestroyApplic
 	for i, arg := range args.Entities {
 		v5args.Applications[i].ApplicationTag = arg.Tag
 	}
-	return api.APIv5.DestroyApplication(v5args)
+	return api.APIBase.DestroyApplication(v5args)
 }
 
 // DestroyApplication removes a given set of applications.
-func (api *APIv5) DestroyApplication(args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
+func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.DestroyApplicationResults{}, err
 	}
@@ -1142,7 +1155,7 @@ func (api *APIv5) DestroyApplication(args params.DestroyApplicationsParams) (par
 }
 
 // DestroyConsumedApplications removes a given set of consumed (remote) applications.
-func (api *APIv5) DestroyConsumedApplications(args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
+func (api *APIBase) DestroyConsumedApplications(args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -1171,7 +1184,7 @@ func (api *APIv5) DestroyConsumedApplications(args params.DestroyConsumedApplica
 }
 
 // GetConstraints returns the constraints for a given application.
-func (api *APIv5) GetConstraints(args params.Entities) (params.ApplicationGetConstraintsResults, error) {
+func (api *APIBase) GetConstraints(args params.Entities) (params.ApplicationGetConstraintsResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConstraintsResults{}, errors.Trace(err)
 	}
@@ -1186,7 +1199,7 @@ func (api *APIv5) GetConstraints(args params.Entities) (params.ApplicationGetCon
 	return results, nil
 }
 
-func (api *APIv5) getConstraints(entity string) (constraints.Value, error) {
+func (api *APIBase) getConstraints(entity string) (constraints.Value, error) {
 	tag, err := names.ParseTag(entity)
 	if err != nil {
 		return constraints.Value{}, err
@@ -1204,7 +1217,7 @@ func (api *APIv5) getConstraints(entity string) (constraints.Value, error) {
 }
 
 // SetConstraints sets the constraints for a given application.
-func (api *APIv5) SetConstraints(args params.SetConstraints) error {
+func (api *APIBase) SetConstraints(args params.SetConstraints) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1219,7 +1232,7 @@ func (api *APIv5) SetConstraints(args params.SetConstraints) error {
 }
 
 // AddRelation adds a relation between the specified endpoints and returns the relation info.
-func (api *APIv5) AddRelation(args params.AddRelation) (_ params.AddRelationResults, err error) {
+func (api *APIBase) AddRelation(args params.AddRelation) (_ params.AddRelationResults, err error) {
 	var rel Relation
 	defer func() {
 		if err != nil && rel != nil {
@@ -1277,7 +1290,7 @@ func (api *APIv5) AddRelation(args params.AddRelation) (_ params.AddRelationResu
 
 // DestroyRelation removes the relation between the
 // specified endpoints or an id.
-func (api *APIv5) DestroyRelation(args params.DestroyRelation) (err error) {
+func (api *APIBase) DestroyRelation(args params.DestroyRelation) (err error) {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1304,7 +1317,7 @@ func (api *APIv5) DestroyRelation(args params.DestroyRelation) (err error) {
 }
 
 // SetRelationsSuspended sets the suspended status of the specified relations.
-func (api *APIv5) SetRelationsSuspended(args params.RelationSuspendedArgs) (params.ErrorResults, error) {
+func (api *APIBase) SetRelationsSuspended(args params.RelationSuspendedArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return statusResults, errors.Trace(err)
@@ -1354,7 +1367,7 @@ func (api *APIv5) SetRelationsSuspended(args params.RelationSuspendedArgs) (para
 
 // Consume adds remote applications to the model without creating any
 // relations.
-func (api *APIv5) Consume(args params.ConsumeApplicationArgs) (params.ErrorResults, error) {
+func (api *APIBase) Consume(args params.ConsumeApplicationArgs) (params.ErrorResults, error) {
 	var consumeResults params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return consumeResults, errors.Trace(err)
@@ -1372,7 +1385,7 @@ func (api *APIv5) Consume(args params.ConsumeApplicationArgs) (params.ErrorResul
 	return consumeResults, nil
 }
 
-func (api *APIv5) consumeOne(arg params.ConsumeApplicationArg) error {
+func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 	sourceModelTag, err := names.ParseModelTag(arg.SourceModelTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1408,7 +1421,7 @@ func (api *APIv5) consumeOne(arg params.ConsumeApplicationArg) error {
 
 // saveRemoteApplication saves the details of the specified remote application and its endpoints
 // to the state model so relations to the remote application can be created.
-func (api *APIv5) saveRemoteApplication(
+func (api *APIBase) saveRemoteApplication(
 	sourceModelTag names.ModelTag,
 	applicationName string,
 	offer params.ApplicationOfferDetails,
@@ -1478,7 +1491,7 @@ func providerSpaceInfoFromParams(space params.RemoteSpace) *environs.ProviderSpa
 // specified name and source model tag and tries to update its endpoints with the
 // new ones specified. If the endpoints are compatible, the newly updated remote
 // application is returned.
-func (api *APIv5) maybeUpdateExistingApplicationEndpoints(
+func (api *APIBase) maybeUpdateExistingApplicationEndpoints(
 	applicationName string, sourceModelTag names.ModelTag, remoteEps []charm.Relation,
 ) (RemoteApplication, error) {
 	existingRemoteApp, err := api.backend.RemoteApplication(applicationName)
@@ -1554,15 +1567,28 @@ func (api *APIv4) GetConstraints(args params.GetApplicationConstraints) (params.
 	return params.GetConstraintsResults{cons}, errors.Trace(err)
 }
 
+// Mask the new methods from the v4 and v5 API. The API reflection code in
+// rpc/rpcreflect/type.go:newMethod skips 2-argument methods, so this
+// removes the method as far as the RPC machinery is concerned.
+//
+// Since the v4 builds on v5, we can just make the methods unavailable on v5
+// and they will also be unavailable on v4.
+
+// CharmConfig isn't on the v5 API.
+func (u *APIv5) CharmConfig(_, _ struct{}) {}
+
 // CharmConfig is a shim to GetConfig on APIv5. It returns just the charm config.
-func (api *APIv6) CharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+func (api *APIBase) CharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
 	return api.GetConfig(args)
 }
+
+// SetApplicationsConfig isn't on the v5 API.
+func (u *APIv5) SetApplicationsConfig(_, _ struct{}) {}
 
 // SetApplicationsConfig implements the server side of Application.SetApplicationsConfig.
 // It does not unset values that are set to an empty string.
 // Unset should be used for that.
-func (api *APIv6) SetApplicationsConfig(args params.ApplicationConfigSetArgs) (params.ErrorResults, error) {
+func (api *APIBase) SetApplicationsConfig(args params.ApplicationConfigSetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
@@ -1578,7 +1604,7 @@ func (api *APIv6) SetApplicationsConfig(args params.ApplicationConfigSetArgs) (p
 	return result, nil
 }
 
-func (api *APIv6) setApplicationConfig(arg params.ApplicationConfigSet) error {
+func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error {
 	app, err := api.backend.Application(arg.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
@@ -1615,8 +1641,11 @@ func (api *APIv6) setApplicationConfig(arg params.ApplicationConfigSet) error {
 	return nil
 }
 
+// UnsetApplicationsConfig isn't on the v5 API.
+func (u *APIv5) UnsetApplicationsConfig(_, _ struct{}) {}
+
 // UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig.
-func (api *APIv6) UnsetApplicationsConfig(args params.ApplicationConfigUnsetArgs) (params.ErrorResults, error) {
+func (api *APIBase) UnsetApplicationsConfig(args params.ApplicationConfigUnsetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
@@ -1632,7 +1661,7 @@ func (api *APIv6) UnsetApplicationsConfig(args params.ApplicationConfigUnsetArgs
 	return result, nil
 }
 
-func (api *APIv6) unsetApplicationConfig(arg params.ApplicationUnset) error {
+func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 	app, err := api.backend.Application(arg.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
@@ -1667,8 +1696,11 @@ func (api *APIv6) unsetApplicationConfig(arg params.ApplicationUnset) error {
 	return nil
 }
 
+// ResolveUnitErrors isn't on the v5 API.
+func (u *APIv5) ResolveUnitErrors(_, _ struct{}) {}
+
 // ResolveUnitErrors marks errors on the specified units as resolved.
-func (api *APIv6) ResolveUnitErrors(p params.UnitsResolved) (params.ErrorResults, error) {
+func (api *APIBase) ResolveUnitErrors(p params.UnitsResolved) (params.ErrorResults, error) {
 	if p.All {
 		unitsWithErrors, err := api.backend.UnitsInError()
 		if err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -186,6 +186,33 @@ func (api *APIBase) SetMetricCredentials(args params.ApplicationMetricCredential
 
 // Deploy fetches the charms from the charm store and deploys them
 // using the specified placement directives.
+// V5 deploy did not support policy, so pass through an empty string.
+func (api *APIv5) Deploy(args params.ApplicationsDeployV5) (params.ErrorResults, error) {
+	noDefinedPolicy := ""
+	var newArgs params.ApplicationsDeploy
+	for _, value := range args.Applications {
+		newArgs.Applications = append(newArgs.Applications, params.ApplicationDeploy{
+			ApplicationName:  value.ApplicationName,
+			Series:           value.Series,
+			CharmURL:         value.CharmURL,
+			Channel:          value.Channel,
+			NumUnits:         value.NumUnits,
+			Config:           value.Config,
+			ConfigYAML:       value.ConfigYAML,
+			Constraints:      value.Constraints,
+			Placement:        value.Placement,
+			Policy:           noDefinedPolicy,
+			Storage:          value.Storage,
+			AttachStorage:    value.AttachStorage,
+			EndpointBindings: value.EndpointBindings,
+			Resources:        value.Resources,
+		})
+	}
+	return api.APIBase.Deploy(newArgs)
+}
+
+// Deploy fetches the charms from the charm store and deploys them
+// using the specified placement directives.
 func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -839,6 +866,18 @@ func (api *APIBase) Unexpose(args params.ApplicationUnexpose) error {
 		return err
 	}
 	return app.ClearExposed()
+}
+
+// AddUnits adds a given number of units to an application.
+func (api *APIv5) AddUnits(args params.AddApplicationUnitsV5) (params.AddApplicationUnitsResults, error) {
+	noDefinedPolicy := ""
+	return api.APIBase.AddUnits(params.AddApplicationUnits{
+		ApplicationName: args.ApplicationName,
+		NumUnits:        args.NumUnits,
+		Placement:       args.Placement,
+		Policy:          noDefinedPolicy,
+		AttachStorage:   args.AttachStorage,
+	})
 }
 
 // AddUnits adds a given number of units to an application.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -90,7 +90,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv6 {
 	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
-	api, err := application.NewAPIV5(
+	api, err := application.NewAPIBase(
 		backend,
 		s.authorizer,
 		blockChecker,

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Get returns the charm configuration for an application.
-func (api *APIv6) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
+func (api *APIBase) Get(args params.ApplicationGet) (params.ApplicationGetResults, error) {
 	return api.getConfig(args, describe)
 }
 
@@ -43,7 +43,7 @@ func (api *APIv4) Get(args params.ApplicationGet) (params.ApplicationGetResults,
 }
 
 // Get returns the charm configuration for an application.
-func (api *APIv5) getConfig(
+func (api *APIBase) getConfig(
 	args params.ApplicationGet,
 	describe func(settings charm.Settings, config *charm.Config) map[string]interface{},
 ) (params.ApplicationGetResults, error) {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -43,7 +43,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	backend, err := application.NewStateBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
-	api, err := application.NewAPIV5(
+	api, err := application.NewAPIBase(
 		backend,
 		s.authorizer,
 		blockChecker,
@@ -56,7 +56,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 
 func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v4 := &application.APIv4{s.applicationAPI.APIv5}
+	v4 := &application.APIv4{&application.APIv5{s.applicationAPI}}
 	results, err := v4.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -76,7 +76,7 @@ func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 
 func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v5 := s.applicationAPI.APIv5
+	v5 := &application.APIv5{s.applicationAPI}
 	results, err := v5.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -180,7 +180,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 	backend, err := application.NewStateBackend(st)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(st)
-	api, err := application.NewAPIV5(
+	api, err := application.NewAPIBase(
 		backend,
 		s.authorizer,
 		blockChecker,

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -261,6 +261,30 @@ type ApplicationDeploy struct {
 	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
 	Constraints      constraints.Value              `json:"constraints"`
 	Placement        []*instance.Placement          `json:"placement,omitempty"`
+	Policy           string                         `json:"policy,omitempty"`
+	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	AttachStorage    []string                       `json:"attach-storage,omitempty"`
+	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
+	Resources        map[string]string              `json:"resources,omitempty"`
+}
+
+// ApplicationsDeployV5 holds the parameters for deploying one or more applications.
+type ApplicationsDeployV5 struct {
+	Applications []ApplicationDeployV5 `json:"applications"`
+}
+
+// ApplicationDeployV5 holds the parameters for making the application Deploy call for
+// application facades older than v6. Missing the newer Policy arg.
+type ApplicationDeployV5 struct {
+	ApplicationName  string                         `json:"application"`
+	Series           string                         `json:"series"`
+	CharmURL         string                         `json:"charm-url"`
+	Channel          string                         `json:"channel"`
+	NumUnits         int                            `json:"num-units"`
+	Config           map[string]string              `json:"config,omitempty"`
+	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Constraints      constraints.Value              `json:"constraints"`
+	Placement        []*instance.Placement          `json:"placement,omitempty"`
 	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
 	AttachStorage    []string                       `json:"attach-storage,omitempty"`
 	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
@@ -481,6 +505,16 @@ type AddApplicationUnitsResults struct {
 
 // AddApplicationUnits holds parameters for the AddUnits call.
 type AddApplicationUnits struct {
+	ApplicationName string                `json:"application"`
+	NumUnits        int                   `json:"num-units"`
+	Placement       []*instance.Placement `json:"placement"`
+	Policy          string                `json:"policy,omitempty"`
+	AttachStorage   []string              `json:"attach-storage,omitempty"`
+}
+
+// AddApplicationUnitsV5 holds parameters for the AddUnits call.
+// V5 is missing the new policy arg.
+type AddApplicationUnitsV5 struct {
 	ApplicationName string                `json:"application"`
 	NumUnits        int                   `json:"num-units"`
 	Placement       []*instance.Placement `json:"placement"`


### PR DESCRIPTION
In order to fix a bundle deployment bug, we need to be able to pass in a policy value to the add unit API call. Also added it to deploy because it doesn't make sense to have it just on add unit (even though that is the only call that the bundle deployment code calls).

This isn't hooked up on the client nor server side just yet, this branch just adds the policy arg to the structure of the v6 parameter structs.

As part of this work (the first commit), the application facade structures were refactored so there is a common base, and each versioned structure depends on the version after it. This is the agreed upon best practice for defining multiple versioned API structures in a package.

This preparation work is being done now because the application facade version has already been bumped for 2.4. Juju 2.3 has v5, 2.4 has v6. Getting this change in now means that we wouldn't have to bump to v7 when we fix this post 2.4.0 release.

## QA steps

Unit and CI tests still pass.

## Documentation changes

No doc changes needed at this stage.

## Bug reference

Prepares the API server to fix this bug:
https://bugs.launchpad.net/juju/+bug/1765436
