### PR TITLE
Fix one of the tests that are failing on Bionic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ install-dependencies:
 	@echo Installing dependencies
 	@sudo apt-get --yes install  \
 	$(strip $(DEPENDENCIES)) \
-	$(shell apt-cache madison juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
+	$(shell apt-cache madison mongodb-server-core juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
 
 # Install bash_completion
 install-etc:

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -47,6 +47,12 @@ func (s *oplogSuite) TestWithRealOplog(c *gc.C) {
 		var actualObj bson.D
 		err := doc.UnmarshalObject(&actualObj)
 		c.Assert(err, jc.ErrorIsNil)
+		// In Mongo 3.6, the documents add a "$V" to every document
+		// https://jira.mongodb.org/browse/SERVER-32240
+		// It seems to track the client information about what created the doc.
+		if len(actualObj) > 1 && actualObj[0].Name == "$v" {
+			actualObj = actualObj[1:]
+		}
 		c.Assert(actualObj, jc.DeepEquals, expectedObj)
 
 		var actualUpdate bson.D


### PR DESCRIPTION
## Description of change

It seems the Oplog format has changed slightly, allowing for a new
"version" indicator. This test just strips that indicator, allowing the
test to pass on all supported mongo versions.

## QA steps

We now have the Bionic CI run, and this is trying to make it pass clean.

Simply doing
```
$ cd mongo
$ go test -check.v
```

Will fail on Bionic w/ Mongo 3.6, but pass with this patch.

## Documentation changes

None.

## Bug reference

Ongoing work around Mongo Support:
 * https://bugs.launchpad.net/bugs/1760390
