### PR TITLE
Smarter bundle placement

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/bundlechanges"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/apiserver/common"
@@ -71,7 +72,11 @@ func (b *bundleAPI) GetChanges(args params.BundleChangesParams) (params.BundleCh
 		// This should never happen as Verify only returns verification errors.
 		return results, errors.Annotate(err, "cannot verify bundle")
 	}
-	changes, err := bundlechanges.FromData(data, nil)
+	changes, err := bundlechanges.FromData(
+		bundlechanges.ChangesConfig{
+			Bundle: data,
+			Logger: loggo.GetLogger("juju.apiserver.bundlechanges"),
+		})
 	if err != nil {
 		return results, err
 	}

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -316,7 +316,12 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 }
 
 func (h *bundleHandler) getChanges() error {
-	changes, err := bundlechanges.FromData(h.data, h.model)
+	changes, err := bundlechanges.FromData(
+		bundlechanges.ChangesConfig{
+			Bundle: h.data,
+			Model:  h.model,
+			Logger: logger,
+		})
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
-github.com/juju/bundlechanges	git	6e161783b56db0f558218579fa6a76fec55eacc8	2018-04-23T05:15:47Z
+github.com/juju/bundlechanges	git	07aab68846ebfa55ec9e2a12937dd0fcef0136e5	2018-05-10T23:36:39Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
 github.com/juju/description	git	7ee30d2bc01ef20938adea2efeb991eb817c1f2a	2018-02-21T00:58:49Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z


### PR DESCRIPTION
When redeploying a bundle, the code now makes smarter decisions around placement.

## QA steps

Create a bundle.yaml with the following:
```
applications:
  ubuntu:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 3
    to: [0,1,2]
  ubun2:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 3
    to: [0,1,2]
machines:
  0:
  1:
  2:
```

bootstrap lxd,
deploy the bundle
remove ubuntu/0
deploy the bundle again
the new ubuntu unit is placed on machine 0, rather than the current behaviour of putting it on machine 2.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1765719