### PR TITLE
raft: Add featureflag worker and disable-raft feature flag

### DIFF
--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -77,7 +77,8 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"pubsub-forwarder",
 		"raft",
 		"raft-clusterer",
-		"raft-flag",
+		"raft-enabled-flag",
+		"raft-leader-flag",
 		"raft-transport",
 		"reboot-executor",
 		"restore-watcher",
@@ -148,7 +149,8 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"upgrader",
 		"raft",
 		"raft-clusterer",
-		"raft-flag",
+		"raft-enabled-flag",
+		"raft-leader-flag",
 		"raft-transport",
 	)
 	manifolds := machine.Manifolds(machine.ManifoldsConfig{
@@ -171,7 +173,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"certificate-watcher",
 		"audit-config-updater",
 		"is-primary-controller-flag",
-		"raft-transport",
+		"raft-enabled-flag",
 	)
 	primaryControllerWorkers := set.NewStrings(
 		"external-controller-updater",

--- a/controller/config.go
+++ b/controller/config.go
@@ -201,9 +201,6 @@ var (
 	// AllowedUpdateConfigAttributes contains all of the controller
 	// config attributes that are allowed to be updated after the
 	// controller has been created.
-	// TODO(babbageclunk): initially this will only be audit log
-	// values, but we should work out which others can also be changed
-	// safely.
 	AllowedUpdateConfigAttributes = set.NewStrings(
 		AuditingEnabled,
 		AuditLogCaptureArgs,

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -49,3 +49,9 @@ const NewPresence = "new-presence"
 // NewProxyOnly is a temporary traditional feature flag that will disable writing
 // the proxy information into the /etc locations (for users and systemd).
 const NewProxyOnly = "new-proxy-only"
+
+// DisableRaft will prevent the raft workers from running. At the
+// moment the raft cluster isn't managing leadership, so we want the
+// ability to stop the workers from running if they cause any issues
+// (or just unwanted noise).
+const DisableRaft = "disable-raft"

--- a/worker/featureflag/flag.go
+++ b/worker/featureflag/flag.go
@@ -1,0 +1,127 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featureflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// This implements a flag worker that restarts any time the specified
+// feature flag is turned on or off, and exposes whether the the
+// feature flag is set in its Check method. (The sense of the feature
+// flag can be inverted if needed, so that Check returns true when it
+// is off.)
+
+// ConfigSource lets us get notifications of changes to controller
+// configuration, and then get the changed config. (Primary
+// implementation is State.)
+type ConfigSource interface {
+	WatchControllerConfig() state.NotifyWatcher
+	ControllerConfig() (controller.Config, error)
+}
+
+// ErrRefresh indicates that the flag's Check result is no longer valid,
+// and a new featureflag.Worker must be started to get a valid result.
+var ErrRefresh = errors.New("feature flag changed, restart worker")
+
+// Config holds the information needed by the featureflag worker.
+type Config struct {
+	Source   ConfigSource
+	Logger   loggo.Logger
+	FlagName string
+	Invert   bool
+}
+
+// Value returns whether the feature flag is set (inverted if
+// necessary).
+func (config Config) Value() (bool, error) {
+	controllerConfig, err := config.Source.ControllerConfig()
+	if err != nil {
+		return false, errors.Annotate(err, "getting controller config")
+	}
+	flagSet := controllerConfig.Features().Contains(config.FlagName)
+	return flagSet != config.Invert, nil
+}
+
+// Worker implements worker.Worker and util.Flag, representing
+// controller ownership of a model, such that the Flag's validity is
+// tied to the Worker's lifetime.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	value    bool
+}
+
+// NewWorker creates a feature flag worker with the specified config.
+func NewWorker(config Config) (worker.Worker, error) {
+	value, err := config.Value()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	flag := &Worker{
+		config: config,
+		value:  value,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &flag.catacomb,
+		Work: flag.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return flag, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (flag *Worker) Kill() {
+	flag.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (flag *Worker) Wait() error {
+	return flag.catacomb.Wait()
+}
+
+// Check is part of the util.Flag interface.
+//
+// Check returns whether the feature flag is set (or the not set, if
+// Invert was set).
+//
+// The validity of this result is tied to the lifetime of the Worker;
+// once the worker has stopped, no inferences may be drawn from any
+// Check result.
+func (flag *Worker) Check() bool {
+	return flag.value
+}
+
+func (flag *Worker) loop() error {
+	watcher := flag.config.Source.WatchControllerConfig()
+	if err := flag.catacomb.Add(watcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-flag.catacomb.Dying():
+			return flag.catacomb.ErrDying()
+		case _, ok := <-watcher.Changes():
+			if !ok {
+				return errors.Errorf("watcher channel closed")
+			}
+			newValue, err := flag.config.Value()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if newValue != flag.value {
+				flag.config.Logger.Debugf("feature flag changed: %v", newValue)
+				return ErrRefresh
+			}
+		}
+	}
+}

--- a/worker/featureflag/flag_test.go
+++ b/worker/featureflag/flag_test.go
@@ -1,0 +1,134 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featureflag_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher/watchertest"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/featureflag"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+	config  featureflag.Config
+	source  *configSource
+	changes chan struct{}
+	worker  worker.Worker
+	flag    engine.Flag
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.changes = make(chan struct{})
+	s.source = &configSource{
+		cfg: controller.Config{
+			"features": []interface{}{"new-hotness"},
+		},
+		watcher: watchertest.NewNotifyWatcher(s.changes),
+	}
+	s.config = featureflag.Config{
+		Source:   s.source,
+		FlagName: "new-hotness",
+	}
+	worker, err := featureflag.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	s.worker = worker
+	s.flag = worker.(engine.Flag)
+}
+
+func (s *WorkerSuite) TestCleanKill(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *WorkerSuite) TestCheckFeatureFlag(c *gc.C) {
+	c.Assert(s.flag.Check(), jc.IsTrue)
+}
+
+func (s *WorkerSuite) TestCheckInverted(c *gc.C) {
+	s.config.Invert = true
+	w, err := featureflag.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, w)
+	})
+
+	c.Assert(w.(engine.Flag).Check(), jc.IsFalse)
+}
+
+func (s *WorkerSuite) TestFlagOff(c *gc.C) {
+	s.source.setConfig(controller.Config{"features": []interface{}{}})
+	w, err := featureflag.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, w)
+	})
+
+	c.Assert(w.(engine.Flag).Check(), jc.IsFalse)
+}
+
+func (s *WorkerSuite) TestDiesWhenFlagChanges(c *gc.C) {
+	s.source.setConfig(controller.Config{"features": []interface{}{}})
+	select {
+	case s.changes <- struct{}{}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out sending config change")
+	}
+
+	c.Assert(workertest.CheckKilled(c, s.worker), gc.Equals, featureflag.ErrRefresh)
+}
+
+func (s *WorkerSuite) TestNoDieWhenNoChange(c *gc.C) {
+	select {
+	case s.changes <- struct{}{}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out sending config change")
+	}
+	time.Sleep(coretesting.ShortWait)
+	workertest.CheckAlive(c, s.worker)
+}
+
+type configSource struct {
+	mu      sync.Mutex
+	stub    testing.Stub
+	watcher *watchertest.NotifyWatcher
+	cfg     controller.Config
+}
+
+func (s *configSource) WatchControllerConfig() state.NotifyWatcher {
+	s.stub.AddCall("WatchControllerConfig")
+	return s.watcher
+}
+
+func (s *configSource) ControllerConfig() (controller.Config, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stub.AddCall("ControllerConfig")
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.cfg, nil
+}
+
+func (s *configSource) setConfig(cfg controller.Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cfg = cfg
+}

--- a/worker/featureflag/manifold.go
+++ b/worker/featureflag/manifold.go
@@ -1,0 +1,90 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featureflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/worker/common"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/state"
+)
+
+// ManifoldConfig holds the information necessary to run a
+// featureflag.Worker in a dependency.Engine.
+type ManifoldConfig struct {
+	StateName string
+
+	FlagName  string
+	Invert    bool
+	Logger    loggo.Logger
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.FlagName == "" {
+		return errors.NotValidf("empty FlagName")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker state.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	flag, err := config.NewWorker(Config{
+		Source:   statePool.SystemState(),
+		Logger:   config.Logger,
+		FlagName: config.FlagName,
+		Invert:   config.Invert,
+	})
+	if err != nil {
+		stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+	return common.NewCleanupWorker(flag, func() { stTracker.Done() }), nil
+}
+
+// Manifold returns a dependency.Manifold that will run a FlagWorker and
+// expose it to clients as a engine.Flag resource.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start: config.start,
+		Filter: func(err error) error {
+			if errors.Cause(err) == ErrRefresh {
+				return dependency.ErrBounce
+			}
+			return err
+		},
+		Output: func(in worker.Worker, out interface{}) error {
+			if w, ok := in.(*common.CleanupWorker); ok {
+				in = w.Worker
+			}
+			return engine.FlagOutput(in, out)
+		},
+	}
+}

--- a/worker/featureflag/manifold_test.go
+++ b/worker/featureflag/manifold_test.go
@@ -1,0 +1,202 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featureflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	worker "gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/featureflag"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type ValidationSuite struct {
+	testing.IsolationSuite
+	config featureflag.ManifoldConfig
+}
+
+var _ = gc.Suite(&ValidationSuite{})
+
+func (s *ValidationSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config.StateName = "state"
+	s.config.FlagName = "new-hotness"
+	s.config.NewWorker = func(featureflag.Config) (worker.Worker, error) {
+		return nil, nil
+	}
+}
+
+func (s *ValidationSuite) TestMissingStateName(c *gc.C) {
+	s.config.StateName = ""
+	c.Assert(s.config.Validate(), gc.ErrorMatches, "empty StateName not valid")
+}
+
+func (s *ValidationSuite) TestMissingFlagName(c *gc.C) {
+	s.config.FlagName = ""
+	c.Assert(s.config.Validate(), gc.ErrorMatches, "empty FlagName not valid")
+}
+
+func (s *ValidationSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	c.Assert(s.config.Validate(), gc.ErrorMatches, "nil NewWorker not valid")
+}
+
+type ManifoldSuite struct {
+	statetesting.StateSuite
+
+	manifold     dependency.Manifold
+	context      dependency.Context
+	stateTracker stubStateTracker
+	worker       *mockWorker
+
+	stub testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+
+	s.stub.ResetCalls()
+	s.worker = &mockWorker{}
+	s.stateTracker.ResetCalls()
+	s.stateTracker.pool = s.StatePool
+
+	s.context = s.newContext(nil)
+	s.manifold = featureflag.Manifold(featureflag.ManifoldConfig{
+		StateName: "state",
+		FlagName:  "new-hotness",
+		Invert:    true,
+		NewWorker: s.newWorker,
+	})
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"state": &s.stateTracker,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) newWorker(config featureflag.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{"state"}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], jc.DeepEquals, featureflag.Config{
+		Source:   s.State,
+		FlagName: "new-hotness",
+		Invert:   true,
+	})
+}
+
+func (s *ManifoldSuite) TestErrRefresh(c *gc.C) {
+	w := s.startWorkerClean(c)
+
+	s.worker.SetErrors(featureflag.ErrRefresh)
+	err := w.Wait()
+	c.Assert(s.manifold.Filter(err), gc.Equals, dependency.ErrBounce)
+}
+
+func (s *ManifoldSuite) TestOutput(c *gc.C) {
+	s.worker.result = true
+	w := s.startWorkerClean(c)
+
+	var flag engine.Flag
+	err := s.manifold.Output(w, &flag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(flag.Check(), jc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestStopWorkerClosesState(c *gc.C) {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.stateTracker.CheckCallNames(c, "Use")
+
+	workertest.CleanKill(c, w)
+	s.stateTracker.CheckCallNames(c, "Use", "Done")
+}
+
+func (s *ManifoldSuite) TestClosesStateOnWorkerError(c *gc.C) {
+	s.stub.SetErrors(errors.Errorf("splat"))
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, gc.ErrorMatches, "splat")
+	c.Assert(w, gc.IsNil)
+
+	s.stateTracker.CheckCallNames(c, "Use", "Done")
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	return w
+}
+
+type mockWorker struct {
+	testing.Stub
+	result bool
+}
+
+func (w *mockWorker) Check() bool {
+	return w.result
+}
+
+func (w *mockWorker) Kill() {}
+
+func (w *mockWorker) Wait() error {
+	return w.NextErr()
+}
+
+type stubStateTracker struct {
+	testing.Stub
+	pool *state.StatePool
+}
+
+func (s *stubStateTracker) Use() (*state.StatePool, error) {
+	s.MethodCall(s, "Use")
+	return s.pool, s.NextErr()
+}
+
+func (s *stubStateTracker) Done() error {
+	s.MethodCall(s, "Done")
+	return s.NextErr()
+}

--- a/worker/featureflag/package_test.go
+++ b/worker/featureflag/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featureflag_test
+
+import (
+	"testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	coretesting.MgoTestPackage(t)
+}


### PR DESCRIPTION
## Description of change

The raft workers will be in new controllers, but they don't currently manage leadership or anything else. This change adds a feature flag that will let us turn them off in a running controller if needed.

It adds a feature flag worker (not raft-specific) that enables turning off dependent workers if a feature flag is set or unset.

## QA steps

Bootstrap a new controller. See that the raft workers are running (in the log and juju-engine-report). Set the disable-raft feature flag:
```
juju controller-config features=[disable-raft]
```
The raft workers will stop (visible in the log and the engine report).
Turn the feature flag off again:
```
juju controller-config features=[]
```
The raft workers will start again.

## Documentation changes
As far as I can tell we don't document feature flags.
