### PR TITLE
2.3 bionic netplan bridging vlans and bonds 1764735

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -188,7 +188,8 @@ func GenerateNetplan(networkConfig *container.NetworkConfig) (string, error) {
 		if cidr := info.CIDRAddress(); cidr != "" {
 			iface.Addresses = append(iface.Addresses, cidr)
 		} else if info.ConfigType == network.ConfigDHCP {
-			iface.DHCP4 = true
+			t := true
+			iface.DHCP4 = &t
 		}
 
 		for _, dns := range info.DNSServers {
@@ -217,7 +218,7 @@ func GenerateNetplan(networkConfig *container.NetworkConfig) (string, error) {
 			route := netplan.Route{
 				To:     route.DestinationCIDR,
 				Via:    route.GatewayIP,
-				Metric: route.Metric,
+				Metric: &route.Metric,
 			}
 			iface.Routes = append(iface.Routes, route)
 		}

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -188,7 +188,7 @@ func GenerateNetplan(networkConfig *container.NetworkConfig) (string, error) {
 		if cidr := info.CIDRAddress(); cidr != "" {
 			iface.Addresses = append(iface.Addresses, cidr)
 		} else if info.ConfigType == network.ConfigDHCP {
-			iface.Dhcp4 = true
+			iface.DHCP4 = true
 		}
 
 		for _, dns := range info.DNSServers {

--- a/network/netplan/activate.go
+++ b/network/netplan/activate.go
@@ -48,7 +48,7 @@ func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 
 	for _, device := range params.Devices {
 		var deviceId string
-		deviceId, deviceType, err := netplan.FindDeviceByMACOrName(device.MACAddress, device.DeviceName)
+		deviceId, deviceType, err := netplan.FindDeviceByNameOrMAC(device.DeviceName, device.MACAddress)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/network/netplan/activate.go
+++ b/network/netplan/activate.go
@@ -26,8 +26,8 @@ type ActivationParams struct {
 // ActivationResult captures the result of actively bridging the
 // interfaces using ifup/ifdown.
 type ActivationResult struct {
-	Stdout []byte
-	Stderr []byte
+	Stdout string
+	Stderr string
 	Code   int
 }
 
@@ -82,8 +82,8 @@ func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 	result, err := scriptrunner.RunCommand(command, environ, params.Clock, params.Timeout)
 
 	activationResult := ActivationResult{
-		Stderr: result.Stderr,
-		Stdout: result.Stdout,
+		Stderr: string(result.Stderr),
+		Stdout: string(result.Stdout),
 		Code:   result.Code,
 	}
 

--- a/network/netplan/activate.go
+++ b/network/netplan/activate.go
@@ -58,10 +58,18 @@ func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 			if err != nil {
 				return nil, err
 			}
-		// case TypeBond:
-		// case TypeVLAN:
+		case TypeBond:
+			err = netplan.BridgeBondById(deviceId, device.BridgeName)
+			if err != nil {
+				return nil, err
+			}
+		case TypeVLAN:
+			err = netplan.BridgeVLANById(deviceId, device.BridgeName)
+			if err != nil {
+				return nil, err
+			}
 		default:
-			return nil, errors.Errorf("don't know how to bridge the device %q of type %q", deviceId, deviceType)
+			return nil, errors.Errorf("unable to create bridge for %q, unknown device type %q", deviceId, deviceType)
 		}
 	}
 	_, err = netplan.Write("")

--- a/network/netplan/activate_test.go
+++ b/network/netplan/activate_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network/netplan"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type ActivateSuite struct {
@@ -39,6 +40,7 @@ func (s *ActivateSuite) TestNoDirectory(c *gc.C) {
 }
 
 func (s *ActivateSuite) TestActivateSuccess(c *gc.C) {
+	coretesting.SkipIfWindowsBug(c, "lp:1771077")
 	tempDir := c.MkDir()
 	params := netplan.ActivationParams{
 		Devices: []netplan.DeviceToBridge{
@@ -71,6 +73,7 @@ func (s *ActivateSuite) TestActivateSuccess(c *gc.C) {
 }
 
 func (s *ActivateSuite) TestActivateFailure(c *gc.C) {
+	coretesting.SkipIfWindowsBug(c, "lp:1771077")
 	tempDir := c.MkDir()
 	params := netplan.ActivationParams{
 		Devices: []netplan.DeviceToBridge{
@@ -99,8 +102,8 @@ func (s *ActivateSuite) TestActivateFailure(c *gc.C) {
 	}
 	result, err := netplan.BridgeAndActivate(params)
 	c.Assert(result, gc.NotNil)
-	c.Check(result.Stdout, gc.DeepEquals, []byte("This is stdout"))
-	c.Check(result.Stderr, gc.DeepEquals, []byte("This is stderr"))
+	c.Check(string(result.Stdout), gc.DeepEquals, "This is stdout")
+	c.Check(string(result.Stderr), gc.DeepEquals, "This is stderr")
 	c.Check(result.Code, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, "bridge activation error code 1")
 

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -23,23 +23,24 @@ type Nameservers struct {
 
 // Interface includes all the fields that are common between all interfaces (ethernet, wifi, bridge, bond)
 type Interface struct {
-	AcceptRA bool `yaml:"accept-ra,omitempty"`
+	AcceptRA  bool     `yaml:"accept-ra,omitempty"`
+	Addresses []string `yaml:"addresses,omitempty"`
+	// Critical doesn't have to be *bool because it is only used if True
 	Critical bool `yaml:"critical,omitempty"`
 	// DHCP4 defaults to true, so we must use a pointer to know if it was specified as false
-	DHCP4          *bool       `yaml:"dhcp4,omitempty"`
-	DHCP6          *bool       `yaml:"dhcp6,omitempty"`
-	DHCPIdentifier string      `yaml:"dhcp-identifier,omitempty"` // "duid" or  "mac"
-	Addresses      []string    `yaml:"addresses,omitempty"`
-	Gateway4       string      `yaml:"gateway4,omitempty"`
-	Gateway6       string      `yaml:"gateway6,omitempty"`
-	Nameservers    Nameservers `yaml:"nameservers,omitempty"`
-	MACAddress     string      `yaml:"macaddress,omitempty"`
-	MTU            int         `yaml:"mtu,omitempty"`
-	Renderer       string      `yaml:"renderer,omitempty"` // NetworkManager or networkd
-	Routes         []Route     `yaml:"routes,omitempty"`
-	// TODO: Should Optional be a *bool so we know if someone explicitly set 'false' ?
+	DHCP4          *bool         `yaml:"dhcp4,omitempty"`
+	DHCP6          *bool         `yaml:"dhcp6,omitempty"`
+	DHCPIdentifier string        `yaml:"dhcp-identifier,omitempty"` // "duid" or  "mac"
+	Gateway4       string        `yaml:"gateway4,omitempty"`
+	Gateway6       string        `yaml:"gateway6,omitempty"`
+	Nameservers    Nameservers   `yaml:"nameservers,omitempty"`
+	MACAddress     string        `yaml:"macaddress,omitempty"`
+	MTU            int           `yaml:"mtu,omitempty"`
+	Renderer       string        `yaml:"renderer,omitempty"` // NetworkManager or networkd
+	Routes         []Route       `yaml:"routes,omitempty"`
+	RoutingPolicy  []RoutePolicy `yaml:"routing-policy,omitempty"`
+	// Optional doesn't have to be *bool because it is only used if True
 	Optional bool `yaml:"optional,omitempty"`
-	// RoutingPolicy []Blah   `yaml:"routing-policy,omitempty"`
 }
 
 // Ethernet defines fields for just Ethernet devices
@@ -69,9 +70,23 @@ type Bridge struct {
 }
 
 type Route struct {
+	From   string `yaml:"from,omitempty"`
+	OnLink *bool  `yaml:"on-link,omitempty"`
+	Scope  string `yaml:"scope,omitempty"`
+	Table  *int   `yaml:"table,omitempty"`
 	To     string `yaml:"to,omitempty"`
+	Type   string `yaml:"type,omitempty"`
 	Via    string `yaml:"via,omitempty"`
-	Metric int    `yaml:"metric,omitempty"`
+	Metric *int   `yaml:"metric,omitempty"`
+}
+
+type RoutePolicy struct {
+	From          string `yaml:"from,omitempty"`
+	Mark          *int   `yaml:"mark,omitempty"`
+	Priority      *int   `yaml:"priority,omitempty"`
+	Table         *int   `yaml:"table,omitempty"`
+	To            string `yaml:"to,omitempty"`
+	TypeOfService *int   `yaml:"type-of-service,omitempty"`
 }
 
 type Network struct {
@@ -95,8 +110,10 @@ type Netplan struct {
 
 // VLAN represents the structures for defining VLAN sections
 type VLAN struct {
-	Interface `yaml:",inline"`
 	// TODO: more attributes, like VLAN ID ?
+	Id        *int   `yaml:"id,omitempty"`
+	Link      string `yaml:"link,omitempty"`
+	Interface `yaml:",inline"`
 }
 
 // Bond is the interface definition of the bonds: section of netplan

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -63,10 +63,21 @@ type Wifi struct {
 	Interface    `yaml:",inline"`
 }
 
+type BridgeParameters struct {
+	AgeingTime   *int           `yaml:"ageing-time,omitempty"`
+	ForwardDelay *int           `yaml:"forward-delay,omitempty"`
+	HelloTime    *int           `yaml:"hello-time,omitempty"`
+	MaxAge       *int           `yaml:"max-age,omitempty"`
+	PathCost     map[string]int `yaml:"path-cost,omitempty"`
+	PortPriority map[string]int `yaml:"port-priority,omitempty"`
+	Priority     *int           `yaml:"priority,omitempty"`
+	STP          *bool          `yaml:"stp,omitempty"`
+}
+
 type Bridge struct {
 	Interfaces []string `yaml:"interfaces,omitempty,flow"`
 	Interface  `yaml:",inline"`
-	// TODO: parameters
+	Parameters BridgeParameters `yaml:"parameters,omitempty"`
 }
 
 type Route struct {
@@ -166,7 +177,7 @@ type BondParameters struct {
 	MinLinks           *int      `yaml:"min-links,omitempty"`
 	TransmitHashPolicy string    `yaml:"transmit-hash-policy,omitempty"`
 	ADSelect           IntString `yaml:"ad-select,omitempty"`
-	AllSlavesActive    bool      `yaml:"all-slaves-active,omitempty"`
+	AllSlavesActive    *bool     `yaml:"all-slaves-active,omitempty"`
 	ARPInterval        *int      `yaml:"arp-interval,omitempty"`
 	ARPIPTargets       []string  `yaml:"arp-ip-targets,omitempty"`
 	ARPValidate        IntString `yaml:"arp-validate,omitempty"`

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -23,10 +23,11 @@ type Nameservers struct {
 
 // Interface includes all the fields that are common between all interfaces (ethernet, wifi, bridge, bond)
 type Interface struct {
-	AcceptRA       bool        `yaml:"accept-ra,omitempty"`
-	Critical       bool        `yaml:"critical,omitempty"`
-	DHCP4          bool        `yaml:"dhcp4,omitempty"`
-	DHCP6          bool        `yaml:"dhcp6,omitempty"`
+	AcceptRA bool `yaml:"accept-ra,omitempty"`
+	Critical bool `yaml:"critical,omitempty"`
+	// DHCP4 defaults to true, so we must use a pointer to know if it was specified as false
+	DHCP4          *bool       `yaml:"dhcp4,omitempty"`
+	DHCP6          *bool       `yaml:"dhcp6,omitempty"`
 	DHCPIdentifier string      `yaml:"dhcp-identifier,omitempty"` // "duid" or  "mac"
 	Addresses      []string    `yaml:"addresses,omitempty"`
 	Gateway4       string      `yaml:"gateway4,omitempty"`
@@ -43,7 +44,7 @@ type Interface struct {
 
 // Ethernet defines fields for just Ethernet devices
 type Ethernet struct {
-	Match     map[string]string `yaml:"match"`
+	Match     map[string]string `yaml:"match,omitempty"`
 	Wakeonlan bool              `yaml:"wakeonlan,omitempty"`
 	SetName   string            `yaml:"set-name,omitempty"`
 	Interface `yaml:",inline"`
@@ -141,6 +142,7 @@ func (i IntString) MarshalYAML() (interface{}, error) {
 // https://www.kernel.org/doc/Documentation/networking/bonding.txt
 // Note that most parameters can be specified as integers or as strings, which you need to be careful with YAML
 // as it defaults to strongly typing them.
+// TODO: (jam 2018-05-14) Should we be sorting the attributes alphabetically?
 type BondParameters struct {
 	Mode               IntString `yaml:"mode,omitempty"`
 	LACPRate           IntString `yaml:"lacp-rate,omitempty"`

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -23,7 +23,7 @@ type Nameservers struct {
 
 // Interface includes all the fields that are common between all interfaces (ethernet, wifi, bridge, bond)
 type Interface struct {
-	AcceptRA  bool     `yaml:"accept-ra,omitempty"`
+	AcceptRA  *bool    `yaml:"accept-ra,omitempty"`
 	Addresses []string `yaml:"addresses,omitempty"`
 	// Critical doesn't have to be *bool because it is only used if True
 	Critical bool `yaml:"critical,omitempty"`

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -216,7 +216,7 @@ network:
 `)
 }
 
-func (s *NetplanSuite) DONTTestBondWithVLAN(c *gc.C) {
+func (s *NetplanSuite) TestBondWithVLAN(c *gc.C) {
 	checkNetplanRoundTrips(c, `
 network:
   version: 2
@@ -236,21 +236,20 @@ network:
       - id0
       - id1
       parameters:
-        down-delay: 0
+        mode: 802.3ad
         lacp-rate: fast
         mii-monitor-interval: 100
-        mode: 802.3ad
         transmit-hash-policy: layer2
         up-delay: 0
+        down-delay: 0
   vlans:
     bond0.209:
-      addresses:
-      - 123.123.123.123/24
       id: 209
       link: bond0
+      addresses:
+      - 123.123.123.123/24
       nameservers:
-        addresses:
-        - 8.8.8.8
+        addresses: [8.8.8.8]
 `)
 }
 
@@ -383,6 +382,10 @@ network:
       - from: 192.168.5.0/24
         table: 103
       optional: true
+    id0.456:
+      id: 456
+      link: id0
+      accept-ra: false
 `)
 }
 
@@ -993,7 +996,7 @@ func readExampleStrings(c *gc.C) []Example {
 	}
 	// Make sure we find all the example files, if we change the count, update this number, but we don't allow the test
 	// suite to find the wrong number of files.
-	c.Assert(len(examples), gc.Equals, 14)
+	c.Assert(len(examples), gc.Equals, 13)
 	return examples
 }
 

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -46,12 +46,12 @@ network:
       match:
         macaddress: "00:11:22:33:44:55"
       wakeonlan: true
-      critical: true
-      dhcp4: true
-      dhcp-identifier: mac
       addresses:
       - 192.168.14.2/24
       - 2001:1::1/64
+      critical: true
+      dhcp4: true
+      dhcp-identifier: mac
       gateway4: 192.168.14.1
       gateway6: 2001:1::2
       nameservers:
@@ -304,8 +304,86 @@ func (s *NetplanSuite) TestAllEthernetParams(c *gc.C) {
 	// Make sure we can handle any fields in Ethernet stanzas
 }
 
-func (s *NetplanSuite) TestAllVLANParams(c *gc.C) {
+func (s *NetplanSuite) TestAllRoutesParams(c *gc.C) {
+	checkNetplanRoundTrips(c, `
+network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    id0:
+      match:
+        macaddress: "00:11:22:33:44:55"
+        set-name: id0
+      routes:
+      - from: 192.168.0.0/24
+        on-link: true
+        scope: global
+        table: 1234
+        to: 192.168.3.1/24
+        type: unicast
+        via: 192.168.3.1
+        metric: 1234567
+      - on-link: false
+        to: 192.168.5.1/24
+        via: 192.168.5.1
+        metric: 0
+      - to: 192.168.5.1/24
+        type: unreachable
+        via: 192.168.5.1
+      routing-policy:
+      - from: 192.168.10.0/24
+        mark: 123
+        priority: 10
+        table: 1234
+        to: 192.168.3.1/24
+        type-of-service: 0
+      - from: 192.168.12.0/24
+        mark: 0
+        priority: 0
+        table: 0
+        to: 192.168.3.1/24
+        type-of-service: 255
+`)
+}
 
+func (s *NetplanSuite) TestAllVLANParams(c *gc.C) {
+	checkNetplanRoundTrips(c, `
+network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    id0:
+      match:
+        macaddress: "00:11:22:33:44:55"
+        set-name: id0
+  vlans:
+    id0.123:
+      id: 123
+      link: id0
+      accept-ra: true
+      addresses:
+      - 123.123.123.123/24
+      critical: true
+      dhcp4: false
+      dhcp6: false
+      dhcp-identifier: duid
+      gateway4: 123.123.123.123
+      gateway6: dead::beef
+      nameservers:
+        addresses: [8.8.8.8]
+      macaddress: de:ad:be:ef:12:34
+      mtu: 9000
+      renderer: NetworkManager
+      routes:
+      - table: 102
+        to: 100.0.0.0/8
+        via: 1.2.3.10
+        metric: 5
+      routing-policy:
+      - from: 192.168.5.0/24
+        table: 103
+      optional: true
+`)
 }
 
 func (s *NetplanSuite) TestSimpleBridger(c *gc.C) {

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -164,7 +164,7 @@ network:
 `)
 }
 
-func (s *NetplanSuite) TestBondIntValues(c *gc.C) {
+func (s *NetplanSuite) TestBondsIntParameters(c *gc.C) {
 	// several parameters can be specified as an integer or a string
 	// such as 'mode: 0' is the same as 'balance-rr'
 	checkNetplanRoundTrips(c, `
@@ -187,6 +187,7 @@ network:
         mode: 0
         lacp-rate: 1
         ad-select: 1
+        all-slaves-active: true
         arp-validate: 0
         arp-all-targets: 0
         fail-over-mac-policy: 1
@@ -212,6 +213,7 @@ network:
         mode: balance-rr
         lacp-rate: fast
         ad-select: bandwidth
+        all-slaves-active: false
         arp-validate: filter
         arp-all-targets: all
         fail-over-mac-policy: follow
@@ -269,6 +271,12 @@ network:
       match:
         macaddress: de:ad:be:ef:01:02
         set-name: id1
+    id2:
+      match:
+        macaddress: de:ad:be:ef:01:03
+    id3:
+      match:
+        macaddress: de:ad:be:ef:01:04
   bonds:
     bond0:
       interfaces: [id0, id1]
@@ -285,7 +293,7 @@ network:
         - 192.168.0.1
         - 192.168.10.20
         arp-validate: none
-        arp-all-targets: boo
+        arp-all-targets: all
         up-delay: 0
         down-delay: 0
         fail-over-mac-policy: follow
@@ -298,8 +306,71 @@ network:
 `)
 }
 
-func (s *NetplanSuite) TestAllEthernetParams(c *gc.C) {
-	// Make sure we can handle any fields in Ethernet stanzas
+func (s *NetplanSuite) TestBridgesAllParameters(c *gc.C) {
+	// All parameters don't inherently make sense at the same time, but we should be able to parse all of them.
+	checkNetplanRoundTrips(c, `
+network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    id0:
+      match:
+        macaddress: "00:11:22:33:44:55"
+        set-name: id0
+    id1:
+      match:
+        macaddress: de:ad:be:ef:01:02
+        set-name: id1
+    id2:
+      match:
+        macaddress: de:ad:be:ef:01:03
+        set-name: id2
+  bridges:
+    br-id0:
+      interfaces: [id0]
+      accept-ra: true
+      addresses:
+      - 123.123.123.123/24
+      dhcp4: false
+      dhcp6: true
+      dhcp-identifier: duid
+      parameters:
+        ageing-time: 0
+        forward-delay: 0
+        hello-time: 0
+        max-age: 0
+        path-cost:
+          id0: 0
+        port-priority:
+          id0: 0
+        priority: 0
+        stp: false
+    br-id1:
+      interfaces: [id1]
+      accept-ra: false
+      addresses:
+      - 2001::1/64
+      dhcp4: true
+      dhcp6: true
+      dhcp-identifier: mac
+      parameters:
+        ageing-time: 100
+        forward-delay: 10
+        hello-time: 20
+        max-age: 10
+        path-cost:
+          id1: 50
+        port-priority:
+          id1: 50
+        priority: 20000
+        stp: true
+    br-id2:
+      interfaces: [id2]
+    br-id3:
+      interfaces: [id2]
+      parameters:
+        ageing-time: 10
+`)
 }
 
 func (s *NetplanSuite) TestAllRoutesParams(c *gc.C) {

--- a/network/netplan/testdata/TestReadWriteBackup/00.yaml
+++ b/network/netplan/testdata/TestReadWriteBackup/00.yaml
@@ -2,7 +2,7 @@ network:
   version: 2
   renderer: NetworkManager
   ethernets:
-    id0:
+    eno1:
       match:
         macaddress: "00:11:22:33:44:55"
       addresses:
@@ -25,3 +25,8 @@ network:
       nameservers:
         search: [baz.local]
         addresses: [8.8.4.4]
+  vlans:
+    eno1.123:
+      id: 123
+      link: eno1
+      macaddress: "00:11:22:33:44:55"

--- a/network/netplan/testdata/examples/bonding.yaml
+++ b/network/netplan/testdata/examples/bonding.yaml
@@ -1,0 +1,12 @@
+network:
+  version: 2
+  renderer: networkd
+  bonds:
+    bond0:
+      dhcp4: yes
+      interfaces:
+        - enp3s0
+        - enp4s0
+      parameters:
+        mode: active-backup
+        primary: enp3s0

--- a/network/netplan/testdata/examples/bonding_router.yaml
+++ b/network/netplan/testdata/examples/bonding_router.yaml
@@ -1,0 +1,44 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp1s0:
+      dhcp4: no
+    enp2s0:
+      dhcp4: no
+    enp3s0:
+      dhcp4: no
+      optional: true
+    enp4s0:
+      dhcp4: no
+      optional: true
+    enp5s0:
+      dhcp4: no
+      optional: true
+    enp6s0:
+      dhcp4: no
+      optional: true
+  bonds:
+    bond-lan:
+      interfaces: [enp2s0, enp3s0]
+      addresses: [192.168.93.2/24]
+      parameters:
+        mode: 802.3ad
+        mii-monitor-interval: 1
+    bond-wan:
+      interfaces: [enp1s0, enp4s0]
+      addresses: [192.168.1.252/24]
+      gateway4: 192.168.1.1
+      nameservers:
+        search: [local]
+        addresses: [8.8.8.8, 8.8.4.4]
+      parameters:
+        mode: active-backup
+        mii-monitor-interval: 1
+        gratuitious-arp: 5
+    bond-conntrack:
+      interfaces: [enp5s0, enp6s0]
+      addresses: [192.168.254.2/24]
+      parameters:
+        mode: balance-rr
+        mii-monitor-interval: 1

--- a/network/netplan/testdata/examples/bridge.yaml
+++ b/network/netplan/testdata/examples/bridge.yaml
@@ -1,0 +1,8 @@
+network:
+  version: 2
+  renderer: networkd
+  bridges:
+    br0:
+      dhcp4: yes
+      interfaces:
+        - enp3s0

--- a/network/netplan/testdata/examples/bridge_vlan.yaml
+++ b/network/netplan/testdata/examples/bridge_vlan.yaml
@@ -1,0 +1,15 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp0s25:
+      dhcp4: true
+  bridges:
+    br0:
+      addresses: [ 10.3.99.25/24 ]
+      interfaces: [ vlan15 ]
+  vlans:
+    vlan15:
+      accept-ra: no
+      id: 15
+      link: enp0s25

--- a/network/netplan/testdata/examples/dhcp.yaml
+++ b/network/netplan/testdata/examples/dhcp.yaml
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp3s0:
+      dhcp4: true

--- a/network/netplan/testdata/examples/direct_connect_gateway.yaml
+++ b/network/netplan/testdata/examples/direct_connect_gateway.yaml
@@ -1,0 +1,9 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    addresses: [ "10.10.10.1/24" ]
+    routes:
+      - to: 0.0.0.0/0
+        via: 9.9.9.9
+        on-link: true

--- a/network/netplan/testdata/examples/direct_connect_gateway.yaml
+++ b/network/netplan/testdata/examples/direct_connect_gateway.yaml
@@ -1,9 +1,0 @@
-network:
-  version: 2
-  renderer: networkd
-  ethernets:
-    addresses: [ "10.10.10.1/24" ]
-    routes:
-      - to: 0.0.0.0/0
-        via: 9.9.9.9
-        on-link: true

--- a/network/netplan/testdata/examples/loopback_interface.yaml
+++ b/network/netplan/testdata/examples/loopback_interface.yaml
@@ -1,0 +1,8 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lo:
+      match:
+        name: lo
+      addresses: [ 7.7.7.7/32 ]

--- a/network/netplan/testdata/examples/network_manager.yaml
+++ b/network/netplan/testdata/examples/network_manager.yaml
@@ -1,0 +1,3 @@
+network:
+  version: 2
+  renderer: NetworkManager

--- a/network/netplan/testdata/examples/source_routing.yaml
+++ b/network/netplan/testdata/examples/source_routing.yaml
@@ -1,0 +1,27 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ens3:
+      addresses:
+       - 192.168.3.30/24
+      dhcp4: no
+      routes:
+       - to: 192.168.3.0/24
+         via: 192.168.3.1
+         table: 101
+      routing-policy:
+       - from: 192.168.3.0/24
+         table: 101
+    ens5:
+      addresses:
+       - 192.168.5.24/24
+      dhcp4: no
+      gateway4: 192.168.5.1
+      routes:
+       - to: 192.168.5.0/24
+         via: 192.168.5.1
+         table: 102
+      routing-policy:
+        - from: 192.168.5.0/24
+          table: 102

--- a/network/netplan/testdata/examples/static.yaml
+++ b/network/netplan/testdata/examples/static.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp3s0:
+      addresses:
+        - 10.10.10.2/24
+      gateway4: 10.10.10.1
+      nameservers:
+          search: [mydomain,otherdomain]
+          addresses: [10.10.10.1, 1.1.1.1]

--- a/network/netplan/testdata/examples/static_multiaddress.yaml
+++ b/network/netplan/testdata/examples/static_multiaddress.yaml
@@ -1,0 +1,9 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp3s0:
+     addresses:
+       - 10.100.1.38/24
+       - 10.100.1.39/24
+     gateway4: 10.100.1.1

--- a/network/netplan/testdata/examples/vlan.yaml
+++ b/network/netplan/testdata/examples/vlan.yaml
@@ -1,0 +1,25 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    mainif:
+      match:
+        macaddress: "de:ad:be:ef:ca:fe"
+      set-name: mainif
+      addresses: [ "10.3.0.5/23" ]
+      gateway4: 10.3.0.1
+      nameservers:
+        addresses: [ "8.8.8.8", "8.8.4.4" ]
+        search: [ example.com ]
+  vlans:
+    vlan15:
+      id: 15
+      link: mainif
+      addresses: [ "10.3.99.5/24" ]
+    vlan10:
+      id: 10
+      link: mainif
+      addresses: [ "10.3.98.5/24" ]
+      nameservers:
+        addresses: [ "127.0.0.1" ]
+        search: [ domain1.example.com, domain2.example.com ]

--- a/network/netplan/testdata/examples/windows_dhcp_server.yaml
+++ b/network/netplan/testdata/examples/windows_dhcp_server.yaml
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  ethernets:
+    enp3s0:
+      dhcp4: yes
+      dhcp-identifier: mac

--- a/network/netplan/testdata/examples/wireless.yaml
+++ b/network/netplan/testdata/examples/wireless.yaml
@@ -1,0 +1,14 @@
+network:
+  version: 2
+  renderer: networkd
+  wifis:
+    wlp2s0b1:
+      dhcp4: no
+      dhcp6: no
+      addresses: [192.168.0.21/24]
+      gateway4: 192.168.0.1
+      nameservers:
+        addresses: [192.168.0.1, 8.8.8.8]
+      access-points:
+        "network_ssid_name":
+          password: "**********"


### PR DESCRIPTION
## Description of change

This adds support for Netplan to parse a lot more of the values that can be set. It adds support for parsing VLAN and Bond information, and ultimately will support creating bridges on those devices.

## QA steps

```
$ juju bootstrap MAASWITHVLANORBOND --bootstrap-series bionic
$ juju deploy cs;~jameinel/ubuntu-lite -m controller --to lxd:0
```

## Documentation changes

Adds support for Bionic, but doesn't otherwise change how a user would interact with the system.

## Bug reference

[lp:1764735](https://bugs.launchpad.net/juju/+bug/1764735)
[lp:1771120](https://bugs.launchpad.net/juju/+bug/1771120)