### PR TITLE
raft-clusterer: Demote a server when there are an even number of them

### DIFF
--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -300,6 +300,9 @@ func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 func newRaftConfig(config Config) (*raft.Config, error) {
 	raftConfig := raft.DefaultConfig()
 	raftConfig.LocalID = raft.ServerID(config.Tag.String())
+	// Having ShutdownOnRemove true means that the raft node also
+	// stops when it's demoted if it's the leader.
+	raftConfig.ShutdownOnRemove = false
 
 	logWriter := &raftutil.LoggoWriter{config.Logger, loggo.DEBUG}
 	raftConfig.Logger = log.New(logWriter, "", 0)


### PR DESCRIPTION
## Description of change

To avoid problems resulting from having an even number of voters, the raft clusterer (running on the leader) will demote one of the other servers to nonvoting status. If another server is added (so the total number is odd again) the demoted server will be promoted back to voting.

If the clusterer sees that the machine it's running on is being removed, it will demote itself but then stop, allowing the new leader to remove it and select which other remaining server should be demoted.

## QA steps

Bootstrap a controller and enable-ha on it. Then remove machine 0 - once everything is stable again there should be two machines, one of which is the leader and the other a nonvoter (you can see this in juju-engine-report). Add another controller machine with `juju enable-ha -n 3`. Once the machine is up and happy, check juju-engine-report - all three machines will be voting again.
