### PR TITLE
Remove controller cloud

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -191,6 +191,20 @@ func (c *Client) AddCloud(cloud jujucloud.Cloud) error {
 	return nil
 }
 
+// RemoveCloud removes a cloud from the current controller.
+func (c *Client) RemoveCloud(cloud string) error {
+	if bestVer := c.BestAPIVersion(); bestVer < 2 {
+		return errors.NotImplementedf("RemoveCloud() (need v2+, have v%d)", bestVer)
+	}
+	args := params.Entities{Entities: []params.Entity{{Tag: names.NewCloudTag(cloud).String()}}}
+	var result params.ErrorResults
+	err := c.facade.FacadeCall("RemoveClouds", args, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return result.OneError()
+}
+
 // CredentialContents returns contents of the credential values for the specified
 // cloud and credential name. Secrets will be included if requested.
 func (c *Client) CredentialContents(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -153,7 +153,7 @@ func AllFacades() *facade.Registry {
 	reg("Client", 1, client.NewFacadeV1)
 	reg("Client", 2, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacade)
-	reg("Cloud", 2, cloud.NewFacadeV2) // adds CredentialContents
+	reg("Cloud", 2, cloud.NewFacadeV2) // adds CredentialContents, RemoveCloud
 
 	// CAAS related facades.
 	// Move these to the correct place above once the feature flag disappears.

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -22,6 +22,7 @@ type Backend interface {
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
 	RemoveCloudCredential(names.CloudCredentialTag) error
 	AddCloud(cloud.Cloud) error
+	RemoveCloud(string) error
 	AllCloudCredentials(user names.UserTag) ([]state.Credential, error)
 	CredentialModelsAndOwnerAccess(tag names.CloudCredentialTag) ([]state.CredentialOwnerModelAccess, error)
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -393,6 +393,24 @@ func (api *CloudAPIV2) AddCloud(cloudArgs params.AddCloudArgs) error {
 	return nil
 }
 
+// RemoveClouds removes the specified clouds from the controller.
+// If a cloud is in use (has models deployed to it), the removal will fail.
+func (api *CloudAPIV2) RemoveClouds(args params.Entities) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseCloudTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		err = api.backend.RemoveCloud(tag.Id())
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
 // CredentialContents returns the specified cloud credentials,
 // including the secrets if requested.
 // If no specific credential name/cloud was passed in, all credentials for this user

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -208,6 +208,18 @@ func (s *cloudSuiteV2) TestAddCloudInV2(c *gc.C) {
 	})
 }
 
+func (s *cloudSuiteV2) TestRemoveCloudInV2(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("admin")
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: "cloud-foo"}, {Tag: "cloud-bar"}}}
+	result, err := s.apiv2.RemoveClouds(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{}, {}}})
+	s.backend.CheckCallNames(c, "RemoveCloud", "RemoveCloud")
+	s.backend.CheckCall(c, 0, "RemoveCloud", "foo")
+	s.backend.CheckCall(c, 1, "RemoveCloud", "bar")
+}
+
 func (s *cloudSuiteV2) TestAddCredentialInV2(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("admin")
 	paramsCreds := params.TaggedCredentials{Credentials: []params.TaggedCredential{{
@@ -306,6 +318,11 @@ func (st *mockBackendV2) UpdateCloudCredential(tag names.CloudCredentialTag, cre
 
 func (st *mockBackendV2) AddCloud(cloud cloud.Cloud) error {
 	st.MethodCall(st, "AddCloud", cloud)
+	return st.NextErr()
+}
+
+func (st *mockBackendV2) RemoveCloud(name string) error {
+	st.MethodCall(st, "RemoveCloud", name)
 	return st.NextErr()
 }
 

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -338,6 +338,11 @@ func (st *mockBackend) AddCloud(cloud cloud.Cloud) error {
 	return errors.NewNotImplemented(nil, "This mock is used for v1, so AddCloud")
 }
 
+func (st *mockBackend) RemoveCloud(name string) error {
+	st.MethodCall(st, "RemoveCloud", name)
+	return errors.NewNotImplemented(nil, "This mock is used for v1, so RemoveCloud")
+}
+
 func (st *mockBackend) AllCloudCredentials(user names.UserTag) ([]state.Credential, error) {
 	st.MethodCall(st, "AllCloudCredentials", user)
 	return nil, errors.NewNotImplemented(nil, "This mock is used for v1, so AllCloudCredentials")

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -103,6 +103,9 @@ type Cloud struct {
 	// Description describes the type of cloud.
 	Description string
 
+	// ModelCount is the number of models using this cloud.
+	ModelCount int
+
 	// AuthTypes are the authentication modes supported by the cloud.
 	AuthTypes AuthTypes
 

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -103,9 +103,6 @@ type Cloud struct {
 	// Description describes the type of cloud.
 	Description string
 
-	// ModelCount is the number of models using this cloud.
-	ModelCount int
-
 	// AuthTypes are the authentication modes supported by the cloud.
 	AuthTypes AuthTypes
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -276,7 +276,14 @@ func allCollections() collectionSchema {
 
 		// meterStatusC is the collection used to store meter status information.
 		meterStatusC: {},
-		refcountsC:   {},
+
+		// These collections hold reference counts which are used
+		// by the nsRefcounts struct.
+		refcountsC: {}, // Per model.
+		globalRefcountsC: {
+			global: true,
+		},
+
 		relationsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "endpoints.relationname"},
@@ -510,6 +517,7 @@ const (
 	filesystemAttachmentsC   = "filesystemAttachments"
 	filesystemsC             = "filesystems"
 	globalClockC             = "globalclock"
+	globalRefcountsC         = "globalRefcounts"
 	globalSettingsC          = "globalSettings"
 	guimetadataC             = "guimetadata"
 	guisettingsC             = "guisettings"

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -6,8 +6,10 @@ package state
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
@@ -25,6 +27,7 @@ type cloudDoc struct {
 	StorageEndpoint  string                       `bson:"storage-endpoint,omitempty"`
 	Regions          map[string]cloudRegionSubdoc `bson:"regions,omitempty"`
 	CACertificates   []string                     `bson:"ca-certificates,omitempty"`
+	ModelCount       int                          `bson:"modelcount"`
 }
 
 // cloudRegionSubdoc records information about cloud regions.
@@ -62,6 +65,7 @@ func createCloudOp(cloud cloud.Cloud) txn.Op {
 			StorageEndpoint:  cloud.StorageEndpoint,
 			Regions:          regions,
 			CACertificates:   cloud.CACertificates,
+			ModelCount:       cloud.ModelCount,
 		},
 	}
 }
@@ -88,6 +92,7 @@ func (d cloudDoc) toCloud() cloud.Cloud {
 	return cloud.Cloud{
 		Name:             d.Name,
 		Type:             d.Type,
+		ModelCount:       d.ModelCount,
 		AuthTypes:        authTypes,
 		Endpoint:         d.Endpoint,
 		IdentityEndpoint: d.IdentityEndpoint,
@@ -155,6 +160,9 @@ func validateCloud(cloud cloud.Cloud) error {
 	if cloud.Type == "" {
 		return errors.NotValidf("empty Type")
 	}
+	if cloud.ModelCount > 0 {
+		return errors.NotValidf("model count (%d) > 0", cloud.ModelCount)
+	}
 	if len(cloud.AuthTypes) == 0 {
 		return errors.NotValidf("empty auth-types")
 	}
@@ -167,4 +175,84 @@ func validateCloud(cloud cloud.Cloud) error {
 // regionSettingsGlobalKey concatenates the cloud a hash and the region string.
 func regionSettingsGlobalKey(cloud, region string) string {
 	return cloud + "#" + region
+}
+
+// RemoveCloud removes a cloud and any credentials for that cloud.
+// If the cloud is in use, ie has models deployed to it, the operation fails.
+func (st *State) RemoveCloud(name string) error {
+
+	checkUnused := func() error {
+		c, err := st.Cloud(name)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if c.ModelCount > 0 {
+			return errors.Errorf("cloud is used by %d model%s", c.ModelCount, plural(c.ModelCount))
+		}
+		return nil
+	}
+	// Check that the cloud is not used by any models.
+	if err := checkUnused(); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Check that the cloud is not the primary controller cloud.
+	// This shouldn't be needed since the above model check will
+	// pick it up, but just in case....
+	ci, err := st.ControllerInfo()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if ci.CloudName == name {
+		return errors.Errorf("cloud is used by controller")
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			err := checkUnused()
+			if err == nil {
+				return nil, jujutxn.ErrNoOperations
+			}
+			return nil, errors.Trace(err)
+		}
+		ops := removeCloudOps(name)
+		return ops, nil
+	}
+	if err := st.db().Run(buildTxn); err != nil {
+		return err
+	}
+
+	// Cloud has been removed, now bulk remove any credentials for that cloud.
+	// We could use removeInCollectionOps to generate a slice of ops to
+	// use in the previous Run() call but on large systems there could be
+	// many user credentials to remove and so a bulk op is better. There's
+	// a small risk of orphaned credentials if an error occurs but there'll
+	// be no adverse effects.
+	return st.removeCloudCredentials(name)
+}
+
+// removeCloudOp returns a list of txn.Ops that will remove
+// the specified cloud.
+func removeCloudOps(name string) []txn.Op {
+	ops := []txn.Op{{
+		C:      cloudsC,
+		Id:     name,
+		Assert: bson.D{{"modelcount", 0}},
+		Remove: true,
+	}}
+	return ops
+}
+
+func (st *State) removeCloudCredentials(cloud string) error {
+	coll, closer := st.db().GetRawCollection(cloudCredentialsC)
+	defer closer()
+
+	bulk := coll.Bulk()
+	bulk.Unordered()
+	bulk.RemoveAll(bson.D{{"_id", bson.D{{"$regex", "^" + cloud + "#"}}}})
+	_, err := bulk.Run()
+	return errors.Annotate(err, "deleting cloud credentials")
 }

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -8,8 +8,12 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type CloudSuite struct {
@@ -105,4 +109,126 @@ func (s *CloudSuite) TestAddCloudNoAuthTypes(c *gc.C) {
 		Type: "foo",
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty auth-types not valid`)
+}
+
+func (s *CloudSuite) TestAddCloudNonZeroModelCount(c *gc.C) {
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:       "stratus",
+		Type:       "foo",
+		AuthTypes:  cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+		ModelCount: 1,
+	})
+	c.Assert(err, gc.ErrorMatches, `invalid cloud: model count \(1\) > 0 not valid`)
+}
+
+func (s *CloudSuite) TestRemoveCloud(c *gc.C) {
+	// Doesn't exist already is a no-op.
+	err := s.State.RemoveCloud(lowCloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AddCloud(lowCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveCloud(lowCloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.Cloud(lowCloud.Name)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	// Idempotent.
+	err = s.State.RemoveCloud(lowCloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CloudSuite) TestRemoveCloudAlsoRemovesCredentials(c *gc.C) {
+	err := s.State.AddCloud(lowCloud)
+	c.Assert(err, jc.ErrorIsNil)
+
+	credTag := names.NewCloudCredentialTag(lowCloud.Name + "/admin/cred")
+	err = s.State.UpdateCloudCredential(credTag, cloud.NewCredential(cloud.UserPassAuthType, nil))
+	c.Assert(err, jc.ErrorIsNil)
+	credTag = names.NewCloudCredentialTag(lowCloud.Name + "/bob/cred")
+	err = s.State.UpdateCloudCredential(credTag, cloud.NewCredential(cloud.UserPassAuthType, nil))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add credential for a different cloud, shouldn't be touched.
+	otherCredTag := names.NewCloudCredentialTag("dummy/mary/cred")
+	err = s.State.UpdateCloudCredential(otherCredTag, cloud.NewEmptyCredential())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveCloud(lowCloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	coll, closer := state.GetCollection(s.State, "cloudCredentials")
+	defer closer()
+
+	// Creds for removed cloud are gone.
+	n, err := coll.Find(bson.D{{"_id", bson.D{{"$regex", "^" + lowCloud.Name + "#"}}}}).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, 0)
+
+	// Creds for other clouds are not affected.
+	n, err = coll.Find(bson.D{{"_id", bson.D{{"$regex", "^dummy#"}}}}).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, 1)
+	_, err = s.State.CloudCredential(otherCredTag)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CloudSuite) TestRemoveControllerModelCloudNotAllowed(c *gc.C) {
+	err := s.State.RemoveCloud("dummy")
+	c.Assert(err, gc.ErrorMatches, "cloud is used by 1 model")
+	_, err = s.State.Cloud("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CloudSuite) TestRemoveInUseCloudNotAllowed(c *gc.C) {
+	err := s.State.AddCloud(lowCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	otherModelOwner := s.Factory.MakeModelUser(c, nil)
+	credTag := names.NewCloudCredentialTag(lowCloud.Name + "/" + otherModelOwner.UserName + "/cred")
+	err = s.State.UpdateCloudCredential(credTag, cloud.NewCredential(cloud.UserPassAuthType, nil))
+	c.Assert(err, jc.ErrorIsNil)
+
+	otherSt := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "caas-model",
+		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		CloudName:       lowCloud.Name,
+		CloudCredential: credTag,
+		Owner:           otherModelOwner.UserTag,
+		ConfigAttrs: testing.Attrs{
+			"controller": false,
+		},
+		StorageProviderRegistry: factory.NilStorageProviderRegistry{}})
+	defer otherSt.Close()
+
+	err = otherSt.RemoveCloud(lowCloud.Name)
+	c.Assert(err, gc.ErrorMatches, "cloud is used by 1 model")
+	_, err = s.State.Cloud(lowCloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+}
+
+func (s *CloudSuite) TestRemoveCloudRace(c *gc.C) {
+	err := s.State.AddCloud(lowCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	otherModelOwner := s.Factory.MakeModelUser(c, nil)
+	credTag := names.NewCloudCredentialTag(lowCloud.Name + "/" + otherModelOwner.UserName + "/cred")
+	err = s.State.UpdateCloudCredential(credTag, cloud.NewCredential(cloud.UserPassAuthType, nil))
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		otherSt := s.Factory.MakeModel(c, &factory.ModelParams{
+			Name: "caas-model",
+			Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+			CloudName:       lowCloud.Name,
+			CloudCredential: credTag,
+			Owner:           otherModelOwner.UserTag,
+			ConfigAttrs: testing.Attrs{
+				"controller": false,
+			},
+			StorageProviderRegistry: factory.NilStorageProviderRegistry{}})
+		defer otherSt.Close()
+	}).Check()
+
+	err = s.State.RemoveCloud(lowCloud.Name)
+	c.Assert(err, gc.ErrorMatches, "cloud is used by 1 model")
 }

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -111,16 +111,6 @@ func (s *CloudSuite) TestAddCloudNoAuthTypes(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty auth-types not valid`)
 }
 
-func (s *CloudSuite) TestAddCloudNonZeroModelCount(c *gc.C) {
-	err := s.State.AddCloud(cloud.Cloud{
-		Name:       "stratus",
-		Type:       "foo",
-		AuthTypes:  cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
-		ModelCount: 1,
-	})
-	c.Assert(err, gc.ErrorMatches, `invalid cloud: model count \(1\) > 0 not valid`)
-}
-
 func (s *CloudSuite) TestRemoveCloud(c *gc.C) {
 	// Doesn't exist already is a no-op.
 	err := s.State.RemoveCloud(lowCloud.Name)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -134,6 +134,14 @@ func (doc *MachineDoc) String() string {
 	return m.String()
 }
 
+func CloudModelRefCount(st *State, cloudName string) (int, error) {
+	refcounts, closer := st.db().GetCollection(globalRefcountsC)
+	defer closer()
+
+	key := cloudModelRefCountKey(cloudName)
+	return nsRefcounts.read(refcounts, key)
+}
+
 func ApplicationSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
 	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -7,8 +7,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/clock"
-	names "gopkg.in/juju/names.v2"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
@@ -214,6 +214,10 @@ func Initialize(args InitializeParams) (_ *Controller, _ *State, err error) {
 		salt,
 		dateCreated,
 	)
+
+	// The controller cloud is initially used by 1 model (the controller model).
+	args.Cloud.ModelCount = 1
+
 	ops = append(ops,
 		txn.Op{
 			C:      controllersC,

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -216,7 +216,10 @@ func Initialize(args InitializeParams) (_ *Controller, _ *State, err error) {
 	)
 
 	// The controller cloud is initially used by 1 model (the controller model).
-	args.Cloud.ModelCount = 1
+	cloudRefCountOp, err := incCloudModelRefOp(st, args.Cloud.Name)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	ops = append(ops,
 		txn.Op{
@@ -229,6 +232,7 @@ func Initialize(args InitializeParams) (_ *Controller, _ *State, err error) {
 			},
 		},
 		createCloudOp(args.Cloud),
+		cloudRefCountOp,
 		txn.Op{
 			C:      controllersC,
 			Id:     apiHostPortsKey,

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -210,7 +210,10 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	// Check that the cloud's model count is initially 1.
 	cloud, err := s.State.Cloud("dummy")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloud.ModelCount, gc.Equals, 1)
+
+	refCount, err := state.CloudModelRefCount(s.State, cloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(refCount, gc.Equals, 1)
 }
 
 func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -206,6 +206,11 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 		"dummy/initialize-admin/some-credential":  expectedUserpassCredential,
 		"dummy/initialize-admin/empty-credential": expectedEmptyCredential,
 	})
+
+	// Check that the cloud's model count is initially 1.
+	cloud, err := s.State.Cloud("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud.ModelCount, gc.Equals, 1)
 }
 
 func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -114,6 +114,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// reference counts are implementation details that should be
 		// reconstructed on the other side.
 		refcountsC,
+		globalRefcountsC,
 		// upgradeInfoC is used to coordinate upgrades and schema migrations,
 		// and aren't needed for model migrations.
 		upgradeInfoC,

--- a/state/model.go
+++ b/state/model.go
@@ -396,8 +396,19 @@ func (st *State) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
 	}
 
 	ops := append(prereqOps, modelOps...)
+
+	// Increment the model count for the cloud to which this model belongs.
+	ops = append(ops, updateCloudModelCountOp(args.CloudName, 1))
+
 	err = newSt.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
+		// Check that the cloud exists.
+		// TODO(wallyworld) - this can't yet be tested since we check that the
+		// model cloud is the same as the controller cloud, and hooks can't be
+		// used because a new state is created.
+		if _, err := newSt.Cloud(args.CloudName); err != nil {
+			return nil, nil, errors.Trace(err)
+		}
 
 		// We have a  unique key restriction on the "owner" and "name" fields,
 		// which will cause the insert to fail if there is another record with
@@ -1510,6 +1521,15 @@ func createModelEntityRefsOp(uuid string) txn.Op {
 		Id:     uuid,
 		Assert: txn.DocMissing,
 		Insert: &modelEntityRefsDoc{UUID: uuid},
+	}
+}
+
+func updateCloudModelCountOp(cloud string, inc int) txn.Op {
+	return txn.Op{
+		C:      cloudsC,
+		Id:     cloud,
+		Assert: txn.DocExists,
+		Update: bson.D{{"$inc", bson.D{{"modelcount", inc}}}},
 	}
 }
 

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -187,6 +187,11 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertModelMatches(model)
 
+	// Check that the cloud's model count is incremented.
+	cloud, err := s.State.Cloud("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud.ModelCount, gc.Equals, 2)
+
 	// Since the model tag for the State connection is different,
 	// asking for this model through FindEntity returns a not found error.
 	_, err = s.State.FindEntity(modelTag)

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -190,7 +190,9 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	// Check that the cloud's model count is incremented.
 	cloud, err := s.State.Cloud("dummy")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloud.ModelCount, gc.Equals, 2)
+	refCount, err := state.CloudModelRefCount(st, cloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(refCount, gc.Equals, 2)
 
 	// Since the model tag for the State connection is different,
 	// asking for this model through FindEntity returns a not found error.

--- a/state/state.go
+++ b/state/state.go
@@ -297,6 +297,10 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 		Assert: modelAssertion,
 		Remove: true,
 	}}
+
+	// Decrement the model count for the cloud to which this model belongs.
+	ops = append(ops, updateCloudModelCountOp(model.Cloud(), -1))
+
 	if !st.IsController() {
 		ops = append(ops, decHostedModelCountOp())
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -299,7 +299,11 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	}}
 
 	// Decrement the model count for the cloud to which this model belongs.
-	ops = append(ops, updateCloudModelCountOp(model.Cloud(), -1))
+	decCloudRefOp, err := decCloudModelRefOp(st, model.Cloud())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ops = append(ops, decCloudRefOp)
 
 	if !st.IsController() {
 		ops = append(ops, decHostedModelCountOp())

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2698,14 +2698,17 @@ func (s *StateSuite) TestRemoveAllModelDocs(c *gc.C) {
 
 	cloud, err := s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloud.ModelCount, gc.Equals, 1)
+	refCount, err := state.CloudModelRefCount(st, cloud.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(refCount, gc.Equals, 1)
 
 	err = st.RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
 
 	cloud, err = s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloud.ModelCount, gc.Equals, 0)
+	_, err = state.CloudModelRefCount(st, cloud.Name)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	// test that we can not find the user:envName unique index
 	s.checkUserModelNameExists(c, checkUserModelNameArgs{st: st, id: userModelKey, exists: false})

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2696,8 +2696,16 @@ func (s *StateSuite) TestRemoveAllModelDocs(c *gc.C) {
 	err = model.SetDead()
 	c.Assert(err, jc.ErrorIsNil)
 
+	cloud, err := s.State.Cloud(model.Cloud())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud.ModelCount, gc.Equals, 1)
+
 	err = st.RemoveAllModelDocs()
 	c.Assert(err, jc.ErrorIsNil)
+
+	cloud, err = s.State.Cloud(model.Cloud())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud.ModelCount, gc.Equals, 0)
 
 	// test that we can not find the user:envName unique index
 	s.checkUserModelNameExists(c, checkUserModelNameArgs{st: st, id: userModelKey, exists: false})

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2548,21 +2548,14 @@ func (s *upgradesSuite) TestAddCloudModelCounts(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
+	refCountColl, closer := s.state.db().GetRawCollection(globalRefcountsC)
+	defer closer()
 	expected := []bson.M{{
-		"_id":        "cloud-foo",
-		"name":       "cloud-foo",
-		"type":       "dummy",
-		"auth-types": []interface{}{"empty"},
-		"endpoint":   "here",
-		"modelcount": 2,
+		"_id":      "cloudModel#cloud-foo",
+		"refcount": 2,
 	}, {
-		"_id":        "dummy",
-		"name":       "dummy",
-		"type":       "dummy",
-		"auth-types": []interface{}{"empty"},
-		"regions":    bson.M{"dummy-region": bson.M{}},
-		"endpoint":   "",
-		"modelcount": 1, // unchanged
+		"_id":      "cloudModel#dummy",
+		"refcount": 1, // unchanged
 	}}
-	s.assertUpgradedData(c, AddCloudModelCounts, expectUpgradedData{cloudsColl, expected})
+	s.assertUpgradedData(c, AddCloudModelCounts, expectUpgradedData{refCountColl, expected})
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -41,6 +41,7 @@ type StateBackend interface {
 	MoveMongoSpaceToHASpaceConfig() error
 	CreateMissingApplicationConfig() error
 	RemoveVotingMachineIds() error
+	AddCloudModelCounts() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -153,6 +154,10 @@ func (s stateBackend) CreateMissingApplicationConfig() error {
 
 func (s stateBackend) RemoveVotingMachineIds() error {
 	return state.RemoveVotingMachineIds(s.st)
+}
+
+func (s stateBackend) AddCloudModelCounts() error {
+	return state.AddCloudModelCounts(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -45,6 +45,13 @@ func stateStepsFor24() []Step {
 				return context.State().RemoveVotingMachineIds()
 			},
 		},
+		&upgradeStep{
+			description: "add cloud model counts",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddCloudModelCounts()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_24_test.go
+++ b/upgrades/steps_24_test.go
@@ -43,3 +43,9 @@ func (s *steps24Suite) TestRemoveVotingMachineIds(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps24Suite) TestCloudModelCounts(c *gc.C) {
+	step := findStateStep(c, v24, "add cloud model counts")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
## Description of change

Add support for removing a cloud from a controller. Broken into 3 commits:

1. Add state support for counting how many models a cloud has deployed and support for removing clouds with zero models.
2. Add upgrade steps to count and record the models for each cloud
3. Add API support for removing a cloud.

## QA steps

Nothing is wired up to use the remove yet. 
Deploy a 2.3 model and upgrade to 2.4 Check the cloud model counts.
Add/remove models and check cloud model counts.
