### PR TITLE
Code changes to write resources in /var/lib/juju

### DIFF
--- a/resource/context/context.go
+++ b/resource/context/context.go
@@ -5,7 +5,6 @@ package context
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -89,26 +88,11 @@ func (deps *contextDeps) OpenResource() (internal.ContextOpenedResource, error) 
 }
 
 func (deps *contextDeps) Download(target internal.DownloadTarget, remote internal.ContextOpenedResource) error {
-	return internal.DownloadIndirect(target, remote, deps)
+	return internal.Download(target, remote)
 }
 
 func (deps *contextDeps) DownloadDirect(target internal.DownloadTarget, remote internal.ContentSource) error {
 	return internal.Download(target, remote)
-}
-
-func (deps *contextDeps) ReplaceDirectory(tgt, src string) error {
-	return internal.ReplaceDirectory(tgt, src, deps)
-}
-
-func (deps *contextDeps) NewTempDirSpec() (internal.DownloadTempTarget, error) {
-	spec, err := internal.NewTempDirectorySpec(deps.name, deps)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	dir := &internal.ContextDownloadDirectory{
-		spec,
-	}
-	return dir, nil
 }
 
 func (deps *contextDeps) WriteContent(target io.Writer, content internal.Content) error {
@@ -128,18 +112,8 @@ func (deps contextDeps) CreateWriter(filename string) (io.WriteCloser, error) {
 	return os.Create(filename)
 }
 
-func (deps contextDeps) NewTempDir() (string, error) {
-	return ioutil.TempDir("", "juju-resource-")
-}
-
 func (deps contextDeps) RemoveDir(dirname string) error {
 	return os.RemoveAll(dirname)
-}
-
-func (deps contextDeps) Move(target, source string) error {
-	// Note that we follow the io.Copy() argument arder here
-	// (os.Rename does not).
-	return os.Rename(source, target)
 }
 
 func (deps contextDeps) Copy(target io.Writer, source io.Reader) error {

--- a/resource/context/context.go
+++ b/resource/context/context.go
@@ -91,10 +91,6 @@ func (deps *contextDeps) Download(target internal.DownloadTarget, remote interna
 	return internal.Download(target, remote)
 }
 
-func (deps *contextDeps) DownloadDirect(target internal.DownloadTarget, remote internal.ContentSource) error {
-	return internal.Download(target, remote)
-}
-
 func (deps *contextDeps) WriteContent(target io.Writer, content internal.Content) error {
 	return internal.WriteContent(target, content, deps)
 }

--- a/resource/context/internal/context.go
+++ b/resource/context/internal/context.go
@@ -37,7 +37,7 @@ func ContextDownload(deps ContextDownloadDeps) (path string, err error) {
 		return path, nil
 	}
 
-	if err := deps.Download(resDirSpec, remote); err != nil {
+	if err := Download(resDirSpec, remote); err != nil {
 		return "", errors.Trace(err)
 	}
 

--- a/resource/context/internal/context.go
+++ b/resource/context/internal/context.go
@@ -37,7 +37,7 @@ func ContextDownload(deps ContextDownloadDeps) (path string, err error) {
 		return path, nil
 	}
 
-	if err := Download(resDirSpec, remote); err != nil {
+	if err := deps.Download(resDirSpec, remote); err != nil {
 		return "", errors.Trace(err)
 	}
 

--- a/resource/context/internal/download.go
+++ b/resource/context/internal/download.go
@@ -7,8 +7,6 @@ package internal
 //  (e.g. top-level resource pkg, charm/resource)
 
 import (
-	"io"
-
 	"github.com/juju/errors"
 )
 
@@ -26,50 +24,6 @@ func Download(target DownloadTarget, remote ContentSource) error {
 	return nil
 }
 
-// DownloadIndirect downloads the resource from the source into a temp
-// directory. Then the target is replaced by the temp directory.
-func DownloadIndirect(target DownloadTarget, remote ContentSource, deps DownloadIndirectDeps) error {
-	tempDirSpec, err := deps.NewTempDirSpec()
-	defer deps.CloseAndLog(tempDirSpec, "resource temp dir")
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := deps.DownloadDirect(tempDirSpec, remote); err != nil {
-		return errors.Trace(err)
-	}
-
-	resDir, err := target.Initialize()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	oldDir := tempDirSpec.Resolve()
-	newDir := resDir.Resolve()
-	if err := deps.ReplaceDirectory(newDir, oldDir); err != nil {
-		return errors.Annotate(err, "could not replace existing resource directory")
-	}
-
-	return nil
-}
-
-// DownloadIndirectDeps exposes the external functionality needed
-// by DownloadIndirect.
-type DownloadIndirectDeps interface {
-	// NewTempDirSpec returns a directory spec for the resource under a temporary datadir.
-	NewTempDirSpec() (DownloadTempTarget, error)
-
-	// CloseAndLog closes the closer and logs any error.
-	CloseAndLog(io.Closer, string)
-
-	// DownloadDirect downloads the source into the target.
-	DownloadDirect(DownloadTarget, ContentSource) error
-
-	// ReplaceDirectory moves the source directory path to the target
-	// path. If the target path already exists then it is replaced atomically.
-	ReplaceDirectory(tgt, src string) error
-}
-
 // DownloadTarget exposes the functionality of a directory spec
 // needed by Download().
 type DownloadTarget interface {
@@ -85,13 +39,6 @@ type DownloadDirectory interface {
 	// Write writes all the relevant files for the provided source
 	// to the directory.
 	Write(ContentSource) error
-}
-
-// DownloadTempTarget represents a temporary download directory.
-type DownloadTempTarget interface {
-	DownloadTarget
-	Resolver
-	io.Closer
 }
 
 // Resolver exposes the functionality of DirectorySpec needed

--- a/resource/context/internal/download_test.go
+++ b/resource/context/internal/download_test.go
@@ -40,54 +40,6 @@ func (s *DownloadSuite) TestDownload(c *gc.C) {
 	s.stub.CheckCall(c, 1, "Write", remote)
 }
 
-func (s *DownloadSuite) TestDownloadIndirectOkay(c *gc.C) {
-	stub := &stubDownload{
-		internalStub: s.stub,
-	}
-	stub.ReturnNewTempDirSpec = stub
-	stub.ReturnResolve = []string{
-		"/tmp/xyz/eggs",
-		"/var/lib/juju/agents/unit-spam-1/resources/eggs",
-	}
-	target := stub
-	remote := stub
-	deps := stub
-
-	err := internal.DownloadIndirect(target, remote, deps)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.stub.CheckCallNames(c,
-		"NewTempDirSpec",
-		"DownloadDirect",
-		"Initialize",
-		"Resolve",
-		"Resolve",
-		"ReplaceDirectory",
-		"CloseAndLog",
-	)
-	s.stub.CheckCall(c, 1, "DownloadDirect", stub, remote)
-}
-
-func (s *DownloadSuite) TestDownloadIndirectTempDirFailure(c *gc.C) {
-	stub := &stubDownload{
-		internalStub: s.stub,
-	}
-	stub.ReturnNewTempDirSpec = stub
-	failure := errors.New("<failure>")
-	stub.SetErrors(failure)
-	target := stub
-	remote := stub
-	deps := stub
-
-	err := internal.DownloadIndirect(target, remote, deps)
-
-	c.Check(errors.Cause(err), gc.Equals, failure)
-	s.stub.CheckCallNames(c,
-		"NewTempDirSpec",
-		"CloseAndLog",
-	)
-}
-
 type stubDownload struct {
 	*internalStub
 	internal.ContentSource

--- a/resource/context/internal/resourcedir_test.go
+++ b/resource/context/internal/resourcedir_test.go
@@ -157,38 +157,6 @@ func (s *TempDirectorySpecSuite) SetUpTest(c *gc.C) {
 	s.stub = newInternalStub()
 }
 
-func (s *TempDirectorySpecSuite) TestNewTempDirectorySpec(c *gc.C) {
-	s.stub.ReturnNewTempDir = "/tmp/juju-resource-xyz"
-	deps := s.stub
-
-	spec, err := internal.NewTempDirectorySpec("eggs", deps)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.stub.CheckCallNames(c, "NewTempDir", "Join")
-	c.Check(spec.CleanUp, gc.NotNil) // We can't compare functions.
-	spec.CleanUp = nil
-	c.Check(spec, jc.DeepEquals, &internal.TempDirectorySpec{
-		DirectorySpec: &internal.DirectorySpec{
-			Name:    "eggs",
-			Dirname: "/tmp/juju-resource-xyz/eggs",
-			Deps:    deps,
-		},
-	})
-}
-
-func (s *TempDirectorySpecSuite) TestClose(c *gc.C) {
-	s.stub.ReturnNewTempDir = "/tmp/juju-resource-xyz"
-	deps := s.stub
-	spec, err := internal.NewTempDirectorySpec("eggs", deps)
-	c.Assert(err, jc.ErrorIsNil)
-	s.stub.ResetCalls()
-
-	err = spec.Close()
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.stub.CheckCallNames(c, "RemoveDir")
-}
-
 var _ = gc.Suite(&DirectorySuite{})
 
 type DirectorySuite struct {

--- a/resource/context/internal/stub_test.go
+++ b/resource/context/internal/stub_test.go
@@ -22,10 +22,8 @@ type internalStub struct {
 	ReturnGetResourceData         io.ReadCloser
 	ReturnNewContextDirectorySpec internal.ContextDirectorySpec
 	ReturnOpenResource            internal.ContextOpenedResource
-	ReturnNewTempDirSpec          internal.DownloadTempTarget
 	ReturnNewChecker              internal.ContentChecker
 	ReturnCreateWriter            io.WriteCloser
-	ReturnNewTempDir              string
 	ReturnFingerprintMatches      bool
 }
 
@@ -88,15 +86,6 @@ func (s *internalStub) ReplaceDirectory(tgt, src string) error {
 	return nil
 }
 
-func (s *internalStub) NewTempDirSpec() (internal.DownloadTempTarget, error) {
-	s.Stub.AddCall("NewTempDirSpec")
-	if err := s.Stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.ReturnNewTempDirSpec, nil
-}
-
 func (s *internalStub) NewChecker(content internal.Content) internal.ContentChecker {
 	s.Stub.AddCall("NewChecker", content)
 	s.Stub.NextErr() // Pop one off.
@@ -134,15 +123,6 @@ func (s *internalStub) CreateWriter(filename string) (io.WriteCloser, error) {
 	}
 
 	return s.ReturnCreateWriter, nil
-}
-
-func (s *internalStub) NewTempDir() (string, error) {
-	s.Stub.AddCall("NewTempDir")
-	if err := s.Stub.NextErr(); err != nil {
-		return "", errors.Trace(err)
-	}
-
-	return s.ReturnNewTempDir, nil
 }
 
 func (s *internalStub) RemoveDir(dirname string) error {

--- a/resource/context/internal/util.go
+++ b/resource/context/internal/util.go
@@ -22,13 +22,3 @@ func CloseAndLog(closer io.Closer, label string, logger Logger) {
 		logger.Errorf("while closing %s: %v", label, err)
 	}
 }
-
-// ReplaceDirectoryDeps exposes the functionality needed by ReplaceDirectory.
-type ReplaceDirectoryDeps interface {
-	// RemoveDir deletes the directory at the given path.
-	RemoveDir(dirname string) error
-
-	//XXXXXX
-	// Move moves the directory at the source path to the target path.
-	Move(target, source string) error
-}

--- a/resource/context/internal/util.go
+++ b/resource/context/internal/util.go
@@ -5,10 +5,6 @@ package internal
 
 import (
 	"io"
-	"os"
-	"path/filepath"
-
-	"github.com/juju/errors"
 )
 
 // Logger exposes the logger functionality needed by CloseAndLog.
@@ -27,30 +23,12 @@ func CloseAndLog(closer io.Closer, label string, logger Logger) {
 	}
 }
 
-// ReplaceDirectory replaces the target directory with the source. This
-// involves removing the target if it exists and then moving the source
-// into place.
-func ReplaceDirectory(targetDir, sourceDir string, deps ReplaceDirectoryDeps) error {
-	// TODO(ericsnow) Move it out of the way and remove it after the rename.
-	if err := deps.RemoveDir(targetDir); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(targetDir), 0755); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := deps.Move(targetDir, sourceDir); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 // ReplaceDirectoryDeps exposes the functionality needed by ReplaceDirectory.
 type ReplaceDirectoryDeps interface {
 	// RemoveDir deletes the directory at the given path.
 	RemoveDir(dirname string) error
 
+	//XXXXXX
 	// Move moves the directory at the source path to the target path.
 	Move(target, source string) error
 }

--- a/resource/context/internal/util_test.go
+++ b/resource/context/internal/util_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/filetesting"
 	gc "gopkg.in/check.v1"
 
@@ -48,15 +47,6 @@ func (s *UtilSuite) TestCloseAndLog(c *gc.C) {
 
 	s.stub.CheckCallNames(c, "Close", "Errorf")
 	c.Check(logger.logged, gc.Equals, "while closing a thing: <failure>")
-}
-
-func (s *UtilSuite) TestReplaceDirectory(c *gc.C) {
-	deps := s.stub
-
-	err := internal.ReplaceDirectory("target_dir", "source_dir", deps)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.stub.CheckCallNames(c, "RemoveDir", "Move")
 }
 
 type stubLogger struct {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:
## Description of change
This PR address the issue of having /tmp and /var on different filesystems and copying the resources downloaded from /tmp to /var.
## QA steps
Install juju bootstrap and deploy charm that uses resources and make sure the resource are saved in /var/lib/juju/agents/unit-<resourcename>-0/resources/ folder.
How do we verify that the change works?
Execute juju run command with "restore-get" -  this gets executed in the hook context of the unit.
eg: juju run --unit <unitName> restore-get '<cmd>'

This can be verified by running hook install or config-changed using juju debug-hook <unitName>

## Documentation changes
Does it affect current user workflow? CLI? API?
N/A
## Bug reference
https://bugs.launchpad.net/juju/+bug/1751291
Does this change fix a bug? Please add a link to it.