### PR TITLE
Fix LXD tests for non-amd64 Architectures

### DIFF
--- a/container/lxd/client_test.go
+++ b/container/lxd/client_test.go
@@ -10,16 +10,13 @@ import (
 
 	"github.com/juju/juju/container/lxd"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type clientSuite struct {
-	coretesting.BaseSuite
+	lxdtesting.BaseSuite
 }
 
 var _ = gc.Suite(&clientSuite{})
-
-const eTag = "etag"
 
 func (s *connectionSuite) TestUpdateServerConfig(c *gc.C) {
 	ctrl := gomock.NewController(c)
@@ -28,8 +25,8 @@ func (s *connectionSuite) TestUpdateServerConfig(c *gc.C) {
 
 	updateReq := api.ServerPut{Config: map[string]interface{}{"key1": "val1"}}
 	gomock.InOrder(
-		cSvr.EXPECT().GetServer().Return(&api.Server{}, eTag, nil).Times(2),
-		cSvr.EXPECT().UpdateServer(updateReq, eTag).Return(nil),
+		cSvr.EXPECT().GetServer().Return(&api.Server{}, lxdtesting.ETag, nil).Times(2),
+		cSvr.EXPECT().UpdateServer(updateReq, lxdtesting.ETag).Return(nil),
 	)
 
 	client := lxd.NewClient(cSvr)
@@ -47,9 +44,9 @@ func (s *connectionSuite) TestUpdateContainerConfig(c *gc.C) {
 	updateReq := api.ContainerPut{Config: newConfig}
 	op := lxdtesting.NewMockOperation(ctrl)
 	gomock.InOrder(
-		cSvr.EXPECT().GetServer().Return(&api.Server{}, eTag, nil),
-		cSvr.EXPECT().GetContainer(cName).Return(&api.Container{}, eTag, nil),
-		cSvr.EXPECT().UpdateContainer(cName, updateReq, eTag).Return(op, nil),
+		cSvr.EXPECT().GetServer().Return(&api.Server{}, lxdtesting.ETag, nil),
+		cSvr.EXPECT().GetContainer(cName).Return(&api.Container{}, lxdtesting.ETag, nil),
+		cSvr.EXPECT().UpdateContainer(cName, updateReq, lxdtesting.ETag).Return(op, nil),
 		op.EXPECT().Wait().Return(nil),
 	)
 

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -14,13 +14,12 @@ import (
 
 	"github.com/juju/juju/container/lxd"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&imageSuite{})
 
 type imageSuite struct {
-	coretesting.BaseSuite
+	lxdtesting.BaseSuite
 }
 
 func (t *imageSuite) patch(remotes map[string]lxdclient.ImageServer) {
@@ -30,7 +29,7 @@ func (t *imageSuite) patch(remotes map[string]lxdclient.ImageServer) {
 func (s *imageSuite) TestCopyImageUsesPassedCallback(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	iSvr := newMockServer(ctrl)
+	iSvr := s.NewMockServer(ctrl)
 
 	copyOp := lxdtesting.NewMockRemoteOperation(ctrl)
 	copyOp.EXPECT().Wait().Return(nil).AnyTimes()
@@ -54,17 +53,17 @@ func (s *imageSuite) TestCopyImageUsesPassedCallback(c *gc.C) {
 func (s *imageSuite) TestFindImageLocalServer(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	iSvr := newMockServer(ctrl)
+	iSvr := s.NewMockServer(ctrl)
 
 	alias := &lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-target"}}
 	image := lxdapi.Image{Filename: "this-is-our-image"}
 	gomock.InOrder(
-		iSvr.EXPECT().GetImageAlias("juju/xenial/amd64").Return(alias, "ETAG", nil),
-		iSvr.EXPECT().GetImage("foo-target").Return(&image, "ETAG", nil),
+		iSvr.EXPECT().GetImageAlias("juju/xenial/"+s.Arch()).Return(alias, lxdtesting.ETag, nil),
+		iSvr.EXPECT().GetImage("foo-target").Return(&image, lxdtesting.ETag, nil),
 	)
 
 	jSvr := lxd.NewClient(iSvr)
-	found, err := jSvr.FindImage("xenial", "amd64", []lxd.RemoteServer{{}}, false, nil)
+	found, err := jSvr.FindImage("xenial", s.Arch(), []lxd.RemoteServer{{}}, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, iSvr)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -73,18 +72,18 @@ func (s *imageSuite) TestFindImageLocalServer(c *gc.C) {
 func (s *imageSuite) TestFindImageLocalServerUnknownSeries(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	iSvr := newMockServer(ctrl)
-	iSvr.EXPECT().GetImageAlias("juju/pldlinux/amd64").Return(nil, "ETAG", nil)
+	iSvr := s.NewMockServer(ctrl)
+	iSvr.EXPECT().GetImageAlias("juju/pldlinux/"+s.Arch()).Return(nil, lxdtesting.ETag, nil)
 
 	jSvr := lxd.NewClient(iSvr)
-	_, err := jSvr.FindImage("pldlinux", "amd64", []lxd.RemoteServer{{}}, false, nil)
+	_, err := jSvr.FindImage("pldlinux", s.Arch(), []lxd.RemoteServer{{}}, false, nil)
 	c.Check(err, gc.ErrorMatches, `.*series: "pldlinux".*`)
 }
 
 func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	iSvr := newMockServer(ctrl)
+	iSvr := s.NewMockServer(ctrl)
 
 	rSvr1 := lxdtesting.NewMockImageServer(ctrl)
 	rSvr2 := lxdtesting.NewMockImageServer(ctrl)
@@ -96,10 +95,10 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 	image := lxdapi.Image{Filename: "this-is-our-image"}
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	gomock.InOrder(
-		iSvr.EXPECT().GetImageAlias("juju/xenial/amd64").Return(nil, "ETAG", nil),
-		rSvr1.EXPECT().GetImageAlias("xenial/amd64").Return(nil, "ETAG", nil),
-		rSvr2.EXPECT().GetImageAlias("xenial/amd64").Return(&alias, "ETAG", nil),
-		rSvr2.EXPECT().GetImage("foo-remote-target").Return(&image, "ETAG", nil),
+		iSvr.EXPECT().GetImageAlias("juju/xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, nil),
+		rSvr1.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, nil),
+		rSvr2.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
+		rSvr2.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 	)
 
 	jSvr := lxd.NewClient(iSvr)
@@ -108,7 +107,7 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 		{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol},
 		{Name: "server-that-should-not-be-touched", Protocol: lxd.LXDProtocol},
 	}
-	found, err := jSvr.FindImage("xenial", "amd64", remotes, false, nil)
+	found, err := jSvr.FindImage("xenial", s.Arch(), remotes, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, rSvr2)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -117,7 +116,7 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	iSvr := newMockServer(ctrl)
+	iSvr := s.NewMockServer(ctrl)
 
 	rSvr := lxdtesting.NewMockImageServer(ctrl)
 	s.patch(map[string]lxdclient.ImageServer{
@@ -128,14 +127,14 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 	copyOp.EXPECT().Wait().Return(nil).AnyTimes()
 	copyOp.EXPECT().GetTarget().Return(&lxdapi.Operation{StatusCode: lxdapi.Success}, nil)
 
-	localAlias := "juju/xenial/amd64"
+	localAlias := "juju/xenial/" + s.Arch()
 	image := lxdapi.Image{Filename: "this-is-our-image"}
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	copyReq := &lxdclient.ImageCopyArgs{Aliases: []lxdapi.ImageAlias{{Name: localAlias}}}
 	gomock.InOrder(
-		iSvr.EXPECT().GetImageAlias(localAlias).Return(nil, "ETAG", nil),
-		rSvr.EXPECT().GetImageAlias("xenial/amd64").Return(&alias, "ETAG", nil),
-		rSvr.EXPECT().GetImage("foo-remote-target").Return(&image, "ETAG", nil),
+		iSvr.EXPECT().GetImageAlias(localAlias).Return(nil, lxdtesting.ETag, nil),
+		rSvr.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
+		rSvr.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 		iSvr.EXPECT().CopyImage(rSvr, image, copyReq).Return(copyOp, nil),
 	)
 
@@ -143,7 +142,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 	remotes := []lxd.RemoteServer{
 		{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol},
 	}
-	found, err := jSvr.FindImage("xenial", "amd64", remotes, true, nil)
+	found, err := jSvr.FindImage("xenial", s.Arch(), remotes, true, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, iSvr)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -152,7 +151,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 func (s *imageSuite) TestFindImageRemoteServersNotFound(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	iSvr := newMockServer(ctrl)
+	iSvr := s.NewMockServer(ctrl)
 
 	rSvr := lxdtesting.NewMockImageServer(ctrl)
 	s.patch(map[string]lxdclient.ImageServer{
@@ -161,13 +160,14 @@ func (s *imageSuite) TestFindImageRemoteServersNotFound(c *gc.C) {
 
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	gomock.InOrder(
-		iSvr.EXPECT().GetImageAlias("juju/centos7/amd64").Return(nil, "ETAG", nil),
-		rSvr.EXPECT().GetImageAlias("centos/7/amd64").Return(&alias, "ETAG", nil),
-		rSvr.EXPECT().GetImage("foo-remote-target").Return(nil, "ETAG", errors.New("failed to retrieve image")),
+		iSvr.EXPECT().GetImageAlias("juju/centos7/"+s.Arch()).Return(nil, lxdtesting.ETag, nil),
+		rSvr.EXPECT().GetImageAlias("centos/7/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
+		rSvr.EXPECT().GetImage("foo-remote-target").Return(
+			nil, lxdtesting.ETag, errors.New("failed to retrieve image")),
 	)
 
 	jSvr := lxd.NewClient(iSvr)
 	remotes := []lxd.RemoteServer{{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol}}
-	_, err := jSvr.FindImage("centos7", "amd64", remotes, false, nil)
+	_, err := jSvr.FindImage("centos7", s.Arch(), remotes, false, nil)
 	c.Assert(err, gc.ErrorMatches, ".*failed to retrieve image.*")
 }

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -104,12 +104,12 @@ func (s *networkSuite) TestVerifyDefaultBridgeNetSupportNoBridge(c *gc.C) {
 		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(nil, "", errors.New("not found")),
 		cSvr.EXPECT().CreateNetwork(netCreateReq).Return(nil),
 		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(newNet, "", nil),
-		cSvr.EXPECT().UpdateProfile("default", defaultProfile().Writable(), eTag).Return(nil),
+		cSvr.EXPECT().UpdateProfile("default", defaultProfile().Writable(), lxdtesting.ETag).Return(nil),
 	)
 
 	profile := defaultProfile()
 	delete(profile.Devices, "eth0")
-	err := lxd.NewClient(cSvr).VerifyDefaultBridge(profile, eTag)
+	err := lxd.NewClient(cSvr).VerifyDefaultBridge(profile, lxdtesting.ETag)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -8,12 +8,12 @@ import (
 
 	"errors"
 	"github.com/juju/juju/container/lxd"
+	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	"github.com/juju/juju/network"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type networkSuite struct {
-	coretesting.BaseSuite
+	lxdtesting.BaseSuite
 }
 
 var _ = gc.Suite(&networkSuite{})
@@ -36,7 +36,7 @@ func defaultProfile() *lxdapi.Profile {
 func (s *networkSuite) TestVerifyDefaultBridgeNetSupportDevicePresent(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	cSvr := newMockServer(ctrl, "network")
+	cSvr := s.NewMockServer(ctrl, "network")
 
 	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(&lxdapi.Network{}, "", nil)
 
@@ -47,7 +47,7 @@ func (s *networkSuite) TestVerifyDefaultBridgeNetSupportDevicePresent(c *gc.C) {
 func (s *networkSuite) TestVerifyDefaultBridgeNetSupportDeviceNotBridged(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	cSvr := newMockServer(ctrl, "network")
+	cSvr := s.NewMockServer(ctrl, "network")
 
 	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(&lxdapi.Network{}, "", nil)
 
@@ -60,7 +60,7 @@ func (s *networkSuite) TestVerifyDefaultBridgeNetSupportDeviceNotBridged(c *gc.C
 func (s *networkSuite) TestVerifyDefaultBridgeNetSupportIPv6Present(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	cSvr := newMockServer(ctrl, "network")
+	cSvr := s.NewMockServer(ctrl, "network")
 
 	net := &lxdapi.Network{
 		Name:    network.DefaultLXDBridge,
@@ -80,7 +80,7 @@ func (s *networkSuite) TestVerifyDefaultBridgeNetSupportIPv6Present(c *gc.C) {
 func (s *networkSuite) TestVerifyDefaultBridgeNetSupportNoBridge(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	cSvr := newMockServer(ctrl, "network")
+	cSvr := s.NewMockServer(ctrl, "network")
 
 	netConf := map[string]string{
 		"ipv4.address": "auto",

--- a/container/lxd/testing/suite.go
+++ b/container/lxd/testing/suite.go
@@ -1,0 +1,45 @@
+package testing
+
+import (
+	"github.com/golang/mock/gomock"
+	lxdapi "github.com/lxc/lxd/shared/api"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/utils/arch"
+)
+
+const ETag = "eTag"
+
+// BaseSuite facilitates LXD testing.
+// Do not instantiate this suite directly.
+type BaseSuite struct {
+	coretesting.BaseSuite
+	arch string
+}
+
+func (s *BaseSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.arch = arch.HostArch()
+}
+
+func (s *BaseSuite) Arch() string {
+	return s.arch
+}
+
+// NewMockServer initialises a mock container server and adds an
+// expectation for the GetServer function, which is called each time NewClient
+// is used to instantiate our wrapper.
+// The return from GetServer indicates the input supported API extensions.
+func (s *BaseSuite) NewMockServer(ctrl *gomock.Controller, extensions ...string) *MockContainerServer {
+	svr := NewMockContainerServer(ctrl)
+
+	cfg := &lxdapi.Server{
+		ServerUntrusted: lxdapi.ServerUntrusted{
+			APIExtensions: extensions,
+		},
+	}
+	svr.EXPECT().GetServer().Return(cfg, ETag, nil)
+
+	return svr
+}


### PR DESCRIPTION
## Description of change

Tests were failing for non-AMD64 architectures due to "amd64" being hard coded in image alias expectations.

This change:
- Adds and uses new BaseSuite for LXD testing.
- Makes image aliases in tests dependent on system architecture rather than assuming amd64.

## QA steps

Reworked tests all green.
