### PR TITLE
Fixes lp#1633972: Status shows no relations in tabular format by default.

### DIFF
--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -23,23 +23,27 @@ type statusFormatter struct {
 	controllerName string
 	relations      map[int]params.RelationStatus
 	isoTime        bool
+	showRelations  bool
 }
 
 // NewStatusFormatter takes stored model information (params.FullStatus) and populates
 // the statusFormatter struct used in various status formatting methods
 func NewStatusFormatter(status *params.FullStatus, isoTime bool) *statusFormatter {
-	return newStatusFormatter(status, "", isoTime)
+	return newStatusFormatter(status, "", isoTime, true)
 }
 
-func newStatusFormatter(status *params.FullStatus, controllerName string, isoTime bool) *statusFormatter {
+func newStatusFormatter(status *params.FullStatus, controllerName string, isoTime, showRelations bool) *statusFormatter {
 	sf := statusFormatter{
 		status:         status,
 		controllerName: controllerName,
 		relations:      make(map[int]params.RelationStatus),
 		isoTime:        isoTime,
+		showRelations:  showRelations,
 	}
-	for _, relation := range status.Relations {
-		sf.relations[relation.Id] = relation
+	if showRelations {
+		for _, relation := range status.Relations {
+			sf.relations[relation.Id] = relation
+		}
 	}
 	return &sf
 }

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -29,7 +29,9 @@ type statusAPI interface {
 // NewStatusCommand returns a new command, which reports on the
 // runtime state of various system entities.
 func NewStatusCommand() cmd.Command {
-	return modelcmd.Wrap(&statusCommand{})
+	return modelcmd.Wrap(&statusCommand{
+		relationsFlagProvidedF: func() bool { return false },
+	})
 }
 
 type statusCommand struct {
@@ -40,6 +42,12 @@ type statusCommand struct {
 	api      statusAPI
 
 	color bool
+
+	// relations indicates if 'relations' section is displayed
+	relations bool
+
+	// relationsFlagProvidedF indicates whether 'relations' option was provided by the user.
+	relationsFlagProvidedF func() bool
 }
 
 var usageSummary = `
@@ -72,11 +80,16 @@ The available output formats are:
       in structured YAML format.
 - json: Displays information about the model, machines, applications, and units
       in structured JSON format.
+      
+In tabular format, 'Relations' section is not displayed by default. 
+Use --relations option to see this section. This option is ignored in all other 
+formats.
 
 Examples:
     juju show-status
     juju show-status mysql
     juju show-status nova-*
+    juju show-status --relations
 
 See also:
     machines
@@ -99,6 +112,18 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.isoTime, "utc", false, "Display time as UTC in RFC3339 format")
 	f.BoolVar(&c.color, "color", false, "Force use of ANSI color codes")
+
+	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section")
+
+	c.relationsFlagProvidedF = func() bool {
+		provided := false
+		f.Visit(func(flag *gnuflag.Flag) {
+			if flag.Name == "relations" {
+				provided = true
+			}
+		})
+		return provided
+	}
 
 	defaultFormat := "tabular"
 
@@ -156,7 +181,17 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	formatter := newStatusFormatter(status, controllerName, c.isoTime)
+
+	showRelations := true
+	if c.out.Name() != "tabular" {
+		if c.relationsFlagProvidedF() {
+			// For non-tabular formats this is redundant and needs to be mentioned to the user.
+			ctx.Infof("provided --relations option is ignored")
+		}
+	} else {
+		showRelations = c.relations
+	}
+	formatter := newStatusFormatter(status, controllerName, c.isoTime, showRelations)
 	formatted, err := formatter.format()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4147,7 +4147,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
-	code, stdout, stderr := runStatus(c, "--format", "tabular")
+	code, stdout, stderr := runStatus(c, "--format", "tabular", "--relations")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
@@ -4970,4 +4970,39 @@ func (s *StatusSuite) TestMissingControllerTimestampInFullStatus(c *gc.C) {
 		RemoteApplications: map[string]remoteApplicationStatus{},
 		Offers:             map[string]offerStatus{},
 	})
+}
+func (s *StatusSuite) TestTabularNoRelations(c *gc.C) {
+	ctx := s.FilteringTestSetup(c)
+	defer s.resetContext(c, ctx)
+
+	_, stdout, stderr := runStatus(c)
+	c.Assert(stderr, gc.IsNil)
+	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsFalse)
+}
+
+func (s *StatusSuite) TestTabularDisplayRelations(c *gc.C) {
+	ctx := s.FilteringTestSetup(c)
+	defer s.resetContext(c, ctx)
+
+	_, stdout, stderr := runStatus(c, "--relations")
+	c.Assert(stderr, gc.IsNil)
+	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsTrue)
+}
+
+func (s *StatusSuite) TestNonTabularDisplayRelations(c *gc.C) {
+	ctx := s.FilteringTestSetup(c)
+	defer s.resetContext(c, ctx)
+
+	_, stdout, stderr := runStatus(c, "--format=yaml", "--relations")
+	c.Assert(string(stderr), gc.Equals, "provided --relations option is ignored\n")
+	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+}
+
+func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
+	ctx := s.FilteringTestSetup(c)
+	defer s.resetContext(c, ctx)
+
+	_, stdout, stderr := runStatus(c, "--format=yaml")
+	c.Assert(stderr, gc.IsNil)
+	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
 }


### PR DESCRIPTION
## Description of change

As per the linked bug, status output on a large deployment can be too long for an operator to digest. This is especially uncomfortable in tabular format which is meant to be the most human-readable output.

This PR hides relations section of tabular status output by default. Users can make this section visible again by using --relations option.

Since this is only affecting tabular format, if the option is used with any other format, it will be ignored and user notified.

(forward-port of https://github.com/juju/juju/pull/8702)

## QA steps

Run juju status in different format, providing and omitting --relations options.

## Documentation changes

@juju/docs , this is a new option that affects status output \o/

## Bug reference

https://bugs.launchpad.net/juju/+bug/1633972
