### PR TITLE
Tweak makefile so it works with docker from snap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ check-deps:
 
 # CAAS related targets
 DOCKER_USERNAME?=jujusolutions
-JUJUD_STAGING_DIR=/tmp/jujud-operator
+JUJUD_STAGING_DIR?=/tmp/jujud-operator
 JUJUD_BIN_DIR=${GOPATH}/bin
 OPERATOR_IMAGE_TAG = $(shell jujud version | cut -d- -f1,2)
 
@@ -155,6 +155,7 @@ operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requi
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
 	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
+	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
 	docker push ${DOCKER_USERNAME}/caas-jujud-operator

--- a/caas/jujud-operator-dockerfile
+++ b/caas/jujud-operator-dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:latest
 
 # Some Python dependencies.
 RUN apt-get update && apt-get install -y \
-    python3-dev \
     python3-yaml \
     python3-pip \
  && pip3 install --upgrade pip setuptools \


### PR DESCRIPTION
## Description of change

When running docker from a snap, it can't see directories under /tmp
So tweak the makefile to allow the JUJUD_STAGING_DIR to be set externally.
Also remove python-dev from docker makefile.

## QA steps

Make the docker operator image

