### PR TITLE
Relations in status ouput: filter futher.

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -268,13 +268,24 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 
 		// Filter applications
 		for appName, app := range context.applications {
-			if matchedSvcs.Contains(appName) {
-				// There are matched units for this application.
-				continue
-			} else if matches, err := predicate(app); err != nil {
+			matches, err := predicate(app)
+			if err != nil {
 				return noStatus, errors.Annotate(err, "could not filter applications")
-			} else if !matches {
+			}
+
+			// There are matched units for this application
+			// or the application matched the given criteria.
+			deleted := false
+			if !matchedSvcs.Contains(appName) && !matches {
 				delete(context.applications, appName)
+				deleted = true
+			}
+
+			// Filter relations:
+			// Remove relations for applications that were deleted and
+			// for the applications that did not match the
+			// given criteria.
+			if deleted || !matches {
 				// delete relations for this app
 				if relations, ok := context.relations[appName]; ok {
 					for _, r := range relations {

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -433,6 +433,73 @@ func (s *statusUnitTestSuite) TestRelationFiltered(c *gc.C) {
 	assertApplicationRelations(c, a3.Name(), 1, status.Relations)
 }
 
+// TestFilterOutRelationsForRelatedApplicationsThatDoNotMatchCriteriaDirectly
+// tests scenario where applications are returned as part of the status because
+// they are related to an application that matches given filter.
+// However, the relations for these applications should not be returned.
+// In other words, if there are two applications, A and B, such that:
+//
+// * an application A matches the supplied filter directly;
+// * an application B has units on the same machine as units of an application A and, thus,
+// qualifies to be returned by the status result;
+//
+// application B's relations should not be returned.
+func (s *statusUnitTestSuite) TestFilterOutRelationsForRelatedApplicationsThatDoNotMatchCriteriaDirectly(c *gc.C) {
+	// Application A has no touch points with application C
+	// but will have a unit on the same machine is a unit of an application B.
+	applicationA := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
+			Name: "mysql",
+		}),
+	})
+
+	// Application B will have a unit on the same machine as a unit of an application A
+	// and will have a relation to an application C.
+	applicationB := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	endpoint1, err := applicationB.Endpoint("juju-info")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Application C has a relation to application B but has no touch points with
+	// an application A.
+	applicationC := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{Name: "logging"}),
+	})
+	endpoint2, err := applicationC.Endpoint("info")
+	c.Assert(err, jc.ErrorIsNil)
+	s.Factory.MakeRelation(c, &factory.RelationParams{
+		Endpoints: []state.Endpoint{endpoint2, endpoint1},
+	})
+
+	// Put a unit from each, application A and B, on the same machine.
+	// This will be enough to ensure that the application B qualifies to be
+	// in the status result filtered by the application A.
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs: []state.MachineJob{state.JobHostUnits},
+	})
+	s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: applicationA,
+		Machine:     machine,
+	})
+	s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: applicationB,
+		Machine:     machine,
+	})
+
+	// Filtering status on application A should get:
+	// * no relations;
+	// * two applications.
+	client := s.APIState.Client()
+	status, err := client.Status([]string{applicationA.Name()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.NotNil)
+	c.Assert(status.Applications, gc.HasLen, 2)
+	c.Assert(status.Relations, gc.HasLen, 0)
+}
+
 func assertApplicationRelations(c *gc.C, appName string, expectedNumber int, relations []params.RelationStatus) {
 	c.Assert(relations, gc.HasLen, expectedNumber)
 	for _, relation := range relations {


### PR DESCRIPTION
## Description of change

When an operator specifies an application name as a filter to ```juju status```, i.e. ```juju status $APP-NAME```, there could be some applications returned that do not match the filter exactly. They are deemed to be relevant in some for to the requested $APP-NAME. For example, a unit of this application may be deployed to a unit of application $APP-NAME. However, the relations for these 'discovered' applications should not be returned.

In other words, if there are two applications, A and B, such that:
 * an application A matches the supplied filter directly;
 * an application B has units on the same machine as units of an application A and, thus, qualifies to be returned by the status result;
then the application B's relations should not be returned.

## QA steps

Above scenario works.


## Bug reference
n/a
