### PR TITLE
Tweaker docker image to reduce size

### DIFF
--- a/caas/jujud-operator-dockerfile
+++ b/caas/jujud-operator-dockerfile
@@ -1,12 +1,13 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 # Some Python dependencies.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-yaml \
     python3-pip \
+    python3-distutils \
  && pip3 install --upgrade pip setuptools \
  && rm -rf /var/lib/apt/lists/* \
- && rm -r /root/.cache
+ && rm -rf /root/.cache
 
 # Install the standard charm dependencies.
 ENV WHEELHOUSE=/tmp/wheelhouse


### PR DESCRIPTION
## Description of change

Tweak the caas operator docker image to base on a fixed version of Ubuntu and reduce the size of the image from approx 600MB to 220MB

## QA steps

Deploy a caas charm