### PR TITLE
Ensure image server tests use aliases supported by all architectures

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -15,6 +15,7 @@ var (
 	NICDevice             = nicDevice
 	NetworkDevices        = networkDevices
 	CheckBridgeConfigFile = checkBridgeConfigFile
+	SeriesRemoteAliases   = seriesRemoteAliases
 	GetImageSources       = func(mgr container.Manager) ([]RemoteServer, error) {
 		return mgr.(*containerManager).getImageSources()
 	}


### PR DESCRIPTION
## Description of change

One test is failing with an unexpected error message due to CentOS not being supported on ARM64.

- Uses "bionic" in place of "centos7" for architecture-agnostic tests.
- Add explicit tests for unsupported series/architecture combos.
