### PR TITLE
Change the code so EnsureMongoServer reports the version.

### DIFF
--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -15,10 +15,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/juju/paths"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/proxyupdater"
 )
@@ -63,9 +61,7 @@ type AgentSuite struct {
 func (s *AgentSuite) SetUpSuite(c *gc.C) {
 	s.JujuConnSuite.SetUpSuite(c)
 
-	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
-		return nil
-	})
+	agenttest.InstallFakeEnsureMongo(s)
 }
 
 func (s *AgentSuite) SetUpTest(c *gc.C) {

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	"github.com/juju/replicaset"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -81,7 +82,7 @@ func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error
 	}, nil
 }
 
-func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
+func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) (mongo.Version, error) {
 	f.EnsureCount++
 	f.DataDir, f.OplogSize = args.DataDir, args.OplogSize
 	f.Info = state.StateServingInfo{
@@ -93,7 +94,15 @@ func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
 		SharedSecret:   args.SharedSecret,
 		SystemIdentity: args.SystemIdentity,
 	}
-	return f.Err
+	v, err := gitjujutesting.MongodVersion()
+	if err != nil {
+		return mongo.Version{}, errors.Trace(err)
+	}
+	return mongo.Version{
+		Major: v.Major,
+		Minor: v.Minor,
+		Patch: fmt.Sprint(v.Patch),
+	}, f.Err
 }
 
 func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams) error {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1511,19 +1511,15 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
+	var mongodVersion mongo.Version
+	if mongodVersion, err = cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
 		return err
 	}
 	logger.Debugf("mongodb service is installed")
 
 	// Mongo is installed, record the version.
 	err = a.ChangeConfig(func(config agent.ConfigSetter) error {
-		finder := mongo.NewMongodFinder()
-		_, version, err := finder.FindBest()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		config.SetMongoVersion(version)
+		config.SetMongoVersion(mongodVersion)
 		return nil
 	})
 	if err != nil {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -366,7 +366,7 @@ func (c *BootstrapCommand) startMongo(addrs []network.Address, agentConfig agent
 	if err != nil {
 		return err
 	}
-	err = cmdutil.EnsureMongoServer(ensureServerParams)
+	_, err = cmdutil.EnsureMongoServer(ensureServerParams)
 	if err != nil {
 		return err
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -52,7 +52,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T14:24:45Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
+github.com/juju/testing	git	72703b1e95eb8ce4737fd8a3d8496c6b0be280a6	2018-05-17T13:41:05Z
 github.com/juju/txn	git	f50b17d1ff3c31b7ea1c70e0d38a83f19af6d334	2018-04-06T04:58:51Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/constraints"
 	envtesting "github.com/juju/juju/environs/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 	coretesting "github.com/juju/juju/testing"
@@ -89,10 +88,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 		}
 	}()
 
-	// TODO(mjs) - the following should maybe be part of AgentSuite.SetUpTest()
-	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
-		return nil
-	})
+	agenttest.InstallFakeEnsureMongo(s)
 	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 
 }

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -44,7 +44,7 @@ func PatchService(patchValue func(interface{}, interface{}), data *svctesting.Fa
 	})
 }
 
-func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
+func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) (Version, error) {
 	return ensureServer(args, sysctlFiles)
 }
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -451,11 +451,12 @@ type EnsureServerParams struct {
 //
 // This method will remove old versions of the mongo init service as necessary
 // before installing the new version.
-func EnsureServer(args EnsureServerParams) error {
+func EnsureServer(args EnsureServerParams) (Version, error) {
 	return ensureServer(args, mongoKernelTweaks)
 }
 
-func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) error {
+func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) (Version, error) {
+	var zeroVersion Version
 	tweakSysctlForMongo(mongoKernelTweaks)
 	logger.Infof(
 		"Ensuring mongo server is running; data directory %s; port %d",
@@ -464,14 +465,14 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 
 	dbDir := filepath.Join(args.DataDir, "db")
 	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return fmt.Errorf("cannot create mongo database directory: %v", err)
+		return zeroVersion, errors.Errorf("cannot create mongo database directory: %v", err)
 	}
 
 	oplogSizeMB := args.OplogSize
 	if oplogSizeMB == 0 {
 		var err error
 		if oplogSizeMB, err = defaultOplogSize(dbDir); err != nil {
-			return err
+			return zeroVersion, errors.Trace(err)
 		}
 	}
 
@@ -484,19 +485,19 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 		logger.Errorf("cannot install/upgrade mongod (will proceed anyway): %v", err)
 	}
 	finder := NewMongodFinder()
-	mongoPath, mgoVersion, err := finder.FindBest()
+	mongoPath, mongodVersion, err := finder.FindBest()
 	if err != nil {
-		return err
+		return zeroVersion, errors.Trace(err)
 	}
 	logVersion(mongoPath)
 
 	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
-		return err
+		return zeroVersion, errors.Trace(err)
 	}
 
 	err = utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
 	if err != nil {
-		return fmt.Errorf("cannot write mongod shared secret: %v", err)
+		return zeroVersion, errors.Errorf("cannot write mongod shared secret: %v", err)
 	}
 
 	// Disable the default mongodb installed by the mongodb-server package.
@@ -509,7 +510,7 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 			0644,
 		)
 		if err != nil {
-			return err
+			return zeroVersion, errors.Trace(err)
 		}
 	}
 
@@ -520,51 +521,51 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 		Port:          args.StatePort,
 		OplogSizeMB:   oplogSizeMB,
 		WantNUMACtl:   args.SetNUMAControlPolicy,
-		Version:       mgoVersion,
+		Version:       mongodVersion,
 		Auth:          true,
 		IPv6:          network.SupportsIPv6(),
 		MemoryProfile: args.MemoryProfile,
 	})
 	svc, err := newService(ServiceName, svcConf)
 	if err != nil {
-		return err
+		return zeroVersion, errors.Trace(err)
 	}
 	installed, err := svc.Installed()
 	if err != nil {
-		return errors.Trace(err)
+		return zeroVersion, errors.Trace(err)
 	}
 	if installed {
 		exists, err := svc.Exists()
 		if err != nil {
-			return errors.Trace(err)
+			return zeroVersion, errors.Trace(err)
 		}
 		if exists {
 			logger.Debugf("mongo exists as expected")
 			running, err := svc.Running()
 			if err != nil {
-				return errors.Trace(err)
+				return zeroVersion, errors.Trace(err)
 			}
 			if !running {
-				return svc.Start()
+				return mongodVersion, errors.Trace(svc.Start())
 			}
-			return nil
+			return mongodVersion, nil
 		}
 	}
 
 	if err := svc.Stop(); err != nil {
-		return errors.Annotatef(err, "failed to stop mongo")
+		return zeroVersion, errors.Annotatef(err, "failed to stop mongo")
 	}
 	if err := makeJournalDirs(dbDir); err != nil {
-		return fmt.Errorf("error creating journal directories: %v", err)
+		return zeroVersion, fmt.Errorf("error creating journal directories: %v", err)
 	}
 	if err := preallocOplog(dbDir, oplogSizeMB); err != nil {
-		return fmt.Errorf("error creating oplog files: %v", err)
+		return zeroVersion, fmt.Errorf("error creating oplog files: %v", err)
 	}
 
 	if err := service.InstallAndStart(svc); err != nil {
-		return errors.Trace(err)
+		return zeroVersion, errors.Trace(err)
 	}
-	return nil
+	return mongodVersion, nil
 }
 
 func truncateAndWriteIfExists(procFile, value string) error {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -278,7 +278,7 @@ func (s *MongoSuite) TestEnsureServerSetsSysctlValues(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "original value")
 
-	err = mongo.SysctlEditableEnsureServer(makeEnsureServerParams(dataDir),
+	_, err = mongo.SysctlEditableEnsureServer(makeEnsureServerParams(dataDir),
 		map[string]string{dataFilePath: "new value"})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -247,7 +247,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsAndRunning(c *gc.C) {
 	s.data.SetStatus(mongo.ServiceName, "running")
 	s.data.SetErrors(nil, nil, nil, errors.New("shouldn't be called"))
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// These should still be written out even if the service was installed.
@@ -296,7 +296,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsNotRunningIsStarted(c *gc.C) {
 
 	s.data.SetStatus(mongo.ServiceName, "installed")
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// These should still be written out even if the service was installed.
@@ -319,7 +319,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsNotRunningStartError(c *gc.C) {
 	failure := errors.New("won't start")
 	s.data.SetErrors(nil, nil, nil, failure) // Installed, Exists, Running, Running, Start
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	c.Check(s.data.Installed(), gc.HasLen, 0)
@@ -340,7 +340,7 @@ func (s *MongoSuite) testEnsureServerNUMACtl(c *gc.C, setNUMAPolicy bool) string
 
 	testParams := makeEnsureServerParams(dataDir)
 	testParams.SetNUMAControlPolicy = setNUMAPolicy
-	err = mongo.EnsureServer(testParams)
+	_, err = mongo.EnsureServer(testParams)
 	c.Assert(err, jc.ErrorIsNil)
 
 	testJournalDirs(dbDir, c)
@@ -383,7 +383,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 		c.Logf("install for series %v", test.series)
 		dataDir := c.MkDir()
 		s.patchSeries(test.series)
-		err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+		_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 		c.Assert(err, jc.ErrorIsNil)
 
 		for _, cmd := range test.cmd {
@@ -443,7 +443,7 @@ func (s *MongoSuite) TestInstallMongodFallsBack(c *gc.C) {
 	for _, test := range tests {
 		c.Logf("Testing mongo install for series: %s", test.series)
 		s.patchSeries(test.series)
-		err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+		_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 		c.Assert(err, jc.ErrorIsNil)
 
 		args, err := ioutil.ReadFile(outputFile)
@@ -521,7 +521,7 @@ func (s *MongoSuite) assertSuccessWithInstallStepFailCentOS(c *gc.C, exec []stri
 	c.Assert(loggo.RegisterWriter("mongosuite", &tw), jc.ErrorIsNil)
 	defer loggo.RemoveWriter("mongosuite")
 
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tw.Log(), jc.LogMatches, expectedResult)
 }
@@ -542,7 +542,7 @@ func (s *MongoSuite) TestInstallSuccessMongodCentOS(c *gc.C) {
 	dataDir := c.MkDir()
 	s.patchSeries(test.series)
 
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := append(expectedArgs.YumBase, "epel-release")
@@ -581,7 +581,7 @@ func (s *MongoSuite) assertTestMongoGetFails(c *gc.C, series string, packageMana
 	defer loggo.RemoveWriter("test-writer")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 
 	// Even though apt-get failed, EnsureServer should continue and
 	// not return the error - even though apt-get failed, the Juju
@@ -613,7 +613,7 @@ func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 	s.data.SetStatus(mongo.ServiceName, "running")
 	s.data.SetErrors(nil, nil, nil, errors.New("shouldn't be called"))
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.data.Installed(), gc.HasLen, 0)
@@ -674,7 +674,7 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 	testing.PatchExecutableAsEchoArgs(c, s, pm.PackageManager)
 
 	dataDir := filepath.Join(c.MkDir(), "dir", "data")
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Check(err, jc.ErrorIsNil)
 
 	_, err = os.Stat(filepath.Join(dataDir, "db"))
@@ -747,7 +747,7 @@ func (s *MongoSuite) TestAddEpelInCentOS(c *gc.C) {
 	testing.PatchExecutableAsEchoArgs(c, s, "yum-config-manager")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedEpelRelease := append(expectedArgs.YumBase, "epel-release")


### PR DESCRIPTION
## Description of change

All of the real code paths know it, and the code that patches it can use
the testing version rather than searching PATH again.

This needs:
  https://github.com/juju/testing/pull/137

But this should avoid us having troubles on various platforms where
Testing is searching path and Production doesn't want to LookPath.

## QA steps

The real test will be to watch the CI results against Windows and CentOS which were failing because we stopped using LookPath, but we don't run the Controller on those platforms so we don't really want to LookPath always.

## Documentation changes

None.

## Bug reference

None.
