### PR TITLE
Fix backups.

### DIFF
--- a/api/backups/create.go
+++ b/api/backups/create.go
@@ -12,32 +12,17 @@ import (
 // Create sends a request to create a backup of juju's state.  It
 // returns the metadata associated with the resulting backup and a
 // filename for download.
-func (c *Client) Create(notes string, keepCopy, noDownload bool) (*params.BackupsCreateResult, error) {
-	var result params.BackupsCreateResult
+func (c *Client) Create(notes string, keepCopy, noDownload bool) (*params.BackupsMetadataResult, error) {
+	var result params.BackupsMetadataResult
 	args := params.BackupsCreateArgs{
 		Notes:      notes,
 		KeepCopy:   keepCopy,
 		NoDownload: noDownload,
 	}
-	if err := c.facade.FacadeCall("CreateBackup", args, &result); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &result, nil
-}
 
-// CreateDeprecated sends a request to create a backup of juju's state.  It
-// returns the metadata associated with the resulting backup.
-//
-// NOTE(hml) this exists only for backwards compatibility, for API facade
-// versions 1; clients should prefer its successor, Create, above.
-//
-// TODO(hml) 2018-05-02
-// Drop this in Juju 3.0.
-func (c *Client) CreateDeprecated(notes string) (*params.BackupsMetadataResult, error) {
-	var result params.BackupsMetadataResult
-	args := params.BackupsCreateArgs{Notes: notes}
 	if err := c.facade.FacadeCall("Create", args, &result); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	return &result, nil
 }

--- a/api/backups/info_test.go
+++ b/api/backups/info_test.go
@@ -28,7 +28,7 @@ func (s *infoSuite) TestInfo(c *gc.C) {
 			c.Check(p.ID, gc.Equals, "spam")
 
 			if result, ok := resp.(*params.BackupsMetadataResult); ok {
-				*result = apiserverbackups.ResultFromMetadata(s.Meta)
+				*result = apiserverbackups.CreateResult(s.Meta, "test-filename")
 			} else {
 				c.Fatalf("wrong output structure")
 			}

--- a/api/backups/list_test.go
+++ b/api/backups/list_test.go
@@ -27,7 +27,7 @@ func (s *listSuite) TestList(c *gc.C) {
 
 			if result, ok := resp.(*params.BackupsListResult); ok {
 				result.List = make([]params.BackupsMetadataResult, 1)
-				result.List[0] = apiserverbackups.ResultFromMetadata(s.Meta)
+				result.List[0] = apiserverbackups.CreateResult(s.Meta, "test-filename")
 			} else {
 				c.Fatalf("wrong output structure")
 			}

--- a/api/backups/upload_test.go
+++ b/api/backups/upload_test.go
@@ -24,7 +24,7 @@ func (s *uploadSuite) TestSuccessfulRequest(c *gc.C) {
 	data := "<compressed archive data>"
 	archive := strings.NewReader(data)
 
-	meta := apiserverbackups.ResultFromMetadata(s.Meta)
+	meta := apiserverbackups.CreateResult(s.Meta, "")
 	meta.ID = ""
 	meta.Stored = time.Time{}
 	meta.Size = int64(len(data))
@@ -53,7 +53,7 @@ func (s *uploadSuite) TestFailedRequest(c *gc.C) {
 	data := "<compressed archive data>"
 	archive := strings.NewReader(data)
 
-	meta := apiserverbackups.ResultFromMetadata(s.Meta)
+	meta := apiserverbackups.CreateResult(s.Meta, "test-filename")
 	meta.ID = ""
 	meta.Size = int64(len(data))
 	// The Model field is required, so zero it so that

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -193,7 +193,7 @@ func (s *backupsUploadSuite) sendValid(c *gc.C, id string) *http.Response {
 
 	// Set the metadata part.
 	s.meta = backups.NewMetadata()
-	metaResult := apiserverbackups.ResultFromMetadata(s.meta)
+	metaResult := apiserverbackups.CreateResult(s.meta, "test-filename")
 	header := make(textproto.MIMEHeader)
 	header.Set("Content-Disposition", `form-data; name="metadata"`)
 	header.Set("Content-Type", params.ContentTypeJSON)

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -38,7 +38,7 @@ type Backend interface {
 	RestoreInfo() *state.RestoreInfo
 }
 
-// APIv2 provides backup-specific API methods for version 2.
+// API provides backup-specific API methods for version 2.
 type API struct {
 	backend Backend
 	paths   *backups.Paths

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -82,14 +82,13 @@ func (s *backupsSuite) setBackups(c *gc.C, meta *backups.Metadata, err string) *
 }
 
 func (s *backupsSuite) TestNewAPIOkay(c *gc.C) {
-	_, err := backupsAPI.NewAPI(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
+	_, err := backupsAPI.NewAPIv2(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *backupsSuite) TestNewAPINotAuthorized(c *gc.C) {
 	s.authorizer.Tag = names.NewApplicationTag("eggs")
-	_, err := backupsAPI.NewAPI(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
-
+	_, err := backupsAPI.NewAPIv2(&stateShim{s.State, s.IAASModel.Model}, s.resources, s.authorizer)
 	c.Check(errors.Cause(err), gc.Equals, common.ErrPerm)
 }
 
@@ -98,6 +97,6 @@ func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
 	defer otherState.Close()
 	otherModel, err := otherState.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = backupsAPI.NewAPI(&stateShim{otherState, otherModel}, s.resources, s.authorizer)
+	_, err = backupsAPI.NewAPIv2(&stateShim{otherState, otherModel}, s.resources, s.authorizer)
 	c.Check(err, gc.ErrorMatches, "backups are only supported from the controller model\nUse juju switch to select the controller model")
 }

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -17,79 +17,65 @@ var waitUntilReady = replicaset.WaitUntilReady
 // Create is the API method that requests juju to create a new backup
 // of its state.  It returns the metadata for that backup.
 //
-// NOTE(hml) this exists only for backwards compatibility,
-// for API facade versions 1; clients should prefer its
-// successor, CreateBackup, below. Until all consumers
-// have been updated, or we bump a major version, we can't
-// drop this.
-//
-// TODO(hml) 2017-05-03
-// Drop this in Juju 3.0.
-func (a *APIv2) Create(args params.BackupsCreateArgs) (p params.BackupsCreateResult, _ error) {
-	return a.CreateBackup(args)
-}
-
-// Create is the API method that requests juju to create a new backup
-// of its state.  It returns the metadata for that backup.
-//
 // NOTE(hml) this provides backwards compatibility for facade version 1.
-func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataResult, err error) {
+func (a *API) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
 	args.KeepCopy = true
 	args.NoDownload = true
-	result, err := a.APIv2.Create(args)
+
+	apiv2 := APIv2{a}
+	result, err := apiv2.Create(args)
 	if err != nil {
-		return p, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
-	return result.Metadata, nil
+	return result, nil
 }
 
-func (a *APIv2) CreateBackup(args params.BackupsCreateArgs) (p params.BackupsCreateResult, _ error) {
+func (a *APIv2) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
 	backupsMethods, closer := newBackups(a.backend)
 	defer closer.Close()
 
 	session := a.backend.MongoSession().Copy()
 	defer session.Close()
 
+	result := params.BackupsMetadataResult{}
 	// Don't go if HA isn't ready.
 	err := waitUntilReady(session, 60)
 	if err != nil {
-		return p, errors.Annotatef(err, "HA not ready; try again later")
+		return result, errors.Annotatef(err, "HA not ready; try again later")
 	}
 
 	mgoInfo, err := mongoInfo(a.paths.DataDir, a.machineID)
 	if err != nil {
-		return p, errors.Annotatef(err, "getting mongo info")
+		return result, errors.Annotatef(err, "getting mongo info")
 	}
 	v, err := a.backend.MongoVersion()
 	if err != nil {
-		return p, errors.Annotatef(err, "discovering mongo version")
+		return result, errors.Annotatef(err, "discovering mongo version")
 	}
 	mongoVersion, err := mongo.NewVersion(v)
 	if err != nil {
-		return p, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
 	dbInfo, err := backups.NewDBInfo(mgoInfo, session, mongoVersion)
 	if err != nil {
-		return p, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
 	mSeries, err := a.backend.MachineSeries(a.machineID)
 	if err != nil {
-		return p, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
 
 	meta, err := backups.NewMetadataState(a.backend, a.machineID, mSeries)
 	if err != nil {
-		return p, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
 	meta.Notes = args.Notes
 
 	fileName, err := backupsMethods.Create(meta, a.paths, dbInfo, args.KeepCopy, args.NoDownload)
 	if err != nil {
-		return p, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
 
-	return params.BackupsCreateResult{
-		Metadata: ResultFromMetadata(meta),
-		Filename: fileName,
-	}, nil
+	result = CreateResult(meta, fileName)
+	return result, nil
 }

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -22,10 +22,9 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	//result, err := apiv2.Create(args)
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := backups.ResultFromMetadata(s.meta)
+	expected := backups.CreateResult(s.meta, "test-filename")
 
-	c.Check(result.Metadata, gc.DeepEquals, expected)
-	c.Check(result.Filename, jc.Contains, "test-filename")
+	c.Check(result, gc.DeepEquals, expected)
 }
 
 func (s *backupsSuite) TestCreateNotes(c *gc.C) {
@@ -37,15 +36,13 @@ func (s *backupsSuite) TestCreateNotes(c *gc.C) {
 	args := params.BackupsCreateArgs{
 		Notes: "this backup is important",
 	}
-	//apiv2 := &backups.APIv2{s.api}
-	//result, err := apiv2.Create(args)
+
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := backups.ResultFromMetadata(s.meta)
+	expected := backups.CreateResult(s.meta, "test-filename")
 	expected.Notes = "this backup is important"
 
-	c.Check(result.Metadata, gc.DeepEquals, expected)
-	c.Check(result.Filename, jc.Contains, "test-filename")
+	c.Check(result, gc.DeepEquals, expected)
 }
 
 func (s *backupsSuite) TestCreateError(c *gc.C) {
@@ -53,9 +50,7 @@ func (s *backupsSuite) TestCreateError(c *gc.C) {
 	s.PatchValue(backups.WaitUntilReady,
 		func(*mgo.Session, int) error { return nil },
 	)
-	//apiv2 := &backups.APIv2{s.api}
 	var args params.BackupsCreateArgs
-	//_, err := apiv2.Create(args)
 	_, err := s.api.Create(args)
 
 	c.Logf("%v", err)

--- a/apiserver/facades/client/backups/info.go
+++ b/apiserver/facades/client/backups/info.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Info provides the implementation of the API method.
-func (a *APIv2) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult, error) {
+func (a *API) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult, error) {
 	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 

--- a/apiserver/facades/client/backups/info.go
+++ b/apiserver/facades/client/backups/info.go
@@ -24,5 +24,5 @@ func (a *APIv2) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult,
 		defer file.Close()
 	}
 
-	return ResultFromMetadata(meta), nil
+	return CreateResult(meta, ""), nil
 }

--- a/apiserver/facades/client/backups/info_test.go
+++ b/apiserver/facades/client/backups/info_test.go
@@ -22,7 +22,7 @@ func (s *backupsSuite) TestInfoOkay(c *gc.C) {
 	}
 	result, err := s.api.Info(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := backups.ResultFromMetadata(s.meta)
+	expected := backups.CreateResult(s.meta, "")
 	c.Check(result, gc.DeepEquals, expected)
 }
 
@@ -33,7 +33,7 @@ func (s *backupsSuite) TestInfoMissingFile(c *gc.C) {
 	}
 	result, err := s.api.Info(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := backups.ResultFromMetadata(s.meta)
+	expected := backups.CreateResult(s.meta, "")
 
 	c.Check(result, gc.DeepEquals, expected)
 }

--- a/apiserver/facades/client/backups/list.go
+++ b/apiserver/facades/client/backups/list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // List provides the implementation of the API method.
-func (a *APIv2) List(args params.BackupsListArgs) (params.BackupsListResult, error) {
+func (a *API) List(args params.BackupsListArgs) (params.BackupsListResult, error) {
 	var result params.BackupsListResult
 
 	backups, closer := newBackups(a.backend)

--- a/apiserver/facades/client/backups/list.go
+++ b/apiserver/facades/client/backups/list.go
@@ -23,7 +23,7 @@ func (a *APIv2) List(args params.BackupsListArgs) (params.BackupsListResult, err
 
 	result.List = make([]params.BackupsMetadataResult, len(metaList))
 	for i, meta := range metaList {
-		result.List[i] = ResultFromMetadata(meta)
+		result.List[i] = CreateResult(meta, "")
 	}
 
 	return result, nil

--- a/apiserver/facades/client/backups/list_test.go
+++ b/apiserver/facades/client/backups/list_test.go
@@ -21,7 +21,7 @@ func (s *backupsSuite) TestListOkay(c *gc.C) {
 	result, err := s.api.List(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	item := backups.ResultFromMetadata(s.meta)
+	item := backups.CreateResult(s.meta, "")
 	expected := params.BackupsListResult{
 		List: []params.BackupsMetadataResult{item},
 	}

--- a/apiserver/facades/client/backups/remove.go
+++ b/apiserver/facades/client/backups/remove.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-func (a *APIv2) Remove(args params.BackupsRemoveArgs) error {
+func (a *API) Remove(args params.BackupsRemoveArgs) error {
 	backups, closer := newBackups(a.backend)
 	defer closer.Close()
 

--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -20,7 +20,7 @@ import (
 var bootstrapNode = names.NewMachineTag("0")
 
 // Restore implements the server side of Backups.Restore.
-func (a *APIv2) Restore(p params.RestoreArgs) error {
+func (a *API) Restore(p params.RestoreArgs) error {
 	logger.Infof("Starting server side restore")
 
 	// Get hold of a backup file Reader

--- a/apiserver/facades/client/backups/shim.go
+++ b/apiserver/facades/client/backups/shim.go
@@ -32,15 +32,6 @@ func (s *stateShim) MachineSeries(id string) (string, error) {
 	return m.Series(), nil
 }
 
-// NewFacade provides the required signature for facade registration.
-func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return NewAPI(&stateShim{st, model}, resources, authorizer)
-}
-
 // NewFacadeV2 provides the required signature for version 2 facade registration.
 func NewFacadeV2(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*APIv2, error) {
 	model, err := st.Model()
@@ -48,6 +39,15 @@ func NewFacadeV2(st *state.State, resources facade.Resources, authorizer facade.
 		return nil, errors.Trace(err)
 	}
 	return NewAPIv2(&stateShim{st, model}, resources, authorizer)
+}
+
+// NewFacade provides the required signature for facade registration.
+func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*API, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return NewAPI(&stateShim{st, model}, resources, authorizer)
 }
 
 // ControllerTag disambiguates the ControllerTag method pending further

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -72,15 +72,11 @@ type BackupsMetadataResult struct {
 
 	CACert       string `json:"ca-cert"`
 	CAPrivateKey string `json:"ca-private-key"`
+	Filename     string `json:"filename"`
 }
 
 // RestoreArgs Holds the backup file or id
 type RestoreArgs struct {
 	// BackupId holds the id of the backup in server if any
 	BackupId string `json:"backup-id"`
-}
-
-type BackupsCreateResult struct {
-	Metadata BackupsMetadataResult `json:"metadata"`
-	Filename string                `json:"filename"`
 }

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -24,10 +24,7 @@ import (
 type APIClient interface {
 	io.Closer
 	// Create sends an RPC request to create a new backup.
-	Create(notes string, keepCopy, noDownload bool) (*params.BackupsCreateResult, error)
-	// CreateDeprecated sends an RPC request in the old style to
-	// create a new backup.
-	CreateDeprecated(notes string) (*params.BackupsMetadataResult, error)
+	Create(notes string, keepCopy, noDownload bool) (*params.BackupsMetadataResult, error)
 	// Info gets the backup's metadata.
 	Info(id string) (*params.BackupsMetadataResult, error)
 	// List gets all stored metadata.
@@ -173,7 +170,7 @@ func getArchive(filename string) (rc ArchiveReader, metaResult *params.BackupsMe
 	// Pack the metadata into a result.
 	// TODO(perrito666) change the identity of ResultfromMetadata to
 	// return a pointer.
-	mResult := apiserverbackups.ResultFromMetadata(meta)
+	mResult := apiserverbackups.CreateResult(meta, "")
 	metaResult = &mResult
 
 	return archive, metaResult, nil

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -176,8 +176,8 @@ func (s *createSuite) TestDefaultV1(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand)
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.CheckCalls(c, "CreateDeprecated", "Download")
-	client.CheckArgs(c, "", "spam")
+	client.CheckCalls(c, "Create", "Download")
+	client.CheckArgs(c, "", "true", "false", "spam")
 	c.Assert(s.command.KeepCopy, jc.IsTrue)
 	s.checkDownload(c, ctx)
 	c.Check(s.command.Filename, gc.Equals, backups.NotSet)

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -58,7 +58,8 @@ func (s *BaseBackupsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
 	s.metaresult = &params.BackupsMetadataResult{
-		ID: "spam",
+		ID:       "spam",
+		Filename: "filename",
 	}
 	s.data = "<compressed archive data>"
 
@@ -151,28 +152,16 @@ func (f *fakeAPIClient) CheckArgs(c *gc.C, args ...string) {
 	c.Check(f.args, jc.DeepEquals, args)
 }
 
-func (c *fakeAPIClient) CreateDeprecated(notes string) (*params.BackupsMetadataResult, error) {
-	c.calls = append(c.calls, "CreateDeprecated")
-	c.args = append(c.args, notes)
-	c.notes = notes
-	if c.err != nil {
-		return nil, c.err
-	}
-	return c.metaresult, nil
-}
-
-func (c *fakeAPIClient) Create(notes string, keepCopy, noDownload bool) (*params.BackupsCreateResult, error) {
+func (c *fakeAPIClient) Create(notes string, keepCopy, noDownload bool) (*params.BackupsMetadataResult, error) {
 	c.calls = append(c.calls, "Create")
 	c.args = append(c.args, notes, fmt.Sprintf("%t", keepCopy), fmt.Sprintf("%t", noDownload))
 	c.notes = notes
 	if c.err != nil {
 		return nil, c.err
 	}
-	createResult := params.BackupsCreateResult{
-		Metadata: *c.metaresult,
-		Filename: "filename",
-	}
-	return &createResult, nil
+	createResult := c.metaresult
+
+	return createResult, nil
 }
 
 func (c *fakeAPIClient) Info(id string) (*params.BackupsMetadataResult, error) {


### PR DESCRIPTION
## Description of change

Backups are not working in 2.4. This PR confirms compatibility with 2.3 clients and that the feature works on 2.4.

## QA steps

1. Bootstrap a controller
2. Backup the controller
3. Restore the controller

With a 2.3 client you should see the old behavior of both creating a backup on the controller as well as a  local download of a backup file:

```bash
$ juju create-backup
20180518-082039.8e012941-5d8a-4868-8c53-b2f0b743b985
downloading to juju-backup-20180518-082039.tar.gz
```

With 2.4 client you should see the new behavior, that is, a backup is only stored to the controller if the `--no-download` option is selected:

```bash
$ juju create-backup
downloading to juju-backup-20180518-082311.tar.gz
``` 

```bash
$ juju create-backup --no-download
WARNING downloading backup archives is recommended; backups stored remotely are not guaranteed to be available
20180518-082639.8e012941-5d8a-4868-8c53-b2f0b743b985
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1771202
