### PR TITLE
status display bindings

### DIFF
--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -208,6 +208,11 @@ var scenarioStatus = &params.FullStatus{
 				Info:   "waiting for machine",
 				Data:   map[string]interface{}{},
 			},
+			EndpointBindings: map[string]string{
+				"info": "",
+				"logging-client": "",
+				"logging-directory": "",
+			},
 		},
 		"mysql": {
 			Charm:         "local:quantal/mysql-1",
@@ -219,6 +224,10 @@ var scenarioStatus = &params.FullStatus{
 				Status: "waiting",
 				Info:   "waiting for machine",
 				Data:   map[string]interface{}{},
+			},
+			EndpointBindings: map[string]string{
+				"server": "",
+				"server-admin": "",
 			},
 		},
 		"wordpress": {
@@ -287,6 +296,16 @@ var scenarioStatus = &params.FullStatus{
 						},
 					},
 				},
+			},
+			EndpointBindings: map[string]string{
+				"foo-bar": "",
+				"logging-dir": "",
+				"monitoring-port": "",
+				"url": "",
+				"admin-api": "",
+				"cache": "",
+				"db": "",
+				"db-client": "",
 			},
 		},
 	},

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -115,18 +115,19 @@ type MachineStatus struct {
 
 // ApplicationStatus holds status info about an application.
 type ApplicationStatus struct {
-	Err             error                  `json:"err,omitempty"`
-	Charm           string                 `json:"charm"`
-	Series          string                 `json:"series"`
-	Exposed         bool                   `json:"exposed"`
-	Life            string                 `json:"life"`
-	Relations       map[string][]string    `json:"relations"`
-	CanUpgradeTo    string                 `json:"can-upgrade-to"`
-	SubordinateTo   []string               `json:"subordinate-to"`
-	Units           map[string]UnitStatus  `json:"units"`
-	MeterStatuses   map[string]MeterStatus `json:"meter-statuses"`
-	Status          DetailedStatus         `json:"status"`
-	WorkloadVersion string                 `json:"workload-version"`
+	Err              error                  `json:"err,omitempty"`
+	Charm            string                 `json:"charm"`
+	Series           string                 `json:"series"`
+	Exposed          bool                   `json:"exposed"`
+	Life             string                 `json:"life"`
+	Relations        map[string][]string    `json:"relations"`
+	CanUpgradeTo     string                 `json:"can-upgrade-to"`
+	SubordinateTo    []string               `json:"subordinate-to"`
+	Units            map[string]UnitStatus  `json:"units"`
+	MeterStatuses    map[string]MeterStatus `json:"meter-statuses"`
+	Status           DetailedStatus         `json:"status"`
+	WorkloadVersion  string                 `json:"workload-version"`
+	EndpointBindings map[string]string      `json:"endpoint-bindings"`
 }
 
 // RemoteApplicationStatus holds status info about a remote application.

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -87,21 +87,22 @@ func (s machineStatus) MarshalYAML() (interface{}, error) {
 }
 
 type applicationStatus struct {
-	Err           error                 `json:"-" yaml:",omitempty"`
-	Charm         string                `json:"charm" yaml:"charm"`
-	Series        string                `json:"series"`
-	OS            string                `json:"os"`
-	CharmOrigin   string                `json:"charm-origin" yaml:"charm-origin"`
-	CharmName     string                `json:"charm-name" yaml:"charm-name"`
-	CharmRev      int                   `json:"charm-rev" yaml:"charm-rev"`
-	CanUpgradeTo  string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
-	Exposed       bool                  `json:"exposed" yaml:"exposed"`
-	Life          string                `json:"life,omitempty" yaml:"life,omitempty"`
-	StatusInfo    statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
-	Relations     map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
-	SubordinateTo []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
-	Units         map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
-	Version       string                `json:"version,omitempty" yaml:"version,omitempty"`
+	Err              error                 `json:"-" yaml:",omitempty"`
+	Charm            string                `json:"charm" yaml:"charm"`
+	Series           string                `json:"series"`
+	OS               string                `json:"os"`
+	CharmOrigin      string                `json:"charm-origin" yaml:"charm-origin"`
+	CharmName        string                `json:"charm-name" yaml:"charm-name"`
+	CharmRev         int                   `json:"charm-rev" yaml:"charm-rev"`
+	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
+	Exposed          bool                  `json:"exposed" yaml:"exposed"`
+	Life             string                `json:"life,omitempty" yaml:"life,omitempty"`
+	StatusInfo       statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
+	Relations        map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
+	SubordinateTo    []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
+	Units            map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
+	Version          string                `json:"version,omitempty" yaml:"version,omitempty"`
+	EndpointBindings map[string]string     `json:"endpoint-bindings,omitempty" yaml:"endpoint-bindings,omitempty"`
 }
 
 type applicationStatusNoMarshal applicationStatus

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -186,21 +186,22 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 	}
 
 	out := applicationStatus{
-		Err:           application.Err,
-		Charm:         application.Charm,
-		Series:        application.Series,
-		OS:            strings.ToLower(appOS.String()),
-		CharmOrigin:   charmOrigin,
-		CharmName:     charmName,
-		CharmRev:      charmRev,
-		Exposed:       application.Exposed,
-		Life:          application.Life,
-		Relations:     application.Relations,
-		CanUpgradeTo:  application.CanUpgradeTo,
-		SubordinateTo: application.SubordinateTo,
-		Units:         make(map[string]unitStatus),
-		StatusInfo:    sf.getApplicationStatusInfo(application),
-		Version:       application.WorkloadVersion,
+		Err:              application.Err,
+		Charm:            application.Charm,
+		Series:           application.Series,
+		OS:               strings.ToLower(appOS.String()),
+		CharmOrigin:      charmOrigin,
+		CharmName:        charmName,
+		CharmRev:         charmRev,
+		Exposed:          application.Exposed,
+		Life:             application.Life,
+		Relations:        application.Relations,
+		CanUpgradeTo:     application.CanUpgradeTo,
+		SubordinateTo:    application.SubordinateTo,
+		Units:            make(map[string]unitStatus),
+		StatusInfo:       sf.getApplicationStatusInfo(application),
+		Version:          application.WorkloadVersion,
+		EndpointBindings: application.EndpointBindings,
 	}
 	for k, m := range application.Units {
 		out.Units[k] = sf.formatUnit(unitFormatInfo{
@@ -210,6 +211,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 			meterStatuses:   application.MeterStatuses,
 		})
 	}
+
 	return out
 }
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -396,6 +396,11 @@ var (
 			"logging-directory": L{"wordpress"},
 			"info":              L{"mysql"},
 		},
+		"endpoint-bindings": M{
+			"info":              "",
+			"logging-client":    "",
+			"logging-directory": "",
+		},
 		"subordinate-to": L{"mysql", "wordpress"},
 	}
 )
@@ -704,8 +709,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"dummy"},
-		addService{name: "dummy-application", charm: "dummy"},
-		addService{name: "exposed-application", charm: "dummy"},
+		addApplication{name: "dummy-application", charm: "dummy"},
+		addApplication{name: "exposed-application", charm: "dummy"},
 		expect{
 			what: "no applications exposed yet",
 			output: M{
@@ -1183,11 +1188,11 @@ var statusTests = []testCase{
 		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		addAliveUnit{"wordpress", "1"},
 
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		addAliveUnit{"mysql", "1"},
 
 		relateServices{"wordpress", "mysql", ""},
@@ -1229,6 +1234,16 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"logging-dir":     "",
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+						},
 					}),
 					"mysql": mysqlCharm(M{
 						"relations": M{
@@ -1254,6 +1269,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -1272,11 +1291,11 @@ var statusTests = []testCase{
 		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		addAliveUnit{"wordpress", "1"},
 
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		addAliveUnit{"mysql", "1"},
 
 		relateServices{"wordpress", "mysql", ""},
@@ -1318,6 +1337,16 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+							"monitoring-port": "",
+							"url":             "",
+						},
 					}),
 					"mysql": mysqlCharm(M{
 						"relations": M{
@@ -1343,6 +1372,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -1351,7 +1384,7 @@ var statusTests = []testCase{
 	test( // 7
 		"add a dying application",
 		addCharm{"dummy"},
-		addService{name: "dummy-application", charm: "dummy"},
+		addApplication{name: "dummy-application", charm: "dummy"},
 		addMachine{machineId: "0", job: state.JobHostUnits},
 		addAliveUnit{"dummy-application", "0"},
 		ensureDyingService{"dummy-application"},
@@ -1404,7 +1437,7 @@ var statusTests = []testCase{
 	test( // 8
 		"a unit where the agent is down shows as lost",
 		addCharm{"dummy"},
-		addService{name: "dummy-application", charm: "dummy"},
+		addApplication{name: "dummy-application", charm: "dummy"},
 		addMachine{machineId: "0", job: state.JobHostUnits},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
@@ -1469,7 +1502,7 @@ var statusTests = []testCase{
 		addCharm{"mysql"},
 		addCharm{"varnish"},
 
-		addService{name: "project", charm: "wordpress"},
+		addApplication{name: "project", charm: "wordpress"},
 		setServiceExposed{"project", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -1479,7 +1512,7 @@ var statusTests = []testCase{
 		setAgentStatus{"project/0", status.Idle, "", nil},
 		setUnitStatus{"project/0", status.Active, "", nil},
 
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
@@ -1489,7 +1522,7 @@ var statusTests = []testCase{
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
 		setUnitStatus{"mysql/0", status.Active, "", nil},
 
-		addService{name: "varnish", charm: "varnish"},
+		addApplication{name: "varnish", charm: "varnish"},
 		setServiceExposed{"varnish", true},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("10.0.3.1")},
@@ -1498,7 +1531,7 @@ var statusTests = []testCase{
 		setMachineInstanceStatus{"3", status.Started, "I am number three"},
 		addAliveUnit{"varnish", "3"},
 
-		addService{name: "private", charm: "wordpress"},
+		addApplication{name: "private", charm: "wordpress"},
 		setServiceExposed{"private", true},
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("10.0.4.1")},
@@ -1542,6 +1575,16 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+							"cache":           "",
+						},
 						"relations": M{
 							"db":    L{"mysql"},
 							"cache": L{"varnish"},
@@ -1566,6 +1609,10 @@ var statusTests = []testCase{
 								},
 								"public-address": "10.0.2.1",
 							},
+						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
 						},
 						"relations": M{
 							"server": L{"private", "project"},
@@ -1599,6 +1646,9 @@ var statusTests = []testCase{
 								"public-address": "10.0.3.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"webcache": "",
+						},
 						"relations": M{
 							"webcache": L{"project"},
 						},
@@ -1625,6 +1675,16 @@ var statusTests = []testCase{
 								"public-address": "10.0.4.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"logging-dir":     "",
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+						},
 						"relations": M{
 							"db": L{"mysql"},
 						},
@@ -1642,7 +1702,7 @@ var statusTests = []testCase{
 		addCharm{"riak"},
 		addCharm{"wordpress"},
 
-		addService{name: "riak", charm: "riak"},
+		addApplication{name: "riak", charm: "riak"},
 		setServiceExposed{"riak", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -1730,6 +1790,11 @@ var statusTests = []testCase{
 								"public-address": "10.0.3.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"admin":    "",
+							"endpoint": "",
+							"ring":     "",
+						},
 						"relations": M{
 							"ring": L{"riak"},
 						},
@@ -1750,7 +1815,7 @@ var statusTests = []testCase{
 		addCharm{"mysql"},
 		addCharm{"logging"},
 
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -1760,7 +1825,7 @@ var statusTests = []testCase{
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
 		setUnitStatus{"wordpress/0", status.Active, "", nil},
 
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
@@ -1770,7 +1835,7 @@ var statusTests = []testCase{
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
 		setUnitStatus{"mysql/0", status.Active, "", nil},
 
-		addService{name: "logging", charm: "logging"},
+		addApplication{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
 
 		relateServices{"wordpress", "mysql", ""},
@@ -1833,6 +1898,16 @@ var statusTests = []testCase{
 								"leader":         true,
 							},
 						},
+						"endpoint-bindings": M{
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+						},
 						"relations": M{
 							"db":          L{"mysql"},
 							"logging-dir": L{"logging"},
@@ -1873,6 +1948,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.2.1",
 								"leader":         true,
 							},
+						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
 						},
 						"relations": M{
 							"server":    L{"wordpress"},
@@ -1929,6 +2008,16 @@ var statusTests = []testCase{
 								"leader":         true,
 							},
 						},
+						"endpoint-bindings": M{
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+						},
 						"relations": M{
 							"db":          L{"mysql"},
 							"logging-dir": L{"logging"},
@@ -1969,6 +2058,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.2.1",
 								"leader":         true,
 							},
+						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
 						},
 						"relations": M{
 							"server":    L{"wordpress"},
@@ -2024,6 +2117,16 @@ var statusTests = []testCase{
 								"leader":         true,
 							},
 						},
+						"endpoint-bindings": M{
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+							"monitoring-port": "",
+							"url":             "",
+						},
 						"relations": M{
 							"db":          L{"mysql"},
 							"logging-dir": L{"logging"},
@@ -2042,7 +2145,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 
 		// step 7
@@ -2110,6 +2213,10 @@ var statusTests = []testCase{
 								},
 								"public-address": "10.0.2.1",
 							},
+						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
 						},
 					}),
 				},
@@ -2192,6 +2299,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.2.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -2208,7 +2319,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addCharmPlaceholder{"mysql", 23},
 		addAliveUnit{"mysql", "1"},
@@ -2245,6 +2356,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -2261,7 +2376,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addAliveUnit{"mysql", "1"},
 		setUnitCharmURL{"mysql/0", "cs:quantal/mysql-1"},
@@ -2300,6 +2415,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -2316,7 +2435,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addAliveUnit{"mysql", "1"},
 		setUnitCharmURL{"mysql/0", "cs:quantal/mysql-1"},
@@ -2357,6 +2476,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -2373,7 +2496,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addAliveUnit{"mysql", "1"},
 		setUnitCharmURL{"mysql/0", "cs:quantal/mysql-1"},
@@ -2413,6 +2536,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -2447,11 +2574,11 @@ var statusTests = []testCase{
 		setMachineStatus{"4", status.Started, ""},
 
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 
 		addCharm{"metered"},
-		addService{name: "servicewithmeterstatus", charm: "metered"},
+		addApplication{name: "servicewithmeterstatus", charm: "metered"},
 
 		addAliveUnit{"mysql", "1"},
 		addAliveUnit{"servicewithmeterstatus", "2"},
@@ -2503,6 +2630,10 @@ var statusTests = []testCase{
 								},
 								"public-address": "10.0.1.1",
 							},
+						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
 						},
 					}),
 
@@ -2595,7 +2726,7 @@ var statusTests = []testCase{
 		setMachineStatus{"0", status.Started, ""},
 
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -2635,6 +2766,10 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
+						},
 					}),
 				},
 			},
@@ -2648,7 +2783,7 @@ var statusTests = []testCase{
 		setMachineStatus{"0", status.Started, ""},
 
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -2708,6 +2843,10 @@ var statusTests = []testCase{
 								},
 								"public-address": "10.0.2.1",
 							},
+						},
+						"endpoint-bindings": M{
+							"server":       "",
+							"server-admin": "",
 						},
 					}),
 				},
@@ -2796,7 +2935,7 @@ var statusTests = []testCase{
 		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		addAliveUnit{"wordpress", "1"},
 
 		addCharm{"mysql"},
@@ -2854,6 +2993,16 @@ var statusTests = []testCase{
 								"public-address": "10.0.1.1",
 							},
 						},
+						"endpoint-bindings": M{
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+							"cache":           "",
+							"db":              "",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+						},
 					}),
 				},
 			},
@@ -2909,6 +3058,128 @@ var statusTests = []testCase{
 				"applications": M{},
 			},
 			stderr: "Model \"controller\" is empty.\n",
+		},
+	),
+	test( //26
+		"deploy application with endpoint bound to space",
+		addMachine{machineId: "0", job: state.JobManageModel},
+		setAddresses{"0", network.NewAddresses("10.0.0.1")},
+		startAliveMachine{"0"},
+		setMachineStatus{"0", status.Started, ""},
+		addMachine{machineId: "1", job: state.JobHostUnits},
+		setAddresses{"1", network.NewAddresses("10.0.1.1")},
+		startAliveMachine{"1"},
+		setMachineStatus{"1", status.Started, ""},
+
+		addSpace{"myspace1"},
+
+		addCharm{"wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress", binding: map[string]string{"db-client": "", "logging-dir": "", "cache": "", "db": "myspace1", "monitoring-port": "", "url": "", "admin-api": "", "foo-bar": ""}},
+		addAliveUnit{"wordpress", "1"},
+
+		scopedExpect{
+			output: M{
+				"model": M{
+					"region":  "dummy-region",
+					"version": "1.2.3",
+					"model-status": M{
+						"current": "available",
+						"since":   "01 Apr 15 01:23+10:00",
+					},
+					"sla":        "unsupported",
+					"name":       "controller",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+				},
+				"machines": M{
+					"1": M{
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"dns-name":     "10.0.1.1",
+						"ip-addresses": []string{"10.0.1.1"},
+						"instance-id":  "controller-1",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.1.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        bool(true),
+							},
+						},
+						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
+					},
+					"0": M{
+						"series": "quantal",
+						"network-interfaces": M{
+							"eth0": M{
+								"ip-addresses": []string{"10.0.0.1"},
+								"mac-address":  "aa:bb:cc:dd:ee:ff",
+								"is-up":        bool(true),
+							},
+						},
+						"controller-member-status": "adding-vote",
+						"dns-name":                 "10.0.0.1",
+						"ip-addresses":             []string{"10.0.0.1"},
+						"instance-id":              "controller-0",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
+					},
+				},
+				"applications": M{
+					"wordpress": M{
+						"series":     "quantal",
+						"os":         "ubuntu",
+						"charm-name": "wordpress",
+						"exposed":    bool(false),
+						"units": M{
+							"wordpress/0": M{
+								"public-address": "10.0.1.1",
+								"workload-status": M{
+									"current": "waiting",
+									"message": "waiting for machine",
+									"since":   "01 Apr 15 01:23+10:00",
+								},
+								"juju-status": M{
+									"current": "allocating",
+									"since":   "01 Apr 15 01:23+10:00",
+								},
+								"machine": "1",
+							},
+						},
+						"charm":        "cs:quantal/wordpress-3",
+						"charm-origin": "jujucharms",
+						"charm-rev":    int(3),
+						"application-status": M{
+							"current": "waiting",
+							"message": "waiting for machine",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"endpoint-bindings": M{
+							"cache":           "",
+							"db":              "myspace1",
+							"db-client":       "",
+							"foo-bar":         "",
+							"logging-dir":     "",
+							"monitoring-port": "",
+							"url":             "",
+							"admin-api":       "",
+						},
+					},
+				},
+			},
 		},
 	),
 }
@@ -3117,6 +3388,16 @@ func (sm setMachineInstanceStatus) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+type addSpace struct {
+	spaceName string
+}
+
+func (sp addSpace) step(c *gc.C, ctx *context) {
+	f := factory.NewFactory(ctx.st)
+	f.MakeSpace(c, &factory.SpaceParams{
+		Name: sp.spaceName, ProviderID: network.Id("provider"), IsPublic: true})
+}
+
 type setAddresses struct {
 	machineId string
 	addresses []network.Address
@@ -3222,19 +3503,20 @@ func (ac addCharmWithRevision) step(c *gc.C, ctx *context) {
 	ac.addCharmStep(c, ctx, ac.scheme, ac.rev)
 }
 
-type addService struct {
-	name  string
-	charm string
-	cons  constraints.Value
+type addApplication struct {
+	name    string
+	charm   string
+	binding map[string]string
+	cons    constraints.Value
 }
 
-func (as addService) step(c *gc.C, ctx *context) {
+func (as addApplication) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddApplication(state.AddApplicationArgs{Name: as.name, Charm: ch})
+	app, err := ctx.st.AddApplication(state.AddApplicationArgs{Name: as.name, Charm: ch, EndpointBindings: as.binding})
 	c.Assert(err, jc.ErrorIsNil)
-	if svc.IsPrincipal() {
-		err = svc.SetConstraints(as.cons)
+	if app.IsPrincipal() {
+		err = app.SetConstraints(as.cons)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -3867,7 +4149,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addCharm{"logging"},
 		addCharm{"riak"},
 		addRemoteApplication{name: "hosted-riak", url: "me/model.riak", charm: "riak", endpoints: []string{"endpoint"}},
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("localhost")},
@@ -3876,7 +4158,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addAliveUnit{"wordpress", "1"},
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
 		setUnitStatus{"wordpress/0", status.Active, "", nil},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
@@ -3885,7 +4167,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addAliveUnit{"mysql", "2"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
 		setUnitStatus{"mysql/0", status.Active, "", nil},
-		addService{name: "logging", charm: "logging"},
+		addApplication{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
 		relateServices{"wordpress", "mysql", ""},
 		relateServices{"wordpress", "logging", ""},
@@ -3935,7 +4217,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addCharm{"mysql"},
 		addCharm{"logging"},
 
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -3945,7 +4227,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
 		setUnitStatus{"wordpress/0", status.Active, "", nil},
 
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
@@ -3955,7 +4237,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
 		setUnitStatus{"mysql/0", status.Active, "", nil},
 
-		addService{name: "logging", charm: "logging"},
+		addApplication{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
 
 		relateServices{"wordpress", "mysql", ""},
@@ -4014,7 +4296,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addCharm{"logging"},
 		addCharm{"riak"},
 		addRemoteApplication{name: "hosted-riak", url: "me/model.riak", charm: "riak", endpoints: []string{"endpoint"}},
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -4024,7 +4306,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
 		setUnitStatus{"wordpress/0", status.Active, "", nil},
 		setUnitTools{"wordpress/0", version.MustParseBinary("1.2.3-trusty-ppc")},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
@@ -4037,7 +4319,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 			status.Maintenance,
 			"installing all the things", nil},
 		setUnitTools{"mysql/0", version.MustParseBinary("1.2.3-trusty-ppc")},
-		addService{name: "logging", charm: "logging"},
+		addApplication{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
 		relateServices{"wordpress", "mysql", "suspended"},
 		relateServices{"wordpress", "logging", ""},
@@ -4248,10 +4530,10 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 
 		// And the "wordpress" charm is available
 		addCharm{"wordpress"},
-		addService{name: "wordpress", charm: "wordpress"},
+		addApplication{name: "wordpress", charm: "wordpress"},
 		// And the "mysql" charm is available
 		addCharm{"mysql"},
-		addService{name: "mysql", charm: "mysql"},
+		addApplication{name: "mysql", charm: "mysql"},
 		// And the "logging" charm is available
 		addCharm{"logging"},
 
@@ -4283,7 +4565,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
 		setUnitStatus{"mysql/0", status.Active, "", nil},
 		// And the "logging" service is added
-		addService{name: "logging", charm: "logging"},
+		addApplication{name: "logging", charm: "logging"},
 		// And the service is exposed
 		setServiceExposed{"logging", true},
 		// And the "wordpress" service is related to the "mysql" service
@@ -4662,7 +4944,7 @@ var statusTimeTest = test(
 	startAliveMachine{"0"},
 	setMachineStatus{"0", status.Started, ""},
 	addCharm{"dummy"},
-	addService{name: "dummy-application", charm: "dummy"},
+	addApplication{name: "dummy-application", charm: "dummy"},
 
 	addMachine{machineId: "1", job: state.JobHostUnits},
 	startAliveMachine{"1"},

--- a/state/model.go
+++ b/state/model.go
@@ -871,6 +871,43 @@ func (m *Model) AllUnits() ([]*Unit, error) {
 	return units, nil
 }
 
+// ApplicationEndpointBindings - endpointBinding->space details for each application
+type ApplicationEndpointBindings struct {
+	AppName  string
+	Bindings map[string]string
+}
+
+// AllEndpointBindings returns all endpoint->space bindings for every application
+func (m *Model) AllEndpointBindings() ([]ApplicationEndpointBindings, error) {
+	endpointBindings, closer := m.st.db().GetCollection(endpointBindingsC)
+	defer closer()
+
+	var docs []endpointBindingsDoc
+	err := endpointBindings.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get endpoint bindings")
+	}
+
+	var appEndpointBindings []ApplicationEndpointBindings
+	for _, doc := range docs {
+		var applicationName string
+		applicationKey := m.localID(doc.DocID)
+		// for each application deployed we have an instance of ApplicationEndpointBindings struct
+		if strings.HasPrefix(applicationKey, "a#") {
+			applicationName = applicationKey[2:]
+		} else {
+			return nil, errors.NotValidf("application key %v", applicationKey)
+		}
+		endpointBindings := ApplicationEndpointBindings{
+			AppName:  applicationName,
+			Bindings: doc.Bindings,
+		}
+
+		appEndpointBindings = append(appEndpointBindings, endpointBindings)
+	}
+	return appEndpointBindings, nil
+}
+
 // Users returns a slice of all users for this model.
 func (m *Model) Users() ([]permission.UserAccess, error) {
 	coll, closer := m.st.db().GetCollection(modelUsersC)

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/mongo/mongotest"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -495,6 +496,39 @@ func (s *ModelSuite) TestAllUnits(c *gc.C) {
 	sort.Strings(names)
 	c.Assert(names, jc.DeepEquals, []string{
 		"mysql/0", "wordpress/0", "wordpress/1",
+	})
+}
+
+func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
+	type mockApplicationEndpointBindings struct {
+		appName string
+		binding map[string]string
+	}
+
+	s.Factory.MakeSpace(c, &factory.SpaceParams{
+		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+	state.AddTestingApplicationWithBindings(
+		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
+		map[string]string{"db": "one"})
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	listBindings, err := model.AllEndpointBindings()
+	c.Assert(listBindings, gc.HasLen, 1)
+
+	c.Assert(listBindings[0], jc.DeepEquals, state.ApplicationEndpointBindings{
+		AppName: "wordpress",
+		Bindings: map[string]string{
+			"cache":           "",
+			"foo-bar":         "",
+			"db-client":       "",
+			"admin-api":       "",
+			"url":             "",
+			"logging-dir":     "",
+			"monitoring-port": "",
+			"db":              "one",
+		},
 	})
 }
 


### PR DESCRIPTION
## Description of change
Why is this change needed?
This PR has initial code changes required to display binding-space details in "juju status" command. this is targetting only for json and yaml formats.
## QA steps
execute "juju status" command with --format json or yaml
