### PR TITLE
Status machine filter tests.

### DIFF
--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -21,7 +21,7 @@ type StatusSuite struct {
 	jujutesting.JujuConnSuite
 }
 
-func (s *StatusSuite) assertMultipleRelationsBetweenApplications(c *gc.C) {
+func (s *StatusSuite) setupMultipleRelationsBetweenApplications(c *gc.C) {
 	// make an application with 2 endpoints
 	application1 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
@@ -67,7 +67,7 @@ func (s *StatusSuite) run(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *StatusSuite) TestMultipleRelationsInYamlFormat(c *gc.C) {
-	s.assertMultipleRelationsBetweenApplications(c)
+	s.setupMultipleRelationsBetweenApplications(c)
 	context := s.run(c, "status", "--format=yaml")
 	out := cmdtesting.Stdout(context)
 
@@ -92,7 +92,7 @@ func (s *StatusSuite) TestMultipleRelationsInYamlFormat(c *gc.C) {
 }
 
 func (s *StatusSuite) TestMultipleRelationsInTabularFormat(c *gc.C) {
-	s.assertMultipleRelationsBetweenApplications(c)
+	s.setupMultipleRelationsBetweenApplications(c)
 	context := s.run(c, "status", "--relations")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 Relation provider      Requirer                   Interface  Type         Message
@@ -101,16 +101,13 @@ wordpress:logging-dir  logging:logging-directory  logging    subordinate  joinin
 `[1:])
 }
 
-func (s *StatusSuite) assertServeralUnitsOnAMachines(c *gc.C) {
-	// Application A will have a unit on the same machine is a unit of an application B.
+func (s *StatusSuite) setupSeveralUnitsOnAMachine(c *gc.C) {
 	applicationA := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
 			Name:     "mysql",
 			Revision: "1",
 		}),
 	})
-
-	// Application B will have a unit on the same machine as a unit of an application A.
 	applicationB := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
 			Name:     "wordpress",
@@ -135,9 +132,9 @@ func (s *StatusSuite) assertServeralUnitsOnAMachines(c *gc.C) {
 }
 
 func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
-	s.assertServeralUnitsOnAMachines(c)
+	s.setupSeveralUnitsOnAMachine(c)
 
-	// Put a unit from the application C on a different machine.
+	// Put a unit from an application on a new machine.
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Jobs:       []state.MachineJob{state.JobHostUnits},
 		InstanceId: instance.Id("id1"),
@@ -187,7 +184,7 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 }
 
 func (s *StatusSuite) TestStatusFilteringByMachineIDMatchesExactly(c *gc.C) {
-	s.assertServeralUnitsOnAMachines(c)
+	s.setupSeveralUnitsOnAMachine(c)
 
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "another",
@@ -224,6 +221,7 @@ func (s *StatusSuite) TestStatusFilteringByMachineIDMatchesExactly(c *gc.C) {
 		Application: application,
 		Machine:     machine10,
 	})
+
 	context := s.run(c, "status", "1")
 	// Should not have matched anything from machine 10.
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
@@ -232,6 +230,17 @@ another/0  waiting   allocating  1                               waiting for mac
 
 Machine  State    DNS  Inst id  Series   AZ  Message
 1        pending       id1      quantal      
+
+`)
+
+	context = s.run(c, "status", "10")
+	// Should not have matched anything from machine 1.
+	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
+Unit       Workload  Agent       Machine  Public address  Ports  Message
+another/1  waiting   allocating  10                              waiting for machine
+
+Machine  State    DNS  Inst id  Series   AZ  Message
+10       pending       id10     quantal      
 
 `)
 


### PR DESCRIPTION
## Description of change

There are outdated bugs around status and its ability to filter by machine id.

This PR proposes tests to ensure that the functionality was delivered, is functioning as expected and that we do not regress in the future. 

These tests ensure that:
* we can filter by machine id to see units, and hence, applications that are relevant to this machine;
* we filter on machine id exactly, i.e. searching for machine "1" does not also return anything related to machine "10".

## Bug reference

https://bugs.launchpad.net/juju/+bug/1748915
https://bugs.launchpad.net/juju/+bug/1584170
