### PR TITLE
raft: Turn off ShutdownOnRemove in test fixture raft config

### DIFF
--- a/worker/raft/rafttest/fixtures.go
+++ b/worker/raft/rafttest/fixtures.go
@@ -74,6 +74,7 @@ func (s *RaftFixture) NewRaft(c *gc.C, id raft.ServerID, fsm raft.FSM) (
 
 func (s *RaftFixture) DefaultConfig(id raft.ServerID) *raft.Config {
 	raftConfig := raft.DefaultConfig()
+	raftConfig.ShutdownOnRemove = false
 	raftConfig.LocalID = id
 	raftConfig.HeartbeatTimeout = 100 * time.Millisecond
 	raftConfig.ElectionTimeout = raftConfig.HeartbeatTimeout


### PR DESCRIPTION
## Description of change
With this config option on, the leader raft node shuts down after being demoted. Generally, the test then manages to finish ok because it does before another node takes over, but occasionally one of the other nodes reaches their heartbeat timeout and gets elected. In that case the new leader seems to go into a state where it can't be shut down cleanly because it can't talk to the former leader (which has itself shut down) so the teardown hangs.

The same option is turned off in our real raft worker, this change makes test raft nodes behave the same.

This hang on shutdown seems like a bug in hashicorp/raft (or at least the version we're using) - I'm still chasing it down, but this fixes the hang in our tests anyway.

## QA steps

Run the hanging test `worker/raft/raftclusterer_test:WorkerSuite.TestDemotesLeaderIfRemoved` under the race stress test script - without the option turned off it fails after about 5 runs. With the fix it runs indefinitely. 

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1771477
