### PR TITLE
Add remove-k8s command

### DIFF
--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -27,7 +27,7 @@ import (
 type addCAASSuite struct {
 	jujutesting.IsolationSuite
 	dir                 string
-	fakeCloudAPI        *fakeCloudAPI
+	fakeCloudAPI        *fakeAddCloudAPI
 	store               *fakeCloudMetadataStore
 	fileCredentialStore *fakeCredentialStore
 	fakeK8SConfigFunc   clientconfig.ClientConfigFunc
@@ -86,22 +86,22 @@ func (f *fakeCloudMetadataStore) WritePersonalCloudMetadata(cloudsMap map[string
 	return jujutesting.TypeAssertError(results[0])
 }
 
-type fakeCloudAPI struct {
-	caas.CloudAPI
+type fakeAddCloudAPI struct {
+	caas.AddCloudAPI
 	jujutesting.Stub
 	authTypes   []cloud.AuthType
 	credentials []names.CloudCredentialTag
 }
 
-func (api *fakeCloudAPI) Close() error {
+func (api *fakeAddCloudAPI) Close() error {
 	return nil
 }
 
-func (api *fakeCloudAPI) AddCloud(cloud.Cloud) error {
+func (api *fakeAddCloudAPI) AddCloud(cloud.Cloud) error {
 	return nil
 }
 
-func (api *fakeCloudAPI) AddCredential(tag string, credential cloud.Credential) error {
+func (api *fakeAddCloudAPI) AddCredential(tag string, credential cloud.Credential) error {
 	return nil
 }
 
@@ -160,7 +160,7 @@ func (fcs *fakeCredentialStore) UpdateCredential(cloudName string, details cloud
 func (s *addCAASSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.dir = c.MkDir()
-	s.fakeCloudAPI = &fakeCloudAPI{
+	s.fakeCloudAPI = &fakeAddCloudAPI{
 		authTypes: []cloud.AuthType{
 			cloud.EmptyAuthType,
 			cloud.AccessKeyAuthType,
@@ -211,7 +211,7 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists bool, emptyClientCon
 	addcmd := caas.NewAddCAASCommandForTest(s.store,
 		&fakeCredentialStore{},
 		NewMockClientStore(),
-		func() (caas.CloudAPI, error) {
+		func() (caas.AddCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
 		func(caasType string) (clientconfig.ClientConfigFunc, error) {

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -15,7 +15,7 @@ func NewAddCAASCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
 	fileCredentialStore jujuclient.CredentialStore,
 	clientStore jujuclient.ClientStore,
-	addCloudAPIFunc func() (CloudAPI, error),
+	addCloudAPIFunc func() (AddCloudAPI, error),
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),
 ) cmd.Command {
 	cmd := &AddCAASCommand{

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -6,8 +6,6 @@ package caas
 import (
 	"github.com/juju/cmd"
 
-	"github.com/juju/juju/api"
-	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -17,16 +15,29 @@ func NewAddCAASCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
 	fileCredentialStore jujuclient.CredentialStore,
 	clientStore jujuclient.ClientStore,
-	apiRoot api.Connection,
-	newCloudAPIFunc func(base.APICallCloser) CloudAPI,
+	addCloudAPIFunc func() (CloudAPI, error),
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),
 ) cmd.Command {
 	cmd := &AddCAASCommand{
 		cloudMetadataStore:    cloudMetadataStore,
 		fileCredentialStore:   fileCredentialStore,
-		apiRoot:               apiRoot,
-		newCloudAPI:           newCloudAPIFunc,
+		apiFunc:               addCloudAPIFunc,
 		newClientConfigReader: newClientConfigReaderFunc,
+	}
+	cmd.SetClientStore(clientStore)
+	return modelcmd.WrapController(cmd)
+}
+
+func NewRemoveCAASCommandForTest(
+	cloudMetadataStore CloudMetadataStore,
+	fileCredentialStore jujuclient.CredentialStore,
+	clientStore jujuclient.ClientStore,
+	removeCloudAPIFunc func() (RemoveCloudAPI, error),
+) cmd.Command {
+	cmd := &RemoveCAASCommand{
+		cloudMetadataStore:  cloudMetadataStore,
+		fileCredentialStore: fileCredentialStore,
+		apiFunc:             removeCloudAPIFunc,
 	}
 	cmd.SetClientStore(clientStore)
 	return modelcmd.WrapController(cmd)

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -1,0 +1,122 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/juju/cloud"
+
+	cloudapi "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+var usageRemoveCAASSummary = `
+Removes a k8s endpoint from Juju.`[1:]
+
+var usageRemoveCAASDetails = `
+Removes the specified k8s cloud from the controller (if it is not in use),
+and user-defined cloud details from this client.
+
+Examples:
+    juju remove-k8s myk8scloud
+    
+See also:
+    add-k8s
+`
+
+// Implemented by cloudapi.Client
+type RemoveCloudAPI interface {
+	RemoveCloud(string) error
+	Close() error
+}
+
+// RemoveCAASCommand is the command that allows you to remove a k8s cloud.
+type RemoveCAASCommand struct {
+	modelcmd.ControllerCommandBase
+
+	// cloudName is the name of the caas cloud to remove.
+	cloudName string
+
+	cloudMetadataStore  CloudMetadataStore
+	fileCredentialStore jujuclient.CredentialStore
+	apiFunc             func() (RemoveCloudAPI, error)
+}
+
+// NewRemoveCAASCommand returns a command to add caas information.
+func NewRemoveCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
+	cmd := &RemoveCAASCommand{
+		cloudMetadataStore:  cloudMetadataStore,
+		fileCredentialStore: jujuclient.NewFileCredentialStore(),
+	}
+	cmd.apiFunc = func() (RemoveCloudAPI, error) {
+		root, err := cmd.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return cloudapi.NewClient(root), nil
+	}
+	return modelcmd.WrapController(cmd)
+}
+
+// Info returns help information about the command.
+func (c *RemoveCAASCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "remove-k8s",
+		Args:    "<k8s name>",
+		Purpose: usageRemoveCAASSummary,
+		Doc:     usageRemoveCAASDetails,
+	}
+}
+
+// SetFlags initializes the flags supported by the command.
+func (c *RemoveCAASCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+}
+
+// Init populates the command with the args from the command line.
+func (c *RemoveCAASCommand) Init(args []string) (err error) {
+	if len(args) == 0 {
+		return errors.Errorf("missing k8s name.")
+	}
+	c.cloudName = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run is defined on the Command interface.
+func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
+	cloudAPI, err := c.apiFunc()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer cloudAPI.Close()
+
+	if err := cloudAPI.RemoveCloud(c.cloudName); err != nil {
+		return errors.Annotatef(err, "cannot remove k8s cloud from controller")
+	}
+
+	if err := removeCloudFromLocal(c.cloudMetadataStore, c.cloudName); err != nil {
+		return errors.Annotatef(err, "cannot remove cloud from local cache")
+	}
+
+	return c.fileCredentialStore.UpdateCredential(c.cloudName, cloud.CloudCredential{})
+}
+
+func removeCloudFromLocal(cloudMetadataStore CloudMetadataStore, cloudName string) error {
+	personalClouds, err := cloudMetadataStore.PersonalCloudMetadata()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if personalClouds == nil {
+		return nil
+	}
+	_, ok := personalClouds[cloudName]
+	if !ok {
+		return nil
+	}
+	delete(personalClouds, cloudName)
+	return cloudMetadataStore.WritePersonalCloudMetadata(personalClouds)
+}

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -1,0 +1,120 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/caas"
+)
+
+type removeCAASSuite struct {
+	jujutesting.IsolationSuite
+	fakeCloudAPI        *fakeRemoveCloudAPI
+	store               *fakeCloudMetadataStore
+	fileCredentialStore *fakeCredentialStore
+}
+
+var _ = gc.Suite(&removeCAASSuite{})
+
+type fakeRemoveCloudAPI struct {
+	caas.RemoveCloudAPI
+	jujutesting.Stub
+}
+
+func (api *fakeRemoveCloudAPI) RemoveCloud(cloud string) error {
+	api.AddCall("RemoveCloud", cloud)
+	return api.NextErr()
+}
+
+func (api *fakeRemoveCloudAPI) Close() error {
+	return nil
+}
+
+func (s *removeCAASSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.fakeCloudAPI = &fakeRemoveCloudAPI{}
+	s.fileCredentialStore = &fakeCredentialStore{}
+
+	var logger loggo.Logger
+	s.store = &fakeCloudMetadataStore{CallMocker: jujutesting.NewCallMocker(logger)}
+
+	k8sCloud := cloud.Cloud{Name: "myk8s", Type: "kubernetes"}
+	initialCloudMap := map[string]cloud.Cloud{"myk8s": k8sCloud}
+
+	s.store.Call("PersonalCloudMetadata").Returns(initialCloudMap, nil)
+	s.store.Call("WritePersonalCloudMetadata", map[string]cloud.Cloud{}).Returns(nil)
+}
+
+func (s *removeCAASSuite) makeCommand() cmd.Command {
+	removecmd := caas.NewRemoveCAASCommandForTest(
+		s.store,
+		s.fileCredentialStore,
+		NewMockClientStore(),
+		func() (caas.RemoveCloudAPI, error) {
+			return s.fakeCloudAPI, nil
+		},
+	)
+	return removecmd
+}
+
+func (s *removeCAASSuite) runCommand(c *gc.C, cmd cmd.Command, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, cmd, args...)
+}
+
+func (s *removeCAASSuite) TestExtraArg(c *gc.C) {
+	cmd := s.makeCommand()
+	_, err := s.runCommand(c, cmd, "k8sname", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *removeCAASSuite) TestMissingName(c *gc.C) {
+	cmd := s.makeCommand()
+	_, err := s.runCommand(c, cmd)
+	c.Assert(err, gc.ErrorMatches, `missing k8s name.`)
+}
+
+func (s *removeCAASSuite) TestRemove(c *gc.C) {
+	cmd := s.makeCommand()
+	_, err := s.runCommand(c, cmd, "myk8s")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")
+	s.fakeCloudAPI.CheckCall(c, 0, "RemoveCloud", "myk8s")
+
+	s.store.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata")
+	s.store.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
+
+	s.fileCredentialStore.CheckCallNames(c, "UpdateCredential")
+	s.fileCredentialStore.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
+}
+
+func (s *removeCAASSuite) TestRemoveNotInController(c *gc.C) {
+	s.fakeCloudAPI.SetErrors(errors.NotFoundf("cloud"))
+	cmd := s.makeCommand()
+	_, err := s.runCommand(c, cmd, "myk8s")
+	c.Assert(err, gc.ErrorMatches, "cannot remove k8s cloud from controller.*")
+
+	s.store.CheckNoCalls(c)
+	s.fileCredentialStore.CheckNoCalls(c)
+}
+
+func (s *removeCAASSuite) TestRemoveNotInLocal(c *gc.C) {
+	cmd := s.makeCommand()
+	_, err := s.runCommand(c, cmd, "yourk8s")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")
+	s.fakeCloudAPI.CheckCall(c, 0, "RemoveCloud", "yourk8s")
+
+	s.store.CheckCallNames(c, "PersonalCloudMetadata")
+	s.fileCredentialStore.CheckCall(c, 0, "UpdateCredential", "yourk8s", cloud.CloudCredential{})
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -461,6 +461,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// CAAS commands
 	r.Register(caas.NewAddCAASCommand(&cloudToCommandAdapter{}))
+	r.Register(caas.NewRemoveCAASCommand(&cloudToCommandAdapter{}))
 
 	// Manage Application Credential Access
 	r.Register(application.NewTrustCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -501,6 +501,7 @@ var commandNames = []string{
 	"remove-cloud",
 	"remove-consumed-application",
 	"remove-credential",
+	"remove-k8s",
 	"remove-machine",
 	"remove-offer",
 	"remove-relation",


### PR DESCRIPTION
## Description of change

Add a remove-k8s command.
This will remove a k8s cloud from the controller (if no models are using it) as well as locally if present.
Any cloud credentials are also removed.

Also fix the recent RemoveCloud() state API to return a NotFound error if the cloud is not present.

## QA steps

Deploy a k8s cluster
juju add-k8s
juju add-model 
check remove-k8s fails
juju destroy-model
check remove-k8s works as expected

## Documentation changes

@pmatulis 
New remove-k8s command.
