### PR TITLE
Clarify why status output is empty, when it is.

### DIFF
--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -30,6 +30,14 @@ type FullStatus struct {
 	Relations          []RelationStatus                   `json:"relations"`
 }
 
+func (fs *FullStatus) IsEmpty() bool {
+	return len(fs.Applications) == 0 &&
+		len(fs.Machines) == 0 &&
+		len(fs.Offers) == 0 &&
+		len(fs.RemoteApplications) == 0 &&
+		len(fs.Relations) == 0
+}
+
 // ModelStatusInfo holds status information about the model itself.
 type ModelStatusInfo struct {
 	Name             string         `json:"name"`

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -30,6 +30,8 @@ type FullStatus struct {
 	Relations          []RelationStatus                   `json:"relations"`
 }
 
+// IsEmpty checks all collections on FullStatus to determine if the status is empty.
+// Note that only the collections are checked here as Model information will always be populated.
 func (fs *FullStatus) IsEmpty() bool {
 	return len(fs.Applications) == 0 &&
 		len(fs.Machines) == 0 &&

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -205,22 +205,23 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	if status.IsEmpty() {
-		if len(c.patterns) == 0 {
-			modelName, err := c.ModelName()
-			if err != nil {
-				return err
-			}
-			ctx.Infof("Model %q is empty.", modelName)
-		} else {
-			plural := func() string {
-				if len(c.patterns) == 1 {
-					return ""
-				}
-				return "s"
-			}
-			ctx.Infof("Nothing matched specified filter%v.", plural())
+	if !status.IsEmpty() {
+		return nil
+	}
+	if len(c.patterns) == 0 {
+		modelName, err := c.ModelName()
+		if err != nil {
+			return err
 		}
+		ctx.Infof("Model %q is empty.", modelName)
+	} else {
+		plural := func() string {
+			if len(c.patterns) == 1 {
+				return ""
+			}
+			return "s"
+		}
+		ctx.Infof("Nothing matched specified filter%v.", plural())
 	}
 	return nil
 }

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -422,8 +422,8 @@ var statusTests = []testCase{
 
 		addMachine{machineId: "0", job: state.JobManageModel},
 		expect{
-			"simulate juju bootstrap by adding machine/0 to the state",
-			M{
+			what: "simulate juju bootstrap by adding machine/0 to the state",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -450,8 +450,8 @@ var statusTests = []testCase{
 			network.NewAddress("10.0.0.2"),
 		}},
 		expect{
-			"simulate the PA starting an instance in response to the state change",
-			M{
+			what: "simulate the PA starting an instance in response to the state change",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -489,8 +489,8 @@ var statusTests = []testCase{
 
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"simulate the MA started and set the machine status",
-			M{
+			what: "simulate the MA started and set the machine status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -528,8 +528,8 @@ var statusTests = []testCase{
 
 		setTools{"0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		expect{
-			"simulate the MA setting the version",
-			M{
+			what: "simulate the MA setting the version",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -576,8 +576,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has specific hardware characteristics",
-			M{
+			what: "machine 0 has specific hardware characteristics",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -620,8 +620,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has no dns-name",
-			M{
+			what: "machine 0 has no dns-name",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -648,8 +648,8 @@ var statusTests = []testCase{
 		"test pending and missing machines",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		expect{
-			"machine 0 reports pending",
-			M{
+			what: "machine 0 reports pending",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -672,8 +672,8 @@ var statusTests = []testCase{
 
 		startMissingMachine{"0"},
 		expect{
-			"machine 0 reports missing",
-			M{
+			what: "machine 0 reports missing",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -707,8 +707,8 @@ var statusTests = []testCase{
 		addService{name: "dummy-application", charm: "dummy"},
 		addService{name: "exposed-application", charm: "dummy"},
 		expect{
-			"no applications exposed yet",
-			M{
+			what: "no applications exposed yet",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -723,8 +723,8 @@ var statusTests = []testCase{
 		// step 8
 		setServiceExposed{"exposed-application", true},
 		expect{
-			"one exposed application",
-			M{
+			what: "one exposed application",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -746,8 +746,8 @@ var statusTests = []testCase{
 		startAliveMachine{"2"},
 		setMachineStatus{"2", status.Started, ""},
 		expect{
-			"two more machines added",
-			M{
+			what: "two more machines added",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -778,8 +778,8 @@ var statusTests = []testCase{
 		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
 
 		expect{
-			"add two units, one alive (in error state), one started",
-			M{
+			what: "add two units, one alive (in error state), one started",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -851,8 +851,8 @@ var statusTests = []testCase{
 		addMachine{machineId: "5", job: state.JobHostUnits},
 		ensureDeadMachine{"5"},
 		expect{
-			"add three more machine, one with a dead agent, one in error state and one dead itself; also one dying unit",
-			M{
+			what: "add three more machine, one with a dead agent, one in error state and one dead itself; also one dying unit",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -971,9 +971,9 @@ var statusTests = []testCase{
 
 		// step 41
 		scopedExpect{
-			"scope status on dummy-application/0 unit",
-			[]string{"dummy-application/0"},
-			M{
+			what:  "scope status on dummy-application/0 unit",
+			scope: []string{"dummy-application/0"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1003,9 +1003,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on exposed-application application",
-			[]string{"exposed-application"},
-			M{
+			what:  "scope status on exposed-application application",
+			scope: []string{"exposed-application"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"2": machine2,
@@ -1041,9 +1041,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on application pattern",
-			[]string{"d*-application"},
-			M{
+			what:  "scope status on application pattern",
+			scope: []string{"d*-application"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1073,9 +1073,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on unit pattern",
-			[]string{"e*posed-application/*"},
-			M{
+			what:  "scope status on unit pattern",
+			scope: []string{"e*posed-application/*"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"2": machine2,
@@ -1111,9 +1111,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on combination of application and unit patterns",
-			[]string{"exposed-application", "dummy-application", "e*posed-application/*", "dummy-application/*"},
-			M{
+			what:  "scope status on combination of application and unit patterns",
+			scope: []string{"exposed-application", "dummy-application", "e*posed-application/*", "dummy-application/*"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1197,8 +1197,8 @@ var statusTests = []testCase{
 			map[string]interface{}{"relation-id": 0}},
 
 		expect{
-			"a unit with a hook relation error",
-			M{
+			what: "a unit with a hook relation error",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1286,8 +1286,8 @@ var statusTests = []testCase{
 			map[string]interface{}{"relation-id": 0}},
 
 		expect{
-			"a unit with a hook relation error when the agent is down",
-			M{
+			what: "a unit with a hook relation error when the agent is down",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1356,8 +1356,8 @@ var statusTests = []testCase{
 		addAliveUnit{"dummy-application", "0"},
 		ensureDyingService{"dummy-application"},
 		expect{
-			"application shows life==dying",
-			M{
+			what: "application shows life==dying",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -1412,8 +1412,8 @@ var statusTests = []testCase{
 		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
 		setUnitStatus{"dummy-application/0", status.Active, "", nil},
 		expect{
-			"unit shows that agent is lost",
-			M{
+			what: "unit shows that agent is lost",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -1511,8 +1511,8 @@ var statusTests = []testCase{
 		relateServices{"private", "mysql", ""},
 
 		expect{
-			"multiples services with relations between some of them",
-			M{
+			what: "multiples services with relations between some of them",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1669,8 +1669,8 @@ var statusTests = []testCase{
 		setUnitAsLeader{"riak/1"},
 
 		expect{
-			"multiples related peer units",
-			M{
+			what: "multiples related peer units",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1790,8 +1790,8 @@ var statusTests = []testCase{
 		setUnitAsLeader{"wordpress/0"},
 
 		expect{
-			"multiples related peer units",
-			M{
+			what: "multiples related peer units",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1886,9 +1886,9 @@ var statusTests = []testCase{
 
 		// scoped on 'logging'
 		scopedExpect{
-			"subordinates scoped on logging",
-			[]string{"logging"},
-			M{
+			what:  "subordinates scoped on logging",
+			scope: []string{"logging"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1982,9 +1982,9 @@ var statusTests = []testCase{
 
 		// scoped on wordpress/0
 		scopedExpect{
-			"subordinates scoped on wordpress",
-			[]string{"wordpress/0"},
-			M{
+			what:  "subordinates scoped on wordpress",
+			scope: []string{"wordpress/0"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -2071,8 +2071,8 @@ var statusTests = []testCase{
 		setMachineStatus{"1/lxd/0/lxd/0", status.Started, ""},
 
 		expect{
-			"machines with nested containers",
-			M{
+			what: "machines with nested containers",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2118,9 +2118,9 @@ var statusTests = []testCase{
 
 		// step 27: once again, with a scope on mysql/1
 		scopedExpect{
-			"machines with nested containers 2",
-			[]string{"mysql/1"},
-			M{
+			what:  "machines with nested containers 2",
+			scope: []string{"mysql/1"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": M{
@@ -2214,8 +2214,8 @@ var statusTests = []testCase{
 		addAliveUnit{"mysql", "1"},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2269,8 +2269,8 @@ var statusTests = []testCase{
 		setServiceCharm{"mysql", "local:quantal/mysql-1"},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2325,8 +2325,8 @@ var statusTests = []testCase{
 		addCharmPlaceholder{"mysql", 23},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2382,8 +2382,8 @@ var statusTests = []testCase{
 		addCharmPlaceholder{"mysql", 23},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2473,8 +2473,8 @@ var statusTests = []testCase{
 		setUnitMeterStatus{"servicewithmeterstatus/2", "RED", "test red status"},
 
 		expect{
-			"simulate just the two services and a bootstrap node",
-			M{
+			what: "simulate just the two services and a bootstrap node",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2566,8 +2566,8 @@ var statusTests = []testCase{
 		"upgrade available",
 		setToolsUpgradeAvailable{},
 		expect{
-			"upgrade availability should be shown in model-status",
-			M{
+			what: "upgrade availability should be shown in model-status",
+			output: M{
 				"model": M{
 					"name":              "controller",
 					"controller":        "kontroll",
@@ -2584,6 +2584,7 @@ var statusTests = []testCase{
 				"machines":     M{},
 				"applications": M{},
 			},
+			stderr: "Model \"controller\" is empty.\n",
 		},
 	),
 	test( // 19
@@ -2604,8 +2605,8 @@ var statusTests = []testCase{
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
 
 		expect{
-			"application and unit with correct workload version",
-			M{
+			what: "application and unit with correct workload version",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2664,8 +2665,8 @@ var statusTests = []testCase{
 		setUnitWorkloadVersion{"mysql/1", "not as good"},
 
 		expect{
-			"application and unit with correct workload version",
-			M{
+			what: "application and unit with correct workload version",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2727,8 +2728,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has localhost addresses that should not display",
-			M{
+			what: "machine 0 has localhost addresses that should not display",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2750,8 +2751,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has an IPv6 address",
-			M{
+			what: "machine 0 has an IPv6 address",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -2803,8 +2804,8 @@ var statusTests = []testCase{
 		relateServices{"wordpress", "hosted-mysql", ""},
 
 		expect{
-			"a remote application",
-			M{
+			what: "a remote application",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2862,8 +2863,8 @@ var statusTests = []testCase{
 		"set meter status on the model",
 		setModelMeterStatus{"RED", "status message"},
 		expect{
-			"simulate just the two services and a bootstrap node",
-			M{
+			what: "simulate just the two services and a bootstrap node",
+			output: M{
 				"model": M{
 					"name":       "controller",
 					"controller": "kontroll",
@@ -2883,14 +2884,15 @@ var statusTests = []testCase{
 				"machines":     M{},
 				"applications": M{},
 			},
+			stderr: "Model \"controller\" is empty.\n",
 		},
 	),
 	test( // 25
 		"set sla on the model",
 		setSLA{"advanced"},
 		expect{
-			"set sla on the model",
-			M{
+			what: "set sla on the model",
+			output: M{
 				"model": M{
 					"name":       "controller",
 					"controller": "kontroll",
@@ -2906,6 +2908,7 @@ var statusTests = []testCase{
 				"machines":     M{},
 				"applications": M{},
 			},
+			stderr: "Model \"controller\" is empty.\n",
 		},
 	),
 }
@@ -3635,11 +3638,13 @@ type scopedExpect struct {
 	what   string
 	scope  []string
 	output M
+	stderr string
 }
 
 type expect struct {
 	what   string
 	output M
+	stderr string
 }
 
 // substituteFakeTime replaces all "since" values
@@ -3684,9 +3689,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 		c.Logf("running status %s", strings.Join(args, " "))
 		code, stdout, stderr := runStatus(c, args...)
 		c.Assert(code, gc.Equals, 0)
-		if !c.Check(stderr, gc.HasLen, 0) {
-			c.Fatalf("status failed: %s", string(stderr))
-		}
+		c.Assert(string(stderr), gc.Equals, e.stderr)
 
 		// Prepare the output in the same format.
 		buf, err := format.marshal(e.output)
@@ -3705,7 +3708,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 }
 
 func (e expect) step(c *gc.C, ctx *context) {
-	scopedExpect{e.what, nil, e.output}.step(c, ctx)
+	scopedExpect{e.what, nil, e.output, e.stderr}.step(c, ctx)
 }
 
 type setToolsUpgradeAvailable struct{}
@@ -3756,7 +3759,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 	for _, format := range statusFormats {
 		code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", format.name)
 		c.Check(code, gc.Equals, 0)
-		c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+		c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 		stdout = substituteFakeSinceTime(c, stdout, false)
 
@@ -3778,19 +3781,13 @@ func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 Model   Controller  Cloud/Region        Version  Notes               SLA
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-
-Unit  Workload  Agent  Machine  Public address  Ports  Message
-
-Machine  State  DNS  Inst id  Series  AZ  Message
-
 `[1:]
 
 	st := s.setupMigrationTest(c)
 	defer st.Close()
 	code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", "tabular")
-	c.Check(code, gc.Equals, 0)
-	c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 	c.Assert(string(stdout), gc.Equals, expected)
 }
 
@@ -3798,12 +3795,6 @@ func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
 Model   Controller  Cloud/Region        Version  Notes               SLA
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
-
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-
-Unit  Workload  Agent  Machine  Public address  Ports  Message
-
-Machine  State  DNS  Inst id  Series  AZ  Message
 
 `[1:]
 
@@ -3816,8 +3807,8 @@ Machine  State  DNS  Inst id  Series  AZ  Message
 	c.Assert(err, jc.ErrorIsNil)
 
 	code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", "tabular")
-	c.Check(code, gc.Equals, 0)
-	c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 	c.Assert(string(stdout), gc.Equals, expected)
 }
 
@@ -4165,7 +4156,6 @@ Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
 foo/1  maintenance  executing                                  (backup database) doing some work
 
-Machine  State  DNS  Inst id  Series  AZ  Message
 `[1:])
 }
 
@@ -4235,8 +4225,7 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 		"Entity  Meter status  Message\n"+
 		"foo/0   strange       warning: stable strangelets  \n"+
 		"foo/1   up            things are looking up        \n"+
-		"\n"+
-		"Machine  State  DNS  Inst id  Series  AZ  Message\n")
+		"\n")
 }
 
 //
@@ -4684,8 +4673,8 @@ var statusTimeTest = test(
 
 	addAliveUnit{"dummy-application", "1"},
 	expect{
-		"add two units, one alive (in error state), one started",
-		M{
+		what: "add two units, one alive (in error state), one started",
+		output: M{
 			"model": M{
 				"name":       "controller",
 				"controller": "kontroll",

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4818,3 +4818,30 @@ func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
 }
+
+func (s *StatusSuite) TestStatusFormatTabularEmptyModel(c *gc.C) {
+	code, stdout, stderr := runStatus(c)
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "Model \"controller\" is empty.\n")
+	expected := `
+Model       Controller  Cloud/Region        Version  SLA
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported
+
+`[1:]
+	c.Assert(string(stdout), gc.Equals, expected)
+}
+
+func (s *StatusSuite) TestStatusFormatTabularForUnmatchedFilter(c *gc.C) {
+	code, stdout, stderr := runStatus(c, "unmatched")
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "Nothing matched specified filter.\n")
+	expected := `
+Model       Controller  Cloud/Region        Version  SLA
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported
+
+`[1:]
+	c.Assert(string(stdout), gc.Equals, expected)
+
+	_, _, stderr = runStatus(c, "cannot", "match", "me")
+	c.Check(string(stderr), gc.Equals, "Nothing matched specified filters.\n")
+}


### PR DESCRIPTION
## Description of change

This PR addresses couple of usability bugs and adds clarity when status output is empty. 

Status output can be empty under several circumstances - the model is empty or the user specified filtering criteria that could not be matched. See linked bugs for more details.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1696245
https://bugs.launchpad.net/juju/+bug/1255786
https://bugs.launchpad.net/juju/+bug/1594883
