### PR TITLE
clarity when output is empty.

### DIFF
--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -31,6 +31,16 @@ type FullStatus struct {
 	ControllerTimestamp *time.Time                         `json:"controller-timestamp"`
 }
 
+// IsEmpty checks all collections on FullStatus to determine if the status is empty.
+// Note that only the collections are checked here as Model information will always be populated.
+func (fs *FullStatus) IsEmpty() bool {
+	return len(fs.Applications) == 0 &&
+		len(fs.Machines) == 0 &&
+		len(fs.Offers) == 0 &&
+		len(fs.RemoteApplications) == 0 &&
+		len(fs.Relations) == 0
+}
+
 // ModelStatusInfo holds status information about the model itself.
 type ModelStatusInfo struct {
 	Name             string         `json:"name"`

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -24,45 +24,32 @@ import (
 	"github.com/juju/juju/status"
 )
 
-const caasModelType = "caas"
+const (
+	caasModelType       = "caas"
+	ellipsis            = "..."
+	iaasMaxVersionWidth = 15
+	caasMaxVersionWidth = 30
+)
 
 // FormatTabular writes a tabular summary of machines, applications, and
 // units. Any subordinate items are indented by two spaces beneath
 // their superior.
 func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
-	const ellipsis = "..."
-	const iaasMaxVersionWidth = 15
-	const caasMaxVersionWidth = 30
-
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {
 		return errors.Errorf("expected value of type %T, got %T", fs, value)
 	}
-
-	maxVersionWidth := iaasMaxVersionWidth
-	if fs.Model.Type == caasModelType {
-		maxVersionWidth = caasMaxVersionWidth
-	}
-	truncatedWidth := maxVersionWidth - len(ellipsis)
 
 	// To format things into columns.
 	tw := output.TabWriter(writer)
 	if forceColor {
 		tw.SetColorCapable(forceColor)
 	}
-	w := output.Wrapper{tw}
-	p := w.Println
-	outputHeaders := func(values ...interface{}) {
-		p()
-		p(values...)
-	}
 
 	cloudRegion := fs.Model.Cloud
 	if fs.Model.CloudRegion != "" {
 		cloudRegion += "/" + fs.Model.CloudRegion
 	}
-
-	metering := fs.Model.MeterStatus != nil
 
 	header := []interface{}{"Model", "Controller", "Cloud/Region", "Version"}
 	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion, fs.Model.Version}
@@ -77,35 +64,55 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	// The first set of headers don't use outputHeaders because it adds the blank line.
-	p(header...)
-	p(values...)
+	w := output.Wrapper{tw}
+	w.Println(header...)
+	w.Println(values...)
 
 	if len(fs.RemoteApplications) > 0 {
-		outputHeaders("SAAS", "Status", "Store", "URL")
-		for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.RemoteApplications)) {
-			app := fs.RemoteApplications[appName]
-			var store, urlPath string
-			url, err := crossmodel.ParseOfferURL(app.OfferURL)
-			if err == nil {
-				store = url.Source
-				url.Source = ""
-				urlPath = url.Path()
-				if store == "" {
-					store = "local"
-				}
-			} else {
-				// This is not expected.
-				logger.Errorf("invalid offer URL %q: %v", app.OfferURL, err)
-				store = "unknown"
-				urlPath = app.OfferURL
-			}
-			w.Print(appName)
-			w.PrintStatus(app.StatusInfo.Current)
-			p(store, urlPath)
-		}
-		tw.Flush()
+		printRemoteApplications(tw, fs.RemoteApplications)
 	}
 
+	if len(fs.Applications) > 0 {
+		printApplications(tw, fs)
+	}
+
+	if fs.Model.Type != caasModelType && len(fs.Machines) > 0 {
+		w.Println()
+		printMachines(tw, fs.Machines)
+	}
+
+	if err := printOffers(tw, fs.Offers); err != nil {
+		w.Println(err.Error())
+	}
+
+	if len(fs.Relations) > 0 {
+		printRelations(tw, fs.Relations)
+	}
+
+	if fs.ControllerTimestamp != "" {
+		w.Println()
+		w.Println("Controller Timestamp")
+		w.Print(fs.ControllerTimestamp)
+	}
+
+	tw.Flush()
+	return nil
+}
+
+func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
+	w := output.Wrapper{tw}
+	outputHeaders := func(values ...interface{}) {
+		w.Println()
+		w.Println(values...)
+	}
+
+	maxVersionWidth := iaasMaxVersionWidth
+	if fs.Model.Type == caasModelType {
+		maxVersionWidth = caasMaxVersionWidth
+	}
+	truncatedWidth := maxVersionWidth - len(ellipsis)
+
+	metering := fs.Model.MeterStatus != nil
 	units := make(map[string]unitStatus)
 	if fs.Model.Type == caasModelType {
 		outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
@@ -148,7 +155,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		if fs.Model.Type == caasModelType {
 			w.Print(app.Address)
 		}
-		p(notes)
+		w.Println(notes)
 		for un, u := range app.Units {
 			units[un] = u
 			if u.MeterStatus != nil {
@@ -170,14 +177,14 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		w.PrintStatus(u.WorkloadStatusInfo.Current)
 		w.PrintStatus(u.JujuStatusInfo.Current)
 		if fs.Model.Type == caasModelType {
-			p(
+			w.Println(
 				u.Address,
 				strings.Join(u.OpenedPorts, ","),
 				message,
 			)
 			return
 		}
-		p(
+		w.Println(
 			u.Machine,
 			u.PublicAddress,
 			strings.Join(u.OpenedPorts, ","),
@@ -217,44 +224,59 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 			}
 		}
 	}
+}
 
-	if fs.Model.Type != caasModelType || len(fs.Machines) > 0 {
-		p()
-		printMachines(tw, fs.Machines)
-	}
-
-	if err := printOffers(tw, fs.Offers); err != nil {
-		w.Println(err.Error())
-	}
-
-	if len(fs.Relations) > 0 {
-		sort.Slice(fs.Relations, func(i, j int) bool {
-			a, b := fs.Relations[i], fs.Relations[j]
-			if a.Provider == b.Provider {
-				return a.Requirer < b.Requirer
+func printRemoteApplications(tw *ansiterm.TabWriter, remoteApplications map[string]remoteApplicationStatus) {
+	w := output.Wrapper{tw}
+	w.Println()
+	w.Println("SAAS", "Status", "Store", "URL")
+	for _, appName := range naturalsort.Sort(stringKeysFromMap(remoteApplications)) {
+		app := remoteApplications[appName]
+		var store, urlPath string
+		url, err := crossmodel.ParseOfferURL(app.OfferURL)
+		if err == nil {
+			store = url.Source
+			url.Source = ""
+			urlPath = url.Path()
+			if store == "" {
+				store = "local"
 			}
-			return a.Provider < b.Provider
-		})
-		outputHeaders("Relation provider", "Requirer", "Interface", "Type", "Message")
-		for _, r := range fs.Relations {
-			w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
-			if r.Status != string(relation.Joined) {
-				w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
-				if r.Message != "" {
-					w.Print(" - " + r.Message)
-				}
-			}
-			w.Println()
+		} else {
+			// This is not expected.
+			logger.Errorf("invalid offer URL %q: %v", app.OfferURL, err)
+			store = "unknown"
+			urlPath = app.OfferURL
 		}
+		w.Print(appName)
+		w.PrintStatus(app.StatusInfo.Current)
+		w.Println(store, urlPath)
 	}
-
-	if fs.ControllerTimestamp != "" {
-		outputHeaders("Controller Timestamp")
-		w.Print(fs.ControllerTimestamp)
-	}
-
 	tw.Flush()
-	return nil
+}
+
+func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
+	sort.Slice(relations, func(i, j int) bool {
+		a, b := relations[i], relations[j]
+		if a.Provider == b.Provider {
+			return a.Requirer < b.Requirer
+		}
+		return a.Provider < b.Provider
+	})
+
+	w := output.Wrapper{tw}
+	w.Println()
+	w.Println("Relation provider", "Requirer", "Interface", "Type", "Message")
+
+	for _, r := range relations {
+		w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
+		if r.Status != string(relation.Joined) {
+			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
+			if r.Message != "" {
+				w.Print(" - " + r.Message)
+			}
+		}
+		w.Println()
+	}
 }
 
 type offerItems []offerStatus

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -63,6 +63,10 @@ machines, applications, and units will also be displayed. If a subordinate unit
 is matched, then its principal unit will be displayed. If a principal unit is
 matched, then all of its subordinates will be displayed.
 
+Machine numbers may also be used as output filters. This will only display data 
+in each section relevant to the specified machines. For example, application 
+section will only contain the applications that have units on these machines, etc.
+
 The available output formats are:
 
 - tabular (default): Displays status in a tabular format with a separate table
@@ -196,7 +200,30 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return c.out.Write(ctx, formatted)
+	err = c.out.Write(ctx, formatted)
+	if err != nil {
+		return err
+	}
+
+	if !status.IsEmpty() {
+		return nil
+	}
+	if len(c.patterns) == 0 {
+		modelName, err := c.ModelName()
+		if err != nil {
+			return err
+		}
+		ctx.Infof("Model %q is empty.", modelName)
+	} else {
+		plural := func() string {
+			if len(c.patterns) == 1 {
+				return ""
+			}
+			return "s"
+		}
+		ctx.Infof("Nothing matched specified filter%v.", plural())
+	}
+	return nil
 }
 
 func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -425,8 +425,8 @@ var statusTests = []testCase{
 
 		addMachine{machineId: "0", job: state.JobManageModel},
 		expect{
-			"simulate juju bootstrap by adding machine/0 to the state",
-			M{
+			what: "simulate juju bootstrap by adding machine/0 to the state",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -454,8 +454,8 @@ var statusTests = []testCase{
 			network.NewAddress("10.0.0.2"),
 		}},
 		expect{
-			"simulate the PA starting an instance in response to the state change",
-			M{
+			what: "simulate the PA starting an instance in response to the state change",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -494,8 +494,8 @@ var statusTests = []testCase{
 
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"simulate the MA started and set the machine status",
-			M{
+			what: "simulate the MA started and set the machine status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -534,8 +534,8 @@ var statusTests = []testCase{
 
 		setTools{"0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		expect{
-			"simulate the MA setting the version",
-			M{
+			what: "simulate the MA setting the version",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -583,8 +583,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has specific hardware characteristics",
-			M{
+			what: "machine 0 has specific hardware characteristics",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -628,8 +628,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has no dns-name",
-			M{
+			what: "machine 0 has no dns-name",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -657,8 +657,8 @@ var statusTests = []testCase{
 		"test pending and missing machines",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		expect{
-			"machine 0 reports pending",
-			M{
+			what: "machine 0 reports pending",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -682,8 +682,8 @@ var statusTests = []testCase{
 
 		startMissingMachine{"0"},
 		expect{
-			"machine 0 reports missing",
-			M{
+			what: "machine 0 reports missing",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -718,8 +718,8 @@ var statusTests = []testCase{
 		addService{name: "dummy-application", charm: "dummy"},
 		addService{name: "exposed-application", charm: "dummy"},
 		expect{
-			"no applications exposed yet",
-			M{
+			what: "no applications exposed yet",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -735,8 +735,8 @@ var statusTests = []testCase{
 		// step 8
 		setServiceExposed{"exposed-application", true},
 		expect{
-			"one exposed application",
-			M{
+			what: "one exposed application",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -759,8 +759,8 @@ var statusTests = []testCase{
 		startAliveMachine{"2"},
 		setMachineStatus{"2", status.Started, ""},
 		expect{
-			"two more machines added",
-			M{
+			what: "two more machines added",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -792,8 +792,8 @@ var statusTests = []testCase{
 		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
 
 		expect{
-			"add two units, one alive (in error state), one started",
-			M{
+			what: "add two units, one alive (in error state), one started",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -866,8 +866,8 @@ var statusTests = []testCase{
 		addMachine{machineId: "5", job: state.JobHostUnits},
 		ensureDeadMachine{"5"},
 		expect{
-			"add three more machine, one with a dead agent, one in error state and one dead itself; also one dying unit",
-			M{
+			what: "add three more machine, one with a dead agent, one in error state and one dead itself; also one dying unit",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -987,9 +987,9 @@ var statusTests = []testCase{
 
 		// step 41
 		scopedExpect{
-			"scope status on dummy-application/0 unit",
-			[]string{"dummy-application/0"},
-			M{
+			what:  "scope status on dummy-application/0 unit",
+			scope: []string{"dummy-application/0"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1020,9 +1020,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on exposed-application application",
-			[]string{"exposed-application"},
-			M{
+			what:  "scope status on exposed-application application",
+			scope: []string{"exposed-application"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"2": machine2,
@@ -1059,9 +1059,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on application pattern",
-			[]string{"d*-application"},
-			M{
+			what:  "scope status on application pattern",
+			scope: []string{"d*-application"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1092,9 +1092,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on unit pattern",
-			[]string{"e*posed-application/*"},
-			M{
+			what:  "scope status on unit pattern",
+			scope: []string{"e*posed-application/*"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"2": machine2,
@@ -1131,9 +1131,9 @@ var statusTests = []testCase{
 			},
 		},
 		scopedExpect{
-			"scope status on combination of application and unit patterns",
-			[]string{"exposed-application", "dummy-application", "e*posed-application/*", "dummy-application/*"},
-			M{
+			what:  "scope status on combination of application and unit patterns",
+			scope: []string{"exposed-application", "dummy-application", "e*posed-application/*", "dummy-application/*"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -1218,8 +1218,8 @@ var statusTests = []testCase{
 			map[string]interface{}{"relation-id": 0}},
 
 		expect{
-			"a unit with a hook relation error",
-			M{
+			what: "a unit with a hook relation error",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1308,8 +1308,8 @@ var statusTests = []testCase{
 			map[string]interface{}{"relation-id": 0}},
 
 		expect{
-			"a unit with a hook relation error when the agent is down",
-			M{
+			what: "a unit with a hook relation error when the agent is down",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1379,8 +1379,8 @@ var statusTests = []testCase{
 		addAliveUnit{"dummy-application", "0"},
 		ensureDyingService{"dummy-application"},
 		expect{
-			"application shows life==dying",
-			M{
+			what: "application shows life==dying",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -1436,8 +1436,8 @@ var statusTests = []testCase{
 		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
 		setUnitStatus{"dummy-application/0", status.Active, "", nil},
 		expect{
-			"unit shows that agent is lost",
-			M{
+			what: "unit shows that agent is lost",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -1536,8 +1536,8 @@ var statusTests = []testCase{
 		relateServices{"private", "mysql", ""},
 
 		expect{
-			"multiples services with relations between some of them",
-			M{
+			what: "multiples services with relations between some of them",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1695,8 +1695,8 @@ var statusTests = []testCase{
 		setUnitAsLeader{"riak/1"},
 
 		expect{
-			"multiples related peer units",
-			M{
+			what: "multiples related peer units",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1817,8 +1817,8 @@ var statusTests = []testCase{
 		setUnitAsLeader{"wordpress/0"},
 
 		expect{
-			"multiples related peer units",
-			M{
+			what: "multiples related peer units",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -1914,9 +1914,9 @@ var statusTests = []testCase{
 
 		// scoped on 'logging'
 		scopedExpect{
-			"subordinates scoped on logging",
-			[]string{"logging"},
-			M{
+			what:  "subordinates scoped on logging",
+			scope: []string{"logging"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -2011,9 +2011,9 @@ var statusTests = []testCase{
 
 		// scoped on wordpress/0
 		scopedExpect{
-			"subordinates scoped on wordpress",
-			[]string{"wordpress/0"},
-			M{
+			what:  "subordinates scoped on wordpress",
+			scope: []string{"wordpress/0"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": machine1,
@@ -2101,8 +2101,8 @@ var statusTests = []testCase{
 		setMachineStatus{"1/lxd/0/lxd/0", status.Started, ""},
 
 		expect{
-			"machines with nested containers",
-			M{
+			what: "machines with nested containers",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2149,9 +2149,9 @@ var statusTests = []testCase{
 
 		// step 27: once again, with a scope on mysql/1
 		scopedExpect{
-			"machines with nested containers 2",
-			[]string{"mysql/1"},
-			M{
+			what:  "machines with nested containers 2",
+			scope: []string{"mysql/1"},
+			output: M{
 				"model": model,
 				"machines": M{
 					"1": M{
@@ -2246,8 +2246,8 @@ var statusTests = []testCase{
 		addAliveUnit{"mysql", "1"},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2302,8 +2302,8 @@ var statusTests = []testCase{
 		setServiceCharm{"mysql", "local:quantal/mysql-1"},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2359,8 +2359,8 @@ var statusTests = []testCase{
 		addCharmPlaceholder{"mysql", 23},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2417,8 +2417,8 @@ var statusTests = []testCase{
 		addCharmPlaceholder{"mysql", 23},
 
 		expect{
-			"services and units with correct charm status",
-			M{
+			what: "services and units with correct charm status",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2509,8 +2509,8 @@ var statusTests = []testCase{
 		setUnitMeterStatus{"servicewithmeterstatus/2", "RED", "test red status"},
 
 		expect{
-			"simulate just the two services and a bootstrap node",
-			M{
+			what: "simulate just the two services and a bootstrap node",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2603,8 +2603,8 @@ var statusTests = []testCase{
 		"upgrade available",
 		setToolsUpgradeAvailable{},
 		expect{
-			"upgrade availability should be shown in model-status",
-			M{
+			what: "upgrade availability should be shown in model-status",
+			output: M{
 				"model": M{
 					"name":              "controller",
 					"type":              "iaas",
@@ -2623,6 +2623,7 @@ var statusTests = []testCase{
 				"applications":         M{},
 				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
+			stderr: "Model \"controller\" is empty.\n",
 		},
 	),
 	test( // 19
@@ -2643,8 +2644,8 @@ var statusTests = []testCase{
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
 
 		expect{
-			"application and unit with correct workload version",
-			M{
+			what: "application and unit with correct workload version",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2704,8 +2705,8 @@ var statusTests = []testCase{
 		setUnitWorkloadVersion{"mysql/1", "not as good"},
 
 		expect{
-			"application and unit with correct workload version",
-			M{
+			what: "application and unit with correct workload version",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2768,8 +2769,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has localhost addresses that should not display",
-			M{
+			what: "machine 0 has localhost addresses that should not display",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2792,8 +2793,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
-			"machine 0 has an IPv6 address",
-			M{
+			what: "machine 0 has an IPv6 address",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": M{
@@ -2846,8 +2847,8 @@ var statusTests = []testCase{
 		relateServices{"wordpress", "hosted-mysql", ""},
 
 		expect{
-			"a remote application",
-			M{
+			what: "a remote application",
+			output: M{
 				"model": model,
 				"machines": M{
 					"0": machine0,
@@ -2906,8 +2907,8 @@ var statusTests = []testCase{
 		"set meter status on the model",
 		setModelMeterStatus{"RED", "status message"},
 		expect{
-			"simulate just the two services and a bootstrap node",
-			M{
+			what: "simulate just the two services and a bootstrap node",
+			output: M{
 				"model": M{
 					"name":       "controller",
 					"type":       "iaas",
@@ -2929,14 +2930,15 @@ var statusTests = []testCase{
 				"applications":         M{},
 				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
+			stderr: "Model \"controller\" is empty.\n",
 		},
 	),
 	test( // 25
 		"set sla on the model",
 		setSLA{"advanced"},
 		expect{
-			"set sla on the model",
-			M{
+			what: "set sla on the model",
+			output: M{
 				"model": M{
 					"name":       "controller",
 					"type":       "iaas",
@@ -2954,6 +2956,7 @@ var statusTests = []testCase{
 				"applications":         M{},
 				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
+			stderr: "Model \"controller\" is empty.\n",
 		},
 	),
 }
@@ -3683,11 +3686,13 @@ type scopedExpect struct {
 	what   string
 	scope  []string
 	output M
+	stderr string
 }
 
 type expect struct {
 	what   string
 	output M
+	stderr string
 }
 
 // substituteFakeTime replaces all key values
@@ -3740,9 +3745,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 		c.Logf("running status %s", strings.Join(args, " "))
 		code, stdout, stderr := runStatus(c, args...)
 		c.Assert(code, gc.Equals, 0)
-		if !c.Check(stderr, gc.HasLen, 0) {
-			c.Fatalf("status failed: %s", string(stderr))
-		}
+		c.Assert(string(stderr), gc.Equals, e.stderr)
 
 		// Prepare the output in the same format.
 		buf, err := format.marshal(e.output)
@@ -3762,7 +3765,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 }
 
 func (e expect) step(c *gc.C, ctx *context) {
-	scopedExpect{e.what, nil, e.output}.step(c, ctx)
+	scopedExpect{e.what, nil, e.output, e.stderr}.step(c, ctx)
 }
 
 type setToolsUpgradeAvailable struct{}
@@ -3815,7 +3818,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 	for _, format := range statusFormats {
 		code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", format.name)
 		c.Check(code, gc.Equals, 0)
-		c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+		c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 		stdout = substituteFakeTime(c, "since", stdout, false)
 		stdout = substituteFakeTime(c, "controller-timestamp", stdout, false)
@@ -3838,19 +3841,13 @@ func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 Model   Controller  Cloud/Region        Version  Notes               SLA
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-
-Unit  Workload  Agent  Machine  Public address  Ports  Message
-
-Machine  State  DNS  Inst id  Series  AZ  Message
-
 Controller Timestamp`[1:]
 
 	st := s.setupMigrationTest(c)
 	defer st.Close()
 	code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", "tabular")
-	c.Check(code, gc.Equals, 0)
-	c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 	_, output := popControllerTimestamp(c, string(stdout))
 	c.Assert(output, gc.Equals, expected)
@@ -3860,12 +3857,6 @@ func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
 Model   Controller  Cloud/Region        Version  Notes               SLA
 hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
-
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-
-Unit  Workload  Agent  Machine  Public address  Ports  Message
-
-Machine  State  DNS  Inst id  Series  AZ  Message
 
 Controller Timestamp`[1:]
 
@@ -3878,8 +3869,8 @@ Controller Timestamp`[1:]
 	c.Assert(err, jc.ErrorIsNil)
 
 	code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", "tabular")
-	c.Check(code, gc.Equals, 0)
-	c.Assert(stderr, gc.HasLen, 0, gc.Commentf("status failed: %s", stderr))
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 	_, output := popControllerTimestamp(c, string(stdout))
 	c.Assert(output, gc.Equals, expected)
@@ -4241,8 +4232,6 @@ Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
 foo/1  maintenance  executing                                  (backup database) doing some work
 
-Machine  State  DNS  Inst id  Series  AZ  Message
-
 Controller Timestamp
 %s`[1:], controllerTimestamp))
 }
@@ -4368,8 +4357,6 @@ foo/1
 Entity  Meter status  Message
 foo/0   strange       warning: stable strangelets  
 foo/1   up            things are looking up        
-
-Machine  State  DNS  Inst id  Series  AZ  Message
 
 Controller Timestamp
 %s`[1:], controllerTimestamp))
@@ -4823,8 +4810,8 @@ var statusTimeTest = test(
 
 	addAliveUnit{"dummy-application", "1"},
 	expect{
-		"add two units, one alive (in error state), one started",
-		M{
+		what: "add two units, one alive (in error state), one started",
+		output: M{
 			"model": M{
 				"name":       "controller",
 				"type":       "iaas",
@@ -5006,4 +4993,33 @@ func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
 	_, stdout, stderr := runStatus(c, "--format=yaml")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+}
+
+func (s *StatusSuite) TestStatusFormatTabularEmptyModel(c *gc.C) {
+	code, stdout, stderr := runStatus(c)
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "Model \"controller\" is empty.\n")
+	expected := `
+Model       Controller  Cloud/Region        Version  SLA
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported
+
+Controller Timestamp`[1:]
+	_, output := popControllerTimestamp(c, string(stdout))
+	c.Assert(output, gc.Equals, expected)
+}
+
+func (s *StatusSuite) TestStatusFormatTabularForUnmatchedFilter(c *gc.C) {
+	code, stdout, stderr := runStatus(c, "unmatched")
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "Nothing matched specified filter.\n")
+	expected := `
+Model       Controller  Cloud/Region        Version  SLA
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported
+
+Controller Timestamp`[1:]
+	_, output := popControllerTimestamp(c, string(stdout))
+	c.Assert(output, gc.Equals, expected)
+
+	_, _, stderr = runStatus(c, "cannot", "match", "me")
+	c.Check(string(stderr), gc.Equals, "Nothing matched specified filters.\n")
 }


### PR DESCRIPTION
## Description of change

Slightly adjusted forward port of https://github.com/juju/juju/pull/8727.
Differences here only cater CAAS models' output and additional timestamp. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1696245
https://bugs.launchpad.net/juju/+bug/1255786
https://bugs.launchpad.net/juju/+bug/1594883
