### PR TITLE
Query MaaS provider for DNS search domain info.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -39,7 +39,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	663f786f595ba1707f56f62f7f4f2284c47c0f1d	2017-12-05T12:16:38Z
+github.com/juju/gomaasapi	git	abe11904dd8cd40f0777b7704ae60348a876542e	2018-05-21T08:20:44Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	fb1dc7175251ac8e2dc460897313e05175cbbc0d	2016-11-07T14:02:50Z

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1051,7 +1051,11 @@ func (environ *maasEnviron) StartInstance(
 		if err != nil {
 			return nil, common.ZoneIndependentError(err)
 		}
-		interfaces, err = maas2NetworkInterfaces(ctx, startedInst, subnetsMap)
+		domains, err := environ.Domains(ctx)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		interfaces, err = maas2NetworkInterfaces(ctx, startedInst, subnetsMap, domains...)
 		if err != nil {
 			return nil, common.ZoneIndependentError(err)
 		}
@@ -2349,4 +2353,18 @@ func (*maasEnviron) SSHAddresses(ctx context.ProviderCallContext, addresses []ne
 // SuperSubnets implements environs.SuperSubnets
 func (*maasEnviron) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	return nil, errors.NotSupportedf("super subnets")
+}
+
+// Get the domains managed by MAAS. Currently we only need the name of the domain. If more information is needed
+// This function can be updated to parse and return a structure. Client code would need to be updated.
+func (env *maasEnviron) Domains(ctx context.ProviderCallContext) ([]string, error) {
+	maasDomains, err := env.maasController.Domains()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := []string{}
+	for _, domain := range maasDomains {
+		result = append(result, domain.Name())
+	}
+	return result, nil
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -43,6 +43,7 @@ func (suite *maas2EnvironSuite) getEnvWithServer(c *gc.C) (*maasEnviron, error) 
 	testServer := gomaasapi.NewSimpleServer()
 	testServer.AddGetResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
 	testServer.AddGetResponse("/api/2.0/users/?op=whoami", http.StatusOK, "{}")
+	testServer.AddGetResponse("/api/2.0/domains", http.StatusOK, maas2DomainsResponse)
 	// Weirdly, rather than returning a 404 when the version is
 	// unknown, MAAS2 returns some HTML (the login page).
 	testServer.AddGetResponse("/api/1.0/version/", http.StatusOK, "<html></html>")

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -63,6 +63,7 @@ type fakeController struct {
 	gomaasapi.Controller
 	*testing.Stub
 
+	domains            []gomaasapi.Domain
 	bootResources      []gomaasapi.BootResource
 	bootResourcesError error
 	machines           []gomaasapi.Machine
@@ -91,6 +92,9 @@ func newFakeController() *fakeController {
 		zones: []gomaasapi.Zone{
 			&fakeZone{name: "mossack"},
 			&fakeZone{name: "fonseca"},
+		},
+		domains: []gomaasapi.Domain{
+			&fakeDomain{},
 		},
 	}
 }
@@ -130,6 +134,10 @@ func (c *fakeController) Machines(args gomaasapi.MachinesArgs) ([]gomaasapi.Mach
 		return result, nil
 	}
 	return c.machines, nil
+}
+
+func (c *fakeController) Domains() ([]gomaasapi.Domain, error) {
+	return c.domains, nil
 }
 
 func (c *fakeController) AllocateMachine(args gomaasapi.AllocateMachineArgs) (gomaasapi.Machine, gomaasapi.ConstraintMatches, error) {
@@ -645,4 +653,10 @@ func (d *fakeDevice) Delete() error {
 		d.deleteCB()
 	}
 	return d.NextErr()
+}
+
+type fakeDomain struct{}
+
+func (*fakeDomain) Name() string {
+	return "maas"
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -36,6 +36,19 @@ import (
 
 const maas2VersionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`
 
+const maas2DomainsResponse = `
+[
+    {
+        "authoritative": "true",
+        "resource_uri": "/MAAS/api/2.0/domains/0/",
+        "name": "maas",
+        "id": 0,
+        "ttl": null,
+        "resource_record_count": 3
+    }
+]
+`
+
 type baseProviderSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	envtesting.ToolsFixture


### PR DESCRIPTION

## Description of change

Sometimes the fallback method of scraping the host for DNS config can fail on a MaaS provider. We should be querying the provider directly in the case of MaaS2.

## QA steps

1. Bootstrap a Xenial host on MaaS2.
2. SSH into the instance and remove the search domain from the DNS config.
3. Bootstrap a LXD container. The container should still get the appropriate search domain since it is querying MaaS directly and not querying the host MaaS node.

## Documentation changes

### Does it affect current user workflow? CLI? API?

No

### Does this change fix a bug?

https://bugs.launchpad.net/juju/+bug/1771885
