### PR TITLE
raft: Server IDs should be machine IDs not tags

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	coreraft "github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
@@ -264,7 +265,7 @@ func initRaft(agentConfig agent.Config) error {
 		Clock:      clock.WallClock,
 		StorageDir: raftDir,
 		Logger:     logger,
-		Tag:        agentConfig.Tag(),
+		LocalID:    coreraft.ServerID(agentConfig.Tag().Id()),
 	})
 }
 

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -94,7 +94,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		FSM:        config.FSM,
 		Logger:     config.Logger,
 		StorageDir: raftDir,
-		Tag:        agentConfig.Tag(),
+		LocalID:    raft.ServerID(agentConfig.Tag().Id()),
 		Transport:  transport,
 		Clock:      clk,
 	})

--- a/worker/raft/manifold_test.go
+++ b/worker/raft/manifold_test.go
@@ -126,7 +126,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		FSM:        s.fsm,
 		Logger:     s.logger,
 		StorageDir: filepath.Join(s.agent.conf.dataDir, "raft"),
-		Tag:        s.agent.conf.tag,
+		LocalID:    "99",
 		Transport:  s.transport,
 		Clock:      s.clock,
 	})

--- a/worker/raft/manifold_test.go
+++ b/worker/raft/manifold_test.go
@@ -55,7 +55,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.stub.ResetCalls()
 
 	_, transport := coreraft.NewInmemTransport(coreraft.ServerAddress(
-		s.agent.conf.tag.String(),
+		s.agent.conf.tag.Id(),
 	))
 	s.transport = transport
 	s.AddCleanup(func(c *gc.C) {

--- a/worker/raft/raftbackstop/manifold.go
+++ b/worker/raft/raftbackstop/manifold.go
@@ -50,7 +50,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		LogStore: logStore,
 		Hub:      hub,
 		Logger:   config.Logger,
-		Tag:      agent.CurrentConfig().Tag(),
+		LocalID:  raft.ServerID(agent.CurrentConfig().Tag().Id()),
 	})
 }
 

--- a/worker/raft/raftbackstop/manifold_test.go
+++ b/worker/raft/raftbackstop/manifold_test.go
@@ -117,7 +117,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		Raft:     s.raft,
 		Hub:      s.hub,
 		LogStore: s.logStore,
-		Tag:      names.NewMachineTag("3"),
+		LocalID:  "3",
 		Logger:   s.logger,
 	})
 }

--- a/worker/raft/raftbackstop/worker.go
+++ b/worker/raft/raftbackstop/worker.go
@@ -151,7 +151,8 @@ func (w *backstopWorker) maybeRecoverCluster(details apiserver.Details) error {
 	if len(details.Servers) != 1 {
 		return nil
 	}
-	if _, found := details.Servers[w.config.Tag.Id()]; !found {
+	machineId := w.config.Tag.Id()
+	if _, found := details.Servers[machineId]; !found {
 		return nil
 	}
 	if w.config.Raft.State() == raft.Leader {
@@ -164,7 +165,7 @@ func (w *backstopWorker) maybeRecoverCluster(details apiserver.Details) error {
 	}
 
 	numServers := len(raftServers)
-	localServer := raftServers[raft.ServerID(w.config.Tag.String())]
+	localServer := raftServers[raft.ServerID(machineId)]
 	if localServer == nil {
 		return nil
 	}

--- a/worker/raft/raftbackstop/worker_test.go
+++ b/worker/raft/raftbackstop/worker_test.go
@@ -43,7 +43,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		Raft:     s.raft,
 		LogStore: s.logStore,
 		Hub:      s.hub,
-		Tag:      tag,
+		LocalID:  "23",
 		Logger:   loggo.GetLogger("raftbackstop_test"),
 	}
 }
@@ -69,8 +69,8 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		func(cfg *raftbackstop.Config) { cfg.LogStore = nil },
 		"nil LogStore not valid",
 	}, {
-		func(cfg *raftbackstop.Config) { cfg.Tag = nil },
-		"nil Tag not valid",
+		func(cfg *raftbackstop.Config) { cfg.LocalID = "" },
+		"empty LocalID not valid",
 	}, {
 		func(cfg *raftbackstop.Config) { cfg.Logger = nil },
 		"nil Logger not valid",

--- a/worker/raft/raftbackstop/worker_test.go
+++ b/worker/raft/raftbackstop/worker_test.go
@@ -175,7 +175,7 @@ func (s *WorkerSuite) assertRecovery(c *gc.C, index, term uint64, server raft.Se
 func (s *WorkerSuite) TestRecoversClusterOneNonvoter(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-23",
+			ID:       "23",
 			Address:  "address",
 			Suffrage: raft.Nonvoter,
 		}},
@@ -187,7 +187,7 @@ func (s *WorkerSuite) TestRecoversClusterOneNonvoter(c *gc.C) {
 	})
 	s.publishDetails(c, map[string]string{"23": "address"})
 	s.assertRecovery(c, 452, 66, raft.Server{
-		ID:       "machine-23",
+		ID:       "23",
 		Address:  "address",
 		Suffrage: raft.Voter,
 	})
@@ -196,11 +196,11 @@ func (s *WorkerSuite) TestRecoversClusterOneNonvoter(c *gc.C) {
 func (s *WorkerSuite) TestRecoversClusterTwoVoters(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-23",
+			ID:       "23",
 			Address:  "address",
 			Suffrage: raft.Voter,
 		}, {
-			ID:       "machine-100",
+			ID:       "100",
 			Address:  "otheraddress",
 			Suffrage: raft.Voter,
 		}},
@@ -211,7 +211,7 @@ func (s *WorkerSuite) TestRecoversClusterTwoVoters(c *gc.C) {
 	})
 	s.publishDetails(c, map[string]string{"23": "address"})
 	s.assertRecovery(c, 452, 66, raft.Server{
-		ID:       "machine-23",
+		ID:       "23",
 		Address:  "address",
 		Suffrage: raft.Voter,
 	})
@@ -225,7 +225,7 @@ func (s *WorkerSuite) assertNoRecovery(c *gc.C) {
 func (s *WorkerSuite) TestOnlyRecoversClusterOnce(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-23",
+			ID:       "23",
 			Address:  "address",
 			Suffrage: raft.Nonvoter,
 		}},
@@ -237,7 +237,7 @@ func (s *WorkerSuite) TestOnlyRecoversClusterOnce(c *gc.C) {
 	})
 	s.publishDetails(c, map[string]string{"23": "address"})
 	s.assertRecovery(c, 452, 66, raft.Server{
-		ID:       "machine-23",
+		ID:       "23",
 		Address:  "address",
 		Suffrage: raft.Voter,
 	})
@@ -249,11 +249,11 @@ func (s *WorkerSuite) TestOnlyRecoversClusterOnce(c *gc.C) {
 func (s *WorkerSuite) TestNoRecoveryIfMultipleMachines(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-23",
+			ID:       "23",
 			Address:  "address",
 			Suffrage: raft.Voter,
 		}, {
-			ID:       "machine-100",
+			ID:       "100",
 			Address:  "otheraddress",
 			Suffrage: raft.Voter,
 		}},
@@ -272,11 +272,11 @@ func (s *WorkerSuite) TestNoRecoveryIfMultipleMachines(c *gc.C) {
 func (s *WorkerSuite) TestNoRecoveryIfNotInServerDetails(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-23",
+			ID:       "23",
 			Address:  "address",
 			Suffrage: raft.Voter,
 		}, {
-			ID:       "machine-100",
+			ID:       "100",
 			Address:  "otheraddress",
 			Suffrage: raft.Voter,
 		}},
@@ -292,7 +292,7 @@ func (s *WorkerSuite) TestNoRecoveryIfNotInServerDetails(c *gc.C) {
 func (s *WorkerSuite) TestNoRecoveryIfNotInRaftConfig(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-100",
+			ID:       "100",
 			Address:  "otheraddress",
 			Suffrage: raft.Voter,
 		}},
@@ -310,7 +310,7 @@ func (s *WorkerSuite) TestNoRecoveryIfNotInRaftConfig(c *gc.C) {
 func (s *WorkerSuite) TestNoRecoveryIfOneRaftNodeAndVoter(c *gc.C) {
 	s.raft.setValues(raft.Follower, &mockConfigFuture{conf: raft.Configuration{
 		Servers: []raft.Server{{
-			ID:       "machine-23",
+			ID:       "23",
 			Address:  "address",
 			Suffrage: raft.Voter,
 		}},

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/pubsub/apiserver"
@@ -124,8 +123,6 @@ func (w *Worker) getConfiguration() (map[raft.ServerID]*raft.Server, uint64, err
 	servers := make(map[raft.ServerID]*raft.Server)
 	config := future.Configuration()
 	for i := range config.Servers {
-		// Use a local var so we don't get all entries pointing to
-		// the loop variable.
 		server := config.Servers[i]
 		servers[server.ID] = &server
 	}
@@ -142,7 +139,7 @@ func (w *Worker) updateConfiguration(
 		if server.InternalAddress == "" {
 			continue
 		}
-		serverID := raft.ServerID(names.NewMachineTag(server.ID).String())
+		serverID := raft.ServerID(server.ID)
 		serverAddress := raft.ServerAddress(server.InternalAddress)
 		newServers[serverID] = serverAddress
 	}

--- a/worker/raft/raftflag/flag_test.go
+++ b/worker/raft/raftflag/flag_test.go
@@ -92,20 +92,17 @@ func (s *WorkerSuite) TestCheckLeader(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestErrRefresh(c *gc.C) {
-	raft1, _, transport1, _, _ := s.NewRaft(c, "machine-1", &raft.SimpleFSM{})
-	raft2, _, transport2, _, _ := s.NewRaft(c, "machine-2", &raft.SimpleFSM{})
+	raft1, _, transport1, _, _ := s.NewRaft(c, "1", &raft.SimpleFSM{})
+	raft2, _, transport2, _, _ := s.NewRaft(c, "2", &raft.SimpleFSM{})
 	transports := []coreraft.LoopbackTransport{s.Transport, transport1, transport2}
 	for _, t1 := range transports {
 		for _, t2 := range transports {
-			//if t1 == t2 {
-			//	continue
-			//}
 			t1.Connect(t2.LocalAddr(), t2)
 		}
 	}
-	var f coreraft.Future = s.Raft.AddVoter("machine-1", transport1.LocalAddr(), 0, 0)
+	var f coreraft.Future = s.Raft.AddVoter("1", transport1.LocalAddr(), 0, 0)
 	c.Assert(f.Error(), jc.ErrorIsNil)
-	f = s.Raft.AddVoter("machine-2", transport2.LocalAddr(), 0, 0)
+	f = s.Raft.AddVoter("2", transport2.LocalAddr(), 0, 0)
 	c.Assert(f.Error(), jc.ErrorIsNil)
 
 	// Start a new raftflag worker for the second raft.

--- a/worker/raft/rafttest/fixtures.go
+++ b/worker/raft/rafttest/fixtures.go
@@ -34,7 +34,7 @@ func (s *RaftFixture) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	c.Assert(s.FSM, gc.NotNil, gc.Commentf("FSM must be set by embedding test suite"))
 
-	s.Raft, s.Config, s.Transport, s.Store, s.SnapshotStore = s.NewRaft(c, "machine-0", s.FSM)
+	s.Raft, s.Config, s.Transport, s.Store, s.SnapshotStore = s.NewRaft(c, "0", s.FSM)
 	c.Assert(s.Raft.BootstrapCluster(raft.Configuration{
 		Servers: []raft.Server{{
 			ID:      s.Config.LocalID,

--- a/worker/raft/rafttransport/manifold.go
+++ b/worker/raft/rafttransport/manifold.go
@@ -122,7 +122,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		Hub:           hub,
 		Mux:           mux,
 		Path:          config.Path,
-		Tag:           agent.CurrentConfig().Tag(),
+		LocalID:       raft.ServerID(agent.CurrentConfig().Tag().Id()),
 		TLSConfig:     api.NewTLSConfig(certPool),
 		Clock:         clk,
 	})

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -147,7 +147,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		Mux:           s.mux,
 		Authenticator: s.auth,
 		Path:          "raft/path",
-		Tag:           s.agent.conf.tag,
+		LocalID:       "123",
 		Clock:         s.clock,
 	})
 }

--- a/worker/raft/rafttransport/worker.go
+++ b/worker/raft/rafttransport/worker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/pubsub"
 	"github.com/juju/replicaset"
 	"github.com/juju/utils/clock"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api"
@@ -61,8 +60,8 @@ type Config struct {
 	// Path is the path of the raft HTTP endpoint.
 	Path string
 
-	// Tag is the tag of the agent running this worker.
-	Tag names.Tag
+	// LocalID is the raft.ServerID of the agent running this worker.
+	LocalID raft.ServerID
 
 	// Timeout, if non-zero, is the timeout to apply to transport
 	// operations. See raft.NetworkTransportConfig.Timeout for more
@@ -104,8 +103,8 @@ func (config Config) Validate() error {
 	if config.Path == "" {
 		return errors.NotValidf("empty Path")
 	}
-	if config.Tag == nil {
-		return errors.NotValidf("nil Tag")
+	if config.LocalID == "" {
+		return errors.NotValidf("empty LocalID")
 	}
 	if config.TLSConfig == nil {
 		return errors.NotValidf("nil TLSConfig")
@@ -136,7 +135,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 	const logPrefix = "[transport] "
 	logWriter := &raftutil.LoggoWriter{logger, loggo.DEBUG}
 	logLogger := log.New(logWriter, logPrefix, 0)
-	stream, err := newStreamLayer(config.Tag, config.Hub, w.connections, config.Clock, &Dialer{
+	stream, err := newStreamLayer(config.LocalID, config.Hub, w.connections, config.Clock, &Dialer{
 		APIInfo: config.APIInfo,
 		DialRaw: w.dialRaw,
 		Path:    config.Path,

--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -197,7 +197,7 @@ func (s *WorkerSuite) newWorker(c *gc.C, config rafttransport.Config) *rafttrans
 func (s *WorkerSuite) requestVote(t raft.Transport) (raft.RequestVoteResponse, error) {
 	var resp raft.RequestVoteResponse
 	req := &raft.RequestVoteRequest{}
-	serverID := raft.ServerID("machine-123")
+	serverID := raft.ServerID("123")
 	serverAddress := raft.ServerAddress(s.server.Listener.Addr().String())
 	return resp, t.RequestVote(serverID, serverAddress, req, &resp)
 }
@@ -256,7 +256,7 @@ func (s *WorkerSuite) TestTransportTimeout(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	var resp raft.RequestVoteResponse
 	req := &raft.RequestVoteRequest{}
-	serverID := raft.ServerID("machine-123")
+	serverID := raft.ServerID("123")
 	serverAddress := raft.ServerAddress(noAcceptListener.Addr().String())
 	_, err = resp, worker.RequestVote(serverID, serverAddress, req, &resp)
 

--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -54,7 +54,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		Mux:           apiserverhttp.NewMux(),
 		Authenticator: &mockAuthenticator{auth: s.auth},
 		Path:          "/raft/path",
-		Tag:           tag,
+		LocalID:       "123",
 		Timeout:       coretesting.LongWait,
 		TLSConfig:     &tls.Config{},
 		Clock:         s.clock,
@@ -116,8 +116,8 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		func(cfg *rafttransport.Config) { cfg.Path = "" },
 		"empty Path not valid",
 	}, {
-		func(cfg *rafttransport.Config) { cfg.Tag = nil },
-		"nil Tag not valid",
+		func(cfg *rafttransport.Config) { cfg.LocalID = "" },
+		"empty LocalID not valid",
 	}, {
 		func(cfg *rafttransport.Config) { cfg.TLSConfig = nil },
 		"nil TLSConfig not valid",

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -171,7 +171,7 @@ func Bootstrap(config Config) error {
 
 	// During bootstrap we use an in-memory transport. We just need
 	// to make sure we use the same local address as we'll use later.
-	localID := raft.ServerID(config.Tag.String())
+	localID := raft.ServerID(config.Tag.Id())
 	_, transport := raft.NewInmemTransport(bootstrapAddress)
 	defer transport.Close()
 	config.Transport = transport
@@ -371,7 +371,7 @@ func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 
 func newRaftConfig(config Config) (*raft.Config, error) {
 	raftConfig := raft.DefaultConfig()
-	raftConfig.LocalID = raft.ServerID(config.Tag.String())
+	raftConfig.LocalID = raft.ServerID(config.Tag.Id())
 	// Having ShutdownOnRemove true means that the raft node also
 	// stops when it's demoted if it's the leader.
 	raftConfig.ShutdownOnRemove = false

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -13,7 +13,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/raft"
@@ -35,7 +34,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		FSM:        s.fsm,
 		Logger:     loggo.GetLogger("juju.worker.raft_test"),
 		StorageDir: c.MkDir(),
-		Tag:        names.NewMachineTag("123"),
+		LocalID:    "123",
 		Transport:  s.newTransport("123"),
 		Clock:      testing.NewClock(time.Time{}),
 	}
@@ -70,8 +69,8 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		func(cfg *raft.Config) { cfg.StorageDir = "" },
 		"empty StorageDir not valid",
 	}, {
-		func(cfg *raft.Config) { cfg.Tag = nil },
-		"nil Tag not valid",
+		func(cfg *raft.Config) { cfg.LocalID = "" },
+		"empty LocalID not valid",
 	}, {
 		func(cfg *raft.Config) { cfg.HeartbeatTimeout = time.Millisecond },
 		"validating raft config: Heartbeat timeout is too low",

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -36,7 +36,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		Logger:     loggo.GetLogger("juju.worker.raft_test"),
 		StorageDir: c.MkDir(),
 		Tag:        names.NewMachineTag("123"),
-		Transport:  s.newTransport("machine-123"),
+		Transport:  s.newTransport("123"),
 		Clock:      testing.NewClock(time.Time{}),
 	}
 }
@@ -174,7 +174,7 @@ func (s *WorkerSuite) TestBootstrapAddress(c *gc.C) {
 	c.Assert(f.Error(), jc.ErrorIsNil)
 	c.Assert(f.Configuration().Servers, jc.DeepEquals, []coreraft.Server{{
 		Suffrage: coreraft.Voter,
-		ID:       "machine-123",
+		ID:       "123",
 		Address:  "localhost",
 	}})
 }
@@ -283,31 +283,31 @@ func (s *WorkerSuite) TestNoLeaderTimeout(c *gc.C) {
 	// leader by adding 2 more nodes, demoting the local one so that
 	// it isn't the leader, then stopping the other nodes.
 	transport0 := s.config.Transport.(coreraft.LoopbackTransport)
-	raft1, transport1 := s.newRaft(c, "machine-1")
-	raft2, transport2 := s.newRaft(c, "machine-2")
+	raft1, transport1 := s.newRaft(c, "1")
+	raft2, transport2 := s.newRaft(c, "2")
 	connectTransports(transport0, transport1, transport2)
 
 	raft0 := s.waitLeader(c)
-	f1 := raft0.AddVoter("machine-1", transport1.LocalAddr(), 0, 0)
-	f2 := raft0.AddVoter("machine-2", transport2.LocalAddr(), 0, 0)
+	f1 := raft0.AddVoter("1", transport1.LocalAddr(), 0, 0)
+	f2 := raft0.AddVoter("2", transport2.LocalAddr(), 0, 0)
 	c.Assert(f1.Error(), jc.ErrorIsNil)
 	c.Assert(f2.Error(), jc.ErrorIsNil)
 
 	rafttest.CheckConfiguration(c, raft0, []coreraft.Server{{
-		ID:       "machine-123",
+		ID:       "123",
 		Address:  coreraft.ServerAddress("localhost"),
 		Suffrage: coreraft.Voter,
 	}, {
-		ID:       "machine-1",
+		ID:       "1",
 		Address:  transport1.LocalAddr(),
 		Suffrage: coreraft.Voter,
 	}, {
-		ID:       "machine-2",
+		ID:       "2",
 		Address:  transport2.LocalAddr(),
 		Suffrage: coreraft.Voter,
 	}})
 
-	f3 := raft0.DemoteVoter("machine-123", 0, 0)
+	f3 := raft0.DemoteVoter("123", 0, 0)
 	c.Assert(f3.Error(), jc.ErrorIsNil)
 
 	// Wait until raft0 isn't the leader anymore.


### PR DESCRIPTION
## Description of change
Nothing other than a machine can be a raft node, and it better matches the information the peer grouper is emitting. Tags are supposed to be used as a serialisation mechanism, not exposed.

Also change the tag field in worker config structs into a raft.ServerID called LocalID.

## QA steps

Bootstrap a controller and enable HA. Use `juju-engine-report` to check that the raft configuration in all controllers lists machine IDs with no `machine-` prefix, and that they all agree on who the leader is. Run all the corrected tests.
