### PR TITLE
Fix for Windows Test Failures due to Local LXD Socket Connection

### DIFF
--- a/container/factory/factory.go
+++ b/container/factory/factory.go
@@ -19,7 +19,7 @@ import (
 func NewContainerManager(forType instance.ContainerType, conf container.ManagerConfig) (container.Manager, error) {
 	switch forType {
 	case instance.LXD:
-		svr, err := lxd.ConnectLocal()
+		svr, err := lxd.NewLocalServer()
 		if err != nil {
 			return nil, errors.Annotate(err, "creating LXD container manager")
 		}

--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -32,3 +32,8 @@ func (ci *containerInitialiser) Initialise() error {
 func ConfigureLXDProxies(proxies proxy.Settings) error {
 	return nil
 }
+
+// NewLocalServer returns a nil Server.
+func NewLocalServer() (*Server, error) {
+	return nil, nil
+}

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -517,3 +517,12 @@ func bridgeConfiguration(input string) (string, error) {
 	}
 	return input, nil
 }
+
+// NewLocalServer returns a Server based on a local socket connection.
+func NewLocalServer() (*Server, error) {
+	cSvr, err := ConnectLocal()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return NewServer(cSvr), nil
+}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujuarch "github.com/juju/utils/arch"
-	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -54,7 +53,7 @@ var _ container.Manager = (*containerManager)(nil)
 // LXD containers.
 // TODO(jam): This needs to grow support for things like LXC's ImageURLGetter
 // functionality.
-func NewContainerManager(cfg container.ManagerConfig, cSvr lxd.ContainerServer) (container.Manager, error) {
+func NewContainerManager(cfg container.ManagerConfig, svr *Server) (container.Manager, error) {
 	modelUUID := cfg.PopValue(container.ConfigModelUUID)
 	if modelUUID == "" {
 		return nil, errors.Errorf("model UUID is required")
@@ -74,7 +73,7 @@ func NewContainerManager(cfg container.ManagerConfig, cSvr lxd.ContainerServer) 
 
 	cfg.WarnAboutUnused()
 	return &containerManager{
-		server:           NewServer(cSvr),
+		server:           svr,
 		modelUUID:        modelUUID,
 		namespace:        namespace,
 		availabilityZone: availabilityZone,
@@ -146,7 +145,7 @@ func (m *containerManager) ListContainers() (result []instance.Instance, err err
 
 // IsInitialized implements container.Manager.
 func (m *containerManager) IsInitialized() bool {
-	return m.server.ContainerServer != nil
+	return m.server != nil
 }
 
 // startContainer starts previously created container.

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -51,7 +51,7 @@ func (t *LxdSuite) makeManager(c *gc.C, svr lxdclient.ContainerServer) container
 func (t *LxdSuite) makeManagerForConfig(
 	c *gc.C, cfg container.ManagerConfig, svr lxdclient.ContainerServer,
 ) container.Manager {
-	manager, err := lxd.NewContainerManager(cfg, svr)
+	manager, err := lxd.NewContainerManager(cfg, lxd.NewServer(svr))
 	c.Assert(err, jc.ErrorIsNil)
 	return manager
 }


### PR DESCRIPTION
## Description of change

A previous patch modified the container manager factory to establish a local socket connection to LXD prior to manager instantiation.

Before that patch, the behaviour was to check for this connection at the top of each method in the manager.

The effect of this early instantiation is to cause an error on Windows due to the early attempted use of a Unix socket:
http://10.125.0.203:8080/view/Unit%20Tests/job/RunUnittests-win2012/lastCompletedBuild/testReport/github/com_juju_juju_cmd_jujud_reboot/TestAll/

This patch ensures that the factory supplies a nil server to the LXD container manager on Windows instead of attempting a socket connection. The manager's ```IsInitialized()``` call will always return false in the scenario. 

## QA steps

Unit tests passing for container, lxdclient and provider.
Bootstrapping to LXD and deploying to LXD container machines continues to work on Linux.
