### PR TITLE
2.3 into develop

### DIFF
--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -15,10 +15,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/juju/paths"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/proxyupdater"
 )
@@ -63,9 +61,7 @@ type AgentSuite struct {
 func (s *AgentSuite) SetUpSuite(c *gc.C) {
 	s.JujuConnSuite.SetUpSuite(c)
 
-	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
-		return nil
-	})
+	agenttest.InstallFakeEnsureMongo(s)
 }
 
 func (s *AgentSuite) SetUpTest(c *gc.C) {

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	"github.com/juju/replicaset"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -81,7 +82,7 @@ func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error
 	}, nil
 }
 
-func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
+func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) (mongo.Version, error) {
 	f.EnsureCount++
 	f.DataDir, f.OplogSize = args.DataDir, args.OplogSize
 	f.Info = state.StateServingInfo{
@@ -93,7 +94,15 @@ func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
 		SharedSecret:   args.SharedSecret,
 		SystemIdentity: args.SystemIdentity,
 	}
-	return f.Err
+	v, err := gitjujutesting.MongodVersion()
+	if err != nil {
+		return mongo.Version{}, errors.Trace(err)
+	}
+	return mongo.Version{
+		Major: v.Major,
+		Minor: v.Minor,
+		Patch: fmt.Sprint(v.Patch),
+	}, f.Err
 }
 
 func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams) error {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1031,19 +1031,15 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
+	var mongodVersion mongo.Version
+	if mongodVersion, err = cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
 		return err
 	}
 	logger.Debugf("mongodb service is installed")
 
 	// Mongo is installed, record the version.
 	err = a.ChangeConfig(func(config agent.ConfigSetter) error {
-		finder := mongo.NewMongodFinder()
-		_, version, err := finder.FindBest()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		config.SetMongoVersion(version)
+		config.SetMongoVersion(mongodVersion)
 		return nil
 	})
 	if err != nil {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -368,7 +368,7 @@ func (c *BootstrapCommand) startMongo(addrs []network.Address, agentConfig agent
 	if err != nil {
 		return err
 	}
-	err = cmdutil.EnsureMongoServer(ensureServerParams)
+	_, err = cmdutil.EnsureMongoServer(ensureServerParams)
 	if err != nil {
 		return err
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -59,7 +59,7 @@ github.com/juju/rfc	git	ebdbbdb950cd039a531d15cdc2ac2cbd94f068ee	2016-07-11T02:4
 github.com/juju/romulus	git	5b6f449d5c36ed6927c417c68379ab5acb7d7b46	2018-03-27T20:54:18Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
-github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
+github.com/juju/testing	git	72703b1e95eb8ce4737fd8a3d8496c6b0be280a6	2018-05-17T13:41:05Z
 github.com/juju/txn	git	f50b17d1ff3c31b7ea1c70e0d38a83f19af6d334	2018-04-06T04:58:51Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	2000ea4ff0431598aec2b7e1d11d5d49b5384d63	2018-04-24T09:41:59Z

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 	coretesting "github.com/juju/juju/testing"
@@ -90,10 +89,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 		}
 	}()
 
-	// TODO(mjs) - the following should maybe be part of AgentSuite.SetUpTest()
-	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
-		return nil
-	})
+	agenttest.InstallFakeEnsureMongo(s)
 	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 
 }

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -44,7 +44,7 @@ func PatchService(patchValue func(interface{}, interface{}), data *svctesting.Fa
 	})
 }
 
-func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
+func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) (Version, error) {
 	return ensureServer(args, sysctlFiles)
 }
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -247,7 +247,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsAndRunning(c *gc.C) {
 	s.data.SetStatus(mongo.ServiceName, "running")
 	s.data.SetErrors(nil, nil, nil, errors.New("shouldn't be called"))
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// These should still be written out even if the service was installed.
@@ -278,7 +278,7 @@ func (s *MongoSuite) TestEnsureServerSetsSysctlValues(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "original value")
 
-	err = mongo.SysctlEditableEnsureServer(makeEnsureServerParams(dataDir),
+	_, err = mongo.SysctlEditableEnsureServer(makeEnsureServerParams(dataDir),
 		map[string]string{dataFilePath: "new value"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -296,7 +296,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsNotRunningIsStarted(c *gc.C) {
 
 	s.data.SetStatus(mongo.ServiceName, "installed")
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// These should still be written out even if the service was installed.
@@ -319,7 +319,7 @@ func (s *MongoSuite) TestEnsureServerServerExistsNotRunningStartError(c *gc.C) {
 	failure := errors.New("won't start")
 	s.data.SetErrors(nil, nil, nil, failure) // Installed, Exists, Running, Running, Start
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	c.Check(s.data.Installed(), gc.HasLen, 0)
@@ -340,7 +340,7 @@ func (s *MongoSuite) testEnsureServerNUMACtl(c *gc.C, setNUMAPolicy bool) string
 
 	testParams := makeEnsureServerParams(dataDir)
 	testParams.SetNUMAControlPolicy = setNUMAPolicy
-	err = mongo.EnsureServer(testParams)
+	_, err = mongo.EnsureServer(testParams)
 	c.Assert(err, jc.ErrorIsNil)
 
 	testJournalDirs(dbDir, c)
@@ -383,7 +383,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 		c.Logf("install for series %v", test.series)
 		dataDir := c.MkDir()
 		s.patchSeries(test.series)
-		err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+		_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 		c.Assert(err, jc.ErrorIsNil)
 
 		for _, cmd := range test.cmd {
@@ -443,7 +443,7 @@ func (s *MongoSuite) TestInstallMongodFallsBack(c *gc.C) {
 	for _, test := range tests {
 		c.Logf("Testing mongo install for series: %s", test.series)
 		s.patchSeries(test.series)
-		err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+		_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 		c.Assert(err, jc.ErrorIsNil)
 
 		args, err := ioutil.ReadFile(outputFile)
@@ -521,7 +521,7 @@ func (s *MongoSuite) assertSuccessWithInstallStepFailCentOS(c *gc.C, exec []stri
 	c.Assert(loggo.RegisterWriter("mongosuite", &tw), jc.ErrorIsNil)
 	defer loggo.RemoveWriter("mongosuite")
 
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tw.Log(), jc.LogMatches, expectedResult)
 }
@@ -542,7 +542,7 @@ func (s *MongoSuite) TestInstallSuccessMongodCentOS(c *gc.C) {
 	dataDir := c.MkDir()
 	s.patchSeries(test.series)
 
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := append(expectedArgs.YumBase, "epel-release")
@@ -581,7 +581,7 @@ func (s *MongoSuite) assertTestMongoGetFails(c *gc.C, series string, packageMana
 	defer loggo.RemoveWriter("test-writer")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 
 	// Even though apt-get failed, EnsureServer should continue and
 	// not return the error - even though apt-get failed, the Juju
@@ -613,7 +613,7 @@ func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 	s.data.SetStatus(mongo.ServiceName, "running")
 	s.data.SetErrors(nil, nil, nil, errors.New("shouldn't be called"))
 
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.data.Installed(), gc.HasLen, 0)
@@ -674,7 +674,7 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 	testing.PatchExecutableAsEchoArgs(c, s, pm.PackageManager)
 
 	dataDir := filepath.Join(c.MkDir(), "dir", "data")
-	err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err = mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Check(err, jc.ErrorIsNil)
 
 	_, err = os.Stat(filepath.Join(dataDir, "db"))
@@ -718,7 +718,7 @@ func (s *MongoSuite) TestAddEpelInCentOS(c *gc.C) {
 	testing.PatchExecutableAsEchoArgs(c, s, "yum-config-manager")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+	_, err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedEpelRelease := append(expectedArgs.YumBase, "epel-release")


### PR DESCRIPTION
## Description of change

Merge 2.3 into develop, including the Mongo changes and resolving any small issue with the double ported status changes.

This includes these new patches:

 * Merge pull request #8718 from jameinel/2.3-mongodb-version

And these patches that were independently directly merged into develop:

 * Merge pull request #8727 from anastasiamac/empty-status-friendly-msg
 * Merge pull request #8724 from anastasiamac/status-machine-filter-tests-23
 * Merge pull request #8717 from anastasiamac/multi-relations-status-test


## QA steps

See individual patches.

## Documentation changes

See individual changes

## Bug reference

None.
