### PR TITLE
2.3 Fixes Container Machines on Xenial with LXD Updated from Backports

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	NICDevice       = nicDevice
-	NetworkDevices  = networkDevices
-	GetImageSources = func(mgr container.Manager) ([]lxdclient.Remote, error) {
+	NewNicDevice             = newNICDevice
+	NetworkDevicesFromConfig = networkDevicesFromConfig
+	GetImageSources          = func(mgr container.Manager) ([]lxdclient.Remote, error) {
 		return mgr.(*containerManager).getImageSources()
 	}
 )

--- a/tools/lxdclient/client_network.go
+++ b/tools/lxdclient/client_network.go
@@ -14,9 +14,12 @@ import (
 	"github.com/juju/juju/network"
 )
 
+var errNotSupported = errors.NotSupportedf("network API not supported on this remote")
+
 type rawNetworkClient interface {
 	NetworkCreate(name string, config map[string]string) error
 	NetworkGet(name string) (api.Network, error)
+	NetworkPut(name string, network api.NetworkPut) error
 }
 
 type networkClient struct {
@@ -27,19 +30,25 @@ type networkClient struct {
 // NetworkCreate creates the specified network.
 func (c *networkClient) NetworkCreate(name string, config map[string]string) error {
 	if !c.supported {
-		return errors.NotSupportedf("network API not supported on this remote")
+		return errNotSupported
 	}
-
 	return c.raw.NetworkCreate(name, config)
 }
 
 // NetworkGet returns the specified network's configuration.
 func (c *networkClient) NetworkGet(name string) (api.Network, error) {
 	if !c.supported {
-		return api.Network{}, errors.NotSupportedf("network API not supported on this remote")
+		return api.Network{}, errNotSupported
 	}
-
 	return c.raw.NetworkGet(name)
+}
+
+// NetworkPut updates a network's configuration
+func (c *networkClient) NetworkPut(name string, network api.NetworkPut) error {
+	if !c.supported {
+		return errNotSupported
+	}
+	return c.raw.NetworkPut(name, network)
 }
 
 type creator interface {


### PR DESCRIPTION
## Description of change

On a Xenial machine, if LXD is updated from backports, the default bridge (lxdbr0) is created without any network configuration.

This situation can be detected in the network configuration passed to the call to _CreateContainer_. It is indicated by the presence of a network device with no CIDR.

If this situation is detected, and if it applies specifically to the default bridge, then an attempt will be made to configure the bridge's IPv4 address as "auto".

If there are multiple networks with no CIDR, if the network is not the default bridge, or if the LXD network API is not available, no action is taken. Instead a warning is logged indicating that the operator should intervene.

## QA steps

- Modified unit tests for generating network devices from config.
- System tests for:
  - Normal bootstrap, create machine and deployment to container machines.
  - Bootstrap create machine, upgrade LXD from backports and deployment to container machines.

## Documentation changes

No.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1668547