### PR TITLE
Ensure caas units are removed when model is destroyed

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -173,6 +173,22 @@ func (c *Client) WatchUnits(application string) (watcher.StringsWatcher, error) 
 	return w, nil
 }
 
+// RemoveUnit removes the specified unit from the current model.
+func (c *Client) RemoveUnit(unitName string) error {
+	if !names.IsValidUnit(unitName) {
+		return errors.NotValidf("unit name %q", unitName)
+	}
+	var result params.ErrorResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: names.NewUnitTag(unitName).String()}},
+	}
+	err := c.facade.FacadeCall("Remove", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}
+
 // Life returns the lifecycle state for the specified CAAS application
 // or unit in the current model.
 func (c *Client) Life(entityName string) (life.Value, error) {

--- a/api/caasoperator/client_test.go
+++ b/api/caasoperator/client_test.go
@@ -194,6 +194,42 @@ func (s *operatorSuite) TestWatchUnits(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
+func (s *operatorSuite) TestRemoveUnit(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASOperator")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "Remove")
+		c.Check(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: "unit-gitlab-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		called = true
+		return nil
+	})
+
+	client := caasoperator.NewClient(apiCaller)
+	err := client.RemoveUnit("gitlab/0")
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *operatorSuite) TestRemoveUnitInvalidUnitame(c *gc.C) {
+	client := caasoperator.NewClient(basetesting.APICallerFunc(func(_ string, _ int, _, _ string, _, _ interface{}) error {
+		return errors.New("should not be called")
+	}))
+	err := client.RemoveUnit("")
+	c.Assert(err, gc.ErrorMatches, `unit name "" not valid`)
+}
+
 func (s *operatorSuite) TestLife(c *gc.C) {
 	s.testLife(c, names.NewApplicationTag("gitlab"))
 	s.testLife(c, names.NewUnitTag("gitlab/0"))

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -160,6 +160,16 @@ func (u *mockUnit) Life() state.Life {
 	return u.life
 }
 
+func (u *mockUnit) Remove() error {
+	u.MethodCall(u, "Remove")
+	return nil
+}
+
+func (u *mockUnit) EnsureDead() error {
+	u.MethodCall(u, "EnsureDead")
+	return nil
+}
+
 type mockCharm struct {
 	url    *charm.URL
 	sha256 string

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -22,6 +22,7 @@ type Facade struct {
 	state     CAASOperatorState
 	*common.LifeGetter
 	*common.AgentEntityWatcher
+	*common.Remover
 
 	model Model
 }
@@ -50,9 +51,11 @@ func NewFacade(
 		common.AuthFuncForTagKind(names.ApplicationTagKind),
 		common.AuthFuncForTagKind(names.UnitTagKind),
 	)
+	canWrite := canRead
 	return &Facade{
 		LifeGetter:         common.NewLifeGetter(st, canRead),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, resources, canRead),
+		Remover:            common.NewRemover(st, true, canWrite),
 		auth:               authorizer,
 		resources:          resources,
 		state:              st,

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -172,6 +172,26 @@ func (s *CAASOperatorSuite) TestLife(c *gc.C) {
 	})
 }
 
+func (s *CAASOperatorSuite) TestRemove(c *gc.C) {
+	results, err := s.facade.Remove(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "unit-gitlab-0"},
+			{Tag: "machine-0"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{
+				Error: &params.Error{
+					Code:    "unauthorized access",
+					Message: "permission denied",
+				},
+			}},
+	})
+}
+
 func (s *CAASOperatorSuite) TestSetPodSpec(c *gc.C) {
 	validSpecStr := `
 containers:

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -72,14 +73,34 @@ func (s *CAASModelSuite) TestNewModel(c *gc.C) {
 	c.Assert(model.CloudRegion(), gc.Equals, "")
 }
 
-func (s *CAASModelSuite) TestModelDestroy(c *gc.C) {
+func (s *CAASModelSuite) TestDestroyEmptyModel(c *gc.C) {
 	model, _ := s.newCAASModel(c)
 	err := model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = model.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(caas) - this will be dying when we add cleanup steps.
 	c.Assert(model.Life(), gc.Equals, state.Dead)
+}
+
+func (s *CAASModelSuite) TestDestroyModel(c *gc.C) {
+	model, st := s.newCAASModel(c)
+
+	app := factory.NewFactory(st).MakeApplication(c, nil)
+	unit, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = model.Destroy(state.DestroyModelParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dying)
+
+	assertCleanupCount(c, st, 2)
+	err = app.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	err = unit.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	assertDoesNotNeedCleanup(c, st)
 }
 
 func (s *CAASModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {

--- a/state/model.go
+++ b/state/model.go
@@ -1268,7 +1268,8 @@ func (m *Model) destroyOps(
 		ops = append(ops,
 			newCleanupOp(cleanupApplicationsForDyingModel, modelUUID),
 		)
-		if m.Type() == ModelTypeIAAS {
+		switch m.Type() {
+		case ModelTypeIAAS:
 			ops = append(ops, newCleanupOp(cleanupMachinesForDyingModel, modelUUID))
 			if args.DestroyStorage != nil {
 				// The user has specified that the storage should be destroyed
@@ -1283,6 +1284,8 @@ func (m *Model) destroyOps(
 					*args.DestroyStorage,
 				))
 			}
+		case ModelTypeCAAS:
+			ops = append(ops, newCleanupOp(cleanupUnitsForDyingModel, modelUUID))
 		}
 	}
 	return append(prereqOps, ops...), nil

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -304,6 +304,7 @@ func (ru *RelationUnit) LeaveScope() error {
 	// Destroy changes the Life attribute in memory (units could join before
 	// the database is actually changed).
 	desc := fmt.Sprintf("unit %q in relation %q", ru.unitName, ru.relation)
+	logger.Debugf("%v leaving scope", desc)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := ru.relation.Refresh(); errors.IsNotFound(err) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -543,15 +543,13 @@ func (u *Unit) destroyOps(destroyStorage bool) ([]txn.Op, error) {
 	} else if agentErr != nil {
 		return nil, errors.Trace(agentErr)
 	}
-	if isAssigned && agentStatusInfo.Status != status.Allocating {
+	if (isAssigned || !shouldBeAssigned) && agentStatusInfo.Status != status.Allocating {
 		return setDyingOps, nil
 	}
-	if shouldBeAssigned {
-		switch agentStatusInfo.Status {
-		case status.Error, status.Allocating, status.Running:
-		default:
-			return nil, errors.Errorf("unexpected unit state - unit with status %v is not assigned to a machine", agentStatusInfo.Status)
-		}
+	switch agentStatusInfo.Status {
+	case status.Error, status.Allocating:
+	default:
+		return nil, errors.Errorf("unexpected unit state - unit with status %v is not deployed", agentStatusInfo.Status)
 	}
 
 	statusOp := txn.Op{

--- a/worker/caasfirewaller/application_worker.go
+++ b/worker/caasfirewaller/application_worker.go
@@ -4,6 +4,8 @@
 package caasfirewaller
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
 
@@ -76,6 +78,9 @@ func (w *applicationWorker) loop() (err error) {
 				return errors.New("application watcher closed")
 			}
 			if err := w.processApplicationChange(); err != nil {
+				if strings.Contains(err.Error(), "unexpected EOF") {
+					return nil
+				}
 				return errors.Trace(err)
 			}
 		}

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -17,6 +17,7 @@ import (
 type Client interface {
 	CharmGetter
 	UnitGetter
+	UnitRemover
 	ApplicationWatcher
 	PodSpecSetter
 	StatusSetter
@@ -37,6 +38,12 @@ type CharmGetter interface {
 type UnitGetter interface {
 	WatchUnits(string) (watcher.StringsWatcher, error)
 	Life(string) (life.Value, error)
+}
+
+// UnitRemover provides an interface for
+// removing a unit.
+type UnitRemover interface {
+	RemoveUnit(string) error
 }
 
 // ApplicationWatcher provides an interface watching

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -149,6 +149,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Downloader:         downloader,
 				StatusSetter:       client,
 				UnitGetter:         client,
+				UnitRemover:        client,
 				ApplicationWatcher: client,
 				StartUniterFunc:    uniter.StartUniter,
 

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -154,6 +154,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		Downloader:         &s.charmDownloader,
 		StatusSetter:       &s.client,
 		UnitGetter:         &s.client,
+		UnitRemover:        &s.client,
 		ApplicationWatcher: &s.client,
 		UniterParams: &uniter.UniterParams{
 			DataDir:         s.dataDir,

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -5,6 +5,7 @@ package caasunitprovisioner
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -118,6 +119,10 @@ func (aw *applicationWorker) loop() error {
 		if brokerUnitsWatcher == nil {
 			brokerUnitsWatcher, err = aw.containerBroker.WatchUnits(aw.application)
 			if err != nil {
+				if strings.Contains(err.Error(), "unexpected EOF") {
+					logger.Warningf("k8s cloud hosting %q has disappeared", aw.application)
+					return nil
+				}
 				return errors.Annotatef(err, "failed to start unit watcher for %q", aw.application)
 			}
 		}


### PR DESCRIPTION
## Description of change

This PR has 2 commits.

Commit 1
Destroying a CAAS model was not removing the units, and hence the application would stick around and prevent the model destroy from completing. For IAAS models, unit removal is done in the machine cleanup operation. CAAS models don't have machines so add a new unit cleanup operation. The unit tests missed this because no units were added in the caas tests.

As a driveby, remove some log spam from the caas unit provisoner and firewaller workers. If the k8s cloud disappears, we get an EOF and don't want to continually spam the logs with that.

Commit 2
Units destroyed individually were going to dead but were not being removed by the CAAS operator. The CAAS operator now removes the units and also any local files of that unit.

As a driveby, the unit test for upgrade charm was broken and when fixed, highlighted a problem in the operator which was also fixed.

## QA steps

deploy and relate some caas charms
juju destroy-model and ensure it completes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1772179
