### PR TITLE
Fixes lp#1684718: unassigned units erred when status filtering was used.

### DIFF
--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -186,6 +186,9 @@ func unitMatchExposure(u *state.Unit, patterns []string) (bool, bool, error) {
 func unitMatchPort(u *state.Unit, patterns []string) (bool, bool, error) {
 	portRanges, err := u.OpenedPorts()
 	if err != nil {
+		if errors.IsNotAssigned(err) {
+			return false, false, nil
+		}
 		return false, false, err
 	}
 	return matchPortRanges(patterns, portRanges...)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -312,6 +312,7 @@ func getModelMessage(model modelStatus) string {
 
 func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
 	w := output.Wrapper{tw}
+	w.Println()
 	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
 	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -312,7 +312,6 @@ func getModelMessage(model modelStatus) string {
 
 func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
 	w := output.Wrapper{tw}
-	w.Println()
 	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
 	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -128,7 +128,6 @@ func (s *StatusSuite) setupSeveralUnitsOnAMachine(c *gc.C) {
 		Application: applicationB,
 		Machine:     machine1,
 	})
-
 }
 
 func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -266,9 +266,9 @@ func (s *StatusSuite) TestStatusMachineFilteringWithUnassignedUnits(c *gc.C) {
 
 	context := s.run(c, "status", "1")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-Machine  State    DNS  Inst id  Series   AZ  Message
-1        pending       id1      quantal      
+Machine     State       DNS                 Inst id  Series   AZ  Message
+1           pending                         id1      quantal      
 
-`)
+`[1:])
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, ``)
 }


### PR DESCRIPTION
## Description of change

As per linked bug, when users filtered status by machine and had unassigned unit(s) in the model, status erred.

This PR eliminates the err. One of the checks we run when filtering is whether any of the open ports on a machine for a unit match. Of course, when the unit is not assigned to a machine the check failed saying that we could not figure out unit's machine. I have changed the logic to treat the case of an unassigned unit as a non-match instead of erring out.

As a drive-by, a 'machine' section header was missing a leading newline to separate the section. Added it back in. (I have probably overlooked it when I was re-factoring logic for sections' layouts).  

## Bug reference

https://bugs.launchpad.net/juju/+bug/1684718
