### PR TITLE
Fixes lp#1684718: unassigned units erred when status filtering was used.

### DIFF
--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -186,6 +186,9 @@ func unitMatchExposure(u *state.Unit, patterns []string) (bool, bool, error) {
 func unitMatchPort(u *state.Unit, patterns []string) (bool, bool, error) {
 	portRanges, err := u.OpenedPorts()
 	if err != nil {
+		if errors.IsNotAssigned(err) {
+			return false, false, nil
+		}
 		return false, false, err
 	}
 	return matchPortRanges(patterns, portRanges...)

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -243,3 +243,31 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 `)
 }
+
+// TestStatusMachineFilteringWithUnassignedUnits ensures that machine filtering
+// functions even if there are unassigned units. Reproduces scenario
+// described in lp#1684718.
+func (s *StatusSuite) TestStatusMachineFilteringWithUnassignedUnits(c *gc.C) {
+	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "another",
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{Name: "mysql"}),
+	})
+	u := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: application,
+	})
+	err := u.UnassignFromMachine()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs:       []state.MachineJob{state.JobHostUnits},
+		InstanceId: instance.Id("id1"),
+	})
+
+	context := s.run(c, "status", "1")
+	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
+Machine  State    DNS  Inst id  Series   AZ  Message
+1        pending       id1      quantal      
+
+`)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, ``)
+}


### PR DESCRIPTION
## Description of change

Forward-port of https://github.com/juju/juju/pull/8744

## Bug reference

https://bugs.launchpad.net/juju/+bug/1684718
