### PR TITLE
Separate broker's container DNS fallback overrides.

### DIFF
--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -98,11 +98,12 @@ func finishNetworkConfig(bridgeDevice string, interfaces []network.InterfaceInfo
 	}
 
 	if !haveNameservers || !haveSearchDomains {
+		warnMissing := func(s string) { logger.Warningf("no %s supplied by provider, using host's %s.", s, s) }
 		if !haveNameservers {
-			logger.Warningf("no name servers supplied by provider, using host's name servers.")
+			warnMissing("name servers")
 		}
 		if !haveSearchDomains {
-			logger.Warningf("no search domains were supplied by provider, using host's name servers.")
+			warnMissing("search domains")
 		}
 
 		logger.Warningf("incomplete DNS config found, discovering host's DNS config")

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -98,6 +98,13 @@ func finishNetworkConfig(bridgeDevice string, interfaces []network.InterfaceInfo
 	}
 
 	if !haveNameservers || !haveSearchDomains {
+		if !haveNameservers {
+			logger.Warningf("no name servers supplied by provider, using host's name servers.")
+		}
+		if !haveSearchDomains {
+			logger.Warningf("no search domains were supplied by provider, using host's name servers.")
+		}
+
 		logger.Warningf("incomplete DNS config found, discovering host's DNS config")
 		dnsConfig, err := findDNSServerConfig()
 		if err != nil {


### PR DESCRIPTION
## Description of change

The possibility exists if a container is configured without a good DNS search domain but a good DNS address or vice versa both values will be overridden or replaced rather than just the missing information. This commit logs information related to the issue for future debugging purposes.

## QA steps

N/A

## Documentation changes

Does it affect current user workflow? CLI? API?

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1771885
