### PR TITLE
Status, tabular output: consistent formatting of sections.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -186,7 +186,6 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			}
 		}
 	}
-	w.Println()
 }
 
 func printRemoteApplications(tw *ansiterm.TabWriter, remoteApplications map[string]remoteApplicationStatus) {
@@ -312,6 +311,7 @@ func getModelMessage(model modelStatus) string {
 
 func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
 	w := output.Wrapper{tw}
+	w.Println()
 	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
 	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -91,10 +91,10 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	return nil
 }
 
-func startSection(tw *ansiterm.TabWriter, values ...interface{}) output.Wrapper {
+func startSection(tw *ansiterm.TabWriter, headers ...interface{}) output.Wrapper {
 	w := output.Wrapper{tw}
 	w.Println()
-	w.Println(values...)
+	w.Println(headers...)
 	return w
 }
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4155,7 +4155,6 @@ foo                       2                  0
 Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
 foo/1  maintenance  executing                                  (backup database) doing some work
-
 `[1:])
 }
 
@@ -4224,8 +4223,7 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 		"\n"+
 		"Entity  Meter status  Message\n"+
 		"foo/0   strange       warning: stable strangelets  \n"+
-		"foo/1   up            things are looking up        \n"+
-		"\n")
+		"foo/1   up            things are looking up        \n")
 }
 
 //

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -266,8 +266,8 @@ func (s *StatusSuite) TestStatusMachineFilteringWithUnassignedUnits(c *gc.C) {
 
 	context := s.run(c, "status", "1")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-Machine     State       DNS                 Inst id  Series   AZ  Message
-1           pending                         id1      quantal      
+Machine  State    DNS  Inst id  Series   AZ  Message
+1        pending       id1      quantal      
 
 `[1:])
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, ``)


### PR DESCRIPTION
## Description of change

Status, in tabular output, displays information in different sections - applications, units, machines, relations, etc... Each section is separate from previous by a new line. If the section is empty, it will not be displayed.

There are 2 ways to ensure that there is a new line - add one at the end of a section or add one at the beginning. As there is no guarantee that a section will be displayed, it is easier to ensure that a newline is present whenever a section is rendered. We know we'd be rendering a section when we are rendering headers.

This PR ensures that all headers are preceded by a newline and removes redundant empty lines after sections that had them.

Without this change, some sections will be separated by several  newlines (I have seen 2); and others will have no newlines in between (for example, if there are only machines to display).
