### PR TITLE
Status, tabular output: consistent formatting of sections.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -64,8 +64,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	// The first set of headers don't use outputHeaders because it adds the blank line.
-	w := output.Wrapper{tw}
-	w.Println(header...)
+	w := startSection(tw, true, header...)
 	w.Println(values...)
 
 	if len(fs.RemoteApplications) > 0 {
@@ -77,8 +76,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	if fs.Model.Type != caasModelType && len(fs.Machines) > 0 {
-		w.Println()
-		printMachines(tw, fs.Machines)
+		printMachines(tw, false, fs.Machines)
 	}
 
 	if err := printOffers(tw, fs.Offers); err != nil {
@@ -95,17 +93,24 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		w.Print(fs.ControllerTimestamp)
 	}
 
-	tw.Flush()
+	endSection(tw)
 	return nil
 }
 
-func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
+func startSection(tw *ansiterm.TabWriter, top bool, headers ...interface{}) output.Wrapper {
 	w := output.Wrapper{tw}
-	outputHeaders := func(values ...interface{}) {
+	if !top {
 		w.Println()
-		w.Println(values...)
 	}
+	w.Println(headers...)
+	return w
+}
 
+func endSection(tw *ansiterm.TabWriter) {
+	tw.Flush()
+}
+
+func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	maxVersionWidth := iaasMaxVersionWidth
 	if fs.Model.Type == caasModelType {
 		maxVersionWidth = caasMaxVersionWidth
@@ -114,10 +119,11 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 
 	metering := fs.Model.MeterStatus != nil
 	units := make(map[string]unitStatus)
+	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
 	} else {
-		outputHeaders("App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
 	}
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
@@ -163,6 +169,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			}
 		}
 	}
+	endSection(tw)
 
 	pUnit := func(name string, u unitStatus, level int) {
 		message := u.WorkloadStatusInfo.Message
@@ -192,44 +199,48 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		)
 	}
 
-	if fs.Model.Type == caasModelType {
-		outputHeaders("Unit", "Workload", "Agent", "Address", "Ports", "Message")
-	} else {
-		outputHeaders("Unit", "Workload", "Agent", "Machine", "Public address", "Ports", "Message")
-	}
-	for _, name := range naturalsort.Sort(stringKeysFromMap(units)) {
-		u := units[name]
-		pUnit(name, u, 0)
-		const indentationLevel = 1
-		recurseUnits(u, indentationLevel, pUnit)
-	}
-
-	if metering {
-		outputHeaders("Entity", "Meter status", "Message")
-		if fs.Model.MeterStatus != nil {
-			w.Print("model")
-			outputColor := fromMeterStatusColor(fs.Model.MeterStatus.Color)
-			w.PrintColor(outputColor, fs.Model.MeterStatus.Color)
-			w.PrintColor(outputColor, fs.Model.MeterStatus.Message)
-			w.Println()
+	if len(units) > 0 {
+		if fs.Model.Type == caasModelType {
+			startSection(tw, false, "Unit", "Workload", "Agent", "Address", "Ports", "Message")
+		} else {
+			startSection(tw, false, "Unit", "Workload", "Agent", "Machine", "Public address", "Ports", "Message")
 		}
 		for _, name := range naturalsort.Sort(stringKeysFromMap(units)) {
 			u := units[name]
-			if u.MeterStatus != nil {
-				w.Print(name)
-				outputColor := fromMeterStatusColor(u.MeterStatus.Color)
-				w.PrintColor(outputColor, u.MeterStatus.Color)
-				w.PrintColor(outputColor, u.MeterStatus.Message)
-				w.Println()
-			}
+			pUnit(name, u, 0)
+			const indentationLevel = 1
+			recurseUnits(u, indentationLevel, pUnit)
+		}
+		endSection(tw)
+	}
+
+	if !metering {
+		return
+	}
+
+	startSection(tw, false, "Entity", "Meter status", "Message")
+	if fs.Model.MeterStatus != nil {
+		w.Print("model")
+		outputColor := fromMeterStatusColor(fs.Model.MeterStatus.Color)
+		w.PrintColor(outputColor, fs.Model.MeterStatus.Color)
+		w.PrintColor(outputColor, fs.Model.MeterStatus.Message)
+		w.Println()
+	}
+	for _, name := range naturalsort.Sort(stringKeysFromMap(units)) {
+		u := units[name]
+		if u.MeterStatus != nil {
+			w.Print(name)
+			outputColor := fromMeterStatusColor(u.MeterStatus.Color)
+			w.PrintColor(outputColor, u.MeterStatus.Color)
+			w.PrintColor(outputColor, u.MeterStatus.Message)
+			w.Println()
 		}
 	}
+	endSection(tw)
 }
 
 func printRemoteApplications(tw *ansiterm.TabWriter, remoteApplications map[string]remoteApplicationStatus) {
-	w := output.Wrapper{tw}
-	w.Println()
-	w.Println("SAAS", "Status", "Store", "URL")
+	w := startSection(tw, false, "SAAS", "Status", "Store", "URL")
 	for _, appName := range naturalsort.Sort(stringKeysFromMap(remoteApplications)) {
 		app := remoteApplications[appName]
 		var store, urlPath string
@@ -251,7 +262,7 @@ func printRemoteApplications(tw *ansiterm.TabWriter, remoteApplications map[stri
 		w.PrintStatus(app.StatusInfo.Current)
 		w.Println(store, urlPath)
 	}
-	tw.Flush()
+	endSection(tw)
 }
 
 func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
@@ -263,9 +274,7 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 		return a.Provider < b.Provider
 	})
 
-	w := output.Wrapper{tw}
-	w.Println()
-	w.Println("Relation provider", "Requirer", "Interface", "Type", "Message")
+	w := startSection(tw, false, "Relation provider", "Requirer", "Interface", "Type", "Message")
 
 	for _, r := range relations {
 		w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
@@ -277,6 +286,7 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 		}
 		w.Println()
 	}
+	endSection(tw)
 }
 
 type offerItems []offerStatus
@@ -286,10 +296,7 @@ func printOffers(tw *ansiterm.TabWriter, offers map[string]offerStatus) error {
 	if len(offers) == 0 {
 		return nil
 	}
-	w := output.Wrapper{tw}
-	w.Println()
-
-	w.Println("Offer", "Application", "Charm", "Rev", "Connected", "Endpoint", "Interface", "Role")
+	w := startSection(tw, false, "Offer", "Application", "Charm", "Rev", "Connected", "Endpoint", "Interface", "Role")
 	for _, offerName := range naturalsort.Sort(stringKeysFromMap(offers)) {
 		offer := offers[offerName]
 		// Sort endpoints alphabetically.
@@ -319,7 +326,7 @@ func printOffers(tw *ansiterm.TabWriter, offers map[string]offerStatus) error {
 			w.Println("", "", "", "", endpointName, endpoint.Interface, endpoint.Role)
 		}
 	}
-	tw.Flush()
+	endSection(tw)
 	return nil
 }
 
@@ -347,12 +354,12 @@ func getModelMessage(model modelStatus) string {
 	}
 }
 
-func printMachines(tw *ansiterm.TabWriter, machines map[string]machineStatus) {
-	w := output.Wrapper{tw}
-	w.Println("Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
+func printMachines(tw *ansiterm.TabWriter, standAlone bool, machines map[string]machineStatus) {
+	w := startSection(tw, standAlone, "Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
 	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])
 	}
+	endSection(tw)
 }
 
 func printMachine(w output.Wrapper, m machineStatus) {
@@ -383,9 +390,7 @@ func FormatMachineTabular(writer io.Writer, forceColor bool, value interface{}) 
 	if forceColor {
 		tw.SetColorCapable(forceColor)
 	}
-	printMachines(tw, fs.Machines)
-	tw.Flush()
-
+	printMachines(tw, true, fs.Machines)
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

manual forward-port of https://github.com/juju/juju/pull/8756 as the status codebase changed dramatically between versions with the addition of a timestamp.
