### PR TITLE
Soften the LXD network device checks when clustered

### DIFF
--- a/container/lxd/testing/suite.go
+++ b/container/lxd/testing/suite.go
@@ -53,7 +53,6 @@ func (s *BaseSuite) NewMockServer(ctrl *gomock.Controller, svrMutations ...func(
 	for _, f := range svrMutations {
 		f(cfg)
 	}
-
 	svr.EXPECT().GetServer().Return(cfg, ETag, nil)
 
 	return svr

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -151,7 +151,7 @@ func Connect(cfg Config, verifyBridgeConfig bool) (*Client, error) {
 		// If this is the LXD provider on the localhost, let's do an extra check to
 		// make sure the default profile has a correctly configured bridge, and
 		// which one is it.
-		if err := newServer.VerifyDefaultBridge(defaultProfile, profileETag); err != nil {
+		if err := newServer.VerifyNetworkDevice(defaultProfile, profileETag); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}


### PR DESCRIPTION
## Description of change

Because the extant LXD logic assumes operating with a stand-alone server, we attempt to detect the network and a child device, and create a bridged NIC device if not present. We also throw an error when such a NIC exists and is not of type "bridged".

This breaks when attempting to bootstrap on a local clustered LXD server, so the following changes are necessary:

- When LXD server is part of a cluster, no attempt is made to create an _eth0_ NIC device as a child of the default bridge.
- Verification of the eth0 device is now a separate method and allows "macvlan" in addition to "bridged" for _nictype_.

This initially places the burden of cluster network configuration on the operator, but at the minimum does not prevent bootstrapping on a cluster altogether. This mode of operation will be revisited as we enrich clustering functionality.

## QA steps

New green unit tests.
Bootstrapping to LXD and deploying to LXD container machines continues to work.

## Documentation changes

- Should not affect current work-flows.
- When we are ready to "announce" some level of clustering support, the operator's obligations should be documented.

## Bug reference

N/A
