### PR TITLE
Status timestamp

### DIFF
--- a/cmd/juju/common/format.go
+++ b/cmd/juju/common/format.go
@@ -68,6 +68,18 @@ func FormatTime(t *time.Time, formatISO bool) string {
 	return t.Local().Format("02 Jan 2006 15:04:05Z07:00")
 }
 
+// FormatTimeAsTimestamp formats a time.Time to a given machine readable format.
+// Returns a string with the local time formatted or uses the localized tz or
+// in UTC timezone.
+// The difference between this and `common.FormatTime` is that this version
+// drops the date part of the time.Time.
+func FormatTimeAsTimestamp(t *time.Time, formatISO bool) string {
+	if formatISO {
+		return t.UTC().Format("15:04:05Z")
+	}
+	return t.Local().Format("15:04:05Z07:00")
+}
+
 // ConformYAML ensures all keys of any nested maps are strings.  This is
 // necessary because YAML unmarshals map[interface{}]interface{} in nested
 // maps, which cannot be serialized by bson. Also, handle []interface{}.

--- a/cmd/juju/common/format.go
+++ b/cmd/juju/common/format.go
@@ -75,7 +75,7 @@ func FormatTime(t *time.Time, formatISO bool) string {
 // drops the date part of the time.Time.
 func FormatTimeAsTimestamp(t *time.Time, formatISO bool) string {
 	if formatISO {
-		return t.UTC().Format("15:04:05Z")
+		return t.UTC().Format("15:04:05")
 	}
 	return t.Local().Format("15:04:05Z07:00")
 }

--- a/cmd/juju/common/format_test.go
+++ b/cmd/juju/common/format_test.go
@@ -58,7 +58,7 @@ var _ = gc.Suite(&FormatTimeAsTimestampSuite{})
 
 func (s *FormatTimeAsTimestampSuite) TestFormatTimeAsTimestamp(c *gc.C) {
 	now := time.Now().Round(time.Second)
-	utcFormat := "15:04:05Z"
+	utcFormat := "15:04:05"
 	localFormat := "15:04:05Z07:00"
 	var tests = []struct {
 		description  string

--- a/cmd/juju/common/format_test.go
+++ b/cmd/juju/common/format_test.go
@@ -13,6 +13,89 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 )
 
+type FormatTimeSuite struct{}
+
+var _ = gc.Suite(&FormatTimeSuite{})
+
+func (s *FormatTimeSuite) TestFormatTime(c *gc.C) {
+	now := time.Now().Round(time.Second)
+	utcFormat := "2006-01-02 15:04:05Z"
+	localFormat := "02 Jan 2006 15:04:05Z07:00"
+	var tests = []struct {
+		description  string
+		input        time.Time
+		isoTime      bool
+		outputFormat string
+		output       string
+	}{
+		{
+			description:  "ISOTime conforms to the correct layout",
+			input:        now,
+			isoTime:      true,
+			outputFormat: utcFormat,
+			output:       now.UTC().Format(utcFormat),
+		},
+		{
+			description:  "Time conforms to the correct layout",
+			input:        now,
+			isoTime:      false,
+			outputFormat: localFormat,
+			output:       now.Local().Format(localFormat),
+		},
+	}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.description)
+		formatted := common.FormatTime(&test.input, test.isoTime)
+		parsed, err := time.Parse(test.outputFormat, formatted)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(parsed, jc.DeepEquals, test.input)
+	}
+}
+
+type FormatTimeAsTimestampSuite struct{}
+
+var _ = gc.Suite(&FormatTimeAsTimestampSuite{})
+
+func (s *FormatTimeAsTimestampSuite) TestFormatTimeAsTimestamp(c *gc.C) {
+	now := time.Now().Round(time.Second)
+	utcFormat := "15:04:05Z"
+	localFormat := "15:04:05Z07:00"
+	var tests = []struct {
+		description  string
+		input        time.Time
+		isoTime      bool
+		outputFormat string
+		output       string
+	}{
+		{
+			description:  "ISOTime conforms to the correct layout",
+			input:        now,
+			isoTime:      true,
+			outputFormat: utcFormat,
+			output:       now.UTC().Format(utcFormat),
+		},
+		{
+			description:  "Time conforms to the correct layout",
+			input:        now,
+			isoTime:      false,
+			outputFormat: localFormat,
+			output:       now.UTC().Format(localFormat),
+		},
+	}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.description)
+		formatted := common.FormatTimeAsTimestamp(&test.input, test.isoTime)
+		parsed, err := time.Parse(test.outputFormat, formatted)
+		c.Assert(err, jc.ErrorIsNil)
+
+		expected := test.input.Local()
+		if test.isoTime {
+			expected = test.input.UTC()
+		}
+		c.Assert(parsed.Format(test.outputFormat), jc.DeepEquals, expected.Format(test.outputFormat))
+	}
+}
+
 type ConformSuite struct{}
 
 var _ = gc.Suite(&ConformSuite{})

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -14,13 +14,12 @@ import (
 )
 
 type formattedStatus struct {
-	Model               modelStatus                        `json:"model"`
-	Machines            map[string]machineStatus           `json:"machines"`
-	Applications        map[string]applicationStatus       `json:"applications"`
-	RemoteApplications  map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
-	Offers              map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
-	Relations           []relationStatus                   `json:"-" yaml:"-"`
-	ControllerTimestamp string                             `json:"controller-timestamp,omitempty" yaml:"controller-timestamp,omitempty"`
+	Model              modelStatus                        `json:"model"`
+	Machines           map[string]machineStatus           `json:"machines"`
+	Applications       map[string]applicationStatus       `json:"applications"`
+	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
+	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
+	Relations          []relationStatus                   `json:"-" yaml:"-"`
 }
 
 type formattedMachineStatus struct {
@@ -43,6 +42,11 @@ type modelStatus struct {
 	Status           statusInfoContents `json:"model-status,omitempty" yaml:"model-status,omitempty"`
 	MeterStatus      *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 	SLA              string             `json:"sla,omitempty" yaml:"sla,omitempty"`
+	ControllerStatus *controllerStatus  `json:"controller-status,omitempty" yaml:"controller-status,omitempty"`
+}
+
+type controllerStatus struct {
+	Timestamp string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
 }
 
 type networkInterface struct {

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -20,6 +20,7 @@ type formattedStatus struct {
 	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
 	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
 	Relations          []relationStatus                   `json:"-" yaml:"-"`
+	Controller         *controllerStatus                  `json:"controller,omitempty" yaml:"controller,omitempty"`
 }
 
 type formattedMachineStatus struct {
@@ -42,7 +43,6 @@ type modelStatus struct {
 	Status           statusInfoContents `json:"model-status,omitempty" yaml:"model-status,omitempty"`
 	MeterStatus      *meterStatus       `json:"meter-status,omitempty" yaml:"meter-status,omitempty"`
 	SLA              string             `json:"sla,omitempty" yaml:"sla,omitempty"`
-	ControllerStatus *controllerStatus  `json:"controller-status,omitempty" yaml:"controller-status,omitempty"`
 }
 
 type controllerStatus struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -80,6 +80,11 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 			Message: sf.status.Model.MeterStatus.Message,
 		}
 	}
+	if sf.status.ControllerTimestamp != nil {
+		out.Model.ControllerStatus = &controllerStatus{
+			Timestamp: common.FormatTimeAsTimestamp(sf.status.ControllerTimestamp, sf.isoTime),
+		}
+	}
 	for k, m := range sf.status.Machines {
 		out.Machines[k] = sf.formatMachine(m)
 	}
@@ -96,9 +101,6 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 	for _, rel := range sf.relations {
 		out.Relations[i] = sf.formatRelation(rel)
 		i++
-	}
-	if sf.status.ControllerTimestamp != nil {
-		out.ControllerTimestamp = common.FormatTime(sf.status.ControllerTimestamp, sf.isoTime)
 	}
 	return out, nil
 }

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -81,7 +81,7 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 		}
 	}
 	if sf.status.ControllerTimestamp != nil {
-		out.Model.ControllerStatus = &controllerStatus{
+		out.Controller = &controllerStatus{
 			Timestamp: common.FormatTimeAsTimestamp(sf.status.ControllerTimestamp, sf.isoTime),
 		}
 	}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -61,7 +61,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		header = append(header, "SLA")
 		values = append(values, fs.Model.SLA)
 	}
-	if cs := fs.Model.ControllerStatus; cs != nil && cs.Timestamp != "" {
+	if cs := fs.Controller; cs != nil && cs.Timestamp != "" {
 		header = append(header, "Timestamp")
 		values = append(values, cs.Timestamp)
 	}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -51,8 +51,11 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		cloudRegion += "/" + fs.Model.CloudRegion
 	}
 
+	// Default table output
 	header := []interface{}{"Model", "Controller", "Cloud/Region", "Version"}
 	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion, fs.Model.Version}
+
+	// Optional table output if values exist
 	message := getModelMessage(fs.Model)
 	if message != "" {
 		header = append(header, "Notes")
@@ -61,6 +64,10 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	if fs.Model.SLA != "" {
 		header = append(header, "SLA")
 		values = append(values, fs.Model.SLA)
+	}
+	if cs := fs.Model.ControllerStatus; cs != nil && cs.Timestamp != "" {
+		header = append(header, "Timestamp")
+		values = append(values, cs.Timestamp)
 	}
 
 	// The first set of headers don't use outputHeaders because it adds the blank line.
@@ -85,12 +92,6 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 
 	if len(fs.Relations) > 0 {
 		printRelations(tw, fs.Relations)
-	}
-
-	if fs.ControllerTimestamp != "" {
-		w.Println()
-		w.Println("Controller Timestamp")
-		w.Print(fs.ControllerTimestamp)
 	}
 
 	endSection(tw)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -57,10 +57,6 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 
 	// Optional table output if values exist
 	message := getModelMessage(fs.Model)
-	if message != "" {
-		header = append(header, "Notes")
-		values = append(values, message)
-	}
 	if fs.Model.SLA != "" {
 		header = append(header, "SLA")
 		values = append(values, fs.Model.SLA)
@@ -68,6 +64,10 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	if cs := fs.Model.ControllerStatus; cs != nil && cs.Timestamp != "" {
 		header = append(header, "Timestamp")
 		values = append(values, cs.Timestamp)
+	}
+	if message != "" {
+		header = append(header, "Notes")
+		values = append(values, message)
 	}
 
 	// The first set of headers don't use outputHeaders because it adds the blank line.

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -173,6 +173,9 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"sla": "unsupported",
+		"controller-status": M{
+			"timestamp": "15:04:05+07:00",
+		},
 	}
 
 	machine0 = M{
@@ -443,8 +446,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 
@@ -487,8 +489,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 
@@ -527,8 +528,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 
@@ -568,8 +568,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 	),
@@ -617,8 +616,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 	),
@@ -648,8 +646,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 	),
@@ -675,8 +672,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 
@@ -702,8 +698,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 	),
@@ -728,7 +723,6 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedService,
 					"exposed-application": unexposedService,
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -745,7 +739,6 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedService,
 					"exposed-application": exposedService,
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -771,7 +764,6 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedService,
 					"exposed-application": exposedService,
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -848,7 +840,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -981,7 +972,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -1016,7 +1006,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 		scopedExpect{
@@ -1055,7 +1044,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 		scopedExpect{
@@ -1088,7 +1076,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 		scopedExpect{
@@ -1127,7 +1114,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 		scopedExpect{
@@ -1187,7 +1173,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1277,7 +1262,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1367,7 +1351,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1421,7 +1404,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1478,7 +1460,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1655,7 +1636,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1761,7 +1741,6 @@ var statusTests = []testCase{
 						},
 					},
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -1908,7 +1887,6 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -2005,7 +1983,6 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -2060,7 +2037,6 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2143,7 +2119,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 
@@ -2225,7 +2200,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2279,7 +2253,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2335,7 +2308,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2393,7 +2365,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2450,7 +2421,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2595,7 +2565,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2618,10 +2587,12 @@ var statusTests = []testCase{
 						"since":   "01 Apr 15 01:23+10:00",
 					},
 					"sla": "unsupported",
+					"controller-status": M{
+						"timestamp": "15:04:05+07:00",
+					},
 				},
-				"machines":             M{},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"machines":     M{},
+				"applications": M{},
 			},
 			stderr: "Model \"controller\" is empty.\n",
 		},
@@ -2676,7 +2647,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2751,7 +2721,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2775,8 +2744,7 @@ var statusTests = []testCase{
 				"machines": M{
 					"0": machine0,
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 	),
@@ -2822,8 +2790,7 @@ var statusTests = []testCase{
 						"controller-member-status": "adding-vote",
 					},
 				},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"applications": M{},
 			},
 		},
 	),
@@ -2899,7 +2866,6 @@ var statusTests = []testCase{
 						},
 					}),
 				},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
 			},
 		},
 	),
@@ -2925,10 +2891,12 @@ var statusTests = []testCase{
 						"message": "status message",
 					},
 					"sla": "unsupported",
+					"controller-status": M{
+						"timestamp": "15:04:05+07:00",
+					},
 				},
-				"machines":             M{},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"machines":     M{},
+				"applications": M{},
 			},
 			stderr: "Model \"controller\" is empty.\n",
 		},
@@ -2951,10 +2919,12 @@ var statusTests = []testCase{
 						"since":   "01 Apr 15 01:23+10:00",
 					},
 					"sla": "advanced",
+					"controller-status": M{
+						"timestamp": "15:04:05+07:00",
+					},
 				},
-				"machines":             M{},
-				"applications":         M{},
-				"controller-timestamp": "01 Apr 15 01:23+10:00",
+				"machines":     M{},
+				"applications": M{},
 			},
 			stderr: "Model \"controller\" is empty.\n",
 		},
@@ -3722,6 +3692,39 @@ func substituteFakeTime(c *gc.C, key string, in []byte, expectIsoTime bool) []by
 	return []byte(out)
 }
 
+// substituteFakeTimestamp replaces all key values for a given timestamp
+// in actual status output with a known fake value.
+func substituteFakeTimestamp(c *gc.C, in []byte, expectIsoTime bool) []byte {
+	timeFormat := "15:04:05Z07:00"
+	if expectIsoTime {
+		timeFormat = "15:04:05Z"
+	}
+	// This regexp will work for any input type
+	exp := regexp.MustCompile(`(?P<timestamp>[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|(\+[0-9]{2}:[0-9]{2})?))`)
+	if matches := exp.FindStringSubmatch(string(in)); matches != nil {
+		for i, name := range exp.SubexpNames() {
+			if name != "timestamp" {
+				continue
+			}
+			value := matches[i]
+			if expectIsoTime {
+				if index := strings.IndexRune(value, '+'); index >= 0 {
+					value = fmt.Sprintf("%sZ", value[:index])
+				}
+			}
+			_, err := time.Parse(timeFormat, value)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	out := exp.ReplaceAllString(string(in), `<timestamp>`)
+	// Substitute a made up time used in our expected output.
+	out = strings.Replace(out, "<timestamp>", timeFormat, -1)
+	return []byte(out)
+}
+
 // popControllerTimestamp removes the status time date string from the end of a output
 // block.
 func popControllerTimestamp(c *gc.C, str string) (string, string) {
@@ -3750,6 +3753,11 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 		// Prepare the output in the same format.
 		buf, err := format.marshal(e.output)
 		c.Assert(err, jc.ErrorIsNil)
+
+		// we have to force the timestamp into the correct format as the model
+		// is in string.
+		buf = substituteFakeTimestamp(c, buf, ctx.expectIsoTime)
+
 		expected := make(M)
 		err = format.unmarshal(buf, &expected)
 		c.Assert(err, jc.ErrorIsNil)
@@ -3757,7 +3765,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 		// Check the output is as expected.
 		actual := make(M)
 		out := substituteFakeTime(c, "since", stdout, ctx.expectIsoTime)
-		out = substituteFakeTime(c, "controller-timestamp", out, ctx.expectIsoTime)
+		out = substituteFakeTimestamp(c, out, ctx.expectIsoTime)
 		err = format.unmarshal(out, &actual)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(actual, jc.DeepEquals, expected)
@@ -3809,10 +3817,12 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 				"message": "migrating: foo bar",
 			},
 			"sla": "unsupported",
+			"controller-status": M{
+				"timestamp": "15:04:05Z07:00",
+			},
 		},
-		"machines":             M{},
-		"applications":         M{},
-		"controller-timestamp": "01 Apr 15 01:23+10:00",
+		"machines":     M{},
+		"applications": M{},
 	}
 
 	for _, format := range statusFormats {
@@ -3821,7 +3831,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 		c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 		stdout = substituteFakeTime(c, "since", stdout, false)
-		stdout = substituteFakeTime(c, "controller-timestamp", stdout, false)
+		stdout = substituteFakeTimestamp(c, stdout, false)
 
 		// Roundtrip expected through format so that types will match.
 		buf, err := format.marshal(expected)
@@ -3838,10 +3848,10 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
-Model   Controller  Cloud/Region        Version  Notes               SLA
-hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
+Model   Controller  Cloud/Region        Version  Notes               SLA          Timestamp
+hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported  15:04:05Z07:00
 
-Controller Timestamp`[1:]
+`[1:]
 
 	st := s.setupMigrationTest(c)
 	defer st.Close()
@@ -3849,16 +3859,16 @@ Controller Timestamp`[1:]
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
-	_, output := popControllerTimestamp(c, string(stdout))
-	c.Assert(output, gc.Equals, expected)
+	output := substituteFakeTimestamp(c, stdout, false)
+	c.Assert(string(output), gc.Equals, expected)
 }
 
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
-Model   Controller  Cloud/Region        Version  Notes               SLA
-hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
+Model   Controller  Cloud/Region        Version  Notes               SLA          Timestamp
+hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported  15:04:05Z07:00
 
-Controller Timestamp`[1:]
+`[1:]
 
 	st := s.setupMigrationTest(c)
 	defer st.Close()
@@ -3872,8 +3882,8 @@ Controller Timestamp`[1:]
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
-	_, output := popControllerTimestamp(c, string(stdout))
-	c.Assert(output, gc.Equals, expected)
+	output := substituteFakeTimestamp(c, stdout, false)
+	c.Assert(string(output), gc.Equals, expected)
 }
 
 func (s *StatusSuite) setupMigrationTest(c *gc.C) *state.State {
@@ -4142,8 +4152,8 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-Model       Controller  Cloud/Region        Version  Notes                     SLA
-controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4  unsupported
+Model       Controller  Cloud/Region        Version  Notes                     SLA          Timestamp
+controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4  unsupported  15:04:05Z07:00
 
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
@@ -4173,22 +4183,13 @@ mysql:juju-info        logging:info               juju-info  subordinate
 mysql:server           wordpress:db               mysql      regular      suspended  
 wordpress:logging-dir  logging:logging-directory  logging    subordinate  
 
-Controller Timestamp`[1:]
+`[1:]
 
-	// we have to pop the status time as there is no way to reliably know what
-	// the time is 100% of the time. To prevent failing tests, we pop the time
-	// and parse it against a time layout, to make sure it's valid.
-	strControllerTimestamp, output := popControllerTimestamp(c, string(stdout))
-	c.Assert(output, gc.Equals, expected)
-
-	controllerTimestamp, err := time.Parse("02 Jan 2006 15:04:05Z07:00", strControllerTimestamp)
-	c.Assert(err, gc.IsNil)
-	c.Assert(controllerTimestamp, gc.Not(gc.Equals), time.Time{})
+	output := substituteFakeTimestamp(c, stdout, false)
+	c.Assert(string(output), gc.Equals, expected)
 }
 
 func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
-	now := time.Now()
-	controllerTimestamp := common.FormatTime(&now, false)
 	status := formattedStatus{
 		Applications: map[string]applicationStatus{
 			"foo": {
@@ -4216,12 +4217,11 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 				},
 			},
 		},
-		ControllerTimestamp: controllerTimestamp,
 	}
 	out := &bytes.Buffer{}
 	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.String(), gc.Equals, fmt.Sprintf(`
+	c.Assert(out.String(), gc.Equals, `
 Model  Controller  Cloud/Region  Version
                                  
 
@@ -4231,14 +4231,10 @@ foo                       2                  0
 Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
 foo/1  maintenance  executing                                  (backup database) doing some work
-
-Controller Timestamp
-%s`[1:], controllerTimestamp))
+`[1:])
 }
 
 func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
-	now := time.Now()
-	controllerTimestamp := common.FormatTime(&now, false)
 	status := formattedStatus{
 		Model: modelStatus{
 			Type: "caas",
@@ -4268,12 +4264,11 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 				},
 			},
 		},
-		ControllerTimestamp: controllerTimestamp,
 	}
 	out := &bytes.Buffer{}
 	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.String(), gc.Equals, fmt.Sprintf(`
+	c.Assert(out.String(), gc.Equals, `
 Model  Controller  Cloud/Region  Version
                                  
 
@@ -4283,9 +4278,7 @@ foo                     1/2                  0      54.32.1.2
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
 foo/1  active    running     10.0.0.1  80/TCP  
-
-Controller Timestamp
-%s`[1:], controllerTimestamp))
+`[1:])
 }
 
 func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
@@ -4317,8 +4310,6 @@ func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 }
 
 func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
-	now := time.Now()
-	controllerTimestamp := common.FormatTime(&now, false)
 	status := formattedStatus{
 		Applications: map[string]applicationStatus{
 			"foo": {
@@ -4338,12 +4329,11 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 				},
 			},
 		},
-		ControllerTimestamp: controllerTimestamp,
 	}
 	out := &bytes.Buffer{}
 	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.String(), gc.Equals, fmt.Sprintf(`
+	c.Assert(out.String(), gc.Equals, `
 Model  Controller  Cloud/Region  Version
                                  
 
@@ -4357,9 +4347,7 @@ foo/1
 Entity  Meter status  Message
 foo/0   strange       warning: stable strangelets  
 foo/1   up            things are looking up        
-
-Controller Timestamp
-%s`[1:], controllerTimestamp))
+`[1:])
 }
 
 //
@@ -4502,8 +4490,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 	// When I run juju status --format yaml 0/lxd/0
 	_, stdout, stderr := runStatus(c, "--format", "yaml", "0/lxd/0")
 	c.Assert(string(stderr), gc.Equals, "")
-	out := substituteFakeTime(c, "since", stdout, ctx.expectIsoTime)
-	out = substituteFakeTime(c, "controller-timestamp", out, ctx.expectIsoTime)
+
 	const expected = "" +
 		"model:\n" +
 		"  name: controller\n" +
@@ -4516,6 +4503,8 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"    current: available\n" +
 		"    since: 01 Apr 15 01:23+10:00\n" +
 		"  sla: unsupported\n" +
+		"  controller-status:\n" +
+		"    timestamp: 15:04:05Z07:00\n" +
 		"machines:\n" +
 		"  \"0\":\n" +
 		"    juju-status:\n" +
@@ -4547,9 +4536,10 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"        series: quantal\n" +
 		"    hardware: arch=amd64 cores=1 mem=1024M root-disk=8192M\n" +
 		"    controller-member-status: adding-vote\n" +
-		"applications: {}\n" +
-		"controller-timestamp: 01 Apr 15 01:23+10:00\n"
+		"applications: {}\n"
 
+	out := substituteFakeTime(c, "since", stdout, ctx.expectIsoTime)
+	out = substituteFakeTimestamp(c, out, ctx.expectIsoTime)
 	c.Assert(string(out), gc.Equals, expected)
 }
 
@@ -4824,6 +4814,9 @@ var statusTimeTest = test(
 					"since":   "01 Apr 15 01:23+10:00",
 				},
 				"sla": "unsupported",
+				"controller-status": M{
+					"timestamp": "15:04:05Z",
+				},
 			},
 			"machines": M{
 				"0": machine0,
@@ -4853,7 +4846,6 @@ var statusTimeTest = test(
 					},
 				}),
 			},
-			"controller-timestamp": "01 Apr 15 01:23+10:00",
 		},
 	},
 )
@@ -4897,6 +4889,9 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
 		Model: modelStatus{
 			Cloud: "dummy",
+			ControllerStatus: &controllerStatus{
+				Timestamp: common.FormatTimeAsTimestamp(&now, isoTime),
+			},
 		},
 		Machines: map[string]machineStatus{
 			"1": {
@@ -4908,10 +4903,9 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 				NetworkInterfaces: map[string]networkInterface{},
 			},
 		},
-		Applications:        map[string]applicationStatus{},
-		RemoteApplications:  map[string]remoteApplicationStatus{},
-		Offers:              map[string]offerStatus{},
-		ControllerTimestamp: common.FormatTime(&now, isoTime),
+		Applications:       map[string]applicationStatus{},
+		RemoteApplications: map[string]remoteApplicationStatus{},
+		Offers:             map[string]offerStatus{},
 	})
 }
 
@@ -4942,6 +4936,55 @@ func (s *StatusSuite) TestMissingControllerTimestampInFullStatus(c *gc.C) {
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
 		Model: modelStatus{
 			Cloud: "dummy",
+		},
+		Machines: map[string]machineStatus{
+			"1": {
+				JujuStatus:        statusInfoContents{Current: "error", Message: "<error while provisioning>"},
+				InstanceId:        "pending",
+				Series:            "trusty",
+				Id:                "1",
+				Containers:        map[string]machineStatus{},
+				NetworkInterfaces: map[string]networkInterface{},
+			},
+		},
+		Applications:       map[string]applicationStatus{},
+		RemoteApplications: map[string]remoteApplicationStatus{},
+		Offers:             map[string]offerStatus{},
+	})
+}
+
+func (s *StatusSuite) TestControllerTimestampInFullStatus(c *gc.C) {
+	now := time.Now()
+	status := &params.FullStatus{
+		Model: params.ModelStatusInfo{
+			CloudTag: "cloud-dummy",
+		},
+		Machines: map[string]params.MachineStatus{
+			"1": {
+				AgentStatus: params.DetailedStatus{
+					Status: "error",
+					Info:   "<error while provisioning>",
+				},
+				InstanceId:     "pending",
+				InstanceStatus: params.DetailedStatus{},
+				Series:         "trusty",
+				Id:             "1",
+				Jobs:           []multiwatcher.MachineJob{"JobHostUnits"},
+			},
+		},
+		ControllerTimestamp: &now,
+	}
+	isoTime := true
+	formatter := NewStatusFormatter(status, isoTime)
+	formatted, err := formatter.format()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(formatted, jc.DeepEquals, formattedStatus{
+		Model: modelStatus{
+			Cloud: "dummy",
+			ControllerStatus: &controllerStatus{
+				Timestamp: common.FormatTimeAsTimestamp(&now, isoTime),
+			},
 		},
 		Machines: map[string]machineStatus{
 			"1": {
@@ -5000,12 +5043,12 @@ func (s *StatusSuite) TestStatusFormatTabularEmptyModel(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "Model \"controller\" is empty.\n")
 	expected := `
-Model       Controller  Cloud/Region        Version  SLA
-controller  kontroll    dummy/dummy-region  1.2.3    unsupported
+Model       Controller  Cloud/Region        Version  SLA          Timestamp
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00
 
-Controller Timestamp`[1:]
-	_, output := popControllerTimestamp(c, string(stdout))
-	c.Assert(output, gc.Equals, expected)
+`[1:]
+	output := substituteFakeTimestamp(c, stdout, false)
+	c.Assert(string(output), gc.Equals, expected)
 }
 
 func (s *StatusSuite) TestStatusFormatTabularForUnmatchedFilter(c *gc.C) {
@@ -5013,12 +5056,12 @@ func (s *StatusSuite) TestStatusFormatTabularForUnmatchedFilter(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "Nothing matched specified filter.\n")
 	expected := `
-Model       Controller  Cloud/Region        Version  SLA
-controller  kontroll    dummy/dummy-region  1.2.3    unsupported
+Model       Controller  Cloud/Region        Version  SLA          Timestamp
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00
 
-Controller Timestamp`[1:]
-	_, output := popControllerTimestamp(c, string(stdout))
-	c.Assert(output, gc.Equals, expected)
+`[1:]
+	output := substituteFakeTimestamp(c, stdout, false)
+	c.Assert(string(output), gc.Equals, expected)
 
 	_, _, stderr = runStatus(c, "cannot", "match", "me")
 	c.Check(string(stderr), gc.Equals, "Nothing matched specified filters.\n")

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3848,8 +3848,8 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
-Model   Controller  Cloud/Region        Version  Notes               SLA          Timestamp
-hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported  15:04:05Z07:00
+Model   Controller  Cloud/Region        Version  SLA          Timestamp       Notes
+hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00  migrating: foo bar
 
 `[1:]
 
@@ -3865,8 +3865,8 @@ hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported
 
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
-Model   Controller  Cloud/Region        Version  Notes               SLA          Timestamp
-hosted  kontroll    dummy/dummy-region  1.2.3    migrating: foo bar  unsupported  15:04:05Z07:00
+Model   Controller  Cloud/Region        Version  SLA          Timestamp       Notes
+hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00  migrating: foo bar
 
 `[1:]
 
@@ -4152,8 +4152,8 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	expected := `
-Model       Controller  Cloud/Region        Version  Notes                     SLA          Timestamp
-controller  kontroll    dummy/dummy-region  1.2.3    upgrade available: 1.2.4  unsupported  15:04:05Z07:00
+Model       Controller  Cloud/Region        Version  SLA          Timestamp       Notes
+controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00  upgrade available: 1.2.4
 
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -173,9 +173,6 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"sla": "unsupported",
-		"controller-status": M{
-			"timestamp": "15:04:05+07:00",
-		},
 	}
 
 	machine0 = M{
@@ -447,6 +444,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -490,6 +490,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -529,6 +532,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -569,6 +575,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -617,6 +626,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -647,6 +659,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -673,6 +688,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -699,6 +717,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -723,6 +744,9 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedService,
 					"exposed-application": unexposedService,
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -738,6 +762,9 @@ var statusTests = []testCase{
 				"applications": M{
 					"dummy-application":   unexposedService,
 					"exposed-application": exposedService,
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -763,6 +790,9 @@ var statusTests = []testCase{
 				"applications": M{
 					"dummy-application":   unexposedService,
 					"exposed-application": exposedService,
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -839,6 +869,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -972,6 +1005,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -1005,6 +1041,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1044,6 +1083,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 		scopedExpect{
@@ -1075,6 +1117,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1113,6 +1158,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1172,6 +1220,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1262,6 +1313,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -1351,6 +1405,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -1403,6 +1460,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1459,6 +1519,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1636,6 +1699,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -1740,6 +1806,9 @@ var statusTests = []testCase{
 							"ring": L{"riak"},
 						},
 					},
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -1887,6 +1956,9 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -1983,6 +2055,9 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -2036,6 +2111,9 @@ var statusTests = []testCase{
 						},
 					}),
 					"logging": loggingCharm,
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -2119,6 +2197,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 
@@ -2200,6 +2281,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2252,6 +2336,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -2307,6 +2394,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -2365,6 +2455,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2420,6 +2513,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -2565,6 +2661,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2587,12 +2686,12 @@ var statusTests = []testCase{
 						"since":   "01 Apr 15 01:23+10:00",
 					},
 					"sla": "unsupported",
-					"controller-status": M{
-						"timestamp": "15:04:05+07:00",
-					},
 				},
 				"machines":     M{},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 			stderr: "Model \"controller\" is empty.\n",
 		},
@@ -2646,6 +2745,9 @@ var statusTests = []testCase{
 							},
 						},
 					}),
+				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
 				},
 			},
 		},
@@ -2721,6 +2823,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2745,6 +2850,9 @@ var statusTests = []testCase{
 					"0": machine0,
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2791,6 +2899,9 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2866,6 +2977,9 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 		},
 	),
@@ -2891,12 +3005,12 @@ var statusTests = []testCase{
 						"message": "status message",
 					},
 					"sla": "unsupported",
-					"controller-status": M{
-						"timestamp": "15:04:05+07:00",
-					},
 				},
 				"machines":     M{},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 			stderr: "Model \"controller\" is empty.\n",
 		},
@@ -2919,12 +3033,12 @@ var statusTests = []testCase{
 						"since":   "01 Apr 15 01:23+10:00",
 					},
 					"sla": "advanced",
-					"controller-status": M{
-						"timestamp": "15:04:05+07:00",
-					},
 				},
 				"machines":     M{},
 				"applications": M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
 			},
 			stderr: "Model \"controller\" is empty.\n",
 		},
@@ -3713,9 +3827,7 @@ func substituteFakeTimestamp(c *gc.C, in []byte, expectIsoTime bool) []byte {
 				}
 			}
 			_, err := time.Parse(timeFormat, value)
-			if err != nil {
-				panic(err)
-			}
+			c.Assert(err, jc.ErrorIsNil)
 		}
 	}
 
@@ -3725,12 +3837,14 @@ func substituteFakeTimestamp(c *gc.C, in []byte, expectIsoTime bool) []byte {
 	return []byte(out)
 }
 
-// popControllerTimestamp removes the status time date string from the end of a output
-// block.
-func popControllerTimestamp(c *gc.C, str string) (string, string) {
-	lines := strings.Split(str, "\n")
-	c.Assert(len(lines), jc.GreaterThan, 1)
-	return lines[len(lines)-2], strings.Join(lines[:len(lines)-2], "\n")
+// substituteSpacingBetweenTimestampAndNotes forces the spacing between the
+// headers Timestamp and Notes to be consistent regardless of the time. This
+// happens because we're dealing with the result of the strings of stdout and
+// not with any useable AST
+func substituteSpacingBetweenTimestampAndNotes(c *gc.C, in []byte) []byte {
+	exp := regexp.MustCompile(`Timestamp(?P<spacing>\s+)Notes`)
+	result := exp.ReplaceAllString(string(in), fmt.Sprintf("Timestamp%sNotes", strings.Repeat(" ", 7)))
+	return []byte(result)
 }
 
 func (e scopedExpect) step(c *gc.C, ctx *context) {
@@ -3817,12 +3931,12 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 				"message": "migrating: foo bar",
 			},
 			"sla": "unsupported",
-			"controller-status": M{
-				"timestamp": "15:04:05Z07:00",
-			},
 		},
 		"machines":     M{},
 		"applications": M{},
+		"controller": M{
+			"timestamp": "15:04:05Z07:00",
+		},
 	}
 
 	for _, format := range statusFormats {
@@ -3860,6 +3974,7 @@ hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00  mi
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 	output := substituteFakeTimestamp(c, stdout, false)
+	output = substituteSpacingBetweenTimestampAndNotes(c, output)
 	c.Assert(string(output), gc.Equals, expected)
 }
 
@@ -3883,6 +3998,7 @@ hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05Z07:00  mi
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
 	output := substituteFakeTimestamp(c, stdout, false)
+	output = substituteSpacingBetweenTimestampAndNotes(c, output)
 	c.Assert(string(output), gc.Equals, expected)
 }
 
@@ -4186,6 +4302,7 @@ wordpress:logging-dir  logging:logging-directory  logging    subordinate
 `[1:]
 
 	output := substituteFakeTimestamp(c, stdout, false)
+	output = substituteSpacingBetweenTimestampAndNotes(c, output)
 	c.Assert(string(output), gc.Equals, expected)
 }
 
@@ -4503,8 +4620,6 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"    current: available\n" +
 		"    since: 01 Apr 15 01:23+10:00\n" +
 		"  sla: unsupported\n" +
-		"  controller-status:\n" +
-		"    timestamp: 15:04:05Z07:00\n" +
 		"machines:\n" +
 		"  \"0\":\n" +
 		"    juju-status:\n" +
@@ -4536,7 +4651,9 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"        series: quantal\n" +
 		"    hardware: arch=amd64 cores=1 mem=1024M root-disk=8192M\n" +
 		"    controller-member-status: adding-vote\n" +
-		"applications: {}\n"
+		"applications: {}\n" +
+		"controller:\n" +
+		"  timestamp: 15:04:05Z07:00\n"
 
 	out := substituteFakeTime(c, "since", stdout, ctx.expectIsoTime)
 	out = substituteFakeTimestamp(c, out, ctx.expectIsoTime)
@@ -4814,9 +4931,6 @@ var statusTimeTest = test(
 					"since":   "01 Apr 15 01:23+10:00",
 				},
 				"sla": "unsupported",
-				"controller-status": M{
-					"timestamp": "15:04:05Z",
-				},
 			},
 			"machines": M{
 				"0": machine0,
@@ -4845,6 +4959,9 @@ var statusTimeTest = test(
 						},
 					},
 				}),
+			},
+			"controller": M{
+				"timestamp": "15:04:05Z",
 			},
 		},
 	},
@@ -4889,9 +5006,6 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
 		Model: modelStatus{
 			Cloud: "dummy",
-			ControllerStatus: &controllerStatus{
-				Timestamp: common.FormatTimeAsTimestamp(&now, isoTime),
-			},
 		},
 		Machines: map[string]machineStatus{
 			"1": {
@@ -4906,6 +5020,9 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 		Applications:       map[string]applicationStatus{},
 		RemoteApplications: map[string]remoteApplicationStatus{},
 		Offers:             map[string]offerStatus{},
+		Controller: &controllerStatus{
+			Timestamp: common.FormatTimeAsTimestamp(&now, isoTime),
+		},
 	})
 }
 
@@ -4982,9 +5099,6 @@ func (s *StatusSuite) TestControllerTimestampInFullStatus(c *gc.C) {
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
 		Model: modelStatus{
 			Cloud: "dummy",
-			ControllerStatus: &controllerStatus{
-				Timestamp: common.FormatTimeAsTimestamp(&now, isoTime),
-			},
 		},
 		Machines: map[string]machineStatus{
 			"1": {
@@ -4999,6 +5113,9 @@ func (s *StatusSuite) TestControllerTimestampInFullStatus(c *gc.C) {
 		Applications:       map[string]applicationStatus{},
 		RemoteApplications: map[string]remoteApplicationStatus{},
 		Offers:             map[string]offerStatus{},
+		Controller: &controllerStatus{
+			Timestamp: common.FormatTimeAsTimestamp(&now, isoTime),
+		},
 	})
 }
 


### PR DESCRIPTION
## Description of change

> Why is this change needed?

The following PR changes the location of the controller timestamp. Previously it was dangling at the bottom as an orphan, this time it's aligned with the model. There is also an additional object in the model for both yaml and json formats, where the controller now has a status leaf. This allows additional meta data in the future if it's ever required. 

## QA steps

> How do we verify that the change works?

Running `juju status`

## Documentation changes

> Does it affect current user workflow? CLI? API?

Both the CLI and the user workflow will now be able to see the new location.

## Bug reference

> Does this change fix a bug? Please add a link to it.

https://bugs.launchpad.net/juju/+bug/1765404


## Demo

[![demo](https://asciinema.org/a/183587.png)](https://asciinema.org/a/183587?autoplay=1&speed=3)