### PR TITLE
Check invariants before you release the lock.

### DIFF
--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -389,8 +389,8 @@ func (m *fakeMachine) mutate(f func(*machineDoc)) {
 	doc := m.doc()
 	f(&doc)
 	m.val.Set(doc)
-	m.mu.Unlock()
 	m.checker.checkInvariants()
+	m.mu.Unlock()
 }
 
 func (m *fakeMachine) setAddresses(addrs ...network.Address) {


### PR DESCRIPTION
## Description of change

We had the invariant fail in a racy way. This is the best way I could think of as to what might be the cause.
Specifically, we don't allow concurrent updates while we hold the lock, but we were releasing the lock, and then checking the invariants. My guess is that there was an asynchronous step that was moving to a new state, which got detected halfway through.

## QA steps

I didn't reproduce the original failure. I have only see the one report but it does seem plausible.

## Documentation changes

None.

## Bug reference

[lp:1773169](https://bugs.launchpad.net/juju/+bug/1773169)