### PR TITLE
Add --keep-latest to remove-backup cmd

### DIFF
--- a/api/backups/remove.go
+++ b/api/backups/remove.go
@@ -9,10 +9,18 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-func (c *Client) Remove(id string) error {
-	args := params.BackupsRemoveArgs{ID: id}
-	if err := c.facade.FacadeCall("Remove", args, nil); err != nil {
-		return errors.Trace(err)
+func (c *Client) Remove(ids ...string) ([]params.ErrorResult, error) {
+	if len(ids) == 0 {
+		return []params.ErrorResult{}, nil
 	}
-	return nil
+	args := params.BackupsRemoveArgs{IDs: ids}
+	results := params.ErrorResults{}
+	err := c.facade.FacadeCall("Remove", args, &results)
+	if len(results.Results) != len(ids) {
+		return nil, errors.Errorf(
+			"expected %d result(s), got %d",
+			len(ids), len(results.Results),
+		)
+	}
+	return results.Results, errors.Trace(err)
 }

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -38,7 +38,7 @@ type Backend interface {
 	RestoreInfo() *state.RestoreInfo
 }
 
-// API provides backup-specific API methods for version 2.
+// API provides backup-specific API methods.
 type API struct {
 	backend Backend
 	paths   *backups.Paths
@@ -47,7 +47,7 @@ type API struct {
 	machineID string
 }
 
-// API serves backup-specific API methods.
+// APIv2 serves backup-specific API methods for version 2.
 type APIv2 struct {
 	*API
 }

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -17,9 +17,7 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 		func(*mgo.Session, int) error { return nil },
 	)
 	s.setBackups(c, s.meta, "")
-	//apiv2 := &backups.APIv2{s.api}
 	var args params.BackupsCreateArgs
-	//result, err := apiv2.Create(args)
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := backups.CreateResult(s.meta, "test-filename")

--- a/apiserver/facades/client/backups/remove.go
+++ b/apiserver/facades/client/backups/remove.go
@@ -4,15 +4,18 @@
 package backups
 
 import (
-	"github.com/juju/errors"
-
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 )
 
-func (a *API) Remove(args params.BackupsRemoveArgs) error {
+// Remove deletes the backups defined by ID from the database.
+func (a *APIv2) Remove(args params.BackupsRemoveArgs) (params.ErrorResults, error) {
 	backups, closer := newBackups(a.backend)
 	defer closer.Close()
-
-	err := backups.Remove(args.ID)
-	return errors.Trace(err)
+	results := make([]params.ErrorResult, len(args.IDs))
+	for i, id := range args.IDs {
+		err := backups.Remove(id)
+		results[i].Error = common.ServerError(err)
+	}
+	return params.ErrorResults{results}, nil
 }

--- a/apiserver/facades/client/backups/remove_test.go
+++ b/apiserver/facades/client/backups/remove_test.go
@@ -13,18 +13,20 @@ import (
 func (s *backupsSuite) TestRemoveOkay(c *gc.C) {
 	s.setBackups(c, nil, "")
 	args := params.BackupsRemoveArgs{
-		ID: "some-id",
+		IDs: []string{"some-id"},
 	}
-	err := s.api.Remove(args)
+	results, err := s.api.Remove(args)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
 }
 
 func (s *backupsSuite) TestRemoveError(c *gc.C) {
 	s.setBackups(c, nil, "failed!")
 	args := params.BackupsRemoveArgs{
-		ID: "some-id",
+		IDs: []string{"some-id"},
 	}
-	err := s.api.Remove(args)
-
-	c.Check(err, gc.ErrorMatches, "failed!")
+	results, err := s.api.Remove(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Check(results.Results[0].Error, gc.ErrorMatches, "failed!")
 }

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -38,7 +38,7 @@ type BackupsUploadArgs struct {
 
 // BackupsRemoveArgs holds the args for the API Remove method.
 type BackupsRemoveArgs struct {
-	ID string `json:"id"`
+	IDs []string `json:"ids"`
 }
 
 // BackupsListResult holds the list of all stored backups.

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -37,8 +37,8 @@ type APIClient interface {
 	Download(id string) (io.ReadCloser, error)
 	// Upload pushes a backup archive to storage.
 	Upload(ar io.ReadSeeker, meta params.BackupsMetadataResult) (string, error)
-	// Remove removes the stored backup.
-	Remove(id string) error
+	// Remove removes the stored backups.
+	Remove(ids ...string) ([]params.ErrorResult, error)
 	// Restore will restore a backup with the given id into the controller.
 	Restore(string, backups.ClientConnection) error
 	// RestoreReader will restore a backup file into the controller.

--- a/cmd/juju/backups/mock_test.go
+++ b/cmd/juju/backups/mock_test.go
@@ -161,15 +161,20 @@ func (mr *MockAPIClientMockRecorder) List() *gomock.Call {
 }
 
 // Remove mocks base method
-func (m *MockAPIClient) Remove(arg0 string) error {
-	ret := m.ctrl.Call(m, "Remove", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (m *MockAPIClient) Remove(arg0 ...string) ([]params.ErrorResult, error) {
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Remove", varargs...)
+	ret0, _ := ret[0].([]params.ErrorResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Remove indicates an expected call of Remove
-func (mr *MockAPIClientMockRecorder) Remove(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockAPIClient)(nil).Remove), arg0)
+func (mr *MockAPIClientMockRecorder) Remove(arg0 ...interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockAPIClient)(nil).Remove), arg0...)
 }
 
 // Restore mocks base method

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -127,6 +127,8 @@ func (s *BaseBackupsSuite) checkStd(c *gc.C, ctx *cmd.Context, out, err string) 
 	jujutesting.CheckString(c, ctx.Stderr.(*bytes.Buffer).String(), err)
 }
 
+// TODO (hml) 2018-05-01
+// Replace this fakeAPIClient with MockAPIClient for all tests.
 type fakeAPIClient struct {
 	metaresult *params.BackupsMetadataResult
 	archive    io.ReadCloser
@@ -201,13 +203,16 @@ func (c *fakeAPIClient) Upload(ar io.ReadSeeker, meta params.BackupsMetadataResu
 	return c.metaresult.ID, nil
 }
 
-func (c *fakeAPIClient) Remove(id string) error {
+func (c *fakeAPIClient) Remove(id ...string) ([]params.ErrorResult, error) {
 	c.calls = append(c.calls, "Remove")
-	c.args = append(c.args, id)
+	c.args = append(c.args, "id")
+	c.idArg = id[0]
 	if c.err != nil {
-		return c.err
+		return []params.ErrorResult{
+			{Error: &params.Error{Message: c.err.Error()}},
+		}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (c *fakeAPIClient) Close() error {

--- a/cmd/juju/backups/remove_test.go
+++ b/cmd/juju/backups/remove_test.go
@@ -4,39 +4,172 @@
 package backups_test
 
 import (
+	"bytes"
+	"io"
+	"time"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/golang/mock/gomock"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/backups"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
 )
 
 type removeSuite struct {
-	BaseBackupsSuite
+	testing.FakeJujuXDGDataHomeSuite
+
 	command cmd.Command
 }
 
 var _ = gc.Suite(&removeSuite{})
 
 func (s *removeSuite) SetUpTest(c *gc.C) {
-	s.BaseBackupsSuite.SetUpTest(c)
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
 	s.command = backups.NewRemoveCommandForTest(jujuclienttesting.MinimalStore())
 }
 
-func (s *removeSuite) TestOkay(c *gc.C) {
-	s.setSuccess()
-	ctx, err := cmdtesting.RunCommand(c, s.command, "spam")
-	c.Check(err, jc.ErrorIsNil)
-
-	out := "successfully removed: spam\n"
-	s.checkStd(c, ctx, out, "")
+func (s *removeSuite) patch(c *gc.C) (*gomock.Controller, *MockAPIClient) {
+	ctrl := gomock.NewController(c)
+	client := NewMockAPIClient(ctrl)
+	s.PatchValue(backups.NewGetAPI,
+		func(c *backups.CommandBase) (backups.APIClient, int, error) {
+			return client, 2, nil
+		},
+	)
+	return ctrl, client
 }
 
-func (s *removeSuite) TestError(c *gc.C) {
-	s.setFailure("failed!")
+func (s *removeSuite) TestRemovePassWithId(c *gc.C) {
+	ctrl, client := s.patch(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		client.EXPECT().Remove([]string{"one"}).Return(
+			[]params.ErrorResult{
+				{},
+			}, nil,
+		),
+		client.EXPECT().Close(),
+	)
+	ctx, err := cmdtesting.RunCommand(c, s.command, "one")
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "successfully removed: one\n")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+}
+
+var passWithKeepLatest = `
+successfully removed: four
+successfully removed: one
+successfully removed: three
+kept: two
+`[1:]
+
+func (s *removeSuite) TestRemovePassWithKeepLatest(c *gc.C) {
+	ctrl, client := s.patch(c)
+	defer ctrl.Finish()
+	one := time.Now().Add(time.Minute * 20)
+	two := time.Now().Add(time.Hour * 1)
+	three := time.Now().Add(time.Minute * 40)
+	four := time.Now()
+
+	gomock.InOrder(
+		client.EXPECT().List().Return(
+			&params.BackupsListResult{
+				List: []params.BackupsMetadataResult{
+					{ID: "one", Started: one},
+					{ID: "three", Started: three},
+					{ID: "two", Started: two},
+					{ID: "four", Started: four},
+				},
+			}, nil,
+		),
+		client.EXPECT().Remove([]string{"four", "one", "three"}).Return(
+			[]params.ErrorResult{{}, {}, {}}, nil,
+		),
+		client.EXPECT().Close(),
+	)
+	ctx, err := cmdtesting.RunCommand(c, s.command, "--keep-latest")
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, passWithKeepLatest)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+}
+
+var failWithKeepLatest = `
+successfully removed: three
+successfully removed: two
+kept: four
+`[1:]
+
+func (s *removeSuite) TestRemoveFailWithKeepLatest(c *gc.C) {
+	ctrl, client := s.patch(c)
+	defer ctrl.Finish()
+	one := time.Now().Add(time.Minute * 20)
+	two := time.Now()
+	three := time.Now().Add(time.Minute * 40)
+	four := time.Now().Add(time.Hour * 1)
+
+	gomock.InOrder(
+		client.EXPECT().List().Return(
+			&params.BackupsListResult{
+				List: []params.BackupsMetadataResult{
+					{ID: "one", Started: one},
+					{ID: "three", Started: three},
+					{ID: "two", Started: two},
+					{ID: "four", Started: four},
+				},
+			}, nil,
+		),
+		client.EXPECT().Remove([]string{"one", "three", "two"}).Return(
+			[]params.ErrorResult{{Error: &params.Error{Message: "failme"}}, {}, {}},
+			nil,
+		),
+		client.EXPECT().Close(),
+	)
+	ctx, err := cmdtesting.RunCommand(c, s.command, "--keep-latest")
+	c.Check(errors.Cause(err), gc.ErrorMatches, "failed to remove one: failme")
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, failWithKeepLatest)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+}
+
+func (s *removeSuite) TestRemoveFailWithId(c *gc.C) {
+	ctrl, client := s.patch(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		client.EXPECT().Remove([]string{"spam"}).Return(
+			[]params.ErrorResult{{Error: &params.Error{Message: "failed!"}}},
+			nil,
+		),
+		client.EXPECT().Close(),
+	)
+
 	_, err := cmdtesting.RunCommand(c, s.command, "spam")
-	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
+	c.Check(errors.Cause(err), gc.ErrorMatches, "failed to remove spam: failed!")
+}
+
+func (s *removeSuite) TestRemoveFail(c *gc.C) {
+	ctrl, client := s.patch(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		client.EXPECT().Remove([]string{"spam"}).Return(
+			nil,
+			errors.Errorf("not found"),
+		),
+		client.EXPECT().Close(),
+	)
+
+	_, err := cmdtesting.RunCommand(c, s.command, "spam")
+	c.Check(errors.Cause(err), gc.ErrorMatches, "not found")
+}
+
+func bufferString(w io.Writer) string {
+	return w.(*bytes.Buffer).String()
 }


### PR DESCRIPTION
 ## Description of change

Add --keep-latest to remove-backup cmd, so that all but the latest backup can be removed easily.  To facilitate this, made backups.Remove() a bulk call to handle more than 1 id at a time.  Unit tests were also added.

Drive by to remove some commented out code in apiserver/facades/client/backups/create_test.go

## QA steps

1. juju bootstrap
2. run 'juju create-backup -m controller --no-download' three times
3. run 'juju backups  -m controller' to verify 3 backups and determine which is the most recent.
4. run 'juju remove-backup -m controller --keep-latest', output should include the two deleted and the one kept.
5. run 'juju remove-backup -m controller <most recent backup id>', now there should be no backups.

## Documentation changes

yes

## Bug reference

n/a