### PR TITLE
add-k8s now trys to read kubeconfig file if piped stdIn has no content

### DIFF
--- a/acceptancetests/assess_caas_bootstrap.py
+++ b/acceptancetests/assess_caas_bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Test caas k8s cluster bootstrap
 
     Spinning up k8s cluster and asserting the cluster is `healthy` - in this case, healthy means the k8s api server

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -139,14 +139,11 @@ def deploy_caas_stack(bundle_path, client, timeout=3600):
     # workaround to ensure lxd profile
     model_name = client.model_name
     profile = LXD_PROFILE.format(model_name=model_name)
-    echo = subprocess.Popen(('echo', profile), stdout=subprocess.PIPE)
-    try:
+    with subprocess.Popen(('echo', profile), stdout=subprocess.PIPE) as echo:
         subprocess.check_output(
             ('lxc', 'profile', 'edit', 'juju-%s' % model_name),
             stdin=echo.stdout
         ).decode('UTF-8').strip()
-    finally:
-        echo.wait()
 
     client.deploy_bundle(bundle_path, static_bundle=True)
     # Wait for the deployment to finish.

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -173,6 +173,7 @@ func getKubeConfigPath() string {
 	if envPath == "" {
 		return clientcmd.RecommendedHomeFile
 	}
+	logger.Debugf("KubuConfig file path: %q", envPath)
 	return envPath
 }
 

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -173,7 +173,7 @@ func getKubeConfigPath() string {
 	if envPath == "" {
 		return clientcmd.RecommendedHomeFile
 	}
-	logger.Debugf("KubuConfig file path: %q", envPath)
+	logger.Debugf("The kubeconfig file path: %q", envPath)
 	return envPath
 }
 

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -54,9 +54,7 @@ which one to use.
 
 Examples:
     juju add-k8s myk8scloud
-
     KUBECONFIG=path-to-kubuconfig-file juju add-k8s myk8scloud --cluster-name=my_cluster_name
-
     kubectl config view --raw | juju add-k8s myk8scloud --cluster-name=my_cluster_name
 
 See also:


### PR DESCRIPTION
## Description of change

add-k8s now trys to read kubeconfig file if piped stdIn has no content;

The problem this PR trys to solve is Jenkins always has piped StdIn(I assume which is for log streaming) accessible which makes `getStdinPipe` confused. So now `getStdinPipe` checks the stdIn content size to ensure that only non empty piped stdIn is valid to read, or it will fall back to read the `kubeconfig` file