### PR TITLE
Increase the timeout on the machine dying test.

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -51,7 +51,6 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -231,12 +230,12 @@ func (s *MachineSuite) TestDyingMachine(c *gc.C) {
 	<-a.WorkersStarted()
 	err := m.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+	// Tearing down the dependency engine can take a non-trivial amount of
+	// time.
 	select {
 	case err := <-done:
 		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(watcher.Period * 5 / 4):
-		// TODO(rog) Fix this so it doesn't wait for so long.
-		// https://bugs.launchpad.net/juju-core/+bug/1163983
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for agent to terminate")
 	}
 	err = m.Refresh()


### PR DESCRIPTION
Evidence has shown that particularly on bionic, this test can take longer than the wait period given.

I haven't been able to reproduce the timeout, even with a bionic container with the host under load.
