### PR TITLE
Remove Hard Check for "eth0" When Validating LXD Networking

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -18,6 +18,11 @@ var (
 	GetImageSources          = func(mgr container.Manager) ([]RemoteServer, error) {
 		return mgr.(*containerManager).getImageSources()
 	}
+	VerifyNICsWithConfigFile = func(
+		svr *Server, nics map[string]map[string]string, reader func(string) ([]byte, error),
+	) error {
+		return svr.verifyNICsWithConfigFile(nics, reader)
+	}
 )
 
 type patcher interface {

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -162,7 +162,7 @@ var configureLXDBridge = func() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return server.ensureDefaultBridge(profile, eTag)
+		return server.ensureDefaultNetworking(profile, eTag)
 	}
 	return configureLXDBridgeForOlderLXD()
 }


### PR DESCRIPTION
## Description of change

The current pre-check of the LXD networking configuration checks specifically for a profile device named "eth0". This is an over-rigid check that can cause validation failure, or creation of a new profile device even when there is otherwise usable networking config present.

This change checks instead for _any_ NIC device that is of a suitable type, and has a usable parent network.

## QA steps

- New/modified unit tests.
- System tests for bootstrapping to LXD and deploying to container machines, both Xenial and Bionic. 

## Documentation changes

None.

## Bug reference

N/A
