### PR TITLE
Fix errors with network get cidrs.

### DIFF
--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -142,7 +142,10 @@ func (w *EgressAddressWatcher) loop() error {
 			}
 			changed = false
 			if !setEquals(addresses, lastAddresses) {
-				addressesCIDR = network.FormatAsCIDR(addresses.Values())
+				addressesCIDR, err = network.FormatAsCIDR(addresses.Values())
+				if err != nil {
+					return errors.Trace(err)
+				}
 				ready = ready || sentInitial
 			}
 		}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2114,7 +2114,10 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 		// default to the first ingress address. This matches the behaviour when
 		// there's a relation in place.
 		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
-			info.EgressSubnets = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
+			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
+			if err != nil {
+				return result, errors.Trace(err)
+			}
 		}
 
 		result.Results[binding] = info

--- a/network/network.go
+++ b/network/network.go
@@ -610,20 +610,23 @@ func SubnetInAnyRange(cidrs []*net.IPNet, subnet *net.IPNet) bool {
 
 // FormatAsCIDR converts the specified IP addresses to
 // a slice of CIDRs.
-func FormatAsCIDR(addresses []string) []string {
+func FormatAsCIDR(addresses []string) ([]string, error) {
 	result := make([]string, len(addresses))
 	for i, a := range addresses {
 		cidr := a
 		// If address is not already a cidr, add a /32 (ipv4) or /128 (ipv6).
 		if _, _, err := net.ParseCIDR(a); err != nil {
-			ip := net.ParseIP(a)
-			if ip.To4() != nil {
-				cidr = a + "/32"
+			address, err := net.ResolveIPAddr("ip", a)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if address.IP.To4() != nil {
+				cidr = address.String() + "/32"
 			} else {
-				cidr = a + "/128"
+				cidr = address.String() + "/128"
 			}
 		}
 		result[i] = cidr
 	}
-	return result
+	return result, nil
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -586,7 +586,10 @@ func NetworksForRelation(
 
 	// If no egress subnets defined, We default to the ingress address.
 	if len(egress) == 0 && len(ingress) > 0 {
-		egress = network.FormatAsCIDR([]string{ingress[0]})
+		egress, err = network.FormatAsCIDR([]string{ingress[0]})
+		if err != nil {
+			return "", nil, nil, errors.Trace(err)
+		}
 	}
 	return boundSpace, ingress, egress, nil
 }


### PR DESCRIPTION
## Description of change

Juju can store unresolved hostnames in network info Address fields. These hostnames can show up in network-get output which should always be IP addresses and not hostnames. To solve the issue simply, we resolve the hostnames on network get output.  

## QA steps

On a local provider you may:

1. Bootstrap 
2. Launch a lxd instance
3. Ensure that you can ssh into the machine
4. Assign the machine a resolvable hostname (e.g. add an entry to /etc/hosts)
5. manually provision machine using `ssh:<user>@<hostname>` placement directive format 
6. deploy mysql to manually provisioned machine
7. `juju run mysql/0 -- network-get --primary-address --format yaml db` 

You should see an IP Address and not a hostname 

## Documentation changes

N/A

## Does it affect current user workflow? CLI? API?

If a user is depending on hostnames, for whatever reason, they might be in for a surprise.

## Bug reference


