### PR TITLE
More rename of service to application, mainly in state

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -91,7 +91,7 @@ func (c *Client) Cancel(arg params.Entities) (params.ActionResults, error) {
 }
 
 // applicationsCharmActions is a batched query for the charm.Actions for a slice
-// of services by Entity.
+// of applications by Entity.
 func (c *Client) applicationsCharmActions(arg params.Entities) (params.ApplicationsCharmActionsResults, error) {
 	results := params.ApplicationsCharmActionsResults{}
 	err := c.facade.FacadeCall("ApplicationsCharmsActions", arg, &results)
@@ -99,7 +99,7 @@ func (c *Client) applicationsCharmActions(arg params.Entities) (params.Applicati
 }
 
 // ApplicationCharmActions is a single query which uses ApplicationsCharmsActions to
-// get the charm.Actions for a single Service by tag.
+// get the charm.Actions for a single Application by tag.
 func (c *Client) ApplicationCharmActions(arg params.Entity) (map[string]params.ActionSpec, error) {
 	tags := params.Entities{Entities: []params.Entity{{Tag: arg.Tag}}}
 	results, err := c.applicationsCharmActions(tags)

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -34,7 +34,7 @@ func (s *actionSuite) TestApplicationCharmActions(c *gc.C) {
 		expectedErr    string
 		expectedResult map[string]params.ActionSpec
 	}{{
-		description: "result from wrong service",
+		description: "result from wrong application",
 		patchResults: []params.ApplicationCharmActionsResult{
 			{
 				ApplicationTag: names.NewApplicationTag("bar").String(),

--- a/api/action/run.go
+++ b/api/action/run.go
@@ -19,7 +19,7 @@ func (c *Client) RunOnAllMachines(commands string, timeout time.Duration) ([]par
 }
 
 // Run the Commands specified on the machines identified through the ids
-// provided in the machines, services and units slices.
+// provided in the machines, applications and units slices.
 func (c *Client) Run(run params.RunParams) ([]params.ActionResult, error) {
 	var results params.ActionResults
 	err := c.facade.FacadeCall("Run", run, &results)

--- a/api/allwatcher.go
+++ b/api/allwatcher.go
@@ -76,7 +76,7 @@ func (o orderedDeltas) kindPriority(kind string) int {
 	switch kind {
 	case "machine":
 		return 1
-	case "service":
+	case "application":
 		return 2
 	case "relation":
 		return 3

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -25,8 +25,8 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 	annts := map[string]string{"annotation1": "test"}
 	annts2 := map[string]string{"annotation2": "test"}
 	setParams := map[string]map[string]string{
-		"charmA":   annts,
-		"serviceB": annts2,
+		"charmA":       annts,
+		"applicationB": annts2,
 	}
 	apiCaller := basetesting.APICallerFunc(
 		func(objType string,

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -25,7 +25,7 @@ import (
 
 var logger = loggo.GetLogger("juju.api.application")
 
-// Client allows access to the service API end point.
+// Client allows access to the application API end point.
 type Client struct {
 	base.ClientFacade
 	st     base.APICallCloser
@@ -39,9 +39,9 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // SetMetricCredentials sets the metric credentials for the application specified.
-func (c *Client) SetMetricCredentials(service string, credentials []byte) error {
+func (c *Client) SetMetricCredentials(application string, credentials []byte) error {
 	creds := []params.ApplicationMetricCredential{
-		{service, credentials},
+		{application, credentials},
 	}
 	p := params.ApplicationMetricCredentials{creds}
 	results := new(params.ErrorResults)
@@ -61,7 +61,7 @@ func (c *Client) ModelUUID() string {
 	return tag.Id()
 }
 
-// DeployArgs holds the arguments to be sent to Client.ServiceDeploy.
+// DeployArgs holds the arguments to be sent to Client.ApplicationDeploy.
 type DeployArgs struct {
 
 	// CharmID identifies the charm to deploy.
@@ -154,11 +154,11 @@ func (c *Client) Deploy(args DeployArgs) error {
 	return errors.Trace(results.OneError())
 }
 
-// GetCharmURL returns the charm URL the given service is
+// GetCharmURL returns the charm URL the given application is
 // running at present.
-func (c *Client) GetCharmURL(serviceName string) (*charm.URL, error) {
+func (c *Client) GetCharmURL(applicationName string) (*charm.URL, error) {
 	result := new(params.StringResult)
-	args := params.ApplicationGet{ApplicationName: serviceName}
+	args := params.ApplicationGet{ApplicationName: applicationName}
 	err := c.facade.FacadeCall("GetCharmURL", args, result)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -242,7 +242,7 @@ func describeV5(config map[string]interface{}) (map[string]interface{}, error) {
 }
 
 // SetCharmConfig holds the configuration for setting a new revision of a charm
-// on a service.
+// on a application.
 type SetCharmConfig struct {
 	// ApplicationName is the name of the application to set the charm on.
 	ApplicationName string
@@ -278,7 +278,7 @@ type SetCharmConfig struct {
 	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
 }
 
-// SetCharm sets the charm for a given service.
+// SetCharm sets the charm for a given application.
 func (c *Client) SetCharm(cfg SetCharmConfig) error {
 	var storageConstraints map[string]params.StorageConstraints
 	if len(cfg.StorageConstraints) > 0 {

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -37,7 +37,7 @@ func newClientV4(f basetesting.APICallerFunc) *application.Client {
 	return application.NewClient(basetesting.BestVersionCaller{f, 4})
 }
 
-func (s *applicationSuite) TestSetServiceMetricCredentials(c *gc.C) {
+func (s *applicationSuite) TestSetApplicationMetricCredentials(c *gc.C) {
 	var called bool
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		called = true
@@ -47,19 +47,19 @@ func (s *applicationSuite) TestSetServiceMetricCredentials(c *gc.C) {
 		args, ok := a.(params.ApplicationMetricCredentials)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(args.Creds, gc.HasLen, 1)
-		c.Assert(args.Creds[0].ApplicationName, gc.Equals, "serviceA")
+		c.Assert(args.Creds[0].ApplicationName, gc.Equals, "applicationA")
 		c.Assert(args.Creds[0].MetricCredentials, gc.DeepEquals, []byte("creds 1"))
 
 		result := response.(*params.ErrorResults)
 		result.Results = make([]params.ErrorResult, 1)
 		return nil
 	})
-	err := client.SetMetricCredentials("serviceA", []byte("creds 1"))
+	err := client.SetMetricCredentials("applicationA", []byte("creds 1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *applicationSuite) TestSetServiceMetricCredentialsFails(c *gc.C) {
+func (s *applicationSuite) TestSetApplicationMetricCredentialsFails(c *gc.C) {
 	var called bool
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		called = true
@@ -88,7 +88,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 				c.Assert(args.Applications, gc.HasLen, 1)
 				app := args.Applications[0]
 				c.Assert(app.CharmURL, gc.Equals, "cs:trusty/a-charm-1")
-				c.Assert(app.ApplicationName, gc.Equals, "serviceA")
+				c.Assert(app.ApplicationName, gc.Equals, "applicationA")
 				c.Assert(app.Series, gc.Equals, "series")
 				c.Assert(app.NumUnits, gc.Equals, 1)
 				c.Assert(app.ConfigYAML, gc.Equals, "configYAML")
@@ -112,7 +112,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 		CharmID: charmstore.CharmID{
 			URL: charm.MustParseURL("trusty/a-charm-1"),
 		},
-		ApplicationName:  "serviceA",
+		ApplicationName:  "applicationA",
 		Series:           "series",
 		NumUnits:         1,
 		ConfigYAML:       "configYAML",
@@ -227,7 +227,7 @@ func (s *applicationSuite) TestAddUnitsAttachStorageMultipleUnits(c *gc.C) {
 	c.Assert(called, jc.IsFalse)
 }
 
-func (s *applicationSuite) TestServiceGetCharmURL(c *gc.C) {
+func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
 	var called bool
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		called = true

--- a/api/applicationscaler/api.go
+++ b/api/applicationscaler/api.go
@@ -32,7 +32,7 @@ func NewAPI(caller base.APICaller, newWatcher NewWatcherFunc) *API {
 	}
 }
 
-// Watch returns a StringsWatcher that delivers the names of services
+// Watch returns a StringsWatcher that delivers the names of applications
 // that may need to be rescaled.
 func (api *API) Watch() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
@@ -50,15 +50,15 @@ func (api *API) Watch() (watcher.StringsWatcher, error) {
 // Rescale requests that all supplied application names be rescaled to
 // their minimum configured sizes. It returns the first error it
 // encounters.
-func (api *API) Rescale(services []string) error {
+func (api *API) Rescale(applications []string) error {
 	args := params.Entities{
-		Entities: make([]params.Entity, len(services)),
+		Entities: make([]params.Entity, len(applications)),
 	}
-	for i, service := range services {
-		if !names.IsValidApplication(service) {
-			return errors.NotValidf("application name %q", service)
+	for i, application := range applications {
+		if !names.IsValidApplication(application) {
+			return errors.NotValidf("application name %q", application)
 		}
-		tag := names.NewApplicationTag(service)
+		tag := names.NewApplicationTag(application)
 		args.Entities[i].Tag = tag.String()
 	}
 	var results params.ErrorResults

--- a/api/base/types.go
+++ b/api/base/types.go
@@ -32,7 +32,7 @@ type ModelStatus struct {
 	TotalMachineCount  int
 	CoreCount          int
 	HostedMachineCount int
-	ServiceCount       int
+	ApplicationCount   int
 	Machines           []Machine
 	Volumes            []Volume
 	Filesystems        []Filesystem

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -89,7 +89,7 @@ func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.Mo
 		Life:               string(r.Life),
 		Owner:              owner.Id(),
 		HostedMachineCount: r.HostedMachineCount,
-		ServiceCount:       r.ApplicationCount,
+		ApplicationCount:   r.ApplicationCount,
 		TotalMachineCount:  len(r.Machines),
 		Volumes:            volumes,
 		Filesystems:        filesystems,

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -332,7 +332,7 @@ func (s *Suite) TestModelStatus(c *gc.C) {
 		UUID:               coretesting.ModelTag.Id(),
 		TotalMachineCount:  1,
 		HostedMachineCount: 2,
-		ServiceCount:       3,
+		ApplicationCount:   3,
 		Owner:              "glenda",
 		Life:               string(params.Alive),
 		Machines:           []base.Machine{{Id: "0", InstanceId: "inst-ance", Status: "pending"}},

--- a/api/firewaller/unit_test.go
+++ b/api/firewaller/unit_test.go
@@ -70,10 +70,10 @@ func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	c.Assert(err, jc.Satisfies, params.IsCodeNotAssigned)
 }
 
-func (s *unitSuite) TestService(c *gc.C) {
-	service, err := s.apiUnit.Application()
+func (s *unitSuite) TestApplication(c *gc.C) {
+	application, err := s.apiUnit.Application()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(service.Name(), gc.Equals, s.application.Name())
+	c.Assert(application.Name(), gc.Equals, s.application.Name())
 }
 
 func (s *unitSuite) TestName(c *gc.C) {

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -377,7 +377,7 @@ func (s *modelmanagerSuite) TestModelStatus(c *gc.C) {
 		UUID:               coretesting.ModelTag.Id(),
 		TotalMachineCount:  1,
 		HostedMachineCount: 2,
-		ServiceCount:       3,
+		ApplicationCount:   3,
 		Owner:              "glenda",
 		Life:               string(params.Alive),
 		Machines:           []base.Machine{{Id: "0", InstanceId: "inst-ance", Status: "pending"}},

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -556,7 +556,7 @@ func commonServiceInstances(st *state.State, m *state.Machine) ([]instance.Id, e
 		if !unit.IsPrincipal() {
 			continue
 		}
-		instanceIds, err := state.ServiceInstances(st, unit.ApplicationName())
+		instanceIds, err := state.ApplicationInstances(st, unit.ApplicationName())
 		if err != nil {
 			return nil, err
 		}

--- a/apiserver/facades/agent/resourceshookcontext/stub_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/stub_test.go
@@ -17,7 +17,7 @@ type stubUnitDataStore struct {
 
 	ReturnOpenResource  resource.Opened
 	ReturnGetResource   resource.Resource
-	ReturnListResources resource.ServiceResources
+	ReturnListResources resource.ApplicationResources
 }
 
 func (s *stubUnitDataStore) OpenResource(name string) (resource.Resource, io.ReadCloser, error) {
@@ -38,10 +38,10 @@ func (s *stubUnitDataStore) GetResource(name string) (resource.Resource, error) 
 	return s.ReturnGetResource, nil
 }
 
-func (s *stubUnitDataStore) ListResources() (resource.ServiceResources, error) {
+func (s *stubUnitDataStore) ListResources() (resource.ApplicationResources, error) {
 	s.AddCall("ListResources")
 	if err := s.NextErr(); err != nil {
-		return resource.ServiceResources{}, errors.Trace(err)
+		return resource.ApplicationResources{}, errors.Trace(err)
 	}
 
 	return s.ReturnListResources, nil

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade.go
@@ -30,7 +30,7 @@ type resourcesUnitDataStore struct {
 }
 
 // ListResources implements resource/api/private/server.UnitDataStore.
-func (ds *resourcesUnitDataStore) ListResources() (resource.ServiceResources, error) {
+func (ds *resourcesUnitDataStore) ListResources() (resource.ApplicationResources, error) {
 	return ds.resources.ListResources(ds.unit.ApplicationName())
 }
 
@@ -38,7 +38,7 @@ func (ds *resourcesUnitDataStore) ListResources() (resource.ServiceResources, er
 // All functionality is tied to the unit's application.
 type UnitDataStore interface {
 	// ListResources lists all the resources for the application.
-	ListResources() (resource.ServiceResources, error)
+	ListResources() (resource.ApplicationResources, error)
 }
 
 // NewUnitFacade returns the resources portion of the uniter's API facade.

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
@@ -46,7 +46,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoOkay(c *gc.C) {
 	opened2 := resourcetesting.NewResource(c, s.stub, "eggs", "a-application", "other data")
 	res2 := opened2.Resource
 	store := &stubUnitDataStore{Stub: s.stub}
-	store.ReturnListResources = resource.ServiceResources{
+	store.ReturnListResources = resource.ApplicationResources{
 		Resources: []resource.Resource{res1, res2},
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
@@ -69,7 +69,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoOkay(c *gc.C) {
 func (s *UnitFacadeSuite) TestGetResourceInfoEmpty(c *gc.C) {
 	opened := resourcetesting.NewResource(c, s.stub, "spam", "a-application", "some data")
 	store := &stubUnitDataStore{Stub: s.stub}
-	store.ReturnListResources = resource.ServiceResources{
+	store.ReturnListResources = resource.ApplicationResources{
 		Resources: []resource.Resource{opened.Resource},
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
@@ -88,7 +88,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoEmpty(c *gc.C) {
 func (s *UnitFacadeSuite) TestGetResourceInfoNotFound(c *gc.C) {
 	opened := resourcetesting.NewResource(c, s.stub, "spam", "a-application", "some data")
 	store := &stubUnitDataStore{Stub: s.stub}
-	store.ReturnListResources = resource.ServiceResources{
+	store.ReturnListResources = resource.ApplicationResources{
 		Resources: []resource.Resource{opened.Resource},
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -44,7 +44,7 @@ func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
 	newFactory := factory.NewFactory(s.State)
-	// Create two machines, two applications and add a unit to each service.
+	// Create two machines, two applications and add a unit to each application.
 	s.machine0 = newFactory.MakeMachine(c, &factory.MachineParams{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits, state.JobManageModel},

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -57,9 +57,9 @@ type uniterSuiteBase struct {
 	wordpressUnit *state.Unit
 	mysqlUnit     *state.Unit
 
-	meteredService *state.Application
-	meteredCharm   *state.Charm
-	meteredUnit    *state.Unit
+	meteredApplication *state.Application
+	meteredCharm       *state.Charm
+	meteredUnit        *state.Unit
 }
 
 func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
@@ -103,11 +103,11 @@ func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
 		Name: "metered",
 		URL:  "cs:quantal/metered",
 	})
-	s.meteredService = s.Factory.MakeApplication(c, &jujufactory.ApplicationParams{
+	s.meteredApplication = s.Factory.MakeApplication(c, &jujufactory.ApplicationParams{
 		Charm: s.meteredCharm,
 	})
 	s.meteredUnit = s.Factory.MakeUnit(c, &jujufactory.UnitParams{
-		Application: s.meteredService,
+		Application: s.meteredApplication,
 		SetCharmURL: true,
 	})
 
@@ -642,7 +642,7 @@ func (s *uniterSuite) TestClearResolved(c *gc.C) {
 
 func (s *uniterSuite) TestGetPrincipal(c *gc.C) {
 	// Add a subordinate to wordpressUnit.
-	_, _, subordinate := s.addRelatedService(c, "wordpress", "logging", s.wordpressUnit)
+	_, _, subordinate := s.addRelatedApplication(c, "wordpress", "logging", s.wordpressUnit)
 
 	principal, ok := subordinate.PrincipalName()
 	c.Assert(principal, gc.Equals, s.wordpressUnit.Name())
@@ -704,8 +704,8 @@ func (s *uniterSuite) TestHasSubordinates(c *gc.C) {
 	})
 
 	// Add two subordinates to wordpressUnit and try again.
-	s.addRelatedService(c, "wordpress", "logging", s.wordpressUnit)
-	s.addRelatedService(c, "wordpress", "monitoring", s.wordpressUnit)
+	s.addRelatedApplication(c, "wordpress", "logging", s.wordpressUnit)
+	s.addRelatedApplication(c, "wordpress", "monitoring", s.wordpressUnit)
 
 	result, err = s.uniter.HasSubordinates(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -744,8 +744,8 @@ func (s *uniterSuite) TestDestroy(c *gc.C) {
 
 func (s *uniterSuite) TestDestroyAllSubordinates(c *gc.C) {
 	// Add two subordinates to wordpressUnit.
-	_, _, loggingSub := s.addRelatedService(c, "wordpress", "logging", s.wordpressUnit)
-	_, _, monitoringSub := s.addRelatedService(c, "wordpress", "monitoring", s.wordpressUnit)
+	_, _, loggingSub := s.addRelatedApplication(c, "wordpress", "logging", s.wordpressUnit)
+	_, _, monitoringSub := s.addRelatedApplication(c, "wordpress", "monitoring", s.wordpressUnit)
 	c.Assert(loggingSub.Life(), gc.Equals, state.Alive)
 	c.Assert(monitoringSub.Life(), gc.Equals, state.Alive)
 
@@ -786,7 +786,7 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
 	c.Assert(ok, jc.IsTrue)
 
-	// Make sure wordpress service's charm is what we expect.
+	// Make sure wordpress application's charm is what we expect.
 	curl, force := s.wordpress.CharmURL()
 	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
 	c.Assert(force, jc.IsFalse)
@@ -1738,9 +1738,9 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 	wpEp, err := rel.Endpoint("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Add another relation to mysql service, so we can see we can't
+	// Add another relation to mysql application, so we can see we can't
 	// get it.
-	otherRel, _, _ := s.addRelatedService(c, "mysql", "logging", s.mysqlUnit)
+	otherRel, _, _ := s.addRelatedApplication(c, "mysql", "logging", s.mysqlUnit)
 
 	args := params.RelationIds{
 		RelationIds: []int{-1, rel.Id(), otherRel.Id(), 42, 234},
@@ -2524,8 +2524,8 @@ func (s *uniterSuite) TestGetMeterStatusBadTag(c *gc.C) {
 	}
 }
 
-func (s *uniterSuite) addRelatedService(c *gc.C, firstSvc, relatedSvc string, unit *state.Unit) (*state.Relation, *state.Application, *state.Unit) {
-	relatedService := s.AddTestingApplication(c, relatedSvc, s.AddTestingCharm(c, relatedSvc))
+func (s *uniterSuite) addRelatedApplication(c *gc.C, firstSvc, relatedSvc string, unit *state.Unit) (*state.Relation, *state.Application, *state.Unit) {
+	relatedApplication := s.AddTestingApplication(c, relatedSvc, s.AddTestingCharm(c, relatedSvc))
 	rel := s.addRelation(c, firstSvc, relatedSvc)
 	relUnit, err := rel.Unit(unit)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2533,7 +2533,7 @@ func (s *uniterSuite) addRelatedService(c *gc.C, firstSvc, relatedSvc string, un
 	c.Assert(err, jc.ErrorIsNil)
 	relatedUnit, err := s.State.Unit(relatedSvc + "/0")
 	c.Assert(err, jc.ErrorIsNil)
-	return rel, relatedService, relatedUnit
+	return rel, relatedApplication, relatedUnit
 }
 
 func (s *uniterSuite) TestRequestReboot(c *gc.C) {
@@ -2586,8 +2586,8 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 	sCons := map[string]state.StorageConstraints{
 		"data": {Pool: "", Size: 1024, Count: 1},
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-block", ch, sCons)
-	unit, err := service.AddUnit(state.AddUnitParams{})
+	application := s.AddTestingApplicationWithStorage(c, "storage-block", ch, sCons)
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3203,7 +3203,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 }
 
 func (s *unitMetricBatchesSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
-	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.meteredService, SetCharmURL: true})
+	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.meteredApplication, SetCharmURL: true})
 
 	metrics := []params.Metric{{Key: "pings", Value: "5", Time: time.Now().UTC()}}
 	uuid := utils.MustNewUUID().String()

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -233,7 +233,7 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 			{Name: "fakeaction"},
 			// Good.
 			{Receiver: s.wordpressUnit.Tag().String(), Name: expectedName, Parameters: expectedParameters},
-			// Service tag instead of Unit tag.
+			// Application tag instead of Unit tag.
 			{Receiver: s.wordpress.Tag().String(), Name: "fakeaction"},
 			// Missing name.
 			{Receiver: s.mysqlUnit.Tag().String(), Parameters: expectedParameters},

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -47,8 +47,8 @@ func (s *runSuite) addMachine(c *gc.C) *state.Machine {
 	return machine
 }
 
-func (s *runSuite) addUnit(c *gc.C, service *state.Application) *state.Unit {
-	unit, err := service.AddUnit(state.AddUnitParams{})
+func (s *runSuite) addUnit(c *gc.C, application *state.Application) *state.Unit {
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -85,32 +85,32 @@ func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i, test := range []struct {
-		message  string
-		expected []string
-		units    []string
-		services []string
-		error    string
+		message      string
+		expected     []string
+		units        []string
+		applications []string
+		error        string
 	}{{
 		message: "no units, expected nil slice",
 	}, {
-		message:  "asking for an empty string service",
-		services: []string{""},
-		error:    `"" is not a valid application name`,
+		message:      "asking for an empty string application",
+		applications: []string{""},
+		error:        `"" is not a valid application name`,
 	}, {
 		message: "asking for an empty string unit",
 		units:   []string{""},
 		error:   `invalid unit name ""`,
 	}, {
-		message:  "asking for a service that isn't there",
-		services: []string{"foo"},
-		error:    `application "foo" not found`,
+		message:      "asking for a application that isn't there",
+		applications: []string{"foo"},
+		error:        `application "foo" not found`,
 	}, {
-		message:  "service with no units is not really an error",
-		services: []string{"no-units"},
+		message:      "application with no units is not really an error",
+		applications: []string{"no-units"},
 	}, {
-		message:  "A service with units",
-		services: []string{"magic"},
-		expected: []string{"magic/0", "magic/1"},
+		message:      "A application with units",
+		applications: []string{"magic"},
+		expected:     []string{"magic/0", "magic/1"},
 	}, {
 		message:  "Asking for just a unit",
 		units:    []string{"magic/0"},
@@ -120,13 +120,13 @@ func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 		units:    []string{"logging/0"},
 		expected: []string{"logging/0"},
 	}, {
-		message:  "Asking for a unit, and the service",
-		services: []string{"magic"},
-		units:    []string{"magic/0"},
-		expected: []string{"magic/0", "magic/1"},
+		message:      "Asking for a unit, and the application",
+		applications: []string{"magic"},
+		units:        []string{"magic/0"},
+		expected:     []string{"magic/0", "magic/1"},
 	}} {
 		c.Logf("%v: %s", i, test.message)
-		result, err := action.GetAllUnitNames(s.State, test.units, test.services)
+		result, err := action.GetAllUnitNames(s.State, test.units, test.applications)
 		if test.error == "" {
 			c.Check(err, jc.ErrorIsNil)
 			var units []string
@@ -159,9 +159,9 @@ func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {
 	s.AssertBlocked(c, err, "TestBlockRunOnAllMachines")
 }
 
-func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
+func (s *runSuite) TestBlockRunMachineAndApplication(c *gc.C) {
 	// block all changes
-	s.BlockAllChanges(c, "TestBlockRunMachineAndService")
+	s.BlockAllChanges(c, "TestBlockRunMachineAndApplication")
 	_, err := s.client.Run(
 		params.RunParams{
 			Commands:     "hostname",
@@ -169,10 +169,10 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 			Machines:     []string{"0"},
 			Applications: []string{"magic"},
 		})
-	s.AssertBlocked(c, err, "TestBlockRunMachineAndService")
+	s.AssertBlocked(c, err, "TestBlockRunMachineAndApplication")
 }
 
-func (s *runSuite) TestRunMachineAndService(c *gc.C) {
+func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 	// We only test that we create the actions correctly
 	// There is no need to test anything else at this level.
 	expectedPayload := map[string]interface{}{

--- a/apiserver/facades/client/annotations/client_test.go
+++ b/apiserver/facades/client/annotations/client_test.go
@@ -63,14 +63,14 @@ func (s *annotationSuite) TestCharmAnnotations(c *gc.C) {
 	s.testSetGetEntitiesAnnotations(c, charm.Tag())
 }
 
-func (s *annotationSuite) TestServiceAnnotations(c *gc.C) {
+func (s *annotationSuite) TestApplicationAnnotations(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
 	wordpress := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: charm,
 	})
 	s.testSetGetEntitiesAnnotations(c, wordpress.Tag())
 
-	// on service removal
+	// on application removal
 	err := wordpress.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAnnotationsRemoval(c, wordpress.Tag())
@@ -128,7 +128,7 @@ func (s *annotationSuite) TestUnitAnnotations(c *gc.C) {
 
 func (s *annotationSuite) makeRelation(c *gc.C) (*state.Application, *state.Relation) {
 	s1 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Name: "service1",
+		Name: "application1",
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
 			Name: "wordpress",
 		}),
@@ -137,7 +137,7 @@ func (s *annotationSuite) makeRelation(c *gc.C) (*state.Application, *state.Rela
 	c.Assert(err, jc.ErrorIsNil)
 
 	s2 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Name: "service2",
+		Name: "application2",
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
 			Name: "mysql",
 		}),
@@ -196,7 +196,7 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	sEntity := sTag.String()
 
 	entities := []string{
-		sEntity, //service: expect success in set/get
+		sEntity, //application: expect success in set/get
 		rEntity, //relation:expect failure in set/get - cannot annotate relations
 	}
 	annotations := map[string]string{"mykey": "myvalue"}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -330,7 +330,7 @@ func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -406,7 +406,7 @@ func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -441,7 +441,7 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
 	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
@@ -558,7 +558,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 
-	app := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
 
 	appConfig, err := app.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -593,7 +593,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 
-	app := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
 	appConfig, err := app.ApplicationConfig()
 	trust := appConfig.GetBool(application.TrustConfigOptionName, true)
 	c.Assert(trust, jc.IsFalse)
@@ -1220,7 +1220,7 @@ func (s *applicationSuite) assertApplicationDeployPrincipal(c *gc.C, curl *charm
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "application", curl, false, ch, mem4g)
+	apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, mem4g)
 }
 
 func (s *applicationSuite) assertApplicationDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -335,45 +335,45 @@ func (s *DeployLocalSuite) TestDeployWithApplicationConfig(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
-	serviceCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
-			Constraints:     serviceCons,
+			Constraints:     applicationCons,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, app, serviceCons)
+	s.assertConstraints(c, app, applicationCons)
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 	var f fakeDeployer
 
-	serviceCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
-			Constraints:     serviceCons,
+			Constraints:     applicationCons,
 			NumUnits:        2,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(f.args.Name, gc.Equals, "bob")
 	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
-	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.Constraints, gc.DeepEquals, applicationCons)
 	c.Assert(f.args.NumUnits, gc.Equals, 2)
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 	var f fakeDeployer
 
-	serviceCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
-			Constraints:     serviceCons,
+			Constraints:     applicationCons,
 			NumUnits:        1,
 			Placement:       []*instance.Placement{instance.MustParsePlacement("0")},
 		})
@@ -381,7 +381,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 
 	c.Assert(f.args.Name, gc.Equals, "bob")
 	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
-	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.Constraints, gc.DeepEquals, applicationCons)
 	c.Assert(f.args.NumUnits, gc.Equals, 1)
 	c.Assert(f.args.Placement, gc.HasLen, 1)
 	c.Assert(*f.args.Placement[0], gc.Equals, instance.Placement{Scope: instance.MachineScope, Directive: "0"})
@@ -390,19 +390,19 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 	var f fakeDeployer
 
-	serviceCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
-			Constraints:     serviceCons,
+			Constraints:     applicationCons,
 			NumUnits:        1,
 			Placement:       []*instance.Placement{instance.MustParsePlacement(fmt.Sprintf("%s:0", instance.LXD))},
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.args.Name, gc.Equals, "bob")
 	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
-	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.Constraints, gc.DeepEquals, applicationCons)
 	c.Assert(f.args.NumUnits, gc.Equals, 1)
 	c.Assert(f.args.Placement, gc.HasLen, 1)
 	c.Assert(*f.args.Placement[0], gc.Equals, instance.Placement{Scope: string(instance.LXD), Directive: "0"})
@@ -411,7 +411,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 	var f fakeDeployer
 
-	serviceCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	placement := []*instance.Placement{
 		{Scope: s.State.ModelUUID(), Directive: "valid"},
 		{Scope: "#", Directive: "0"},
@@ -422,7 +422,7 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
-			Constraints:     serviceCons,
+			Constraints:     applicationCons,
 			NumUnits:        4,
 			Placement:       placement,
 		})
@@ -430,27 +430,27 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 
 	c.Assert(f.args.Name, gc.Equals, "bob")
 	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
-	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.Constraints, gc.DeepEquals, applicationCons)
 	c.Assert(f.args.NumUnits, gc.Equals, 4)
 	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 	var f fakeDeployer
-	serviceCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	placement := []*instance.Placement{{Scope: s.State.ModelUUID(), Directive: "valid"}}
 	_, err := application.DeployApplication(&f,
 		application.DeployApplicationParams{
 			ApplicationName: "bob",
 			Charm:           s.charm,
-			Constraints:     serviceCons,
+			Constraints:     applicationCons,
 			NumUnits:        3,
 			Placement:       placement,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.args.Name, gc.Equals, "bob")
 	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
-	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.Constraints, gc.DeepEquals, applicationCons)
 	c.Assert(f.args.NumUnits, gc.Equals, 3)
 	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }

--- a/apiserver/facades/client/metricsdebug/metricsdebug_test.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug_test.go
@@ -39,13 +39,13 @@ func (s *metricsDebugSuite) SetUpTest(c *gc.C) {
 
 func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 	testCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	testService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: testCharm})
-	testUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testService, SetCharmURL: true})
-	testUnit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testService, SetCharmURL: true})
+	testApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: testCharm})
+	testUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testApplication, SetCharmURL: true})
+	testUnit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: testApplication, SetCharmURL: true})
 
 	csCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
-	csService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "cs-service", Charm: csCharm})
-	csUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: csService, SetCharmURL: true})
+	csApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "cs-application", Charm: csCharm})
+	csUnit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: csApplication, SetCharmURL: true})
 
 	tests := []struct {
 		about  string
@@ -56,7 +56,7 @@ func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 		about: "set application meter status",
 		params: params.MeterStatusParams{
 			Statuses: []params.MeterStatusParam{{
-				Tag:  testService.Tag().String(),
+				Tag:  testApplication.Tag().String(),
 				Code: "RED",
 				Info: "test",
 			},
@@ -102,7 +102,7 @@ func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 		about: "not a local charm - application",
 		params: params.MeterStatusParams{
 			Statuses: []params.MeterStatusParam{{
-				Tag:  csService.Tag().String(),
+				Tag:  csApplication.Tag().String(),
 				Code: "AMBER",
 				Info: "test",
 			},
@@ -171,8 +171,8 @@ func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 
 func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: t0}
@@ -201,8 +201,8 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 
 func (s *metricsDebugSuite) TestGetMetricsLabelOrdering(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: unit, Metrics: []state.Metric{{
 		Key: "pings", Value: "6", Time: t0,
@@ -236,9 +236,9 @@ func (s *metricsDebugSuite) TestGetMetricsLabelOrdering(c *gc.C) {
 
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: t1}
@@ -277,9 +277,9 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEachBatch(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: t1}
@@ -313,9 +313,9 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEac
 
 func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPerUnit(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	t0 := time.Now().Round(time.Second)
 	t1 := t0.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: t1}
@@ -350,11 +350,11 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPer
 
 func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocks(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
-	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 
 	metricUnit0 := s.Factory.MakeMetric(c, &factory.MetricParams{
 		Unit: unit0,
@@ -385,13 +385,13 @@ func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocks(c *gc.C) {
 	c.Assert(metrics1.Results[0].Metrics[0].Time, jc.TimeBetween(metricUnit1.Metrics()[0].Time, metricUnit1.Metrics()[0].Time))
 }
 
-func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocksWithService(c *gc.C) {
+func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocksWithApplication(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
-	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 
 	metricUnit0 := s.Factory.MakeMetric(c, &factory.MetricParams{
 		Unit: unit0,
@@ -419,11 +419,11 @@ func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocksWithService(c *gc.C) {
 
 func (s *metricsDebugSuite) TestGetModelNoMocks(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: meteredCharm,
 	})
-	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	unit0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit1 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 
 	metricUnit0 := s.Factory.MakeMetric(c, &factory.MetricParams{
 		Unit: unit0,

--- a/apiserver/facades/client/resources/base_test.go
+++ b/apiserver/facades/client/resources/base_test.go
@@ -74,7 +74,7 @@ func newResource(c *gc.C, name, username, data string) (resource.Resource, param
 type stubDataStore struct {
 	stub *testing.Stub
 
-	ReturnListResources         resource.ServiceResources
+	ReturnListResources         resource.ApplicationResources
 	ReturnAddPendingResource    string
 	ReturnGetResource           resource.Resource
 	ReturnGetPendingResource    resource.Resource
@@ -90,17 +90,17 @@ func (s *stubDataStore) OpenResource(application, name string) (resource.Resourc
 	return s.ReturnGetResource, nil, nil
 }
 
-func (s *stubDataStore) ListResources(service string) (resource.ServiceResources, error) {
-	s.stub.AddCall("ListResources", service)
+func (s *stubDataStore) ListResources(application string) (resource.ApplicationResources, error) {
+	s.stub.AddCall("ListResources", application)
 	if err := s.stub.NextErr(); err != nil {
-		return resource.ServiceResources{}, errors.Trace(err)
+		return resource.ApplicationResources{}, errors.Trace(err)
 	}
 
 	return s.ReturnListResources, nil
 }
 
-func (s *stubDataStore) AddPendingResource(service, userID string, chRes charmresource.Resource) (string, error) {
-	s.stub.AddCall("AddPendingResource", service, userID, chRes)
+func (s *stubDataStore) AddPendingResource(application, userID string, chRes charmresource.Resource) (string, error) {
+	s.stub.AddCall("AddPendingResource", application, userID, chRes)
 	if err := s.stub.NextErr(); err != nil {
 		return "", errors.Trace(err)
 	}
@@ -108,8 +108,8 @@ func (s *stubDataStore) AddPendingResource(service, userID string, chRes charmre
 	return s.ReturnAddPendingResource, nil
 }
 
-func (s *stubDataStore) GetResource(service, name string) (resource.Resource, error) {
-	s.stub.AddCall("GetResource", service, name)
+func (s *stubDataStore) GetResource(application, name string) (resource.Resource, error) {
+	s.stub.AddCall("GetResource", application, name)
 	if err := s.stub.NextErr(); err != nil {
 		return resource.Resource{}, errors.Trace(err)
 	}
@@ -117,8 +117,8 @@ func (s *stubDataStore) GetResource(service, name string) (resource.Resource, er
 	return s.ReturnGetResource, nil
 }
 
-func (s *stubDataStore) GetPendingResource(service, name, pendingID string) (resource.Resource, error) {
-	s.stub.AddCall("GetPendingResource", service, name, pendingID)
+func (s *stubDataStore) GetPendingResource(application, name, pendingID string) (resource.Resource, error) {
+	s.stub.AddCall("GetPendingResource", application, name, pendingID)
 	if err := s.stub.NextErr(); err != nil {
 		return resource.Resource{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -26,7 +26,7 @@ var logger = loggo.GetLogger("juju.apiserver.resources")
 // Backend is the functionality of Juju's state needed for the resources API.
 type Backend interface {
 	// ListResources returns the resources for the given application.
-	ListResources(service string) (resource.ServiceResources, error)
+	ListResources(service string) (resource.ApplicationResources, error)
 
 	// AddPendingResource adds the resource to the data store in a
 	// "pending" state. It will stay pending (and unavailable) until
@@ -119,7 +119,7 @@ func (f Facade) ListResources(args params.ListResourcesArgs) (params.ResourcesRe
 			continue
 		}
 
-		r.Results[i] = api.ServiceResources2APIResult(svcRes)
+		r.Results[i] = api.ApplicationResources2APIResult(svcRes)
 	}
 	return r, nil
 }

--- a/apiserver/facades/client/resources/server_listresources_test.go
+++ b/apiserver/facades/client/resources/server_listresources_test.go
@@ -38,7 +38,7 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 	apiChRes1.Revision++
 	apiChRes2.Revision++
 
-	s.data.ReturnListResources = resource.ServiceResources{
+	s.data.ReturnListResources = resource.ApplicationResources{
 		Resources: []resource.Resource{
 			res1,
 			res2,

--- a/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
@@ -45,8 +45,8 @@ func (s *metricsManagerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.metricsmanager = manager
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 }
 
 func (s *metricsManagerSuite) TestNewMetricsManagerAPIRefusesNonController(c *gc.C) {

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -143,12 +143,12 @@ func (h *ResourcesHandler) readResource(backend ResourcesBackend, req *http.Requ
 	}
 	var res resource.Resource
 	if uReq.PendingID != "" {
-		res, err = backend.GetPendingResource(uReq.Service, uReq.Name, uReq.PendingID)
+		res, err = backend.GetPendingResource(uReq.Application, uReq.Name, uReq.PendingID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	} else {
-		res, err = backend.GetResource(uReq.Service, uReq.Name)
+		res, err = backend.GetResource(uReq.Application, uReq.Name)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -164,7 +164,7 @@ func (h *ResourcesHandler) readResource(backend ResourcesBackend, req *http.Requ
 		return nil, errors.Trace(err)
 	}
 	return &uploadedResource{
-		Service:   uReq.Service,
+		Service:   uReq.Application,
 		PendingID: uReq.PendingID,
 		Resource:  chRes,
 		Data:      req.Body,
@@ -224,7 +224,7 @@ func extractUploadRequest(req *http.Request) (api.UploadRequest, error) {
 	}
 
 	ur = api.UploadRequest{
-		Service:     service,
+		Application: service,
 		Name:        name,
 		Filename:    filename,
 		Size:        size,

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -102,12 +102,12 @@ func (h *ResourcesHandler) upload(backend ResourcesBackend, req *http.Request, u
 
 	var stored resource.Resource
 	if uploaded.PendingID != "" {
-		stored, err = backend.UpdatePendingResource(uploaded.Service, uploaded.PendingID, username, uploaded.Resource, uploaded.Data)
+		stored, err = backend.UpdatePendingResource(uploaded.Application, uploaded.PendingID, username, uploaded.Resource, uploaded.Data)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	} else {
-		stored, err = backend.SetResource(uploaded.Service, username, uploaded.Resource, uploaded.Data)
+		stored, err = backend.SetResource(uploaded.Application, username, uploaded.Resource, uploaded.Data)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -122,8 +122,8 @@ func (h *ResourcesHandler) upload(backend ResourcesBackend, req *http.Request, u
 // uploadedResource holds both the information about an uploaded
 // resource and the reader containing its data.
 type uploadedResource struct {
-	// Service is the name of the application associated with the resource.
-	Service string
+	// Application is the name of the application associated with the resource.
+	Application string
 
 	// PendingID is the resource-specific sub-ID for a pending resource.
 	PendingID string
@@ -164,10 +164,10 @@ func (h *ResourcesHandler) readResource(backend ResourcesBackend, req *http.Requ
 		return nil, errors.Trace(err)
 	}
 	return &uploadedResource{
-		Service:   uReq.Application,
-		PendingID: uReq.PendingID,
-		Resource:  chRes,
-		Data:      req.Body,
+		Application: uReq.Application,
+		PendingID:   uReq.PendingID,
+		Resource:    chRes,
+		Data:        req.Body,
 	}, nil
 }
 
@@ -203,7 +203,7 @@ func extractUploadRequest(req *http.Request) (api.UploadRequest, error) {
 		return ur, errors.Errorf("unsupported content type %q", ctype)
 	}
 
-	service, name := api.ExtractEndpointDetails(req.URL)
+	application, name := api.ExtractEndpointDetails(req.URL)
 	fingerprint := req.Header.Get(api.HeaderContentSha384) // This parallels "Content-MD5".
 	sizeRaw := req.Header.Get(api.HeaderContentLength)
 	pendingID := req.URL.Query().Get(api.QueryParamPendingID)
@@ -224,7 +224,7 @@ func extractUploadRequest(req *http.Request) (api.UploadRequest, error) {
 	}
 
 	ur = api.UploadRequest{
-		Application: service,
+		Application: application,
 		Name:        name,
 		Filename:    filename,
 		Size:        size,

--- a/apiserver/testing/service.go
+++ b/apiserver/testing/service.go
@@ -13,8 +13,8 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-func AssertPrincipalServiceDeployed(c *gc.C, st *state.State, serviceName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Application {
-	service, err := st.Application(serviceName)
+func AssertPrincipalApplicationDeployed(c *gc.C, st *state.State, applicationName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Application {
+	service, err := st.Application(applicationName)
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -47,30 +47,30 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		expectedErr: "no application name specified",
 	}, {
 		should:      "fail with invalid application name",
-		args:        []string{invalidServiceId},
-		expectedErr: "invalid application name \"" + invalidServiceId + "\"",
+		args:        []string{invalidApplicationId},
+		expectedErr: "invalid application name \"" + invalidApplicationId + "\"",
 	}, {
 		should:      "fail with too many args",
 		args:        []string{"two", "things"},
 		expectedErr: "unrecognized args: \\[\"things\"\\]",
 	}, {
 		should:      "init properly with valid application name",
-		args:        []string{validServiceId},
-		expectedSvc: names.NewApplicationTag(validServiceId),
+		args:        []string{validApplicationId},
+		expectedSvc: names.NewApplicationTag(validApplicationId),
 	}, {
 		should:      "schema with tabular output",
-		args:        []string{"--format=tabular", "--schema", validServiceId},
+		args:        []string{"--format=tabular", "--schema", validApplicationId},
 		expectedErr: "full schema not compatible with tabular output",
 	}, {
 		should:               "init properly with valid application name and --schema",
-		args:                 []string{"--format=yaml", "--schema", validServiceId},
+		args:                 []string{"--format=yaml", "--schema", validApplicationId},
 		expectedOutputSchema: true,
-		expectedSvc:          names.NewApplicationTag(validServiceId),
+		expectedSvc:          names.NewApplicationTag(validApplicationId),
 	}, {
 		should:               "default to yaml output when --schema flag is specified",
-		args:                 []string{"--schema", validServiceId},
+		args:                 []string{"--schema", validApplicationId},
 		expectedOutputSchema: true,
-		expectedSvc:          names.NewApplicationTag(validServiceId),
+		expectedSvc:          names.NewApplicationTag(validApplicationId),
 	}}
 
 	for i, t := range tests {
@@ -111,30 +111,30 @@ snapshot        Take a snapshot of the database.
 		expectedErr      string
 	}{{
 		should:      "pass back API error correctly",
-		withArgs:    []string{validServiceId},
+		withArgs:    []string{validApplicationId},
 		withAPIErr:  "an API error",
 		expectedErr: "an API error",
 	}, {
 		should:           "get short results properly",
-		withArgs:         []string{validServiceId},
+		withArgs:         []string{validApplicationId},
 		withCharmActions: someCharmActions,
 	}, {
 		should:           "get full schema results properly",
-		withArgs:         []string{"--format=yaml", "--schema", validServiceId},
+		withArgs:         []string{"--format=yaml", "--schema", validApplicationId},
 		expectFullSchema: true,
 		withCharmActions: someCharmActions,
 	}, {
 		should:          "work properly when no results found",
-		withArgs:        []string{validServiceId},
+		withArgs:        []string{validApplicationId},
 		expectNoResults: true,
-		expectMessage:   fmt.Sprintf("No actions defined for %s.\n", validServiceId),
+		expectMessage:   fmt.Sprintf("No actions defined for %s.\n", validApplicationId),
 	}, {
 		should:           "get tabular default output when --schema is NOT specified",
-		withArgs:         []string{"--format=default", validServiceId},
+		withArgs:         []string{"--format=default", validApplicationId},
 		withCharmActions: someCharmActions,
 	}, {
 		should:           "get full schema default output (YAML) when --schema is specified",
-		withArgs:         []string{"--format=default", "--schema", validServiceId},
+		withArgs:         []string{"--format=default", "--schema", validApplicationId},
 		expectFullSchema: true,
 		withCharmActions: someCharmActions,
 	}}

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -29,8 +29,8 @@ const (
 	validUnitId            = "mysql/0"
 	validUnitId2           = "mysql/1"
 	invalidUnitId          = "something-strange-"
-	validServiceId         = "mysql"
-	invalidServiceId       = "something-strange-"
+	validApplicationId     = "mysql"
+	invalidApplicationId   = "something-strange-"
 )
 
 func TestPackage(t *testing.T) {

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -139,7 +139,7 @@ type addUnitCommand struct {
 	modelcmd.ModelCommandBase
 	UnitCommandBase
 	ApplicationName string
-	api             serviceAddUnitAPI
+	api             applicationAddUnitAPI
 }
 
 func (c *addUnitCommand) Info() *cmd.Info {
@@ -169,16 +169,16 @@ func (c *addUnitCommand) Init(args []string) error {
 	return c.UnitCommandBase.Init(args)
 }
 
-// serviceAddUnitAPI defines the methods on the client API
+// applicationAddUnitAPI defines the methods on the client API
 // that the application add-unit command calls.
-type serviceAddUnitAPI interface {
+type applicationAddUnitAPI interface {
 	BestAPIVersion() int
 	Close() error
 	ModelUUID() string
 	AddUnits(application.AddUnitsParams) ([]string, error)
 }
 
-func (c *addUnitCommand) getAPI() (serviceAddUnitAPI, error) {
+func (c *addUnitCommand) getAPI() (applicationAddUnitAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -23,10 +23,10 @@ import (
 
 type AddUnitSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fake *fakeServiceAddUnitAPI
+	fake *fakeApplicationAddUnitAPI
 }
 
-type fakeServiceAddUnitAPI struct {
+type fakeApplicationAddUnitAPI struct {
 	envType        string
 	application    string
 	numUnits       int
@@ -36,19 +36,19 @@ type fakeServiceAddUnitAPI struct {
 	err            error
 }
 
-func (f *fakeServiceAddUnitAPI) BestAPIVersion() int {
+func (f *fakeApplicationAddUnitAPI) BestAPIVersion() int {
 	return f.bestAPIVersion
 }
 
-func (f *fakeServiceAddUnitAPI) Close() error {
+func (f *fakeApplicationAddUnitAPI) Close() error {
 	return nil
 }
 
-func (f *fakeServiceAddUnitAPI) ModelUUID() string {
+func (f *fakeApplicationAddUnitAPI) ModelUUID() string {
 	return "fake-uuid"
 }
 
-func (f *fakeServiceAddUnitAPI) AddUnits(args apiapplication.AddUnitsParams) ([]string, error) {
+func (f *fakeApplicationAddUnitAPI) AddUnits(args apiapplication.AddUnitsParams) ([]string, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -62,7 +62,7 @@ func (f *fakeServiceAddUnitAPI) AddUnits(args apiapplication.AddUnitsParams) ([]
 	return nil, nil
 }
 
-func (f *fakeServiceAddUnitAPI) ModelGet() (map[string]interface{}, error) {
+func (f *fakeApplicationAddUnitAPI) ModelGet() (map[string]interface{}, error) {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"type": f.envType,
 		"name": "dummy",
@@ -76,7 +76,7 @@ func (f *fakeServiceAddUnitAPI) ModelGet() (map[string]interface{}, error) {
 
 func (s *AddUnitSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.fake = &fakeServiceAddUnitAPI{
+	s.fake = &fakeApplicationAddUnitAPI{
 		application:    "some-application-name",
 		numUnits:       1,
 		envType:        "dummy",

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -212,7 +212,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSuccess(c 
 		"mysql":                    {charm: "cs:xenial/mysql-42", config: mysqlch.Config().DefaultSettings()},
 		"wordpress-extra-bindings": {charm: "cs:xenial/wordpress-extra-bindings-47", config: wpch.Config().DefaultSettings()},
 	})
-	s.assertDeployedServiceBindings(c, map[string]applicationInfo{
+	s.assertDeployedApplicationBindings(c, map[string]applicationInfo{
 		"mysql": {
 			endpointBindings: map[string]string{"server": "db", "server-admin": ""},
 		},
@@ -517,7 +517,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleResources(c *gc.C) {
 	}})
 }
 
-func (s *BundleDeployCharmStoreSuite) checkResources(c *gc.C, serviceName string, expected []resource.Resource) {
+func (s *BundleDeployCharmStoreSuite) checkResources(c *gc.C, serviceapplication string, expected []resource.Resource) {
 	_, err := s.State.Application("starsay")
 	c.Check(err, jc.ErrorIsNil)
 	st, err := s.State.Resources()

--- a/cmd/juju/application/constraints.go
+++ b/cmd/juju/application/constraints.go
@@ -67,8 +67,8 @@ See also:
     get-model-constraints
     set-model-constraints`
 
-// NewServiceGetConstraintsCommand returns a command which gets application constraints.
-func NewServiceGetConstraintsCommand() modelcmd.ModelCommand {
+// NewApplicationGetConstraintsCommand returns a command which gets application constraints.
+func NewApplicationGetConstraintsCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&serviceGetConstraintsCommand{})
 }
 
@@ -154,8 +154,8 @@ type serviceSetConstraintsCommand struct {
 	Constraints constraints.Value
 }
 
-// NewServiceSetConstraintsCommand returns a command which sets application constraints.
-func NewServiceSetConstraintsCommand() modelcmd.ModelCommand {
+// NewApplicationSetConstraintsCommand returns a command which sets application constraints.
+func NewApplicationSetConstraintsCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&serviceSetConstraintsCommand{})
 }
 

--- a/cmd/juju/application/constraints_test.go
+++ b/cmd/juju/application/constraints_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type ServiceConstraintsCommandsSuite struct {
+type ApplicationConstraintsCommandsSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 }
 
-var _ = gc.Suite(&ServiceConstraintsCommandsSuite{})
+var _ = gc.Suite(&ApplicationConstraintsCommandsSuite{})
 
-func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
+func (s *ApplicationConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 	for _, test := range []struct {
 		args []string
 		err  string
@@ -41,7 +41,7 @@ func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 	}, {
 		args: []string{"mysql", "cpu-power=250"},
 	}} {
-		cmd := application.NewServiceSetConstraintsCommand()
+		cmd := application.NewApplicationSetConstraintsCommand()
 		cmd.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {
@@ -52,7 +52,7 @@ func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
 	}
 }
 
-func (s *ServiceConstraintsCommandsSuite) TestGetInit(c *gc.C) {
+func (s *ApplicationConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 	for _, test := range []struct {
 		args []string
 		err  string
@@ -73,7 +73,7 @@ func (s *ServiceConstraintsCommandsSuite) TestGetInit(c *gc.C) {
 			args: []string{"mysql"},
 		},
 	} {
-		cmd := application.NewServiceGetConstraintsCommand()
+		cmd := application.NewApplicationGetConstraintsCommand()
 		cmd.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(cmd, test.args)
 		if test.err == "" {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -161,7 +161,7 @@ func (s *DeploySuite) TestCharmDir(c *gc.C) {
 	err := runDeploy(c, ch, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathRelativeDir(c *gc.C) {
@@ -183,7 +183,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharm(c *gc.C) {
 	err := runDeploy(c, path, "--series", "precise", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:precise/dummy-1")
-	s.AssertService(c, "dummy", curl, 1, 0)
+	s.AssertApplication(c, "dummy", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeries(c *gc.C) {
@@ -202,7 +202,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c 
 	err := runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", version.SupportedLTS()))
-	s.AssertService(c, "dummy", curl, 1, 0)
+	s.AssertApplication(c, "dummy", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathDefaultSeries(c *gc.C) {
@@ -216,7 +216,7 @@ func (s *DeploySuite) TestDeployFromPathDefaultSeries(c *gc.C) {
 	err = runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
@@ -224,7 +224,7 @@ func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
 	err := runDeploy(c, path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeries(c *gc.C) {
@@ -238,7 +238,7 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {
 	err := runDeploy(c, path, "--series", "quantal", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:quantal/multi-series-1")
-	s.AssertService(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestUpgradeCharmDir(c *gc.C) {
@@ -251,7 +251,7 @@ func (s *DeploySuite) TestUpgradeCharmDir(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	upgradedRev := dummyCharm.Revision() + 1
 	curl := dummyCharm.URL().WithRevision(upgradedRev)
-	s.AssertService(c, "dummy", curl, 1, 0)
+	s.AssertApplication(c, "dummy", curl, 1, 0)
 	// Check the charm dir was left untouched.
 	ch, err := charm.ReadCharmDir(dirPath)
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,7 +263,7 @@ func (s *DeploySuite) TestCharmBundle(c *gc.C) {
 	err := runDeploy(c, ch, "some-application-name", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "some-application-name", curl, 1, 0)
+	s.AssertApplication(c, "some-application-name", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestSubordinateCharm(c *gc.C) {
@@ -271,7 +271,7 @@ func (s *DeploySuite) TestSubordinateCharm(c *gc.C) {
 	err := runDeploy(c, ch, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/logging-1")
-	s.AssertService(c, "logging", curl, 0, 0)
+	s.AssertApplication(c, "logging", curl, 0, 0)
 }
 
 func (s *DeploySuite) combinedSettings(ch charm.Charm, inSettings charm.Settings) charm.Settings {
@@ -362,7 +362,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	err := runDeploy(c, ch, "--constraints", "mem=2G cores=2", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	application, _ := s.AssertService(c, "multi-series", curl, 1, 0)
+	application, _ := s.AssertApplication(c, "multi-series", curl, 1, 0)
 	cons, err := application.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2"))
@@ -403,7 +403,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 	err := runDeploy(c, ch, "--storage", "data=machinescoped,1G", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/storage-block-1")
-	application, _ := s.AssertService(c, "storage-block", curl, 1, 0)
+	application, _ := s.AssertApplication(c, "storage-block", curl, 1, 0)
 
 	cons, err := application.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -457,7 +457,7 @@ func (s *DeploySuite) TestNumUnits(c *gc.C) {
 	err := runDeploy(c, ch, "-n", "13", "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "multi-series", curl, 13, 0)
+	s.AssertApplication(c, "multi-series", curl, 13, 0)
 }
 
 func (s *DeploySuite) TestNumUnitsSubordinate(c *gc.C) {
@@ -564,7 +564,7 @@ func (s *DeploySuite) TestDeployLocalWithTerms(c *gc.C) {
 	c.Check(stdErr, gc.Equals, `Deploying charm "local:trusty/terms1-1".`)
 
 	curl := charm.MustParseURL("local:trusty/terms1-1")
-	s.AssertService(c, "terms1", curl, 1, 0)
+	s.AssertApplication(c, "terms1", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFlags(c *gc.C) {
@@ -879,14 +879,14 @@ type applicationInfo struct {
 	endpointBindings map[string]string
 }
 
-// assertDeployedServiceBindings checks that services were deployed into the
-// expected spaces. It is separate to assertServicesDeployed because it is only
+// assertDeployedApplicationBindings checks that applications were deployed into the
+// expected spaces. It is separate to assertApplicationsDeployed because it is only
 // relevant to a couple of tests.
-func (s *charmStoreSuite) assertDeployedServiceBindings(c *gc.C, info map[string]applicationInfo) {
-	services, err := s.State.AllApplications()
+func (s *charmStoreSuite) assertDeployedApplicationBindings(c *gc.C, info map[string]applicationInfo) {
+	applications, err := s.State.AllApplications()
 	c.Assert(err, jc.ErrorIsNil)
 
-	for _, application := range services {
+	for _, application := range applications {
 		endpointBindings, err := application.EndpointBindings()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(endpointBindings, jc.DeepEquals, info[application.Name()].endpointBindings)
@@ -962,8 +962,8 @@ type testMetricCredentialsSetter struct {
 	err    error
 }
 
-func (t *testMetricCredentialsSetter) SetMetricCredentials(serviceName string, data []byte) error {
-	t.assert(serviceName, data)
+func (t *testMetricCredentialsSetter) SetMetricCredentials(applicationName string, data []byte) error {
+	t.assert(applicationName, data)
 	return t.err
 }
 
@@ -1211,7 +1211,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmWithSomeEndpointBindingsSpecified
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"wordpress-extra-bindings": {charm: "cs:quantal/wordpress-extra-bindings-1", config: ch.Config().DefaultSettings()},
 	})
-	s.assertDeployedServiceBindings(c, map[string]applicationInfo{
+	s.assertDeployedApplicationBindings(c, map[string]applicationInfo{
 		"wordpress-extra-bindings": {
 			endpointBindings: map[string]string{
 				"":                "public",
@@ -1281,7 +1281,7 @@ func (s *ParseBindSuite) TestParseSuccessWithEndpointsOnly(c *gc.C) {
 	s.checkParseOKForArgs(c, "foo=a bar=b", map[string]string{"foo": "a", "bar": "b"})
 }
 
-func (s *ParseBindSuite) TestParseSuccessWithServiceDefaultSpaceOnly(c *gc.C) {
+func (s *ParseBindSuite) TestParseSuccessWithApplicationDefaultSpaceOnly(c *gc.C) {
 	s.checkParseOKForArgs(c, "application-default", map[string]string{"": "application-default"})
 }
 
@@ -1654,8 +1654,8 @@ func (f *fakeDeployAPI) IsMetered(charmURL string) (bool, error) {
 	return results[0].(bool), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) SetMetricCredentials(service string, credentials []byte) error {
-	results := f.MethodCall(f, "SetMetricCredentials", service, credentials)
+func (f *fakeDeployAPI) SetMetricCredentials(application string, credentials []byte) error {
+	results := f.MethodCall(f, "SetMetricCredentials", application, credentials)
 	return jujutesting.TypeAssertError(results[0])
 }
 
@@ -1784,8 +1784,8 @@ func (f *fakeDeployAPI) SetAnnotation(annotations map[string]map[string]string) 
 	return results[0].([]params.ErrorResult), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) GetCharmURL(serviceName string) (*charm.URL, error) {
-	results := f.MethodCall(f, "GetCharmURL", serviceName)
+func (f *fakeDeployAPI) GetCharmURL(applicationName string) (*charm.URL, error) {
+	results := f.MethodCall(f, "GetCharmURL", applicationName)
 	return results[0].(*charm.URL), jujutesting.TypeAssertError(results[1])
 }
 

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -47,7 +47,7 @@ func NewResolvedCommandForTest(applicationResolveAPI applicationResolveAPI, clie
 }
 
 // NewAddUnitCommandForTest returns an AddUnitCommand with the api provided as specified.
-func NewAddUnitCommandForTest(api serviceAddUnitAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+func NewAddUnitCommandForTest(api applicationAddUnitAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &addUnitCommand{api: api}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)

--- a/cmd/juju/application/fakeapplication_test.go
+++ b/cmd/juju/application/fakeapplication_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-// fakeServiceAPI is the fake application API for testing the application
+// fakeApplicationAPI is the fake application API for testing the application
 // update command.
 type fakeApplicationAPI struct {
 	name        string

--- a/cmd/juju/application/register_test.go
+++ b/cmd/juju/application/register_test.go
@@ -817,7 +817,7 @@ func (m *mockMeteredDeployAPI) IsMetered(charmURL string) (bool, error) {
 	return false, m.NextErr()
 
 }
-func (m *mockMeteredDeployAPI) SetMetricCredentials(service string, credentials []byte) error {
-	m.AddCall("SetMetricCredentials", service, credentials)
+func (m *mockMeteredDeployAPI) SetMetricCredentials(application string, credentials []byte) error {
+	m.AddCall("SetMetricCredentials", application, credentials)
 	return m.NextErr()
 }

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -111,13 +111,13 @@ func (s *RemoveApplicationSuite) TestRemoveLocalMetered(c *gc.C) {
 	c.Assert(multiSeries.Life(), gc.Equals, state.Dying)
 }
 
-func (s *RemoveApplicationSuite) TestBlockRemoveService(c *gc.C) {
+func (s *RemoveApplicationSuite) TestBlockRemoveApplication(c *gc.C) {
 	s.setupTestApplication(c)
 
 	// block operation
-	s.BlockRemoveObject(c, "TestBlockRemoveService")
+	s.BlockRemoveObject(c, "TestBlockRemoveApplication")
 	_, err := runRemoveApplication(c, "multi-series")
-	s.AssertBlocked(c, err, ".*TestBlockRemoveService.*")
+	s.AssertBlocked(c, err, ".*TestBlockRemoveApplication.*")
 	multiSeries, err := s.State.Application("multi-series")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(multiSeries.Life(), gc.Equals, state.Alive)

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -41,7 +41,7 @@ func (s *RemoveUnitSuite) setupUnitForRemove(c *gc.C) *state.Application {
 	err := runDeploy(c, "-n", "2", ch, "multi-series", "--series", "precise")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:precise/multi-series-1")
-	svc, _ := s.AssertService(c, "multi-series", curl, 2, 0)
+	svc, _ := s.AssertApplication(c, "multi-series", curl, 2, 0)
 	return svc
 }
 

--- a/cmd/juju/application/unexpose_test.go
+++ b/cmd/juju/application/unexpose_test.go
@@ -48,7 +48,7 @@ func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "some-application-name", curl, 1, 0)
+	s.AssertApplication(c, "some-application-name", curl, 1, 0)
 
 	err = runExpose(c, "some-application-name")
 	c.Assert(err, jc.ErrorIsNil)
@@ -71,7 +71,7 @@ func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.AssertService(c, "some-application-name", curl, 1, 0)
+	s.AssertApplication(c, "some-application-name", curl, 1, 0)
 
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockUnexpose")

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -77,7 +77,7 @@ type CharmClient interface {
 // ResourceLister defines a subset of the resources facade, as required
 // by the upgrade-charm command.
 type ResourceLister interface {
-	ListResources([]string) ([]resource.ServiceResources, error)
+	ListResources([]string) ([]resource.ApplicationResources, error)
 }
 
 // NewCharmAdderFunc is the type of a function used to construct

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -199,7 +199,7 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 Deploying charm "cs:trusty/starsay-1".`
 	c.Assert(output, gc.Equals, expectedOutput)
 	s.assertCharmsUploaded(c, "cs:trusty/starsay-1")
-	s.assertServicesDeployed(c, map[string]serviceInfo{
+	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"starsay": {charm: "cs:trusty/starsay-1"},
 	})
 	_, err = s.State.Unit("starsay/0")
@@ -279,7 +279,7 @@ Deploying charm "cs:trusty/starsay-1".`
 	_, err = cmdtesting.RunCommand(c, application.NewUpgradeCharmCommand(), "starsay")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertServicesDeployed(c, map[string]serviceInfo{
+	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"starsay": {charm: "cs:trusty/starsay-2"},
 	})
 
@@ -332,12 +332,12 @@ func (s *charmStoreSuite) assertCharmsUploaded(c *gc.C, ids ...string) {
 	c.Assert(uploaded, jc.SameContents, ids)
 }
 
-// assertServicesDeployed checks that the given services have been deployed.
-func (s *charmStoreSuite) assertServicesDeployed(c *gc.C, info map[string]serviceInfo) {
-	services, err := s.State.AllApplications()
+// assertApplicationsDeployed checks that the given applications have been deployed.
+func (s *charmStoreSuite) assertApplicationsDeployed(c *gc.C, info map[string]applicationInfo) {
+	applications, err := s.State.AllApplications()
 	c.Assert(err, jc.ErrorIsNil)
-	deployed := make(map[string]serviceInfo, len(services))
-	for _, application := range services {
+	deployed := make(map[string]applicationInfo, len(applications))
+	for _, application := range applications {
 		charm, _ := application.CharmURL()
 		config, err := application.CharmConfig()
 		c.Assert(err, jc.ErrorIsNil)
@@ -351,7 +351,7 @@ func (s *charmStoreSuite) assertServicesDeployed(c *gc.C, info map[string]servic
 		if len(storage) == 0 {
 			storage = nil
 		}
-		deployed[application.Name()] = serviceInfo{
+		deployed[application.Name()] = applicationInfo{
 			charm:       charm.String(),
 			config:      config,
 			constraints: constraints,
@@ -362,8 +362,8 @@ func (s *charmStoreSuite) assertServicesDeployed(c *gc.C, info map[string]servic
 	c.Assert(deployed, jc.DeepEquals, info)
 }
 
-// serviceInfo holds information about a deployed application.
-type serviceInfo struct {
+// applicationInfo holds information about a deployed application.
+type applicationInfo struct {
 	charm            string
 	config           charm.Settings
 	constraints      constraints.Value

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -276,7 +276,7 @@ func (s *UpgradeCharmErrorsStateSuite) TestInvalidArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bar"\]`)
 }
 
-func (s *UpgradeCharmErrorsStateSuite) TestInvalidService(c *gc.C) {
+func (s *UpgradeCharmErrorsStateSuite) TestInvalidApplication(c *gc.C) {
 	err := runUpgradeCharm(c, "phony")
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `application "phony" not found`,
@@ -284,14 +284,14 @@ func (s *UpgradeCharmErrorsStateSuite) TestInvalidService(c *gc.C) {
 	})
 }
 
-func (s *UpgradeCharmErrorsStateSuite) deployService(c *gc.C) {
+func (s *UpgradeCharmErrorsStateSuite) deployApplication(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "riak")
 	err := runDeploy(c, ch, "riak", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeCharmErrorsStateSuite) TestInvalidSwitchURL(c *gc.C) {
-	s.deployService(c)
+	s.deployApplication(c)
 	err := runUpgradeCharm(c, "riak", "--switch=blah")
 	c.Assert(err, gc.ErrorMatches, `cannot resolve URL "cs:blah": charm or bundle not found`)
 	err = runUpgradeCharm(c, "riak", "--switch=cs:missing/one")
@@ -300,31 +300,31 @@ func (s *UpgradeCharmErrorsStateSuite) TestInvalidSwitchURL(c *gc.C) {
 }
 
 func (s *UpgradeCharmErrorsStateSuite) TestNoPathFails(c *gc.C) {
-	s.deployService(c)
+	s.deployApplication(c)
 	err := runUpgradeCharm(c, "riak")
 	c.Assert(err, gc.ErrorMatches, "upgrading a local charm requires either --path or --switch")
 }
 
 func (s *UpgradeCharmErrorsStateSuite) TestSwitchAndRevisionFails(c *gc.C) {
-	s.deployService(c)
+	s.deployApplication(c)
 	err := runUpgradeCharm(c, "riak", "--switch=riak", "--revision=2")
 	c.Assert(err, gc.ErrorMatches, "--switch and --revision are mutually exclusive")
 }
 
 func (s *UpgradeCharmErrorsStateSuite) TestPathAndRevisionFails(c *gc.C) {
-	s.deployService(c)
+	s.deployApplication(c)
 	err := runUpgradeCharm(c, "riak", "--path=foo", "--revision=2")
 	c.Assert(err, gc.ErrorMatches, "--path and --revision are mutually exclusive")
 }
 
 func (s *UpgradeCharmErrorsStateSuite) TestSwitchAndPathFails(c *gc.C) {
-	s.deployService(c)
+	s.deployApplication(c)
 	err := runUpgradeCharm(c, "riak", "--switch=riak", "--path=foo")
 	c.Assert(err, gc.ErrorMatches, "--switch and --path are mutually exclusive")
 }
 
 func (s *UpgradeCharmErrorsStateSuite) TestInvalidRevision(c *gc.C) {
-	s.deployService(c)
+	s.deployApplication(c)
 	err := runUpgradeCharm(c, "riak", "--revision=blah")
 	c.Assert(err, gc.ErrorMatches, `invalid value "blah" for flag --revision: strconv.(ParseInt|Atoi): parsing "blah": invalid syntax`)
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -389,8 +389,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewDeployCommand())
 	r.Register(application.NewExposeCommand())
 	r.Register(application.NewUnexposeCommand())
-	r.Register(application.NewServiceGetConstraintsCommand())
-	r.Register(application.NewServiceSetConstraintsCommand())
+	r.Register(application.NewApplicationGetConstraintsCommand())
+	r.Register(application.NewApplicationSetConstraintsCommand())
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -232,7 +232,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 			UUID:               uuid,
 			Life:               string(params.Dead),
 			HostedMachineCount: 0,
-			ServiceCount:       0,
+			ApplicationCount:   0,
 			Owner:              owner.Id(),
 		}
 	}

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -115,7 +115,7 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 		Life:               string(params.Dying),
 		Owner:              "admin",
 		HostedMachineCount: 2,
-		ServiceCount:       2,
+		ApplicationCount:   2,
 	})
 	wrapped := s.newKillCommand()
 	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
@@ -217,7 +217,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 		Life:               string(params.Dying),
 		Owner:              "admin",
 		HostedMachineCount: 2,
-		ServiceCount:       2,
+		ApplicationCount:   2,
 	})
 	wrapped := s.newKillCommand()
 	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=20s"})
@@ -268,7 +268,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 		Life:               string(params.Dying),
 		Owner:              "admin",
 		HostedMachineCount: 2,
-		ServiceCount:       2,
+		ApplicationCount:   2,
 	})
 	wrapped := s.newKillCommand()
 	err := cmdtesting.InitCommand(wrapped, []string{"test1", "--timeout=1m"})
@@ -496,7 +496,7 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 			UUID:               env.UUID,
 			Life:               string(params.Dying),
 			HostedMachineCount: 2,
-			ServiceCount:       1,
+			ApplicationCount:   1,
 			Owner:              owner.Id(),
 		}
 	}

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -127,7 +127,7 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 			modelName[model.UUID],
 			model.Life,
 			model.HostedMachineCount,
-			model.ServiceCount,
+			model.ApplicationCount,
 			len(model.Volumes),
 			len(model.Filesystems),
 			persistentVolumeCount,
@@ -144,7 +144,7 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 			aliveModelCount++
 		}
 		hostedMachinesCount += model.HostedMachineCount
-		servicesCount += model.ServiceCount
+		servicesCount += model.ApplicationCount
 		volumeCount += modelData.VolumeCount
 		filesystemCount += modelData.FilesystemCount
 	}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -360,7 +360,7 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 		}
 		return &modelData{
 			machineCount:     status[0].HostedMachineCount,
-			applicationCount: status[0].ServiceCount,
+			applicationCount: status[0].ApplicationCount,
 			volumeCount:      len(status[0].Volumes),
 			filesystemCount:  len(status[0].Filesystems),
 		}

--- a/cmd/juju/resource/formatter.go
+++ b/cmd/juju/resource/formatter.go
@@ -88,7 +88,7 @@ func FormatAppResource(res resource.Resource) FormattedAppResource {
 	return result
 }
 
-func formatApplicationResources(sr resource.ServiceResources) (FormattedApplicationInfo, error) {
+func formatApplicationResources(sr resource.ApplicationResources) (FormattedApplicationInfo, error) {
 	var formatted FormattedApplicationInfo
 	updates, err := sr.Updates()
 	if err != nil {
@@ -108,9 +108,9 @@ func formatApplicationResources(sr resource.ServiceResources) (FormattedApplicat
 	return formatted, nil
 }
 
-// FormatApplicationDetails converts a ServiceResources value into a formatted value
+// FormatApplicationDetails converts a ApplicationResources value into a formatted value
 // for display on the command line.
-func FormatApplicationDetails(sr resource.ServiceResources) (FormattedApplicationDetails, error) {
+func FormatApplicationDetails(sr resource.ApplicationResources) (FormattedApplicationDetails, error) {
 	var formatted FormattedApplicationDetails
 	details, err := detailedResources("", sr)
 	if err != nil {
@@ -209,7 +209,7 @@ func unitNum(unit names.UnitTag) (int, error) {
 // detailedResources shows the version of each resource on each unit, with the
 // corresponding version of the resource that exists in the controller. if unit
 // is non-empty, only units matching that unitID will be returned.
-func detailedResources(unit string, sr resource.ServiceResources) ([]FormattedDetailResource, error) {
+func detailedResources(unit string, sr resource.ApplicationResources) ([]FormattedDetailResource, error) {
 	var formatted []FormattedDetailResource
 	for _, ur := range sr.UnitResources {
 		if unit == "" || unit == ur.Tag.Id() {

--- a/cmd/juju/resource/list.go
+++ b/cmd/juju/resource/list.go
@@ -18,7 +18,7 @@ import (
 // ListClient has the API client methods needed by ListCommand.
 type ListClient interface {
 	// ListResources returns info about resources for applications in the model.
-	ListResources(services []string) ([]resource.ServiceResources, error)
+	ListResources(services []string) ([]resource.ApplicationResources, error)
 	// Close closes the connection.
 	Close() error
 }
@@ -132,7 +132,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 
 const noResources = "No resources to display."
 
-func (c *ListCommand) formatApplicationResources(ctx *cmd.Context, sr resource.ServiceResources) error {
+func (c *ListCommand) formatApplicationResources(ctx *cmd.Context, sr resource.ApplicationResources) error {
 	if c.details {
 		formatted, err := FormatApplicationDetails(sr)
 		if err != nil {
@@ -157,7 +157,7 @@ func (c *ListCommand) formatApplicationResources(ctx *cmd.Context, sr resource.S
 	return c.out.Write(ctx, formatted)
 }
 
-func (c *ListCommand) formatUnitResources(ctx *cmd.Context, unit, service string, sr resource.ServiceResources) error {
+func (c *ListCommand) formatUnitResources(ctx *cmd.Context, unit, service string, sr resource.ApplicationResources) error {
 	if len(sr.Resources) == 0 && len(sr.UnitResources) == 0 {
 		ctx.Infof(noResources)
 		return nil
@@ -191,7 +191,7 @@ func (c *ListCommand) formatUnitResources(ctx *cmd.Context, unit, service string
 
 }
 
-func unitResources(unit, service string, sr resource.ServiceResources) map[string]resource.Resource {
+func unitResources(unit, service string, sr resource.ApplicationResources) map[string]resource.Resource {
 	var resources []resource.Resource
 	for _, res := range sr.UnitResources {
 		if res.Tag.Id() == unit {

--- a/cmd/juju/resource/list_test.go
+++ b/cmd/juju/resource/list_test.go
@@ -18,46 +18,46 @@ import (
 	"github.com/juju/juju/resource"
 )
 
-var _ = gc.Suite(&ShowServiceSuite{})
+var _ = gc.Suite(&ShowApplicationSuite{})
 
-type ShowServiceSuite struct {
+type ShowApplicationSuite struct {
 	testing.IsolationSuite
 
-	stubDeps *stubShowServiceDeps
+	stubDeps *stubShowApplicationDeps
 }
 
-func (s *ShowServiceSuite) SetUpTest(c *gc.C) {
+func (s *ShowApplicationSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
 	stub := &testing.Stub{}
-	s.stubDeps = &stubShowServiceDeps{
+	s.stubDeps = &stubShowApplicationDeps{
 		stub:   stub,
-		client: &stubServiceClient{stub: stub},
+		client: &stubApplicationClient{stub: stub},
 	}
 }
 
-func (*ShowServiceSuite) TestInitEmpty(c *gc.C) {
+func (*ShowApplicationSuite) TestInitEmpty(c *gc.C) {
 	s := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{})
 
 	err := s.Init([]string{})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
-func (*ShowServiceSuite) TestInitGood(c *gc.C) {
+func (*ShowApplicationSuite) TestInitGood(c *gc.C) {
 	s := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{})
 	err := s.Init([]string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resourcecmd.ListCommandTarget(s), gc.Equals, "foo")
 }
 
-func (*ShowServiceSuite) TestInitTooManyArgs(c *gc.C) {
+func (*ShowApplicationSuite) TestInitTooManyArgs(c *gc.C) {
 	s := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{})
 
 	err := s.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
-func (s *ShowServiceSuite) TestInfo(c *gc.C) {
+func (s *ShowApplicationSuite) TestInfo(c *gc.C) {
 	var command resourcecmd.ListCommand
 	info := command.Info()
 
@@ -74,8 +74,8 @@ updates available for resources from the charmstore.
 	})
 }
 
-func (s *ShowServiceSuite) TestRunNoResourcesForService(c *gc.C) {
-	data := []resource.ServiceResources{resource.ServiceResources{}}
+func (s *ShowApplicationSuite) TestRunNoResourcesForApplication(c *gc.C) {
+	data := []resource.ApplicationResources{resource.ApplicationResources{}}
 	s.stubDeps.client.ReturnResources = data
 
 	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
@@ -89,8 +89,8 @@ func (s *ShowServiceSuite) TestRunNoResourcesForService(c *gc.C) {
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-func (s *ShowServiceSuite) TestRun(c *gc.C) {
-	data := []resource.ServiceResources{
+func (s *ShowApplicationSuite) TestRun(c *gc.C) {
+	data := []resource.ApplicationResources{
 		{
 			Resources: []resource.Resource{
 				{
@@ -203,8 +203,8 @@ openjdk   10
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-func (s *ShowServiceSuite) TestRunNoResourcesForUnit(c *gc.C) {
-	data := []resource.ServiceResources{resource.ServiceResources{}}
+func (s *ShowApplicationSuite) TestRunNoResourcesForUnit(c *gc.C) {
+	data := []resource.ApplicationResources{resource.ApplicationResources{}}
 	s.stubDeps.client.ReturnResources = data
 
 	cmd := resourcecmd.NewListCommandForTest(resourcecmd.ListDeps{
@@ -218,10 +218,10 @@ func (s *ShowServiceSuite) TestRunNoResourcesForUnit(c *gc.C) {
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-func (s *ShowServiceSuite) TestRunResourcesForAppButNoResourcesForUnit(c *gc.C) {
+func (s *ShowApplicationSuite) TestRunResourcesForAppButNoResourcesForUnit(c *gc.C) {
 	unitName := "svc/0"
 
-	data := []resource.ServiceResources{resource.ServiceResources{
+	data := []resource.ApplicationResources{resource.ApplicationResources{
 		Resources: []resource.Resource{
 			{
 				Resource: charmresource.Resource{
@@ -271,9 +271,9 @@ openjdk   -
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-func (s *ShowServiceSuite) TestRunUnit(c *gc.C) {
-	data := []resource.ServiceResources{
-		resource.ServiceResources{
+func (s *ShowApplicationSuite) TestRunUnit(c *gc.C) {
+	data := []resource.ApplicationResources{
+		resource.ApplicationResources{
 			Resources: []resource.Resource{
 				{
 					Resource: charmresource.Resource{
@@ -355,8 +355,8 @@ website2  2012-12-12T12:12
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-func (s *ShowServiceSuite) TestRunDetails(c *gc.C) {
-	data := []resource.ServiceResources{{
+func (s *ShowApplicationSuite) TestRunDetails(c *gc.C) {
+	data := []resource.ApplicationResources{{
 		Resources: []resource.Resource{
 			{
 				Resource: charmresource.Resource{
@@ -520,8 +520,8 @@ svc/10  charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 9%)
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-func (s *ShowServiceSuite) TestRunUnitDetails(c *gc.C) {
-	data := []resource.ServiceResources{{
+func (s *ShowApplicationSuite) TestRunUnitDetails(c *gc.C) {
+	data := []resource.ApplicationResources{{
 		Resources: []resource.Resource{
 			{
 				Resource: charmresource.Resource{
@@ -654,12 +654,12 @@ charlie   2011-11-11T11:11  2012-12-12T12:12 (fetching: 0%)
 	s.stubDeps.stub.CheckCall(c, 1, "ListResources", []string{"svc"})
 }
 
-type stubShowServiceDeps struct {
+type stubShowApplicationDeps struct {
 	stub   *testing.Stub
-	client *stubServiceClient
+	client *stubApplicationClient
 }
 
-func (s *stubShowServiceDeps) NewClient(c *resourcecmd.ListCommand) (resourcecmd.ListClient, error) {
+func (s *stubShowApplicationDeps) NewClient(c *resourcecmd.ListCommand) (resourcecmd.ListClient, error) {
 	s.stub.AddCall("NewClient", c)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -668,20 +668,20 @@ func (s *stubShowServiceDeps) NewClient(c *resourcecmd.ListCommand) (resourcecmd
 	return s.client, nil
 }
 
-type stubServiceClient struct {
+type stubApplicationClient struct {
 	stub            *testing.Stub
-	ReturnResources []resource.ServiceResources
+	ReturnResources []resource.ApplicationResources
 }
 
-func (s *stubServiceClient) ListResources(services []string) ([]resource.ServiceResources, error) {
-	s.stub.AddCall("ListResources", services)
+func (s *stubApplicationClient) ListResources(applications []string) ([]resource.ApplicationResources, error) {
+	s.stub.AddCall("ListResources", applications)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return s.ReturnResources, nil
 }
 
-func (s *stubServiceClient) Close() error {
+func (s *stubApplicationClient) Close() error {
 	s.stub.AddCall("Close")
 	if err := s.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/resource/output_tabular_test.go
+++ b/cmd/juju/resource/output_tabular_test.go
@@ -241,7 +241,7 @@ func (s *SvcTabularSuite) TestFormatSvcTabularMulti(c *gc.C) {
 		},
 	}
 
-	formatted, err := resourcecmd.FormatApplicationResources(resource.ServiceResources{
+	formatted, err := resourcecmd.FormatApplicationResources(resource.ApplicationResources{
 		Resources:           res,
 		CharmStoreResources: charmResources,
 	})

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -35,7 +35,7 @@ const (
 )
 
 // Value describes a user's requirements of the hardware on which units
-// of a service will run. Constraints are used to choose an existing machine
+// of an application will run. Constraints are used to choose an existing machine
 // onto which a unit will be deployed, or to provision a new machine if no
 // existing one satisfies the requirements.
 type Value struct {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -197,7 +197,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	}
 
 	_, supportsNetworking := environs.SupportsNetworking(environ)
-	logger.Debugf("model %q supports service/machine networks: %v", cfg.Name(), supportsNetworking)
+	logger.Debugf("model %q supports application/machine networks: %v", cfg.Name(), supportsNetworking)
 	disableNetworkManagement, _ := cfg.DisableNetworkManagement()
 	logger.Debugf("network management by juju enabled: %v", !disableNetworkManagement)
 

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -71,9 +71,9 @@ type StartInstanceParams struct {
 	// are present.
 	SubnetsToZones map[network.Id][]string
 
-	// EndpointBindings holds the mapping between service endpoint names to
+	// EndpointBindings holds the mapping between application endpoint names to
 	// provider-specific space IDs. It is populated when provisioning a machine
-	// to host a unit of a service with endpoint bindings.
+	// to host a unit of an application with endpoint bindings.
 	EndpointBindings map[string]network.Id
 
 	// ImageMetadata is a collection of image metadata

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -264,7 +264,7 @@ const (
 	HarvestUnknown
 	// HarvestDestroyed signifies that Juju should only harvest
 	// machines which have been explicitly released by the user
-	// through a destroy of a service/model/unit.
+	// through a destroy of an application/model/unit.
 	HarvestDestroyed
 	// HarvestAll signifies that Juju should harvest both unknown and
 	// destroyed instances. ♫ Don't fear the reaper. ♫

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -675,8 +675,8 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)
 
-	// Create a new service and deploy a unit of it.
-	c.Logf("deploying service")
+	// Create a new application and deploy a unit of it.
+	c.Logf("deploying application")
 	repoDir := c.MkDir()
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)

--- a/environs/tags/tags.go
+++ b/environs/tags/tags.go
@@ -32,7 +32,7 @@ const (
 	JujuStorageInstance = JujuTagPrefix + "storage-instance"
 
 	// JujuStorageOwner is the tag name used for identifying
-	// the service or unit that owns the Juju storage instance
+	// the application or unit that owns the Juju storage instance
 	// that an IaaS storage resource is assigned to.
 	JujuStorageOwner = JujuTagPrefix + "storage-owner"
 

--- a/featuretests/cmd_juju_metrics.go
+++ b/featuretests/cmd_juju_metrics.go
@@ -58,9 +58,9 @@ func formatTabular(metrics ...tabularMetric) string {
 
 func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1, Labels: map[string]string{"foo": "bar"}}
@@ -98,9 +98,9 @@ func (s *cmdMetricsCommandSuite) TestUnits(c *gc.C) {
 
 func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
@@ -132,9 +132,9 @@ func (s *cmdMetricsCommandSuite) TestAll(c *gc.C) {
 
 func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1, Labels: map[string]string{"abc": "123"}}
@@ -170,9 +170,9 @@ func (s *cmdMetricsCommandSuite) TestFormatJSON(c *gc.C) {
 
 func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
-	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
+	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	newTime1 := time.Now().Round(time.Second)
 	newTime2 := newTime1.Add(time.Second)
 	metricA := state.Metric{Key: "pings", Value: "5", Time: newTime1}
@@ -192,8 +192,8 @@ func (s *cmdMetricsCommandSuite) TestFormatYAML(c *gc.C) {
 
 func (s *cmdMetricsCommandSuite) TestNoMetrics(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "local:quantal/metered-1"})
-	meteredService := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredService, SetCharmURL: true})
+	meteredApplication := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: meteredApplication, SetCharmURL: true})
 	ctx, err := cmdtesting.RunCommand(c, metricsdebug.New(), "metered")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -53,7 +53,7 @@ func (s *cmdJujuSuite) TestGetConstraints(c *gc.C) {
 	err := app.SetConstraints(constraints.Value{CpuCores: uint64p(64)})
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := cmdtesting.RunCommand(c, application.NewServiceGetConstraintsCommand(), "app")
+	context, err := cmdtesting.RunCommand(c, application.NewApplicationGetConstraintsCommand(), "app")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "cores=64\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 }

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -31,23 +31,23 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *RepoSuite) AssertService(c *gc.C, name string, expectCurl *charm.URL, unitCount, relCount int) (*state.Application, []*state.Relation) {
-	svc, err := s.State.Application(name)
+func (s *RepoSuite) AssertApplication(c *gc.C, name string, expectCurl *charm.URL, unitCount, relCount int) (*state.Application, []*state.Relation) {
+	app, err := s.State.Application(name)
 	c.Assert(err, jc.ErrorIsNil)
-	ch, _, err := svc.Charm()
+	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL(), gc.DeepEquals, expectCurl)
 	s.AssertCharmUploaded(c, expectCurl)
 
-	units, err := svc.AllUnits()
-	c.Logf("Service units: %+v", units)
+	units, err := app.AllUnits()
+	c.Logf("Application units: %+v", units)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, unitCount)
 	s.AssertUnitMachines(c, units)
-	rels, err := svc.Relations()
+	rels, err := app.Relations()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rels, gc.HasLen, relCount)
-	return svc, rels
+	return app, rels
 }
 
 func (s *RepoSuite) AssertCharmUploaded(c *gc.C, curl *charm.URL) {

--- a/payload/status/util_test.go
+++ b/payload/status/util_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/juju/payload"
 )
 
-func NewPayload(name, service string, machine, unit int, labels ...string) payload.FullPayloadInfo {
+func NewPayload(name, application string, machine, unit int, labels ...string) payload.FullPayloadInfo {
 	if len(labels) == 0 {
 		labels = nil
 	}
@@ -24,7 +24,7 @@ func NewPayload(name, service string, machine, unit int, labels ...string) paylo
 			ID:     "id" + name,
 			Status: payload.StateRunning,
 			Labels: labels,
-			Unit:   fmt.Sprintf("%s/%d", service, unit),
+			Unit:   fmt.Sprintf("%s/%d", application, unit),
 		},
 		Machine: fmt.Sprintf("%d", machine),
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -528,7 +528,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	// args.SubnetsToZones map. In AWS a subnet can span only one zone, so here
 	// we build the reverse map zonesToSubnets, which we will use to below in
 	// the RunInstance loop to provide an explicit subnet ID, rather than just
-	// AZ. This ensures instances in the same group (units of a service or all
+	// AZ. This ensures instances in the same group (units of an application or all
 	// instances when adding a machine manually) will still be evenly
 	// distributed across AZs, but only within subnets of the space constraint.
 	//

--- a/resource/api/client/client_listresources_test.go
+++ b/resource/api/client/client_listresources_test.go
@@ -29,7 +29,7 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 	results, err := cl.ListResources(services)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(results, jc.DeepEquals, []resource.ServiceResources{
+	c.Check(results, jc.DeepEquals, []resource.ApplicationResources{
 		{Resources: expected},
 	})
 	c.Check(s.stub.Calls(), gc.HasLen, 1)
@@ -58,7 +58,7 @@ func (s *ListResourcesSuite) TestBulk(c *gc.C) {
 	results, err := cl.ListResources(services)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(results, jc.DeepEquals, []resource.ServiceResources{
+	c.Check(results, jc.DeepEquals, []resource.ApplicationResources{
 		{Resources: expected1},
 		{Resources: expected2},
 	})
@@ -121,7 +121,7 @@ func (s *ListResourcesSuite) TestServiceEmpty(c *gc.C) {
 	results, err := cl.ListResources(services)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(results, jc.DeepEquals, []resource.ServiceResources{
+	c.Check(results, jc.DeepEquals, []resource.ApplicationResources{
 		{},
 	})
 	s.stub.CheckCallNames(c, "FacadeCall")

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -26,14 +26,14 @@ func Resource2API(res resource.Resource) params.Resource {
 	}
 }
 
-// APIResult2ServiceResources converts a ResourcesResult into a resource.ServiceResources.
-func APIResult2ServiceResources(apiResult params.ResourcesResult) (resource.ServiceResources, error) {
-	var result resource.ServiceResources
+// APIResult2ApplicationResources converts a ResourcesResult into a resource.ApplicationResources.
+func APIResult2ApplicationResources(apiResult params.ResourcesResult) (resource.ApplicationResources, error) {
+	var result resource.ApplicationResources
 
 	if apiResult.Error != nil {
 		// TODO(ericsnow) Return the resources too?
 		err := common.RestoreError(apiResult.Error)
-		return resource.ServiceResources{}, errors.Trace(err)
+		return resource.ApplicationResources{}, errors.Trace(err)
 	}
 
 	for _, apiRes := range apiResult.Resources {
@@ -42,7 +42,7 @@ func APIResult2ServiceResources(apiResult params.ResourcesResult) (resource.Serv
 			// This could happen if the server is misbehaving
 			// or non-conforming.
 			// TODO(ericsnow) Aggregate errors?
-			return resource.ServiceResources{}, errors.Annotate(err, "got bad data from server")
+			return resource.ApplicationResources{}, errors.Annotate(err, "got bad data from server")
 		}
 		result.Resources = append(result.Resources, res)
 	}
@@ -50,14 +50,14 @@ func APIResult2ServiceResources(apiResult params.ResourcesResult) (resource.Serv
 	for _, unitRes := range apiResult.UnitResources {
 		tag, err := names.ParseUnitTag(unitRes.Tag)
 		if err != nil {
-			return resource.ServiceResources{}, errors.Annotate(err, "got bad data from server")
+			return resource.ApplicationResources{}, errors.Annotate(err, "got bad data from server")
 		}
 		resNames := map[string]bool{}
 		unitResources := resource.UnitResources{Tag: tag}
 		for _, apiRes := range unitRes.Resources {
 			res, err := API2Resource(apiRes)
 			if err != nil {
-				return resource.ServiceResources{}, errors.Annotate(err, "got bad data from server")
+				return resource.ApplicationResources{}, errors.Annotate(err, "got bad data from server")
 			}
 			resNames[res.Name] = true
 			unitResources.Resources = append(unitResources.Resources, res)
@@ -67,7 +67,7 @@ func APIResult2ServiceResources(apiResult params.ResourcesResult) (resource.Serv
 			for resName, progress := range unitRes.DownloadProgress {
 				if _, ok := resNames[resName]; !ok {
 					err := errors.Errorf("got progress from unrecognized resource %q", resName)
-					return resource.ServiceResources{}, errors.Annotate(err, "got bad data from server")
+					return resource.ApplicationResources{}, errors.Annotate(err, "got bad data from server")
 				}
 				unitResources.DownloadProgress[resName] = progress
 			}
@@ -78,7 +78,7 @@ func APIResult2ServiceResources(apiResult params.ResourcesResult) (resource.Serv
 	for _, chRes := range apiResult.CharmStoreResources {
 		res, err := API2CharmResource(chRes)
 		if err != nil {
-			return resource.ServiceResources{}, errors.Annotate(err, "got bad data from server")
+			return resource.ApplicationResources{}, errors.Annotate(err, "got bad data from server")
 		}
 		result.CharmStoreResources = append(result.CharmStoreResources, res)
 	}
@@ -86,7 +86,7 @@ func APIResult2ServiceResources(apiResult params.ResourcesResult) (resource.Serv
 	return result, nil
 }
 
-func ServiceResources2APIResult(svcRes resource.ServiceResources) params.ResourcesResult {
+func ApplicationResources2APIResult(svcRes resource.ApplicationResources) params.ResourcesResult {
 	var result params.ResourcesResult
 	for _, res := range svcRes.Resources {
 		result.Resources = append(result.Resources, Resource2API(res))

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -74,7 +74,7 @@ func (HelpersSuite) TestResource2API(c *gc.C) {
 	})
 }
 
-func (HelpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ApplicationResourcesOkay(c *gc.C) {
 	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
@@ -185,7 +185,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 		Size:        11,
 	}
 
-	resources, err := api.APIResult2ServiceResources(params.ResourcesResult{
+	resources, err := api.APIResult2ApplicationResources(params.ResourcesResult{
 		Resources: []params.Resource{
 			apiRes,
 		},
@@ -208,7 +208,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceResource := resource.ServiceResources{
+	serviceResource := resource.ApplicationResources{
 		Resources: []resource.Resource{
 			expected,
 		},
@@ -231,7 +231,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 	c.Check(resources, jc.DeepEquals, serviceResource)
 }
 
-func (HelpersSuite) TestAPIResult2ServiceResourcesBadUnitTag(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ApplicationResourcesBadUnitTag(c *gc.C) {
 	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
@@ -315,7 +315,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesBadUnitTag(c *gc.C) {
 		Timestamp:     now,
 	}
 
-	_, err = api.APIResult2ServiceResources(params.ResourcesResult{
+	_, err = api.APIResult2ApplicationResources(params.ResourcesResult{
 		Resources: []params.Resource{
 			apiRes,
 		},
@@ -333,7 +333,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesBadUnitTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ".*got bad data from server.*")
 }
 
-func (HelpersSuite) TestAPIResult2ServiceResourcesFailure(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ApplicationResourcesFailure(c *gc.C) {
 	apiRes := params.Resource{
 		CharmResource: params.CharmResource{
 			Name:        "spam",
@@ -349,7 +349,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesFailure(c *gc.C) {
 	}
 	failure := errors.New("<failure>")
 
-	_, err := api.APIResult2ServiceResources(params.ResourcesResult{
+	_, err := api.APIResult2ApplicationResources(params.ResourcesResult{
 		ErrorResult: params.ErrorResult{
 			Error: &params.Error{
 				Message: failure.Error(),
@@ -364,7 +364,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesFailure(c *gc.C) {
 	c.Check(errors.Cause(err), gc.Not(gc.Equals), failure)
 }
 
-func (HelpersSuite) TestAPIResult2ServiceResourcesNotFound(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ApplicationResourcesNotFound(c *gc.C) {
 	apiRes := params.Resource{
 		CharmResource: params.CharmResource{
 			Name:        "spam",
@@ -379,7 +379,7 @@ func (HelpersSuite) TestAPIResult2ServiceResourcesNotFound(c *gc.C) {
 		ApplicationID: "a-application",
 	}
 
-	_, err := api.APIResult2ServiceResources(params.ResourcesResult{
+	_, err := api.APIResult2ApplicationResources(params.ResourcesResult{
 		ErrorResult: params.ErrorResult{
 			Error: &params.Error{
 				Message: `application "a-application" not found`,
@@ -518,7 +518,7 @@ func (HelpersSuite) TestServiceResources2API(c *gc.C) {
 	chres1.Revision++
 	chres2.Revision++
 
-	svcRes := resource.ServiceResources{
+	svcRes := resource.ApplicationResources{
 		Resources: []resource.Resource{
 			res1,
 			res2,
@@ -544,7 +544,7 @@ func (HelpersSuite) TestServiceResources2API(c *gc.C) {
 		},
 	}
 
-	result := api.ServiceResources2APIResult(svcRes)
+	result := api.ApplicationResources2APIResult(svcRes)
 
 	apiRes1 := api.Resource2API(res1)
 	apiRes2 := api.Resource2API(res2)

--- a/resource/api/http.go
+++ b/resource/api/http.go
@@ -63,16 +63,16 @@ const (
 )
 
 // NewEndpointPath returns the API URL path for the identified resource.
-func NewEndpointPath(service, name string) string {
-	return fmt.Sprintf(HTTPEndpointPath, service, name)
+func NewEndpointPath(application, name string) string {
+	return fmt.Sprintf(HTTPEndpointPath, application, name)
 }
 
 // ExtractEndpointDetails pulls the endpoint wildcard values from
 // the provided URL.
-func ExtractEndpointDetails(url *url.URL) (service, name string) {
-	service = url.Query().Get(":application")
+func ExtractEndpointDetails(url *url.URL) (application, name string) {
+	application = url.Query().Get(":application")
 	name = url.Query().Get(":resource")
-	return service, name
+	return application, name
 }
 
 // TODO(ericsnow) These are copied from apiserver/httpcontext.go...

--- a/resource/api/upload.go
+++ b/resource/api/upload.go
@@ -18,8 +18,8 @@ import (
 
 // UploadRequest defines a single upload request.
 type UploadRequest struct {
-	// Service is the application ID.
-	Service string
+	// Application is the application ID.
+	Application string
 
 	// Name is the resource name.
 	Name string
@@ -38,9 +38,9 @@ type UploadRequest struct {
 }
 
 // NewUploadRequest generates a new upload request for the given resource.
-func NewUploadRequest(service, name, filename string, r io.ReadSeeker) (UploadRequest, error) {
-	if !names.IsValidApplication(service) {
-		return UploadRequest{}, errors.Errorf("invalid application %q", service)
+func NewUploadRequest(application, name, filename string, r io.ReadSeeker) (UploadRequest, error) {
+	if !names.IsValidApplication(application) {
+		return UploadRequest{}, errors.Errorf("invalid application %q", application)
 	}
 
 	content, err := resource.GenerateContent(r)
@@ -49,7 +49,7 @@ func NewUploadRequest(service, name, filename string, r io.ReadSeeker) (UploadRe
 	}
 
 	ur := UploadRequest{
-		Service:     service,
+		Application: application,
 		Name:        name,
 		Filename:    filename,
 		Size:        content.Size,
@@ -82,7 +82,7 @@ const FilenameParamForContentDispositionHeader = "filename"
 // HTTPRequest generates a new HTTP request.
 func (ur UploadRequest) HTTPRequest() (*http.Request, error) {
 	// TODO(ericsnow) What about the rest of the URL?
-	urlStr := NewEndpointPath(ur.Service, ur.Name)
+	urlStr := NewEndpointPath(ur.Application, ur.Name)
 
 	// TODO(natefinch): Use http.MethodPut when we upgrade to go1.5+.
 	req, err := http.NewRequest(MethodPut, urlStr, nil)

--- a/resource/application.go
+++ b/resource/application.go
@@ -9,9 +9,9 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
-// ServiceResources contains the list of resources for the application and all its
+// ApplicationResources contains the list of resources for the application and all its
 // units.
-type ServiceResources struct {
+type ApplicationResources struct {
 	// Resources are the current version of the resource for the application that
 	// resource-get will retrieve.
 	Resources []Resource
@@ -32,7 +32,7 @@ type ServiceResources struct {
 // the application's resources that are out of date. Note that there must be
 // a charm store resource for each of the application resources and
 // vice-versa. If they are out of sync then an error is returned.
-func (sr ServiceResources) Updates() ([]resource.Resource, error) {
+func (sr ApplicationResources) Updates() ([]resource.Resource, error) {
 	storeResources, err := sr.alignStoreResources()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -53,7 +53,7 @@ func (sr ServiceResources) Updates() ([]resource.Resource, error) {
 	return updates, nil
 }
 
-func (sr ServiceResources) alignStoreResources() ([]resource.Resource, error) {
+func (sr ApplicationResources) alignStoreResources() ([]resource.Resource, error) {
 	if len(sr.CharmStoreResources) > len(sr.Resources) {
 		return nil, errors.Errorf("have more charm store resources than application resources")
 	}

--- a/resource/application_test.go
+++ b/resource/application_test.go
@@ -23,7 +23,7 @@ func (s *ServiceResourcesSuite) TestUpdatesUploaded(c *gc.C) {
 	csRes := newStoreResource(c, "spam", "a-application", 2)
 	res := csRes // a copy
 	res.Origin = charmresource.OriginUpload
-	sr := resource.ServiceResources{
+	sr := resource.ApplicationResources{
 		Resources: []resource.Resource{
 			res,
 		},
@@ -43,7 +43,7 @@ func (s *ServiceResourcesSuite) TestUpdatesDifferent(c *gc.C) {
 	eggs := newStoreResource(c, "eggs", "a-application", 3)
 	expected := eggs.Resource
 	expected.Revision += 1
-	sr := resource.ServiceResources{
+	sr := resource.ApplicationResources{
 		Resources: []resource.Resource{
 			spam,
 			eggs,
@@ -65,7 +65,7 @@ func (s *ServiceResourcesSuite) TestUpdatesBadOrdering(c *gc.C) {
 	eggs := newStoreResource(c, "eggs", "a-application", 3)
 	expected := eggs.Resource
 	expected.Revision += 1
-	sr := resource.ServiceResources{
+	sr := resource.ApplicationResources{
 		Resources: []resource.Resource{
 			spam,
 			eggs,
@@ -85,7 +85,7 @@ func (s *ServiceResourcesSuite) TestUpdatesBadOrdering(c *gc.C) {
 func (s *ServiceResourcesSuite) TestUpdatesNone(c *gc.C) {
 	spam := newStoreResource(c, "spam", "a-application", 2)
 	eggs := newStoreResource(c, "eggs", "a-application", 3)
-	sr := resource.ServiceResources{
+	sr := resource.ApplicationResources{
 		Resources: []resource.Resource{
 			spam,
 			eggs,

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -26,15 +26,15 @@ import (
 
 type ActionSuite struct {
 	ConnSuite
-	charm             *state.Charm
-	actionlessCharm   *state.Charm
-	service           *state.Application
-	actionlessService *state.Application
-	unit              *state.Unit
-	unit2             *state.Unit
-	charmlessUnit     *state.Unit
-	actionlessUnit    *state.Unit
-	model             *state.Model
+	charm                 *state.Charm
+	actionlessCharm       *state.Charm
+	application           *state.Application
+	actionlessApplication *state.Application
+	unit                  *state.Unit
+	unit2                 *state.Unit
+	charmlessUnit         *state.Unit
+	actionlessUnit        *state.Unit
+	model                 *state.Model
 }
 
 var _ = gc.Suite(&ActionSuite{})
@@ -47,35 +47,35 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 	s.charm = s.AddTestingCharm(c, "dummy")
 	s.actionlessCharm = s.AddTestingCharm(c, "actionless")
 
-	s.service = s.AddTestingApplication(c, "dummy", s.charm)
+	s.application = s.AddTestingApplication(c, "dummy", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	s.actionlessService = s.AddTestingApplication(c, "actionless", s.actionlessCharm)
+	s.actionlessApplication = s.AddTestingApplication(c, "actionless", s.actionlessCharm)
 	c.Assert(err, jc.ErrorIsNil)
 
-	sURL, _ := s.service.CharmURL()
+	sURL, _ := s.application.CharmURL()
 	c.Assert(sURL, gc.NotNil)
-	actionlessSURL, _ := s.actionlessService.CharmURL()
+	actionlessSURL, _ := s.actionlessApplication.CharmURL()
 	c.Assert(actionlessSURL, gc.NotNil)
 
-	s.unit, err = s.service.AddUnit(state.AddUnitParams{})
+	s.unit, err = s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit.Series(), gc.Equals, "quantal")
 
 	err = s.unit.SetCharmURL(sURL)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.unit2, err = s.service.AddUnit(state.AddUnitParams{})
+	s.unit2, err = s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit2.Series(), gc.Equals, "quantal")
 
 	err = s.unit2.SetCharmURL(sURL)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.charmlessUnit, err = s.service.AddUnit(state.AddUnitParams{})
+	s.charmlessUnit, err = s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.charmlessUnit.Series(), gc.Equals, "quantal")
 
-	s.actionlessUnit, err = s.actionlessService.AddUnit(state.AddUnitParams{})
+	s.actionlessUnit, err = s.actionlessApplication.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.actionlessUnit.Series(), gc.Equals, "quantal")
 
@@ -283,11 +283,11 @@ func makeUnits(c *gc.C, s *ActionSuite, units map[string]*state.Unit, schemas ma
 	}
 
 	for name, schema := range schemas {
-		svcName := name + "-defaults-application"
+		appName := name + "-defaults-application"
 
 		// Add a testing application
 		ch := s.AddActionsCharm(c, freeCharms[name], schema, 1)
-		app := s.AddTestingApplication(c, svcName, ch)
+		app := s.AddTestingApplication(c, appName, ch)
 
 		// Get its charm URL
 		sURL, _ := app.CharmURL()

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -539,15 +539,15 @@ func (app *backingRemoteApplication) updated(st *State, store *multiwatcherStore
 		logger.Debugf("new remote application %q added to backing state", app.Name)
 		// Fetch the status.
 		key := remoteApplicationGlobalKey(app.Name)
-		serviceStatus, err := getStatus(st.db(), key, "remote application")
+		appStatus, err := getStatus(st.db(), key, "remote application")
 		if err != nil {
 			return errors.Annotatef(err, "reading remote application status for key %s", key)
 		}
 		info.Status = multiwatcher.StatusInfo{
-			Current: serviceStatus.Status,
-			Message: serviceStatus.Message,
-			Data:    normaliseStatusData(serviceStatus.Data),
-			Since:   serviceStatus.Since,
+			Current: appStatus.Status,
+			Message: appStatus.Message,
+			Data:    normaliseStatusData(appStatus.Data),
+			Since:   appStatus.Since,
 		}
 		logger.Debugf("remote application status %#v", info.Status)
 	}
@@ -968,7 +968,7 @@ func (s *backingSettings) updated(st *State, store *multiwatcherStore, id string
 	case *multiwatcher.ApplicationInfo:
 		// If we're seeing settings for the application with a different
 		// charm URL, we ignore them - we will fetch
-		// them again when the service charm changes.
+		// them again when the application charm changes.
 		// By doing this we make sure that the settings in the
 		// ApplicationInfo are always consistent with the charm URL.
 		if info.CharmURL != url {
@@ -987,7 +987,7 @@ func (s *backingSettings) updated(st *State, store *multiwatcherStore, id string
 func (s *backingSettings) removed(store *multiwatcherStore, modelUUID, id string, _ *State) error {
 	parentID, url, ok := backingEntityIdForSettingsKey(modelUUID, id)
 	if !ok {
-		// Service is already gone along with its settings.
+		// Application is already gone along with its settings.
 		return nil
 	}
 	parent := store.Get(parentID)

--- a/state/application.go
+++ b/state/application.go
@@ -1707,15 +1707,15 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D) ([]txn.Op, error) {
 		}
 		return append(ops, removeOps...), nil
 	}
-	svcOp := txn.Op{
+	appOp := txn.Op{
 		C:      applicationsC,
 		Id:     a.doc.DocID,
 		Update: bson.D{{"$inc", bson.D{{"unitcount", -1}}}},
 	}
 	if a.doc.Life == Alive {
-		svcOp.Assert = bson.D{{"life", Alive}, {"unitcount", bson.D{{"$gt", 0}}}}
+		appOp.Assert = bson.D{{"life", Alive}, {"unitcount", bson.D{{"$gt", 0}}}}
 	} else {
-		svcOp.Assert = bson.D{
+		appOp.Assert = bson.D{
 			{"life", Dying},
 			{"$or", []bson.D{
 				{{"unitcount", bson.D{{"$gt", 1}}}},
@@ -1723,7 +1723,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D) ([]txn.Op, error) {
 			}},
 		}
 	}
-	ops = append(ops, svcOp)
+	ops = append(ops, appOp)
 
 	return ops, nil
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -171,7 +171,7 @@ func (s *ApplicationSuite) TestSetCharmLegacy(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "mysql" to charm "local:precise/precise-mysql-1": cannot change an application's series`)
 }
 
-func (s *ApplicationSuite) TestClientServiceSetCharmUnsupportedSeries(c *gc.C) {
+func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeries(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
 	app := state.AddTestingApplicationForSeries(c, s.State, "precise", "application", ch)
 
@@ -183,7 +183,7 @@ func (s *ApplicationSuite) TestClientServiceSetCharmUnsupportedSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "cs:multi-series2-8": only these series are supported: trusty, wily`)
 }
 
-func (s *ApplicationSuite) TestClientServiceSetCharmUnsupportedSeriesForce(c *gc.C) {
+func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeriesForce(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
 	app := state.AddTestingApplicationForSeries(c, s.State, "precise", "application", ch)
 
@@ -201,7 +201,7 @@ func (s *ApplicationSuite) TestClientServiceSetCharmUnsupportedSeriesForce(c *gc
 	c.Assert(ch.URL().String(), gc.Equals, "cs:multi-series2-8")
 }
 
-func (s *ApplicationSuite) TestClientServiceSetCharmWrongOS(c *gc.C) {
+func (s *ApplicationSuite) TestClientApplicationSetCharmWrongOS(c *gc.C) {
 	ch := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
 	app := state.AddTestingApplicationForSeries(c, s.State, "precise", "application", ch)
 
@@ -233,7 +233,7 @@ func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	oldCharm := s.AddMetaCharm(c, "mysql", metaBase, 44)
 
-	service, err := s.State.AddApplication(state.AddApplicationArgs{
+	application, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  "yoursql",
 		Charm: oldCharm,
 		EndpointBindings: map[string]string{
@@ -245,16 +245,16 @@ func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 43)
 	cfg := state.SetCharmConfig{Charm: newCharm}
-	err = service.SetCharm(cfg)
+	err = application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	updatedBindings, err := service.EndpointBindings()
+	updatedBindings, err := application.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(updatedBindings, jc.DeepEquals, map[string]string{
 		// Existing bindings are preserved.
 		"":        "db",
 		"server":  "db",
 		"client":  "client",
-		"cluster": "db", // inherited from defaults in AddService.
+		"cluster": "db", // inherited from defaults in AddApplication.
 		// New endpoints use defaults.
 		"foo":  "db",
 		"baz":  "db",
@@ -574,7 +574,7 @@ func (s *ApplicationSuite) TestSetCharmWhenDead(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.Equals, state.ErrDead)
 }
 
-func (s *ApplicationSuite) TestSetCharmWithRemovedService(c *gc.C) {
+func (s *ApplicationSuite) TestSetCharmWithRemovedApplication(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 
 	err := s.mysql.Destroy()
@@ -882,7 +882,7 @@ func (s *ApplicationSuite) TestSetCharmRetriesWhenOldBindingsChanged(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-var serviceUpdateCharmConfigTests = []struct {
+var applicationUpdateCharmConfigTests = []struct {
 	about   string
 	initial charm.Settings
 	update  charm.Settings
@@ -935,7 +935,7 @@ var serviceUpdateCharmConfigTests = []struct {
 
 func (s *ApplicationSuite) TestUpdateCharmConfig(c *gc.C) {
 	sch := s.AddTestingCharm(c, "dummy")
-	for i, t := range serviceUpdateCharmConfigTests {
+	for i, t := range applicationUpdateCharmConfigTests {
 		c.Logf("test %d. %s", i, t.about)
 		app := s.AddTestingApplication(c, "dummy-application", sch)
 		if t.initial != nil {
@@ -1729,7 +1729,7 @@ func (s *ApplicationSuite) TestWordpressEndpoints(c *gc.C) {
 	c.Assert(eps, gc.DeepEquals, []state.Endpoint{cacheEP, dbEP, jiEP, ldEP, mpEP, urlEP})
 }
 
-func (s *ApplicationSuite) TestServiceRefresh(c *gc.C) {
+func (s *ApplicationSuite) TestApplicationRefresh(c *gc.C) {
 	s1, err := s.State.Application(s.mysql.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1765,7 +1765,7 @@ func (s *ApplicationSuite) TestSetPassword(c *gc.C) {
 	})
 }
 
-func (s *ApplicationSuite) TestServiceExposed(c *gc.C) {
+func (s *ApplicationSuite) TestApplicationExposed(c *gc.C) {
 	// Check that querying for the exposed flag works correctly.
 	c.Assert(s.mysql.IsExposed(), jc.IsFalse)
 
@@ -2186,7 +2186,7 @@ func (s *ApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 	s.assertNoCleanup(c)
 }
 
-func (s *ApplicationSuite) TestRemoveServiceMachine(c *gc.C) {
+func (s *ApplicationSuite) TestRemoveApplicationMachine(c *gc.C) {
 	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
@@ -2196,7 +2196,7 @@ func (s *ApplicationSuite) TestRemoveServiceMachine(c *gc.C) {
 	c.Assert(s.mysql.Destroy(), gc.IsNil)
 	assertLife(c, s.mysql, state.Dying)
 
-	// Service.Destroy adds units to cleanup, make it happen now.
+	// Application.Destroy adds units to cleanup, make it happen now.
 	c.Assert(s.State.Cleanup(), gc.IsNil)
 
 	c.Assert(unit.Refresh(), jc.Satisfies, errors.IsNotFound)
@@ -2344,7 +2344,7 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	err = s.mysql.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	// ...but we can check that old constraints do not affect new services
+	// ...but we can check that old constraints do not affect new applications
 	// with matching names.
 	ch, _, err := s.mysql.Charm()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2624,21 +2624,21 @@ func (s *ApplicationSuite) TestWatchApplication(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Make one change (to a separate instance), check one event.
-	service, err := s.State.Application(s.mysql.Name())
+	application, err := s.State.Application(s.mysql.Name())
 	c.Assert(err, jc.ErrorIsNil)
-	err = service.SetExposed()
+	err = application.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Make two changes, check one event.
-	err = service.ClearExposed()
+	err = application.ClearExposed()
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := state.SetCharmConfig{
 		Charm:      s.charm,
 		ForceUnits: true,
 	}
-	err = service.SetCharm(cfg)
+	err = application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -2647,7 +2647,7 @@ func (s *ApplicationSuite) TestWatchApplication(c *gc.C) {
 	wc.AssertClosed()
 
 	// Remove application, start new watch, check single event.
-	err = service.Destroy()
+	err = application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	w = s.mysql.Watch()
 	defer testing.AssertStop(c, w)
@@ -2659,8 +2659,8 @@ func (s *ApplicationSuite) TestMetricCredentials(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mysql.MetricCredentials(), gc.DeepEquals, []byte("hello there"))
 
-	service, err := s.State.Application(s.mysql.Name())
-	c.Assert(service.MetricCredentials(), gc.DeepEquals, []byte("hello there"))
+	application, err := s.State.Application(s.mysql.Name())
+	c.Assert(application.MetricCredentials(), gc.DeepEquals, []byte("hello there"))
 }
 
 func (s *ApplicationSuite) TestMetricCredentialsOnDying(c *gc.C) {
@@ -2995,25 +2995,25 @@ func (s *ApplicationSuite) TestSetCharmStorageWithLocationSingletonToMultipleAdd
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "test" to charm "local:quantal/quantal-mysql-3": existing storage "data0" with location changed from single to multiple`)
 }
 
-func (s *ApplicationSuite) assertApplicationRemovedWithItsBindings(c *gc.C, service *state.Application) {
+func (s *ApplicationSuite) assertApplicationRemovedWithItsBindings(c *gc.C, application *state.Application) {
 	// Removing the application removes the bindings with it.
-	err := service.Destroy()
+	err := application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = service.Refresh()
+	err = application.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	state.AssertEndpointBindingsNotFoundForService(c, service)
+	state.AssertEndpointBindingsNotFoundForApplication(c, application)
 }
 
 func (s *ApplicationSuite) TestEndpointBindingsReturnsDefaultsWhenNotFound(c *gc.C) {
 	ch := s.AddMetaCharm(c, "mysql", metaBase, 42)
-	service := s.AddTestingApplicationWithBindings(c, "yoursql", ch, nil)
-	state.RemoveEndpointBindingsForService(c, service)
+	application := s.AddTestingApplicationWithBindings(c, "yoursql", ch, nil)
+	state.RemoveEndpointBindingsForApplication(c, application)
 
-	s.assertApplicationHasOnlyDefaultEndpointBindings(c, service)
+	s.assertApplicationHasOnlyDefaultEndpointBindings(c, application)
 }
 
-func (s *ApplicationSuite) assertApplicationHasOnlyDefaultEndpointBindings(c *gc.C, service *state.Application) {
-	charm, _, err := service.Charm()
+func (s *ApplicationSuite) assertApplicationHasOnlyDefaultEndpointBindings(c *gc.C, application *state.Application) {
+	charm, _, err := application.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
 	knownEndpoints := set.NewStrings()
@@ -3022,7 +3022,7 @@ func (s *ApplicationSuite) assertApplicationHasOnlyDefaultEndpointBindings(c *gc
 		knownEndpoints.Add(endpoint)
 	}
 
-	setBindings, err := service.EndpointBindings()
+	setBindings, err := application.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(setBindings, gc.NotNil)
 
@@ -3037,10 +3037,10 @@ func (s *ApplicationSuite) TestEndpointBindingsJustDefaults(c *gc.C) {
 	// With unspecified bindings, all endpoints are explicitly bound to the
 	// default space when saved in state.
 	ch := s.AddMetaCharm(c, "mysql", metaBase, 42)
-	service := s.AddTestingApplicationWithBindings(c, "yoursql", ch, nil)
+	application := s.AddTestingApplicationWithBindings(c, "yoursql", ch, nil)
 
-	s.assertApplicationHasOnlyDefaultEndpointBindings(c, service)
-	s.assertApplicationRemovedWithItsBindings(c, service)
+	s.assertApplicationHasOnlyDefaultEndpointBindings(c, application)
+	s.assertApplicationRemovedWithItsBindings(c, application)
 }
 
 func (s *ApplicationSuite) TestEndpointBindingsWithExplictOverrides(c *gc.C) {
@@ -3054,9 +3054,9 @@ func (s *ApplicationSuite) TestEndpointBindingsWithExplictOverrides(c *gc.C) {
 		"cluster": "ha",
 	}
 	ch := s.AddMetaCharm(c, "mysql", metaBase, 42)
-	service := s.AddTestingApplicationWithBindings(c, "yoursql", ch, bindings)
+	application := s.AddTestingApplicationWithBindings(c, "yoursql", ch, bindings)
 
-	setBindings, err := service.EndpointBindings()
+	setBindings, err := application.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(setBindings, jc.DeepEquals, map[string]string{
 		"server":  "db",
@@ -3064,7 +3064,7 @@ func (s *ApplicationSuite) TestEndpointBindingsWithExplictOverrides(c *gc.C) {
 		"cluster": "ha",
 	})
 
-	s.assertApplicationRemovedWithItsBindings(c, service)
+	s.assertApplicationRemovedWithItsBindings(c, application)
 }
 
 func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
@@ -3076,8 +3076,8 @@ func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 		"kludge": "db",
 		"client": "db",
 	}
-	service := s.AddTestingApplicationWithBindings(c, "yoursql", oldCharm, oldBindings)
-	setBindings, err := service.EndpointBindings()
+	application := s.AddTestingApplicationWithBindings(c, "yoursql", oldCharm, oldBindings)
+	setBindings, err := application.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	effectiveOld := map[string]string{
 		"kludge":  "db",
@@ -3089,9 +3089,9 @@ func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 43)
 
 	cfg := state.SetCharmConfig{Charm: newCharm}
-	err = service.SetCharm(cfg)
+	err = application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	setBindings, err = service.EndpointBindings()
+	setBindings, err = application.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	effectiveNew := map[string]string{
 		// These two should be preserved from oldCharm.
@@ -3106,20 +3106,20 @@ func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 	}
 	c.Assert(setBindings, jc.DeepEquals, effectiveNew)
 
-	s.assertApplicationRemovedWithItsBindings(c, service)
+	s.assertApplicationRemovedWithItsBindings(c, application)
 }
 
 func (s *ApplicationSuite) TestSetCharmHandlesMissingBindingsAsDefaults(c *gc.C) {
 	oldCharm := s.AddMetaCharm(c, "mysql", metaDifferentProvider, 69)
-	service := s.AddTestingApplicationWithBindings(c, "theirsql", oldCharm, nil)
-	state.RemoveEndpointBindingsForService(c, service)
+	application := s.AddTestingApplicationWithBindings(c, "theirsql", oldCharm, nil)
+	state.RemoveEndpointBindingsForApplication(c, application)
 
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 70)
 
 	cfg := state.SetCharmConfig{Charm: newCharm}
-	err := service.SetCharm(cfg)
+	err := application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	setBindings, err := service.EndpointBindings()
+	setBindings, err := application.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	effectiveNew := map[string]string{
 		// The following two exist for both oldCharm and newCharm.
@@ -3134,7 +3134,7 @@ func (s *ApplicationSuite) TestSetCharmHandlesMissingBindingsAsDefaults(c *gc.C)
 	}
 	c.Assert(setBindings, jc.DeepEquals, effectiveNew)
 
-	s.assertApplicationRemovedWithItsBindings(c, service)
+	s.assertApplicationRemovedWithItsBindings(c, application)
 }
 
 func (s *ApplicationSuite) setupAppicationWithUnitsForUpgradeCharmScenario(c *gc.C, numOfUnits int) (deployedV int, err error) {

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -326,7 +326,7 @@ func (s *applicationOffers) AddOffer(offerArgs crossmodel.AddApplicationOfferArg
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
-		// environment may have been destroyed.
+		// model may have been destroyed.
 		if attempt > 0 {
 			if err := checkModelActive(s.st); err != nil {
 				return nil, errors.Trace(err)
@@ -410,7 +410,7 @@ func (s *applicationOffers) UpdateOffer(offerArgs crossmodel.AddApplicationOffer
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
-		// environment may have been destroyed.
+		// model may have been destroyed.
 		if attempt > 0 {
 			if err := checkModelActive(s.st); err != nil {
 				return nil, errors.Trace(err)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -965,7 +965,7 @@ func (s *assignCleanSuite) TestAssignUsingConstraintsToMachine(c *gc.C) {
 	}
 }
 
-func (s *assignCleanSuite) TestAssignUnitWithRemovedService(c *gc.C) {
+func (s *assignCleanSuite) TestAssignUnitWithRemovedApplication(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
@@ -1016,11 +1016,11 @@ func (s *assignCleanSuite) setupSingleStorage(c *gc.C, kind, pool string) (*stat
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := service.AddUnit(state.AddUnitParams{})
+	application := s.AddTestingApplicationWithStorage(c, "storage-"+kind, ch, storage)
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag := names.NewStorageTag("data/0")
-	return service, unit, storageTag
+	return application, unit, storageTag
 }
 
 func (s *assignCleanSuite) TestAssignToMachine(c *gc.C) {

--- a/state/bench_test.go
+++ b/state/bench_test.go
@@ -82,8 +82,8 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", charm)
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	serviceCharmURL, _ := app.CharmURL()
-	err = unit.SetCharmURL(serviceCharmURL)
+	applicationCharmURL, _ := app.CharmURL()
+	err = unit.SetCharmURL(applicationCharmURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
@@ -92,7 +92,7 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 				state.BatchParam{
 					UUID:     utils.MustNewUUID().String(),
 					Created:  now,
-					CharmURL: serviceCharmURL.String(),
+					CharmURL: applicationCharmURL.String(),
 					Metrics:  metrics,
 					Unit:     unit.UnitTag(),
 				},
@@ -116,8 +116,8 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", charm)
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	serviceCharmURL, _ := app.CharmURL()
-	err = unit.SetCharmURL(serviceCharmURL)
+	applicationCharmURL, _ := app.CharmURL()
+	err = unit.SetCharmURL(applicationCharmURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
@@ -126,7 +126,7 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 				state.BatchParam{
 					UUID:     utils.MustNewUUID().String(),
 					Created:  oldTime,
-					CharmURL: serviceCharmURL.String(),
+					CharmURL: applicationCharmURL.String(),
 					Metrics:  []state.Metric{{}},
 					Unit:     unit.UnitTag(),
 				},

--- a/state/block.go
+++ b/state/block.go
@@ -44,7 +44,7 @@ const (
 	DestroyBlock BlockType = iota
 
 	// RemoveBlock type identifies block that prevents
-	// removal of machines, services, units or relations.
+	// removal of machines, applications, units or relations.
 	RemoveBlock
 
 	// ChangeBlock type identifies block that prevents model changes such

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -186,15 +186,15 @@ func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModelsWithResources(c
 	// add some applications
 	otherModel, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.Factory.MakeApplication(c, nil)
-	ch, _, err := service.Charm()
+	application := s.Factory.MakeApplication(c, nil)
+	ch, _, err := application.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := state.AddApplicationArgs{
-		Name:  service.Name(),
+		Name:  application.Name(),
 		Charm: ch,
 	}
-	service, err = otherSt.AddApplication(args)
+	application, err = otherSt.AddApplication(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerModel, err := s.State.Model()

--- a/state/charm.go
+++ b/state/charm.go
@@ -556,7 +556,7 @@ func validateCharmVersion(ch hasMeta) error {
 	minver := ch.Meta().MinJujuVersion
 	if minver != version.Zero {
 		if minver.Compare(jujuversion.Current) > 0 {
-			return errors.Errorf("Charm's min version (%s) is higher than this juju environment's version (%s)", minver, jujuversion.Current)
+			return errors.Errorf("Charm's min version (%s) is higher than this juju model's version (%s)", minver, jujuversion.Current)
 		}
 	}
 	return nil

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -28,7 +28,7 @@ type ConnSuite struct {
 	machines     *mgo.Collection
 	instanceData *mgo.Collection
 	relations    *mgo.Collection
-	services     *mgo.Collection
+	applications *mgo.Collection
 	units        *mgo.Collection
 	controllers  *mgo.Collection
 	policy       statetesting.MockPolicy
@@ -58,7 +58,7 @@ func (s *ConnSuite) SetUpTest(c *gc.C) {
 	s.machines = jujuDB.C("machines")
 	s.instanceData = jujuDB.C("instanceData")
 	s.relations = jujuDB.C("relations")
-	s.services = jujuDB.C("applications")
+	s.applications = jujuDB.C("applications")
 	s.units = jujuDB.C("units")
 	s.controllers = jujuDB.C("controllers")
 }

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -29,7 +29,7 @@ type ConnWithWallClockSuite struct {
 	machines     *mgo.Collection
 	instanceData *mgo.Collection
 	relations    *mgo.Collection
-	services     *mgo.Collection
+	applications *mgo.Collection
 	units        *mgo.Collection
 	controllers  *mgo.Collection
 	policy       statetesting.MockPolicy
@@ -59,7 +59,7 @@ func (cs *ConnWithWallClockSuite) SetUpTest(c *gc.C) {
 	cs.machines = jujuDB.C("machines")
 	cs.instanceData = jujuDB.C("instanceData")
 	cs.relations = jujuDB.C("relations")
-	cs.services = jujuDB.C("applications")
+	cs.applications = jujuDB.C("applications")
 	cs.units = jujuDB.C("units")
 	cs.controllers = jujuDB.C("controllers")
 }

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -55,19 +55,19 @@ var setConstraintsTests = []struct {
 	consToSet    string
 	consFallback string
 
-	effectiveModelCons   string // model constraints after setting consFallback
-	effectiveServiceCons string // application constraints after setting consToSet
-	effectiveUnitCons    string // unit constraints after setting consToSet on the application
-	effectiveMachineCons string // machine constraints after setting consToSet
+	effectiveModelCons       string // model constraints after setting consFallback
+	effectiveApplicationCons string // application constraints after setting consToSet
+	effectiveUnitCons        string // unit constraints after setting consToSet on the application
+	effectiveMachineCons     string // machine constraints after setting consToSet
 }{{
 	about:        "(implictly) empty constraints are OK and stored as empty",
 	consToSet:    "",
 	consFallback: "",
 
-	effectiveModelCons:   "",
-	effectiveServiceCons: "",
-	effectiveUnitCons:    "",
-	effectiveMachineCons: "",
+	effectiveModelCons:       "",
+	effectiveApplicationCons: "",
+	effectiveUnitCons:        "",
+	effectiveMachineCons:     "",
 }, {
 	about:        "(implicitly) empty fallback constraints never override set constraints",
 	consToSet:    "instance-type=foo-42 cpu-power=9001 spaces=bar",
@@ -75,17 +75,17 @@ var setConstraintsTests = []struct {
 
 	effectiveModelCons: "", // model constraints are stored as empty.
 	// i.e. there are no fallbacks and all the following cases are the same.
-	effectiveServiceCons: "instance-type=foo-42 cpu-power=9001 spaces=bar",
-	effectiveUnitCons:    "instance-type=foo-42 cpu-power=9001 spaces=bar",
-	effectiveMachineCons: "instance-type=foo-42 cpu-power=9001 spaces=bar",
+	effectiveApplicationCons: "instance-type=foo-42 cpu-power=9001 spaces=bar",
+	effectiveUnitCons:        "instance-type=foo-42 cpu-power=9001 spaces=bar",
+	effectiveMachineCons:     "instance-type=foo-42 cpu-power=9001 spaces=bar",
 }, {
 	about:        "(implicitly) empty constraints never override explicitly set fallbacks",
 	consToSet:    "",
 	consFallback: "arch=amd64 cores=42 mem=2G tags=foo",
 
-	effectiveModelCons:   "arch=amd64 cores=42 mem=2G tags=foo",
-	effectiveServiceCons: "", // set as given.
-	effectiveUnitCons:    "arch=amd64 cores=42 mem=2G tags=foo",
+	effectiveModelCons:       "arch=amd64 cores=42 mem=2G tags=foo",
+	effectiveApplicationCons: "", // set as given.
+	effectiveUnitCons:        "arch=amd64 cores=42 mem=2G tags=foo",
 	// set as given, then merged with fallbacks; since consToSet is
 	// empty, the effective values inherit everything from fallbacks;
 	// like the unit, but only because the application constraints are
@@ -96,36 +96,36 @@ var setConstraintsTests = []struct {
 	consToSet:    "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	consFallback: "",
 
-	effectiveModelCons:   "",
-	effectiveServiceCons: "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveUnitCons:    "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveMachineCons: "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
+	effectiveModelCons:       "",
+	effectiveApplicationCons: "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveUnitCons:        "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveMachineCons:     "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:        "(explicitly) empty fallback constraints are OK and stored as given",
 	consToSet:    "",
 	consFallback: "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 
-	effectiveModelCons:   "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveServiceCons: "",
-	effectiveUnitCons:    "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveMachineCons: "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
+	effectiveModelCons:       "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveApplicationCons: "",
+	effectiveUnitCons:        "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveMachineCons:     "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
 }, {
-	about:                "(explicitly) empty constraints and fallbacks are OK and stored as given",
-	consToSet:            "arch= mem= cores= container=",
-	consFallback:         "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveModelCons:   "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveServiceCons: "arch= mem= cores= container=",
-	effectiveUnitCons:    "arch= container= cores= cpu-power= mem= root-disk= tags= spaces=",
-	effectiveMachineCons: "arch= cores= cpu-power= mem= root-disk= tags= spaces=", // container= is dropped
+	about:                    "(explicitly) empty constraints and fallbacks are OK and stored as given",
+	consToSet:                "arch= mem= cores= container=",
+	consFallback:             "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveModelCons:       "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveApplicationCons: "arch= mem= cores= container=",
+	effectiveUnitCons:        "arch= container= cores= cpu-power= mem= root-disk= tags= spaces=",
+	effectiveMachineCons:     "arch= cores= cpu-power= mem= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:        "(explicitly) empty constraints override set fallbacks for deployment and provisioning",
 	consToSet:    "cores= arch= spaces= cpu-power=",
 	consFallback: "cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
 
-	effectiveModelCons:   "cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
-	effectiveServiceCons: "cores= arch= spaces= cpu-power=",
-	effectiveUnitCons:    "arch= cores= cpu-power= mem=4G tags=foo spaces=",
-	effectiveMachineCons: "arch= cores= cpu-power= mem=4G tags=foo spaces=",
+	effectiveModelCons:       "cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
+	effectiveApplicationCons: "cores= arch= spaces= cpu-power=",
+	effectiveUnitCons:        "arch= cores= cpu-power= mem=4G tags=foo spaces=",
+	effectiveMachineCons:     "arch= cores= cpu-power= mem=4G tags=foo spaces=",
 	// we're also checking if m.SetConstraints() does the same with
 	// regards to the effective constraints as AddMachine(), because
 	// some of these tests proved they had different behavior (i.e.
@@ -135,26 +135,26 @@ var setConstraintsTests = []struct {
 	consToSet:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
 	consFallback: "cores= arch= tags=",
 
-	effectiveModelCons:   "cores= arch= tags=",
-	effectiveServiceCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveUnitCons:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveMachineCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveModelCons:       "cores= arch= tags=",
+	effectiveApplicationCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveUnitCons:        "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveMachineCons:     "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
 }, {
 	about:        "non-empty constraints always override set fallbacks",
 	consToSet:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
 	consFallback: "cores=12 root-disk=10G arch=i386  tags=bar",
 
-	effectiveModelCons:   "cores=12 root-disk=10G arch=i386  tags=bar",
-	effectiveServiceCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveUnitCons:    "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
-	effectiveMachineCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveModelCons:       "cores=12 root-disk=10G arch=i386  tags=bar",
+	effectiveApplicationCons: "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveUnitCons:        "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
+	effectiveMachineCons:     "cores=42 root-disk=20G arch=amd64 tags=foo,bar",
 }, {
 	about:        "non-empty constraints override conflicting set fallbacks",
 	consToSet:    "mem=8G arch=amd64 cores=4 tags=bar",
 	consFallback: "instance-type=small cpu-power=1000", // instance-type conflicts mem, arch
 
-	effectiveModelCons:   "instance-type=small cpu-power=1000",
-	effectiveServiceCons: "mem=8G arch=amd64 cores=4 tags=bar",
+	effectiveModelCons:       "instance-type=small cpu-power=1000",
+	effectiveApplicationCons: "mem=8G arch=amd64 cores=4 tags=bar",
 	// both of the following contain the explicitly set constraints after
 	// resolving any conflicts with fallbacks (by dropping them).
 	effectiveUnitCons:    "mem=8G arch=amd64 cores=4 tags=bar cpu-power=1000",
@@ -167,10 +167,10 @@ var setConstraintsTests = []struct {
 	// a variation of the above case showing there's no difference
 	// between deployment (application, unit) and provisioning (machine)
 	// constraints when it comes to effective values.
-	effectiveModelCons:   "tags=foo cpu-power=42",
-	effectiveServiceCons: "cpu-power= tags= spaces=bar",
-	effectiveUnitCons:    "cpu-power= tags= spaces=bar",
-	effectiveMachineCons: "cpu-power= tags= spaces=bar",
+	effectiveModelCons:       "tags=foo cpu-power=42",
+	effectiveApplicationCons: "cpu-power= tags= spaces=bar",
+	effectiveUnitCons:        "cpu-power= tags= spaces=bar",
+	effectiveMachineCons:     "cpu-power= tags= spaces=bar",
 }, {
 	about:        "container type can only be used for deployment, not provisioning",
 	consToSet:    "container=kvm arch=amd64",
@@ -181,10 +181,10 @@ var setConstraintsTests = []struct {
 	// sense currently as a deployment constraint, so it's cleared
 	// when merging application/model deployment constraints into
 	// effective machine provisioning constraints.
-	effectiveModelCons:   "container=lxd mem=8G",
-	effectiveServiceCons: "container=kvm arch=amd64",
-	effectiveUnitCons:    "container=kvm mem=8G arch=amd64",
-	effectiveMachineCons: "mem=8G arch=amd64",
+	effectiveModelCons:       "container=lxd mem=8G",
+	effectiveApplicationCons: "container=kvm arch=amd64",
+	effectiveUnitCons:        "container=kvm mem=8G arch=amd64",
+	effectiveMachineCons:     "mem=8G arch=amd64",
 }, {
 	about:        "specify image virt-type when deploying applications on multi-hypervisor aware openstack",
 	consToSet:    "virt-type=kvm",
@@ -193,10 +193,10 @@ var setConstraintsTests = []struct {
 	// application deployment constraints are transformed into machine
 	// provisioning constraints. Unit constraints must also have virt-type set
 	// to ensure consistency in scalability.
-	effectiveModelCons:   "",
-	effectiveServiceCons: "virt-type=kvm",
-	effectiveUnitCons:    "virt-type=kvm",
-	effectiveMachineCons: "virt-type=kvm",
+	effectiveModelCons:       "",
+	effectiveApplicationCons: "virt-type=kvm",
+	effectiveUnitCons:        "virt-type=kvm",
+	effectiveMachineCons:     "virt-type=kvm",
 }, {
 	about:        "ensure model and application constraints are separate",
 	consToSet:    "virt-type=kvm",
@@ -205,10 +205,10 @@ var setConstraintsTests = []struct {
 	// application deployment constraints are transformed into machine
 	// provisioning constraints. Unit constraints must also have virt-type set
 	// to ensure consistency in scalability.
-	effectiveModelCons:   "mem=2G",
-	effectiveServiceCons: "virt-type=kvm",
-	effectiveUnitCons:    "mem=2G virt-type=kvm",
-	effectiveMachineCons: "mem=2G virt-type=kvm",
+	effectiveModelCons:       "mem=2G",
+	effectiveApplicationCons: "virt-type=kvm",
+	effectiveUnitCons:        "mem=2G virt-type=kvm",
+	effectiveMachineCons:     "mem=2G virt-type=kvm",
 }}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {
@@ -238,9 +238,9 @@ func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {
 	}
 }
 
-func (s *constraintsValidationSuite) TestServiceConstraints(c *gc.C) {
+func (s *constraintsValidationSuite) TestApplicationConstraints(c *gc.C) {
 	charm := s.AddTestingCharm(c, "wordpress")
-	service := s.AddTestingApplication(c, "wordpress", charm)
+	application := s.AddTestingApplication(c, "wordpress", charm)
 	for i, t := range setConstraintsTests {
 		c.Logf(
 			"test %d: %s\nconsToSet: %q\nconsFallback: %q\n",
@@ -252,18 +252,18 @@ func (s *constraintsValidationSuite) TestServiceConstraints(c *gc.C) {
 		econs, err := s.State.ModelConstraints()
 		c.Check(econs, jc.DeepEquals, constraints.MustParse(t.effectiveModelCons))
 		// Set the application deployment constraints.
-		err = service.SetConstraints(constraints.MustParse(t.consToSet))
+		err = application.SetConstraints(constraints.MustParse(t.consToSet))
 		c.Check(err, jc.ErrorIsNil)
-		u, err := service.AddUnit(state.AddUnitParams{})
+		u, err := application.AddUnit(state.AddUnitParams{})
 		c.Check(err, jc.ErrorIsNil)
 		// New unit deployment constraints get merged with the fallbacks.
 		ucons, err := u.Constraints()
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(*ucons, jc.DeepEquals, constraints.MustParse(t.effectiveUnitCons))
-		// Service constraints remain as set.
-		scons, err := service.Constraints()
+		// Application constraints remain as set.
+		scons, err := application.Constraints()
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(scons, jc.DeepEquals, constraints.MustParse(t.effectiveServiceCons))
+		c.Check(scons, jc.DeepEquals, constraints.MustParse(t.effectiveApplicationCons))
 	}
 }
 
@@ -291,12 +291,12 @@ func (s *applicationConstraintsSuite) TestAddApplicationInvalidConstraints(c *gc
 
 func (s *applicationConstraintsSuite) TestAddApplicationValidConstraints(c *gc.C) {
 	cons := constraints.MustParse("virt-type=kvm")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{
+	application, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        s.applicationName,
 		Series:      "",
 		Charm:       s.testCharm,
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(service, gc.NotNil)
+	c.Assert(application, gc.NotNil)
 }

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -32,7 +32,7 @@ func distributeUnit(u *Unit, candidates []instance.Id) ([]instance.Id, error) {
 	if distributor == nil {
 		return nil, fmt.Errorf("policy returned nil instance distributor without an error")
 	}
-	distributionGroup, err := ServiceInstances(u.st, u.doc.Application)
+	distributionGroup, err := ApplicationInstances(u.st, u.doc.Application)
 	if err != nil {
 		return nil, err
 	}
@@ -42,9 +42,9 @@ func distributeUnit(u *Unit, candidates []instance.Id) ([]instance.Id, error) {
 	return distributor.DistributeInstances(CallContext(u.st), candidates, distributionGroup)
 }
 
-// ServiceInstances returns the instance IDs of provisioned
+// ApplicationInstances returns the instance IDs of provisioned
 // machines that are assigned units of the specified application.
-func ServiceInstances(st *State, application string) ([]instance.Id, error) {
+func ApplicationInstances(st *State, application string) ([]instance.Id, error) {
 	units, err := allUnits(st, application)
 	if err != nil {
 		return nil, err

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -20,14 +20,14 @@ import (
 // individually.
 const defaultEndpointName = ""
 
-// endpointBindingsDoc represents how a service endpoints are bound to spaces.
-// The DocID field contains the service's global key, so there is always one
-// endpointBindingsDoc per service.
+// endpointBindingsDoc represents how a application's endpoints are bound to spaces.
+// The DocID field contains the applications's global key, so there is always one
+// endpointBindingsDoc per application.
 type endpointBindingsDoc struct {
-	// DocID is always the same as a service's global key.
+	// DocID is always the same as a application's global key.
 	DocID string `bson:"_id"`
 
-	// Bindings maps a service endpoint name to the space name it is bound to.
+	// Bindings maps an application endpoint name to the space name it is bound to.
 	Bindings bindingsMap `bson:"bindings"`
 
 	// TxnRevno is used to assert the collection have not changed since this
@@ -219,7 +219,7 @@ func removeEndpointBindingsOp(key string) txn.Op {
 }
 
 // readEndpointBindings returns the stored bindings and TxnRevno for the given
-// service global key, or an error satisfying errors.IsNotFound() otherwise.
+// application global key, or an error satisfying errors.IsNotFound() otherwise.
 func readEndpointBindings(st *State, key string) (map[string]string, int64, error) {
 	endpointBindings, closer := st.db().GetCollection(endpointBindingsC)
 	defer closer()

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -529,7 +529,7 @@ func RemoveController(c *gc.C, m *Machine) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func RemoveEndpointBindingsForService(c *gc.C, app *Application) {
+func RemoveEndpointBindingsForApplication(c *gc.C, app *Application) {
 	globalKey := app.globalKey()
 	removeOp := removeEndpointBindingsOp(globalKey)
 
@@ -549,7 +549,7 @@ func RelationCount(app *Application) int {
 	return app.doc.RelationCount
 }
 
-func AssertEndpointBindingsNotFoundForService(c *gc.C, app *Application) {
+func AssertEndpointBindingsNotFoundForApplication(c *gc.C, app *Application) {
 	globalKey := app.globalKey()
 	storedBindings, _, err := readEndpointBindings(app.st, globalKey)
 	c.Assert(storedBindings, gc.IsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -21,7 +21,7 @@ type FilesystemStateSuite struct {
 
 var _ = gc.Suite(&FilesystemStateSuite{})
 
-func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
+func (s *FilesystemStateSuite) TestAddApplicationInvalidPool(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-filesystem")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
@@ -30,38 +30,38 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
-func (s *FilesystemStateSuite) TestAddServiceNoPoolNoDefault(c *gc.C) {
+func (s *FilesystemStateSuite) TestAddApplicationNoPoolNoDefault(c *gc.C) {
 	// no pool specified, no default configured: use rootfs.
-	s.testAddServiceDefaultPool(c, "rootfs", 0)
+	s.testAddApplicationDefaultPool(c, "rootfs", 0)
 }
 
-func (s *FilesystemStateSuite) TestAddServiceNoPoolNoDefaultWithUnits(c *gc.C) {
+func (s *FilesystemStateSuite) TestAddApplicationNoPoolNoDefaultWithUnits(c *gc.C) {
 	// no pool specified, no default configured: use rootfs, add a unit during
 	// app deploy.
-	s.testAddServiceDefaultPool(c, "rootfs", 1)
+	s.testAddApplicationDefaultPool(c, "rootfs", 1)
 }
 
-func (s *FilesystemStateSuite) TestAddServiceNoPoolDefaultFilesystem(c *gc.C) {
+func (s *FilesystemStateSuite) TestAddApplicationNoPoolDefaultFilesystem(c *gc.C) {
 	// no pool specified, default filesystem configured: use default
 	// filesystem.
 	err := s.IAASModel.UpdateModelConfig(map[string]interface{}{
 		"storage-default-filesystem-source": "machinescoped",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.testAddServiceDefaultPool(c, "machinescoped", 0)
+	s.testAddApplicationDefaultPool(c, "machinescoped", 0)
 }
 
-func (s *FilesystemStateSuite) TestAddServiceNoPoolDefaultBlock(c *gc.C) {
+func (s *FilesystemStateSuite) TestAddApplicationNoPoolDefaultBlock(c *gc.C) {
 	// no pool specified, default block configured: use default
 	// block with managed fs on top.
 	err := s.IAASModel.UpdateModelConfig(map[string]interface{}{
 		"storage-default-block-source": "modelscoped-block",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.testAddServiceDefaultPool(c, "modelscoped-block", 0)
+	s.testAddApplicationDefaultPool(c, "modelscoped-block", 0)
 }
 
-func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool string, numUnits int) {
+func (s *FilesystemStateSuite) testAddApplicationDefaultPool(c *gc.C, expectedPool string, numUnits int) {
 	ch := s.AddTestingCharm(c, "storage-filesystem")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
@@ -73,9 +73,9 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 		Storage:  storage,
 		NumUnits: numUnits,
 	}
-	svc, err := s.State.AddApplication(args)
+	app, err := s.State.AddApplication(args)
 	c.Assert(err, jc.ErrorIsNil)
-	cons, err := svc.StorageConstraints()
+	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := map[string]state.StorageConstraints{
 		"data": state.StorageConstraints{
@@ -86,10 +86,10 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 	}
 	c.Assert(cons, jc.DeepEquals, expected)
 
-	svc, err = s.State.Application(args.Name)
+	app, err = s.State.Application(args.Name)
 	c.Assert(err, jc.ErrorIsNil)
 
-	units, err := svc.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, numUnits)
 

--- a/state/interface.go
+++ b/state/interface.go
@@ -107,7 +107,7 @@ type ControllerAccessor interface {
 }
 
 // UnitsWatcher defines the methods needed to retrieve an entity (a
-// machine or a service) and watch its units.
+// machine or an application) and watch its units.
 type UnitsWatcher interface {
 	Entity
 	WatchUnits() StringsWatcher

--- a/state/interface_test.go
+++ b/state/interface_test.go
@@ -49,12 +49,12 @@ var (
 	_ InstanceIdGetter = (*Machine)(nil)
 
 	_ ActionsWatcher = (*Unit)(nil)
-	// TODO(jcw4): when we implement service level Actions
-	// _ ActionsWatcher = (*Service)(nil)
+	// TODO(jcw4): when we implement application level Actions
+	// _ ActionsWatcher = (*Application)(nil)
 
 	_ ActionReceiver = (*Unit)(nil)
 	// TODO(jcw4) - use when Actions can be queued for applications.
-	//_ ActionReceiver = (*Service)(nil)
+	//_ ActionReceiver = (*Application)(nil)
 
 	_ GlobalEntity = (*Machine)(nil)
 	_ GlobalEntity = (*Unit)(nil)

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -25,7 +25,7 @@ func leadershipSettingsKey(applicationId string) string {
 	return fmt.Sprintf("a#%s#leader", applicationId)
 }
 
-// LeadershipClaimer returns a leadership.Claimer for units and services in the
+// LeadershipClaimer returns a leadership.Claimer for units and applications in the
 // state's model.
 func (st *State) LeadershipClaimer() leadership.Claimer {
 	return leadershipClaimer{
@@ -35,7 +35,7 @@ func (st *State) LeadershipClaimer() leadership.Claimer {
 	}
 }
 
-// LeadershipChecker returns a leadership.Checker for units and services in the
+// LeadershipChecker returns a leadership.Checker for units and applications in the
 // state's model.
 func (st *State) LeadershipChecker() leadership.Checker {
 	return leadershipChecker{

--- a/state/life.go
+++ b/state/life.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Life represents the lifecycle state of the entities
-// Relation, Unit, Service and Machine.
+// Relation, Unit, Application and Machine.
 type Life int8
 
 const (

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -14,13 +14,13 @@ import (
 type LifeSuite struct {
 	ConnSuite
 	charm *state.Charm
-	svc   *state.Application
+	app   *state.Application
 }
 
 func (s *LifeSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.charm = s.AddTestingCharm(c, "dummy")
-	s.svc = s.AddTestingApplication(c, "dummysvc", s.charm)
+	s.app = s.AddTestingApplication(c, "dummyapp", s.charm)
 }
 
 var _ = gc.Suite(&LifeSuite{})
@@ -94,7 +94,7 @@ func (l *unitLife) id() (coll string, id interface{}) {
 }
 
 func (l *unitLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
-	unit, err := s.svc.AddUnit(state.AddUnitParams{})
+	unit, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	preventUnitDestroyRemove(c, unit)
 	l.unit = unit

--- a/state/machine.go
+++ b/state/machine.go
@@ -744,7 +744,7 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 		}
 		// Check that the machine does not have any responsibilities that
 		// prevent a lifecycle change.
-		// If there are no alive units left on the machine, or all the services are dying,
+		// If there are no alive units left on the machine, or all the applications are dying,
 		// then the machine may be soon destroyed by a cleanup worker.
 		// In that case, we don't want to return any error about not being able to
 		// destroy a machine with units as it will be a lie.
@@ -776,11 +776,11 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 				if err != nil {
 					return nil, errors.Annotatef(err, "reading machine %s principal unit %v", m, m.doc.Principals[0])
 				}
-				svc, err := u.Application()
+				app, err := u.Application()
 				if err != nil {
-					return nil, errors.Annotatef(err, "reading machine %s principal unit service %v", m, u.doc.Application)
+					return nil, errors.Annotatef(err, "reading machine %s principal unit application %v", m, u.doc.Application)
 				}
-				if u.Life() == Alive && svc.Life() == Alive {
+				if u.Life() == Alive && app.Life() == Alive {
 					canDie = false
 					break
 				}

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -1117,7 +1117,7 @@ const macAddressTemplate = "00:16:3e:%02x:%02x:%02x"
 // macAddressTemplate above.
 //
 // TODO(dimitern): We should make a best effort to ensure the MAC address we
-// generate is unique at least within the current environment.
+// generate is unique at least within the current model.
 func generateMACAddress() string {
 	digits := make([]interface{}, 3)
 	for i := range digits {
@@ -1221,7 +1221,7 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string](Machin
 		}
 	}
 
-	// For a spaceless environment we won't find a subnet that's linked to privateAddress,
+	// For a spaceless model we won't find a subnet that's linked to privateAddress,
 	// we have to work around that and at least return minimal information.
 	if r, filledPrivateAddress := results[environs.DefaultSpaceName]; !filledPrivateAddress && spaces.Contains(environs.DefaultSpaceName) {
 		r.NetworkInfos = []network.NetworkInfo{{

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -431,7 +431,7 @@ func (s *MachineSuite) TestDestroyContention(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "machine 1 cannot advance lifecycle: state changing too quickly; try again soon")
 }
 
-func (s *MachineSuite) TestDestroyWithServiceDestroyPending(c *gc.C) {
+func (s *MachineSuite) TestDestroyWithApplicationDestroyPending(c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1093,7 +1093,7 @@ func (s *MachineSuite) TestRefreshWhenNotAlive(c *gc.C) {
 func (s *MachineSuite) TestMachinePrincipalUnits(c *gc.C) {
 	// Check that Machine.Units and st.UnitsFor work correctly.
 
-	// Make three machines, three services and three units for each application;
+	// Make three machines, three applications and three units for each application;
 	// variously assign units to machines and check that Machine.Units
 	// tells us the right thing.
 
@@ -1201,12 +1201,12 @@ func (s *MachineSuite) TestMachineDirtyAfterUnassigningUnit(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineDirtyAfterRemovingUnit(c *gc.C) {
-	m, svc, unit := s.assertMachineDirtyAfterAddingUnit(c)
+	m, app, unit := s.assertMachineDirtyAfterAddingUnit(c)
 	err := unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	err = svc.Destroy()
+	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Clean(), jc.IsFalse)
 }
@@ -1251,7 +1251,7 @@ func (s *MachineSuite) TestWatchDiesOnStateClose(c *gc.C) {
 	// This test is testing logic in watcher.entityWatcher, which
 	// is also used by:
 	//  Machine.WatchHardwareCharacteristics
-	//  Service.Watch
+	//  Application.Watch
 	//  Unit.Watch
 	//  State.WatchForModelConfigChanges
 	//  Unit.WatchConfigSettings

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -302,11 +302,11 @@ func (st *State) MetricBatchesForModel() ([]MetricBatch, error) {
 
 // MetricBatchesForApplication returns metric batches for the given application.
 func (st *State) MetricBatchesForApplication(application string) ([]MetricBatch, error) {
-	svc, err := st.Application(application)
+	app, err := st.Application(application)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	units, err := svc.AllUnits()
+	units, err := app.AllUnits()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -844,8 +844,8 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 	defer st.Close()
 	f := factory.NewFactory(st)
 	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
-	service := f.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	unit := f.MakeUnit(c, &factory.UnitParams{Application: service, SetCharmURL: true})
+	application := f.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	unit := f.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	_, err = st.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
@@ -1079,7 +1079,7 @@ func mustCreateMeteredModel(c *gc.C, stateFactory *factory.Factory) (modelData, 
 	}, cleanup
 }
 
-func (s *CrossModelMetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
+func (s *CrossModelMetricSuite) TestMetricsAcrossmodels(c *gc.C) {
 	now := state.NowToTheSecond(s.State).Add(-48 * time.Hour)
 	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	m1, err := s.models[0].state.AddMetrics(

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -663,7 +663,7 @@ type addApplicationContext struct {
 	meterStatus      map[string]*meterStatusDoc
 	leader           string
 	payloads         map[string][]payload.FullPayloadInfo
-	resources        resource.ServiceResources
+	resources        resource.ApplicationResources
 	endpoingBindings map[string]bindingsMap
 
 	// CAAS
@@ -836,7 +836,7 @@ func (e *exporter) unitWorkloadVersion(unit *Unit) (string, error) {
 	return info.Message, nil
 }
 
-func (e *exporter) setResources(exApp description.Application, resources resource.ServiceResources) error {
+func (e *exporter) setResources(exApp description.Application, resources resource.ApplicationResources) error {
 	if len(resources.Resources) != len(resources.CharmStoreResources) {
 		return errors.New("number of resources don't match charm store resources")
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -118,8 +118,8 @@ func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := service.AddUnit(state.AddUnitParams{})
+	application := s.AddTestingApplicationWithStorage(c, "storage-"+kind, ch, storage)
+	unit, err := application.AddUnit(state.AddUnitParams{})
 
 	machine := s.Factory.MakeMachine(c, nil)
 	err = unit.AssignToMachine(machine)
@@ -130,7 +130,7 @@ func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *
 	agentVersion := version.MustParseBinary("2.0.1-quantal-and64")
 	err = unit.SetAgentVersion(agentVersion)
 	c.Assert(err, jc.ErrorIsNil)
-	return service, unit, storageTag
+	return application, unit, storageTag
 }
 
 type MigrationExportSuite struct {
@@ -587,7 +587,7 @@ func (s *MigrationExportSuite) assertMigrateUnits(c *gc.C, st *state.State) {
 	}
 }
 
-func (s *MigrationExportSuite) TestServiceLeadership(c *gc.C) {
+func (s *MigrationExportSuite) TestApplicationLeadership(c *gc.C) {
 	s.makeApplicationWithLeader(c, "mysql", 2, 1)
 	s.makeApplicationWithLeader(c, "wordpress", 4, 2)
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -35,8 +35,8 @@ import (
 
 // When we import a new model, we need to give the leaders some time to
 // settle. We don't want to have leader switches just because we migrated an
-// environment, so this time needs to be long enough to make sure we cover
-// the time taken to migration a reasonable sized environment. We don't yet
+// model, so this time needs to be long enough to make sure we cover
+// the time taken to migration a reasonable sized model. We don't yet
 // know how long this is going to be, but we need something.
 var initialLeaderClaimTime = time.Minute
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -140,8 +140,8 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// uses object containment for this purpose.
 		containerRefsC,
 		// The min units collection is only used to trigger a watcher
-		// in order to have the service add or remove units if the minimum
-		// number of units is changed. The Service doc has all we need
+		// in order to have the application add or remove units if the minimum
+		// number of units is changed. The Application doc has all we need
 		// for migratino.
 		minUnitsC,
 		// This is a transitory collection of units that need to be assigned
@@ -364,7 +364,7 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"Life",
 		// TxnRevno is mgo internals and should not be migrated.
 		"TxnRevno",
-		// UnitCount is handled by the number of units for the exported service.
+		// UnitCount is handled by the number of units for the exported application.
 		"UnitCount",
 		// RelationCount is handled by the number of times the application name
 		// appears in relation endpoints.
@@ -395,7 +395,7 @@ func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {
 		"Application",
 		// Resolved is not migrated as we check that all is good before we start.
 		"Resolved",
-		// Series and CharmURL also come from the service.
+		// Series and CharmURL also come from the application.
 		"Series",
 		"CharmURL",
 		"TxnRevno",

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -22,7 +22,7 @@ import (
 // alive units: new units are added if required.
 type minUnitsDoc struct {
 	// ApplicationName is safe to be used here in place of its globalKey, since
-	// the referred entity type is always the Service.
+	// the referred entity type is always the Application.
 	DocID           string `bson:"_id"`
 	ApplicationName string
 	ModelUUID       string `bson:"model-uuid"`

--- a/state/minimumunits_test.go
+++ b/state/minimumunits_test.go
@@ -37,7 +37,7 @@ func (s *MinUnitsSuite) addUnits(c *gc.C, count int) {
 }
 
 func (s *MinUnitsSuite) TestSetMinUnits(c *gc.C) {
-	service := s.application
+	application := s.application
 	for i, t := range []struct {
 		about   string
 		initial int
@@ -85,21 +85,21 @@ func (s *MinUnitsSuite) TestSetMinUnits(c *gc.C) {
 		c.Logf("test %d. %s", i, t.about)
 		// Set up initial minimum units if required.
 		if t.initial > 0 {
-			err := service.SetMinUnits(t.initial)
+			err := application.SetMinUnits(t.initial)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		// Insert/update minimum units.
 		for _, input := range t.changes {
-			err := service.SetMinUnits(input)
+			err := application.SetMinUnits(input)
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(service.MinUnits(), gc.Equals, input)
-			c.Assert(service.Refresh(), gc.IsNil)
-			c.Assert(service.MinUnits(), gc.Equals, input)
+			c.Assert(application.MinUnits(), gc.Equals, input)
+			c.Assert(application.Refresh(), gc.IsNil)
+			c.Assert(application.MinUnits(), gc.Equals, input)
 		}
 		// Check the document existence and revno.
 		s.assertRevno(c, t.revno, t.err)
 		// Clean up, if required, the minUnits document.
-		err := service.SetMinUnits(0)
+		err := application.SetMinUnits(0)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -150,7 +150,7 @@ func (s *MinUnitsSuite) TestMinUnitsRemoveBefore(c *gc.C) {
 	c.Assert(s.application.MinUnits(), gc.Equals, 0)
 }
 
-func (s *MinUnitsSuite) testDestroyOrRemoveServiceBefore(c *gc.C, initial, input int, preventRemoval bool) {
+func (s *MinUnitsSuite) testDestroyOrRemoveApplicationBefore(c *gc.C, initial, input int, preventRemoval bool) {
 	err := s.application.SetMinUnits(initial)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `cannot set minimum units for application "dummy-application": application "dummy-application" not found`
@@ -167,28 +167,28 @@ func (s *MinUnitsSuite) testDestroyOrRemoveServiceBefore(c *gc.C, initial, input
 	s.assertRevno(c, 0, mgo.ErrNotFound)
 }
 
-func (s *MinUnitsSuite) TestMinUnitsInsertDestroyServiceBefore(c *gc.C) {
-	s.testDestroyOrRemoveServiceBefore(c, 0, 42, true)
+func (s *MinUnitsSuite) TestMinUnitsInsertDestroyApplicationBefore(c *gc.C) {
+	s.testDestroyOrRemoveApplicationBefore(c, 0, 42, true)
 }
 
-func (s *MinUnitsSuite) TestMinUnitsUpdateDestroyServiceBefore(c *gc.C) {
-	s.testDestroyOrRemoveServiceBefore(c, 1, 42, true)
+func (s *MinUnitsSuite) TestMinUnitsUpdateDestroyApplicationBefore(c *gc.C) {
+	s.testDestroyOrRemoveApplicationBefore(c, 1, 42, true)
 }
 
-func (s *MinUnitsSuite) TestMinUnitsRemoveDestroyServiceBefore(c *gc.C) {
-	s.testDestroyOrRemoveServiceBefore(c, 1, 0, true)
+func (s *MinUnitsSuite) TestMinUnitsRemoveDestroyApplicationBefore(c *gc.C) {
+	s.testDestroyOrRemoveApplicationBefore(c, 1, 0, true)
 }
 
-func (s *MinUnitsSuite) TestMinUnitsInsertRemoveServiceBefore(c *gc.C) {
-	s.testDestroyOrRemoveServiceBefore(c, 0, 42, false)
+func (s *MinUnitsSuite) TestMinUnitsInsertRemoveApplicationBefore(c *gc.C) {
+	s.testDestroyOrRemoveApplicationBefore(c, 0, 42, false)
 }
 
-func (s *MinUnitsSuite) TestMinUnitsUpdateRemoveServiceBefore(c *gc.C) {
-	s.testDestroyOrRemoveServiceBefore(c, 1, 42, false)
+func (s *MinUnitsSuite) TestMinUnitsUpdateRemoveApplicationBefore(c *gc.C) {
+	s.testDestroyOrRemoveApplicationBefore(c, 1, 42, false)
 }
 
-func (s *MinUnitsSuite) TestMinUnitsRemoveRemoveServiceBefore(c *gc.C) {
-	s.testDestroyOrRemoveServiceBefore(c, 1, 0, false)
+func (s *MinUnitsSuite) TestMinUnitsRemoveRemoveApplicationBefore(c *gc.C) {
+	s.testDestroyOrRemoveApplicationBefore(c, 1, 0, false)
 }
 
 func (s *MinUnitsSuite) TestMinUnitsSetDestroyEntities(c *gc.C) {
@@ -243,14 +243,14 @@ func (s *MinUnitsSuite) TestMinUnitsNotSetDestroyEntities(c *gc.C) {
 	s.assertRevno(c, 0, mgo.ErrNotFound)
 }
 
-func assertAllUnits(c *gc.C, service *state.Application, expected int) {
-	units, err := service.AllUnits()
+func assertAllUnits(c *gc.C, application *state.Application, expected int) {
+	units, err := application.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, expected)
 }
 
 func (s *MinUnitsSuite) TestEnsureMinUnits(c *gc.C) {
-	service := s.application
+	application := s.application
 	for i, t := range []struct {
 		about    string // Test description.
 		initial  int    // Initial number of units.
@@ -293,11 +293,11 @@ func (s *MinUnitsSuite) TestEnsureMinUnits(c *gc.C) {
 		s.addUnits(c, t.initial)
 
 		// Set up minimum units if required.
-		err := service.SetMinUnits(t.minimum)
+		err := application.SetMinUnits(t.minimum)
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Destroy units if required.
-		allUnits, err := service.AllUnits()
+		allUnits, err := application.AllUnits()
 		c.Assert(err, jc.ErrorIsNil)
 		for i := 0; i < t.destroy; i++ {
 			preventUnitDestroyRemove(c, allUnits[i])
@@ -306,19 +306,19 @@ func (s *MinUnitsSuite) TestEnsureMinUnits(c *gc.C) {
 		}
 
 		// Ensure the minimum number of units is correctly restored.
-		c.Assert(service.Refresh(), gc.IsNil)
-		err = service.EnsureMinUnits()
+		c.Assert(application.Refresh(), gc.IsNil)
+		err = application.EnsureMinUnits()
 		c.Assert(err, jc.ErrorIsNil)
-		assertAllUnits(c, service, t.expected)
+		assertAllUnits(c, application, t.expected)
 
 		// Clean up the minUnits document and the units.
-		err = service.SetMinUnits(0)
+		err = application.SetMinUnits(0)
 		c.Assert(err, jc.ErrorIsNil)
-		removeAllUnits(c, service)
+		removeAllUnits(c, application)
 	}
 }
 
-func (s *MinUnitsSuite) TestEnsureMinUnitsServiceNotAlive(c *gc.C) {
+func (s *MinUnitsSuite) TestEnsureMinUnitsApplicationNotAlive(c *gc.C) {
 	err := s.application.SetMinUnits(2)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnits(c, 1)
@@ -363,13 +363,13 @@ func (s *MinUnitsSuite) TestEnsureMinUnitsAddUnitsRetry(c *gc.C) {
 }
 
 func (s *MinUnitsSuite) testEnsureMinUnitsBefore(c *gc.C, f func(), minUnits, expectedUnits int) {
-	service := s.application
-	err := service.SetMinUnits(minUnits)
+	application := s.application
+	err := application.SetMinUnits(minUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	defer state.SetBeforeHooks(c, s.State, f).Check()
-	err = service.EnsureMinUnits()
+	err = application.EnsureMinUnits()
 	c.Assert(err, jc.ErrorIsNil)
-	assertAllUnits(c, service, expectedUnits)
+	assertAllUnits(c, application, expectedUnits)
 }
 
 func (s *MinUnitsSuite) TestEnsureMinUnitsDecreaseMinUnitsBefore(c *gc.C) {
@@ -395,7 +395,7 @@ func (s *MinUnitsSuite) TestEnsureMinUnitsAddUnitsBefore(c *gc.C) {
 	s.testEnsureMinUnitsBefore(c, f, 2, 2)
 }
 
-func (s *MinUnitsSuite) TestEnsureMinUnitsDestroyServiceBefore(c *gc.C) {
+func (s *MinUnitsSuite) TestEnsureMinUnitsDestroyApplicationBefore(c *gc.C) {
 	s.addUnits(c, 1)
 	err := s.application.SetMinUnits(42)
 	c.Assert(err, jc.ErrorIsNil)
@@ -409,15 +409,15 @@ func (s *MinUnitsSuite) TestEnsureMinUnitsDestroyServiceBefore(c *gc.C) {
 
 func (s *MinUnitsSuite) TestEnsureMinUnitsDecreaseMinUnitsAfter(c *gc.C) {
 	s.addUnits(c, 2)
-	service := s.application
-	err := service.SetMinUnits(5)
+	application := s.application
+	err := application.SetMinUnits(5)
 	c.Assert(err, jc.ErrorIsNil)
 	defer state.SetAfterHooks(c, s.State, func() {
-		err := service.SetMinUnits(3)
+		err := application.SetMinUnits(3)
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
-	c.Assert(service.Refresh(), gc.IsNil)
-	err = service.EnsureMinUnits()
+	c.Assert(application.Refresh(), gc.IsNil)
+	err = application.EnsureMinUnits()
 	c.Assert(err, jc.ErrorIsNil)
-	assertAllUnits(c, service, 3)
+	assertAllUnits(c, application, 3)
 }

--- a/state/model.go
+++ b/state/model.go
@@ -935,7 +935,7 @@ func (m *Model) uniqueIndexID() string {
 }
 
 // Destroy sets the models's lifecycle to Dying, preventing
-// addition of services or machines to state. If called on
+// addition of applications or machines to state. If called on
 // an empty hosted model, the lifecycle will be advanced
 // straight to Dead.
 func (m *Model) Destroy(args DestroyModelParams) (err error) {

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -696,7 +696,7 @@ func (*storeManagerSuite) TestEmptyModel(c *gc.C) {
 	checkNext(c, w, nil, "")
 }
 
-func (*storeManagerSuite) TestMultipleEnvironments(c *gc.C) {
+func (*storeManagerSuite) TestMultiplemodels(c *gc.C) {
 	b := newTestBacking([]multiwatcher.EntityInfo{
 		&multiwatcher.MachineInfo{ModelUUID: "uuid0", Id: "0"},
 		&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"},

--- a/state/payloads_test.go
+++ b/state/payloads_test.go
@@ -495,10 +495,10 @@ var _ = gc.Suite(&PayloadsFunctionalSuite{})
 func (s *PayloadsFunctionalSuite) TestModelPayloads(c *gc.C) {
 	machine := "0"
 	unit := addUnit(c, s.ConnSuite, unitArgs{
-		charm:    "dummy",
-		service:  "a-application",
-		metadata: payloadsMetaYAML,
-		machine:  machine,
+		charm:       "dummy",
+		application: "a-application",
+		metadata:    payloadsMetaYAML,
+		machine:     machine,
 	})
 
 	ust, err := s.State.UnitPayloads(unit)
@@ -556,10 +556,10 @@ func (s *PayloadsFunctionalSuite) TestModelPayloads(c *gc.C) {
 func (s *PayloadsFunctionalSuite) TestUnitPayloads(c *gc.C) {
 	machine := "0"
 	unit := addUnit(c, s.ConnSuite, unitArgs{
-		charm:    "dummy",
-		service:  "a-application",
-		metadata: payloadsMetaYAML,
-		machine:  machine,
+		charm:       "dummy",
+		application: "a-application",
+		metadata:    payloadsMetaYAML,
+		machine:     machine,
 	})
 
 	st, err := s.State.UnitPayloads(unit)
@@ -656,17 +656,17 @@ payloads:
 `
 
 type unitArgs struct {
-	charm    string
-	service  string
-	metadata string
-	machine  string
+	charm       string
+	application string
+	metadata    string
+	machine     string
 }
 
 func addUnit(c *gc.C, s ConnSuite, args unitArgs) *state.Unit {
 	ch := s.AddTestingCharm(c, args.charm)
 	ch = s.AddMetaCharm(c, args.charm, args.metadata, 2)
 
-	app := s.AddTestingApplication(c, args.service, ch)
+	app := s.AddTestingApplication(c, args.application, ch)
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/persistence.go
+++ b/state/persistence.go
@@ -26,7 +26,7 @@ type Persistence interface {
 	// function. It may be retried several times.
 	Run(transactions jujutxn.TransactionSource) error
 
-	// NewStorage returns a new blob storage for the environment.
+	// NewStorage returns a new blob storage for the model.
 	NewStorage() storage.Storage
 
 	// ApplicationExistsOps returns the operations that verify that the
@@ -81,7 +81,7 @@ func (sp statePersistence) Run(transactions jujutxn.TransactionSource) error {
 	return nil
 }
 
-// NewStorage returns a new blob storage for the environment.
+// NewStorage returns a new blob storage for the model.
 func (sp *statePersistence) NewStorage() storage.Storage {
 	modelUUID := sp.st.ModelUUID()
 	// TODO(ericsnow) Copy the session?
@@ -91,7 +91,7 @@ func (sp *statePersistence) NewStorage() storage.Storage {
 }
 
 // ApplicationExistsOps returns the operations that verify that the
-// identified service exists.
+// identified application exists.
 func (sp *statePersistence) ApplicationExistsOps(applicationID string) []txn.Op {
 	return []txn.Op{{
 		C:      applicationsC,
@@ -101,7 +101,7 @@ func (sp *statePersistence) ApplicationExistsOps(applicationID string) []txn.Op 
 }
 
 // IncCharmModifiedVersionOps returns the operations necessary to increment the
-// CharmModifiedVersion field for the given service.
+// CharmModifiedVersion field for the given application.
 func (sp *statePersistence) IncCharmModifiedVersionOps(applicationID string) []txn.Op {
 	return incCharmModifiedVersionOps(applicationID)
 }

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -20,7 +20,7 @@ import (
 type PortsDocSuite struct {
 	ConnSuite
 	charm              *state.Charm
-	service            *state.Application
+	application        *state.Application
 	unit1              *state.Unit
 	unit2              *state.Unit
 	machine            *state.Machine
@@ -36,10 +36,10 @@ func (s *PortsDocSuite) SetUpTest(c *gc.C) {
 
 	f := factory.NewFactory(s.State)
 	s.charm = f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
-	s.service = f.MakeApplication(c, &factory.ApplicationParams{Name: "wordpress", Charm: s.charm})
+	s.application = f.MakeApplication(c, &factory.ApplicationParams{Name: "wordpress", Charm: s.charm})
 	s.machine = f.MakeMachine(c, &factory.MachineParams{Series: "quantal"})
-	s.unit1 = f.MakeUnit(c, &factory.UnitParams{Application: s.service, Machine: s.machine})
-	s.unit2 = f.MakeUnit(c, &factory.UnitParams{Application: s.service, Machine: s.machine})
+	s.unit1 = f.MakeUnit(c, &factory.UnitParams{Application: s.application, Machine: s.machine})
+	s.unit2 = f.MakeUnit(c, &factory.UnitParams{Application: s.application, Machine: s.machine})
 
 	var err error
 	s.subnet, err = s.State.AddSubnet(state.SubnetInfo{CIDR: "0.1.2.0/24"})

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -483,7 +483,7 @@ func (s *PresenceSuite) TestSync(c *gc.C) {
 	}
 }
 
-func (s *PresenceSuite) TestTwoEnvironments(c *gc.C) {
+func (s *PresenceSuite) TestTwomodels(c *gc.C) {
 	key := "a"
 	w1, p1, ch1 := s.setup(c, key)
 	defer assertStopped(c, w1)

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -483,7 +483,7 @@ func (s *PresenceSuite) TestSync(c *gc.C) {
 	}
 }
 
-func (s *PresenceSuite) TestTwomodels(c *gc.C) {
+func (s *PresenceSuite) TestTwoModels(c *gc.C) {
 	key := "a"
 	w1, p1, ch1 := s.setup(c, key)
 	defer assertStopped(c, w1)

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -37,7 +37,7 @@ func (s *RelationSuite) TestAddRelationErrors(c *gc.C) {
 	riakEP, err := riak.Endpoint("ring")
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Check we can't add a relation with services that don't exist.
+	// Check we can't add a relation with application that don't exist.
 	yoursqlEP := mysqlEP
 	yoursqlEP.ApplicationName = "yoursql"
 	_, err = s.State.AddRelation(yoursqlEP, wordpressEP)
@@ -509,7 +509,7 @@ func (s *RelationSuite) TestWatchLifeSuspendedStatus(c *gc.C) {
 }
 
 func (s *RelationSuite) TestWatchLifeSuspendedStatusDead(c *gc.C) {
-	// Create a pair of services and a relation between them.
+	// Create a pair of application and a relation between them.
 	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	eps, err := s.State.InferEndpoints("wordpress", "mysql")

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -164,9 +164,9 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 
 	// The relation or unit might no longer be Alive. (Note that there is no
 	// need for additional checks if we're trying to create a subordinate
-	// unit: this could fail due to the subordinate service's not being Alive,
+	// unit: this could fail due to the subordinate applications not being Alive,
 	// but this case will always be caught by the check for the relation's
-	// life (because a relation cannot be Alive if its services are not).)
+	// life (because a relation cannot be Alive if its applications are not).)
 	relations, closer := db.GetCollection(relationsC)
 	defer closer()
 	if alive, err := isAliveWithSession(relations, relationDocID); err != nil {
@@ -457,7 +457,7 @@ func (ru *RelationUnit) Settings() (*Settings, error) {
 
 // ReadSettings returns a map holding the settings of the unit with the
 // supplied name within this relation. An error will be returned if the
-// relation no longer exists, or if the unit's service is not part of the
+// relation no longer exists, or if the unit's application is not part of the
 // relation, or the settings are invalid; but mere non-existence of the
 // unit is not grounds for an error, because the unit settings are
 // guaranteed to persist for the lifetime of the relation, regardless

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1043,7 +1043,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	c.Assert(ingress, gc.HasLen, 0)
 	c.Assert(egress, gc.HasLen, 0)
 
-	// Add a service address.
+	// Add a application address.
 	err = mysql.UpdateCloudService("", []network.Address{
 		{Value: "1.2.3.4", Scope: network.ScopeCloudLocal},
 	})
@@ -1442,7 +1442,7 @@ func (s *WatchScopeSuite) TestPeer(c *gc.C) {
 }
 
 func (s *WatchScopeSuite) TestProviderRequirerGlobal(c *gc.C) {
-	// Create a pair of services and a relation between them.
+	// Create a pair of application and a relation between them.
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("server")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1452,7 +1452,7 @@ func (s *WatchScopeSuite) TestProviderRequirerGlobal(c *gc.C) {
 	rel, err := s.State.AddRelation(mysqlEP, wordpressEP)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Add some units to the services and set their private addresses.
+	// Add some units to the application and set their private addresses.
 	addUnit := func(srv *state.Application, sub string, ep state.Endpoint) *state.RelationUnit {
 		unit, err := srv.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
@@ -1572,7 +1572,7 @@ func (s *WatchScopeSuite) TestProviderRequirerGlobal(c *gc.C) {
 }
 
 func (s *WatchScopeSuite) TestProviderRequirerContainer(c *gc.C) {
-	// Create a pair of services and a relation between them.
+	// Create a pair of application and a relation between them.
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("juju-info")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1585,7 +1585,7 @@ func (s *WatchScopeSuite) TestProviderRequirerContainer(c *gc.C) {
 	// Change mysqlEP to match the endpoint that will actually be used by the relation.
 	mysqlEP.Scope = charm.ScopeContainer
 
-	// Add some units to the services and set their private addresses.
+	// Add some units to the application and set their private addresses.
 	addUnits := func(i int) (*state.RelationUnit, *state.RelationUnit) {
 		msu, err := mysql.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
@@ -1719,7 +1719,7 @@ type WatchUnitsSuite struct {
 var _ = gc.Suite(&WatchUnitsSuite{})
 
 func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
-	// Create a pair of services and a relation between them.
+	// Create a pair of applications and a relation between them.
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("server")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1729,7 +1729,7 @@ func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
 	rel, err := s.State.AddRelation(mysqlEP, wordpressEP)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Add some units to the services and set their private addresses.
+	// Add some units to the applications and set their private addresses.
 	addUnit := func(srv *state.Application) *state.RelationUnit {
 		unit, err := srv.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
@@ -1771,7 +1771,7 @@ func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
 }
 
 func (s *WatchUnitsSuite) TestProviderRequirerContainer(c *gc.C) {
-	// Create a pair of services and a relation between them.
+	// Create a pair of applications and a relation between them.
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("juju-info")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -148,15 +148,15 @@ func (s *RemoteApplication) OfferUUID() string {
 	return s.doc.OfferUUID
 }
 
-// URL returns the remote service URL, and a boolean indicating whether or not
-// a URL is known for the remote service. A URL will only be available for the
-// consumer of an offered service.
+// URL returns the remote application URL, and a boolean indicating whether or not
+// a URL is known for the remote application. A URL will only be available for the
+// consumer of an offered application.
 func (s *RemoteApplication) URL() (string, bool) {
 	return s.doc.URL, s.doc.URL != ""
 }
 
 // Token returns the token for the remote application, provided by the remote
-// model to identify the service in future communications.
+// model to identify the application in future communications.
 func (s *RemoteApplication) Token() (string, error) {
 	r := s.st.RemoteEntities()
 	return r.GetToken(s.Tag())
@@ -554,8 +554,8 @@ func (s *RemoteApplication) Relations() (relations []*Relation, err error) {
 	return applicationRelations(s.st, s.doc.Name)
 }
 
-// AddRemoteApplicationParams contains the parameters for adding a remote service
-// to the environment.
+// AddRemoteApplicationParams contains the parameters for adding a remote application
+// to the model.
 type AddRemoteApplicationParams struct {
 	// Name is the name to give the remote application. This does not have to
 	// match the application name in the URL, or the name in the remote model.

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -108,8 +108,8 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *remoteApplicationSuite) assertApplicationRelations(c *gc.C, svc *state.Application, expectedKeys ...string) []*state.Relation {
-	rels, err := svc.Relations()
+func (s *remoteApplicationSuite) assertApplicationRelations(c *gc.C, app *state.Application, expectedKeys ...string) []*state.Relation {
+	rels, err := app.Relations()
 	c.Assert(err, jc.ErrorIsNil)
 	if len(rels) == 0 {
 		return nil
@@ -704,9 +704,9 @@ func (s *remoteApplicationSuite) assertAddRemoteRelation(c *gc.C, application1, 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rel.String(), gc.Equals, "wordpress:db mysql:db")
 	c.Assert(rel.Endpoints(), jc.DeepEquals, []state.Endpoint{endpoints[application1], endpoints[application2]})
-	remoteSvc, err := s.State.RemoteApplication("mysql")
+	remoteapp, err := s.State.RemoteApplication("mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	relations, err := remoteSvc.Relations()
+	relations, err := remoteapp.Relations()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(relations, gc.HasLen, 1)
 	c.Assert(relations[0], jc.DeepEquals, rel)

--- a/state/resources.go
+++ b/state/resources.go
@@ -16,7 +16,7 @@ import (
 // Resources describes the state functionality for resources.
 type Resources interface {
 	// ListResources returns the list of resources for the given application.
-	ListResources(applicationID string) (resource.ServiceResources, error)
+	ListResources(applicationID string) (resource.ApplicationResources, error)
 
 	// ListPendingResources returns the list of pending resources for
 	// the given application.
@@ -50,7 +50,7 @@ type Resources interface {
 	OpenResourceForUniter(unit resource.Unit, name string) (resource.Resource, io.ReadCloser, error)
 
 	// SetCharmStoreResources sets the "polled" resources for the
-	// service to the provided values.
+	// application to the provided values.
 	SetCharmStoreResources(applicationID string, info []charmresource.Resource, lastPolled time.Time) error
 
 	// RemovePendingAppResources removes any pending application-level
@@ -80,7 +80,7 @@ type ResourcesPersistence interface {
 	NewRemoveUnitResourcesOps(unitID string) ([]txn.Op, error)
 
 	// NewRemoveResourcesOps returns mgo transaction operations that
-	// remove all the service's resources from state.
+	// remove all the application's resources from state.
 	NewRemoveResourcesOps(applicationID string) ([]txn.Op, error)
 }
 

--- a/state/resources_adapters.go
+++ b/state/resources_adapters.go
@@ -59,8 +59,8 @@ func (st rawState) Units(applicationID string) (tags []names.UnitTag, err error)
 	return tags, nil
 }
 
-// VerifyService implements resource/state.RawState.
-func (st rawState) VerifyService(id string) error {
+// VerifyApplication implements resource/state.RawState.
+func (st rawState) VerifyApplication(id string) error {
 	app, err := st.base.Application(id)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/resources_persistence.go
+++ b/state/resources_persistence.go
@@ -41,7 +41,7 @@ type ResourcePersistenceBase interface {
 }
 
 // ResourcePersistence provides the persistence functionality for the
-// Juju environment as a whole.
+// Juju model as a whole.
 type ResourcePersistence struct {
 	base ResourcePersistenceBase
 }
@@ -54,20 +54,20 @@ func NewResourcePersistence(base ResourcePersistenceBase) *ResourcePersistence {
 }
 
 // ListResources returns the info for each non-pending resource of the
-// identified service.
-func (p ResourcePersistence) ListResources(applicationID string) (resource.ServiceResources, error) {
+// identified application.
+func (p ResourcePersistence) ListResources(applicationID string) (resource.ApplicationResources, error) {
 	logger.Tracef("listing all resources for application %q", applicationID)
 
 	docs, err := p.resources(applicationID)
 	if err != nil {
-		return resource.ServiceResources{}, errors.Trace(err)
+		return resource.ApplicationResources{}, errors.Trace(err)
 	}
 
 	store := map[string]charmresource.Resource{}
 	units := map[names.UnitTag][]resource.Resource{}
 	downloadProgress := make(map[names.UnitTag]map[string]int64)
 
-	var results resource.ServiceResources
+	var results resource.ApplicationResources
 	for _, doc := range docs {
 		if doc.PendingID != "" {
 			continue
@@ -75,7 +75,7 @@ func (p ResourcePersistence) ListResources(applicationID string) (resource.Servi
 
 		res, err := doc2basicResource(doc)
 		if err != nil {
-			return resource.ServiceResources{}, errors.Trace(err)
+			return resource.ApplicationResources{}, errors.Trace(err)
 		}
 		if !doc.LastPolled.IsZero() {
 			store[res.Name] = res.Resource
@@ -111,7 +111,7 @@ func (p ResourcePersistence) ListResources(applicationID string) (resource.Servi
 }
 
 // ListPendingResources returns the extended, model-related info for
-// each pending resource of the identifies service.
+// each pending resource of the identifies application.
 func (p ResourcePersistence) ListPendingResources(applicationID string) ([]resource.Resource, error) {
 	docs, err := p.resources(applicationID)
 	if err != nil {
@@ -208,7 +208,7 @@ func (p ResourcePersistence) SetResource(res resource.Resource) error {
 			return nil, errors.New("setting the resource failed")
 		}
 		if stored.PendingID == "" {
-			// Only non-pending resources must have an existing service.
+			// Only non-pending resources must have an existing application.
 			ops = append(ops, p.base.ApplicationExistsOps(res.ApplicationID)...)
 		}
 		return ops, nil

--- a/state/resources_persistence_staged.go
+++ b/state/resources_persistence_staged.go
@@ -32,7 +32,7 @@ func (staged StagedResource) stage() error {
 			return nil, errors.NewAlreadyExists(nil, "already staged")
 		}
 		if staged.stored.PendingID == "" {
-			// Only non-pending resources must have an existing service.
+			// Only non-pending resources must have an existing application.
 			ops = append(ops, staged.base.ApplicationExistsOps(staged.stored.ApplicationID)...)
 		}
 
@@ -84,7 +84,7 @@ func (staged StagedResource) Activate() error {
 		ops = append(ops, newRemoveStagedResourceOps(staged.id)...)
 
 		// If we are changing the bytes for a resource, we increment the
-		// CharmModifiedVersion on the service, since resources are integral to
+		// CharmModifiedVersion on the application, since resources are integral to
 		// the high level "version" of the charm.
 		if staged.stored.PendingID == "" {
 			hasNewBytes, err := staged.hasNewBytes()

--- a/state/resources_persistence_staged_test.go
+++ b/state/resources_persistence_staged_test.go
@@ -34,8 +34,8 @@ func (s *StagedResourceSuite) SetUpTest(c *gc.C) {
 	}}
 }
 
-func (s *StagedResourceSuite) newStagedResource(c *gc.C, serviceID, name string) (*StagedResource, resourceDoc) {
-	stored, doc := newPersistenceResource(c, serviceID, name)
+func (s *StagedResourceSuite) newStagedResource(c *gc.C, applicationID, name string) (*StagedResource, resourceDoc) {
+	stored, doc := newPersistenceResource(c, applicationID, name)
 	ignoredErr := errors.New("<never reached>")
 	s.stub.SetErrors(nil, nil, ignoredErr)
 	staged := &StagedResource{

--- a/state/resources_persistence_test.go
+++ b/state/resources_persistence_test.go
@@ -622,31 +622,31 @@ func (s *ResourcePersistenceSuite) TestRemovePendingAppResources(c *gc.C) {
 	c.Assert(ops[1].Insert.(*cleanupDoc).Prefix, gc.Equals, appResource2.storagePath)
 }
 
-func newPersistenceUnitResources(c *gc.C, serviceID, unitID string, resources []resource.Resource) ([]resource.Resource, []resourceDoc) {
+func newPersistenceUnitResources(c *gc.C, applicationID, unitID string, resources []resource.Resource) ([]resource.Resource, []resourceDoc) {
 	var unitResources []resource.Resource
 	var docs []resourceDoc
 	for _, res := range resources {
-		res, doc := newPersistenceUnitResource(c, serviceID, unitID, res.Name)
+		res, doc := newPersistenceUnitResource(c, applicationID, unitID, res.Name)
 		unitResources = append(unitResources, res)
 		docs = append(docs, doc)
 	}
 	return unitResources, docs
 }
 
-func newPersistenceUnitResource(c *gc.C, serviceID, unitID, name string) (resource.Resource, resourceDoc) {
-	res, doc := newPersistenceResource(c, serviceID, name)
+func newPersistenceUnitResource(c *gc.C, applicationID, unitID, name string) (resource.Resource, resourceDoc) {
+	res, doc := newPersistenceResource(c, applicationID, name)
 	doc.DocID += "#unit-" + unitID
 	doc.UnitID = unitID
 	return res.Resource, doc
 }
 
-func newPersistenceResources(c *gc.C, serviceID string, names ...string) (resource.ServiceResources, []resourceDoc) {
-	var svcResources resource.ServiceResources
+func newPersistenceResources(c *gc.C, applicationID string, names ...string) (resource.ApplicationResources, []resourceDoc) {
+	var appResources resource.ApplicationResources
 	var docs []resourceDoc
 	for _, name := range names {
-		res, doc := newPersistenceResource(c, serviceID, name)
-		svcResources.Resources = append(svcResources.Resources, res.Resource)
-		svcResources.CharmStoreResources = append(svcResources.CharmStoreResources, res.Resource.Resource)
+		res, doc := newPersistenceResource(c, applicationID, name)
+		appResources.Resources = append(appResources.Resources, res.Resource)
+		appResources.CharmStoreResources = append(appResources.CharmStoreResources, res.Resource.Resource)
 		docs = append(docs, doc)
 		csDoc := doc // a copy
 		csDoc.DocID += "#charmstore"
@@ -656,17 +656,17 @@ func newPersistenceResources(c *gc.C, serviceID string, names ...string) (resour
 		csDoc.LastPolled = coretesting.NonZeroTime().UTC()
 		docs = append(docs, csDoc)
 	}
-	return svcResources, docs
+	return appResources, docs
 }
 
-func newPersistenceResource(c *gc.C, serviceID, name string) (storedResource, resourceDoc) {
+func newPersistenceResource(c *gc.C, applicationID, name string) (storedResource, resourceDoc) {
 	content := name
-	opened := resourcetesting.NewResource(c, nil, name, serviceID, content)
+	opened := resourcetesting.NewResource(c, nil, name, applicationID, content)
 	res := opened.Resource
 
 	stored := storedResource{
 		Resource:    res,
-		storagePath: "application-" + serviceID + "/resources/" + name,
+		storagePath: "application-" + applicationID + "/resources/" + name,
 	}
 
 	doc := resourceDoc{
@@ -693,7 +693,7 @@ func newPersistenceResource(c *gc.C, serviceID, name string) (storedResource, re
 	return stored, doc
 }
 
-func checkResources(c *gc.C, resources, expected resource.ServiceResources) {
+func checkResources(c *gc.C, resources, expected resource.ApplicationResources) {
 	resMap := make(map[string]resource.Resource)
 	for _, res := range resources.Resources {
 		resMap[res.Name] = res

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -22,7 +22,7 @@ import (
 type resourcePersistence interface {
 	// ListResources returns the resource data for the given application ID.
 	// None of the resources will be pending.
-	ListResources(applicationID string) (resource.ServiceResources, error)
+	ListResources(applicationID string) (resource.ApplicationResources, error)
 
 	// ListPendingResources returns the resource data for the given
 	// application ID.
@@ -82,18 +82,18 @@ type resourceState struct {
 }
 
 // ListResources returns the resource data for the given application ID.
-func (st resourceState) ListResources(applicationID string) (resource.ServiceResources, error) {
+func (st resourceState) ListResources(applicationID string) (resource.ApplicationResources, error) {
 	resources, err := st.persist.ListResources(applicationID)
 	if err != nil {
-		if err := st.raw.VerifyService(applicationID); err != nil {
-			return resource.ServiceResources{}, errors.Trace(err)
+		if err := st.raw.VerifyApplication(applicationID); err != nil {
+			return resource.ApplicationResources{}, errors.Trace(err)
 		}
-		return resource.ServiceResources{}, errors.Trace(err)
+		return resource.ApplicationResources{}, errors.Trace(err)
 	}
 
 	unitIDs, err := st.raw.Units(applicationID)
 	if err != nil {
-		return resource.ServiceResources{}, errors.Trace(err)
+		return resource.ApplicationResources{}, errors.Trace(err)
 	}
 	for _, unitID := range unitIDs {
 		found := false
@@ -136,7 +136,7 @@ func (st resourceState) GetResource(applicationID, name string) (resource.Resour
 	id := newResourceID(applicationID, name)
 	res, _, err := st.persist.GetResource(id)
 	if err != nil {
-		if err := st.raw.VerifyService(applicationID); err != nil {
+		if err := st.raw.VerifyApplication(applicationID); err != nil {
 			return resource.Resource{}, errors.Trace(err)
 		}
 		return res, errors.Trace(err)
@@ -150,7 +150,7 @@ func (st resourceState) GetPendingResource(applicationID, name, pendingID string
 
 	resources, err := st.persist.ListPendingResources(applicationID)
 	if err != nil {
-		// We do not call VerifyService() here because pending resources
+		// We do not call VerifyApplication() here because pending resources
 		// do not have to have an existing application.
 		return res, errors.Trace(err)
 	}
@@ -302,7 +302,7 @@ func (st resourceState) OpenResource(applicationID, name string) (resource.Resou
 	id := newResourceID(applicationID, name)
 	resourceInfo, storagePath, err := st.persist.GetResource(id)
 	if err != nil {
-		if err := st.raw.VerifyService(applicationID); err != nil {
+		if err := st.raw.VerifyApplication(applicationID); err != nil {
 			return resource.Resource{}, nil, errors.Trace(err)
 		}
 		return resource.Resource{}, nil, errors.Annotate(err, "while getting resource info")

--- a/state/resources_test.go
+++ b/state/resources_test.go
@@ -56,7 +56,7 @@ func (s *ResourcesSuite) TestFunctional(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	res.Timestamp = resources.Resources[0].Timestamp
-	c.Check(resources, jc.DeepEquals, resource.ServiceResources{
+	c.Check(resources, jc.DeepEquals, resource.ApplicationResources{
 		Resources:           []resource.Resource{res},
 		CharmStoreResources: csResources,
 	})

--- a/state/singular.go
+++ b/state/singular.go
@@ -18,7 +18,7 @@ import (
 // strings.
 //
 // It would be nicer to have a single controller-level component managing all
-// singular leases for all environments -- and thus be able to validate that
+// singular leases for all models -- and thus be able to validate that
 // proposed holders really are env managers -- but the complexity of threading
 // data from *two* states through a single api connection is excessive by
 // comparison.
@@ -52,7 +52,7 @@ func (s singularSecretary) CheckDuration(duration time.Duration) error {
 }
 
 // SingularClaimer returns a lease.Claimer representing the exclusive right to
-// manage the environment.
+// manage the model.
 func (st *State) SingularClaimer() corelease.Claimer {
 	return lazyLeaseManager{func() *lease.Manager {
 		return st.workers.singularManager()

--- a/state/statetest/persistence_stubs.go
+++ b/state/statetest/persistence_stubs.go
@@ -107,8 +107,8 @@ func (s *StubPersistence) RunTransaction(ops []txn.Op) error {
 	return nil
 }
 
-func (s *StubPersistence) ApplicationExistsOps(serviceID string) []txn.Op {
-	s.AddCall("ApplicationExistsOps", serviceID)
+func (s *StubPersistence) ApplicationExistsOps(applicationID string) []txn.Op {
+	s.AddCall("ApplicationExistsOps", applicationID)
 	// pop off an error so num errors == num calls, even though this call
 	// doesn't actually use the error.
 	s.NextErr()
@@ -116,8 +116,8 @@ func (s *StubPersistence) ApplicationExistsOps(serviceID string) []txn.Op {
 	return s.ReturnApplicationExistsOps
 }
 
-func (s *StubPersistence) IncCharmModifiedVersionOps(serviceID string) []txn.Op {
-	s.AddCall("IncCharmModifiedVersionOps", serviceID)
+func (s *StubPersistence) IncCharmModifiedVersionOps(applicationID string) []txn.Op {
+	s.AddCall("IncCharmModifiedVersionOps", applicationID)
 	// pop off an error so num errors == num calls, even though this call
 	// doesn't actually use the error.
 	s.NextErr()

--- a/state/status.go
+++ b/state/status.go
@@ -194,9 +194,9 @@ type statusDoc struct {
 	Updated int64 `bson:"updated"`
 
 	// TODO(fwereade/wallyworld): lp:1479278
-	// NeverSet is a short-term hack to work around a misfeature in service
-	// status. To maintain current behaviour, we create service status docs
-	// (and only service status documents) with NeverSet true; and then, when
+	// NeverSet is a short-term hack to work around a misfeature in application
+	// status. To maintain current behaviour, we create application status docs
+	// (and only application status documents) with NeverSet true; and then, when
 	// reading them, if NeverSet is still true, we aggregate status from the
 	// units instead.
 	NeverSet bool `bson:"neverset"`

--- a/state/status_application_test.go
+++ b/state/status_application_test.go
@@ -14,42 +14,42 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type ServiceStatusSuite struct {
+type ApplicationStatusSuite struct {
 	ConnSuite
-	service *state.Application
+	application *state.Application
 }
 
-var _ = gc.Suite(&ServiceStatusSuite{})
+var _ = gc.Suite(&ApplicationStatusSuite{})
 
-func (s *ServiceStatusSuite) SetUpTest(c *gc.C) {
+func (s *ApplicationStatusSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.service = s.Factory.MakeApplication(c, nil)
+	s.application = s.Factory.MakeApplication(c, nil)
 }
 
-func (s *ServiceStatusSuite) TestInitialStatus(c *gc.C) {
+func (s *ApplicationStatusSuite) TestInitialStatus(c *gc.C) {
 	s.checkInitialStatus(c)
 }
 
-func (s *ServiceStatusSuite) checkInitialStatus(c *gc.C) {
-	statusInfo, err := s.service.Status()
+func (s *ApplicationStatusSuite) checkInitialStatus(c *gc.C) {
+	statusInfo, err := s.application.Status()
 	c.Check(err, jc.ErrorIsNil)
 	checkInitialWorkloadStatus(c, statusInfo)
 }
 
-func (s *ServiceStatusSuite) TestSetUnknownStatus(c *gc.C) {
+func (s *ApplicationStatusSuite) TestSetUnknownStatus(c *gc.C) {
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Status("vliegkat"),
 		Message: "orville",
 		Since:   &now,
 	}
-	err := s.service.SetStatus(sInfo)
+	err := s.application.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
-func (s *ServiceStatusSuite) TestSetOverwritesData(c *gc.C) {
+func (s *ApplicationStatusSuite) TestSetOverwritesData(c *gc.C) {
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
@@ -59,17 +59,17 @@ func (s *ServiceStatusSuite) TestSetOverwritesData(c *gc.C) {
 		},
 		Since: &now,
 	}
-	err := s.service.SetStatus(sInfo)
+	err := s.application.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
 	s.checkGetSetStatus(c)
 }
 
-func (s *ServiceStatusSuite) TestGetSetStatusAlive(c *gc.C) {
+func (s *ApplicationStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 	s.checkGetSetStatus(c)
 }
 
-func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
+func (s *ApplicationStatusSuite) checkGetSetStatus(c *gc.C) {
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Active,
@@ -81,13 +81,13 @@ func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
 		},
 		Since: &now,
 	}
-	err := s.service.SetStatus(sInfo)
+	err := s.application.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
-	service, err := s.State.Application(s.service.Name())
+	application, err := s.State.Application(s.application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
-	statusInfo, err := service.Status()
+	statusInfo, err := application.Status()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(statusInfo.Status, gc.Equals, status.Active)
 	c.Check(statusInfo.Message, gc.Equals, "healthy")
@@ -99,17 +99,17 @@ func (s *ServiceStatusSuite) checkGetSetStatus(c *gc.C) {
 	c.Check(statusInfo.Since, gc.NotNil)
 }
 
-func (s *ServiceStatusSuite) TestGetSetStatusDying(c *gc.C) {
-	_, err := s.service.AddUnit(state.AddUnitParams{})
+func (s *ApplicationStatusSuite) TestGetSetStatusDying(c *gc.C) {
+	_, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.service.Destroy()
+	err = s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkGetSetStatus(c)
 }
 
-func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
-	err := s.service.Destroy()
+func (s *ApplicationStatusSuite) TestGetSetStatusGone(c *gc.C) {
+	err := s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	now := testing.ZeroTime()
@@ -118,24 +118,24 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 		Message: "not really",
 		Since:   &now,
 	}
-	err = s.service.SetStatus(sInfo)
+	err = s.application.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status: application not found`)
 
-	statusInfo, err := s.service.Status()
+	statusInfo, err := s.application.Status()
 	c.Check(err, gc.ErrorMatches, `cannot get status: application not found`)
 	c.Check(statusInfo, gc.DeepEquals, status.StatusInfo{})
 }
 
-func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
+func (s *ApplicationStatusSuite) TestSetStatusSince(c *gc.C) {
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
 		Status:  status.Maintenance,
 		Message: "",
 		Since:   &now,
 	}
-	err := s.service.SetStatus(sInfo)
+	err := s.application.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	statusInfo, err := s.service.Status()
+	statusInfo, err := s.application.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	firstTime := statusInfo.Since
 	c.Assert(firstTime, gc.NotNil)
@@ -148,21 +148,21 @@ func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
 		Message: "",
 		Since:   &now,
 	}
-	err = s.service.SetStatus(sInfo)
+	err = s.application.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	statusInfo, err = s.service.Status()
+	statusInfo, err = s.application.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(timeBeforeOrEqual(*firstTime, *statusInfo.Since), jc.IsTrue)
 }
 
-func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
+func (s *ApplicationStatusSuite) TestDeriveStatus(c *gc.C) {
 	// NOTE(fwereade): as detailed in the code, this implementation is not sane.
 	// The specified behaviour is arguably sane, but the code is in the wrong
 	// place.
 
 	// Create a unit with each possible status.
 	addUnit := func(unitStatus status.Status) *state.Unit {
-		unit, err := s.service.AddUnit(state.AddUnitParams{})
+		unit, err := s.application.AddUnit(state.AddUnitParams{})
 		c.Assert(err, gc.IsNil)
 		now := testing.ZeroTime()
 		sInfo := status.StatusInfo{
@@ -182,7 +182,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 	unknownUnit := addUnit(status.Unknown)
 
 	// ...and create one with error status by setting it on the agent :-/.
-	errorUnit, err := s.service.AddUnit(state.AddUnitParams{})
+	errorUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.IsNil)
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
@@ -197,7 +197,7 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 	// derived from that unit status; then remove that unit and proceed to
 	// the next severity.
 	checkAndRemove := func(unit *state.Unit, status status.Status) {
-		info, err := s.service.Status()
+		info, err := s.application.Status()
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(info.Status, gc.Equals, status)
 
@@ -217,8 +217,8 @@ func (s *ServiceStatusSuite) TestDeriveStatus(c *gc.C) {
 	checkAndRemove(unknownUnit, status.Unknown)
 }
 
-func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
-	unit, err := s.service.AddUnit(state.AddUnitParams{})
+func (s *ApplicationStatusSuite) TestApplicationStatusOverridesDerivedStatus(c *gc.C) {
+	unit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, gc.IsNil)
 	now := testing.ZeroTime()
 	sInfo := status.StatusInfo{
@@ -233,10 +233,10 @@ func (s *ServiceStatusSuite) TestServiceStatusOverridesDerivedStatus(c *gc.C) {
 		Message: "zot",
 		Since:   &now,
 	}
-	err = s.service.SetStatus(sInfo)
+	err = s.application.SetStatus(sInfo)
 	c.Assert(err, gc.IsNil)
 
-	info, err := s.service.Status()
+	info, err := s.application.Status()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(info.Status, gc.Equals, status.Maintenance)
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -57,7 +57,7 @@ type StorageInstance interface {
 // StorageAttachment represents the state of a unit's attachment to a storage
 // instance. A non-shared storage instance will have a single attachment for
 // the storage instance's owning unit, whereas a shared storage instance will
-// have an attachment for each unit of the service owning the storage instance.
+// have an attachment for each unit of the application owning the storage instance.
 type StorageAttachment interface {
 	// StorageInstance returns the tag of the corresponding storage
 	// instance.
@@ -624,16 +624,16 @@ type machineAssignable interface {
 }
 
 // createStorageOps returns txn.Ops for creating storage instances
-// and attachments for the newly created unit or service. A map
+// and attachments for the newly created unit or application. A map
 // of storage names to number of storage instances created will
 // be returned, along with the total number of storage attachments
 // made. These should be used to initialise or update refcounts.
 //
 // The entity tag identifies the entity that owns the storage instance
-// either a unit or a service. Shared storage instances are owned by a
-// service, and non-shared storage instances are owned by a unit.
+// either a unit or a application. Shared storage instances are owned by a
+// application, and non-shared storage instances are owned by a unit.
 //
-// The charm metadata corresponds to the charm that the owner (service/unit)
+// The charm metadata corresponds to the charm that the owner (application/unit)
 // is or will be running, and is used to extract storage constraints,
 // default values, etc.
 //
@@ -690,7 +690,7 @@ func createStorageOps(
 			continue
 		}
 		if createdShared != charmStorage.Shared {
-			// services only get shared storage instances,
+			// applications only get shared storage instances,
 			// units only get non-shared storage instances.
 			continue
 		}
@@ -764,11 +764,11 @@ func createStorageOps(
 	}
 
 	// TODO(axw) create storage attachments for each shared storage
-	// instance owned by the service.
+	// instance owned by the application.
 	//
-	// TODO(axw) prevent creation of shared storage after service
+	// TODO(axw) prevent creation of shared storage after application
 	// creation, because the only sane time to add storage attachments
-	// is when units are added to said service.
+	// is when units are added to said application.
 
 	return ops, storageTags, numStorageAttachments, nil
 }
@@ -1501,7 +1501,7 @@ type storageConstraintsDoc struct {
 }
 
 // StorageConstraints contains the user-specified constraints for provisioning
-// storage instances for a service unit.
+// storage instances for an application unit.
 type StorageConstraints struct {
 	// Pool is the name of the storage pool from which to provision the
 	// storage instances.

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -30,9 +30,9 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("persistent-block", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: charm, Storage: storageCons})
+	application, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: charm, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := service.AddUnit(state.AddUnitParams{})
+	u, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.unitTag = u.UnitTag()
 	all, err := s.IAASModel.AllStorageInstances()

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -383,7 +383,7 @@ type StorageStateSuite struct {
 
 var _ = gc.Suite(&StorageStateSuite{})
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	storageBlock, err := s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
@@ -416,13 +416,13 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
-	addService := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
+	addApplication := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
 		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block2", Charm: ch, Storage: storage})
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
-		_, err := addService(storage)
+		_, err := addApplication(storage)
 		c.Assert(err, gc.ErrorMatches, expect)
 	}
 
@@ -439,11 +439,11 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) 
 	storageCons["multi1to10"] = makeStorageCons("ebs-fast", 1024, 10)
 	assertErr(storageCons, `cannot add application "storage-block2": pool "ebs-fast" not found`)
 	storageCons["multi1to10"] = makeStorageCons("loop-pool", 1024, 10)
-	_, err := addService(storageCons)
+	_, err := addApplication(storageCons)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, pool string, cons, expect map[string]state.StorageConstraints) {
+func (s *StorageStateSuite) assertAddApplicationStorageConstraintsDefaults(c *gc.C, pool string, cons, expect map[string]state.StorageConstraints) {
 	if pool != "" {
 		err := s.IAASModel.UpdateModelConfig(map[string]interface{}{
 			"storage-default-block-source": pool,
@@ -459,7 +459,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 	// TODO(wallyworld) - test pool name stored in data model
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoConstraintsUsed(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsNoConstraintsUsed(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 0, 0),
 	}
@@ -467,10 +467,10 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoConstraintsUsed(c 
 		"data":    makeStorageCons("loop", 1024, 1),
 		"allecto": makeStorageCons("loop", 1024, 0),
 	}
-	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsJustCount(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsJustCount(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 0, 1),
 	}
@@ -478,10 +478,10 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsJustCount(c *gc.C) {
 		"data":    makeStorageCons("loop-pool", 1024, 1),
 		"allecto": makeStorageCons("loop", 1024, 0),
 	}
-	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsDefaultPool(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 2048, 1),
 	}
@@ -489,10 +489,10 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C)
 		"data":    makeStorageCons("loop-pool", 2048, 1),
 		"allecto": makeStorageCons("loop", 1024, 0),
 	}
-	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoUserDefaultPool(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsNoUserDefaultPool(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 2048, 1),
 	}
@@ -500,10 +500,10 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoUserDefaultPool(c 
 		"data":    makeStorageCons("loop", 2048, 1),
 		"allecto": makeStorageCons("loop", 1024, 0),
 	}
-	s.assertAddServiceStorageConstraintsDefaults(c, "", storageCons, expectedCons)
+	s.assertAddApplicationStorageConstraintsDefaults(c, "", storageCons, expectedCons)
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFallback(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsDefaultSizeFallback(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop-pool", 0, 1),
 	}
@@ -511,10 +511,10 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFallback(
 		"data":    makeStorageCons("loop-pool", 1024, 1),
 		"allecto": makeStorageCons("loop", 1024, 0),
 	}
-	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm(c *gc.C) {
+func (s *StorageStateSuite) TestAddApplicationStorageConstraintsDefaultSizeFromCharm(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
@@ -532,13 +532,13 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	addService := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
+	addApplication := func(storage map[string]state.StorageConstraints) (*state.Application, error) {
 		return s.State.AddApplication(state.AddApplicationArgs{Name: "storage-block", Charm: ch, Storage: storage})
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),
 	}
-	_, err := addService(storageCons)
+	_, err := addApplication(storageCons)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1197,10 +1197,10 @@ func (s *StorageStateSuite) testStorageLocationConflict(c *gc.C, first, second, 
 		CountMax: 1,
 		Location: second,
 	})
-	svc1 := s.AddTestingApplication(c, "storage-filesystem", ch1)
-	svc2 := s.AddTestingApplication(c, "storage-filesystem2", ch2)
+	app1 := s.AddTestingApplication(c, "storage-filesystem", ch1)
+	app2 := s.AddTestingApplication(c, "storage-filesystem2", ch2)
 
-	u1, err := svc1.AddUnit(state.AddUnitParams{})
+	u1, err := app1.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(u1, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1210,7 +1210,7 @@ func (s *StorageStateSuite) testStorageLocationConflict(c *gc.C, first, second, 
 	m, err := s.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	u2, err := svc2.AddUnit(state.AddUnitParams{})
+	u2, err := app2.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = u2.AssignToMachine(m)
 	if expectErr == "" {

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -18,14 +18,14 @@ type UnitAssignmentSuite struct {
 
 var _ = gc.Suite(&UnitAssignmentSuite{})
 
-func (s *UnitAssignmentSuite) testAddServiceUnitAssignment(c *gc.C) (*state.Application, []state.UnitAssignment) {
+func (s *UnitAssignmentSuite) testAddApplicationUnitAssignment(c *gc.C) (*state.Application, []state.UnitAssignment) {
 	charm := s.AddTestingCharm(c, "dummy")
-	svc, err := s.State.AddApplication(state.AddApplicationArgs{
+	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name: "dummy", Charm: charm, NumUnits: 2,
 		Placement: []*instance.Placement{{s.State.ModelUUID(), "abc"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	units, err := svc.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 2)
 	for _, u := range units {
@@ -39,15 +39,15 @@ func (s *UnitAssignmentSuite) testAddServiceUnitAssignment(c *gc.C) (*state.Appl
 		{Unit: "dummy/0", Scope: s.State.ModelUUID(), Directive: "abc"},
 		{Unit: "dummy/1"},
 	})
-	return svc, assignments
+	return app, assignments
 }
 
-func (s *UnitAssignmentSuite) TestAddServiceUnitAssignment(c *gc.C) {
-	s.testAddServiceUnitAssignment(c)
+func (s *UnitAssignmentSuite) TestAddApplicationUnitAssignment(c *gc.C) {
+	s.testAddApplicationUnitAssignment(c)
 }
 
 func (s *UnitAssignmentSuite) TestAssignStagedUnits(c *gc.C) {
-	svc, _ := s.testAddServiceUnitAssignment(c)
+	app, _ := s.testAddApplicationUnitAssignment(c)
 
 	results, err := s.State.AssignStagedUnits([]string{
 		"dummy/0", "dummy/1",
@@ -58,7 +58,7 @@ func (s *UnitAssignmentSuite) TestAssignStagedUnits(c *gc.C) {
 		{Unit: "dummy/1"},
 	})
 
-	units, err := svc.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 2)
 	for _, u := range units {
@@ -78,14 +78,14 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementMakesContainerInNewMach
 	// https://bugs.launchpad.net/juju-core/+bug/1590960
 	charm := s.AddTestingCharm(c, "dummy")
 	placement := instance.Placement{Scope: "lxd"}
-	svc, err := s.State.AddApplication(state.AddApplicationArgs{
+	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:      "dummy",
 		Charm:     charm,
 		NumUnits:  1,
 		Placement: []*instance.Placement{&placement},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	units, err := svc.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
 	unit := units[0]

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -57,9 +57,9 @@ func (s *UnitSuite) TestUnitNotFound(c *gc.C) {
 }
 
 func (s *UnitSuite) TestApplication(c *gc.C) {
-	svc, err := s.unit.Application()
+	app, err := s.unit.Application()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(svc.Name(), gc.Equals, s.unit.ApplicationName())
+	c.Assert(app.Name(), gc.Equals, s.unit.ApplicationName())
 }
 
 func (s *UnitSuite) TestConfigSettingsNeedCharmURLSet(c *gc.C) {

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/status"
 )
 
-// UnitAgent represents the state of a service's unit agent.
+// UnitAgent represents the state of an application's unit agent.
 type UnitAgent struct {
 	st   *State
 	tag  names.Tag

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -667,7 +667,7 @@ func (s *UpgradeSuite) TestClearUpgradeInfo(c *gc.C) {
 	s.assertUpgrading(c, true)
 }
 
-func (s *UpgradeSuite) TestServiceUnitSeqToSequence(c *gc.C) {
+func (s *UpgradeSuite) TestApplicationUnitSeqToSequence(c *gc.C) {
 	v123 := vers("1.2.3")
 	v124 := vers("1.2.4")
 

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -80,7 +80,7 @@ func (s *VolumeStateSuite) assertMachineVolume(c *gc.C, unit *state.Unit) {
 	assertMachineStorageRefs(c, s.IAASModel, machine.MachineTag())
 }
 
-func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
+func (s *VolumeStateSuite) TestAddApplicationInvalidPool(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
@@ -89,7 +89,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
-func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
+func (s *VolumeStateSuite) TestAddApplicationNoUserDefaultPool(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
@@ -112,7 +112,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	})
 }
 
-func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
+func (s *VolumeStateSuite) TestAddApplicationDefaultPool(c *gc.C) {
 	// Register a default pool.
 	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
 		dummy.StorageProviders(),

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -331,7 +331,7 @@ func (im *IAASModel) watchMachineStorageAttachments(m names.MachineTag, collecti
 }
 
 // WatchApplications returns a StringsWatcher that notifies of changes to
-// the lifecycles of the services in the model.
+// the lifecycles of the applications in the model.
 func (st *State) WatchApplications() StringsWatcher {
 	return newLifecycleWatcher(st, applicationsC, nil, isLocalID(st), nil)
 }
@@ -614,11 +614,11 @@ func (w *lifecycleWatcher) loop() error {
 	}
 }
 
-// minUnitsWatcher notifies about MinUnits changes of the services requiring
+// minUnitsWatcher notifies about MinUnits changes of the applications requiring
 // a minimum number of units to be alive. The first event returned by the
 // watcher is the set of application names requiring a minimum number of units.
-// Subsequent events are generated when a service increases MinUnits, or when
-// one or more units belonging to a service are destroyed.
+// Subsequent events are generated when an application increases MinUnits, or when
+// one or more units belonging to an application are destroyed.
 type minUnitsWatcher struct {
 	commonWatcher
 	known map[string]int
@@ -931,8 +931,8 @@ func (ru *RelationUnit) Watch() RelationUnitsWatcher {
 // WatchUnits returns a watcher that notifies of changes to the units of the
 // specified application endpoint in the relation. This method will return an error
 // if the endpoint is not globally scoped.
-func (r *Relation) WatchUnits(serviceName string) (RelationUnitsWatcher, error) {
-	return r.watchUnits(serviceName, false)
+func (r *Relation) WatchUnits(appName string) (RelationUnitsWatcher, error) {
+	return r.watchUnits(appName, false)
 }
 
 func (r *Relation) watchUnits(applicationName string, counterpart bool) (RelationUnitsWatcher, error) {
@@ -1518,7 +1518,7 @@ func (a *Application) Watch() NotifyWatcher {
 	return newEntityWatcher(a.st, applicationsC, a.doc.DocID)
 }
 
-// WatchLeaderSettings returns a watcher for observing changed to a service's
+// WatchLeaderSettings returns a watcher for observing changed to an application's
 // leader settings.
 func (a *Application) WatchLeaderSettings() NotifyWatcher {
 	docId := a.st.docID(leadershipSettingsKey(a.Name()))
@@ -1559,7 +1559,7 @@ func (st *State) WatchModelEntityReferences(mUUID string) NotifyWatcher {
 	return newEntityWatcher(st, modelEntityRefsC, mUUID)
 }
 
-// WatchForUnitAssignment watches for new services that request units to be
+// WatchForUnitAssignment watches for new applications that request units to be
 // assigned to machines.
 func (st *State) WatchForUnitAssignment() StringsWatcher {
 	return newCollectionWatcher(st, colWCfg{col: assignUnitC})
@@ -1607,7 +1607,7 @@ func (a *Application) WatchCharmConfig() (NotifyWatcher, error) {
 }
 
 // WatchConfigSettings returns a watcher for observing changes to the
-// unit's service configuration settings. The unit must have a charm URL
+// unit's application configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be
 // valid only while the unit's charm URL is not changed.
 // TODO(fwereade): this could be much smarter; if it were, uniter.Filter

--- a/status/status.go
+++ b/status/status.go
@@ -12,7 +12,7 @@ import (
 // very clear reason.
 //
 // Status values currently apply to machine (agents), unit (agents), unit
-// (workloads), service (workloads), volumes, filesystems, and models.
+// (workloads), application (workloads), volumes, filesystems, and models.
 type Status string
 
 // String returns a string representation of the Status.
@@ -55,7 +55,7 @@ const (
 	// For unit agents, this is a state we preserve for backwards
 	// compatibility with scripts during the life of Juju 1.x.
 	// In Juju 2.x, the agent-state will remain “active” and scripts
-	// will watch the unit-state instead for signals of service readiness.
+	// will watch the unit-state instead for signals of application readiness.
 	Started Status = "started"
 )
 
@@ -135,7 +135,7 @@ const (
 	Unknown Status = "unknown"
 
 	// Waiting is set when:
-	// The unit is unable to progress to an active state because a service to
+	// The unit is unable to progress to an active state because an application to
 	// which it is related is not running.
 	Waiting Status = "waiting"
 
@@ -275,7 +275,7 @@ func (status Status) KnownWorkloadStatus() bool {
 }
 
 // ValidWorkloadStatus returns true if status has a valid value (that is to say,
-// a value that it's OK to set) for units or services.
+// a value that it's OK to set) for units or applications.
 func ValidWorkloadStatus(status Status) bool {
 	switch status {
 	case

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -26,7 +26,7 @@ func (k StorageKind) String() string {
 	}
 }
 
-// StorageInstance describes a storage instance, assigned to a service or
+// StorageInstance describes a storage instance, assigned to an application or
 // unit.
 type StorageInstance struct {
 	// Tag is a unique tag assigned by Juju to the storage instance.

--- a/worker/applicationscaler/worker.go
+++ b/worker/applicationscaler/worker.go
@@ -14,12 +14,12 @@ import (
 type Facade interface {
 
 	// Watch returns a StringsWatcher reporting names of
-	// services which may have insufficient units.
+	// applications which may have insufficient units.
 	Watch() (watcher.StringsWatcher, error)
 
-	// Rescale scales up any named service observed to be
+	// Rescale scales up any named application observed to be
 	// running too few units.
-	Rescale(services []string) error
+	Rescale(applications []string) error
 }
 
 // Config defines a worker's dependencies.
@@ -37,7 +37,7 @@ func (config Config) Validate() error {
 }
 
 // New returns a worker that will attempt to rescale any
-// services that might be undersized.
+// applications that might be undersized.
 func New(config Config) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -60,8 +60,8 @@ func (handler *handler) SetUp() (watcher.StringsWatcher, error) {
 }
 
 // Handle is part of the watcher.StringsHandler interface.
-func (handler *handler) Handle(_ <-chan struct{}, services []string) error {
-	return handler.config.Facade.Rescale(services)
+func (handler *handler) Handle(_ <-chan struct{}, applications []string) error {
+	return handler.config.Facade.Rescale(applications)
 }
 
 // TearDown is part of the watcher.StringsHandler interface.

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -43,7 +43,7 @@ type FirewallerAPI interface {
 	ControllerAPIInfoForModel(modelUUID string) (*api.Info, error)
 	MacaroonForRelation(relationKey string) (*macaroon.Macaroon, error)
 	SetRelationStatus(relationKey string, status relation.Status, message string) error
-	FirewallRules(serviceNames ...string) ([]params.FirewallRule, error)
+	FirewallRules(applicationNames ...string) ([]params.FirewallRule, error)
 }
 
 // CrossModelFirewallerFacade exposes firewaller functionality on the

--- a/worker/minunitsworker/minunitsworker.go
+++ b/worker/minunitsworker/minunitsworker.go
@@ -18,9 +18,9 @@ type MinUnitsWorker struct {
 	st *state.State
 }
 
-// NewMinUnitsWorker returns a Worker that runs service.EnsureMinUnits()
-// if the number of alive units belonging to a service decreases, or if the
-// minimum required number of units for a service is increased.
+// NewMinUnitsWorker returns a Worker that runs application.EnsureMinUnits()
+// if the number of alive units belonging to a application decreases, or if the
+// minimum required number of units for a application is increased.
 func NewMinUnitsWorker(st *state.State) worker.Worker {
 	mu := &MinUnitsWorker{st: st}
 	return legacy.NewStringsWorker(mu)
@@ -30,19 +30,19 @@ func (mu *MinUnitsWorker) SetUp() (state.StringsWatcher, error) {
 	return mu.st.WatchMinUnits(), nil
 }
 
-func (mu *MinUnitsWorker) handleOneService(serviceName string) error {
-	service, err := mu.st.Application(serviceName)
+func (mu *MinUnitsWorker) handleOneApplication(applicationName string) error {
+	application, err := mu.st.Application(applicationName)
 	if err != nil {
 		return err
 	}
-	return service.EnsureMinUnits()
+	return application.EnsureMinUnits()
 }
 
-func (mu *MinUnitsWorker) Handle(serviceNames []string) error {
-	for _, name := range serviceNames {
-		logger.Infof("processing service %q", name)
-		if err := mu.handleOneService(name); err != nil {
-			logger.Errorf("failed to process service %q: %v", name, err)
+func (mu *MinUnitsWorker) Handle(applicationNames []string) error {
+	for _, name := range applicationNames {
+		logger.Infof("processing application %q", name)
+		if err := mu.handleOneApplication(name); err != nil {
+			logger.Errorf("failed to process application %q: %v", name, err)
 			return err
 		}
 	}

--- a/worker/minunitsworker/minunitsworker_test.go
+++ b/worker/minunitsworker/minunitsworker_test.go
@@ -29,7 +29,7 @@ func (s *minUnitsWorkerSuite) TestMinUnitsWorker(c *gc.C) {
 	mu := minunitsworker.NewMinUnitsWorker(s.State)
 	defer func() { c.Assert(worker.Stop(mu), gc.IsNil) }()
 
-	// Set up services and units for later use.
+	// Set up applications and units for later use.
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	unit, err := wordpress.AddUnit(state.AddUnitParams{})
@@ -43,7 +43,7 @@ func (s *minUnitsWorkerSuite) TestMinUnitsWorker(c *gc.C) {
 	err = mysql.SetMinUnits(2)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Remove a unit for a service.
+	// Remove a unit for an application.
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -107,11 +107,11 @@ type Factory interface {
 	NewCommands(args CommandArgs, sendResponse CommandResponseFunc) (Operation, error)
 
 	// NewAcceptLeadership creates an operation to ensure the uniter acts as
-	// service leader.
+	// application leader.
 	NewAcceptLeadership() (Operation, error)
 
 	// NewResignLeadership creates an operation to ensure the uniter does not
-	// act as service leader.
+	// act as application leader.
 	NewResignLeadership() (Operation, error)
 }
 
@@ -163,7 +163,7 @@ type Callbacks interface {
 	// SetCurrentCharm records intent to deploy a given charm. It must be called
 	// *before* recording local state referencing that charm, to ensure there's
 	// no path by which the controller can legitimately garbage collect that
-	// charm or the service's settings for it. It's only used by Deploy operations.
+	// charm or the application's settings for it. It's only used by Deploy operations.
 	SetCurrentCharm(charmURL *corecharm.URL) error
 }
 

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -87,7 +87,7 @@ type apiUnit struct {
 	*uniter.Unit
 }
 
-type apiService struct {
+type apiApplication struct {
 	*uniter.Application
 }
 
@@ -107,5 +107,5 @@ func (st apiState) Unit(tag names.UnitTag) (Unit, error) {
 
 func (u apiUnit) Application() (Application, error) {
 	s, err := u.Unit.Application()
-	return apiService{s}, err
+	return apiApplication{s}, err
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -106,7 +106,7 @@ type HookContext struct {
 	unit *uniter.Unit
 
 	// state is the handle to the uniter State so that HookContext can make
-	// API calls on the stateservice.
+	// API calls on the state.
 	// NOTE: We would like to be rid of the fake-remote-Unit and switch
 	// over fully to API calls on State.  This adds that ability, but we're
 	// not fully there yet.
@@ -129,7 +129,7 @@ type HookContext struct {
 	// availabilityzone is the cached value of the unit's availability zone name.
 	availabilityzone string
 
-	// configSettings holds the service configuration.
+	// configSettings holds the application configuration.
 	configSettings charm.Settings
 
 	// goalState holds the goal state struct
@@ -324,7 +324,7 @@ func (ctx *HookContext) UnitStatus() (*jujuc.StatusInfo, error) {
 }
 
 // ApplicationStatus returns the status for the application and all the units on
-// the service to which this context unit belongs, only if this unit is
+// the application to which this context unit belongs, only if this unit is
 // the leader.
 func (ctx *HookContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error) {
 	var err error
@@ -335,11 +335,11 @@ func (ctx *HookContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error)
 	if !isLeader {
 		return jujuc.ApplicationStatusInfo{}, ErrIsNotLeader
 	}
-	service, err := ctx.unit.Application()
+	application, err := ctx.unit.Application()
 	if err != nil {
 		return jujuc.ApplicationStatusInfo{}, errors.Trace(err)
 	}
-	status, err := service.Status(ctx.unit.Name())
+	status, err := application.Status(ctx.unit.Name())
 	if err != nil {
 		return jujuc.ApplicationStatusInfo{}, errors.Trace(err)
 	}
@@ -356,7 +356,7 @@ func (ctx *HookContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error)
 	}
 	return jujuc.ApplicationStatusInfo{
 		Application: jujuc.StatusInfo{
-			Tag:    service.Tag().String(),
+			Tag:    application.Tag().String(),
 			Status: status.Application.Status,
 			Info:   status.Application.Info,
 			Data:   status.Application.Data,
@@ -376,10 +376,10 @@ func (ctx *HookContext) SetUnitStatus(unitStatus jujuc.StatusInfo) error {
 	)
 }
 
-// SetApplicationStatus will set the given status to the service to which this
+// SetApplicationStatus will set the given status to the application to which this
 // unit's belong, only if this unit is the leader.
-func (ctx *HookContext) SetApplicationStatus(serviceStatus jujuc.StatusInfo) error {
-	logger.Tracef("[APPLICATION-STATUS] %s: %s", serviceStatus.Status, serviceStatus.Info)
+func (ctx *HookContext) SetApplicationStatus(applicationStatus jujuc.StatusInfo) error {
+	logger.Tracef("[APPLICATION-STATUS] %s: %s", applicationStatus.Status, applicationStatus.Info)
 	isLeader, err := ctx.IsLeader()
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine leadership")
@@ -388,15 +388,15 @@ func (ctx *HookContext) SetApplicationStatus(serviceStatus jujuc.StatusInfo) err
 		return ErrIsNotLeader
 	}
 
-	service, err := ctx.unit.Application()
+	application, err := ctx.unit.Application()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return service.SetStatus(
+	return application.SetStatus(
 		ctx.unit.Name(),
-		status.Status(serviceStatus.Status),
-		serviceStatus.Info,
-		serviceStatus.Data,
+		status.Status(applicationStatus.Status),
+		applicationStatus.Info,
+		applicationStatus.Data,
 	)
 }
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -219,7 +219,7 @@ func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
 
 	// Change remote config.
-	err = s.service.UpdateCharmConfig(charm.Settings{
+	err = s.application.UpdateCharmConfig(charm.Settings{
 		"blog-title": "Something Else",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -187,9 +187,9 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	sCons := map[string]state.StorageConstraints{
 		"data": {Pool: "", Size: 1024, Count: 1},
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-block", ch, sCons)
+	application := s.AddTestingApplicationWithStorage(c, "storage-block", ch, sCons)
 	s.machine = nil // allocate a new machine
-	unit := s.AddUnit(c, service)
+	unit := s.AddUnit(c, application)
 
 	storageAttachments, err := s.IAASModel.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -102,7 +102,7 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	c.Assert(machinePorts, gc.HasLen, 0)
 
 	// Add another unit on the same machine.
-	otherUnit, err := s.service.AddUnit(state.AddUnitParams{})
+	otherUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = otherUnit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/leader_test.go
+++ b/worker/uniter/runner/context/leader_test.go
@@ -30,7 +30,7 @@ func (s *LeaderSuite) SetUpTest(c *gc.C) {
 	}
 	s.tracker = &StubTracker{
 		Stub:            &s.Stub,
-		applicationName: "led-service",
+		applicationName: "led-application",
 	}
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ApplicationName",
@@ -118,7 +118,7 @@ func (s *LeaderSuite) TestIsLeaderFailureAfterSuccess(c *gc.C) {
 func (s *LeaderSuite) TestLeaderSettingsSuccess(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "Read",
-		Args:     []interface{}{"led-service"},
+		Args:     []interface{}{"led-application"},
 	}}, func() {
 		// The first call grabs the settings...
 		s.accessor.results = []map[string]string{{
@@ -168,7 +168,7 @@ func (s *LeaderSuite) TestLeaderSettingsCopyMap(c *gc.C) {
 func (s *LeaderSuite) TestLeaderSettingsError(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "Read",
-		Args:     []interface{}{"led-service"},
+		Args:     []interface{}{"led-application"},
 	}}, func() {
 		s.accessor.results = []map[string]string{nil}
 		s.Stub.SetErrors(errors.New("blort"))
@@ -183,7 +183,7 @@ func (s *LeaderSuite) TestWriteLeaderSettingsSuccess(c *gc.C) {
 		FuncName: "ClaimLeader",
 	}, {
 		FuncName: "Merge",
-		Args: []interface{}{"led-service", "u/0", map[string]string{
+		Args: []interface{}{"led-application", "u/0", map[string]string{
 			"some": "very",
 			"nice": "data",
 		}},
@@ -219,7 +219,7 @@ func (s *LeaderSuite) TestWriteLeaderSettingsError(c *gc.C) {
 		FuncName: "ClaimLeader",
 	}, {
 		FuncName: "Merge",
-		Args: []interface{}{"led-service", "u/0", map[string]string{
+		Args: []interface{}{"led-application", "u/0", map[string]string{
 			"some": "very",
 			"nice": "data",
 		}},
@@ -237,7 +237,7 @@ func (s *LeaderSuite) TestWriteLeaderSettingsError(c *gc.C) {
 func (s *LeaderSuite) TestWriteLeaderSettingsClearsCache(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "Read",
-		Args:     []interface{}{"led-service"},
+		Args:     []interface{}{"led-application"},
 	}}, func() {
 		// Start off by populating the cache...
 		s.accessor.results = []map[string]string{{
@@ -252,7 +252,7 @@ func (s *LeaderSuite) TestWriteLeaderSettingsClearsCache(c *gc.C) {
 		FuncName: "ClaimLeader",
 	}, {
 		FuncName: "Merge",
-		Args: []interface{}{"led-service", "u/0", map[string]string{
+		Args: []interface{}{"led-application", "u/0", map[string]string{
 			"some": "very",
 			"nice": "data",
 		}},
@@ -268,7 +268,7 @@ func (s *LeaderSuite) TestWriteLeaderSettingsClearsCache(c *gc.C) {
 
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "Read",
-		Args:     []interface{}{"led-service"},
+		Args:     []interface{}{"led-application"},
 	}}, func() {
 		s.accessor.results = []map[string]string{{
 			"totally": "different",

--- a/worker/uniter/runner/context/unitStorage_test.go
+++ b/worker/uniter/runner/context/unitStorage_test.go
@@ -148,8 +148,8 @@ func setupTestStorageSupport(c *gc.C, s *state.State) {
 
 func (s *unitStorageSuite) createStorageEnabledUnit(c *gc.C) {
 	s.ch = s.AddTestingCharm(c, s.charmName)
-	s.service = s.AddTestingApplicationWithStorage(c, s.charmName, s.ch, s.initCons)
-	s.unit = s.AddUnit(c, s.service)
+	s.application = s.AddTestingApplicationWithStorage(c, s.charmName, s.ch, s.initCons)
+	s.unit = s.AddUnit(c, s.application)
 
 	s.assertStorageCreated(c)
 	s.createHookSupport(c)

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -38,13 +38,13 @@ var expectedAPIAddrs = strings.Join(apiAddrs, " ")
 // methods should not be added to this type, because they'll get run repeatedly.
 type HookContextSuite struct {
 	testing.JujuConnSuite
-	service  *state.Application
-	unit     *state.Unit
-	machine  *state.Machine
-	relch    *state.Charm
-	relunits map[int]*state.RelationUnit
-	storage  *runnertesting.StorageContextAccessor
-	clock    *jujutesting.Clock
+	application *state.Application
+	unit        *state.Unit
+	machine     *state.Machine
+	relch       *state.Charm
+	relunits    map[int]*state.RelationUnit
+	storage     *runnertesting.StorageContextAccessor
+	clock       *jujutesting.Clock
 
 	st             api.Connection
 	uniter         *uniter.State
@@ -66,12 +66,12 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	s.machine = nil
 
 	sch := s.AddTestingCharm(c, "wordpress")
-	s.service = s.AddTestingApplication(c, "u", sch)
-	s.unit = s.AddUnit(c, s.service)
+	s.application = s.AddTestingApplication(c, "u", sch)
+	s.unit = s.AddUnit(c, s.application)
 
 	s.meteredCharm = s.AddTestingCharm(c, "metered")
-	meteredService := s.AddTestingApplication(c, "m", s.meteredCharm)
-	meteredUnit := s.addUnit(c, meteredService)
+	meteredApplication := s.AddTestingApplication(c, "m", s.meteredCharm)
+	meteredUnit := s.addUnit(c, meteredApplication)
 	err = meteredUnit.SetCharmURL(s.meteredCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -126,9 +126,9 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	sCons := map[string]state.StorageConstraints{
 		"data": {Pool: "", Size: 1024, Count: 1},
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-block", ch, sCons)
+	application := s.AddTestingApplicationWithStorage(c, "storage-block", ch, sCons)
 	s.machine = nil // allocate a new machine
-	unit := s.AddUnit(c, service)
+	unit := s.AddUnit(c, application)
 
 	storageAttachments, err := s.IAASModel.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -296,7 +296,7 @@ func (s *FactorySuite) TestNewActionRunnerMissingAction(c *gc.C) {
 
 func (s *FactorySuite) TestNewActionRunnerUnauthAction(c *gc.C) {
 	s.SetCharm(c, "dummy")
-	otherUnit, err := s.service.AddUnit(state.AddUnitParams{})
+	otherUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	action, err := s.model.EnqueueAction(otherUnit.Tag(), "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -92,7 +92,7 @@ type ContextUnit interface {
 	// UnitName returns the executing unit's name.
 	UnitName() string
 
-	// Config returns the current service configuration of the executing unit.
+	// Config returns the current application configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)
 
 	// GoalState returns the goal state for the current unit.
@@ -113,11 +113,11 @@ type ContextStatus interface {
 	// SetUnitStatus updates the unit's status.
 	SetUnitStatus(StatusInfo) error
 
-	// ApplicationStatus returns the executing unit's service status
+	// ApplicationStatus returns the executing unit's application status
 	// (including all units).
 	ApplicationStatus() (ApplicationStatusInfo, error)
 
-	// SetApplicationStatus updates the status for the unit's service.
+	// SetApplicationStatus updates the status for the unit's application.
 	SetApplicationStatus(StatusInfo) error
 }
 
@@ -146,11 +146,11 @@ type ContextNetworking interface {
 	PrivateAddress() (string, error)
 
 	// OpenPorts marks the supplied port range for opening when the
-	// executing unit's service is exposed.
+	// executing unit's application is exposed.
 	OpenPorts(protocol string, fromPort, toPort int) error
 
 	// ClosePorts ensures the supplied port range is closed even when
-	// the executing unit's service is exposed (unless it is opened
+	// the executing unit's application is exposed (unless it is opened
 	// separately by a co- located unit).
 	ClosePorts(protocol string, fromPort, toPort int) error
 
@@ -176,7 +176,7 @@ type ContextLeadership interface {
 	LeaderSettings() (map[string]string, error)
 
 	// WriteLeaderSettings writes the supplied settings directly to state, or
-	// fails if the local unit is not the service's leader.
+	// fails if the local unit is not the application's leader.
 	WriteLeaderSettings(map[string]string) error
 }
 

--- a/worker/uniter/runner/jujuc/jujuctesting/status.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/status.go
@@ -15,10 +15,10 @@ type Status struct {
 	ApplicationStatus jujuc.ApplicationStatusInfo
 }
 
-// SetApplicationStatus builds a service status and sets it on the Status.
-func (s *Status) SetApplicationStatus(service jujuc.StatusInfo, units []jujuc.StatusInfo) {
+// SetApplicationStatus builds a application status and sets it on the Status.
+func (s *Status) SetApplicationStatus(application jujuc.StatusInfo, units []jujuc.StatusInfo) {
 	s.ApplicationStatus = jujuc.ApplicationStatusInfo{
-		Application: service,
+		Application: application,
 		Units:       units,
 	}
 }

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -24,8 +24,8 @@ var _ = gc.Suite(&RelationIdsSuite{})
 func (s *RelationIdsSuite) newHookContext(relid int, remote string) (jujuc.Context, *relationInfo) {
 	hctx, info := s.relationSuite.newHookContext(-1, "")
 	info.reset()
-	info.addRelatedServices("x", 3)
-	info.addRelatedServices("y", 1)
+	info.addRelatedApplications("x", 3)
+	info.addRelatedApplications("y", 1)
 	if relid >= 0 {
 		info.SetAsRelationHook(relid, remote)
 	}

--- a/worker/uniter/runner/jujuc/relation_test.go
+++ b/worker/uniter/runner/jujuc/relation_test.go
@@ -61,7 +61,7 @@ func (ri *relationInfo) setNextRelation(name, unit string, settings jujuctesting
 	return id
 }
 
-func (ri *relationInfo) addRelatedServices(relname string, count int) {
+func (ri *relationInfo) addRelatedApplications(relname string, count int) {
 	if ri.rels == nil {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -52,7 +52,7 @@ func setFakeStatus(ctx *Context) {
 	})
 }
 
-func setFakeServiceStatus(ctx *Context) {
+func setFakeApplicationStatus(ctx *Context) {
 	ctx.info.Status.SetApplicationStatus(
 		jujuc.StatusInfo{
 			Status: "active",
@@ -144,7 +144,7 @@ func (s *statusGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(out, gc.DeepEquals, statusAttributes)
 }
 
-func (s *statusGetSuite) TestServiceStatus(c *gc.C) {
+func (s *statusGetSuite) TestApplicationStatus(c *gc.C) {
 	expected := map[string]interface{}{
 		"application-status": map[interface{}]interface{}{
 			"status-data": map[interface{}]interface{}{},
@@ -159,7 +159,7 @@ func (s *statusGetSuite) TestServiceStatus(c *gc.C) {
 			"status":  "active"},
 	}
 	hctx := s.GetStatusHookContext(c)
-	setFakeServiceStatus(hctx)
+	setFakeApplicationStatus(hctx)
 	com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -90,7 +90,7 @@ func (s *statusSetSuite) TestStatus(c *gc.C) {
 	}
 }
 
-func (s *statusSetSuite) TestServiceStatus(c *gc.C) {
+func (s *statusSetSuite) TestApplicationStatus(c *gc.C) {
 	for i, args := range [][]string{
 		[]string{"--application", "maintenance", "doing some work"},
 		[]string{"--application", "active", ""},

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -41,14 +41,14 @@ type ContextSuite struct {
 	contextFactory context.ContextFactory
 	membership     map[int][]string
 
-	st      api.Connection
-	model   *state.Model
-	service *state.Application
-	machine *state.Machine
-	unit    *state.Unit
-	uniter  *uniter.State
-	apiUnit *uniter.Unit
-	storage *runnertesting.StorageContextAccessor
+	st          api.Connection
+	model       *state.Model
+	application *state.Application
+	machine     *state.Machine
+	unit        *state.Unit
+	uniter      *uniter.State
+	apiUnit     *uniter.Unit
+	storage     *runnertesting.StorageContextAccessor
 
 	apiRelunits map[int]*uniter.RelationUnit
 	relch       *state.Charm
@@ -61,8 +61,8 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 	s.machine = nil
 
 	ch := s.AddTestingCharm(c, "wordpress")
-	s.service = s.AddTestingApplication(c, "u", ch)
-	s.unit = s.AddUnit(c, s.service)
+	s.application = s.AddTestingApplication(c, "u", ch)
+	s.unit = s.AddUnit(c, s.application)
 
 	storageData0 := names.NewStorageTag("data/0")
 	s.storage = &runnertesting.StorageContextAccessor{

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -146,7 +146,7 @@ func (s *UniterSuite) TestUniterStartup(c *gc.C) {
 		), ut(
 			"unknown unit",
 			// We still need to create a unit, because that's when we also
-			// connect to the API, but here we use a different service
+			// connect to the API, but here we use a different application
 			// (and hence unit) name.
 			createCharm{},
 			createApplicationAndUnit{applicationName: "w"},


### PR DESCRIPTION
## Description of change

A mechanical change to clean up most of the remaining places where we use "service" instead of "application". The bulk are in state.
There's also a few file renames where the file name included "service".

There was one latent bug fixed as part of this - the allwatcher api was ordering deltas using "service" but the backend was producing records with "application".

## QA steps

Smoke test using a bootstrap and deploy.

