### PR TITLE
Create cloud context for workers.

### DIFF
--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -70,3 +70,17 @@ func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, er
 	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
+
+// InvalidateModelCredential invalidates cloud credential for the model that made a connection.
+func (c *Facade) InvalidateModelCredential(reason string) error {
+	var result params.ErrorResult
+	err := c.facade.FacadeCall("InvalidateModelCredential", reason, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}

--- a/apiserver/facades/agent/credentialvalidator/backend.go
+++ b/apiserver/facades/agent/credentialvalidator/backend.go
@@ -12,9 +12,20 @@ import (
 
 // Backend defines behavior that credential validator needs.
 type Backend interface {
+
+	// ModelUsesCredential determines if the model uses given cloud credential.
 	ModelUsesCredential(tag names.CloudCredentialTag) (bool, error)
+
+	// ModelCredential retrieves the cloud credential that a model uses.
 	ModelCredential() (*ModelCredential, error)
+
+	// WatchCredential returns a watcher that is keeping an eye on all changes to
+	// a given cloud credential.
 	WatchCredential(names.CloudCredentialTag) state.NotifyWatcher
+
+	// InvalidateModelCredential marks the cloud credential that a current model
+	// uses as invalid.
+	InvalidateModelCredential(reason string) error
 }
 
 func NewBackend(st StateAccessor) Backend {
@@ -25,6 +36,7 @@ type backend struct {
 	StateAccessor
 }
 
+// ModelUsesCredential implements Backend.ModelUsesCredential.
 func (b *backend) ModelUsesCredential(tag names.CloudCredentialTag) (bool, error) {
 	m, err := b.Model()
 	if err != nil {
@@ -34,6 +46,7 @@ func (b *backend) ModelUsesCredential(tag names.CloudCredentialTag) (bool, error
 	return exists && tag == modelCredentialTag, nil
 }
 
+// ModelCredential implements Backend.ModelCredential.
 func (b *backend) ModelCredential() (*ModelCredential, error) {
 	m, err := b.Model()
 	if err != nil {
@@ -53,7 +66,6 @@ func (b *backend) ModelCredential() (*ModelCredential, error) {
 	}
 	result.Valid = credential.IsValid()
 	return result, nil
-
 }
 
 // ModelCredential stores model's cloud credential information.

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -17,6 +17,7 @@ var logger = loggo.GetLogger("juju.api.credentialvalidator")
 
 // CredentialValidator defines the methods on credentialvalidator API endpoint.
 type CredentialValidator interface {
+	InvalidateModelCredential(reason string) (params.ErrorResult, error)
 	ModelCredential() (params.ModelCredential, error)
 	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
 }
@@ -92,4 +93,13 @@ func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, er
 		Exists:          c.Exists,
 		Valid:           c.Valid,
 	}, nil
+}
+
+// InvalidateModelCredential marks the cloud credential for this model as invalid.
+func (api *CredentialValidatorAPI) InvalidateModelCredential(reason string) (params.ErrorResult, error) {
+	err := api.backend.InvalidateModelCredential(reason)
+	if err != nil {
+		return params.ErrorResult{Error: common.ServerError(err)}, nil
+	}
+	return params.ErrorResult{}, nil
 }

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -14,6 +14,7 @@ type StateAccessor interface {
 	Model() (*state.Model, error)
 	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
 	WatchCredential(names.CloudCredentialTag) state.NotifyWatcher
+	InvalidateModelCredential(reason string) error
 }
 
 type stateShim struct {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -69,6 +69,7 @@ import (
 	"github.com/juju/juju/watcher"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apicaller"
+	workercommon "github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/conv2state"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/deployer"
@@ -847,6 +848,11 @@ func (a *MachineAgent) updateSupportedContainers(
 	}
 	// Start the watcher to fire when a container is first requested on the machine.
 	watcherName := fmt.Sprintf("%s-container-watcher", machine.Id())
+
+	credentialAPI, err := workercommon.NewCredentialInvalidatorFacade(st)
+	if err != nil {
+		return errors.Annotatef(err, "cannot get credential invalidator facade")
+	}
 	params := provisioner.ContainerSetupParams{
 		Runner:              runner,
 		WorkerName:          watcherName,
@@ -855,6 +861,7 @@ func (a *MachineAgent) updateSupportedContainers(
 		Provisioner:         pr,
 		Config:              agentConfig,
 		InitLockName:        agent.MachineLockName,
+		CredentialAPI:       credentialAPI,
 	}
 	handler := provisioner.NewContainerSetupHandler(params)
 	a.startWorkerAfterUpgrade(runner, watcherName, func() (worker.Worker, error) {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/worker/charmrevision"
 	"github.com/juju/juju/worker/charmrevision/charmrevisionmanifold"
 	"github.com/juju/juju/worker/cleaner"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/credentialvalidator"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/environ"
@@ -331,16 +332,18 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			CloudDestroyerName: environTrackerName,
 
-			NewFacade: undertaker.NewFacade,
-			NewWorker: undertaker.NewWorker,
+			NewFacade:                    undertaker.NewFacade,
+			NewWorker:                    undertaker.NewWorker,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		}))),
 
 		// All the rest depend on ifNotMigrating.
 		computeProvisionerName: ifNotMigrating(provisioner.Manifold(provisioner.ManifoldConfig{
-			AgentName:          agentName,
-			APICallerName:      apiCallerName,
-			EnvironName:        environTrackerName,
-			NewProvisionerFunc: provisioner.NewEnvironProvisioner,
+			AgentName:                    agentName,
+			APICallerName:                apiCallerName,
+			EnvironName:                  environTrackerName,
+			NewProvisionerFunc:           provisioner.NewEnvironProvisioner,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		})),
 		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName: apiCallerName,
@@ -354,9 +357,10 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			EnvironName:             environTrackerName,
 			NewControllerConnection: apicaller.NewExternalControllerConnection,
 
-			NewFirewallerWorker:      firewaller.NewWorker,
-			NewFirewallerFacade:      firewaller.NewFirewallerFacade,
-			NewRemoteRelationsFacade: firewaller.NewRemoteRelationsFacade,
+			NewFirewallerWorker:          firewaller.NewWorker,
+			NewFirewallerFacade:          firewaller.NewFirewallerFacade,
+			NewRemoteRelationsFacade:     firewaller.NewRemoteRelationsFacade,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		})),
 		unitAssignerName: ifNotMigrating(unitassigner.Manifold(unitassigner.ManifoldConfig{
 			APICallerName: apiCallerName,
@@ -371,6 +375,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			EnvironName:   environTrackerName,
 			ClockName:     clockName,
 			Delay:         config.InstPollerAggregationDelay,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		})),
 		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
@@ -381,13 +386,14 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:     machineundertaker.NewWorker,
 		})),
 		modelUpgraderName: modelupgrader.Manifold(modelupgrader.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			GateName:      modelUpgradeGateName,
-			ControllerTag: controllerTag,
-			ModelTag:      modelTag,
-			NewFacade:     modelupgrader.NewFacade,
-			NewWorker:     modelupgrader.NewWorker,
+			APICallerName:                apiCallerName,
+			EnvironName:                  environTrackerName,
+			GateName:                     modelUpgradeGateName,
+			ControllerTag:                controllerTag,
+			ModelTag:                     modelTag,
+			NewFacade:                    modelupgrader.NewFacade,
+			NewWorker:                    modelupgrader.NewWorker,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		}),
 	}
 	result := commonManifolds(config)
@@ -409,8 +415,9 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			CloudDestroyerName: caasBrokerTrackerName,
 
-			NewFacade: undertaker.NewFacade,
-			NewWorker: undertaker.NewWorker,
+			NewFacade:                    undertaker.NewFacade,
+			NewWorker:                    undertaker.NewWorker,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		}))),
 
 		caasBrokerTrackerName: ifResponsible(caasbroker.Manifold(caasbroker.ManifoldConfig{

--- a/worker/common/credentialinvalidator.go
+++ b/worker/common/credentialinvalidator.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/credentialvalidator"
+	"github.com/juju/juju/environs/context"
+)
+
+// CredentialAPI exposes functionality of the credential validator API facade to a worker.
+type CredentialAPI interface {
+	InvalidateModelCredential(reason string) error
+}
+
+// NewCredentialInvalidatorFacade creates an API facade capable of invalidating credential.
+func NewCredentialInvalidatorFacade(apiCaller base.APICaller) (CredentialAPI, error) {
+	f := credentialvalidator.NewFacade(apiCaller)
+	if f == nil {
+		return nil, errors.New("could not create credential validator facade")
+	}
+	return f, nil
+}
+
+func NewCloudCallContext(c CredentialAPI) context.ProviderCallContext {
+	return &context.CloudCallContext{
+		InvalidateCredentialF: c.InvalidateModelCredential,
+	}
+}

--- a/worker/common/credentialinvalidator.go
+++ b/worker/common/credentialinvalidator.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/credentialvalidator"
 	"github.com/juju/juju/environs/context"
@@ -18,13 +16,10 @@ type CredentialAPI interface {
 
 // NewCredentialInvalidatorFacade creates an API facade capable of invalidating credential.
 func NewCredentialInvalidatorFacade(apiCaller base.APICaller) (CredentialAPI, error) {
-	f := credentialvalidator.NewFacade(apiCaller)
-	if f == nil {
-		return nil, errors.New("could not create credential validator facade")
-	}
-	return f, nil
+	return credentialvalidator.NewFacade(apiCaller), nil
 }
 
+// NewCloudCallContext creates a cloud call context to be used by workers.
 func NewCloudCallContext(c CredentialAPI) context.ProviderCallContext {
 	return &context.CloudCallContext{
 		InvalidateCredentialF: c.InvalidateModelCredential,

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -59,8 +59,8 @@ type firewallerBaseSuite struct {
 	crossmodelFirewaller *crossmodelrelations.Client
 	clock                clock.Clock
 
-	callCtx     context.ProviderCallContext
-	credentials *credentialvalidator.Facade
+	callCtx           context.ProviderCallContext
+	credentialsFacade *credentialvalidator.Facade
 }
 
 func (s *firewallerBaseSuite) SetUpSuite(c *gc.C) {
@@ -114,8 +114,7 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C, firewallMode string) {
 	s.remoteRelations = remoterelations.NewClient(s.st)
 	c.Assert(s.remoteRelations, gc.NotNil)
 
-	s.credentials = credentialvalidator.NewFacade(s.st)
-	c.Assert(s.credentials, gc.NotNil)
+	s.credentialsFacade = credentialvalidator.NewFacade(s.st)
 }
 
 // assertPorts retrieves the open ports of the instance and compares them
@@ -240,7 +239,7 @@ func (s *InstanceModeSuite) newFirewallerWithClock(c *gc.C, clock clock.Clock) w
 			return s.crossmodelFirewaller, nil
 		},
 		Clock:         s.clock,
-		CredentialAPI: s.credentials,
+		CredentialAPI: s.credentialsFacade,
 	}
 	fw, err := firewaller.NewFirewaller(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1277,7 +1276,7 @@ func (s *GlobalModeSuite) newFirewaller(c *gc.C) worker.Worker {
 		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
-		CredentialAPI: s.credentials,
+		CredentialAPI: s.credentialsFacade,
 	}
 	fw, err := firewaller.NewFirewaller(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1528,7 +1527,7 @@ func (s *NoneModeSuite) TestStopImmediately(c *gc.C) {
 		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
-		CredentialAPI: s.credentials,
+		CredentialAPI: s.credentialsFacade,
 	}
 	_, err := firewaller.NewFirewaller(cfg)
 	c.Assert(err, gc.ErrorMatches, `invalid firewall-mode "none"`)

--- a/worker/instancepoller/aggregate_test.go
+++ b/worker/instancepoller/aggregate_test.go
@@ -94,11 +94,7 @@ func (s *aggregateSuite) TestSingleRequest(c *gc.C) {
 	testGetter := new(testInstanceGetter)
 	clock := jujutesting.NewClock(time.Now())
 	delay := time.Minute
-	cfg := aggregatorConfig{
-		Clock:   clock,
-		Delay:   delay,
-		Environ: testGetter,
-	}
+	cfg := aggregatorConfigForTest(clock, delay, testGetter)
 
 	// Add a new test instance.
 	testGetter.newTestInstance("foo", "foobar", []string{"127.0.0.1", "192.168.1.1"})
@@ -133,6 +129,21 @@ func (s *aggregateSuite) TestSingleRequest(c *gc.C) {
 	c.Assert(ids, gc.DeepEquals, []instance.Id{"foo"})
 }
 
+type credentialAPIForTest struct{}
+
+func (*credentialAPIForTest) InvalidateModelCredential(reason string) error {
+	return nil
+}
+
+func aggregatorConfigForTest(clock *jujutesting.Clock, delay time.Duration, environ InstanceGetter) aggregatorConfig {
+	return aggregatorConfig{
+		Clock:         clock,
+		Delay:         delay,
+		Environ:       environ,
+		CredentialAPI: &credentialAPIForTest{},
+	}
+}
+
 // Test several requests in a short space of time get batched.
 func (s *aggregateSuite) TestMultipleResponseHandling(c *gc.C) {
 	// We setup a couple variables here so that we can use them locally without
@@ -140,11 +151,7 @@ func (s *aggregateSuite) TestMultipleResponseHandling(c *gc.C) {
 	testGetter := new(testInstanceGetter)
 	clock := jujutesting.NewClock(time.Now())
 	delay := time.Minute
-	cfg := aggregatorConfig{
-		Clock:   clock,
-		Delay:   delay,
-		Environ: testGetter,
-	}
+	cfg := aggregatorConfigForTest(clock, delay, testGetter)
 
 	// Setup multiple instances to batch
 	testGetter.newTestInstance("foo", "foobar", []string{"127.0.0.1", "192.168.1.1"})
@@ -200,11 +207,7 @@ func (s *aggregateSuite) TestKillingWorkerKillsPendinReqs(c *gc.C) {
 	testGetter := new(testInstanceGetter)
 	clock := jujutesting.NewClock(time.Now())
 	delay := time.Minute
-	cfg := aggregatorConfig{
-		Clock:   clock,
-		Delay:   delay,
-		Environ: testGetter,
-	}
+	cfg := aggregatorConfigForTest(clock, delay, testGetter)
 
 	testGetter.newTestInstance("foo", "foobar", []string{"127.0.0.1", "192.168.1.1"})
 	testGetter.newTestInstance("foo2", "not foobar", []string{"192.168.1.2"})
@@ -255,11 +258,7 @@ func (s *aggregateSuite) TestMultipleBatches(c *gc.C) {
 	testGetter := new(testInstanceGetter)
 	clock := jujutesting.NewClock(time.Now())
 	delay := time.Second
-	cfg := aggregatorConfig{
-		Clock:   clock,
-		Delay:   delay,
-		Environ: testGetter,
-	}
+	cfg := aggregatorConfigForTest(clock, delay, testGetter)
 
 	testGetter.newTestInstance("foo2", "not foobar", []string{"192.168.1.2"})
 	testGetter.newTestInstance("foo3", "ok-ish", []string{"192.168.1.3"})
@@ -338,11 +337,7 @@ func (s *aggregateSuite) TestInstancesErrors(c *gc.C) {
 	testGetter := new(testInstanceGetter)
 	clock := jujutesting.NewClock(time.Now())
 	delay := time.Millisecond
-	cfg := aggregatorConfig{
-		Clock:   clock,
-		Delay:   delay,
-		Environ: testGetter,
-	}
+	cfg := aggregatorConfigForTest(clock, delay, testGetter)
 
 	testGetter.newTestInstance("foo", "foobar", []string{"192.168.1.2"})
 	testGetter.err = environs.ErrNoInstances
@@ -378,11 +373,7 @@ func (s *aggregateSuite) TestPartialInstanceErrors(c *gc.C) {
 	clock := jujutesting.NewClock(time.Now())
 	delay := time.Second
 
-	cfg := aggregatorConfig{
-		Clock:   clock,
-		Delay:   delay,
-		Environ: testGetter,
-	}
+	cfg := aggregatorConfigForTest(clock, delay, testGetter)
 
 	testGetter.err = environs.ErrPartialInstances
 	testGetter.newTestInstance("foo", "not foobar", []string{"192.168.1.2"})

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/common"
 )
 
 type Config struct {
@@ -21,6 +22,8 @@ type Config struct {
 	Delay   time.Duration
 	Facade  *instancepoller.API
 	Environ InstanceGetter
+
+	CredentialAPI common.CredentialAPI
 }
 
 func (config Config) Validate() error {
@@ -35,6 +38,9 @@ func (config Config) Validate() error {
 	}
 	if config.Environ == nil {
 		return errors.NotValidf("nil Environ")
+	}
+	if config.CredentialAPI == nil {
+		return errors.NotValidf("nil CredentialAPI")
 	}
 	return nil
 }
@@ -78,9 +84,10 @@ func (u *updaterWorker) Wait() error {
 func (u *updaterWorker) loop() (err error) {
 	u.aggregator, err = newAggregator(
 		aggregatorConfig{
-			Clock:   u.config.Clock,
-			Delay:   u.config.Delay,
-			Environ: u.config.Environ,
+			Clock:         u.config.Clock,
+			Delay:         u.config.Delay,
+			Environ:       u.config.Environ,
+			CredentialAPI: u.config.CredentialAPI,
 		},
 	)
 	if err != nil {

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -59,10 +59,11 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	machines, insts := s.setupScenario(c)
 	s.State.StartSync()
 	w, err := NewWorker(Config{
-		Delay:   time.Millisecond * 10,
-		Clock:   clock.WallClock,
-		Facade:  s.api,
-		Environ: s.Environ,
+		Delay:         time.Millisecond * 10,
+		Clock:         clock.WallClock,
+		Facade:        s.api,
+		Environ:       s.Environ,
+		CredentialAPI: &credentialAPIForTest{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {

--- a/worker/modelupgrader/manifold_test.go
+++ b/worker/modelupgrader/manifold_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/gate"
@@ -109,6 +110,7 @@ func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
 			c.Check(config.Facade, gc.Equals, expectFacade)
 			return nil, errors.New("boof")
 		},
+		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) { return nil, nil },
 	})
 
 	worker, err := manifold.Start(context)
@@ -136,6 +138,7 @@ func (*ManifoldSuite) TestNewWorkerSuccessWithEnviron(c *gc.C) {
 			newWorkerConfig = config
 			return expectWorker, nil
 		},
+		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) { return nil, nil },
 	})
 
 	worker, err := manifold.Start(context)
@@ -163,6 +166,7 @@ func (*ManifoldSuite) TestNewWorkerSuccessWithoutEnviron(c *gc.C) {
 			newWorkerConfig = config
 			return expectWorker, nil
 		},
+		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) { return nil, nil },
 	})
 
 	worker, err := manifold.Start(context)

--- a/worker/modelupgrader/worker_test.go
+++ b/worker/modelupgrader/worker_test.go
@@ -43,6 +43,7 @@ func (*WorkerSuite) TestNewWorker(c *gc.C) {
 		GateUnlocker:  &mockGateUnlocker,
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
+		CredentialAPI: &credentialAPIForTest{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -66,6 +67,7 @@ func (*WorkerSuite) TestNonUpgradeable(c *gc.C) {
 		GateUnlocker:  &mockGateUnlocker,
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
+		CredentialAPI: &credentialAPIForTest{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -117,6 +119,7 @@ func (*WorkerSuite) TestRunUpgradeOperations(c *gc.C) {
 		GateUnlocker:  &mockGateUnlocker,
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
+		CredentialAPI: &credentialAPIForTest{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -163,6 +166,7 @@ func (*WorkerSuite) TestRunUpgradeOperationsStepError(c *gc.C) {
 		GateUnlocker:  &mockGateUnlocker,
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
+		CredentialAPI: &credentialAPIForTest{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -192,6 +196,7 @@ func (*WorkerSuite) TestWaitForUpgrade(c *gc.C) {
 		GateUnlocker:  &mockGateUnlocker,
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
+		CredentialAPI: &credentialAPIForTest{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -350,4 +355,10 @@ func (w *mockNotifyWatcher) Kill() {
 
 func (w *mockNotifyWatcher) Wait() error {
 	return w.tomb.Wait()
+}
+
+type credentialAPIForTest struct{}
+
+func (*credentialAPIForTest) InvalidateModelCredential(reason string) error {
+	return nil
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -36,6 +36,7 @@ import (
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/watcher"
 	jworker "github.com/juju/juju/worker"
+	workercommon "github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/provisioner"
 	"github.com/juju/juju/worker/workertest"
 )
@@ -79,7 +80,7 @@ func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 	// Set up provisioner for the state machine.
 	s.agentConfig = s.AgentConfigForTag(c, names.NewMachineTag("0"))
 	var err error
-	s.p, err = provisioner.NewEnvironProvisioner(s.provisioner, s.agentConfig, s.Environ)
+	s.p, err = provisioner.NewEnvironProvisioner(s.provisioner, s.agentConfig, s.Environ, &credentialAPIForTest{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.lockName = "provisioner-test"
 }
@@ -117,6 +118,7 @@ func (s *ContainerSetupSuite) setupContainerWorker(c *gc.C, tag names.MachineTag
 		Provisioner:         pr,
 		Config:              cfg,
 		InitLockName:        s.lockName,
+		CredentialAPI:       &credentialAPIForTest{},
 	}
 	handler := provisioner.NewContainerSetupHandler(params)
 	runner.StartWorker(watcherName, func() (worker.Worker, error) {
@@ -160,7 +162,8 @@ func (s *ContainerSetupSuite) assertContainerProvisionerStarted(
 	var provisionerStarted uint32
 	startProvisionerWorker := func(runner *worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
-		toolsFinder provisioner.ToolsFinder, distributionGroupFinder provisioner.DistributionGroupFinder) error {
+		toolsFinder provisioner.ToolsFinder, distributionGroupFinder provisioner.DistributionGroupFinder,
+		credentialAPI workercommon.CredentialAPI) error {
 		c.Assert(containerType, gc.Equals, ctype)
 		c.Assert(cfg.Tag(), gc.Equals, host.Tag())
 		atomic.StoreUint32(&provisionerStarted, 1)
@@ -237,7 +240,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 
 	s.PatchValue(&provisioner.StartProvisioner, func(runner *worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
-		toolsFinder provisioner.ToolsFinder, distributionGroupFinder provisioner.DistributionGroupFinder) error {
+		toolsFinder provisioner.ToolsFinder, distributionGroupFinder provisioner.DistributionGroupFinder, credentialAPI workercommon.CredentialAPI) error {
 		toolsFinder.FindTools(jujuversion.Current, series.MustHostSeries(), arch.AMD64)
 		return nil
 	})
@@ -280,7 +283,8 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 	// A noop worker callback.
 	startProvisionerWorker := func(runner *worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
-		toolsFinder provisioner.ToolsFinder, distributionGroupFinder provisioner.DistributionGroupFinder) error {
+		toolsFinder provisioner.ToolsFinder, distributionGroupFinder provisioner.DistributionGroupFinder,
+		credentialAPI workercommon.CredentialAPI) error {
 		return nil
 	}
 	s.PatchValue(&provisioner.StartProvisioner, startProvisionerWorker)
@@ -404,4 +408,10 @@ func getContainerInstance() (cont []ContainerInstance, err error) {
 		{instance.KVM, pkgs},
 	}
 	return cont, nil
+}
+
+type credentialAPIForTest struct{}
+
+func (*credentialAPIForTest) InvalidateModelCredential(reason string) error {
+	return nil
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -418,7 +418,8 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	broker, brokerErr := provisioner.NewKVMBroker(noopPrepareHostFunc, s.provisioner, manager, agentConfig)
 	c.Assert(brokerErr, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
-	w, err := provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder, &mockDistributionGroupFinder{})
+	w, err := provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker,
+		toolsFinder, &mockDistributionGroupFinder{}, &credentialAPIForTest{})
 	c.Assert(err, jc.ErrorIsNil)
 	return w
 }

--- a/worker/provisioner/manifold_test.go
+++ b/worker/provisioner/manifold_test.go
@@ -14,6 +14,7 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/provisioner"
@@ -31,15 +32,17 @@ func (s *ManifoldSuite) makeManifold() dependency.Manifold {
 		apiSt *apiprovisioner.State,
 		agentConf agent.Config,
 		environ environs.Environ,
+		credentialAPI common.CredentialAPI,
 	) (provisioner.Provisioner, error) {
 		s.stub.AddCall("NewProvisionerFunc")
 		return struct{ provisioner.Provisioner }{}, nil
 	}
 	return provisioner.Manifold(provisioner.ManifoldConfig{
-		AgentName:          "agent",
-		APICallerName:      "api-caller",
-		EnvironName:        "environ",
-		NewProvisionerFunc: fakeNewProvFunc,
+		AgentName:                    "agent",
+		APICallerName:                "api-caller",
+		EnvironName:                  "environ",
+		NewProvisionerFunc:           fakeNewProvFunc,
+		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) { return nil, nil },
 	})
 }
 

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/common"
 )
 
 var logger = loggo.GetLogger("juju.provisioner")
@@ -189,16 +190,18 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 // NewEnvironProvisioner returns a new Provisioner for an environment.
 // When new machines are added to the state, it allocates instances
 // from the environment and allocates them to the new machines.
-func NewEnvironProvisioner(st *apiprovisioner.State, agentConfig agent.Config, environ environs.Environ) (Provisioner, error) {
-	callCtx := context.NewCloudCallContext()
-
+func NewEnvironProvisioner(st *apiprovisioner.State,
+	agentConfig agent.Config,
+	environ environs.Environ,
+	credentialAPI common.CredentialAPI,
+) (Provisioner, error) {
 	p := &environProvisioner{
 		provisioner: provisioner{
 			st:                      st,
 			agentConfig:             agentConfig,
 			toolsFinder:             getToolsFinder(st),
 			distributionGroupFinder: getDistributionGroupFinder(st),
-			callContext:             callCtx,
+			callContext:             common.NewCloudCallContext(credentialAPI),
 		},
 		environ: environ,
 	}
@@ -290,9 +293,8 @@ func NewContainerProvisioner(
 	broker environs.InstanceBroker,
 	toolsFinder ToolsFinder,
 	distributionGroupFinder DistributionGroupFinder,
+	credentialAPI common.CredentialAPI,
 ) (Provisioner, error) {
-	callCtx := context.NewCloudCallContext()
-
 	p := &containerProvisioner{
 		provisioner: provisioner{
 			st:                      st,
@@ -300,7 +302,7 @@ func NewContainerProvisioner(
 			broker:                  broker,
 			toolsFinder:             toolsFinder,
 			distributionGroupFinder: distributionGroupFinder,
-			callContext:             callCtx,
+			callContext:             common.NewCloudCallContext(credentialAPI),
 		},
 		containerType: containerType,
 	}

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -466,7 +466,7 @@ func (s *CommonProvisionerSuite) newEnvironProvisioner(c *gc.C) provisioner.Prov
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	apiState := apiprovisioner.NewState(s.st)
-	w, err := provisioner.NewEnvironProvisioner(apiState, agentConfig, s.Environ)
+	w, err := provisioner.NewEnvironProvisioner(apiState, agentConfig, s.Environ, &credentialAPIForTest{})
 	c.Assert(err, jc.ErrorIsNil)
 	return w
 }

--- a/worker/undertaker/mock_test.go
+++ b/worker/undertaker/mock_test.go
@@ -109,8 +109,9 @@ func (fix fixture) run(c *gc.C, test func(worker.Worker)) *testing.Stub {
 	}
 	stub.SetErrors(fix.errors...)
 	w, err := undertaker.NewUndertaker(undertaker.Config{
-		Facade:    facade,
-		Destroyer: environOrBroker,
+		Facade:        facade,
+		Destroyer:     environOrBroker,
+		CredentialAPI: &fakeCredentialAPI{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer fix.cleanup(c, w)

--- a/worker/undertaker/validate_test.go
+++ b/worker/undertaker/validate_test.go
@@ -30,10 +30,17 @@ func (*ValidateSuite) TestNilDestroyer(c *gc.C) {
 	checkInvalid(c, config, "nil Destroyer not valid")
 }
 
+func (*ValidateSuite) TestNilCredentialAPI(c *gc.C) {
+	config := validConfig()
+	config.CredentialAPI = nil
+	checkInvalid(c, config, "nil CredentialAPI not valid")
+}
+
 func validConfig() undertaker.Config {
 	return undertaker.Config{
-		Facade:    &fakeFacade{},
-		Destroyer: &fakeEnviron{},
+		Facade:        &fakeFacade{},
+		Destroyer:     &fakeEnviron{},
+		CredentialAPI: &fakeCredentialAPI{},
 	}
 }
 


### PR DESCRIPTION
This is part of the credential work that allows Juju to react when a model cloud credential expires or becomes invalid.

Some of the Juju workers make cloud provider calls directly. This patch ensures that these workers have correct context to make these cloud calls. Specifically, workers' call context contains correct callback that providers can use to invalid model's credential. 

Start review from model manifolds definition because for model-scoped worker manifolds we now provide an additional facade construction method. This facade knows how to invalidate model credential (see cmd/jujud/agent/model/manifolds.go).

This new manifold config is used to construct the workers with the correct cloud call context and invalidate-credential callback using this facade.


