### PR TITLE
CAAS operator sets agent version on startup, restarts when api addresses change

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -5,6 +5,7 @@ package caasoperator
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
@@ -232,4 +233,24 @@ func maybeNotFound(err *params.Error) error {
 		return err
 	}
 	return errors.NewNotFound(err, "")
+}
+
+// SetVersion sets the tools version associated with
+// the given application.
+func (c *Client) SetVersion(appName string, v version.Binary) error {
+	if !names.IsValidApplication(appName) {
+		return errors.NotValidf("application name %q", appName)
+	}
+	var results params.ErrorResults
+	args := params.EntitiesVersion{
+		AgentTools: []params.EntityVersion{{
+			Tag:   names.NewApplicationTag(appName).String(),
+			Tools: &params.Version{v},
+		}},
+	}
+	err := c.facade.FacadeCall("SetTools", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
 }

--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -5,9 +5,11 @@ package caasoperatorprovisioner
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
@@ -16,6 +18,7 @@ import (
 
 // Client allows access to the CAAS operator provisioner API endpoint.
 type Client struct {
+	*common.APIAddresser
 	facade base.FacadeCaller
 }
 
@@ -23,7 +26,8 @@ type Client struct {
 func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, "CAASOperatorProvisioner")
 	return &Client{
-		facade: facadeCaller,
+		facade:       facadeCaller,
+		APIAddresser: common.NewAPIAddresser(facadeCaller),
 	}
 }
 
@@ -102,6 +106,7 @@ func (c *Client) Life(appName string) (life.Value, error) {
 // OperatorProvisioningInfo holds the info needed to provision an operator.
 type OperatorProvisioningInfo struct {
 	ImagePath string
+	Version   version.Number
 }
 
 // OperatorProvisioningInfo returns the info needed to provision an operator.
@@ -112,5 +117,6 @@ func (c *Client) OperatorProvisioningInfo() (OperatorProvisioningInfo, error) {
 	}
 	return OperatorProvisioningInfo{
 		ImagePath: result.ImagePath,
+		Version:   result.Version,
 	}, nil
 }

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -154,6 +155,7 @@ func (s *provisionerSuite) TestLifeCount(c *gc.C) {
 }
 
 func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
+	vers := version.MustParse("2.99.0")
 	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
 		c.Check(objType, gc.Equals, "CAASOperatorProvisioner")
 		c.Check(id, gc.Equals, "")
@@ -162,6 +164,7 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.OperatorProvisioningInfo{})
 		*(result.(*params.OperatorProvisioningInfo)) = params.OperatorProvisioningInfo{
 			ImagePath: "juju-operator-image",
+			Version:   vers,
 		}
 		return nil
 	})
@@ -169,5 +172,6 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, caasoperatorprovisioner.OperatorProvisioningInfo{
 		ImagePath: "juju-operator-image",
+		Version:   vers,
 	})
 }

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -6,6 +6,7 @@ package caasoperator_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
@@ -16,6 +17,7 @@ import (
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
 )
 
 type mockState struct {
@@ -152,6 +154,23 @@ func (a *mockApplication) WatchUnits() state.StringsWatcher {
 func (a *mockApplication) Watch() state.NotifyWatcher {
 	a.MethodCall(a, "Watch")
 	return a.watcher
+}
+
+func (a *mockApplication) AllUnits() ([]caasoperator.Unit, error) {
+	a.MethodCall(a, "AllUnits")
+	if err := a.NextErr(); err != nil {
+		return nil, err
+	}
+	return []caasoperator.Unit{&mockUnit{}}, nil
+}
+
+func (a *mockApplication) AgentTools() (*tools.Tools, error) {
+	return nil, errors.NotImplementedf("AgentTools")
+}
+
+func (a *mockApplication) SetAgentVersion(vers version.Binary) error {
+	a.MethodCall(a, "SetAgentVersion", vers)
+	return nil
 }
 
 type mockUnit struct {

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -37,6 +37,7 @@ type Application interface {
 	CharmModifiedVersion() int
 	SetStatus(status.StatusInfo) error
 	WatchUnits() state.StringsWatcher
+	AllUnits() ([]Unit, error)
 }
 
 // Charm provides the subset of charm state required by the
@@ -72,4 +73,20 @@ type applicationShim struct {
 
 func (a applicationShim) Charm() (Charm, bool, error) {
 	return a.Application.Charm()
+}
+
+func (a applicationShim) AllUnits() ([]Unit, error) {
+	all, err := a.Application.AllUnits()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]Unit, len(all))
+	for i, u := range all {
+		result[i] = u
+	}
+	return result, nil
+}
+
+type Unit interface {
+	Tag() names.Tag
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -9,13 +9,17 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/apiserver/common"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type mockState struct {
 	testing.Stub
+	common.AddressAndCertGetter
 	applicationWatcher *mockStringsWatcher
 	app                *mockApplication
 	operatorImage      string
@@ -43,6 +47,16 @@ func (st *mockState) ControllerConfig() (controller.Config, error) {
 	cfg := coretesting.FakeControllerConfig()
 	cfg[controller.CAASOperatorImagePath] = st.operatorImage
 	return cfg, nil
+}
+
+func (st *mockState) APIHostPortsForAgents() ([][]network.HostPort, error) {
+	st.MethodCall(st, "APIHostPortsForAgents")
+	return nil, nil
+}
+
+func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	st.MethodCall(st, "WatchAPIHostPortsForAgents")
+	return apiservertesting.NewFakeNotifyWatcher()
 }
 
 type mockApplication struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -18,6 +18,7 @@ import (
 type API struct {
 	*common.PasswordChanger
 	*common.LifeGetter
+	*common.APIAddresser
 
 	auth      facade.Authorizer
 	resources facade.Resources
@@ -45,6 +46,7 @@ func NewCAASOperatorProvisionerAPI(
 	return &API{
 		PasswordChanger: common.NewPasswordChanger(st, common.AuthFuncForTagKind(names.ApplicationTagKind)),
 		LifeGetter:      common.NewLifeGetter(st, common.AuthFuncForTagKind(names.ApplicationTagKind)),
+		APIAddresser:    common.NewAPIAddresser(st, resources),
 		auth:            authorizer,
 		resources:       resources,
 		state:           st,
@@ -81,5 +83,6 @@ func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error
 
 	return params.OperatorProvisioningInfo{
 		ImagePath: imagePath,
+		Version:   version.Current,
 	}, nil
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -121,6 +121,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
 		ImagePath: fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
+		Version:   version.Current,
 	})
 }
 
@@ -130,5 +131,18 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
 		ImagePath: s.st.operatorImage,
+		Version:   version.Current,
 	})
+}
+
+func (s *CAASProvisionerSuite) TestAddresses(c *gc.C) {
+	_, err := s.api.APIAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "APIHostPortsForAgents")
+}
+
+func (s *CAASProvisionerSuite) TestWatchAPIHostPorts(c *gc.C) {
+	_, err := s.api.WatchAPIHostPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "WatchAPIHostPortsForAgents")
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -16,4 +17,8 @@ type CAASOperatorProvisionerState interface {
 	ControllerConfig() (controller.Config, error)
 	WatchApplications() state.StringsWatcher
 	FindEntity(tag names.Tag) (state.Entity, error)
+	Addresses() ([]string, error)
+	ModelUUID() string
+	APIHostPortsForAgents() ([][]network.HostPort, error)
+	WatchAPIHostPortsForAgents() state.NotifyWatcher
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -454,7 +454,8 @@ type ConfigResult struct {
 
 // OperatorProvisioningInfo holds info need to provision an operator.
 type OperatorProvisioningInfo struct {
-	ImagePath string `json:"image-path"`
+	ImagePath string         `json:"image-path"`
+	Version   version.Number `json:"version"`
 }
 
 // PublicAddress holds parameters for the PublicAddress call.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -5,6 +5,7 @@ package caas
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/environs"
@@ -119,6 +120,9 @@ type Unit struct {
 type OperatorConfig struct {
 	// OperatorImagePath is the docker registry URL for the image.
 	OperatorImagePath string
+
+	// Version is the Juju version of the operator image.
+	Version version.Number
 
 	// AgentConf is the contents of the agent.conf file.
 	AgentConf []byte

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type K8sSuite struct {
@@ -113,10 +112,12 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 }
 
 func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
-	pod := provider.OperatorPod("gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator")
-	vers := version.Current
-	vers.Build = 0
+	pod := provider.OperatorPod("gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator", "2.99.0")
 	c.Assert(pod.Name, gc.Equals, "juju-operator-gitlab")
+	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
+		"juju-operator": "gitlab",
+		"juju-version":  "2.99.0",
+	})
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
 	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/caas-jujud-operator")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 1)

--- a/worker/apiaddressupdater/manifold.go
+++ b/worker/apiaddressupdater/manifold.go
@@ -6,7 +6,7 @@ package apiaddressupdater
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -4,6 +4,7 @@
 package caasoperator
 
 import (
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/core/life"
@@ -22,6 +23,7 @@ type Client interface {
 	ApplicationWatcher
 	PodSpecSetter
 	StatusSetter
+	VersionSetter
 	Model() (*model.Model, error)
 }
 
@@ -76,4 +78,10 @@ type StatusSetter interface {
 type CharmConfigGetter interface {
 	CharmConfig(string) (charm.Settings, error)
 	WatchCharmConfig(string) (watcher.NotifyWatcher, error)
+}
+
+// VersionSetter provides an interface for setting
+// the operator agent version.
+type VersionSetter interface {
+	SetVersion(appName string, v version.Binary) error
 }

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -151,6 +151,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				UnitGetter:         client,
 				UnitRemover:        client,
 				ApplicationWatcher: client,
+				VersionSetter:      client,
 				StartUniterFunc:    uniter.StartUniter,
 
 				LeadershipTrackerFunc: leadershipTrackerFunc,

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -156,6 +156,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		UnitGetter:         &s.client,
 		UnitRemover:        &s.client,
 		ApplicationWatcher: &s.client,
+		VersionSetter:      &s.client,
 		UniterParams: &uniter.UniterParams{
 			DataDir:         s.dataDir,
 			MachineLockName: "machine-lock",

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/proxy"
 	"github.com/juju/testing"
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
@@ -123,6 +124,11 @@ func (c *fakeClient) Watch(application string) (watcher.NotifyWatcher, error) {
 func (c *fakeClient) RemoveUnit(unit string) error {
 	c.MethodCall(c, "RemoveUnit", unit)
 	c.unitRemoved <- struct{}{}
+	return c.NextErr()
+}
+
+func (c *fakeClient) SetVersion(appName string, v version.Binary) error {
+	c.MethodCall(c, "SetVersion", appName, v)
 	return c.NextErr()
 }
 

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
@@ -30,6 +29,8 @@ type CAASProvisionerFacade interface {
 	WatchApplications() (watcher.StringsWatcher, error)
 	SetPasswords([]apicaasprovisioner.ApplicationPassword) (params.ErrorResults, error)
 	Life(string) (life.Value, error)
+	WatchAPIHostPorts() (watcher.NotifyWatcher, error)
+	APIAddresses() ([]string, error)
 }
 
 // Config defines the operation of a Worker.
@@ -47,6 +48,7 @@ func NewProvisionerWorker(config Config) (worker.Worker, error) {
 		broker:            config.Broker,
 		modelTag:          config.ModelTag,
 		agentConfig:       config.AgentConfig,
+		appPasswords:      make(map[string]string),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &p.catacomb,
@@ -62,6 +64,8 @@ type provisioner struct {
 
 	modelTag    names.ModelTag
 	agentConfig agent.Config
+
+	appPasswords map[string]string
 }
 
 // Kill is part of the worker.Worker interface.
@@ -80,23 +84,46 @@ func (p *provisioner) loop() error {
 	// away. For some runtimes we *could* rely on the the runtime's
 	// features to do this.
 
-	w, err := p.provisionerFacade.WatchApplications()
+	appWatcher, err := p.provisionerFacade.WatchApplications()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := p.catacomb.Add(w); err != nil {
+	if err := p.catacomb.Add(appWatcher); err != nil {
 		return errors.Trace(err)
 	}
 
+	apiAddressWatcher, err := p.provisionerFacade.WatchAPIHostPorts()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := p.catacomb.Add(apiAddressWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	var apiAddressChanged watcher.NotifyChannel
 	for {
 		select {
 		case <-p.catacomb.Dying():
 			return p.catacomb.ErrDying()
-		case apps, ok := <-w.Changes():
+
+		// API addresses have changed so we need to update
+		// each operator pod so it has the new addresses.
+		case _, ok := <-apiAddressChanged:
 			if !ok {
-				return errors.New("watcher closed channel")
+				return errors.New("api watcher closed channel")
 			}
-			var appPasswords []apicaasprovisioner.ApplicationPassword
+			for app, password := range p.appPasswords {
+				if err := p.ensureOperator(app, password); err != nil {
+					return errors.Annotatef(err, "updating operator for q with new api addresses", app)
+				}
+			}
+
+		// CAAS applications changed so either create or remove pods as appropriate.
+		case apps, ok := <-appWatcher.Changes():
+			if !ok {
+				return errors.New("app watcher closed channel")
+			}
+			var newApps []apicaasprovisioner.ApplicationPassword
 			for _, app := range apps {
 				appLife, err := p.provisionerFacade.Life(app)
 				if errors.IsNotFound(err) || appLife == life.Dead {
@@ -104,6 +131,7 @@ func (p *provisioner) loop() error {
 					if err := p.broker.DeleteOperator(app); err != nil {
 						return errors.Annotatef(err, "failed to stop operator for %q", app)
 					}
+					delete(p.appPasswords, app)
 					continue
 				}
 				if appLife != life.Alive {
@@ -114,35 +142,50 @@ func (p *provisioner) loop() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				appPasswords = append(appPasswords, apicaasprovisioner.ApplicationPassword{Name: app, Password: password})
+				newApps = append(newApps, apicaasprovisioner.ApplicationPassword{Name: app, Password: password})
 			}
-			if len(appPasswords) == 0 {
+			if len(newApps) == 0 {
 				continue
 			}
-			errorResults, err := p.provisionerFacade.SetPasswords(appPasswords)
-			if err != nil {
-				return errors.Annotate(err, "failed to set application api passwords")
+			if err := p.ensureOperators(newApps); err != nil {
+				return errors.Trace(err)
 			}
-			var errorStrings []string
-			for i, r := range errorResults.Results {
-				if r.Error != nil {
-					errorStrings = append(errorStrings, r.Error.Error())
-					continue
-				}
-				if err := p.createOperator(appPasswords[i].Name, appPasswords[i].Password); err != nil {
-					return errors.Trace(err)
-				}
+			// Store the apps we have just added.
+			for _, ap := range newApps {
+				p.appPasswords[ap.Name] = ap.Password
 			}
-			if errorStrings != nil {
-				err := errors.New(strings.Join(errorStrings, "\n"))
-				return errors.Annotate(err, "failed to set application api passwords")
-			}
+
+			// Now we have been through all the applications at least once, we can
+			// listen for api address changes.
+			apiAddressChanged = apiAddressWatcher.Changes()
 		}
 	}
 }
 
-func (p *provisioner) createOperator(app, password string) error {
-	logger.Debugf("creating operator for %q", app)
+// ensureOperators creates operator pods for the specified app names -> api passwords.
+func (p *provisioner) ensureOperators(appPasswords []apicaasprovisioner.ApplicationPassword) error {
+	errorResults, err := p.provisionerFacade.SetPasswords(appPasswords)
+	if err != nil {
+		return errors.Annotate(err, "failed to set application api passwords")
+	}
+	var errorStrings []string
+	for i, r := range errorResults.Results {
+		if r.Error != nil {
+			errorStrings = append(errorStrings, r.Error.Error())
+			continue
+		}
+		if err := p.ensureOperator(appPasswords[i].Name, appPasswords[i].Password); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if errorStrings != nil {
+		err := errors.New(strings.Join(errorStrings, "\n"))
+		return errors.Annotate(err, "failed to set application api passwords")
+	}
+	return nil
+}
+
+func (p *provisioner) ensureOperator(app, password string) error {
 	config, err := p.newOperatorConfig(app, password)
 	if err != nil {
 		return errors.Trace(err)
@@ -150,26 +193,28 @@ func (p *provisioner) createOperator(app, password string) error {
 	if err := p.broker.EnsureOperator(app, p.agentConfig.DataDir(), config); err != nil {
 		return errors.Annotatef(err, "failed to start operator for %q", app)
 	}
+	logger.Infof("started operator for application %q", app)
 	return nil
 }
 
 func (p *provisioner) newOperatorConfig(appName string, password string) (*caas.OperatorConfig, error) {
 	appTag := names.NewApplicationTag(appName)
-
-	// TODO(caas) - restart operator when api addresses change
-	apiAddrs, err := p.agentConfig.APIAddresses()
+	apiAddrs, err := p.provisionerFacade.APIAddresses()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	info, err := p.provisionerFacade.OperatorProvisioningInfo()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	conf, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{
 			Paths: agent.Paths{
 				DataDir: p.agentConfig.DataDir(),
 				LogDir:  p.agentConfig.LogDir(),
 			},
-			// This isn't actually used but needs to be supplied.
-			UpgradedToVersion: version.Current,
+			UpgradedToVersion: info.Version,
 			Tag:               appTag,
 			Password:          password,
 			Controller:        p.agentConfig.Controller(),
@@ -187,10 +232,10 @@ func (p *provisioner) newOperatorConfig(appName string, password string) (*caas.
 		return nil, errors.Trace(err)
 	}
 
-	info, err := p.provisionerFacade.OperatorProvisioningInfo()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	logger.Debugf("using caas operator info %+v", info)
-	return &caas.OperatorConfig{AgentConf: confBytes, OperatorImagePath: info.ImagePath}, nil
+	return &caas.OperatorConfig{
+		AgentConf:         confBytes,
+		OperatorImagePath: info.ImagePath,
+		Version:           info.Version,
+	}, nil
 }


### PR DESCRIPTION
## Description of change

Three key functional additions:
1. caas operator sets agent version metadata in application state on startup
(similar to what unit agents do for their units)
2. controller api address changes (eg going to HA) trigger an operator restart
(and hence new addresses are used)
3. juju upgrades will trigger caas operator restart with an updated docker image

Also a driveby fix for permission checks removing a caas unit.

A fair bit of boilerplate in this PR to add the necessary facade API changes. Not a great deal of logic changes. The tools metadata setting uses a common API plugin. The API address watching also uses a common API plugin.

## QA steps

bootstrap caas model and deploy a charm
observe tools metadata being set
enable ha and observe operator restart
exec into the operator and check the agent file for new addresses
upgrade juju and observe an operator restart using new docker image

