### PR TITLE
Credential validation worker is a flag that switches off/on other workers.

### DIFF
--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -41,7 +41,9 @@ func (c *Facade) ModelCredential() (base.StoredCredential, bool, error) {
 	}
 
 	if !out.Exists {
-		return emptyResult, false, nil
+		// On some clouds, model credential may not be required.
+		// So, it may be valid for models to not have a credential set.
+		return base.StoredCredential{Valid: out.Valid}, false, nil
 	}
 
 	credentialTag, err := names.ParseCloudCredentialTag(out.CloudCredential)

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -20,7 +20,7 @@ import (
 type BackendSuite struct {
 	coretesting.BaseSuite
 
-	state   *testState
+	state   *mockState
 	backend credentialvalidator.Backend
 }
 
@@ -80,8 +80,8 @@ func (s *BackendSuite) TestModelCredentialUnsetSupported(c *gc.C) {
 	s.state.CheckCallNames(c, "Model", "CloudCredential", "ModelTag", "Cloud")
 }
 
-func newMockState() *testState {
-	b := &testState{
+func newMockState() *mockState {
+	b := &mockState{
 		Stub:        &testing.Stub{},
 		aCredential: statetesting.NewEmptyCredential(),
 		aCloud: cloud.Cloud{
@@ -98,7 +98,7 @@ func newMockState() *testState {
 	return b
 }
 
-type testState struct {
+type mockState struct {
 	*testing.Stub
 
 	aCloud      cloud.Cloud
@@ -106,7 +106,7 @@ type testState struct {
 	aCredential state.Credential
 }
 
-func (b *testState) Model() (credentialvalidator.ModelAccessor, error) {
+func (b *mockState) Model() (credentialvalidator.ModelAccessor, error) {
 	b.AddCall("Model")
 	if err := b.NextErr(); err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func (b *testState) Model() (credentialvalidator.ModelAccessor, error) {
 	return b.aModel, nil
 }
 
-func (b *testState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+func (b *mockState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
 	b.AddCall("CloudCredential", tag)
 	if err := b.NextErr(); err != nil {
 		return state.Credential{}, err
@@ -122,17 +122,17 @@ func (b *testState) CloudCredential(tag names.CloudCredentialTag) (state.Credent
 	return b.aCredential, nil
 }
 
-func (b *testState) WatchCredential(tag names.CloudCredentialTag) state.NotifyWatcher {
+func (b *mockState) WatchCredential(tag names.CloudCredentialTag) state.NotifyWatcher {
 	b.AddCall("WatchCredential", tag)
 	return apiservertesting.NewFakeNotifyWatcher()
 }
 
-func (b *testState) InvalidateModelCredential(reason string) error {
+func (b *mockState) InvalidateModelCredential(reason string) error {
 	b.AddCall("InvalidateModelCredential", reason)
 	return b.NextErr()
 }
 
-func (b *testState) Cloud(name string) (cloud.Cloud, error) {
+func (b *mockState) Cloud(name string) (cloud.Cloud, error) {
 	b.AddCall("Cloud", name)
 	if err := b.NextErr(); err != nil {
 		return cloud.Cloud{}, err

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -1,0 +1,166 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialvalidator_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/facades/agent/credentialvalidator"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type BackendSuite struct {
+	coretesting.BaseSuite
+
+	state   *testState
+	backend credentialvalidator.Backend
+}
+
+var _ = gc.Suite(&BackendSuite{})
+
+func (s *BackendSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.state = newMockState()
+
+	s.backend = credentialvalidator.NewBackend(s.state)
+}
+
+func (s *BackendSuite) TestModelUsesCredential(c *gc.C) {
+	uses, err := s.backend.ModelUsesCredential(s.state.aModel.credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uses, jc.IsTrue)
+	s.state.CheckCallNames(c, "Model", "CloudCredential")
+}
+
+func (s *BackendSuite) TestModelUsesCredentialUnset(c *gc.C) {
+	s.state.aModel.credentialSet = false
+	uses, err := s.backend.ModelUsesCredential(s.state.aModel.credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uses, jc.IsFalse)
+	s.state.CheckCallNames(c, "Model", "CloudCredential")
+}
+
+func (s *BackendSuite) TestModelUsesCredentialWrongCredential(c *gc.C) {
+	uses, err := s.backend.ModelUsesCredential(names.NewCloudCredentialTag("foo/bob/two"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uses, jc.IsFalse)
+	s.state.CheckCallNames(c, "Model", "CloudCredential")
+}
+
+func (s *BackendSuite) TestModelCredentialUnsetNotSupported(c *gc.C) {
+	s.state.aModel.credentialSet = false
+	mc, err := s.backend.ModelCredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mc, gc.DeepEquals, &credentialvalidator.ModelCredential{
+		Exists:     false,
+		Credential: names.CloudCredentialTag{},
+		Valid:      false,
+	})
+	s.state.CheckCallNames(c, "Model", "CloudCredential", "ModelTag", "Cloud")
+}
+
+func (s *BackendSuite) TestModelCredentialUnsetSupported(c *gc.C) {
+	s.state.aModel.credentialSet = false
+	s.state.aCloud.AuthTypes = cloud.AuthTypes{cloud.EmptyAuthType}
+	mc, err := s.backend.ModelCredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mc, gc.DeepEquals, &credentialvalidator.ModelCredential{
+		Exists:     false,
+		Credential: names.CloudCredentialTag{},
+		Valid:      true,
+	})
+	s.state.CheckCallNames(c, "Model", "CloudCredential", "ModelTag", "Cloud")
+}
+
+func newMockState() *testState {
+	b := &testState{
+		Stub:        &testing.Stub{},
+		aCredential: statetesting.NewEmptyCredential(),
+		aCloud: cloud.Cloud{
+			Name:      "stratus",
+			Type:      "low",
+			AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+		},
+	}
+	b.aModel = &mockModel{
+		Stub:          b.Stub,
+		credentialTag: names.NewCloudCredentialTag("foo/bob/one"),
+		credentialSet: true,
+	}
+	return b
+}
+
+type testState struct {
+	*testing.Stub
+
+	aCloud      cloud.Cloud
+	aModel      *mockModel
+	aCredential state.Credential
+}
+
+func (b *testState) Model() (credentialvalidator.ModelAccessor, error) {
+	b.AddCall("Model")
+	if err := b.NextErr(); err != nil {
+		return nil, err
+	}
+	return b.aModel, nil
+}
+
+func (b *testState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+	b.AddCall("CloudCredential", tag)
+	if err := b.NextErr(); err != nil {
+		return state.Credential{}, err
+	}
+	return b.aCredential, nil
+}
+
+func (b *testState) WatchCredential(tag names.CloudCredentialTag) state.NotifyWatcher {
+	b.AddCall("WatchCredential", tag)
+	return apiservertesting.NewFakeNotifyWatcher()
+}
+
+func (b *testState) InvalidateModelCredential(reason string) error {
+	b.AddCall("InvalidateModelCredential", reason)
+	return b.NextErr()
+}
+
+func (b *testState) Cloud(name string) (cloud.Cloud, error) {
+	b.AddCall("Cloud", name)
+	if err := b.NextErr(); err != nil {
+		return cloud.Cloud{}, err
+	}
+	return b.aCloud, nil
+}
+
+type mockModel struct {
+	*testing.Stub
+
+	modelTag names.ModelTag
+
+	credentialTag names.CloudCredentialTag
+	credentialSet bool
+
+	cloud string
+}
+
+func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+	m.MethodCall(m, "CloudCredential")
+	return m.credentialTag, m.credentialSet
+}
+
+func (m *mockModel) ModelTag() names.ModelTag {
+	m.MethodCall(m, "ModelTag")
+	return m.modelTag
+}
+
+func (m *mockModel) Cloud() string {
+	return m.cloud
+}

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -31,7 +31,7 @@ var _ CredentialValidator = (*CredentialValidatorAPI)(nil)
 
 // NewCredentialValidatorAPI creates a new CredentialValidator API endpoint on server-side.
 func NewCredentialValidatorAPI(ctx facade.Context) (*CredentialValidatorAPI, error) {
-	return internalNewCredentialValidatorAPI(NewBackend(ctx.State()), ctx.Resources(), ctx.Auth())
+	return internalNewCredentialValidatorAPI(NewBackend(NewStateShim(ctx.State())), ctx.Resources(), ctx.Auth())
 }
 
 func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*CredentialValidatorAPI, error) {

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -58,8 +58,6 @@ func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
 
 func (s *CredentialValidatorSuite) TestModelCredentialNotNeeded(c *gc.C) {
 	s.backend.mc.Exists = false
-	// In real life, these properties will not be set if Exists is false, so
-	// doing the same in test.
 	s.backend.mc.Credential = names.CloudCredentialTag{}
 	s.backend.mc.Valid = false
 	result, err := s.api.ModelCredential()

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -6,15 +6,24 @@ package credentialvalidator
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/state"
 )
 
+// ModelAccessor exposes Model methods needed by credential validator.
+type ModelAccessor interface {
+	CloudCredential() (names.CloudCredentialTag, bool)
+	ModelTag() names.ModelTag
+	Cloud() string
+}
+
 // StateAccessor exposes State methods needed by credential validator.
 type StateAccessor interface {
-	Model() (*state.Model, error)
+	Model() (ModelAccessor, error)
 	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
 	WatchCredential(names.CloudCredentialTag) state.NotifyWatcher
 	InvalidateModelCredential(reason string) error
+	Cloud(name string) (cloud.Cloud, error)
 }
 
 type stateShim struct {
@@ -24,4 +33,10 @@ type stateShim struct {
 // NewStateShim creates new state shim to be used by credential validator Facade.
 func NewStateShim(st *state.State) StateAccessor {
 	return &stateShim{st}
+}
+
+// Model returns model from this shim.
+func (s *stateShim) Model() (ModelAccessor, error) {
+	m, err := s.State.Model()
+	return m, err
 }

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -37,6 +37,5 @@ func NewStateShim(st *state.State) StateAccessor {
 
 // Model returns model from this shim.
 func (s *stateShim) Model() (ModelAccessor, error) {
-	m, err := s.State.Model()
-	return m, err
+	return s.State.Model()
 }

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -24,11 +24,32 @@ var (
 		"api-caller",
 		"api-config-watcher",
 		"clock",
+		"credential-validator-flag",
 		"is-responsible-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
 		"not-alive-flag",
 		"not-dead-flag",
+	}
+	requireValidCredentialModelWorkers = []string{
+		"action-pruner",          // tertiary dependency: will be inactive because migration workers will be inactive
+		"application-scaler",     // tertiary dependency: will be inactive because migration workers will be inactive
+		"charm-revision-updater", // tertiary dependency: will be inactive because migration workers will be inactive
+		"compute-provisioner",
+		"firewaller",
+		"instance-poller",
+		"machine-undertaker",      // tertiary dependency: will be inactive because migration workers will be inactive
+		"metric-worker",           // tertiary dependency: will be inactive because migration workers will be inactive
+		"migration-fortress",      // secondary dependency: will be inactive because depends on model-upgrader
+		"migration-inactive-flag", // secondary dependency: will be inactive because depends on model-upgrader
+		"migration-master",        // secondary dependency: will be inactive because depends on model-upgrader
+		"model-upgrader",
+		"remote-relations",      // tertiary dependency: will be inactive because migration workers will be inactive
+		"state-cleaner",         // tertiary dependency: will be inactive because migration workers will be inactive
+		"status-history-pruner", // tertiary dependency: will be inactive because migration workers will be inactive
+		"storage-provisioner",   // tertiary dependency: will be inactive because migration workers will be inactive
+		"undertaker",
+		"unit-assigner", // tertiary dependency: will be inactive because migration workers will be inactive
 	}
 	aliveModelWorkers = []string{
 		"action-pruner",

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1091,11 +1091,12 @@ func (s *MachineSuite) TestWorkersForHostedModelWithInvalidCredential(c *gc.C) {
 	s.PatchValue(&iaasModelManifolds, instrumented)
 
 	expectedWorkers := append(alwaysModelWorkers, aliveModelWorkers...)
-	// only expect workers that don't require valid credential
-	all := set.NewStrings(expectedWorkers...).Difference(
+	// Since this model's cloud credential is no longer valid,
+	// only the workers that don't require a valid credential should remain.
+	remainingWorkers := set.NewStrings(expectedWorkers...).Difference(
 		set.NewStrings(requireValidCredentialModelWorkers...))
 
-	matcher := agenttest.NewWorkerMatcher(c, tracker, uuid, all.SortedValues())
+	matcher := agenttest.NewWorkerMatcher(c, tracker, uuid, remainingWorkers.SortedValues())
 	s.assertJobWithState(c, state.JobManageModel, func(agent.Config, *state.State) {
 		agenttest.WaitMatch(c, matcher.Check, ReallyLongWait, st.StartSync)
 	})

--- a/worker/credentialvalidator/manifold.go
+++ b/worker/credentialvalidator/manifold.go
@@ -69,10 +69,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 func filterErrors(err error) error {
 	cause := errors.Cause(err)
-	if cause == ErrValidityChanged || cause == ErrModelCredentialChanged {
+	if cause == ErrValidityChanged ||
+		cause == ErrModelMissingCredentialRequired {
 		return dependency.ErrBounce
-	} else if cause == ErrModelDoesNotNeedCredential {
-		return dependency.ErrUninstall
 	}
 	return err
 }

--- a/worker/credentialvalidator/manifold_test.go
+++ b/worker/credentialvalidator/manifold_test.go
@@ -48,16 +48,10 @@ func (*ManifoldSuite) TestFilterErrChanged(c *gc.C) {
 	c.Check(err, gc.Equals, dependency.ErrBounce)
 }
 
-func (*ManifoldSuite) TestFilterErrModelCredentialChanged(c *gc.C) {
-	manifold := credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{})
-	err := manifold.Filter(credentialvalidator.ErrModelCredentialChanged)
-	c.Check(err, gc.Equals, dependency.ErrBounce)
-}
-
 func (*ManifoldSuite) TestFilterErrModelDoesNotNeedCredential(c *gc.C) {
 	manifold := credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{})
-	err := manifold.Filter(credentialvalidator.ErrModelDoesNotNeedCredential)
-	c.Check(err, gc.Equals, dependency.ErrUninstall)
+	err := manifold.Filter(credentialvalidator.ErrModelMissingCredentialRequired)
+	c.Check(err, gc.Equals, dependency.ErrBounce)
 }
 
 func (*ManifoldSuite) TestFilterOther(c *gc.C) {

--- a/worker/credentialvalidator/util_test.go
+++ b/worker/credentialvalidator/util_test.go
@@ -21,10 +21,16 @@ import (
 // mockFacade implements credentialvalidator.Facade for use in the tests.
 type mockFacade struct {
 	*testing.Stub
-	credential base.StoredCredential
+	credential *base.StoredCredential
 	exists     bool
 
 	watcher *watchertest.MockNotifyWatcher
+}
+
+func (m *mockFacade) setupModelHasNoCredential() {
+	m.credential.CloudCredential = ""
+	m.exists = false
+	m.watcher = nil
 }
 
 // ModelCredential is part of the credentialvalidator.Facade interface.
@@ -33,7 +39,7 @@ func (m *mockFacade) ModelCredential() (base.StoredCredential, bool, error) {
 	if err := m.NextErr(); err != nil {
 		return base.StoredCredential{}, false, err
 	}
-	return m.credential, m.exists, nil
+	return *m.credential, m.exists, nil
 }
 
 // WatchCredential is part of the credentialvalidator.Facade interface.


### PR DESCRIPTION
## Description of change

This PR changes credential validation worker to act as a flag to ensure that we can switch on/off other workers that depend on the model having valid authentication setup. What setup is considered to be valid depends on what cloud the model is on. Since the workers have a hierarchy and depend on each other, we test that the workers that depend on valid authentication are manipulated as well as the workers that depend on them.

To change the worker to be a flag, this PR augments worker implementation by implementing the necessary interface and by adjusting the supporting api. This also changed existing tests to ensure that all the models have this worker running, including the models that do not have credentials set. The central part of this change is clarifying the definition of model authentication validity - model authentication is valid if a model has a valid credential set or, if the model credential is unset, it is valid as long as the model's cloud does not require authentication.

This is an intermediary implementation of credential validation worker. Once we support changing (i.e. replacing) model credential, the worker will additionally watch model credential reference. 
