### PR TITLE
Adds Container Module to New LXD Server

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -17,10 +17,10 @@ import (
 
 const (
 	UserNamespacePrefix = "user."
-	UserDataKey = UserNamespacePrefix + "user-data"
-	NetworkConfigKey = UserNamespacePrefix + "network-config"
-	JujuModelKey = UserNamespacePrefix + "juju-model"
-	AutoStartKey = "boot.autostart"
+	UserDataKey         = UserNamespacePrefix + "user-data"
+	NetworkConfigKey    = UserNamespacePrefix + "network-config"
+	JujuModelKey        = UserNamespacePrefix + "juju-model"
+	AutoStartKey        = "boot.autostart"
 )
 
 // ContainerSpec represents the data required to create a new container.

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -1,0 +1,333 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/network"
+	"github.com/juju/utils/arch"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+const UserNamespacePrefix = "user."
+
+// ContainerSpec represents the data required to create a new container.
+type ContainerSpec struct {
+	Name     string
+	Image    SourcedImage
+	Devices  map[string]device
+	Config   map[string]string
+	Profiles []string
+}
+
+// Normalise config ensures that configuration keys are prefixed with the
+// "user" namespace where appropriate.
+func (c *ContainerSpec) NormaliseConfig() {
+	newConfig := make(map[string]string, len(c.Config))
+	for k, v := range c.Config {
+		if strings.HasPrefix(k, UserNamespacePrefix) || strings.HasPrefix(k, "limits.") || k == "boot.autostart" {
+			newConfig[k] = v
+			continue
+		}
+		newConfig[UserNamespacePrefix+k] = v
+	}
+	c.Config = newConfig
+}
+
+// Container extends the upstream LXD container type.
+type Container struct {
+	api.Container
+}
+
+// Metadata returns the value from container config for the input key.
+// Such values are stored with the "user" namespace prefix.
+func (c *Container) Metadata(key string) string {
+	return c.Config[UserNamespacePrefix+key]
+}
+
+// Arch returns the architecture of the container.
+func (c *Container) Arch() string {
+	return arch.NormaliseArch(c.Architecture)
+}
+
+// CPUs returns the configured limit for number of container CPU cores.
+// If unset, zero is returned.
+func (c *Container) CPUs() uint {
+	var cores uint = 0
+	if v := c.Config["limits.cpu"]; v != "" {
+		fmt.Sscanf(v, "%d", &cores)
+	}
+	return cores
+}
+
+// Mem returns the configured limit for container memory in MiB.
+func (c *Container) Mem() uint {
+	v := c.Config["limits.memory"]
+	if v == "" {
+		return 0
+	}
+
+	bytes, err := shared.ParseByteSizeString(v)
+	if err != nil {
+		logger.Errorf("failed to parse %q into bytes, ignoring err: %s", v, err)
+		return 0
+	}
+
+	const oneMiB = 1024 * 1024
+	mib := bytes / oneMiB
+	if mib > math.MaxUint32 {
+		logger.Errorf("byte string %q overflowed uint32, using max value", v)
+		return math.MaxUint32
+	}
+
+	return uint(mib)
+}
+
+// AddDisk modifies updates the container's devices map to represent a disk
+// device described by the input arguments.
+// If the device already exists, an error is returned
+func (c *Container) AddDisk(name, path, source, pool string, readOnly bool) error {
+	if _, ok := c.Devices[name]; ok {
+		return errors.Errorf("container %q already has a device %q", c.Name, name)
+	}
+
+	if c.Devices == nil {
+		c.Devices = map[string]device{}
+	}
+	c.Devices[name] = map[string]string{
+		"path":   path,
+		"source": source,
+	}
+	if pool != "" {
+		c.Devices[name]["pool"] = pool
+	}
+	if readOnly {
+		c.Devices[name]["readonly"] = "true"
+	}
+	return nil
+}
+
+// aliveStatus is the list of status strings that indicate
+// a container is "alive".
+var aliveStatus = []string{
+	api.Starting.String(),
+	api.Started.String(),
+	api.Running.String(),
+	api.Stopping.String(),
+	api.Stopped.String(),
+}
+
+// AliveContainers returns the list of containers based on the input namespace
+// prefixed that are in a status indicating they are "alive".
+func (s *Server) AliveContainers(prefix string) ([]Container, error) {
+	c, err := s.FilterContainers(prefix, aliveStatus...)
+	return c, errors.Trace(err)
+}
+
+// FilterContainers retrieves the list of containers from the server and filters
+// them based on the input namespace prefix and any supplied statuses.
+func (s *Server) FilterContainers(prefix string, statuses ...string) ([]Container, error) {
+	containers, err := s.GetContainers()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var results []Container
+	for _, c := range containers {
+		if prefix != "" && !strings.HasPrefix(c.Name, prefix) {
+			continue
+		}
+		if len(statuses) > 0 && !containerHasStatus(c, statuses) {
+			continue
+		}
+		results = append(results, Container{c})
+	}
+	return results, nil
+}
+
+// ContainerAddresses gets usable network addresses for the container
+// identified by the input name.
+func (s *Server) ContainerAddresses(name string) ([]network.Address, error) {
+	state, _, err := s.GetContainerState(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	networks := state.Network
+	if networks == nil {
+		return []network.Address{}, nil
+	}
+
+	var results []network.Address
+	for netName, net := range networks {
+		// TODO (manadart 2018-05-29): Should this check localBridgeName too?
+		if netName == network.DefaultLXCBridge || netName == network.DefaultLXDBridge {
+			continue
+		}
+		for _, addr := range net.Addresses {
+			netAddr := network.NewAddress(addr.Address)
+			if netAddr.Scope == network.ScopeLinkLocal || netAddr.Scope == network.ScopeMachineLocal {
+				logger.Tracef("ignoring address %q for container %q", addr, name)
+				continue
+			}
+			results = append(results, netAddr)
+		}
+	}
+	return results, nil
+}
+
+// CreateContainerFromSpec creates a new container based on the input spec,
+// and starts it immediately.
+// If the container fails to be started, it is removed.
+// Upon successful creation and start, the container is returned.
+func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error) {
+	spec.NormaliseConfig()
+
+	req := api.ContainersPost{
+		Name: spec.Name,
+		ContainerPut: api.ContainerPut{
+			Profiles:  spec.Profiles,
+			Devices:   spec.Devices,
+			Config:    spec.Config,
+			Ephemeral: false,
+		},
+	}
+	op, err := s.CreateContainerFromImage(spec.Image.LXDServer, *spec.Image.Image, req)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err := op.Wait(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	opInfo, err := op.GetTarget()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if opInfo.StatusCode != api.Success {
+		return nil, fmt.Errorf("container creation failed: %s", opInfo.Err)
+	}
+
+	if err := s.StartContainer(spec.Name); err != nil {
+		if remErr := s.RemoveContainer(spec.Name); remErr != nil {
+			logger.Errorf("failed to remove container after unsuccessful start: %s", remErr.Error())
+		}
+		return nil, errors.Trace(err)
+	}
+
+	container, _, err := s.GetContainer(spec.Name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c := Container{*container}
+	return &c, nil
+}
+
+func (s *Server) StartContainer(name string) error {
+	req := api.ContainerStatePut{
+		Action:   "start",
+		Timeout:  -1,
+		Force:    false,
+		Stateful: false,
+	}
+	op, err := s.UpdateContainerState(name, req, "")
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := op.Wait(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// Remove containers stops and deletes containers matching the input list of
+// names. Any failed removals are indicated in the returned error.
+func (s *Server) RemoveContainers(names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	var failed []string
+	for _, name := range names {
+		if err := s.RemoveContainer(name); err != nil {
+			failed = append(failed, name)
+			logger.Errorf("removing container %q: %v", name, err)
+		}
+	}
+	if len(failed) != 0 {
+		return errors.Errorf("failed to remove containers: %s", strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// Remove container first ensures that the container is stopped,
+// then deletes it.
+func (s *Server) RemoveContainer(name string) error {
+	state, eTag, err := s.GetContainerState(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if state.StatusCode != api.Stopped {
+		req := api.ContainerStatePut{
+			Action:   "stop",
+			Timeout:  -1,
+			Force:    true,
+			Stateful: false,
+		}
+		op, err := s.UpdateContainerState(name, req, eTag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := op.Wait(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	op, err := s.DeleteContainer(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := op.Wait(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// WriteContainer writes the current representation of the input container to
+// the server.
+func (s *Server) WriteContainer(c *Container) error {
+	resp, err := s.UpdateContainer(c.Name, c.Writable(), "")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := resp.Wait(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// containerHasStatus returns true if the input container has a status
+// matching one from the input list.
+//
+// TODO (manadart 2018-05-29) This logic mimics that previously in lxdclient.
+// api.Container appears to have a plain string status,
+// which if always populated, and congruent with the status code,
+// could be used directly for comparison.
+func containerHasStatus(container api.Container, statuses []string) bool {
+	for _, status := range statuses {
+		if container.StatusCode.String() == status {
+			return true
+		}
+	}
+	return false
+}

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -315,10 +315,11 @@ func (s *containerSuite) TestCreateContainerFromSpecSuccess(c *gc.C) {
 	}
 
 	// Container created, started and returned.
+	exp := cSvr.EXPECT()
 	gomock.InOrder(
-		cSvr.EXPECT().CreateContainerFromImage(cSvr, image, createReq).Return(createOp, nil),
-		cSvr.EXPECT().UpdateContainerState(spec.Name, startReq, "").Return(startOp, nil),
-		cSvr.EXPECT().GetContainer(spec.Name).Return(&api.Container{}, lxdtesting.ETag, nil),
+		exp.CreateContainerFromImage(cSvr, image, createReq).Return(createOp, nil),
+		exp.UpdateContainerState(spec.Name, startReq, "").Return(startOp, nil),
+		exp.GetContainer(spec.Name).Return(&api.Container{}, lxdtesting.ETag, nil),
 	)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
@@ -381,12 +382,13 @@ func (s *containerSuite) TestCreateContainerFromSpecStartFailed(c *gc.C) {
 	}
 
 	// Container created, starting fails, container state checked, container deleted.
+	exp := cSvr.EXPECT()
 	gomock.InOrder(
-		cSvr.EXPECT().CreateContainerFromImage(cSvr, image, createReq).Return(createOp, nil),
-		cSvr.EXPECT().UpdateContainerState(spec.Name, startReq, "").Return(nil, errors.New("start failed")),
-		cSvr.EXPECT().GetContainerState(spec.Name).Return(
+		exp.CreateContainerFromImage(cSvr, image, createReq).Return(createOp, nil),
+		exp.UpdateContainerState(spec.Name, startReq, "").Return(nil, errors.New("start failed")),
+		exp.GetContainerState(spec.Name).Return(
 			&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil),
-		cSvr.EXPECT().DeleteContainer(spec.Name).Return(deleteOp, nil),
+		exp.DeleteContainer(spec.Name).Return(deleteOp, nil),
 	)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
@@ -416,11 +418,12 @@ func (s *containerSuite) TestRemoveContainersSuccess(c *gc.C) {
 	}
 
 	// Container c1 is already stopped. Container c2 is started and stopped before deletion.
-	cSvr.EXPECT().GetContainerState("c1").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
-	cSvr.EXPECT().DeleteContainer("c1").Return(deleteOp, nil)
-	cSvr.EXPECT().GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
-	cSvr.EXPECT().UpdateContainerState("c2", stopReq, lxdtesting.ETag).Return(stopOp, nil)
-	cSvr.EXPECT().DeleteContainer("c2").Return(deleteOp, nil)
+	exp := cSvr.EXPECT()
+	exp.GetContainerState("c1").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
+	exp.DeleteContainer("c1").Return(deleteOp, nil)
+	exp.GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
+	exp.UpdateContainerState("c2", stopReq, lxdtesting.ETag).Return(stopOp, nil)
+	exp.DeleteContainer("c2").Return(deleteOp, nil)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -448,13 +451,14 @@ func (s *containerSuite) TestRemoveContainersPartialFailure(c *gc.C) {
 	}
 
 	// Container c1, c2 already stopped, but delete fails. Container c2 is started and stopped before deletion.
-	cSvr.EXPECT().GetContainerState("c1").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
-	cSvr.EXPECT().DeleteContainer("c1").Return(nil, errors.New("deletion failed"))
-	cSvr.EXPECT().GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
-	cSvr.EXPECT().DeleteContainer("c2").Return(nil, errors.New("deletion failed"))
-	cSvr.EXPECT().GetContainerState("c3").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
-	cSvr.EXPECT().UpdateContainerState("c3", stopReq, lxdtesting.ETag).Return(stopOp, nil)
-	cSvr.EXPECT().DeleteContainer("c3").Return(deleteOp, nil)
+	exp := cSvr.EXPECT()
+	exp.GetContainerState("c1").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
+	exp.DeleteContainer("c1").Return(nil, errors.New("deletion failed"))
+	exp.GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
+	exp.DeleteContainer("c2").Return(nil, errors.New("deletion failed"))
+	exp.GetContainerState("c3").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
+	exp.UpdateContainerState("c3", stopReq, lxdtesting.ETag).Return(stopOp, nil)
+	exp.DeleteContainer("c3").Return(deleteOp, nil)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -25,26 +25,6 @@ type containerSuite struct {
 
 var _ = gc.Suite(&containerSuite{})
 
-func (s *containerSuite) TestContainerSpecNormaliseConfig(c *gc.C) {
-	cfg := lxd.ContainerSpec{
-		Config: map[string]string{
-			"limits.cpu":        "2",
-			"limits.mem":        "2GB",
-			"boot.autostart":    "true",
-			tags.JujuController: "something",
-		},
-	}
-	cfg.NormaliseConfig()
-
-	expected := map[string]string{
-		"limits.cpu":                "2",
-		"limits.mem":                "2GB",
-		"boot.autostart":            "true",
-		"user.juju-controller-uuid": "something",
-	}
-	c.Check(cfg.Config, gc.DeepEquals, expected)
-}
-
 func (s *containerSuite) TestContainerMetadata(c *gc.C) {
 	container := lxd.Container{}
 	container.Config = map[string]string{"user.juju-controller-uuid": "something"}

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -1,0 +1,464 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd_test
+
+import (
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/osarch"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/container/lxd"
+	lxdtesting "github.com/juju/juju/container/lxd/testing"
+	"github.com/juju/juju/environs/tags"
+	"github.com/juju/juju/network"
+)
+
+type containerSuite struct {
+	lxdtesting.BaseSuite
+}
+
+var _ = gc.Suite(&containerSuite{})
+
+func (s *containerSuite) TestContainerSpecNormaliseConfig(c *gc.C) {
+	cfg := lxd.ContainerSpec{
+		Config: map[string]string{
+			"limits.cpu":        "2",
+			"limits.mem":        "2GB",
+			"boot.autostart":    "true",
+			tags.JujuController: "something",
+		},
+	}
+	cfg.NormaliseConfig()
+
+	expected := map[string]string{
+		"limits.cpu":                "2",
+		"limits.mem":                "2GB",
+		"boot.autostart":            "true",
+		"user.juju-controller-uuid": "something",
+	}
+	c.Check(cfg.Config, gc.DeepEquals, expected)
+}
+
+func (s *containerSuite) TestContainerMetadata(c *gc.C) {
+	container := lxd.Container{}
+	container.Config = map[string]string{"user.juju-controller-uuid": "something"}
+	c.Check(container.Metadata(tags.JujuController), gc.Equals, "something")
+}
+
+func (s *containerSuite) TestContainerArch(c *gc.C) {
+	lxdArch, _ := osarch.ArchitectureName(osarch.ARCH_64BIT_INTEL_X86)
+	container := lxd.Container{}
+	container.Architecture = lxdArch
+	c.Check(container.Arch(), gc.Equals, arch.AMD64)
+}
+
+func (s *containerSuite) TestContainerCPUs(c *gc.C) {
+	container := lxd.Container{}
+	container.Config = map[string]string{"limits.cpu": "2"}
+	c.Check(container.CPUs(), gc.Equals, uint(2))
+}
+
+func (s *containerSuite) TestContainerMem(c *gc.C) {
+	container := lxd.Container{}
+	container.Config = map[string]string{"limits.memory": "1MB"}
+	c.Check(container.Mem(), gc.Equals, uint(1))
+}
+
+func (s *containerSuite) TestContainerAddDiskNoDevices(c *gc.C) {
+	container := lxd.Container{}
+	err := container.AddDisk("root", "/", "source", "default", true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := map[string]string{
+		"path":     "/",
+		"source":   "source",
+		"pool":     "default",
+		"readonly": "true",
+	}
+	c.Check(container.Devices["root"], gc.DeepEquals, expected)
+}
+
+func (s *containerSuite) TestContainerAddDiskDevicePresentError(c *gc.C) {
+	container := lxd.Container{}
+	container.Name = "seeyounexttuesday"
+	container.Devices = map[string]map[string]string{"root": {}}
+
+	err := container.AddDisk("root", "/", "source", "default", true)
+	c.Check(err, gc.ErrorMatches, `container "seeyounexttuesday" already has a device "root"`)
+}
+
+func (s *containerSuite) TestFilterContainers(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	matching := []api.Container{
+		{
+			Name:       "prefix-c1",
+			StatusCode: api.Starting,
+		},
+		{
+			Name:       "prefix-c2",
+			StatusCode: api.Stopped,
+		},
+	}
+	ret := append(matching, []api.Container{
+		{
+			Name:       "prefix-c3",
+			StatusCode: api.Started,
+		},
+		{
+			Name:       "not-prefix-c4",
+			StatusCode: api.Stopped,
+		},
+	}...)
+	cSvr.EXPECT().GetContainers().Return(ret, nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	filtered, err := jujuSvr.FilterContainers("prefix", "Starting", "Stopped")
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := make([]lxd.Container, len(matching))
+	for i, v := range matching {
+		expected[i] = lxd.Container{v}
+	}
+
+	c.Check(filtered, gc.DeepEquals, expected)
+}
+
+func (s *containerSuite) TestAliveContainers(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	matching := []api.Container{
+		{
+			Name:       "c1",
+			StatusCode: api.Starting,
+		},
+		{
+			Name:       "c2",
+			StatusCode: api.Stopped,
+		},
+		{
+			Name:       "c3",
+			StatusCode: api.Running,
+		},
+	}
+	ret := append(matching, api.Container{
+		Name:       "c4",
+		StatusCode: api.Frozen,
+	})
+	cSvr.EXPECT().GetContainers().Return(ret, nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	filtered, err := jujuSvr.AliveContainers("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := make([]lxd.Container, len(matching))
+	for i, v := range matching {
+		expected[i] = lxd.Container{v}
+	}
+	c.Check(filtered, gc.DeepEquals, expected)
+}
+
+func (s *containerSuite) TestContainerAddresses(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	state := api.ContainerState{
+		Network: map[string]api.ContainerStateNetwork{
+			"eth0": {
+				Addresses: []api.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.0.8.173",
+						Netmask: "24",
+						Scope:   "global",
+					},
+					{
+						Family:  "inet6",
+						Address: "fe80::216:3eff:fe3b:e582",
+						Netmask: "64",
+						Scope:   "link",
+					},
+				},
+			},
+			"lo": {
+				Addresses: []api.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "127.0.0.1",
+						Netmask: "8",
+						Scope:   "local",
+					},
+					{
+						Family:  "inet6",
+						Address: "::1",
+						Netmask: "128",
+						Scope:   "local",
+					},
+				},
+			},
+			"lxcbr0": {
+				Addresses: []api.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.0.5.12",
+						Netmask: "24",
+						Scope:   "global",
+					},
+					{
+						Family:  "inet6",
+						Address: "fe80::216:3eff:fe3b:e432",
+						Netmask: "64",
+						Scope:   "link",
+					},
+				},
+			},
+			"lxdbr0": {
+				Addresses: []api.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.0.6.17",
+						Netmask: "24",
+						Scope:   "global",
+					},
+					{
+						Family:  "inet6",
+						Address: "fe80::5c9b:b2ff:feaf:4cf2",
+						Netmask: "64",
+						Scope:   "link",
+					},
+				},
+			},
+		},
+	}
+	cSvr.EXPECT().GetContainerState("c1").Return(&state, lxdtesting.ETag, nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := jujuSvr.ContainerAddresses("c1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := []network.Address{
+		{
+			Value: "10.0.8.173",
+			Type:  network.IPv4Address,
+			Scope: network.ScopeCloudLocal,
+		},
+	}
+	c.Check(addrs, gc.DeepEquals, expected)
+}
+
+func (s *containerSuite) TestCreateContainerFromSpecSuccess(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	// Operation arrangements.
+	createOp := lxdtesting.NewMockRemoteOperation(ctrl)
+	createOp.EXPECT().Wait().Return(nil)
+	createOp.EXPECT().GetTarget().Return(&api.Operation{StatusCode: api.Success}, nil)
+
+	startOp := lxdtesting.NewMockOperation(ctrl)
+	startOp.EXPECT().Wait().Return(nil)
+
+	// Request data.
+	image := api.Image{Filename: "container-image"}
+	spec := lxd.ContainerSpec{
+		Name: "c1",
+		Image: lxd.SourcedImage{
+			Image:     &image,
+			LXDServer: cSvr,
+		},
+		Profiles: []string{"default"},
+		Devices: map[string]map[string]string{
+			"eth0": {
+				"parent":  network.DefaultLXDBridge,
+				"type":    "nic",
+				"nictype": "bridged",
+			},
+		},
+		Config: map[string]string{
+			"limits.cpu": "2",
+		},
+	}
+
+	createReq := api.ContainersPost{
+		Name: spec.Name,
+		ContainerPut: api.ContainerPut{
+			Profiles:  spec.Profiles,
+			Devices:   spec.Devices,
+			Config:    spec.Config,
+			Ephemeral: false,
+		},
+	}
+
+	startReq := api.ContainerStatePut{
+		Action:   "start",
+		Timeout:  -1,
+		Force:    false,
+		Stateful: false,
+	}
+
+	// Container created, started and returned.
+	gomock.InOrder(
+		cSvr.EXPECT().CreateContainerFromImage(cSvr, image, createReq).Return(createOp, nil),
+		cSvr.EXPECT().UpdateContainerState(spec.Name, startReq, "").Return(startOp, nil),
+		cSvr.EXPECT().GetContainer(spec.Name).Return(&api.Container{}, lxdtesting.ETag, nil),
+	)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	container, err := jujuSvr.CreateContainerFromSpec(spec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(container, gc.NotNil)
+}
+
+func (s *containerSuite) TestCreateContainerFromSpecStartFailed(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	// Operation arrangements.
+	createOp := lxdtesting.NewMockRemoteOperation(ctrl)
+	createOp.EXPECT().Wait().Return(nil)
+	createOp.EXPECT().GetTarget().Return(&api.Operation{StatusCode: api.Success}, nil)
+
+	deleteOp := lxdtesting.NewMockOperation(ctrl)
+	deleteOp.EXPECT().Wait().Return(nil)
+
+	// Request data.
+	image := api.Image{Filename: "container-image"}
+	spec := lxd.ContainerSpec{
+		Name: "c1",
+		Image: lxd.SourcedImage{
+			Image:     &image,
+			LXDServer: cSvr,
+		},
+		Profiles: []string{"default"},
+		Devices: map[string]map[string]string{
+			"eth0": {
+				"parent":  network.DefaultLXDBridge,
+				"type":    "nic",
+				"nictype": "bridged",
+			},
+		},
+		Config: map[string]string{
+			"limits.cpu": "2",
+		},
+	}
+
+	createReq := api.ContainersPost{
+		Name: spec.Name,
+		ContainerPut: api.ContainerPut{
+			Profiles:  spec.Profiles,
+			Devices:   spec.Devices,
+			Config:    spec.Config,
+			Ephemeral: false,
+		},
+	}
+
+	startReq := api.ContainerStatePut{
+		Action:   "start",
+		Timeout:  -1,
+		Force:    false,
+		Stateful: false,
+	}
+
+	// Container created, starting fails, container state checked, container deleted.
+	gomock.InOrder(
+		cSvr.EXPECT().CreateContainerFromImage(cSvr, image, createReq).Return(createOp, nil),
+		cSvr.EXPECT().UpdateContainerState(spec.Name, startReq, "").Return(nil, errors.New("start failed")),
+		cSvr.EXPECT().GetContainerState(spec.Name).Return(
+			&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil),
+		cSvr.EXPECT().DeleteContainer(spec.Name).Return(deleteOp, nil),
+	)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	container, err := jujuSvr.CreateContainerFromSpec(spec)
+	c.Assert(err, gc.ErrorMatches, "start failed")
+	c.Check(container, gc.IsNil)
+}
+
+func (s *containerSuite) TestRemoveContainersSuccess(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	stopOp := lxdtesting.NewMockOperation(ctrl)
+	stopOp.EXPECT().Wait().Return(nil)
+
+	deleteOp := lxdtesting.NewMockOperation(ctrl)
+	deleteOp.EXPECT().Wait().Return(nil).Times(2)
+
+	stopReq := api.ContainerStatePut{
+		Action:   "stop",
+		Timeout:  -1,
+		Force:    true,
+		Stateful: false,
+	}
+
+	// Container c1 is already stopped. Container c2 is started and stopped before deletion.
+	cSvr.EXPECT().GetContainerState("c1").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
+	cSvr.EXPECT().DeleteContainer("c1").Return(deleteOp, nil)
+	cSvr.EXPECT().GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
+	cSvr.EXPECT().UpdateContainerState("c2", stopReq, lxdtesting.ETag).Return(stopOp, nil)
+	cSvr.EXPECT().DeleteContainer("c2").Return(deleteOp, nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = jujuSvr.RemoveContainers([]string{"c1", "c2"})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *containerSuite) TestRemoveContainersPartialFailure(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+
+	stopOp := lxdtesting.NewMockOperation(ctrl)
+	stopOp.EXPECT().Wait().Return(nil)
+
+	deleteOp := lxdtesting.NewMockOperation(ctrl)
+	deleteOp.EXPECT().Wait().Return(nil)
+
+	stopReq := api.ContainerStatePut{
+		Action:   "stop",
+		Timeout:  -1,
+		Force:    true,
+		Stateful: false,
+	}
+
+	// Container c1, c2 already stopped, but delete fails. Container c2 is started and stopped before deletion.
+	cSvr.EXPECT().GetContainerState("c1").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
+	cSvr.EXPECT().DeleteContainer("c1").Return(nil, errors.New("deletion failed"))
+	cSvr.EXPECT().GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Stopped}, lxdtesting.ETag, nil)
+	cSvr.EXPECT().DeleteContainer("c2").Return(nil, errors.New("deletion failed"))
+	cSvr.EXPECT().GetContainerState("c3").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
+	cSvr.EXPECT().UpdateContainerState("c3", stopReq, lxdtesting.ETag).Return(stopOp, nil)
+	cSvr.EXPECT().DeleteContainer("c3").Return(deleteOp, nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = jujuSvr.RemoveContainers([]string{"c1", "c2", "c3"})
+	c.Assert(err, gc.ErrorMatches, "failed to remove containers: c1, c2")
+}

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -15,15 +15,7 @@ var (
 	NetworkDevicesFromConfig = networkDevicesFromConfig
 	CheckBridgeConfigFile    = checkBridgeConfigFile
 	SeriesRemoteAliases      = seriesRemoteAliases
-	GetImageSources          = func(mgr container.Manager) ([]RemoteServer, error) {
-		return mgr.(*containerManager).getImageSources()
-	}
-	VerifyNICsWithConfigFile = func(
-		svr *Server, nics map[string]map[string]string, reader func(string) ([]byte, error),
-	) error {
-		return svr.verifyNICsWithConfigFile(nics, reader)
-	}
-	ErrIPV6NotSupported = errIPV6NotSupported
+	ErrIPV6NotSupported      = errIPV6NotSupported
 )
 
 type patcher interface {
@@ -39,4 +31,12 @@ func PatchConnectRemote(patcher patcher, remotes map[string]lxdclient.ImageServe
 		}
 		return nil, errors.New("unrecognised remote server")
 	})
+}
+
+func GetImageSources(mgr container.Manager) ([]RemoteServer, error) {
+	return mgr.(*containerManager).getImageSources()
+}
+
+func VerifyNICsWithConfigFile(svr *Server, nics map[string]device, reader func(string) ([]byte, error)) error {
+	return svr.verifyNICsWithConfigFile(nics, reader)
 }

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -30,10 +30,6 @@ var (
 )
 
 const lxdDefaultProfileName = "default"
-const UserDataKey = "user.user-data"
-const NetworkConfigKey = "user.network-config"
-const JujuModelKey = "user.juju-model"
-const AutoStartKey = "boot.autostart"
 
 type containerManager struct {
 	server *Server


### PR DESCRIPTION
## Description of change

This is the first in a series of PRs to unify container concerns across the LXD provider and the LXD container manager. 

Ultimately this will culminate in consistent behaviour for cloud-init and network device handling.

## QA steps

- New unit test suite.
- Provider and manager have been modified to use this module (not in this commit). Bootstrapping to LXD and deploying LXD container machines continues to work in system tests.

## Documentation changes

None.

## Bug reference

N/A
