### PR TITLE
Show test remove potential race condition

### DIFF
--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -185,7 +185,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				Size:         512,
 			},
 			Life:   "alive",
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
 				"machine-0": {
 					Life: "alive",
@@ -199,7 +199,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
 				Life:       "alive",
-				Status:     createTestStatus(status.Attached, ""),
+				Status:     createTestStatus(status.Attached, "", s.time),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1001",
@@ -218,7 +218,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-1",
 				Size:         2048,
 			},
-			Status: createTestStatus(status.Attaching, "failed to attach, will retry"),
+			Status: createTestStatus(status.Attaching, "failed to attach, will retry", s.time),
 			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
 				"machine-0": {},
 			},
@@ -230,7 +230,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 			Info: params.FilesystemInfo{
 				Size: 42,
 			},
-			Status: createTestStatus(status.Pending, ""),
+			Status: createTestStatus(status.Pending, "", s.time),
 			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
 				"machine-1": {},
 			},
@@ -243,7 +243,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-2",
 				Size:         3,
 			},
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
 				"machine-1": {
 					FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
@@ -261,7 +261,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				Pool:         "radiance",
 				Size:         1024,
 			},
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
 				"machine-0": {
 					FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
@@ -280,7 +280,7 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				StorageTag: "storage-shared-fs-0",
 				OwnerTag:   "application-transcode",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(status.Attached, ""),
+				Status:     createTestStatus(status.Attached, "", s.time),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-transcode-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-shared-fs-0",
@@ -304,13 +304,13 @@ func (s mockListAPI) ListFilesystems(machines []string) ([]params.FilesystemDeta
 				FilesystemId: "provider-supplied-filesystem-5",
 				Size:         3,
 			},
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			Storage: &params.StorageDetails{
 				StorageTag: "storage-db-dir-1100",
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
 				Life:       "alive",
-				Status:     createTestStatus(status.Attached, ""),
+				Status:     createTestStatus(status.Attached, "", s.time),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1100",

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -187,7 +187,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 				Size:     512,
 			},
 			Life:   "alive",
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			MachineAttachments: map[string]params.VolumeAttachmentDetails{
 				"machine-0": {
 					Life: "alive",
@@ -201,7 +201,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
 				Life:       "alive",
-				Status:     createTestStatus(status.Attached, ""),
+				Status:     createTestStatus(status.Attached, "", s.time),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1001",
@@ -222,7 +222,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 				Persistent: true,
 				Size:       2048,
 			},
-			Status: createTestStatus(status.Attaching, "failed to attach, will retry"),
+			Status: createTestStatus(status.Attaching, "failed to attach, will retry", s.time),
 			MachineAttachments: map[string]params.VolumeAttachmentDetails{
 				"machine-0": {},
 			},
@@ -234,7 +234,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 			Info: params.VolumeInfo{
 				Size: 42,
 			},
-			Status: createTestStatus(status.Pending, ""),
+			Status: createTestStatus(status.Pending, "", s.time),
 			MachineAttachments: map[string]params.VolumeAttachmentDetails{
 				"machine-1": {},
 			},
@@ -247,7 +247,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 				VolumeId: "provider-supplied-volume-2",
 				Size:     3,
 			},
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			MachineAttachments: map[string]params.VolumeAttachmentDetails{
 				"machine-1": {
 					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
@@ -265,7 +265,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 				Persistent: true,
 				Size:       1024,
 			},
-			Status: createTestStatus(status.Attached, ""),
+			Status: createTestStatus(status.Attached, "", s.time),
 			MachineAttachments: map[string]params.VolumeAttachmentDetails{
 				"machine-0": {
 					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
@@ -284,7 +284,7 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 				StorageTag: "storage-shared-fs-0",
 				OwnerTag:   "application-transcode",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(status.Attached, ""),
+				Status:     createTestStatus(status.Attached, "", s.time),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-transcode-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-shared-fs-0",
@@ -313,10 +313,10 @@ func (s *mockListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsList
 	return results, nil
 }
 
-func createTestStatus(testStatus status.Status, message string) params.EntityStatus {
+func createTestStatus(testStatus status.Status, message string, since time.Time) params.EntityStatus {
 	return params.EntityStatus{
 		Status: testStatus,
 		Info:   message,
-		Since:  &time.Time{},
+		Since:  &since,
 	}
 }


### PR DESCRIPTION
## Description of change

> Why is this change needed?

The following commit removes the potential race condition, by
removing the dangerous `PatchValue` on `time.Local`. Instead we give
the mock API a time value that we can actually match against.

## QA steps

> How do we verify that the change works?

Tests should go green

## Documentation changes

> Does it affect current user workflow? CLI? API?

no

## Bug reference

> Does this change fix a bug? Please add a link to it.

https://bugs.launchpad.net/juju/+bug/1759761