### PR TITLE
Clarify model manifolds - worker dependencies.

### DIFF
--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -172,17 +172,9 @@ func (s *ManifoldsSuite) assertManifoldsDependencies(c *gc.C, manifolds dependen
 	dependencies := make(map[string][]string, len(manifolds))
 	manifoldNames := set.NewStrings()
 
-	for name, manifold := range manifolds {
+	for name, _ := range manifolds {
 		manifoldNames.Add(name)
-		dependencies[name] = []string{}
-
-		if len(manifold.Inputs) == 0 {
-			continue
-		}
-		manifoldDependencies := manifolds.ManifoldDependencies(name, manifolds[name])
-		for _, input := range manifoldDependencies.SortedValues() {
-			dependencies[name] = append(dependencies[name], input)
-		}
+		dependencies[name] = manifolds.ManifoldDependencies(name, manifolds[name]).SortedValues()
 	}
 	c.Assert(len(dependencies), gc.Equals, len(expected))
 

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -172,9 +172,9 @@ func (s *ManifoldsSuite) assertManifoldsDependencies(c *gc.C, manifolds dependen
 	dependencies := make(map[string][]string, len(manifolds))
 	manifoldNames := set.NewStrings()
 
-	for name, _ := range manifolds {
+	for name, manifold := range manifolds {
 		manifoldNames.Add(name)
-		dependencies[name] = manifolds.ManifoldDependencies(name, manifolds[name]).SortedValues()
+		dependencies[name] = manifolds.ManifoldDependencies(name, manifold).SortedValues()
 	}
 	c.Assert(len(dependencies), gc.Equals, len(expected))
 

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -179,7 +179,7 @@ func (s *ManifoldsSuite) assertManifoldsDependencies(c *gc.C, manifolds dependen
 		if len(manifold.Inputs) == 0 {
 			continue
 		}
-		manifoldDependencies := dependency.ManifoldDependencies(name, manifolds[name], manifolds)
+		manifoldDependencies := manifolds.ManifoldDependencies(name, manifolds[name])
 		for _, input := range manifoldDependencies.SortedValues() {
 			dependencies[name] = append(dependencies[name], input)
 		}

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -174,17 +174,15 @@ func (s *ManifoldsSuite) assertManifoldsDependencies(c *gc.C, manifolds dependen
 
 	for name, manifold := range manifolds {
 		manifoldNames.Add(name)
+		dependencies[name] = []string{}
 
 		if len(manifold.Inputs) == 0 {
-			dependencies[name] = []string{}
 			continue
 		}
 		manifoldDependencies := dependency.ManifoldDependencies(name, manifolds[name], manifolds)
-		all := []string{}
 		for _, input := range manifoldDependencies.SortedValues() {
-			all = append(all, input)
+			dependencies[name] = append(dependencies[name], input)
 		}
-		dependencies[name] = all
 	}
 	c.Assert(len(dependencies), gc.Equals, len(expected))
 

--- a/worker/apicaller/manifold.go
+++ b/worker/apicaller/manifold.go
@@ -55,11 +55,15 @@ type ManifoldConfig struct {
 // Manifold returns a manifold whose worker wraps an API connection
 // made as configured.
 func Manifold(config ManifoldConfig) dependency.Manifold {
+	inputs := []string{config.AgentName}
+	if config.APIConfigWatcherName != "" {
+		// config.APIConfigWatcherName is only applicable to unit
+		// and machine scoped manifold.
+		// It will be empty for model manifolds.
+		inputs = append(inputs, config.APIConfigWatcherName)
+	}
 	return dependency.Manifold{
-		Inputs: []string{
-			config.AgentName,
-			config.APIConfigWatcherName,
-		},
+		Inputs: inputs,
 		Output: outputFunc,
 		Start:  config.startFunc(),
 		Filter: config.Filter,

--- a/worker/dependency/util.go
+++ b/worker/dependency/util.go
@@ -104,9 +104,6 @@ func SelfManifold(engine *Engine) Manifold {
 
 // ManifoldDependencies returns all manifold dependencies.
 func (all Manifolds) ManifoldDependencies(name string, manifold Manifold) set.Strings {
-	if len(manifold.Inputs) == 0 {
-		return nil
-	}
 	result := set.NewStrings()
 	for _, input := range manifold.Inputs {
 		result.Add(input)

--- a/worker/dependency/util.go
+++ b/worker/dependency/util.go
@@ -109,9 +109,6 @@ func (all Manifolds) ManifoldDependencies(name string, manifold Manifold) set.St
 	}
 	result := set.NewStrings()
 	for _, input := range manifold.Inputs {
-		if input == "" {
-			continue
-		}
 		result.Add(input)
 		result = result.Union(all.ManifoldDependencies(input, all[input]))
 	}

--- a/worker/dependency/util.go
+++ b/worker/dependency/util.go
@@ -4,6 +4,7 @@
 package dependency
 
 import (
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
 )
@@ -99,4 +100,21 @@ func SelfManifold(engine *Engine) Manifold {
 			return nil
 		},
 	}
+}
+
+// ManifoldDependencies returns all manifold dependencies.
+func ManifoldDependencies(name string, manifold Manifold, all Manifolds) set.Strings {
+	if len(manifold.Inputs) == 0 {
+		return set.NewStrings(name)
+	}
+	result := set.NewStrings()
+	for _, input := range manifold.Inputs {
+		result.Add(input)
+		deps := ManifoldDepenencies(input, all[input], all)
+		for _, v := range deps.SortedValues() {
+			result.Add(v)
+		}
+	}
+	result.Remove("")
+	return result
 }

--- a/worker/dependency/util.go
+++ b/worker/dependency/util.go
@@ -105,16 +105,15 @@ func SelfManifold(engine *Engine) Manifold {
 // ManifoldDependencies returns all manifold dependencies.
 func (all Manifolds) ManifoldDependencies(name string, manifold Manifold) set.Strings {
 	if len(manifold.Inputs) == 0 {
-		return set.NewStrings(name)
+		return nil
 	}
 	result := set.NewStrings()
 	for _, input := range manifold.Inputs {
-		result.Add(input)
-		deps := all.ManifoldDependencies(input, all[input])
-		for _, v := range deps.SortedValues() {
-			result.Add(v)
+		if input == "" {
+			continue
 		}
+		result.Add(input)
+		result = result.Union(all.ManifoldDependencies(input, all[input]))
 	}
-	result.Remove("")
 	return result
 }

--- a/worker/dependency/util.go
+++ b/worker/dependency/util.go
@@ -110,7 +110,7 @@ func ManifoldDependencies(name string, manifold Manifold, all Manifolds) set.Str
 	result := set.NewStrings()
 	for _, input := range manifold.Inputs {
 		result.Add(input)
-		deps := ManifoldDepenencies(input, all[input], all)
+		deps := ManifoldDependencies(input, all[input], all)
 		for _, v := range deps.SortedValues() {
 			result.Add(v)
 		}

--- a/worker/dependency/util.go
+++ b/worker/dependency/util.go
@@ -103,14 +103,14 @@ func SelfManifold(engine *Engine) Manifold {
 }
 
 // ManifoldDependencies returns all manifold dependencies.
-func ManifoldDependencies(name string, manifold Manifold, all Manifolds) set.Strings {
+func (all Manifolds) ManifoldDependencies(name string, manifold Manifold) set.Strings {
 	if len(manifold.Inputs) == 0 {
 		return set.NewStrings(name)
 	}
 	result := set.NewStrings()
 	for _, input := range manifold.Inputs {
 		result.Add(input)
-		deps := ManifoldDependencies(input, all[input], all)
+		deps := all.ManifoldDependencies(input, all[input])
 		for _, v := range deps.SortedValues() {
 			result.Add(v)
 		}


### PR DESCRIPTION
## Description of change

During development as well as incident investigations, it is sometimes unclear what workers are running and what other workers/input they depend on.

We have originally thought to just add additional comments or code indentation for clarification. However, both of these approaches are static and can become outdated and irrelevant to the actual code base. Instead, this PR uses unit tests to document current state of manifolds dependencies. This will also encourage (i.e. force) future additions and modifications to existing worker dependencies to be rationalized rather than blindly copied.

Similar approach will be applied to machine and unit manifolds.
