### PR TITLE
We don't need to use a type alias, we are really doing a type definition

### DIFF
--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -35,7 +35,7 @@ type NetworkGetCommand struct {
 	out cmd.Output
 }
 
-type resolver = func(host string) (addrs []string, err error)
+type resolver func(host string) (addrs []string, err error)
 
 var LookupHost resolver = net.LookupHost
 


### PR DESCRIPTION
## Description of change

Go 1.9 introduced type aliases, which allow you to specify
```
  type foo = bar
```
Which allows references to 'foo' to take a 'bar' without complaining that it is the wrong type.
However, we don't need a type alias here, and it breaks the ability to build Juju with older golang.

## QA steps

Tests should still pass.

## Documentation changes

None.

## Bug reference

None.
