### PR TITLE
Add support for creating k8s storage pools

### DIFF
--- a/apiserver/facades/client/storage/filesystemlist_test.go
+++ b/apiserver/facades/client/storage/filesystemlist_test.go
@@ -62,7 +62,7 @@ func (s *filesystemSuite) TestListFilesystemsEmptyFilter(c *gc.C) {
 
 func (s *filesystemSuite) TestListFilesystemsError(c *gc.C) {
 	msg := "inventing error"
-	s.state.allFilesystems = func() ([]state.Filesystem, error) {
+	s.storageAccessor.allFilesystems = func() ([]state.Filesystem, error) {
 		return nil, errors.New(msg)
 	}
 	results, err := s.api.ListFilesystems(params.FilesystemFilters{
@@ -74,7 +74,7 @@ func (s *filesystemSuite) TestListFilesystemsError(c *gc.C) {
 }
 
 func (s *filesystemSuite) TestListFilesystemsNoFilesystems(c *gc.C) {
-	s.state.allFilesystems = func() ([]state.Filesystem, error) {
+	s.storageAccessor.allFilesystems = func() ([]state.Filesystem, error) {
 		return nil, nil
 	}
 	results, err := s.api.ListFilesystems(params.FilesystemFilters{})
@@ -124,6 +124,7 @@ func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
 		MountPoint: "/tmp",
 		ReadOnly:   true,
 	}
+	s.state.assignedMachine = s.machineTag.Id()
 	expected := s.expectedFilesystemDetails()
 	expected.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentDetails{
 		FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{

--- a/apiserver/facades/client/storage/storageadd_test.go
+++ b/apiserver/facades/client/storage/storageadd_test.go
@@ -89,7 +89,7 @@ func (s *storageAddSuite) TestStorageAddUnitInvalidName(c *gc.C) {
 
 func (s *storageAddSuite) TestStorageAddUnitStateError(c *gc.C) {
 	msg := "add test directive error"
-	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
+	s.storageAccessor.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
 		s.stub.AddCall(addStorageForUnitCall)
 		return nil, errors.Errorf(msg)
 	}
@@ -118,7 +118,7 @@ func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *gc.C) {
 		UnitTag: s.unitTag.String(),
 	}
 	msg := "storage name missing error"
-	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
+	s.storageAccessor.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
 		s.stub.AddCall(addStorageForUnitCall)
 		if name == "" {
 			return nil, errors.Errorf(msg)
@@ -143,7 +143,7 @@ func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *gc.C) {
 
 func (s *storageAddSuite) TestStorageAddUnitTags(c *gc.C) {
 	tags := []names.StorageTag{names.NewStorageTag("foo/0"), names.NewStorageTag("foo/1")}
-	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
+	s.storageAccessor.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
 		return tags, nil
 	}
 
@@ -162,7 +162,7 @@ func (s *storageAddSuite) TestStorageAddUnitTags(c *gc.C) {
 
 func (s *storageAddSuite) TestStorageAddUnitNotFoundErr(c *gc.C) {
 	msg := "sanity"
-	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
+	s.storageAccessor.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
 		s.stub.AddCall(addStorageForUnitCall)
 		return nil, errors.NotFoundf(msg)
 	}

--- a/apiserver/facades/client/storage/volumelist_test.go
+++ b/apiserver/facades/client/storage/volumelist_test.go
@@ -69,7 +69,7 @@ func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
 
 func (s *volumeSuite) TestListVolumesError(c *gc.C) {
 	msg := "inventing error"
-	s.state.allVolumes = func() ([]state.Volume, error) {
+	s.storageAccessor.allVolumes = func() ([]state.Volume, error) {
 		return nil, errors.New(msg)
 	}
 	results, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
@@ -79,7 +79,7 @@ func (s *volumeSuite) TestListVolumesError(c *gc.C) {
 }
 
 func (s *volumeSuite) TestListVolumesNoVolumes(c *gc.C) {
-	s.state.allVolumes = func() ([]state.Volume, error) {
+	s.storageAccessor.allVolumes = func() ([]state.Volume, error) {
 		return nil, nil
 	}
 	results, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
@@ -134,6 +134,7 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 		DeviceName: "xvdf1",
 		ReadOnly:   true,
 	}
+	s.state.assignedMachine = s.machineTag.Id()
 	expected := s.expectedVolumeDetails()
 	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentDetails{
 		VolumeAttachmentInfo: params.VolumeAttachmentInfo{
@@ -172,7 +173,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
 }
 
 func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
-	s.state.blockDevices = func(names.MachineTag) ([]state.BlockDeviceInfo, error) {
+	s.storageAccessor.blockDevices = func(names.MachineTag) ([]state.BlockDeviceInfo, error) {
 		return []state.BlockDeviceInfo{{
 			BusAddress: "bus-addr",
 			DeviceName: "sdd",

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -39,6 +39,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"RetryStrategy",
 	"Singular",
 	"StatusHistory",
+	"Storage",
 	"StringsWatcher",
 	"Undertaker",
 	"Uniter",

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/status"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/watcher"
 )
 
@@ -98,6 +99,9 @@ type Broker interface {
 
 	// Units returns all units of the specified application.
 	Units(appName string) ([]Unit, error)
+
+	// ProviderRegistry is an interface for obtaining storage providers.
+	storage.ProviderRegistry
 }
 
 // Service represents information about the status of a caas service entity.

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -145,7 +145,7 @@ func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Creden
 			}
 		} else if user.Username != "" {
 			if user.Password == "" {
-				logger.Warningf("empty password")
+				logger.Debugf("credential for user %q has empty password", user.Username)
 			}
 			attrs["username"] = user.Username
 			attrs["password"] = user.Password

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -1,0 +1,122 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"github.com/golang/mock/gomock"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/caas/kubernetes/provider/mocks"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/testing"
+)
+
+type BaseSuite struct {
+	testing.BaseSuite
+
+	broker caas.Broker
+
+	k8sClient                  *mocks.MockInterface
+	mockNamespaces             *mocks.MockNamespaceInterface
+	mockExtensions             *mocks.MockExtensionsV1beta1Interface
+	mockDeploymentInterface    *mocks.MockDeploymentInterface
+	mockPods                   *mocks.MockPodInterface
+	mockServices               *mocks.MockServiceInterface
+	mockConfigMaps             *mocks.MockConfigMapInterface
+	mockPersistentVolumes      *mocks.MockPersistentVolumeInterface
+	mockPersistentVolumeClaims *mocks.MockPersistentVolumeClaimInterface
+	mockStorage                *mocks.MockStorageV1Interface
+	mockStorageClass           *mocks.MockStorageClassInterface
+	mockIngressInterface       *mocks.MockIngressInterface
+}
+
+const testNamespace = "test"
+
+func (s *BaseSuite) setupBroker(c *gc.C) *gomock.Controller {
+	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"username":              "fred",
+		"password":              "secret",
+		"ClientCertificateData": "cert-data",
+		"ClientKeyData":         "cert-key",
+	})
+	cloudSpec := environs.CloudSpec{
+		Endpoint:       "some-host",
+		Credential:     &cred,
+		CACertificates: []string{testing.CACert},
+	}
+
+	ctrl := gomock.NewController(c)
+
+	// Set up the mock k8sclient we pass to our broker under test.
+	s.k8sClient = mocks.NewMockInterface(ctrl)
+	newClient := func(cfg *rest.Config) (kubernetes.Interface, error) {
+		c.Assert(cfg.Username, gc.Equals, "fred")
+		c.Assert(cfg.Password, gc.Equals, "secret")
+		c.Assert(cfg.Host, gc.Equals, "some-host")
+		c.Assert(cfg.TLSClientConfig, jc.DeepEquals, rest.TLSClientConfig{
+			CertData: []byte("cert-data"),
+			KeyData:  []byte("cert-key"),
+			CAData:   []byte(testing.CACert),
+		})
+		return s.k8sClient, nil
+	}
+
+	// Plug in the various k8s client modules we need.
+	// eg namespaces, pods, services, ingress resources, volumes etc.
+	// We make the mock and assign it to the corresponding core getter function.
+	mockCoreV1 := mocks.NewMockCoreV1Interface(ctrl)
+	s.k8sClient.EXPECT().CoreV1().AnyTimes().Return(mockCoreV1)
+
+	s.mockNamespaces = mocks.NewMockNamespaceInterface(ctrl)
+	mockCoreV1.EXPECT().Namespaces().AnyTimes().Return(s.mockNamespaces)
+
+	s.mockPods = mocks.NewMockPodInterface(ctrl)
+	mockCoreV1.EXPECT().Pods(testNamespace).AnyTimes().Return(s.mockPods)
+
+	s.mockServices = mocks.NewMockServiceInterface(ctrl)
+	mockCoreV1.EXPECT().Services(testNamespace).AnyTimes().Return(s.mockServices)
+
+	s.mockConfigMaps = mocks.NewMockConfigMapInterface(ctrl)
+	mockCoreV1.EXPECT().ConfigMaps(testNamespace).AnyTimes().Return(s.mockConfigMaps)
+
+	s.mockPersistentVolumes = mocks.NewMockPersistentVolumeInterface(ctrl)
+	mockCoreV1.EXPECT().PersistentVolumes().AnyTimes().Return(s.mockPersistentVolumes)
+
+	s.mockPersistentVolumeClaims = mocks.NewMockPersistentVolumeClaimInterface(ctrl)
+	mockCoreV1.EXPECT().PersistentVolumeClaims(testNamespace).AnyTimes().Return(s.mockPersistentVolumeClaims)
+
+	s.mockExtensions = mocks.NewMockExtensionsV1beta1Interface(ctrl)
+	s.mockDeploymentInterface = mocks.NewMockDeploymentInterface(ctrl)
+	s.mockIngressInterface = mocks.NewMockIngressInterface(ctrl)
+	s.k8sClient.EXPECT().ExtensionsV1beta1().AnyTimes().Return(s.mockExtensions)
+	s.mockExtensions.EXPECT().Deployments(testNamespace).AnyTimes().Return(s.mockDeploymentInterface)
+	s.mockExtensions.EXPECT().Ingresses(testNamespace).AnyTimes().Return(s.mockIngressInterface)
+
+	s.mockStorage = mocks.NewMockStorageV1Interface(ctrl)
+	s.mockStorageClass = mocks.NewMockStorageClassInterface(ctrl)
+	s.k8sClient.EXPECT().StorageV1().AnyTimes().Return(s.mockStorage)
+	s.mockStorage.EXPECT().StorageClasses().AnyTimes().Return(s.mockStorageClass)
+
+	var err error
+	s.broker, err = provider.NewK8sBroker(cloudSpec, testNamespace, newClient)
+	c.Assert(err, jc.ErrorIsNil)
+	return ctrl
+}
+
+func (s *BaseSuite) k8sNotFoundError() *k8serrors.StatusError {
+	return k8serrors.NewNotFound(schema.GroupResource{}, "test")
+}
+
+func (s *BaseSuite) deleteOptions(orphanDependents bool) *v1.DeleteOptions {
+	return &v1.DeleteOptions{OrphanDependents: &orphanDependents}
+}

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -5,8 +5,10 @@ package provider
 
 import (
 	core "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/storage"
 )
 
 var (
@@ -21,4 +23,8 @@ func PodSpec(u *unitSpec) core.PodSpec {
 
 func NewProvider() caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{}
+}
+
+func StorageProvider(k8sClient kubernetes.Interface, namespace string) storage.Provider {
+	return &storageProvider{&kubernetesClient{Interface: k8sClient, namespace: namespace}}
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -8,17 +8,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/caas/kubernetes/provider/mocks"
-	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/testing"
 )
 
@@ -125,109 +118,13 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 }
 
 type K8sBrokerSuite struct {
-	testing.BaseSuite
-
-	broker caas.Broker
-
-	k8sClient                  *mocks.MockInterface
-	mockNamespaces             *mocks.MockNamespaceInterface
-	mockExtensions             *mocks.MockExtensionsV1beta1Interface
-	mockDeploymentInterface    *mocks.MockDeploymentInterface
-	mockPods                   *mocks.MockPodInterface
-	mockServices               *mocks.MockServiceInterface
-	mockConfigMaps             *mocks.MockConfigMapInterface
-	mockPersistentVolumes      *mocks.MockPersistentVolumeInterface
-	mockPersistentVolumeClaims *mocks.MockPersistentVolumeClaimInterface
-	mockStorage                *mocks.MockStorageV1Interface
-	mockStorageClass           *mocks.MockStorageClassInterface
-	mockIngressInterface       *mocks.MockIngressInterface
+	BaseSuite
 }
 
 var _ = gc.Suite(&K8sBrokerSuite{})
 
-const testNamespace = "test"
-
-func (s *K8sBrokerSuite) newBroker(c *gc.C) *gomock.Controller {
-	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-		"username":              "fred",
-		"password":              "secret",
-		"ClientCertificateData": "cert-data",
-		"ClientKeyData":         "cert-key",
-	})
-	cloudSpec := environs.CloudSpec{
-		Endpoint:       "some-host",
-		Credential:     &cred,
-		CACertificates: []string{testing.CACert},
-	}
-
-	ctrl := gomock.NewController(c)
-
-	// Set up the mock k8sclient we pass to our broker under test.
-	s.k8sClient = mocks.NewMockInterface(ctrl)
-	newClient := func(cfg *rest.Config) (kubernetes.Interface, error) {
-		c.Assert(cfg.Username, gc.Equals, "fred")
-		c.Assert(cfg.Password, gc.Equals, "secret")
-		c.Assert(cfg.Host, gc.Equals, "some-host")
-		c.Assert(cfg.TLSClientConfig, jc.DeepEquals, rest.TLSClientConfig{
-			CertData: []byte("cert-data"),
-			KeyData:  []byte("cert-key"),
-			CAData:   []byte(testing.CACert),
-		})
-		return s.k8sClient, nil
-	}
-
-	// Plug in the various k8s client modules we need.
-	// eg namespaces, pods, services, ingress resources, volumes etc.
-	// We make the mock and assign it to the corresponding core getter function.
-	mockCoreV1 := mocks.NewMockCoreV1Interface(ctrl)
-	s.k8sClient.EXPECT().CoreV1().AnyTimes().Return(mockCoreV1)
-
-	s.mockNamespaces = mocks.NewMockNamespaceInterface(ctrl)
-	mockCoreV1.EXPECT().Namespaces().AnyTimes().Return(s.mockNamespaces)
-
-	s.mockPods = mocks.NewMockPodInterface(ctrl)
-	mockCoreV1.EXPECT().Pods(testNamespace).AnyTimes().Return(s.mockPods)
-
-	s.mockServices = mocks.NewMockServiceInterface(ctrl)
-	mockCoreV1.EXPECT().Services(testNamespace).AnyTimes().Return(s.mockServices)
-
-	s.mockConfigMaps = mocks.NewMockConfigMapInterface(ctrl)
-	mockCoreV1.EXPECT().ConfigMaps(testNamespace).AnyTimes().Return(s.mockConfigMaps)
-
-	s.mockPersistentVolumes = mocks.NewMockPersistentVolumeInterface(ctrl)
-	mockCoreV1.EXPECT().PersistentVolumes().AnyTimes().Return(s.mockPersistentVolumes)
-
-	s.mockPersistentVolumeClaims = mocks.NewMockPersistentVolumeClaimInterface(ctrl)
-	mockCoreV1.EXPECT().PersistentVolumeClaims(testNamespace).AnyTimes().Return(s.mockPersistentVolumeClaims)
-
-	s.mockExtensions = mocks.NewMockExtensionsV1beta1Interface(ctrl)
-	s.mockDeploymentInterface = mocks.NewMockDeploymentInterface(ctrl)
-	s.mockIngressInterface = mocks.NewMockIngressInterface(ctrl)
-	s.k8sClient.EXPECT().ExtensionsV1beta1().AnyTimes().Return(s.mockExtensions)
-	s.mockExtensions.EXPECT().Deployments(testNamespace).AnyTimes().Return(s.mockDeploymentInterface)
-	s.mockExtensions.EXPECT().Ingresses(testNamespace).AnyTimes().Return(s.mockIngressInterface)
-
-	s.mockStorage = mocks.NewMockStorageV1Interface(ctrl)
-	s.mockStorageClass = mocks.NewMockStorageClassInterface(ctrl)
-	s.k8sClient.EXPECT().StorageV1().AnyTimes().Return(s.mockStorage)
-	s.mockStorage.EXPECT().StorageClasses().AnyTimes().Return(s.mockStorageClass)
-
-	var err error
-	s.broker, err = provider.NewK8sBroker(cloudSpec, testNamespace, newClient)
-	c.Assert(err, jc.ErrorIsNil)
-	return ctrl
-}
-
-func (s *K8sBrokerSuite) k8sNotFoundError() *k8serrors.StatusError {
-	return k8serrors.NewNotFound(schema.GroupResource{}, "test")
-}
-
-func (s *K8sBrokerSuite) deleteOptions(orphanDependents bool) *v1.DeleteOptions {
-	return &v1.DeleteOptions{OrphanDependents: &orphanDependents}
-}
-
 func (s *K8sBrokerSuite) TestEnsureNamespace(c *gc.C) {
-	ctrl := s.newBroker(c)
+	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}}
@@ -248,7 +145,7 @@ func (s *K8sBrokerSuite) TestEnsureNamespace(c *gc.C) {
 }
 
 func (s *K8sBrokerSuite) TestDeleteService(c *gc.C) {
-	ctrl := s.newBroker(c)
+	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
 	// Delete operations below return a not found to ensure it's treated as a no-op.

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -72,7 +72,15 @@ func (p kubernetesEnvironProvider) PrepareConfig(args environs.PrepareConfigPara
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	return args.Config, nil
+	// Set the default storage sources.
+	attrs := make(map[string]interface{})
+	if _, ok := args.Config.StorageDefaultBlockSource(); !ok {
+		attrs[config.StorageDefaultBlockSourceKey] = K8s_ProviderType
+	}
+	if _, ok := args.Config.StorageDefaultFilesystemSource(); !ok {
+		attrs[config.StorageDefaultFilesystemSourceKey] = K8s_ProviderType
+	}
+	return args.Config.Apply(attrs)
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
+	"github.com/juju/schema"
+
+	"github.com/juju/juju/storage"
+)
+
+const (
+	// K8s_ProviderType defines the Juju storage type which can be used
+	// to provision storage on k8s models.
+	K8s_ProviderType = storage.ProviderType("kubernetes")
+
+	// K8s storage pool attributes.
+	storageClass = "storage-class"
+
+	// K8s storage pool attribute default values.
+	defaultStorageClass = "<default>"
+)
+
+// StorageProviderTypes is defined on the storage.ProviderRegistry interface.
+func (k *kubernetesClient) StorageProviderTypes() ([]storage.ProviderType, error) {
+	return []storage.ProviderType{K8s_ProviderType}, nil
+}
+
+// StorageProvider is defined on the storage.ProviderRegistry interface.
+func (k *kubernetesClient) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
+	if t == K8s_ProviderType {
+		return &storageProvider{k}, nil
+	}
+	return nil, errors.NotFoundf("storage provider %q", t)
+}
+
+type storageProvider struct {
+	client caas.Broker
+}
+
+var _ storage.Provider = (*storageProvider)(nil)
+
+var storageConfigFields = schema.Fields{
+	storageClass: schema.String(),
+}
+
+var storageConfigChecker = schema.FieldMap(
+	storageConfigFields,
+	schema.Defaults{
+		storageClass: defaultStorageClass,
+	},
+)
+
+type storageConfig struct {
+	storageClass string
+}
+
+func newStorageConfig(attrs map[string]interface{}) (*storageConfig, error) {
+	out, err := storageConfigChecker.Coerce(attrs, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "validating storage config")
+	}
+	coerced := out.(map[string]interface{})
+	storageClass := coerced[storageClass].(string)
+	storageConfig := &storageConfig{
+		storageClass: storageClass,
+	}
+	return storageConfig, nil
+}
+
+// ValidateConfig is defined on the storage.Provider interface.
+func (g *storageProvider) ValidateConfig(cfg *storage.Config) error {
+	_, err := newStorageConfig(cfg.Attrs())
+	return errors.Trace(err)
+}
+
+// Supports is defined on the storage.Provider interface.
+func (g *storageProvider) Supports(k storage.StorageKind) bool {
+	// Support both block and filesystem storage.
+	return true
+}
+
+// Scope is defined on the storage.Provider interface.
+func (g *storageProvider) Scope() storage.Scope {
+	return storage.ScopeEnviron
+}
+
+// Dynamic is defined on the storage.Provider interface.
+func (g *storageProvider) Dynamic() bool {
+	return true
+}
+
+// Releasable is defined on the storage.Provider interface.
+func (e *storageProvider) Releasable() bool {
+	return false
+}
+
+// DefaultPools is defined on the storage.Provider interface.
+func (g *storageProvider) DefaultPools() []*storage.Config {
+	return nil
+}
+
+// VolumeSource is defined on the storage.Provider interface.
+func (g *storageProvider) VolumeSource(cfg *storage.Config) (storage.VolumeSource, error) {
+	return nil, errors.NotSupportedf("volumes")
+}
+
+// FilesystemSource is defined on the storage.Provider interface.
+func (g *storageProvider) FilesystemSource(providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystems")
+}

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"github.com/golang/mock/gomock"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/caas/kubernetes/provider/mocks"
+	"github.com/juju/juju/storage"
+)
+
+var _ = gc.Suite(&storageSuite{})
+
+type storageSuite struct {
+	BaseSuite
+	k8sClient kubernetes.Interface
+}
+
+func (s *storageSuite) k8sProvider(c *gc.C, ctrl *gomock.Controller) storage.Provider {
+	s.k8sClient = mocks.NewMockInterface(ctrl)
+
+	return provider.StorageProvider(s.k8sClient, testNamespace)
+}
+
+func (s *storageSuite) TestValidateConfig(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	p := s.k8sProvider(c, ctrl)
+	cfg, err := storage.NewConfig("name", provider.K8s_ProviderType, map[string]interface{}{
+		"storage-class": "my-storage",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Attrs(), jc.DeepEquals, map[string]interface{}{
+		"storage-class": "my-storage",
+	})
+}
+
+func (s *storageSuite) TestValidateConfigDefaultStorageClass(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	p := s.k8sProvider(c, ctrl)
+	cfg, err := storage.NewConfig("name", provider.K8s_ProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestSupports(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	p := s.k8sProvider(c, ctrl)
+	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsTrue)
+	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsTrue)
+}
+
+func (s *storageSuite) TestScope(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	p := s.k8sProvider(c, ctrl)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeEnviron)
+}

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -80,6 +80,7 @@ Examples:
 // addCommand adds unit storage instances dynamically.
 type addCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	unitTag names.UnitTag
 
 	// storageCons is a map of storage constraints, keyed on the storage name

--- a/cmd/juju/storage/attach.go
+++ b/cmd/juju/storage/attach.go
@@ -45,6 +45,7 @@ Examples:
 // attachStorageCommand adds unit storage instances dynamically.
 type attachStorageCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	newEntityAttacherCloser NewEntityAttacherCloserFunc
 	unitId                  string
 	storageIds              []string

--- a/cmd/juju/storage/detach.go
+++ b/cmd/juju/storage/detach.go
@@ -46,6 +46,7 @@ Examples:
 // detachStorageCommand detaches storage instances.
 type detachStorageCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	newEntityDetacherCloser NewEntityDetacherCloserFunc
 	storageIds              []string
 }

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 // FilesystemCommandBase is a helper base structure for filesystem commands.
 type FilesystemCommandBase struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 }
 
 // FilesystemInfo defines the serialization behaviour for storage filesystem.

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -81,6 +81,7 @@ Examples:
 // importFilesystemCommand imports filesystems into the model.
 type importFilesystemCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	newAPIFunc NewStorageImporterFunc
 
 	storagePool       string

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -31,6 +31,7 @@ List information about storage.
 // listCommand returns storage instances.
 type listCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	out        cmd.Output
 	ids        []string
 	filesystem bool

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -48,6 +48,7 @@ Examples:
 
 type removeStorageCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	newStorageRemoverCloser NewStorageRemoverCloserFunc
 	storageIds              []string
 	force                   bool

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -35,6 +35,7 @@ separated when more than one id is desired.
 // showCommand attempts to release storage instance.
 type showCommand struct {
 	StorageCommandBase
+	modelcmd.IAASOnlyCommand
 	ids        []string
 	out        cmd.Output
 	newAPIFunc func() (StorageShowAPI, error)

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -20,7 +20,6 @@ import (
 // storage managing client.
 type StorageCommandBase struct {
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
 }
 
 // NewStorageAPI returns a storage api for the root api endpoint

--- a/state/caasmodel.go
+++ b/state/caasmodel.go
@@ -3,7 +3,10 @@
 
 package state
 
-import "github.com/juju/errors"
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+)
 
 // CAASModel contains functionality that is specific to an
 // Containers-As-A-Service (CAAS) model. It embeds a Model so that
@@ -11,6 +14,9 @@ import "github.com/juju/errors"
 type CAASModel struct {
 	// TODO(caas) - this is all still messy until things shake out.
 	*Model
+	// TODO(caas) - placeholder until storage done.
+	noopStorage
+
 	mb modelBackend
 }
 
@@ -23,4 +29,117 @@ func (m *Model) CAASModel() (*CAASModel, error) {
 		Model: m,
 		mb:    m.st,
 	}, nil
+}
+
+// noopStorage implements the storageAccessor interface and returns
+// NotSupported errors for all methods.
+// Used as a placeholder until storage is implemented.
+type noopStorage struct{}
+
+func (noopStorage) StorageInstance(names.StorageTag) (StorageInstance, error) {
+	return nil, errors.NotSupportedf("StorageInstance")
+}
+
+func (noopStorage) AllStorageInstances() ([]StorageInstance, error) {
+	return nil, errors.NotSupportedf("AllStorageInstances")
+}
+
+func (noopStorage) StorageAttachments(names.StorageTag) ([]StorageAttachment, error) {
+	return nil, errors.NotSupportedf("StorageAttachments")
+}
+
+func (noopStorage) FilesystemAttachment(names.MachineTag, names.FilesystemTag) (FilesystemAttachment, error) {
+	return nil, errors.NotSupportedf("FilesystemAttachment")
+}
+
+func (noopStorage) StorageInstanceFilesystem(names.StorageTag) (Filesystem, error) {
+	return nil, errors.NotSupportedf("StorageInstanceFilesystem")
+}
+
+func (noopStorage) StorageInstanceVolume(names.StorageTag) (Volume, error) {
+	return nil, errors.NotSupportedf("StorageInstance")
+}
+
+func (noopStorage) VolumeAttachment(names.MachineTag, names.VolumeTag) (VolumeAttachment, error) {
+	return nil, errors.NotSupportedf("StorageInstanceVolume")
+}
+
+func (noopStorage) WatchStorageAttachment(names.StorageTag, names.UnitTag) NotifyWatcher {
+	return nil
+}
+
+func (noopStorage) WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) NotifyWatcher {
+	return nil
+}
+
+func (noopStorage) WatchVolumeAttachment(names.MachineTag, names.VolumeTag) NotifyWatcher {
+	return nil
+}
+
+func (noopStorage) WatchBlockDevices(names.MachineTag) NotifyWatcher {
+	return nil
+}
+
+func (noopStorage) BlockDevices(names.MachineTag) ([]BlockDeviceInfo, error) {
+	return nil, errors.NotSupportedf("BlockDevices")
+}
+
+func (noopStorage) AllVolumes() ([]Volume, error) {
+	return nil, errors.NotSupportedf("AllVolumes")
+}
+
+func (noopStorage) VolumeAttachments(volume names.VolumeTag) ([]VolumeAttachment, error) {
+	return nil, errors.NotSupportedf("VolumeAttachments")
+}
+
+func (noopStorage) MachineVolumeAttachments(machine names.MachineTag) ([]VolumeAttachment, error) {
+	return nil, errors.NotSupportedf("MachineVolumeAttachments")
+}
+
+func (noopStorage) Volume(tag names.VolumeTag) (Volume, error) {
+	return nil, errors.NotSupportedf("Volume")
+}
+
+func (noopStorage) AllFilesystems() ([]Filesystem, error) {
+	return nil, errors.NotSupportedf("AllFilesystems")
+}
+
+func (noopStorage) FilesystemAttachments(filesystem names.FilesystemTag) ([]FilesystemAttachment, error) {
+	return nil, errors.NotSupportedf("FilesystemAttachments")
+}
+
+func (noopStorage) MachineFilesystemAttachments(machine names.MachineTag) ([]FilesystemAttachment, error) {
+	return nil, errors.NotSupportedf("MachineFilesystemAttachments")
+}
+
+func (noopStorage) Filesystem(tag names.FilesystemTag) (Filesystem, error) {
+	return nil, errors.NotSupportedf("Filesystem")
+}
+
+func (noopStorage) AddStorageForUnit(tag names.UnitTag, name string, cons StorageConstraints) ([]names.StorageTag, error) {
+	return nil, errors.NotSupportedf("AddStorageForUnit")
+}
+
+func (noopStorage) AttachStorage(names.StorageTag, names.UnitTag) error {
+	return errors.NotSupportedf("AttachStorage")
+}
+
+func (noopStorage) DetachStorage(names.StorageTag, names.UnitTag) error {
+	return errors.NotSupportedf("DetachStorage")
+}
+
+func (noopStorage) DestroyStorageInstance(names.StorageTag, bool) error {
+	return errors.NotSupportedf("DestroyStorageInstance")
+}
+
+func (noopStorage) ReleaseStorageInstance(names.StorageTag, bool) error {
+	return errors.NotSupportedf("ReleaseStorageInstance")
+}
+
+func (noopStorage) UnitStorageAttachments(names.UnitTag) ([]StorageAttachment, error) {
+	return nil, errors.NotSupportedf("UnitStorageAttachments")
+}
+
+func (noopStorage) AddExistingFilesystem(f FilesystemInfo, v *VolumeInfo, storageName string) (names.StorageTag, error) {
+	return names.StorageTag{}, errors.NotSupportedf("AddExistingFilesystem")
 }

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -4,6 +4,7 @@
 package stateenvirons_test
 
 import (
+	"github.com/juju/juju/caas"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -67,4 +68,20 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 		StorageEndpoint:  "dummy-storage-endpoint",
 		Credential:       &emptyCredential,
 	})
+}
+
+func (s *environSuite) TestGetNewCAASBrokerFunc(c *gc.C) {
+	var calls int
+	var callArgs environs.OpenParams
+	newBroker := func(args environs.OpenParams) (caas.Broker, error) {
+		calls++
+		callArgs = args
+		return nil, nil
+	}
+	stateenvirons.GetNewCAASBrokerFunc(newBroker)(s.State)
+	c.Assert(calls, gc.Equals, 1)
+
+	cfg, err := s.Model.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(callArgs.Config, jc.DeepEquals, cfg)
 }

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -137,9 +137,9 @@ func (p environStatePolicy) StorageProviderRegistry() (storage.ProviderRegistry,
 }
 
 // NewStorageProviderRegistry returns a storage.ProviderRegistry that chains
-// the provided Environ with the common storage providers.
-func NewStorageProviderRegistry(env environs.Environ) storage.ProviderRegistry {
-	return storage.ChainedProviderRegistry{env, provider.CommonStorageProviders()}
+// the provided registry with the common storage providers.
+func NewStorageProviderRegistry(reg storage.ProviderRegistry) storage.ProviderRegistry {
+	return storage.ChainedProviderRegistry{reg, provider.CommonStorageProviders()}
 }
 
 func environProvider(st *state.State) (environs.EnvironProvider, error) {


### PR DESCRIPTION
## Description of change

Add support for managing storage pools for k8s models.
This PR is the first of many which will add storage support to k8s. There's some key points:

The storage facade used a big storageAccessor interface which mingled model related and storage related apis. This has been broken up to split out the model related apis from the storage ones There's a noop caas storage implementation which will be progressed over time. Following PRs will further split up the storage interface to separate common concerns like watching volumes etc to enable caas and iaas stuff to be shared.

The k8s test suite has been refactored to break out common functionality to set up the mock client.

## QA steps

bootstrap a k8s model
juju create-storage-pool blah
juju storage-pools etc

