### PR TITLE
Test optional api-caller manifold property.

### DIFF
--- a/worker/apicaller/manifold_test.go
+++ b/worker/apicaller/manifold_test.go
@@ -22,10 +22,12 @@ import (
 type ManifoldSuite struct {
 	testing.IsolationSuite
 	testing.Stub
-	manifold dependency.Manifold
-	agent    *mockAgent
-	conn     *mockConn
-	context  dependency.Context
+
+	manifold       dependency.Manifold
+	manifoldConfig apicaller.ManifoldConfig
+	agent          *mockAgent
+	conn           *mockConn
+	context        dependency.Context
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
@@ -33,7 +35,7 @@ var _ = gc.Suite(&ManifoldSuite{})
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.Stub = testing.Stub{}
-	s.manifold = apicaller.Manifold(apicaller.ManifoldConfig{
+	s.manifoldConfig = apicaller.ManifoldConfig{
 		AgentName:            "agent-name",
 		APIConfigWatcherName: "api-config-watcher-name",
 		APIOpen: func(*api.Info, api.DialOpts) (api.Connection, error) {
@@ -50,7 +52,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		Filter: func(err error) error {
 			panic(err)
 		},
-	})
+	}
+	s.manifold = apicaller.Manifold(s.manifoldConfig)
 	checkFilter := func() {
 		s.manifold.Filter(errors.New("arrgh"))
 	}
@@ -71,6 +74,13 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		stub:   &testing.Stub{},
 		broken: make(chan struct{}),
 	}
+}
+
+func (s *ManifoldSuite) TestInputsOptionalConfigPropertiesUnset(c *gc.C) {
+	s.manifoldConfig.APIConfigWatcherName = ""
+	c.Check(apicaller.Manifold(s.manifoldConfig).Inputs, jc.DeepEquals, []string{
+		"agent-name",
+	})
 }
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {


### PR DESCRIPTION
## Description of change

api-caller manifold configuration has an optional property, api-config-watcher. This property is only used by machine and unit scoped manifolds. It is omitted for model scoped manifolds. However, the code that constructed api-caller manifold based on the given config did not cater for model scoped path, resulting in a confusing empty input (dependency) in model manifolds. The correction for this code went in https://github.com/juju/juju/commit/5d14a9151104a53ebca82d3c148f66d000708282

This PR just adds a test to ensure that juju constructs manifold correctly given a config with optional properties omitted.