### PR TITLE
Machine undertaker worker needs the ability to invalidate credentials.

### DIFF
--- a/cmd/jujud/agent/agenttest/engine.go
+++ b/cmd/jujud/agent/agenttest/engine.go
@@ -201,7 +201,7 @@ func AssertManifoldsDependencies(c *gc.C, manifolds dependency.Manifolds, expect
 	c.Assert(len(dependencies), gc.Equals, len(expected))
 
 	for _, n := range manifoldNames.SortedValues() {
-		c.Assert(dependencies[n], jc.SameContents, expected[n])
+		c.Assert(dependencies[n], jc.SameContents, expected[n], gc.Commentf("mismatched dependencies for worker %q", n))
 	}
 }
 

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -380,11 +380,12 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
-		machineUndertakerName: ifNotMigrating(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			NewWorker:     machineundertaker.NewWorker,
-		})),
+		machineUndertakerName: ifNotMigrating(ifCredentialValid(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
+			APICallerName:                apiCallerName,
+			EnvironName:                  environTrackerName,
+			NewWorker:                    machineundertaker.NewWorker,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
+		}))),
 		modelUpgraderName: ifCredentialValid(modelupgrader.Manifold(modelupgrader.ManifoldConfig{
 			APICallerName:                apiCallerName,
 			EnvironName:                  environTrackerName,

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -451,6 +451,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
+		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",

--- a/worker/machineundertaker/manifold_test.go
+++ b/worker/machineundertaker/manifold_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/machineundertaker"
@@ -80,8 +81,11 @@ func makeManifold(workerResult worker.Worker, workerError error) dependency.Mani
 	return machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 		APICallerName: "the-caller",
 		EnvironName:   "the-environ",
-		NewWorker: func(machineundertaker.Facade, environs.Environ) (worker.Worker, error) {
+		NewWorker: func(machineundertaker.Facade, environs.Environ, common.CredentialAPI) (worker.Worker, error) {
 			return workerResult, workerError
+		},
+		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) {
+			return &fakeCredentialAPI{}, nil
 		},
 	})
 }

--- a/worker/machineundertaker/package_test.go
+++ b/worker/machineundertaker/package_test.go
@@ -12,3 +12,9 @@ import (
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }
+
+type fakeCredentialAPI struct{}
+
+func (*fakeCredentialAPI) InvalidateModelCredential(reason string) error {
+	return nil
+}

--- a/worker/machineundertaker/undertaker.go
+++ b/worker/machineundertaker/undertaker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/common"
 )
 
 var logger = loggo.GetLogger("juju.worker.machineundertaker")
@@ -43,14 +44,13 @@ type Undertaker struct {
 // NewWorker returns a machine undertaker worker that will watch for
 // machines that need to be removed and remove them, cleaning up any
 // necessary provider-level resources first.
-func NewWorker(api Facade, env environs.Environ) (worker.Worker, error) {
+func NewWorker(api Facade, env environs.Environ, credentialAPI common.CredentialAPI) (worker.Worker, error) {
 	envNetworking, _ := environs.SupportsNetworking(env)
-	callCtx := context.NewCloudCallContext()
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
 		Handler: &Undertaker{
 			API:         api,
 			Releaser:    envNetworking,
-			CallContext: callCtx,
+			CallContext: common.NewCloudCallContext(credentialAPI),
 		},
 	})
 	if err != nil {

--- a/worker/machineundertaker/undertaker_test.go
+++ b/worker/machineundertaker/undertaker_test.go
@@ -32,7 +32,7 @@ var _ = gc.Suite(&undertakerSuite{})
 func (s *undertakerSuite) TestErrorWatching(c *gc.C) {
 	api := s.makeAPIWithWatcher()
 	api.SetErrors(errors.New("blam"))
-	w, err := machineundertaker.NewWorker(api, &fakeEnviron{})
+	w, err := machineundertaker.NewWorker(api, &fakeEnviron{}, &fakeCredentialAPI{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
 	c.Check(err, gc.ErrorMatches, "blam")
@@ -42,7 +42,7 @@ func (s *undertakerSuite) TestErrorWatching(c *gc.C) {
 func (s *undertakerSuite) TestErrorGettingRemovals(c *gc.C) {
 	api := s.makeAPIWithWatcher()
 	api.SetErrors(nil, errors.New("explodo"))
-	w, err := machineundertaker.NewWorker(api, &fakeEnviron{})
+	w, err := machineundertaker.NewWorker(api, &fakeEnviron{}, &fakeCredentialAPI{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
 	c.Check(err, gc.ErrorMatches, "explodo")


### PR DESCRIPTION
## Description of change

Machine undertaker has been missed in the bigger PR [1] that made sure all other workers have the ability to invalidate cloud credential. We enable that ability here.

[1] https://github.com/juju/juju/pull/8786

