### PR TITLE
Rename credential-validator-flag to valid-credential-flag

### DIFF
--- a/cmd/jujud/agent/agenttest/engine.go
+++ b/cmd/jujud/agent/agenttest/engine.go
@@ -201,7 +201,7 @@ func AssertManifoldsDependencies(c *gc.C, manifolds dependency.Manifolds, expect
 	c.Assert(len(dependencies), gc.Equals, len(expected))
 
 	for _, n := range manifoldNames.SortedValues() {
-		c.Assert(dependencies[n], jc.SameContents, expected[n])
+		c.Assert(dependencies[n], jc.SameContents, expected[n], gc.Commentf("mismatched dependencies for worker %q", n))
 	}
 }
 

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -24,12 +24,12 @@ var (
 		"api-caller",
 		"api-config-watcher",
 		"clock",
-		"credential-validator-flag",
 		"is-responsible-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
 		"not-alive-flag",
 		"not-dead-flag",
+		"valid-credential-flag",
 	}
 	requireValidCredentialModelWorkers = []string{
 		"action-pruner",          // tertiary dependency: will be inactive because migration workers will be inactive

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -380,11 +380,12 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
 		})),
-		machineUndertakerName: ifNotMigrating(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
-			APICallerName: apiCallerName,
-			EnvironName:   environTrackerName,
-			NewWorker:     machineundertaker.NewWorker,
-		})),
+		machineUndertakerName: ifNotMigrating(ifCredentialValid(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
+			APICallerName:                apiCallerName,
+			EnvironName:                  environTrackerName,
+			NewWorker:                    machineundertaker.NewWorker,
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
+		}))),
 		modelUpgraderName: ifCredentialValid(modelupgrader.Manifold(modelupgrader.ManifoldConfig{
 			APICallerName:                apiCallerName,
 			EnvironName:                  environTrackerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -172,9 +172,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade: singular.NewFacade,
 			NewWorker: singular.NewWorker,
 		}),
-		// Cloud credential validator runs on all models, and
-		// determines if model's cloud credential is valid.
-		credentialValidatorFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{
+		// This flag runs on all models, and
+		// indicates if model's cloud credential is valid.
+		validCredentialFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{
 			APICallerName: apiCallerName,
 			NewFacade:     credentialvalidator.NewFacade,
 			NewWorker:     credentialvalidator.NewWorker,
@@ -540,7 +540,7 @@ var (
 	// the model has a valid credential.
 	ifCredentialValid = engine.Housing{
 		Flags: []string{
-			credentialValidatorFlagName,
+			validCredentialFlagName,
 		},
 	}.Decorate
 )
@@ -585,5 +585,5 @@ const (
 	caasUnitProvisionerName     = "caas-unit-provisioner"
 	caasBrokerTrackerName       = "caas-broker-tracker"
 
-	credentialValidatorFlagName = "credential-validator-flag"
+	validCredentialFlagName = "valid-credential-flag"
 )

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -460,7 +460,9 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-dead-flag"},
+		"not-dead-flag",
+		"valid-credential-flag",
+	},
 
 	"metric-worker": []string{
 		"agent",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -40,7 +40,6 @@ func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 		"charm-revision-updater",
 		"clock",
 		"compute-provisioner",
-		"credential-validator-flag",
 		"environ-tracker",
 		"firewaller",
 		"instance-poller",
@@ -62,6 +61,7 @@ func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 		"storage-provisioner",
 		"undertaker",
 		"unit-assigner",
+		"valid-credential-flag",
 	})
 }
 
@@ -86,7 +86,6 @@ func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
 		"caas-unit-provisioner",
 		"charm-revision-updater",
 		"clock",
-		"credential-validator-flag",
 		"is-responsible-flag",
 		"log-forwarder",
 		"migration-fortress",
@@ -101,6 +100,7 @@ func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
 		"state-cleaner",
 		"status-history-pruner",
 		"undertaker",
+		"valid-credential-flag",
 	})
 }
 
@@ -110,7 +110,6 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 		"api-caller",
 		"api-config-watcher",
 		"clock",
-		"credential-validator-flag",
 		"is-responsible-flag",
 		"not-alive-flag",
 		"not-dead-flag",
@@ -119,6 +118,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 		"model-upgrade-gate",
 		"model-upgraded-flag",
 		"model-upgrader",
+		"valid-credential-flag",
 	)
 	manifolds := model.IAASManifolds(model.ManifoldsConfig{
 		Agent: &mockAgent{},
@@ -256,8 +256,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 
 	"clock": []string{},
 
-	"credential-validator-flag": []string{"agent", "api-caller"},
-
 	"is-responsible-flag": []string{"agent", "api-caller", "clock"},
 
 	"log-forwarder": []string{
@@ -344,11 +342,14 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"caas-broker-tracker",
 		"clock",
-		"credential-validator-flag",
 		"is-responsible-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-alive-flag"},
+		"not-alive-flag",
+		"valid-credential-flag",
+	},
+
+	"valid-credential-flag": []string{"agent", "api-caller"},
 }
 
 var expectedIAASModelManifoldsWithDependencies = map[string][]string{
@@ -399,16 +400,15 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
-		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-dead-flag"},
-
-	"credential-validator-flag": []string{"agent", "api-caller"},
+		"not-dead-flag",
+		"valid-credential-flag",
+	},
 
 	"environ-tracker": []string{"agent", "api-caller", "clock", "is-responsible-flag"},
 
@@ -416,27 +416,29 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
-		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-dead-flag"},
+		"not-dead-flag",
+		"valid-credential-flag",
+	},
 
 	"instance-poller": []string{
 		"agent",
 		"api-caller",
 		"clock",
-		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-dead-flag"},
+		"not-dead-flag",
+		"valid-credential-flag",
+	},
 
 	"is-responsible-flag": []string{"agent", "api-caller", "clock"},
 
@@ -507,10 +509,11 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
-		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
-		"model-upgrade-gate"},
+		"model-upgrade-gate",
+		"valid-credential-flag",
+	},
 
 	"not-alive-flag": []string{"agent", "api-caller"},
 
@@ -566,12 +569,13 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
-		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-alive-flag"},
+		"not-alive-flag",
+		"valid-credential-flag",
+	},
 
 	"unit-assigner": []string{
 		"agent",
@@ -583,4 +587,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"model-upgrade-gate",
 		"model-upgraded-flag",
 		"not-dead-flag"},
+
+	"valid-credential-flag": []string{"agent", "api-caller"},
 }

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -451,6 +451,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
+		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -453,7 +453,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"clock",
-		"credential-validator-flag",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",

--- a/worker/machineundertaker/manifold_test.go
+++ b/worker/machineundertaker/manifold_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/machineundertaker"
@@ -80,8 +81,11 @@ func makeManifold(workerResult worker.Worker, workerError error) dependency.Mani
 	return machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 		APICallerName: "the-caller",
 		EnvironName:   "the-environ",
-		NewWorker: func(machineundertaker.Facade, environs.Environ) (worker.Worker, error) {
+		NewWorker: func(machineundertaker.Facade, environs.Environ, common.CredentialAPI) (worker.Worker, error) {
 			return workerResult, workerError
+		},
+		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) {
+			return &fakeCredentialAPI{}, nil
 		},
 	})
 }

--- a/worker/machineundertaker/package_test.go
+++ b/worker/machineundertaker/package_test.go
@@ -12,3 +12,9 @@ import (
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }
+
+type fakeCredentialAPI struct{}
+
+func (*fakeCredentialAPI) InvalidateModelCredential(reason string) error {
+	return nil
+}

--- a/worker/machineundertaker/undertaker.go
+++ b/worker/machineundertaker/undertaker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/common"
 )
 
 var logger = loggo.GetLogger("juju.worker.machineundertaker")
@@ -43,14 +44,13 @@ type Undertaker struct {
 // NewWorker returns a machine undertaker worker that will watch for
 // machines that need to be removed and remove them, cleaning up any
 // necessary provider-level resources first.
-func NewWorker(api Facade, env environs.Environ) (worker.Worker, error) {
+func NewWorker(api Facade, env environs.Environ, credentialAPI common.CredentialAPI) (worker.Worker, error) {
 	envNetworking, _ := environs.SupportsNetworking(env)
-	callCtx := context.NewCloudCallContext()
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
 		Handler: &Undertaker{
 			API:         api,
 			Releaser:    envNetworking,
-			CallContext: callCtx,
+			CallContext: common.NewCloudCallContext(credentialAPI),
 		},
 	})
 	if err != nil {

--- a/worker/machineundertaker/undertaker_test.go
+++ b/worker/machineundertaker/undertaker_test.go
@@ -32,7 +32,7 @@ var _ = gc.Suite(&undertakerSuite{})
 func (s *undertakerSuite) TestErrorWatching(c *gc.C) {
 	api := s.makeAPIWithWatcher()
 	api.SetErrors(errors.New("blam"))
-	w, err := machineundertaker.NewWorker(api, &fakeEnviron{})
+	w, err := machineundertaker.NewWorker(api, &fakeEnviron{}, &fakeCredentialAPI{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
 	c.Check(err, gc.ErrorMatches, "blam")
@@ -42,7 +42,7 @@ func (s *undertakerSuite) TestErrorWatching(c *gc.C) {
 func (s *undertakerSuite) TestErrorGettingRemovals(c *gc.C) {
 	api := s.makeAPIWithWatcher()
 	api.SetErrors(nil, errors.New("explodo"))
-	w, err := machineundertaker.NewWorker(api, &fakeEnviron{})
+	w, err := machineundertaker.NewWorker(api, &fakeEnviron{}, &fakeCredentialAPI{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
 	c.Check(err, gc.ErrorMatches, "explodo")


### PR DESCRIPTION
## Description of change

Juju model workers have a flag that allows them to determine whether model has a valid authentication mechanism to communicate with the cloud. This flag is misleading named 'validator' - it does not actually validates. This PR renames the flag to avoid future confusion.