### PR TITLE
add juju set-series command

### DIFF
--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package application
+package application_test
 
 import (
 	"strings"
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jtesting "github.com/juju/juju/testing"
@@ -37,7 +38,7 @@ func (s *AddRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&AddRelationSuite{})
 
 func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
-	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
+	cmd := application.NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
 	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	return err
@@ -86,7 +87,7 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
+	cmd := application.NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
 	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	ctx, _ := cmdtesting.RunCommand(c, cmd, "application1", "application2")
 	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -92,6 +92,18 @@ func NewUpdateSeriesCommandForTest(
 	return modelcmd.Wrap(cmd)
 }
 
+// NewSetSeriesCommandForTest returns a SetSeriesCommand with the specified api.
+func NewSetSeriesCommandForTest(
+	seriesAPI setSeriesAPI,
+	store jujuclient.ClientStore,
+) modelcmd.ModelCommand {
+	cmd := &setSeriesCommand{
+		setSeriesClient: seriesAPI,
+	}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
 // NewSuspendRelationCommandForTest returns a SuspendRelationCommand with the api provided as specified.
 func NewSuspendRelationCommandForTest(api SetRelationSuspendedAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &suspendRelationCommand{newAPIFunc: func() (SetRelationSuspendedAPI, error) {

--- a/cmd/juju/application/setseries.go
+++ b/cmd/juju/application/setseries.go
@@ -1,0 +1,140 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils/series"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewSetSeriesCommand returns a command which updates the series of
+// an application.
+func NewSetSeriesCommand() cmd.Command {
+	return modelcmd.Wrap(&setSeriesCommand{})
+}
+
+// setSeriesAPI defines a subset of the application facade, as required
+// by the set-series command.
+type setSeriesAPI interface {
+	BestAPIVersion() int
+	Close() error
+	UpdateApplicationSeries(string, string, bool) error
+}
+
+// setSeriesCommand is responsible for updating the series of an application or machine.
+type setSeriesCommand struct {
+	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
+
+	setSeriesClient setSeriesAPI
+
+	applicationName string
+	force           bool
+	series          string
+}
+
+var setSeriesDoc = `
+When no flags are set, an application series value with be set within juju.
+
+The update is disallowed unless the --force flag is used if the requested
+series is not explicitly supported by the application's charm and all
+subordinates, as well as any other charms which may be deployed to the same
+machine.
+
+Examples:
+	juju set-series <application> <series>
+	juju set-series <application> <series> --force
+
+See also:
+    status
+    upgrade-charm
+`
+
+func (c *setSeriesCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "set-series",
+		Args:    "<application> <series>",
+		Purpose: "Set an application's series.",
+		Doc:     setSeriesDoc,
+	}
+}
+
+func (c *setSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	f.BoolVar(&c.force, "force", false, "Set even if the series is not supported by the charm and/or related subordinate charms.")
+}
+
+// Init implements cmd.Command.
+func (c *setSeriesCommand) Init(args []string) error {
+	switch len(args) {
+	case 2:
+		if names.IsValidApplication(args[0]) {
+			c.applicationName = args[0]
+		} else {
+			return errors.Errorf("invalid application name %q", args[0])
+		}
+		if _, err := series.GetOSFromSeries(args[1]); err != nil {
+			return errors.Errorf("invalid series %q", args[1])
+		}
+		c.series = args[1]
+	case 1:
+		if _, err := series.GetOSFromSeries(args[0]); err != nil {
+			return errors.Errorf("no series specified")
+		} else {
+			return errors.Errorf("no application name")
+		}
+	case 0:
+		return errors.Errorf("application name and series required")
+	default:
+		return cmd.CheckEmpty(args[2:])
+	}
+	return nil
+}
+
+// Run implements cmd.Run.
+func (c *setSeriesCommand) Run(ctx *cmd.Context) error {
+	var apiRoot api.Connection
+	if c.setSeriesClient == nil {
+		var err error
+		apiRoot, err = c.NewAPIRoot()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer apiRoot.Close()
+	}
+
+	if c.applicationName != "" {
+		if c.setSeriesClient == nil {
+			c.setSeriesClient = application.NewClient(apiRoot)
+			defer c.setSeriesClient.Close()
+		}
+		if c.setSeriesClient.BestAPIVersion() < 5 {
+			return errors.New("setting the application series is not supported by this API server")
+		}
+		return c.updateApplicationSeries()
+	}
+
+	// This should never happen...
+	return errors.New("no application nor machine name specified")
+}
+
+func (c *setSeriesCommand) updateApplicationSeries() error {
+	err := block.ProcessBlockedError(
+		c.setSeriesClient.UpdateApplicationSeries(c.applicationName, c.series, c.force),
+		block.BlockChange)
+
+	if params.IsCodeIncompatibleSeries(err) {
+		return errors.Errorf("%v. Use --force to set the series anyway.", err)
+	}
+	return err
+}

--- a/cmd/juju/application/setseries.go
+++ b/cmd/juju/application/setseries.go
@@ -44,7 +44,7 @@ type setSeriesCommand struct {
 }
 
 var setSeriesDoc = `
-When no flags are set, an application series value with be set within juju.
+When no flags are set, an application series value will be set within juju.
 
 The update is disallowed unless the --force flag is used if the requested
 series is not explicitly supported by the application's charm and all

--- a/cmd/juju/application/setseries_test.go
+++ b/cmd/juju/application/setseries_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package application
+package application_test
 
 import (
 	"github.com/juju/cmd"
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
@@ -29,7 +30,7 @@ func (s *setSeriesSuite) SetUpTest(c *gc.C) {
 
 func (s *setSeriesSuite) runUpdateSeries(c *gc.C, args ...string) (*cmd.Context, error) {
 	store := jujuclienttesting.MinimalStore()
-	return cmdtesting.RunCommand(c, NewSetSeriesCommandForTest(s.mockApplicationAPI, store), args...)
+	return cmdtesting.RunCommand(c, application.NewSetSeriesCommandForTest(s.mockApplicationAPI, store), args...)
 }
 
 func (s *setSeriesSuite) TestSetSeriesApplicationGoodPath(c *gc.C) {

--- a/cmd/juju/application/setseries_test.go
+++ b/cmd/juju/application/setseries_test.go
@@ -1,0 +1,90 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+)
+
+type setSeriesSuite struct {
+	testing.IsolationSuite
+	mockApplicationAPI *mockSetApplicationSeriesAPI
+}
+
+var _ = gc.Suite(&setSeriesSuite{})
+
+func (s *setSeriesSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.mockApplicationAPI = &mockSetApplicationSeriesAPI{Stub: &testing.Stub{}}
+	s.mockApplicationAPI.apiVersion = 5
+}
+
+func (s *setSeriesSuite) runUpdateSeries(c *gc.C, args ...string) (*cmd.Context, error) {
+	store := jujuclienttesting.MinimalStore()
+	return cmdtesting.RunCommand(c, NewSetSeriesCommandForTest(s.mockApplicationAPI, store), args...)
+}
+
+func (s *setSeriesSuite) TestSetSeriesApplicationGoodPath(c *gc.C) {
+	_, err := s.runUpdateSeries(c, "ghost", "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	s.mockApplicationAPI.CheckCall(c, 0, "UpdateApplicationSeries", "ghost", "xenial", false)
+}
+
+func (s *setSeriesSuite) TestSetSeriesApplicationGoodPathForce(c *gc.C) {
+	_, err := s.runUpdateSeries(c, "--force", "ghost", "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	s.mockApplicationAPI.CheckCall(c, 0, "UpdateApplicationSeries", "ghost", "xenial", true)
+}
+
+func (s *setSeriesSuite) TestNoArguments(c *gc.C) {
+	_, err := s.runUpdateSeries(c)
+	c.Assert(err, gc.ErrorMatches, "application name and series required")
+}
+
+func (s *setSeriesSuite) TestArgumentsSeriesOnly(c *gc.C) {
+	_, err := s.runUpdateSeries(c, "ghost")
+	c.Assert(err, gc.ErrorMatches, "no series specified")
+}
+
+func (s *setSeriesSuite) TestArgumentsApplicationOnly(c *gc.C) {
+	_, err := s.runUpdateSeries(c, "xenial")
+	c.Assert(err, gc.ErrorMatches, "no application name")
+}
+
+func (s *setSeriesSuite) TestTooManyArguments(c *gc.C) {
+	_, err := s.runUpdateSeries(c, "ghost", "xenial", "something else")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["something else"\]`, gc.Commentf("details: %s", errors.Details(err)))
+}
+
+func (s *setSeriesSuite) TestOldAPI(c *gc.C) {
+	s.mockApplicationAPI.apiVersion = 4
+	_, err := s.runUpdateSeries(c, "ghost", "xenial")
+	c.Assert(err, gc.ErrorMatches, "setting the application series is not supported by this API server")
+}
+
+type mockSetApplicationSeriesAPI struct {
+	*testing.Stub
+	apiVersion int
+}
+
+func (a *mockSetApplicationSeriesAPI) Close() error {
+	a.MethodCall(a, "Close")
+	return a.NextErr()
+}
+
+func (a *mockSetApplicationSeriesAPI) BestAPIVersion() int {
+	return a.apiVersion
+}
+
+func (a *mockSetApplicationSeriesAPI) UpdateApplicationSeries(appName, series string, force bool) error {
+	a.MethodCall(a, "UpdateApplicationSeries", appName, series, force)
+	return a.NextErr()
+}

--- a/cmd/juju/application/suspendrelation_test.go
+++ b/cmd/juju/application/suspendrelation_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package application
+package application_test
 
 import (
 	"github.com/juju/cmd/cmdtesting"
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -32,7 +33,7 @@ var _ = gc.Suite(&SuspendRelationSuite{})
 
 func (s *SuspendRelationSuite) runSuspendRelation(c *gc.C, args ...string) error {
 	store := jujuclienttesting.MinimalStore()
-	_, err := cmdtesting.RunCommand(c, NewSuspendRelationCommandForTest(s.mockAPI, store), args...)
+	_, err := cmdtesting.RunCommand(c, application.NewSuspendRelationCommandForTest(s.mockAPI, store), args...)
 	return err
 }
 

--- a/cmd/juju/application/updateseries.go
+++ b/cmd/juju/application/updateseries.go
@@ -19,6 +19,10 @@ import (
 
 // NewUpdateSeriesCommand returns a command which updates the series of
 // an application or machine.
+//
+// TODO (hml) 2018-06-06
+// This command should be deprecated, it's been replaced with set-series
+// and upgrade-series.
 func NewUpdateSeriesCommand() cmd.Command {
 	return modelcmd.Wrap(&updateSeriesCommand{})
 }

--- a/cmd/juju/application/updateseries_test.go
+++ b/cmd/juju/application/updateseries_test.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package application
+package application_test
 
 import (
 	"github.com/juju/cmd"
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
@@ -30,7 +31,7 @@ func (s *updateSeriesSuite) SetUpTest(c *gc.C) {
 
 func (s *updateSeriesSuite) runUpdateSeries(c *gc.C, args ...string) (*cmd.Context, error) {
 	store := jujuclienttesting.MinimalStore()
-	return cmdtesting.RunCommand(c, NewUpdateSeriesCommandForTest(s.mockApplicationAPI, s.mockMachineAPI, store), args...)
+	return cmdtesting.RunCommand(c, application.NewUpdateSeriesCommandForTest(s.mockApplicationAPI, s.mockMachineAPI, store), args...)
 }
 
 func (s *updateSeriesSuite) TestUpdateSeriesApplicationGoodPath(c *gc.C) {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -314,6 +314,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(newUpgradeJujuCommand(nil, nil))
 	r.Register(application.NewUpgradeCharmCommand())
 	r.Register(application.NewUpdateSeriesCommand())
+	r.Register(application.NewSetSeriesCommand())
 
 	// Charm tool commands.
 	r.Register(newHelpToolCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -527,6 +527,7 @@ var commandNames = []string{
 	"set-meter-status",
 	"set-model-constraints",
 	"set-plan",
+	"set-series",
 	"set-wallet",
 	"show-action-output",
 	"show-action-status",

--- a/featuretests/cmd_juju_setseries_test.go
+++ b/featuretests/cmd_juju_setseries_test.go
@@ -18,7 +18,7 @@ type cmdSetSeriesSuite struct {
 func (s *cmdSetSeriesSuite) TestSetApplicationSeries(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "multi-series", URL: "local:quantal/multi-series-1"})
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
-	_ = s.Factory.MakeUnit(c, &factory.UnitParams{Application: app, SetCharmURL: true})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: app, SetCharmURL: true})
 	c.Assert(app.Series(), gc.Equals, "quantal")
 	runCommandExpectSuccess(c, "set-series", "multi-series", "trusty")
 	err := app.Refresh()

--- a/featuretests/cmd_juju_setseries_test.go
+++ b/featuretests/cmd_juju_setseries_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type cmdSetSeriesSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *cmdSetSeriesSuite) TestSetApplicationSeries(c *gc.C) {
+	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "multi-series", URL: "local:quantal/multi-series-1"})
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: charm})
+	_ = s.Factory.MakeUnit(c, &factory.UnitParams{Application: app, SetCharmURL: true})
+	c.Assert(app.Series(), gc.Equals, "quantal")
+	runCommandExpectSuccess(c, "set-series", "multi-series", "trusty")
+	err := app.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(app.Series(), gc.Equals, "trusty")
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -67,6 +67,7 @@ func init() {
 	gc.Suite(&meterStatusIntegrationSuite{})
 	gc.Suite(&CAASOperatorSuite{})
 	gc.Suite(&StatusSuite{})
+	gc.Suite(&cmdSetSeriesSuite{})
 
 	// TODO (anastasiamac 2016-07-19) Bug#1603585
 	// These tests cannot run on windows - they require a bootstrapped controller.


### PR DESCRIPTION
## Description of change

juju update-series <application> is becoming juju set-series <application> as part of managed series upgrade work.  juju update-series should be deprecated in the near future.

## QA steps

juju deploy ubuntu --series trusty
juju set-series ubuntu xenial
juju add-unit ubuntu
verify ubuntu/0 is using trusty and ubuntu/1 is using xenial

## Documentation changes

@pmatulis, a new command for juju is being added here. 

## Bug reference

n/a