### PR TITLE
Split state storage interface into 3 parts

### DIFF
--- a/apiserver/common/storagecommon/mock_test.go
+++ b/apiserver/common/storagecommon/mock_test.go
@@ -16,8 +16,8 @@ import (
 
 type fakeStorage struct {
 	testing.Stub
-	storagecommon.StorageInstanceInterface
-	storagecommon.StorageFilesystemInterface
+	storagecommon.StorageAccess
+	storagecommon.FilesystemAccess
 	storageInstance       func(names.StorageTag) (state.StorageInstance, error)
 	storageInstanceVolume func(names.StorageTag) (state.Volume, error)
 	volumeAttachment      func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -9,60 +9,54 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 )
 
-// StorageInterface is an interface for obtaining information about storage
-// instances and related entities.
-type StorageInterface interface {
+// StorageInstanceInterface is an interface for obtaining information about storage
+// instances and any associated unit attachments.
+type StorageInstanceInterface interface {
 	// StorageInstance returns the state.StorageInstance corresponding
 	// to the specified storage tag.
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
-
-	// StorageInstanceFilesystem returns the state.Filesystem assigned
-	// to the storage instance with the specified storage tag.
-	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
-
-	// StorageInstanceVolume returns the state.Volume assigned to the
-	// storage instance with the specified storage tag.
-	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
-
-	// FilesystemAttachment returns the state.FilesystemAttachment
-	// corresponding to the specified machine and filesystem.
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
-
-	// VolumeAttachment returns the state.VolumeAttachment corresponding
-	// to the specified machine and volume.
-	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
-
-	// WatchStorageAttachment watches for changes to the storage attachment
-	// corresponding to the identfified unit and storage instance.
-	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
-
-	// WatchFilesystemAttachment watches for changes to the filesystem
-	// attachment corresponding to the identfified machine and filesystem.
-	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
-
-	// WatchVolumeAttachment watches for changes to the volume attachment
-	// corresponding to the identfified machine and volume.
-	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
-
-	// WatchBlockDevices watches for changes to block devices associated
-	// with the specified machine.
-	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
-
-	// BlockDevices returns information about block devices published
-	// for the specified machine.
-	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 
 	// UnitStorageAttachments returns the storage attachments for the
 	// specified unit.
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 }
+
+// StorageVolumeInterface is an interface for obtaining information about
+// block storage instances and related entities.
+type StorageVolumeInterface interface {
+	// StorageInstanceVolume returns the state.Volume assigned to the
+	// storage instance with the specified storage tag.
+	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
+
+	// VolumeAttachment returns the state.VolumeAttachment corresponding
+	// to the specified machine and volume.
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+
+	// BlockDevices returns information about block devices published
+	// for the specified machine.
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
+}
+
+// StorageFilesystemInterface is an interface for obtaining information about
+// filesystem storage instances and related entities.
+type StorageFilesystemInterface interface {
+	// StorageInstanceFilesystem returns the state.Filesystem assigned
+	// to the storage instance with the specified storage tag.
+	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
+
+	// FilesystemAttachment returns the state.FilesystemAttachment
+	// corresponding to the specified machine and filesystem.
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+}
+
+// StorageAttachmentInfo is called by the uniter facade to get info needed to
+// run storage hooks and also the client facade to display storage info.
 
 // StorageAttachmentInfo returns the StorageAttachmentInfo for the specified
 // StorageAttachment by gathering information from related entities (volumes,
@@ -72,7 +66,9 @@ type StorageInterface interface {
 // if the storage attachment is not yet fully provisioned and ready for use
 // by a charm.
 func StorageAttachmentInfo(
-	st StorageInterface,
+	st StorageInstanceInterface,
+	stVolume StorageVolumeInterface,
+	stFile StorageFilesystemInterface,
 	att state.StorageAttachment,
 	machineTag names.MachineTag,
 ) (*storage.StorageAttachmentInfo, error) {
@@ -82,15 +78,21 @@ func StorageAttachmentInfo(
 	}
 	switch storageInstance.Kind() {
 	case state.StorageKindBlock:
-		return volumeStorageAttachmentInfo(st, storageInstance, machineTag)
+		if stVolume == nil {
+			return nil, errors.NotImplementedf("BlockStorage instance")
+		}
+		return volumeStorageAttachmentInfo(stVolume, storageInstance, machineTag)
 	case state.StorageKindFilesystem:
-		return filesystemStorageAttachmentInfo(st, storageInstance, machineTag)
+		if stFile == nil {
+			return nil, errors.NotImplementedf("FilesystemStorage instance")
+		}
+		return filesystemStorageAttachmentInfo(stFile, storageInstance, machineTag)
 	}
 	return nil, errors.Errorf("invalid storage kind %v", storageInstance.Kind())
 }
 
 func volumeStorageAttachmentInfo(
-	st StorageInterface,
+	st StorageVolumeInterface,
 	storageInstance state.StorageInstance,
 	machineTag names.MachineTag,
 ) (*storage.StorageAttachmentInfo, error) {
@@ -148,7 +150,7 @@ func volumeStorageAttachmentInfo(
 }
 
 func filesystemStorageAttachmentInfo(
-	st StorageInterface,
+	st StorageFilesystemInterface,
 	storageInstance state.StorageInstance,
 	machineTag names.MachineTag,
 ) (*storage.StorageAttachmentInfo, error) {
@@ -175,55 +177,6 @@ func filesystemStorageAttachmentInfo(
 		storage.StorageKindFilesystem,
 		filesystemAttachmentInfo.MountPoint,
 	}, nil
-}
-
-// WatchStorageAttachment returns a state.NotifyWatcher that reacts to changes
-// to the VolumeAttachmentInfo or FilesystemAttachmentInfo corresponding to the
-// tags specified.
-func WatchStorageAttachment(
-	st StorageInterface,
-	storageTag names.StorageTag,
-	machineTag names.MachineTag,
-	unitTag names.UnitTag,
-) (state.NotifyWatcher, error) {
-	storageInstance, err := st.StorageInstance(storageTag)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting storage instance")
-	}
-	var watchers []state.NotifyWatcher
-	switch storageInstance.Kind() {
-	case state.StorageKindBlock:
-		volume, err := st.StorageInstanceVolume(storageTag)
-		if err != nil {
-			return nil, errors.Annotate(err, "getting storage volume")
-		}
-		// We need to watch both the volume attachment, and the
-		// machine's block devices. A volume attachment's block
-		// device could change (most likely, become present).
-		watchers = []state.NotifyWatcher{
-			st.WatchVolumeAttachment(machineTag, volume.VolumeTag()),
-			// TODO(axw) 2015-09-30 #1501203
-			// We should filter the events to only those relevant
-			// to the volume attachment. This means we would need
-			// to either start th block device watcher after we
-			// have provisioned the volume attachment (cleaner?),
-			// or have the filter ignore changes until the volume
-			// attachment is provisioned.
-			st.WatchBlockDevices(machineTag),
-		}
-	case state.StorageKindFilesystem:
-		filesystem, err := st.StorageInstanceFilesystem(storageTag)
-		if err != nil {
-			return nil, errors.Annotate(err, "getting storage filesystem")
-		}
-		watchers = []state.NotifyWatcher{
-			st.WatchFilesystemAttachment(machineTag, filesystem.FilesystemTag()),
-		}
-	default:
-		return nil, errors.Errorf("invalid storage kind %v", storageInstance.Kind())
-	}
-	watchers = append(watchers, st.WatchStorageAttachment(storageTag, unitTag))
-	return common.NewMultiNotifyWatcher(watchers...), nil
 }
 
 // volumeAttachmentDevicePath returns the absolute device path for
@@ -253,6 +206,11 @@ func volumeAttachmentDevicePath(
 	}
 	return storage.BlockDevicePath(BlockDeviceFromState(blockDevice))
 }
+
+// Called by agent/provisioner and storageprovisioner.
+// agent/provisioner so that params used to create a machine
+// are augmented with the volumes to be attached at creation time.
+// storageprovisioner to provide resource tags for new volumes.
 
 // MaybeAssignedStorageInstance calls the provided function to get a
 // StorageTag, and returns the corresponding state.StorageInstance if
@@ -291,8 +249,11 @@ func storageTags(
 	return storageTags, nil
 }
 
+// These methods are used by ModelManager and Application facades
+// when destroying models and applications/units.
+
 // UnitStorage returns the storage instances attached to the specified unit.
-func UnitStorage(st StorageInterface, unit names.UnitTag) ([]state.StorageInstance, error) {
+func UnitStorage(st StorageInstanceInterface, unit names.UnitTag) ([]state.StorageInstance, error) {
 	attachments, err := st.UnitStorageAttachments(unit)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -314,14 +275,19 @@ func UnitStorage(st StorageInterface, unit names.UnitTag) ([]state.StorageInstan
 // be destroyed, and those that will be detached, when their attachment is
 // removed. Any storage that is not found will be omitted.
 func ClassifyDetachedStorage(
-	st StorageInterface,
+	st StorageInstanceInterface,
+	stVolume StorageVolumeInterface,
+	stFile StorageFilesystemInterface,
 	storage []state.StorageInstance,
 ) (destroyed, detached []params.Entity, _ error) {
 	for _, storage := range storage {
 		var detachable bool
 		switch storage.Kind() {
 		case state.StorageKindFilesystem:
-			f, err := st.StorageInstanceFilesystem(storage.StorageTag())
+			if stFile == nil {
+				return nil, nil, errors.NotImplementedf("FilesystemStorage instance")
+			}
+			f, err := stFile.StorageInstanceFilesystem(storage.StorageTag())
 			if errors.IsNotFound(err) {
 				continue
 			} else if err != nil {
@@ -329,7 +295,10 @@ func ClassifyDetachedStorage(
 			}
 			detachable = f.Detachable()
 		case state.StorageKindBlock:
-			v, err := st.StorageInstanceVolume(storage.StorageTag())
+			if stVolume == nil {
+				return nil, nil, errors.NotImplementedf("BlockStorage instance")
+			}
+			v, err := stVolume.StorageInstanceVolume(storage.StorageTag())
 			if errors.IsNotFound(err) {
 				continue
 			} else if err != nil {

--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -10,17 +10,26 @@ import (
 )
 
 var (
-	GetZone = &getZone
+	GetZone                = &getZone
+	WatchStorageAttachment = watchStorageAttachment
 
 	_ meterstatus.MeterStatus = (*UniterAPI)(nil)
 )
 
-type StorageStateInterface storageStateInterface
+type (
+	Backend                    backend
+	StorageStateInterface      storageInterface
+	StorageVolumeInterface     storageVolumeInterface
+	StorageFilesystemInterface storageFilesystemInterface
+)
 
 func NewStorageAPI(
-	st StorageStateInterface,
+	backend backend,
+	storage storageInterface,
+	stVolume storageVolumeInterface,
+	stFile storageFilesystemInterface,
 	resources facade.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
-	return newStorageAPI(storageStateInterface(st), resources, accessUnit)
+	return newStorageAPI(backend, storage, stVolume, stFile, resources, accessUnit)
 }

--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -19,17 +19,15 @@ var (
 type (
 	Backend                    backend
 	StorageStateInterface      storageInterface
-	StorageVolumeInterface     storageVolumeInterface
-	StorageFilesystemInterface storageFilesystemInterface
+	StorageVolumeInterface     = storageVolumeInterface
+	StorageFilesystemInterface = storageFilesystemInterface
 )
 
 func NewStorageAPI(
 	backend backend,
 	storage storageInterface,
-	stVolume storageVolumeInterface,
-	stFile storageFilesystemInterface,
 	resources facade.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
-	return newStorageAPI(backend, storage, stVolume, stFile, resources, accessUnit)
+	return newStorageAPI(backend, storage, resources, accessUnit)
 }

--- a/apiserver/facades/agent/uniter/mock_test.go
+++ b/apiserver/facades/agent/uniter/mock_test.go
@@ -1,27 +1,28 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storagecommon_test
+package uniter_test
 
 import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/apiserver/facades/agent/uniter"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/poolmanager"
 )
 
 type fakeStorage struct {
 	testing.Stub
-	storagecommon.StorageInstanceInterface
-	storagecommon.StorageFilesystemInterface
-	storageInstance       func(names.StorageTag) (state.StorageInstance, error)
-	storageInstanceVolume func(names.StorageTag) (state.Volume, error)
-	volumeAttachment      func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
-	blockDevices          func(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	uniter.StorageStateInterface
+	uniter.StorageFilesystemInterface
+	storageInstance        func(names.StorageTag) (state.StorageInstance, error)
+	storageInstanceVolume  func(names.StorageTag) (state.Volume, error)
+	volumeAttachment       func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	blockDevices           func(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	watchVolumeAttachment  func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	watchBlockDevices      func(names.MachineTag) state.NotifyWatcher
+	watchStorageAttachment func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 }
 
 func (s *fakeStorage) StorageInstance(tag names.StorageTag) (state.StorageInstance, error) {
@@ -42,6 +43,21 @@ func (s *fakeStorage) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (s
 func (s *fakeStorage) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, error) {
 	s.MethodCall(s, "BlockDevices", m)
 	return s.blockDevices(m)
+}
+
+func (s *fakeStorage) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchVolumeAttachment", m, v)
+	return s.watchVolumeAttachment(m, v)
+}
+
+func (s *fakeStorage) WatchBlockDevices(m names.MachineTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchBlockDevices", m)
+	return s.watchBlockDevices(m)
+}
+
+func (s *fakeStorage) WatchStorageAttachment(st names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchStorageAttachment", st, u)
+	return s.watchStorageAttachment(st, u)
 }
 
 type fakeStorageInstance struct {
@@ -65,15 +81,6 @@ func (i *fakeStorageInstance) Owner() (names.Tag, bool) {
 
 func (i *fakeStorageInstance) Kind() state.StorageKind {
 	return i.kind
-}
-
-type fakeStorageAttachment struct {
-	state.StorageAttachment
-	storageTag names.StorageTag
-}
-
-func (a *fakeStorageAttachment) StorageInstance() names.StorageTag {
-	return a.storageTag
 }
 
 type fakeVolume struct {
@@ -105,22 +112,6 @@ func (v *fakeVolume) Info() (state.VolumeInfo, error) {
 	return *v.info, nil
 }
 
-type fakeVolumeAttachment struct {
-	state.VolumeAttachment
-	info *state.VolumeAttachmentInfo
-}
+type nopSyncStarter struct{}
 
-func (v *fakeVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {
-	if v.info == nil {
-		return state.VolumeAttachmentInfo{}, errors.NotProvisionedf("volume attachment")
-	}
-	return *v.info, nil
-}
-
-type fakePoolManager struct {
-	poolmanager.PoolManager
-}
-
-func (pm *fakePoolManager) Get(name string) (*storage.Config, error) {
-	return nil, errors.NotFoundf("pool")
-}
+func (nopSyncStarter) StartSync() {}

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -10,45 +10,79 @@ import (
 	"github.com/juju/juju/state"
 )
 
-type storageStateInterface interface {
-	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
+type storageInterface interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
-	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
-	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
 	DestroyUnitStorageAttachments(names.UnitTag) error
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
-	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
-	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
 	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
-	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
-	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
-	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
-	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
-	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
-	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }
 
-type storageStateShim struct {
-	*state.State
+type storageVolumeInterface interface {
+	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+}
+
+type storageFilesystemInterface interface {
+	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
+}
+
+var getStorageState = func(st *state.State) (storageInterface, storageVolumeInterface, storageFilesystemInterface, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if m.Type() == state.ModelTypeIAAS {
+		im, _ := m.IAASModel()
+		storageAccess := &iaasModelShim{Model: m, IAASModel: im}
+		return im, storageAccess, storageAccess, nil
+	}
+	caasModel, _ := m.CAASModel()
+	storageAccess := caasModelShim{Model: m, CAASModel: caasModel}
+	// CAAS models don't support volume storage yet.
+	return caasModel, nil, storageAccess, nil
+}
+
+type iaasModelShim struct {
+	*state.Model
 	*state.IAASModel
 }
 
-var getStorageState = func(st *state.State) (storageStateInterface, error) {
-	im, err := st.IAASModel()
-	if err != nil {
-		return nil, err
-	}
-	return storageStateShim{State: st, IAASModel: im}, nil
+type caasModelShim struct {
+	*state.Model
+	*state.CAASModel
 }
 
-// UnitAssignedMachine returns the tag of the machine that the unit
+type backend interface {
+	Unit(string) (Unit, error)
+}
+
+type Unit interface {
+	AssignedMachineId() (string, error)
+	StorageConstraints() (map[string]state.StorageConstraints, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) Unit(name string) (Unit, error) {
+	return s.State.Unit(name)
+}
+
+// unitAssignedMachine returns the tag of the machine that the unit
 // is assigned to, or an error if the unit cannot be obtained or is
 // not assigned to a machine.
-func (s storageStateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineTag, error) {
-	unit, err := s.Unit(tag.Id())
+func unitAssignedMachine(backend backend, tag names.UnitTag) (names.MachineTag, error) {
+	unit, err := backend.Unit(tag.Id())
 	if err != nil {
 		return names.MachineTag{}, errors.Trace(err)
 	}
@@ -59,10 +93,10 @@ func (s storageStateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineT
 	return names.NewMachineTag(mid), nil
 }
 
-// UnitStorageConstraints returns storage constraints for this unit,
+// unitStorageConstraints returns storage constraints for this unit,
 // or an error if the unit or its constraints cannot be obtained.
-func (s storageStateShim) UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {
-	unit, err := s.Unit(u.Id())
+func unitStorageConstraints(backend backend, u names.UnitTag) (map[string]state.StorageConstraints, error) {
+	unit, err := backend.Unit(u.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/uniter/storage.go
+++ b/apiserver/facades/agent/uniter/storage.go
@@ -17,20 +17,29 @@ import (
 
 // StorageAPI provides access to the Storage API facade.
 type StorageAPI struct {
-	st         storageStateInterface
+	backend    backend
+	storage    storageInterface
+	stVolume   storageVolumeInterface
+	stFile     storageFilesystemInterface
 	resources  facade.Resources
 	accessUnit common.GetAuthFunc
 }
 
 // newStorageAPI creates a new server-side Storage API facade.
 func newStorageAPI(
-	st storageStateInterface,
+	backend backend,
+	storage storageInterface,
+	stVolume storageVolumeInterface,
+	stFile storageFilesystemInterface,
 	resources facade.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
 
 	return &StorageAPI{
-		st:         st,
+		backend:    backend,
+		storage:    storage,
+		stVolume:   stVolume,
+		stFile:     stFile,
 		resources:  resources,
 		accessUnit: accessUnit,
 	}, nil
@@ -62,7 +71,7 @@ func (s *StorageAPI) getOneUnitStorageAttachmentIds(canAccess common.AuthFunc, u
 	if err != nil || !canAccess(tag) {
 		return nil, common.ErrPerm
 	}
-	stateStorageAttachments, err := s.st.UnitStorageAttachments(tag)
+	stateStorageAttachments, err := s.storage.UnitStorageAttachments(tag)
 	if errors.IsNotFound(err) {
 		return nil, common.ErrPerm
 	} else if err != nil {
@@ -96,7 +105,7 @@ func (s *StorageAPI) DestroyUnitStorageAttachments(args params.Entities) (params
 		if !canAccess(unitTag) {
 			return common.ErrPerm
 		}
-		return s.st.DestroyUnitStorageAttachments(unitTag)
+		return s.storage.DestroyUnitStorageAttachments(unitTag)
 	}
 	for i, entity := range args.Entities {
 		err := one(entity.Tag)
@@ -165,19 +174,19 @@ func (s *StorageAPI) getOneStateStorageAttachment(canAccess common.AuthFunc, id 
 	if err != nil {
 		return nil, err
 	}
-	return s.st.StorageAttachment(storageTag, unitTag)
+	return s.storage.StorageAttachment(storageTag, unitTag)
 }
 
 func (s *StorageAPI) fromStateStorageAttachment(stateStorageAttachment state.StorageAttachment) (params.StorageAttachment, error) {
-	machineTag, err := s.st.UnitAssignedMachine(stateStorageAttachment.Unit())
+	machineTag, err := unitAssignedMachine(s.backend, stateStorageAttachment.Unit())
 	if err != nil {
 		return params.StorageAttachment{}, err
 	}
-	info, err := storagecommon.StorageAttachmentInfo(s.st, stateStorageAttachment, machineTag)
+	info, err := storagecommon.StorageAttachmentInfo(s.storage, s.stVolume, s.stFile, stateStorageAttachment, machineTag)
 	if err != nil {
 		return params.StorageAttachment{}, err
 	}
-	stateStorageInstance, err := s.st.StorageInstance(stateStorageAttachment.StorageInstance())
+	stateStorageInstance, err := s.storage.StorageInstance(stateStorageAttachment.StorageInstance())
 	if err != nil {
 		return params.StorageAttachment{}, err
 	}
@@ -222,7 +231,7 @@ func (s *StorageAPI) watchOneUnitStorageAttachments(tag string, canAccess func(n
 	if err != nil || !canAccess(unitTag) {
 		return nothing, common.ErrPerm
 	}
-	watch := s.st.WatchStorageAttachments(unitTag)
+	watch := s.storage.WatchStorageAttachments(unitTag)
 	if changes, ok := <-watch.Changes(); ok {
 		return params.StringsWatchResult{
 			StringsWatcherId: s.resources.Register(watch),
@@ -268,11 +277,11 @@ func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, ca
 	if err != nil {
 		return nothing, err
 	}
-	machineTag, err := s.st.UnitAssignedMachine(unitTag)
+	machineTag, err := unitAssignedMachine(s.backend, unitTag)
 	if err != nil {
 		return nothing, err
 	}
-	watch, err := storagecommon.WatchStorageAttachment(s.st, storageTag, machineTag, unitTag)
+	watch, err := watchStorageAttachment(s.storage, s.stVolume, s.stFile, storageTag, machineTag, unitTag)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}
@@ -315,7 +324,7 @@ func (s *StorageAPI) removeOneStorageAttachment(id params.StorageAttachmentId, c
 	if err != nil {
 		return err
 	}
-	err = s.st.RemoveStorageAttachment(storageTag, unitTag)
+	err = s.storage.RemoveStorageAttachment(storageTag, unitTag)
 	if errors.IsNotFound(err) {
 		err = nil
 	}
@@ -325,10 +334,10 @@ func (s *StorageAPI) removeOneStorageAttachment(id params.StorageAttachmentId, c
 // AddUnitStorage validates and creates additional storage instances for units.
 // Failures on an individual storage instance do not block remaining
 // instances from being processed.
-func (a *StorageAPI) AddUnitStorage(
+func (s *StorageAPI) AddUnitStorage(
 	args params.StoragesAddParams,
 ) (params.ErrorResults, error) {
-	canAccess, err := a.accessUnit()
+	canAccess, err := s.accessUnit()
 	if err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -352,7 +361,7 @@ func (a *StorageAPI) AddUnitStorage(
 			continue
 		}
 
-		cons, err := a.st.UnitStorageConstraints(u)
+		cons, err := unitStorageConstraints(s.backend, u)
 		if err != nil {
 			result[i] = serverErr(err)
 			continue
@@ -364,7 +373,7 @@ func (a *StorageAPI) AddUnitStorage(
 			continue
 		}
 
-		_, err = a.st.AddStorageForUnit(u, one.StorageName, oneCons)
+		_, err = s.storage.AddStorageForUnit(u, one.StorageName, oneCons)
 		if err != nil {
 			result[i] = storageErr(err, one.StorageName, one.UnitTag)
 		}
@@ -405,4 +414,55 @@ func accessUnitTag(tag string, canAccess func(names.Tag) bool) (names.UnitTag, e
 		return names.UnitTag{}, common.ErrPerm
 	}
 	return u, nil
+}
+
+// watchStorageAttachment returns a state.NotifyWatcher that reacts to changes
+// to the VolumeAttachmentInfo or FilesystemAttachmentInfo corresponding to the
+// tags specified.
+func watchStorageAttachment(
+	st storageInterface,
+	stVolume storageVolumeInterface,
+	stFile storageFilesystemInterface,
+	storageTag names.StorageTag,
+	machineTag names.MachineTag,
+	unitTag names.UnitTag,
+) (state.NotifyWatcher, error) {
+	storageInstance, err := st.StorageInstance(storageTag)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting storage instance")
+	}
+	var watchers []state.NotifyWatcher
+	switch storageInstance.Kind() {
+	case state.StorageKindBlock:
+		volume, err := stVolume.StorageInstanceVolume(storageTag)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting storage volume")
+		}
+		// We need to watch both the volume attachment, and the
+		// machine's block devices. A volume attachment's block
+		// device could change (most likely, become present).
+		watchers = []state.NotifyWatcher{
+			stVolume.WatchVolumeAttachment(machineTag, volume.VolumeTag()),
+			// TODO(axw) 2015-09-30 #1501203
+			// We should filter the events to only those relevant
+			// to the volume attachment. This means we would need
+			// to either start th block device watcher after we
+			// have provisioned the volume attachment (cleaner?),
+			// or have the filter ignore changes until the volume
+			// attachment is provisioned.
+			stVolume.WatchBlockDevices(machineTag),
+		}
+	case state.StorageKindFilesystem:
+		filesystem, err := stFile.StorageInstanceFilesystem(storageTag)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting storage filesystem")
+		}
+		watchers = []state.NotifyWatcher{
+			stFile.WatchFilesystemAttachment(machineTag, filesystem.FilesystemTag()),
+		}
+	default:
+		return nil, errors.Errorf("invalid storage kind %v", storageInstance.Kind())
+	}
+	watchers = append(watchers, st.WatchStorageAttachment(storageTag, unitTag))
+	return common.NewMultiNotifyWatcher(watchers...), nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -199,9 +199,9 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		return nil, errors.Trace(err)
 	}
 
-	storageAccessor, storageVolume, storageFile, err := getStorageState(st)
+	storageAccessor, err := getStorageState(st)
 	storageAPI, err := newStorageAPI(
-		stateShim{st}, storageAccessor, storageVolume, storageFile, resources, accessUnit)
+		stateShim{st}, storageAccessor, resources, accessUnit)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -199,17 +199,11 @@ func NewUniterAPI(st *state.State, resources facade.Resources, authorizer facade
 		return nil, errors.Trace(err)
 	}
 
-	// // Only IAAS models support storage (for now).
-	var storageAPI *StorageAPI
-	if m.Type() == state.ModelTypeIAAS {
-		ss, err := getStorageState(st)
-		if err != nil {
-			return nil, errors.Annotate(err, "getting storage state")
-		}
-		storageAPI, err = newStorageAPI(ss, resources, accessUnit)
-		if err != nil {
-			return nil, err
-		}
+	storageAccessor, storageVolume, storageFile, err := getStorageState(st)
+	storageAPI, err := newStorageAPI(
+		stateShim{st}, storageAccessor, storageVolume, storageFile, resources, accessUnit)
+	if err != nil {
+		return nil, err
 	}
 	msAPI, err := meterstatus.NewMeterStatusAPI(st, resources, authorizer)
 	if err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -60,9 +60,15 @@ type APIv6 struct {
 //
 // API provides the Application API facade for version 5.
 type APIBase struct {
-	backend    Backend
+	backend  Backend
+	stVolume storagecommon.StorageVolumeInterface
+	stFile   storagecommon.StorageFilesystemInterface
+
 	authorizer facade.Authorizer
 	check      BlockChecker
+
+	modelTag  names.ModelTag
+	modelType state.ModelType
 
 	// TODO(axw) stateCharm only exists because I ran out
 	// of time unwinding all of the tendrils of state. We
@@ -104,16 +110,24 @@ func NewFacadeV6(ctx facade.Context) (*APIv6, error) {
 }
 
 func newFacadeBase(ctx facade.Context) (*APIBase, error) {
-	backend, err := NewStateBackend(ctx.State())
+	backend, stVolume, stFile, err := NewStateBackend(ctx.State())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting state")
+	}
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting model")
 	}
 	blockChecker := common.NewBlockChecker(ctx.State())
 	stateCharm := CharmToStateCharm
 	return NewAPIBase(
 		backend,
+		stVolume,
+		stFile,
 		ctx.Auth(),
 		blockChecker,
+		model.ModelTag(),
+		model.Type(),
 		stateCharm,
 		DeployApplication,
 	)
@@ -122,8 +136,12 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 // NewAPIBase returns a new application API facade.
 func NewAPIBase(
 	backend Backend,
+	stVolume storagecommon.StorageVolumeInterface,
+	stFile storagecommon.StorageFilesystemInterface,
 	authorizer facade.Authorizer,
 	blockChecker BlockChecker,
+	modelTag names.ModelTag,
+	modelType state.ModelType,
 	stateCharm func(Charm) *state.Charm,
 	deployApplication func(ApplicationDeployer, DeployApplicationParams) (Application, error),
 ) (*APIBase, error) {
@@ -132,8 +150,12 @@ func NewAPIBase(
 	}
 	return &APIBase{
 		backend:               backend,
+		stVolume:              stVolume,
+		stFile:                stFile,
 		authorizer:            authorizer,
 		check:                 blockChecker,
+		modelTag:              modelTag,
+		modelType:             modelType,
 		stateCharm:            stateCharm,
 		deployApplicationFunc: deployApplication,
 	}, nil
@@ -151,11 +173,11 @@ func (api *APIBase) checkPermission(tag names.Tag, perm permission.Access) error
 }
 
 func (api *APIBase) checkCanRead() error {
-	return api.checkPermission(api.backend.ModelTag(), permission.ReadAccess)
+	return api.checkPermission(api.modelTag, permission.ReadAccess)
 }
 
 func (api *APIBase) checkCanWrite() error {
-	return api.checkPermission(api.backend.ModelTag(), permission.WriteAccess)
+	return api.checkPermission(api.modelTag, permission.WriteAccess)
 }
 
 // SetMetricCredentials sets credentials on the application.
@@ -223,7 +245,7 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Applications {
-		err := deployApplication(api.backend, api.stateCharm, arg, api.deployApplicationFunc)
+		err := deployApplication(api.backend, api.modelType, api.stateCharm, arg, api.deployApplicationFunc)
 		result.Results[i].Error = common.ServerError(err)
 
 		if err != nil && len(arg.Resources) != 0 {
@@ -290,6 +312,7 @@ func splitApplicationAndCharmConfig(modelType state.ModelType, inConfig map[stri
 // both the legacy API on the client facade, as well as the new application facade.
 func deployApplication(
 	backend Backend,
+	modelType state.ModelType,
 	stateCharm func(Charm) *state.Charm,
 	args params.ApplicationDeploy,
 	deployApplicationFunc func(ApplicationDeployer, DeployApplicationParams) (Application, error),
@@ -302,17 +325,17 @@ func deployApplication(
 		return errors.Errorf("charm url must include revision")
 	}
 
-	if backend.ModelType() != state.ModelTypeIAAS {
+	if modelType != state.ModelTypeIAAS {
 		if len(args.AttachStorage) > 0 {
 			return errors.Errorf(
 				"AttachStorage may not be specified for %s models",
-				backend.ModelType(),
+				modelType,
 			)
 		}
 		if len(args.Placement) > 0 {
 			return errors.Errorf(
 				"Placement may not be specified for %s models",
-				backend.ModelType(),
+				modelType,
 			)
 		}
 	}
@@ -338,13 +361,13 @@ func deployApplication(
 		return errors.Trace(err)
 	}
 
-	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(backend.ModelType(), args.Config)
+	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(modelType, args.Config)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	var applicationConfig *application.Config
-	schema, defaults, err := applicationConfigSchema(backend.ModelType())
+	schema, defaults, err := applicationConfigSchema(modelType)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -837,7 +860,7 @@ func (api *APIBase) Expose(args params.ApplicationExpose) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if api.backend.ModelType() == state.ModelTypeCAAS {
+	if api.modelType == state.ModelTypeCAAS {
 		appConfig, err := app.ApplicationConfig()
 		if err != nil {
 			return errors.Trace(err)
@@ -887,7 +910,7 @@ func (api *APIBase) AddUnits(args params.AddApplicationUnits) (params.AddApplica
 	if err := api.check.ChangeAllowed(); err != nil {
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)
 	}
-	units, err := addApplicationUnits(api.backend, args)
+	units, err := addApplicationUnits(api.backend, api.modelType, args)
 	if err != nil {
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)
 	}
@@ -899,26 +922,26 @@ func (api *APIBase) AddUnits(args params.AddApplicationUnits) (params.AddApplica
 }
 
 // addApplicationUnits adds a given number of units to an application.
-func addApplicationUnits(backend Backend, args params.AddApplicationUnits) ([]Unit, error) {
+func addApplicationUnits(backend Backend, modelType state.ModelType, args params.AddApplicationUnits) ([]Unit, error) {
 	if args.NumUnits < 1 {
 		return nil, errors.New("must add at least one unit")
 	}
 
 	assignUnits := true
-	if backend.ModelType() != state.ModelTypeIAAS {
+	if modelType != state.ModelTypeIAAS {
 		// In a CAAS model, there are no machines for
 		// units to be assigned to.
 		assignUnits = false
 		if len(args.AttachStorage) > 0 {
 			return nil, errors.Errorf(
 				"AttachStorage may not be specified for %s models",
-				backend.ModelType(),
+				modelType,
 			)
 		}
 		if len(args.Placement) > 0 {
 			return nil, errors.Errorf(
 				"Placement may not be specified for %s models",
-				backend.ModelType(),
+				modelType,
 			)
 		}
 	}
@@ -1022,7 +1045,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 			return nil, errors.Errorf("unit %q is a subordinate", name)
 		}
 		var info params.DestroyUnitInfo
-		if api.backend.ModelType() == state.ModelTypeIAAS {
+		if api.modelType == state.ModelTypeIAAS {
 			storage, err := storagecommon.UnitStorage(api.backend, unit.UnitTag())
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -1036,7 +1059,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 				}
 			} else {
 				info.DestroyedStorage, info.DetachedStorage, err = storagecommon.ClassifyDetachedStorage(
-					api.backend, storage,
+					api.backend, api.stVolume, api.stFile, storage,
 				)
 				if err != nil {
 					return nil, errors.Trace(err)
@@ -1132,7 +1155,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				info.DestroyedUnits,
 				params.Entity{unit.UnitTag().String()},
 			)
-			if api.backend.ModelType() != state.ModelTypeIAAS {
+			if api.modelType != state.ModelTypeIAAS {
 				// Non-IAAS model; no need to deal with storage below.
 				arg.DestroyStorage = false
 				continue
@@ -1164,7 +1187,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				}
 			} else {
 				destroyed, detached, err := storagecommon.ClassifyDetachedStorage(
-					api.backend, storage,
+					api.backend, api.stVolume, api.stFile, storage,
 				)
 				if err != nil {
 					return nil, err
@@ -1648,11 +1671,11 @@ func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error 
 		return errors.Trace(err)
 	}
 
-	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(api.backend.ModelType(), arg.Config)
+	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(api.modelType, arg.Config)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	schema, defaults, err := applicationConfigSchema(api.backend.ModelType())
+	schema, defaults, err := applicationConfigSchema(api.modelType)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1705,7 +1728,7 @@ func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 		return errors.Trace(err)
 	}
 
-	schema, defaults, err := applicationConfigSchema(api.backend.ModelType())
+	schema, defaults, err := applicationConfigSchema(api.modelType)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -87,14 +87,14 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv6 {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-	backend, stVolume, stFile, err := application.NewStateBackend(s.State)
+	storageAccess, err := application.GetStorageState(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	api, err := application.NewAPIBase(
-		backend,
-		stVolume, stFile,
+		application.GetState(s.State),
+		storageAccess,
 		s.authorizer,
 		blockChecker,
 		model.ModelTag(),

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -87,13 +87,18 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv6 {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-	backend, err := application.NewStateBackend(s.State)
+	backend, stVolume, stFile, err := application.NewStateBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	api, err := application.NewAPIBase(
 		backend,
+		stVolume, stFile,
 		s.authorizer,
 		blockChecker,
+		model.ModelTag(),
+		model.Type(),
 		application.CharmToStateCharm,
 		application.DeployApplication,
 	)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -49,7 +49,6 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	api, err := application.NewAPIBase(
 		&s.backend,
 		&s.backend,
-		&s.backend,
 		s.authorizer,
 		&s.blockChecker,
 		names.NewModelTag(utils.MustNewUUID().String()),

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -48,8 +48,12 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
 	api, err := application.NewAPIBase(
 		&s.backend,
+		&s.backend,
+		&s.backend,
 		s.authorizer,
 		&s.blockChecker,
+		names.NewModelTag(utils.MustNewUUID().String()),
+		state.ModelTypeIAAS,
 		func(application.Charm) *state.Charm {
 			return &state.Charm{}
 		},
@@ -74,7 +78,6 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	}
 	s.relation = mockRelation{tag: names.NewRelationTag("wordpress:db mysql:db")}
 	s.backend = mockBackend{
-		modelType:   state.ModelTypeIAAS,
 		controllers: make(map[string]crossmodel.ControllerInfo),
 		applications: map[string]*mockApplication{
 			"postgresql": {
@@ -468,7 +471,7 @@ func (s *ApplicationSuite) TestDeployAttachStorage(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "foo",
@@ -510,7 +513,7 @@ func (s *ApplicationSuite) TestAddUnits(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestAddUnitsCAASModel(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	results, err := s.api.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "postgresql",
 		NumUnits:        1,
@@ -558,7 +561,7 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorageInvalidStorageTag(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestAddUnitsAttachStorageCAASModel(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	_, err := s.api.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "postgresql",
 		NumUnits:        1,
@@ -568,7 +571,7 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorageCAASModel(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestAddUnitsPlacementCAASModel(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	_, err := s.api.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "postgresql",
 		NumUnits:        1,
@@ -1039,7 +1042,7 @@ func (s *ApplicationSuite) TestRemoteRelationDisAllowedCIDR(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	result, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
 		Args: []params.ApplicationConfigSet{{
 			ApplicationName: "postgresql",
@@ -1084,7 +1087,7 @@ func (s *ApplicationSuite) TestSetApplicationConfigPermissionDenied(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestUnsetApplicationConfig(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	result, err := s.api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{
 		Args: []params.ApplicationUnset{{
 			ApplicationName: "postgresql",
@@ -1183,7 +1186,7 @@ func (s *ApplicationSuite) TestResolveUnitErrorsPermissionDenied(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestCAASExposeWithoutHostname(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	err := s.api.Expose(params.ApplicationExpose{
 		ApplicationName: "postgresql",
 	})
@@ -1193,7 +1196,7 @@ func (s *ApplicationSuite) TestCAASExposeWithoutHostname(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestCAASExposeWithHostname(c *gc.C) {
-	s.backend.modelType = state.ModelTypeCAAS
+	application.SetModelType(s.api, state.ModelTypeCAAS)
 	app := s.backend.applications["postgresql"]
 	app.config = coreapplication.ConfigAttributes{"juju-external-hostname": "exthost"}
 	err := s.api.Expose(params.ApplicationExpose{

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -8,7 +8,12 @@ import "github.com/juju/juju/state"
 var (
 	ParseSettingsCompatible = parseSettingsCompatible
 	NewStateStorage         = &newStateStorage
+	GetStorageState         = getStorageState
 )
+
+func GetState(st *state.State) Backend {
+	return stateShim{st}
+}
 
 func SetModelType(api *APIv6, modelType state.ModelType) {
 	api.modelType = modelType

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -3,7 +3,13 @@
 
 package application
 
+import "github.com/juju/juju/state"
+
 var (
 	ParseSettingsCompatible = parseSettingsCompatible
 	NewStateStorage         = &newStateStorage
 )
+
+func SetModelType(api *APIv6, modelType state.ModelType) {
+	api.modelType = modelType
+}

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -68,7 +68,7 @@ func (api *APIBase) getConfig(
 		return params.ApplicationGetResults{}, err
 	}
 
-	providerSchema, providerDefaults, err := applicationConfigSchema(api.backend.ModelType())
+	providerSchema, providerDefaults, err := applicationConfigSchema(api.modelType)
 	if err != nil {
 		return params.ApplicationGetResults{}, err
 	}

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -41,14 +41,14 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	backend, stVolume, stFile, err := application.NewStateBackend(s.State)
+	storageAccess, err := application.GetStorageState(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := application.NewAPIBase(
-		backend,
-		stVolume, stFile,
+		application.GetState(s.State),
+		storageAccess,
 		s.authorizer,
 		blockChecker,
 		model.ModelTag(),
@@ -183,12 +183,12 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 		expectedAppConfig[name] = info
 	}
 
-	backend, stVolume, stFile, err := application.NewStateBackend(st)
+	storageAccess, err := application.GetStorageState(st)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(st)
 	api, err := application.NewAPIBase(
-		backend,
-		stVolume, stFile,
+		application.GetState(st),
+		storageAccess,
 		s.authorizer,
 		blockChecker,
 		names.NewModelTag(st.ModelUUID()),

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon.v2-unstable"
 
+	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facades/client/application"
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/crossmodel"
@@ -222,56 +223,17 @@ func (m *mockRemoteApplication) Destroy() error {
 	return nil
 }
 
-type mockSpace struct {
-	name       string
-	providerId network.Id
-	subnets    []application.Subnet
-}
-
-func (m *mockSpace) Name() string {
-	return m.name
-}
-
-func (m *mockSpace) ProviderId() network.Id {
-	return m.providerId
-}
-
-type mockSubnet struct {
-	cidr              string
-	vlantag           int
-	providerId        network.Id
-	providerNetworkId network.Id
-	zones             []string
-}
-
-func (m *mockSubnet) CIDR() string {
-	return m.cidr
-}
-
-func (m *mockSubnet) VLANTag() int {
-	return m.vlantag
-}
-
-func (m *mockSubnet) ProviderId() network.Id {
-	return m.providerId
-}
-
-func (m *mockSubnet) ProviderNetworkId() network.Id {
-	return m.providerNetworkId
-}
-
 type mockBackend struct {
 	jtesting.Stub
 	application.Backend
+	storagecommon.StorageVolumeInterface
+	storagecommon.StorageFilesystemInterface
 
-	modelUUID                  string
-	modelType                  state.ModelType
 	charm                      *mockCharm
 	allmodels                  []application.Model
 	users                      set.Strings
 	applications               map[string]*mockApplication
 	remoteApplications         map[string]application.RemoteApplication
-	spaces                     map[string]application.Space
 	endpoints                  *[]state.Endpoint
 	relations                  map[int]*mockRelation
 	offerConnections           map[string]application.OfferConnection
@@ -498,26 +460,6 @@ func (m *mockExternalController) ControllerInfo() crossmodel.ControllerInfo {
 func (m *mockBackend) SaveController(controllerInfo crossmodel.ControllerInfo, modelUUID string) (application.ExternalController, error) {
 	m.controllers[modelUUID] = controllerInfo
 	return &mockExternalController{controllerInfo.ControllerTag.Id(), controllerInfo}, nil
-}
-
-func (m *mockBackend) Space(name string) (application.Space, error) {
-	space, ok := m.spaces[name]
-	if !ok {
-		return nil, errors.NotFoundf("space %q", name)
-	}
-	return space, nil
-}
-
-func (m *mockBackend) ModelUUID() string {
-	return m.modelUUID
-}
-
-func (m *mockBackend) ModelTag() names.ModelTag {
-	return names.NewModelTag(m.modelUUID)
-}
-
-func (m *mockBackend) ModelType() state.ModelType {
-	return m.modelType
 }
 
 type mockBlockChecker struct {

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -226,8 +226,6 @@ func (m *mockRemoteApplication) Destroy() error {
 type mockBackend struct {
 	jtesting.Stub
 	application.Backend
-	storagecommon.StorageVolumeInterface
-	storagecommon.StorageFilesystemInterface
 
 	charm                      *mockCharm
 	allmodels                  []application.Model
@@ -241,6 +239,19 @@ type mockBackend struct {
 	storageInstances           map[string]*mockStorage
 	storageInstanceFilesystems map[string]*mockFilesystem
 	controllers                map[string]crossmodel.ControllerInfo
+}
+
+type mockFilesystemAccess struct {
+	storagecommon.FilesystemAccess
+	*mockBackend
+}
+
+func (m *mockBackend) VolumeAccess() storagecommon.VolumeAccess {
+	return nil
+}
+
+func (m *mockBackend) FilesystemAccess() storagecommon.FilesystemAccess {
+	return &mockFilesystemAccess{mockBackend: m}
 }
 
 func (m *mockBackend) ControllerTag() names.ControllerTag {
@@ -358,7 +369,7 @@ func (m *mockBackend) StorageInstance(tag names.StorageTag) (state.StorageInstan
 	return s, nil
 }
 
-func (m *mockBackend) StorageInstanceFilesystem(tag names.StorageTag) (state.Filesystem, error) {
+func (m *mockFilesystemAccess) StorageInstanceFilesystem(tag names.StorageTag) (state.Filesystem, error) {
 	m.MethodCall(m, "StorageInstanceFilesystem", tag)
 	if err := m.NextErr(); err != nil {
 		return nil, err

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facades/client/machinemanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
@@ -49,7 +50,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 			},
 		},
 	}
-	api, err := machinemanager.NewMachineManagerAPI(backend, pool, authorizer, context.NewCloudCallContext())
+	api, err := machinemanager.NewMachineManagerAPI(backend, backend, backend, pool, authorizer, backend.ModelTag(), context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := params.ModelInstanceTypesConstraints{
@@ -84,6 +85,8 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 
 type mockBackend struct {
 	machinemanager.Backend
+	storagecommon.StorageVolumeInterface
+	storagecommon.StorageFilesystemInterface
 
 	cloudSpec environs.CloudSpec
 }

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -5,12 +5,12 @@ package machinemanager_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common/storagecommon"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facades/client/machinemanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
@@ -50,7 +50,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 			},
 		},
 	}
-	api, err := machinemanager.NewMachineManagerAPI(backend, backend, backend, pool, authorizer, backend.ModelTag(), context.NewCloudCallContext())
+	api, err := machinemanager.NewMachineManagerAPI(backend, backend, pool, authorizer, backend.ModelTag(), context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := params.ModelInstanceTypesConstraints{
@@ -85,10 +85,17 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 
 type mockBackend struct {
 	machinemanager.Backend
-	storagecommon.StorageVolumeInterface
-	storagecommon.StorageFilesystemInterface
+	storagecommon.StorageAccess
 
 	cloudSpec environs.CloudSpec
+}
+
+func (st *mockBackend) VolumeAccess() storagecommon.VolumeAccess {
+	return nil
+}
+
+func (st *mockBackend) FilesystemAccess() storagecommon.FilesystemAccess {
+	return nil
 }
 
 func (b *mockBackend) ModelTag() names.ModelTag {

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -26,10 +26,13 @@ var logger = loggo.GetLogger("juju.apiserver.machinemanager")
 // MachineManagerAPI provides access to the MachineManager API facade.
 type MachineManagerAPI struct {
 	st         Backend
+	stVolume   storagecommon.StorageVolumeInterface
+	stFile     storagecommon.StorageFilesystemInterface
 	pool       Pool
 	authorizer facade.Authorizer
 	check      *common.BlockChecker
 
+	modelTag    names.ModelTag
 	callContext context.ProviderCallContext
 }
 
@@ -37,13 +40,36 @@ type MachineManagerAPI struct {
 // is used for facade registration.
 func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 	st := ctx.State()
-	im, err := st.IAASModel()
+	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	backend := &stateShim{State: st, IAASModel: im}
+	var (
+		storage  storagecommon.StorageInstanceInterface
+		stVolume storagecommon.StorageVolumeInterface
+		stFile   storagecommon.StorageFilesystemInterface
+	)
+	if model.Type() == state.ModelTypeIAAS {
+		im, err := model.IAASModel()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		storage = im
+		stVolume = im
+		stFile = im
+	} else {
+		// CAAS models don't support block devices.
+		cm, err := model.CAASModel()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		storage = cm
+		stFile = cm
+	}
+
+	backend := &stateShim{State: st, StorageInstanceInterface: storage}
 	pool := &poolShim{ctx.StatePool()}
-	return NewMachineManagerAPI(backend, pool, ctx.Auth(), state.CallContext(st))
+	return NewMachineManagerAPI(backend, stVolume, stFile, pool, ctx.Auth(), model.ModelTag(), state.CallContext(st))
 }
 
 type MachineManagerAPIV4 struct {
@@ -60,21 +86,32 @@ func NewFacadeV4(ctx facade.Context) (*MachineManagerAPIV4, error) {
 }
 
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
-func NewMachineManagerAPI(backend Backend, pool Pool, auth facade.Authorizer, callCtx context.ProviderCallContext) (*MachineManagerAPI, error) {
+func NewMachineManagerAPI(
+	backend Backend,
+	stVolume storagecommon.StorageVolumeInterface,
+	stFile storagecommon.StorageFilesystemInterface,
+	pool Pool,
+	auth facade.Authorizer,
+	modelTag names.ModelTag,
+	callCtx context.ProviderCallContext,
+) (*MachineManagerAPI, error) {
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
 	return &MachineManagerAPI{
 		st:          backend,
+		stVolume:    stVolume,
+		stFile:      stFile,
 		pool:        pool,
 		authorizer:  auth,
 		check:       common.NewBlockChecker(backend),
+		modelTag:    modelTag,
 		callContext: callCtx,
 	}, nil
 }
 
 func (mm *MachineManagerAPI) checkCanWrite() error {
-	canWrite, err := mm.authorizer.HasPermission(permission.WriteAccess, mm.st.ModelTag())
+	canWrite, err := mm.authorizer.HasPermission(permission.WriteAccess, mm.modelTag)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -133,7 +170,11 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 	}
 
 	if p.Series == "" {
-		conf, err := mm.st.ModelConfig()
+		model, err := mm.st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		conf, err := model.Config()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -266,7 +307,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 			}
 			storage = unseen
 
-			destroyed, detached, err := storagecommon.ClassifyDetachedStorage(mm.st, storage)
+			destroyed, detached, err := storagecommon.ClassifyDetachedStorage(mm.st, mm.stVolume, mm.stFile, storage)
 			if err != nil {
 				return nil, err
 			}

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -4,7 +4,7 @@
 package machinemanager
 
 import (
-	names "gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common/storagecommon"
@@ -14,13 +14,11 @@ import (
 )
 
 type Backend interface {
-	storagecommon.StorageInterface
+	storagecommon.StorageInstanceInterface
 	state.CloudAccessor
 
 	Machine(string) (Machine, error)
-	ModelConfig() (*config.Config, error)
 	Model() (Model, error)
-	ModelTag() names.ModelTag
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 	AddOneMachine(template state.MachineTemplate) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
@@ -51,7 +49,7 @@ type Machine interface {
 
 type stateShim struct {
 	*state.State
-	*state.IAASModel
+	storagecommon.StorageInstanceInterface
 }
 
 func (s stateShim) Machine(name string) (Machine, error) {

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -63,9 +63,9 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.poolManager = s.constructPoolManager()
 
 	var err error
-	s.api, err = storage.NewAPIv4(s.state, s.storageAccessor, s.storageAccessor, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.api, err = storage.NewAPIv4(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	s.apiv3, err = storage.NewAPIv3(s.state, s.storageAccessor, s.storageAccessor, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.apiv3, err = storage.NewAPIv3(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -63,9 +63,9 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.poolManager = s.constructPoolManager()
 
 	var err error
-	s.api, err = storage.NewAPIv4(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.api, err = storage.NewAPIv4(s.state, s.storageAccessor, s.storageAccessor, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	s.apiv3, err = storage.NewAPIv3(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.apiv3, err = storage.NewAPIv3(s.state, s.storageAccessor, s.storageAccessor, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/storage/export_test.go
+++ b/apiserver/facades/client/storage/export_test.go
@@ -8,3 +8,8 @@ var (
 	ValidateNameCriteria     = (*APIv4).validateNameCriteria
 	ValidateProviderCriteria = (*APIv4).validateProviderCriteria
 )
+
+type (
+	StorageVolume = storageVolume
+	StorageFile   = storageFile
+)

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -63,6 +63,14 @@ type mockStorageAccessor struct {
 	addExistingFilesystem               func(state.FilesystemInfo, *state.VolumeInfo, string) (names.StorageTag, error)
 }
 
+func (st *mockStorageAccessor) VolumeAccess() storage.StorageVolume {
+	return st
+}
+
+func (st *mockStorageAccessor) FilesystemAccess() storage.StorageFile {
+	return st
+}
+
 func (st *mockStorageAccessor) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
 	return st.storageInstance(s)
 }

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -46,10 +46,6 @@ type mockStorageAccessor struct {
 	volumeAttachment                    func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	storageInstanceFilesystem           func(names.StorageTag) (state.Filesystem, error)
 	storageInstanceFilesystemAttachment func(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error)
-	watchStorageAttachment              func(names.StorageTag, names.UnitTag) state.NotifyWatcher
-	watchFilesystemAttachment           func(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
-	watchVolumeAttachment               func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
-	watchBlockDevices                   func(names.MachineTag) state.NotifyWatcher
 	volume                              func(tag names.VolumeTag) (state.Volume, error)
 	machineVolumeAttachments            func(machine names.MachineTag) ([]state.VolumeAttachment, error)
 	volumeAttachments                   func(volume names.VolumeTag) ([]state.VolumeAttachment, error)
@@ -93,22 +89,6 @@ func (st *mockStorageAccessor) StorageInstanceVolume(s names.StorageTag) (state.
 
 func (st *mockStorageAccessor) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
 	return st.volumeAttachment(m, v)
-}
-
-func (st *mockStorageAccessor) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
-	return st.watchStorageAttachment(s, u)
-}
-
-func (st *mockStorageAccessor) WatchFilesystemAttachment(mtag names.MachineTag, f names.FilesystemTag) state.NotifyWatcher {
-	return st.watchFilesystemAttachment(mtag, f)
-}
-
-func (st *mockStorageAccessor) WatchVolumeAttachment(mtag names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
-	return st.watchVolumeAttachment(mtag, v)
-}
-
-func (st *mockStorageAccessor) WatchBlockDevices(mtag names.MachineTag) state.NotifyWatcher {
-	return st.watchBlockDevices(mtag)
 }
 
 func (st *mockStorageAccessor) AllVolumes() ([]state.Volume, error) {

--- a/state/caasmodel.go
+++ b/state/caasmodel.go
@@ -68,6 +68,10 @@ func (noopStorage) WatchStorageAttachment(names.StorageTag, names.UnitTag) Notif
 	return nil
 }
 
+func (noopStorage) WatchStorageAttachments(names.UnitTag) StringsWatcher {
+	return nil
+}
+
 func (noopStorage) WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) NotifyWatcher {
 	return nil
 }
@@ -142,4 +146,16 @@ func (noopStorage) UnitStorageAttachments(names.UnitTag) ([]StorageAttachment, e
 
 func (noopStorage) AddExistingFilesystem(f FilesystemInfo, v *VolumeInfo, storageName string) (names.StorageTag, error) {
 	return names.StorageTag{}, errors.NotSupportedf("AddExistingFilesystem")
+}
+
+func (noopStorage) StorageAttachment(names.StorageTag, names.UnitTag) (StorageAttachment, error) {
+	return nil, errors.NotSupportedf("StorageAttachment")
+}
+
+func (noopStorage) DestroyUnitStorageAttachments(unit names.UnitTag) (err error) {
+	return errors.NotSupportedf("DestroyUnitStorageAttachments")
+}
+
+func (noopStorage) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {
+	return errors.NotSupportedf("RemoveStorageAttachment")
 }


### PR DESCRIPTION
## Description of change

The state storage interface is split into 3 separate, smaller interfaces:
- storage instance management
- volume storage
- file storage

The affected facades are storagecommon, uniter, modelmanager, application. Also, storagecommon contained watcher code that was only used by the uniter facade so this was moved across.

Followup PRs will refactor IAAS and CAAS model types to add supported storage features to both models.

## QA steps

Deploy postgresql charm with storage
attach/detach/import storage etc

