### PR TITLE
Cloud call context from bootstrap.

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -181,7 +181,7 @@ func withDefaultControllerConstraints(cons constraints.Value) constraints.Value 
 // Bootstrap bootstraps the given environment. The supplied constraints are
 // used to provision the instance, and are also set within the bootstrapped
 // environment.
-func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args BootstrapParams) error {
+func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, callCtx context.ProviderCallContext, args BootstrapParams) error {
 	if err := args.Validate(); err != nil {
 		return errors.Annotate(err, "validating bootstrap parameters")
 	}
@@ -396,7 +396,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	ctx.Verbosef("Starting new instance for initial controller")
 
 	result, err := environ.Bootstrap(ctx,
-		context.NewCloudCallContext(),
+		callCtx,
 		environs.BootstrapParams{
 			CloudName:            args.Cloud.Name,
 			CloudRegion:          args.CloudRegion,

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -60,6 +60,8 @@ const (
 type bootstrapSuite struct {
 	coretesting.BaseSuite
 	envtesting.ToolsFixture
+
+	callContext context.ProviderCallContext
 }
 
 var _ = gc.Suite(&bootstrapSuite{})
@@ -80,6 +82,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(bootstrap.GUIFetchMetadata, func(string, ...simplestreams.DataSource) ([]*gui.Metadata, error) {
 		return nil, nil
 	})
+	s.callContext = context.NewCloudCallContext()
 }
 
 func (s *bootstrapSuite) TearDownTest(c *gc.C) {
@@ -91,44 +94,50 @@ func (s *bootstrapSuite) TestBootstrapNeedsSettings(c *gc.C) {
 	env := newEnviron("bar", noKeysDefined, nil)
 	s.setDummyStorage(c, env)
 
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext,
+		bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, gc.ErrorMatches, "validating bootstrap parameters: admin-secret is empty")
 
 	controllerCfg := coretesting.FakeControllerConfig()
 	delete(controllerCfg, "ca-cert")
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: controllerCfg,
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: controllerCfg,
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, gc.ErrorMatches, "validating bootstrap parameters: controller configuration has no ca-cert")
 
 	controllerCfg = coretesting.FakeControllerConfig()
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: controllerCfg,
-		AdminSecret:      "admin-secret",
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: controllerCfg,
+			AdminSecret:      "admin-secret",
+		})
 	c.Assert(err, gc.ErrorMatches, "validating bootstrap parameters: empty ca-private-key")
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: controllerCfg,
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: controllerCfg,
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *bootstrapSuite) TestBootstrapEmptyConstraints(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	env.args.AvailableTools = nil
@@ -143,13 +152,14 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	s.setDummyStorage(c, env)
 	bootstrapCons := constraints.MustParse("cores=3 mem=7G")
 	modelCons := constraints.MustParse("cores=2 mem=4G")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: bootstrapCons,
-		ModelConstraints:     modelCons,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: bootstrapCons,
+			ModelConstraints:     modelCons,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.args.BootstrapConstraints, gc.DeepEquals, bootstrapCons)
@@ -165,12 +175,13 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedBootstrapSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		BootstrapSeries:  "trusty",
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			BootstrapSeries:  "trusty",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(env.bootstrapCount, gc.Equals, 1)
 	c.Check(env.args.BootstrapSeries, gc.Equals, "trusty")
@@ -181,11 +192,12 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	placement := "directive"
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		Placement:        placement})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			Placement:        placement})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.args.Placement, gc.DeepEquals, placement)
@@ -214,15 +226,16 @@ func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
 	bootstrapCons := constraints.MustParse("arch=amd64")
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapImage:       "img-id",
-		BootstrapSeries:      "precise",
-		BootstrapConstraints: bootstrapCons,
-		MetadataDir:          metadataDir,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapImage:       "img-id",
+			BootstrapSeries:      "precise",
+			BootstrapConstraints: bootstrapCons,
+			MetadataDir:          metadataDir,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.args.ImageMetadata, gc.HasLen, 1)
@@ -251,15 +264,16 @@ func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToExistingProviderSupport
 	// Bootstrap should succeed with no failures as constraints validator used internally
 	// would have both provider supported architectures and architectures retrieved from images metadata.
 	bootstrapCons := constraints.MustParse(fmt.Sprintf("arch=%v", data.architecture))
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapImage:       "img-id",
-		BootstrapSeries:      "precise",
-		BootstrapConstraints: bootstrapCons,
-		MetadataDir:          data.metadataDir,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapImage:       "img-id",
+			BootstrapSeries:      "precise",
+			BootstrapConstraints: bootstrapCons,
+			MetadataDir:          data.metadataDir,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedCons := bootstrapCons
 	expectedCons.Mem = intPtr(3584)
@@ -332,15 +346,16 @@ func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToProviderWithNoSupported
 	// Bootstrap should succeed with no failures as constraints validator used internally
 	// would have both provider supported architectures and architectures retrieved from images metadata.
 	bootstrapCons := constraints.MustParse(fmt.Sprintf("arch=%v", data.architecture))
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapImage:       "img-id",
-		BootstrapSeries:      "precise",
-		BootstrapConstraints: bootstrapCons,
-		MetadataDir:          data.metadataDir,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapImage:       "img-id",
+			BootstrapSeries:      "precise",
+			BootstrapConstraints: bootstrapCons,
+			MetadataDir:          data.metadataDir,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedCons := bootstrapCons
 	expectedCons.Mem = intPtr(3584)
@@ -398,13 +413,14 @@ func (s *bootstrapSuite) TestBootstrapImageMetadataFromAllSources(c *gc.C) {
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
 	bootstrapCons := constraints.MustParse("arch=amd64")
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: bootstrapCons,
-		MetadataDir:          metadataDir,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: bootstrapCons,
+			MetadataDir:          metadataDir,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	datasources, err := environs.ImageMetadataSources(env)
@@ -429,15 +445,16 @@ func (s *bootstrapSuite) TestBootstrapLocalTools(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-		BootstrapSeries: "centos7",
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+			BootstrapSeries: "centos7",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(env.bootstrapCount, gc.Equals, 1)
@@ -459,15 +476,16 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsMismatchingOS(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-		BootstrapSeries: "trusty",
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+			BootstrapSeries: "trusty",
+		})
 	c.Assert(err, gc.ErrorMatches, `cannot use agent built for "trusty" using a machine running "Windows"`)
 }
 
@@ -486,15 +504,16 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsDifferentLinuxes(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-		BootstrapSeries: "trusty",
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+			BootstrapSeries: "trusty",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(env.bootstrapCount, gc.Equals, 1)
@@ -516,29 +535,30 @@ func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
 	})
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		BuildAgent:       true,
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
-			c.Logf("BuildAgentTarball version %s", ver)
-			c.Assert(build, jc.IsTrue)
-			c.Assert(ver.String(), gc.Equals, "1.99.0.1")
-			localVer := *ver
-			// If we found an official build we suppress the build number.
-			localVer.Build = 0
-			return &sync.BuiltAgent{
-				Dir:      c.MkDir(),
-				Official: true,
-				Version: version.Binary{
-					Number: localVer,
-					Series: "quental",
-					Arch:   "arm64",
-				},
-			}, nil
-		},
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			BuildAgent:       true,
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
+				c.Logf("BuildAgentTarball version %s", ver)
+				c.Assert(build, jc.IsTrue)
+				c.Assert(ver.String(), gc.Equals, "1.99.0.1")
+				localVer := *ver
+				// If we found an official build we suppress the build number.
+				localVer.Build = 0
+				return &sync.BuiltAgent{
+					Dir:      c.MkDir(),
+					Official: true,
+					Version: version.Binary{
+						Number: localVer,
+						Series: "quental",
+						Arch:   "arm64",
+					},
+				}, nil
+			},
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	// Check that the model config has the correct version set.
 	cfg := env.instanceConfig.Bootstrap.ControllerModelConfig
@@ -571,16 +591,17 @@ func (s *bootstrapSuite) assertBootstrapPackagedToolsAvailable(c *gc.C, clientAr
 	})
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BootstrapSeries:  "quantal",
-		BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
-			c.Fatal("should not call BuildAgentTarball if there are packaged tools")
-			return nil, nil
-		},
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BootstrapSeries:  "quantal",
+			BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
+				c.Fatal("should not call BuildAgentTarball if there are packaged tools")
+				return nil, nil
+			},
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(findToolsOk, jc.IsTrue)
 }
@@ -607,14 +628,15 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-stream": "proposed"})
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+		})
 	// bootstrap.Bootstrap leaves it to the provider to
 	// locate bootstrap tools.
 	c.Assert(err, jc.ErrorIsNil)
@@ -631,14 +653,15 @@ func (s *bootstrapSuite) TestBootstrapNoToolsDevelopmentConfig(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"development": true})
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			BuildAgentTarball: func(bool, *version.Number, string) (*sync.BuiltAgent, error) {
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+		})
 	// bootstrap.Bootstrap leaves it to the provider to
 	// locate bootstrap tools.
 	c.Assert(err, jc.ErrorIsNil)
@@ -715,12 +738,13 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessRemote(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.0.42\n")
 
@@ -736,11 +760,12 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Fetching Juju GUI 2.2.0 from local archive\n")
 
@@ -766,11 +791,12 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapGUISuccessNoGUI(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Juju GUI installation has been disabled\n")
 	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
@@ -782,12 +808,13 @@ func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "No available Juju GUI archives found\n")
 	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
@@ -799,12 +826,13 @@ func (s *bootstrapSuite) TestBootstrapGUIStreamsFailure(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          "admin-secret",
-		CAPrivateKey:         coretesting.CAKey,
-		GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          "admin-secret",
+			CAPrivateKey:         coretesting.CAKey,
+			GUIDataSourceBaseURL: "https://1.2.3.4/gui/sources",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Unable to fetch Juju GUI info: bad wolf\n")
 	c.Assert(env.instanceConfig.Bootstrap.GUI, gc.IsNil)
@@ -814,11 +842,12 @@ func (s *bootstrapSuite) TestBootstrapGUIErrorNotFound(c *gc.C) {
 	s.PatchEnvironment("JUJU_GUI", "/no/such/file")
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cannot use Juju GUI at "/no/such/file": cannot open Juju GUI archive:`)
 }
@@ -830,11 +859,12 @@ func (s *bootstrapSuite) TestBootstrapGUIErrorInvalidArchive(c *gc.C) {
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, fmt.Sprintf("Cannot use Juju GUI at %q: cannot read Juju GUI archive", path))
 }
@@ -844,11 +874,12 @@ func (s *bootstrapSuite) TestBootstrapGUIErrorInvalidVersion(c *gc.C) {
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, fmt.Sprintf(`Cannot use Juju GUI at %q: cannot parse version "invalid"`, path))
 }
@@ -858,11 +889,12 @@ func (s *bootstrapSuite) TestBootstrapGUIErrorUnexpectedArchive(c *gc.C) {
 	s.PatchEnvironment("JUJU_GUI", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, fmt.Sprintf("Cannot use Juju GUI at %q: cannot find Juju GUI version", path))
 }
@@ -921,12 +953,13 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		MetadataDir:      metadataDir,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			MetadataDir:      metadataDir,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(envtools.DefaultBaseURL, gc.Equals, metadataDir)
@@ -951,12 +984,13 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapMetadataDirNonexistend(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	nonExistentFileName := "/tmp/TestBootstrapMetadataDirNonexistend"
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		MetadataDir:      nonExistentFileName,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			MetadataDir:      nonExistentFileName,
+		})
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("simplestreams metadata source: %s not found", nonExistentFileName))
 }
@@ -974,12 +1008,13 @@ func (s *bootstrapSuite) TestBootstrapMetadataImagesNoTools(c *gc.C) {
 	startingDefaultBaseURL := envtools.DefaultBaseURL
 	for i, suffix := range []string{"", "images"} {
 		environs.UnregisterImageDataSourceFunc("bootstrap metadata")
-		err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-			ControllerConfig: coretesting.FakeControllerConfig(),
-			AdminSecret:      "admin-secret",
-			CAPrivateKey:     coretesting.CAKey,
-			MetadataDir:      filepath.Join(metadataDir, suffix),
-		})
+		err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+			s.callContext, bootstrap.BootstrapParams{
+				ControllerConfig: coretesting.FakeControllerConfig(),
+				AdminSecret:      "admin-secret",
+				CAPrivateKey:     coretesting.CAKey,
+				MetadataDir:      filepath.Join(metadataDir, suffix),
+			})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(env.bootstrapCount, gc.Equals, i+1)
 		c.Assert(envtools.DefaultBaseURL, gc.Equals, startingDefaultBaseURL)
@@ -1006,12 +1041,13 @@ func (s *bootstrapSuite) TestBootstrapMetadataToolsNoImages(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	for i, suffix := range []string{"", "tools"} {
-		err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-			ControllerConfig: coretesting.FakeControllerConfig(),
-			AdminSecret:      "admin-secret",
-			CAPrivateKey:     coretesting.CAKey,
-			MetadataDir:      filepath.Join(metadataDir, suffix),
-		})
+		err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+			s.callContext, bootstrap.BootstrapParams{
+				ControllerConfig: coretesting.FakeControllerConfig(),
+				AdminSecret:      "admin-secret",
+				CAPrivateKey:     coretesting.CAKey,
+				MetadataDir:      filepath.Join(metadataDir, suffix),
+			})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(env.bootstrapCount, gc.Equals, i+1)
 		c.Assert(envtools.DefaultBaseURL, gc.Equals, metadataDir)
@@ -1040,7 +1076,7 @@ func (s *bootstrapSuite) TestBootstrapCloudCredential(c *gc.C) {
 		CloudCredentialName: "credential-name",
 		CloudCredential:     &credential,
 	}
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, args)
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, s.callContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.instanceConfig, gc.NotNil)
@@ -1056,11 +1092,12 @@ func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
 	s.PatchEnvironment("JUJU_STREAMS_PUBLICKEY_FILE", path)
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.instanceConfig.Controller.PublicImageSigningKey, gc.Equals, "publickey")
 }
@@ -1085,13 +1122,14 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 	}
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:          coretesting.FakeControllerConfig(),
-		ControllerInheritedConfig: map[string]interface{}{"ftp-proxy": "http://proxy"},
-		Cloud:        dummyCloud,
-		AdminSecret:  password,
-		CAPrivateKey: coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:          coretesting.FakeControllerConfig(),
+			ControllerInheritedConfig: map[string]interface{}{"ftp-proxy": "http://proxy"},
+			Cloud:        dummyCloud,
+			AdminSecret:  password,
+			CAPrivateKey: coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	icfg := env.instanceConfig
 
@@ -1142,12 +1180,13 @@ func (s *bootstrapSuite) TestBootstrapMetadataImagesMissing(c *gc.C) {
 
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		MetadataDir:      noImagesDir,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			MetadataDir:      noImagesDir,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 
@@ -1195,17 +1234,18 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, cli
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		AgentVersion:     toolsVersion,
-		BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
-			c.Logf("BuildAgentTarball version %s", ver)
-			c.Assert(build, jc.IsFalse)
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			AgentVersion:     toolsVersion,
+			BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
+				c.Logf("BuildAgentTarball version %s", ver)
+				c.Assert(build, jc.IsFalse)
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+		})
 	vers, _ := env.cfg.AgentVersion()
 	return err, env.bootstrapCount, vers
 }
@@ -1275,17 +1315,18 @@ func (s *bootstrapSuite) TestAvailableToolsInvalidArch(c *gc.C) {
 	})
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		BuildAgent:       true,
-		AdminSecret:      "admin-secret",
-		CAPrivateKey:     coretesting.CAKey,
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
-			c.Logf("BuildAgentTarball version %s", ver)
-			c.Assert(build, jc.IsTrue)
-			return &sync.BuiltAgent{Dir: c.MkDir()}, nil
-		},
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			BuildAgent:       true,
+			AdminSecret:      "admin-secret",
+			CAPrivateKey:     coretesting.CAKey,
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
+				c.Logf("BuildAgentTarball version %s", ver)
+				c.Assert(build, jc.IsTrue)
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+		})
 	c.Assert(err, gc.ErrorMatches, `model "foo" of type dummy does not support instances running on "s390x"`)
 }
 

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -222,7 +222,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	args := t.bootstrapParams()
 	args.BootstrapConstraints = cons
 	args.ModelConstraints = cons
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.Env, args)
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.Env, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 	t.bootstrapped = true
 }
@@ -978,7 +978,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer environs.Destroy("livetests", env, t.ProviderCallContext, t.ControllerStore)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, t.bootstrapParams())
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, t.ProviderCallContext, t.bootstrapParams())
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := t.Env.(jujutesting.GetStater).GetStateInAPIServer()

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -212,7 +212,7 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	}
 
 	e := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), e, args)
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), e, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerInstances, err := e.ControllerInstances(t.ProviderCallContext, t.ControllerUUID)
@@ -231,7 +231,7 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	// Prepare again because Destroy invalidates old environments.
 	e3 := t.Prepare(c)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), e3, args)
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), e3, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = environs.Destroy(e3.Config().Name(), e3, t.ProviderCallContext, t.ControllerStore)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -67,7 +67,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.UploadFakeTools(c, stor, cfg.AgentStream(), cfg.AgentStream())
-	err = bootstrap.Bootstrap(ctx, env, bootstrap.BootstrapParams{
+	err = bootstrap.Bootstrap(ctx, env, context.NewCloudCallContext(), bootstrap.BootstrapParams{
 		ControllerConfig: controllerCfg,
 		AdminSecret:      "admin-secret",
 		CAPrivateKey:     testing.CAKey,

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -370,7 +370,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	apiPort := dummy.APIPort(environ.Provider())
 	s.ControllerConfig["api-port"] = apiPort
 	s.ProviderCallContext = context.NewCloudCallContext()
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
+	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
 		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1157,7 +1157,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	s.sender = append(s.sender, s.startInstanceSendersNoSizes()...)
 	s.requests = nil
 	err := bootstrap.Bootstrap(
-		ctx, env, bootstrap.BootstrapParams{
+		ctx, env, s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -134,16 +134,17 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 	netenv, supported := environs.SupportsNetworking(env)
 	c.Assert(supported, jc.IsTrue)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv, bootstrap.BootstrapParams{
-		ControllerConfig: testing.FakeControllerConfig(),
-		Cloud: cloud.Cloud{
-			Name:      "dummy",
-			Type:      "dummy",
-			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
-		},
-		AdminSecret:  AdminSecret,
-		CAPrivateKey: testing.CAKey,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv,
+		context.NewCloudCallContext(), bootstrap.BootstrapParams{
+			ControllerConfig: testing.FakeControllerConfig(),
+			Cloud: cloud.Cloud{
+				Name:      "dummy",
+				Type:      "dummy",
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
+			},
+			AdminSecret:  AdminSecret,
+			CAPrivateKey: testing.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	return netenv
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -339,12 +339,13 @@ func (t *localServerSuite) prepareWithParamsAndBootstrapWithVPCID(c *gc.C, param
 	c.Check(vpcID, gc.Equals, expectedVPCID)
 	c.Check(ok, jc.IsTrue)
 
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-		Placement:        "zone=test-available",
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+			Placement:        "zone=test-available",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -364,13 +365,14 @@ func (t *localServerSuite) TestPrepareForBootstrapWithDefaultVPCID(c *gc.C) {
 
 func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C) {
 	env := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		// TODO(redir): BBB: When we no longer support upstart based systems this can change to series.LatestLts()
-		BootstrapSeries: "xenial",
-		AdminSecret:     testing.AdminSecret,
-		CAPrivateKey:    coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			// TODO(redir): BBB: When we no longer support upstart based systems this can change to series.LatestLts()
+			BootstrapSeries: "xenial",
+			AdminSecret:     testing.AdminSecret,
+			CAPrivateKey:    coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check that ControllerInstances returns the id of the bootstrap machine.
@@ -442,12 +444,13 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 // TODO(redir): BBB: remove when trusty is no longer supported
 func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C) {
 	env := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		BootstrapSeries:  "trusty",
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			BootstrapSeries:  "trusty",
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check that ControllerInstances returns the id of the bootstrap machine.
@@ -516,11 +519,12 @@ func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C)
 
 func (t *localServerSuite) TestTerminateInstancesIgnoresNotFound(c *gc.C) {
 	env := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
@@ -551,11 +555,12 @@ func (t *localServerSuite) TestDestroyErr(c *gc.C) {
 
 func (t *localServerSuite) TestGetTerminatedInstances(c *gc.C) {
 	env := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// create another instance to terminate
@@ -715,11 +720,12 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 
 func (t *localServerSuite) TestInstanceStatus(c *gc.C) {
 	env := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	t.srv.ec2srv.SetInitialInstanceState(ec2test.Terminated)
 	inst, _ := testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "1")
@@ -1168,12 +1174,13 @@ func (t *localServerSuite) prepareAndBootstrapWithConfig(c *gc.C, config coretes
 	args := t.PrepareParams(c)
 	args.ModelConfig = coretesting.Attrs(args.ModelConfig).Merge(config)
 	env := t.PrepareWithParams(c, args)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-		Placement:        "zone=test-available",
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+			Placement:        "zone=test-available",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }
@@ -1579,11 +1586,12 @@ func (t *localServerSuite) TestSupportsNetworking(c *gc.C) {
 
 func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.NetworkingEnviron, instance.Id) {
 	env := t.prepareEnviron(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		t.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceIds, err := env.ControllerInstances(t.callCtx, t.ControllerUUID)

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -170,11 +170,12 @@ func bootstrapContext(c *gc.C) environs.BootstrapContext {
 // allocate a public address.
 func (s *localServerSuite) TestStartInstance(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+		s.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, s.callCtx, s.ControllerUUID, "100")
 	err = env.StopInstances(s.callCtx, inst.Id())
@@ -183,11 +184,12 @@ func (s *localServerSuite) TestStartInstance(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+		s.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	inst, hwc := testing.AssertStartInstance(c, env, s.callCtx, s.ControllerUUID, "100")
 	err = env.StopInstances(s.callCtx, inst.Id())
@@ -198,11 +200,12 @@ func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+		s.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	_, hc := testing.AssertStartInstanceWithConstraints(c, env, s.callCtx, s.ControllerUUID, "100", constraints.MustParse("mem=1024"))
 	c.Check(*hc.Arch, gc.Equals, "amd64")
@@ -312,11 +315,12 @@ func (s *localServerSuite) TestInstancesGathering(c *gc.C) {
 // It should be moved to environs.jujutests.Tests.
 func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+		s.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check that ControllerInstances returns the id of the bootstrap machine.

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -151,12 +151,13 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	// Create node 0: it will be used as the bootstrap node.
 	suite.newNode(c, "node0", "host0", nil)
 	suite.addSubnet(c, 9, 9, "node0")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          testing.AdminSecret,
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: constraints.MustParse("mem=1G"),
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          testing.AdminSecret,
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: constraints.MustParse("mem=1G"),
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	// The bootstrap node has been acquired and started.
 	operations := suite.testMAASObject.TestServer.NodeOperations()
@@ -348,12 +349,13 @@ func (suite *environSuite) TestBootstrapSucceeds(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.newNode(c, "thenode", "host", nil)
 	suite.addSubnet(c, 9, 9, "thenode")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          testing.AdminSecret,
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: constraints.MustParse("mem=1G"),
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          testing.AdminSecret,
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: constraints.MustParse("mem=1G"),
+		})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -364,12 +366,13 @@ func (suite *environSuite) TestBootstrapNodeNotDeployed(c *gc.C) {
 	suite.addSubnet(c, 9, 9, "thenode")
 	// Ensure node will not be reported as deployed by changing its status.
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "4")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          testing.AdminSecret,
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: constraints.MustParse("mem=1G"),
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          testing.AdminSecret,
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: constraints.MustParse("mem=1G"),
+		})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state.*")
 }
 
@@ -380,38 +383,41 @@ func (suite *environSuite) TestBootstrapNodeFailedDeploy(c *gc.C) {
 	suite.addSubnet(c, 9, 9, "thenode")
 	// Set the node status to "Failed deployment"
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "11")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          testing.AdminSecret,
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: constraints.MustParse("mem=1G"),
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          testing.AdminSecret,
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: constraints.MustParse("mem=1G"),
+		})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state. instance \"/api/.*/nodes/thenode/\" failed to deploy")
 }
 
 func (suite *environSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	env := suite.makeEnviron()
 	vers := version.MustParse("1.2.3")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-		// Disable auto-uploading by setting the agent version
-		// to something that's not the current version.
-		AgentVersion: &vers,
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+			// Disable auto-uploading by setting the agent version
+			// to something that's not the current version.
+			AgentVersion: &vers,
+		})
 	c.Check(err, gc.ErrorMatches, "Juju cannot bootstrap because no agent binaries are available for your model(.|\n)*")
 }
 
 func (suite *environSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron()
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		AdminSecret:          testing.AdminSecret,
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: constraints.MustParse("mem=1G"),
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			AdminSecret:          testing.AdminSecret,
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: constraints.MustParse("mem=1G"),
+		})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
 	c.Check(err, gc.ErrorMatches, ".*409.*")
@@ -950,13 +956,14 @@ func (s *environSuite) bootstrap(c *gc.C) environs.Environ {
 	s.addSubnet(c, 9, 9, "node0")
 	s.setupFakeTools(c)
 	env := s.makeEnviron()
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		Placement:            "bootstrap-host",
-		AdminSecret:          testing.AdminSecret,
-		CAPrivateKey:         coretesting.CAKey,
-		BootstrapConstraints: constraints.MustParse("mem=1G"),
-	})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig:     coretesting.FakeControllerConfig(),
+			Placement:            "bootstrap-host",
+			AdminSecret:          testing.AdminSecret,
+			CAPrivateKey:         coretesting.CAKey,
+			BootstrapConstraints: constraints.MustParse("mem=1G"),
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -678,11 +678,12 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, gc.ErrorMatches, "bootstrap instance started but did not change to Deployed state.*")
 }
 
@@ -697,11 +698,12 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentRetry(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Check(c.GetTestLog(), jc.Contains, "WARNING juju.provider.maas failed to get instance from provider attempt")
 }
 
@@ -716,11 +718,12 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2152,11 +2155,12 @@ func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	}
 
 	env := suite.makeEnviron(c, controller)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine.Stub.CheckCallNames(c, "Start", "SetOwnerData")
@@ -2264,14 +2268,15 @@ func (suite *maas2EnvironSuite) TestDestroy(c *gc.C) {
 func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	env := suite.makeEnviron(c, newFakeController())
 	vers := version.MustParse("1.2.3")
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-		// Disable auto-uploading by setting the agent version
-		// to something that's not the current version.
-		AgentVersion: &vers,
-	})
+	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+			// Disable auto-uploading by setting the agent version
+			// to something that's not the current version.
+			AgentVersion: &vers,
+		})
 	c.Check(err, gc.ErrorMatches, "Juju cannot bootstrap because no agent binaries are available for your model(.|\n)*")
 }
 
@@ -2280,11 +2285,12 @@ func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	controller := newFakeController()
 	controller.allocateMachineError = gomaasapi.NewNoMatchError("oops")
 	env := suite.makeEnviron(c, controller)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      jujutesting.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+		suite.callCtx, bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      jujutesting.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
 	c.Check(err, gc.ErrorMatches, "cannot start bootstrap instance in any availability zone \\(mossack, fonseca\\)")

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2791,11 +2791,13 @@ func (s *noSwiftSuite) TestBootstrap(c *gc.C) {
 	err = s.env.SetConfig(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), s.env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), s.env,
+		context.NewCloudCallContext(),
+		bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2820,9 +2822,11 @@ func newNovaNetworkingOpenstackService(cred *identity.Credentials, auth identity
 }
 
 func bootstrapEnv(c *gc.C, env environs.Environ) error {
-	return bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		AdminSecret:      testing.AdminSecret,
-		CAPrivateKey:     coretesting.CAKey,
-	})
+	return bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		context.NewCloudCallContext(),
+		bootstrap.BootstrapParams{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			AdminSecret:      testing.AdminSecret,
+			CAPrivateKey:     coretesting.CAKey,
+		})
 }


### PR DESCRIPTION
## Description of change

When an invalid cloud credential is used for bootstrap, there is nothing to do on the server-side (it does not exist yet!). So, this PR creates a cloud call context that can be used in cloud calls to log an informative message about credential.