### PR TITLE
Add upgrade series command.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -358,6 +358,10 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(machine.NewListMachinesCommand())
 	r.Register(machine.NewShowMachineCommand())
 
+	if featureflag.Enabled(feature.UpgradeSeries) {
+		r.Register(machine.NewUpgradeSeriesCommand())
+	}
+
 	// Manage model
 	r.Register(model.NewConfigCommand())
 	r.Register(model.NewDefaultsCommand())

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -59,6 +59,13 @@ func NewRemoveCommandForTest(apiRoot api.Connection, machineAPI RemoveMachineAPI
 	return modelcmd.Wrap(cmd), &RemoveCommand{cmd}
 }
 
+// NewUpgradeSeriesCommand returns an upgrade series command for test
+func NewUpgradeSeriesCommandForTest() cmd.Command {
+	cmd := &upgradeSeriesCommand{}
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(cmd)
+}
+
 func NewDisksFlag(disks *[]storage.Constraints) *disksFlag {
 	return &disksFlag{disks}
 }

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -103,7 +103,7 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 	if names.IsValidMachine(args[1]) {
 		c.machineNumber = args[1]
 	} else {
-		return errors.Errorf("invalid machine name %q", args[1])
+		return errors.Errorf("%q is an invalid machine name", args[1])
 	}
 
 	if c.prepCommand == PrepareCommand {

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -71,6 +71,7 @@ func (c *upgradeSeriesCommand) Info() *cmd.Info {
 func (c *upgradeSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.force, "force", false, "Upgrade even if the series is not supported by the charm and/or related subordinate charms.")
+	f.BoolVar(&c.force, "agree", false, "Agree to upgrade the series. Otherwise, a confirmation prompt will be displayed after the command is run.")
 }
 
 // Init implements cmd.Command.

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -129,7 +129,7 @@ func checkPrepCommands(prepCommands []string, argCommand string) (string, error)
 		}
 	}
 
-	return "", errors.New("%q is an invalid upgrade-series command")
+	return "", errors.Errorf("%q is an invalid upgrade-series command", argCommand)
 }
 
 func checkSeries(supportedSeries []string, seriesArgument string) (string, error) {

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -93,7 +93,6 @@ func (c *upgradeSeriesCommand) Info() *cmd.Info {
 func (c *upgradeSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.force, "force", false, "Upgrade even if the series is not supported by the charm and/or related subordinate charms.")
-	f.BoolVar(&c.force, "agree", false, "Agree to upgrade the series. Otherwise, a confirmation prompt will be displayed after the command is run.")
 }
 
 // Init implements cmd.Command.

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -48,13 +48,30 @@ type upgradeSeriesCommand struct {
 var upgradeSeriesDoc = `
 Upgrade a machine's operating system series.
 
-When a machine's series, the --force option should be used
-with caution since using a charm on a machine running an unsupported series may
-cause unexpected behavior. Alternately, if the requested series supported in
-later revisions of the charm, upgrade-charm can run beforehand.
+upgrade-series allows users to perform a managed upgrade of the operating system
+series of a machine. This command is performed in two steps; prepare and complete.
+
+The "prepare" step notifies Juju that a series upgrade is taking place for a given
+machine and as such Juju guards that machine against operations that would
+interfere with the upgrade process.
+
+The "complete" step notifies juju that the managed upgrade has been successfully completed.
+
+It should be noted that once the prepare command is issued there is no way to
+cancel or abort the process. Once you commit to prepare you must complete the
+process or you will end up with an unusable machine!
+
+The requested series must be explicitly supported by all charms deployed to
+the specified machine. To override this constraint the --force option may be used.
+
+The --force option should be used with caution since using a charm on a machine
+running an unsupported series may cause unexpected behavior. Alternately, if the
+requested series is supported in later revisions of the charm, upgrade-charm can
+run beforehand.
 
 Examples:
 	juju upgrade-series prepare <machine> <series>
+        juju upgrade-series prepare <machine> <series> --force
 	juju upgrade-series complete <machine>
 
 See also:

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -4,9 +4,12 @@
 package machine
 
 import (
+	"strings"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/os/series"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/modelcmd"
@@ -104,7 +107,11 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 	}
 
 	if c.prepCommand == PrepareCommand {
-		c.series = args[2]
+		series, err := checkSeries(series.SupportedSeries(), args[2])
+		if err != nil {
+			return err
+		}
+		c.series = series
 	}
 
 	return nil
@@ -123,4 +130,14 @@ func checkPrepCommands(prepCommands []string, argCommand string) (string, error)
 	}
 
 	return "", errors.New("%q is an invalid upgrade-series command")
+}
+
+func checkSeries(supportedSeries []string, seriesArgument string) (string, error) {
+	for _, series := range supportedSeries {
+		if series == strings.ToLower(seriesArgument) {
+			return series, nil
+		}
+	}
+
+	return "", errors.Errorf("%q is an unsupported series", seriesArgument)
 }

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/os/series"
 	"gopkg.in/juju/names.v2"
 
+	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -119,6 +121,27 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 
 // Run implements cmd.Run.
 func (c *upgradeSeriesCommand) Run(ctx *cmd.Context) error {
+	if c.prepCommand == PrepareCommand {
+		err := c.promptConfirmation(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *upgradeSeriesCommand) promptConfirmation(ctx *cmd.Context) error {
+	var confirmationMsg = `
+WARNING This command will mark machine %q as being upgraded to series %q
+This operation cannot be reverted or canceled once started.
+
+Continue [y/N]? `[1:]
+	fmt.Fprintf(ctx.Stdout, confirmationMsg, c.machineNumber, c.series)
+
+	if err := jujucmd.UserConfirmYes(ctx); err != nil {
+		return errors.Annotate(err, "upgrade series")
+	}
+
 	return nil
 }
 

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// Actions
+const (
+	PrepareCommand  = "prepare"
+	CompleteCommand = "complete"
+)
+
+// NewUpgradeSeriesCommand returns a command which upgrades the series of
+// an application or machine.
+func NewUpgradeSeriesCommand() cmd.Command {
+	return modelcmd.Wrap(&upgradeSeriesCommand{})
+}
+
+type upgradeMachineSeriesAPI interface {
+}
+
+// upgradeSeriesCommand is responsible for updating the series of an application or machine.
+type upgradeSeriesCommand struct {
+	modelcmd.ModelCommandBase
+	// modelcmd.IAASOnlyCommand
+
+	// upgradeMachineSeriesClient upgradeMachineSeriesAPI
+
+	prepCommand   string
+	force         bool
+	machineNumber string
+	series        string
+}
+
+var upgradeSeriesDoc = `
+Upgrade a machine's operating system series.
+
+When a machine's series, the --force option should be used
+with caution since using a charm on a machine running an unsupported series may
+cause unexpected behavior. Alternately, if the requested series supported in
+later revisions of the charm, upgrade-charm can run beforehand.
+
+Examples:
+	juju upgrade-series prepare <machine> <series>
+	juju upgrade-series complete <machine>
+
+See also:
+    machines
+    status
+    upgrade-charm
+    set-series
+`
+
+func (c *upgradeSeriesCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "upgrade-series",
+		Args:    "<action> [args]",
+		Purpose: "Upgrade a machine's series.",
+		Doc:     upgradeSeriesDoc,
+	}
+}
+
+func (c *upgradeSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	f.BoolVar(&c.force, "force", false, "Upgrade even if the series is not supported by the charm and/or related subordinate charms.")
+}
+
+// Init implements cmd.Command.
+func (c *upgradeSeriesCommand) Init(args []string) error {
+	numArguments := 3
+
+	if len(args) < 1 {
+		return errors.Errorf("wrong number of arguments")
+	}
+
+	prepCommandStrings := []string{PrepareCommand, CompleteCommand}
+	prepCommand, err := checkPrepCommands(prepCommandStrings, args[0])
+	if err != nil {
+		return errors.Annotate(err, "invalid argument")
+	}
+	c.prepCommand = prepCommand
+
+	if c.prepCommand == CompleteCommand {
+		numArguments = 2
+	}
+
+	if len(args) != numArguments {
+		return errors.Errorf("wrong number of arguments")
+	}
+
+	if names.IsValidMachine(args[1]) {
+		c.machineNumber = args[1]
+	} else {
+		return errors.Errorf("invalid machine name %q", args[1])
+	}
+
+	if c.prepCommand == PrepareCommand {
+		c.series = args[2]
+	}
+
+	return nil
+}
+
+// Run implements cmd.Run.
+func (c *upgradeSeriesCommand) Run(ctx *cmd.Context) error {
+	return nil
+}
+
+func checkPrepCommands(prepCommands []string, argCommand string) (string, error) {
+	for _, prepCommand := range prepCommands {
+		if prepCommand == argCommand {
+			return prepCommand, nil
+		}
+	}
+
+	return "", errors.New("%q is an invalid upgrade-series command")
+}

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -37,6 +37,12 @@ func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidPrepCommand
 	c.Assert(err, gc.ErrorMatches, ".* \"actuate\" is an invalid upgrade-series command")
 }
 
+func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidMachineArgs(c *gc.C) {
+	invalidMachineArg := "machine5"
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, invalidMachineArg, seriesArg)
+	c.Assert(err, gc.ErrorMatches, "\"machine5\" is an invalid machine name")
+}
+
 func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
 	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -24,6 +24,19 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommand(c *gc.C, args ...string) er
 	return err
 }
 
+func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldAcceptValidPrepCommands(c *gc.C) {
+	for _, command := range []string{machine.PrepareCommand, machine.CompleteCommand} {
+		err := s.runUpgradeSeriesCommand(c, command, machineArg, seriesArg)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidPrepCommands(c *gc.C) {
+	invalidPrepCommand := "actuate"
+	err := s.runUpgradeSeriesCommand(c, invalidPrepCommand, machineArg, seriesArg)
+	c.Assert(err, gc.ErrorMatches, ".* \"actuate\" is an invalid upgrade-series command")
+}
+
 func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
 	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -1,6 +1,10 @@
 package machine_test
 
 import (
+	"bytes"
+	"errors"
+
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,19 +20,48 @@ var _ = gc.Suite(&UpgradeSeriesSuite{})
 const machineArg = "1"
 const seriesArg = "xenial"
 
-func (s *UpgradeSeriesSuite) SetUpTest(c *gc.C) {
-}
+func (s *UpgradeSeriesSuite) SetUpTest(c *gc.C) {}
 
 func (s *UpgradeSeriesSuite) runUpgradeSeriesCommand(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, machine.NewUpgradeSeriesCommandForTest(), args...)
+	err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", args...)
 	return err
 }
 
-func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldAcceptValidPrepCommands(c *gc.C) {
-	for _, command := range []string{machine.PrepareCommand, machine.CompleteCommand} {
-		err := s.runUpgradeSeriesCommand(c, command, machineArg, seriesArg)
-		c.Assert(err, jc.ErrorIsNil)
+func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(c *gc.C, confirmation string, args ...string) error {
+	var stdin, stdout, stderr bytes.Buffer
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
+	ctx.Stderr = &stderr
+	ctx.Stdout = &stdout
+	ctx.Stdin = &stdin
+	stdin.WriteString(confirmation)
+
+	com := machine.NewUpgradeSeriesCommandForTest()
+	err = cmdtesting.InitCommand(com, args)
+	if err != nil {
+		return err
 	}
+
+	err = com.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	if stderr.String() != "" {
+		return errors.New(stderr.String())
+	}
+
+	return nil
+}
+
+func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAbortOnFailedConfirmation(c *gc.C) {
+	err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machine.PrepareCommand, machineArg, seriesArg)
+	c.Assert(err, gc.ErrorMatches, "upgrade series: aborted")
 }
 
 func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidPrepCommands(c *gc.C) {
@@ -41,11 +74,6 @@ func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidMachineArgs
 	invalidMachineArg := "machine5"
 	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, invalidMachineArg, seriesArg)
 	c.Assert(err, gc.ErrorMatches, "\"machine5\" is an invalid machine name")
-}
-
-func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeFlag(c *gc.C) {

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -34,6 +34,18 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeFlag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldOnlyAcceptSupportedSeries(c *gc.C) {
+	BadSeries := "Combative Caribou"
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, BadSeries)
+	c.Assert(err, gc.ErrorMatches, ".* is an unsupported series")
+}
+
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldSupportSeriesRegardlessOfCase(c *gc.C) {
+	capitalizedCaseXenial := "Xenial"
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, capitalizedCaseXenial)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *UpgradeSeriesSuite) TestCompleteCommand(c *gc.C) {
 	err := s.runUpgradeSeriesCommand(c, machine.CompleteCommand, machineArg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -76,11 +76,6 @@ func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidMachineArgs
 	c.Assert(err, gc.ErrorMatches, "\"machine5\" is an invalid machine name")
 }
 
-func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeFlag(c *gc.C) {
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "--agree")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldOnlyAcceptSupportedSeries(c *gc.C) {
 	BadSeries := "Combative Caribou"
 	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, BadSeries)

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/juju/juju/cmd/juju/machine"
 )
 
-type UpgradeSeriesSuite struct{}
+type UpgradeSeriesSuite struct {
+}
 
 var _ = gc.Suite(&UpgradeSeriesSuite{})
 
@@ -19,7 +20,7 @@ func (s *UpgradeSeriesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *UpgradeSeriesSuite) runUpgradeSeriesCommand(c *gc.C, args ...string) error {
-	_, err := cmdtesting.RunCommand(c, machine.NewUpgradeSeriesCommand(), args...)
+	_, err := cmdtesting.RunCommand(c, machine.NewUpgradeSeriesCommandForTest(), args...)
 	return err
 }
 

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -1,0 +1,39 @@
+package machine_test
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/machine"
+)
+
+type UpgradeSeriesSuite struct{}
+
+var _ = gc.Suite(&UpgradeSeriesSuite{})
+
+const machineArg = "1"
+const seriesArg = "xenial"
+
+func (s *UpgradeSeriesSuite) SetUpTest(c *gc.C) {
+}
+
+func (s *UpgradeSeriesSuite) runUpgradeSeriesCommand(c *gc.C, args ...string) error {
+	_, err := cmdtesting.RunCommand(c, machine.NewUpgradeSeriesCommand(), args...)
+	return err
+}
+
+func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpgradeSeriesSuite) TestCompleteCommand(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.CompleteCommand, machineArg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpgradeSeriesSuite) TestCompleteCommandDoesNotAcceptSeries(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.CompleteCommand, machineArg, seriesArg)
+	c.Assert(err, gc.ErrorMatches, "wrong number of arguments")
+}

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -28,6 +28,11 @@ func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeFlag(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "--agree")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *UpgradeSeriesSuite) TestCompleteCommand(c *gc.C) {
 	err := s.runUpgradeSeriesCommand(c, machine.CompleteCommand, machineArg)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

Managed Series Upgrades

## QA steps

1.  bootstrap 
2.  export JUJU_DEV_FEATURE_FLAGS=upgrade-series
3.  `juju upgrade-series prepare <machine> <series>` should be a noop for all supported series and machine names. 
4. `juju upgrade-series complete <machine>` should be a noop for all valid machine names. 

## Does it affect current user workflow? CLI? API?

Yes, this changes how a user should perform a series upgrade
