### PR TITLE
Code changes for charm version

### DIFF
--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -201,6 +201,26 @@ func (s *charmsSuite) TestUploadBumpsRevision(c *gc.C) {
 	c.Assert(sch.BundleSha256(), gc.Not(gc.Equals), "")
 }
 
+func (s *charmsSuite) TestUploadVersion(c *gc.C) {
+	// Add the dummy charm with version "juju-2.4-beta3-146-g725cfd3-dirty".
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+
+	expectedVersion := "dummy-146-g725cfd3-dirty"
+
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", f)
+
+	inputURL := charm.MustParseURL("local:quantal/dummy-1")
+	s.assertUploadResponse(c, resp, inputURL.String())
+	sch, err := s.State.Charm(inputURL)
+	c.Assert(err, jc.ErrorIsNil)
+
+	version := sch.Version()
+	c.Assert(version, gc.Equals, expectedVersion)
+}
+
 func (s *charmsSuite) TestUploadRespectsLocalRevision(c *gc.C) {
 	// Make a dummy charm dir with revision 123.
 	dir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy")

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -206,6 +206,9 @@ type CharmArchive struct {
 
 	// Macaroon is the authorization macaroon for accessing the charmstore.
 	Macaroon macaroon.Slice
+
+	// Charm Version contains semantic version of charm, typically the output of git describe.
+	CharmVersion string
 }
 
 // StoreCharmArchive stores a charm archive in environment storage.
@@ -225,6 +228,7 @@ func StoreCharmArchive(st *state.State, archive CharmArchive) error {
 		StoragePath: storagePath,
 		SHA256:      archive.SHA256,
 		Macaroon:    archive.Macaroon,
+		Version:     archive.CharmVersion,
 	}
 
 	// Now update the charm data in state and mark it as no longer pending.

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -969,10 +969,11 @@ func (context *statusContext) processApplication(application *state.Application)
 	}
 
 	var processedStatus = params.ApplicationStatus{
-		Charm:   applicationCharm.URL().String(),
-		Series:  application.Series(),
-		Exposed: application.IsExposed(),
-		Life:    processLife(application),
+		Charm:        applicationCharm.URL().String(),
+		Series:       application.Series(),
+		Exposed:      application.IsExposed(),
+		Life:         processLife(application),
+		CharmVersion: applicationCharm.Version(),
 	}
 
 	if latestCharm, ok := context.allAppsUnitsCharmBindings.latestCharms[*applicationCharm.URL().WithRevision(-1)]; ok && latestCharm != nil {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -129,6 +129,7 @@ type ApplicationStatus struct {
 	MeterStatuses    map[string]MeterStatus `json:"meter-statuses"`
 	Status           DetailedStatus         `json:"status"`
 	WorkloadVersion  string                 `json:"workload-version"`
+	CharmVersion     string                 `json:"charm-verion"`
 	EndpointBindings map[string]string      `json:"endpoint-bindings"`
 
 	// The following are for CAAS models.

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -100,6 +100,7 @@ type applicationStatus struct {
 	CharmOrigin      string                `json:"charm-origin" yaml:"charm-origin"`
 	CharmName        string                `json:"charm-name" yaml:"charm-name"`
 	CharmRev         int                   `json:"charm-rev" yaml:"charm-rev"`
+	CharmVersion     string                `json:"charm-version,omitempty" yaml:"charm-version,omitempty"`
 	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
 	ProviderId       string                `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
 	Address          string                `json:"address,omitempty" yaml:"address,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -207,6 +207,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		CharmOrigin:      charmOrigin,
 		CharmName:        charmName,
 		CharmRev:         charmRev,
+		CharmVersion:     application.CharmVersion,
 		Exposed:          application.Exposed,
 		Life:             application.Life,
 		ProviderId:       application.ProviderId,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -122,9 +122,9 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Charm version", "Notes")
 	} else {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Charm version", "Notes")
 	}
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
@@ -155,6 +155,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		} else {
 			w.Print(scale)
 		}
+
 		w.Print(app.CharmName,
 			app.CharmOrigin,
 			app.CharmRev,
@@ -162,6 +163,14 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		if fs.Model.Type == caasModelType {
 			w.Print(app.Address)
 		}
+
+		charmVersion := fmt.Sprintf("%.15s", app.CharmVersion)
+		if len(app.CharmVersion) > len(charmVersion) {
+			w.Print(charmVersion + "...")
+		} else {
+			w.Print(charmVersion)
+		}
+
 		w.Println(notes)
 		for un, u := range app.Units {
 			units[un] = u

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -152,10 +152,10 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 
 	context := s.run(c, "status")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Notes
-another             waiting    0/1  mysql      jujucharms    5  ubuntu  
-mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  
-wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  
+App        Version  Status   Scale  Charm      Store       Rev  OS      Charm version  Notes
+another             waiting    0/1  mysql      jujucharms    5  ubuntu                 
+mysql               waiting    0/1  mysql      jujucharms    1  ubuntu                 
+wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu                 
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 another/0    waiting   allocating  1                               waiting for machine
@@ -169,9 +169,9 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 	context = s.run(c, "status", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Notes
-mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  
-wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  
+App        Version  Status   Scale  Charm      Store       Rev  OS      Charm version  Notes
+mysql               waiting    0/1  mysql      jujucharms    1  ubuntu                 
+wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu                 
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -141,6 +141,7 @@ func (s *CharmSuite) dummyCharm(c *gc.C, curlOverride string) state.CharmInfo {
 		Charm:       testcharms.Repo.CharmDir("dummy"),
 		StoragePath: "dummy-1",
 		SHA256:      "dummy-1-sha256",
+		Version:     "dummy-146-g725cfd3-dirty",
 	}
 	if curlOverride != "" {
 		info.ID = charm.MustParseURL(curlOverride)
@@ -280,6 +281,9 @@ func (s *CharmSuite) TestAddCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
 	c.Assert(doc.URL, gc.DeepEquals, info.ID)
+
+	expVersion := "dummy-146-g725cfd3-dirty"
+	c.Assert(doc.CharmVersion, gc.Equals, expVersion)
 }
 
 func (s *CharmSuite) TestAddCharmWithAuth(c *gc.C) {

--- a/testcharms/charm-repo/quantal/dummy/version
+++ b/testcharms/charm-repo/quantal/dummy/version
@@ -1,0 +1,1 @@
+dummy-146-g725cfd3-dirty


### PR DESCRIPTION
## Description of change
This feature is to reflect to juju user another attribute(charm-version) that remain unchanged if the same charm is deployed on the model.

This PR addresses code changes for writing the version details from charm manifest(version file) into the Database and display the version details in juju status.

## QA steps
As for this PR is concerned, the user can deploy a local charm with a version file manually written containing the output of 'git describe --dirty' command.
The complex logic of how its handled in different scenarios is going to be addressed in another PR.

The tabular form of status is displays the trimmed part of the version details. The yams and son has complete details of version from the charm manifest.

## Documentation changes
Yes. juju status needs to get updated on the additional information that gets displayed plus how it is going to be in different format.
