### PR TITLE
LXD container manager uses new container module.

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -221,6 +221,7 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	return &c, nil
 }
 
+// StartContainer starts the extant container identified by the input name.
 func (s *Server) StartContainer(name string) error {
 	req := api.ContainerStatePut{
 		Action:   "start",
@@ -233,11 +234,7 @@ func (s *Server) StartContainer(name string) error {
 		return errors.Trace(err)
 	}
 
-	if err := op.Wait(); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
+	return errors.Trace(op.Wait())
 }
 
 // Remove containers stops and deletes containers matching the input list of
@@ -288,11 +285,8 @@ func (s *Server) RemoveContainer(name string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := op.Wait(); err != nil {
-		return errors.Trace(err)
-	}
 
-	return nil
+	return errors.Trace(op.Wait())
 }
 
 // WriteContainer writes the current representation of the input container to

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -40,6 +40,10 @@ func (s *Server) FindImage(
 	copyLocal bool,
 	callback environs.StatusCallbackFunc,
 ) (SourcedImage, error) {
+	if callback != nil {
+		callback(status.Provisioning, "acquiring LXD image", nil)
+	}
+
 	// First we check if we have the image locally.
 	localAlias := seriesLocalAlias(series, arch)
 	var target string


### PR DESCRIPTION
## Description of change

This PR begins unifying LXD container provisioning between the provider and container manager, by modifying the container manager to use the new logic from https://github.com/juju/juju/pull/8790

Once landed, the provider side PR will use the new common container logic, along with networking pass-through via cloud init user data. A removal of all container handling logic from _tools/lxdclient_ will accompany that change. 

## QA steps

- Modified manager test suite.
- Bootstrapping to LXD and deploying LXD container machines continues to work in system tests. Provider changes to come as mentioned above.

## Documentation changes

None.

## Bug reference

N/A
