### PR TITLE
Add snap enterprise proxy settings.

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -659,11 +659,13 @@ type ProxyConfig struct {
 
 // ProxyConfigResult contains information needed to configure a clients proxy settings
 type ProxyConfigResult struct {
-	LegacyProxySettings ProxyConfig `json:"legacy-proxy-settings"`
-	JujuProxySettings   ProxyConfig `json:"juju-proxy-settings"`
-	APTProxySettings    ProxyConfig `json:"apt-proxy-settings"`
-	SnapProxySettings   ProxyConfig `json:"snap-proxy-settings"`
-	Error               *Error      `json:"error,omitempty"`
+	LegacyProxySettings           ProxyConfig `json:"legacy-proxy-settings"`
+	JujuProxySettings             ProxyConfig `json:"juju-proxy-settings"`
+	APTProxySettings              ProxyConfig `json:"apt-proxy-settings,omitempty"`
+	SnapProxySettings             ProxyConfig `json:"snap-proxy-settings,omitempty"`
+	SnapEnterpriseProxyId         string      `json:"snap-store-id,omitempty"`
+	SnapEnterpriseProxyAssertions string      `json:"snap-store-assertions,omitempty"`
+	Error                         *Error      `json:"error,omitempty"`
 }
 
 // ProxyConfigResults contains information needed to configure multiple clients proxy settings


### PR DESCRIPTION
This PR just adds two fields to the proxy config struct which is used to return values to the proxy updater worker. These fields are as yet unused, as is the snap proxy values.

These fields are to provide the two pieces of data we need to enable the snap enterprise proxy as shown here:
  https://docs.ubuntu.com/snap-enterprise-proxy/en/devices

We are adding them now to avoid the necessity to bump the facade version post release.

These values are not yet set nor acted on.