### PR TITLE
Cloud call context for calls made from add-cloud command.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -81,16 +81,16 @@ type AddCloudCommand struct {
 
 // NewAddCloudCommand returns a command to add cloud information.
 func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) *AddCloudCommand {
-	cmd := AddCloudCommand{
+	cloudCallCtx := context.NewCloudCallContext()
+	return &AddCloudCommand{
 		cloudMetadataStore: cloudMetadataStore,
-		CloudCallCtx:       context.NewCloudCallContext(),
+		CloudCallCtx:       cloudCallCtx,
+		// Ping is provider.Ping except in tests where we don't actually want to
+		// require a valid cloud.
+		Ping: func(p environs.EnvironProvider, endpoint string) error {
+			return p.Ping(cloudCallCtx, endpoint)
+		},
 	}
-	// Ping is provider.Ping except in tests where we don't actually want to
-	// require a valid cloud.
-	cmd.Ping = func(p environs.EnvironProvider, endpoint string) error {
-		return p.Ping(cmd.CloudCallCtx, endpoint)
-	}
-	return &cmd
 }
 
 // Info returns help information about the command.

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -74,20 +74,23 @@ type AddCloudCommand struct {
 	// default it just calls the correct provider's Ping method.
 	Ping func(p environs.EnvironProvider, endpoint string) error
 
+	// CloudCallCtx contains context to be used for any cloud calls.
+	CloudCallCtx       *context.CloudCallContext
 	cloudMetadataStore CloudMetadataStore
 }
 
 // NewAddCloudCommand returns a command to add cloud information.
 func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) *AddCloudCommand {
-	cloudCallCtx := context.NewCloudCallContext()
+	cmd := AddCloudCommand{
+		cloudMetadataStore: cloudMetadataStore,
+		CloudCallCtx:       context.NewCloudCallContext(),
+	}
 	// Ping is provider.Ping except in tests where we don't actually want to
 	// require a valid cloud.
-	return &AddCloudCommand{
-		cloudMetadataStore: cloudMetadataStore,
-		Ping: func(p environs.EnvironProvider, endpoint string) error {
-			return p.Ping(cloudCallCtx, endpoint)
-		},
+	cmd.Ping = func(p environs.EnvironProvider, endpoint string) error {
+		return p.Ping(cmd.CloudCallCtx, endpoint)
 	}
+	return &cmd
 }
 
 // Info returns help information about the command.
@@ -192,6 +195,14 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	// At this stage, since we do not have a reference to any model, nor can we get it,
+	// nor do we need to have a model for anything that this command does,
+	// no cloud credential stored server-side can be invalidated.
+	// So, just log an informative message.
+	c.CloudCallCtx.InvalidateCredentialF = func(reason string) error {
+		ctxt.Infof("Cloud credential is not accepted by cloud provider: %v", reason)
+		return nil
+	}
 	pollster.VerifyURLs = func(s string) (ok bool, msg string, err error) {
 		err = c.Ping(provider, s)
 		if err != nil {


### PR DESCRIPTION
## Description of change

Although 'add-cloud' command does call environs directly, by-passing api, there is no model needed. Consequently, there is no need to invalidate credential stored on the controller.

This PR ensures that cloud call context used just highlights the issue by logging a message.
