### PR TITLE
Consolidating common credential api.

### DIFF
--- a/api/credentialmanager/client.go
+++ b/api/credentialmanager/client.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var logger = loggo.GetLogger("juju.api.credentialmanager")
+
+// Client allows access to the credential management API end point.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new client for accessing the credential manager API.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "CredentialManager")
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// InvalidateModelCredential invalidates cloud credential for the model that made a connection.
+func (c *Client) InvalidateModelCredential(reason string) error {
+	var result params.ErrorResult
+	err := c.facade.FacadeCall("InvalidateModelCredential", reason, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}

--- a/api/credentialmanager/client_test.go
+++ b/api/credentialmanager/client_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/credentialmanager"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var _ = gc.Suite(&CredentialManagerSuite{})
+
+type CredentialManagerSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CredentialManager")
+		c.Check(request, gc.Equals, "InvalidateModelCredential")
+		c.Assert(arg, gc.Equals, "")
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
+		*(result.(*params.ErrorResult)) = params.ErrorResult{}
+		return nil
+	})
+
+	client := credentialmanager.NewClient(apiCaller)
+	err := client.InvalidateModelCredential("")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CredentialManagerSuite) TestInvalidateModelCredentialBackendFailure(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResult)) = params.ErrorResult{Error: common.ServerError(errors.New("boom"))}
+		return nil
+	})
+
+	client := credentialmanager.NewClient(apiCaller)
+	err := client.InvalidateModelCredential("")
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *CredentialManagerSuite) TestInvalidateModelCredentialError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("foo")
+	})
+
+	client := credentialmanager.NewClient(apiCaller)
+	err := client.InvalidateModelCredential("")
+	c.Assert(err, gc.ErrorMatches, "foo")
+}

--- a/api/credentialmanager/package_test.go
+++ b/api/credentialmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -35,6 +35,7 @@ var facadeVersions = map[string]int{
 	"Client":                       2,
 	"Cloud":                        2,
 	"Controller":                   5,
+	"CredentialManager":            1,
 	"CredentialValidator":          1,
 	"CrossController":              1,
 	"CrossModelRelations":          1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -50,6 +50,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/client"     // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/client/cloud"      // ModelUser Read
 	"github.com/juju/juju/apiserver/facades/client/controller" // ModelUser Admin (although some methods check for read only)
+	"github.com/juju/juju/apiserver/facades/client/credentialmanager"
 	"github.com/juju/juju/apiserver/facades/client/firewallrules"
 	"github.com/juju/juju/apiserver/facades/client/highavailability" // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/client/imagemanager"     // ModelUser Write
@@ -168,6 +169,7 @@ func AllFacades() *facade.Registry {
 	reg("Controller", 5, controller.NewControllerAPIv5)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
+	reg("CredentialManager", 1, credentialmanager.NewCredentialManagerAPI)
 	reg("CredentialValidator", 1, credentialvalidator.NewCredentialValidatorAPI)
 	reg("ExternalControllerUpdater", 1, externalcontrollerupdater.NewStateAPI)
 

--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -4,56 +4,29 @@
 package credentialcommon
 
 import (
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/state"
 )
 
-// Backend is an interface for manipulating cloud credential.
-type Backend interface {
-
-	// CloudCredential returns the cloud credential for the given tag.
-	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
-
-	// UpdateCloudCredential adds or updates a cloud credential with the given tag.
-	UpdateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error
+// StateBackend exposes State methods needed by credential manager.
+type StateBackend interface {
+	InvalidateModelCredential(reason string) error
 }
 
-// ChangeCloudCredentialsValidity marks given cloud credentials as valid/invalid according
-// to supplied validity indicators using given persistence interface.
-func ChangeCloudCredentialsValidity(b Backend, creds params.ValidateCredentialArgs) ([]params.ErrorResult, error) {
-	if len(creds.All) == 0 {
-		return nil, nil
-	}
-	all := make([]params.ErrorResult, len(creds.All))
-	for i, one := range creds.All {
-		tag, err := names.ParseCloudCredentialTag(one.CredentialTag)
-		if err != nil {
-			all[i].Error = common.ServerError(err)
-			continue
-		}
-		storedCredential, err := b.CloudCredential(tag)
-		if err != nil {
-			all[i].Error = common.ServerError(err)
-			continue
-		}
-		cloudCredential := cloud.NewNamedCredential(
-			storedCredential.Name,
-			cloud.AuthType(storedCredential.AuthType),
-			storedCredential.Attributes,
-			storedCredential.Revoked,
-		)
+type CredentialManagerAPI struct {
+	backend StateBackend
+}
 
-		cloudCredential.Invalid = !one.Valid
-		cloudCredential.InvalidReason = one.Reason
+// NewCredentialManagerAPI creates new model credential manager api endpoint.
+func NewCredentialManagerAPI(backend StateBackend) *CredentialManagerAPI {
+	return &CredentialManagerAPI{backend: backend}
+}
 
-		err = b.UpdateCloudCredential(tag, cloudCredential)
-		if err != nil {
-			all[i].Error = common.ServerError(err)
-		}
+// InvalidateModelCredential marks the cloud credential for this model as invalid.
+func (api *CredentialManagerAPI) InvalidateModelCredential(reason string) (params.ErrorResult, error) {
+	err := api.backend.InvalidateModelCredential(reason)
+	if err != nil {
+		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}
-	return all, nil
+	return params.ErrorResult{}, nil
 }

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/credentialcommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/watcher"
@@ -23,6 +24,8 @@ type CredentialValidator interface {
 }
 
 type CredentialValidatorAPI struct {
+	*credentialcommon.CredentialManagerAPI
+
 	backend   Backend
 	resources facade.Resources
 }
@@ -41,8 +44,9 @@ func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resourc
 	}
 
 	return &CredentialValidatorAPI{
-		resources: resources,
-		backend:   backend,
+		CredentialManagerAPI: credentialcommon.NewCredentialManagerAPI(backend),
+		resources:            resources,
+		backend:              backend,
 	}, nil
 }
 
@@ -93,13 +97,4 @@ func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, er
 		Exists:          c.Exists,
 		Valid:           c.Valid,
 	}, nil
-}
-
-// InvalidateModelCredential marks the cloud credential for this model as invalid.
-func (api *CredentialValidatorAPI) InvalidateModelCredential(reason string) (params.ErrorResult, error) {
-	err := api.backend.InvalidateModelCredential(reason)
-	if err != nil {
-		return params.ErrorResult{Error: common.ServerError(err)}, nil
-	}
-	return params.ErrorResult{}, nil
 }

--- a/apiserver/facades/client/credentialmanager/client.go
+++ b/apiserver/facades/client/credentialmanager/client.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager
+
+import (
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/credentialcommon"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var logger = loggo.GetLogger("juju.api.credentialmanager")
+
+// CredentialManager defines the methods on credentialmanager API endpoint.
+type CredentialManager interface {
+	InvalidateModelCredential(reason string) (params.ErrorResult, error)
+}
+
+type CredentialManagerAPI struct {
+	*credentialcommon.CredentialManagerAPI
+
+	resources facade.Resources
+}
+
+var _ CredentialManager = (*CredentialManagerAPI)(nil)
+
+// NewCredentialManagerAPI creates a new CredentialManager API endpoint on server-side.
+func NewCredentialManagerAPI(ctx facade.Context) (*CredentialManagerAPI, error) {
+	return internalNewCredentialManagerAPI(NewStateShim(ctx.State()), ctx.Resources(), ctx.Auth())
+}
+
+func internalNewCredentialManagerAPI(backend credentialcommon.StateBackend, resources facade.Resources, authorizer facade.Authorizer) (*CredentialManagerAPI, error) {
+	hostAuthTag := authorizer.GetAuthTag()
+	if hostAuthTag == nil {
+		return nil, common.ErrPerm
+	}
+
+	return &CredentialManagerAPI{
+		resources:            resources,
+		CredentialManagerAPI: credentialcommon.NewCredentialManagerAPI(backend),
+	}, nil
+}

--- a/apiserver/facades/client/credentialmanager/export_test.go
+++ b/apiserver/facades/client/credentialmanager/export_test.go
@@ -1,0 +1,13 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager
+
+import (
+	"github.com/juju/juju/apiserver/common/credentialcommon"
+	"github.com/juju/juju/apiserver/facade"
+)
+
+func NewCredentialManagerAPIForTest(b credentialcommon.StateBackend, resources facade.Resources, authorizer facade.Authorizer) (*CredentialManagerAPI, error) {
+	return internalNewCredentialManagerAPI(b, resources, authorizer)
+}

--- a/apiserver/facades/client/credentialmanager/package_test.go
+++ b/apiserver/facades/client/credentialmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/facades/client/credentialmanager/state.go
+++ b/apiserver/facades/client/credentialmanager/state.go
@@ -1,0 +1,18 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialmanager
+
+import (
+	"github.com/juju/juju/apiserver/common/credentialcommon"
+	"github.com/juju/juju/state"
+)
+
+type stateShim struct {
+	*state.State
+}
+
+// NewStateShim creates new state shim to be used by credential validator Facade.
+func NewStateShim(st *state.State) credentialcommon.StateBackend {
+	return &stateShim{st}
+}


### PR DESCRIPTION
## Description of change

Juju needs the ability to invalidate cloud credentials both from the client side (CLI) and sever-side (agent via workers). Although, the logic and underlying functionality is the same, we need 2 separate api to allow for different access path.

This PR (1) introduces new client facade that will be used from CLI, (2) moves common implementation into credentialcommon area for both existing and new api to use, (3) removes previously written, never-used, now-redundant implementation for invalidating credentials. 

