### PR TITLE
Complete command for upgrade

### DIFF
--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -171,5 +171,9 @@ func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return result.Error
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
 }

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -158,3 +158,18 @@ func (client *Client) UpgradeSeriesPrepare(machineName string) error {
 
 	return nil
 }
+
+func (client *Client) UpgradeSeriesComplete(machineName string) error {
+	if client.BestAPIVersion() < 5 {
+		return errors.NotSupportedf("upgrade-series prepare")
+	}
+	args := params.UpdateSeriesArg{
+		Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},
+	}
+	result := new(params.ErrorResult)
+	err := client.facade.FacadeCall("UpgradeSeriesComplete", args, result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return result.Error
+}

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -159,9 +159,11 @@ func (client *Client) UpgradeSeriesPrepare(machineName string) error {
 	return nil
 }
 
+// UpgradeSeriesComplete notifies the controller that a given machine has
+// successfully completed the managed series upgrade process.
 func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	if client.BestAPIVersion() < 5 {
-		return errors.NotSupportedf("upgrade-series prepare")
+		return errors.NotSupportedf("upgrade-series complete")
 	}
 	args := params.UpdateSeriesArg{
 		Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -57,7 +57,7 @@ type MachineManagerAPIV4 struct {
 	*MachineManagerAPIV5
 }
 
-// Version 5 of Machine Manger API. Adds CreateUpgradeSeriesPrepareLock.
+// Version 5 of Machine Manger API. Adds CreateUpgradeSeriesLock.
 type MachineManagerAPIV5 struct {
 	*MachineManagerAPI
 }
@@ -336,7 +336,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesPrepare(args params.UpdateSeriesArg) (
 	if err := mm.check.ChangeAllowed(); err != nil {
 		return params.ErrorResult{}, err
 	}
-	err := mm.createUpgradeSeriesPrepareLock(args)
+	err := mm.createUpgradeSeriesLock(args)
 	if err != nil {
 		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}
@@ -351,7 +351,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesComplete(args params.UpdateSeriesArg) 
 	if err := mm.check.ChangeAllowed(); err != nil {
 		return params.ErrorResult{}, err
 	}
-	err := mm.removeUpgradeSeriesPrepareLock(args)
+	err := mm.removeUpgradeSeriesLock(args)
 	if err != nil {
 		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}
@@ -399,7 +399,7 @@ func (mm *MachineManagerAPI) updateOneMachineSeries(arg params.UpdateSeriesArg) 
 	return machine.UpdateMachineSeries(arg.Series, arg.Force)
 }
 
-func (mm *MachineManagerAPI) createUpgradeSeriesPrepareLock(arg params.UpdateSeriesArg) error {
+func (mm *MachineManagerAPI) createUpgradeSeriesLock(arg params.UpdateSeriesArg) error {
 	machineTag, err := names.ParseMachineTag(arg.Entity.Tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -408,10 +408,10 @@ func (mm *MachineManagerAPI) createUpgradeSeriesPrepareLock(arg params.UpdateSer
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return machine.CreateUpgradeSeriesPrepareLock()
+	return machine.CreateUpgradeSeriesLock()
 }
 
-func (mm *MachineManagerAPI) removeUpgradeSeriesPrepareLock(arg params.UpdateSeriesArg) error {
+func (mm *MachineManagerAPI) removeUpgradeSeriesLock(arg params.UpdateSeriesArg) error {
 	machineTag, err := names.ParseMachineTag(arg.Entity.Tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -420,5 +420,5 @@ func (mm *MachineManagerAPI) removeUpgradeSeriesPrepareLock(arg params.UpdateSer
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return machine.RemoveUpgradeSeriesPrepareLock()
+	return machine.RemoveUpgradeSeriesLock()
 }

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -352,7 +352,11 @@ func (mm *MachineManagerAPI) UpgradeSeriesComplete(args params.UpdateSeriesArg) 
 		return params.ErrorResult{}, err
 	}
 	err := mm.removeUpgradeSeriesPrepareLock(args)
-	return params.ErrorResult{Error: common.ServerError(err)}, nil
+	if err != nil {
+		return params.ErrorResult{Error: common.ServerError(err)}, nil
+	}
+
+	return params.ErrorResult{}, nil
 }
 
 // DEPRECATED: UpdateMachineSeries updates the series of the given machine(s) as well as all

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -343,7 +343,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesPrepare(args params.UpdateSeriesArg) (
 	return params.ErrorResult{}, nil
 }
 
-// UpgradeSeriesPrepare prepares a machine for a OS series upgrade.
+// UpgradeSeriesComplete marks a machine as having completed a managed series upgrade.
 func (mm *MachineManagerAPI) UpgradeSeriesComplete(args params.UpdateSeriesArg) (params.ErrorResult, error) {
 	if err := mm.checkCanWrite(); err != nil {
 		return params.ErrorResult{}, err

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -318,7 +318,7 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesPermissionDenied(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
-func (s *MachineManagerSuite) TestUpgradeSeriesPrepareLocksMachine(c *gc.C) {
+func (s *MachineManagerSuite) TestUpgradeSeriesLocksMachine(c *gc.C) {
 	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
 	machineTag := names.NewMachineTag("0")
 	_, err := apiV5.UpgradeSeriesPrepare(

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -45,6 +45,7 @@ type Machine interface {
 	SetKeepInstance(keepInstance bool) error
 	UpdateMachineSeries(string, bool) error
 	CreateUpgradeSeriesPrepareLock() error
+	RemoveUpgradeSeriesPrepareLock() error
 }
 
 type stateShim struct {

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -44,8 +44,8 @@ type Machine interface {
 	Units() ([]Unit, error)
 	SetKeepInstance(keepInstance bool) error
 	UpdateMachineSeries(string, bool) error
-	CreateUpgradeSeriesPrepareLock() error
-	RemoveUpgradeSeriesPrepareLock() error
+	CreateUpgradeSeriesLock() error
+	RemoveUpgradeSeriesLock() error
 }
 
 type stateShim struct {

--- a/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
+++ b/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
@@ -56,6 +56,18 @@ func (mr *MockUpgradeMachineSeriesAPIMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).Close))
 }
 
+// UpgradeSeriesComplete mocks base method
+func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesComplete(arg0 string) error {
+	ret := m.ctrl.Call(m, "UpgradeSeriesComplete", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpgradeSeriesComplete indicates an expected call of UpgradeSeriesComplete
+func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UpgradeSeriesComplete(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesComplete", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UpgradeSeriesComplete), arg0)
+}
+
 // UpgradeSeriesPrepare mocks base method
 func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesPrepare(arg0 string) error {
 	ret := m.ctrl.Call(m, "UpgradeSeriesPrepare", arg0)

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -42,6 +42,7 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(c *gc.C, co
 	mockController := gomock.NewController(c)
 	mockUpgradeSeriesAPI := mocks.NewMockUpgradeMachineSeriesAPI(mockController)
 	mockUpgradeSeriesAPI.EXPECT().UpgradeSeriesPrepare(gomock.Any()).AnyTimes()
+	mockUpgradeSeriesAPI.EXPECT().UpgradeSeriesComplete(gomock.Any()).AnyTimes()
 
 	com := machine.NewUpgradeSeriesCommandForTest(mockUpgradeSeriesAPI)
 

--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package state
 
 import (

--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
@@ -11,6 +12,11 @@ import (
 )
 
 type MachineInternalSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *MachineInternalSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
 }
 
 var _ = gc.Suite(&MachineInternalSuite{})

--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -1,0 +1,57 @@
+package state
+
+import (
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+type MachineInternalSuite struct {
+}
+
+var _ = gc.Suite(&MachineInternalSuite{})
+
+func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsMachineAlive(c *gc.C) {
+	arbitraryId := "1"
+	arbitraryData := &upgradeSeriesLock{}
+	for _, op := range createUpgradeSeriesPrepareLockTxnOps(arbitraryId, arbitraryData) {
+		assertVal, ok := op.Assert.(bson.D)
+		if op.C == machinesC && ok && assertVal.Map()["life"] == Alive {
+			c.SucceedNow()
+		}
+	}
+	c.Fatal("Transaction does not assert that machines are of status Alive")
+}
+
+func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsDocDoesNOTExist(c *gc.C) {
+	arbitraryId := "1"
+	arbitraryData := &upgradeSeriesLock{}
+	expectedOp := txn.Op{
+		C:      machineUpgradeSeriesLocksC,
+		Id:     arbitraryId,
+		Assert: txn.DocMissing,
+		Insert: arbitraryData,
+	}
+	assertConstainsOP(c, expectedOp, createUpgradeSeriesPrepareLockTxnOps(arbitraryId, arbitraryData))
+}
+
+func (s *MachineInternalSuite) TestRemoveUpgradePrepareLockTxnAssertsDocExists(c *gc.C) {
+	arbitraryId := "1"
+	expectedOp := txn.Op{
+		C:      machineUpgradeSeriesLocksC,
+		Id:     arbitraryId,
+		Assert: txn.DocExists,
+		Remove: true,
+	}
+	assertConstainsOP(c, expectedOp, removeUpgradeSeriesPrepareLockTxnOps(arbitraryId))
+}
+
+func assertConstainsOP(c *gc.C, expectedOp txn.Op, actualOps []txn.Op) {
+	for _, actualOp := range actualOps {
+		if actualOp == expectedOp {
+			c.SucceedNow()
+		}
+	}
+	c.Fatalf("expected %#v to contain %#v", actualOps, expectedOp)
+	return
+}

--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -17,13 +18,15 @@ var _ = gc.Suite(&MachineInternalSuite{})
 func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsMachineAlive(c *gc.C) {
 	arbitraryId := "1"
 	arbitraryData := &upgradeSeriesLock{}
+	var found bool
 	for _, op := range createUpgradeSeriesPrepareLockTxnOps(arbitraryId, arbitraryData) {
 		assertVal, ok := op.Assert.(bson.D)
 		if op.C == machinesC && ok && assertVal.Map()["life"] == Alive {
-			c.SucceedNow()
+			found = true
+			break
 		}
 	}
-	c.Fatal("Transaction does not assert that machines are of status Alive")
+	c.Assert(found, jc.IsTrue, gc.Commentf("Transaction does not assert that machines are of status Alive"))
 }
 
 func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsDocDoesNOTExist(c *gc.C) {
@@ -50,11 +53,12 @@ func (s *MachineInternalSuite) TestRemoveUpgradePrepareLockTxnAssertsDocExists(c
 }
 
 func assertConstainsOP(c *gc.C, expectedOp txn.Op, actualOps []txn.Op) {
+	var found bool
 	for _, actualOp := range actualOps {
 		if actualOp == expectedOp {
-			c.SucceedNow()
+			found = true
+			break
 		}
 	}
-	c.Fatalf("expected %#v to contain %#v", actualOps, expectedOp)
-	return
+	c.Assert(found, jc.IsTrue, gc.Commentf("expected %#v to contain %#v", actualOps, expectedOp))
 }

--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -21,11 +21,11 @@ func (s *MachineInternalSuite) SetUpTest(c *gc.C) {
 
 var _ = gc.Suite(&MachineInternalSuite{})
 
-func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsMachineAlive(c *gc.C) {
+func (s *MachineInternalSuite) TestCreateUpgradeLockTxnAssertsMachineAlive(c *gc.C) {
 	arbitraryId := "1"
 	arbitraryData := &upgradeSeriesLock{}
 	var found bool
-	for _, op := range createUpgradeSeriesPrepareLockTxnOps(arbitraryId, arbitraryData) {
+	for _, op := range createUpgradeSeriesLockTxnOps(arbitraryId, arbitraryData) {
 		assertVal, ok := op.Assert.(bson.D)
 		if op.C == machinesC && ok && assertVal.Map()["life"] == Alive {
 			found = true
@@ -35,7 +35,7 @@ func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsMachineAliv
 	c.Assert(found, jc.IsTrue, gc.Commentf("Transaction does not assert that machines are of status Alive"))
 }
 
-func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsDocDoesNOTExist(c *gc.C) {
+func (s *MachineInternalSuite) TestCreateUpgradeLockTxnAssertsDocDoesNOTExist(c *gc.C) {
 	arbitraryId := "1"
 	arbitraryData := &upgradeSeriesLock{}
 	expectedOp := txn.Op{
@@ -44,10 +44,10 @@ func (s *MachineInternalSuite) TestCreateUpgradePrepareLockTxnAssertsDocDoesNOTE
 		Assert: txn.DocMissing,
 		Insert: arbitraryData,
 	}
-	assertConstainsOP(c, expectedOp, createUpgradeSeriesPrepareLockTxnOps(arbitraryId, arbitraryData))
+	assertConstainsOP(c, expectedOp, createUpgradeSeriesLockTxnOps(arbitraryId, arbitraryData))
 }
 
-func (s *MachineInternalSuite) TestRemoveUpgradePrepareLockTxnAssertsDocExists(c *gc.C) {
+func (s *MachineInternalSuite) TestRemoveUpgradeLockTxnAssertsDocExists(c *gc.C) {
 	arbitraryId := "1"
 	expectedOp := txn.Op{
 		C:      machineUpgradeSeriesLocksC,
@@ -55,7 +55,7 @@ func (s *MachineInternalSuite) TestRemoveUpgradePrepareLockTxnAssertsDocExists(c
 		Assert: txn.DocExists,
 		Remove: true,
 	}
-	assertConstainsOP(c, expectedOp, removeUpgradeSeriesPrepareLockTxnOps(arbitraryId))
+	assertConstainsOP(c, expectedOp, removeUpgradeSeriesLockTxnOps(arbitraryId))
 }
 
 func assertConstainsOP(c *gc.C, expectedOp txn.Op, actualOps []txn.Op) {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2602,47 +2602,47 @@ func (s *MachineSuite) TestUpdateMachineSeriesSubordinateListChangeIncompatibleS
 	s.assertMachineAndUnitSeriesChanged(c, mach, "precise")
 }
 
-func (s *MachineSuite) TestCreateUgradeSeriesPrepareLock(c *gc.C) {
+func (s *MachineSuite) TestCreateUgradeSeriesLock(c *gc.C) {
 	mach := s.setupTestUpdateMachineSeries(c)
 	locked, err := mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsFalse)
-	err = mach.CreateUpgradeSeriesPrepareLock()
+	err = mach.CreateUpgradeSeriesLock()
 	c.Assert(err, jc.ErrorIsNil)
 	locked, err = mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsTrue)
 }
 
-func (s *MachineSuite) TestCreateUgradeSeriesPrepareLockErrorsIfLockExists(c *gc.C) {
+func (s *MachineSuite) TestCreateUgradeSeriesLockErrorsIfLockExists(c *gc.C) {
 	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.CreateUpgradeSeriesPrepareLock()
+	err := mach.CreateUpgradeSeriesLock()
 	c.Assert(err, jc.ErrorIsNil)
-	err = mach.CreateUpgradeSeriesPrepareLock()
-	c.Assert(err, gc.ErrorMatches, "upgrade series prepare lock for machine \".*\" already exists")
+	err = mach.CreateUpgradeSeriesLock()
+	c.Assert(err, gc.ErrorMatches, "upgrade series lock for machine \".*\" already exists")
 }
 
-func (s *MachineSuite) TestDoesNotCreateUgradeSeriesPrepareLockOnDyingMachine(c *gc.C) {
+func (s *MachineSuite) TestDoesNotCreateUgradeSeriesLockOnDyingMachine(c *gc.C) {
 	mach, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = mach.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = mach.CreateUpgradeSeriesPrepareLock()
+	err = mach.CreateUpgradeSeriesLock()
 	c.Assert(err, gc.ErrorMatches, "machine not found or not alive")
 }
 
-func (s *MachineSuite) TestRemoveUpgradeSeriesPrepareLockUnlocksMachine(c *gc.C) {
+func (s *MachineSuite) TestRemoveUpgradeSeriesLockUnlocksMachine(c *gc.C) {
 	mach, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	AssertMachineIsNOTLockedForPrepare(c, mach)
 
-	err = mach.CreateUpgradeSeriesPrepareLock()
+	err = mach.CreateUpgradeSeriesLock()
 	c.Assert(err, jc.ErrorIsNil)
 	AssertMachineLockedForPrepare(c, mach)
 
-	err = mach.RemoveUpgradeSeriesPrepareLock()
+	err = mach.RemoveUpgradeSeriesLock()
 	c.Assert(err, jc.ErrorIsNil)
 	AssertMachineIsNOTLockedForPrepare(c, mach)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2636,24 +2636,24 @@ func (s *MachineSuite) TestDoesNotCreateUgradeSeriesPrepareLockOnDyingMachine(c 
 func (s *MachineSuite) TestRemoveUpgradeSeriesPrepareLockUnlocksMachine(c *gc.C) {
 	mach, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	AssertMachinedIsNOTLockedForPrepare(c, mach)
+	AssertMachineIsNOTLockedForPrepare(c, mach)
 
 	err = mach.CreateUpgradeSeriesPrepareLock()
 	c.Assert(err, jc.ErrorIsNil)
-	AssertMachinedLockedForPrepare(c, mach)
+	AssertMachineLockedForPrepare(c, mach)
 
 	err = mach.RemoveUpgradeSeriesPrepareLock()
 	c.Assert(err, jc.ErrorIsNil)
-	AssertMachinedIsNOTLockedForPrepare(c, mach)
+	AssertMachineIsNOTLockedForPrepare(c, mach)
 }
 
-func AssertMachinedLockedForPrepare(c *gc.C, mach *state.Machine) {
+func AssertMachineLockedForPrepare(c *gc.C, mach *state.Machine) {
 	locked, err := mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsTrue)
 }
 
-func AssertMachinedIsNOTLockedForPrepare(c *gc.C, mach *state.Machine) {
+func AssertMachineIsNOTLockedForPrepare(c *gc.C, mach *state.Machine) {
 	locked, err := mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsFalse)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2632,3 +2632,29 @@ func (s *MachineSuite) TestDoesNotCreateUgradeSeriesPrepareLockOnDyingMachine(c 
 	err = mach.CreateUpgradeSeriesPrepareLock()
 	c.Assert(err, gc.ErrorMatches, "machine not found or not alive")
 }
+
+func (s *MachineSuite) TestRemoveUpgradeSeriesPrepareLockUnlocksMachine(c *gc.C) {
+	mach, err := s.State.AddMachine("precise", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	AssertMachinedIsNOTLockedForPrepare(c, mach)
+
+	err = mach.CreateUpgradeSeriesPrepareLock()
+	c.Assert(err, jc.ErrorIsNil)
+	AssertMachinedLockedForPrepare(c, mach)
+
+	err = mach.RemoveUpgradeSeriesPrepareLock()
+	c.Assert(err, jc.ErrorIsNil)
+	AssertMachinedIsNOTLockedForPrepare(c, mach)
+}
+
+func AssertMachinedLockedForPrepare(c *gc.C, mach *state.Machine) {
+	locked, err := mach.IsLocked()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(locked, jc.IsTrue)
+}
+
+func AssertMachinedIsNOTLockedForPrepare(c *gc.C, mach *state.Machine) {
+	locked, err := mach.IsLocked()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(locked, jc.IsFalse)
+}


### PR DESCRIPTION
## Description of change

`juju upgrade-series complete <machine>` should complete and upgrade. This PR removes the lock that is placed on the machine when the `prepare` sub-command is called.


