### PR TITLE
Store lock file

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -46,7 +46,7 @@ github.com/juju/idmclient	git	fb1dc7175251ac8e2dc460897313e05175cbbc0d	2016-11-0
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
-github.com/juju/mutex	git	1fe2a4bf0a3a2c10881501233ff7c6aed7790082	2017-11-10T02:00:13Z
+github.com/juju/mutex	git	d21b13acf4bfd8a8b0482a3a78e44d98880b40d3	2018-06-19T14:58:57Z
 github.com/juju/naturalsort	git	5b81707e882b8293e6cf77854b4cd49f29776e11	2018-04-23T03:48:42Z
 github.com/juju/os	git	cc9fc68ca9414ccda586ad2f66e72a208c3eb54d	2018-05-31T22:01:20Z
 github.com/juju/packaging	git	ba21344fff207f4fa06b0a08bac386b179a2e6a1	2018-05-16T20:30:43Z
@@ -63,7 +63,7 @@ github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-0
 github.com/juju/testing	git	72703b1e95eb8ce4737fd8a3d8496c6b0be280a6	2018-05-17T13:41:05Z
 github.com/juju/txn	git	f50b17d1ff3c31b7ea1c70e0d38a83f19af6d334	2018-04-06T04:58:51Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
-github.com/juju/utils	git	2000ea4ff0431598aec2b7e1d11d5d49b5384d63	2018-04-24T09:41:59Z
+github.com/juju/utils	git	c746c6e86f4fb2a04bc08d66b7a0f7e900d9cbab	2018-06-19T11:28:06Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/jujuclient/controllers.go
+++ b/jujuclient/controllers.go
@@ -28,6 +28,15 @@ func ReadControllersFile(file string) (*Controllers, error) {
 		if os.IsNotExist(err) {
 			return &Controllers{}, nil
 		}
+		if os.IsPermission(err) {
+			u, userErr := utils.LocalUsername()
+			if userErr != nil {
+				return nil, err
+			}
+			if ok, fileErr := utils.IsFileOwner(file, u); fileErr == nil && !ok {
+				err = errors.Annotatef(err, "it appears the ownership of the file is not the same as the current user")
+			}
+		}
 		return nil, err
 	}
 	controllers, err := ParseControllers(data)

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -84,7 +84,9 @@ func (s *store) acquireLock() (mutex.Releaser, error) {
 func (s *store) AllControllers() (map[string]ControllerDetails, error) {
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot read all controllers")
+		return nil, errors.Annotate(err,
+			"cannot acquire lock file to read all the controllers",
+		)
 	}
 	defer releaser.Release()
 	controllers, err := ReadControllersFile(JujuControllersPath())
@@ -98,7 +100,9 @@ func (s *store) AllControllers() (map[string]ControllerDetails, error) {
 func (s *store) CurrentController() (string, error) {
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return "", errors.Annotate(err, "cannot get current controller name")
+		return "", errors.Annotate(err,
+			"cannot acquire lock file to get the current controller name",
+		)
 	}
 	defer releaser.Release()
 	controllers, err := ReadControllersFile(JujuControllersPath())
@@ -119,7 +123,9 @@ func (s *store) ControllerByName(name string) (*ControllerDetails, error) {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannot read controller %v", name)
+		return nil, errors.Annotatef(err,
+			"cannot acquire lock file to read controller %s", name,
+		)
 	}
 	defer releaser.Release()
 
@@ -144,7 +150,9 @@ func (s *store) AddController(name string, details ControllerDetails) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Annotatef(err, "cannot add controller %v", name)
+		return errors.Annotatef(err,
+			"cannot acquire lock file to add controller %s", name,
+		)
 	}
 	defer releaser.Release()
 
@@ -183,7 +191,9 @@ func (s *store) UpdateController(name string, details ControllerDetails) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Annotatef(err, "cannot update controller %v", name)
+		return errors.Annotatef(err,
+			"cannot acquire lock file to update controller %s", name,
+		)
 	}
 	defer releaser.Release()
 
@@ -219,7 +229,9 @@ func (s *store) SetCurrentController(name string) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Annotate(err, "cannot set current controller name")
+		return errors.Annotate(err,
+			"cannot acquire lock file to set the current controller name",
+		)
 	}
 	defer releaser.Release()
 
@@ -245,7 +257,9 @@ func (s *store) RemoveController(name string) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Annotatef(err, "cannot remove controller %v", name)
+		return errors.Annotatef(err,
+			"cannot acquire lock file to remove controller %s", name,
+		)
 	}
 	defer releaser.Release()
 
@@ -336,7 +350,9 @@ func (s *store) UpdateModel(controllerName, modelName string, details ModelDetai
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for updating model %s on controller %s", modelName, controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -373,7 +389,9 @@ func (s *store) SetCurrentModel(controllerName, modelName string) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for setting current model %s on controller %s", modelName, controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -404,7 +422,9 @@ func (s *store) AllModels(controllerName string) (map[string]ModelDetails, error
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err,
+			"cannot acquire lock file for getting all models for controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -430,7 +450,9 @@ func (s *store) CurrentModel(controllerName string) (string, error) {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotatef(err,
+			"cannot acquire lock file for getting current model for controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -465,7 +487,9 @@ func (s *store) ModelByName(controllerName, modelName string) (*ModelDetails, er
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err,
+			"cannot acquire lock file for getting model %s for controller %s", modelName, controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -503,7 +527,9 @@ func (s *store) RemoveModel(controllerName, modelName string) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for removing model %s on controller %s", modelName, controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -568,7 +594,9 @@ func (s *store) SetModels(controllerName string, models map[string]ModelDetails)
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for setting models on controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -611,7 +639,9 @@ func (s *store) UpdateAccount(controllerName string, details AccountDetails) err
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for updating account on controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -643,7 +673,9 @@ func (s *store) AccountDetails(controllerName string) (*AccountDetails, error) {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err,
+			"cannot acquire lock file for getting account details on controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -666,7 +698,9 @@ func (s *store) RemoveAccount(controllerName string) error {
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for removing account on controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 
@@ -686,7 +720,9 @@ func (s *store) RemoveAccount(controllerName string) error {
 func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Annotatef(err, "cannot update credentials for %v", cloudName)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for updating credentials for %s", cloudName,
+		)
 	}
 	defer releaser.Release()
 
@@ -754,7 +790,9 @@ func (s *store) UpdateBootstrapConfig(controllerName string, cfg BootstrapConfig
 
 	releaser, err := s.acquireLock()
 	if err != nil {
-		return errors.Annotatef(err, "cannot update bootstrap config for controller %s", controllerName)
+		return errors.Annotatef(err,
+			"cannot acquire lock file for updating bootstrap config for controller %s", controllerName,
+		)
 	}
 	defer releaser.Release()
 


### PR DESCRIPTION
## Description of change

> Why is this change needed?

Improved error messaging around file locking

The current implementation doesn't distinguish between a file lock problem and a problem with the reading/writing (think input/output) of the standard flow.

To help with this, we tell people that there is a problem with a lock file, by giving them much better error messages. That way they maybe able to resolve the issue themselves

## QA steps

> How do we verify that the change works?

```sh
juju bootstrap localhost lxd-test
juju add-model lxd-test
sudo rm /tmp/juju-store-lock-*
sudo juju list-controllers
juju status
```

Prior to this, the juju status would fail.

```sh
juju bootstrap localhost lxd-test
juju add-model lxd-test
sudo juju status
juju status
```

The error message should give a better description about what the error
is and how to fix it.

## Documentation changes

> Does it affect current user workflow? CLI? API?

CLI: support of command run in sudo shouldn't cause cryptic errors. Instead they should either put files into the right permission group or give better error messages about how to fix them manually. This doesn't mean that sudo is supported on all commands, just that we handle the output gracefully.

## Bug reference

> Does this change fix a bug? Please add a link to it.

https://bugs.launchpad.net/juju/+bug/1758369