### PR TITLE
kill- and destroy- commands cloud call context.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -199,7 +199,7 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 	// nor do we need to have a model for anything that this command does,
 	// no cloud credential stored server-side can be invalidated.
 	// So, just log an informative message.
-	c.CloudCallCtx.InvalidateCredentialF = func(reason string) error {
+	c.CloudCallCtx.InvalidateCredentialFunc = func(reason string) error {
 		ctxt.Infof("Cloud credential is not accepted by cloud provider: %v", reason)
 		return nil
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -419,7 +419,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	// At this stage, the credential we intend to use is not yet stored
 	// server-side. So, if the credential is not accepted by the provider,
 	// we cannot mark it as invalid, just log it as an informative message.
-	cloudCallCtx.InvalidateCredentialF = func(reason string) error {
+	cloudCallCtx.InvalidateCredentialFunc = func(reason string) error {
 		ctx.Infof("Cloud credential %q is not accepted by cloud provider: %v", credentials.name, reason)
 		return nil
 	}

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -630,7 +630,7 @@ type newCredentialAPIFunc func() (CredentialAPI, error)
 
 func cloudCallContext(newAPIFunc newCredentialAPIFunc) context.ProviderCallContext {
 	callCtx := context.NewCloudCallContext()
-	callCtx.InvalidateCredentialF = func(reason string) error {
+	callCtx.InvalidateCredentialFunc = func(reason string) error {
 		api, err := newAPIFunc()
 		if err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/api/credentialmanager"
 	"github.com/juju/juju/api/storage"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
@@ -31,13 +32,15 @@ import (
 
 // NewDestroyCommand returns a command to destroy a controller.
 func NewDestroyCommand() cmd.Command {
+	cmd := destroyCommand{}
+	cmd.controllerCredentialAPIF = cmd.credentialAPIForControllerModel
 	// Even though this command is all about destroying a controller we end up
 	// needing environment endpoints so we can fall back to the client destroy
 	// environment method. This shouldn't really matter in practice as the
 	// user trying to take down the controller will need to have access to the
 	// controller environment anyway.
 	return modelcmd.WrapController(
-		&destroyCommand{},
+		&cmd,
 		modelcmd.WrapControllerSkipControllerFlags,
 		modelcmd.WrapControllerSkipDefaultController,
 	)
@@ -214,7 +217,7 @@ upgrade the controller to version 2.3 or greater.
 		return errors.Annotate(err, "getting controller environ")
 	}
 
-	cloudCallCtx := context.NewCloudCallContext()
+	cloudCallCtx := cloudCallContext(c.controllerCredentialAPIF)
 
 	for {
 		// Attempt to destroy the controller.
@@ -282,9 +285,11 @@ upgrade the controller to version 2.3 or greater.
 			}
 		}
 		ctx.Infof("All hosted models reclaimed, cleaning up controller machines")
-		return environs.Destroy(controllerName, controllerEnviron, cloudCallCtx, store)
+		return environsDestroy(controllerName, controllerEnviron, cloudCallCtx, store)
 	}
 }
+
+var environsDestroy = environs.Destroy
 
 func (c *destroyCommand) modelHasStorage(modelName string) (bool, error) {
 	client, err := c.getStorageAPI(modelName)
@@ -463,6 +468,8 @@ type destroyCommandBase struct {
 	api       destroyControllerAPI
 	apierr    error
 	clientapi destroyClientAPI
+
+	controllerCredentialAPIF func() (CredentialAPI, error)
 }
 
 func (c *destroyCommandBase) getControllerAPI() (destroyControllerAPI, error) {
@@ -599,4 +606,36 @@ func confirmDestruction(ctx *cmd.Context, controllerName string) error {
 	}
 
 	return nil
+}
+
+// CredentialAPI defines the methods on the credential API endpoint that the
+// destroy command might call.
+type CredentialAPI interface {
+	InvalidateModelCredential(string) error
+	Close() error
+}
+
+func (c *destroyCommandBase) credentialAPIForControllerModel() (CredentialAPI, error) {
+	// Note that the api here needs to operate on a controller model itself,
+	// as the controller model's cloud credential is the controller cloud credential.
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return credentialmanager.NewClient(root), nil
+}
+
+type newCredentialAPIFunc func() (CredentialAPI, error)
+
+func cloudCallContext(newAPIF newCredentialAPIFunc) context.ProviderCallContext {
+	callCtx := context.NewCloudCallContext()
+	callCtx.InvalidateCredentialF = func(reason string) error {
+		api, err := newAPIF()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer api.Close()
+		return api.InvalidateModelCredential(reason)
+	}
+	return callCtx
 }

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -100,12 +100,14 @@ func NewDestroyCommandForTest(
 	storageAPI storageAPI,
 	store jujuclient.ClientStore,
 	apierr error,
+	controllerCredentialAPIF func() (CredentialAPI, error),
 ) cmd.Command {
 	cmd := &destroyCommand{
 		destroyCommandBase: destroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,
+			controllerCredentialAPIF: controllerCredentialAPIF,
 		},
 		storageAPI: storageAPI,
 	}
@@ -126,12 +128,14 @@ func NewKillCommandForTest(
 	apierr error,
 	clock clock.Clock,
 	apiOpen api.OpenFunc,
+	controllerCredentialAPIF func() (CredentialAPI, error),
 ) cmd.Command {
 	kill := &killCommand{
 		destroyCommandBase: destroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,
+			controllerCredentialAPIF: controllerCredentialAPIF,
 		},
 		clock: clock,
 	}
@@ -153,7 +157,7 @@ func KillWaitForModels(command cmd.Command, ctx *cmd.Context, api destroyControl
 	return modelcmd.InnerCommand(command).(*killCommand).WaitForModels(ctx, api, uuid)
 }
 
-// NewConfigCommandCommandForTest returns a ConfigCommand with
+// NewConfigCommandForTest returns a ConfigCommand with
 // the api provided as specified.
 func NewConfigCommandForTest(api controllerAPI, store jujuclient.ClientStore) cmd.Command {
 	c := &configCommand{api: api}
@@ -178,4 +182,5 @@ func NewData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, er
 
 var (
 	NoModelsMessage = noModelsMessage
+	EnvironsDestroy = &environsDestroy
 )

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -100,14 +101,17 @@ func NewDestroyCommandForTest(
 	storageAPI storageAPI,
 	store jujuclient.ClientStore,
 	apierr error,
-	controllerCredentialAPIF func() (CredentialAPI, error),
+	controllerCredentialAPIFunc newCredentialAPIFunc,
+	environsDestroy func(string, environs.Environ, context.ProviderCallContext, jujuclient.ControllerStore) error,
+
 ) cmd.Command {
 	cmd := &destroyCommand{
 		destroyCommandBase: destroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,
-			controllerCredentialAPIF: controllerCredentialAPIF,
+			controllerCredentialAPIFunc: controllerCredentialAPIFunc,
+			environsDestroy:             environsDestroy,
 		},
 		storageAPI: storageAPI,
 	}
@@ -128,14 +132,16 @@ func NewKillCommandForTest(
 	apierr error,
 	clock clock.Clock,
 	apiOpen api.OpenFunc,
-	controllerCredentialAPIF func() (CredentialAPI, error),
+	controllerCredentialAPIFunc newCredentialAPIFunc,
+	environsDestroy func(string, environs.Environ, context.ProviderCallContext, jujuclient.ControllerStore) error,
 ) cmd.Command {
 	kill := &killCommand{
 		destroyCommandBase: destroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,
-			controllerCredentialAPIF: controllerCredentialAPIF,
+			controllerCredentialAPIFunc: controllerCredentialAPIFunc,
+			environsDestroy:             environsDestroy,
 		},
 		clock: clock,
 	}
@@ -182,5 +188,4 @@ func NewData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, er
 
 var (
 	NoModelsMessage = noModelsMessage
-	EnvironsDestroy = &environsDestroy
 )

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/environs"
 	_ "github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -52,6 +53,7 @@ func (s *KillSuite) newKillCommand() cmd.Command {
 	return controller.NewKillCommandForTest(
 		s.api, s.clientapi, s.store, s.apierror, clock, nil,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
+		environs.Destroy,
 	)
 }
 
@@ -441,6 +443,7 @@ func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
 	}
 	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, testDialer,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
+		environs.Destroy,
 	)
 	_, err := cmdtesting.RunCommand(c, cmd, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
@@ -459,6 +462,7 @@ func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
 
 	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock, testDialer,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
+		environs.Destroy,
 	)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "test1", "-y")
 	c.Check(err, jc.ErrorIsNil)

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -184,7 +184,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	// At this stage, cloud credential has not yet been stored server-side
 	// as there is no server-side. If these cloud calls will fail with
 	// invalid credential, just log it.
-	callCtx.InvalidateCredentialF = func(reason string) error {
+	callCtx.InvalidateCredentialFunc = func(reason string) error {
 		logger.Errorf("Cloud credential %q is not accepted by cloud provider: %v", args.ControllerCloudCredentialName, reason)
 		return nil
 	}

--- a/environs/context/callcontext.go
+++ b/environs/context/callcontext.go
@@ -16,7 +16,7 @@ type ProviderCallContext interface {
 
 func NewCloudCallContext() *CloudCallContext {
 	return &CloudCallContext{
-		InvalidateCredentialF: func(string) error {
+		InvalidateCredentialFunc: func(string) error {
 			return errors.NotImplementedf("InvalidateCredentialCallback")
 		},
 	}
@@ -35,10 +35,12 @@ func NewCloudCallContext() *CloudCallContext {
 // as this knowledge is specific to where the call was made *from* not on what object
 // it was made.
 type CloudCallContext struct {
-	InvalidateCredentialF func(string) error
+	// InvalidateCredentialFunc is the actual callback function
+	// that invalidates the credential used in the context of this call.
+	InvalidateCredentialFunc func(string) error
 }
 
 // InvalidateCredentialCallback implements context.InvalidateCredentialCallback.
 func (c *CloudCallContext) InvalidateCredential(reason string) error {
-	return c.InvalidateCredentialF(reason)
+	return c.InvalidateCredentialFunc(reason)
 }

--- a/state/callcontext.go
+++ b/state/callcontext.go
@@ -7,6 +7,6 @@ import "github.com/juju/juju/environs/context"
 
 func CallContext(st *State) context.ProviderCallContext {
 	callCtx := context.NewCloudCallContext()
-	callCtx.InvalidateCredentialF = st.InvalidateModelCredential
+	callCtx.InvalidateCredentialFunc = st.InvalidateModelCredential
 	return callCtx
 }

--- a/worker/common/credentialinvalidator.go
+++ b/worker/common/credentialinvalidator.go
@@ -22,6 +22,6 @@ func NewCredentialInvalidatorFacade(apiCaller base.APICaller) (CredentialAPI, er
 // NewCloudCallContext creates a cloud call context to be used by workers.
 func NewCloudCallContext(c CredentialAPI) context.ProviderCallContext {
 	return &context.CloudCallContext{
-		InvalidateCredentialF: c.InvalidateModelCredential,
+		InvalidateCredentialFunc: c.InvalidateModelCredential,
 	}
 }


### PR DESCRIPTION
## Description of change

Some Juju commands make direct call to cloud providers by-passing api layer. These commands need to have well-formed cloud call context that is capable of invalidating cloud credential.

This PR provides that.