### PR TITLE
Storage call context signatures.

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/storage"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
 	jujustorage "github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -47,7 +48,8 @@ type baseStorageSuite struct {
 	poolManager *mockPoolManager
 	pools       map[string]*jujustorage.Config
 
-	blocks map[state.BlockType]state.Block
+	blocks      map[state.BlockType]state.Block
+	callContext context.ProviderCallContext
 }
 
 func (s *baseStorageSuite) SetUpTest(c *gc.C) {
@@ -62,10 +64,11 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.pools = make(map[string]*jujustorage.Config)
 	s.poolManager = s.constructPoolManager()
 
+	s.callContext = context.NewCloudCallContext()
 	var err error
-	s.api, err = storage.NewAPIv4(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.api, err = storage.NewAPIv4(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
-	s.apiv3, err = storage.NewAPIv3(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer)
+	s.apiv3, err = storage.NewAPIv3(s.state, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -44,7 +44,8 @@ func NewFacadeV4(
 	return NewAPIv4(
 		stateShim{st},
 		storageAccessor,
-		registry, pm, resources, authorizer)
+		registry, pm, resources, authorizer,
+		state.CallContext(st))
 }
 
 // NewFacadeV3 provides the signature required for facade registration.
@@ -67,7 +68,8 @@ func NewFacadeV3(
 	return NewAPIv3(
 		stateShim{st},
 		storageAccessor,
-		registry, pm, resources, authorizer)
+		registry, pm, resources, authorizer,
+		state.CallContext(st))
 }
 
 type storageAccess interface {

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
@@ -518,6 +519,7 @@ func (s *storageSuite) TestImportFilesystem(c *gc.C) {
 	}})
 	filesystemSource.CheckCalls(c, []testing.StubCall{
 		{"ImportFilesystem", []interface{}{
+			s.callContext,
 			"foo", map[string]string{
 				"juju-model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 				"juju-controller-uuid": "deadbeef-1bad-500d-9000-4b1d0d06f00d",
@@ -567,6 +569,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBacked(c *gc.C) {
 	}})
 	volumeSource.CheckCalls(c, []testing.StubCall{
 		{"ImportVolume", []interface{}{
+			s.callContext,
 			"foo", map[string]string{
 				"juju-model-uuid":      "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 				"juju-controller-uuid": "deadbeef-1bad-500d-9000-4b1d0d06f00d",
@@ -700,8 +703,8 @@ type filesystemImporter struct {
 }
 
 // ImportFilesystem is part of the storage.FilesystemImporter interface.
-func (f filesystemImporter) ImportFilesystem(providerId string, tags map[string]string) (storage.FilesystemInfo, error) {
-	f.MethodCall(f, "ImportFilesystem", providerId, tags)
+func (f filesystemImporter) ImportFilesystem(ctx context.ProviderCallContext, providerId string, tags map[string]string) (storage.FilesystemInfo, error) {
+	f.MethodCall(f, "ImportFilesystem", ctx, providerId, tags)
 	return storage.FilesystemInfo{
 		FilesystemId: providerId,
 		Size:         123,
@@ -713,8 +716,8 @@ type volumeImporter struct {
 }
 
 // ImportVolume is part of the storage.VolumeImporter interface.
-func (v volumeImporter) ImportVolume(providerId string, tags map[string]string) (storage.VolumeInfo, error) {
-	v.MethodCall(v, "ImportVolume", providerId, tags)
+func (v volumeImporter) ImportVolume(ctx context.ProviderCallContext, providerId string, tags map[string]string) (storage.VolumeInfo, error) {
+	v.MethodCall(v, "ImportVolume", ctx, providerId, tags)
 	return storage.VolumeInfo{
 		VolumeId:   providerId,
 		Size:       123,

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -130,6 +130,7 @@ var (
 		"upgrade-steps-flag",
 		"upgrade-steps-gate",
 		"upgrader",
+		"valid-credential-flag",
 	}
 	notMigratingMachineWorkers = []string{
 		"api-address-updater",

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -101,6 +101,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrade-steps-gate",
 		"upgrade-steps-runner",
 		"upgrader",
+		"valid-credential-flag",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }
@@ -155,6 +156,7 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"raft-enabled-flag",
 		"raft-leader-flag",
 		"raft-transport",
+		"valid-credential-flag",
 	)
 	manifolds := machine.Manifolds(machine.ManifoldsConfig{
 		Agent: &mockAgent{},
@@ -650,7 +652,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-check-flag",
 		"upgrade-check-gate",
 		"upgrade-steps-flag",
-		"upgrade-steps-gate"},
+		"upgrade-steps-gate",
+		"valid-credential-flag",
+	},
 
 	"termination-signal-handler": {},
 
@@ -723,4 +727,10 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"upgrade-check-gate",
 		"upgrade-steps-gate"},
+
+	"valid-credential-flag": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+	},
 }

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -345,12 +345,13 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewProvisionerFunc:           provisioner.NewEnvironProvisioner,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		}))),
-		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
+		storageProvisionerName: ifNotMigrating(ifCredentialValid(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName: apiCallerName,
 			ClockName:     clockName,
 			EnvironName:   environTrackerName,
 			Scope:         modelTag,
-		})),
+			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
+		}))),
 		firewallerName: ifNotMigrating(ifCredentialValid(firewaller.Manifold(firewaller.ManifoldConfig{
 			AgentName:               agentName,
 			APICallerName:           apiCallerName,

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -564,7 +564,9 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"model-upgrade-gate",
 		"model-upgraded-flag",
-		"not-dead-flag"},
+		"not-dead-flag",
+		"valid-credential-flag",
+	},
 
 	"undertaker": {
 		"agent",

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/schema"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	internalazurestorage "github.com/juju/juju/provider/azure/internal/azurestorage"
@@ -160,7 +161,7 @@ type azureVolumeSource struct {
 }
 
 // CreateVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []storage.CreateVolumesResult, err error) {
+func (v *azureVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) (_ []storage.CreateVolumesResult, err error) {
 	results := make([]storage.CreateVolumesResult, len(params))
 	for i, p := range params {
 		if err := v.ValidateVolumeParams(p); err != nil {
@@ -318,7 +319,7 @@ func (v *azureVolumeSource) createUnmanagedDiskVolume(
 }
 
 // ListVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) ListVolumes() ([]string, error) {
+func (v *azureVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
 	if v.maybeStorageClient == nil {
 		return v.listManagedDiskVolumes()
 	}
@@ -384,7 +385,7 @@ func (v *azureVolumeSource) listBlobs() ([]internalazurestorage.Blob, error) {
 }
 
 // DescribeVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.DescribeVolumesResult, error) {
+func (v *azureVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]storage.DescribeVolumesResult, error) {
 	if v.maybeStorageClient == nil {
 		return v.describeManagedDiskVolumes(volumeIds)
 	}
@@ -452,7 +453,7 @@ func (v *azureVolumeSource) describeUnmanagedDiskVolumes(volumeIds []string) ([]
 }
 
 // DestroyVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) {
+func (v *azureVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	if v.maybeStorageClient == nil {
 		return v.destroyManagedDiskVolumes(volumeIds)
 	}
@@ -495,7 +496,7 @@ func foreachVolume(volumeIds []string, f func(string) error) []error {
 }
 
 // ReleaseVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+func (v *azureVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	// Releasing volumes is not supported, see azureStorageProvider.Releasable.
 	//
 	// When managed disks can be moved between resource groups, we may want to
@@ -517,7 +518,7 @@ func (v *azureVolumeSource) ValidateVolumeParams(params storage.VolumeParams) er
 }
 
 // AttachVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+func (v *azureVolumeSource) AttachVolumes(ctx context.ProviderCallContext, attachParams []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	results := make([]storage.AttachVolumesResult, len(attachParams))
 	instanceIds := make([]instance.Id, len(attachParams))
 	for i, p := range attachParams {
@@ -662,7 +663,7 @@ func (v *azureVolumeSource) addDataDisk(
 }
 
 // DetachVolumes is specified on the storage.VolumeSource interface.
-func (v *azureVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmentParams) ([]error, error) {
+func (v *azureVolumeSource) DetachVolumes(ctx context.ProviderCallContext, attachParams []storage.VolumeAttachmentParams) ([]error, error) {
 	results := make([]error, len(attachParams))
 	instanceIds := make([]instance.Id, len(attachParams))
 	for i, p := range attachParams {

--- a/provider/common/destroy.go
+++ b/provider/common/destroy.go
@@ -22,7 +22,7 @@ func Destroy(env environs.Environ, ctx context.ProviderCallContext) error {
 	if err := destroyInstances(env, ctx); err != nil {
 		return errors.Annotate(err, "destroying instances")
 	}
-	if err := destroyStorage(env); err != nil {
+	if err := destroyStorage(env, ctx); err != nil {
 		return errors.Annotate(err, "destroying storage")
 	}
 	return nil
@@ -52,7 +52,7 @@ func destroyInstances(env environs.Environ, ctx context.ProviderCallContext) err
 // to destroy persistent storage. Trying to include it in the storage
 // source abstraction doesn't work well with dynamic, non-persistent
 // storage like tmpfs, rootfs, etc.
-func destroyStorage(env environs.Environ) error {
+func destroyStorage(env environs.Environ, ctx context.ProviderCallContext) error {
 	logger.Infof("destroying storage")
 	storageProviderTypes, err := env.StorageProviderTypes()
 	if err != nil {
@@ -82,7 +82,7 @@ func destroyStorage(env environs.Environ) error {
 			if err != nil {
 				return errors.Annotate(err, "getting volume source")
 			}
-			if err := destroyVolumes(volumeSource); err != nil {
+			if err := destroyVolumes(volumeSource, ctx); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -90,14 +90,14 @@ func destroyStorage(env environs.Environ) error {
 	return nil
 }
 
-func destroyVolumes(volumeSource storage.VolumeSource) error {
-	volumeIds, err := volumeSource.ListVolumes()
+func destroyVolumes(volumeSource storage.VolumeSource, ctx context.ProviderCallContext) error {
+	volumeIds, err := volumeSource.ListVolumes(ctx)
 	if err != nil {
 		return errors.Annotate(err, "listing volumes")
 	}
 
 	var errStrings []string
-	errs, err := volumeSource.DestroyVolumes(volumeIds)
+	errs, err := volumeSource.DestroyVolumes(ctx, volumeIds)
 	if err != nil {
 		return errors.Annotate(err, "destroying volumes")
 	}

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -137,10 +137,10 @@ func (s *DestroySuite) TestSuccessWhenNoInstances(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyEnvScopedVolumes(c *gc.C) {
 	volumeSource := &dummy.VolumeSource{
-		ListVolumesFunc: func() ([]string, error) {
+		ListVolumesFunc: func(ctx context.ProviderCallContext) ([]string, error) {
 			return []string{"vol-0", "vol-1", "vol-2"}, nil
 		},
-		DestroyVolumesFunc: func(ids []string) ([]error, error) {
+		DestroyVolumesFunc: func(ctx context.ProviderCallContext, ids []string) ([]error, error) {
 			return make([]error, len(ids)), nil
 		},
 	}
@@ -169,17 +169,17 @@ func (s *DestroySuite) TestDestroyEnvScopedVolumes(c *gc.C) {
 	// common.Destroy will ignore machine-scoped storage providers.
 	storageProvider.CheckCallNames(c, "Dynamic", "Scope", "Supports", "VolumeSource")
 	volumeSource.CheckCalls(c, []gitjujutesting.StubCall{
-		{"ListVolumes", nil},
-		{"DestroyVolumes", []interface{}{[]string{"vol-0", "vol-1", "vol-2"}}},
+		{"ListVolumes", []interface{}{s.callCtx}},
+		{"DestroyVolumes", []interface{}{s.callCtx, []string{"vol-0", "vol-1", "vol-2"}}},
 	})
 }
 
 func (s *DestroySuite) TestDestroyVolumeErrors(c *gc.C) {
 	volumeSource := &dummy.VolumeSource{
-		ListVolumesFunc: func() ([]string, error) {
+		ListVolumesFunc: func(ctx context.ProviderCallContext) ([]string, error) {
 			return []string{"vol-0", "vol-1", "vol-2"}, nil
 		},
-		DestroyVolumesFunc: func(ids []string) ([]error, error) {
+		DestroyVolumesFunc: func(ctx context.ProviderCallContext, ids []string) ([]error, error) {
 			return []error{
 				nil,
 				errors.New("cannot destroy vol-1"),

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
@@ -38,6 +39,8 @@ type ebsSuite struct {
 	srv         localServer
 	modelConfig *config.Config
 	instanceId  string
+
+	cloudCallCtx context.ProviderCallContext
 }
 
 var _ = gc.Suite(&ebsSuite{})
@@ -57,6 +60,8 @@ func (s *ebsSuite) SetUpTest(c *gc.C) {
 
 	restoreEC2Patching := patchEC2ForTesting(c, s.srv.region)
 	s.AddCleanup(func(c *gc.C) { restoreEC2Patching() })
+
+	s.cloudCallCtx = context.NewCloudCallContext()
 }
 
 func (s *ebsSuite) ebsProvider(c *gc.C) storage.Provider {
@@ -188,7 +193,7 @@ func (s *ebsSuite) createVolumesParams(instanceId string) []storage.VolumeParams
 }
 
 func (s *ebsSuite) createVolumes(vs storage.VolumeSource, instanceId string) ([]storage.CreateVolumesResult, error) {
-	return vs.CreateVolumes(s.createVolumesParams(instanceId))
+	return vs.CreateVolumes(s.cloudCallCtx, s.createVolumesParams(instanceId))
 }
 
 func (s *ebsSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, instanceId string) {
@@ -388,7 +393,7 @@ func (s *ebsSuite) TestVolumeTypeAliases(c *gc.C) {
 		if alias[1] == "io1" {
 			params[0].Attributes["iops"] = 30
 		}
-		results, err := vs.CreateVolumes(params)
+		results, err := vs.CreateVolumes(s.cloudCallCtx, params)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(results, gc.HasLen, 1)
 		c.Assert(results[0].Error, jc.ErrorIsNil)
@@ -407,7 +412,7 @@ func (s *ebsSuite) TestVolumeTypeAliases(c *gc.C) {
 
 func (s *ebsSuite) TestDestroyVolumesNotFoundReturnsNil(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	results, err := vs.DestroyVolumes([]string{"vol-42"})
+	results, err := vs.DestroyVolumes(s.cloudCallCtx, []string{"vol-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Assert(results[0], jc.ErrorIsNil)
@@ -424,7 +429,7 @@ func (s *ebsSuite) TestDestroyVolumesCredentialError(c *gc.C) {
 		}}})
 	}
 	in := []string{"vol-0"}
-	results, err := vs.DestroyVolumes(in)
+	results, err := vs.DestroyVolumes(s.cloudCallCtx, in)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, len(in))
 	for i, result := range results {
@@ -436,7 +441,7 @@ func (s *ebsSuite) TestDestroyVolumesCredentialError(c *gc.C) {
 func (s *ebsSuite) TestDestroyVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	errs, err := vs.DestroyVolumes([]string{"vol-0"})
+	errs, err := vs.DestroyVolumes(s.cloudCallCtx, []string{"vol-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
@@ -454,9 +459,9 @@ func (s *ebsSuite) TestDestroyVolumes(c *gc.C) {
 func (s *ebsSuite) TestDestroyVolumesStillAttached(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	_, err := vs.AttachVolumes(params)
+	_, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
-	errs, err := vs.DestroyVolumes([]string{"vol-0"})
+	errs, err := vs.DestroyVolumes(s.cloudCallCtx, []string{"vol-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
@@ -473,7 +478,7 @@ func (s *ebsSuite) TestDestroyVolumesStillAttached(c *gc.C) {
 func (s *ebsSuite) TestReleaseVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	errs, err := vs.ReleaseVolumes([]string{"vol-0"})
+	errs, err := vs.ReleaseVolumes(s.cloudCallCtx, []string{"vol-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
@@ -499,7 +504,7 @@ func (s *ebsSuite) TestReleaseVolumesCredentialError(c *gc.C) {
 		}}})
 	}
 	in := []string{"vol-0"}
-	results, err := vs.ReleaseVolumes(in)
+	results, err := vs.ReleaseVolumes(s.cloudCallCtx, in)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, len(in))
 	for i, result := range results {
@@ -511,9 +516,9 @@ func (s *ebsSuite) TestReleaseVolumesCredentialError(c *gc.C) {
 func (s *ebsSuite) TestReleaseVolumesStillAttached(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	_, err := vs.AttachVolumes(params)
+	_, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
-	errs, err := vs.ReleaseVolumes([]string{"vol-0"})
+	errs, err := vs.ReleaseVolumes(s.cloudCallCtx, []string{"vol-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(errs[0], gc.ErrorMatches, `cannot release volume "vol-0": attachments still active`)
@@ -538,14 +543,14 @@ func (s *ebsSuite) TestAttachVolumesCredentialError(c *gc.C) {
 			Code: "Blocked",
 		}}})
 	}
-	results, err := vs.AttachVolumes(params)
+	results, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Assert(results, gc.IsNil)
 }
 
 func (s *ebsSuite) TestReleaseVolumesNotFound(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	errs, err := vs.ReleaseVolumes([]string{"vol-42"})
+	errs, err := vs.ReleaseVolumes(s.cloudCallCtx, []string{"vol-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(errs[0], gc.ErrorMatches, `cannot release volume "vol-42": vol-42 not found`)
@@ -555,7 +560,7 @@ func (s *ebsSuite) TestDescribeVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	s.assertCreateVolumes(c, vs, "")
 
-	vols, err := vs.DescribeVolumes([]string{"vol-0", "vol-1"})
+	vols, err := vs.DescribeVolumes(s.cloudCallCtx, []string{"vol-0", "vol-1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, jc.DeepEquals, []storage.DescribeVolumesResult{{
 		VolumeInfo: &storage.VolumeInfo{
@@ -574,7 +579,7 @@ func (s *ebsSuite) TestDescribeVolumes(c *gc.C) {
 
 func (s *ebsSuite) TestDescribeVolumesNotFound(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	vols, err := vs.DescribeVolumes([]string{"vol-42"})
+	vols, err := vs.DescribeVolumes(s.cloudCallCtx, []string{"vol-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 1)
 	c.Assert(vols[0].Error, gc.ErrorMatches, "vol-42 not found")
@@ -588,7 +593,7 @@ func (s *ebsSuite) TestDescribeVolumesCredentialError(c *gc.C) {
 			Code: "Blocked",
 		}}})
 	}
-	results, err := vs.DescribeVolumes([]string{"vol-42"})
+	results, err := vs.DescribeVolumes(s.cloudCallCtx, []string{"vol-42"})
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Assert(results, gc.IsNil)
 }
@@ -599,7 +604,7 @@ func (s *ebsSuite) TestListVolumes(c *gc.C) {
 
 	// Only one volume created by assertCreateVolumes has
 	// the model-uuid tag with the expected value.
-	volIds, err := vs.ListVolumes()
+	volIds, err := vs.ListVolumes(s.cloudCallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volIds, jc.SameContents, []string{"vol-0"})
 }
@@ -612,7 +617,7 @@ func (s *ebsSuite) TestListVolumesCredentialError(c *gc.C) {
 			Code: "Blocked",
 		}}})
 	}
-	results, err := vs.ListVolumes()
+	results, err := vs.ListVolumes(s.cloudCallCtx)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Assert(results, gc.IsNil)
 }
@@ -628,7 +633,7 @@ func (s *ebsSuite) TestListVolumesIgnoresRootDisks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	vs := s.volumeSource(c, nil)
-	volIds, err := vs.ListVolumes()
+	volIds, err := vs.ListVolumes(s.cloudCallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volIds, gc.HasLen, 0)
 }
@@ -815,7 +820,7 @@ func (s *ebsSuite) TestCreateVolumesErrors(c *gc.C) {
 		},
 		err: `IOPS specified, but volume type is "sc1"`,
 	}} {
-		results, err := vs.CreateVolumes([]storage.VolumeParams{test.params})
+		results, err := vs.CreateVolumes(s.cloudCallCtx, []storage.VolumeParams{test.params})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(results, gc.HasLen, 1)
 		c.Check(results[0].Error, gc.ErrorMatches, test.err)
@@ -831,7 +836,7 @@ func (s *ebsSuite) TestCreateVolumesCredentialError(c *gc.C) {
 			Code: "Blocked",
 		}}})
 	}
-	results, err := vs.CreateVolumes(params)
+	results, err := vs.CreateVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	for i, result := range results {
 		c.Logf("checking volume creation %d", i)
@@ -874,7 +879,7 @@ func (s *ebsSuite) TestAttachVolumesNotRunning(c *gc.C) {
 func (s *ebsSuite) TestAttachVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	result, err := vs.AttachVolumes(params)
+	result, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0].Error, jc.ErrorIsNil)
@@ -900,7 +905,7 @@ func (s *ebsSuite) TestAttachVolumes(c *gc.C) {
 	}})
 
 	// Test idempotency.
-	result, err = vs.AttachVolumes(params)
+	result, err = vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0].Error, jc.ErrorIsNil)
@@ -928,7 +933,7 @@ func (s *ebsSuite) TestAttachVolumesNVMe(c *gc.C) {
 		},
 	}}
 
-	result, err := vs.AttachVolumes(params)
+	result, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0].Error, jc.ErrorIsNil)
@@ -957,7 +962,7 @@ func (s *ebsSuite) TestAttachVolumesCreating(c *gc.C) {
 		}
 		return nil
 	})
-	result, err := vs.AttachVolumes(params)
+	result, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0].Error, jc.ErrorIsNil)
@@ -977,7 +982,7 @@ func (s *ebsSuite) TestAttachVolumesDetaching(c *gc.C) {
 		})
 		return nil
 	})
-	result, err := vs.AttachVolumes(params)
+	result, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0].Error, gc.ErrorMatches, "volume vol-0 is attached to something else")
@@ -986,9 +991,9 @@ func (s *ebsSuite) TestAttachVolumesDetaching(c *gc.C) {
 func (s *ebsSuite) TestDetachVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	_, err := vs.AttachVolumes(params)
+	_, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
-	errs, err := vs.DetachVolumes(params)
+	errs, err := vs.DetachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
@@ -1000,7 +1005,7 @@ func (s *ebsSuite) TestDetachVolumes(c *gc.C) {
 	c.Assert(ec2Vols.Volumes[0].Attachments, gc.HasLen, 0)
 
 	// Test idempotent
-	errs, err = vs.DetachVolumes(params)
+	errs, err = vs.DetachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 }
@@ -1016,7 +1021,7 @@ func (s *ebsSuite) TestDetachVolumesAttachmentNotFound(c *gc.C) {
 func (s *ebsSuite) testDetachVolumesDetachedState(c *gc.C, errorCode string) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	_, err := vs.AttachVolumes(params)
+	_, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.srv.proxy.ModifyResponse = func(resp *http.Response) error {
@@ -1025,7 +1030,7 @@ func (s *ebsSuite) testDetachVolumesDetachedState(c *gc.C, errorCode string) {
 			Code: errorCode,
 		}}})
 	}
-	errs, err := vs.DetachVolumes(params)
+	errs, err := vs.DetachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 }
@@ -1041,7 +1046,7 @@ func (s *ebsSuite) TestImportVolume(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	volInfo, err := vs.(storage.VolumeImporter).ImportVolume(resp.Id, map[string]string{
+	volInfo, err := vs.(storage.VolumeImporter).ImportVolume(s.cloudCallCtx, resp.Id, map[string]string{
 		"foo": "bar",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1075,7 +1080,7 @@ func (s *ebsSuite) TestImportVolumeCredentialError(c *gc.C) {
 			Code: "Blocked",
 		}}})
 	}
-	_, err = vs.(storage.VolumeImporter).ImportVolume(resp.Id, map[string]string{
+	_, err = vs.(storage.VolumeImporter).ImportVolume(s.cloudCallCtx, resp.Id, map[string]string{
 		"foo": "bar",
 	})
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
@@ -1086,11 +1091,11 @@ func (s *ebsSuite) TestImportVolumeInUse(c *gc.C) {
 	c.Assert(vs, gc.Implements, new(storage.VolumeImporter))
 
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	_, err := vs.AttachVolumes(params)
+	_, err := vs.AttachVolumes(s.cloudCallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	volId := params[0].VolumeId
-	_, err = vs.(storage.VolumeImporter).ImportVolume(volId, map[string]string{})
+	_, err = vs.(storage.VolumeImporter).ImportVolume(s.cloudCallCtx, volId, map[string]string{})
 	c.Assert(err, gc.ErrorMatches, `cannot import volume with status "in-use"`)
 }
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -656,7 +656,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 	c.Assert(err, jc.ErrorIsNil)
 	vs, err := ebsProvider.VolumeSource(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeResults, err := vs.CreateVolumes([]storage.VolumeParams{{
+	volumeResults, err := vs.CreateVolumes(t.callCtx, []storage.VolumeParams{{
 		Tag:      names.NewVolumeTag("0"),
 		Size:     1024,
 		Provider: ec2.EBS_ProviderType,
@@ -684,7 +684,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 		c.Assert(ids, jc.SameContents, expect)
 	}
 	assertVolumes := func(expect ...string) {
-		volIds, err := vs.ListVolumes()
+		volIds, err := vs.ListVolumes(t.callCtx)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(volIds, jc.SameContents, expect)
 	}
@@ -1844,7 +1844,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	vs, err := ebsProvider.VolumeSource(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeResults, err := vs.CreateVolumes([]storage.VolumeParams{{
+	volumeResults, err := vs.CreateVolumes(s.callCtx, []storage.VolumeParams{{
 		Tag:      names.NewVolumeTag("0"),
 		Size:     1024,
 		Provider: ec2.EBS_ProviderType,

--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -101,7 +101,7 @@ func (s *volumeSourceSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *volumeSourceSuite) TestCreateVolumesNoInstance(c *gc.C) {
-	res, err := s.source.CreateVolumes(s.params)
+	res, err := s.source.CreateVolumes(s.CallCtx, s.params)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 	expectedErr := "cannot obtain \"spam\" from instance cache: cannot attach to non-running instance spam"
@@ -111,7 +111,7 @@ func (s *volumeSourceSuite) TestCreateVolumesNoInstance(c *gc.C) {
 
 func (s *volumeSourceSuite) TestCreateVolumesNoDiskCreated(c *gc.C) {
 	s.FakeConn.Insts = []google.Instance{*s.BaseInstance}
-	res, err := s.source.CreateVolumes(s.params)
+	res, err := s.source.CreateVolumes(s.CallCtx, s.params)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 	c.Assert(res[0].Error, gc.ErrorMatches, "unexpected number of disks created: 0")
@@ -127,7 +127,7 @@ func (s *volumeSourceSuite) TestCreateVolumes(c *gc.C) {
 		DeviceName: "home-zone-1234567",
 		Mode:       "READ_WRITE",
 	}
-	res, err := s.source.CreateVolumes(s.params)
+	res, err := s.source.CreateVolumes(s.CallCtx, s.params)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 	// Volume was created
@@ -167,7 +167,7 @@ func (s *volumeSourceSuite) TestCreateVolumes(c *gc.C) {
 }
 
 func (s *volumeSourceSuite) TestDestroyVolumes(c *gc.C) {
-	errs, err := s.source.DestroyVolumes([]string{"a--volume-name"})
+	errs, err := s.source.DestroyVolumes(s.CallCtx, []string{"a--volume-name"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(errs, gc.HasLen, 1)
 	c.Assert(errs[0], jc.ErrorIsNil)
@@ -182,7 +182,7 @@ func (s *volumeSourceSuite) TestDestroyVolumes(c *gc.C) {
 func (s *volumeSourceSuite) TestReleaseVolumes(c *gc.C) {
 	s.FakeConn.GoogleDisk = s.BaseDisk
 
-	errs, err := s.source.ReleaseVolumes([]string{s.BaseDisk.Name})
+	errs, err := s.source.ReleaseVolumes(s.CallCtx, []string{s.BaseDisk.Name})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(errs, gc.HasLen, 1)
 	c.Assert(errs[0], jc.ErrorIsNil)
@@ -203,6 +203,7 @@ func (s *volumeSourceSuite) TestImportVolume(c *gc.C) {
 
 	c.Assert(s.source, gc.Implements, new(storage.VolumeImporter))
 	volumeInfo, err := s.source.(storage.VolumeImporter).ImportVolume(
+		s.CallCtx,
 		s.BaseDisk.Name, map[string]string{
 			"juju-model-uuid":      "foo",
 			"juju-controller-uuid": "bar",
@@ -232,6 +233,7 @@ func (s *volumeSourceSuite) TestImportVolumeNotReady(c *gc.C) {
 	s.FakeConn.GoogleDisk.Status = "floop"
 
 	_, err := s.source.(storage.VolumeImporter).ImportVolume(
+		s.CallCtx,
 		s.BaseDisk.Name, map[string]string{},
 	)
 	c.Check(err, gc.ErrorMatches, `cannot import volume "`+s.BaseDisk.Name+`" with status "floop"`)
@@ -242,7 +244,7 @@ func (s *volumeSourceSuite) TestImportVolumeNotReady(c *gc.C) {
 
 func (s *volumeSourceSuite) TestListVolumes(c *gc.C) {
 	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk}
-	vols, err := s.source.ListVolumes()
+	vols, err := s.source.ListVolumes(s.CallCtx)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 1)
 
@@ -264,7 +266,7 @@ func (s *volumeSourceSuite) TestListVolumesOnlyListsCurrentModelUUID(c *gc.C) {
 		},
 	}
 	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
-	vols, err := s.source.ListVolumes()
+	vols, err := s.source.ListVolumes(s.CallCtx)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 1)
 }
@@ -279,7 +281,7 @@ func (s *volumeSourceSuite) TestListVolumesIgnoresNamesFormatteDifferently(c *gc
 		Description: "",
 	}
 	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
-	vols, err := s.source.ListVolumes()
+	vols, err := s.source.ListVolumes(s.CallCtx)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 1)
 }
@@ -287,7 +289,7 @@ func (s *volumeSourceSuite) TestListVolumesIgnoresNamesFormatteDifferently(c *gc
 func (s *volumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 	s.FakeConn.GoogleDisk = s.BaseDisk
 	volName := "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4"
-	res, err := s.source.DescribeVolumes([]string{volName})
+	res, err := s.source.DescribeVolumes(s.CallCtx, []string{volName})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 	c.Assert(res[0].VolumeInfo.Size, gc.Equals, uint64(1024))
@@ -308,7 +310,7 @@ func (s *volumeSourceSuite) TestAttachVolumes(c *gc.C) {
 		DeviceName: "home-zone-1234567",
 		Mode:       "READ_WRITE",
 	}
-	res, err := s.source.AttachVolumes(attachments)
+	res, err := s.source.AttachVolumes(s.CallCtx, attachments)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 	c.Assert(res[0].VolumeAttachment.Volume.String(), gc.Equals, "volume-0")
@@ -329,7 +331,7 @@ func (s *volumeSourceSuite) TestAttachVolumes(c *gc.C) {
 func (s *volumeSourceSuite) TestDetachVolumes(c *gc.C) {
 	volName := "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4"
 	attachments := []storage.VolumeAttachmentParams{*s.attachmentParams}
-	errs, err := s.source.DetachVolumes(attachments)
+	errs, err := s.source.DetachVolumes(s.CallCtx, attachments)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(errs[0], jc.ErrorIsNil)

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -228,7 +228,7 @@ type lxdFilesystemSource struct {
 }
 
 // CreateFilesystems is specified on the storage.FilesystemSource interface.
-func (s *lxdFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) (_ []storage.CreateFilesystemsResult, err error) {
+func (s *lxdFilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemParams) (_ []storage.CreateFilesystemsResult, err error) {
 	results := make([]storage.CreateFilesystemsResult, len(args))
 	for i, arg := range args {
 		if err := s.ValidateFilesystemParams(arg); err != nil {
@@ -348,7 +348,7 @@ func destroyFilesystems(env *environ, match func(api.StorageVolume) bool) error 
 }
 
 // DestroyFilesystems is specified on the storage.FilesystemSource interface.
-func (s *lxdFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+func (s *lxdFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	results := make([]error, len(filesystemIds))
 	for i, filesystemId := range filesystemIds {
 		results[i] = s.destroyFilesystem(filesystemId)
@@ -369,7 +369,7 @@ func (s *lxdFilesystemSource) destroyFilesystem(filesystemId string) error {
 }
 
 // ReleaseFilesystems is specified on the storage.FilesystemSource interface.
-func (s *lxdFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+func (s *lxdFilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	results := make([]error, len(filesystemIds))
 	for i, filesystemId := range filesystemIds {
 		results[i] = s.releaseFilesystem(filesystemId)
@@ -406,7 +406,7 @@ func (s *lxdFilesystemSource) ValidateFilesystemParams(params storage.Filesystem
 }
 
 // AttachFilesystems is specified on the storage.FilesystemSource interface.
-func (s *lxdFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+func (s *lxdFilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	var instanceIds []instance.Id
 	instanceIdsSeen := make(set.Strings)
 	for _, arg := range args {
@@ -416,7 +416,7 @@ func (s *lxdFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachm
 		instanceIdsSeen.Add(string(arg.InstanceId))
 		instanceIds = append(instanceIds, arg.InstanceId)
 	}
-	instances, err := s.env.Instances(context.NewCloudCallContext(), instanceIds)
+	instances, err := s.env.Instances(ctx, instanceIds)
 	switch err {
 	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
 	default:
@@ -489,7 +489,7 @@ func (s *lxdFilesystemSource) attachFilesystem(
 }
 
 // DetachFilesystems is specified on the storage.FilesystemSource interface.
-func (s *lxdFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) ([]error, error) {
+func (s *lxdFilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]error, error) {
 	var instanceIds []instance.Id
 	instanceIdsSeen := make(set.Strings)
 	for _, arg := range args {
@@ -499,7 +499,7 @@ func (s *lxdFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachm
 		instanceIdsSeen.Add(string(arg.InstanceId))
 		instanceIds = append(instanceIds, arg.InstanceId)
 	}
-	instances, err := s.env.Instances(context.NewCloudCallContext(), instanceIds)
+	instances, err := s.env.Instances(ctx, instanceIds)
 	switch err {
 	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
 	default:
@@ -543,6 +543,7 @@ func (s *lxdFilesystemSource) detachFilesystem(
 
 // ImportFilesystem is part of the storage.FilesystemImporter interface.
 func (s *lxdFilesystemSource) ImportFilesystem(
+	callCtx context.ProviderCallContext,
 	filesystemId string,
 	tags map[string]string,
 ) (storage.FilesystemInfo, error) {

--- a/provider/oci/storage_volumes.go
+++ b/provider/oci/storage_volumes.go
@@ -6,6 +6,7 @@ package oci
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -13,23 +14,23 @@ type volumeSource struct{}
 
 var _ storage.VolumeSource = (*volumeSource)(nil)
 
-func (v *volumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+func (v *volumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
 	return nil, errors.NotImplementedf("CreateVolumes")
 }
 
-func (v *volumeSource) ListVolumes() ([]string, error) {
+func (v *volumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
 	return nil, errors.NotImplementedf("ListVolumes")
 }
 
-func (v *volumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVolumesResult, error) {
+func (v *volumeSource) DescribeVolumes(ctx context.ProviderCallContext, volIds []string) ([]storage.DescribeVolumesResult, error) {
 	return nil, errors.NotImplementedf("DescribeVolumes")
 }
 
-func (v *volumeSource) DestroyVolumes(volIds []string) ([]error, error) {
+func (v *volumeSource) DestroyVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
 	return nil, errors.NotImplementedf("DestroyVolumes")
 }
 
-func (v *volumeSource) ReleaseVolumes(volIds []string) ([]error, error) {
+func (v *volumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
 	return nil, errors.NotImplementedf("ReleaseVolumes")
 }
 
@@ -37,10 +38,10 @@ func (v *volumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
 	return errors.NotImplementedf("ValidateVolumeParams")
 }
 
-func (v *volumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+func (v *volumeSource) AttachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	return nil, errors.NotImplementedf("AttachVolumes")
 }
 
-func (v *volumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) ([]error, error) {
+func (v *volumeSource) DetachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]error, error) {
 	return nil, errors.NotImplementedf("DetachVolumes")
 }

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/goose.v2/identity"
 	"gopkg.in/goose.v2/nova"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
@@ -201,7 +202,7 @@ type cinderVolumeSource struct {
 var _ storage.VolumeSource = (*cinderVolumeSource)(nil)
 
 // CreateVolumes implements storage.VolumeSource.
-func (s *cinderVolumeSource) CreateVolumes(args []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+func (s *cinderVolumeSource) CreateVolumes(ctx context.ProviderCallContext, args []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
 	results := make([]storage.CreateVolumesResult, len(args))
 	for i, arg := range args {
 		volume, err := s.createVolume(arg)
@@ -256,7 +257,7 @@ func (s *cinderVolumeSource) createVolume(arg storage.VolumeParams) (*storage.Vo
 }
 
 // ListVolumes is specified on the storage.VolumeSource interface.
-func (s *cinderVolumeSource) ListVolumes() ([]string, error) {
+func (s *cinderVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
 	cinderVolumes, err := modelCinderVolumes(s.storageAdapter, s.modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -302,7 +303,7 @@ func volumeInfoToVolumeIds(volumes []storage.VolumeInfo) []string {
 }
 
 // DescribeVolumes implements storage.VolumeSource.
-func (s *cinderVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.DescribeVolumesResult, error) {
+func (s *cinderVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]storage.DescribeVolumesResult, error) {
 	// In most cases, it is quicker to get all volumes and loop
 	// locally than to make several round-trips to the provider.
 	cinderVolumes, err := s.storageAdapter.GetVolumesDetail()
@@ -327,12 +328,12 @@ func (s *cinderVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.Desc
 }
 
 // DestroyVolumes implements storage.VolumeSource.
-func (s *cinderVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) {
+func (s *cinderVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	return foreachVolume(s.storageAdapter, volumeIds, destroyVolume), nil
 }
 
 // ReleaseVolumes implements storage.VolumeSource.
-func (s *cinderVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+func (s *cinderVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	return foreachVolume(s.storageAdapter, volumeIds, releaseVolume), nil
 }
 
@@ -437,7 +438,7 @@ func (s *cinderVolumeSource) ValidateVolumeParams(params storage.VolumeParams) e
 }
 
 // AttachVolumes implements storage.VolumeSource.
-func (s *cinderVolumeSource) AttachVolumes(args []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+func (s *cinderVolumeSource) AttachVolumes(ctx context.ProviderCallContext, args []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	results := make([]storage.AttachVolumesResult, len(args))
 	for i, arg := range args {
 		attachment, err := s.attachVolume(arg)
@@ -486,7 +487,7 @@ func (s *cinderVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (*
 }
 
 // ImportVolume is part of the storage.VolumeImporter interface.
-func (s *cinderVolumeSource) ImportVolume(volumeId string, resourceTags map[string]string) (storage.VolumeInfo, error) {
+func (s *cinderVolumeSource) ImportVolume(ctx context.ProviderCallContext, volumeId string, resourceTags map[string]string) (storage.VolumeInfo, error) {
 	volume, err := s.storageAdapter.GetVolume(volumeId)
 	if err != nil {
 		return storage.VolumeInfo{}, errors.Annotate(err, "getting volume")
@@ -524,7 +525,7 @@ func waitVolume(
 }
 
 // DetachVolumes implements storage.VolumeSource.
-func (s *cinderVolumeSource) DetachVolumes(args []storage.VolumeAttachmentParams) ([]error, error) {
+func (s *cinderVolumeSource) DetachVolumes(ctx context.ProviderCallContext, args []storage.VolumeAttachmentParams) ([]error, error) {
 	return detachVolumes(s.storageAdapter, args), nil
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2386,8 +2386,8 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	_, _, _, err = testing.StartInstance(env, s.callCtx, originalController, "0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	addVolume(c, s.env, originalController, "99/9")
-	addVolume(c, env, originalController, "23/9")
+	addVolume(c, s.env, s.callCtx, originalController, "99/9")
+	addVolume(c, env, s.callCtx, originalController, "23/9")
 
 	s.checkInstanceTags(c, s.env, originalController)
 	s.checkInstanceTags(c, env, originalController)
@@ -2449,12 +2449,12 @@ func (s *localServerSuite) TestAdoptResourcesNoStorage(c *gc.C) {
 	s.checkGroupController(c, env, newController)
 }
 
-func addVolume(c *gc.C, env environs.Environ, controllerUUID, name string) *storage.Volume {
+func addVolume(c *gc.C, env environs.Environ, callCtx context.ProviderCallContext, controllerUUID, name string) *storage.Volume {
 	storageAdapter, err := (*openstack.NewOpenstackStorage)(env.(*openstack.Environ))
 	c.Assert(err, jc.ErrorIsNil)
 	modelUUID := env.Config().UUID()
 	source := openstack.NewCinderVolumeSourceForModel(storageAdapter, modelUUID)
-	result, err := source.CreateVolumes([]storage.VolumeParams{{
+	result, err := source.CreateVolumes(callCtx, []storage.VolumeParams{{
 		Tag: names.NewVolumeTag(name),
 		ResourceTags: tags.ResourceTags(
 			names.NewModelTag(modelUUID),
@@ -2482,7 +2482,7 @@ func (s *localServerSuite) checkVolumeTags(c *gc.C, env environs.Environ, expect
 	storage, err := (*openstack.NewOpenstackStorage)(env.(*openstack.Environ))
 	c.Assert(err, jc.ErrorIsNil)
 	source := openstack.NewCinderVolumeSourceForModel(storage, env.Config().UUID())
-	volumeIds, err := source.ListVolumes()
+	volumeIds, err := source.ListVolumes(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeIds, gc.Not(gc.HasLen), 0)
 	for _, volumeId := range volumeIds {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1447,7 +1447,7 @@ func (e *Environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 		}
 	}
 
-	failedVolumes, err := e.adoptVolumes(controllerTag)
+	failedVolumes, err := e.adoptVolumes(controllerTag, ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1463,7 +1463,7 @@ func (e *Environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	return nil
 }
 
-func (e *Environ) adoptVolumes(controllerTag map[string]string) ([]string, error) {
+func (e *Environ) adoptVolumes(controllerTag map[string]string, ctx context.ProviderCallContext) ([]string, error) {
 	cinder, err := e.cinderProvider()
 	if errors.IsNotSupported(err) {
 		logger.Debugf("volumes not supported: not transferring ownership for volumes")
@@ -1481,7 +1481,7 @@ func (e *Environ) adoptVolumes(controllerTag map[string]string) ([]string, error
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	volumeIds, err := volumeSource.ListVolumes()
+	volumeIds, err := volumeSource.ListVolumes(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -16,6 +16,7 @@ import (
 	ociResponse "github.com/juju/go-oracle-cloud/response"
 	"github.com/juju/utils/clock"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
@@ -156,7 +157,7 @@ func (s *oracleVolumeSource) createVolume(p storage.VolumeParams) (_ *storage.Vo
 }
 
 // CreateVolumes is specified on the storage.VolumeSource interface
-func (s *oracleVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+func (s *oracleVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
 	if params == nil {
 		return []storage.CreateVolumesResult{}, nil
 	}
@@ -231,7 +232,7 @@ func (o *oracleVolumeSource) waitForResourceStatus(
 }
 
 // ListVolumes is specified on the storage.VolumeSource interface.
-func (s *oracleVolumeSource) ListVolumes() ([]string, error) {
+func (s *oracleVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
 	tag := fmt.Sprintf("%s=%s", tags.JujuModel, s.modelUUID)
 	filter := []oci.Filter{{
 		Arg:   "tags",
@@ -251,7 +252,7 @@ func (s *oracleVolumeSource) ListVolumes() ([]string, error) {
 }
 
 // DescribeVolumes is specified on the storage.VolumeSource interface.
-func (s *oracleVolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVolumesResult, error) {
+func (s *oracleVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volIds []string) ([]storage.DescribeVolumesResult, error) {
 	if volIds == nil || len(volIds) == 0 {
 		return []storage.DescribeVolumesResult{}, nil
 	}
@@ -293,12 +294,12 @@ func makeVolumeInfo(vol ociResponse.StorageVolume) storage.VolumeInfo {
 }
 
 // DestroyVolumes is specified on the storage.VolumeSource interface.
-func (s *oracleVolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
+func (s *oracleVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
 	return foreachVolume(volIds, s.api.DeleteStorageVolume), nil
 }
 
 // ReleaseVolumes is specified on the storage.VolumeSource interface.
-func (s *oracleVolumeSource) ReleaseVolumes(volIds []string) ([]error, error) {
+func (s *oracleVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
 	releaseStorageVolume := func(volumeId string) error {
 		details, err := s.api.StorageVolumeDetails(volumeId)
 		if err != nil {
@@ -341,7 +342,7 @@ func foreachVolume(volIds []string, f func(string) error) []error {
 }
 
 // ImportVolume is specified on the storage.VolumeImporter interface.
-func (s *oracleVolumeSource) ImportVolume(volumeId string, tags map[string]string) (storage.VolumeInfo, error) {
+func (s *oracleVolumeSource) ImportVolume(ctx context.ProviderCallContext, volumeId string, tags map[string]string) (storage.VolumeInfo, error) {
 	details, err := s.api.StorageVolumeDetails(volumeId)
 	if err != nil {
 		return storage.VolumeInfo{}, errors.Trace(err)
@@ -431,7 +432,7 @@ func (s *oracleVolumeSource) getStorageAttachments() (map[string][]ociResponse.S
 }
 
 // AttachVolumes is specified on the storage.VolumeSource interface.
-func (s *oracleVolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+func (s *oracleVolumeSource) AttachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	instanceIds := []instance.Id{}
 	for _, val := range params {
 		instanceIds = append(instanceIds, val.InstanceId)
@@ -593,7 +594,7 @@ func (s *oracleVolumeSource) attachVolume(
 }
 
 // DetachVolumes is specified on the storage.VolumeSource interface.
-func (s *oracleVolumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) ([]error, error) {
+func (s *oracleVolumeSource) DetachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]error, error) {
 	attachAsMap, err := s.getStorageAttachments()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/oracle/storage_volumes_test.go
+++ b/provider/oracle/storage_volumes_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/oracle"
 	oracletesting "github.com/juju/juju/provider/oracle/testing"
 	"github.com/juju/juju/storage"
@@ -22,6 +23,8 @@ import (
 
 type oracleVolumeSource struct {
 	testing.BaseSuite
+
+	callCtx context.ProviderCallContext
 }
 
 var _ = gc.Suite(&oracleVolumeSource{})
@@ -32,6 +35,7 @@ func (s *oracleVolumeSource) SetUpTest(c *gc.C) {
 	// Reset name from changes in environ_test SetUpTest()
 	// not required here.
 	oracletesting.DefaultEnvironAPI.FakeInstance.All.Result[0].Name = "/Compute-a432100/sgiulitti@cloudbase.com/0/ebc4ce91-56bb-4120-ba78-13762597f837"
+	s.callCtx = context.NewCloudCallContext()
 }
 
 func (o *oracleVolumeSource) NewVolumeSource(
@@ -70,14 +74,14 @@ func (o *oracleVolumeSource) NewVolumeSource(
 
 func (o *oracleVolumeSource) TestCreateVolumesWithEmptyParams(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	result, err := source.CreateVolumes(nil)
+	result, err := source.CreateVolumes(o.callCtx, nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.NotNil)
 }
 
 func (o *oracleVolumeSource) TestCreateVolumes(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	results, err := source.CreateVolumes([]storage.VolumeParams{
+	results, err := source.CreateVolumes(o.callCtx, []storage.VolumeParams{
 		{
 			Size:     uint64(10000),
 			Provider: oracle.DefaultTypes[0],
@@ -105,7 +109,7 @@ func (o *oracleVolumeSource) TestCreateVolumesAlreadyExists(c *gc.C) {
 		},
 	}, nil)
 	volumeTag := names.NewVolumeTag("666")
-	results, err := source.CreateVolumes([]storage.VolumeParams{{
+	results, err := source.CreateVolumes(o.callCtx, []storage.VolumeParams{{
 		Tag:      volumeTag,
 		Size:     uint64(10000),
 		Provider: oracle.DefaultTypes[0],
@@ -133,7 +137,7 @@ func (o *oracleVolumeSource) TestCreateVolumeError(c *gc.C) {
 		},
 	}
 	source := o.NewVolumeSource(c, fake, nil)
-	results, err := source.CreateVolumes([]storage.VolumeParams{
+	results, err := source.CreateVolumes(o.callCtx, []storage.VolumeParams{
 		{
 			Size:     uint64(10000),
 			Provider: oracle.DefaultTypes[0],
@@ -147,7 +151,7 @@ func (o *oracleVolumeSource) TestCreateVolumeError(c *gc.C) {
 
 func (o *oracleVolumeSource) TestListVolumes(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	volumes, err := source.ListVolumes()
+	volumes, err := source.ListVolumes(o.callCtx)
 	c.Assert(err, gc.IsNil)
 	c.Assert(volumes, gc.NotNil)
 }
@@ -164,18 +168,18 @@ func (o *oracleVolumeSource) TestListVolumesWithErrors(c *gc.C) {
 		},
 	} {
 		source := o.NewVolumeSource(c, fake, nil)
-		_, err := source.ListVolumes()
+		_, err := source.ListVolumes(o.callCtx)
 		c.Assert(err, gc.NotNil)
 	}
 }
 
 func (o *oracleVolumeSource) TestDescribeVolumes(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	volumes, err := source.DescribeVolumes([]string{})
+	volumes, err := source.DescribeVolumes(o.callCtx, []string{})
 	c.Assert(err, gc.IsNil)
 	c.Assert(volumes, gc.NotNil)
 
-	volumes, err = source.DescribeVolumes([]string{"JujuTools_storage"})
+	volumes, err = source.DescribeVolumes(o.callCtx, []string{"JujuTools_storage"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(volumes, gc.NotNil)
 }
@@ -192,14 +196,14 @@ func (o *oracleVolumeSource) TestDescribeVolumesWithErrors(c *gc.C) {
 		},
 	} {
 		source := o.NewVolumeSource(c, fake, nil)
-		_, err := source.DescribeVolumes([]string{"JujuTools_storage"})
+		_, err := source.DescribeVolumes(o.callCtx, []string{"JujuTools_storage"})
 		c.Assert(err, gc.NotNil)
 	}
 }
 
 func (o *oracleVolumeSource) TestDestroyVolumes(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	errs, err := source.DestroyVolumes([]string{"foo"})
+	errs, err := source.DestroyVolumes(o.callCtx, []string{"foo"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 }
@@ -216,7 +220,7 @@ func (o *oracleVolumeSource) TestDestroyVolumesWithErrors(c *gc.C) {
 		},
 	} {
 		source := o.NewVolumeSource(c, fake, nil)
-		errs, err := source.DestroyVolumes([]string{"JujuTools_storage"})
+		errs, err := source.DestroyVolumes(o.callCtx, []string{"JujuTools_storage"})
 		c.Assert(err, gc.IsNil)
 		for _, val := range errs {
 			c.Assert(val, gc.NotNil)
@@ -231,7 +235,7 @@ func (o *oracleVolumeSource) TestReleaseVolumes(c *gc.C) {
 	)
 
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	errs, err := source.ReleaseVolumes([]string{"foo"})
+	errs, err := source.ReleaseVolumes(o.callCtx, []string{"foo"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
@@ -251,7 +255,7 @@ func (o *oracleVolumeSource) TestReleaseVolumesUnchanged(c *gc.C) {
 	)
 
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	errs, err := source.ReleaseVolumes([]string{"foo"})
+	errs, err := source.ReleaseVolumes(o.callCtx, []string{"foo"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
@@ -270,7 +274,7 @@ func (o *oracleVolumeSource) TestImportVolume(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
 	c.Assert(source, gc.Implements, new(storage.VolumeImporter))
 
-	info, err := source.(storage.VolumeImporter).ImportVolume("foo", map[string]string{"bar": "baz"})
+	info, err := source.(storage.VolumeImporter).ImportVolume(o.callCtx, "foo", map[string]string{"bar": "baz"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(info, jc.DeepEquals, storage.VolumeInfo{
 		VolumeId:   "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
@@ -308,7 +312,7 @@ func (o *oracleVolumeSource) TestValidateVolumeParams(c *gc.C) {
 
 func (o *oracleVolumeSource) TestAttachVolumes(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, oracletesting.DefaultEnvironAPI)
-	_, err := source.AttachVolumes([]storage.VolumeAttachmentParams{
+	_, err := source.AttachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
 		{
 			AttachmentParams: storage.AttachmentParams{
 				Provider:   oracle.DefaultTypes[0],
@@ -323,7 +327,7 @@ func (o *oracleVolumeSource) TestAttachVolumes(c *gc.C) {
 
 func (o *oracleVolumeSource) TestDetachVolumes(c *gc.C) {
 	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
-	errs, err := source.DetachVolumes([]storage.VolumeAttachmentParams{
+	errs, err := source.DetachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
 		{
 			AttachmentParams: storage.AttachmentParams{
 				Provider:   oracle.DefaultTypes[0],
@@ -345,7 +349,7 @@ func (o *oracleVolumeSource) TestDetachVolumesWithErrors(c *gc.C) {
 		FakeStorageAttachment: oracletesting.FakeStorageAttachment{
 			AllErr: errors.New("FakeStorageAttachmentErr"),
 		}}, oracletesting.DefaultEnvironAPI)
-	_, err := source.DetachVolumes([]storage.VolumeAttachmentParams{
+	_, err := source.DetachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
 		{
 			AttachmentParams: storage.AttachmentParams{
 				Provider:   oracle.DefaultTypes[0],
@@ -378,7 +382,7 @@ func (o *oracleVolumeSource) TestDetachVolumesWithErrors(c *gc.C) {
 				},
 			},
 			DeleteErr: errors.New("FakeStorageAttachmentErr")}}, oracletesting.DefaultEnvironAPI)
-	results, err := source.DetachVolumes([]storage.VolumeAttachmentParams{
+	results, err := source.DetachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
 		{
 			AttachmentParams: storage.AttachmentParams{
 				Provider:   oracle.DefaultTypes[0],

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 )
 
@@ -93,23 +94,23 @@ type VolumeSource interface {
 	// CreateVolumes creates volumes with the specified parameters. If the
 	// volumes are initially attached, then CreateVolumes returns
 	// information about those attachments too.
-	CreateVolumes(params []VolumeParams) ([]CreateVolumesResult, error)
+	CreateVolumes(ctx context.ProviderCallContext, params []VolumeParams) ([]CreateVolumesResult, error)
 
 	// ListVolumes lists the provider volume IDs for every volume
 	// created by this volume source.
-	ListVolumes() ([]string, error)
+	ListVolumes(ctx context.ProviderCallContext) ([]string, error)
 
 	// DescribeVolumes returns the properties of the volumes with the
 	// specified provider volume IDs.
-	DescribeVolumes(volIds []string) ([]DescribeVolumesResult, error)
+	DescribeVolumes(ctx context.ProviderCallContext, volIds []string) ([]DescribeVolumesResult, error)
 
 	// DestroyVolumes destroys the volumes with the specified provider
 	// volume IDs.
-	DestroyVolumes(volIds []string) ([]error, error)
+	DestroyVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error)
 
 	// ReleaseVolumes releases the volumes with the specified provider
 	// volume IDs from the model/controller.
-	ReleaseVolumes(volIds []string) ([]error, error)
+	ReleaseVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error)
 
 	// ValidateVolumeParams validates the provided volume creation
 	// parameters, returning an error if they are invalid.
@@ -125,7 +126,7 @@ type VolumeSource interface {
 	// recording in state. For example, the ec2 provider must reject
 	// an attempt to attach a volume to an instance if they are in
 	// different availability zones.
-	AttachVolumes(params []VolumeAttachmentParams) ([]AttachVolumesResult, error)
+	AttachVolumes(ctx context.ProviderCallContext, params []VolumeAttachmentParams) ([]AttachVolumesResult, error)
 
 	// DetachVolumes detaches the volumes with the specified provider
 	// volume IDs from the instances with the corresponding index.
@@ -133,7 +134,7 @@ type VolumeSource interface {
 	// TODO(axw) we need to record in state whether or not volumes
 	// are detachable, and reject attempts to attach/detach on
 	// that basis.
-	DetachVolumes(params []VolumeAttachmentParams) ([]error, error)
+	DetachVolumes(ctx context.ProviderCallContext, params []VolumeAttachmentParams) ([]error, error)
 }
 
 // FilesystemSource provides an interface for creating, destroying and
@@ -145,15 +146,15 @@ type FilesystemSource interface {
 	ValidateFilesystemParams(params FilesystemParams) error
 
 	// CreateFilesystems creates filesystems with the specified size, in MiB.
-	CreateFilesystems(params []FilesystemParams) ([]CreateFilesystemsResult, error)
+	CreateFilesystems(ctx context.ProviderCallContext, params []FilesystemParams) ([]CreateFilesystemsResult, error)
 
 	// DestroyFilesystems destroys the filesystems with the specified
 	// providerd filesystem IDs.
-	DestroyFilesystems(fsIds []string) ([]error, error)
+	DestroyFilesystems(ctx context.ProviderCallContext, fsIds []string) ([]error, error)
 
 	// ReleaseFilesystems releases the filesystems with the specified provider
 	// filesystem IDs from the model/controller.
-	ReleaseFilesystems(volIds []string) ([]error, error)
+	ReleaseFilesystems(ctx context.ProviderCallContext, volIds []string) ([]error, error)
 
 	// AttachFilesystems attaches filesystems to machines.
 	//
@@ -165,12 +166,12 @@ type FilesystemSource interface {
 	// recording in state. For example, the ec2 provider must reject
 	// an attempt to attach a volume to an instance if they are in
 	// different availability zones.
-	AttachFilesystems(params []FilesystemAttachmentParams) ([]AttachFilesystemsResult, error)
+	AttachFilesystems(ctx context.ProviderCallContext, params []FilesystemAttachmentParams) ([]AttachFilesystemsResult, error)
 
 	// DetachFilesystems detaches the filesystems with the specified
 	// provider filesystem IDs from the instances with the corresponding
 	// index.
-	DetachFilesystems(params []FilesystemAttachmentParams) ([]error, error)
+	DetachFilesystems(ctx context.ProviderCallContext, params []FilesystemAttachmentParams) ([]error, error)
 }
 
 // FilesystemImporter provides an interface for importing filesystems
@@ -188,6 +189,7 @@ type FilesystemImporter interface {
 	// filesystem is not in use before allowing the import to proceed.
 	// Once it is imported, it is assumed to be in a detached state.
 	ImportFilesystem(
+		ctx context.ProviderCallContext,
 		filesystemId string,
 		resourceTags map[string]string,
 	) (FilesystemInfo, error)
@@ -208,6 +210,7 @@ type VolumeImporter interface {
 	// volume is not in use before allowing the import to proceed.
 	// Once it is imported, it is assumed to be in a detached state.
 	ImportVolume(
+		ctx context.ProviderCallContext,
 		volumeId string,
 		resourceTags map[string]string,
 	) (VolumeInfo, error)

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 )
@@ -38,7 +39,7 @@ func (s *providerCommonSuite) TestCommonProvidersExported(c *gc.C) {
 
 // testDetachFilesystems is a test-case for detaching filesystems that use
 // the common "maybeUnmount" method.
-func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.FilesystemSource, mounted bool) {
+func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.FilesystemSource, callCtx context.ProviderCallContext, mounted bool) {
 	const testMountPoint = "/in/the/place"
 
 	cmd := commands.expect("df", "--output=source", filepath.Dir(testMountPoint))
@@ -51,7 +52,7 @@ func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.Fil
 		cmd.respond("headers\n/same/as/rootfs", nil)
 	}
 
-	results, err := source.DetachFilesystems([]storage.FilesystemAttachmentParams{{
+	results, err := source.DetachFilesystems(callCtx, []storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("0/0"),
 		FilesystemId: "filesystem-0-0",
 		AttachmentParams: storage.AttachmentParams{

--- a/storage/provider/dummy/filesystemsource.go
+++ b/storage/provider/dummy/filesystemsource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -16,37 +17,37 @@ import (
 type FilesystemSource struct {
 	testing.Stub
 
-	CreateFilesystemsFunc        func([]storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error)
-	DestroyFilesystemsFunc       func([]string) ([]error, error)
-	ReleaseFilesystemsFunc       func([]string) ([]error, error)
+	CreateFilesystemsFunc        func(context.ProviderCallContext, []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error)
+	DestroyFilesystemsFunc       func(context.ProviderCallContext, []string) ([]error, error)
+	ReleaseFilesystemsFunc       func(context.ProviderCallContext, []string) ([]error, error)
 	ValidateFilesystemParamsFunc func(storage.FilesystemParams) error
-	AttachFilesystemsFunc        func([]storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error)
-	DetachFilesystemsFunc        func([]storage.FilesystemAttachmentParams) ([]error, error)
+	AttachFilesystemsFunc        func(context.ProviderCallContext, []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error)
+	DetachFilesystemsFunc        func(context.ProviderCallContext, []storage.FilesystemAttachmentParams) ([]error, error)
 }
 
 // CreateFilesystems is defined on storage.FilesystemSource.
-func (s *FilesystemSource) CreateFilesystems(params []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
-	s.MethodCall(s, "CreateFilesystems", params)
+func (s *FilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+	s.MethodCall(s, "CreateFilesystems", ctx, params)
 	if s.CreateFilesystemsFunc != nil {
-		return s.CreateFilesystemsFunc(params)
+		return s.CreateFilesystemsFunc(ctx, params)
 	}
 	return nil, errors.NotImplementedf("CreateFilesystems")
 }
 
 // DestroyFilesystems is defined on storage.FilesystemSource.
-func (s *FilesystemSource) DestroyFilesystems(volIds []string) ([]error, error) {
-	s.MethodCall(s, "DestroyFilesystems", volIds)
+func (s *FilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
+	s.MethodCall(s, "DestroyFilesystems", ctx, volIds)
 	if s.DestroyFilesystemsFunc != nil {
-		return s.DestroyFilesystemsFunc(volIds)
+		return s.DestroyFilesystemsFunc(ctx, volIds)
 	}
 	return nil, errors.NotImplementedf("DestroyFilesystems")
 }
 
 // ReleaseFilesystems is defined on storage.FilesystemSource.
-func (s *FilesystemSource) ReleaseFilesystems(volIds []string) ([]error, error) {
-	s.MethodCall(s, "ReleaseFilesystems", volIds)
+func (s *FilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
+	s.MethodCall(s, "ReleaseFilesystems", ctx, volIds)
 	if s.ReleaseFilesystemsFunc != nil {
-		return s.ReleaseFilesystemsFunc(volIds)
+		return s.ReleaseFilesystemsFunc(ctx, volIds)
 	}
 	return nil, errors.NotImplementedf("ReleaseFilesystems")
 }
@@ -61,19 +62,19 @@ func (s *FilesystemSource) ValidateFilesystemParams(params storage.FilesystemPar
 }
 
 // AttachFilesystems is defined on storage.FilesystemSource.
-func (s *FilesystemSource) AttachFilesystems(params []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
-	s.MethodCall(s, "AttachFilesystems", params)
+func (s *FilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+	s.MethodCall(s, "AttachFilesystems", ctx, params)
 	if s.AttachFilesystemsFunc != nil {
-		return s.AttachFilesystemsFunc(params)
+		return s.AttachFilesystemsFunc(ctx, params)
 	}
 	return nil, errors.NotImplementedf("AttachFilesystems")
 }
 
 // DetachFilesystems is defined on storage.FilesystemSource.
-func (s *FilesystemSource) DetachFilesystems(params []storage.FilesystemAttachmentParams) ([]error, error) {
-	s.MethodCall(s, "DetachFilesystems", params)
+func (s *FilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemAttachmentParams) ([]error, error) {
+	s.MethodCall(s, "DetachFilesystems", ctx, params)
 	if s.DetachFilesystemsFunc != nil {
-		return s.DetachFilesystemsFunc(params)
+		return s.DetachFilesystemsFunc(ctx, params)
 	}
 	return nil, errors.NotImplementedf("DetachFilesystems")
 }

--- a/storage/provider/dummy/volumesource.go
+++ b/storage/provider/dummy/volumesource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -16,57 +17,57 @@ import (
 type VolumeSource struct {
 	testing.Stub
 
-	CreateVolumesFunc        func([]storage.VolumeParams) ([]storage.CreateVolumesResult, error)
-	ListVolumesFunc          func() ([]string, error)
-	DescribeVolumesFunc      func([]string) ([]storage.DescribeVolumesResult, error)
-	DestroyVolumesFunc       func([]string) ([]error, error)
-	ReleaseVolumesFunc       func([]string) ([]error, error)
+	CreateVolumesFunc        func(context.ProviderCallContext, []storage.VolumeParams) ([]storage.CreateVolumesResult, error)
+	ListVolumesFunc          func(context.ProviderCallContext) ([]string, error)
+	DescribeVolumesFunc      func(context.ProviderCallContext, []string) ([]storage.DescribeVolumesResult, error)
+	DestroyVolumesFunc       func(context.ProviderCallContext, []string) ([]error, error)
+	ReleaseVolumesFunc       func(context.ProviderCallContext, []string) ([]error, error)
 	ValidateVolumeParamsFunc func(storage.VolumeParams) error
-	AttachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
-	DetachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]error, error)
+	AttachVolumesFunc        func(context.ProviderCallContext, []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
+	DetachVolumesFunc        func(context.ProviderCallContext, []storage.VolumeAttachmentParams) ([]error, error)
 }
 
 // CreateVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
-	s.MethodCall(s, "CreateVolumes", params)
+func (s *VolumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+	s.MethodCall(s, "CreateVolumes", ctx, params)
 	if s.CreateVolumesFunc != nil {
-		return s.CreateVolumesFunc(params)
+		return s.CreateVolumesFunc(ctx, params)
 	}
 	return nil, errors.NotImplementedf("CreateVolumes")
 }
 
 // ListVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) ListVolumes() ([]string, error) {
-	s.MethodCall(s, "ListVolumes")
+func (s *VolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
+	s.MethodCall(s, "ListVolumes", ctx)
 	if s.ListVolumesFunc != nil {
-		return s.ListVolumesFunc()
+		return s.ListVolumesFunc(ctx)
 	}
 	return nil, nil
 }
 
 // DescribeVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVolumesResult, error) {
-	s.MethodCall(s, "DescribeVolumes", volIds)
+func (s *VolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volIds []string) ([]storage.DescribeVolumesResult, error) {
+	s.MethodCall(s, "DescribeVolumes", ctx, volIds)
 	if s.DescribeVolumesFunc != nil {
-		return s.DescribeVolumesFunc(volIds)
+		return s.DescribeVolumesFunc(ctx, volIds)
 	}
 	return nil, errors.NotImplementedf("DescribeVolumes")
 }
 
 // DestroyVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
-	s.MethodCall(s, "DestroyVolumes", volIds)
+func (s *VolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
+	s.MethodCall(s, "DestroyVolumes", ctx, volIds)
 	if s.DestroyVolumesFunc != nil {
-		return s.DestroyVolumesFunc(volIds)
+		return s.DestroyVolumesFunc(ctx, volIds)
 	}
 	return nil, errors.NotImplementedf("DestroyVolumes")
 }
 
 // ReleaseVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) ReleaseVolumes(volIds []string) ([]error, error) {
-	s.MethodCall(s, "ReleaseVolumes", volIds)
+func (s *VolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
+	s.MethodCall(s, "ReleaseVolumes", ctx, volIds)
 	if s.ReleaseVolumesFunc != nil {
-		return s.ReleaseVolumesFunc(volIds)
+		return s.ReleaseVolumesFunc(ctx, volIds)
 	}
 	return nil, errors.NotImplementedf("ReleaseVolumes")
 }
@@ -81,19 +82,19 @@ func (s *VolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
 }
 
 // AttachVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
-	s.MethodCall(s, "AttachVolumes", params)
+func (s *VolumeSource) AttachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+	s.MethodCall(s, "AttachVolumes", ctx, params)
 	if s.AttachVolumesFunc != nil {
-		return s.AttachVolumesFunc(params)
+		return s.AttachVolumesFunc(ctx, params)
 	}
 	return nil, errors.NotImplementedf("AttachVolumes")
 }
 
 // DetachVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) ([]error, error) {
-	s.MethodCall(s, "DetachVolumes", params)
+func (s *VolumeSource) DetachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]error, error) {
+	s.MethodCall(s, "DetachVolumes", ctx, params)
 	if s.DetachVolumesFunc != nil {
-		return s.DetachVolumesFunc(params)
+		return s.DetachVolumesFunc(ctx, params)
 	}
 	return nil, errors.NotImplementedf("DetachVolumes")
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -105,7 +106,7 @@ type loopVolumeSource struct {
 var _ storage.VolumeSource = (*loopVolumeSource)(nil)
 
 // CreateVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) CreateVolumes(args []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+func (lvs *loopVolumeSource) CreateVolumes(ctx context.ProviderCallContext, args []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
 	results := make([]storage.CreateVolumesResult, len(args))
 	for i, arg := range args {
 		volume, err := lvs.createVolume(arg)
@@ -140,19 +141,19 @@ func (lvs *loopVolumeSource) volumeFilePath(tag names.VolumeTag) string {
 }
 
 // ListVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) ListVolumes() ([]string, error) {
+func (lvs *loopVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
 	// TODO(axw) implement this when we need it.
 	return nil, errors.NotImplementedf("ListVolumes")
 }
 
 // DescribeVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.DescribeVolumesResult, error) {
+func (lvs *loopVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]storage.DescribeVolumesResult, error) {
 	// TODO(axw) implement this when we need it.
 	return nil, errors.NotImplementedf("DescribeVolumes")
 }
 
 // DestroyVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) {
+func (lvs *loopVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	results := make([]error, len(volumeIds))
 	for i, volumeId := range volumeIds {
 		if err := lvs.destroyVolume(volumeId); err != nil {
@@ -163,7 +164,7 @@ func (lvs *loopVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error)
 }
 
 // ReleaseVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+func (lvs *loopVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	return make([]error, len(volumeIds)), nil
 }
 
@@ -189,7 +190,7 @@ func (lvs *loopVolumeSource) ValidateVolumeParams(params storage.VolumeParams) e
 }
 
 // AttachVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) AttachVolumes(args []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+func (lvs *loopVolumeSource) AttachVolumes(ctx context.ProviderCallContext, args []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	results := make([]storage.AttachVolumesResult, len(args))
 	for i, arg := range args {
 		attachment, err := lvs.attachVolume(arg)
@@ -220,7 +221,7 @@ func (lvs *loopVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (*
 }
 
 // DetachVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) DetachVolumes(args []storage.VolumeAttachmentParams) ([]error, error) {
+func (lvs *loopVolumeSource) DetachVolumes(ctx context.ProviderCallContext, args []storage.VolumeAttachmentParams) ([]error, error) {
 	results := make([]error, len(args))
 	for i, arg := range args {
 		if err := lvs.detachVolume(arg.Volume); err != nil {

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -68,7 +69,7 @@ func (s *managedFilesystemSource) backingVolumeBlockDevice(v names.VolumeTag) (s
 }
 
 // CreateFilesystems is defined on storage.FilesystemSource.
-func (s *managedFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+func (s *managedFilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
 	results := make([]storage.CreateFilesystemsResult, len(args))
 	for i, arg := range args {
 		filesystem, err := s.createFilesystem(arg)
@@ -110,7 +111,7 @@ func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams)
 }
 
 // DestroyFilesystems is defined on storage.FilesystemSource.
-func (s *managedFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+func (s *managedFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	// DestroyFilesystems is a no-op; there is nothing to destroy,
 	// since the filesystem is just data on a volume. The volume
 	// is destroyed separately.
@@ -118,12 +119,12 @@ func (s *managedFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]
 }
 
 // ReleaseFilesystems is defined on storage.FilesystemSource.
-func (s *managedFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+func (s *managedFilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	return make([]error, len(filesystemIds)), nil
 }
 
 // AttachFilesystems is defined on storage.FilesystemSource.
-func (s *managedFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+func (s *managedFilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))
 	for i, arg := range args {
 		attachment, err := s.attachFilesystem(arg)
@@ -163,7 +164,7 @@ func (s *managedFilesystemSource) attachFilesystem(arg storage.FilesystemAttachm
 }
 
 // DetachFilesystems is defined on storage.FilesystemSource.
-func (s *managedFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) ([]error, error) {
+func (s *managedFilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]error, error) {
 	results := make([]error, len(args))
 	for i, arg := range args {
 		if err := maybeUnmount(s.run, s.dirFuncs, arg.Path); err != nil {

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -143,7 +144,7 @@ func (s *rootfsFilesystemSource) ValidateFilesystemParams(params storage.Filesys
 }
 
 // CreateFilesystems is defined on the FilesystemSource interface.
-func (s *rootfsFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+func (s *rootfsFilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
 	results := make([]storage.CreateFilesystemsResult, len(args))
 	for i, arg := range args {
 		filesystem, err := s.createFilesystem(arg)
@@ -187,19 +188,19 @@ func (s *rootfsFilesystemSource) createFilesystem(params storage.FilesystemParam
 }
 
 // DestroyFilesystems is defined on the FilesystemSource interface.
-func (s *rootfsFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+func (s *rootfsFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	// DestroyFilesystems is a no-op; we leave the storage directory
 	// in tact for post-mortems and such.
 	return make([]error, len(filesystemIds)), nil
 }
 
 // ReleaseFilesystems is defined on the FilesystemSource interface.
-func (s *rootfsFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+func (s *rootfsFilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	return make([]error, len(filesystemIds)), nil
 }
 
 // AttachFilesystems is defined on the FilesystemSource interface.
-func (s *rootfsFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+func (s *rootfsFilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))
 	for i, arg := range args {
 		attachment, err := s.attachFilesystem(arg)
@@ -313,7 +314,7 @@ func (s *rootfsFilesystemSource) validateSameMountPoints(source, target string) 
 }
 
 // DetachFilesystems is defined on the FilesystemSource interface.
-func (s *rootfsFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) ([]error, error) {
+func (s *rootfsFilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]error, error) {
 	results := make([]error, len(args))
 	for i, arg := range args {
 		if err := maybeUnmount(s.run, s.dirFuncs, arg.Path); err != nil {

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
@@ -110,7 +111,7 @@ func (s *tmpfsFilesystemSource) ValidateFilesystemParams(params storage.Filesyst
 }
 
 // CreateFilesystems is defined on the FilesystemSource interface.
-func (s *tmpfsFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+func (s *tmpfsFilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
 	results := make([]storage.CreateFilesystemsResult, len(args))
 	for i, arg := range args {
 		filesystem, err := s.createFilesystem(arg)
@@ -154,7 +155,7 @@ func (s *tmpfsFilesystemSource) createFilesystem(params storage.FilesystemParams
 }
 
 // DestroyFilesystems is defined on the FilesystemSource interface.
-func (s *tmpfsFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+func (s *tmpfsFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	// DestroyFilesystems is a no-op; there is nothing to destroy,
 	// since the filesystem is ephemeral and disappears once
 	// detached.
@@ -162,12 +163,12 @@ func (s *tmpfsFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]er
 }
 
 // ReleaseFilesystems is defined on the FilesystemSource interface.
-func (s *tmpfsFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+func (s *tmpfsFilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	return make([]error, len(filesystemIds)), nil
 }
 
 // AttachFilesystems is defined on the FilesystemSource interface.
-func (s *tmpfsFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+func (s *tmpfsFilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))
 	for i, arg := range args {
 		attachment, err := s.attachFilesystem(arg)
@@ -225,7 +226,7 @@ func (s *tmpfsFilesystemSource) attachFilesystem(arg storage.FilesystemAttachmen
 }
 
 // DetachFilesystems is defined on the FilesystemSource interface.
-func (s *tmpfsFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) ([]error, error) {
+func (s *tmpfsFilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]error, error) {
 	results := make([]error, len(args))
 	for i, arg := range args {
 		if err := maybeUnmount(s.run, s.dirFuncs, arg.Path); err != nil {

--- a/worker/storageprovisioner/config.go
+++ b/worker/storageprovisioner/config.go
@@ -8,20 +8,22 @@ import (
 	"github.com/juju/utils/clock"
 	"gopkg.in/juju/names.v2"
 
+	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
 )
 
 // Config holds configuration and dependencies for a storageprovisioner worker.
 type Config struct {
-	Scope       names.Tag
-	StorageDir  string
-	Volumes     VolumeAccessor
-	Filesystems FilesystemAccessor
-	Life        LifecycleManager
-	Registry    storage.ProviderRegistry
-	Machines    MachineAccessor
-	Status      StatusSetter
-	Clock       clock.Clock
+	Scope            names.Tag
+	StorageDir       string
+	Volumes          VolumeAccessor
+	Filesystems      FilesystemAccessor
+	Life             LifecycleManager
+	Registry         storage.ProviderRegistry
+	Machines         MachineAccessor
+	Status           StatusSetter
+	Clock            clock.Clock
+	CloudCallContext environscontext.ProviderCallContext
 }
 
 // Validate returns an error if the config cannot be relied upon to start a worker.
@@ -60,6 +62,9 @@ func (config Config) Validate() error {
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")
+	}
+	if config.CloudCallContext == nil {
+		return errors.NotValidf("nil CloudCallContext")
 	}
 	return nil
 }

--- a/worker/storageprovisioner/manifold_machine_test.go
+++ b/worker/storageprovisioner/manifold_machine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/agent/engine/enginetest"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/storageprovisioner"
 )
@@ -45,6 +46,7 @@ func (s *MachineManifoldSuite) SetUpTest(c *gc.C) {
 		AgentName:     config.AgentName,
 		APICallerName: config.APICallerName,
 		Clock:         testing.NewClock(defaultClockStart),
+		NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 	}
 }
 

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/watcher"
@@ -519,7 +520,7 @@ func (s *dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) er
 }
 
 // CreateVolumes makes some volumes that we can check later to ensure things went as expected.
-func (s *dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+func (s *dummyVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
 	if s.provider != nil && s.provider.createVolumesFunc != nil {
 		return s.provider.createVolumesFunc(params)
 	}
@@ -545,7 +546,7 @@ func (s *dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]stor
 }
 
 // DestroyVolumes destroys volumes.
-func (s *dummyVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) {
+func (s *dummyVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	if s.provider.destroyVolumesFunc != nil {
 		return s.provider.destroyVolumesFunc(volumeIds)
 	}
@@ -553,7 +554,7 @@ func (s *dummyVolumeSource) DestroyVolumes(volumeIds []string) ([]error, error) 
 }
 
 // ReleaseVolumes destroys volumes.
-func (s *dummyVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) {
+func (s *dummyVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volumeIds []string) ([]error, error) {
 	if s.provider.releaseVolumesFunc != nil {
 		return s.provider.releaseVolumesFunc(volumeIds)
 	}
@@ -561,7 +562,7 @@ func (s *dummyVolumeSource) ReleaseVolumes(volumeIds []string) ([]error, error) 
 }
 
 // AttachVolumes attaches volumes to machines.
-func (s *dummyVolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+func (s *dummyVolumeSource) AttachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	if s.provider != nil && s.provider.attachVolumesFunc != nil {
 		return s.provider.attachVolumesFunc(params)
 	}
@@ -587,7 +588,7 @@ func (s *dummyVolumeSource) AttachVolumes(params []storage.VolumeAttachmentParam
 }
 
 // DetachVolumes detaches volumes from machines.
-func (s *dummyVolumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) ([]error, error) {
+func (s *dummyVolumeSource) DetachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]error, error) {
 	if s.provider.detachVolumesFunc != nil {
 		return s.provider.detachVolumesFunc(params)
 	}
@@ -602,7 +603,7 @@ func (s *dummyFilesystemSource) ValidateFilesystemParams(params storage.Filesyst
 }
 
 // CreateFilesystems makes some filesystems that we can check later to ensure things went as expected.
-func (s *dummyFilesystemSource) CreateFilesystems(params []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+func (s *dummyFilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
 	if s.provider != nil && s.provider.createFilesystemsFunc != nil {
 		return s.provider.createFilesystemsFunc(params)
 	}
@@ -625,7 +626,7 @@ func (s *dummyFilesystemSource) CreateFilesystems(params []storage.FilesystemPar
 }
 
 // DestroyFilesystems destroys filesystems.
-func (s *dummyFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+func (s *dummyFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	if s.provider.destroyFilesystemsFunc != nil {
 		return s.provider.destroyFilesystemsFunc(filesystemIds)
 	}
@@ -633,7 +634,7 @@ func (s *dummyFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]er
 }
 
 // ReleaseFilesystems destroys filesystems.
-func (s *dummyFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+func (s *dummyFilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	if s.provider.releaseFilesystemsFunc != nil {
 		return s.provider.releaseFilesystemsFunc(filesystemIds)
 	}
@@ -641,7 +642,7 @@ func (s *dummyFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]er
 }
 
 // AttachFilesystems attaches filesystems to machines.
-func (s *dummyFilesystemSource) AttachFilesystems(params []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+func (s *dummyFilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	if s.provider != nil && s.provider.attachFilesystemsFunc != nil {
 		return s.provider.attachFilesystemsFunc(params)
 	}
@@ -666,7 +667,7 @@ func (s *dummyFilesystemSource) AttachFilesystems(params []storage.FilesystemAtt
 }
 
 // DetachFilesystems detaches filesystems from machines.
-func (s *dummyFilesystemSource) DetachFilesystems(params []storage.FilesystemAttachmentParams) ([]error, error) {
+func (s *dummyFilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemAttachmentParams) ([]error, error) {
 	if s.provider.detachFilesystemsFunc != nil {
 		return s.provider.detachFilesystemsFunc(params)
 	}
@@ -682,7 +683,7 @@ func (s *mockManagedFilesystemSource) ValidateFilesystemParams(params storage.Fi
 	return nil
 }
 
-func (s *mockManagedFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
+func (s *mockManagedFilesystemSource) CreateFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemParams) ([]storage.CreateFilesystemsResult, error) {
 	results := make([]storage.CreateFilesystemsResult, len(args))
 	for i, arg := range args {
 		blockDevice, ok := s.blockDevices[arg.Volume]
@@ -701,15 +702,15 @@ func (s *mockManagedFilesystemSource) CreateFilesystems(args []storage.Filesyste
 	return results, nil
 }
 
-func (s *mockManagedFilesystemSource) DestroyFilesystems(filesystemIds []string) ([]error, error) {
+func (s *mockManagedFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	return make([]error, len(filesystemIds)), nil
 }
 
-func (s *mockManagedFilesystemSource) ReleaseFilesystems(filesystemIds []string) ([]error, error) {
+func (s *mockManagedFilesystemSource) ReleaseFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	return make([]error, len(filesystemIds)), nil
 }
 
-func (s *mockManagedFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
+func (s *mockManagedFilesystemSource) AttachFilesystems(ctx context.ProviderCallContext, args []storage.FilesystemAttachmentParams) ([]storage.AttachFilesystemsResult, error) {
 	results := make([]storage.AttachFilesystemsResult, len(args))
 	for i, arg := range args {
 		if arg.FilesystemId == "" {
@@ -740,7 +741,7 @@ func (s *mockManagedFilesystemSource) AttachFilesystems(args []storage.Filesyste
 	return results, nil
 }
 
-func (s *mockManagedFilesystemSource) DetachFilesystems(params []storage.FilesystemAttachmentParams) ([]error, error) {
+func (s *mockManagedFilesystemSource) DetachFilesystems(ctx context.ProviderCallContext, params []storage.FilesystemAttachmentParams) ([]error, error) {
 	return nil, errors.NotImplementedf("DetachFilesystems")
 }
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -14,6 +14,7 @@ import (
 	worker "gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -58,14 +59,15 @@ func (s *storageProvisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
 	worker, err := storageprovisioner.NewStorageProvisioner(storageprovisioner.Config{
-		Scope:       coretesting.ModelTag,
-		Volumes:     newMockVolumeAccessor(),
-		Filesystems: newMockFilesystemAccessor(),
-		Life:        &mockLifecycleManager{},
-		Registry:    s.registry,
-		Machines:    newMockMachineAccessor(c),
-		Status:      &mockStatusSetter{},
-		Clock:       &mockClock{},
+		Scope:            coretesting.ModelTag,
+		Volumes:          newMockVolumeAccessor(),
+		Filesystems:      newMockFilesystemAccessor(),
+		Life:             &mockLifecycleManager{},
+		Registry:         s.registry,
+		Machines:         newMockMachineAccessor(c),
+		Status:           &mockStatusSetter{},
+		Clock:            &mockClock{},
+		CloudCallContext: context.NewCloudCallContext(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1785,15 +1787,16 @@ func newStorageProvisioner(c *gc.C, args *workerArgs) worker.Worker {
 		args.statusSetter = &mockStatusSetter{}
 	}
 	worker, err := storageprovisioner.NewStorageProvisioner(storageprovisioner.Config{
-		Scope:       args.scope,
-		StorageDir:  storageDir,
-		Volumes:     args.volumes,
-		Filesystems: args.filesystems,
-		Life:        args.life,
-		Registry:    args.registry,
-		Machines:    args.machines,
-		Status:      args.statusSetter,
-		Clock:       args.clock,
+		Scope:            args.scope,
+		StorageDir:       storageDir,
+		Volumes:          args.volumes,
+		Filesystems:      args.filesystems,
+		Life:             args.life,
+		Registry:         args.registry,
+		Machines:         args.machines,
+		Status:           args.statusSetter,
+		Clock:            args.clock,
+		CloudCallContext: context.NewCloudCallContext(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return worker


### PR DESCRIPTION
## Description of change

All functionality that call into providers require a context. This context allows to react to cloud responses, for example if the cloud will not accept a credential that a call was made with.

Most of our functionality has the context. This is a very mechanical PR that enables storage interfaces to have context. No actual work has been done yet - we are just updating signatures here.