### PR TITLE
juju-updateseries run pre-reboot should link systemd files to new location

### DIFF
--- a/cmd/jujud/updateseries/updateseries.go
+++ b/cmd/jujud/updateseries/updateseries.go
@@ -163,7 +163,7 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 		startedSysdServiceNames, startedSymServiceNames, failedAgentNames, err := c.manager.WriteSystemdAgents(
 			c.machineAgent,
 			c.unitAgents,
-			c.dataDir,
+			service.SystemdDataDir,
 			systemdDir,
 			systemdMultiUserDir,
 			c.toSeries,

--- a/cmd/jujud/updateseries/updateseries_test.go
+++ b/cmd/jujud/updateseries/updateseries_test.go
@@ -452,7 +452,7 @@ func (s *updateSeriesCmdSuite) assertServiceSymLinks(c *gc.C) {
 		svcFileName := svcName + ".service"
 		result, err := os.Readlink(path.Join(systemdDir, svcFileName))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(result, gc.Equals, path.Join(s.dataDir, "init", svcName, svcFileName))
+		c.Assert(result, gc.Equals, path.Join(service.SystemdDataDir, svcName, svcFileName))
 	}
 }
 

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -157,12 +157,12 @@ func (s *systemdServiceManager) WriteSystemdAgents(machineAgent string, unitAgen
 		}
 
 		svcFileName := svcName + ".service"
-		if err = os.Symlink(path.Join(dataDir, "init", svcName, svcFileName),
+		if err = os.Symlink(path.Join(dataDir, svcName, svcFileName),
 			path.Join(symLinkSystemdDir, svcFileName)); err != nil && !os.IsExist(err) {
 			return nil, nil, nil, errors.Errorf("failed to link service file (%s) in systemd dir: %s\n", svcFileName, err)
 		}
 
-		if err = os.Symlink(path.Join(dataDir, "init", svcName, svcFileName),
+		if err = os.Symlink(path.Join(dataDir, svcName, svcFileName),
 			path.Join(symLinkSystemdMultiUserDir, svcFileName)); err != nil && !os.IsExist(err) {
 			return nil, nil, nil, errors.Errorf("failed to link service file (%s) in multi-user.target.wants dir: %s\n", svcFileName, err)
 		}

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -291,7 +291,7 @@ func (s *systemdServiceManager) StartAllAgents(machineAgent string, unitAgents [
 
 	for _, unit := range unitAgents {
 		if err = startAgent(unit, AgentKindUnit, dataDir, series); err != nil {
-			return "", nil, errors.Annotatef(err, "failed to start %s service", serviceName(unit))
+			return "", startedUnitNames, errors.Annotatef(err, "failed to start %s service", serviceName(unit))
 		}
 		startedUnitNames = append(startedUnitNames, serviceName(unit))
 		logger.Infof("started %s service", serviceName(unit))

--- a/service/common/testing/fake.go
+++ b/service/common/testing/fake.go
@@ -4,9 +4,6 @@
 package testing
 
 import (
-	"io/ioutil"
-	"os"
-	"path"
 	"strings"
 	"sync"
 
@@ -276,16 +273,6 @@ func (ss *FakeService) WriteService() error {
 	retErr := ss.NextErr()
 	if retErr != nil {
 		return retErr
-	}
-	dirName := path.Join(ss.DataDir, "init", ss.Service.Name)
-	if err := os.MkdirAll(dirName, os.ModeDir|os.ModePerm); err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(path.Join(dirName, "exec_start.sh"), []byte{}, 0644); err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(path.Join(dirName, ss.Service.Name+".service"), []byte{}, 0644); err != nil {
-		return err
 	}
 	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -30,9 +30,8 @@ const (
 	InitSystemSystemd = "systemd"
 	InitSystemUpstart = "upstart"
 	InitSystemWindows = "windows"
+	SystemdDataDir    = "/lib/systemd/system"
 )
-
-var SystemdDataDir = "/lib/systemd/system"
 
 // linuxInitSystems lists the names of the init systems that juju might
 // find on a linux host.

--- a/service/service.go
+++ b/service/service.go
@@ -32,6 +32,8 @@ const (
 	InitSystemWindows = "windows"
 )
 
+var SystemdDataDir = "/lib/systemd/system"
+
 // linuxInitSystems lists the names of the init systems that juju might
 // find on a linux host.
 var linuxInitSystems = []string{
@@ -138,7 +140,7 @@ func newService(name string, conf common.Conf, initSystem, series string) (Servi
 		svc, err := systemd.NewService(
 			name,
 			conf,
-			"/lib/systemd/system",
+			SystemdDataDir,
 			systemd.NewDBusAPI,
 			renderer.Join(dataDir, "init"),
 		)

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -23,11 +23,13 @@ var (
 
 	renderer = shell.BashRenderer{}
 	cmds     = commands{renderer, executable}
+
+	SystemPath = "/run/systemd/system"
 )
 
 // IsRunning returns whether or not systemd is the local init system.
 func IsRunning() (bool, error) {
-	if _, err := os.Stat("/run/systemd/system"); err == nil {
+	if _, err := os.Stat(SystemPath); err == nil {
 		return true, nil
 	} else if os.IsNotExist(err) {
 		return false, nil


### PR DESCRIPTION
## Description of change

The location of machine and agent service files written on a unit was recently changed to /lib/systemd/system.  Update juju-updateseries, when run to pre-reboot after an series upgrade,
to link to files in the new location. 

## QA steps

juju deploy ubuntu --series trusty
juju set-series ubuntu xenial
juju add-unit ubuntu
juju ssh 0
sudo juju-updateseries --to-series xenial --from-series trusty
ls -la /etc/systemd/system/jujud-*  <-- verify link valid
juju ssh 1
sudo juju-updateseries --to-series xenial --from-series trusty
ls -la /etc/systemd/system/jujud-*  <-- verify link valid

## Documentation changes

n/a

## Bug reference

n/a