### PR TITLE
juju deploy create/overwrite charm version file

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -314,6 +314,10 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, err
 	switch ch := ch.(type) {
 	case *charm.CharmDir:
 		var err error
+		// For local charm check if it is revision control directory, generate version file.
+		if err = charm.MaybeCreateVersionFile(ch.Path); err != nil {
+			return nil, errors.Annotate(err, "cannot create/overwrite version file")
+		}
 		if archive, err = ioutil.TempFile("", "charm"); err != nil {
 			return nil, errors.Annotate(err, "cannot create temp file")
 		}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
@@ -121,6 +123,48 @@ func (s *clientSuite) TestAddLocalCharm(c *gc.C) {
 	savedURL, err = client.AddLocalCharm(curl, charmDir)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
+}
+
+func (s *clientSuite) TestAddLocalCharmVersionFile(c *gc.C) {
+	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy-resource")
+	curl := charm.MustParseURL(
+		fmt.Sprintf("local:quantal/%s-%d", charmDir.Meta().Name, charmDir.Revision()),
+	)
+	client := s.APIState.Client()
+
+	// Add a .git file inside the charmDir.Path.
+	vcsPath := path.Join(charmDir.Path, ".git")
+	_, err := os.Create(vcsPath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	testing.PatchExecutableAsEchoArgs(c, s, "git")
+
+	// Upload the charm.
+	_, err = client.AddLocalCharm(curl, charmDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := []string{"describe", "--dirty"}
+	testing.AssertEchoArgs(c, "git", args...)
+
+	versionPath := path.Join(charmDir.Path, "version")
+	_, err = os.Stat(versionPath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedVersion := "git"
+	for _, arg := range args {
+		expectedVersion = fmt.Sprintf("%s %s", expectedVersion, utils.ShQuote(arg))
+	}
+
+	f, err := os.Open(versionPath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	version, err := ioutil.ReadAll(f)
+	c.Assert(err, jc.ErrorIsNil)
+
+	actualVersion := strings.TrimSuffix(string(version), "\n")
+
+	c.Assert(actualVersion, gc.Equals, expectedVersion)
 }
 
 func (s *clientSuite) TestAddLocalCharmOtherModel(c *gc.C) {

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -419,6 +419,7 @@ func (h *charmsHandler) repackageAndUploadCharm(st *state.State, archive *charm.
 			errors.New("invalid version file")
 			version = ""
 		}
+		version = fmt.Sprintf("%.100s", version)
 	} else {
 		errors.Annotate(err, "cannot open version file")
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -111,7 +111,7 @@ gopkg.in/goose.v2	git	36df5d12fc6d0ef1c102e1c18a22ddf345b18821	2018-03-22T12:54:
 gopkg.in/httprequest.v1	git	1a21782420ea13c3c6fb1d03578f446b3248edb1	2018-03-08T16:26:44Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6	git	d019eb633b8e040e414a8a5df3bba0a5f76e9757	2018-06-20T04:49:47Z
+gopkg.in/juju/charm.v6	git	b38325e23176f6d201c7ad6970f99ddbe2645f97	2018-06-25T06:14:05Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/charmrepo.v3	git	7f799297ba8d526feb52630477bd44e71037f92e	2018-04-11T22:45:32Z
 gopkg.in/juju/charmstore.v5	git	0d59319d1dba8418eaa72667f3ef447561aaefee	2018-02-26T10:50:37Z


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:
## Description of change
Why is this change needed?
This PR has code changes for juju deploy command creating or overwriting charm version file for local charm if it is in revision control directory.
## QA steps
How do we verify that the change works?
deploy a local charm. 
(clone the charm from git repo inot local directoy first and deploy it.)
## Documentation changes
Does it affect current user workflow? CLI? API?
juju deploy command needs to be updated.
## Bug reference
Does this change fix a bug? Please add a link to it.
N/A