### PR TITLE
Initial caasunit filestorage

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -263,7 +263,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	template := state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{
 				Pool: "loop-pool",
 				Size: 123,

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -185,7 +185,7 @@ func (s *watcherSuite) TestStringsWatcherStopsWithPendingSend(c *gc.C) {
 func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 	f := factory.NewFactory(s.BackingState)
 	f.MakeMachine(c, &factory.MachineParams{
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{
 				Pool: "modelscoped",
 				Size: 1024,

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -133,7 +133,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 		Jobs:            []state.MachineJob{state.JobManageModel},
 		Characteristics: &instance.HardwareCharacteristics{CpuCores: &eight},
 		InstanceId:      "id-4",
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{
 				Pool: "modelscoped",
 				Size: 123,
@@ -143,7 +143,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 	s.Factory.MakeMachine(c, &factory.MachineParams{
 		Jobs:       []state.MachineJob{state.JobHostUnits},
 		InstanceId: "id-5",
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{
 				Pool: "modelscoped",
 				Size: 123,

--- a/apiserver/common/storagecommon/filesystems.go
+++ b/apiserver/common/storagecommon/filesystems.go
@@ -137,7 +137,7 @@ func FilesystemAttachmentFromState(v state.FilesystemAttachment) (params.Filesys
 	}
 	return params.FilesystemAttachment{
 		v.Filesystem().String(),
-		v.Machine().String(),
+		v.Host().String(),
 		FilesystemAttachmentInfoFromState(info),
 	}, nil
 }

--- a/apiserver/common/storagecommon/mock_test.go
+++ b/apiserver/common/storagecommon/mock_test.go
@@ -20,7 +20,7 @@ type fakeStorage struct {
 	storagecommon.FilesystemAccess
 	storageInstance       func(names.StorageTag) (state.StorageInstance, error)
 	storageInstanceVolume func(names.StorageTag) (state.Volume, error)
-	volumeAttachment      func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	volumeAttachment      func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 	blockDevices          func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }
 
@@ -34,7 +34,7 @@ func (s *fakeStorage) StorageInstanceVolume(tag names.StorageTag) (state.Volume,
 	return s.storageInstanceVolume(tag)
 }
 
-func (s *fakeStorage) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+func (s *fakeStorage) VolumeAttachment(m names.Tag, v names.VolumeTag) (state.VolumeAttachment, error) {
 	s.MethodCall(s, "VolumeAttachment", m, v)
 	return s.volumeAttachment(m, v)
 }

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -35,8 +35,8 @@ type VolumeAccess interface {
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 
 	// VolumeAttachment returns the state.VolumeAttachment corresponding
-	// to the specified machine and volume.
-	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	// to the specified host and volume.
+	VolumeAttachment(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 
 	// BlockDevices returns information about block devices published
 	// for the specified machine.
@@ -51,8 +51,8 @@ type FilesystemAccess interface {
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 
 	// FilesystemAttachment returns the state.FilesystemAttachment
-	// corresponding to the specified machine and filesystem.
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+	// corresponding to the specified host and filesystem.
+	FilesystemAttachment(names.Tag, names.FilesystemTag) (state.FilesystemAttachment, error)
 }
 
 // StorageAttachmentInfo is called by the uniter facade to get info needed to

--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -64,7 +64,7 @@ func (s *storageAttachmentInfoSuite) SetUpTest(c *gc.C) {
 		storageInstanceVolume: func(tag names.StorageTag) (state.Volume, error) {
 			return s.volume, nil
 		},
-		volumeAttachment: func(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+		volumeAttachment: func(m names.Tag, v names.VolumeTag) (state.VolumeAttachment, error) {
 			return s.volumeAttachment, nil
 		},
 		blockDevices: func(m names.MachineTag) ([]state.BlockDeviceInfo, error) {

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1179,7 +1179,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 	volumesMachine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Size: 1000},
 		}},
 	})

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -37,7 +37,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 		Placement:   "valid",
-		Volumes: []state.MachineVolumeParams{
+		Volumes: []state.HostVolumeParams{
 			{Volume: state.VolumeParams{Size: 1000, Pool: "static-pool"}},
 			{Volume: state.VolumeParams{Size: 2000, Pool: "static-pool"}},
 		},
@@ -284,7 +284,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 		Series:    "quantal",
 		Jobs:      []state.MachineJob{state.JobHostUnits},
 		Placement: "valid",
-		Volumes: []state.MachineVolumeParams{
+		Volumes: []state.HostVolumeParams{
 			{Volume: state.VolumeParams{Size: 1000, Pool: "loop"}},
 			{Volume: state.VolumeParams{Size: 1000, Pool: "static"}},
 		},
@@ -341,7 +341,7 @@ func (s *withoutControllerSuite) TestStorageProviderVolumes(c *gc.C) {
 	template := state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{
+		Volumes: []state.HostVolumeParams{
 			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
 			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
 		},

--- a/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/backend.go
+++ b/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/backend.go
@@ -13,7 +13,7 @@ import (
 // filesystem watchers to use.
 type Backend interface {
 	Filesystem(names.FilesystemTag) (state.Filesystem, error)
-	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	VolumeAttachment(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
 	WatchMachineFilesystemAttachments(names.MachineTag) state.StringsWatcher
 	WatchModelFilesystems() state.StringsWatcher

--- a/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/mock_test.go
+++ b/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/mock_test.go
@@ -30,7 +30,7 @@ func (b *mockBackend) Filesystem(tag names.FilesystemTag) (state.Filesystem, err
 	return nil, errors.NotFoundf("filesystem %s", tag.Id())
 }
 
-func (b *mockBackend) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+func (b *mockBackend) VolumeAttachment(m names.Tag, v names.VolumeTag) (state.VolumeAttachment, error) {
 	if m.Id() != "0" {
 		// The tests all operate on machine "0", and the watchers
 		// should ignore attachments for other machines, so we should

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -78,25 +78,25 @@ type StorageBackend interface {
 	DetachStorage(names.StorageTag, names.UnitTag) error
 
 	Filesystem(names.FilesystemTag) (state.Filesystem, error)
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+	FilesystemAttachment(names.Tag, names.FilesystemTag) (state.FilesystemAttachment, error)
 
 	Volume(names.VolumeTag) (state.Volume, error)
-	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	VolumeAttachment(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 
 	RemoveFilesystem(names.FilesystemTag) error
-	RemoveFilesystemAttachment(names.MachineTag, names.FilesystemTag) error
+	RemoveFilesystemAttachment(names.Tag, names.FilesystemTag) error
 	RemoveVolume(names.VolumeTag) error
 	RemoveVolumeAttachment(names.MachineTag, names.VolumeTag) error
-	DetachFilesystem(names.MachineTag, names.FilesystemTag) error
+	DetachFilesystem(names.Tag, names.FilesystemTag) error
 	DestroyFilesystem(names.FilesystemTag) error
-	DetachVolume(names.MachineTag, names.VolumeTag) error
+	DetachVolume(names.Tag, names.VolumeTag) error
 	DestroyVolume(names.VolumeTag) error
 
 	SetFilesystemInfo(names.FilesystemTag, state.FilesystemInfo) error
-	SetFilesystemAttachmentInfo(names.MachineTag, names.FilesystemTag, state.FilesystemAttachmentInfo) error
+	SetFilesystemAttachmentInfo(names.Tag, names.FilesystemTag, state.FilesystemAttachmentInfo) error
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
-	SetVolumeAttachmentInfo(names.MachineTag, names.VolumeTag, state.VolumeAttachmentInfo) error
+	SetVolumeAttachmentInfo(names.Tag, names.VolumeTag, state.VolumeAttachmentInfo) error
 }
 
 // TODO - CAAS(ericclaudejones): This should contain state alone, model will be

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -933,9 +933,7 @@ func (s *StorageProvisionerAPIv3) FilesystemAttachmentParams(
 			ok         bool
 		)
 		if machineTag, ok = filesystemAttachment.Host().(names.MachineTag); !ok {
-			if err != nil {
-				return params.FilesystemAttachmentParams{}, errors.NotValidf("machine tag %q", filesystemAttachment.Host())
-			}
+			return params.FilesystemAttachmentParams{}, errors.NotValidf("machine tag %q", filesystemAttachment.Host())
 		}
 		instanceId, err := s.st.MachineInstanceId(machineTag)
 		if errors.IsNotProvisioned(err) {

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -80,7 +80,7 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 func (s *provisionerSuite) setupVolumes(c *gc.C) {
 	s.factory.MakeMachine(c, &factory.MachineParams{
 		InstanceId: instance.Id("inst-id"),
-		Volumes: []state.MachineVolumeParams{
+		Volumes: []state.HostVolumeParams{
 			{Volume: state.VolumeParams{Pool: "machinescoped", Size: 1024}},
 			{Volume: state.VolumeParams{Pool: "modelscoped", Size: 2048}},
 			{Volume: state.VolumeParams{Pool: "modelscoped", Size: 4096}},
@@ -116,7 +116,7 @@ func (s *provisionerSuite) setupVolumes(c *gc.C) {
 	_, err = s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{
+		Volumes: []state.HostVolumeParams{
 			{Volume: state.VolumeParams{Pool: "modelscoped", Size: 2048}},
 		},
 	})
@@ -126,7 +126,7 @@ func (s *provisionerSuite) setupVolumes(c *gc.C) {
 func (s *provisionerSuite) setupFilesystems(c *gc.C) {
 	s.factory.MakeMachine(c, &factory.MachineParams{
 		InstanceId: instance.Id("inst-id"),
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{Pool: "machinescoped", Size: 1024},
 			Attachment: state.FilesystemAttachmentParams{
 				Location: "/srv",
@@ -160,7 +160,7 @@ func (s *provisionerSuite) setupFilesystems(c *gc.C) {
 	_, err = s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{Pool: "modelscoped", Size: 2048},
 		}},
 	})
@@ -341,7 +341,7 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
-				Message: `filesystem attachment "2" on "0" not provisioned`,
+				Message: `filesystem attachment "2" on "machine 0" not provisioned`,
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
@@ -1197,7 +1197,7 @@ func (s *provisionerSuite) TestAttachmentLife(c *gc.C) {
 			{Life: params.Alive},
 			{Life: params.Alive},
 			{Life: params.Alive},
-			{Error: &params.Error{Message: `volume "42" on machine "0" not found`, Code: "not found"}},
+			{Error: &params.Error{Message: `volume "42" on "machine 0" not found`, Code: "not found"}},
 		},
 	})
 }
@@ -1355,7 +1355,7 @@ func (s *provisionerSuite) TestRemoveVolumeAttachments(c *gc.C) {
 			{Error: &params.Error{Message: "removing attachment of volume 0/0 from machine 0: volume attachment is not dying"}},
 			{Error: nil},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
-			{Error: &params.Error{Message: `removing attachment of volume 42 from machine 0: volume "42" on machine "0" not found`, Code: "not found"}},
+			{Error: &params.Error{Message: `removing attachment of volume 42 from machine 0: volume "42" on "machine 0" not found`, Code: "not found"}},
 		},
 	})
 }
@@ -1388,7 +1388,7 @@ func (s *provisionerSuite) TestRemoveFilesystemAttachments(c *gc.C) {
 			{Error: &params.Error{Message: "removing attachment of filesystem 0/0 from machine 0: filesystem attachment is not dying"}},
 			{Error: nil},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
-			{Error: &params.Error{Message: `removing attachment of filesystem 42 from machine 0: filesystem "42" on machine "0" not found`, Code: "not found"}},
+			{Error: &params.Error{Message: `removing attachment of filesystem 42 from machine 0: filesystem "42" on "machine 0" not found`, Code: "not found"}},
 		},
 	})
 }

--- a/apiserver/facades/agent/uniter/mock_test.go
+++ b/apiserver/facades/agent/uniter/mock_test.go
@@ -18,7 +18,7 @@ type fakeStorage struct {
 	uniter.StorageFilesystemInterface
 	storageInstance        func(names.StorageTag) (state.StorageInstance, error)
 	storageInstanceVolume  func(names.StorageTag) (state.Volume, error)
-	volumeAttachment       func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	volumeAttachment       func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 	blockDevices           func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	watchVolumeAttachment  func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	watchBlockDevices      func(names.MachineTag) state.NotifyWatcher
@@ -35,7 +35,7 @@ func (s *fakeStorage) StorageInstanceVolume(tag names.StorageTag) (state.Volume,
 	return s.storageInstanceVolume(tag)
 }
 
-func (s *fakeStorage) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+func (s *fakeStorage) VolumeAttachment(m names.Tag, v names.VolumeTag) (state.VolumeAttachment, error) {
 	s.MethodCall(s, "VolumeAttachment", m, v)
 	return s.volumeAttachment(m, v)
 }

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -32,12 +32,12 @@ type storageVolumeInterface interface {
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
-	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	VolumeAttachment(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 }
 
 type storageFilesystemInterface interface {
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+	FilesystemAttachment(names.Tag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -187,7 +187,7 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		placementDirective = p.Placement.Directive
 	}
 
-	volumes := make([]state.MachineVolumeParams, 0, len(p.Disks))
+	volumes := make([]state.HostVolumeParams, 0, len(p.Disks))
 	for _, cons := range p.Disks {
 		if cons.Count == 0 {
 			return nil, errors.Errorf("invalid volume params: count not specified")
@@ -199,7 +199,7 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		}
 		volumeAttachmentParams := state.VolumeAttachmentParams{}
 		for i := uint64(0); i < cons.Count; i++ {
-			volumes = append(volumes, state.MachineVolumeParams{
+			volumes = append(volumes, state.HostVolumeParams{
 				volumeParams, volumeAttachmentParams,
 			})
 		}

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -70,7 +70,7 @@ func (s *MachineManagerSuite) TestAddMachines(c *gc.C) {
 		{
 			Series: "trusty",
 			Jobs:   []state.MachineJob{state.JobHostUnits},
-			Volumes: []state.MachineVolumeParams{
+			Volumes: []state.HostVolumeParams{
 				{
 					Volume:     state.VolumeParams{Pool: "", Size: 1},
 					Attachment: state.VolumeAttachmentParams{ReadOnly: false},
@@ -88,7 +88,7 @@ func (s *MachineManagerSuite) TestAddMachines(c *gc.C) {
 		{
 			Series: "trusty",
 			Jobs:   []state.MachineJob{state.JobHostUnits},
-			Volumes: []state.MachineVolumeParams{
+			Volumes: []state.HostVolumeParams{
 				{
 					Volume:     state.VolumeParams{Pool: "three", Size: 1},
 					Attachment: state.VolumeAttachmentParams{ReadOnly: false},

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -177,7 +177,7 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(sTag))
 		},
-		storageInstanceFilesystemAttachment: func(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error) {
+		storageInstanceFilesystemAttachment: func(m names.Tag, f names.FilesystemTag) (state.FilesystemAttachment, error) {
 			s.stub.AddCall(storageInstanceFilesystemAttachmentCall)
 			if m == s.machineTag && f == s.filesystemTag {
 				return s.filesystemAttachment, nil
@@ -191,7 +191,7 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(t))
 		},
-		volumeAttachment: func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error) {
+		volumeAttachment: func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error) {
 			s.stub.AddCall(volumeAttachmentCall)
 			return s.volumeAttachment, nil
 		},

--- a/apiserver/facades/client/storage/filesystemlist_test.go
+++ b/apiserver/facades/client/storage/filesystemlist_test.go
@@ -30,6 +30,7 @@ func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
 				Life: "dead",
 			},
 		},
+		UnitAttachments: map[string]params.FilesystemAttachmentDetails{},
 		Storage: &params.StorageDetails{
 			StorageTag: "storage-data-0",
 			OwnerTag:   "unit-mysql-0",

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -43,9 +43,9 @@ type mockStorageAccessor struct {
 	allStorageInstances                 func() ([]state.StorageInstance, error)
 	storageInstanceAttachments          func(names.StorageTag) ([]state.StorageAttachment, error)
 	storageInstanceVolume               func(names.StorageTag) (state.Volume, error)
-	volumeAttachment                    func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	volumeAttachment                    func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 	storageInstanceFilesystem           func(names.StorageTag) (state.Filesystem, error)
-	storageInstanceFilesystemAttachment func(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error)
+	storageInstanceFilesystemAttachment func(m names.Tag, f names.FilesystemTag) (state.FilesystemAttachment, error)
 	volume                              func(tag names.VolumeTag) (state.Volume, error)
 	machineVolumeAttachments            func(machine names.MachineTag) ([]state.VolumeAttachment, error)
 	volumeAttachments                   func(volume names.VolumeTag) ([]state.VolumeAttachment, error)
@@ -83,7 +83,7 @@ func (st *mockStorageAccessor) StorageAttachments(tag names.StorageTag) ([]state
 	return st.storageInstanceAttachments(tag)
 }
 
-func (st *mockStorageAccessor) FilesystemAttachment(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error) {
+func (st *mockStorageAccessor) FilesystemAttachment(m names.Tag, f names.FilesystemTag) (state.FilesystemAttachment, error) {
 	return st.storageInstanceFilesystemAttachment(m, f)
 }
 
@@ -95,7 +95,7 @@ func (st *mockStorageAccessor) StorageInstanceVolume(s names.StorageTag) (state.
 	return st.storageInstanceVolume(s)
 }
 
-func (st *mockStorageAccessor) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+func (st *mockStorageAccessor) VolumeAttachment(m names.Tag, v names.VolumeTag) (state.VolumeAttachment, error) {
 	return st.volumeAttachment(m, v)
 }
 
@@ -261,7 +261,7 @@ func (m *mockFilesystemAttachment) Filesystem() names.FilesystemTag {
 	return m.filesystem
 }
 
-func (m *mockFilesystemAttachment) Machine() names.MachineTag {
+func (m *mockFilesystemAttachment) Host() names.Tag {
 	return m.machine
 }
 

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -222,6 +222,7 @@ func createStorageDetails(
 	if len(storageAttachments) > 0 {
 		storageAttachmentDetails = make(map[string]params.StorageAttachmentDetails)
 		for _, a := range storageAttachments {
+			// TODO(caas) - handle attachments to units
 			machineTag, location, err := storageAttachmentInfo(backend, st, a)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -229,9 +230,11 @@ func createStorageDetails(
 			details := params.StorageAttachmentDetails{
 				StorageTag: a.StorageInstance().String(),
 				UnitTag:    a.Unit().String(),
-				MachineTag: machineTag.String(),
 				Location:   location,
 				Life:       params.Life(a.Life().String()),
+			}
+			if machineTag.Id() != "" {
+				details.MachineTag = machineTag.String()
 			}
 			storageAttachmentDetails[a.Unit().String()] = details
 		}
@@ -703,6 +706,7 @@ func createFilesystemDetails(
 
 	if len(attachments) > 0 {
 		details.MachineAttachments = make(map[string]params.FilesystemAttachmentDetails, len(attachments))
+		details.UnitAttachments = make(map[string]params.FilesystemAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
 			attDetails := params.FilesystemAttachmentDetails{
 				Life: params.Life(attachment.Life().String()),
@@ -712,7 +716,11 @@ func createFilesystemDetails(
 					stateInfo,
 				)
 			}
-			details.MachineAttachments[attachment.Machine().String()] = attDetails
+			if names.IsValidMachine(attachment.Host().Id()) {
+				details.MachineAttachments[attachment.Host().String()] = attDetails
+			} else {
+				details.UnitAttachments[attachment.Host().String()] = attDetails
+			}
 		}
 	}
 

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -716,7 +716,7 @@ func createFilesystemDetails(
 					stateInfo,
 				)
 			}
-			if names.IsValidMachine(attachment.Host().Id()) {
+			if attachment.Host().Kind() == names.MachineTagKind {
 				details.MachineAttachments[attachment.Host().String()] = attDetails
 			} else {
 				details.UnitAttachments[attachment.Host().String()] = attDetails

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -706,8 +706,12 @@ type FilesystemDetails struct {
 	Status EntityStatus `json:"status"`
 
 	// MachineAttachments contains a mapping from
-	// machine tag to filesystem attachment information.
+	// machine tag to filesystem attachment information (IAAS models).
 	MachineAttachments map[string]FilesystemAttachmentDetails `json:"machine-attachments,omitempty"`
+
+	// UnitAttachments contains a mapping from
+	// unit tag to filesystem attachment information (CAAS models).
+	UnitAttachments map[string]FilesystemAttachmentDetails `json:"unit-attachments,omitempty"`
 
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -22,8 +22,8 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
 	print("[Filesystems]")
-	print("Machine", "Unit", "Storage", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
 
+	haveMachines := false
 	filesystemAttachmentInfos := make(filesystemAttachmentInfos, 0, len(infos))
 	for filesystemId, info := range infos {
 		filesystemAttachmentInfo := filesystemAttachmentInfo{
@@ -42,7 +42,7 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 		for machineId, machineInfo := range info.Attachments.Machines {
 			filesystemAttachmentInfo := filesystemAttachmentInfo
 			filesystemAttachmentInfo.MachineId = machineId
-			filesystemAttachmentInfo.MachineFilesystemAttachment = machineInfo
+			filesystemAttachmentInfo.FilesystemAttachment = machineInfo
 			for unitId, unitInfo := range info.Attachments.Units {
 				if unitInfo.MachineId == machineId {
 					filesystemAttachmentInfo.UnitId = unitId
@@ -50,22 +50,45 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 					break
 				}
 			}
+			haveMachines = true
+			filesystemAttachmentInfos = append(filesystemAttachmentInfos, filesystemAttachmentInfo)
+		}
+
+		for _, machineInfo := range info.Attachments.Containers {
+			filesystemAttachmentInfo := filesystemAttachmentInfo
+			filesystemAttachmentInfo.FilesystemAttachment = machineInfo
+			// TODO(caas) - fill out details
 			filesystemAttachmentInfos = append(filesystemAttachmentInfos, filesystemAttachmentInfo)
 		}
 	}
 	sort.Sort(filesystemAttachmentInfos)
+
+	if haveMachines {
+		print("Machine", "Unit", "Storage", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
+	} else {
+		print("Unit", "Storage", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
+	}
 
 	for _, info := range filesystemAttachmentInfos {
 		var size string
 		if info.Size > 0 {
 			size = humanize.IBytes(info.Size * humanize.MiByte)
 		}
-		print(
-			info.MachineId, info.UnitId, info.Storage,
-			info.FilesystemId, info.Volume, info.ProviderFilesystemId,
-			info.MountPoint, size,
-			string(info.Status.Current), info.Status.Message,
-		)
+		if haveMachines {
+			print(
+				info.MachineId, info.UnitId, info.Storage,
+				info.FilesystemId, info.Volume, info.ProviderFilesystemId,
+				info.MountPoint, size,
+				string(info.Status.Current), info.Status.Message,
+			)
+		} else {
+			print(
+				info.UnitId, info.Storage,
+				info.FilesystemId, info.Volume, info.ProviderFilesystemId,
+				info.MountPoint, size,
+				string(info.Status.Current), info.Status.Message,
+			)
+		}
 	}
 
 	return tw.Flush()
@@ -76,7 +99,7 @@ type filesystemAttachmentInfo struct {
 	FilesystemInfo
 
 	MachineId string
-	MachineFilesystemAttachment
+	FilesystemAttachment
 
 	UnitId string
 	UnitStorageAttachment

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -117,7 +117,7 @@ gopkg.in/juju/charmrepo.v3	git	7f799297ba8d526feb52630477bd44e71037f92e	2018-04-
 gopkg.in/juju/charmstore.v5	git	0d59319d1dba8418eaa72667f3ef447561aaefee	2018-02-26T10:50:37Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v3	git	6f7342099e20c84f560bd9fc8afe96ff7486613e	2017-11-14T17:07:01Z
-gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
+gopkg.in/juju/names.v2	git	fd59336b4621bc2a70bf96d9e2f49954115ad19b	2018-06-21T09:39:30Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon-bakery.v2	git	ec9d2ad6796100720c154f614b6dea8798ec1181	2017-11-03T09:26:24Z

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -753,7 +753,7 @@ func (s *CleanupSuite) TestCleanupVolumeAttachments(c *gc.C) {
 	_, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: "loop", Size: 1024},
 		}},
 	})
@@ -773,7 +773,7 @@ func (s *CleanupSuite) TestCleanupFilesystemAttachments(c *gc.C) {
 	_, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{Pool: "rootfs", Size: 1024},
 		}},
 	})

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -472,7 +472,7 @@ func (sb *storageBackend) FilesystemAttachments(filesystem names.FilesystemTag) 
 func (sb *storageBackend) MachineFilesystemAttachments(machine names.MachineTag) ([]FilesystemAttachment, error) {
 	attachments, err := sb.filesystemAttachments(bson.D{{"machineid", machine.Id()}})
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting filesystem attachments for machine %q", machine.Id())
+		return nil, errors.Annotatef(err, "getting filesystem attachments for %q", names.ReadableString(machine))
 	}
 	return attachments, nil
 }
@@ -482,7 +482,7 @@ func (sb *storageBackend) MachineFilesystemAttachments(machine names.MachineTag)
 func (sb *storageBackend) UnitFilesystemAttachments(unit names.UnitTag) ([]FilesystemAttachment, error) {
 	attachments, err := sb.filesystemAttachments(bson.D{{"hostid", unit.Id()}})
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting filesystem attachments for unit %q", unit.Id())
+		return nil, errors.Annotatef(err, "getting filesystem attachments for %q", names.ReadableString(unit))
 	}
 	return attachments, nil
 }

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -76,8 +76,8 @@ type FilesystemAttachment interface {
 	// Filesystem returns the tag of the related Filesystem.
 	Filesystem() names.FilesystemTag
 
-	// Machine returns the tag of the related Machine.
-	Machine() names.MachineTag
+	// Host returns the tag of the entity to which this attachment belongs.
+	Host() names.Tag
 
 	// Info returns the filesystem attachment's FilesystemAttachmentInfo, or a
 	// NotProvisioned error if the attachment has not yet been made.
@@ -126,13 +126,17 @@ type filesystemDoc struct {
 // filesystemAttachmentDoc records information about a filesystem attachment.
 type filesystemAttachmentDoc struct {
 	// DocID is the machine global key followed by the filesystem name.
-	DocID      string                      `bson:"_id"`
-	ModelUUID  string                      `bson:"model-uuid"`
-	Filesystem string                      `bson:"filesystemid"`
-	Machine    string                      `bson:"machineid"`
-	Life       Life                        `bson:"life"`
-	Info       *FilesystemAttachmentInfo   `bson:"info,omitempty"`
-	Params     *FilesystemAttachmentParams `bson:"params,omitempty"`
+	DocID      string `bson:"_id"`
+	ModelUUID  string `bson:"model-uuid"`
+	Filesystem string `bson:"filesystemid"`
+
+	// TODO(caas) - consolidate Machine and Host using upgrade step
+	Machine string `bson:"machineid"`
+	Host    string `bson:"hostid"`
+
+	Life   Life                        `bson:"life"`
+	Info   *FilesystemAttachmentInfo   `bson:"info,omitempty"`
+	Params *FilesystemAttachmentParams `bson:"params,omitempty"`
 }
 
 // FilesystemParams records parameters for provisioning a new filesystem.
@@ -295,9 +299,20 @@ func (f *filesystemAttachment) Filesystem() names.FilesystemTag {
 	return names.NewFilesystemTag(f.doc.Filesystem)
 }
 
-// Machine is required to implement FilesystemAttachment.
-func (f *filesystemAttachment) Machine() names.MachineTag {
-	return names.NewMachineTag(f.doc.Machine)
+func filesystemAttachmentHost(id string) names.Tag {
+	if names.IsValidUnit(id) {
+		return names.NewUnitTag(id)
+	}
+	return names.NewMachineTag(id)
+}
+
+// Host is required to implement FilesystemAttachment.
+func (f *filesystemAttachment) Host() names.Tag {
+	// TODO(caas) - consolidate host and machine
+	if f.doc.Host != "" {
+		return filesystemAttachmentHost(f.doc.Host)
+	}
+	return filesystemAttachmentHost(f.doc.Machine)
 }
 
 // Life is required to implement FilesystemAttachment.
@@ -308,7 +323,13 @@ func (f *filesystemAttachment) Life() Life {
 // Info is required to implement FilesystemAttachment.
 func (f *filesystemAttachment) Info() (FilesystemAttachmentInfo, error) {
 	if f.doc.Info == nil {
-		return FilesystemAttachmentInfo{}, errors.NotProvisionedf("filesystem attachment %q on %q", f.doc.Filesystem, f.doc.Machine)
+		host := f.doc.Host
+		if host == "" {
+			host = f.doc.Machine
+		}
+		hostTag := filesystemAttachmentHost(host)
+		return FilesystemAttachmentInfo{}, errors.NotProvisionedf(
+			"filesystem attachment %q on %q", f.doc.Filesystem, names.ReadableString(hostTag))
 	}
 	return *f.doc.Info, nil
 }
@@ -422,16 +443,16 @@ func getFilesystemDocs(db Database, query interface{}) ([]filesystemDoc, error) 
 
 // FilesystemAttachment returns the FilesystemAttachment corresponding to
 // the specified filesystem and machine.
-func (sb *storageBackend) FilesystemAttachment(machine names.MachineTag, filesystem names.FilesystemTag) (FilesystemAttachment, error) {
+func (sb *storageBackend) FilesystemAttachment(host names.Tag, filesystem names.FilesystemTag) (FilesystemAttachment, error) {
 	coll, cleanup := sb.mb.db().GetCollection(filesystemAttachmentsC)
 	defer cleanup()
 
 	var att filesystemAttachment
-	err := coll.FindId(filesystemAttachmentId(machine.Id(), filesystem.Id())).One(&att.doc)
+	err := coll.FindId(filesystemAttachmentId(host.Id(), filesystem.Id())).One(&att.doc)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("filesystem %q on machine %q", filesystem.Id(), machine.Id())
+		return nil, errors.NotFoundf("filesystem %q on %q", filesystem.Id(), names.ReadableString(host))
 	} else if err != nil {
-		return nil, errors.Annotatef(err, "getting filesystem %q on machine %q", filesystem.Id(), machine.Id())
+		return nil, errors.Annotatef(err, "getting filesystem %q on %q", filesystem.Id(), names.ReadableString(host))
 	}
 	return &att, nil
 }
@@ -452,6 +473,16 @@ func (sb *storageBackend) MachineFilesystemAttachments(machine names.MachineTag)
 	attachments, err := sb.filesystemAttachments(bson.D{{"machineid", machine.Id()}})
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting filesystem attachments for machine %q", machine.Id())
+	}
+	return attachments, nil
+}
+
+// UnitFilesystemAttachments returns all of the FilesystemAttachments for the
+// specified unit.
+func (sb *storageBackend) UnitFilesystemAttachments(unit names.UnitTag) ([]FilesystemAttachment, error) {
+	attachments, err := sb.filesystemAttachments(bson.D{{"hostid", unit.Id()}})
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting filesystem attachments for unit %q", unit.Id())
 	}
 	return attachments, nil
 }
@@ -575,10 +606,10 @@ func isDetachableFilesystemPool(sb *storageBackend, pool string) (bool, error) {
 // DetachFilesystem marks the filesystem attachment identified by the specified machine
 // and filesystem tags as Dying, if it is Alive. DetachFilesystem will fail for
 // inherently machine-bound filesystems.
-func (sb *storageBackend) DetachFilesystem(machine names.MachineTag, filesystem names.FilesystemTag) (err error) {
-	defer errors.DeferredAnnotatef(&err, "detaching filesystem %s from machine %s", filesystem.Id(), machine.Id())
+func (sb *storageBackend) DetachFilesystem(host names.Tag, filesystem names.FilesystemTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "detaching filesystem %s from %s", filesystem.Id(), names.ReadableString(host))
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		fsa, err := sb.FilesystemAttachment(machine, filesystem)
+		fsa, err := sb.FilesystemAttachment(host, filesystem)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -592,13 +623,13 @@ func (sb *storageBackend) DetachFilesystem(machine names.MachineTag, filesystem 
 		if !detachable {
 			return nil, errors.New("filesystem is not detachable")
 		}
-		ops := detachFilesystemOps(machine, filesystem)
+		ops := detachFilesystemOps(host, filesystem)
 		return ops, nil
 	}
 	return sb.mb.db().Run(buildTxn)
 }
 
-func (sb *storageBackend) filesystemVolumeAttachment(m names.MachineTag, f names.FilesystemTag) (VolumeAttachment, error) {
+func (sb *storageBackend) filesystemVolumeAttachment(host names.Tag, f names.FilesystemTag) (VolumeAttachment, error) {
 	filesystem, err := getFilesystemByTag(sb.mb, f)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -607,13 +638,13 @@ func (sb *storageBackend) filesystemVolumeAttachment(m names.MachineTag, f names
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return sb.VolumeAttachment(m, v)
+	return sb.VolumeAttachment(host, v)
 }
 
-func detachFilesystemOps(m names.MachineTag, f names.FilesystemTag) []txn.Op {
+func detachFilesystemOps(host names.Tag, f names.FilesystemTag) []txn.Op {
 	return []txn.Op{{
 		C:      filesystemAttachmentsC,
-		Id:     filesystemAttachmentId(m.Id(), f.Id()),
+		Id:     filesystemAttachmentId(host.Id(), f.Id()),
 		Assert: isAliveDoc,
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
 	}}
@@ -622,10 +653,10 @@ func detachFilesystemOps(m names.MachineTag, f names.FilesystemTag) []txn.Op {
 // RemoveFilesystemAttachment removes the filesystem attachment from state.
 // Removing a volume-backed filesystem attachment will cause the volume to
 // be detached.
-func (sb *storageBackend) RemoveFilesystemAttachment(machine names.MachineTag, filesystem names.FilesystemTag) (err error) {
-	defer errors.DeferredAnnotatef(&err, "removing attachment of filesystem %s from machine %s", filesystem.Id(), machine.Id())
+func (sb *storageBackend) RemoveFilesystemAttachment(host names.Tag, filesystem names.FilesystemTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "removing attachment of filesystem %s from %s", filesystem.Id(), names.ReadableString(host))
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		attachment, err := sb.FilesystemAttachment(machine, filesystem)
+		attachment, err := sb.FilesystemAttachment(host, filesystem)
 		if errors.IsNotFound(err) && attempt > 0 {
 			// We only ignore IsNotFound on attempts after the
 			// first, since we expect the filesystem attachment to
@@ -642,11 +673,11 @@ func (sb *storageBackend) RemoveFilesystemAttachment(machine names.MachineTag, f
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ops, err := removeFilesystemAttachmentOps(sb, machine, f)
+		ops, err := removeFilesystemAttachmentOps(sb, host, f)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		volumeAttachment, err := sb.filesystemVolumeAttachment(machine, filesystem)
+		volumeAttachment, err := sb.filesystemVolumeAttachment(host, filesystem)
 		if err != nil {
 			if errors.Cause(err) != ErrNoBackingVolume && !errors.IsNotFound(err) {
 				return nil, errors.Trace(err)
@@ -663,7 +694,7 @@ func (sb *storageBackend) RemoveFilesystemAttachment(machine names.MachineTag, f
 				return nil, errors.Trace(err)
 			}
 			if detachableVolume {
-				volOps := detachVolumeOps(machine, volume)
+				volOps := detachVolumeOps(host, volume)
 				ops = append(ops, volOps...)
 			}
 		}
@@ -672,7 +703,7 @@ func (sb *storageBackend) RemoveFilesystemAttachment(machine names.MachineTag, f
 	return sb.mb.db().Run(buildTxn)
 }
 
-func removeFilesystemAttachmentOps(sb *storageBackend, m names.MachineTag, f *filesystem) ([]txn.Op, error) {
+func removeFilesystemAttachmentOps(sb *storageBackend, host names.Tag, f *filesystem) ([]txn.Op, error) {
 	var ops []txn.Op
 	if f.doc.VolumeId != "" && f.doc.Life == Dying && f.doc.AttachmentCount == 1 {
 		// Volume-backed filesystems are removed immediately, instead
@@ -689,18 +720,18 @@ func removeFilesystemAttachmentOps(sb *storageBackend, m names.MachineTag, f *fi
 	} else {
 		decrefFilesystemOp := machineStorageDecrefOp(
 			filesystemsC, f.doc.FilesystemId,
-			f.doc.AttachmentCount, f.doc.Life, m,
+			f.doc.AttachmentCount, f.doc.Life,
 		)
 		ops = []txn.Op{decrefFilesystemOp}
 	}
 	return append(ops, txn.Op{
 		C:      filesystemAttachmentsC,
-		Id:     filesystemAttachmentId(m.Id(), f.doc.FilesystemId),
+		Id:     filesystemAttachmentId(host.Id(), f.doc.FilesystemId),
 		Assert: bson.D{{"life", Dying}},
 		Remove: true,
 	}, txn.Op{
 		C:      machinesC,
-		Id:     m.Id(),
+		Id:     host.Id(),
 		Assert: txn.DocExists,
 		Update: bson.D{{"$pull", bson.D{{"filesystems", f.doc.FilesystemId}}}},
 	}), nil
@@ -787,7 +818,7 @@ func destroyFilesystemOps(sb *storageBackend, f *filesystem, release bool, extra
 			)
 		}
 		detachOps := detachFilesystemOps(
-			attachments[0].Machine(),
+			attachments[0].Host(),
 			f.FilesystemTag(),
 		)
 		ops = append(ops, detachOps...)
@@ -964,20 +995,26 @@ func validateAddExistingFilesystem(
 
 // filesystemAttachmentId returns a filesystem attachment document ID,
 // given the corresponding filesystem name and machine ID.
-func filesystemAttachmentId(machineId, filesystemId string) string {
-	return fmt.Sprintf("%s:%s", machineId, filesystemId)
+func filesystemAttachmentId(hostId, filesystemId string) string {
+	return fmt.Sprintf("%s:%s", hostId, filesystemId)
 }
 
 // ParseFilesystemAttachmentId parses a string as a filesystem attachment ID,
-// returning the machine and filesystem components.
-func ParseFilesystemAttachmentId(id string) (names.MachineTag, names.FilesystemTag, error) {
+// returning the host and filesystem components.
+func ParseFilesystemAttachmentId(id string) (names.Tag, names.FilesystemTag, error) {
 	fields := strings.SplitN(id, ":", 2)
-	if len(fields) != 2 || !names.IsValidMachine(fields[0]) || !names.IsValidFilesystem(fields[1]) {
+	isValidHost := names.IsValidMachine(fields[0]) || names.IsValidUnit(fields[0])
+	if len(fields) != 2 || !isValidHost || !names.IsValidFilesystem(fields[1]) {
 		return names.MachineTag{}, names.FilesystemTag{}, errors.Errorf("invalid filesystem attachment ID %q", id)
 	}
-	machineTag := names.NewMachineTag(fields[0])
+	var hostTag names.Tag
+	if names.IsValidMachine(fields[0]) {
+		hostTag = names.NewMachineTag(fields[0])
+	} else {
+		hostTag = names.NewUnitTag(fields[0])
+	}
 	filesystemTag := names.NewFilesystemTag(fields[1])
-	return machineTag, filesystemTag, nil
+	return hostTag, filesystemTag, nil
 }
 
 // newFilesystemId returns a unique filesystem ID.
@@ -1000,7 +1037,7 @@ func newFilesystemId(mb modelBackend, machineId string) (string, error) {
 // specified parameters. If the storage source cannot create filesystems
 // directly, a volume will be created and Juju will manage a filesystem
 // on it.
-func (sb *storageBackend) addFilesystemOps(params FilesystemParams, machineId string) ([]txn.Op, names.FilesystemTag, names.VolumeTag, error) {
+func (sb *storageBackend) addFilesystemOps(params FilesystemParams, hostId string) ([]txn.Op, names.FilesystemTag, names.VolumeTag, error) {
 	var err error
 	params, err = sb.filesystemParamsWithDefaults(params)
 	if err != nil {
@@ -1010,13 +1047,13 @@ func (sb *storageBackend) addFilesystemOps(params FilesystemParams, machineId st
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
 	}
-	origMachineId := machineId
-	machineId, err = sb.validateFilesystemParams(params, machineId)
+	origMachineId := hostId
+	hostId, err = sb.validateFilesystemParams(params, hostId)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "validating filesystem params")
 	}
 
-	filesystemId, err := newFilesystemId(sb.mb, machineId)
+	filesystemId, err := newFilesystemId(sb.mb, hostId)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "cannot generate filesystem name")
 	}
@@ -1043,7 +1080,7 @@ func (sb *storageBackend) addFilesystemOps(params FilesystemParams, machineId st
 			params.Pool,
 			params.Size,
 		}
-		volumeOps, volumeTag, err = sb.addVolumeOps(volumeParams, machineId)
+		volumeOps, volumeTag, err = sb.addVolumeOps(volumeParams, hostId)
 		if err != nil {
 			return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "creating backing volume")
 		}
@@ -1136,19 +1173,20 @@ type filesystemAttachmentTemplate struct {
 }
 
 // createMachineFilesystemAttachmentInfo creates filesystem
-// attachments for the specified machine, and attachment
+// attachments for the specified host, and attachment
 // parameters keyed by filesystem tags.
-func createMachineFilesystemAttachmentsOps(machineId string, attachments []filesystemAttachmentTemplate) []txn.Op {
+func createMachineFilesystemAttachmentsOps(hostId string, attachments []filesystemAttachmentTemplate) []txn.Op {
 	ops := make([]txn.Op, len(attachments))
 	for i, attachment := range attachments {
 		paramsCopy := attachment.params
 		ops[i] = txn.Op{
 			C:      filesystemAttachmentsC,
-			Id:     filesystemAttachmentId(machineId, attachment.tag.Id()),
+			Id:     filesystemAttachmentId(hostId, attachment.tag.Id()),
 			Assert: txn.DocMissing,
 			Insert: &filesystemAttachmentDoc{
 				Filesystem: attachment.tag.Id(),
-				Machine:    machineId,
+				Machine:    hostId,
+				Host:       hostId,
 				Params:     &paramsCopy,
 			},
 		}
@@ -1266,11 +1304,11 @@ func setFilesystemInfoOps(tag names.FilesystemTag, info FilesystemInfo, unsetPar
 // SetFilesystemAttachmentInfo sets the FilesystemAttachmentInfo for the
 // specified filesystem attachment.
 func (sb *storageBackend) SetFilesystemAttachmentInfo(
-	machineTag names.MachineTag,
+	hostTag names.Tag,
 	filesystemTag names.FilesystemTag,
 	info FilesystemAttachmentInfo,
 ) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot set info for filesystem attachment %s:%s", filesystemTag.Id(), machineTag.Id())
+	defer errors.DeferredAnnotatef(&err, "cannot set info for filesystem attachment %s:%s", filesystemTag.Id(), hostTag.Id())
 	f, err := sb.Filesystem(filesystemTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1282,15 +1320,17 @@ func (sb *storageBackend) SetFilesystemAttachmentInfo(
 		return errors.Trace(err)
 	}
 	// Also ensure the machine is provisioned.
-	m, err := sb.machine(machineTag.Id())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if _, err := m.InstanceId(); err != nil {
-		return errors.Trace(err)
+	if _, ok := hostTag.(names.MachineTag); ok {
+		m, err := sb.machine(hostTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := m.InstanceId(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		fsa, err := sb.FilesystemAttachment(machineTag, filesystemTag)
+		fsa, err := sb.FilesystemAttachment(hostTag, filesystemTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1298,14 +1338,14 @@ func (sb *storageBackend) SetFilesystemAttachmentInfo(
 		// when we set info for the first time, ensuring that params
 		// and info are mutually exclusive.
 		_, unsetParams := fsa.Params()
-		ops := setFilesystemAttachmentInfoOps(machineTag, filesystemTag, info, unsetParams)
+		ops := setFilesystemAttachmentInfoOps(hostTag, filesystemTag, info, unsetParams)
 		return ops, nil
 	}
 	return sb.mb.db().Run(buildTxn)
 }
 
 func setFilesystemAttachmentInfoOps(
-	machine names.MachineTag,
+	host names.Tag,
 	filesystem names.FilesystemTag,
 	info FilesystemAttachmentInfo,
 	unsetParams bool,
@@ -1321,7 +1361,7 @@ func setFilesystemAttachmentInfoOps(
 	}
 	return []txn.Op{{
 		C:      filesystemAttachmentsC,
-		Id:     filesystemAttachmentId(machine.Id(), filesystem.Id()),
+		Id:     filesystemAttachmentId(host.Id(), filesystem.Id()),
 		Assert: asserts,
 		Update: update,
 	}}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1909,9 +1909,7 @@ func (e *exporter) addFilesystem(fs *filesystem, fsAttachments []filesystemAttac
 	for _, doc := range fsAttachments {
 		va := filesystemAttachment{doc}
 		logger.Debugf("  attachment %#v", doc)
-		args := description.FilesystemAttachmentArgs{
-			Machine: va.Machine(),
-		}
+		var args description.FilesystemAttachmentArgs
 		if info, err := va.Info(); err == nil {
 			logger.Debugf("    info %#v", info)
 			args.Provisioned = true
@@ -1922,6 +1920,10 @@ func (e *exporter) addFilesystem(fs *filesystem, fsAttachments []filesystemAttac
 			logger.Debugf("    params %#v", params)
 			args.ReadOnly = params.ReadOnly
 			args.MountPoint = params.Location
+		}
+		// TODO(caas) - handle non-machine hosts
+		if m, ok := va.Host().(names.MachineTag); ok {
+			args.Machine = m
 		}
 		exFilesystem.AddAttachment(args)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1106,7 +1106,7 @@ func (*goodToken) Check(interface{}) error {
 
 func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume:     state.VolumeParams{Size: 1234},
 			Attachment: state.VolumeAttachmentParams{ReadOnly: true},
 		}, {
@@ -1185,7 +1185,7 @@ func (s *MigrationExportSuite) TestVolumes(c *gc.C) {
 
 func (s *MigrationExportSuite) TestFilesystems(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{Size: 1234},
 			Attachment: state.FilesystemAttachmentParams{
 				Location: "location",

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1255,7 +1255,7 @@ func (s *MigrationImportSuite) TestAction(c *gc.C) {
 
 func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume:     state.VolumeParams{Size: 1234},
 			Attachment: state.VolumeAttachmentParams{ReadOnly: true},
 		}, {
@@ -1325,7 +1325,7 @@ func (s *MigrationImportSuite) TestVolumes(c *gc.C) {
 
 func (s *MigrationImportSuite) TestFilesystems(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{Size: 1234},
 			Attachment: state.FilesystemAttachmentParams{
 				Location: "location",

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -773,6 +773,9 @@ func (s *MigrationSuite) TestFilesystemAttachmentDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
+
+		// TODO(caas)
+		"Host",
 	)
 	migrated := set.NewStrings(
 		"Filesystem",

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1023,7 +1023,7 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumeBackedFilesystems(c *gc.C) {
 	machine, err := st.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{
 				Pool: "modelscoped-block",
 				Size: 123,
@@ -1074,7 +1074,7 @@ func (s *ModelSuite) TestProcessDyingModelWithVolumes(c *gc.C) {
 	machine, err := st.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{
 				Pool: "modelscoped",
 				Size: 123,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1057,7 +1057,7 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 		InstanceId:              "inst-id",
 		Nonce:                   "nonce",
 		Jobs:                    oneJob,
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			volume0, volumeAttachment0,
 		}, {
 			volume1, volumeAttachment1,

--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -26,7 +26,7 @@ func (s *FilesystemStatusSuite) SetUpTest(c *gc.C) {
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Filesystems: []state.MachineFilesystemParams{{
+		Filesystems: []state.HostFilesystemParams{{
 			Filesystem: state.FilesystemParams{
 				Pool: "modelscoped", Size: 1024,
 			},

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -26,7 +26,7 @@ func (s *VolumeStatusSuite) SetUpTest(c *gc.C) {
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{
 				Pool: "modelscoped", Size: 1024,
 			},

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -589,7 +589,10 @@ func addNonDetachableStorageMachineId(st *State) error {
 			// are not met.
 			continue
 		}
-		machineId := attachments[0].Machine().Id()
+		machineId := attachments[0].Host().Id()
+		if !names.IsValidMachine(machineId) {
+			continue
+		}
 		ops = append(ops, txn.Op{
 			C:      filesystemsC,
 			Id:     f.doc.DocID,

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -192,7 +192,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 		InstanceId:              "inst-id",
 		Nonce:                   "nonce",
 		Jobs:                    oneJob,
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: volumeParams,
 		}},
 	}
@@ -476,7 +476,7 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: "persistent-block", Size: 1024},
 		}, {
 			Volume: state.VolumeParams{Pool: "loop-pool", Size: 2048},
@@ -765,7 +765,7 @@ func (s *VolumeStateSuite) TestRemoveLastVolumeAttachmentConcurrently(c *gc.C) {
 func (s *VolumeStateSuite) TestRemoveVolumeAttachmentNotFound(c *gc.C) {
 	err := s.storageBackend.RemoveVolumeAttachment(names.NewMachineTag("42"), names.NewVolumeTag("42"))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, `removing attachment of volume 42 from machine 42: volume "42" on machine "42" not found`)
+	c.Assert(err, gc.ErrorMatches, `removing attachment of volume 42 from machine 42: volume "42" on "machine 42" not found`)
 }
 
 func (s *VolumeStateSuite) TestRemoveVolumeAttachmentConcurrently(c *gc.C) {
@@ -793,7 +793,7 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: "persistent-block", Size: 1024}, // unprovisioned
 		}, {
 			Volume: state.VolumeParams{Pool: "loop-pool", Size: 2048}, // provisioned
@@ -857,7 +857,7 @@ func (s *VolumeStateSuite) TestEnsureMachineDeadAddVolumeConcurrently(c *gc.C) {
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: "static", Size: 1024},
 		}},
 	})
@@ -881,7 +881,7 @@ func (s *VolumeStateSuite) TestEnsureMachineDeadRemoveVolumeConcurrently(c *gc.C
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: "static", Size: 1024},
 		}},
 	})
@@ -901,7 +901,7 @@ func (s *VolumeStateSuite) TestVolumeMachineScoped(c *gc.C) {
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: "loop", Size: 1024},
 		}},
 	})
@@ -965,7 +965,7 @@ func (s *VolumeStateSuite) setupVolumeAttachment(c *gc.C, pool string) (state.Vo
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.MachineVolumeParams{{
+		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{Pool: pool, Size: 1024},
 		}},
 	})

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -88,8 +88,8 @@ type MachineParams struct {
 	InstanceId      instance.Id
 	Characteristics *instance.HardwareCharacteristics
 	Addresses       []network.Address
-	Volumes         []state.MachineVolumeParams
-	Filesystems     []state.MachineFilesystemParams
+	Volumes         []state.HostVolumeParams
+	Filesystems     []state.HostFilesystemParams
 }
 
 // ApplicationParams is used when specifying parameters for a new application.

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -239,8 +239,8 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	nonce := "some-nonce"
 	id := instance.Id("some-id")
-	volumes := []state.MachineVolumeParams{{Volume: state.VolumeParams{Size: 1024}}}
-	filesystems := []state.MachineFilesystemParams{{
+	volumes := []state.HostVolumeParams{{Volume: state.VolumeParams{Size: 1024}}}
+	filesystems := []state.HostFilesystemParams{{
 		Filesystem: state.FilesystemParams{Pool: "loop", Size: 2048},
 	}}
 
@@ -288,7 +288,7 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 	fsAttachments, err := sb.MachineFilesystemAttachments(machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fsAttachments, gc.HasLen, 1)
-	c.Assert(fsAttachments[0].Machine(), gc.Equals, machine.Tag())
+	c.Assert(fsAttachments[0].Host(), gc.Equals, machine.Tag())
 
 	saved, err := s.State.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1110,7 +1110,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 	s.testProvisioningFailsAndSetsErrorStatusForConstraints(c, cons, expectedErrorStatus)
 }
 
-func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.MachineVolumeParams, cons constraints.Value) (*state.Machine, error) {
+func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.HostVolumeParams, cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
 		Series:      supportedversion.SupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
@@ -1129,7 +1129,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedVolumes(c *gc.C)
 	defer workertest.CleanKill(c, p)
 
 	// Add a machine with volumes to state.
-	requestedVolumes := []state.MachineVolumeParams{{
+	requestedVolumes := []state.HostVolumeParams{{
 		Volume:     state.VolumeParams{Pool: "static", Size: 1024},
 		Attachment: state.VolumeAttachmentParams{},
 	}, {


### PR DESCRIPTION
## Description of change

First PR of many to add support for deploying CAAS units with storage. This one allows filesystem storage to be requested when deploying a charm. Storage attachments are tied to their unit and mot the machine. To reuse the IAAS storage infrastructure, unnecessary machine specific aspects were made generic. This require renaming structs and using name.Tag instead of MachineTag.

There's limitations, eg unit storage attachments not removed with unit etc. Needs many PRs to do the work.

We initially just store the intent to have storage. Provisioner worker etc all needs to be done.

Commit 1
Main changes - storage artefacts in state support attaching storage to (caas) units. CAAS storage created with the unit rather than when assigned to machine.

Commit 2
Testing changes. The filesystem storage test suite is used as a base suite for IAAS and CAAS models. Because volume storage not yet support for CAAS, some tests skipped or only on CAAS suite.

Commit 3
Fallout from struct renames and tag changes.

Commit 4
Initial support for showing CAAS storage info in the storage CLI.

## QA steps

Regression test IAAS storage
Deploy a caas charm with filesystem storage
juju list-storage (--filesystem) and check output

