### PR TITLE
Unskip windows tests

### DIFF
--- a/api/backups/package_test.go
+++ b/api/backups/package_test.go
@@ -4,16 +4,11 @@
 package backups_test
 
 import (
-	"runtime"
 	"testing"
 
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestAll(t *testing.T) {
-	// TODO(bogdanteleaga): Fix these tests on windows
-	if runtime.GOOS == "windows" {
-		t.Skip("bug 1403084: Skipping this on windows for now")
-	}
 	coretesting.MgoTestPackage(t)
 }

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -99,10 +98,6 @@ func (s *charmsSuite) setModelImporting(c *gc.C) {
 }
 
 func (s *charmsSuite) SetUpSuite(c *gc.C) {
-	// TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Skipping this on windows for now")
-	}
 	s.apiserverBaseSuite.SetUpSuite(c)
 }
 

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"regexp"
-	"runtime"
 
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
@@ -129,11 +128,6 @@ var debugHooksTests = []struct {
 }}
 
 func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
-	//TODO(bogdanteleaga): Fix once debughooks are supported on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Skipping on windows for now")
-	}
-
 	s.setupModel(c)
 
 	for i, t := range debugHooksTests {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -137,12 +137,6 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 }
 
 func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
-	//TODO(bogdanteleaga): cannot read the env file because of some suite
-	//problems. The juju home, when calling something from the command line is
-	//not the same as in the test suite.
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: cannot read env file on windows because of suite problems")
-	}
 	s.PatchEnvironment(osenv.JujuModelEnvKey, "current")
 	logpath := filepath.Join(c.MkDir(), "log")
 	tests := [][]string{

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"text/template"
 	"time"
 
@@ -31,10 +30,6 @@ type PluginSuite struct {
 var _ = gc.Suite(&PluginSuite{})
 
 func (suite *PluginSuite) SetUpTest(c *gc.C) {
-	//TODO(bogdanteleaga): Fix bash tests
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: tests use bash scrips, will be rewritten for windows")
-	}
 	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	suite.oldPath = os.Getenv("PATH")
 	os.Setenv("PATH", "/bin:"+gitjujutesting.HomePath())

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -672,10 +672,6 @@ func (s *MachineSuite) TestJobManageModelRunsMinUnitsWorker(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineAgentRunsAuthorisedKeysWorker(c *gc.C) {
-	//TODO(bogdanteleaga): Fix once we get authentication worker up on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: authentication worker not yet implemented on windows")
-	}
 	// Start the machine agent.
 	m, _, _ := s.primeAgent(c, state.JobHostUnits)
 	a := s.newAgent(c, m)

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -228,9 +228,6 @@ var argsTests = []struct {
 }
 
 func (s *HookToolMainSuite) TestArgs(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
-	}
 	for _, t := range argsTests {
 		c.Log(t.args)
 		output := run(c, s.sockPath, "bill", t.code, nil, t.args...)
@@ -248,25 +245,16 @@ func (s *HookToolMainSuite) TestNoClientId(c *gc.C) {
 }
 
 func (s *HookToolMainSuite) TestBadClientId(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
-	}
 	output := run(c, s.sockPath, "ben", 1, nil, "remote")
 	c.Assert(output, jc.Contains, "bad request: bad context: ben\n")
 }
 
 func (s *HookToolMainSuite) TestNoSockPath(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
-	}
 	output := run(c, "", "bill", 1, nil, "remote")
 	c.Assert(output, jc.Contains, "JUJU_AGENT_SOCKET not set\n")
 }
 
 func (s *HookToolMainSuite) TestBadSockPath(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
-	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
 	output := run(c, badSock, "bill", 1, nil, "remote")
 	err := fmt.Sprintf("^.* dial unix %s: .*\n", badSock)
@@ -274,9 +262,6 @@ func (s *HookToolMainSuite) TestBadSockPath(c *gc.C) {
 }
 
 func (s *HookToolMainSuite) TestStdin(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
-	}
 	output := run(c, s.sockPath, "bill", 0, []byte("some standard input"), "remote")
 	c.Assert(output, gc.Equals, "some standard input")
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -416,10 +416,6 @@ func (s *bootstrapSuite) TestBootstrapImageMetadataFromAllSources(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapLocalTools(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
-
 	// Client host is CentOS, wanting to bootstrap a CentOS
 	// controller. This is fine.
 
@@ -446,10 +442,6 @@ func (s *bootstrapSuite) TestBootstrapLocalTools(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapLocalToolsMismatchingOS(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
-
 	// Client host is a Windows system, wanting to bootstrap a trusty
 	// controller with local tools. This can't work.
 
@@ -472,10 +464,6 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsMismatchingOS(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapLocalToolsDifferentLinuxes(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
-
 	// Client host is some unspecified Linux system, wanting to
 	// bootstrap a trusty controller with local tools. This should be
 	// OK.
@@ -503,10 +491,6 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsDifferentLinuxes(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
-
 	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
 	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
@@ -586,19 +570,12 @@ func (s *bootstrapSuite) assertBootstrapPackagedToolsAvailable(c *gc.C, clientAr
 }
 
 func (s *bootstrapSuite) TestBootstrapPackagedTools(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
 	for _, a := range arch.AllSupportedArches {
 		s.assertBootstrapPackagedToolsAvailable(c, a)
 	}
 }
 
 func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
-
 	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
 	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
@@ -621,10 +598,6 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapNoToolsDevelopmentConfig(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
-
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
 	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"testing"
 
@@ -58,9 +57,6 @@ var _ = gc.Suite(&uploadSuite{})
 var _ = gc.Suite(&badBuildSuite{})
 
 func (s *syncSuite) setUpTest(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 
@@ -227,9 +223,6 @@ type uploadSuite struct {
 }
 
 func (s *uploadSuite) SetUpTest(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 
@@ -373,9 +366,6 @@ exit 1
 `[1:]
 
 func (s *badBuildSuite) SetUpSuite(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("issue 1403084: Currently does not work because of jujud problems")
-	}
 	s.CleanupSuite.SetUpSuite(c)
 	s.LoggingSuite.SetUpSuite(c)
 }

--- a/mongo/package_test.go
+++ b/mongo/package_test.go
@@ -4,16 +4,11 @@
 package mongo_test
 
 import (
-	"runtime"
 	stdtesting "testing"
 
 	gc "gopkg.in/check.v1"
 )
 
 func Test(t *stdtesting.T) {
-	//TODO(bogdanteleaga): Fix these on windows
-	if runtime.GOOS == "windows" {
-		t.Skip("bug 1403084: Skipping for now on windows")
-	}
 	gc.TestingT(t)
 }

--- a/state/backups/create_test.go
+++ b/state/backups/create_test.go
@@ -6,7 +6,6 @@ package backups_test
 import (
 	"os"
 	"path"
-	"runtime"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -31,9 +30,6 @@ func (d *TestDBDumper) Dump(dumpDir string) error {
 }
 
 func (s *createSuite) TestLegacy(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Currently does not work on windows, see comments inside backups.create function")
-	}
 	meta := backupstesting.NewMetadataStarted()
 	metadataFile, err := meta.AsJSONBuffer()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/authenticationworker/worker_test.go
+++ b/worker/authenticationworker/worker_test.go
@@ -4,7 +4,6 @@
 package authenticationworker_test
 
 import (
-	"runtime"
 	"strings"
 	"time"
 
@@ -37,10 +36,6 @@ type workerSuite struct {
 var _ = gc.Suite(&workerSuite{})
 
 func (s *workerSuite) SetUpTest(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: authentication worker not implemented yet on windows")
-	}
 	s.JujuConnSuite.SetUpTest(c)
 	// Default ssh user is currently "ubuntu".
 	c.Assert(authenticationworker.SSHUser, gc.Equals, "ubuntu")

--- a/worker/deployer/package_test.go
+++ b/worker/deployer/package_test.go
@@ -4,16 +4,11 @@
 package deployer_test
 
 import (
-	"runtime"
 	stdtesting "testing"
 
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		t.Skip("bug 1403084: Currently does not work under windows")
-	}
 	coretesting.MgoTestPackage(t)
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -6,7 +6,6 @@ package provisioner_test
 import (
 	"fmt"
 	"os/exec"
-	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -53,10 +52,6 @@ type ContainerSetupSuite struct {
 var _ = gc.Suite(&ContainerSetupSuite{})
 
 func (s *ContainerSetupSuite) SetUpSuite(c *gc.C) {
-	// TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Skipping container tests on windows")
-	}
 	s.CommonProvisionerSuite.SetUpSuite(c)
 }
 

--- a/worker/terminationworker/worker_test.go
+++ b/worker/terminationworker/worker_test.go
@@ -5,7 +5,6 @@ package terminationworker_test
 
 import (
 	"os"
-	"runtime"
 	"testing"
 
 	jc "github.com/juju/testing/checkers"
@@ -35,10 +34,6 @@ func (s *TerminationWorkerSuite) TestStartStop(c *gc.C) {
 }
 
 func (s *TerminationWorkerSuite) TestSignal(c *gc.C) {
-	//TODO(bogdanteleaga): Inspect this further on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: sending this signal is not supported on windows")
-	}
 	w := terminationworker.NewWorker()
 	proc, err := os.FindProcess(os.Getpid())
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/charm/manifest_deployer_test.go
+++ b/worker/uniter/charm/manifest_deployer_test.go
@@ -6,7 +6,6 @@ package charm_test
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 
 	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
@@ -97,10 +96,6 @@ func (s *ManifestDeployerSuite) TestDeployWithoutStage(c *gc.C) {
 }
 
 func (s *ManifestDeployerSuite) TestInstall(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: cannot symlink to relative paths on windows")
-	}
 	s.deployCharm(c, 1,
 		ft.File{"some-file", "hello", 0644},
 		ft.Dir{"some-dir", 0755},
@@ -109,10 +104,6 @@ func (s *ManifestDeployerSuite) TestInstall(c *gc.C) {
 }
 
 func (s *ManifestDeployerSuite) TestUpgradeOverwrite(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: cannot symlink to relative paths on windows")
-	}
 	s.deployCharm(c, 1,
 		ft.File{"some-file", "hello", 0644},
 		ft.Dir{"some-dir", 0755},
@@ -131,10 +122,6 @@ func (s *ManifestDeployerSuite) TestUpgradeOverwrite(c *gc.C) {
 }
 
 func (s *ManifestDeployerSuite) TestUpgradePreserveUserFiles(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: cannot symlink to relative paths on windows")
-	}
 	originalCharmContent := ft.Entries{
 		ft.File{"charm-file", "to-be-removed", 0644},
 		ft.Dir{"charm-dir", 0755},

--- a/worker/uniter/runlistener_test.go
+++ b/worker/uniter/runlistener_test.go
@@ -52,9 +52,6 @@ func (s *ListenerSuite) NewRunListener(c *gc.C) *uniter.RunListener {
 }
 
 func (s *ListenerSuite) TestNewRunListenerOnExistingSocketRemovesItAndSucceeds(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Current named pipes implementation does not support this")
-	}
 	s.NewRunListener(c)
 	s.NewRunListener(c)
 }

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -39,9 +38,6 @@ exit $EXIT_CODE
 var fakecommands = []string{"sleep", "tmux"}
 
 func (s *DebugHooksServerSuite) SetUpTest(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Currently debug does not work on windows")
-	}
 	s.fakebin = c.MkDir()
 
 	// Create a clean $TMPDIR for the debug hooks scripts.

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -35,12 +34,6 @@ var _ = gc.Suite(&RunCommandSuite{})
 var noProxies = proxy.Settings{}
 
 func (s *RunCommandSuite) TestRunCommandsEnvStdOutAndErrAndRC(c *gc.C) {
-	// TODO(bogdanteleaga): powershell throws another exit status code when
-	// outputting to stderr using Write-Error. Either find another way to
-	// output to stderr or change the checks
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: Have to figure out a good way to output to stderr from powershell")
-	}
 	ctx, err := s.contextFactory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 	paths := runnertesting.NewRealPaths(c)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -174,10 +173,6 @@ func (s *UniterSuite) TestPreviousDownloadsCleared(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterBootstrap(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: currently does not work on windows")
-	}
 	s.runUniterTests(c, []uniterTest{
 		// Check error conditions during unit bootstrap phase.
 		ut(
@@ -743,8 +738,6 @@ resources:
 }
 
 func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	coretesting.SkipIfWindowsBug(c, "lp:1403084")
 	//TODO(hml): Fix this on S390X, intermittent there.
 	coretesting.SkipIfS390X(c, "lp:1534637")
 	makeTest := func(description string, content, extraChecks ft.Entries) uniterTest {
@@ -916,10 +909,6 @@ func (s *UniterSuite) TestUniterErrorStateForcedUpgrade(c *gc.C) {
 
 func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 	coretesting.SkipIfPPC64EL(c, "lp:1448308")
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: currently does not work on windows")
-	}
 	s.runUniterTests(c, []uniterTest{
 		// Upgrade scenarios - handling conflicts.
 		ut(
@@ -1740,10 +1729,6 @@ func (s *UniterSuite) TestJujuRunExecutionSerialized(c *gc.C) {
 }
 
 func (s *UniterSuite) TestRebootFromJujuRun(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
-	if runtime.GOOS == "windows" {
-		c.Skip("bug 1403084: currently does not work on windows")
-	}
 	s.runUniterTests(c, []uniterTest{
 		ut(
 			"test juju-reboot",


### PR DESCRIPTION
## Description of change

These tests have been skipped on windows previously. However, the bug that they are all linked to has been fixed and released a looong while back. This PR unskips the tests to get a run on windows machine to see if we are ready to have these tests participate in QA.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1403084
