### PR TITLE
Unskip because 1425569 is fixed and i386 no longer matters.

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1622,8 +1622,6 @@ func (s *withControllerSuite) TestCACert(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
-	coretesting.SkipIfI386(c, "lp:1425569")
-
 	s.PatchValue(&provisioner.ErrorRetryWaitDelay, 2*coretesting.ShortWait)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 

--- a/cmd/juju/application/package_test.go
+++ b/cmd/juju/application/package_test.go
@@ -4,7 +4,6 @@
 package application_test
 
 import (
-	"runtime"
 	stdtesting "testing"
 
 	_ "github.com/juju/juju/provider/dummy"
@@ -14,8 +13,5 @@ import (
 // TODO(wallyworld) - convert tests moved across from commands package to not require mongo
 
 func TestPackage(t *stdtesting.T) {
-	if runtime.GOARCH == "386" {
-		t.Skipf("skipping package for %v/%v, see http://pad.lv/1425569", runtime.GOOS, runtime.GOARCH)
-	}
 	testing.MgoTestPackage(t)
 }

--- a/cmd/juju/commands/package_test.go
+++ b/cmd/juju/commands/package_test.go
@@ -4,7 +4,6 @@
 package commands_test
 
 import (
-	"runtime"
 	stdtesting "testing"
 
 	"github.com/juju/juju/component/all"
@@ -19,8 +18,5 @@ func init() {
 }
 
 func TestPackage(t *stdtesting.T) {
-	if runtime.GOARCH == "386" {
-		t.Skipf("skipping package for %v/%v, see http://pad.lv/1425569", runtime.GOOS, runtime.GOARCH)
-	}
 	testing.MgoTestPackage(t)
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -393,8 +393,6 @@ func (s *workerSuite) TestFatalErrors(c *gc.C) {
 }
 
 func (s *workerSuite) TestSetMembersErrorIsNotFatal(c *gc.C) {
-	coretesting.SkipIfI386(c, "lp:1425569")
-
 	DoTestForIPv4AndIPv6(c, s, func(ipVersion TestIPVersion) {
 		st := NewFakeState()
 		InitState(c, st, 3, ipVersion)


### PR DESCRIPTION
## Description of change

These are pretty much redundant skips now as we no longer test against i386.

## Bug reference

https://bugs.launchpad.net/juju-core/1.22/+bug/1425569
