### PR TITLE
add verification of series supported by units to juju upgrade-series

### DIFF
--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -140,12 +140,15 @@ func (client *Client) UpdateMachineSeries(machineName, series string, force bool
 // UpgradeSeriesPrepare notifies the controller that a series upgrade is taking
 // place for a given machine and as such the machine is guarded against
 // operations that would impede, fail, or interfere with the upgrade process.
-func (client *Client) UpgradeSeriesPrepare(machineName string) error {
+func (client *Client) UpgradeSeriesPrepare(machineName, series string, force bool) error {
 	if client.BestAPIVersion() < 5 {
 		return errors.NotSupportedf("upgrade-series prepare")
 	}
 	args := params.UpdateSeriesArg{
-		Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},
+		Entity: params.Entity{
+			Tag: names.NewMachineTag(machineName).String()},
+		Series: series,
+		Force:  force,
 	}
 	result := params.ErrorResult{}
 	err := client.facade.FacadeCall("UpgradeSeriesPrepare", args, &result)

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -46,6 +46,8 @@ type Machine interface {
 	UpdateMachineSeries(string, bool) error
 	CreateUpgradeSeriesLock() error
 	RemoveUpgradeSeriesLock() error
+	VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error)
+	Principals() []string
 }
 
 type stateShim struct {
@@ -94,6 +96,18 @@ func (m machineShim) Units() ([]Unit, error) {
 
 type Unit interface {
 	UnitTag() names.UnitTag
+}
+
+func (m machineShim) VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error) {
+	units, err := m.Machine.VerifyUnitsSeries(unitNames, series, force)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Unit, len(units))
+	for i, u := range units {
+		out[i] = u
+	}
+	return out, nil
 }
 
 type storageInterface interface {

--- a/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
+++ b/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
@@ -69,13 +69,13 @@ func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UpgradeSeriesComplete(arg0 in
 }
 
 // UpgradeSeriesPrepare mocks base method
-func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesPrepare(arg0 string) error {
-	ret := m.ctrl.Call(m, "UpgradeSeriesPrepare", arg0)
+func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesPrepare(arg0, arg1 string, arg2 bool) error {
+	ret := m.ctrl.Call(m, "UpgradeSeriesPrepare", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpgradeSeriesPrepare indicates an expected call of UpgradeSeriesPrepare
-func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UpgradeSeriesPrepare(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesPrepare", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UpgradeSeriesPrepare), arg0)
+func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UpgradeSeriesPrepare(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesPrepare", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UpgradeSeriesPrepare), arg0, arg1, arg2)
 }

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -35,7 +35,7 @@ func NewUpgradeSeriesCommand() cmd.Command {
 type UpgradeMachineSeriesAPI interface {
 	BestAPIVersion() int
 	Close() error
-	UpgradeSeriesPrepare(string) error
+	UpgradeSeriesPrepare(string, string, bool) error
 	UpgradeSeriesComplete(string) error
 }
 
@@ -196,7 +196,7 @@ func (c *upgradeSeriesCommand) UpgradeSeriesPrepare(ctx *cmd.Context) error {
 		c.upgradeMachineSeriesClient = machinemanager.NewClient(apiRoot)
 	}
 
-	err = c.upgradeMachineSeriesClient.UpgradeSeriesPrepare(c.machineNumber)
+	err = c.upgradeMachineSeriesClient.UpgradeSeriesPrepare(c.machineNumber, c.series, c.force)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -41,7 +41,7 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(c *gc.C, co
 	// mock remote API
 	mockController := gomock.NewController(c)
 	mockUpgradeSeriesAPI := mocks.NewMockUpgradeMachineSeriesAPI(mockController)
-	mockUpgradeSeriesAPI.EXPECT().UpgradeSeriesPrepare(gomock.Any()).AnyTimes()
+	mockUpgradeSeriesAPI.EXPECT().UpgradeSeriesPrepare(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	mockUpgradeSeriesAPI.EXPECT().UpgradeSeriesComplete(gomock.Any()).AnyTimes()
 
 	com := machine.NewUpgradeSeriesCommandForTest(mockUpgradeSeriesAPI)

--- a/state/machine.go
+++ b/state/machine.go
@@ -2001,7 +2001,7 @@ func (m *Machine) UpdateMachineSeries(series string, force bool) error {
 		}
 
 		principals := m.Principals() // unit names
-		verifiedUnits, err := m.verifyUnitsSeries(principals, series, force)
+		verifiedUnits, err := m.VerifyUnitsSeries(principals, series, force)
 		if err != nil {
 			return nil, err
 		}
@@ -2030,7 +2030,7 @@ func (m *Machine) UpdateMachineSeries(series string, force bool) error {
 	return errors.Annotatef(err, "cannot update series for %q to %s", m, series)
 }
 
-func (m *Machine) verifyUnitsSeries(unitNames []string, series string, force bool) ([]*Unit, error) {
+func (m *Machine) VerifyUnitsSeries(unitNames []string, series string, force bool) ([]*Unit, error) {
 	results := []*Unit{}
 	for _, u := range unitNames {
 		unit, err := m.st.Unit(u)
@@ -2047,7 +2047,7 @@ func (m *Machine) verifyUnitsSeries(unitNames []string, series string, force boo
 		}
 
 		subordinates := unit.SubordinateNames()
-		subUnits, err := m.verifyUnitsSeries(subordinates, series, force)
+		subUnits, err := m.VerifyUnitsSeries(subordinates, series, force)
 		if err != nil {
 			return nil, err
 		}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -2657,4 +2657,24 @@ func AssertMachineIsNOTLockedForPrepare(c *gc.C, mach *state.Machine) {
 	locked, err := mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsFalse)
+}
+
+// VerifyUnitsSeries is also tested via TestUpdateMachineSeries*
+func (s *MachineSuite) TestVerifyUnitsSeries(c *gc.C) {
+	mach := s.setupTestUpdateMachineSeries(c)
+	err := mach.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedUnits, err := mach.Units()
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedUnits, err := mach.VerifyUnitsSeries([]string{"wordpress/0", "multi-series/0"}, "trusty", false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitNames(obtainedUnits), jc.SameContents, unitNames(expectedUnits))
+}
+
+func unitNames(units []*state.Unit) []string {
+	names := make([]string, len(units))
+	for i := range units {
+		names[i] = units[i].Name()
+	}
+	return names
 }


### PR DESCRIPTION
## Description of change

Part of Managed Series Upgrades: add verification of series supported by units to juju upgrade-series prepare

## QA steps

1. juju bootstrap
2. export JUJU_DEV_FEATURE_FLAGS=upgrade-series
3. juju deploy ghost  (chosen because it doesn't support bionic)
4. juju upgrade-series prepare 0 bionic
ERROR series "bionic" not supported by charm, supported series are: xenial,trusty
5. juju upgrade-series prepare 0 bionic --force

## Documentation changes

N/A

## Bug reference

N/A