### PR TITLE
raft: Upgrade step to bootstrap raft cluster

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -739,7 +739,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// All the other raft workers hang off the raft transport, so
 		// it's the only one that needs to be gated by the enabled flag.
-		raftTransportName: ifRaftEnabled(rafttransport.Manifold(rafttransport.ManifoldConfig{
+		raftTransportName: ifRaftEnabled(ifFullyUpgraded(rafttransport.Manifold(rafttransport.ManifoldConfig{
 			ClockName:         clockName,
 			AgentName:         agentName,
 			AuthenticatorName: httpServerName,
@@ -748,7 +748,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			DialConn:          rafttransport.DialConn,
 			NewWorker:         rafttransport.NewWorker,
 			Path:              "/raft",
-		})),
+		}))),
 
 		raftName: raft.Manifold(raft.ManifoldConfig{
 			ClockName:     clockName,

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -264,9 +264,9 @@ func (s *ManifoldsSuite) TestManifoldsDependencies(c *gc.C) {
 
 var expectedMachineManifoldsWithDependencies = map[string][]string{
 
-	"agent": []string{},
+	"agent": {},
 
-	"api-address-updater": []string{
+	"api-address-updater": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -277,11 +277,11 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"api-caller": []string{"agent", "api-config-watcher"},
+	"api-caller": {"agent", "api-config-watcher"},
 
-	"api-config-watcher": []string{"agent"},
+	"api-config-watcher": {"agent"},
 
-	"api-server": []string{
+	"api-server": {
 		"agent",
 		"audit-config-updater",
 		"certificate-watcher",
@@ -293,15 +293,15 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"state-config-watcher",
 		"upgrade-steps-gate"},
 
-	"audit-config-updater": []string{
+	"audit-config-updater": {
 		"agent",
 		"is-controller-flag",
 		"state",
 		"state-config-watcher"},
 
-	"central-hub": []string{"agent", "state-config-watcher"},
+	"central-hub": {"agent", "state-config-watcher"},
 
-	"certificate-updater": []string{
+	"certificate-updater": {
 		"agent",
 		"state",
 		"state-config-watcher",
@@ -310,15 +310,15 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"certificate-watcher": []string{
+	"certificate-watcher": {
 		"agent",
 		"is-controller-flag",
 		"state",
 		"state-config-watcher"},
 
-	"clock": []string{},
+	"clock": {},
 
-	"disk-manager": []string{
+	"disk-manager": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -329,7 +329,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"external-controller-updater": []string{
+	"external-controller-updater": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -345,7 +345,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"fan-configurer": []string{
+	"fan-configurer": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -356,13 +356,13 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"global-clock-updater": []string{
+	"global-clock-updater": {
 		"agent",
 		"clock",
 		"state",
 		"state-config-watcher"},
 
-	"host-key-reporter": []string{
+	"host-key-reporter": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -373,7 +373,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"http-server": []string{
+	"http-server": {
 		"agent",
 		"certificate-watcher",
 		"clock",
@@ -381,9 +381,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"state",
 		"state-config-watcher"},
 
-	"is-controller-flag": []string{"agent", "state", "state-config-watcher"},
+	"is-controller-flag": {"agent", "state", "state-config-watcher"},
 
-	"is-primary-controller-flag": []string{
+	"is-primary-controller-flag": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -392,7 +392,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"state",
 		"state-config-watcher"},
 
-	"log-pruner": []string{
+	"log-pruner": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -408,7 +408,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"log-sender": []string{
+	"log-sender": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -419,7 +419,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"logging-config-updater": []string{
+	"logging-config-updater": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -430,7 +430,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"machine-action-runner": []string{
+	"machine-action-runner": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -441,7 +441,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"machiner": []string{
+	"machiner": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -453,7 +453,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"mgo-txn-resumer": []string{
+	"mgo-txn-resumer": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -464,18 +464,18 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"migration-fortress": []string{
+	"migration-fortress": {
 		"upgrade-check-flag",
 		"upgrade-check-gate",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"migration-inactive-flag": []string{
+	"migration-inactive-flag": {
 		"agent",
 		"api-caller",
 		"api-config-watcher"},
 
-	"migration-minion": []string{
+	"migration-minion": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -485,7 +485,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"model-worker-manager": []string{
+	"model-worker-manager": {
 		"agent",
 		"state",
 		"state-config-watcher",
@@ -494,7 +494,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"peer-grouper": []string{
+	"peer-grouper": {
 		"agent",
 		"clock",
 		"state",
@@ -504,9 +504,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"presence": []string{"agent", "central-hub", "state-config-watcher"},
+	"presence": {"agent", "central-hub", "state-config-watcher"},
 
-	"proxy-config-updater": []string{
+	"proxy-config-updater": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -517,12 +517,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"pubsub-forwarder": []string{
+	"pubsub-forwarder": {
 		"agent",
 		"central-hub",
 		"state-config-watcher"},
 
-	"raft": []string{
+	"raft": {
 		"agent",
 		"central-hub",
 		"certificate-watcher",
@@ -532,9 +532,14 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"raft-enabled-flag",
 		"raft-transport",
 		"state",
-		"state-config-watcher"},
+		"state-config-watcher",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
-	"raft-backstop": []string{
+	"raft-backstop": {
 		"agent",
 		"central-hub",
 		"certificate-watcher",
@@ -545,9 +550,14 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"raft-enabled-flag",
 		"raft-transport",
 		"state",
-		"state-config-watcher"},
+		"state-config-watcher",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
-	"raft-clusterer": []string{
+	"raft-clusterer": {
 		"agent",
 		"central-hub",
 		"certificate-watcher",
@@ -559,15 +569,20 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"raft-leader-flag",
 		"raft-transport",
 		"state",
-		"state-config-watcher"},
+		"state-config-watcher",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
-	"raft-enabled-flag": []string{
+	"raft-enabled-flag": {
 		"agent",
 		"is-controller-flag",
 		"state",
 		"state-config-watcher"},
 
-	"raft-leader-flag": []string{
+	"raft-leader-flag": {
 		"agent",
 		"central-hub",
 		"certificate-watcher",
@@ -578,9 +593,14 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"raft-enabled-flag",
 		"raft-transport",
 		"state",
-		"state-config-watcher"},
+		"state-config-watcher",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
-	"raft-transport": []string{
+	"raft-transport": {
 		"agent",
 		"central-hub",
 		"certificate-watcher",
@@ -589,9 +609,14 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"is-controller-flag",
 		"raft-enabled-flag",
 		"state",
-		"state-config-watcher"},
+		"state-config-watcher",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
-	"reboot-executor": []string{
+	"reboot-executor": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -602,9 +627,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"restore-watcher": []string{"agent", "state", "state-config-watcher"},
+	"restore-watcher": {"agent", "state", "state-config-watcher"},
 
-	"serving-info-setter": []string{
+	"serving-info-setter": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -615,7 +640,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"ssh-authkeys-updater": []string{
+	"ssh-authkeys-updater": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -626,7 +651,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"ssh-identity-writer": []string{
+	"ssh-identity-writer": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -637,11 +662,11 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"state": []string{"agent", "state-config-watcher"},
+	"state": {"agent", "state-config-watcher"},
 
-	"state-config-watcher": []string{"agent"},
+	"state-config-watcher": {"agent"},
 
-	"storage-provisioner": []string{
+	"storage-provisioner": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -652,9 +677,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"termination-signal-handler": []string{},
+	"termination-signal-handler": {},
 
-	"tools-version-checker": []string{
+	"tools-version-checker": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -665,7 +690,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"transaction-pruner": []string{
+	"transaction-pruner": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -681,7 +706,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"unconverted-api-workers": []string{
+	"unconverted-api-workers": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -692,7 +717,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"unit-agent-deployer": []string{
+	"unit-agent-deployer": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
@@ -703,21 +728,21 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 
-	"upgrade-check-flag": []string{"upgrade-check-gate"},
+	"upgrade-check-flag": {"upgrade-check-gate"},
 
-	"upgrade-check-gate": []string{},
+	"upgrade-check-gate": {},
 
-	"upgrade-steps-flag": []string{"upgrade-steps-gate"},
+	"upgrade-steps-flag": {"upgrade-steps-gate"},
 
-	"upgrade-steps-gate": []string{},
+	"upgrade-steps-gate": {},
 
-	"upgrade-steps-runner": []string{
+	"upgrade-steps-runner": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
 		"upgrade-steps-gate"},
 
-	"upgrader": []string{
+	"upgrader": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/replicaset"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -1589,4 +1590,12 @@ func RemoveContainerImageStreamFromNonModelSettings(st *State) error {
 		return errors.Trace(st.runRawTransaction(ops))
 	}
 	return nil
+}
+
+// ReplicaSetMembers gets the members of the current Mongo replica
+// set. These are needed to bootstrap the raft cluster in an upgrade
+// and using MongoSession directly from an upgrade steps would make
+// testing difficult.
+func ReplicaSetMembers(st *State) ([]replicaset.Member, error) {
+	return replicaset.CurrentMembers(st.MongoSession())
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -4,6 +4,8 @@
 package upgrades
 
 import (
+	"github.com/juju/replicaset"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -14,6 +16,7 @@ import (
 // StateBackend provides an interface for upgrading the global state database.
 type StateBackend interface {
 	ControllerUUID() string
+	StateServingInfo() (state.StateServingInfo, error)
 
 	StripLocalUserDomain() error
 	RenameAddModelPermission() error
@@ -42,6 +45,7 @@ type StateBackend interface {
 	CreateMissingApplicationConfig() error
 	RemoveVotingMachineIds() error
 	AddCloudModelCounts() error
+	ReplicaSetMembers() ([]replicaset.Member, error)
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -62,6 +66,10 @@ type stateBackend struct {
 
 func (s stateBackend) ControllerUUID() string {
 	return s.st.ControllerUUID()
+}
+
+func (s stateBackend) StateServingInfo() (state.StateServingInfo, error) {
+	return s.st.StateServingInfo()
 }
 
 func (s stateBackend) StripLocalUserDomain() error {
@@ -158,6 +166,10 @@ func (s stateBackend) RemoveVotingMachineIds() error {
 
 func (s stateBackend) AddCloudModelCounts() error {
 	return state.AddCloudModelCounts(s.st)
+}
+
+func (s stateBackend) ReplicaSetMembers() ([]replicaset.Member, error) {
+	return state.ReplicaSetMembers(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"net"
+	"path/filepath"
+	"strconv"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/replicaset"
+
+	raftworker "github.com/juju/juju/worker/raft"
+)
+
+// jujuMachineKey is the key for the replset member tag where we
+// store the member's corresponding machine id.
+const jujuMachineKey = "juju-machine-id"
+
+// BootstrapRaft initialises the raft cluster in a controller that is
+// being upgraded.
+func BootstrapRaft(context Context) error {
+	agentConfig := context.AgentConfig()
+	_, transport := raft.NewInmemTransport(raft.ServerAddress("notused"))
+	defer transport.Close()
+
+	conf, err := raftworker.NewRaftConfig(raftworker.Config{
+		LocalID:   raft.ServerID(agentConfig.Tag().Id()),
+		Logger:    logger,
+		Transport: transport,
+		FSM:       raftworker.BootstrapFSM{},
+	})
+	if err != nil {
+		return errors.Annotate(err, "getting raft config")
+	}
+	storageDir := filepath.Join(agentConfig.DataDir(), "raft")
+	logStore, err := raftworker.NewLogStore(storageDir)
+	if err != nil {
+		return errors.Annotate(err, "making log store")
+	}
+	defer logStore.Close()
+
+	snapshotStore, err := raftworker.NewSnapshotStore(storageDir, 2, logger)
+	if err != nil {
+		return errors.Annotate(err, "making snapshot store")
+	}
+
+	st := context.State()
+	members, err := st.ReplicaSetMembers()
+	if err != nil {
+		return errors.Annotate(err, "getting replica set members")
+	}
+	info, err := st.StateServingInfo()
+	if err != nil {
+		return errors.Annotate(err, "getting state serving info")
+	}
+	servers, err := makeRaftServers(members, info.APIPort)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = raft.BootstrapCluster(conf, logStore, logStore, snapshotStore, transport, servers)
+	return errors.Annotate(err, "bootstrapping raft cluster")
+}
+
+func makeRaftServers(members []replicaset.Member, apiPort int) (raft.Configuration, error) {
+	var empty raft.Configuration
+	var servers []raft.Server
+	for _, member := range members {
+		id, ok := member.Tags[jujuMachineKey]
+		if !ok {
+			return empty, errors.NotFoundf("juju machine id for replset member %d", member.Id)
+		}
+		baseAddress, _, err := net.SplitHostPort(member.Address)
+		if err != nil {
+			return empty, errors.Annotatef(err, "getting base address for replset member %d", member.Id)
+		}
+		apiAddress := net.JoinHostPort(baseAddress, strconv.Itoa(apiPort))
+		suffrage := raft.Voter
+		if member.Votes != nil && *member.Votes < 1 {
+			suffrage = raft.Nonvoter
+		}
+		server := raft.Server{
+			ID:       raft.ServerID(id),
+			Address:  raft.ServerAddress(apiAddress),
+			Suffrage: suffrage,
+		}
+		servers = append(servers, server)
+	}
+	return raft.Configuration{Servers: servers}, nil
+}

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -1,0 +1,129 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/hashicorp/raft"
+	"github.com/hashicorp/raft-boltdb"
+	"github.com/juju/replicaset"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+	raftworker "github.com/juju/juju/worker/raft"
+	"github.com/juju/juju/worker/raft/rafttest"
+)
+
+type raftSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&raftSuite{})
+
+func (s *raftSuite) TestBootstrapRaft(c *gc.C) {
+	votes := 1
+	noVotes := 0
+	dataDir := c.MkDir()
+	context := &mockContext{
+		agentConfig: &mockAgentConfig{
+			tag:     names.NewMachineTag("23"),
+			dataDir: dataDir,
+		},
+		state: &mockState{
+			members: []replicaset.Member{{
+				Address: "somewhere.else:37012",
+				Tags:    map[string]string{"juju-machine-id": "42"},
+			}, {
+				Address: "nowhere.else:37012",
+				Tags:    map[string]string{"juju-machine-id": "23"},
+				Votes:   &votes,
+			}, {
+				Address: "everywhere.else:37012",
+				Tags:    map[string]string{"juju-machine-id": "7"},
+				Votes:   &noVotes,
+			}},
+			info: state.StateServingInfo{APIPort: 1234},
+		},
+	}
+	err := upgrades.BootstrapRaft(context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now make the raft node and check that the configuration is as
+	// we expect.
+
+	// Capture logging to include in test output.
+	output := captureWriter{c}
+	config := raft.DefaultConfig()
+	config.LocalID = "23"
+	config.Logger = log.New(output, "", 0)
+	c.Assert(raft.ValidateConfig(config), jc.ErrorIsNil)
+
+	raftDir := filepath.Join(dataDir, "raft")
+	logStore, err := raftboltdb.New(raftboltdb.Options{
+		Path: filepath.Join(raftDir, "logs"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	snapshotStore, err := raft.NewFileSnapshotStore(raftDir, 1, output)
+	c.Assert(err, jc.ErrorIsNil)
+	_, transport := raft.NewInmemTransport(raft.ServerAddress("nowhere.else"))
+
+	r, err := raft.NewRaft(
+		config,
+		&raftworker.SimpleFSM{},
+		logStore,
+		logStore,
+		snapshotStore,
+		transport,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		c.Assert(r.Shutdown().Error(), jc.ErrorIsNil)
+	})
+
+	rafttest.CheckConfiguration(c, r, []raft.Server{{
+		ID:       "42",
+		Address:  "somewhere.else:1234",
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "23",
+		Address:  "nowhere.else:1234",
+		Suffrage: raft.Voter,
+	}, {
+		ID:       "7",
+		Address:  "everywhere.else:1234",
+		Suffrage: raft.Nonvoter,
+	}})
+}
+
+type mockState struct {
+	upgrades.StateBackend
+	stub    testing.Stub
+	members []replicaset.Member
+	info    state.StateServingInfo
+}
+
+func (s *mockState) ReplicaSetMembers() ([]replicaset.Member, error) {
+	return s.members, s.stub.NextErr()
+}
+
+func (s *mockState) StateServingInfo() (state.StateServingInfo, error) {
+	return s.info, s.stub.NextErr()
+}
+
+type captureWriter struct {
+	c *gc.C
+}
+
+func (w captureWriter) Write(p []byte) (int, error) {
+	w.c.Logf("%s", p[:len(p)-1]) // omit trailling newline
+	return len(p), nil
+}

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -52,6 +52,11 @@ func stateStepsFor24() []Step {
 				return context.State().AddCloudModelCounts()
 			},
 		},
+		&upgradeStep{
+			description: "bootstrap raft cluster",
+			targets:     []Target{Controller},
+			run:         BootstrapRaft,
+		},
 	}
 }
 

--- a/upgrades/steps_24_test.go
+++ b/upgrades/steps_24_test.go
@@ -49,3 +49,8 @@ func (s *steps24Suite) TestCloudModelCounts(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+func (s *steps24Suite) TestBootstrapRaft(c *gc.C) {
+	step := findStateStep(c, v24, "bootstrap raft cluster")
+	// Logic for step itself is tested in raft_test.go.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.Controller})
+}


### PR DESCRIPTION
## Description of change

The raft cluster needs to be bootstrapped for the raft workers to run correctly. This normally done when bootstrapping the controller, but needs to be done at upgrade time for pre-2.4 controllers. Without this, the raft worker restarts every minute with an error complaining that it isn't in contact with the leader.

Exposes NewRaftConfig, NewLogStore, NewSnapshotStore and BootstrapFSM from juju/worker/raft so they can be used in the upgrade step.

## QA steps

* Bootstrap a 2.3.8 controller, upgrade to a 2.4 version with this change. Once the upgrade is complete the raft worker starts successfully (no timeout errors from the worker in the debug-log, the raft worker's state is correct in the output of juju-engine-report on the controller machine).
* Do the same on a multi-machine controller - check that the raft configuration matches across the controller machines and that they agree on which one is the leader.
