### PR TITLE
Gofmt simplify

### DIFF
--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -13,7 +13,7 @@ VERSION=`go version | awk '{print $3}'`
 echo "go version $VERSION"
 
 echo "checking: go fmt ..."
-BADFMT=`find * -name '*.go' -not -name '.#*' | xargs gofmt -l`
+BADFMT=`find * -name '*.go' -not -name '.#*' | xargs gofmt -l -s`
 if [ -n "$BADFMT" ]; then
     BADFMT=`echo "$BADFMT" | sed "s/^/  /"`
     echo -e "gofmt is sad:\n\n$BADFMT"

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -16,10 +16,12 @@ echo "checking: go fmt ..."
 BADFMT=`find * -name '*.go' -not -name '.#*' | xargs gofmt -l -s`
 if [ -n "$BADFMT" ]; then
     BADFMT=`echo "$BADFMT" | sed "s/^/  /"`
-    echo -e "gofmt is sad:\n\n$BADFMT"
+    echo -e "gofmt is sad:\n"
+    for item in $BADFMT; do
+        echo "gofmt -l -s -w $item"
+    done
     exit 1
 fi
-
 
 echo "checking: go vet ..."
 


### PR DESCRIPTION
## Description of change

> Why is this change needed?

The following changes just makes sure we have the same setup as
gometalinter. Eventually we will remove gofmt and govet and fallback
to only gometalinter, so that pushing to a branch will be a lot
quicker. For now...

@hmlanigan spotted that our gofmt differs from gometalinter and it's
not clear which one we should enforce.

## QA steps

> How do we verify that the change works?

Push a branch or run `./scripts/verify.bash`

## Documentation changes

> Does it affect current user workflow? CLI? API?

Standardise what gofmt does in all aspects of CLI and workflow.
