### PR TITLE
Verify new branches

### DIFF
--- a/scripts/pre-push.bash
+++ b/scripts/pre-push.bash
@@ -16,19 +16,19 @@ do
         git diff --quiet || (echo "unstaged changes"; exit 1)
         git diff --cached --quiet || (echo "uncommitted changes"; exit 1)
 
-        if [ "$remote_sha" = $z40 ]
-        then
-            # New branch, examine all commits not on master
-            range="$local_sha...master"
-        else
+        # We always want to check against new branches, so we're only here
+        # wanting to check to see if there is any difference between an updated
+        # branch and the remote sha of that branch. If no files have changed,
+        # skip the verify phase.
+        if ! [ "$remote_sha" = $z40 ]; then
             # Update to existing branch, examine new commits
             range="$remote_sha...$local_sha"
-        fi
 
-        FILECOUNT=`git log --name-only '--pretty=format:' $range | grep '.go$' | wc -l`
-        if [ $FILECOUNT -eq 0 ]; then
-            # no go files changed, skip go validation
-            exit 0
+            FILECOUNT=`git log --name-only '--pretty=format:' $range | grep '.go$' | wc -l`
+            if [ $FILECOUNT -eq 0 ]; then
+                # no go files changed, skip go validation
+                exit 0
+            fi
         fi
 
         ./scripts/verify.bash


### PR DESCRIPTION
## Description of change

> Why is this change needed?

The following change verifies that all new branches are verified,
before pushing. Previously they where skipped because there where
zero changes between it and master branch. I would rather verify
something rather than nothing, to prevent mistakes.

## QA steps

> How do we verify that the change works?

Create a new branch with these changes and push to origin.

## Documentation changes

> Does it affect current user workflow? CLI? API?

It prevents people from pushing code without first verifying the changes.

