### PR TITLE
To introduce --device flag to client/cmd

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 )
@@ -95,6 +96,10 @@ type DeployArgs struct {
 	// handled.
 	Storage map[string]storage.Constraints
 
+	// Devices contains Constraints specifying how devices should be
+	// handled.
+	Devices map[string]devices.Constraints
+
 	// AttachStorage contains IDs of existing storage that should be
 	// attached to the application unit that will be deployed. This
 	// may be non-empty only if NumUnits is 1.
@@ -140,6 +145,7 @@ func (c *Client) Deploy(args DeployArgs) error {
 			Constraints:      args.Cons,
 			Placement:        args.Placement,
 			Storage:          args.Storage,
+			Devices:          args.Devices,
 			AttachStorage:    attachStorage,
 			EndpointBindings: args.EndpointBindings,
 			Resources:        args.Resources,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -283,6 +283,7 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 	if err := api.check.ChangeAllowed(); err != nil {
 		return result, errors.Trace(err)
 	}
+	logger.Criticalf("Deploy args -> %+v", args)
 	for i, arg := range args.Applications {
 		err := deployApplication(api.backend, api.modelType, api.stateCharm, arg, api.deployApplicationFunc)
 		result.Results[i].Error = common.ServerError(err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -283,7 +283,6 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 	if err := api.check.ChangeAllowed(); err != nil {
 		return result, errors.Trace(err)
 	}
-	logger.Criticalf("Deploy args -> %+v", args)
 	for i, arg := range args.Applications {
 		err := deployApplication(api.backend, api.modelType, api.stateCharm, arg, api.deployApplicationFunc)
 		result.Results[i].Error = common.ServerError(err)

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/resource/resourceadapters"
@@ -66,6 +67,7 @@ func deployBundle(
 	apiRoot DeployAPI,
 	ctx *cmd.Context,
 	bundleStorage map[string]map[string]storage.Constraints,
+	bundleDevices map[string]map[string]devices.Constraints,
 	dryRun bool,
 	useExistingMachines bool,
 	bundleMachines map[string]string,
@@ -163,6 +165,12 @@ type bundleHandler struct {
 	// in the bundle itself.
 	bundleStorage map[string]map[string]storage.Constraints
 
+	// bundleDevices contains a mapping of application-specific device
+	// constraints. For each application, the device constraints in the
+	// map will replace or augment the device constraints specified
+	// in the bundle itself.
+	bundleDevices map[string]map[string]devices.Constraints
+
 	// ctx is the command context, which is used to output messages to the
 	// user, so that the user can keep track of the bundle deployment
 	// progress.
@@ -202,6 +210,7 @@ func makeBundleHandler(
 	ctx *cmd.Context,
 	data *charm.BundleData,
 	bundleStorage map[string]map[string]storage.Constraints,
+	bundleDevices map[string]map[string]devices.Constraints,
 ) *bundleHandler {
 	applications := set.NewStrings()
 	for name := range data.Applications {
@@ -215,6 +224,7 @@ func makeBundleHandler(
 		channel:       channel,
 		api:           api,
 		bundleStorage: bundleStorage,
+		bundleDevices: bundleDevices,
 		ctx:           ctx,
 		data:          data,
 		unitStatus:    make(map[string]string),

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -110,7 +110,7 @@ func deployBundle(
 	}
 
 	// TODO: move bundle parsing and checking into the handler.
-	h := makeBundleHandler(dryRun, bundleDir, channel, apiRoot, ctx, data, bundleStorage)
+	h := makeBundleHandler(dryRun, bundleDir, channel, apiRoot, ctx, data, bundleStorage, bundleDevices)
 	if err := h.makeModel(useExistingMachines, bundleMachines); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -389,6 +389,11 @@ Constraints can be specified by specifying the '--constraints' option. If the
 application is later scaled out with ` + "`juju add-unit`" + `, provisioned machines
 will use the same constraints (unless changed by ` + "`juju set-constraints`" + `).
 
+Devices can be specified by specifying the '--device' option to deploy charms to a
+k8s cluster which require the use of a GPU (or many).
+Devices provided should be in format:
+	<label>=[<count>,]<device-class>|<vendor/type>[,<attributes>]
+
 Application configuration values can be specified using '--config' option. This
 option accepts either a path to a yaml-formatted file or a key=value pair.
 Configuration file provided should be in format
@@ -496,7 +501,16 @@ Examples:
 
     juju deploy haproxy -n 2 --constraints spaces=dmz,^cms,^database
     (deploy 2 units to machines that are in the 'dmz' space but not of
-    the 'cmd' or the 'database' spaces)
+	the 'cmd' or the 'database' spaces)
+
+	juju deploy mycharm --device bitcoinminer=1,nvidia.com/gpu
+	(deploy mycharm requires any Nvidia GPU without needing to further specify any tags)
+
+	juju deploy mycharm --device bitcoinminer=nvidia.com/gpu
+	(deploy mycharm requires any Nvidia GPU. No count is specified, it is assumed to be 1)
+
+	juju deploy mycharm --device bitcoinminer=1,nvidia.com/gpu,gpu=nvidia-tesla-p100;attr2=attr2
+	(deploy mycharm requires 1*nvidia.com/gpu with attributes: gpu=nvidia-tesla-p10 && attr2=attr2)
 
 See also:
     add-unit

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -306,7 +306,7 @@ type DeployCommand struct {
 	// the storage name defined in that application's charm storage metadata.
 	BundleStorage map[string]map[string]storage.Constraints
 
-	// Devices is a map of device constraints, keyed on the device name
+	// Devices is a mapping of device constraints, keyed on the device name
 	// defined in charm devices metadata.
 	Devices map[string]devices.Constraints
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -577,7 +577,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.DryRun, "dry-run", false, "Just show what the bundle deploy would do")
 	f.BoolVar(&c.Force, "force", false, "Allow a charm to be deployed to a machine running an unsupported series")
 	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage constraints")
-	f.Var(deviceFlag{&c.Devices, &c.BundleDevices}, "device", "Charm device constraints")
+	f.Var(devicesFlag{&c.Devices, &c.BundleDevices}, "device", "Charm device constraints")
 	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")
 	f.StringVar(&c.machineMap, "map-machines", "", "Specify the existing machines to use for bundle deployments")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -580,7 +580,7 @@ func (s *DeploySuite) TestDeployFlags(c *gc.C) {
 	c.Assert(command.flagSet, jc.DeepEquals, flagSet)
 	// Add to the slice below if a new flag is introduced which is valid for
 	// both charms and bundles.
-	charmAndBundleFlags := []string{"channel", "storage"}
+	charmAndBundleFlags := []string{"channel", "storage", "device"}
 	var allFlags []string
 	flagSet.VisitAll(func(flag *gnuflag.Flag) {
 		allFlags = append(allFlags, flag.Name)

--- a/cmd/juju/application/flags.go
+++ b/cmd/juju/application/flags.go
@@ -89,9 +89,8 @@ func (f deviceFlag) Set(s string) error {
 	if len(fields) < 2 {
 		if f.bundleDevices != nil {
 			return errors.New("expected [<application>:]<device>=<constraints>")
-		} else {
-			return errors.New("expected <device>=<constraints>")
 		}
+		return errors.New("expected <device>=<constraints>")
 	}
 	var applicationName, deviceName string
 	if colon := strings.IndexRune(fields[0], ':'); colon >= 0 {

--- a/cmd/juju/application/flags.go
+++ b/cmd/juju/application/flags.go
@@ -25,9 +25,8 @@ func (f storageFlag) Set(s string) error {
 	if len(fields) < 2 {
 		if f.bundleStores != nil {
 			return errors.New("expected [<application>:]<store>=<constraints>")
-		} else {
-			return errors.New("expected <store>=<constraints>")
 		}
+		return errors.New("expected <store>=<constraints>")
 	}
 	var applicationName, storageName string
 	if colon := strings.IndexRune(fields[0], ':'); colon >= 0 {

--- a/cmd/juju/application/flags.go
+++ b/cmd/juju/application/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/storage"
 )
 
@@ -72,6 +73,71 @@ func (f storageFlag) String() string {
 		for application, stores := range *f.bundleStores {
 			for store, cons := range stores {
 				strs = append(strs, fmt.Sprintf("%s:%s=%v", application, store, cons))
+			}
+		}
+	}
+	return strings.Join(strs, " ")
+}
+
+type deviceFlag struct {
+	devices       *map[string]devices.Constraints
+	bundleDevices *map[string]map[string]devices.Constraints
+}
+
+// Set implements gnuflag.Value.Set.
+func (f deviceFlag) Set(s string) error {
+	fields := strings.SplitN(s, "=", 2)
+	if len(fields) < 2 {
+		if f.bundleDevices != nil {
+			return errors.New("expected [<application>:]<device>=<constraints>")
+		} else {
+			return errors.New("expected <device>=<constraints>")
+		}
+	}
+	var applicationName, deviceName string
+	if colon := strings.IndexRune(fields[0], ':'); colon >= 0 {
+		if f.bundleDevices == nil {
+			return errors.New("expected <device>=<constraints>")
+		}
+		applicationName = fields[0][:colon]
+		deviceName = fields[0][colon+1:]
+	} else {
+		deviceName = fields[0]
+	}
+	cons, err := devices.ParseConstraints(fields[1])
+	if err != nil {
+		return errors.Annotate(err, "cannot parse device constraints")
+	}
+	var devs map[string]devices.Constraints
+	if applicationName != "" {
+		if *f.bundleDevices == nil {
+			*f.bundleDevices = make(map[string]map[string]devices.Constraints)
+		}
+		devs = (*f.bundleDevices)[applicationName]
+		if devs == nil {
+			devs = make(map[string]devices.Constraints)
+			(*f.bundleDevices)[applicationName] = devs
+		}
+	} else {
+		if *f.devices == nil {
+			*f.devices = make(map[string]devices.Constraints)
+		}
+		devs = *f.devices
+	}
+	devs[deviceName] = cons
+	return nil
+}
+
+// String implements gnuflag.Value.String.
+func (f deviceFlag) String() string {
+	strs := make([]string, 0, len(*f.devices))
+	for device, cons := range *f.devices {
+		strs = append(strs, fmt.Sprintf("%s=%v", device, cons))
+	}
+	if f.bundleDevices != nil {
+		for application, devices := range *f.bundleDevices {
+			for device, cons := range devices {
+				strs = append(strs, fmt.Sprintf("%s:%s=%v", application, device, cons))
 			}
 		}
 	}

--- a/cmd/juju/application/flags.go
+++ b/cmd/juju/application/flags.go
@@ -78,13 +78,13 @@ func (f storageFlag) String() string {
 	return strings.Join(strs, " ")
 }
 
-type deviceFlag struct {
+type devicesFlag struct {
 	devices       *map[string]devices.Constraints
 	bundleDevices *map[string]map[string]devices.Constraints
 }
 
 // Set implements gnuflag.Value.Set.
-func (f deviceFlag) Set(s string) error {
+func (f devicesFlag) Set(s string) error {
 	fields := strings.SplitN(s, "=", 2)
 	if len(fields) < 2 {
 		if f.bundleDevices != nil {
@@ -127,7 +127,7 @@ func (f deviceFlag) Set(s string) error {
 }
 
 // String implements gnuflag.Value.String.
-func (f deviceFlag) String() string {
+func (f devicesFlag) String() string {
 	strs := make([]string, 0, len(*f.devices))
 	for device, cons := range *f.devices {
 		strs = append(strs, fmt.Sprintf("%s=%v", device, cons))

--- a/cmd/juju/application/flags_test.go
+++ b/cmd/juju/application/flags_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/storage"
 )
 
@@ -106,4 +107,62 @@ func (FlagSuite) TestAttachStorageFlagErrors(c *gc.C) {
 	flag := attachStorageFlag{new([]string)}
 	err := flag.Set("zing")
 	c.Assert(err, gc.ErrorMatches, `storage ID "zing" not valid`)
+}
+
+func (FlagSuite) TestDevicesFlag(c *gc.C) {
+	var devs map[string]devices.Constraints
+	flag := devicesFlag{&devs, nil}
+	err := flag.Set("foo=3,nvidia.com/gpu,gpu=nvidia-tesla-p100")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(devs, jc.DeepEquals, map[string]devices.Constraints{
+		"foo": {
+			Type:  "nvidia.com/gpu",
+			Count: 3,
+			Attributes: map[string]string{
+				"gpu": "nvidia-tesla-p100",
+			},
+		},
+	})
+}
+
+func testFlagErrors(c *gc.C, flag devicesFlag, flagStr string, expectedErr string) {
+	err := flag.Set(flagStr)
+	c.Assert(err, gc.ErrorMatches, expectedErr)
+}
+
+func (FlagSuite) TestDevicesFlagErrors(c *gc.C) {
+	flag := devicesFlag{new(map[string]devices.Constraints), nil}
+	testFlagErrors(c, flag, "foo", `expected <device>=<constraints>`)
+	testFlagErrors(c, flag, "foo:bar=baz", `expected <device>=<constraints>`)
+	testFlagErrors(c, flag, "foo:bar=", `expected <device>=<constraints>`)
+
+	testFlagErrors(c, flag, "foo=2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<attributes>\]`)
+	testFlagErrors(c, flag, "foo=2,nvidia.com/gpu,gpu=b=c", `cannot parse device constraints: device attribute key/value pair has bad format: \"gpu=b=c\"`)
+	testFlagErrors(c, flag, "foo=badCount,nvidia.com/gpu", `cannot parse device constraints: count must be greater than zero, got \"badCount\"`)
+	testFlagErrors(c, flag, "foo=0,nvidia.com/gpu", `cannot parse device constraints: count must be greater than zero, got \"0\"`)
+	testFlagErrors(c, flag, "foo=-1,nvidia.com/gpu", `cannot parse device constraints: count must be greater than zero, got \"-1\"`)
+}
+
+func (FlagSuite) TestDevicesFlagBundleDevices(c *gc.C) {
+	var devs map[string]devices.Constraints
+	var bundleDevices map[string]map[string]devices.Constraints
+	flag := devicesFlag{&devs, &bundleDevices}
+	err := flag.Set("foo=bar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = flag.Set("app:baz=qux")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(devs, jc.DeepEquals, map[string]devices.Constraints{
+		"foo": {Type: "bar", Count: 1},
+	})
+	c.Assert(bundleDevices, jc.DeepEquals, map[string]map[string]devices.Constraints{
+		"app": {
+			"baz": {Type: "qux", Count: 1},
+		},
+	})
+}
+
+func (FlagSuite) TestDevicesFlagBundleDevicesErrors(c *gc.C) {
+	flag := devicesFlag{new(map[string]devices.Constraints), new(map[string]map[string]devices.Constraints)}
+	err := flag.Set("foo")
+	c.Assert(err, gc.ErrorMatches, `expected \[<application>\:]<device>=<constraints>`)
 }

--- a/cmd/juju/application/flags_test.go
+++ b/cmd/juju/application/flags_test.go
@@ -136,7 +136,7 @@ func (FlagSuite) TestDevicesFlagErrors(c *gc.C) {
 	testFlagErrors(c, flag, "foo:bar=baz", `expected <device>=<constraints>`)
 	testFlagErrors(c, flag, "foo:bar=", `expected <device>=<constraints>`)
 
-	testFlagErrors(c, flag, "foo=2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<attributes>\]`)
+	testFlagErrors(c, flag, "foo=2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<key>=<value>;...\]`)
 	testFlagErrors(c, flag, "foo=2,nvidia.com/gpu,gpu=b=c", `cannot parse device constraints: device attribute key/value pair has bad format: \"gpu=b=c\"`)
 	testFlagErrors(c, flag, "foo=badCount,nvidia.com/gpu", `cannot parse device constraints: count must be greater than zero, got \"badCount\"`)
 	testFlagErrors(c, flag, "foo=0,nvidia.com/gpu", `cannot parse device constraints: count must be greater than zero, got \"0\"`)

--- a/core/devices/constraints.go
+++ b/core/devices/constraints.go
@@ -86,7 +86,7 @@ func parseAttributes(s string) (map[string]string, error) {
 		}
 		return kv, nil
 	}
-	var attr map[string]string
+	attr := map[string]string{}
 	for _, attrStr := range strings.Split(s, ";") {
 		kv, err := parseAttribute(attrStr)
 		if err != nil {

--- a/core/devices/constraints.go
+++ b/core/devices/constraints.go
@@ -21,4 +21,10 @@ type Constraints struct {
 	Count int64 `bson:"count"`
 }
 
-// TODO (ycliuhw): add parsers later in cmd flag card
+// ParseConstraints parses the specified string and creates a
+// Constraints structure.
+func ParseConstraints(s string) (Constraints, error) {
+	// TODO (ycliuhw): complete here
+	var cons Constraints
+	return cons, nil
+}

--- a/core/devices/constraints.go
+++ b/core/devices/constraints.go
@@ -13,7 +13,7 @@ import (
 
 var logger = loggo.GetLogger("juju.core.devices")
 
-var deviceParseErr = errors.Errorf("cannot parse device constraints string, supported format is [<count>,]<device-class>|<vendor/type>[,<attributes>]")
+var deviceParseErr = errors.Errorf("cannot parse device constraints string, supported format is [<count>,]<device-class>|<vendor/type>[,<key>=<value>;...]")
 
 // DeviceType defines a device type.
 type DeviceType string

--- a/core/devices/constraints.go
+++ b/core/devices/constraints.go
@@ -45,7 +45,7 @@ type Constraints struct {
 // where
 //
 //    COUNT is the number of devices that the user has asked for - count min and max are the
-//    number of devices the charm requires. If unspecified, COUNT defaults to 1
+//    number of devices the charm requires. If unspecified, COUNT defaults to 1.
 func ParseConstraints(s string) (Constraints, error) {
 	var cons Constraints
 	fields := strings.Split(s, ",")

--- a/core/devices/constraints.go
+++ b/core/devices/constraints.go
@@ -3,13 +3,23 @@
 
 package devices
 
+import (
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.core.devices")
+
 // DeviceType defines a device type.
 type DeviceType string
 
 // Constraints describes a set of device constraints.
 type Constraints struct {
 
-	// Type is the device type.
+	// Type is the device type or device-class.
 	// currently supported types are
 	// - gpu
 	// - nvidia.com/gpu
@@ -19,12 +29,70 @@ type Constraints struct {
 	// Count is the number of devices that the user has asked for - count min and max are the
 	// number of devices the charm requires.
 	Count int64 `bson:"count"`
+
+	// Attributes is a collection of key value pairs device related (node affinity labels/tags etc.).
+	Attributes map[string]string `bson:"attributes"`
 }
 
 // ParseConstraints parses the specified string and creates a
 // Constraints structure.
+//
+// The acceptable format for device constraints is a comma separated
+// sequence of: COUNT, TYPE, and ATTRIBUTES with format like
+//
+//    <device-name>=[<count>,]<device-class>|<vendor/type>[,<attributes>]
+//
+// where
+//
+//    COUNT is the number of devices that the user has asked for - count min and max are the
+//    number of devices the charm requires. If unspecified, COUNT defaults to 1
 func ParseConstraints(s string) (Constraints, error) {
-	// TODO (ycliuhw): complete here
 	var cons Constraints
+	fields := strings.Split(s, ",")
+	err := errors.Errorf("cannot parse device constraints string, supported format is [<count>,]<device-class>|<vendor/type>[,<attributes>]")
+
+	fieldsLen := len(fields)
+	if fieldsLen < 1 || fieldsLen > 3 {
+		return cons, err
+	}
+	if fieldsLen == 1 {
+		cons.Count = 1
+		cons.Type = DeviceType(fields[0])
+	} else {
+		count, err := parseCount(fields[0])
+		if err != nil {
+			return cons, err
+		}
+		cons.Count = count
+		cons.Type = DeviceType(fields[1])
+
+		if fieldsLen == 3 {
+			attr, err := parseAttributes(fields[2])
+			if err != nil {
+				return cons, err
+			}
+			cons.Attributes = attr
+		}
+	}
 	return cons, nil
+}
+
+func parseAttributes(s string) (map[string]string, error) {
+	kv := strings.Split(s, "=")
+	if len(kv) != 2 {
+		return nil, errors.Errorf("device attributes can be only one attribute without \"=\" in the string")
+	}
+	return map[string]string{kv[0]: kv[1]}, nil
+}
+
+func parseCount(s string) (int64, error) {
+	errMsg := errors.Errorf("count must be greater than zero, got %q", s)
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, errMsg
+	}
+	if i > 0 {
+		return i, nil
+	}
+	return 0, errMsg
 }

--- a/core/devices/constraints_test.go
+++ b/core/devices/constraints_test.go
@@ -1,0 +1,55 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package devices_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/devices"
+	"github.com/juju/juju/testing"
+)
+
+type ConstraintsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ConstraintsSuite{})
+
+func (*ConstraintsSuite) testParse(c *gc.C, s string, expect devices.Constraints) {
+	cons, err := devices.ParseConstraints(s)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cons, gc.DeepEquals, expect)
+}
+
+func (*ConstraintsSuite) testParseError(c *gc.C, s, expectErr string) {
+	_, err := devices.ParseConstraints(s)
+	c.Check(err, gc.ErrorMatches, expectErr)
+}
+
+func (s *ConstraintsSuite) TestParseConstraintsDeviceGood(c *gc.C) {
+	s.testParse(c, "nvidia.com/gpu", devices.Constraints{
+		Type:  "nvidia.com/gpu",
+		Count: 1,
+	})
+	s.testParse(c, "2,nvidia.com/gpu", devices.Constraints{
+		Type:  "nvidia.com/gpu",
+		Count: 2,
+	})
+	s.testParse(c, "3,nvidia.com/gpu,gpu=nvidia-tesla-p100", devices.Constraints{
+		Type:  "nvidia.com/gpu",
+		Count: 3,
+		Attributes: map[string]string{
+			"gpu": "nvidia-tesla-p100",
+		},
+	})
+}
+
+func (s *ConstraintsSuite) TestParseConstraintsDeviceBad(c *gc.C) {
+	s.testParseError(c, "2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<attributes>\]`)
+	s.testParseError(c, "2,nvidia.com/gpu,gpu=b=c", `device attributes can be only one attribute without \"=\" in the string`)
+	s.testParseError(c, "badCount,nvidia.com/gpu", `count must be greater than zero, got \"badCount\"`)
+	s.testParseError(c, "0,nvidia.com/gpu", `count must be greater than zero, got \"0\"`)
+	s.testParseError(c, "-1,nvidia.com/gpu", `count must be greater than zero, got \"-1\"`)
+}

--- a/core/devices/constraints_test.go
+++ b/core/devices/constraints_test.go
@@ -19,13 +19,13 @@ var _ = gc.Suite(&ConstraintsSuite{})
 
 func (*ConstraintsSuite) testParse(c *gc.C, s string, expect devices.Constraints) {
 	cons, err := devices.ParseConstraints(s)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(cons, gc.DeepEquals, expect)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.DeepEquals, expect)
 }
 
 func (*ConstraintsSuite) testParseError(c *gc.C, s, expectErr string) {
 	_, err := devices.ParseConstraints(s)
-	c.Check(err, gc.ErrorMatches, expectErr)
+	c.Assert(err, gc.ErrorMatches, expectErr)
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsDeviceGood(c *gc.C) {
@@ -44,11 +44,19 @@ func (s *ConstraintsSuite) TestParseConstraintsDeviceGood(c *gc.C) {
 			"gpu": "nvidia-tesla-p100",
 		},
 	})
+	s.testParse(c, "3,nvidia.com/gpu,gpu=nvidia-tesla-p100;2ndattr=another-attr", devices.Constraints{
+		Type:  "nvidia.com/gpu",
+		Count: 3,
+		Attributes: map[string]string{
+			"gpu":     "nvidia-tesla-p100",
+			"2ndattr": "another-attr",
+		},
+	})
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsDeviceBad(c *gc.C) {
 	s.testParseError(c, "2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<attributes>\]`)
-	s.testParseError(c, "2,nvidia.com/gpu,gpu=b=c", `device attributes can be only one attribute without \"=\" in the string`)
+	s.testParseError(c, "2,nvidia.com/gpu,gpu=b=c", `device attribute key/value pair has bad format: \"gpu=b=c\"`)
 	s.testParseError(c, "badCount,nvidia.com/gpu", `count must be greater than zero, got \"badCount\"`)
 	s.testParseError(c, "0,nvidia.com/gpu", `count must be greater than zero, got \"0\"`)
 	s.testParseError(c, "-1,nvidia.com/gpu", `count must be greater than zero, got \"-1\"`)

--- a/core/devices/constraints_test.go
+++ b/core/devices/constraints_test.go
@@ -55,7 +55,7 @@ func (s *ConstraintsSuite) TestParseConstraintsDeviceGood(c *gc.C) {
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsDeviceBad(c *gc.C) {
-	s.testParseError(c, "2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<attributes>\]`)
+	s.testParseError(c, "2,nvidia.com/gpu,gpu=nvidia-tesla-p100,a=b", `cannot parse device constraints string, supported format is \[<count>,\]<device-class>|<vendor/type>\[,<key>=<value>;...\]`)
 	s.testParseError(c, "2,nvidia.com/gpu,gpu=b=c", `device attribute key/value pair has bad format: \"gpu=b=c\"`)
 	s.testParseError(c, "badCount,nvidia.com/gpu", `count must be greater than zero, got \"badCount\"`)
 	s.testParseError(c, "0,nvidia.com/gpu", `count must be greater than zero, got \"0\"`)

--- a/core/devices/package_test.go
+++ b/core/devices/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package devices_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

To introduce `--device` flag to parse device constraints from client/cmd to API for GPU stuff.
 
## QA steps

How do we verify that the change works?

This PR is just introducing `--device` flag and parse the data to back-end API server. It could be tested once back-end has the logic to handle it.

## Documentation changes

Does it affect current user workflow? CLI? API?

added new flag `--device` to the `deploy` cmd