### PR TITLE
data for upgradeSeriesLock doc

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -364,15 +364,16 @@ func (mm *MachineManagerAPI) updateSeriesPrepare(arg params.UpdateSeriesArg) err
 	}
 
 	principals := machine.Principals()
-	// TODO (hml) 2018-06-26 managed series upgrade
-	// units slice to be used with changes to createupgradeserieslock to
-	// pass units, series etc.
-	_, err = machine.VerifyUnitsSeries(principals, arg.Series, arg.Force)
+	units, err := machine.VerifyUnitsSeries(principals, arg.Series, arg.Force)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	unitNames := make([]string, len(units))
+	for i := range units {
+		unitNames[i] = units[i].UnitTag().String()
+	}
 
-	if err = machine.CreateUpgradeSeriesLock(); err != nil {
+	if err = machine.CreateUpgradeSeriesLock(unitNames, arg.Series); err != nil {
 		return errors.Trace(err)
 	}
 	defer func() {

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -370,10 +370,13 @@ func (mm *MachineManagerAPI) updateSeriesPrepare(arg params.UpdateSeriesArg) err
 	}
 	unitNames := make([]string, len(units))
 	for i := range units {
-		unitNames[i] = units[i].UnitTag().String()
+		unitNames[i] = units[i].UnitTag().Id()
 	}
 
 	if err = machine.CreateUpgradeSeriesLock(unitNames, arg.Series); err != nil {
+		// TODO 2018-06-28 managed series upgrade
+		// improve error handling based on error type, there will be cases where retrying
+		// the hooks is needed etc.
 		return errors.Trace(err)
 	}
 	defer func() {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -332,8 +332,10 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	mach := s.st.machines["0"]
-	mach.CheckCallNames(c, "Series", "Principals", "VerifyUnitsSeries", "CreateUpgradeSeriesLock")
 	c.Assert(len(mach.Calls()), gc.Equals, 4)
+	mach.CheckCallNames(c, "Series", "Principals", "VerifyUnitsSeries", "CreateUpgradeSeriesLock")
+	mach.CheckCall(c, 3, "CreateUpgradeSeriesLock", []string{"unit-foo-0", "unit-test-0"}, "xenial")
+
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareAlreadyRunningSeries(c *gc.C) {
@@ -622,8 +624,8 @@ func (m *mockMachine) VerifyUnitsSeries(units []string, series string, force boo
 	return out, m.NextErr()
 }
 
-func (m *mockMachine) CreateUpgradeSeriesLock() error {
-	m.MethodCall(m, "CreateUpgradeSeriesLock")
+func (m *mockMachine) CreateUpgradeSeriesLock(unitTags []string, series string) error {
+	m.MethodCall(m, "CreateUpgradeSeriesLock", unitTags, series)
 	return m.NextErr()
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -334,7 +334,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 	mach := s.st.machines["0"]
 	c.Assert(len(mach.Calls()), gc.Equals, 4)
 	mach.CheckCallNames(c, "Series", "Principals", "VerifyUnitsSeries", "CreateUpgradeSeriesLock")
-	mach.CheckCall(c, 3, "CreateUpgradeSeriesLock", []string{"unit-foo-0", "unit-test-0"}, "xenial")
+	mach.CheckCall(c, 3, "CreateUpgradeSeriesLock", []string{"foo/0", "test/0"}, "xenial")
 
 }
 

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -44,7 +44,7 @@ type Machine interface {
 	Units() ([]Unit, error)
 	SetKeepInstance(keepInstance bool) error
 	UpdateMachineSeries(string, bool) error
-	CreateUpgradeSeriesLock() error
+	CreateUpgradeSeriesLock([]string, string) error
 	RemoveUpgradeSeriesLock() error
 	VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error)
 	Principals() []string

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -784,3 +784,7 @@ func (st *State) IsUserSuperuser(user names.UserTag) (bool, error) {
 func (st *State) ModelQueryForUser(user names.UserTag, isSuperuser bool) (mongo.Query, SessionCloser, error) {
 	return st.modelQueryForUser(user, isSuperuser)
 }
+
+func UnitsHaveChanged(m *Machine, unitNames []string) (bool, error) {
+	return m.unitsHaveChanged(unitNames)
+}

--- a/state/machine.go
+++ b/state/machine.go
@@ -217,7 +217,10 @@ type instanceData struct {
 // upgradeSeriesLock holds the attributes relevant to lock a machine during a
 // series update of a machine
 type upgradeSeriesLock struct {
-	Id string
+	Id         string   `bson:"machineid"`
+	ToSeries   string   `bson:"toseries"`
+	FromSeries string   `bson:"fromseries"`
+	Units      []string `bson:"units"`
 }
 
 func hardwareCharacteristics(instData instanceData) *instance.HardwareCharacteristics {
@@ -2061,7 +2064,7 @@ func (m *Machine) VerifyUnitsSeries(unitNames []string, series string, force boo
 // this item exists in the database for a given machine it indicates that a
 // machine's operating system is being upgraded from one series to another - for
 // example from xenial to bionic.
-func (m *Machine) CreateUpgradeSeriesLock() error {
+func (m *Machine) CreateUpgradeSeriesLock(unitNames []string, toSeries string) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := m.Refresh(); err != nil {
@@ -2076,10 +2079,28 @@ func (m *Machine) CreateUpgradeSeriesLock() error {
 			return nil, errors.AlreadyExistsf("upgrade series lock for machine %q", m)
 		}
 		if err = m.isStillAlive(); err != nil {
-			return nil, errors.Wrap(jujutxn.ErrNoOperations, err)
+			return nil, errors.Trace(err)
+		}
+		// Exit early if the Machine series doesn't need to change.
+		fromSeries := m.Series()
+		if fromSeries == toSeries {
+			return nil, errors.Trace(errors.Errorf("machine %s already at series %s", m.Id(), toSeries))
+		}
+		// If the units have changed, the verification is no longer valid.
+		changed, err := m.unitsHaveChanged(unitNames)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if changed {
+			return nil, errors.Errorf("Units have changed, please retry (%+v)", unitNames)
 		}
 
-		data := &upgradeSeriesLock{Id: m.Id()}
+		data := &upgradeSeriesLock{
+			Id:         m.Id(),
+			ToSeries:   toSeries,
+			FromSeries: fromSeries,
+			Units:      unitNames,
+		}
 		return createUpgradeSeriesLockTxnOps(m.doc.Id, data), nil
 	}
 	err := m.st.db().Run(buildTxn)
@@ -2090,6 +2111,25 @@ func (m *Machine) CreateUpgradeSeriesLock() error {
 	}
 
 	return nil
+}
+
+func (m *Machine) unitsHaveChanged(unitNames []string) (bool, error) {
+	curUnits, err := m.Units()
+	if err != nil {
+		return true, err
+	}
+	if len(curUnits) == 0 && len(unitNames) == 0 {
+		return false, nil
+	}
+	if len(curUnits) != len(unitNames) {
+		return true, nil
+	}
+	curUnitSet := set.NewStrings()
+	for _, unit := range curUnits {
+		curUnitSet.Add(unit.Tag().String())
+	}
+	unitNameSet := set.NewStrings(unitNames...)
+	return !unitNameSet.Difference(curUnitSet).IsEmpty(), nil
 }
 
 // RemoveUpgradeSeriesLock remove a series upgrade prepare lock for a


### PR DESCRIPTION
part of managed series upgrades: add to-series, from-series, prepareStatus, completeStatus and units to upgradeSeriesLock

qa steps;

juju bootstrap
export JUJU_DEV_FEATURE_FLAGS=upgrade-series
juju deploy ghost --series trusty
juju upgrade-series prepare 0 xenial
juju-db.bash
juju:PRIMARY> db.machineUpgradeSeriesLocks.find()
verify doc has the new data.
