### PR TITLE
Adds functionality to apply constraints to a LXD container spec

### DIFF
--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lxc/lxd/shared/osarch"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container/lxd"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	"github.com/juju/juju/environs/tags"
@@ -449,4 +450,49 @@ func (s *containerSuite) TestRemoveContainersPartialFailure(c *gc.C) {
 
 	err = jujuSvr.RemoveContainers([]string{"c1", "c2", "c3"})
 	c.Assert(err, gc.ErrorMatches, "failed to remove containers: c1, c2")
+}
+
+func (s *managerSuite) TestSpecApplyConstraintsNoInstanceType(c *gc.C) {
+	mem := uint64(2046)
+	cores := uint64(4)
+
+	cons := constraints.Value{
+		Mem:      &mem,
+		CpuCores: &cores,
+	}
+
+	spec := lxd.ContainerSpec{
+		Config: map[string]string{lxd.AutoStartKey: "true"},
+	}
+	spec.ApplyConstraints(cons)
+
+	exp := map[string]string{
+		lxd.AutoStartKey: "true",
+		"limits.memory":  "2046MB",
+		"limits.cpu":     "4",
+	}
+	c.Check(spec.Config, gc.DeepEquals, exp)
+	c.Check(spec.InstanceType, gc.Equals, "")
+}
+
+func (s *managerSuite) TestSpecApplyConstraintsWithInstanceType(c *gc.C) {
+	mem := uint64(2046)
+	cores := uint64(4)
+	instType := "t2.micro"
+
+	cons := constraints.Value{
+		Mem:          &mem,
+		CpuCores:     &cores,
+		InstanceType: &instType,
+	}
+
+	exp := map[string]string{lxd.AutoStartKey: "true"}
+
+	spec := lxd.ContainerSpec{
+		Config: exp,
+	}
+	spec.ApplyConstraints(cons)
+
+	c.Check(spec.Config, gc.DeepEquals, exp)
+	c.Check(spec.InstanceType, gc.Equals, instType)
 }

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -206,13 +206,16 @@ func (m *containerManager) getContainerSpec(
 		JujuModelKey: m.modelUUID,
 	}
 
-	return ContainerSpec{
+	spec := ContainerSpec{
 		Name:     name,
 		Image:    found,
 		Config:   cfg,
 		Profiles: nil,
 		Devices:  nics,
-	}, nil
+	}
+	spec.ApplyConstraints(cons)
+
+	return spec, nil
 }
 
 // getImageSources returns a list of LXD remote image sources based on the


### PR DESCRIPTION
## Description of change

This change introduces constraints support for LXD container machines.

The currently supported constraints are:
- Instance type
- CPU cores
- Memory

Instance types are congruent with AWS, GCE and Azure types. Those are listed here:
https://github.com/dustinkirkland/instance-type/tree/master/yaml

If an instance type constraint is supplied and any of CPU cores or memory are also supplied, these are ignored and a warning indicating such is logged.

Given recent networking changes, we should also be able to filter networking devices based on space constraints in a future patch.

## QA steps

```juju add-machine lxd:0 --constraints "cores=2 mem=1G"```
- Check the LXD config for the new container and verify that:
  - limits.cpu = "2" and;
  - limits.memory = "1024MB"

```juju add-machine lxd:0 --constraints "cores=2 mem=1G instance-type=t2.micro"```
- SSH to the host machine, check that the warnings were logged.
- Check the LXD config for the new container and verify that:
  - limits.cpu = "1" and;
  - limits.memory = "1024MB"

## Documentation changes

Support for this enhancement should be documented.

## Bug reference

N/A
