### PR TITLE
WIP: Gosimple linter

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -152,8 +152,7 @@ func (c *Client) Deploy(args DeployArgs) error {
 		}},
 	}
 	var results params.ErrorResults
-	var err error
-	err = c.facade.FacadeCall("Deploy", deployArgs, &results)
+	err := c.facade.FacadeCall("Deploy", deployArgs, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -220,9 +220,7 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 			// Users are not rate limited, all other entities are.
 			if !a.srv.limiter.Acquire() {
 				logger.Debugf("rate limiting for agent %s", req.AuthTag)
-				select {
-				case <-time.After(a.srv.loginRetryPause):
-				}
+				<-time.After(a.srv.loginRetryPause)
 				return nil, common.ErrTryAgain
 			}
 			defer a.srv.limiter.Release()

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -184,10 +184,9 @@ func (m modelShim) Users() ([]permission.UserAccess, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	users := make([]permission.UserAccess, len(stateUsers))
-	for i, user := range stateUsers {
-		users[i] = user
-	}
+	copy(users, stateUsers)
 	return users, nil
 }
 

--- a/apiserver/facades/agent/machineactions/machineactions_test.go
+++ b/apiserver/facades/agent/machineactions/machineactions_test.go
@@ -97,10 +97,7 @@ func (auth agentAuth) AuthMachineAgent() bool {
 }
 
 func (auth agentAuth) AuthOwner(tag names.Tag) bool {
-	if tag.String() == "valid" {
-		return true
-	}
-	return false
+	return tag.String() == "valid"
 }
 
 // mockBackend implements machineactions.Backend for use in the tests.

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -216,8 +216,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 		Machine:     s.machine2,
 	})
 
-	var err error
-	err = s.addRelationToSuiteScope(c, wordpress1Unit, s.mysqlUnit)
+	err := s.addRelationToSuiteScope(c, wordpress1Unit, s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.addRelationToSuiteScope(c, s.wordpressUnit, s.mysqlUnit)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2092,9 +2092,7 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 		// If there is no ingress address explicitly defined for a given binding,
 		// set the ingress addresses to either any defaults set above, or the binding addresses.
 		if len(info.IngressAddresses) == 0 {
-			for _, addr := range defaultIngressAddresses {
-				info.IngressAddresses = append(info.IngressAddresses, addr)
-			}
+			info.IngressAddresses = append(info.IngressAddresses, defaultIngressAddresses...)
 		}
 		if len(info.IngressAddresses) == 0 {
 			for _, nwInfo := range info.Info {

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -212,7 +212,7 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, t.err)
 			continue
 		}
-		if c.Check(err, jc.ErrorIsNil) == false {
+		if !c.Check(err, jc.ErrorIsNil) {
 			continue
 		}
 		c.Check(info, jc.DeepEquals, t.expected)

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -1436,11 +1436,11 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 		client := s.APIState.Client()
 		ref, err := charm.ParseURL(test.url)
 		if test.parseErr == "" {
-			if c.Check(err, jc.ErrorIsNil) == false {
+			if !c.Check(err, jc.ErrorIsNil) {
 				continue
 			}
 		} else {
-			if c.Check(err, gc.NotNil) == false {
+			if !c.Check(err, gc.NotNil) {
 				continue
 			}
 			c.Check(err, gc.ErrorMatches, test.parseErr)
@@ -1449,7 +1449,7 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 
 		curl, err := client.ResolveCharm(ref)
 		if test.resolveErr == "" {
-			if c.Check(err, jc.ErrorIsNil) == false {
+			if !c.Check(err, jc.ErrorIsNil) {
 				continue
 			}
 			c.Check(curl.String(), gc.Equals, test.resolved)

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -388,7 +388,7 @@ func (api *CloudAPI) Credential(args params.Entities) (params.CloudCredentialRes
 func (api *CloudAPIV2) AddCloud(cloudArgs params.AddCloudArgs) error {
 	err := api.backend.AddCloud(common.CloudFromParams(cloudArgs.Name, cloudArgs.Cloud))
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -441,8 +441,6 @@ var commonFakeEntities = []params.Entity{
 }
 
 func addFakeEntities(actual params.Entities) params.Entities {
-	for _, entity := range commonFakeEntities {
-		actual.Entities = append(actual.Entities, entity)
-	}
+	actual.Entities = append(actual.Entities, commonFakeEntities...)
 	return actual
 }

--- a/apiserver/facades/controller/logfwd/lastsent.go
+++ b/apiserver/facades/controller/logfwd/lastsent.go
@@ -92,7 +92,7 @@ func (api *LogForwardingAPI) get(id params.LogForwardingID) params.LogForwarding
 // SetLastSent is a bulk call that sets the log forwarding "last sent"
 // record ID for each requested target.
 func (api *LogForwardingAPI) SetLastSent(args params.LogForwardingSetLastSentParams) params.ErrorResults {
-	results := make([]params.ErrorResult, len(args.Params), len(args.Params))
+	results := make([]params.ErrorResult, len(args.Params))
 	for i, arg := range args.Params {
 		results[i].Error = api.set(arg)
 	}

--- a/apiserver/facades/controller/logfwd/lastsent_test.go
+++ b/apiserver/facades/controller/logfwd/lastsent_test.go
@@ -257,18 +257,10 @@ func (s *stubTracker) Get() (int64, int64, error) {
 
 func (s *stubTracker) Set(recID int64, recTimestamp int64) error {
 	s.stub.AddCall("Set", recID, recTimestamp)
-	if err := s.stub.NextErr(); err != nil {
-		return err
-	}
-
-	return nil
+	return s.stub.NextErr()
 }
 
 func (s *stubTracker) Close() error {
 	s.stub.AddCall("Close")
-	if err := s.stub.NextErr(); err != nil {
-		return err
-	}
-
-	return nil
+	return s.stub.NextErr()
 }

--- a/apiserver/listener.go
+++ b/apiserver/listener.go
@@ -128,7 +128,5 @@ func (l *throttlingListener) pause() {
 		return
 	}
 	pauseTime := l.pauseTime()
-	select {
-	case <-l.clk.After(pauseTime):
-	}
+	<-l.clk.After(pauseTime)
 }

--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -61,7 +61,7 @@ func (f *RPCInstance) ServerRequest(hdr *rpc.Header, body interface{}) {
 // funcName returns the name of the function/method that called
 // funcName() It panics if this is not possible.
 func funcName() string {
-	if pc, _, _, ok := runtime.Caller(1); ok == false {
+	if pc, _, _, ok := runtime.Caller(1); !ok {
 		panic("could not find function name")
 	} else {
 		parts := strings.Split(runtime.FuncForPC(pc).Name(), ".")

--- a/apiserver/params/apierror_test.go
+++ b/apiserver/params/apierror_test.go
@@ -18,10 +18,9 @@ var _ rpc.ErrorCoder = (*params.Error)(nil)
 var _ = gc.Suite(&errorSuite{})
 
 func (*errorSuite) TestErrCode(c *gc.C) {
-	var err error
-	err = &params.Error{Code: params.CodeDead, Message: "brain dead test"}
-	c.Check(params.ErrCode(err), gc.Equals, params.CodeDead)
+	err0 := &params.Error{Code: params.CodeDead, Message: "brain dead test"}
+	c.Check(params.ErrCode(err0), gc.Equals, params.CodeDead)
 
-	err = errors.Trace(err)
-	c.Check(params.ErrCode(err), gc.Equals, params.CodeDead)
+	err1 := errors.Trace(err0)
+	c.Check(params.ErrCode(err1), gc.Equals, params.CodeDead)
 }

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -529,10 +529,7 @@ func (sb *StubBacking) AddSpace(name string, providerId network.Id, subnets []st
 
 func (sb *StubBacking) ReloadSpaces(environ environs.Environ) error {
 	sb.MethodCall(sb, "ReloadSpaces", environ)
-	if err := sb.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return sb.NextErr()
 }
 
 // GoString implements fmt.GoStringer.

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -102,7 +102,7 @@ func checkTLSConnection(c *gc.C, caCert, srvCert *x509.Certificate, srvKey *rsa.
 
 	outData := outBytes.String()
 	c.Assert(outData, gc.Not(gc.HasLen), 0)
-	if strings.Index(outData, msg) != -1 {
+	if strings.Contains(outData, msg) {
 		c.Fatalf("TLS connection not encrypted")
 	}
 	c.Assert(clientState.VerifiedChains, gc.HasLen, 1)

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -120,8 +120,7 @@ func (cfg *centOSCloudConfig) PackagePreferences() []packaging.PackagePreference
 // Render is defined on the the Renderer interface.
 func (cfg *centOSCloudConfig) RenderYAML() ([]byte, error) {
 	// Save the fields that we will modify
-	var oldruncmds []string
-	oldruncmds = copyStringSlice(cfg.RunCmds())
+	oldruncmds := copyStringSlice(cfg.RunCmds())
 
 	// check for package proxy setting and add commands:
 	var proxy string

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -80,8 +80,7 @@ func (cfg *ubuntuCloudConfig) PackagePreferences() []packaging.PackagePreference
 
 func (cfg *ubuntuCloudConfig) RenderYAML() ([]byte, error) {
 	// Save the fields that we will modify
-	var oldbootcmds []string
-	oldbootcmds = copyStringSlice(cfg.BootCmds())
+	oldbootcmds := copyStringSlice(cfg.BootCmds())
 
 	// apt_preferences is not a valid field so we use a fake field in attrs
 	// and then render it differently

--- a/cloudconfig/cloudinit/cloudinit_win.go
+++ b/cloudconfig/cloudinit/cloudinit_win.go
@@ -107,7 +107,6 @@ func (cfg *windowsCloudConfig) AddPackageCommands(
 	addUpdateScripts bool,
 	addUpgradeScripts bool,
 ) {
-	return
 }
 
 // AddCloudArchiveCloudTools is defined on the AdvancedPackagingConfig

--- a/cloudconfig/cloudinit/helpers.go
+++ b/cloudconfig/cloudinit/helpers.go
@@ -98,8 +98,6 @@ func copyStringSlice(s []string) []string {
 		return nil
 	}
 	res := make([]string, len(s))
-	for i, item := range s {
-		res[i] = item
-	}
+	copy(res, s)
 	return res
 }

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -185,13 +185,13 @@ func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, err
 	// the results; otherwise, return a pending status.
 
 	// First, sync.
-	_ = <-time.NewTimer(0 * time.Second).C
+	<-time.NewTimer(0 * time.Second).C
 
 	select {
-	case _ = <-c.delay.C:
+	case <-c.delay.C:
 		// The API delay timer is up.  Pass pre-canned results back.
 		return params.ActionResults{Results: c.actionResults}, c.apiErr
-	case _ = <-c.timeout.C:
+	case <-c.timeout.C:
 		// Timeout to prevent tests from hanging.
 		return params.ActionResults{}, errors.New("test timed out before wait time")
 	default:

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -303,7 +303,7 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	if c.wait.d.Nanoseconds() <= 0 {
 		// Indefinite wait. Discard the tick.
 		wait = time.NewTimer(0 * time.Second)
-		_ = <-wait.C
+		<-wait.C
 	} else {
 		wait = time.NewTimer(c.wait.d)
 	}

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -98,7 +98,7 @@ func (c *showOutputCommand) Run(ctx *cmd.Context) error {
 	case waitDur.Nanoseconds() == 0:
 		// Zero duration signals indefinite wait.  Discard the tick.
 		wait = time.NewTimer(0 * time.Second)
-		_ = <-wait.C
+		<-wait.C
 	default:
 		// Otherwise, start an ordinary timer.
 		wait = time.NewTimer(waitDur)
@@ -151,10 +151,10 @@ func timerLoop(api APIClient, requestedId string, wait, tick *time.Timer) (param
 
 		// Block until a tick happens, or the timeout arrives.
 		select {
-		case _ = <-wait.C:
+		case <-wait.C:
 			return result, nil
 
-		case _ = <-tick.C:
+		case <-tick.C:
 			tick.Reset(2 * time.Second)
 		}
 	}

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -257,10 +257,7 @@ func (h *bundleHandler) makeModel(
 	}
 
 	h.modelConfig, err = getModelConfig(h.api)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // resolveCharmsAndEndpoints will go through the bundle and
@@ -1285,9 +1282,7 @@ func processSingleBundleOverlay(data *charm.BundleData, bundleOverlayFile string
 	}
 
 	// Next process relations.
-	for _, relation := range config.Relations {
-		data.Relations = append(data.Relations, relation)
-	}
+	data.Relations = append(data.Relations, config.Relations...)
 
 	// Finally, if the bundle overlay overrode the machines definition use
 	// that.

--- a/cmd/juju/application/trust.go
+++ b/cmd/juju/application/trust.go
@@ -56,7 +56,6 @@ func (c *trustCommand) Init(args []string) error {
 		return errors.New("no application name specified")
 	}
 	c.applicationName = args[0]
-	var trustOptionPair string
-	trustOptionPair = fmt.Sprintf("%s=%t", application.TrustConfigOptionName, !c.removeTrust)
+	trustOptionPair := fmt.Sprintf("%s=%t", application.TrustConfigOptionName, !c.removeTrust)
 	return c.parseSet([]string{trustOptionPair})
 }

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -179,7 +179,7 @@ func (c *AddCAASCommand) Run(ctxt *cmd.Context) error {
 			}
 		}
 	} else {
-		context, _ = caasConfig.Contexts[caasConfig.CurrentContext]
+		context = caasConfig.Contexts[caasConfig.CurrentContext]
 		logger.Debugf("No cluster name specified, so use current context %q", caasConfig.CurrentContext)
 	}
 

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -84,11 +84,7 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	default:
 		output = details
 	}
-	err = c.out.Write(ctxt, output)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.out.Write(ctxt, output)
 }
 
 type cloudList struct {

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -105,11 +105,7 @@ func (c *listRegionsCommand) Run(ctxt *cmd.Context) error {
 		}
 		regions = details
 	}
-	err = c.out.Write(ctxt, regions)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.out.Write(ctxt, regions)
 }
 
 func (c *listRegionsCommand) formatRegionsListTabular(writer io.Writer, value interface{}) error {

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -175,7 +175,7 @@ func getCloudConfigDetails(cloudType string) map[string]interface{} {
 		}
 		specifics[attr] = common.PrintConfigSchema{
 			Description: providerSchema[attr].Description,
-			Type:        fmt.Sprintf("%s", providerSchema[attr].Type),
+			Type:        string(providerSchema[attr].Type),
 		}
 	}
 	return specifics

--- a/cmd/juju/cloud/updateclouds_test.go
+++ b/cmd/juju/cloud/updateclouds_test.go
@@ -44,7 +44,7 @@ func encodeCloudYAML(c *gc.C, yaml string) string {
 	c.Assert(err, jc.ErrorIsNil)
 	err = plaintext.Close()
 	c.Assert(err, jc.ErrorIsNil)
-	return string(buf.Bytes())
+	return buf.String()
 }
 
 func (s *updateCloudsSuite) setupTestServer(c *gc.C, serverContent string) *httptest.Server {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1401,7 +1401,6 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 			switch op.(type) {
 			case dummy.OpDestroy:
 				c.Error("unexpected call to env.Destroy")
-				break
 			}
 		default:
 			break

--- a/cmd/juju/commands/commands_test.go
+++ b/cmd/juju/commands/commands_test.go
@@ -106,9 +106,7 @@ func (r *stubRegistry) Register(subcmd cmd.Command) {
 	r.stub.NextErr() // pop one off
 
 	r.names = append(r.names, subcmd.Info().Name)
-	for _, name := range subcmd.Info().Aliases {
-		r.names = append(r.names, name)
-	}
+	r.names = append(r.names, subcmd.Info().Aliases...)
 }
 
 func (r *stubRegistry) RegisterSuperAlias(name, super, forName string, check cmd.DeprecationCheck) {
@@ -123,7 +121,5 @@ func (r *stubRegistry) RegisterDeprecated(subcmd cmd.Command, check cmd.Deprecat
 	r.stub.NextErr() // pop one off
 
 	r.names = append(r.names, subcmd.Info().Name)
-	for _, name := range subcmd.Info().Aliases {
-		r.names = append(r.names, name)
-	}
+	r.names = append(r.names, subcmd.Info().Aliases...)
 }

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -996,9 +996,7 @@ func (a *fakeUpgradeJujuAPI) ModelConfig() (map[string]interface{}, error) {
 }
 
 func (a *fakeUpgradeJujuAPI) addTools(tools ...string) {
-	for _, tool := range tools {
-		a.tools = append(a.tools, tool)
-	}
+	a.tools = append(a.tools, tools...)
 }
 
 func (a *fakeUpgradeJujuAPI) ModelGet() (map[string]interface{}, error) {

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -106,9 +106,7 @@ func (f *ConfigFlag) AbsoluteFileNames(ctx *cmd.Context) ([]string, error) {
 // String implements gnuflag.Value.String.
 func (f *ConfigFlag) String() string {
 	strs := make([]string, 0, len(f.attrs)+len(f.files))
-	for _, f := range f.files {
-		strs = append(strs, f)
-	}
+	strs = append(strs, f.files...)
 	for k, v := range f.attrs {
 		strs = append(strs, fmt.Sprintf("%s=%v", k, v))
 	}

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -565,8 +565,7 @@ func (c *registerCommand) promptControllerName(suggestedName string, stderr io.W
 		}
 	}
 	for {
-		var setMsg string
-		setMsg = "Enter a name for this controller: "
+		setMsg := "Enter a name for this controller: "
 		if suggestedName != "" {
 			setMsg = fmt.Sprintf("Enter a name for this controller [%s]: ", suggestedName)
 		}

--- a/cmd/juju/crossmodel/offer.go
+++ b/cmd/juju/crossmodel/offer.go
@@ -176,7 +176,7 @@ type OfferAPI interface {
 
 // applicationParse is used to split an application string
 // into model, application and endpoint names.
-var applicationParse = regexp.MustCompile("/?((?P<model>[^\\.]*)\\.)?(?P<appname>[^:]*)(:(?P<endpoints>.*))?")
+var applicationParse = regexp.MustCompile(`/?((?P<model>[^\.]*)\.)?(?P<appname>[^:]*)(:(?P<endpoints>.*))?`)
 
 func (c *offerCommand) parseEndpoints(controllerName, arg string) error {
 	modelNameArg := applicationParse.ReplaceAllString(arg, "$model")

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -196,7 +196,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 
 	// We want to wait for the action results indefinitely.  Discard the tick.
 	wait := time.NewTimer(0 * time.Second)
-	_ = <-wait.C
+	<-wait.C
 	// trigger sending metrics in parallel
 	resultChannel := make(chan string, len(runResults))
 	for _, result := range runResults {
@@ -269,9 +269,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 
 	for range runResults {
 		// The default is to wait forever for the command to finish.
-		select {
-		case <-resultChannel:
-		}
+		<-resultChannel
 	}
 	return nil
 }

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -429,7 +429,7 @@ func (c *configCommand) modelConfigDetails() (map[string]interface{}, error) {
 		}
 		specifics[key] = common.PrintConfigSchema{
 			Description: attr.Description,
-			Type:        fmt.Sprintf("%s", attr.Type),
+			Type:        string(attr.Type),
 		}
 	}
 	return specifics, nil

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -604,9 +604,7 @@ func (c *defaultsCommand) verifyKnownKeys(client defaultsCommandAPI, keys []stri
 	}
 
 	allKeys := c.resetKeys[:]
-	for _, k := range keys {
-		allKeys = append(allKeys, k)
-	}
+	allKeys = append(allKeys, keys...)
 
 	for _, key := range allKeys {
 		// check if the key exists in the known config

--- a/cmd/juju/resource/util_test.go
+++ b/cmd/juju/resource/util_test.go
@@ -58,7 +58,7 @@ func newCharmResources(c *gc.C, names ...string) []charmresource.Resource {
 func runCmd(c *gc.C, command jujucmd.Command, args ...string) (code int, stdout string, stderr string) {
 	ctx := cmdtesting.Context(c)
 	code = jujucmd.Main(command, ctx, args)
-	stdout = string(ctx.Stdout.(*bytes.Buffer).Bytes())
-	stderr = string(ctx.Stderr.(*bytes.Buffer).Bytes())
+	stdout = ctx.Stdout.(*bytes.Buffer).String()
+	stderr = ctx.Stderr.(*bytes.Buffer).String()
 	return code, stdout, stderr
 }

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -196,7 +196,7 @@ space2
 		if format != "" {
 			args = append(args, "--format", format)
 		}
-		if short == true {
+		if short {
 			args = append(args, "--short")
 		}
 		return args
@@ -206,8 +206,7 @@ space2
 		c.Assert(outFile, jc.DoesNotExist)
 		defer os.Remove(outFile)
 		// Check -o works.
-		var args []string
-		args = makeArgs(format, short, "-o", outFile)
+		args := makeArgs(format, short, "-o", outFile)
 		s.AssertRunSucceeds(c, "", "", args...)
 		assertAPICalls()
 

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -129,9 +129,7 @@ func (sf *statusFormatter) MachineFormat(machineId []string) formattedMachineSta
 }
 
 func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineStatus {
-	var out machineStatus
-
-	out = machineStatus{
+	out := machineStatus{
 		JujuStatus:        sf.getStatusInfoContents(machine.AgentStatus),
 		DNSName:           machine.DNSName,
 		IPAddresses:       machine.IPAddresses,

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -168,7 +168,7 @@ func formatListTabular(writer io.Writer, value interface{}) error {
 			combined.Filesystems,
 			combined.Volumes,
 		); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		return nil
 	}
@@ -177,7 +177,7 @@ func formatListTabular(writer io.Writer, value interface{}) error {
 			fmt.Fprintln(writer)
 		}
 		if err := formatFilesystemListTabular(writer, combined.Filesystems); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		newline = true
 	}
@@ -186,7 +186,7 @@ func formatListTabular(writer io.Writer, value interface{}) error {
 			fmt.Fprintln(writer)
 		}
 		if err := formatVolumeListTabular(writer, combined.Volumes); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	return nil

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -90,9 +90,7 @@ func (c *AddCommand) Init(args []string) (err error) {
 	}
 
 	// Add any given zones.
-	for _, zone := range args[2:] {
-		c.Zones = append(c.Zones, zone)
-	}
+	c.Zones = append(c.Zones, args[2:]...)
 	return nil
 }
 

--- a/cmd/juju/user/list.go
+++ b/cmd/juju/user/list.go
@@ -105,9 +105,6 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements Command.Init.
 func (c *listCommand) Init(args []string) (err error) {
 	c.modelName, err = cmd.ZeroOrOneArgs(args)
-	if err != nil {
-		return err
-	}
 	return err
 }
 

--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -406,8 +406,7 @@ func (u *UpgradeMongoCommand) maybeUpgrade24to26(dataDir string) error {
 	}
 	defer session.Close()
 
-	var res bson.M
-	res = make(bson.M)
+	res := make(bson.M)
 	err = db.Run("authSchemaUpgrade", &res)
 	if err != nil {
 		return errors.Annotate(err, "cannot upgrade auth schema")

--- a/cmd/plugins/juju-metadata/deleteimage.go
+++ b/cmd/plugins/juju-metadata/deleteimage.go
@@ -68,13 +68,13 @@ func (c *deleteImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *deleteImageMetadataCommand) Run(ctx *cmd.Context) (err error) {
 	api, err := c.newAPIFunc()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer api.Close()
 
 	err = api.Delete(c.ImageId)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -89,11 +89,7 @@ func (s *ValidateImageMetadataSuite) makeLocalMetadata(c *gc.C, id, region, seri
 	if err != nil {
 		return err
 	}
-	err = imagemetadata.MergeAndWriteMetadata(series, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
-	if err != nil {
-		return err
-	}
-	return nil
+	return imagemetadata.MergeAndWriteMetadata(series, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
 }
 
 func cacheTestEnvConfig(c *gc.C, store *jujuclient.MemStore) {

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
@@ -89,11 +89,7 @@ func (s *ValidateToolsMetadataSuite) makeLocalMetadata(c *gc.C, stream, version,
 	streamMetadata := map[string][]*tools.ToolsMetadata{
 		stream: tm,
 	}
-	err = tools.WriteMetadata(targetStorage, streamMetadata, []string{stream}, false)
-	if err != nil {
-		return err
-	}
-	return nil
+	return tools.WriteMetadata(targetStorage, streamMetadata, []string{stream}, false)
 }
 
 func (s *ValidateToolsMetadataSuite) SetUpTest(c *gc.C) {

--- a/cmd/plugins/juju-upgrade-mongo/upgrade.go
+++ b/cmd/plugins/juju-upgrade-mongo/upgrade.go
@@ -150,8 +150,7 @@ func (c *upgradeMongoCommand) Run(ctx *cmd.Context) error {
 	}
 
 	var stdout, stderr bytes.Buffer
-	var closer chan int
-	closer = make(chan int, 1)
+	closer := make(chan int, 1)
 	defer func() { closer <- 1 }()
 	go bufferPrinter(&stdout, closer, false)
 
@@ -253,9 +252,7 @@ func (c *upgradeMongoCommand) migratableMachines() (upgradeMongoParams, error) {
 		}
 	}
 	result.rsMembers = make([]replicaset.Member, len(results.RsMembers))
-	for i, rsMember := range results.RsMembers {
-		result.rsMembers[i] = rsMember
-	}
+	copy(result.rsMembers, results.RsMembers)
 
 	return result, nil
 }

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -57,7 +57,7 @@ func (resources) registerState() {
 }
 
 func (r resources) registerHookContext() {
-	if markRegistered(resource.ComponentName, "hook-context") == false {
+	if !markRegistered(resource.ComponentName, "hook-context") {
 		return
 	}
 
@@ -78,7 +78,7 @@ func (r resources) registerHookContext() {
 }
 
 func (r resources) registerHookContextCommands() {
-	if markRegistered(resource.ComponentName, "hook-context-commands") == false {
+	if !markRegistered(resource.ComponentName, "hook-context-commands") {
 		return
 	}
 

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -23,7 +23,6 @@ func MakeCreateMachineParamsTestable(params *CreateMachineParams, pathfinder fun
 	params.runCmd = runCmd
 	params.runCmdAsRoot = runCmd
 	params.arch = arch
-	return
 }
 
 // NewEmptyKvmContainer returns an empty kvmContainer for testing.

--- a/container/kvm/sync_test.go
+++ b/container/kvm/sync_test.go
@@ -82,5 +82,4 @@ func (f fakeFetcher) Fetch() error {
 }
 
 func (f fakeFetcher) Close() {
-	return
 }

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -105,9 +105,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, source := range officialDataSources {
-		sources = append(sources, source)
-	}
+	sources = append(sources, officialDataSources...)
 	for _, ds := range sources {
 		logger.Debugf("obtained image datasource %q", ds.Description())
 	}

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -38,11 +38,7 @@ func (s *ValidateSuite) makeLocalMetadata(c *gc.C, id, region, series, endpoint,
 	}
 	targetStorage, err := filestorage.NewFileStorageWriter(s.metadataDir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(series, metadata, &cloudSpec, targetStorage)
-	if err != nil {
-		return err
-	}
-	return nil
+	return imagemetadata.MergeAndWriteMetadata(series, metadata, &cloudSpec, targetStorage)
 }
 
 func (s *ValidateSuite) SetUpTest(c *gc.C) {

--- a/environs/manual/winrmprovisioner/provisioner_test.go
+++ b/environs/manual/winrmprovisioner/provisioner_test.go
@@ -16,7 +16,7 @@ import (
 type TestClientAPI struct{}
 
 func (t TestClientAPI) AddMachines(p []params.AddMachineParams) ([]params.AddMachinesResult, error) {
-	return make([]params.AddMachinesResult, 1, 1), nil
+	return make([]params.AddMachinesResult, 1), nil
 }
 
 func (t TestClientAPI) ForceDestroyMachines(machines ...string) error {

--- a/environs/manual/winrmprovisioner/winrmprovisioner.go
+++ b/environs/manual/winrmprovisioner/winrmprovisioner.go
@@ -218,11 +218,8 @@ func enableCertAuth(args *manual.ProvisionMachineArgs) (manual.WinrmClientAPI, e
 // just 8192 length commands. We know we have an amount of prefixed scripts
 // that we want to bind for the init process so create an array of scripts
 func bindInitScripts(pass string, keys *winrm.X509) ([]string, error) {
-	var (
-		err error
-	)
-
-	scripts := make([]string, 3, 3)
+	var err error
+	scripts := make([]string, 3)
 
 	if len(pass) == 0 {
 		return scripts, fmt.Errorf("The password is empty, provide a valid password to enable https interactions")
@@ -242,11 +239,7 @@ func bindInitScripts(pass string, keys *winrm.X509) ([]string, error) {
 
 	scripts[2] = fmt.Sprintf(setConnWinrm, pass)
 	scripts[2], err = shell.NewPSEncodedCommand(scripts[2])
-	if err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return nil, err
 }
 
 // setFiles powershell script that will manage and create the conf folder and files

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -231,12 +232,12 @@ func SignFileData(stor storage.Storage, fileName string) error {
 
 	signedName, signedContent, err := sstesting.SignMetadata(fileName, fileData)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	err = stor.Put(signedName, strings.NewReader(string(signedContent)), int64(len(string(signedContent))))
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -278,7 +279,7 @@ func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 		versions = append(versions, vers)
 	}
 	if _, err := UploadFakeToolsVersions(stor, toolsDir, stream, versions...); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -159,10 +159,7 @@ func copyFileWithMode(from, to string, mode os.FileMode) error {
 	}
 	defer destination.Close()
 	_, err = io.Copy(destination, source)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // ExistingJujudLocation returns the directory to

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -131,9 +131,7 @@ func makeTools(c *gc.C, metadataDir, stream string, versionStrings []string, wit
 
 // SHA256sum creates the sha256 checksum for the specified file.
 func SHA256sum(c *gc.C, path string) (int64, string) {
-	if strings.HasPrefix(path, "file://") {
-		path = path[len("file://"):]
-	}
+	path = strings.TrimPrefix(path, "file://")
 	hash, size, err := utils.ReadFileSHA256(path)
 	c.Assert(err, jc.ErrorIsNil)
 	return size, hash

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -29,7 +29,7 @@ func init() {
 
 	flag.Parse()
 
-	if *runFeatureTests == false {
+	if !*runFeatureTests {
 		return
 	}
 	// Initialize all suites here.

--- a/generate/filetoconst/filetoconst.go
+++ b/generate/filetoconst/filetoconst.go
@@ -47,7 +47,7 @@ func main() {
 		CopyrightYear string
 		Pkgname       string
 	}
-	contextData := fmt.Sprintf("%s", string(data))
+	contextData := string(data)
 	// Quote any ` in the data.
 	contextData = strings.Replace(contextData, "`", "`+\"`\"+`", -1)
 	t.Execute(&buf, content{

--- a/logfwd/syslog/client_test.go
+++ b/logfwd/syslog/client_test.go
@@ -203,11 +203,8 @@ func (s *stubSenderOpener) DialFunc(cfg *tls.Config, timeout time.Duration) (rfc
 	if dial == nil {
 		dial = func(network, address string) (rfc5424.Conn, error) {
 			s.stub.AddCall("dial", network, address)
-			if err := s.stub.NextErr(); err != nil {
-				return nil, err
-			}
-
-			return nil, nil
+			err := s.stub.NextErr()
+			return nil, err
 		}
 	}
 	return dial, nil
@@ -228,18 +225,12 @@ type stubSender struct {
 
 func (s *stubSender) Send(msg rfc5424.Message) error {
 	s.stub.AddCall("Send", msg)
-	if err := s.stub.NextErr(); err != nil {
-		return err
-	}
-
-	return nil
+	err := s.stub.NextErr()
+	return err
 }
 
 func (s *stubSender) Close() error {
 	s.stub.AddCall("Close")
-	if err := s.stub.NextErr(); err != nil {
-		return err
-	}
-
-	return nil
+	err := s.stub.NextErr()
+	return err
 }

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -149,7 +149,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		if opts.PostDialServer != nil {
 			before := time.Now()
 			defer func() {
-				taken := time.Now().Sub(before)
+				taken := time.Since(before)
 				opts.PostDialServer(server.String(), taken, err)
 			}()
 		}

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -223,7 +223,7 @@ func BridgeNameForDevice(device string) string {
 func (b *BridgePolicy) FindMissingBridgesForContainer(m Machine, containerMachine Container) ([]network.DeviceToBridge, int, error) {
 	reconfigureDelay := 0
 	containerSpaces, devicesPerSpace, err := b.findSpacesAndDevicesForContainer(m, containerMachine)
-	hostDeviceByName := make(map[string]*state.LinkLayerDevice, 0)
+	hostDeviceByName := make(map[string]*state.LinkLayerDevice)
 	if err != nil {
 		return nil, 0, errors.Trace(err)
 	}

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -298,13 +298,12 @@ func Marshal(in interface{}) (out []byte, err error) {
 func (np *Netplan) readYamlFile(path string) (err error) {
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	err = Unmarshal(contents, np)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
-
 	return nil
 }
 

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -27,18 +27,14 @@ var _ = gc.Suite(&NetplanSuite{})
 
 func MustNetplanFromYaml(c *gc.C, input string) *netplan.Netplan {
 	var np netplan.Netplan
-	if strings.HasPrefix(input, "\n") {
-		input = input[1:]
-	}
+	input = strings.TrimPrefix(input, "\n")
 	err := netplan.Unmarshal([]byte(input), &np)
 	c.Assert(err, jc.ErrorIsNil)
 	return &np
 }
 
 func checkNetplanRoundTrips(c *gc.C, input string) {
-	if strings.HasPrefix(input, "\n") {
-		input = input[1:]
-	}
+	input = strings.TrimPrefix(input, "\n")
 	var np netplan.Netplan
 	err := netplan.Unmarshal([]byte(input), &np)
 	c.Assert(err, jc.ErrorIsNil)

--- a/network/network.go
+++ b/network/network.go
@@ -534,7 +534,6 @@ func gatherLXCAddresses(toRemove map[string][]net.Addr) {
 	if err := scanner.Err(); err != nil {
 		logger.Debugf("failed to read %q: %v (ignoring)", LXCNetDefaultConfig, err)
 	}
-	return
 }
 
 func gatherBridgeAddresses(bridgeName string, toRemove map[string][]net.Addr) {
@@ -545,8 +544,6 @@ func gatherBridgeAddresses(bridgeName string, toRemove map[string][]net.Addr) {
 	}
 	logger.Debugf("%q has addresses %v", bridgeName, addrs)
 	toRemove[bridgeName] = addrs
-	return
-
 }
 
 // FilterBridgeAddresses removes addresses seen as a Bridge address (the IP

--- a/network/ssh/testing/sshserver.go
+++ b/network/ssh/testing/sshserver.go
@@ -52,7 +52,7 @@ func CreateTCPServer(c *gc.C, callback func(net.Conn)) (string, chan struct{}) {
 	c.Assert(err, jc.ErrorIsNil)
 	localAddress := listener.Addr().String()
 
-	shutdown := make(chan struct{}, 0)
+	shutdown := make(chan struct{})
 
 	go func() {
 		for {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -816,7 +816,7 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 		if err != nil {
 			err = errors.Annotate(maybeConvertCredentialError(err), "cannot fetch instance information")
 			logger.Warningf("%v", err)
-			if a.HasNext() == false {
+			if !a.HasNext() {
 				return err
 			}
 			logger.Infof("retrying fetch of instances")

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -180,10 +180,7 @@ func (rc *rawConn) ListAvailabilityZones(projectID, region string) ([]*compute.Z
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-
-		for _, zone := range zoneList.Items {
-			results = append(results, zone)
-		}
+		results = append(results, zoneList.Items...)
 		if zoneList.NextPageToken == "" {
 			break
 		}
@@ -360,7 +357,7 @@ func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attemp
 	}
 	if op.Status != StatusDone {
 		// lp:1558657
-		err := errors.Errorf("timed out after %d seconds", time.Now().Sub(started)/time.Second)
+		err := errors.Errorf("timed out after %d seconds", time.Since(started)/time.Second)
 		return waitError{op, err}
 	}
 	if op.Error != nil {

--- a/provider/joyent/environ_firewall.go
+++ b/provider/joyent/environ_firewall.go
@@ -22,8 +22,8 @@ const (
 )
 
 var (
-	firewallSinglePortRule = regexp.MustCompile("FROM tag [a-z0-9 \\-]+ TO (?:tag|vm) [a-z0-9 \\-]+ ALLOW (?P<protocol>[a-z]+) PORT (?P<port>[0-9]+)")
-	firewallMultiPortRule  = regexp.MustCompile("FROM tag [a-z0-9 \\-]+ TO (?:tag|vm) [a-z0-9 \\-]+ ALLOW (?P<protocol>[a-z]+) \\(\\s*(?P<ports>PORT [0-9]+(?: AND PORT [0-9]+)*)\\s*\\)")
+	firewallSinglePortRule = regexp.MustCompile(`FROM tag [a-z0-9 \-]+ TO (?:tag|vm) [a-z0-9 \-]+ ALLOW (?P<protocol>[a-z]+) PORT (?P<port>[0-9]+)`)
+	firewallMultiPortRule  = regexp.MustCompile(`FROM tag [a-z0-9 \-]+ TO (?:tag|vm) [a-z0-9 \-]+ ALLOW (?P<protocol>[a-z]+) \(\s*(?P<ports>PORT [0-9]+(?: AND PORT [0-9]+)*)\s*\)`)
 )
 
 // Helper method to create a firewall rule string for the given port

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -146,7 +146,7 @@ func (env *maasEnviron) usingMAAS2() bool {
 func (env *maasEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	if ctx.ShouldVerifyCredentials() {
 		if err := verifyCredentials(env); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	return nil
@@ -155,7 +155,7 @@ func (env *maasEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error
 // Create is part of the Environ interface.
 func (env *maasEnviron) Create(context.ProviderCallContext, environs.CreateParams) error {
 	if err := verifyCredentials(env); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func (env *maasEnviron) Create(context.ProviderCallContext, environs.CreateParam
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	result, series, finalizer, err := common.BootstrapInstance(ctx, env, callCtx, args)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	// We want to destroy the started instance if it doesn't transition to Deployed.
@@ -697,7 +697,7 @@ func (env *maasEnviron) getMAASClient() *gomaasapi.MAASObject {
 	return env.maasClientUnlocked
 }
 
-var dashSuffix = regexp.MustCompile("^(.*)-\\d+$")
+var dashSuffix = regexp.MustCompile(`^(.*)-\d+$`)
 
 func spaceNamesToSpaceInfo(spaces []string, spaceMap map[string]network.SpaceInfo) ([]network.SpaceInfo, error) {
 	spaceInfos := []network.SpaceInfo{}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -666,7 +666,7 @@ func (suite *environSuite) TestSubnetsMissingSubnet(c *gc.C) {
 	}
 
 	_, err := suite.makeEnviron().Subnets(suite.callCtx, testInstance.Id(), []network.Id{"1", "3", "6"})
-	errorRe := regexp.MustCompile("failed to find the following subnets: (\\d), (\\d)$")
+	errorRe := regexp.MustCompile(`failed to find the following subnets: (\d), (\d)$`)
 	errorText := err.Error()
 	c.Assert(errorRe.MatchString(errorText), jc.IsTrue)
 	matches := errorRe.FindStringSubmatch(errorText)

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -1265,5 +1265,5 @@ func (suite *environSuite) generateHWTemplate(netMacs map[string]ifaceInfo) (str
 	if err != nil {
 		return "", err
 	}
-	return string(buf.Bytes()), nil
+	return buf.String(), nil
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -91,7 +91,7 @@ func (e *manualEnviron) Config() *config.Config {
 // PrepareForBootstrap is part of the Environ interface.
 func (e *manualEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 	if err := ensureBootstrapUbuntuUser(ctx, e.host, e.user, e.envConfig()); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -112,13 +112,13 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context
 	}
 	hw, series, err := e.seriesAndHardwareCharacteristics()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
 		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = hw
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		return common.ConfigureMachine(ctx, ssh.DefaultClient, e.host, icfg, nil)
 	}

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -123,10 +123,7 @@ func (e *Environ) getOCIInstance(id instance.Id) (*ociInstance, error) {
 }
 
 func (e *Environ) isNotFound(response *http.Response) bool {
-	if response.StatusCode == http.StatusNotFound {
-		return true
-	}
-	return false
+	return response.StatusCode == http.StatusNotFound
 }
 
 // waitForResourceStatus will ping the resource until the fetch function returns true,
@@ -624,14 +621,13 @@ func (e *Environ) StopInstances(ctx envcontext.ProviderCallContext, ids ...insta
 	if err == environs.ErrNoInstances {
 		return nil
 	} else if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	logger.Debugf("terminating instances %v", ids)
 	if err := e.terminateInstances(ociInstances...); err != nil {
-		return err
+		return errors.Trace(err)
 	}
-
 	return nil
 }
 

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -165,10 +165,7 @@ func (i *ImageCache) SetImages(images map[string][]InstanceImage) {
 func (i *ImageCache) isStale() bool {
 	threshold := i.lastRefresh.Add(staleImageCacheTimeoutInMinutes * time.Minute)
 	now := time.Now()
-	if now.After(threshold) {
-		return true
-	}
-	return false
+	return now.After(threshold)
 }
 
 // ImageMetadata returns an array of imagemetadata.ImageMetadata for
@@ -336,7 +333,7 @@ func refreshImageCache(cli common.OCIComputeClient, compartmentID *string) (*Ima
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
 
-	if globalImageCache.isStale() == false {
+	if !globalImageCache.isStale() {
 		return globalImageCache, nil
 	}
 

--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -137,8 +137,8 @@ func (p EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config
 			return nil, fmt.Errorf("policy-target-group has invalid UUID: %q", ptg)
 		}
 	}
-	if useGBP := cfgAttrs["use-openstack-gbp"]; useGBP != nil && useGBP.(bool) == true {
-		if hasPTG == false {
+	if useGBP := cfgAttrs["use-openstack-gbp"]; useGBP != nil && useGBP.(bool) {
+		if !hasPTG {
 			return nil, fmt.Errorf("policy-target-group must be set when use-openstack-gbp is set")
 		}
 		if network := cfgAttrs["network"]; network != nil && network.(string) != "" {

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -278,7 +278,7 @@ func (n *NeutronNetworking) ResolveNetwork(name string, external bool) (string, 
 // the exact given name AND router:external boolean result.
 func networkFilter(name string, external bool) *neutron.Filter {
 	filter := neutron.NewFilter()
-	filter.Set(neutron.FilterNetwork, fmt.Sprintf("%s", name))
+	filter.Set(neutron.FilterNetwork, name)
 	filter.Set(neutron.FilterRouterExternal, fmt.Sprintf("%t", external))
 	return filter
 }

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -489,12 +489,12 @@ func (o *OracleEnviron) StopInstances(ctx context.ProviderCallContext, ids ...in
 	if err == environs.ErrNoInstances {
 		return nil
 	} else if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	logger.Debugf("terminating instances %v", ids)
 	if err := o.terminateInstances(oracleInstances...); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	return nil
@@ -723,7 +723,7 @@ func (o *OracleEnviron) ControllerInstances(ctx context.ProviderCallContext, con
 				break
 			}
 		}
-		if found == false {
+		if !found {
 			continue
 		}
 		ids = append(ids, val.Id())

--- a/provider/oracle/images.go
+++ b/provider/oracle/images.go
@@ -37,7 +37,7 @@ func instanceTypes(c EnvironAPI) ([]instances.InstanceType, error) {
 
 	// convert shapes to InstanceType
 	onlyArch := []string{"amd64"}
-	types := make([]instances.InstanceType, len(shapes.Result), len(shapes.Result))
+	types := make([]instances.InstanceType, len(shapes.Result))
 	for key, val := range shapes.Result {
 		types[key].Name = val.Name
 		types[key].Arches = onlyArch

--- a/provider/oracle/instance.go
+++ b/provider/oracle/instance.go
@@ -308,7 +308,7 @@ func (o *oracleInstance) associatePublicIP() error {
 		assocPoolName,
 		o.machine.Vcable_id,
 	); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	return nil

--- a/provider/oracle/networking.go
+++ b/provider/oracle/networking.go
@@ -53,7 +53,7 @@ func (o *OracleEnviron) DeleteMachineVnicSet(machineId string) error {
 }
 
 func (o *OracleEnviron) ensureVnicSet(ctx context.ProviderCallContext, machineId string, tags []string) (ociResponse.VnicSet, error) {
-	if access, err := o.SupportsSpaces(ctx); err != nil || access == false {
+	if access, err := o.SupportsSpaces(ctx); err != nil || !access {
 		logger.Debugf("Spaces is not supported on this API endpoint.")
 		return ociResponse.VnicSet{}, nil
 	}

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -253,7 +253,7 @@ func (s *oracleVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]str
 
 // DescribeVolumes is specified on the storage.VolumeSource interface.
 func (s *oracleVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volIds []string) ([]storage.DescribeVolumesResult, error) {
-	if volIds == nil || len(volIds) == 0 {
+	if len(volIds) == 0 {
 		return []storage.DescribeVolumesResult{}, nil
 	}
 
@@ -263,7 +263,7 @@ func (s *oracleVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, vo
 		Value: tag,
 	}}
 
-	result := make([]storage.DescribeVolumesResult, len(volIds), len(volIds))
+	result := make([]storage.DescribeVolumesResult, len(volIds))
 	volumes, err := s.api.AllStorageVolumes(filter)
 	if err != nil {
 		return nil, errors.Annotatef(err, "describe volumes")

--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -163,17 +163,7 @@ func (c *Codec) readV0Message(m json.RawMessage) (inMsgV1, int, error) {
 	if err := json.Unmarshal(m, &msg); err != nil {
 		return inMsgV1{}, -1, errors.Trace(err)
 	}
-	return inMsgV1{
-		RequestId: msg.RequestId,
-		Type:      msg.Type,
-		Version:   msg.Version,
-		Id:        msg.Id,
-		Request:   msg.Request,
-		Params:    msg.Params,
-		Error:     msg.Error,
-		ErrorCode: msg.ErrorCode,
-		Response:  msg.Response,
-	}, 0, nil
+	return inMsgV1(msg), 0, nil
 }
 
 func (c *Codec) ReadBody(body interface{}, isRequest bool) error {

--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -46,7 +46,7 @@ func main() {
 		hash := utils.AgentPasswordHash(passwd)
 		fmt.Printf("oldpassword: %s\n", passwd)
 		collection := "UNKNOWN"
-		if strings.Index(agent, "/") < 0 {
+		if !strings.Contains(agent, "/") {
 			// must be a machine
 			collection = "machines"
 		} else {

--- a/scripts/gometalinter.bash
+++ b/scripts/gometalinter.bash
@@ -21,6 +21,7 @@ $GOPATH/bin/gometalinter --vendor \
     --disable-all \
     --enable=gofmt \
     --enable=goimports \
+    --enable=gosimple \
     --enable=misspell \
     --enable=unconvert \
     --enable=vet \

--- a/scripts/ssh-keycheck/ssh_keycheck.go
+++ b/scripts/ssh-keycheck/ssh_keycheck.go
@@ -75,7 +75,7 @@ func main() {
 	pubKeys := getKnownHostKeys(hostFile)
 	hostPorts := make([]network.HostPort, 0, len(args))
 	for _, arg := range args {
-		if strings.Index(arg, ":") < 0 {
+		if !strings.Contains(arg, ":") {
 			// Not valid for IPv6, but good enough for testing
 			arg = arg + ":22"
 		}

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -320,7 +320,7 @@ func startAgent(name string, kind AgentKind, dataDir string, series string) (err
 	svcName := serviceName(name)
 	svc, err := NewService(svcName, conf, series)
 	if err = svc.Start(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -333,17 +333,17 @@ func serviceName(agent string) string {
 func (s *systemdServiceManager) WriteServiceFile() error {
 	hostSeries, err := series.HostSeries()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	dataDir, err := paths.DataDir(hostSeries)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	// find the agents.
 	machineAgent, unitAgents, failedAgentNames, err := s.FindAgents(dataDir)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	startedSysdServiceNames, startedSymServiceNames, failedAgentNames, err := s.WriteSystemdAgents(
@@ -359,7 +359,7 @@ func (s *systemdServiceManager) WriteServiceFile() error {
 			logger.Errorf("failed to write service for %s: %s", agentName, err)
 		}
 		logger.Errorf("%s", err)
-		return err
+		return errors.Trace(err)
 	}
 	for _, sysSvcName := range startedSysdServiceNames {
 		logger.Infof("wrote %s agent, enabled and linked by systemd", sysSvcName)
@@ -371,7 +371,7 @@ func (s *systemdServiceManager) WriteServiceFile() error {
 	// reload the services.
 	err = systemd.SysdReload()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	return nil

--- a/service/common/testing/fake.go
+++ b/service/common/testing/fake.go
@@ -256,23 +256,18 @@ func (ss *FakeService) Remove() error {
 // InstallCommands implements Service.
 func (ss *FakeService) InstallCommands() ([]string, error) {
 	ss.AddCall("InstallCommands")
-
 	return nil, ss.NextErr()
 }
 
 // StartCommands implements Service.
 func (ss *FakeService) StartCommands() ([]string, error) {
 	ss.AddCall("StartCommands")
-
 	return nil, ss.NextErr()
 }
 
 // WriteService implements UpgradableService.
 func (ss *FakeService) WriteService() error {
 	ss.AddCall("WriteService")
-	retErr := ss.NextErr()
-	if retErr != nil {
-		return retErr
-	}
-	return nil
+	err := ss.NextErr()
+	return err
 }

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -105,11 +105,7 @@ func normalize(name string, conf common.Conf, scriptPath string, renderer confRe
 }
 
 func isSimpleCommand(cmd string) bool {
-	if strings.ContainsAny(cmd, "\n;|><&") {
-		return false
-	}
-
-	return true
+	return !strings.ContainsAny(cmd, "\n;|><&")
 }
 
 func validate(name string, conf common.Conf, renderer shell.Renderer) error {

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -22,11 +22,12 @@ import (
 )
 
 var (
-	InitDir = "/etc/init" // the default init directory name.
+	// InitDir is the default init directory name.
+	InitDir = "/etc/init"
 
 	logger      = loggo.GetLogger("juju.service.upstart")
 	initctlPath = "/sbin/initctl"
-	servicesRe  = regexp.MustCompile("^([a-zA-Z0-9-_:]+)\\.conf$")
+	servicesRe  = regexp.MustCompile(`^([a-zA-Z0-9-_:]+)\.conf$`)
 	renderer    = &shell.BashRenderer{}
 )
 

--- a/state/address.go
+++ b/state/address.go
@@ -127,7 +127,7 @@ func (st *State) SetAPIHostPorts(newHostPorts [][]network.HostPort) error {
 		}
 		ops = append(ops, agentAddrOps...)
 
-		if ops == nil || len(ops) == 0 {
+		if len(ops) == 0 {
 			return nil, statetxn.ErrNoOperations
 		}
 		return ops, nil
@@ -396,10 +396,7 @@ func dupeAndSort(a [][]network.HostPort) [][]network.HostPort {
 	var result [][]network.HostPort
 
 	for _, val := range a {
-		var inner []network.HostPort
-		for _, hp := range val {
-			inner = append(inner, hp)
-		}
+		inner := val[:]
 		network.SortHostPorts(inner)
 		result = append(result, inner)
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -3972,8 +3972,7 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 		c.Errorf("entity contents mismatch; same length %d", len(got))
 	}
 	// Lets construct a decent output.
-	var errorOutput string
-	errorOutput = "\ngot: \n"
+	errorOutput := "\ngot: \n"
 	for _, e := range got {
 		errorOutput += fmt.Sprintf("  %T %#v\n", e, e)
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -2310,10 +2310,7 @@ func (a *Application) SetPassword(password string) error {
 // for the given application.
 func (a *Application) PasswordValid(password string) bool {
 	agentHash := utils.AgentPasswordHash(password)
-	if agentHash == a.doc.PasswordHash {
-		return true
-	}
-	return false
+	return agentHash == a.doc.PasswordHash
 }
 
 // UnitUpdateProperties holds information used to update

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -44,9 +44,7 @@ type Paths struct {
 // GetFilesToBackUp returns the paths that should be included in the
 // backup archive.
 func GetFilesToBackUp(rootDir string, paths *Paths, oldmachine string) ([]string, error) {
-	var glob string
-
-	glob = filepath.Join(rootDir, paths.DataDir, agentsDir, agentsConfs)
+	glob := filepath.Join(rootDir, paths.DataDir, agentsDir, agentsConfs)
 	agentConfs, err := filepath.Glob(glob)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to fetch agent config files")

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -427,9 +427,7 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 		"ca-private-key",
 		config.AgentVersionKey,
 	}
-	for _, attr := range controller.ControllerOnlyConfigAttributes {
-		badAttrNames = append(badAttrNames, attr)
-	}
+	badAttrNames = append(badAttrNames, controller.ControllerOnlyConfigAttributes...)
 
 	modelCfg := testing.ModelConfig(c)
 	controllerCfg := testing.FakeControllerConfig()

--- a/state/machine.go
+++ b/state/machine.go
@@ -1200,7 +1200,8 @@ func convertSpacesFromConstraints(spaces *[]string) ([]string, []string) {
 	if spaces == nil || len(*spaces) == 0 {
 		return nil, nil
 	}
-	return parseDelimitedValues(*spaces)
+	positives, negatives := parseDelimitedValues(*spaces)
+	return positives, negatives
 }
 
 // parseDelimitedValues parses a slice of raw values coming from constraints
@@ -1762,7 +1763,7 @@ func (m *Machine) setConstraintsOps(cons constraints.Value) ([]txn.Op, error) {
 func (m *Machine) Status() (status.StatusInfo, error) {
 	mStatus, err := getStatus(m.st.db(), m.globalKey(), "machine")
 	if err != nil {
-		return mStatus, err
+		return mStatus, errors.Trace(err)
 	}
 	return mStatus, nil
 }

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -962,7 +962,7 @@ func (m *Machine) LinkLayerDevicesForSpaces(spaces []string) (map[string][]*Link
 		deviceByName[dev.Name()] = dev
 	}
 	requestedSpaces := set.NewStrings(spaces...)
-	spaceToDevices := make(map[string]map[string]*LinkLayerDevice, 0)
+	spaceToDevices := make(map[string]map[string]*LinkLayerDevice)
 	processedDeviceNames := set.NewStrings()
 	includeDevice := func(spaceName string, device *LinkLayerDevice) {
 		spaceInfo, ok := spaceToDevices[spaceName]

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -957,7 +957,7 @@ func (s *MachineSuite) TestSetProvisionedDupInstanceId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	found := false
 	for _, le := range logWriter.Log() {
-		if found = strings.Contains(le.Message, "duplicate instance id"); found == true {
+		if found = strings.Contains(le.Message, "duplicate instance id"); found {
 			break
 		}
 	}

--- a/state/model.go
+++ b/state/model.go
@@ -631,7 +631,7 @@ func (m *Model) Owner() names.UserTag {
 func (m *Model) Status() (status.StatusInfo, error) {
 	status, err := getStatus(m.st.db(), m.globalKey(), "model")
 	if err != nil {
-		return status, err
+		return status, errors.Trace(err)
 	}
 	return status, nil
 }

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -651,7 +651,7 @@ func (s *PresenceSuite) TestRobustness(c *gc.C) {
 	// Start a watch for changes to 'key'. Never listen for actual events on that channel, though, so we know flush()
 	// will always be blocked, but allowing other events while waiting to send that event.
 	rootKey := "key"
-	keyChan := make(chan presence.Change, 0)
+	keyChan := make(chan presence.Change)
 	w.Watch(rootKey, keyChan)
 	// Whenever we successfully watch in the main loop(), it starts a flush. We should now be able to build up more
 	// watches while waiting. Create enough of these that we know the slice gets reallocated
@@ -661,7 +661,7 @@ func (s *PresenceSuite) TestRobustness(c *gc.C) {
 	const numKeys = 10
 	for i := 0; i < numKeys; i++ {
 		k := fmt.Sprintf("k%d", i)
-		kChan := make(chan presence.Change, 0)
+		kChan := make(chan presence.Change)
 		w.Watch("key", kChan)
 		wg.Add(1)
 		go func() {

--- a/state/presence/pruner_test.go
+++ b/state/presence/pruner_test.go
@@ -205,7 +205,7 @@ func waitForFirstChange(c *gc.C, watch <-chan Change, want Change) {
 			if got == want {
 				return
 			}
-			if got.Alive == false {
+			if !got.Alive {
 				c.Fatalf("got a not-alive before the one we were expecting: %v (want %v)", got, want)
 			}
 		case <-timeout:

--- a/state/relation.go
+++ b/state/relation.go
@@ -115,7 +115,7 @@ func (r *Relation) Life() Life {
 func (r *Relation) Status() (status.StatusInfo, error) {
 	rStatus, err := getStatus(r.st.db(), r.globalScope(), "relation")
 	if err != nil {
-		return rStatus, err
+		return rStatus, errors.Trace(err)
 	}
 	return rStatus, nil
 }

--- a/state/settings.go
+++ b/state/settings.go
@@ -255,7 +255,6 @@ func replaceKeys(m map[string]interface{}, replace func(string) string) {
 			m[newKey] = value
 		}
 	}
-	return
 }
 
 // copyMap copies the keys and values of one map into a new one.  If replace

--- a/state/unit.go
+++ b/state/unit.go
@@ -301,10 +301,7 @@ func (u *Unit) setPasswordHash(passwordHash string) error {
 // for the given unit.
 func (u *Unit) PasswordValid(password string) bool {
 	agentHash := utils.AgentPasswordHash(password)
-	if agentHash == u.doc.PasswordHash {
-		return true
-	}
-	return false
+	return agentHash == u.doc.PasswordHash
 }
 
 // UpdateOperation returns a model operation that will update a unit.

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -32,7 +32,7 @@ type Constraints struct {
 var (
 	poolRE  = regexp.MustCompile("^[a-zA-Z]+[-?a-zA-Z0-9]*$")
 	countRE = regexp.MustCompile("^-?[0-9]+$")
-	sizeRE  = regexp.MustCompile("^-?[0-9]+(?:\\.[0-9]+)?[MGTPEZY](?:i?B)?$")
+	sizeRE  = regexp.MustCompile(`^-?[0-9]+(?:\.[0-9]+)?[MGTPEZY](?:i?B)?$`)
 )
 
 // ParseConstraints parses the specified string and creates a

--- a/tools/lxdclient/testing_test.go
+++ b/tools/lxdclient/testing_test.go
@@ -176,8 +176,5 @@ func (s *stubClient) ContainerInfo(name string) (*api.Container, error) {
 
 func (s *stubClient) PushFile(container, path string, gid int, uid int, mode string, buf io.ReadSeeker) error {
 	s.stub.AddCall("PushFile", container, path, gid, uid, mode, buf)
-	if err := s.stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return s.stub.NextErr()
 }

--- a/worker/caasbroker/broker.go
+++ b/worker/caasbroker/broker.go
@@ -99,10 +99,8 @@ func (t *Tracker) loop() error {
 	// TODO(caas) - watch for config and credential changes
 	for {
 		logger.Debugf("waiting for config and credential notifications")
-		select {
-		case <-t.catacomb.Dying():
-			return t.catacomb.ErrDying()
-		}
+		<-t.catacomb.Dying()
+		return t.catacomb.ErrDying()
 	}
 }
 

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -253,8 +253,5 @@ type mockUnitUpdater struct {
 
 func (m *mockUnitUpdater) UpdateUnits(arg params.UpdateApplicationUnits) error {
 	m.MethodCall(m, "UpdateUnits", arg)
-	if err := m.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return m.NextErr()
 }

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -64,7 +64,7 @@ func recursiveChmod(path string, mode os.FileMode) error {
 		return nil
 	}
 	if err := filepath.Walk(path, walker); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/worker/deployer/simple_test.go
+++ b/worker/deployer/simple_test.go
@@ -230,7 +230,7 @@ func (fix *SimpleToolsFixture) checkUnitInstalled(c *gc.C, name, password string
 	c.Assert(err, jc.ErrorIsNil)
 	uconf := string(uconfData)
 
-	regex := regexp.MustCompile("(?m)(?:^\\s)*exec\\s.+$")
+	regex := regexp.MustCompile(`(?m)(?:^\s)*exec\s.+$`)
 	execs := regex.FindAllString(uconf, -1)
 
 	if nil == execs {

--- a/worker/introspection/pprof/pprof.go
+++ b/worker/introspection/pprof/pprof.go
@@ -225,7 +225,6 @@ func (name handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		runtime.GC()
 	}
 	p.WriteTo(w, debug)
-	return
 }
 
 // Index responds with the pprof-formatted profile named by the request.

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -43,7 +43,6 @@ func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 			case <-stop:
 				logWriter.Close()
 			}
-			return
 		}()
 		var logWriter logsender.LogWriter
 		var err error

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -172,10 +172,7 @@ func (l *mockListener) trigger() (*mockConnection, error) {
 	conn := &mockConnection{}
 	dying := make(chan struct{})
 	err := l.handler.Handle(conn, dying)
-	if err != nil {
-		return conn, err
-	}
-	return conn, nil
+	return conn, err
 }
 
 // Stop implements the stopper interface.

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -733,6 +733,7 @@ func (w *Worker) waitForMinions(
 			if failures > 0 {
 				w.logger.Errorf(formatMinionFailure(reports, infoPrefix))
 				w.setErrorStatus("%s, some agents reported failure", infoPrefix)
+				// nolint: gosimple
 				if waitPolicy == failFast {
 					return false, nil
 				}

--- a/worker/noopworker.go
+++ b/worker/noopworker.go
@@ -13,8 +13,6 @@ func NewNoOpWorker() worker.Worker {
 }
 
 func doNothing(stop <-chan struct{}) error {
-	select {
-	case <-stop:
-		return nil
-	}
+	<-stop
+	return nil
 }

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -324,10 +324,7 @@ func (m *fakeMachine) Refresh() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	doc := m.doc()
-	if err := m.errors.errorFor("Machine.Refresh", doc.id); err != nil {
-		return err
-	}
-	return nil
+	return m.errors.errorFor("Machine.Refresh", doc.id)
 }
 
 func (m *fakeMachine) GoString() string {

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -185,18 +185,12 @@ func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) ([]network.Int
 
 func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
 	f.MethodCall(f, "ReleaseContainerAddresses", tag)
-	if err := f.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return f.NextErr()
 }
 
 func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
 	f.MethodCall(f, "SetHostMachineNetworkConfig", hostMachineTag.String(), netConfig)
-	if err := f.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return f.NextErr()
 }
 
 func (f *fakeAPI) HostChangesForContainer(machineTag names.MachineTag) ([]network.DeviceToBridge, int, error) {

--- a/worker/provisioner/host_preparer_test.go
+++ b/worker/provisioner/host_preparer_test.go
@@ -38,10 +38,7 @@ func (api *fakePrepareAPI) HostChangesForContainer(tag names.MachineTag) ([]netw
 
 func (api *fakePrepareAPI) SetHostMachineNetworkConfig(tag names.MachineTag, config []params.NetworkConfig) error {
 	api.Stub.MethodCall(api, "SetHostMachineNetworkConfig", tag, config)
-	if err := api.Stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return api.Stub.NextErr()
 }
 
 type hostPreparerSuite struct {
@@ -80,10 +77,7 @@ var _ network.Bridger = (*stubBridger)(nil)
 
 func (br *stubBridger) Bridge(devices []network.DeviceToBridge, reconfigureDelay int) error {
 	br.Stub.MethodCall(br, "Bridge", devices, reconfigureDelay)
-	if err := br.Stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return br.Stub.NextErr()
 }
 
 func (s *hostPreparerSuite) createStubBridger() (network.Bridger, error) {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1205,7 +1205,6 @@ func (task *provisionerTask) addMachinetoAZMap(machine *apiprovisioner.Machine, 
 			break
 		}
 	}
-	return
 }
 
 // removeMachineFromAZMap removes the specified machine from availabilityZoneMachines.

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -323,7 +323,6 @@ func (s *CommonProvisionerSuite) checkStartInstancesCustom(
 				if found == len(machines) {
 					return
 				}
-				break
 			default:
 				c.Logf("ignoring unexpected operation %#v", o)
 			}

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -231,10 +231,7 @@ func (m *mockRelationsFacade) WatchLocalRelationUnits(relationKey string) (watch
 
 func (m *mockRelationsFacade) ConsumeRemoteRelationChange(change params.RemoteRelationChangeEvent) error {
 	m.stub.MethodCall(m, "ConsumeRemoteRelationChange", change)
-	if err := m.stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return m.stub.NextErr()
 }
 
 func (m *mockRelationsFacade) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
@@ -275,10 +272,7 @@ func (m *mockRemoteRelationsFacade) Close() error {
 
 func (m *mockRemoteRelationsFacade) PublishRelationChange(change params.RemoteRelationChangeEvent) error {
 	m.stub.MethodCall(m, "PublishRelationChange", change)
-	if err := m.stub.NextErr(); err != nil {
-		return err
-	}
-	return nil
+	return m.stub.NextErr()
 }
 
 func (m *mockRemoteRelationsFacade) RegisterRemoteRelations(relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error) {

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -226,7 +226,7 @@ func (v *mockVolumeAccessor) VolumeAttachmentParams(ids []params.MachineStorageI
 	for _, id := range ids {
 		// Parameters are returned regardless of whether the attachment
 		// exists; this is to support reattachment.
-		instanceId, _ := v.provisionedMachines[id.MachineTag]
+		instanceId := v.provisionedMachines[id.MachineTag]
 		result = append(result, params.VolumeAttachmentParamsResult{Result: params.VolumeAttachmentParams{
 			MachineTag: id.MachineTag,
 			VolumeTag:  id.AttachmentTag,

--- a/worker/uniter/operation/executor_test.go
+++ b/worker/uniter/operation/executor_test.go
@@ -443,8 +443,8 @@ func (mock *mockLockFunc) Release() {
 
 func (mock *mockLockFunc) newFailingLock() func() (mutex.Releaser, error) {
 	return func() (mutex.Releaser, error) {
-		mock.noStepsCalledOnLock = mock.op.prepare.called == false &&
-			mock.op.commit.called == false
+		mock.noStepsCalledOnLock = !mock.op.prepare.called &&
+			!mock.op.commit.called
 		return nil, errors.New("wat")
 	}
 }
@@ -453,8 +453,8 @@ func (mock *mockLockFunc) newSucceedingLock() func() (mutex.Releaser, error) {
 	return func() (mutex.Releaser, error) {
 		mock.calledLock = true
 		// Ensure that when we lock no operation has been called
-		mock.noStepsCalledOnLock = mock.op.prepare.called == false &&
-			mock.op.commit.called == false
+		mock.noStepsCalledOnLock = !mock.op.prepare.called &&
+			!mock.op.commit.called
 		mock.onRelease = func() {
 			// Record steps called when unlocking
 			mock.stepsCalledOnUnlock = []bool{mock.op.prepare.called,

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -121,7 +121,7 @@ func NewWorkerPaths(dataDir string, unitTag names.UnitTag, worker string) Paths 
 
 	socket := func(name string, abstract bool) string {
 		if os.HostOS() == os.Windows {
-			base := fmt.Sprintf("%s", unitTag)
+			base := unitTag.String()
 			if worker != "" {
 				base = fmt.Sprintf("%s-%s", unitTag, worker)
 			}

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -163,11 +163,9 @@ func (s *LoopSuite) TestLoop(c *gc.C) {
 		// change.
 		case 2:
 			s.watcher.changes <- struct{}{}
-			break
 		// On the third call, kill the loop.
 		case 3:
 			close(s.abort)
-			break
 		}
 		return nil, resolver.ErrNoOperation
 	})

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -377,8 +377,7 @@ func (s *InterfaceSuite) TestRequestRebootNow(c *gc.C) {
 	ctx := s.GetContext(c, -1, "").(*context.HookContext)
 
 	var stub testing.Stub
-	var p *mockProcess
-	p = &mockProcess{func() error {
+	p := &mockProcess{func() error {
 		// Reboot priority should be set before the process
 		// is killed, or else the client waiting for the
 		// process to exit will race with the setting of
@@ -402,8 +401,7 @@ func (s *InterfaceSuite) TestRequestRebootNowTimeout(c *gc.C) {
 	ctx := s.GetContext(c, -1, "").(*context.HookContext)
 
 	var advanced bool
-	var p *mockProcess
-	p = &mockProcess{func() error {
+	p := &mockProcess{func() error {
 		// Reboot priority should be set before the process
 		// is killed, or else the client waiting for the
 		// process to exit will race with the setting of

--- a/worker/uniter/runner/jujuc/config-get.go
+++ b/worker/uniter/runner/jujuc/config-get.go
@@ -71,7 +71,7 @@ func (c *ConfigGetCommand) Run(ctx *cmd.Context) error {
 		}
 		value = settings
 	} else {
-		value, _ = settings[c.Key]
+		value = settings[c.Key]
 	}
 	return c.out.Write(ctx, value)
 }

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -140,7 +140,7 @@ func (s *RunHookSuite) TestRunHook(c *gc.C) {
 		} else {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		}
-		if t.spec.background != "" && time.Now().Sub(t0) > 5*time.Second {
+		if t.spec.background != "" && time.Since(t0) > 5*time.Second {
 			c.Errorf("background process holding up hook execution")
 		}
 	}


### PR DESCRIPTION
## Description of change

A new additional gosimple linter. The aim of this linter is to
reduce redundant code, either by using the defaults implied by
the language (think `copy`, `append`) or using reducing the 
number of `if err != nil {` checks.

## QA steps

Check that it passes all the tests.

## Documentation changes

No changes are involved, but you can run it independently using:

```sh
./scripts/gometalinter
```

## Bug reference

N/A