### PR TITLE
Removes verifyStorageConfiguration from tools/lxdclient and implement…

### DIFF
--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -427,7 +427,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.
 	cSvr := s.NewMockServer(ctrl)
 	s.patch(cSvr)
 
-	cSvr.EXPECT().GetProfile("default").Return(defaultProfile(), lxdtesting.ETag, nil)
+	cSvr.EXPECT().GetProfile("default").Return(defaultProfileWithNIC(), lxdtesting.ETag, nil)
 
 	result, _, err := lxd.NetworkDevicesFromConfig(s.makeManager(c, cSvr), &container.NetworkConfig{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/container/lxd/storage.go
+++ b/container/lxd/storage.go
@@ -29,3 +29,59 @@ func (s *Server) CreateVolume(pool, name string, cfg map[string]string) error {
 	}
 	return errors.Annotatef(s.CreateStoragePoolVolume(pool, req), "creating storage pool volume %q", name)
 }
+
+// EnsureDefaultStorage ensures that the input profile is configured with a
+// disk device, creating a new storage pool and a device if required.
+func (s *Server) EnsureDefaultStorage(profile *api.Profile, eTag string) error {
+	// If there is already a "/" device, we have nothing to do.
+	for _, dev := range profile.Devices {
+		if dev["path"] == "/" {
+			return nil
+		}
+	}
+
+	// If there is a "default" pool, use it.
+	// Otherwise if there are other pools available, choose the first.
+	pools, err := s.GetStoragePoolNames()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	poolName := ""
+	for _, p := range pools {
+		if p == "default" {
+			poolName = p
+		}
+	}
+	if poolName == "" && len(pools) > 0 {
+		poolName = pools[0]
+	}
+
+	// We need to create a new storage pool.
+	if poolName == "" {
+		poolName = "default"
+		req := api.StoragePoolsPost{
+			Name:   poolName,
+			Driver: "dir",
+		}
+		err := s.CreateStoragePool(req)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Create a new disk device in the input profile.
+	if profile.Devices == nil {
+		profile.Devices = map[string]device{}
+	}
+	profile.Devices["root"] = map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": poolName,
+	}
+
+	if err := s.UpdateProfile(profile.Name, profile.Writable(), eTag); err != nil {
+		return errors.Trace(err)
+	}
+	logger.Debugf("created new disk device \"root\" in profile %q", profile.Name)
+	return nil
+}

--- a/container/lxd/storage_test.go
+++ b/container/lxd/storage_test.go
@@ -19,6 +19,21 @@ type storageSuite struct {
 
 var _ = gc.Suite(&storageSuite{})
 
+func defaultProfileWithDisk() *lxdapi.Profile {
+	return &lxdapi.Profile{
+		Name: "default",
+		ProfilePut: lxdapi.ProfilePut{
+			Devices: map[string]map[string]string{
+				"root": {
+					"type": "disk",
+					"path": "/",
+					"pool": "default",
+				},
+			},
+		},
+	}
+}
+
 func (s *storageSuite) TestStorageIsSupported(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -85,4 +100,56 @@ func (s *storageSuite) TestCreateVolume(c *gc.C) {
 
 	err = jujuSvr.CreateVolume("default-pool", "volume", cfg)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestEnsureDefaultStorageDevicePresent(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServerWithExtensions(ctrl, "storage")
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(jujuSvr.EnsureDefaultStorage(defaultProfileWithDisk(), ""), jc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestEnsureDefaultStoragePoolExistsDeviceCreated(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServerWithExtensions(ctrl, "storage")
+
+	profile := defaultProfileWithDisk()
+	gomock.InOrder(
+		cSvr.EXPECT().GetStoragePoolNames().Return([]string{"default"}, nil),
+		cSvr.EXPECT().UpdateProfile("default", profile.Writable(), lxdtesting.ETag).Return(nil),
+	)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	profile.Devices = nil
+	c.Assert(jujuSvr.EnsureDefaultStorage(profile, lxdtesting.ETag), jc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestEnsureDefaultStoragePoolAndDeviceCreated(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServerWithExtensions(ctrl, "storage")
+
+	profile := defaultProfileWithDisk()
+	req := lxdapi.StoragePoolsPost{
+		Name:   "default",
+		Driver: "dir",
+	}
+	gomock.InOrder(
+		cSvr.EXPECT().GetStoragePoolNames().Return(nil, nil),
+		cSvr.EXPECT().CreateStoragePool(req).Return(nil),
+		cSvr.EXPECT().UpdateProfile("default", profile.Writable(), lxdtesting.ETag).Return(nil),
+	)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	profile.Devices = nil
+	c.Assert(jujuSvr.EnsureDefaultStorage(profile, lxdtesting.ETag), jc.ErrorIsNil)
 }


### PR DESCRIPTION
## Description of change

This moves the check for a disk device in the default LXD profile from to-be-deprecated tools/lxdclient and implements in container/lxd.

## QA steps

- New unit tests.
- Delete the default NIC and disk devices from the profile, bootstrap and ensure that these are re-created.
- Bootstrap again to ensure that behaviour is correct when they are present.

## Documentation changes

None.

## Bug reference

N/A
