### PR TITLE
Interactive add creds for lxd

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -329,6 +329,12 @@ type CredentialAttr struct {
 	// of the file when the credential is "finalized".
 	FilePath bool
 
+	// ExpandFilePath reads in the FilePath, validating the file path correctly.
+	// If the file path is correct, it will then read and replace the path,
+	// with the associated content. The contents of the file in "finalized" will
+	// be the file contents, not the filepath.
+	ExpandFilePath bool
+
 	// Optional controls whether the attribute is required to have a non-empty
 	// value or not. Attributes default to mandatory.
 	Optional bool

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -229,7 +229,8 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	ctxt.Infof("Cloud %q successfully added", name)
-	ctxt.Infof("You may bootstrap with 'juju bootstrap %s'", name)
+	ctxt.Infof("You may need to `juju add-credential %s' if your cloud needs additional credentials", name)
+	ctxt.Infof("Then you can bootstrap with 'juju bootstrap %s'", name)
 
 	return nil
 }

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -364,7 +364,7 @@ func (c *addCredentialCommand) promptFieldValue(
 }
 
 func enterFile(name string, p *interact.Pollster) (string, error) {
-	input, err := p.EnterVerify(name, func(s string) (ok bool, msg string, err error) {
+	input, err := p.EnterVerify(fmt.Sprintf("file path for %s", name), func(s string) (ok bool, msg string, err error) {
 		_, err = jujucloud.ValidateFileAttrValue(s)
 		if err != nil {
 			return false, err.Error(), nil

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -350,12 +350,15 @@ func (c *addCredentialCommand) promptFieldValue(
 		})
 	}
 
-	// We assume that Hidden and FilePath are mutually exclusive here.
+	// We assume that Hidden, ExpandFilePath and FilePath are mutually
+	// exclusive here.
 	switch {
 	case attr.Hidden:
 		return p.EnterPassword(name)
+	case attr.ExpandFilePath:
+		return enterFile(name, p, true)
 	case attr.FilePath:
-		return enterFile(name, p)
+		return enterFile(name, p, false)
 	case attr.Optional:
 		return p.EnterOptional(name)
 	default:
@@ -363,12 +366,13 @@ func (c *addCredentialCommand) promptFieldValue(
 	}
 }
 
-func enterFile(name string, p *interact.Pollster) (string, error) {
+func enterFile(name string, p *interact.Pollster, expanded bool) (string, error) {
 	input, err := p.EnterVerify(fmt.Sprintf("file path for %s", name), func(s string) (ok bool, msg string, err error) {
 		_, err = jujucloud.ValidateFileAttrValue(s)
 		if err != nil {
 			return false, err.Error(), nil
 		}
+
 		return true, "", nil
 	})
 	if err != nil {
@@ -377,6 +381,17 @@ func enterFile(name string, p *interact.Pollster) (string, error) {
 	// We have to run this twice, since it has glommed together
 	// validation and normalization, and Pollster doesn't deal with the
 	// verification function modifying the value.
-	return jujucloud.ValidateFileAttrValue(input)
+	abs, err := jujucloud.ValidateFileAttrValue(input)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 
+	// If we don't need to expand the file path, exit out early.
+	if !expanded {
+		return abs, err
+	}
+
+	// Expand the file path to consume the contents
+	contents, err := ioutil.ReadFile(abs)
+	return string(contents), errors.Trace(err)
 }

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -79,20 +79,20 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 		return cloud.CredentialSchema{{
 			Name: credAttrServerCert,
 			CredentialAttr: cloud.CredentialAttr{
-				Description: "The LXD server certificate, PEM-encoded.",
-				FilePath:    filePath,
+				Description:    "The LXD server certificate, PEM-encoded.",
+				ExpandFilePath: filePath,
 			},
 		}, {
 			Name: credAttrClientCert,
 			CredentialAttr: cloud.CredentialAttr{
-				Description: "The LXD client certificate, PEM-encoded.",
-				FilePath:    filePath,
+				Description:    "The LXD client certificate, PEM-encoded.",
+				ExpandFilePath: filePath,
 			},
 		}, {
 			Name: credAttrClientKey,
 			CredentialAttr: cloud.CredentialAttr{
-				Description: "The LXD client key, PEM-encoded.",
-				FilePath:    filePath,
+				Description:    "The LXD client key, PEM-encoded.",
+				ExpandFilePath: filePath,
 			},
 		}}
 	}

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -184,6 +184,8 @@ func (p environProviderCredentials) readOrGenerateCert(logf func(string, ...inte
 
 // FinalizeCredential is part of the environs.ProviderCredentials interface.
 func (p environProviderCredentials) FinalizeCredential(ctx environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+	// TODO (stickupkid): if there are no server certs for the following, use
+	// the lxd API
 	switch authType := args.Credential.AuthType(); authType {
 	case interactiveAuthType:
 		// if we have all the credential files, then it should be as simple

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -75,43 +75,30 @@ type environProviderCredentials struct {
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	makeCredentials := func(filePath bool) cloud.CredentialSchema {
+		return cloud.CredentialSchema{{
+			Name: credAttrServerCert,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "The LXD server certificate, PEM-encoded.",
+				FilePath:    filePath,
+			},
+		}, {
+			Name: credAttrClientCert,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "The LXD client certificate, PEM-encoded.",
+				FilePath:    filePath,
+			},
+		}, {
+			Name: credAttrClientKey,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "The LXD client key, PEM-encoded.",
+				FilePath:    filePath,
+			},
+		}}
+	}
 	return map[cloud.AuthType]cloud.CredentialSchema{
-		interactiveAuthType: {{
-			credAttrServerCert,
-			cloud.CredentialAttr{
-				Description: "The LXD server certificate, PEM-encoded.",
-				FilePath:    true,
-			},
-		}, {
-			credAttrClientCert,
-			cloud.CredentialAttr{
-				Description: "The LXD client certificate, PEM-encoded.",
-				FilePath:    true,
-			},
-		}, {
-			credAttrClientKey,
-			cloud.CredentialAttr{
-				Description: "The LXD client key, PEM-encoded.",
-				FilePath:    true,
-			},
-		}},
-
-		cloud.CertificateAuthType: {{
-			credAttrServerCert,
-			cloud.CredentialAttr{
-				Description: "The LXD server certificate, PEM-encoded.",
-			},
-		}, {
-			credAttrClientCert,
-			cloud.CredentialAttr{
-				Description: "The LXD client certificate, PEM-encoded.",
-			},
-		}, {
-			credAttrClientKey,
-			cloud.CredentialAttr{
-				Description: "The LXD client key, PEM-encoded.",
-			},
-		}},
+		interactiveAuthType:       makeCredentials(true),
+		cloud.CertificateAuthType: makeCredentials(false),
 	}
 }
 

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -31,7 +31,7 @@ var cloudSchema = &jsonschema.Schema{
 	// order if this changes.
 	Properties: map[string]*jsonschema.Schema{
 		cloud.EndpointKey: {
-			Singular: "the API endpoint url for the remote LXD cloud",
+			Singular: "the API endpoint url for the remote LXD server",
 			Type:     []jsonschema.Type{jsonschema.StringType},
 			Format:   jsonschema.FormatURI,
 		},

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -265,7 +265,10 @@ func (p *environProvider) validateCloudSpec(spec environs.CloudSpec) (local bool
 	}
 	switch authType := spec.Credential.AuthType(); authType {
 	case cloud.CertificateAuthType, interactiveAuthType:
-		if _, _, ok := getCertificates(spec); !ok {
+		if spec.Credential == nil {
+			return false, errors.NotFoundf("credentials")
+		}
+		if _, _, ok := getCertificates(*spec.Credential); !ok {
 			return false, errors.NotValidf("certificate credentials")
 		}
 	default:

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -30,19 +30,25 @@ var cloudSchema = &jsonschema.Schema{
 	// Order doesn't matter since there's only one thing to ask about.  Add
 	// order if this changes.
 	Properties: map[string]*jsonschema.Schema{
-		cloud.AuthTypesKey: {
-			// don't need a prompt, since there's only one choice.
-			Type: []jsonschema.Type{jsonschema.ArrayType},
-			Enum: []interface{}{
-				[]string{
-					string(cloud.CertificateAuthType),
-				},
-			},
-		},
 		cloud.EndpointKey: {
 			Singular: "the API endpoint url for the remote LXD cloud",
 			Type:     []jsonschema.Type{jsonschema.StringType},
 			Format:   jsonschema.FormatURI,
+		},
+		cloud.AuthTypesKey: {
+			Singular:    "auth type",
+			Plural:      "auth types",
+			Type:        []jsonschema.Type{jsonschema.ArrayType},
+			UniqueItems: jsonschema.Bool(true),
+			Items: &jsonschema.ItemSpec{
+				Schemas: []*jsonschema.Schema{{
+					Type: []jsonschema.Type{jsonschema.StringType},
+					Enum: []interface{}{
+						string(cloud.CertificateAuthType),
+						string(interactiveAuthType),
+					},
+				}},
+			},
 		},
 	},
 }
@@ -258,7 +264,7 @@ func (p *environProvider) validateCloudSpec(spec environs.CloudSpec) (local bool
 		}
 	}
 	switch authType := spec.Credential.AuthType(); authType {
-	case cloud.CertificateAuthType:
+	case cloud.CertificateAuthType, interactiveAuthType:
 		if _, _, ok := getCertificates(spec); !ok {
 			return false, errors.NotValidf("certificate credentials")
 		}

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -162,7 +162,12 @@ func (s *serverFactory) RemoteServer(spec environs.CloudSpec) (Server, error) {
 		return s.LocalServer()
 	}
 
-	clientCert, serverCert, ok := getCertificates(spec)
+	cred := spec.Credential
+	if cred == nil {
+		return nil, errors.NotFoundf("credentials")
+	}
+
+	clientCert, serverCert, ok := getCertificates(*cred)
 	if !ok {
 		return nil, errors.NotValidf("credentials")
 	}


### PR DESCRIPTION
## Description of change

The following adds changes so that you can add certs interactively
for the lxd setup. In addition to add a cloud interactively.

## QA steps

Follow the work flow with the following interactive commands:

```sh
juju add-cloud
```
```sh
juju add-credential lxd
```

## Documentation changes

[![demo](https://asciinema.org/a/189669.png)](https://asciinema.org/a/189669?autoplay=1&speed=3)