### PR TITLE
Ensures network-get returns an IP address for ingress networks.

### DIFF
--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -134,6 +134,7 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 				},
 			},
 		},
+		IngressAddresses: []string{"resolvable-hostname"},
 	}
 
 	hctx.info.NetworkInterface.NetworkInfoResults = presetBindings
@@ -272,7 +273,7 @@ ingress-addresses:
 - 100.1.2.3
 - 100.4.3.2`[1:],
 	}, {
-		summary: "a resolvable hostname as addresss, no args",
+		summary: "a resolvable hostname as address, no args",
 		args:    []string{"resolvable-hostname"},
 		out: `
 bind-addresses:
@@ -281,7 +282,9 @@ bind-addresses:
   addresses:
   - hostname: resolvable-hostname
     address: 10.3.3.3
-    cidr: 10.33.1.8/24`[1:],
+    cidr: 10.33.1.8/24
+ingress-addresses:
+- 10.3.3.3`[1:],
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		com := s.createCommand(c)


### PR DESCRIPTION
## Description of change

A prior patch, https://github.com/juju/juju/pull/8672, ensured that the primary address value from the _network-get_ action returned an IP address when stored as a host-name.

This further extends the same change to ensure that ingress addresses are reported as IP addresses in the same fashion.

## QA steps

1. Bootstrap to localhost. 
2. Manually launch a LXD container.
3. Ensure that you can SSH into the machine (copy a host SSH public key into authorized_keys for a user in the container).
4. Assign the machine a resolvable hostname (e.g. add an entry to /etc/hosts on the host)
5. manually provision machine using `ssh:<user>@<hostname>` placement directive format 
6. deploy mysql to manually provisioned machine
7. `juju run mysql/0 -- network-get --ingress-address --format yaml db` 

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1721368
