### PR TITLE
Add snap proxy value to model config.

### DIFF
--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -193,7 +193,9 @@ func (api *APIBase) proxyConfig() params.ProxyConfigResult {
 
 	result.APTProxySettings = toParams(config.AptProxySettings())
 
-	// TODO: add snap proxy bits.
+	result.SnapProxySettings = toParams(config.SnapProxySettings())
+	result.SnapEnterpriseProxyId = config.SnapStoreProxy()
+	result.SnapEnterpriseProxyAssertions = config.SnapStoreAssertions()
 
 	return result
 }

--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -194,8 +194,8 @@ func (api *APIBase) proxyConfig() params.ProxyConfigResult {
 	result.APTProxySettings = toParams(config.AptProxySettings())
 
 	result.SnapProxySettings = toParams(config.SnapProxySettings())
-	result.SnapEnterpriseProxyId = config.SnapStoreProxy()
-	result.SnapEnterpriseProxyAssertions = config.SnapStoreAssertions()
+	result.SnapStoreProxyId = config.SnapStoreProxy()
+	result.SnapStoreProxyAssertions = config.SnapStoreAssertions()
 
 	return result
 }

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -189,6 +189,30 @@ func (s *ProxyUpdaterSuite) TestProxyConfigNoDuplicates(c *gc.C) {
 	})
 }
 
+func (s *ProxyUpdaterSuite) TestSnapProxyConfig(c *gc.C) {
+	s.state.SetModelConfig(coretesting.Attrs{
+		"snap-http-proxy":       "http proxy",
+		"snap-https-proxy":      "https proxy",
+		"snap-store-proxy":      "store proxy",
+		"snap-store-assertions": "trust us",
+	})
+	cfg := s.facade.ProxyConfig(s.oneEntity())
+	s.state.Stub.CheckCallNames(c,
+		"ModelConfig",
+		"APIHostPortsForAgents",
+	)
+
+	expectedNoProxy := "0.1.2.3,0.1.2.4,0.1.2.5"
+
+	c.Assert(cfg.Results[0], jc.DeepEquals, params.ProxyConfigResult{
+		LegacyProxySettings: params.ProxyConfig{NoProxy: expectedNoProxy},
+		SnapProxySettings: params.ProxyConfig{
+			HTTP: "http proxy", HTTPS: "https proxy"},
+		SnapEnterpriseProxyId:         "store proxy",
+		SnapEnterpriseProxyAssertions: "trust us",
+	})
+}
+
 type stubBackend struct {
 	*testing.Stub
 

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -208,8 +208,8 @@ func (s *ProxyUpdaterSuite) TestSnapProxyConfig(c *gc.C) {
 		LegacyProxySettings: params.ProxyConfig{NoProxy: expectedNoProxy},
 		SnapProxySettings: params.ProxyConfig{
 			HTTP: "http proxy", HTTPS: "https proxy"},
-		SnapEnterpriseProxyId:         "store proxy",
-		SnapEnterpriseProxyAssertions: "trust us",
+		SnapStoreProxyId:         "store proxy",
+		SnapStoreProxyAssertions: "trust us",
 	})
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -142,6 +142,16 @@ const (
 	// AptNoProxyKey stores the key for this setting.
 	AptNoProxyKey = "apt-no-proxy"
 
+	// SnapHTTPProxyKey is used to set the snap core setting proxy.http for deployed machines.
+	SnapHTTPProxyKey = "snap-http-proxy"
+	// SnapHTTPSProxyKey is used to set the snap core setting proxy.https for deployed machines.
+	SnapHTTPSProxyKey = "snap-https-proxy"
+	// SnapStoreProxyKey is used to set the snap core setting proxy.store for deployed machines.
+	SnapStoreProxyKey = "snap-store-proxy"
+	// SnapStoreAssertionsKey is used to configure the deployed machines to acknowledge the
+	// store proxy assertions.
+	SnapStoreAssertionsKey = "snap-store-assertions"
+
 	// NetBondReconfigureDelay is the key to pass when bridging
 	// the network for containers.
 	NetBondReconfigureDelayKey = "net-bond-reconfigure-delay"
@@ -465,6 +475,11 @@ var defaultConfigValues = map[string]interface{}{
 	AptFTPProxyKey:   "",
 	AptNoProxyKey:    "",
 	"apt-mirror":     "",
+
+	SnapHTTPProxyKey:       "",
+	SnapHTTPSProxyKey:      "",
+	SnapStoreProxyKey:      "",
+	SnapStoreAssertionsKey: "",
 
 	// Status history settings
 	MaxStatusHistoryAge:  DefaultStatusHistoryAge,
@@ -989,6 +1004,34 @@ func (c *Config) AptMirror() string {
 	return c.asString("apt-mirror")
 }
 
+// SnapProxySettings returns the two proxy settings; http, and https.
+func (c *Config) SnapProxySettings() proxy.Settings {
+	return proxy.Settings{
+		Http:  c.SnapHTTPProxy(),
+		Https: c.SnapHTTPSProxy(),
+	}
+}
+
+// SnapHTTPProxy returns the snap http proxy for the environment.
+func (c *Config) SnapHTTPProxy() string {
+	return c.asString(SnapHTTPProxyKey)
+}
+
+// SnapHTTPSProxy returns the snap https proxy for the environment.
+func (c *Config) SnapHTTPSProxy() string {
+	return c.asString(SnapHTTPSProxyKey)
+}
+
+// SnapStoreProxy returns the snap store proxy for the environment.
+func (c *Config) SnapStoreProxy() string {
+	return c.asString(SnapStoreProxyKey)
+}
+
+// SnapStoreAssertions returns the snap store assertions for the environment.
+func (c *Config) SnapStoreAssertions() string {
+	return c.asString(SnapStoreAssertionsKey)
+}
+
 // LogFwdSyslog returns the syslog forwarding config.
 func (c *Config) LogFwdSyslog() (*syslog.RawConfig, bool) {
 	partial := false
@@ -1420,6 +1463,10 @@ var alwaysOptional = schema.Defaults{
 	AptHTTPSProxyKey:             schema.Omit,
 	AptFTPProxyKey:               schema.Omit,
 	AptNoProxyKey:                schema.Omit,
+	SnapHTTPProxyKey:             schema.Omit,
+	SnapHTTPSProxyKey:            schema.Omit,
+	SnapStoreProxyKey:            schema.Omit,
+	SnapStoreAssertionsKey:       schema.Omit,
 	"apt-mirror":                 schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	ResourceTagsKey:              schema.Omit,
@@ -1504,7 +1551,6 @@ func (cfg *Config) ValidateUnknownAttrs(extrafields schema.Fields, defaults sche
 	checker := schema.FieldMap(extrafields, defaults)
 	coerced, err := checker.Coerce(attrs, nil)
 	if err != nil {
-		// TODO(ericsnow) Drop this?
 		logger.Debugf("coercion failed attributes: %#v, checker: %#v, %v", attrs, checker, err)
 		return nil, err
 	}
@@ -1754,6 +1800,26 @@ global or per instance security groups.`,
 	},
 	JujuNoProxyKey: {
 		Description: "List of domain addresses not to be proxied (comma-separated), may contain CIDRs. Passed to charms in the JUJU_CHARM_NO_PROXY environment variable",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	SnapHTTPProxyKey: {
+		Description: "The HTTP proxy value to for installing snaps",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	SnapHTTPSProxyKey: {
+		Description: "The HTTPS proxy value to for installing snaps",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	SnapStoreProxyKey: {
+		Description: "The snap store proxy for installing snaps",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	SnapStoreAssertionsKey: {
+		Description: "The assertions for the defined snap store proxy",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1226,6 +1226,30 @@ func (s *ConfigSuite) TestProxyValuesNotSet(c *gc.C) {
 	c.Assert(config.FTPProxy(), gc.Equals, "")
 	c.Assert(config.AptFTPProxy(), gc.Equals, "")
 	c.Assert(config.NoProxy(), gc.Equals, "127.0.0.1,localhost,::1")
+
+	c.Assert(config.SnapHTTPProxy(), gc.Equals, "")
+	c.Assert(config.SnapHTTPSProxy(), gc.Equals, "")
+	c.Assert(config.SnapStoreProxy(), gc.Equals, "")
+	c.Assert(config.SnapStoreAssertions(), gc.Equals, "")
+}
+
+func (s *ConfigSuite) TestSnapProxyValues(c *gc.C) {
+	s.addJujuFiles(c)
+	config := newTestConfig(c, testing.Attrs{
+		"snap-http-proxy":       "http://snap-proxy",
+		"snap-https-proxy":      "https://snap-proxy",
+		"snap-store-proxy":      "42",
+		"snap-store-assertions": "trust us",
+	})
+
+	c.Assert(config.SnapHTTPProxy(), gc.Equals, "http://snap-proxy")
+	c.Assert(config.SnapHTTPSProxy(), gc.Equals, "https://snap-proxy")
+	c.Assert(config.SnapStoreProxy(), gc.Equals, "42")
+	c.Assert(config.SnapStoreAssertions(), gc.Equals, "trust us")
+	c.Assert(config.SnapProxySettings(), gc.Equals, proxy.Settings{
+		Http:  "http://snap-proxy",
+		Https: "https://snap-proxy",
+	})
 }
 
 func (s *ConfigSuite) TestProxyConfigMap(c *gc.C) {


### PR DESCRIPTION
This PR adds four model config variables.
 * snap-http-proxy
 * snap-https-proxy
 * snap-store-proxy
 * snap-store-assertions

The first two provide the standard http and https proxy values for the snapd running on the juju machines.

The second two are for snap store proxies, the new name for the snap enterprise proxy. These are special proxies that allow the pinning of snap versions, and require assertions to be accepted by the machines.

## QA steps
```
juju bootstrap lxd test
juju switch -m controller
juju model-config snap-http-proxy=http://some-proxy snap-https-proxy=https://some-proxy
juju ssh 0
```
run the following and check the output:
```
$ sudo snap get core proxy
Key          Value
proxy.http   http://some-proxy
proxy.https  https://some-proxy
```

## Documentation changes

Yes we'll need to add these to the model config section.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1690539
