### PR TITLE
Removes validation/precedence from LXD constraints

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -38,29 +38,18 @@ const constraintWarnTemplate = "instance type constraint specified; ignoring %s 
 
 // ApplyConstraints applies the input constraints as valid LXD container
 // configuration to the container spec.
-// If an instance type constraint has been specified, conflicting constraints
-// are ignored and a warning is logged.
+// Note that we pass these through as supplied. If an instance type constraint
+// has been specified along with specific cores/mem constraints,
+// LXD behaviour is to override with the specific ones even when lower.
 func (c *ContainerSpec) ApplyConstraints(cons constraints.Value) {
-	typeCon := cons.HasInstanceType()
-	if typeCon {
+	if cons.HasInstanceType() {
 		c.InstanceType = *cons.InstanceType
 	}
-
 	if cons.HasCpuCores() {
-		con := fmt.Sprintf("%d", *cons.CpuCores)
-		if typeCon {
-			logger.Warningf(constraintWarnTemplate, "cores", con)
-		} else {
-			c.Config["limits.cpu"] = con
-		}
+		c.Config["limits.cpu"] = fmt.Sprintf("%d", *cons.CpuCores)
 	}
 	if cons.HasMem() {
-		con := fmt.Sprintf("%dMB", *cons.Mem)
-		if typeCon {
-			logger.Warningf(constraintWarnTemplate, "memory", con)
-		} else {
-			c.Config["limits.memory"] = con
-		}
+		c.Config["limits.memory"] = fmt.Sprintf("%dMB", *cons.Mem)
 	}
 }
 

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -452,13 +452,15 @@ func (s *containerSuite) TestRemoveContainersPartialFailure(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "failed to remove containers: c1, c2")
 }
 
-func (s *managerSuite) TestSpecApplyConstraintsNoInstanceType(c *gc.C) {
+func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 	mem := uint64(2046)
 	cores := uint64(4)
+	instType := "t2.micro"
 
 	cons := constraints.Value{
-		Mem:      &mem,
-		CpuCores: &cores,
+		Mem:          &mem,
+		CpuCores:     &cores,
+		InstanceType: &instType,
 	}
 
 	spec := lxd.ContainerSpec{
@@ -471,28 +473,6 @@ func (s *managerSuite) TestSpecApplyConstraintsNoInstanceType(c *gc.C) {
 		"limits.memory":  "2046MB",
 		"limits.cpu":     "4",
 	}
-	c.Check(spec.Config, gc.DeepEquals, exp)
-	c.Check(spec.InstanceType, gc.Equals, "")
-}
-
-func (s *managerSuite) TestSpecApplyConstraintsWithInstanceType(c *gc.C) {
-	mem := uint64(2046)
-	cores := uint64(4)
-	instType := "t2.micro"
-
-	cons := constraints.Value{
-		Mem:          &mem,
-		CpuCores:     &cores,
-		InstanceType: &instType,
-	}
-
-	exp := map[string]string{lxd.AutoStartKey: "true"}
-
-	spec := lxd.ContainerSpec{
-		Config: exp,
-	}
-	spec.ApplyConstraints(cons)
-
 	c.Check(spec.Config, gc.DeepEquals, exp)
 	c.Check(spec.InstanceType, gc.Equals, instType)
 }


### PR DESCRIPTION
## Description of change

Removes the constrain validation added in https://github.com/juju/juju/pull/8869 and passes constraints through to LXD as config, as they are supplied.

This changes behaviour from https://github.com/juju/juju/pull/8869 where specifying an instance-type would override settings for CPU cores and/or memory.

LXD's behaviour, now deferred to, is for any specific CPU/mem constraints to override those implied by an instance type _even when they are lower_.

## QA steps

Only CPU and Memory
```juju add-machine lxd:0 --constraints "cores=2 mem=1G"```
- Check the LXD config for the new container and verify that:
  - limits.cpu = "2" and;
  - limits.memory = "1024MB"

Specific Overrides Instance Type
```juju add-machine lxd:0 --constraints "cores=2 mem=2G instance-type=t2.micro"```
- Check the LXD config for the new container and verify that:
  - limits.cpu = "2" and;
  - limits.memory = "2048MB"

Merged
```juju add-machine lxd:0 --constraints "mem=2G instance-type=t2.micro"```
- Check the LXD config for the new container and verify that:
  - limits.cpu = "1" and;
  - limits.memory = "2048MB"

## Documentation changes

This changes the documentation requirements from https://github.com/juju/juju/pull/8869.

## Bug reference

N/A
