### PR TITLE
LXD Default logger

### DIFF
--- a/container/lxd/logger.go
+++ b/container/lxd/logger.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/juju/loggo"
+	lxdLogger "github.com/lxc/lxd/shared/logger"
+)
+
+// lxdLogProxy proxies LXD's log calls through the juju logger so we can get
+// more info about what's going on.
+type lxdLogProxy struct {
+	logger loggo.Logger
+}
+
+func (p *lxdLogProxy) render(msg string, ctx []interface{}) string {
+	var result bytes.Buffer
+	result.WriteString(msg)
+	if len(ctx) > 0 {
+		result.WriteString(": ")
+	}
+
+	/* This is sort of a hack, but it's enforced in the LXD code itself as
+	 * well. LXD's logging framework forces us to pass things as "string"
+	 * for one argument and then a "context object" as the next argument.
+	 * So, we do some basic rendering here to make it look slightly less
+	 * ugly.
+	 */
+	var key string
+	for i, entry := range ctx {
+		if i != 0 {
+			result.WriteString(", ")
+		}
+
+		if key == "" {
+			key, _ = entry.(string)
+		} else {
+			result.WriteString(key)
+			result.WriteString(": ")
+			result.WriteString(fmt.Sprintf("%s", entry))
+			key = ""
+		}
+	}
+
+	return result.String()
+}
+
+func (p *lxdLogProxy) Debug(msg string, ctx ...interface{}) {
+	// NOTE(axw) the LXD client logs a lot of detail at
+	// "debug" level, which is its highest level of logging.
+	// We transform this to Trace, to avoid spamming our
+	// logs with too much information.
+	p.logger.Tracef(p.render(msg, ctx))
+}
+
+func (p *lxdLogProxy) Info(msg string, ctx ...interface{}) {
+	p.logger.Infof(p.render(msg, ctx))
+}
+
+func (p *lxdLogProxy) Warn(msg string, ctx ...interface{}) {
+	p.logger.Warningf(p.render(msg, ctx))
+}
+
+func (p *lxdLogProxy) Error(msg string, ctx ...interface{}) {
+	p.logger.Errorf(p.render(msg, ctx))
+}
+
+func (p *lxdLogProxy) Crit(msg string, ctx ...interface{}) {
+	p.logger.Criticalf(p.render(msg, ctx))
+}
+
+func init() {
+	lxdLogger.Log = &lxdLogProxy{
+		logger: loggo.GetLogger("lxd"),
+	}
+}

--- a/container/lxd/logger.go
+++ b/container/lxd/logger.go
@@ -24,12 +24,11 @@ func (p *lxdLogProxy) render(msg string, ctx []interface{}) string {
 		result.WriteString(": ")
 	}
 
-	/* This is sort of a hack, but it's enforced in the LXD code itself as
-	 * well. LXD's logging framework forces us to pass things as "string"
-	 * for one argument and then a "context object" as the next argument.
-	 * So, we do some basic rendering here to make it look slightly less
-	 * ugly.
-	 */
+	// This is sort of a hack, but it's enforced in the LXD code itself as
+	// well. LXD's logging framework forces us to pass things as "string"
+	// for one argument and then a "context object" as the next argument.
+	// So, we do some basic rendering here to make it look slightly less
+	// ugly.
 	var key string
 	for i, entry := range ctx {
 		if i != 0 {

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -4,7 +4,6 @@
 package lxdclient
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"net/url"
@@ -18,79 +17,12 @@ import (
 	lxdclient "github.com/lxc/lxd/client"
 	lxdshared "github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
-	lxdlogger "github.com/lxc/lxd/shared/logger"
 
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/utils/proxy"
 )
 
 var logger = loggo.GetLogger("juju.tools.lxdclient")
-
-// lxdLogProxy proxies LXD's log calls through the juju logger so we can get
-// more info about what's going on.
-type lxdLogProxy struct {
-	logger loggo.Logger
-}
-
-func (p *lxdLogProxy) render(msg string, ctx []interface{}) string {
-	result := bytes.Buffer{}
-	result.WriteString(msg)
-	if len(ctx) > 0 {
-		result.WriteString(": ")
-	}
-
-	/* This is sort of a hack, but it's enforced in the LXD code itself as
-	 * well. LXD's logging framework forces us to pass things as "string"
-	 * for one argument and then a "context object" as the next argument.
-	 * So, we do some basic rendering here to make it look slightly less
-	 * ugly.
-	 */
-	var key string
-	for i, entry := range ctx {
-		if i != 0 {
-			result.WriteString(", ")
-		}
-
-		if key == "" {
-			key, _ = entry.(string)
-		} else {
-			result.WriteString(key)
-			result.WriteString(": ")
-			result.WriteString(fmt.Sprintf("%s", entry))
-			key = ""
-		}
-	}
-
-	return result.String()
-}
-
-func (p *lxdLogProxy) Debug(msg string, ctx ...interface{}) {
-	// NOTE(axw) the LXD client logs a lot of detail at
-	// "debug" level, which is its highest level of logging.
-	// We transform this to Trace, to avoid spamming our
-	// logs with too much information.
-	p.logger.Tracef(p.render(msg, ctx))
-}
-
-func (p *lxdLogProxy) Info(msg string, ctx ...interface{}) {
-	p.logger.Infof(p.render(msg, ctx))
-}
-
-func (p *lxdLogProxy) Warn(msg string, ctx ...interface{}) {
-	p.logger.Warningf(p.render(msg, ctx))
-}
-
-func (p *lxdLogProxy) Error(msg string, ctx ...interface{}) {
-	p.logger.Errorf(p.render(msg, ctx))
-}
-
-func (p *lxdLogProxy) Crit(msg string, ctx ...interface{}) {
-	p.logger.Criticalf(p.render(msg, ctx))
-}
-
-func init() {
-	lxdlogger.Log = &lxdLogProxy{loggo.GetLogger("lxd")}
-}
 
 // Client is a high-level wrapper around the LXD API client.
 type Client struct {


### PR DESCRIPTION
## Description of change

Provides the current lxdclient logger, which overrides the lxd shared logger to the
new lxd/container package.

This currently uses `init()`, in an ideal scenario, this wouldn't do it this way, but it
makes sure that we do overwrite the shared lxd logger at the best time.

## QA steps

Logs from the lxd logger should be formatted correctly or at least in the exact same
way as they where previously.

## Documentation changes

No changes

## Bug reference

N/A
