### PR TITLE
Introduce charmstore-url as controller config.

### DIFF
--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -66,8 +66,12 @@ func NewPublicFacade(st *state.State, _ facade.Resources, authorizer facade.Auth
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	controllerCfg, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	newClient := func() (CharmStore, error) {
-		return charmstore.NewCachingClient(state.MacaroonCache{st}, nil)
+		return charmstore.NewCachingClient(state.MacaroonCache{st}, controllerCfg.CharmStoreURL())
 	}
 	facade, err := NewFacade(rst, newClient)
 	if err != nil {

--- a/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
+++ b/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"fmt"
 	"net/http/httptest"
-	"net/url"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -69,9 +68,7 @@ func (s *CharmSuite) SetUpTest(c *gc.C) {
 	// Patch the charm repo initializer function: it is replaced with a charm
 	// store repo pointing to the testing server.
 	s.jcSuite.PatchValue(&charmrevisionupdater.NewCharmStoreClient, func(st *state.State) (jujucharmstore.Client, error) {
-		csURL, err := url.Parse(s.Server.URL)
-		c.Assert(err, jc.ErrorIsNil)
-		return jujucharmstore.NewCachingClient(state.MacaroonCache{st}, csURL)
+		return jujucharmstore.NewCachingClient(state.MacaroonCache{st}, s.Server.URL)
 	})
 	s.charms = make(map[string]*state.Charm)
 }

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -89,7 +89,11 @@ func (api *CharmRevisionUpdaterAPI) updateLatestRevisions() error {
 // NewCharmStoreClient instantiates a new charm store repository.  Exported so
 // we can change it during testing.
 var NewCharmStoreClient = func(st *state.State) (charmstore.Client, error) {
-	return charmstore.NewCachingClient(state.MacaroonCache{st}, nil)
+	controllerCfg, err := st.ControllerConfig()
+	if err != nil {
+		return charmstore.Client{}, errors.Trace(err)
+	}
+	return charmstore.NewCachingClient(state.MacaroonCache{st}, controllerCfg.CharmStoreURL())
 }
 
 type latestCharmInfo struct {

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -6,7 +6,6 @@ package charmrevisionupdater_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -175,9 +174,7 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 
 	// Point the charm repo initializer to the testing server.
 	s.PatchValue(&charmrevisionupdater.NewCharmStoreClient, func(st *state.State) (charmstore.Client, error) {
-		csURL, err := url.Parse(srv.URL)
-		c.Assert(err, jc.ErrorIsNil)
-		return charmstore.NewCachingClient(state.MacaroonCache{st}, csURL)
+		return charmstore.NewCachingClient(state.MacaroonCache{st}, srv.URL)
 	})
 
 	result, err := s.charmrevisionupdater.UpdateLatestRevisions()

--- a/charmstore/client_test.go
+++ b/charmstore/client_test.go
@@ -52,7 +52,7 @@ func (s *ClientSuite) TestLatestRevisions(c *gc.C) {
 		Sha256:   "fgh",
 	}}}
 
-	client, err := newCachingClient(s.cache, nil, s.wrapper.makeWrapper)
+	client, err := newCachingClient(s.cache, "", s.wrapper.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	foo := charm.MustParseURL("cs:quantal/foo-1")
@@ -118,7 +118,7 @@ func (s *ClientSuite) TestListResources(c *gc.C) {
 	s.wrapper.ReturnListResourcesStable = []resourceResult{oneResourceResult(stable), {err: params.ErrNotFound}}
 	s.wrapper.ReturnListResourcesDev = []resourceResult{oneResourceResult(dev), oneResourceResult(dev2)}
 
-	client, err := newCachingClient(s.cache, nil, s.wrapper.makeWrapper)
+	client, err := newCachingClient(s.cache, "", s.wrapper.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	foo := charm.MustParseURL("cs:quantal/foo-1")
@@ -158,7 +158,7 @@ func (s *ClientSuite) TestListResources(c *gc.C) {
 
 func (s *ClientSuite) TestListResourcesError(c *gc.C) {
 	s.wrapper.ReturnListResourcesStable = []resourceResult{{err: errors.NotFoundf("another error")}}
-	client, err := newCachingClient(s.cache, nil, s.wrapper.makeWrapper)
+	client, err := newCachingClient(s.cache, "", s.wrapper.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ret, err := client.ListResources([]CharmID{{
@@ -188,7 +188,7 @@ func (s *ClientSuite) TestGetResource(c *gc.C) {
 	}
 	s.wrapper.ReturnResourceMeta = apiRes
 
-	client, err := newCachingClient(s.cache, nil, s.wrapper.makeWrapper)
+	client, err := newCachingClient(s.cache, "", s.wrapper.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	req := ResourceRequest{
@@ -222,7 +222,7 @@ func (s *ClientSuite) TestResourceInfo(c *gc.C) {
 	}
 	s.wrapper.ReturnResourceMeta = apiRes
 
-	client, err := newCachingClient(s.cache, nil, s.wrapper.makeWrapper)
+	client, err := newCachingClient(s.cache, "", s.wrapper.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	req := ResourceRequest{

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -66,7 +66,7 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 		{err: params.ErrUnauthorized},
 	}
 
-	client, err := newCachingClient(s.cache, nil, s.lowLevel.makeWrapper)
+	client, err := newCachingClient(s.cache, "", s.lowLevel.makeWrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	metadata := map[string]string{

--- a/charmstore/stub_test.go
+++ b/charmstore/stub_test.go
@@ -53,9 +53,9 @@ type fakeWrapper struct {
 	ReturnResourceMeta params.Resource
 }
 
-func (f *fakeWrapper) makeWrapper(bakeryClient *httpbakery.Client, server *url.URL) csWrapper {
+func (f *fakeWrapper) makeWrapper(bakeryClient *httpbakery.Client, server string) (csWrapper, error) {
 	f.stub.AddCall("makeWrapper", bakeryClient, server)
-	return f
+	return f, nil
 }
 
 func (f *fakeWrapper) ServerURL() string {

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -5,8 +5,6 @@ package application
 
 import (
 	"github.com/juju/cmd"
-	"gopkg.in/juju/charmrepo.v3/csclient"
-	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -24,6 +22,7 @@ func NewUpgradeCharmCommandForTest(
 	newCharmUpgradeClient func(api.Connection) CharmUpgradeClient,
 	newModelConfigGetter func(api.Connection) ModelConfigGetter,
 	newResourceLister func(api.Connection) (ResourceLister, error),
+	charmStoreURLGetter func(api.Connection) (string, error),
 ) cmd.Command {
 	cmd := &upgradeCharmCommand{
 		DeployResources:       deployResources,
@@ -33,6 +32,7 @@ func NewUpgradeCharmCommandForTest(
 		NewCharmUpgradeClient: newCharmUpgradeClient,
 		NewModelConfigGetter:  newModelConfigGetter,
 		NewResourceLister:     newResourceLister,
+		CharmStoreURLGetter:   charmStoreURLGetter,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetAPIOpen(apiOpen)
@@ -129,17 +129,4 @@ func NewRemoveSaasCommandForTest(api RemoveSaasAPI, store jujuclient.ClientStore
 	}}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
-}
-
-type Patcher interface {
-	PatchValue(dest, value interface{})
-}
-
-func PatchNewCharmStoreClient(s Patcher, url string) {
-	s.PatchValue(&newCharmStoreClient, func(bakeryClient *httpbakery.Client) *csclient.Client {
-		return csclient.New(csclient.Params{
-			URL:          url,
-			BakeryClient: bakeryClient,
-		})
-	})
 }

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -165,7 +165,7 @@ func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		cstoreClient := newCharmStoreClient(bakeryClient).WithChannel(deployCmd.Channel)
+		cstoreClient := newCharmStoreClient(bakeryClient, s.srv.URL).WithChannel(deployCmd.Channel)
 		return &deployAPIAdapter{
 			Connection:        apiRoot,
 			apiClient:         &apiClient{Client: apiRoot.Client()},

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -100,8 +100,9 @@ func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channe
 
 // newCharmStoreClient is called to obtain a charm store client.
 // It is defined as a variable so it can be changed for testing purposes.
-var newCharmStoreClient = func(client *httpbakery.Client) *csclient.Client {
+var newCharmStoreClient = func(client *httpbakery.Client, csURL string) *csclient.Client {
 	return csclient.New(csclient.Params{
+		URL:          csURL,
 		BakeryClient: client,
 	})
 }

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd/cmdtesting"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
@@ -20,10 +21,12 @@ import (
 	"gopkg.in/juju/charmrepo.v3"
 	"gopkg.in/juju/charmrepo.v3/csclient"
 	"gopkg.in/juju/charmstore.v5"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/component/all"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
@@ -124,16 +127,19 @@ resources:
 // place to allow testing code that calls addCharmViaAPI.
 type charmStoreSuite struct {
 	jujutesting.JujuConnSuite
-	handler charmstore.HTTPCloseHandler
-	srv     *httptest.Server
-	client  *csclient.Client
+	handler    charmstore.HTTPCloseHandler
+	srv        *httptest.Server
+	srvSession *mgo.Session
+	client     *csclient.Client
 }
 
 func (s *charmStoreSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
+	srvSession, err := gitjujutesting.MgoServer.Dial()
+	c.Assert(err, gc.IsNil)
+	s.srvSession = srvSession
 
 	// Set up the charm store testing server.
-	db := s.Session.DB("juju-testing")
+	db := s.srvSession.DB("juju-testing")
 	params := charmstore.ServerParams{
 		AuthUsername: "test-user",
 		AuthPassword: "test-password",
@@ -148,20 +154,22 @@ func (s *charmStoreSuite) SetUpTest(c *gc.C) {
 		Password: params.AuthPassword,
 	})
 
-	application.PatchNewCharmStoreClient(s, s.srv.URL)
+	// Set charmstore URL config so the config is set during bootstrap
+	if s.ControllerConfigAttrs == nil {
+		s.ControllerConfigAttrs = make(map[string]interface{})
+	}
+	s.JujuConnSuite.ControllerConfigAttrs[controller.CharmStoreURL] = s.srv.URL
+
+	s.JujuConnSuite.SetUpTest(c)
 
 	// Initialize the charm cache dir.
 	s.PatchValue(&charmrepo.CacheDir, c.MkDir())
-
-	// Point the CLI to the charm store testing server.
-
-	// Point the Juju API server to the charm store testing server.
-	s.PatchValue(&csclient.ServerURL, s.srv.URL)
 }
 
 func (s *charmStoreSuite) TearDownTest(c *gc.C) {
 	s.handler.Close()
 	s.srv.Close()
+	s.srvSession.Close()
 	s.JujuConnSuite.TearDownTest(c)
 }
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -76,6 +76,7 @@ var _ = gc.Suite(&MachineSuite{})
 func (s *MachineSuite) SetUpTest(c *gc.C) {
 	s.ControllerConfigAttrs = map[string]interface{}{
 		controller.AuditingEnabled: true,
+		controller.CharmStoreURL:   "staging.charmstore",
 	}
 	s.commonMachineSuite.SetUpTest(c)
 	// Most of these tests normally finish sub-second on a fast machine.

--- a/controller/config.go
+++ b/controller/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	utilscert "github.com/juju/utils/cert"
+	"gopkg.in/juju/charmrepo.v3/csclient"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 
@@ -68,6 +69,9 @@ const (
 
 	// CACertKey is the key for the controller's CA certificate attribute.
 	CACertKey = "ca-cert"
+
+	// CharmStoreURL is the key for the url to use for charmstore API calls
+	CharmStoreURL = "charmstore-url"
 
 	// ControllerUUIDKey is the key for the controller UUID attribute.
 	ControllerUUIDKey = "controller-uuid"
@@ -179,6 +183,7 @@ var (
 		AutocertDNSNameKey,
 		AutocertURLKey,
 		CACertKey,
+		CharmStoreURL,
 		ControllerUUIDKey,
 		IdentityPublicKey,
 		IdentityURL,
@@ -367,6 +372,11 @@ func (c Config) Features() set.Strings {
 		}
 	}
 	return features
+}
+
+// CharmStoreURL returns the URL to use for charmstore api calls.
+func (c Config) CharmStoreURL() string {
+	return c.asString(CharmStoreURL)
 }
 
 // ControllerUUID returns the uuid for the model's controller.
@@ -667,6 +677,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	JujuManagementSpace:     schema.String(),
 	CAASOperatorImagePath:   schema.String(),
 	Features:                schema.List(schema.String()),
+	CharmStoreURL:           schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -689,4 +700,5 @@ var configChecker = schema.FieldMap(schema.Fields{
 	JujuManagementSpace:     schema.Omit,
 	CAASOperatorImagePath:   schema.Omit,
 	Features:                schema.Omit,
+	CharmStoreURL:           csclient.ServerURL,
 })

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -13,6 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	utilscert "github.com/juju/utils/cert"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charmrepo.v3/csclient"
 
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/controller"
@@ -434,4 +435,27 @@ func (s *ConfigSuite) TestCAASOperatorImagePath(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(cfg.CAASOperatorImagePath(), gc.Equals, imagePath)
 	}
+}
+
+func (s *ConfigSuite) TestCharmstoreURLDefault(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.CharmStoreURL(), gc.Equals, csclient.ServerURL)
+}
+
+func (s *ConfigSuite) TestCharmstoreURLSettingValue(c *gc.C) {
+	csURL := "http://homestarrunner.com/charmstore"
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			controller.CharmStoreURL: csURL,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.CharmStoreURL(), gc.Equals, csURL)
 }

--- a/resource/resourceadapters/charmstore.go
+++ b/resource/resourceadapters/charmstore.go
@@ -53,7 +53,11 @@ func newCharmstoreOpener(st *state.State) *charmstoreOpener {
 }
 
 func newCharmStoreClient(st *state.State) (charmstore.Client, error) {
-	return charmstore.NewCachingClient(state.MacaroonCache{st}, nil)
+	conConfig, err := st.ControllerConfig()
+	if err != nil {
+		return charmstore.Client{}, errors.Trace(err)
+	}
+	return charmstore.NewCachingClient(state.MacaroonCache{st}, conConfig.CharmStoreURL())
 }
 
 // NewClient opens a new charm store client.

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -37,6 +37,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.JujuManagementSpace,
 		controller.AuditLogExcludeMethods,
 		controller.CAASOperatorImagePath,
+		controller.CharmStoreURL,
 		controller.Features,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {


### PR DESCRIPTION
## Description of change
Adds the 'charmstore-url' config parameter to the controller enabling users 
to configure which charmstore they consume.

This value is used whenever a charmstore client is created. Some places
occur on the client side (and require a call out to the controller) others
occur on the controller itself.

## Documentation changes
There will need to be some extra command docs added to highlight this 
change: https://bugs.launchpad.net/juju/+bug/1780689