### PR TITLE
Removing critical error

### DIFF
--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -278,7 +278,6 @@ func (c *ModelCommandBase) modelDetails(controllerName, modelName string) (*juju
 	details, err := c.store.ModelByName(controllerName, modelName)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			logger.Criticalf(err.Error())
 			return nil, errors.Trace(err)
 		}
 		logger.Debugf("model %q not found, refreshing", modelName)


### PR DESCRIPTION
## Description of change

The following removes the critical error, I'm not sure it should
be there, because we return the error directly under the log
statement.

An example of this error showing in the wrong place is when you've
bootstrapped to lxd on localhost and deploy something. When you
try and grab some metrics about that deploy and you miss type a
model name, it comes with a critical log.



## QA steps

```sh
juju bootstrap localhost lxd-test
juju deploy postgresql
juju metrics --all -m=lxc-test
```

The following shouldn't log critical error.

## Documentation changes

Nothing

## Bug reference

N/A