### PR TITLE
Migrate storage docs to use hostid not machineid

### DIFF
--- a/apiserver/common/storagecommon/volumes.go
+++ b/apiserver/common/storagecommon/volumes.go
@@ -144,7 +144,7 @@ func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachmen
 	}
 	return params.VolumeAttachment{
 		v.Volume().String(),
-		v.Machine().String(),
+		v.Host().String(),
 		VolumeAttachmentInfoFromState(info),
 	}, nil
 }

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -87,7 +87,7 @@ type StorageBackend interface {
 	RemoveFilesystem(names.FilesystemTag) error
 	RemoveFilesystemAttachment(names.Tag, names.FilesystemTag) error
 	RemoveVolume(names.VolumeTag) error
-	RemoveVolumeAttachment(names.MachineTag, names.VolumeTag) error
+	RemoveVolumeAttachment(names.Tag, names.VolumeTag) error
 	DetachFilesystem(names.Tag, names.FilesystemTag) error
 	DestroyFilesystem(names.FilesystemTag) error
 	DetachVolume(names.Tag, names.VolumeTag) error

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -295,7 +295,7 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
-				Message: `volume attachment "2" on "0" not provisioned`,
+				Message: `volume attachment "2" on "machine 0" not provisioned`,
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -146,9 +146,9 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 	}
 	s.volume = &mockVolume{tag: s.volumeTag, storage: &s.storageTag}
 	s.volumeAttachment = &mockVolumeAttachment{
-		VolumeTag:  s.volumeTag,
-		MachineTag: s.machineTag,
-		life:       state.Alive,
+		VolumeTag: s.volumeTag,
+		HostTag:   s.machineTag,
+		life:      state.Alive,
 	}
 
 	return &mockStorageAccessor{

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -327,18 +327,18 @@ func (m *mockStorageAttachment) Life() state.Life {
 }
 
 type mockVolumeAttachment struct {
-	VolumeTag  names.VolumeTag
-	MachineTag names.MachineTag
-	info       *state.VolumeAttachmentInfo
-	life       state.Life
+	VolumeTag names.VolumeTag
+	HostTag   names.Tag
+	info      *state.VolumeAttachmentInfo
+	life      state.Life
 }
 
 func (va *mockVolumeAttachment) Volume() names.VolumeTag {
 	return va.VolumeTag
 }
 
-func (va *mockVolumeAttachment) Machine() names.MachineTag {
-	return va.MachineTag
+func (va *mockVolumeAttachment) Host() names.Tag {
+	return va.HostTag
 }
 
 func (va *mockVolumeAttachment) Life() state.Life {

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -554,7 +554,7 @@ func createVolumeDetails(
 					stateInfo,
 				)
 			}
-			details.MachineAttachments[attachment.Machine().String()] = attDetails
+			details.MachineAttachments[attachment.Host().String()] = attDetails
 		}
 	}
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -446,8 +446,6 @@ func (a *Facade) updateStatus(params params.ApplicationUnitParams) (
 			Data:    params.Data,
 		}
 	}
-	logger.Criticalf("AGENT STATUS: %v", agentStatus)
-	logger.Criticalf("UNIT STATUS: %v", unitStatus)
 	return agentStatus, unitStatus, nil
 }
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1807,7 +1807,7 @@ func (e *exporter) addVolume(vol *volume, volAttachments []volumeAttachmentDoc) 
 		va := volumeAttachment{doc}
 		logger.Debugf("  attachment %#v", doc)
 		args := description.VolumeAttachmentArgs{
-			Machine: va.Machine(),
+			Machine: va.Host().(names.MachineTag),
 		}
 		if info, err := va.Info(); err == nil {
 			logger.Debugf("    info %#v", info)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1786,7 +1786,7 @@ func (i *importer) addVolume(volume description.Volume, sb *storageBackend) erro
 	if detachable, err := isDetachableVolumePool(sb, volume.Pool()); err != nil {
 		return errors.Trace(err)
 	} else if !detachable && len(attachments) == 1 {
-		doc.MachineId = attachments[0].Machine().Id()
+		doc.HostId = attachments[0].Machine().Id()
 	}
 	status := i.makeStatusDoc(volume.Status())
 	ops := sb.newVolumeOps(doc, status)
@@ -1827,10 +1827,10 @@ func (i *importer) addVolumeAttachmentOp(volID string, attachment description.Vo
 		Id:     volumeAttachmentId(machineId, volID),
 		Assert: txn.DocMissing,
 		Insert: &volumeAttachmentDoc{
-			Volume:  volID,
-			Machine: machineId,
-			Params:  params,
-			Info:    info,
+			Volume: volID,
+			Host:   machineId,
+			Params: params,
+			Info:   info,
 		},
 	}
 }
@@ -1882,7 +1882,7 @@ func (i *importer) addFilesystem(filesystem description.Filesystem, sb *storageB
 	if detachable, err := isDetachableFilesystemPool(sb, filesystem.Pool()); err != nil {
 		return errors.Trace(err)
 	} else if !detachable && len(attachments) == 1 {
-		doc.MachineId = attachments[0].Machine().Id()
+		doc.HostId = attachments[0].Machine().Id()
 	}
 	status := i.makeStatusDoc(filesystem.Status())
 	ops := sb.newFilesystemOps(doc, status)
@@ -1923,7 +1923,7 @@ func (i *importer) addFilesystemAttachmentOp(fsID string, attachment description
 		Assert: txn.DocMissing,
 		Insert: &filesystemAttachmentDoc{
 			Filesystem: fsID,
-			Machine:    machineId,
+			Host:       machineId,
 			// Life: ..., // TODO: import life, default is Alive
 			Params: params,
 			Info:   info,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -707,7 +707,7 @@ func (s *MigrationSuite) TestVolumeDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
-		"MachineId", // recreated from pool properties
+		"HostId",    // recreated from pool properties
 		"Releasing", // only when dying; can't migrate dying storage
 	)
 	migrated := set.NewStrings(
@@ -733,7 +733,7 @@ func (s *MigrationSuite) TestVolumeAttachmentDocFields(c *gc.C) {
 	)
 	migrated := set.NewStrings(
 		"Volume",
-		"Machine",
+		"Host",
 		"Info",
 		"Params",
 	)
@@ -750,7 +750,7 @@ func (s *MigrationSuite) TestFilesystemDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
-		"MachineId", // recreated from pool properties
+		"HostId",    // recreated from pool properties
 		"Releasing", // only when dying; can't migrate dying storage
 	)
 	migrated := set.NewStrings(
@@ -774,13 +774,10 @@ func (s *MigrationSuite) TestFilesystemAttachmentDocFields(c *gc.C) {
 		"ModelUUID",
 		"DocID",
 		"Life",
-
-		// TODO(caas)
-		"Host",
 	)
 	migrated := set.NewStrings(
 		"Filesystem",
-		"Machine",
+		"Host",
 		"Info",
 		"Params",
 	)

--- a/state/storage.go
+++ b/state/storage.go
@@ -1204,7 +1204,7 @@ func (sb *storageBackend) DetachStorage(storage names.StorageTag, unit names.Uni
 				ops = append(ops, txn.Op{
 					C: volumeAttachmentsC,
 					Id: volumeAttachmentId(
-						volumeAttachment.Machine().Id(),
+						volumeAttachment.Host().Id(),
 						volumeAttachment.Volume().Id(),
 					),
 					Assert: assert,

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -346,13 +346,13 @@ func (s *StorageStateSuiteBase) obliterateVolume(c *gc.C, tag names.VolumeTag) {
 	attachments, err := s.storageBackend.VolumeAttachments(tag)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, a := range attachments {
-		s.obliterateVolumeAttachment(c, a.Machine(), a.Volume())
+		s.obliterateVolumeAttachment(c, a.Host(), a.Volume())
 	}
 	err = s.storageBackend.RemoveVolume(tag)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *StorageStateSuiteBase) obliterateVolumeAttachment(c *gc.C, m names.MachineTag, v names.VolumeTag) {
+func (s *StorageStateSuiteBase) obliterateVolumeAttachment(c *gc.C, m names.Tag, v names.VolumeTag) {
 	err := s.storageBackend.DetachVolume(m, v)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.RemoveVolumeAttachment(m, v)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1711,10 +1711,10 @@ func validateDynamicMachineStorageParams(m *Machine, params *storageParams) erro
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if !volume.Detachable() && volume.doc.MachineId != m.Id() {
+		if !volume.Detachable() && volume.doc.HostId != m.Id() {
 			return errors.Errorf(
 				"storage is non-detachable (bound to machine %s)",
-				volume.doc.MachineId,
+				volume.doc.HostId,
 			)
 		}
 	}
@@ -1723,10 +1723,11 @@ func validateDynamicMachineStorageParams(m *Machine, params *storageParams) erro
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if !filesystem.Detachable() && filesystem.doc.MachineId != m.Id() {
+		if !filesystem.Detachable() && filesystem.doc.HostId != m.Id() {
+			host := storageAttachmentHost(filesystem.doc.HostId)
 			return errors.Errorf(
-				"storage is non-detachable (bound to machine %s)",
-				filesystem.doc.MachineId,
+				"storage is non-detachable (bound to %s)",
+				names.ReadableString(host),
 			)
 		}
 	}
@@ -2257,7 +2258,7 @@ func storageParamsForStorageInstance(
 					return nil, errors.Errorf(
 						"%s is attached to %s",
 						names.ReadableString(volume.VolumeTag()),
-						names.ReadableString(existing[0].Machine()),
+						names.ReadableString(existing[0].Host()),
 					)
 				}
 			}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -68,7 +68,7 @@ func (s *VolumeStateSuite) assertMachineVolume(c *gc.C, unit *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 	c.Assert(volumeAttachments[0].Volume(), gc.Equals, volume.VolumeTag())
-	c.Assert(volumeAttachments[0].Machine(), gc.Equals, machine.MachineTag())
+	c.Assert(volumeAttachments[0].Host(), gc.Equals, machine.MachineTag())
 	_, err = volumeAttachments[0].Info()
 	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 	_, ok = volumeAttachments[0].Params()

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -275,7 +275,7 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 		volAttachments, err := sb.VolumeAttachments(volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(volAttachments, gc.HasLen, 1)
-		c.Assert(volAttachments[0].Machine(), gc.Equals, machine.Tag())
+		c.Assert(volAttachments[0].Host(), gc.Equals, machine.Tag())
 	}
 	assertVolume(machine.Id()+"/0", 2048) // backing the filesystem
 	assertVolume(machine.Id()+"/1", 1024)

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -46,6 +46,7 @@ type StateBackend interface {
 	RemoveVotingMachineIds() error
 	AddCloudModelCounts() error
 	ReplicaSetMembers() ([]replicaset.Member, error)
+	MigrateStorageMachineIdFields() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -170,6 +171,10 @@ func (s stateBackend) AddCloudModelCounts() error {
 
 func (s stateBackend) ReplicaSetMembers() ([]replicaset.Member, error) {
 	return state.ReplicaSetMembers(s.st)
+}
+
+func (s stateBackend) MigrateStorageMachineIdFields() error {
+	return state.MigrateStorageMachineIdFields(s.st)
 }
 
 type modelShim struct {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -32,6 +32,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.3.6"), stateStepsFor236()},
 		upgradeToVersion{version.MustParse("2.3.7"), stateStepsFor237()},
 		upgradeToVersion{version.MustParse("2.4.0"), stateStepsFor24()},
+		upgradeToVersion{version.MustParse("2.5.0"), stateStepsFor25()},
 	}
 	return steps
 }

--- a/upgrades/steps_25.go
+++ b/upgrades/steps_25.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor25 returns upgrade steps for Juju 2.5.0 that manipulate state directly.
+func stateStepsFor25() []Step {
+	return []Step{
+		&upgradeStep{
+			description: `migrate storage records to use "hostid" field`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().MigrateStorageMachineIdFields()
+			},
+		},
+	}
+}

--- a/upgrades/steps_25_test.go
+++ b/upgrades/steps_25_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v25 = version.MustParse("2.5.0")
+
+type steps25Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps25Suite{})
+
+func (s *steps25Suite) TestMigrateMachineIdField(c *gc.C) {
+	step := findStateStep(c, v25, `migrate storage records to use "hostid" field`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -648,6 +648,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.3.6",
 		"2.3.7",
 		"2.4.0",
+		"2.5.0",
 	})
 }
 


### PR DESCRIPTION
## Description of change

The 4 collections used to store volume and filesystem info are migrated to use "hostid" instead of "machineid". The bulk of the change is to write the upgrade step. There was an existing 2.2 upgrade step that needed to be modified to use bson maps instead of juju state structs (arguably all upgrade steps should be written this way anyway).

## QA steps

Deploy Juju 2.1 with postgresql using storage
Upgrade to 2.5
Check db to ensure migrations occurred
Check storage functionality

