### PR TITLE
2.4 lxd error non supported system

### DIFF
--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -14,7 +14,8 @@ import (
 // communicating with LXD via a local socket, by default.
 var osSupport = []os.OSType{os.Ubuntu}
 
-func hasSupport() bool {
+// HasSupport defines if the provider has support for a host OS
+func HasSupport() bool {
 	t := os.HostOS()
 	for _, v := range osSupport {
 		if v == t {
@@ -41,7 +42,7 @@ type Server struct {
 // if running on an OS supporting LXD containers by default.
 // Otherwise a nil server is returned.
 func MaybeNewLocalServer() (*Server, error) {
-	if !hasSupport() {
+	if !HasSupport() {
 		return nil, nil
 	}
 	svr, err := NewLocalServer()

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -14,7 +14,8 @@ import (
 // communicating with LXD via a local socket, by default.
 var osSupport = []os.OSType{os.Ubuntu}
 
-// HasSupport defines if the provider has support for a host OS
+// HasSupport returns true if the current OS supports LXD containers by
+// default
 func HasSupport() bool {
 	t := os.HostOS()
 	for _, v := range osSupport {

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	lxdServer "github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/lxd"
 	"github.com/juju/juju/provider/lxd/lxdnames"
@@ -112,6 +113,10 @@ func (s *providerSuite) TestFinalizeCloud(c *gc.C) {
 }
 
 func (s *providerSuite) TestFinalizeCloudNotListening(c *gc.C) {
+	if !lxdServer.HasSupport() {
+		c.Skip("To be rewritten during LXD code refactoring for cluster support")
+	}
+
 	s.Provider.Clock = &mockClock{now: time.Now()}
 	var ctx mockContext
 	s.PatchValue(&s.InterfaceAddr, "8.8.8.8")

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
-	lxdServer "github.com/juju/juju/container/lxd"
+	containerLXD "github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/lxd"
 	"github.com/juju/juju/provider/lxd/lxdnames"
@@ -113,7 +113,7 @@ func (s *providerSuite) TestFinalizeCloud(c *gc.C) {
 }
 
 func (s *providerSuite) TestFinalizeCloudNotListening(c *gc.C) {
-	if !lxdServer.HasSupport() {
+	if !containerLXD.HasSupport() {
 		c.Skip("To be rewritten during LXD code refactoring for cluster support")
 	}
 


### PR DESCRIPTION
## Description of change

Backports commits from https://github.com/juju/juju/pull/8802 to address CentOS unit-test failures.

## QA steps

Unit tests now pass.

## Documentation changes

None.

## Bug reference

N/A
