### PR TITLE
Stop units after prepare

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -52,10 +52,9 @@ func (s *uniterResolver) NextOp(
 		return nil, resolver.ErrTerminate
 	}
 
-	// The if the unit has completed its pre-series-upgrade hook (as noted
-	// by its completed state) then the uniter should idle in the face of
-	// all remote state changes. The unit is waiting to be shutdown by the
-	// machine in preparation for a series upgrade.
+	// If the unit has completed a pre-series-upgrade hook (as noted
+	// by its state) then the uniter should idle in the face of
+	// all remote state changes - the unit is waiting to be shutdown.
 	if localState.UpgradeSeriesStatus == model.UnitCompleted && remoteState.UpgradeSeriesStatus == model.UnitCompleted {
 		return nil, resolver.ErrNoOperation
 	}

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -283,6 +283,11 @@ func (s *uniterResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
 	}
 
+	if localState.UpgradeSeriesStatus == params.UnitStarted &&
+		remote.UpgradeSeriesStatus == params.UnitComplete {
+		return opFactory.NewCompleteSeriesUpgradeOperation()
+	}
+
 	op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -86,7 +86,15 @@ func (e *mockOpExecutor) Run(op operation.Operation) error {
 
 type mockOp struct {
 	operation.Operation
-	commit func(operation.State) (*operation.State, error)
+	commit  func(operation.State) (*operation.State, error)
+	prepare func(operation.State) (*operation.State, error)
+}
+
+func (op mockOp) Prepare(st operation.State) (*operation.State, error) {
+	if op.prepare != nil {
+		return op.prepare(st)
+	}
+	return &st, nil
 }
 
 func (op mockOp) Commit(st operation.State) (*operation.State, error) {

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -119,17 +119,16 @@ func (s *resolverOpFactory) wrapUpgradeOp(op operation.Operation, charmURL *char
 func (s *resolverOpFactory) wrapHookOp(op operation.Operation, info hook.Info) operation.Operation {
 	switch info.Kind {
 	case hooks.PreSeriesUpgrade:
-		remoteStatus := s.RemoteState.UpgradeSeriesStatus
 		op = onPrepareWrapper{op, func() {
 			//on prepare the local status should be made to reflect
 			//that the upgrade process for this united has started.
-			s.LocalState.UpgradeSeriesStatus = remoteStatus
+			s.LocalState.UpgradeSeriesStatus = s.RemoteState.UpgradeSeriesStatus
 		}}
 		op = onCommitWrapper{op, func() {
 			// on commit, the local status should indicate the hook
 			// has completed. The remote status should already
 			// indicate completion. We sync the states here.
-			s.LocalState.UpgradeSeriesStatus = remoteStatus
+			s.LocalState.UpgradeSeriesStatus = s.RemoteState.UpgradeSeriesStatus
 		}}
 	case hooks.ConfigChanged:
 		v := s.RemoteState.ConfigVersion

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -121,6 +121,14 @@ func (s *resolverOpFactory) wrapHookOp(op operation.Operation, info hook.Info) o
 	case hooks.PreSeriesUpgrade:
 		remoteStatus := s.RemoteState.UpgradeSeriesStatus
 		op = onPrepareWrapper{op, func() {
+			//on prepare the local status should be made to reflect
+			//that the upgrade process for this united has started.
+			s.LocalState.UpgradeSeriesStatus = remoteStatus
+		}}
+		op = onCommitWrapper{op, func() {
+			// on commit, the local status should indicate the hook
+			// has completed. The remote status should already
+			// indicate completion. We sync the states here.
 			s.LocalState.UpgradeSeriesStatus = remoteStatus
 		}}
 	case hooks.ConfigChanged:

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -146,6 +146,26 @@ func (s *resolverSuite) TestUpgradeSeriesStatusChanged(c *gc.C) {
 	c.Assert(op.String(), gc.Equals, "run pre-series-upgrade hook")
 }
 
+func (s *resolverSuite) TestUpgradeSeriesStatusIdlesUniterOnUpggradeSeriesCompletion(c *gc.C) {
+	localState := resolver.LocalState{
+		UpgradeSeriesStatus: model.UnitCompleted,
+		State: operation.State{
+			Kind:      operation.Continue,
+			Installed: true,
+		},
+	}
+	s.remoteState.UpgradeSeriesStatus = model.UnitCompleted
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+
+	// changing the series would normally fire a config-changed hook but
+	// since the uniter does not respond to state changes after reaching a
+	// UpgradeSeriesStatus of "Completed" no operation should take place.
+	s.remoteState.Series = "NewSeries"
+	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+}
+
 func (s *resolverSuite) TestSeriesChangedBlank(c *gc.C) {
 	localState := resolver.LocalState{
 		CharmModifiedVersion: s.charmModifiedVersion,


### PR DESCRIPTION
After the `pre-series-upgrade` hook has completed successfully, the `uniter` will stop the processing of any further operations. 
