### PR TITLE
Fix CAAS app/unit/model destruction to cleanup storage

### DIFF
--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -102,19 +102,17 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 		Machines:           modelMachines,
 	}
 
-	if model.Type() == state.ModelTypeIAAS {
-		volumes, err := st.AllVolumes()
-		if err != nil {
-			return status, errors.Trace(err)
-		}
-		result.Volumes = ModelVolumeInfo(volumes)
-
-		filesystems, err := st.AllFilesystems()
-		if err != nil {
-			return status, errors.Trace(err)
-		}
-		result.Filesystems = ModelFilesystemInfo(filesystems)
+	volumes, err := st.AllVolumes()
+	if err != nil {
+		return status, errors.Trace(err)
 	}
+	result.Volumes = ModelVolumeInfo(volumes)
+
+	filesystems, err := st.AllFilesystems()
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+	result.Filesystems = ModelFilesystemInfo(filesystems)
 	return result, nil
 }
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -168,6 +168,8 @@ func (s *K8sBrokerSuite) TestDeleteService(c *gc.C) {
 			Return(s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Delete("juju-test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
+		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-application==test"}).
+			Return(&core.PodList{Items: []core.Pod{}}, nil),
 		s.mockDeployments.EXPECT().Delete("juju-test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
 	)

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -78,18 +78,17 @@ func (g *storageProvider) ValidateConfig(cfg *storage.Config) error {
 
 // Supports is defined on the storage.Provider interface.
 func (g *storageProvider) Supports(k storage.StorageKind) bool {
-	// Support both block and filesystem storage.
-	return true
+	return k == storage.StorageKindFilesystem
 }
 
 // Scope is defined on the storage.Provider interface.
 func (g *storageProvider) Scope() storage.Scope {
-	return storage.ScopeEnviron
+	return storage.ScopeMachine
 }
 
 // Dynamic is defined on the storage.Provider interface.
 func (g *storageProvider) Dynamic() bool {
-	return true
+	return false
 }
 
 // Releasable is defined on the storage.Provider interface.

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -59,7 +59,7 @@ func (s *storageSuite) TestSupports(c *gc.C) {
 	defer ctrl.Finish()
 
 	p := s.k8sProvider(c, ctrl)
-	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsTrue)
+	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsFalse)
 	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsTrue)
 }
 
@@ -68,5 +68,5 @@ func (s *storageSuite) TestScope(c *gc.C) {
 	defer ctrl.Finish()
 
 	p := s.k8sProvider(c, ctrl)
-	c.Assert(p.Scope(), gc.Equals, storage.ScopeEnviron)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
 }

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type RemoveApplicationSuite struct {
@@ -139,6 +140,28 @@ func (s *RemoveApplicationSuite) TestInvalidArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `no application specified`)
 	_, err = runRemoveApplication(c, "invalid:name")
 	c.Assert(err, gc.ErrorMatches, `invalid application name "invalid:name"`)
+}
+
+func (s *RemoveApplicationSuite) TestRemoveCAASApplicationWithStorage(c *gc.C) {
+	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{Name: "caasmodel"})
+	s.AddCleanup(func(*gc.C) { st.Close() })
+
+	repo := testcharms.RepoForSeries("kubernetes")
+	ch := repo.CharmArchivePath(s.CharmsPath, "storage-filesystem")
+	err := runDeploy(c, ch, "-m", "caasmodel", "storage-filesystem", "--storage", "data=2")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = runRemoveApplication(c, "-m", "caasmodel", "storage-filesystem")
+	c.Assert(err, gc.ErrorMatches, `cannot destroy applications \["storage-filesystem"\]
+
+Destroying these kubernetes applications will destroy the storage,
+but you have not indicated that you want to do that.
+
+Please run the the command again with --destroy-storage
+to confirm that you want to destroy the storage along
+with the applications.
+
+`)
 }
 
 type RemoveCharmStoreCharmsSuite struct {

--- a/state/storage.go
+++ b/state/storage.go
@@ -432,6 +432,9 @@ func (sb *storageBackend) destroyStorageInstanceOps(
 	ops := []txn.Op{
 		newCleanupOp(cleanupAttachmentsForDyingStorage, s.doc.Id),
 	}
+	if owner != nil && sb.modelType == ModelTypeCAAS {
+		ops = append(ops, newCleanupOp(cleanupDyingUnitResources, owner.Id()))
+	}
 	ops = append(ops, validateRemoveOps...)
 	ops = append(ops, txn.Op{
 		C:      storageInstancesC,


### PR DESCRIPTION
## Description of change

When destroying a caas model, storage would not be cleaned up and the model destroy would go on forever. This PR fixes cleanup so that all caas storage is destroyed. Simple detaching is not supported.  An unnecessary cleanup step is removed and cleanup fixed; entity destroy is ensured to have destroyStorage = true. Also add a (temporary) warning to CLI is destory-storage = false for CAAS models.
The k8s provider is also fixed to delete PVCs used for storage. And volumes are not supported so reflect that in the provider.

## QA steps

Deploy a caas charm with storage. Add another unit.
destroy-model and ensure the destroy completes and storage is cleaned up.

## Documentation changes

We should document that CAAS storage is always removed with the unit.

