### PR TITLE
LXD: Validate the host and port of endpoint

### DIFF
--- a/container/lxd/connection_test.go
+++ b/container/lxd/connection_test.go
@@ -55,10 +55,53 @@ func (s *connectionSuite) TestEnsureHTTPSUnchangedWhenCorrect(c *gc.C) {
 	c.Check(lxd.EnsureHTTPS(addr), gc.Equals, addr)
 }
 
-func (s *connectionSuite) TestEnsureHTTPSForHTTP(c *gc.C) {
-	c.Check(lxd.EnsureHTTPS("http://somewhere"), gc.Equals, "https://somewhere")
+func (s *connectionSuite) TestEnsureHTTPS(c *gc.C) {
+	for _, t := range []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "http://somewhere",
+			Output: "https://somewhere",
+		},
+		{
+			Input:  "https://somewhere",
+			Output: "https://somewhere",
+		},
+		{
+			Input:  "somewhere",
+			Output: "https://somewhere",
+		},
+	} {
+		got := lxd.EnsureHTTPS(t.Input)
+		c.Assert(got, gc.Equals, t.Output)
+	}
 }
 
-func (s *connectionSuite) TestEnsureHTTPSForNoProtocol(c *gc.C) {
-	c.Check(lxd.EnsureHTTPS("somewhere"), gc.Equals, "https://somewhere")
+func (s *connectionSuite) TestEnsureHostPort(c *gc.C) {
+	for _, t := range []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "https://somewhere",
+			Output: "https://somewhere:8443",
+		},
+		{
+			Input:  "somewhere",
+			Output: "https://somewhere:8443",
+		},
+		{
+			Input:  "http://somewhere:0",
+			Output: "https://somewhere:0",
+		},
+		{
+			Input:  "https://somewhere:123",
+			Output: "https://somewhere:123",
+		},
+	} {
+		got, err := lxd.EnsureHostPort(t.Input)
+		c.Assert(err, gc.IsNil)
+		c.Assert(got, gc.Equals, t.Output)
+	}
 }

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -95,10 +95,18 @@ func (p *environProvider) Ping(ctx context.ProviderCallContext, endpoint string)
 		return nil
 	}
 
+	// Ensure the Port on the Host, if we get an error it is reasonable to
+	// assume that the address in the spec is invalid.
+	var err error
+	endpoint, err = lxd.EnsureHostPort(endpoint)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// Connect to the remote server anonymously so we can just verify it exists
 	// as we're not sure that the certificates are loaded in time for when the
 	// ping occurs i.e. interactive add-cloud
-	_, err := lxd.ConnectRemote(lxd.NewInsecureServerSpec(endpoint))
+	_, err = lxd.ConnectRemote(lxd.NewInsecureServerSpec(endpoint))
 	if err != nil {
 		return errors.Errorf("no lxd server running at %s", endpoint)
 	}

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -314,7 +314,7 @@ func (s *providerSuite) TestPingWithNoEndpoint(c *gc.C) {
 	p, err := environs.Provider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.Ping(context.NewCloudCallContext(), server.URL)
-	c.Assert(err, gc.ErrorMatches, "no lxd server running at "+server.URL)
+	c.Assert(err, gc.ErrorMatches, "no lxd server running at "+containerLXD.EnsureHTTPS(server.URL))
 }
 
 type ProviderFunctionalSuite struct {


### PR DESCRIPTION
## Description of change

The following commit ensures that we have a port for the lxd endpoint.
That way we help people coming to use the lxd-remote flow, will get
a better experience.

## QA steps

Bootstrap a remote host, this should add the default port 8443 if it's not supplied.

## Documentation changes

Users using the CLI should be able to add a URL without the port and it should use the default port to make the user experience of using lxd remoting easier.

## Bug reference

N/A
