### PR TITLE
Add support for caas charms specifying docker command args

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -117,12 +117,6 @@ type Broker interface {
 	// UnexposeService removes external access to the specified service.
 	UnexposeService(appName string) error
 
-	// EnsureUnit creates or updates a pod with the given spec.
-	EnsureUnit(appName, unitName string, spec *PodSpec) error
-
-	// DeleteUnit deletes a unit pod with the given unit name.
-	DeleteUnit(unitName string) error
-
 	// WatchUnits returns a watcher which notifies when there
 	// are changes to units of the specified application.
 	WatchUnits(appName string) (watcher.NotifyWatcher, error)

--- a/caas/containers.go
+++ b/caas/containers.go
@@ -32,6 +32,10 @@ type ContainerSpec struct {
 	Image string          `yaml:"image,omitempty"`
 	Ports []ContainerPort `yaml:"ports,omitempty"`
 
+	Command    []string `yaml:"command,omitempty"`
+	Args       []string `yaml:"args,omitempty"`
+	WorkingDir string   `yaml:"workingDir,omitempty"`
+
 	Config map[string]string `yaml:"config,omitempty"`
 	Files  []FileSet         `yaml:"files,omitempty"`
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -78,9 +78,12 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 
 var basicPodspec = &caas.PodSpec{
 	Containers: []caas.ContainerSpec{{
-		Name:  "test",
-		Ports: []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
-		Image: "juju/image",
+		Name:       "test",
+		Ports:      []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+		Image:      "juju/image",
+		Command:    []string{"sh", "-c"},
+		Args:       []string{"doIt", "--debug"},
+		WorkingDir: "/path/to/here",
 		Config: map[string]string{
 			"foo": "bar",
 		},
@@ -97,9 +100,12 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 	c.Assert(provider.PodSpec(spec), jc.DeepEquals, core.PodSpec{
 		Containers: []core.Container{
 			{
-				Name:  "test",
-				Image: "juju/image",
-				Ports: []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
+				Name:       "test",
+				Image:      "juju/image",
+				Ports:      []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
+				Command:    []string{"sh", "-c"},
+				Args:       []string{"doIt", "--debug"},
+				WorkingDir: "/path/to/here",
 				Env: []core.EnvVar{
 					{Name: "foo", Value: "bar"},
 				},

--- a/caas/kubernetes/provider/k8stypes.go
+++ b/caas/kubernetes/provider/k8stypes.go
@@ -66,11 +66,14 @@ func parseK8sPodSpec(in string) (*caas.PodSpec, error) {
 			return nil, errors.Trace(err)
 		}
 		spec.Containers[i] = caas.ContainerSpec{
-			Name:   c.Name,
-			Image:  c.Image,
-			Ports:  c.Ports,
-			Config: c.Config,
-			Files:  c.Files,
+			Name:       c.Name,
+			Image:      c.Image,
+			Ports:      c.Ports,
+			Command:    c.Command,
+			Args:       c.Args,
+			WorkingDir: c.WorkingDir,
+			Config:     c.Config,
+			Files:      c.Files,
 		}
 		if c.K8sContainerSpec != nil {
 			spec.Containers[i].ProviderContainer = c.K8sContainerSpec

--- a/caas/kubernetes/provider/k8stypes_test.go
+++ b/caas/kubernetes/provider/k8stypes_test.go
@@ -27,10 +27,15 @@ containers:
   - name: gitlab
     image: gitlab/latest
     imagePullPolicy: Always
+    command: ["sh", "-c"]
+    args: ["doIt", "--debug"]
+    workingDir: "/path/to/here"
     ports:
     - containerPort: 80
+      name: fred
       protocol: TCP
     - containerPort: 443
+      name: mary
     livenessProbe:
       initialDelaySeconds: 10
       httpGet:
@@ -67,11 +72,14 @@ foo: bar
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spec, jc.DeepEquals, &caas.PodSpec{
 		Containers: []caas.ContainerSpec{{
-			Name:  "gitlab",
-			Image: "gitlab/latest",
+			Name:       "gitlab",
+			Image:      "gitlab/latest",
+			Command:    []string{"sh", "-c"},
+			Args:       []string{"doIt", "--debug"},
+			WorkingDir: "/path/to/here",
 			Ports: []caas.ContainerPort{
-				{ContainerPort: 80, Protocol: "TCP"},
-				{ContainerPort: 443},
+				{ContainerPort: 80, Protocol: "TCP", Name: "fred"},
+				{ContainerPort: 443, Name: "mary"},
 			},
 			Config: map[string]string{
 				"attr": "foo=bar; fred=blogs",

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -11,8 +11,6 @@ import (
 
 type ContainerBroker interface {
 	Provider() caas.ContainerEnvironProvider
-	EnsureUnit(appName, unitName string, spec *caas.PodSpec) error
-	DeleteUnit(unitName string) error
 	WatchUnits(appName string) (watcher.NotifyWatcher, error)
 	Units(appName string) ([]caas.Unit, error)
 	DeleteService(appName string) error

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -70,9 +70,7 @@ func (m *mockServiceBroker) DeleteService(appName string) error {
 type mockContainerBroker struct {
 	testing.Stub
 	caas.ContainerEnvironProvider
-	ensured            chan<- struct{}
 	serviceDeleted     chan<- struct{}
-	unitDeleted        chan<- struct{}
 	unitsWatcher       *watchertest.MockNotifyWatcher
 	reportedUnitStatus status.Status
 	podSpec            *caas.PodSpec
@@ -84,18 +82,6 @@ func (m *mockContainerBroker) Provider() caas.ContainerEnvironProvider {
 
 func (m *mockContainerBroker) ParsePodSpec(in string) (*caas.PodSpec, error) {
 	return m.podSpec, nil
-}
-
-func (m *mockContainerBroker) EnsureUnit(appName, unitName string, spec *caas.PodSpec) error {
-	m.MethodCall(m, "EnsureUnit", appName, unitName, spec)
-	m.ensured <- struct{}{}
-	return m.NextErr()
-}
-
-func (m *mockContainerBroker) DeleteUnit(unitName string) error {
-	m.MethodCall(m, "DeleteUnit", unitName)
-	m.unitDeleted <- struct{}{}
-	return m.NextErr()
 }
 
 func (m *mockContainerBroker) DeleteService(appName string) error {

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -48,8 +48,6 @@ type WorkerSuite struct {
 	serviceDeleted       chan struct{}
 	serviceEnsured       chan struct{}
 	serviceUpdated       chan struct{}
-	unitEnsured          chan struct{}
-	unitDeleted          chan struct{}
 	clock                *testing.Clock
 }
 
@@ -104,8 +102,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.serviceDeleted = make(chan struct{})
 	s.serviceEnsured = make(chan struct{})
 	s.serviceUpdated = make(chan struct{})
-	s.unitEnsured = make(chan struct{})
-	s.unitDeleted = make(chan struct{})
 
 	s.applicationGetter = mockApplicationGetter{
 		watcher: watchertest.NewMockStringsWatcher(s.applicationChanges),
@@ -134,8 +130,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 
 	s.containerBroker = mockContainerBroker{
 		serviceDeleted: s.serviceDeleted,
-		ensured:        s.unitEnsured,
-		unitDeleted:    s.unitDeleted,
 		unitsWatcher:   watchertest.NewMockNotifyWatcher(s.caasUnitsChanges),
 		podSpec:        &parsedSpec,
 	}


### PR DESCRIPTION
## Description of change

Some k8s charms need to be able to specify the command args for the docker image instead of relying on the default entry point. The pod spec sent by the charm now supports that.
As a driveby, remove old ensure/delete unit code no longer used.

## QA steps

bootstrap a k8s model
deploy a caas charm which specifies command, args, and/or working dir

