### PR TITLE
Adds debug log entry between container creation and start-up.

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -202,7 +202,7 @@ func (s *Server) ContainerAddresses(name string) ([]network.Address, error) {
 // If the container fails to be started, it is removed.
 // Upon successful creation and start, the container is returned.
 func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error) {
-	logger.Infof("starting container %q (image %q)...", spec.Name, spec.Image.Image.Filename)
+	logger.Infof("starting new container %q (image %q)", spec.Name, spec.Image.Image.Filename)
 
 	req := api.ContainersPost{
 		Name:         spec.Name,
@@ -229,6 +229,8 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	if opInfo.StatusCode != api.Success {
 		return nil, fmt.Errorf("container creation failed: %s", opInfo.Err)
 	}
+
+	logger.Debugf("created container %q, waiting for start...", spec.Name)
 
 	if err := s.StartContainer(spec.Name); err != nil {
 		if remErr := s.RemoveContainer(spec.Name); remErr != nil {


### PR DESCRIPTION
## Description of change

Simply adds a debug log statement between LXD container creation and start steps, for the purpose of in-theatre diagnostics.

## QA steps

Start a container machine and check that the debug log entry is emitted.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1779897

As per comment on the bug, the incomplete/erroneous information from the dump hinders a true diagnosis/fix. This provides attempts to add some detail to the panic site.
