### PR TITLE
Fixes lp#1781096: model-upgrader worker to uninstall for destroyed model.

### DIFF
--- a/worker/modelupgrader/manifold.go
+++ b/worker/modelupgrader/manifold.go
@@ -77,6 +77,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.EnvironName,
 			config.GateName,
 		},
-		Start: config.start,
+		Start:  config.start,
+		Filter: bounceErrChanged,
 	}
+}
+
+// bounceErrChanged converts ErrModelRemoved to dependency.ErrUninstall.
+func bounceErrChanged(err error) error {
+	if errors.Cause(err) == ErrModelRemoved {
+		return dependency.ErrUninstall
+	}
+	return err
 }

--- a/worker/modelupgrader/manifold_test.go
+++ b/worker/modelupgrader/manifold_test.go
@@ -170,3 +170,15 @@ func (*ManifoldSuite) TestNewWorkerSuccessWithoutEnviron(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newWorkerConfig.Environ, gc.IsNil)
 }
+
+func (*ManifoldSuite) TestFilterNil(c *gc.C) {
+	manifold := modelupgrader.Manifold(modelupgrader.ManifoldConfig{})
+	err := manifold.Filter(nil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (*ManifoldSuite) TestFilterErrModelRemoved(c *gc.C) {
+	manifold := modelupgrader.Manifold(modelupgrader.ManifoldConfig{})
+	err := manifold.Filter(modelupgrader.ErrModelRemoved)
+	c.Check(err, gc.Equals, dependency.ErrUninstall)
+}

--- a/worker/modelupgrader/worker.go
+++ b/worker/modelupgrader/worker.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
@@ -147,7 +148,7 @@ func (ww *waitWorker) loop() error {
 			}
 			currentVersion, err := ww.facade.ModelEnvironVersion(ww.modelTag)
 			if err != nil {
-				if errors.IsNotFound(err) {
+				if params.IsCodeNotFound(err) {
 					return ErrModelRemoved
 				}
 				return errors.Trace(err)

--- a/worker/modelupgrader/worker_test.go
+++ b/worker/modelupgrader/worker_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	tomb "gopkg.in/tomb.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
@@ -223,6 +224,30 @@ func (*WorkerSuite) TestWaitForUpgrade(c *gc.C) {
 		{"ModelEnvironVersion", []interface{}{coretesting.ModelTag}},
 	})
 	mockGateUnlocker.CheckCallNames(c, "Unlock")
+}
+
+func (*WorkerSuite) TestModelNotFoundWhenRunning(c *gc.C) {
+	ch := make(chan struct{})
+	mockFacade := mockFacade{
+		current: 123,
+		target:  125,
+		watcher: newMockNotifyWatcher(ch),
+	}
+	w, err := modelupgrader.NewWorker(modelupgrader.Config{
+		Facade:        &mockFacade,
+		Environ:       nil, // not responsible for running upgrades
+		GateUnlocker:  &mockGateUnlocker{},
+		ControllerTag: coretesting.ControllerTag,
+		ModelTag:      coretesting.ModelTag,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	mockFacade.SetErrors(&params.Error{Code: params.CodeNotFound})
+	ch <- struct{}{}
+
+	err = workertest.CheckKill(c, w)
+	// We expect NotFound to be changed to modelupgrader.ErrModelRemoved.
+	c.Check(err, gc.ErrorMatches, "model has been removed")
 }
 
 func newStep(stub *testing.Stub, name string) environs.UpgradeStep {


### PR DESCRIPTION
## Description of change

On a big production systems or systems that have starving mongo, there is a chance that destroyed model may have lingering workers running and re-trying to do work for this ghost model. It is best not to bounce these workers but uninstall them.

This PR deals specifically with model-upgrader. The follow-up PRs will address other workers that might be in the same boat. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1781096
