### PR TITLE
LXD Provider - remove local checking

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -44,7 +44,6 @@ type environ struct {
 
 func newEnviron(
 	_ *environProvider,
-	local bool,
 	spec environs.CloudSpec,
 	cfg *config.Config,
 	serverFactory ServerFactory,


### PR DESCRIPTION
## Description of change

The following removes the local checking in validation of the
cloud spec. This isn't required as we should have satisfied the
local endpoint, otherwise the agent with in the container wouldn't
be able to connect to the local host through lxd.ConnectLocal.

This just simplifies the provider code.

## QA steps

```sh
juju bootstrap localhost lxd-test
```

## Documentation changes

N/A

## Bug reference

N/A