### PR TITLE
Run storage hooks for caas models

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -68,7 +68,7 @@ type StorageBackend interface {
 	WatchModelVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
-	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	WatchVolumeAttachment(names.Tag, names.VolumeTag) state.NotifyWatcher
 
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	AllStorageInstances() ([]state.StorageInstance, error)

--- a/apiserver/facades/agent/uniter/mock_test.go
+++ b/apiserver/facades/agent/uniter/mock_test.go
@@ -20,7 +20,7 @@ type fakeStorage struct {
 	storageInstanceVolume  func(names.StorageTag) (state.Volume, error)
 	volumeAttachment       func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 	blockDevices           func(names.MachineTag) ([]state.BlockDeviceInfo, error)
-	watchVolumeAttachment  func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	watchVolumeAttachment  func(names.Tag, names.VolumeTag) state.NotifyWatcher
 	watchBlockDevices      func(names.MachineTag) state.NotifyWatcher
 	watchStorageAttachment func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 }
@@ -45,9 +45,9 @@ func (s *fakeStorage) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo,
 	return s.blockDevices(m)
 }
 
-func (s *fakeStorage) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
-	s.MethodCall(s, "WatchVolumeAttachment", m, v)
-	return s.watchVolumeAttachment(m, v)
+func (s *fakeStorage) WatchVolumeAttachment(host names.Tag, v names.VolumeTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchVolumeAttachment", host, v)
+	return s.watchVolumeAttachment(host, v)
 }
 
 func (s *fakeStorage) WatchBlockDevices(m names.MachineTag) state.NotifyWatcher {

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -30,7 +30,7 @@ type storageInterface interface {
 type storageVolumeInterface interface {
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
-	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	WatchVolumeAttachment(names.Tag, names.VolumeTag) state.NotifyWatcher
 	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 	VolumeAttachment(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
 }
@@ -38,7 +38,7 @@ type storageVolumeInterface interface {
 type storageFilesystemInterface interface {
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	FilesystemAttachment(names.Tag, names.FilesystemTag) (state.FilesystemAttachment, error)
-	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
+	WatchFilesystemAttachment(names.Tag, names.FilesystemTag) state.NotifyWatcher
 }
 
 var getStorageState = func(st *state.State) (storageAccess, error) {
@@ -82,6 +82,7 @@ type backend interface {
 
 type Unit interface {
 	AssignedMachineId() (string, error)
+	ShouldBeAssigned() bool
 	StorageConstraints() (map[string]state.StorageConstraints, error)
 }
 

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -14,6 +14,7 @@ import (
 // and IAAS models.
 var commonModelFacadeNames = set.NewStrings(
 	"ActionPruner",
+	"AllWatcher",
 	"Agent",
 	"Annotations",
 	"Application",

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -624,6 +624,15 @@ func (c *DeployCommand) Init(args []string) error {
 	if c.Force && c.Series == "" && c.PlacementSpec == "" {
 		return errors.New("--force is only used with --series")
 	}
+	if len(c.AttachStorage) > 0 {
+		modelType, err := c.ModelType()
+		if err != nil {
+			return err
+		}
+		if modelType == model.CAAS && len(c.AttachStorage) > 0 {
+			return errors.New("--attach-storage cannot be used on kubernetes models")
+		}
+	}
 	switch len(args) {
 	case 2:
 		if !names.IsValidApplication(args[1]) {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -473,6 +475,17 @@ type CAASDeploySuite struct {
 }
 
 var _ = gc.Suite(&CAASDeploySuite{})
+
+func (s *CAASDeploySuite) TestInitErrorsCaasModel(c *gc.C) {
+	otherModels := map[string]jujuclient.ModelDetails{
+		"admin/caas-model": {ModelUUID: "test.caas.model.uuid", ModelType: model.CAAS},
+	}
+	err := s.ControllerStore.SetModels("kontroll", otherModels)
+	c.Assert(err, jc.ErrorIsNil)
+	args := []string{"-m", "caas-model", "some-application-name", "--attach-storage", "foo/0"}
+	err = cmdtesting.InitCommand(NewDeployCommand(), args)
+	c.Assert(err, gc.ErrorMatches, "--attach-storage cannot be used on kubernetes models")
+}
 
 func (s *CAASDeploySuite) TestDevices(c *gc.C) {
 	m, err := s.State.Model()

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1581,15 +1581,15 @@ func (sb *storageBackend) WatchStorageAttachment(s names.StorageTag, u names.Uni
 
 // WatchVolumeAttachment returns a watcher for observing changes
 // to a volume attachment.
-func (sb *storageBackend) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) NotifyWatcher {
-	id := volumeAttachmentId(m.Id(), v.Id())
+func (sb *storageBackend) WatchVolumeAttachment(host names.Tag, v names.VolumeTag) NotifyWatcher {
+	id := volumeAttachmentId(host.Id(), v.Id())
 	return newEntityWatcher(sb.mb, volumeAttachmentsC, sb.mb.docID(id))
 }
 
 // WatchFilesystemAttachment returns a watcher for observing changes
 // to a filesystem attachment.
-func (sb *storageBackend) WatchFilesystemAttachment(m names.MachineTag, f names.FilesystemTag) NotifyWatcher {
-	id := filesystemAttachmentId(m.Id(), f.Id())
+func (sb *storageBackend) WatchFilesystemAttachment(host names.Tag, f names.FilesystemTag) NotifyWatcher {
+	id := filesystemAttachmentId(host.Id(), f.Id())
 	return newEntityWatcher(sb.mb, filesystemAttachmentsC, sb.mb.docID(id))
 }
 

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -270,17 +270,17 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 		w.applicationChannel = applicationw.Changes()
 		seenApplicationChange = new(bool)
 		requiredEvents++
-
-		storagew, err := w.unit.WatchStorage()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		storageChanges = storagew.Changes()
-		if err := w.catacomb.Add(storagew); err != nil {
-			return errors.Trace(err)
-		}
-		requiredEvents++
 	}
+
+	storagew, err := w.unit.WatchStorage()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	storageChanges = storagew.Changes()
+	if err := w.catacomb.Add(storagew); err != nil {
+		return errors.Trace(err)
+	}
+	requiredEvents++
 
 	var seenLeaderSettingsChange bool
 	leaderSettingsw, err := w.application.WatchLeadershipSettings()

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -173,9 +173,9 @@ func (s *WatcherSuite) signalAll() {
 	s.st.unit.addressesWatcher.changes <- struct{}{}
 	s.st.updateStatusIntervalWatcher.changes <- struct{}{}
 	s.leadership.claimTicket.ch <- struct{}{}
+	s.st.unit.storageWatcher.changes <- []string{}
 	if s.st.modelType == model.IAAS {
 		s.applicationWatcher.changes <- struct{}{}
-		s.st.unit.storageWatcher.changes <- []string{}
 	}
 }
 
@@ -259,10 +259,8 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().ForceCharmUpgrade, jc.IsTrue)
 
-	if s.modelType == model.IAAS {
-		s.st.unit.storageWatcher.changes <- []string{}
-		assertOneChange()
-	}
+	s.st.unit.storageWatcher.changes <- []string{}
+	assertOneChange()
 
 	s.st.unit.configSettingsWatcher.changes <- struct{}{}
 	assertOneChange()
@@ -336,7 +334,7 @@ func (s *WatcherSuite) TestLeadershipLeaderUnchanged(c *gc.C) {
 	assertNoNotifyEvent(c, s.watcher.RemoteStateChanged(), "remote state change")
 }
 
-func (s *WatcherSuiteIAAS) TestStorageChanged(c *gc.C) {
+func (s *WatcherSuite) TestStorageChanged(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
@@ -412,7 +410,7 @@ func (s *WatcherSuiteIAAS) TestStorageChanged(c *gc.C) {
 	})
 }
 
-func (s *WatcherSuiteIAAS) TestStorageUnattachedChanged(c *gc.C) {
+func (s *WatcherSuite) TestStorageUnattachedChanged(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
@@ -458,7 +456,7 @@ func (s *WatcherSuiteIAAS) TestStorageUnattachedChanged(c *gc.C) {
 	})
 }
 
-func (s *WatcherSuiteIAAS) TestStorageAttachmentRemoved(c *gc.C) {
+func (s *WatcherSuite) TestStorageAttachmentRemoved(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
@@ -499,7 +497,7 @@ func (s *WatcherSuiteIAAS) TestStorageAttachmentRemoved(c *gc.C) {
 	c.Assert(s.watcher.Snapshot().Storage, gc.HasLen, 0)
 }
 
-func (s *WatcherSuiteIAAS) TestStorageChangedNotFoundInitially(c *gc.C) {
+func (s *WatcherSuite) TestStorageChangedNotFoundInitially(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 


### PR DESCRIPTION
## Description of change

We now run storage hooks for caas charms with storage. The main logic changes are quite small. Some base storage watcher methods were modified to take a names.Tag instead of MachineTag, since caas storage is associated with units. Much of the content is adding new tests for these watcher changes (testing was a bit incomplete before).

As a driveby, ensure --attach-storage option is not allowed for caas add-unit and deploy

## QA steps

Deploy a caas charm with storage.
run show-status-log and check the storage attached hook has run

