### PR TITLE
LXD Default region

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/juju/provider/lxd/lxdnames"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/lxc/lxd/shared"
@@ -115,7 +117,7 @@ func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 		return nil, errors.Trace(err)
 	}
 
-	const credName = "localhost"
+	const credName = lxdnames.DefaultCloud
 	label := fmt.Sprintf("LXD credential %q", credName)
 	certCredential, err := p.finalizeLocalCertificateCredential(
 		ioutil.Discard, svr, string(certPEM), string(keyPEM), label,

--- a/provider/lxd/lxdnames/names.go
+++ b/provider/lxd/lxdnames/names.go
@@ -11,9 +11,13 @@ package lxdnames
 // the local lxd daemon.
 const DefaultCloud = "localhost"
 
-// DefaultRegion is the name of the only "region" we support in lxd currently,
+// DefaultLocalRegion is the name of the "region" we support in a local lxd,
 // which corresponds to the local lxd daemon.
-const DefaultRegion = "localhost"
+const DefaultLocalRegion = "localhost"
+
+// DefaultRemoteRegion is the name of the "region" we report if there are no
+// other regions for a remote lxd server.
+const DefaultRemoteRegion = "default"
 
 // ProviderType defines the provider/cloud type for lxd.
 const ProviderType = "lxd"

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -224,6 +224,37 @@ func (s *providerSuite) TestFinalizeCloudWithRemoteProviderWithMixedRegions(c *g
 	})
 }
 
+func (s *providerSuite) TestFinalizeCloudWithRemoteProviderWithNoRegion(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	provider, _, _ := s.createProvider(ctrl)
+	cloudFinalizer := provider.(environs.CloudFinalizer)
+
+	cloudSpec := cloud.Cloud{
+		Name:      "test",
+		Type:      "lxd",
+		Endpoint:  "https://192.0.0.1:8443",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions:   []cloud.Region{},
+	}
+
+	ctx := testing.NewMockFinalizeCloudContext(ctrl)
+
+	got, err := cloudFinalizer.FinalizeCloud(ctx, cloudSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, cloud.Cloud{
+		Name:      "test",
+		Type:      "lxd",
+		Endpoint:  "https://192.0.0.1:8443",
+		AuthTypes: []cloud.AuthType{cloud.CertificateAuthType},
+		Regions: []cloud.Region{{
+			Name:     "default",
+			Endpoint: "https://192.0.0.1:8443",
+		}},
+	})
+}
+
 func (s *providerSuite) TestFinalizeCloudNotListening(c *gc.C) {
 	if !containerLXD.HasSupport() {
 		c.Skip("To be rewritten during LXD code refactoring for cluster support")

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -276,7 +276,7 @@ func (s *providerSuite) TestFinalizeCloudAlreadyListeningHTTPS(c *gc.C) {
 func (s *providerSuite) TestDetectRegions(c *gc.C) {
 	regions, err := s.Provider.DetectRegions()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: lxdnames.DefaultRegion}})
+	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: lxdnames.DefaultLocalRegion}})
 }
 
 func (s *providerSuite) TestValidate(c *gc.C) {


### PR DESCRIPTION
## Description of change

The following changes, inserts a default region to the cloud spec, if the cloud spec name is not localhost and if the regions are empty. In this way we can then report back stating that the region is not localhost and can be identified as a different type.

If regions do end up being added to lxd, this insertion of the default region should not happen and user specified regions will be add accordingly. 

## QA steps

1. Add a cloud using lxd
2. Add credentials accordingly
3. Bootstrap a lxd remote cluster

You should see that the region is set to "default".
Consider the `juju status` output:
```sh
$ juju status
Model    Controller   Cloud/Region  Version      SLA          Timestamp
default  lxd-default  lxd/default   2.5-beta1.1  unsupported  14:41:42+01:00
```

## Documentation changes

No changes to the user CLI, but internally we assign a default region to lxd if it's not localhost and there are no regions.

## Bug reference

N/A