### PR TITLE
Handle K8s secrets for using private registries

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -48,7 +48,7 @@ type ResourcesHandler struct {
 
 // ServeHTTP implements http.Handler.
 func (h *ResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	backend, poolhelper, tag, err := h.StateAuthFunc(req, names.UserTagKind, names.MachineTagKind)
+	backend, poolhelper, tag, err := h.StateAuthFunc(req, names.UserTagKind, names.MachineTagKind, names.ApplicationTagKind)
 	if err != nil {
 		api.SendHTTPError(resp, err)
 		return

--- a/apiserver/resources_unit.go
+++ b/apiserver/resources_unit.go
@@ -27,7 +27,7 @@ type UnitResourcesHandler struct {
 func (h *UnitResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET":
-		opener, ph, err := h.NewOpener(req, names.UnitTagKind)
+		opener, ph, err := h.NewOpener(req, names.UnitTagKind, names.ApplicationTagKind)
 		if err != nil {
 			api.SendHTTPError(resp, err)
 			return

--- a/apiserver/resources_unit_test.go
+++ b/apiserver/resources_unit_test.go
@@ -100,7 +100,7 @@ func (s *UnitResourcesHandlerSuite) TestOpenResourceError(c *gc.C) {
 
 	s.checkResp(c, http.StatusInternalServerError, "application/json", expectedBody)
 	s.stub.CheckCalls(c, []testing.StubCall{
-		{"NewOpener", []interface{}{[]string{names.UnitTagKind}}},
+		{"NewOpener", []interface{}{[]string{names.UnitTagKind, names.ApplicationTagKind}}},
 		{"OpenResource", []interface{}{"blob"}},
 		{"Close", nil},
 	})
@@ -127,7 +127,7 @@ func (s *UnitResourcesHandlerSuite) TestSuccess(c *gc.C) {
 
 	s.checkResp(c, http.StatusOK, "application/octet-stream", body)
 	s.stub.CheckCalls(c, []testing.StubCall{
-		{"NewOpener", []interface{}{[]string{names.UnitTagKind}}},
+		{"NewOpener", []interface{}{[]string{names.UnitTagKind, names.ApplicationTagKind}}},
 		{"OpenResource", []interface{}{"blob"}},
 		{"Close", nil},
 	})

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -35,6 +35,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"ModelUpgrader",
 	"NotifyWatcher",
 	"Pinger",
+	"Resources",
 	"RelationUnitsWatcher",
 	"RemoteRelations",
 	"RetryStrategy",

--- a/caas/containers.go
+++ b/caas/containers.go
@@ -74,8 +74,8 @@ func (spec *ContainerSpec) Validate() error {
 	if spec.Name == "" {
 		return errors.New("spec name is missing")
 	}
-	if spec.Image == "" {
-		return errors.New("spec image is missing")
+	if spec.Image == "" && spec.ImageDetails.ImagePath == "" {
+		return errors.New("spec image details is missing")
 	}
 	for _, fs := range spec.Files {
 		if fs.Name == "" {

--- a/caas/containers.go
+++ b/caas/containers.go
@@ -20,6 +20,13 @@ type ContainerPort struct {
 	Protocol      string `yaml:"protocol" json:"protocol"`
 }
 
+// ImageDetails defines all details required to pull a docker image from any registry
+type ImageDetails struct {
+	ImagePath string `yaml:"imagePath" json:"imagePath"`
+	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
+	Password  string `yaml:"password,omitempty" json:"password,omitempty"`
+}
+
 // ProviderContainer defines a provider specific container.
 type ProviderContainer interface {
 	Validate() error
@@ -28,9 +35,11 @@ type ProviderContainer interface {
 // ContainerSpec defines the data values used to configure
 // a container on the CAAS substrate.
 type ContainerSpec struct {
-	Name  string          `yaml:"name"`
-	Image string          `yaml:"image,omitempty"`
-	Ports []ContainerPort `yaml:"ports,omitempty"`
+	Name string `yaml:"name"`
+	// Image is deprecated in preference to using ImageDetails.
+	Image        string          `yaml:"image,omitempty"`
+	ImageDetails ImageDetails    `yaml:"imageDetails"`
+	Ports        []ContainerPort `yaml:"ports,omitempty"`
 
 	Command    []string `yaml:"command,omitempty"`
 	Args       []string `yaml:"args,omitempty"`

--- a/caas/kubernetes/provider/dockerconfig.go
+++ b/caas/kubernetes/provider/dockerconfig.go
@@ -1,0 +1,61 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"github.com/juju/juju/caas"
+)
+
+// Used to extract the registry from an Image Path.
+// i.e. registry.staging.jujucharms.com from registry.staging.jujucharms.com/tester/caas-mysql/mysql-image@sha256:dead-beef
+var dockerURLRegexp = regexp.MustCompile(`^(?P<registryURL>([^.]+([.]+[^.\/]+)+))\/.*$`)
+
+// These Docker Config datatypes have been pulled from
+// "k8s.io/kubernetes/pkg/credentialprovider".
+// multiple k8s packages import the same package, we don't yet have the tooling
+// to flatten the deps.
+// The specific package in this case is golog.
+
+// DockerConfigJson represents ~/.docker/config.json file info.
+type DockerConfigJson struct {
+	Auths DockerConfig `json:"auths"`
+}
+
+// DockerConfig represents the config file used by the docker CLI.
+type DockerConfig map[string]DockerConfigEntry
+
+// DockerConfigEntry represents an Auth entry in the dockerconfigjson.
+type DockerConfigEntry struct {
+	Username string
+	Password string
+	Email    string
+}
+
+func createDockerConfigJSON(imageDetails *caas.ImageDetails) ([]byte, error) {
+	dockerEntry := DockerConfigEntry{
+		Username: imageDetails.Username,
+		Password: imageDetails.Password,
+	}
+	registryURL := extractRegistryURL(imageDetails.ImagePath)
+
+	dockerConfig := DockerConfigJson{
+		Auths: map[string]DockerConfigEntry{
+			registryURL: dockerEntry,
+		},
+	}
+	return json.Marshal(dockerConfig)
+}
+
+// extractRegistryName returns the registry URL part of an images path
+func extractRegistryURL(imagePath string) string {
+	registryURL := "docker.io"
+	hasRegistryURL := dockerURLRegexp.MatchString(imagePath)
+	if hasRegistryURL {
+		registryURL = dockerURLRegexp.ReplaceAllString(imagePath, "$registryURL")
+	}
+	return registryURL
+}

--- a/caas/kubernetes/provider/dockerconfig_test.go
+++ b/caas/kubernetes/provider/dockerconfig_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"encoding/json"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/testing"
+)
+
+type DockerConfigSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&DockerConfigSuite{})
+
+func (s *DockerConfigSuite) TestExtractRegistryURL(c *gc.C) {
+	result := provider.ExtractRegistryURL("test")
+	c.Assert(result, gc.Equals, "docker.io")
+
+	result = provider.ExtractRegistryURL("tester/caas-mysql/mysql-image@sha256:dead-beef")
+	c.Assert(result, gc.Equals, "docker.io")
+
+	result = provider.ExtractRegistryURL("registry.staging.jujucharms.com/tester/caas-mysql/mysql-image@sha256:dead-beef")
+	c.Assert(result, gc.Equals, "registry.staging.jujucharms.com")
+
+}
+
+func (s *DockerConfigSuite) TestCreateDockerConfigJSON(c *gc.C) {
+	imageDetails := caas.ImageDetails{
+		ImagePath: "registry.staging.jujucharms.com/tester/caas-mysql/mysql-image@sha256:dead-beef",
+		Username:  "docker-registry",
+		Password:  "hunter2",
+	}
+
+	config, err := provider.CreateDockerConfigJSON(&imageDetails)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var result provider.DockerConfigJson
+	err = json.Unmarshal(config, &result)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result, jc.DeepEquals, provider.DockerConfigJson{
+		Auths: map[string]provider.DockerConfigEntry{
+			"registry.staging.jujucharms.com": {
+				Username: "docker-registry",
+				Password: "hunter2",
+				Email:    "",
+			},
+		},
+	})
+}

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 var (
-	MakeUnitSpec    = makeUnitSpec
-	ParseK8sPodSpec = parseK8sPodSpec
-	OperatorPod     = operatorPod
+	MakeUnitSpec           = makeUnitSpec
+	ParseK8sPodSpec        = parseK8sPodSpec
+	OperatorPod            = operatorPod
+	ExtractRegistryURL     = extractRegistryURL
+	CreateDockerConfigJSON = createDockerConfigJSON
 )
 
 func PodSpec(u *unitSpec) core.PodSpec {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -154,6 +154,48 @@ func (k *kubernetesClient) deleteNamespace() error {
 	return errors.Trace(err)
 }
 
+// EnsureSecret ensures a secret exists for use with retrieving images from private registries
+func (k *kubernetesClient) EnsureSecret(imageSecretName, appName string, imageDetails *caas.ImageDetails) error {
+	if imageDetails.Password == "" {
+		return errors.New("attempting to create a secret with no password")
+	}
+	secretData, err := createDockerConfigJSON(imageDetails)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	secrets := k.CoreV1().Secrets(k.namespace)
+	// imageSecretName := appSecretName(appName, containerSpec.Name)
+
+	newSecret := &core.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      imageSecretName,
+			Namespace: k.namespace,
+			Labels:    map[string]string{labelApplication: appName}},
+		Type: core.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			core.DockerConfigJsonKey: secretData,
+		},
+	}
+
+	_, err = secrets.Update(newSecret)
+	if k8serrors.IsNotFound(err) {
+		_, err = secrets.Create(newSecret)
+	}
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) deleteSecret(appName, containerName string) error {
+	imageSecretName := appSecretName(appName, containerName)
+	secrets := k.CoreV1().Secrets(k.namespace)
+	err := secrets.Delete(imageSecretName, &v1.DeleteOptions{
+		PropagationPolicy: &defaultPropagationPolicy,
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}
+
 // EnsureOperator creates or updates an operator pod with the given application
 // name, agent path, and operator config.
 func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) error {
@@ -458,9 +500,21 @@ func (k *kubernetesClient) EnsureService(
 		}
 	}()
 
-	unitSpec, err := makeUnitSpec(params.PodSpec)
+	unitSpec, err :=
+		makeUnitSpec(appName, params.PodSpec)
 	if err != nil {
 		return errors.Annotatef(err, "parsing unit spec for %s", appName)
+	}
+
+	for _, c := range params.PodSpec.Containers {
+		if c.ImageDetails.Password == "" {
+			continue
+		}
+		imageSecretName := appSecretName(appName, c.Name)
+		if err := k.EnsureSecret(imageSecretName, appName, &c.ImageDetails); err != nil {
+			return errors.Annotatef(err, "creating secrets for container: %s", c.Name)
+		}
+		cleanups = append(cleanups, func() { k.deleteSecret(appName, c.Name) })
 	}
 
 	// Add a deployment controller configured to create the specified number of units/pods.
@@ -1172,7 +1226,6 @@ pod:
   containers:
   {{- range .Containers }}
   - name: {{.Name}}
-    image: {{.Image}}
     {{if .Ports}}
     ports:
     {{- range .Ports }}
@@ -1200,7 +1253,7 @@ pod:
   {{- end}}
 `[1:]
 
-func makeUnitSpec(podSpec *caas.PodSpec) (*unitSpec, error) {
+func makeUnitSpec(appName string, podSpec *caas.PodSpec) (*unitSpec, error) {
 	// Fill out the easy bits using a template.
 	tmpl := template.Must(template.New("").Parse(defaultPodTemplate))
 	var buf bytes.Buffer
@@ -1215,8 +1268,19 @@ func makeUnitSpec(podSpec *caas.PodSpec) (*unitSpec, error) {
 		return nil, errors.Trace(err)
 	}
 
+	var imageSecretNames []core.LocalObjectReference
 	// Now fill in the hard bits progamatically.
 	for i, c := range podSpec.Containers {
+		if c.Image != "" {
+			logger.Warningf("Image parameter deprecated, use ImageDetails")
+			unitSpec.Pod.Containers[i].Image = c.Image
+		} else {
+			unitSpec.Pod.Containers[i].Image = c.ImageDetails.ImagePath
+		}
+		if c.ImageDetails.Password != "" {
+			imageSecretNames = append(imageSecretNames, core.LocalObjectReference{Name: appSecretName(appName, c.Name)})
+		}
+
 		if c.ProviderContainer == nil {
 			continue
 		}
@@ -1232,6 +1296,7 @@ func makeUnitSpec(podSpec *caas.PodSpec) (*unitSpec, error) {
 			unitSpec.Pod.Containers[i].ReadinessProbe = spec.ReadinessProbe
 		}
 	}
+	unitSpec.Pod.ImagePullSecrets = imageSecretNames
 	return &unitSpec, nil
 }
 
@@ -1253,4 +1318,9 @@ func deploymentName(appName string) string {
 
 func resourceNamePrefix(appName string) string {
 	return "juju-" + names.NewApplicationTag(appName).String() + "-"
+}
+
+func appSecretName(appName, containerName string) string {
+	// A pod may have multiple containers with different images and thus different secrets
+	return "juju-" + appName + "-" + containerName + "-secret"
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -50,7 +50,7 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 			Image: "juju/image2",
 		}},
 	}
-	spec, err := provider.MakeUnitSpec(&podSpec)
+	spec, err := provider.MakeUnitSpec("app-name", &podSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.PodSpec(spec), jc.DeepEquals, core.PodSpec{
 		Containers: []core.Container{
@@ -95,7 +95,7 @@ var basicPodspec = &caas.PodSpec{
 }
 
 func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
-	spec, err := provider.MakeUnitSpec(basicPodspec)
+	spec, err := provider.MakeUnitSpec("app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.PodSpec(spec), jc.DeepEquals, core.PodSpec{
 		Containers: []core.Container{
@@ -183,7 +183,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	defer ctrl.Finish()
 
 	numUnits := int32(2)
-	unitSpec, err := provider.MakeUnitSpec(basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 
@@ -250,7 +250,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	defer ctrl.Finish()
 
 	numUnits := int32(2)
-	unitSpec, err := provider.MakeUnitSpec(basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 	podSpec.Containers[0].VolumeMounts = []core.VolumeMount{{

--- a/caas/kubernetes/provider/k8stypes.go
+++ b/caas/kubernetes/provider/k8stypes.go
@@ -66,14 +66,15 @@ func parseK8sPodSpec(in string) (*caas.PodSpec, error) {
 			return nil, errors.Trace(err)
 		}
 		spec.Containers[i] = caas.ContainerSpec{
-			Name:       c.Name,
-			Image:      c.Image,
-			Ports:      c.Ports,
-			Command:    c.Command,
-			Args:       c.Args,
-			WorkingDir: c.WorkingDir,
-			Config:     c.Config,
-			Files:      c.Files,
+			ImageDetails: c.ImageDetails,
+			Name:         c.Name,
+			Image:        c.Image,
+			Ports:        c.Ports,
+			Command:      c.Command,
+			Args:         c.Args,
+			WorkingDir:   c.WorkingDir,
+			Config:       c.Config,
+			Files:        c.Files,
 		}
 		if c.K8sContainerSpec != nil {
 			spec.Containers[i].ProviderContainer = c.K8sContainerSpec

--- a/caas/kubernetes/provider/k8stypes_test.go
+++ b/caas/kubernetes/provider/k8stypes_test.go
@@ -61,6 +61,14 @@ containers:
     ports:
     - containerPort: 8080
       protocol: TCP
+  - name: secret-image-user
+    imageDetails:
+        imagePath: staging.registry.org/testing/testing-image@sha256:deed-beef
+        username: docker-registry
+        password: hunter2
+  - name: just-image-details
+    imageDetails:
+        imagePath: testing/no-secrets-needed@sha256:deed-beef
 `[1:]
 
 	expectedFileContent := `
@@ -120,6 +128,18 @@ foo: bar
 			Image: "gitlab-helper/latest",
 			Ports: []caas.ContainerPort{
 				{ContainerPort: 8080, Protocol: "TCP"},
+			},
+		}, {
+			Name: "secret-image-user",
+			ImageDetails: caas.ImageDetails{
+				ImagePath: "staging.registry.org/testing/testing-image@sha256:deed-beef",
+				Username:  "docker-registry",
+				Password:  "hunter2",
+			},
+		}, {
+			Name: "just-image-details",
+			ImageDetails: caas.ImageDetails{
+				ImagePath: "testing/no-secrets-needed@sha256:deed-beef",
 			},
 		}}})
 }

--- a/caas/kubernetes/provider/provider_test.go
+++ b/caas/kubernetes/provider/provider_test.go
@@ -248,7 +248,7 @@ containers:
 	spec, err := provider.ParseK8sPodSpec(specStr)
 	c.Assert(err, jc.ErrorIsNil)
 	err = spec.Validate()
-	c.Assert(err, gc.ErrorMatches, "spec image is missing")
+	c.Assert(err, gc.ErrorMatches, "spec image details is missing")
 }
 
 func (s *providerSuite) TestValidateFileSetPath(c *gc.C) {


### PR DESCRIPTION
## Description of change

Updates the Juju pod-spec in use so a charm can pass in username/password details used to access a docker image in a private registry (i.e. an image attached to a charm in the charmstore).

This will create any secrets needed and attach them to the resulting K8s pod-spec.

## QA steps

Manually tested using the staging charmstore, microk8s and modified caas mysql charm.
WIP, Needed: Further unit tests.

## Documentation changes

As part of the ongoing work around docker images/caas/resources this change will need to be highlighted (as there are charm changes required to make use of it, although existing caas charms will continue to work).

