### PR TITLE
When creating symlinks, make sure to dereference jujud dir.

### DIFF
--- a/agent/tools/symlinks.go
+++ b/agent/tools/symlinks.go
@@ -23,12 +23,12 @@ func EnsureSymlinks(jujuDir, dir string, commands []string) (err error) {
 			err = errors.Annotatef(err, "cannot initialize commands in %q", dir)
 		}
 	}()
-	isSymlink, err := symlink.IsSymlink(dir)
+	isSymlink, err := symlink.IsSymlink(jujuDir)
 	if err != nil {
 		return err
 	}
 	if isSymlink {
-		link, err := symlink.Read(dir)
+		link, err := symlink.Read(jujuDir)
 		if err != nil {
 			return err
 		}
@@ -36,8 +36,8 @@ func EnsureSymlinks(jujuDir, dir string, commands []string) (err error) {
 			logger.Infof("%s is relative", link)
 			link = filepath.Join(filepath.Dir(dir), link)
 		}
-		dir = link
-		logger.Infof("was a symlink, now looking at %s", dir)
+		jujuDir = link
+		logger.Infof("was a symlink, now looking at %s", jujuDir)
 	}
 
 	jujudPath := filepath.Join(jujuDir, names.Jujud)

--- a/agent/tools/symlinks_test.go
+++ b/agent/tools/symlinks_test.go
@@ -37,8 +37,11 @@ func (s *SymlinksSuite) SetUpTest(c *gc.C) {
 	})
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = symlink.New(s.toolsDir, tools.ToolsDir(s.dataDir, "unit-u-123"))
+        c.Logf("created %s", s.toolsDir)
+        unitDir := tools.ToolsDir(s.dataDir, "unit-u-123")
+	err = symlink.New(s.toolsDir, unitDir)
 	c.Assert(err, jc.ErrorIsNil)
+        c.Logf("created %s => %s", unitDir, s.toolsDir)
 }
 
 func (s *SymlinksSuite) TestEnsureSymlinks(c *gc.C) {
@@ -49,6 +52,7 @@ func (s *SymlinksSuite) TestEnsureSymlinksSymlinkedDir(c *gc.C) {
 	dirSymlink := filepath.Join(c.MkDir(), "commands")
 	err := symlink.New(s.toolsDir, dirSymlink)
 	c.Assert(err, jc.ErrorIsNil)
+        c.Logf("created %s => %s", dirSymlink, s.toolsDir)
 	s.testEnsureSymlinks(c, dirSymlink)
 }
 
@@ -60,7 +64,8 @@ func (s *SymlinksSuite) testEnsureSymlinks(c *gc.C, dir string) {
 	assertLink := func(path string) time.Time {
 		target, err := symlink.Read(path)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(target, jc.SamePath, jujudPath)
+		c.Check(target, jc.SamePath, jujudPath)
+                c.Check(filepath.Dir(target), gc.Equals, filepath.Dir(jujudPath))
 		fi, err := os.Lstat(path)
 		c.Assert(err, jc.ErrorIsNil)
 		return fi.ModTime()

--- a/agent/tools/symlinks_test.go
+++ b/agent/tools/symlinks_test.go
@@ -37,11 +37,11 @@ func (s *SymlinksSuite) SetUpTest(c *gc.C) {
 	})
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-        c.Logf("created %s", s.toolsDir)
-        unitDir := tools.ToolsDir(s.dataDir, "unit-u-123")
+	c.Logf("created %s", s.toolsDir)
+	unitDir := tools.ToolsDir(s.dataDir, "unit-u-123")
 	err = symlink.New(s.toolsDir, unitDir)
 	c.Assert(err, jc.ErrorIsNil)
-        c.Logf("created %s => %s", unitDir, s.toolsDir)
+	c.Logf("created %s => %s", unitDir, s.toolsDir)
 }
 
 func (s *SymlinksSuite) TestEnsureSymlinks(c *gc.C) {
@@ -52,7 +52,7 @@ func (s *SymlinksSuite) TestEnsureSymlinksSymlinkedDir(c *gc.C) {
 	dirSymlink := filepath.Join(c.MkDir(), "commands")
 	err := symlink.New(s.toolsDir, dirSymlink)
 	c.Assert(err, jc.ErrorIsNil)
-        c.Logf("created %s => %s", dirSymlink, s.toolsDir)
+	c.Logf("created %s => %s", dirSymlink, s.toolsDir)
 	s.testEnsureSymlinks(c, dirSymlink)
 }
 
@@ -65,7 +65,7 @@ func (s *SymlinksSuite) testEnsureSymlinks(c *gc.C, dir string) {
 		target, err := symlink.Read(path)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(target, jc.SamePath, jujudPath)
-                c.Check(filepath.Dir(target), gc.Equals, filepath.Dir(jujudPath))
+		c.Check(filepath.Dir(target), gc.Equals, filepath.Dir(jujudPath))
 		fi, err := os.Lstat(path)
 		c.Assert(err, jc.ErrorIsNil)
 		return fi.ModTime()


### PR DESCRIPTION
## Description of change

We were dereferencing the path where we were creating the symlinks, not
the path to the target we were referencing. That needs to be reversed.

I also tested a 2.4.1 without this patch, then upgraded to 2.4.1 with this patch. Uniter.init calls `EnsureSymlinks` unconditionally on every startup, so as soon as the unit agent restarts with the upgraded agent, it fixes the symlinks. So we don't need a separate upgrade step.

## QA steps

```
$ juju bootstrap
$ juju switch controller
$ juju deploy cs:~jameinel/ubuntu-lite
# wait for ubuntu-lite to be available
$ juju ssh 0 readlink "/var/lib/juju/tools/*/action-get"
```

Without this patch, the paths would include the unit name in the jujud symlink, eg:
```
$ juju ssh 0 readlink "/var/lib/juju/tools/*/action-get"
/var/lib/juju/tools/unit-ubuntu-lite-0/jujud
/var/lib/juju/tools/unit-ubuntu-lite-0/jujud
/var/lib/juju/tools/unit-ubuntu-lite-0/jujud
```

With this patch it does the proper abspath:
```
$ juju ssh 0 readlink "/var/lib/juju/tools/*/action-get"
/var/lib/juju/tools/2.4.1.1-xenial-amd64/jujud
/var/lib/juju/tools/2.4.1.1-xenial-amd64/jujud
/var/lib/juju/tools/2.4.1.1-xenial-amd64/jujud
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/bugs/1778727