### PR TITLE
Fix/1775248

### DIFF
--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
@@ -2225,6 +2226,9 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 			err = m.SetSupportedContainers([]instance.ContainerType{instance.LXD})
 			c.Assert(err, jc.ErrorIsNil)
 
+			err = m.SetAgentVersion(version.MustParseBinary("2.4.1-bionic-amd64"))
+			c.Assert(err, jc.ErrorIsNil)
+
 			return changeTestCase{
 				about: "machine is updated if it's in backing and in Store",
 				initialContents: []multiwatcher.EntityInfo{
@@ -2236,6 +2240,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Message: "another failure",
 							Data:    map[string]interface{}{},
 							Since:   &now,
+							Version: "",
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
 							Current: status.Pending,
@@ -2254,9 +2259,10 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						Id:         "0",
 						InstanceId: "i-0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.Error,
-							Message: "another failure",
+							Current: status.Pending,
+							Message: "",
 							Data:    map[string]interface{}{},
+							Version: "2.4.1",
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
 							Current: status.Pending,
@@ -2898,6 +2904,8 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPort("udp", 17070)
 			c.Assert(err, jc.ErrorIsNil)
+			err = u.SetAgentVersion(version.MustParseBinary("2.4.1-bionic-amd64"))
+			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
 				about: "unit is updated if it's in backing and in multiwatcher.Store",
@@ -2909,6 +2917,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Message: "",
 						Data:    map[string]interface{}{},
 						Since:   &now,
+						Version: "",
 					},
 					WorkloadStatus: multiwatcher.StatusInfo{
 						Current: "error",
@@ -2933,13 +2942,14 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Ports:       []multiwatcher.Port{{"udp", 17070}},
 						PortRanges:  []multiwatcher.PortRange{{17070, 17070, "udp"}},
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: "idle",
+							Current: "allocating",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Version: "2.4.1",
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
-							Current: "error",
-							Message: "another failure",
+							Current: "waiting",
+							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
 						},
 					}}}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2240,7 +2240,6 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Message: "another failure",
 							Data:    map[string]interface{}{},
 							Since:   &now,
-							Version: "",
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
 							Current: status.Pending,
@@ -2259,8 +2258,8 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						Id:         "0",
 						InstanceId: "i-0",
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: status.Pending,
-							Message: "",
+							Current: status.Error,
+							Message: "another failure",
 							Data:    map[string]interface{}{},
 							Version: "2.4.1",
 						},
@@ -2917,7 +2916,6 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Message: "",
 						Data:    map[string]interface{}{},
 						Since:   &now,
-						Version: "",
 					},
 					WorkloadStatus: multiwatcher.StatusInfo{
 						Current: "error",
@@ -2942,14 +2940,14 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Ports:       []multiwatcher.Port{{"udp", 17070}},
 						PortRanges:  []multiwatcher.PortRange{{17070, 17070, "udp"}},
 						AgentStatus: multiwatcher.StatusInfo{
-							Current: "allocating",
+							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
 							Version: "2.4.1",
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
-							Current: "waiting",
-							Message: "waiting for machine",
+							Current: "error",
+							Message: "another failure",
 							Data:    map[string]interface{}{},
 						},
 					}}}


### PR DESCRIPTION
## Description of change

add agent version to unit and machine change data in allwatcher api

## QA steps

```bash
juju bootstrap lxd ctrl1
juju deploy mysql
juju add-unit mysql
```

then open juju gui to see the socket payload in `network` tab on browser
```json
{
    "request-id": 5,
    "response": {
        "deltas": [
            [
                "application",
                "change",
                {
                    "model-uuid": "80271ea3-28c2-473e-82a2-dc03b9b50ec1",
                    "name": "mediawiki",
                    "exposed": false,
                    "charm-url": "cs:mediawiki-19",
                    "owner-tag": "",
                    "life": "alive",
                    "min-units": 0,
                    "constraints": {},
                    "subordinate": false,
                    "status": {
                        "current": "blocked",
                        "message": "Database required",
                        "since": "2018-07-12T07:28:29.793269032Z",
                        "version": ""
                    },
                    "workload-version": "1.19.14"
                }
            ],
            [
                "unit",
                "change",
                {
                    "model-uuid": "80271ea3-28c2-473e-82a2-dc03b9b50ec1",
                    "name": "mediawiki/12",
                    "application": "mediawiki",
                    "series": "trusty",
                    "charm-url": "cs:mediawiki-19",
                    "public-address": "10.10.145.26",
                    "private-address": "10.10.145.26",
                    "machine-id": "12",
                    "ports": [],
                    "port-ranges": [],
                    "subordinate": false,
                    "workload-status": {
                        "current": "blocked",
                        "message": "Database required",
                        "since": "2018-07-12T07:30:51.468064451Z",
                        "version": ""
                    },
                    "agent-status": {
                        "current": "executing",
                        "message": "running install hook",
                        "since": "2018-07-12T07:29:49.570437508Z",
                        "version": "2.4.1.1"
                    }
                }
            ],
            [
                "machine",
                "change",
                {
                    "model-uuid": "80271ea3-28c2-473e-82a2-dc03b9b50ec1",
                    "id": "3",
                    "instance-id": "juju-b50ec1-3",
                    "agent-status": {
                        "current": "started",
                        "message": "",
                        "since": "2018-07-12T06:39:28.892893007Z",
                        "version": "2.4.1.1"
                    },
                    "instance-status": {
                        "current": "running",
                        "message": "Running",
                        "since": "2018-07-12T06:38:04.660977645Z",
                        "version": ""
                    },
                    "life": "alive",
                    "series": "trusty",
                    "supported-containers": [],
                    "supported-containers-known": true,
                    "hardware-characteristics": {
                        "arch": "amd64",
                        "mem": 0,
                        "cpu-cores": 0
                    },
                    "jobs": [
                        "JobHostUnits"
                    ],
                    "addresses": [
                        {
                            "value": "10.10.145.84",
                            "type": "ipv4",
                            "scope": "local-cloud"
                        },
                        {
                            "value": "127.0.0.1",
                            "type": "ipv4",
                            "scope": "local-machine"
                        },
                        {
                            "value": "::1",
                            "type": "ipv6",
                            "scope": "local-machine"
                        }
                    ],
                    "has-vote": false,
                    "wants-vote": false
                }
            ]
        ]
    }
}
```

## Documentation changes

None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1775248
