### PR TITLE
Change Resource Updates to actually be Updates.

### DIFF
--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1323,7 +1323,7 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 	c.Assert(units, gc.HasLen, 2)
 
 	checkUnitRes := func(exUnit description.Unit, unit *state.Unit, res resource.Resource) {
-		c.Assert(exUnit.Name(), gc.Equals, unit.Name())
+		c.Check(exUnit.Name(), gc.Equals, unit.Name())
 		exResources := exUnit.Resources()
 		c.Assert(exResources, gc.HasLen, 1)
 		exRes := exResources[0]

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/kr/pretty"
 	charmresource "gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -118,6 +119,8 @@ func resourceDocToUpdateOp(doc *resourceDoc) bson.M {
 	// The old code was trying to delete the doc and replace it entirely, so for now we'll just set everything except
 	// the doc's own id, which is clearly not allowed to change.
 	return bson.M{"$set": bson.M{
+		"resource-id":                doc.ID,
+		"pending-id":                 doc.PendingID,
 		"application-id":             doc.ApplicationID,
 		"unit-id":                    doc.UnitID,
 		"name":                       doc.Name,
@@ -139,6 +142,7 @@ func resourceDocToUpdateOp(doc *resourceDoc) bson.M {
 func newUpdateResourceOps(stored storedResource) []txn.Op {
 	doc := newResourceDoc(stored)
 
+	logger.Tracef("updating resource %s to %# v", stored.ID, pretty.Formatter(doc))
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
@@ -161,6 +165,7 @@ func newInsertCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 func newUpdateCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 	doc := newCharmStoreResourceDoc(res)
 
+	logger.Tracef("updating charm store resource %s to %# v", res.id, pretty.Formatter(doc))
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
@@ -185,6 +190,7 @@ func newUpdateUnitResourceOps(unitID string, stored storedResource, progress *in
 	doc := newUnitResourceDoc(unitID, stored)
 	doc.DownloadProgress = progress
 
+	logger.Tracef("updating unit resource %s to %# v", unitID, pretty.Formatter(doc))
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -113,16 +113,39 @@ func newInsertResourceOps(stored storedResource) []txn.Op {
 	}}
 }
 
+func resourceDocToUpdateOp(doc *resourceDoc) bson.M {
+	// Note (jam 2018-07-12): What are we actually allowed to update?
+	// The old code was trying to delete the doc and replace it entirely, so for now we'll just set everything except
+	// the doc's own id, which is clearly not allowed to change.
+	return bson.M{"$set": bson.M{
+		"application-id":             doc.ApplicationID,
+		"unit-id":                    doc.UnitID,
+		"name":                       doc.Name,
+		"type":                       doc.Type,
+		"path":                       doc.Path,
+		"description":                doc.Description,
+		"origin":                     doc.Origin,
+		"revision":                   doc.Revision,
+		"fingerprint":                doc.Fingerprint,
+		"size":                       doc.Size,
+		"username":                   doc.Username,
+		"timestamp-when-added":       doc.Timestamp,
+		"storage-path":               doc.StoragePath,
+		"download-progress":          doc.DownloadProgress,
+		"timestamp-when-last-polled": doc.LastPolled,
+	}}
+}
+
 func newUpdateResourceOps(stored storedResource) []txn.Op {
 	doc := newResourceDoc(stored)
 
 	// TODO(ericsnow) Using "update" doesn't work right...
-	return append([]txn.Op{{
+	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
 		Assert: txn.DocExists,
-		Remove: true,
-	}}, newInsertResourceOps(stored)...)
+		Update: resourceDocToUpdateOp(doc),
+	}}
 }
 
 func newInsertCharmStoreResourceOps(res charmStoreResource) []txn.Op {
@@ -139,13 +162,12 @@ func newInsertCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 func newUpdateCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 	doc := newCharmStoreResourceDoc(res)
 
-	// TODO(ericsnow) Using "update" doesn't work right...
-	return append([]txn.Op{{
+	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
 		Assert: txn.DocExists,
-		Remove: true,
-	}}, newInsertCharmStoreResourceOps(res)...)
+		Update: resourceDocToUpdateOp(doc),
+	}}
 }
 
 func newInsertUnitResourceOps(unitID string, stored storedResource, progress *int64) []txn.Op {
@@ -164,13 +186,12 @@ func newUpdateUnitResourceOps(unitID string, stored storedResource, progress *in
 	doc := newUnitResourceDoc(unitID, stored)
 	doc.DownloadProgress = progress
 
-	// TODO(ericsnow) Using "update" doesn't work right...
-	return append([]txn.Op{{
+	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
-		Assert: txn.DocExists,
-		Remove: true,
-	}}, newInsertUnitResourceOps(unitID, stored, progress)...)
+		Assert: txn.DocExists, // feels like we need more
+		Update: resourceDocToUpdateOp(doc),
+	}}
 }
 
 func newRemoveResourcesOps(docs []resourceDoc) []txn.Op {

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -139,7 +139,6 @@ func resourceDocToUpdateOp(doc *resourceDoc) bson.M {
 func newUpdateResourceOps(stored storedResource) []txn.Op {
 	doc := newResourceDoc(stored)
 
-	// TODO(ericsnow) Using "update" doesn't work right...
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,

--- a/state/resources_persistence_staged_test.go
+++ b/state/resources_persistence_staged_test.go
@@ -172,6 +172,8 @@ func (s *StagedResourceSuite) TestActivateExists(c *gc.C) {
 		Id:     "resource#a-application/spam",
 		Assert: txn.DocExists,
 		Update: bson.M{"$set": bson.M{
+			"resource-id":                doc.ID,
+			"pending-id":                 doc.PendingID,
 			"application-id":             doc.ApplicationID,
 			"unit-id":                    doc.UnitID,
 			"name":                       doc.Name,

--- a/state/resources_persistence_staged_test.go
+++ b/state/resources_persistence_staged_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/state/statetest"
@@ -170,12 +171,23 @@ func (s *StagedResourceSuite) TestActivateExists(c *gc.C) {
 		C:      "resources",
 		Id:     "resource#a-application/spam",
 		Assert: txn.DocExists,
-		Remove: true,
-	}, {
-		C:      "resources",
-		Id:     "resource#a-application/spam",
-		Assert: txn.DocMissing,
-		Insert: &doc,
+		Update: bson.M{"$set": bson.M{
+			"application-id":             doc.ApplicationID,
+			"unit-id":                    doc.UnitID,
+			"name":                       doc.Name,
+			"type":                       doc.Type,
+			"path":                       doc.Path,
+			"description":                doc.Description,
+			"origin":                     doc.Origin,
+			"revision":                   doc.Revision,
+			"fingerprint":                doc.Fingerprint,
+			"size":                       doc.Size,
+			"username":                   doc.Username,
+			"timestamp-when-added":       doc.Timestamp,
+			"storage-path":               doc.StoragePath,
+			"download-progress":          doc.DownloadProgress,
+			"timestamp-when-last-polled": doc.LastPolled,
+		}},
 	}, {
 		C:      "application",
 		Id:     "a-application",

--- a/state/resources_persistence_test.go
+++ b/state/resources_persistence_test.go
@@ -400,6 +400,8 @@ func (s *ResourcePersistenceSuite) TestSetUnitResourceExists(c *gc.C) {
 		Id:     "resource#a-application/spam#unit-a-application/0",
 		Assert: txn.DocExists,
 		Update: bson.M{"$set": bson.M{
+			"resource-id":                doc.ID,
+			"pending-id":                 doc.PendingID,
 			"application-id":             doc.ApplicationID,
 			"unit-id":                    doc.UnitID,
 			"name":                       doc.Name,
@@ -509,6 +511,8 @@ func (s *ResourcePersistenceSuite) TestNewResourcePendingResourceOpsExists(c *gc
 		Id:     expected.DocID,
 		Assert: txn.DocExists,
 		Update: bson.M{"$set": bson.M{
+			"resource-id":                expected.ID,
+			"pending-id":                 expected.PendingID,
 			"application-id":             expected.ApplicationID,
 			"unit-id":                    expected.UnitID,
 			"name":                       expected.Name,
@@ -530,6 +534,8 @@ func (s *ResourcePersistenceSuite) TestNewResourcePendingResourceOpsExists(c *gc
 		Id:     csresourceDoc.DocID,
 		Assert: txn.DocExists,
 		Update: bson.M{"$set": bson.M{
+			"resource-id":                csresourceDoc.ID,
+			"pending-id":                 csresourceDoc.PendingID,
 			"application-id":             csresourceDoc.ApplicationID,
 			"unit-id":                    csresourceDoc.UnitID,
 			"name":                       csresourceDoc.Name,

--- a/state/resources_persistence_test.go
+++ b/state/resources_persistence_test.go
@@ -399,12 +399,23 @@ func (s *ResourcePersistenceSuite) TestSetUnitResourceExists(c *gc.C) {
 		C:      "resources",
 		Id:     "resource#a-application/spam#unit-a-application/0",
 		Assert: txn.DocExists,
-		Remove: true,
-	}, {
-		C:      "resources",
-		Id:     "resource#a-application/spam#unit-a-application/0",
-		Assert: txn.DocMissing,
-		Insert: &doc,
+		Update: bson.M{"$set": bson.M{
+			"application-id":             doc.ApplicationID,
+			"unit-id":                    doc.UnitID,
+			"name":                       doc.Name,
+			"type":                       doc.Type,
+			"path":                       doc.Path,
+			"description":                doc.Description,
+			"origin":                     doc.Origin,
+			"revision":                   doc.Revision,
+			"fingerprint":                doc.Fingerprint,
+			"size":                       doc.Size,
+			"username":                   doc.Username,
+			"timestamp-when-added":       doc.Timestamp,
+			"storage-path":               doc.StoragePath,
+			"download-progress":          doc.DownloadProgress,
+			"timestamp-when-last-polled": doc.LastPolled,
+		}},
 	}, {
 		C:      "application",
 		Id:     "a-application",
@@ -483,40 +494,59 @@ func (s *ResourcePersistenceSuite) TestNewResourcePendingResourceOpsExists(c *gc
 	csresourceDoc.StoragePath = ""
 	csresourceDoc.LastPolled = lastPolled
 
-	res := ops[4].Insert.(*resourceDoc)
-	res.LastPolled = res.LastPolled.Round(time.Second)
+	res := ops[2].Update.(bson.M)["$set"].(bson.M)
+	res["timestamp-when-last-polled"] = res["timestamp-when-last-polled"].(time.Time).Round(time.Second)
 
 	s.stub.CheckCallNames(c, "One", "One")
 	s.stub.CheckCall(c, 0, "One", "resources", "resource#a-application/spam#pending-some-unique-ID-001", &doc)
-	c.Check(ops, jc.DeepEquals, []txn.Op{
-		{
-			C:      "resources",
-			Id:     doc.DocID,
-			Assert: txn.DocExists,
-			Remove: true,
-		}, {
-			C:      "resources",
-			Id:     expected.DocID,
-			Assert: txn.DocExists,
-			Remove: true,
-		}, {
-			C:      "resources",
-			Id:     expected.DocID,
-			Assert: txn.DocMissing,
-			Insert: &expected,
-		},
-		{
-			C:      "resources",
-			Id:     csresourceDoc.DocID,
-			Assert: txn.DocExists,
-			Remove: true,
-		},
-		{
-			C:      "resources",
-			Id:     csresourceDoc.DocID,
-			Assert: txn.DocMissing,
-			Insert: &csresourceDoc,
-		},
+	c.Check(ops, jc.DeepEquals, []txn.Op{{
+		C:      "resources",
+		Id:     doc.DocID,
+		Assert: txn.DocExists,
+		Remove: true,
+	}, {
+		C:      "resources",
+		Id:     expected.DocID,
+		Assert: txn.DocExists,
+		Update: bson.M{"$set": bson.M{
+			"application-id":             expected.ApplicationID,
+			"unit-id":                    expected.UnitID,
+			"name":                       expected.Name,
+			"type":                       expected.Type,
+			"path":                       expected.Path,
+			"description":                expected.Description,
+			"origin":                     expected.Origin,
+			"revision":                   expected.Revision,
+			"fingerprint":                expected.Fingerprint,
+			"size":                       expected.Size,
+			"username":                   expected.Username,
+			"timestamp-when-added":       expected.Timestamp,
+			"storage-path":               expected.StoragePath,
+			"download-progress":          expected.DownloadProgress,
+			"timestamp-when-last-polled": expected.LastPolled,
+		}},
+	}, {
+		C:      "resources",
+		Id:     csresourceDoc.DocID,
+		Assert: txn.DocExists,
+		Update: bson.M{"$set": bson.M{
+			"application-id":             csresourceDoc.ApplicationID,
+			"unit-id":                    csresourceDoc.UnitID,
+			"name":                       csresourceDoc.Name,
+			"type":                       csresourceDoc.Type,
+			"path":                       csresourceDoc.Path,
+			"description":                csresourceDoc.Description,
+			"origin":                     csresourceDoc.Origin,
+			"revision":                   csresourceDoc.Revision,
+			"fingerprint":                csresourceDoc.Fingerprint,
+			"size":                       csresourceDoc.Size,
+			"username":                   csresourceDoc.Username,
+			"timestamp-when-added":       csresourceDoc.Timestamp,
+			"storage-path":               csresourceDoc.StoragePath,
+			"download-progress":          csresourceDoc.DownloadProgress,
+			"timestamp-when-last-polled": csresourceDoc.LastPolled,
+		}},
+	},
 	})
 }
 


### PR DESCRIPTION
## Description of change

The old code was a delete + reinsert which was never a valid transaction
and actually breaks the TXN logic. This still isn't being properly
covered by running the updates against the database for real, but at
least it should be closer to correct.

## QA steps

I'm still working on manual reproduction steps. It likely requires deploying a charm that has a resource, and then updating that resource. It might also require a resource that is large enough to have download progress trigger.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1776673
