### PR TITLE
Disabled user has no access.

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -206,7 +206,42 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 
 	// Since these are user login tests, the nonce is empty.
 	err = st.Login(u.Tag(), password, "", nil)
-	assertInvalidEntityPassword(c, err)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: fmt.Sprintf("user %q is disabled", u.Tag().Id()),
+		Code:    "unauthorized access",
+	})
+
+	_, err = st.Client().Status([]string{})
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown object type "Client"`,
+		Code:    "not implemented",
+	})
+}
+
+func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
+	info, srv := s.newServer(c)
+	defer assertStop(c, srv)
+	info.ModelTag = s.IAASModel.ModelTag()
+
+	st := s.openAPIWithoutLogin(c, info)
+	password := "password"
+	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password})
+
+	_, err := st.Client().Status([]string{})
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown object type "Client"`,
+		Code:    "not implemented",
+	})
+
+	err = s.State.RemoveUser(u.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Since these are user login tests, the nonce is empty.
+	err = st.Login(u.Tag(), password, "", nil)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: fmt.Sprintf("user %q is permanently deleted", u.Tag().Id()),
+		Code:    "unauthorized access",
+	})
 
 	_, err = st.Client().Status([]string{})
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{

--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -62,7 +62,7 @@ func HasPermission(
 	return true, nil
 }
 
-// GetPermission returns the permission a user has on te specified target.
+// GetPermission returns the permission a user has on the specified target.
 func GetPermission(accessGetter userAccessFunc, userTag names.UserTag, target names.Tag) (permission.Access, error) {
 	userAccess, err := accessGetter(userTag, target)
 	if err != nil && !errors.IsNotFound(err) {

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -287,7 +287,12 @@ func (api *UserManagerAPI) UserInfo(request params.UserInfoRequest) (params.User
 				Disabled:       user.IsDisabled(),
 			},
 		}
-		accessForUser(user.UserTag(), &result)
+		if user.IsDisabled() {
+			// disabled users have no access to the controller.
+			result.Result.Access = string(permission.NoAccess)
+		} else {
+			accessForUser(user.UserTag(), &result)
+		}
 		return result
 	}
 

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -383,7 +383,7 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 			info: &params.UserInfo{
 				Username:    "barfoo",
 				DisplayName: "Bar Foo",
-				Access:      "login",
+				Access:      "",
 				Disabled:    true,
 			},
 		}, {
@@ -438,7 +438,7 @@ func (s *userManagerSuite) TestUserInfoAll(c *gc.C) {
 		info: &params.UserInfo{
 			Username:    "aardvark",
 			DisplayName: "Aard Vark",
-			Access:      "login",
+			Access:      "",
 			Disabled:    true,
 		},
 	}, {

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -310,6 +310,20 @@ func (s *UserSuite) TestDisableUserDisablesUserAccess(c *gc.C) {
 
 	uac, err = s.State.UserAccess(user.UserTag(), s.State.ControllerTag())
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("user %q is disabled", user.UserTag().Name()))
+
+	// Re-enable the user.
+	err = u.Refresh()
+	c.Check(err, jc.ErrorIsNil)
+	err = u.Enable()
+	c.Check(err, jc.ErrorIsNil)
+
+	uam, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(uam.Access, gc.Equals, permission.AdminAccess)
+
+	uac, err = s.State.UserAccess(user.UserTag(), s.State.ControllerTag())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(uac.Access, gc.Equals, permission.SuperuserAccess)
 }
 
 func (s *UserSuite) activeUsers(c *gc.C) []string {

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -261,7 +261,7 @@ func (s *UserSuite) TestRemoveUserRemovesUserAccess(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("user %q is permanently deleted", user.UserTag().Name()))
 }
 
-func (s *UserSuite) TestDisable(c *gc.C) {
+func (s *UserSuite) TestDisableUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "a-password"})
 	c.Assert(user.IsDisabled(), jc.IsFalse)
 	c.Assert(s.activeUsers(c), jc.DeepEquals, []string{"test-admin", user.Name()})
@@ -277,6 +277,39 @@ func (s *UserSuite) TestDisable(c *gc.C) {
 	c.Assert(user.IsDisabled(), jc.IsFalse)
 	c.Assert(user.PasswordValid("a-password"), jc.IsTrue)
 	c.Assert(s.activeUsers(c), jc.DeepEquals, []string{"test-admin", user.Name()})
+}
+
+func (s *UserSuite) TestDisableUserDisablesUserAccess(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "so sekrit"})
+
+	// Assert user exists and can authenticate.
+	c.Assert(user.PasswordValid("so sekrit"), jc.IsTrue)
+
+	s.State.SetUserAccess(user.UserTag(), s.IAASModel.ModelTag(), permission.AdminAccess)
+	s.State.SetUserAccess(user.UserTag(), s.State.ControllerTag(), permission.SuperuserAccess)
+
+	uam, err := s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(uam.Access, gc.Equals, permission.AdminAccess)
+
+	uac, err := s.State.UserAccess(user.UserTag(), s.State.ControllerTag())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(uac.Access, gc.Equals, permission.SuperuserAccess)
+
+	// Look for the user.
+	u, err := s.State.User(user.UserTag())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(u, jc.DeepEquals, user)
+
+	// Disable the user.
+	err = u.Disable()
+	c.Check(err, jc.ErrorIsNil)
+
+	uam, err = s.State.UserAccess(user.UserTag(), s.IAASModel.ModelTag())
+	c.Check(err, gc.ErrorMatches, fmt.Sprintf("user %q is disabled", user.UserTag().Name()))
+
+	uac, err = s.State.UserAccess(user.UserTag(), s.State.ControllerTag())
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("user %q is disabled", user.UserTag().Name()))
 }
 
 func (s *UserSuite) activeUsers(c *gc.C) []string {

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -186,7 +186,7 @@ func (st *State) userMayHaveAccess(tag names.UserTag) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// Since deleted users will throw an error, we need to check is user has been disabled here.
+	// Since deleted users will throw an error above, we need to check whether the user has been disabled here.
 	if localUser.IsDisabled() {
 		return errors.Errorf("user %q is disabled", tag.Id())
 	}

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -176,9 +176,13 @@ func newUserAccess(perm *userPermission, userDoc userAccessDoc, object names.Tag
 // UserAccess returns a new permission.UserAccess for the passed subject and target.
 func (st *State) UserAccess(subject names.UserTag, target names.Tag) (permission.UserAccess, error) {
 	if subject.IsLocal() {
-		_, err := st.User(subject)
+		localUser, err := st.User(subject)
 		if err != nil {
 			return permission.UserAccess{}, errors.Trace(err)
+		}
+		// Since deleted users will throw an error, we need to check is user has been disabled here.
+		if localUser.IsDisabled() {
+			return permission.UserAccess{}, errors.Errorf("user %q is disabled", subject.Id())
 		}
 	}
 

--- a/state/useraccess.go
+++ b/state/useraccess.go
@@ -142,6 +142,10 @@ func NewControllerUserAccess(st *State, userDoc userAccessDoc) (permission.UserA
 
 // UserPermission returns the access permission for the passed subject and target.
 func (st *State) UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error) {
+	if err := st.userMayHaveAccess(subject); err != nil {
+		return "", errors.Trace(err)
+	}
+
 	switch target.Kind() {
 	case names.ModelTagKind, names.ControllerTagKind:
 		access, err := st.UserAccess(subject, target)
@@ -173,17 +177,26 @@ func newUserAccess(perm *userPermission, userDoc userAccessDoc, object names.Tag
 	}
 }
 
+func (st *State) userMayHaveAccess(tag names.UserTag) error {
+	if !tag.IsLocal() {
+		// external users may have access
+		return nil
+	}
+	localUser, err := st.User(tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Since deleted users will throw an error, we need to check is user has been disabled here.
+	if localUser.IsDisabled() {
+		return errors.Errorf("user %q is disabled", tag.Id())
+	}
+	return nil
+}
+
 // UserAccess returns a new permission.UserAccess for the passed subject and target.
 func (st *State) UserAccess(subject names.UserTag, target names.Tag) (permission.UserAccess, error) {
-	if subject.IsLocal() {
-		localUser, err := st.User(subject)
-		if err != nil {
-			return permission.UserAccess{}, errors.Trace(err)
-		}
-		// Since deleted users will throw an error, we need to check is user has been disabled here.
-		if localUser.IsDisabled() {
-			return permission.UserAccess{}, errors.Errorf("user %q is disabled", subject.Id())
-		}
+	if err := st.userMayHaveAccess(subject); err != nil {
+		return permission.UserAccess{}, errors.Trace(err)
 	}
 
 	var (


### PR DESCRIPTION
## Description of change

In our permission checks we cater for logically-deleted users - they have no access to the system. This PR ensures that the same courtesy is awarded disabled users.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1781442
