### PR TITLE
Fixes lp# 1596607: 'juju controllers' uuid named explicit for model- and controller-.

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -139,7 +139,7 @@ controllers:
     current-model: controller
     user: admin
     recent-server: this-is-aws-test-of-many-api-endpoints
-    uuid: this-is-the-aws-test-uuid
+    controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
@@ -155,7 +155,7 @@ controllers:
     user: admin
     access: superuser
     recent-server: this-is-another-of-many-api-endpoints
-    uuid: this-is-another-uuid
+    controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
@@ -168,7 +168,7 @@ controllers:
   mark-test-prodstack:
     user: admin
     recent-server: this-is-one-of-many-api-endpoints
-    uuid: this-is-a-uuid
+    controller-uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -33,7 +33,7 @@ type ControllerItem struct {
 	User               string              `yaml:"user,omitempty" json:"user,omitempty"`
 	Access             string              `yaml:"access,omitempty" json:"access,omitempty"`
 	Server             string              `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
-	ControllerUUID     string              `yaml:"uuid" json:"uuid"`
+	ControllerUUID     string              `yaml:"controller-uuid" json:"uuid"`
 	APIEndpoints       []string            `yaml:"api-endpoints,flow" json:"api-endpoints"`
 	CACert             string              `yaml:"ca-cert" json:"ca-cert"`
 	Cloud              string              `yaml:"cloud" json:"cloud"`

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -241,7 +241,7 @@ type ShowControllerDetails struct {
 // ControllerDetails holds details of a controller to show.
 type ControllerDetails struct {
 	// ControllerUUID is the unique ID for the controller.
-	ControllerUUID string `yaml:"uuid" json:"uuid"`
+	ControllerUUID string `yaml:"controller-uuid" json:"uuid"`
 
 	// APIEndpoints is the collection of API endpoints running in this controller.
 	APIEndpoints []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
@@ -277,7 +277,7 @@ type MachineDetails struct {
 // ModelDetails holds details of a model to show.
 type ModelDetails struct {
 	// ModelUUID holds the details of a model.
-	ModelUUID string `yaml:"uuid" json:"uuid"`
+	ModelUUID string `yaml:"model-uuid" json:"uuid"`
 
 	// MachineCount holds the number of machines in the model.
 	MachineCount *int `yaml:"machine-count,omitempty" json:"machine-count,omitempty"`

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -61,18 +61,18 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
 	s.expectedOutput = `
 mallards:
   details:
-    uuid: this-is-another-uuid
+    controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
   models:
     controller:
-      uuid: abc
+      model-uuid: abc
       machine-count: 2
       core-count: 4
     my-model:
-      uuid: def
+      model-uuid: def
       machine-count: 2
       core-count: 4
   current-model: admin/my-model
@@ -98,18 +98,18 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
 	s.expectedOutput = `
 mallards:
   details:
-    uuid: this-is-another-uuid
+    controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
   models:
     controller:
-      uuid: abc
+      model-uuid: abc
       machine-count: 2
       core-count: 4
     my-model:
-      uuid: def
+      model-uuid: def
       machine-count: 2
       core-count: 4
   current-model: admin/my-model
@@ -149,7 +149,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	s.expectedOutput = `
 mallards:
   details:
-    uuid: this-is-another-uuid
+    controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
     cloud: mallards
@@ -157,11 +157,11 @@ mallards:
     agent-version: 999.99.99
   models:
     controller:
-      uuid: abc
+      model-uuid: abc
       machine-count: 2
       core-count: 4
     my-model:
-      uuid: def
+      model-uuid: def
       machine-count: 2
       core-count: 4
   current-model: admin/my-model
@@ -179,7 +179,7 @@ func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {
 	s.expectedOutput = `
 aws-test:
   details:
-    uuid: this-is-the-aws-test-uuid
+    controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
@@ -197,7 +197,7 @@ aws-test:
       ha-status: ha-enabled
   models:
     controller:
-      uuid: ghi
+      model-uuid: ghi
       machine-count: 2
       core-count: 4
   current-model: admin/controller
@@ -213,7 +213,7 @@ func (s *ShowControllerSuite) TestShowSomeControllerMoreInStore(c *gc.C) {
 	s.expectedOutput = `
 aws-test:
   details:
-    uuid: this-is-the-aws-test-uuid
+    controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
     cloud: aws
@@ -231,7 +231,7 @@ aws-test:
       ha-status: ha-enabled
   models:
     controller:
-      uuid: ghi
+      model-uuid: ghi
       machine-count: 2
       core-count: 4
   current-model: admin/controller
@@ -240,7 +240,7 @@ aws-test:
     access: superuser
 mark-test-prodstack:
   details:
-    uuid: this-is-a-uuid
+    controller-uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
     cloud: prodstack


### PR DESCRIPTION
## Description of change

User- readable output for 'juju controllers'  and 'juju show-controller' was labeling controller and model uuid as "uuid" unlike other places where both controllers and models are displayed.

This PR pre-fixes uuid label with the component - either controller or model.

## QA steps

Sample output should look like this:
```
mallards:
  details:
    controller-uuid: this-is-another-uuid
    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
    ca-cert: this-is-another-ca-cert
    cloud: mallards
    region: mallards1
    agent-version: 999.99.99
  models:
    controller:
      model-uuid: abc
      machine-count: 2
      core-count: 4
    my-model:
      model-uuid: def
      machine-count: 2
      core-count: 4
  current-model: admin/my-model
  account:
    user: admin
    access: superuser
```

*Please replace with any notes about how it affects current user workflow? CLI? API?* 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1596607
