### PR TITLE
2.4 LXD Provider - Apply Constraints to Containers

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -34,8 +34,6 @@ type ContainerSpec struct {
 	InstanceType string
 }
 
-const constraintWarnTemplate = "instance type constraint specified; ignoring %s constraint %q"
-
 // ApplyConstraints applies the input constraints as valid LXD container
 // configuration to the container spec.
 // Note that we pass these through as supplied. If an instance type constraint

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -18,11 +18,6 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 	if _, err := env.parsePlacement(args.Placement); err != nil {
 		return errors.Trace(err)
 	}
-
-	if args.Constraints.HasInstanceType() {
-		return errors.Errorf("LXD does not support instance types (got %q)", *args.Constraints.InstanceType)
-	}
-
 	return nil
 }
 

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -27,12 +27,10 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 }
 
 var unsupportedConstraints = []string{
-	constraints.Cores,
 	constraints.CpuPower,
-	//TODO(ericsnow) Add constraints.Mem as unsupported?
-	constraints.InstanceType,
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.Container,
 }
 
 // ConstraintsValidator returns a Validator value which is used to
@@ -40,23 +38,12 @@ var unsupportedConstraints = []string{
 func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 
-	// Register conflicts.
-
-	// We don't have any conflicts to register.
-
-	// Register unsupported constraints.
-
 	validator.RegisterUnsupported(unsupportedConstraints)
-
-	// Register the constraints vocab.
 
 	// TODO(natefinch): This is only correct so long as the lxd is running on
 	// the local machine.  If/when we support a remote lxd environment, we'll
 	// need to change this to match the arch of the remote machine.
 	validator.RegisterVocabulary(constraints.Arch, []string{arch.HostArch()})
-
-	// TODO(ericsnow) Get this working...
-	//validator.RegisterVocabulary(constraints.Container, supportedContainerTypes)
 
 	return validator, nil
 }

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -103,8 +103,6 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 
 	expected := []string{
 		"tags",
-		"instance-type",
-		"cores",
 		"cpu-power",
 		"virt-type",
 	}

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -34,7 +34,7 @@ func (s *environPolSuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=some-instance-type")
 	err := s.Env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Constraints: cons})
 
-	c.Check(err, gc.ErrorMatches, `LXD does not support instance types.*`)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -111,11 +111,9 @@ type InstanceSpec struct {
 	// LXD client is concerned and needs to be removed during a refactor.
 	ImageData lxd.SourcedImage
 
-	// TODO(ericsnow) Other possible fields:
-	// Disks
-	// Networks
-	// Metadata
-	// Tags
+	// Instance type can be any known from AWS, GCE or Azure.
+	// LXD translates it into limits for CPU cores and memory.gT
+	InstanceType string
 }
 
 func (spec InstanceSpec) config() map[string]string {


### PR DESCRIPTION
## Description of change

Adds support to LXD provider for constraints:
- CPU cores.
- Memory.
- Instance types.

Also reinstated are tests that were commented out during the LXD refactor, before freezing for a 2.4 release. These have been replaced in the develop branch, but those changes will not be back-ported here.

## QA steps

- Bootstrap with _bootstrap-constraints_; check the created container for expected limits.
- Add a machine with _constraints_; check the created container for expected limits.
- Add a machine without specifying constraints; check that no limit config is present.

## Documentation changes

Should be covered under https://github.com/juju/juju/pull/8891.

## Bug reference

N/A
