### PR TITLE
Create a k8s storage class if the provisioner is specified

### DIFF
--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -17,6 +17,7 @@ var (
 	OperatorPod            = operatorPod
 	ExtractRegistryURL     = extractRegistryURL
 	CreateDockerConfigJSON = createDockerConfigJSON
+	NewStorageConfig       = newStorageConfig
 )
 
 func PodSpec(u *unitSpec) core.PodSpec {
@@ -29,4 +30,16 @@ func NewProvider() caas.ContainerEnvironProvider {
 
 func StorageProvider(k8sClient kubernetes.Interface, namespace string) storage.Provider {
 	return &storageProvider{&kubernetesClient{Interface: k8sClient, namespace: namespace}}
+}
+
+func StorageClass(cfg *storageConfig) string {
+	return cfg.storageClass
+}
+
+func StorageProvisioner(cfg *storageConfig) string {
+	return cfg.storageProvisioner
+}
+
+func StorageParameters(cfg *storageConfig) map[string]string {
+	return cfg.parameters
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -258,7 +258,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 		MountPath: "path/to/here",
 	}}
 
-	scName := "sc"
+	scName := "juju-unit-storage"
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "juju-test",
@@ -309,8 +309,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	gomock.InOrder(
 		s.mockPersistentVolumeClaims.EXPECT().Get("juju-database-0", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{LabelSelector: "juju-storage in (test-unit-storage, test, default)"}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{ObjectMeta: v1.ObjectMeta{Name: "sc"}}}}, nil),
+		s.mockStorageClass.EXPECT().Get("juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "juju-unit-storage"}}, nil),
 		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -33,25 +33,56 @@ func (s *storageSuite) TestValidateConfig(c *gc.C) {
 
 	p := s.k8sProvider(c, ctrl)
 	cfg, err := storage.NewConfig("name", provider.K8s_ProviderType, map[string]interface{}{
-		"storage-class": "my-storage",
+		"storage-class":       "my-storage",
+		"storage-provisioner": "aws-storage",
+		"storage-label":       "storage-fred",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.ValidateConfig(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Attrs(), jc.DeepEquals, map[string]interface{}{
-		"storage-class": "my-storage",
+		"storage-class":       "my-storage",
+		"storage-provisioner": "aws-storage",
+		"storage-label":       "storage-fred",
 	})
+}
+
+func (s *storageSuite) TestValidateConfigError(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	p := s.k8sProvider(c, ctrl)
+	cfg, err := storage.NewConfig("name", provider.K8s_ProviderType, map[string]interface{}{
+		"storage-class":       "",
+		"storage-provisioner": "aws-storage",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	c.Assert(err, gc.ErrorMatches, "storage-class must be specified if storage-provisioner is specified")
 }
 
 func (s *storageSuite) TestValidateConfigDefaultStorageClass(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	p := s.k8sProvider(c, ctrl)
-	cfg, err := storage.NewConfig("name", provider.K8s_ProviderType, map[string]interface{}{})
+	cfg, err := provider.NewStorageConfig(map[string]interface{}{"storage-provisioner": "ebs"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = p.ValidateConfig(cfg)
+	c.Assert(provider.StorageClass(cfg), gc.Equals, "juju-unit-storage")
+}
+
+func (s *storageSuite) TestNewStorageConfig(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	cfg, err := provider.NewStorageConfig(map[string]interface{}{
+		"storage-class":       "juju-ebs",
+		"storage-provisioner": "ebs",
+		"parameters.type":     "gp2",
+	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.StorageClass(cfg), gc.Equals, "juju-ebs")
+	c.Assert(provider.StorageProvisioner(cfg), gc.Equals, "ebs")
+	c.Assert(provider.StorageParameters(cfg), jc.DeepEquals, map[string]string{"type": "gp2"})
 }
 
 func (s *storageSuite) TestSupports(c *gc.C) {


### PR DESCRIPTION
## Description of change

If the juju storage pool nominated to be used to create charm storage specifies a k8s provisioner, then we now create that storage class. Previously, the storage class needed to be set up manually by the user.

We also move all of the code to construct the storage class from k8s.go to storage.go

## QA steps

On an AWS k8s setup, create a caas model.

$ juju create-storage-pool k8s-ebs kubernetes storage-class=juju-ebs storage-provisioner=kubernetes.io/aws-ebs parameters.type=gp2
$ juju deploy ./mariadb --storage database=10M,k8s-ebs



