### PR TITLE
2.4 Openstack Errors for Duplicate Subnets and No Model Config for "network".

### DIFF
--- a/provider/openstack/legacy_networking.go
+++ b/provider/openstack/legacy_networking.go
@@ -70,7 +70,9 @@ func (n *LegacyNovaNetworking) ResolveNetwork(name string, external bool) (strin
 		return "", err
 	}
 	for _, network := range networks {
-		if network.Label == name {
+		// Assuming a positive match on "" makes this behave the same as the
+		// server-side filtering in Neutron networking.
+		if name == "" || network.Label == name {
 			networkIds = append(networkIds, network.Id)
 		}
 	}

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -576,7 +576,7 @@ func (s *localServerSuite) TestStartInstanceNetworkNotSet(c *gc.C) {
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
 	c.Check(inst, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `multiple networks with label .*
-	To resolve this, set a value for "network" in model-config or model-defaults;
+	To resolve this error, set a value for "network" in model-config or model-defaults;
 	or supply it via --config when creating a new model`)
 }
 

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -332,10 +332,12 @@ func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []network.Id) 
 	internalNet := n.env.ecfg().network()
 	netId, err := resolveNeutronNetwork(neutron, internalNet, false)
 	if err != nil {
+		// Note: (jam 2018-05-23) We don't treat this as fatal because we used to never pay attention to it anyway
 		if internalNet == "" {
 			logger.Warningf(noNetConfigMsg(err))
+		} else {
+			logger.Warningf("could not resolve internal network id for %q: %v", internalNet, err)
 		}
-		logger.Warningf("could not resolve internal network id for %q: %v", internalNet, err)
 	} else {
 		netIds.Add(netId)
 		// Note, there are cases where we will detect an external
@@ -405,7 +407,7 @@ func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []network.Id) 
 // internal networks.
 func noNetConfigMsg(err error) string {
 	return fmt.Sprintf(
-		"%s\n\tTo resolve this, set a value for \"network\" in model-config or model-defaults;"+
+		"%s\n\tTo resolve this error, set a value for \"network\" in model-config or model-defaults;"+
 			"\n\tor supply it via --config when creating a new model",
 		err.Error())
 }

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -375,6 +375,13 @@ func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []network.Id) 
 		}
 		if len(subnetIds) == 0 {
 			for _, subnet := range subnets {
+				// TODO (manadart 2018-07-17): If there was an error resolving
+				// an internal network ID, then no subnets will be discovered.
+				// The user will get an error attempting to add machines to
+				// this model and will have to update model config with a
+				// network name; but this does not re-discover the subnets.
+				// If subnets/spaces become important, we will have to address
+				// this somehow.
 				if !netIds.Contains(subnet.NetworkId) {
 					logger.Tracef("ignoring subnet %q, part of network %q", subnet.Id, subnet.NetworkId)
 					continue

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -998,14 +998,15 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		return nil, common.ZoneIndependentError(errors.Annotate(err, "getting initial networks"))
 	}
 	usingNetwork := e.ecfg().network()
-	if usingNetwork != "" {
-		networkId, err := e.networking.ResolveNetwork(usingNetwork, false)
-		if err != nil {
-			return nil, common.ZoneIndependentError(err)
+	networkId, err := e.networking.ResolveNetwork(usingNetwork, false)
+	if err != nil {
+		if usingNetwork == "" {
+			err = errors.New(noNetConfigMsg(err))
 		}
-		logger.Debugf("using network id %q", networkId)
-		networks = append(networks, nova.ServerNetworks{NetworkId: networkId})
+		return nil, common.ZoneIndependentError(err)
 	}
+	logger.Debugf("using network id %q", networkId)
+	networks = append(networks, nova.ServerNetworks{NetworkId: networkId})
 
 	machineName := resourceName(
 		e.namespace,


### PR DESCRIPTION
## Description of change

Adding an Openstack model without a _--config_ stanza or _model-default_ value for _network_, results in an error message when there are:
1) multiple internal networks and;
2) one or more subnets are in more than one network.

The model is actually created successfully, just not switched to. Subsequently attempting to add an instance to the new model ultimately fails because Openstack can not allocate an IP.

This change does the following:
- Nova network resolution behaves the same as Neutron - an empty string is always a positive match for filtering.
- Detection of multiple networks when there is no network config results in messages that include steps to rectify.
- Subnets are no longer accrued for a model when there is a network resolution error.
- Attempting to add an instance results in an error when there are multiple networks and no network config. 

## QA steps

- Set up 2 networks in Openstack.
- Add the same subnet to both networks.
- Bootstrap using one of the network names as network config.
- Add a model with specifying network config and ensure there is no error.
- Ensure that there is a helpful error message reported in status after attempting to add an instance to the new model.
- Set network config and ensure that.
  - Instances can be added without error.
  - Subnets can be detected and listed without error.

## Documentation changes

TBD. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1780274
