### PR TITLE
LXD Provider - Support Non Default Network Devices

### DIFF
--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -268,17 +268,6 @@ func (m *containerManager) networkDevicesFromConfig(netConfig *container.Network
 		}, nil, nil
 	}
 
-	// Get the NICs from the default profile and ensure they have MAC addresses.
-	profile, _, err := m.server.GetProfile(lxdDefaultProfileName)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	nics := getProfileNICs(profile)
-	for name := range nics {
-		if nics[name]["hwaddr"] == "" {
-			nics[name]["hwaddr"] = network.GenerateVirtualMACAddress()
-		}
-	}
-	return nics, nil, nil
+	nics, err := m.server.GetNICsFromProfile(lxdDefaultProfileName)
+	return nics, nil, errors.Trace(err)
 }

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -85,6 +85,23 @@ func (s *Server) EnsureIPv4(netName string) (bool, error) {
 	return modified, nil
 }
 
+// GetNICsFromProfile returns all NIC devices in the profile with the input
+// name. All returned devices have a MAC address; generated if required.
+func (s *Server) GetNICsFromProfile(profName string) (map[string]device, error) {
+	profile, _, err := s.GetProfile(lxdDefaultProfileName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	nics := getProfileNICs(profile)
+	for name := range nics {
+		if nics[name]["hwaddr"] == "" {
+			nics[name]["hwaddr"] = network.GenerateVirtualMACAddress()
+		}
+	}
+	return nics, nil
+}
+
 // VerifyNetworkDevice attempts to ensure that there is a network usable by LXD
 // and that there is a NIC device with said network as its parent.
 // If there are no NIC devices, and this server is *not* in cluster mode,

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
+	containerlxd "github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
 )
@@ -26,8 +27,11 @@ func (s *environBrokerSuite) SetUpTest(c *gc.C) {
 	s.callCtx = context.NewCloudCallContext()
 }
 
-func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
+func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	s.Client.Container = s.Container
+	s.Client.Profile.Devices = map[string]map[string]string{
+		"eth0": {},
+	}
 
 	// Patch the host's arch, so the broker will filter tools.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
@@ -38,8 +42,45 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
 	c.Assert(s.StartInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.ARM64)
 
-	s.Stub.CheckCallNames(c, "FindImage", "CreateContainerFromSpec")
+	s.Stub.CheckCallNames(c, "FindImage", "GetNICsFromProfile", "CreateContainerFromSpec")
 	s.Stub.CheckCall(c, 0, "FindImage", "trusty", "arm64")
+
+	// Check that no custom devices were passed - vanilla cloud-init.
+	spec := s.Stub.Calls()[2].Args[0].(containerlxd.ContainerSpec)
+	c.Check(spec.Devices, gc.IsNil)
+	c.Check(spec.Config[containerlxd.NetworkConfigKey], gc.Equals, "")
+}
+
+func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
+	s.Client.Container = s.Container
+	s.Client.Profile.Devices = map[string]map[string]string{
+		"eno9": {
+			"name":    "eno9",
+			"mtu":     "9000",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+		},
+	}
+
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
+
+	result, err := s.Env.StartInstance(s.callCtx, s.StartInstArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result.Instance, gc.DeepEquals, s.Instance)
+	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
+	c.Assert(s.StartInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.ARM64)
+
+	s.Stub.CheckCallNames(c, "FindImage", "GetNICsFromProfile", "CreateContainerFromSpec")
+	s.Stub.CheckCall(c, 0, "FindImage", "trusty", "arm64")
+
+	// Check that the non-standard devices were passed explicitly.
+	spec := s.Stub.Calls()[2].Args[0].(containerlxd.ContainerSpec)
+	c.Check(spec.Devices, gc.HasLen, 1)
+	c.Check(spec.Devices["eno9"]["name"], gc.Equals, "eno9")
+	c.Check(spec.Config[containerlxd.NetworkConfigKey], gc.Equals, `network:
+  config: "disabled"
+`)
 }
 
 func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {
@@ -91,23 +132,6 @@ func (s *environBrokerSuite) TestImageMetadataURLMungesHTTP(c *gc.C) {
 	})
 }
 
-func (s *environBrokerSuite) checkSources(c *gc.C, expectedURLs []string) {
-	sources, err := lxd.GetImageSources(s.Env)
-	c.Assert(err, jc.ErrorIsNil)
-	var sourceURLs []string
-	for _, source := range sources {
-		sourceURLs = append(sourceURLs, source.Host)
-	}
-	c.Check(sourceURLs, gc.DeepEquals, expectedURLs)
-}
-
-func (s *environBrokerSuite) checkSourcesFromStream(c *gc.C, stream string, expectedURLs []string) {
-	if stream != "" {
-		s.UpdateConfig(c, map[string]interface{}{"image-stream": stream})
-	}
-	s.checkSources(c, expectedURLs)
-}
-
 func (s *environBrokerSuite) TestImageStreamDefault(c *gc.C) {
 	s.checkSourcesFromStream(c, "", []string{
 		"https://streams.canonical.com/juju/images/releases/",
@@ -127,4 +151,21 @@ func (s *environBrokerSuite) TestImageStreamDaily(c *gc.C) {
 		"https://streams.canonical.com/juju/images/daily/",
 		"https://cloud-images.ubuntu.com/daily/",
 	})
+}
+
+func (s *environBrokerSuite) checkSourcesFromStream(c *gc.C, stream string, expectedURLs []string) {
+	if stream != "" {
+		s.UpdateConfig(c, map[string]interface{}{"image-stream": stream})
+	}
+	s.checkSources(c, expectedURLs)
+}
+
+func (s *environBrokerSuite) checkSources(c *gc.C, expectedURLs []string) {
+	sources, err := lxd.GetImageSources(s.Env)
+	c.Assert(err, jc.ErrorIsNil)
+	var sourceURLs []string
+	for _, source := range sources {
+		sourceURLs = append(sourceURLs, source.Host)
+	}
+	c.Check(sourceURLs, gc.DeepEquals, expectedURLs)
 }

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -64,6 +64,7 @@ type Server interface {
 	DeleteStoragePoolVolume(pool string, volType string, name string) (err error)
 	ServerCertificate() string
 	EnableHTTPSListener() error
+	GetNICsFromProfile(profName string) (map[string]map[string]string, error)
 }
 
 // ServerFactory creates a new factory for creating servers that are required

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -230,6 +230,19 @@ func (mr *MockServerMockRecorder) GetConnectionInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionInfo", reflect.TypeOf((*MockServer)(nil).GetConnectionInfo))
 }
 
+// GetNICsFromProfile mocks base method
+func (m *MockServer) GetNICsFromProfile(arg0 string) (map[string]map[string]string, error) {
+	ret := m.ctrl.Call(m, "GetNICsFromProfile", arg0)
+	ret0, _ := ret[0].(map[string]map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNICsFromProfile indicates an expected call of GetNICsFromProfile
+func (mr *MockServerMockRecorder) GetNICsFromProfile(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNICsFromProfile", reflect.TypeOf((*MockServer)(nil).GetNICsFromProfile), arg0)
+}
+
 // GetProfile mocks base method
 func (m *MockServer) GetProfile(arg0 string) (*api.Profile, string, error) {
 	ret := m.ctrl.Call(m, "GetProfile", arg0)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -331,6 +331,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 				Certificate: "server-cert",
 			},
 		},
+		Profile: &api.Profile{},
 	}
 	s.Common = &stubCommon{stub: s.Stub}
 
@@ -651,6 +652,11 @@ func (conn *StubClient) ServerCertificate() string {
 func (conn *StubClient) EnableHTTPSListener() error {
 	conn.AddCall("EnableHTTPSListener")
 	return conn.NextErr()
+}
+
+func (conn *StubClient) GetNICsFromProfile(profName string) (map[string]map[string]string, error) {
+	conn.AddCall("GetNICsFromProfile", profName)
+	return conn.Profile.Devices, conn.NextErr()
 }
 
 type MockClock struct {


### PR DESCRIPTION
## Description of change

This is a working into the LXD provider of changes already in the LXD container manager. It is summarised as follows:
- If the default profile contains a single "eth0" NIC, behaviour is unchanged.
- If the default profile contains multiple, or differently named NICs then;
  - The NIC devices are copied from the profile, given generated MACs, and added directly to the container spec.
  - Cloud-init networking is generated from the NIC devices and added to the container config.

## QA steps

- Bootstrap LXD
- Change the default profile to have a different NIC device name.
```
lxc profile device remove default eth0
lxc profile device add default eno9 nic nictype=bridged parent=lxdbr0 name=eno9
```
- Add Xenial (e/n/i) and Bionic (netplan) machines and check that they get IP addresses, and have connectivity.

## Documentation changes

None.

## Bug reference

N/A
