### PR TITLE
LXD Clustering API Supported Version

### DIFF
--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -328,9 +328,10 @@ func (s *serverFactory) validateServer(svr Server, profile apiProfile) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	clustered := serverInfo.Environment.ServerClustered
 
 	apiVersion := serverInfo.APIVersion
-	if msg, ok := isSupportedAPIVersion(apiVersion); !ok {
+	if msg, ok := isSupportedAPIVersion(apiVersion, clustered); !ok {
 		logger.Warningf(msg)
 		logger.Warningf("trying to use unsupported LXD API version %q", apiVersion)
 	} else {
@@ -348,7 +349,7 @@ func (s *serverFactory) Clock() clock.Clock {
 }
 
 // isSupportedAPIVersion defines what API versions we support.
-func isSupportedAPIVersion(version string) (msg string, ok bool) {
+func isSupportedAPIVersion(version string, clustered bool) (msg string, ok bool) {
 	versionParts := strings.Split(version, ".")
 	if len(versionParts) < 2 {
 		return fmt.Sprintf("LXD API version %q: expected format <major>.<minor>", version), false
@@ -361,6 +362,9 @@ func isSupportedAPIVersion(version string) (msg string, ok bool) {
 
 	if major < 1 {
 		return fmt.Sprintf("LXD API version %q: expected major version 1 or later", version), false
+	}
+	if clustered && major < 3 {
+		return fmt.Sprintf("LXD API version %q: expected major version 3 or later", version), false
 	}
 
 	return "", true

--- a/provider/lxd/server_test.go
+++ b/provider/lxd/server_test.go
@@ -549,42 +549,73 @@ func defaultRemoteServerFunc(ctrl *gomock.Controller) func(containerLXD.ServerSp
 
 func (s *serverSuite) TestIsSupportedAPIVersion(c *gc.C) {
 	for _, t := range []struct {
-		input    string
-		expected bool
-		output   string
+		input     string
+		clustered bool
+		expected  bool
+		output    string
 	}{
 		{
-			input:    "foo",
-			expected: false,
-			output:   `LXD API version "foo": expected format <major>\.<minor>`,
+			input:     "foo",
+			clustered: false,
+			expected:  false,
+			output:    `LXD API version "foo": expected format <major>\.<minor>`,
 		},
 		{
-			input:    "a.b",
-			expected: false,
-			output:   `LXD API version "a.b": unexpected major number: strconv.(ParseInt|Atoi): parsing "a": invalid syntax`,
+			input:     "a.b",
+			clustered: false,
+			expected:  false,
+			output:    `LXD API version "a.b": unexpected major number: strconv.(ParseInt|Atoi): parsing "a": invalid syntax`,
 		},
 		{
-			input:    "0.9",
-			expected: false,
-			output:   `LXD API version "0.9": expected major version 1 or later`,
+			input:     "0.9",
+			clustered: false,
+			expected:  false,
+			output:    `LXD API version "0.9": expected major version 1 or later`,
 		},
 		{
-			input:    "1.0",
-			expected: true,
-			output:   "",
+			input:     "0.9",
+			clustered: true,
+			expected:  false,
+			output:    `LXD API version "0.9": expected major version 1 or later`,
 		},
 		{
-			input:    "2.0",
-			expected: true,
-			output:   "",
+			input:     "1.9",
+			clustered: true,
+			expected:  false,
+			output:    `LXD API version "1.9": expected major version 3 or later`,
 		},
 		{
-			input:    "2.1",
-			expected: true,
-			output:   "",
+			input:     "1.0",
+			clustered: false,
+			expected:  true,
+			output:    "",
+		},
+		{
+			input:     "2.0",
+			clustered: false,
+			expected:  true,
+			output:    "",
+		},
+		{
+			input:     "2.1",
+			clustered: false,
+			expected:  true,
+			output:    "",
+		},
+		{
+			input:     "3.0",
+			clustered: true,
+			expected:  true,
+			output:    "",
+		},
+		{
+			input:     "3.1",
+			clustered: true,
+			expected:  true,
+			output:    "",
 		},
 	} {
-		msg, ok := lxd.IsSupportedAPIVersion(t.input)
+		msg, ok := lxd.IsSupportedAPIVersion(t.input, t.clustered)
 		c.Assert(ok, gc.Equals, t.expected)
 		c.Assert(msg, gc.Matches, t.output)
 	}


### PR DESCRIPTION
## Description of change

The following ensures that when clustering is enabled we have the
right supported API version.

## QA steps

Steps to follow.

## Documentation changes

The following changes just ensure that the server we're talking to with
clustering enabled is the version we support. 

## Bug reference

N/A
