### PR TITLE
Fix legacy proxy setting handling

### DIFF
--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -184,12 +184,16 @@ func (api *APIBase) proxyConfig() params.ProxyConfigResult {
 		return result
 	}
 
-	proxySettings := config.LegacyProxySettings()
-	proxySettings.AutoNoProxy = network.APIHostPortsToNoProxyString(apiHostPorts)
-	result.LegacyProxySettings = toParams(proxySettings)
+	jujuProxySettings := config.JujuProxySettings()
+	legacyProxySettings := config.LegacyProxySettings()
 
-	proxySettings = config.JujuProxySettings()
-	result.JujuProxySettings = toParams(proxySettings)
+	if jujuProxySettings.HasProxySet() {
+		jujuProxySettings.AutoNoProxy = network.APIHostPortsToNoProxyString(apiHostPorts)
+	} else {
+		legacyProxySettings.AutoNoProxy = network.APIHostPortsToNoProxyString(apiHostPorts)
+	}
+	result.JujuProxySettings = toParams(jujuProxySettings)
+	result.LegacyProxySettings = toParams(legacyProxySettings)
 
 	result.APTProxySettings = toParams(config.AptProxySettings())
 

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -161,8 +161,11 @@ func (w *proxyWorker) handleProxyValues(legacyProxySettings, jujuProxySettings p
 	// InProcessUpdate, which installs the proxy into the default HTTP
 	// transport. The same occurs for jujuProxySettings.
 	settings := jujuProxySettings
-	if legacyProxySettings.HasProxySet() {
+	if jujuProxySettings.HasProxySet() {
+		w.config.Logger.Debugf("applying in-process juju proxy settings %#v", jujuProxySettings)
+	} else {
 		settings = legacyProxySettings
+		w.config.Logger.Debugf("applying in-process legacy proxy settings %#v", legacyProxySettings)
 	}
 
 	settings.SetEnvironmentValues()
@@ -182,7 +185,7 @@ func (w *proxyWorker) handleProxyValues(legacyProxySettings, jujuProxySettings p
 
 	// Here we write files to disk. This is done only for legacyProxySettings.
 	if legacyProxySettings != w.proxy || w.first {
-		w.config.Logger.Debugf("new legacy proxy settings %#v", legacyProxySettings)
+		w.config.Logger.Debugf("saving new legacy proxy settings %#v", legacyProxySettings)
 		w.proxy = legacyProxySettings
 		if err := w.saveProxySettings(); err != nil {
 			// It isn't really fatal, but we should record it.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

Auto-population of no-proxy with controller ip addresses caused
proxyupdater to use legacy proxy settings instead of new juju-* proxy
settings.

This change modifies this logic to first check if new juju proxy
settings are present and auto-populate them with controller IPs,
otherwise legacy proxy settings are auto-populated.

Logging is also improved to be more explicit about the type of settings
applied.

## QA steps


```

# 1) replace IPs and ranges for your environment
cat bootstrap-config.yaml 
juju-http-proxy: http://10.10.101.2:8000
juju-https-proxy: http://10.10.101.2:8000
juju-no-proxy: 'localhost,127.0.0.1,10.10.10.0/24,10.10.101.0/24'
logging-config: '<root>=ERROR;unit=TRACE;juju.worker.proxyupdater=TRACE'

# 2) bootstrap a controller with new proxy settings set
juju bootstrap --config bootstrap-config.yaml --bootstrap-constraints mem=2048 vmaas

# 3) validate machine agent log
juju ssh -m controller 0 sudo -i
# the apiserver machine agent log should show
grep proxyupdater /var/log/juju/machine-0.log
2018-07-17 23:43:50 DEBUG juju.worker.proxyupdater proxyupdater.go:165 applying in-process juju proxy settings proxy.Settings{Http:"http://10.10.101.2:8000", Https:"http://10.10.101.2:8000", Ftp:"", NoProxy:"10.10.10.0/24,10.10.101.0/24,10.10.101.46,127.0.0.1,localhost", AutoNoProxy:""}
2018-07-17 23:43:50 DEBUG juju.worker.proxyupdater proxyupdater.go:188 saving new legacy proxy settings proxy.Settings{Http:"", Https:"", Ftp:"", NoProxy:"127.0.0.1,::1,localhost", AutoNoProxy:""}
2018-07-17 23:43:50 TRACE juju.worker.proxyupdater proxyupdater.go:216 setting snap proxy values: proxy.Settings{Http:"", Https:"", Ftp:"", NoProxy:"", AutoNoProxy:""}, "", ""
2018-07-17 23:43:50 DEBUG juju.worker.proxyupdater proxyupdater.go:233 snap core settings [proxy.http= proxy.https= proxy.store=] updated, output: ""

# 4) verify that the proxy server log does not contain any entries from no-proxy hostnames, IPs or subnet ranges
```

## Documentation changes

No changes to CLI or API - this is fix to make this functionality work as documented.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1782236