### PR TITLE
Constraints validator gains a cloud call context.

### DIFF
--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -296,7 +297,7 @@ func (statePolicy) ConfigValidator() (config.Validator, error) {
 	return nil, errors.NotImplementedf("ConfigValidator")
 }
 
-func (statePolicy) ConstraintsValidator() (constraints.Validator, error) {
+func (statePolicy) ConstraintsValidator(context.ProviderCallContext) (constraints.Validator, error) {
 	return nil, errors.NotImplementedf("ConstraintsValidator")
 }
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -574,7 +574,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		metadataDir = ctx.AbsPath(c.MetadataSource)
 	}
 
-	constraintsValidator, err := environ.ConstraintsValidator()
+	constraintsValidator, err := environ.ConstraintsValidator(cloudCallCtx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -256,7 +256,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, callCtx 
 		}
 	}
 
-	constraintsValidator, err := environ.ConstraintsValidator()
+	constraintsValidator, err := environ.ConstraintsValidator(callCtx)
 	if err != nil {
 		return err
 	}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -328,7 +328,7 @@ func (s *bootstrapSuite) setupProviderWithSomeSupportedArches(c *gc.C) bootstrap
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
 	// test provider constraints only has amd64 and arm64 as supported architectures
-	consBefore, err := env.ConstraintsValidator()
+	consBefore, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	desiredArch := constraints.MustParse("arch=i386")
 	unsupported, err := consBefore.Validate(desiredArch)
@@ -374,7 +374,7 @@ func (s *bootstrapSuite) setupProviderWithNoSupportedArches(c *gc.C) bootstrapEn
 	}
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
-	consBefore, err := env.ConstraintsValidator()
+	consBefore, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	// test provider constraints only has amd64 and arm64 as supported architectures
 	desiredArch := constraints.MustParse("arch=i386")
@@ -1409,7 +1409,7 @@ func (e *bootstrapEnviron) Storage() storage.Storage {
 	return e.storage
 }
 
-func (e *bootstrapEnviron) ConstraintsValidator() (constraints.Validator, error) {
+func (e *bootstrapEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	e.constraintsValidatorCount++
 	v := constraints.NewValidator()
 	v.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64})
@@ -1441,7 +1441,7 @@ type bootstrapEnvironNoExplicitArchitectures struct {
 	*bootstrapEnvironWithRegion
 }
 
-func (e bootstrapEnvironNoExplicitArchitectures) ConstraintsValidator() (constraints.Validator, error) {
+func (e bootstrapEnvironNoExplicitArchitectures) ConstraintsValidator(context.ProviderCallContext) (constraints.Validator, error) {
 	e.constraintsValidatorCount++
 	v := constraints.NewValidator()
 	return v, nil

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/context"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -36,7 +37,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleHostArch(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, devVersion)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	arch := arch.PPC64EL
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, &arch, nil, validator)
 	c.Assert(err, gc.ErrorMatches, `cannot use agent built for "ppc64el" using a machine running on "amd64"`)
@@ -47,7 +48,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleHostOS(c *gc.C) {
 	s.PatchValue(&os.HostOS, func() os.OSType { return os.Ubuntu })
 	env := newEnviron("foo", useDefaultKeys, nil)
 	series := "win2012"
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, nil, &series, validator)
 	c.Assert(err, gc.ErrorMatches, `cannot use agent built for "win2012" using a machine running "Ubuntu"`)
@@ -63,7 +64,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleTargetArch(c *gc.C) {
 	devVersion.Build = 1234
 	s.PatchValue(&jujuversion.Current, devVersion)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, nil, nil, validator)
 	c.Assert(err, gc.ErrorMatches, `model "foo" of type dummy does not support instances running on "ppc64el"`)
@@ -76,7 +77,7 @@ func (s *toolsSuite) TestValidateUploadAllowed(c *gc.C) {
 	centos7 := "centos7"
 	s.PatchValue(&arch.HostArch, func() string { return arm64 })
 	s.PatchValue(&os.HostOS, func() os.OSType { return os.CentOS })
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, &arm64, &centos7, validator)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -333,7 +333,7 @@ type Environ interface {
 
 	// ConstraintsValidator returns a Validator instance which
 	// is used to validate and merge constraints.
-	ConstraintsValidator() (constraints.Validator, error)
+	ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error)
 
 	// SetConfig updates the Environ's configuration.
 	//

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -357,7 +357,7 @@ func (env *azureEnviron) SetConfig(cfg *config.Config) error {
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (env *azureEnviron) ConstraintsValidator() (constraints.Validator, error) {
+func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	instanceTypes, err := env.getInstanceTypes()
 	if err != nil {
 		return nil, err

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1471,7 +1471,7 @@ func (s *environSuite) TestConstraintsValidatorMerge(c *gc.C) {
 func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {
 	env := s.openEnviron(c)
 	s.sender = azuretesting.Senders{s.vmSizesSender()}
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	return validator
 }

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -76,7 +76,7 @@ func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, gc.IsNil)
 	c.Check(validator, gc.NotNil)
 

--- a/provider/cloudsigma/environcaps.go
+++ b/provider/cloudsigma/environcaps.go
@@ -5,6 +5,7 @@ package cloudsigma
 
 import (
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/context"
 )
 
 var unsupportedConstraints = []string{
@@ -16,7 +17,7 @@ var unsupportedConstraints = []string{
 
 // ConstraintsValidator returns a Validator instance which
 // is used to validate and merge constraints.
-func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
+func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	return validator, nil

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -994,7 +994,7 @@ func (e *environ) DestroyController(ctx context.ProviderCallContext, controllerU
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (e *environ) ConstraintsValidator() (constraints.Validator, error) {
+func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported([]string{constraints.CpuPower, constraints.VirtType})
 	validator.RegisterConflicts([]string{constraints.InstanceType}, []string{constraints.Mem})

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -166,7 +166,7 @@ var unsupportedConstraints = []string{
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (e *environ) ConstraintsValidator() (constraints.Validator, error) {
+func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterConflicts(
 		[]string{constraints.InstanceType},

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1369,7 +1369,7 @@ func (t *localServerSuite) TestAddresses(c *gc.C) {
 
 func (t *localServerSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	env := t.Prepare(c)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
@@ -1379,7 +1379,7 @@ func (t *localServerSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 
 func (t *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	env := t.Prepare(c)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("instance-type=foo")
 	_, err = validator.Validate(cons)
@@ -1392,12 +1392,12 @@ func (t *localServerSuite) TestConstraintsValidatorVocabNoDefaultOrSpecifiedVPC(
 	c.Assert(err, jc.ErrorIsNil)
 
 	env := t.Prepare(c)
-	assertVPCInstanceTypeNotAvailable(c, env)
+	assertVPCInstanceTypeNotAvailable(c, env, t.callCtx)
 }
 
 func (t *localServerSuite) TestConstraintsValidatorVocabDefaultVPC(c *gc.C) {
 	env := t.Prepare(c)
-	assertVPCInstanceTypeAvailable(c, env)
+	assertVPCInstanceTypeAvailable(c, env, t.callCtx)
 }
 
 func (t *localServerSuite) TestConstraintsValidatorVocabSpecifiedVPC(c *gc.C) {
@@ -1409,18 +1409,18 @@ func (t *localServerSuite) TestConstraintsValidatorVocabSpecifiedVPC(c *gc.C) {
 	defer delete(t.TestConfig, "vpc-id")
 
 	env := t.Prepare(c)
-	assertVPCInstanceTypeAvailable(c, env)
+	assertVPCInstanceTypeAvailable(c, env, t.callCtx)
 }
 
-func assertVPCInstanceTypeAvailable(c *gc.C, env environs.Environ) {
-	validator, err := env.ConstraintsValidator()
+func assertVPCInstanceTypeAvailable(c *gc.C, env environs.Environ, ctx context.ProviderCallContext) {
+	validator, err := env.ConstraintsValidator(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = validator.Validate(constraints.MustParse("instance-type=t2.medium"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func assertVPCInstanceTypeNotAvailable(c *gc.C, env environs.Environ) {
-	validator, err := env.ConstraintsValidator()
+func assertVPCInstanceTypeNotAvailable(c *gc.C, env environs.Environ, ctx context.ProviderCallContext) {
+	validator, err := env.ConstraintsValidator(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = validator.Validate(constraints.MustParse("instance-type=t2.medium"))
 	c.Assert(err, gc.ErrorMatches, "invalid constraint value: instance-type=t2.medium\n.*")
@@ -1428,7 +1428,7 @@ func assertVPCInstanceTypeNotAvailable(c *gc.C, env environs.Environ) {
 
 func (t *localServerSuite) TestConstraintsMerge(c *gc.C) {
 	env := t.Prepare(c)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	consA := constraints.MustParse("arch=amd64 mem=1G cpu-power=10 cores=2 tags=bar")
 	consB := constraints.MustParse("arch=i386 instance-type=m1.small")

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -48,7 +48,7 @@ var instanceTypeConstraints = []string{
 
 // ConstraintsValidator returns a Validator value which is used to
 // validate and merge constraints.
-func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
+func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 
 	// conflicts

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -146,7 +146,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneConflictsVolume(c *gc.C) 
 }
 
 func (s *environPolSuite) TestConstraintsValidator(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
@@ -156,7 +156,7 @@ func (s *environPolSuite) TestConstraintsValidator(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	unsupported, err := validator.Validate(constraints.Value{})
@@ -166,7 +166,7 @@ func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
@@ -177,7 +177,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabInstType(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("instance-type=foo")
@@ -187,7 +187,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabInstType(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabContainer(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("container=lxd")
@@ -197,7 +197,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabContainer(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("instance-type=n1-standard-1")

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -52,7 +52,7 @@ var unsupportedConstraints = []string{
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (env *joyentEnviron) ConstraintsValidator() (constraints.Validator, error) {
+func (env *joyentEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	packages, err := env.compute.cloudapi.ListPackages(nil)

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -384,7 +384,7 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 
 func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 	env := s.Prepare(c)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 tags=bar cpu-power=10 virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
@@ -394,7 +394,7 @@ func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	env := s.Prepare(c)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("instance-type=foo")
 	_, err = validator.Validate(cons)

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -31,7 +31,7 @@ var unsupportedConstraints = []string{
 
 // ConstraintsValidator returns a Validator value which is used to
 // validate and merge constraints.
-func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
+func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 
 	validator.RegisterUnsupported(unsupportedConstraints)

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -63,7 +63,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 func (s *environPolSuite) TestConstraintsValidatorOkay(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
@@ -74,7 +74,7 @@ func (s *environPolSuite) TestConstraintsValidatorOkay(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	unsupported, err := validator.Validate(constraints.Value{})
@@ -86,7 +86,7 @@ func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse(strings.Join([]string{
@@ -112,7 +112,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 func (s *environPolSuite) TestConstraintsValidatorVocabArchKnown(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
@@ -124,7 +124,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabArchKnown(c *gc.C) {
 func (s *environPolSuite) TestConstraintsValidatorVocabArchUnknown(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=ppc64el")
@@ -135,7 +135,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabArchUnknown(c *gc.C) {
 
 func (s *environPolSuite) TestConstraintsValidatorVocabContainerUnknown(c *gc.C) {
 	c.Skip("this will fail until we add a container vocabulary")
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("container=lxd")
@@ -147,7 +147,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabContainerUnknown(c *gc.C)
 func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
-	validator, err := s.Env.ConstraintsValidator()
+	validator, err := s.Env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("instance-type=n1-standard-1")

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/gomaasapi"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 )
 
@@ -23,7 +24,7 @@ var unsupportedConstraints = []string{
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (environ *maasEnviron) ConstraintsValidator() (constraints.Validator, error) {
+func (environ *maasEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	supportedArches, err := environ.getSupportedArchitectures()

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -439,7 +439,7 @@ func (suite *environSuite) TestGetToolsMetadataSources(c *gc.C) {
 func (suite *environSuite) TestConstraintsValidator(c *gc.C) {
 	suite.testMAASObject.TestServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "trusty"}`)
 	env := suite.makeEnviron()
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
@@ -451,7 +451,7 @@ func (suite *environSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	suite.testMAASObject.TestServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "trusty"}`)
 	suite.testMAASObject.TestServer.AddBootImage("uuid-1", `{"architecture": "armhf", "release": "precise"}`)
 	env := suite.makeEnviron()
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=ppc64el")
 	_, err = validator.Validate(cons)

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -2311,7 +2311,7 @@ func (suite *maas2EnvironSuite) TestConstraintsValidator(c *gc.C) {
 	controller := newFakeController()
 	controller.bootResources = []gomaasapi.BootResource{&fakeBootResource{name: "trusty", architecture: "amd64"}}
 	env := suite.makeEnviron(c, controller)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
@@ -2326,7 +2326,7 @@ func (suite *maas2EnvironSuite) TestConstraintsValidatorVocab(c *gc.C) {
 		&fakeBootResource{name: "precise", architecture: "armhf"},
 	}
 	env := suite.makeEnviron(c, controller)
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=ppc64el")
 	_, err = validator.Validate(cons)

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -327,7 +327,7 @@ var unsupportedConstraints = []string{
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (e *manualEnviron) ConstraintsValidator() (constraints.Validator, error) {
+func (e *manualEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	if isRunningController() {

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -169,7 +169,7 @@ func (s *environSuite) TestConstraintsValidator(c *gc.C) {
 		},
 	)
 
-	validator, err := s.env.ConstraintsValidator()
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 instance-type=foo tags=bar cpu-power=10 cores=2 mem=1G virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
@@ -183,7 +183,7 @@ func (s *environSuite) TestConstraintsValidatorInsideController(c *gc.C) {
 	s.PatchValue(&os.Args, []string{"/some/where/containing/jujud", "whatever"})
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
 
-	validator, err := s.env.ConstraintsValidator()
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=arm64")
 	_, err = validator.Validate(cons)

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -315,7 +315,7 @@ func (e *Environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerU
 }
 
 // ConstraintsValidator implements environs.Environ.
-func (e *Environ) ConstraintsValidator() (constraints.Validator, error) {
+func (e *Environ) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	// list of unsupported OCI provider constraints
 	unsupportedConstraints := []string{
 		constraints.Container,

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -5,23 +5,21 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/juju/errors"
-
-	envtesting "github.com/juju/juju/environs/testing"
-
 	gomock "github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	ociCore "github.com/oracle/oci-go-sdk/core"
+	ociIdentity "github.com/oracle/oci-go-sdk/identity"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
+	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/oci"
 	"github.com/juju/juju/testing"
-
-	ociCore "github.com/oracle/oci-go-sdk/core"
-	ociIdentity "github.com/oracle/oci-go-sdk/identity"
 )
 
 type environSuite struct {
@@ -364,7 +362,7 @@ func (e *environSuite) TestCreate(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidator(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator()
+	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
@@ -376,7 +374,7 @@ func (e *environSuite) TestConstraintsValidator(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidatorEmpty(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator()
+	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	unsupported, err := validator.Validate(constraints.Value{})
@@ -386,7 +384,7 @@ func (e *environSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator()
+	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
@@ -397,7 +395,7 @@ func (e *environSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidatorWrongArch(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator()
+	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=ppc64el")

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1253,7 +1253,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 
 func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 	env := s.Open(c, s.env.Config())
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=lxd")
 	unsupported, err := validator.Validate(cons)
@@ -1263,7 +1263,7 @@ func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	env := s.Open(c, s.env.Config())
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("instance-type=foo")
@@ -1277,7 +1277,7 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 
 func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
 	env := s.Open(c, s.env.Config())
-	validator, err := env.ConstraintsValidator()
+	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	consA := constraints.MustParse("arch=amd64 mem=1G root-disk=10G")
 	consB := constraints.MustParse("instance-type=m1.small")

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -501,7 +501,7 @@ var unsupportedConstraints = []string{
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (e *Environ) ConstraintsValidator() (constraints.Validator, error) {
+func (e *Environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterConflicts(
 		[]string{constraints.InstanceType},

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -645,7 +645,7 @@ func (o *OracleEnviron) Config() *config.Config {
 }
 
 // ConstraintsValidator is part of the environs.Environ interface.
-func (o *OracleEnviron) ConstraintsValidator() (constraints.Validator, error) {
+func (o *OracleEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	// list of unsupported oracle provider constraints
 	unsupportedConstraints := []string{
 		constraints.Container,

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -237,7 +237,7 @@ func (e *environSuite) TestConfig(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidator(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator()
+	validator, err := e.env.ConstraintsValidator(e.callCtx)
 	c.Assert(err, gc.IsNil)
 	c.Assert(validator, gc.NotNil)
 }

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -164,8 +164,8 @@ func (e *fakeEnviron) Config() *config.Config {
 	return e.config
 }
 
-func (e *fakeEnviron) ConstraintsValidator() (constraints.Validator, error) {
-	e.Push("ConstraintsValidator")
+func (e *fakeEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+	e.Push("ConstraintsValidator", ctx)
 	return nil, nil
 }
 

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -34,7 +34,7 @@ var unsupportedConstraints = []string{
 
 // ConstraintsValidator returns a Validator value which is used to
 // validate and merge constraints.
-func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
+func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	validator.RegisterVocabulary(constraints.Arch, []string{

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -17,7 +17,7 @@ type environPolSuite struct {
 var _ = gc.Suite(&environPolSuite{})
 
 func (s *environPolSuite) TestConstraintsValidator(c *gc.C) {
-	validator, err := s.env.ConstraintsValidator()
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
@@ -28,7 +28,7 @@ func (s *environPolSuite) TestConstraintsValidator(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
-	validator, err := s.env.ConstraintsValidator()
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	unsupported, err := validator.Validate(constraints.Value{})
@@ -38,7 +38,7 @@ func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
-	validator, err := s.env.ConstraintsValidator()
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
@@ -49,7 +49,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabArch(c *gc.C) {
-	validator, err := s.env.ConstraintsValidator()
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=ppc64el")

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
@@ -132,7 +133,7 @@ func (internalStatePolicy) ConfigValidator() (config.Validator, error) {
 	return nil, errors.NotImplementedf("ConfigValidator")
 }
 
-func (internalStatePolicy) ConstraintsValidator() (constraints.Validator, error) {
+func (internalStatePolicy) ConstraintsValidator(context.ProviderCallContext) (constraints.Validator, error) {
 	return nil, errors.NotImplementedf("ConstraintsValidator")
 }
 

--- a/state/policy.go
+++ b/state/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/storage"
@@ -39,7 +40,7 @@ type Policy interface {
 	ConfigValidator() (config.Validator, error)
 
 	// ConstraintsValidator returns a constraints.Validator or an error.
-	ConstraintsValidator() (constraints.Validator, error)
+	ConstraintsValidator(context.ProviderCallContext) (constraints.Validator, error)
 
 	// InstanceDistributor returns an instance.Distributor or an error.
 	InstanceDistributor() (instance.Distributor, error)
@@ -84,7 +85,7 @@ func (st *State) constraintsValidator() (constraints.Validator, error) {
 	var validator constraints.Validator
 	if st.policy != nil {
 		var err error
-		validator, err = st.policy.ConstraintsValidator()
+		validator, err = st.policy.ConstraintsValidator(CallContext(st))
 		if errors.IsNotImplemented(err) {
 			validator = constraints.NewValidator()
 		} else if err != nil {

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -83,7 +84,7 @@ func (p environStatePolicy) ProviderConfigSchemaSource() (config.ConfigSchemaSou
 }
 
 // ConstraintsValidator implements state.Policy.
-func (p environStatePolicy) ConstraintsValidator() (constraints.Validator, error) {
+func (p environStatePolicy) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	model, err := p.st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -97,7 +98,7 @@ func (p environStatePolicy) ConstraintsValidator() (constraints.Validator, error
 	if err != nil {
 		return nil, err
 	}
-	return env.ConstraintsValidator()
+	return env.ConstraintsValidator(ctx)
 }
 
 // InstanceDistributor implements state.Policy.

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 )
@@ -38,7 +39,7 @@ func (p *MockPolicy) ConfigValidator() (config.Validator, error) {
 	return nil, errors.NotImplementedf("ConfigValidator")
 }
 
-func (p *MockPolicy) ConstraintsValidator() (constraints.Validator, error) {
+func (p *MockPolicy) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	if p.GetConstraintsValidator != nil {
 		return p.GetConstraintsValidator()
 	}


### PR DESCRIPTION
## Description of change

While hooking in ec2 to use cloud credential invalidator callback, I have discovered that environs.ConstraintsValidator() can make cloud calls and consequently also needs a context.

This PR changes interface and implementations to cater for this need.