### PR TITLE
Ensure Single LXD Image Download, Handle Container Spec Creation Errors

### DIFF
--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -156,12 +156,9 @@ func (m *containerManager) getContainerSpec(
 	// The provisioner works concurrently to create containers.
 	// If an image needs to be copied from a remote, we don't many goroutines
 	// attempting to do it at once.
-	var found SourcedImage
-	func() {
-		m.imageMutex.Lock()
-		defer m.imageMutex.Unlock()
-		found, err = m.server.FindImage(series, jujuarch.HostArch(), imageSources, true, callback)
-	}()
+	m.imageMutex.Lock()
+	found, err := m.server.FindImage(series, jujuarch.HostArch(), imageSources, true, callback)
+	m.imageMutex.Unlock()
 	if err != nil {
 		return ContainerSpec{}, errors.Annotatef(err, "acquiring LXD image")
 	}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -153,8 +153,9 @@ func (m *containerManager) getContainerSpec(
 	}
 
 	// Lock around finding an image.
-	// The provisioner works concurrently to create containers. If an image
-	// needs to copied from a remote, we don't many starting this task at once.
+	// The provisioner works concurrently to create containers.
+	// If an image needs to be copied from a remote, we don't many goroutines
+	// attempting to do it at once.
 	var found SourcedImage
 	func() {
 		m.imageMutex.Lock()


### PR DESCRIPTION
## Description of change

Twice we saw field reports of a panic in the LXD container manager, that happened to be after a container was created, but before it started.
This meant that after restarting, the provisioner attempted to create the container again, but failed due to a container with the name already being present.

This patch does the following:
- Adds a lock around image acquisition in the container manager in an attempt to ensure that a given image is acquired from remote sources just once, and thereafter locally.
- Handles errors from container spec creation (where image sourcing happens) so as to avoid panics from errors.

## QA steps

Added test to reproduce panic, and added code to make it pass.

Bootstrap, add a machine, then add multiple units to LXD containers on the machine.
For example: `juju deploy ubuntu -n 5 --to lxd:0,lxd:0,lxd:0,lxd:0,lxd:0`
Watch the machine log and check that the image is sourced remotely for the first container only. 

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1779897
