### PR TITLE
Report k8s storage status

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -423,8 +423,8 @@ func (a *Facade) updateStatus(params params.ApplicationUnitParams) (
 	case status.Allocating:
 		// The container runtime has decided to restart the pod.
 		agentStatus = &status.StatusInfo{
-			Status: status.Allocating,
-			//Message: params.Info,
+			Status:  status.Allocating,
+			Message: params.Info,
 		}
 		unitStatus = &status.StatusInfo{
 			Status:  status.Waiting,
@@ -724,15 +724,25 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 					return errors.Trace(err)
 				}
 				fsInfo := infos[0]
-				filesystemUpdates[fs.FilesystemTag().String()] = filesystemInfo{
-					unitTag:      unitTag,
-					providerId:   unitParams.ProviderId,
-					mountPoint:   fsInfo.MountPoint,
-					readOnly:     fsInfo.ReadOnly,
-					size:         fsInfo.Size,
-					filesystemId: fsInfo.FilesystemId,
+
+				// k8s reports provisioned info even when the volume is not ready.
+				// Only update state when volume is created so Juju doesn't think
+				// the volume is active when it's not.
+				if fsInfo.Status != status.Pending.String() {
+					filesystemUpdates[fs.FilesystemTag().String()] = filesystemInfo{
+						unitTag:      unitTag,
+						providerId:   unitParams.ProviderId,
+						mountPoint:   fsInfo.MountPoint,
+						readOnly:     fsInfo.ReadOnly,
+						size:         fsInfo.Size,
+						filesystemId: fsInfo.FilesystemId,
+					}
 				}
-				filesystemStatus[fs.FilesystemTag().String()] = status.StatusInfo{Status: status.Attached}
+				filesystemStatus[fs.FilesystemTag().String()] = status.StatusInfo{
+					Status:  status.Status(fsInfo.Status),
+					Message: fsInfo.Info,
+					Data:    fsInfo.Data,
+				}
 				infos = infos[1:]
 				if len(infos) == 0 {
 					break
@@ -903,8 +913,10 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 		}
 		now := a.clock.Now()
 		fs.SetStatus(status.StatusInfo{
-			Status: fsStatus.Status,
-			Since:  &now,
+			Status:  fsStatus.Status,
+			Message: fsStatus.Message,
+			Data:    fsStatus.Data,
+			Since:   &now,
 		})
 	}
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -252,9 +252,9 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnits(c *gc.C) {
 
 	units := []params.ApplicationUnitParams{
 		{ProviderId: "uuid", Address: "address", Ports: []string{"port"},
-			Status: "running", Info: "message"},
+			Status: "allocating", Info: ""},
 		{ProviderId: "another-uuid", Address: "another-address", Ports: []string{"another-port"},
-			Status: "running", Info: "another message"},
+			Status: "allocating", Info: "another message"},
 		{ProviderId: "last-uuid", Address: "last-address", Ports: []string{"last-port"},
 			Status: "error", Info: "last message"},
 		{ProviderId: "new-uuid", Address: "new-address", Ports: []string{"new-port"},
@@ -289,15 +289,15 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnits(c *gc.C) {
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("uuid"),
 		Address:    strPtr("address"), Ports: &[]string{"port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "message"},
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
+		UnitStatus:  &status.StatusInfo{Status: status.Waiting, Message: "waiting for container"},
+		AgentStatus: &status.StatusInfo{Status: status.Allocating},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("another-uuid"),
 		Address:    strPtr("another-address"), Ports: &[]string{"another-port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "another message"},
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
+		UnitStatus:  &status.StatusInfo{Status: status.Waiting, Message: "waiting for container"},
+		AgentStatus: &status.StatusInfo{Status: status.Allocating, Message: "another message"},
 	})
 	s.st.application.units[2].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[2].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
@@ -364,13 +364,15 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithStorage(c *gc.C) {
 		{ProviderId: "uuid", Address: "address", Ports: []string{"port"},
 			Status: "running", Info: "message",
 			FilesystemInfo: []params.KubernetesFilesystemInfo{
-				{StorageName: "data", FilesystemId: "fs-id", Size: 100, MountPoint: "/path/to/here", ReadOnly: true},
+				{StorageName: "data", FilesystemId: "fs-id", Size: 100, MountPoint: "/path/to/here", ReadOnly: true,
+					Status: "pending", Info: "not ready"},
 			},
 		},
 		{ProviderId: "another-uuid", Address: "another-address", Ports: []string{"another-port"},
 			Status: "running", Info: "another message",
 			FilesystemInfo: []params.KubernetesFilesystemInfo{
-				{StorageName: "data", FilesystemId: "fs-id2", Size: 200, MountPoint: "/path/to/there", ReadOnly: true},
+				{StorageName: "data", FilesystemId: "fs-id2", Size: 200, MountPoint: "/path/to/there", ReadOnly: true,
+					Status: "attached", Info: "ready"},
 			},
 		},
 	}
@@ -404,7 +406,6 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithStorage(c *gc.C) {
 	s.storage.CheckCallNames(c,
 		"UnitStorageAttachments", "UnitStorageAttachments", "StorageInstance",
 		"UnitStorageAttachments", "StorageInstance", "Filesystem", "SetFilesystemInfo", "SetFilesystemAttachmentInfo",
-		"Filesystem", "SetFilesystemInfo", "SetFilesystemAttachmentInfo",
 		"Filesystem", "SetStatus", "Filesystem", "SetStatus", "Filesystem", "SetStatus")
 	s.storage.CheckCall(c, 0, "UnitStorageAttachments", names.NewUnitTag("gitlab/2"))
 	s.storage.CheckCall(c, 1, "UnitStorageAttachments", names.NewUnitTag("gitlab/0"))
@@ -413,41 +414,25 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithStorage(c *gc.C) {
 	s.storage.CheckCall(c, 4, "StorageInstance", names.NewStorageTag("data/1"))
 
 	s.storage.CheckCall(c, 6, "SetFilesystemInfo",
-		names.NewFilesystemTag("gitlab/0/0"),
-		state.FilesystemInfo{
-			Size:         100,
-			FilesystemId: "fs-id",
-		})
-	s.storage.CheckCall(c, 7, "SetFilesystemAttachmentInfo",
-		names.NewUnitTag("gitlab/0"), names.NewFilesystemTag("gitlab/0/0"),
-		state.FilesystemAttachmentInfo{
-			MountPoint: "/path/to/here",
-			ReadOnly:   true,
-		})
-	s.storage.CheckCall(c, 9, "SetFilesystemInfo",
 		names.NewFilesystemTag("gitlab/1/0"),
 		state.FilesystemInfo{
 			Size:         200,
 			FilesystemId: "fs-id2",
 		})
-	s.storage.CheckCall(c, 10, "SetFilesystemAttachmentInfo",
+	s.storage.CheckCall(c, 7, "SetFilesystemAttachmentInfo",
 		names.NewUnitTag("gitlab/1"), names.NewFilesystemTag("gitlab/1/0"),
 		state.FilesystemAttachmentInfo{
 			MountPoint: "/path/to/there",
 			ReadOnly:   true,
 		})
 	now := s.clock.Now()
-	s.storage.CheckCall(c, 12, "SetStatus",
+	s.storage.CheckCall(c, 11, "SetStatus",
 		status.StatusInfo{
-			Status: status.Attached,
-			Since:  &now,
+			Status:  status.Attached,
+			Message: "ready",
+			Since:   &now,
 		})
-	s.storage.CheckCall(c, 14, "SetStatus",
-		status.StatusInfo{
-			Status: status.Attached,
-			Since:  &now,
-		})
-	s.storage.CheckCall(c, 16, "SetStatus",
+	s.storage.CheckCall(c, 13, "SetStatus",
 		status.StatusInfo{
 			Status: status.Detached,
 			Since:  &now,

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -65,10 +65,13 @@ type KubernetesVolumeAttachmentParams struct {
 // Filesystem describes a storage filesystem in the cloud
 // as reported to the model.
 type KubernetesFilesystemInfo struct {
-	StorageName  string `json:"storagename"`
-	Pool         string `json:"pool"`
-	Size         uint64 `json:"size"`
-	MountPoint   string `json:"mount-point,omitempty"`
-	ReadOnly     bool   `json:"read-only,omitempty"`
-	FilesystemId string `json:"filesystem-id"`
+	StorageName  string                 `json:"storagename"`
+	Pool         string                 `json:"pool"`
+	Size         uint64                 `json:"size"`
+	MountPoint   string                 `json:"mount-point,omitempty"`
+	ReadOnly     bool                   `json:"read-only,omitempty"`
+	FilesystemId string                 `json:"filesystem-id"`
+	Status       string                 `json:"status"`
+	Info         string                 `json:"info"`
+	Data         map[string]interface{} `json:"data,omitempty"`
 }

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -144,6 +144,7 @@ type FilesystemInfo struct {
 	Size         uint64
 	MountPoint   string
 	ReadOnly     bool
+	Status       status.StatusInfo
 }
 
 // Unit represents information about the status of a "pod".

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -24,6 +24,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
@@ -1004,9 +1005,35 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 			}
 		}
 		terminated := p.DeletionTimestamp != nil
+		unitStatus := k.jujuStatus(p.Status.Phase, terminated)
 		statusMessage := p.Status.Message
-		if statusMessage == "" && len(p.Status.Conditions) > 0 {
-			statusMessage = p.Status.Conditions[0].Message
+		since := now
+		if statusMessage == "" {
+			for _, cond := range p.Status.Conditions {
+				statusMessage = cond.Message
+				since = cond.LastProbeTime.Time
+				if cond.Type == core.PodScheduled && cond.Reason == core.PodReasonUnschedulable {
+					unitStatus = status.Allocating
+					break
+				}
+			}
+		}
+
+		if statusMessage == "" {
+			// If there are any events for this pod we can use the
+			// most recent to set the status.
+			events := k.CoreV1().Events(k.namespace)
+			eventList, err := events.List(v1.ListOptions{
+				IncludeUninitialized: true,
+				FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", p.Name).String(),
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			// Take the most recent event.
+			if count := len(eventList.Items); count > 0 {
+				statusMessage = eventList.Items[count-1].Message
+			}
 		}
 		unitInfo := caas.Unit{
 			Id:      string(p.UID),
@@ -1014,9 +1041,9 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 			Ports:   ports,
 			Dying:   terminated,
 			Status: status.StatusInfo{
-				Status:  k.jujuStatus(p.Status.Phase, terminated),
+				Status:  unitStatus,
 				Message: statusMessage,
-				Since:   &now,
+				Since:   &since,
 			},
 		}
 
@@ -1054,12 +1081,40 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 				return nil, errors.Trace(err)
 			}
 
+			statusMessage := ""
+			since = now
+			if len(pvc.Status.Conditions) > 0 {
+				statusMessage = pvc.Status.Conditions[0].Message
+				since = pvc.Status.Conditions[0].LastProbeTime.Time
+			}
+			if statusMessage == "" {
+				// If there are any events for this pvc we can use the
+				// most recent to set the status.
+				events := k.CoreV1().Events(k.namespace)
+				eventList, err := events.List(v1.ListOptions{
+					IncludeUninitialized: true,
+					FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", pvc.Name).String(),
+				})
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				// Take the most recent event.
+				if count := len(eventList.Items); count > 0 {
+					statusMessage = eventList.Items[count-1].Message
+				}
+			}
+
 			unitInfo.FilesystemInfo = append(unitInfo.FilesystemInfo, caas.FilesystemInfo{
 				StorageName:  storageName,
 				Size:         uint64(vol.PersistentVolumeClaim.Size()),
 				FilesystemId: pvc.Name,
 				MountPoint:   volMount.MountPath,
 				ReadOnly:     volMount.ReadOnly,
+				Status: status.StatusInfo{
+					Status:  k.jujuStorageStatus(pvc.Status.Phase),
+					Message: statusMessage,
+					Since:   &since,
+				},
 			})
 		}
 		units = append(units, unitInfo)
@@ -1078,6 +1133,19 @@ func (k *kubernetesClient) jujuStatus(podPhase core.PodPhase, terminated bool) s
 		return status.Error
 	case core.PodPending:
 		return status.Allocating
+	default:
+		return status.Unknown
+	}
+}
+
+func (k *kubernetesClient) jujuStorageStatus(pvcPhase core.PersistentVolumeClaimPhase) status.Status {
+	switch pvcPhase {
+	case core.ClaimPending:
+		return status.Pending
+	case core.ClaimBound:
+		return status.Attached
+	case core.ClaimLost:
+		return status.Detached
 	default:
 		return status.Unknown
 	}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -183,6 +183,10 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 
 	pUnit := func(name string, u unitStatus, level int) {
 		message := u.WorkloadStatusInfo.Message
+		// If we're still allocating and there's a message, show that.
+		if u.JujuStatusInfo.Current == status.Allocating && message == "" {
+			message = u.JujuStatusInfo.Message
+		}
 		agentDoing := agentDoing(u.JujuStatusInfo)
 		if agentDoing != "" {
 			message = fmt.Sprintf("(%s) %s", agentDoing, message)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -4836,7 +4836,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 							Current: status.Allocating,
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: status.Active,
+							Current: status.Error,
+							Message: "no storage",
 						},
 					},
 					"foo/1": {
@@ -4864,7 +4865,7 @@ App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Charm version  No
 foo                     1/2                  0      54.32.1.2                 
 
 Unit   Workload  Agent       Address   Ports   Message
-foo/0  active    allocating                    
+foo/0  error     allocating                    no storage
 foo/1  active    running     10.0.0.1  80/TCP  
 `[1:])
 }

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -185,6 +185,9 @@ func (aw *applicationWorker) loop() error {
 						Size:         info.Size,
 						MountPoint:   info.MountPoint,
 						ReadOnly:     info.ReadOnly,
+						Status:       info.Status.Status.String(),
+						Info:         info.Status.Message,
+						Data:         info.Status.Data,
 					})
 
 				}

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -109,7 +109,8 @@ func (m *mockContainerBroker) Units(appName string) ([]caas.Unit, error) {
 				Status:  status.StatusInfo{Status: m.reportedUnitStatus},
 				FilesystemInfo: []caas.FilesystemInfo{
 					{MountPoint: "/path-to-here", ReadOnly: true, StorageName: "database",
-						Size: 100, FilesystemId: "fs-id"},
+						Size: 100, FilesystemId: "fs-id",
+						Status: status.StatusInfo{Status: status.Attaching, Message: "not ready"}},
 				},
 			},
 		},

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -579,7 +579,8 @@ func (s *WorkerSuite) assertUnitChange(c *gc.C, reported, expected status.Status
 				{ProviderId: "u1", Address: "10.0.0.1", Ports: []string(nil), Status: expected.String(),
 					FilesystemInfo: []params.KubernetesFilesystemInfo{
 						{StorageName: "database", MountPoint: "/path-to-here", ReadOnly: true,
-							FilesystemId: "fs-id", Size: 100, Pool: ""},
+							FilesystemId: "fs-id", Size: 100, Pool: "",
+							Status: "attaching", Info: "not ready"},
 					}},
 			},
 		},

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -561,9 +561,10 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		}
 	} else {
 		initialState = operation.State{
-			Hook: &hook.Info{Kind: hooks.Install},
-			Kind: operation.RunHook,
-			Step: operation.Queued,
+			Hook:      &hook.Info{Kind: hooks.Start},
+			Kind:      operation.RunHook,
+			Step:      operation.Queued,
+			Installed: true,
 		}
 		if err := u.unit.SetCharmURL(charmURL); err != nil {
 			return errors.Trace(err)


### PR DESCRIPTION
## Description of change

Report to Juju the pod and pvc status from a k8s model. Record this status so it can be reported on. Previously the storage status was attached even when there was an error.

As a driveby, tweak the k8s uniter startup pending further improvements.

## QA steps

juju a k8s charm without  having any k8s pv available.
Ensure juju storage shows the pvc message.

