### PR TITLE
leases: make manager run claims and expiry asynchronously

### DIFF
--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -120,9 +120,17 @@ func ValidateString(s string) error {
 	return nil
 }
 
-// ErrInvalid indicates that a Store operation failed because latest state
-// indicates that it's a logical impossibility. It's a short-range signal to
-// calling code only; that code should never pass it on, but should inspect
-// the Store's updated Leases() and either attempt a new operation or return
-// a new error at a suitable level of abstraction.
-var ErrInvalid = errors.New("invalid lease operation")
+var (
+	// ErrInvalid indicates that a Store operation failed because latest state
+	// indicates that it's a logical impossibility. It's a short-range signal to
+	// calling code only; that code should never pass it on, but should inspect
+	// the Store's updated Leases() and either attempt a new operation or return
+	// a new error at a suitable level of abstraction.
+	ErrInvalid = errors.New("invalid lease operation")
+
+	// ErrTimeout indicates that a Store operation failed because it
+	// couldn't update the underlying lease information. This is probably
+	// a transient error due to changes in the cluster, and indicates that
+	// the operation should be retried.
+	ErrTimeout = errors.New("lease operation timed out")
+)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -129,7 +129,7 @@ gopkg.in/macaroon.v2-unstable	git	66ab28d0d56f39a383f7cf5cf3ac9a4e9ab32865	2018-
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z
 gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
-gopkg.in/retry.v1	git	01631078ef2fdce601e38cfe5f527fab24c9a6d2	2017-05-31T09:12:38Z
+gopkg.in/retry.v1	git	2d7c7c65cc71d024968d9ff4385d5e7ad3a83fcc	2018-01-16T15:34:15Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
 gopkg.in/yaml.v2	git	1be3d31502d6eabc0dd7ce5b0daab022e14a5538	2017-07-12T05:45:46Z

--- a/worker/lease/bound.go
+++ b/worker/lease/bound.go
@@ -46,7 +46,7 @@ func (b *boundManager) Claim(leaseName, holderName string, duration time.Duratio
 		},
 		holderName: holderName,
 		duration:   duration,
-		response:   make(chan bool),
+		response:   make(chan error),
 		stop:       b.manager.catacomb.Dying(),
 	}.invoke(b.manager.claims)
 }

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -11,9 +11,20 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
+	"gopkg.in/retry.v1"
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/worker/catacomb"
+)
+
+const (
+	// maxRetries gives the maximum number of attempts we'll try if
+	// there are timeouts.
+	maxRetries = 5
+
+	// initialRetryDelay is the starting delay - this will be
+	// increased exponentially up maxRetries.
+	initialRetryDelay = 50 * time.Millisecond
 )
 
 var logger = loggo.GetLogger("juju.worker.lease")
@@ -145,13 +156,9 @@ func (manager *Manager) choose(blocks blocks) error {
 	case check := <-manager.checks:
 		return manager.handleCheck(check)
 	case manager.now = <-manager.nextTick(manager.now):
-		go func(now time.Time) {
-			manager.errors <- manager.tick(now)
-		}(manager.now)
+		go manager.retryingTick(manager.now)
 	case claim := <-manager.claims:
-		go func() {
-			manager.errors <- manager.handleClaim(claim)
-		}()
+		go manager.retryingClaim(claim)
 	case block := <-manager.blocks:
 		// TODO(raftlease): Include the other key items.
 		logger.Tracef("[%s] adding block for: %s", manager.logContext, block.leaseKey.Lease)
@@ -183,17 +190,52 @@ func (manager *Manager) Claimer(namespace, modelUUID string) (lease.Claimer, err
 	return manager.bind(namespace, modelUUID)
 }
 
-// handleClaim processes and responds to the supplied claim. It will only return
-// unrecoverable errors; mere failure to claim just indicates a bad request, and
-// is communicated back to the claim's originator.
-func (manager *Manager) handleClaim(claim claim) error {
+// retryingClaim handles timeouts when claiming, and responds to the
+// claiming party when it eventually succeeds or fails, or if it times
+// out after a number of retries.
+func (manager *Manager) retryingClaim(claim claim) {
+	var (
+		err     error
+		success bool
+	)
+	for a := manager.startRetry(); a.Next(); {
+		success, err = manager.handleClaim(claim)
+		if errors.Cause(err) != lease.ErrTimeout {
+			break
+		}
+		if a.More() {
+			logger.Tracef("[%s] timed out handling claim, retrying...", manager.logContext)
+		}
+	}
+
+	if success {
+		claim.respond(nil)
+	} else if errors.Cause(err) == lease.ErrTimeout {
+		claim.respond(lease.ErrTimeout)
+	} else if err == nil {
+		claim.respond(lease.ErrClaimDenied)
+	}
+	// Otherwise we allow the fatal error to send errStopped.
+
+	select {
+	case <-manager.catacomb.Dying():
+		return
+	default:
+	}
+	manager.errors <- err
+}
+
+// handleClaim processes the supplied claim. It will only return
+// unrecoverable errors or timeouts; mere failure to claim just
+// indicates a bad request, and is returned as (false, nil).
+func (manager *Manager) handleClaim(claim claim) (bool, error) {
 	store := manager.config.Store
 	request := lease.Request{claim.holderName, claim.duration}
 	err := lease.ErrInvalid
 	for err == lease.ErrInvalid {
 		select {
 		case <-manager.catacomb.Dying():
-			return manager.catacomb.ErrDying()
+			return false, manager.catacomb.ErrDying()
 		default:
 			// TODO(jam) 2017-10-31: We are asking for all leases just to look
 			// up one of them. Shouldn't the store.Leases() interface allow us
@@ -212,16 +254,14 @@ func (manager *Manager) handleClaim(claim claim) error {
 				remaining := info.Expiry.Sub(manager.config.Clock.Now())
 				logger.Tracef("[%s] %s asked for lease %s, held by %s for another %s, rejecting",
 					manager.logContext, claim.holderName, claim.leaseKey.Lease, info.Holder, remaining)
-				claim.respond(false)
-				return nil
+				return false, nil
 			}
 		}
 	}
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
-	claim.respond(true)
-	return nil
+	return true, nil
 }
 
 // handleCheck processes and responds to the supplied check. It will only return
@@ -274,6 +314,28 @@ func (manager *Manager) nextTick(lastTick time.Time) <-chan time.Time {
 	return clock.Alarm(manager.config.Clock, nextTick)
 }
 
+// retryingTick runs tick and retries any timeouts.
+func (manager *Manager) retryingTick(now time.Time) {
+	var err error
+	for a := manager.startRetry(); a.Next(); {
+		err = manager.tick(now)
+		if errors.Cause(err) != lease.ErrTimeout {
+			break
+		}
+		if a.More() {
+			logger.Tracef("[%s] timed out during tick, retrying...", manager.logContext)
+		}
+	}
+	// Don't bother sending an error if we're dying - this avoids a
+	// race in the tests.
+	select {
+	case <-manager.catacomb.Dying():
+		return
+	default:
+	}
+	manager.errors <- err
+}
+
 // tick snapshots recent leases and expires any that it can. There
 // might be none that need attention; or those that do might already
 // have been extended or expired by someone else; so ErrInvalid is
@@ -322,6 +384,17 @@ func (manager *Manager) tick(now time.Time) error {
 		logger.Debugf("[%s] expired %d leases: %s", manager.logContext, len(expired), strings.Join(names, ", "))
 	}
 	return nil
+}
+
+func (manager *Manager) startRetry() *retry.Attempt {
+	return retry.StartWithCancel(
+		retry.LimitCount(maxRetries, retry.Exponential{
+			Initial: initialRetryDelay,
+			Jitter:  true,
+		}),
+		manager.config.Clock,
+		manager.catacomb.Dying(),
+	)
 }
 
 func keysLess(a, b lease.Key) bool {

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
 
 	corelease "github.com/juju/juju/core/lease"
 	coretesting "github.com/juju/juju/testing"
@@ -109,7 +110,172 @@ func (s *AsyncSuite) TestExpirySlow(c *gc.C) {
 }
 
 func (s *AsyncSuite) TestExpiryTimeout(c *gc.C) {
-	c.Fatalf("writeme")
+	// When a timeout happens on expiry we retry.
+	expireCalls := make(chan struct{})
+	fix := Fixture{
+		leases: leaseMap{
+			key("requiem"): {
+				Holder: "verdi",
+				Expiry: offset(-time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "Refresh",
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{key("requiem")},
+			err:    corelease.ErrTimeout,
+			callback: func(_ leaseMap) {
+				select {
+				case expireCalls <- struct{}{}:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out sending expired")
+				}
+			},
+		}, {
+			method: "Refresh",
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{key("requiem")},
+			callback: func(leases leaseMap) {
+				delete(leases, key("requiem"))
+				close(expireCalls)
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		select {
+		case <-expireCalls:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for 1st expireCall")
+		}
+
+		// We want two waiters - one for the main loop, and one for
+		// the retry delay.
+		err := clock.WaitAdvance(50*time.Millisecond, coretesting.LongWait, 2)
+		c.Assert(err, jc.ErrorIsNil)
+
+		select {
+		case _, ok := <-expireCalls:
+			c.Assert(ok, gc.Equals, false)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for 2nd expireCall")
+		}
+	})
+}
+
+func (s *AsyncSuite) TestExpiryRepeatedTimeout(c *gc.C) {
+	// When a timeout happens on expiry we retry - if we hit the retry
+	// limit we should kill the manager.
+	expireCalls := make(chan struct{})
+
+	var calls []call
+	for i := 0; i < 5; i++ {
+		calls = append(calls,
+			call{method: "Refresh"},
+			call{
+				method: "ExpireLease",
+				args:   []interface{}{key("requiem")},
+				err:    corelease.ErrTimeout,
+				callback: func(_ leaseMap) {
+					select {
+					case expireCalls <- struct{}{}:
+					case <-time.After(coretesting.LongWait):
+						c.Fatalf("timed out sending expired")
+					}
+				},
+			},
+		)
+	}
+	fix := Fixture{
+		leases: leaseMap{
+			key("requiem"): {
+				Holder: "mozart",
+				Expiry: offset(-time.Second),
+			},
+		},
+		expectCalls: calls,
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		select {
+		case <-expireCalls:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for 1st expireCall")
+		}
+
+		delay := 50 * time.Millisecond
+		for i := 0; i < 4; i++ {
+			c.Logf("retry %d", i+1)
+			err := clock.WaitAdvance(delay, coretesting.LongWait, 2)
+			c.Assert(err, jc.ErrorIsNil)
+			select {
+			case <-expireCalls:
+			case <-time.After(coretesting.LongWait):
+				c.Fatalf("timed out waiting for expireCall")
+			}
+			delay *= 2
+		}
+		err := manager.Wait()
+		c.Assert(errors.Cause(err), gc.Equals, corelease.ErrTimeout)
+	})
+}
+
+func (s *AsyncSuite) TestExpiryInterruptedRetry(c *gc.C) {
+	// Check that retries are stopped when the manager is killed.
+	expireCalls := make(chan struct{})
+	fix := Fixture{
+		leases: leaseMap{
+			key("requiem"): {
+				Holder: "fauré",
+				Expiry: offset(-time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "Refresh",
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{key("requiem")},
+			err:    corelease.ErrTimeout,
+			callback: func(_ leaseMap) {
+				select {
+				case expireCalls <- struct{}{}:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out sending expired")
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		select {
+		case <-expireCalls:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for 1st expireCall")
+		}
+
+		// Ensure the main loop and the retry loop are both waiting
+		// for the clock without advancing it.
+		err := clock.WaitAdvance(0, coretesting.LongWait, 2)
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Stopping the worker should cancel the retry.
+		err = worker.Stop(manager)
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Advance the clock to trigger the next retry if it's
+		// waiting.
+		err = clock.WaitAdvance(50*time.Millisecond, coretesting.ShortWait, 2)
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Allow some wallclock time for a non-cancelled retry to
+		// happen if stopping the worker didn't cancel it. This is not
+		// ideal but I can't see a better way to verify that the retry
+		// doesn't happen - adding an exploding call to expectCalls
+		// makes the store wait for that call to be made. This is
+		// verified to pass reliably if the retry gets cancelled and
+		// fail reliably otherwise.
+		time.Sleep(coretesting.ShortWait)
+	})
 }
 
 func (s *AsyncSuite) TestClaimSlow(c *gc.C) {
@@ -206,5 +372,135 @@ func (s *AsyncSuite) TestClaimSlow(c *gc.C) {
 }
 
 func (s *AsyncSuite) TestClaimTimeout(c *gc.C) {
-	c.Fatalf("writeme")
+	// When a claim times out we retry.
+	claimCalls := make(chan struct{})
+	fix := Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args: []interface{}{
+				key("icecream"),
+				corelease.Request{"rosie", time.Minute},
+			},
+			err: corelease.ErrTimeout,
+			callback: func(_ leaseMap) {
+				select {
+				case claimCalls <- struct{}{}:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out sending claim")
+				}
+			},
+		}, {
+			method: "ClaimLease",
+			args: []interface{}{
+				key("icecream"),
+				corelease.Request{"rosie", time.Minute},
+			},
+			callback: func(leases leaseMap) {
+				leases[key("icecream")] = corelease.Info{
+					Holder: "rosie",
+					Expiry: offset(time.Minute),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		result := make(chan error)
+		claimer, err := manager.Claimer("namespace", "modelUUID")
+		c.Assert(err, jc.ErrorIsNil)
+		go func() {
+			result <- claimer.Claim("icecream", "rosie", time.Minute)
+		}()
+
+		select {
+		case <-claimCalls:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for claim")
+		}
+
+		// Why three waiters, you ask? I also was confused about that
+		// for a fair amount of time, but after a bit of debugging it
+		// makes sense. There's one for the clock.Alarm created in
+		// nextTick in choose the first time around the mainloop (when
+		// the claim comes in), then there's the next alarm from the
+		// next time around the loop (after the claim goroutine is
+		// launched), and then there's the claim retry timer. (The
+		// nextTick alarms are both for ~1min in the future, since
+		// there are no existing leases.)
+		err = clock.WaitAdvance(50*time.Millisecond, coretesting.LongWait, 3)
+
+		select {
+		case err := <-result:
+			c.Assert(err, jc.ErrorIsNil)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for response")
+		}
+	})
+}
+
+func (s *AsyncSuite) TestClaimRepeatedTimeout(c *gc.C) {
+	// When a claim times out too many times we give up.
+	claimCalls := make(chan struct{})
+	var calls []call
+	for i := 0; i < 5; i++ {
+		calls = append(calls, call{
+			method: "ClaimLease",
+			args: []interface{}{
+				key("icecream"),
+				corelease.Request{"rosie", time.Minute},
+			},
+			err: corelease.ErrTimeout,
+			callback: func(_ leaseMap) {
+				select {
+				case claimCalls <- struct{}{}:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out sending claim")
+				}
+			},
+		})
+	}
+	fix := Fixture{
+		expectCalls: calls,
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		result := make(chan error)
+		claimer, err := manager.Claimer("namespace", "modelUUID")
+		c.Assert(err, jc.ErrorIsNil)
+		go func() {
+			result <- claimer.Claim("icecream", "rosie", time.Minute)
+		}()
+
+		duration := 50 * time.Millisecond
+		for i := 0; i < 4; i++ {
+			c.Logf("retry %d", i)
+			select {
+			case <-claimCalls:
+			case <-result:
+				c.Fatalf("got result too soon")
+			case <-time.After(coretesting.LongWait):
+				c.Fatalf("timed out waiting for claim call")
+			}
+
+			// See above for what the 3 waiters are.
+			err := clock.WaitAdvance(duration, coretesting.LongWait, 3)
+			c.Assert(err, jc.ErrorIsNil)
+			duration *= 2
+		}
+
+		select {
+		case <-claimCalls:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for final claim call")
+		}
+
+		select {
+		case err := <-result:
+			c.Assert(errors.Cause(err), gc.Equals, corelease.ErrTimeout)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for result")
+		}
+
+		err = manager.Wait()
+		c.Assert(errors.Cause(err), gc.Equals, corelease.ErrTimeout)
+	})
 }

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -1,0 +1,210 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	corelease "github.com/juju/juju/core/lease"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/lease"
+)
+
+type leaseMap = map[corelease.Key]corelease.Info
+
+// AsyncSuite checks that expiries and claims that block don't prevent
+// subsequent updates.
+type AsyncSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&AsyncSuite{})
+
+func (s *AsyncSuite) SetUpTest(c *gc.C) {
+	logger := loggo.GetLogger("juju.worker.lease")
+	logger.SetLogLevel(loggo.TRACE)
+}
+
+func (s *AsyncSuite) TestExpirySlow(c *gc.C) {
+	// Ensure that even if an expiry is taking a long time, another
+	// expiry after it can still work.
+
+	slowStarted := make(chan struct{})
+	slowFinish := make(chan struct{})
+
+	quickFinished := make(chan struct{})
+
+	fix := Fixture{
+		leases: leaseMap{
+			key("thing1"): {
+				Holder: "holden",
+				Expiry: offset(-time.Second),
+			},
+			key("thing2"): {
+				Holder: "miller",
+				Expiry: offset(time.Second),
+			},
+		},
+
+		expectCalls: []call{{
+			method: "Refresh",
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{key("thing1")},
+			err:    corelease.ErrInvalid,
+			parallelCallback: func(mu *sync.Mutex, leases leaseMap) {
+				mu.Lock()
+				delete(leases, key("thing1"))
+				mu.Unlock()
+
+				select {
+				case slowStarted <- struct{}{}:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out sending slowStarted")
+				}
+				select {
+				case <-slowFinish:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out waiting for slowFinish")
+				}
+
+			},
+		}, {
+			method: "Refresh",
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{key("thing2")},
+			callback: func(leases leaseMap) {
+				delete(leases, key("thing2"))
+				close(quickFinished)
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		select {
+		case <-slowStarted:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for slowStarted")
+		}
+		err := clock.WaitAdvance(time.Second, coretesting.LongWait, 1)
+		c.Assert(err, jc.ErrorIsNil)
+
+		select {
+		case <-quickFinished:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for quickFinished")
+		}
+
+		close(slowFinish)
+
+	})
+}
+
+func (s *AsyncSuite) TestExpiryTimeout(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
+func (s *AsyncSuite) TestClaimSlow(c *gc.C) {
+	slowStarted := make(chan struct{})
+	slowFinish := make(chan struct{})
+
+	fix := Fixture{
+		leases: leaseMap{
+			key("dmdc"): {
+				Holder: "terry",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args: []interface{}{
+				key("dmdc"),
+				corelease.Request{"terry", time.Minute},
+			},
+			err: corelease.ErrInvalid,
+			parallelCallback: func(mu *sync.Mutex, leases leaseMap) {
+				select {
+				case slowStarted <- struct{}{}:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out sending slowStarted")
+				}
+				select {
+				case <-slowFinish:
+				case <-time.After(coretesting.LongWait):
+					c.Fatalf("timed out waiting for slowFinish")
+				}
+				mu.Lock()
+				leases[key("dmdc")] = corelease.Info{
+					Holder: "lance",
+					Expiry: offset(time.Minute),
+				}
+				mu.Unlock()
+			},
+		}, {
+			method: "ClaimLease",
+			args: []interface{}{
+				key("antiquisearchers"),
+				corelease.Request{"art", time.Minute},
+			},
+			callback: func(leases leaseMap) {
+				leases[key("antiquisearchers")] = corelease.Info{
+					Holder: "art",
+					Expiry: offset(time.Minute),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testing.Clock) {
+		claimer, err := manager.Claimer("namespace", "modelUUID")
+		c.Assert(err, jc.ErrorIsNil)
+
+		response1 := make(chan error)
+		go func() {
+			response1 <- claimer.Claim("dmdc", "terry", time.Minute)
+		}()
+
+		select {
+		case <-slowStarted:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for slowStarted")
+		}
+
+		response2 := make(chan error)
+		go func() {
+			response2 <- claimer.Claim("antiquisearchers", "art", time.Minute)
+		}()
+
+		// We should be able to get the response for the second claim
+		// even though the first hasn't come back yet.
+		select {
+		case err := <-response2:
+			c.Assert(err, jc.ErrorIsNil)
+		case <-response1:
+			c.Fatalf("response1 was ready")
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for response2")
+		}
+
+		close(slowFinish)
+
+		// Now response1 should come back.
+		select {
+		case err := <-response1:
+			c.Assert(errors.Cause(err), gc.Equals, corelease.ErrClaimDenied)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for response1")
+		}
+	})
+}
+
+func (s *AsyncSuite) TestClaimTimeout(c *gc.C) {
+	c.Fatalf("writeme")
+}


### PR DESCRIPTION
## Description of change
The raft-based lease store will potentially return timeouts for write operations that happen while the leader is changing. This is because the requests are forwarded over the pubsub hub to the leader - since the hub isn't a guaranteed-delivery system if there's no raft forwarder running the request will be dropped on the floor, and no response will ever be sent. The store will eventually return a timeout in this case.

That means that the lease manager needs to be able to run those requests asynchronously so they don't block handling subsequent requests (after the raft leadership has transferred successfully). It also retries operations that timeout, up to 5 times with exponential backoff. 

## QA steps
This doesn't/shouldn't change behaviour when the lease store operations aren't timing out. Smoke test by bootstrapping a controller, deploying some applications with mutiple units, enabling HA.
