### PR TITLE
Transition lock to post upgrade statuses on `juju upgrade-series` complete.

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -719,7 +719,7 @@ func (s *unitSuite) TestUpgradeSeriesStatusIsInitializedToUnitStarted(c *gc.C) {
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusFailsIfNoLockExists(c *gc.C) {
-	arbitaryStatus := string(model.UnitNotStarted)
+	arbitraryStatus := string(model.UnitNotStarted)
 
 	err := s.apiUnit.SetUpgradeSeriesStatus(arbitaryStatus)
 	c.Assert(err, gc.ErrorMatches, "machine \"[0-9]*\" is not locked for upgrade")
@@ -732,7 +732,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {
 	s.CreateUpgradeSeriesLock(c)
 
 	// Change the state to something other than the default remote state of UnitStarted
-	err := s.apiUnit.SetUpgradeSeriesStatus(arbitaryNonDefaultStatus)
+	err := s.apiUnit.SetUpgradeSeriesStatus(arbitraryNonDefaultStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check to see that the upgrade status has been set appropriately

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -721,12 +721,12 @@ func (s *unitSuite) TestUpgradeSeriesStatusIsInitializedToUnitStarted(c *gc.C) {
 func (s *unitSuite) TestSetUpgradeSeriesStatusFailsIfNoLockExists(c *gc.C) {
 	arbitraryStatus := string(model.UnitNotStarted)
 
-	err := s.apiUnit.SetUpgradeSeriesStatus(arbitaryStatus)
+	err := s.apiUnit.SetUpgradeSeriesStatus(arbitraryStatus)
 	c.Assert(err, gc.ErrorMatches, "machine \"[0-9]*\" is not locked for upgrade")
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {
-	arbitaryNonDefaultStatus := string(model.UnitNotStarted)
+	arbitraryNonDefaultStatus := string(model.UnitNotStarted)
 
 	// First we create the prepare lock or the required state will not exists
 	s.CreateUpgradeSeriesLock(c)
@@ -738,7 +738,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {
 	// Check to see that the upgrade status has been set appropriately
 	status, err := s.apiUnit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, arbitaryNonDefaultStatus)
+	c.Assert(status, gc.Equals, arbitraryNonDefaultStatus)
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusShouldOnlySetSpecifiedUnit(c *gc.C) {

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -464,6 +464,9 @@ func (mm *MachineManagerAPI) completeUpgradeSeries(arg params.UpdateSeriesArg) e
 	return machine.CompleteUpgradeSeries()
 }
 
+// [TODO](externalreality) We still need this, eventually the lock is going to cleaned up
+// RemoveUpgradeSeriesLock removes a series upgrade prepare lock for a
+// given machine.
 func (mm *MachineManagerAPI) removeUpgradeSeriesLock(arg params.UpdateSeriesArg) error {
 	machineTag, err := names.ParseMachineTag(arg.Entity.Tag)
 	if err != nil {

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -404,10 +404,14 @@ func (mm *MachineManagerAPI) UpgradeSeriesComplete(args params.UpdateSeriesArg) 
 	if err := mm.check.ChangeAllowed(); err != nil {
 		return params.ErrorResult{}, err
 	}
-	err := mm.removeUpgradeSeriesLock(args)
+	err := mm.completeUpgradeSeries(args)
 	if err != nil {
 		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}
+	// err := mm.removeUpgradeSeriesLock(args)
+	// if err != nil {
+	// 	return params.ErrorResult{Error: common.ServerError(err)}, nil
+	// }
 
 	return params.ErrorResult{}, nil
 }
@@ -450,6 +454,18 @@ func (mm *MachineManagerAPI) updateOneMachineSeries(arg params.UpdateSeriesArg) 
 		return nil // no-op
 	}
 	return machine.UpdateMachineSeries(arg.Series, arg.Force)
+}
+
+func (mm *MachineManagerAPI) completeUpgradeSeries(arg params.UpdateSeriesArg) error {
+	machineTag, err := names.ParseMachineTag(arg.Entity.Tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	machine, err := mm.st.Machine(machineTag.Id())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return machine.CompleteUpgradeSeries()
 }
 
 func (mm *MachineManagerAPI) removeUpgradeSeriesLock(arg params.UpdateSeriesArg) error {

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -408,10 +408,6 @@ func (mm *MachineManagerAPI) UpgradeSeriesComplete(args params.UpdateSeriesArg) 
 	if err != nil {
 		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}
-	// err := mm.removeUpgradeSeriesLock(args)
-	// if err != nil {
-	// 	return params.ErrorResult{Error: common.ServerError(err)}, nil
-	// }
 
 	return params.ErrorResult{}, nil
 }

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -454,6 +454,17 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareRemoveLockAfterFail(c *gc.
 	// TODO managed upgrade series
 }
 
+func (s *MachineManagerSuite) TestUpgradeSeriesComplete(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	_, err := apiV5.UpgradeSeriesComplete(
+		params.UpdateSeriesArg{
+			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type mockState struct {
 	machinemanager.Backend
 	calls            int
@@ -631,6 +642,11 @@ func (m *mockMachine) CreateUpgradeSeriesLock(unitTags []string, series string) 
 
 func (m *mockMachine) RemoveUpgradeSeriesLock() error {
 	m.MethodCall(m, "RemoveUpgradeSeriesLock")
+	return m.NextErr()
+}
+
+func (m *mockMachine) CompleteUpgradeSeries() error {
+	m.MethodCall(m, "CompleteUpgradeSeries")
 	return m.NextErr()
 }
 

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -46,6 +46,7 @@ type Machine interface {
 	UpdateMachineSeries(string, bool) error
 	CreateUpgradeSeriesLock([]string, string) error
 	RemoveUpgradeSeriesLock() error
+	CompleteUpgradeSeries() error
 	VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error)
 	Principals() []string
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -2270,11 +2270,9 @@ func completeUpgradeSeriesTxnOps(machineDocID string) []txn.Op {
 			Assert: isAliveDoc,
 		},
 		{
-			C:  machineUpgradeSeriesLocksC,
-			Id: machineDocID,
-			Assert: bson.D{{"$and", []bson.D{
-				{{"prepare-units.status", model.UnitCompleted}},
-				{{"complete-units.status", model.UnitNotStarted}}}}},
+			C:      machineUpgradeSeriesLocksC,
+			Id:     machineDocID,
+			Assert: bson.D{{"prepare-status", model.MachineSeriesUpgradeComplete}},
 			Update: bson.D{{"$set",
 				bson.D{{"complete-units.$[].status", model.UnitStarted},
 					{"complete-status", model.MachineSeriesUpgradeComplete}}},
@@ -2351,12 +2349,7 @@ func (m *Machine) isUpgradeSeriesPrepareComplete() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, prepareUnitStatus := range lock.PrepareUnits {
-		if prepareUnitStatus.Status != model.UnitCompleted {
-			return false, nil
-		}
-	}
-	return true, nil
+	return lock.PrepareStatus == model.MachineSeriesUpgradeComplete, nil
 }
 
 // UpdateOperation returns a model operation that will update the machine.

--- a/state/machine.go
+++ b/state/machine.go
@@ -2389,7 +2389,7 @@ func (m *Machine) IsLocked() (bool, error) {
 		return false, nil
 	}
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("cannot get upgrade series lock for machine %v: %v", m.Id(), err)
 	}
 	return true, nil
 }
@@ -2435,7 +2435,7 @@ func (m *Machine) getUpgradeSeriesLock() (*upgradeSeriesLockDoc, error) {
 	var lock upgradeSeriesLockDoc
 	err := coll.FindId(m.Id()).One(&lock)
 	if err == mgo.ErrNotFound {
-		return nil, err
+		return nil, errors.BadRequestf("machine %q is not locked for upgrade", m)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot get upgrade series lock for machine %v: %v", m.Id(), err)

--- a/state/machine.go
+++ b/state/machine.go
@@ -2328,9 +2328,11 @@ func completeUpgradeSeriesTxnOps(machineDocID string, units []unitStatus) []txn.
 			Assert: isAliveDoc,
 		},
 		{
-			C:      machineUpgradeSeriesLocksC,
-			Id:     machineDocID,
-			Assert: bson.D{{"prepare-status", model.MachineSeriesUpgradeComplete}},
+			C:  machineUpgradeSeriesLocksC,
+			Id: machineDocID,
+			Assert: bson.D{{"$and", []bson.D{
+				{{"prepare-status", model.MachineSeriesUpgradeComplete}},
+				{{"complete-status", model.MachineSeriesUpgradeNotStarted}}}}},
 			Update: bson.D{{"$set",
 				bson.D{{"complete-units", units},
 					{"complete-status", model.MachineSeriesUpgradeComplete}}},

--- a/state/machine.go
+++ b/state/machine.go
@@ -2191,6 +2191,9 @@ func (m *Machine) CompleteUpgradeSeries() error {
 				return nil, errors.Trace(err)
 			}
 		}
+		if err := m.isStillAlive(); err != nil {
+			return nil, errors.Trace(err)
+		}
 		completed, err := m.isUpgradeSeriesPrepareComplete()
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/state/machine.go
+++ b/state/machine.go
@@ -2157,6 +2157,7 @@ func (m *Machine) prepareUpgradeSeriesLock(unitNames []string, toSeries string) 
 	}
 }
 
+// [TODO](externalreality) We still need this, eventually the lock is going to cleaned up
 // RemoveUpgradeSeriesLock removes a series upgrade prepare lock for a
 // given machine.
 func (m *Machine) RemoveUpgradeSeriesLock() error {
@@ -2354,7 +2355,6 @@ func createUpgradeSeriesLockTxnOps(machineDocId string, data *upgradeSeriesLockD
 	}
 }
 
-// [TODO](externalreality) We still need this, eventually the lock is going to cleaned up
 func removeUpgradeSeriesLockTxnOps(machineDocId string) []txn.Op {
 	return []txn.Op{
 		{

--- a/state/machine.go
+++ b/state/machine.go
@@ -2299,6 +2299,7 @@ func createUpgradeSeriesLockTxnOps(machineDocId string, data *upgradeSeriesLockD
 	}
 }
 
+// [TODO](externalreality) We still need this, eventually the lock is going to cleaned up
 func removeUpgradeSeriesLockTxnOps(machineDocId string) []txn.Op {
 	return []txn.Op{
 		{

--- a/state/machine.go
+++ b/state/machine.go
@@ -2184,6 +2184,10 @@ func (m *Machine) RemoveUpgradeSeriesLock() error {
 	return nil
 }
 
+func (m *Machine) CompleteUpgradeSeries() error {
+	return nil
+}
+
 // UpgradeSeriesStatus returns the status of a series upgrade.
 func (m *Machine) UpgradeSeriesStatus(unitName string) (model.UnitSeriesUpgradeStatus, error) {
 	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)

--- a/state/machine.go
+++ b/state/machine.go
@@ -2389,7 +2389,7 @@ func setUpgradeSeriesTxnOps(machineDocId, unitName string, unitIndex int, status
 	}
 }
 
-// IsLocked determines if a machine is locked for upgrade series prepare.
+// IsLocked determines if a machine is locked for upgrade series.
 func (m *Machine) IsLocked() (bool, error) {
 	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
 	defer closer()

--- a/state/machine.go
+++ b/state/machine.go
@@ -2384,7 +2384,11 @@ func setUpgradeSeriesTxnOps(machineDocId, unitName string, unitIndex int, status
 
 // IsLocked determines if a machine is locked for upgrade series prepare.
 func (m *Machine) IsLocked() (bool, error) {
-	_, err := m.getUpgradeSeriesLock()
+	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
+	defer closer()
+
+	var lock upgradeSeriesLockDoc
+	err := coll.FindId(m.Id()).One(&lock)
 	if err == mgo.ErrNotFound {
 		return false, nil
 	}

--- a/state/machine.go
+++ b/state/machine.go
@@ -2185,6 +2185,8 @@ func (m *Machine) RemoveUpgradeSeriesLock() error {
 	return nil
 }
 
+// CompleteUpgradeSeries notifies units and machines that and upgrade series is
+// ready for its "completion" phase.
 func (m *Machine) CompleteUpgradeSeries() error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2692,7 +2692,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailWhenMachineIsNotComple
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()
-	assertMachineIsNotFinishedPreparing(c, err)
+	assertMachineIsNotReadyForCompletion(c, err)
 }
 
 func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareIsComplete(c *gc.C) {
@@ -2705,6 +2705,21 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareI
 
 	err = s.machine.CompleteUpgradeSeries()
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareIsComplete(c *gc.C) {
+	unit0 := s.addMachineUnit(c, s.machine)
+	err := s.machine.CreateUpgradeSeriesLock([]string{unit0.Name()}, "cosmic")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.SetMachineUpgradeSeriesStatus(model.MachineSeriesUpgradeComplete)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.CompleteUpgradeSeries()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.CompleteUpgradeSeries()
+	assertMachineIsNotReadyForCompletion(c, err)
 }
 
 func (s *MachineSuite) addMachineUnit(c *gc.C, mach *state.Machine) *state.Unit {
@@ -2728,8 +2743,8 @@ func (s *MachineSuite) addMachineUnit(c *gc.C, mach *state.Machine) *state.Unit 
 	return unit
 }
 
-func assertMachineIsNotFinishedPreparing(c *gc.C, err error) {
-	c.Assert(err, gc.ErrorMatches, "machine \"[0-9].*\" has not finished preparing")
+func assertMachineIsNotReadyForCompletion(c *gc.C, err error) {
+	c.Assert(err, gc.ErrorMatches, "machine \"[0-9].*\" can not complete, it is either not prepared or already completed")
 }
 
 func (s *MachineSuite) TestUnitsHaveChangedFalse(c *gc.C) {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2707,7 +2707,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareI
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareIsComplete(c *gc.C) {
+func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailIfAlreadyInCompleteState(c *gc.C) {
 	unit0 := s.addMachineUnit(c, s.machine)
 	err := s.machine.CreateUpgradeSeriesLock([]string{unit0.Name()}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Complete series hook should fire upon completion command `juju upgrade series complete <machine>`. 
