### PR TITLE
Introduce metering-url controller config option.

### DIFF
--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -12,6 +12,11 @@ import (
 )
 
 var sendMetrics = func(st metricsender.ModelBackend) error {
+	ccfg, err := st.ControllerConfig()
+	if err != nil {
+		return errors.Annotate(err, "failed to get controller config")
+	}
+	meteringURL := ccfg.MeteringURL()
 	cfg, err := st.ModelConfig()
 	if err != nil {
 		return errors.Annotatef(err, "failed to get model config for %s", st.ModelTag())
@@ -19,7 +24,7 @@ var sendMetrics = func(st metricsender.ModelBackend) error {
 
 	err = metricsender.SendMetrics(
 		st,
-		metricsender.DefaultMetricSender(),
+		metricsender.DefaultSenderFactory()(meteringURL),
 		clock.WallClock,
 		metricsender.DefaultMaxBatchesPerSend(),
 		cfg.TransmitVendorMetrics(),

--- a/apiserver/facades/agent/metricsender/export_test.go
+++ b/apiserver/facades/agent/metricsender/export_test.go
@@ -5,7 +5,9 @@ package metricsender
 import "github.com/juju/testing"
 
 func PatchHost(host string) func() {
-	restoreHost := testing.PatchValue(&metricsHost, host)
+	restoreHost := testing.PatchValue(&defaultSenderFactory, func(url string) MetricSender {
+		return &HTTPSender{url: host}
+	})
 	return func() {
 		restoreHost()
 	}

--- a/apiserver/facades/agent/metricsender/metricsender.go
+++ b/apiserver/facades/agent/metricsender/metricsender.go
@@ -22,9 +22,13 @@ type MetricSender interface {
 	Send([]*wireformat.MetricBatch) (*wireformat.Response, error)
 }
 
+type SenderFactory func(url string) MetricSender
+
 var (
-	defaultMaxBatchesPerSend              = 1000
-	defaultSender            MetricSender = &HTTPSender{}
+	defaultMaxBatchesPerSend               = 1000
+	defaultSenderFactory     SenderFactory = func(url string) MetricSender {
+		return &HTTPSender{url: url}
+	}
 )
 
 func handleModelResponse(st ModelBackend, modelUUID string, modelResp wireformat.EnvResponse) int {
@@ -174,9 +178,9 @@ func DefaultMaxBatchesPerSend() int {
 	return defaultMaxBatchesPerSend
 }
 
-// DefaultMetricSender returns the default metric sender.
-func DefaultMetricSender() MetricSender {
-	return defaultSender
+// DefaultSenderFactory returns the default sender factory.
+func DefaultSenderFactory() SenderFactory {
+	return defaultSenderFactory
 }
 
 // ToWire converts the state.MetricBatch into a type

--- a/apiserver/facades/agent/metricsender/sender.go
+++ b/apiserver/facades/agent/metricsender/sender.go
@@ -12,13 +12,10 @@ import (
 	wireformat "github.com/juju/romulus/wireformat/metrics"
 )
 
-var (
-	metricsHost string = "https://api.jujucharms.com/omnibus/v2/metrics"
-)
-
 // HTTPSender is the default used for sending
 // metrics to the collector service.
 type HTTPSender struct {
+	url string
 }
 
 // Send sends the given metrics to the collector service.
@@ -29,7 +26,7 @@ func (s *HTTPSender) Send(metrics []*wireformat.MetricBatch) (*wireformat.Respon
 	}
 	r := bytes.NewBuffer(b)
 	client := &http.Client{}
-	resp, err := client.Post(metricsHost, "application/json", r)
+	resp, err := client.Post(s.url, "application/json", r)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/metricsender/sender_test.go
+++ b/apiserver/facades/agent/metricsender/sender_test.go
@@ -67,8 +67,8 @@ func (s *SenderSuite) TestHTTPSender(c *gc.C) {
 	for i := range metrics {
 		metrics[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now})
 	}
-	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+	sender := metricsender.DefaultSenderFactory()("http://example.com")
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(receiverChan, gc.HasLen, metricCount)
@@ -148,8 +148,8 @@ func (s *SenderSuite) TestErrorCodes(c *gc.C) {
 		for i := range batches {
 			batches[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now})
 		}
-		var sender metricsender.HTTPSender
-		err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+		sender := metricsender.DefaultSenderFactory()("http://example.com")
+		err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 		c.Assert(err, gc.ErrorMatches, test.expectedErr)
 		for _, batch := range batches {
 			m, err := s.State.MetricBatch(batch.UUID())
@@ -177,8 +177,8 @@ func (s *SenderSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
 
-	var sender metricsender.HTTPSender
-	err = metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+	sender := metricsender.DefaultSenderFactory()("http://example.com")
+	err = metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err = s.unit.GetMeterStatus()
@@ -222,8 +222,8 @@ func (s *SenderSuite) TestMeterStatusInvalid(c *gc.C) {
 		c.Assert(status.Code, gc.Equals, state.MeterNotSet)
 	}
 
-	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+	sender := metricsender.DefaultSenderFactory()("http://example.com")
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err := unit1.GetMeterStatus()
@@ -244,8 +244,8 @@ func (s *SenderSuite) TestGracePeriodResponse(c *gc.C) {
 	_ = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false})
 	cleanup := s.startServer(c, testHandler(c, nil, nil, 47*time.Hour))
 	defer cleanup()
-	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+	sender := metricsender.DefaultSenderFactory()("http://example.com")
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -257,8 +257,8 @@ func (s *SenderSuite) TestNegativeGracePeriodResponse(c *gc.C) {
 
 	cleanup := s.startServer(c, testHandler(c, nil, nil, -47*time.Hour))
 	defer cleanup()
-	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+	sender := metricsender.DefaultSenderFactory()("http://example.com")
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -270,8 +270,8 @@ func (s *SenderSuite) TestZeroGracePeriodResponse(c *gc.C) {
 
 	cleanup := s.startServer(c, testHandler(c, nil, nil, 0))
 	defer cleanup()
-	var sender metricsender.HTTPSender
-	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, &sender, s.clock, 10, true)
+	sender := metricsender.DefaultSenderFactory()("http://example.com")
+	err := metricsender.SendMetrics(TestSenderBackend{s.State, s.Model}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/metricsender/stateinterface.go
+++ b/apiserver/facades/agent/metricsender/stateinterface.go
@@ -8,6 +8,7 @@ package metricsender
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -25,5 +26,6 @@ type ModelBackend interface {
 	Unit(name string) (*state.Unit, error)
 	ModelTag() names.ModelTag
 	ModelConfig() (*config.Config, error)
+	ControllerConfig() (controller.Config, error)
 	SetModelMeterStatus(string, string) error
 }

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -836,6 +836,7 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 		"GetBlockForType",
 		"GetBlockForType",
 		"Model",
+		"ControllerConfig",
 		"ModelConfig",
 		"MetricsManager",
 	)

--- a/apiserver/facades/controller/metricsmanager/export_test.go
+++ b/apiserver/facades/controller/metricsmanager/export_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/metricsender"
 )
 
-func PatchSender(s metricsender.MetricSender) {
-	sender = s
+func (api *MetricsManagerAPI) PatchSender(s metricsender.MetricSender) func() {
+	prior := api.sender
+	api.sender = s
+	return func() {
+		api.sender = prior
+	}
 }

--- a/apiserver/facades/controller/metricsmanager/metricsmanager.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager.go
@@ -28,8 +28,7 @@ import (
 var (
 	logger            = loggo.GetLogger("juju.apiserver.metricsmanager")
 	maxBatchesPerSend = metricsender.DefaultMaxBatchesPerSend()
-
-	sender = metricsender.DefaultMetricSender()
+	senderFactory     = metricsender.DefaultSenderFactory()
 )
 
 // MetricsManager defines the methods on the metricsmanager API end point.
@@ -46,6 +45,7 @@ type MetricsManagerAPI struct {
 	model       *state.Model
 	accessModel common.GetAuthFunc
 	clock       clock.Clock
+	sender      metricsender.MetricSender
 }
 
 var _ MetricsManager = (*MetricsManagerAPI)(nil)
@@ -93,12 +93,21 @@ func NewMetricsManagerAPI(
 		}, nil
 	}
 
+	config, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	sender := senderFactory(config.MeteringURL() + "/metrics")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &MetricsManagerAPI{
 		state:       st,
 		pool:        pool,
 		model:       m,
 		accessModel: accessModel,
 		clock:       clock,
+		sender:      sender,
 	}, nil
 }
 
@@ -239,7 +248,7 @@ func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorRes
 		if err != nil {
 			return result, errors.Trace(err)
 		}
-		err = metricsender.SendMetrics(modelBackend{modelState, model}, sender, api.clock, maxBatchesPerSend, txVendorMetrics)
+		err = metricsender.SendMetrics(modelBackend{modelState, model}, api.sender, api.clock, maxBatchesPerSend, txVendorMetrics)
 		if err != nil {
 			err = errors.Annotatef(err, "failed to send metrics for %s", tag)
 			logger.Warningf("%v", err)

--- a/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager_test.go
@@ -123,7 +123,8 @@ func (s *metricsManagerSuite) TestCleanupArgsIndependent(c *gc.C) {
 
 func (s *metricsManagerSuite) TestSendMetrics(c *gc.C) {
 	var sender testing.MockSender
-	metricsmanager.PatchSender(&sender)
+	cleanup := s.metricsmanager.PatchSender(&sender)
+	defer cleanup()
 	now := time.Now()
 	metric := state.Metric{Key: "pings", Value: "5", Time: now}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: []state.Metric{metric}})
@@ -171,7 +172,8 @@ func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
 	now := time.Now()
 	metric := state.Metric{Key: "pings", Value: "5", Time: now}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: []state.Metric{metric}})
-	metricsmanager.PatchSender(&sender)
+	cleanup := s.metricsmanager.PatchSender(&sender)
+	defer cleanup()
 	args := params.Entities{Entities: []params.Entity{
 		{s.Model.ModelTag().String()},
 	}}
@@ -191,7 +193,8 @@ func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
 	pastTime := s.clock.Now().Add(-time.Second)
 	metric := state.Metric{Key: "pings", Value: "5", Time: pastTime}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &pastTime, Metrics: []state.Metric{metric}})
-	metricsmanager.PatchSender(&sender)
+	cleanup := s.metricsmanager.PatchSender(&sender)
+	defer cleanup()
 	args := params.Entities{Entities: []params.Entity{
 		{s.Model.ModelTag().String()},
 	}}
@@ -205,7 +208,8 @@ func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
 
 func (s *metricsManagerSuite) TestLastSuccessfulNotChangedIfNothingToSend(c *gc.C) {
 	var sender testing.MockSender
-	metricsmanager.PatchSender(&sender)
+	cleanup := s.metricsmanager.PatchSender(&sender)
+	defer cleanup()
 	args := params.Entities{Entities: []params.Entity{
 		{s.Model.ModelTag().String()},
 	}}
@@ -289,7 +293,8 @@ func (s *metricsManagerSuite) TestSendMetricsMachineMetrics(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeMachine(c, nil)
 	var sender testing.MockSender
-	metricsmanager.PatchSender(&sender)
+	cleanup := s.metricsmanager.PatchSender(&sender)
+	defer cleanup()
 	args := params.Entities{Entities: []params.Entity{
 		{s.Model.ModelTag().String()},
 	}}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/model"
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
@@ -41,7 +42,7 @@ type DestroySuite struct {
 
 var _ = gc.Suite(&DestroySuite{})
 
-// fakeDestroyAPI mocks out the cient API
+// fakeDestroyAPI mocks out the client API
 type fakeAPI struct {
 	*jutesting.Stub
 	err             error
@@ -119,7 +120,10 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.sleep = func(time.Duration) {}
 
 	s.budgetAPIClient = &mockBudgetAPIClient{Stub: s.stub}
-	s.PatchValue(model.GetBudgetAPIClient, func(*httpbakery.Client) model.BudgetAPIClient { return s.budgetAPIClient })
+	s.PatchValue(model.GetBudgetAPIClient,
+		func(string, *httpbakery.Client) (model.BudgetAPIClient, error) { return s.budgetAPIClient, nil })
+	s.PatchValue(&rcmd.GetMeteringURLForModelCmd,
+		func(*modelcmd.ModelCommandBase) (string, error) { return "http://example.com", nil })
 }
 
 func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context, error) {

--- a/cmd/juju/romulus/api.go
+++ b/cmd/juju/romulus/api.go
@@ -1,0 +1,42 @@
+package romulus
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// GetMeteringURLForModelCmd returns the controller-configured metering URL for
+// a given model command.
+var GetMeteringURLForModelCmd = getMeteringURLForModelCmdImpl
+
+// GetMeteringURLForControllerCmd returns the controller-configured metering URL for
+// a given controller command.
+var GetMeteringURLForControllerCmd = getMeteringURLForControllerCmdImpl
+
+func getMeteringURLForModelCmdImpl(c *modelcmd.ModelCommandBase) (string, error) {
+	controllerAPIRoot, err := c.NewControllerAPIRoot()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	controllerAPI := controller.NewClient(controllerAPIRoot)
+	controllerCfg, err := controllerAPI.ControllerConfig()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return controllerCfg.MeteringURL(), nil
+}
+
+func getMeteringURLForControllerCmdImpl(c *modelcmd.ControllerCommandBase) (string, error) {
+	controllerAPIRoot, err := c.NewAPIRoot()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	controllerAPI := controller.NewClient(controllerAPIRoot)
+	controllerCfg, err := controllerAPI.ControllerConfig()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return controllerCfg.MeteringURL(), nil
+}

--- a/cmd/juju/romulus/budget/budget_test.go
+++ b/cmd/juju/romulus/budget/budget_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/budget"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
@@ -62,6 +64,9 @@ func (s *budgetSuite) SetUpTest(c *gc.C) {
 	}
 	s.stub = &testing.Stub{}
 	s.mockAPI = newMockAPI(s.stub)
+	s.PatchValue(&rcmd.GetMeteringURLForModelCmd, func(c *modelcmd.ModelCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s *budgetSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {

--- a/cmd/juju/romulus/createwallet/createwallet.go
+++ b/cmd/juju/romulus/createwallet/createwallet.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/juju/romulus/api/budget"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -61,7 +62,11 @@ func (c *createWalletCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to create an http client")
 	}
-	api, err := newAPIClient(client)
+	apiRoot, err := rcmd.GetMeteringURLForControllerCmd(&c.ControllerCommandBase)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	api, err := newAPIClient(apiRoot, client)
 	if err != nil {
 		return errors.Annotate(err, "failed to create an api client")
 	}
@@ -75,9 +80,8 @@ func (c *createWalletCommand) Run(ctx *cmd.Context) error {
 
 var newAPIClient = newAPIClientImpl
 
-func newAPIClientImpl(c *httpbakery.Client) (apiClient, error) {
-	client := api.NewClient(c)
-	return client, nil
+func newAPIClientImpl(apiRoot string, c *httpbakery.Client) (apiClient, error) {
+	return api.NewClient(api.APIRoot(apiRoot), api.HTTPClient(c))
 }
 
 type apiClient interface {

--- a/cmd/juju/romulus/createwallet/createwallet_test.go
+++ b/cmd/juju/romulus/createwallet/createwallet_test.go
@@ -11,7 +11,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/createwallet"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -29,6 +31,9 @@ func (s *createWalletSuite) SetUpTest(c *gc.C) {
 	s.stub = &testing.Stub{}
 	s.mockAPI = newMockAPI(s.stub)
 	s.PatchValue(createwallet.NewAPIClient, createwallet.APIClientFnc(s.mockAPI))
+	s.PatchValue(&rcmd.GetMeteringURLForControllerCmd, func(c *modelcmd.ControllerCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s *createWalletSuite) TestCreateWallet(c *gc.C) {

--- a/cmd/juju/romulus/createwallet/export_test.go
+++ b/cmd/juju/romulus/createwallet/export_test.go
@@ -11,8 +11,8 @@ var (
 	NewAPIClient = &newAPIClient
 )
 
-func APIClientFnc(api apiClient) func(*httpbakery.Client) (apiClient, error) {
-	return func(*httpbakery.Client) (apiClient, error) {
+func APIClientFnc(api apiClient) func(string, *httpbakery.Client) (apiClient, error) {
+	return func(string, *httpbakery.Client) (apiClient, error) {
 		return api, nil
 	}
 }

--- a/cmd/juju/romulus/listplans/export_test.go
+++ b/cmd/juju/romulus/listplans/export_test.go
@@ -13,8 +13,8 @@ var (
 
 // APIClientFnc returns a function that returns the provided apiClient
 // and can be used to patch the NewAPIClient variable for tests.
-func APIClientFnc(api apiClient) func(client *httpbakery.Client) (apiClient, error) {
-	return func(*httpbakery.Client) (apiClient, error) {
+func APIClientFnc(api apiClient) func(string, *httpbakery.Client) (apiClient, error) {
+	return func(string, *httpbakery.Client) (apiClient, error) {
 		return api, nil
 	}
 }

--- a/cmd/juju/romulus/listwallets/export_test.go
+++ b/cmd/juju/romulus/listwallets/export_test.go
@@ -13,8 +13,8 @@ var (
 
 // APIClientFnc returns a function that returns the provided apiClient
 // and can be used to patch the NewAPIClient variable for tests.
-func APIClientFnc(api apiClient) func(*httpbakery.Client) (apiClient, error) {
-	return func(*httpbakery.Client) (apiClient, error) {
+func APIClientFnc(api apiClient) func(string, *httpbakery.Client) (apiClient, error) {
+	return func(string, *httpbakery.Client) (apiClient, error) {
 		return api, nil
 	}
 }

--- a/cmd/juju/romulus/listwallets/list-wallets.go
+++ b/cmd/juju/romulus/listwallets/list-wallets.go
@@ -16,6 +16,7 @@ import (
 	wireformat "github.com/juju/romulus/wireformat/budget"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -62,7 +63,11 @@ func (c *listWalletsCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to create an http client")
 	}
-	api, err := newAPIClient(client)
+	apiRoot, err := rcmd.GetMeteringURLForControllerCmd(&c.ControllerCommandBase)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	api, err := newAPIClient(apiRoot, client)
 	if err != nil {
 		return errors.Annotate(err, "failed to create an api client")
 	}
@@ -112,9 +117,8 @@ func formatTabular(writer io.Writer, value interface{}) error {
 
 var newAPIClient = newAPIClientImpl
 
-func newAPIClientImpl(c *httpbakery.Client) (apiClient, error) {
-	client := api.NewClient(c)
-	return client, nil
+func newAPIClientImpl(apiRoot string, c *httpbakery.Client) (apiClient, error) {
+	return api.NewClient(api.APIRoot(apiRoot), api.HTTPClient(c))
 }
 
 type apiClient interface {

--- a/cmd/juju/romulus/listwallets/list-wallets_test.go
+++ b/cmd/juju/romulus/listwallets/list-wallets_test.go
@@ -12,7 +12,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/listwallets"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -30,6 +32,9 @@ func (s *listWalletsSuite) SetUpTest(c *gc.C) {
 	s.stub = &testing.Stub{}
 	s.mockAPI = &mockapi{Stub: s.stub}
 	s.PatchValue(listwallets.NewAPIClient, listwallets.APIClientFnc(s.mockAPI))
+	s.PatchValue(&rcmd.GetMeteringURLForControllerCmd, func(c *modelcmd.ControllerCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s *listWalletsSuite) TestUnexpectedParameters(c *gc.C) {

--- a/cmd/juju/romulus/setplan/set_plan.go
+++ b/cmd/juju/romulus/setplan/set_plan.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 
 	"github.com/juju/juju/api/application"
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -92,7 +93,11 @@ func (c *setPlanCommand) requestMetricCredentials(client *application.Client, ct
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	authClient, err := newAuthorizationClient(api.HTTPClient(hc))
+	apiRoot, err := rcmd.GetMeteringURLForModelCmd(&c.ModelCommandBase)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	authClient, err := newAuthorizationClient(api.APIRoot(apiRoot), api.HTTPClient(hc))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/romulus/setplan/set_plan_test.go
+++ b/cmd/juju/romulus/setplan/set_plan_test.go
@@ -19,7 +19,9 @@ import (
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	"gopkg.in/macaroon.v2-unstable"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/setplan"
+	"github.com/juju/juju/cmd/modelcmd"
 	jjjtesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -62,6 +64,9 @@ func (s *setPlanCommandSuite) SetUpTest(c *gc.C) {
 	s.mockAPI = mockAPI
 
 	s.PatchValue(setplan.NewAuthorizationClient, setplan.APIClientFnc(s.mockAPI))
+	s.PatchValue(&rcmd.GetMeteringURLForModelCmd, func(c *modelcmd.ModelCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s setPlanCommandSuite) TestSetPlanCommand(c *gc.C) {

--- a/cmd/juju/romulus/setwallet/export_test.go
+++ b/cmd/juju/romulus/setwallet/export_test.go
@@ -11,8 +11,8 @@ var (
 	NewAPIClient = &newAPIClient
 )
 
-func APIClientFnc(api apiClient) func(*httpbakery.Client) (apiClient, error) {
-	return func(*httpbakery.Client) (apiClient, error) {
+func APIClientFnc(api apiClient) func(string, *httpbakery.Client) (apiClient, error) {
+	return func(string, *httpbakery.Client) (apiClient, error) {
 		return api, nil
 	}
 }

--- a/cmd/juju/romulus/setwallet/setwallet.go
+++ b/cmd/juju/romulus/setwallet/setwallet.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/juju/romulus/api/budget"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -62,7 +63,11 @@ func (c *setWalletCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to create an http client")
 	}
-	api, err := newAPIClient(client)
+	apiRoot, err := rcmd.GetMeteringURLForControllerCmd(&c.ControllerCommandBase)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	api, err := newAPIClient(apiRoot, client)
 	if err != nil {
 		return errors.Annotate(err, "failed to create an api client")
 	}
@@ -76,9 +81,8 @@ func (c *setWalletCommand) Run(ctx *cmd.Context) error {
 
 var newAPIClient = newAPIClientImpl
 
-func newAPIClientImpl(c *httpbakery.Client) (apiClient, error) {
-	client := api.NewClient(c)
-	return client, nil
+func newAPIClientImpl(apiRoot string, c *httpbakery.Client) (apiClient, error) {
+	return api.NewClient(api.APIRoot(apiRoot), api.HTTPClient(c))
 }
 
 type apiClient interface {

--- a/cmd/juju/romulus/setwallet/setwallet_test.go
+++ b/cmd/juju/romulus/setwallet/setwallet_test.go
@@ -11,7 +11,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/setwallet"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -29,6 +31,9 @@ func (s *setWalletSuite) SetUpTest(c *gc.C) {
 	s.stub = &testing.Stub{}
 	s.mockAPI = newMockAPI(s.stub)
 	s.PatchValue(setwallet.NewAPIClient, setwallet.APIClientFnc(s.mockAPI))
+	s.PatchValue(&rcmd.GetMeteringURLForControllerCmd, func(c *modelcmd.ControllerCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s *setWalletSuite) TestSetWallet(c *gc.C) {

--- a/cmd/juju/romulus/showwallet/export_test.go
+++ b/cmd/juju/romulus/showwallet/export_test.go
@@ -14,8 +14,8 @@ var (
 
 // WalletAPIClientFnc returns a function that returns the provided walletAPIClient
 // and can be used to patch the NewWalletAPIClient variable for tests.
-func WalletAPIClientFnc(api walletAPIClient) func(*httpbakery.Client) (walletAPIClient, error) {
-	return func(*httpbakery.Client) (walletAPIClient, error) {
+func WalletAPIClientFnc(api walletAPIClient) func(string, *httpbakery.Client) (walletAPIClient, error) {
+	return func(string, *httpbakery.Client) (walletAPIClient, error) {
 		return api, nil
 	}
 }

--- a/cmd/juju/romulus/showwallet/show_wallet.go
+++ b/cmd/juju/romulus/showwallet/show_wallet.go
@@ -16,6 +16,7 @@ import (
 	wireformat "github.com/juju/romulus/wireformat/budget"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -76,7 +77,11 @@ func (c *showWalletCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to create an http client")
 	}
-	api, err := newWalletAPIClient(client)
+	apiRoot, err := rcmd.GetMeteringURLForControllerCmd(&c.ControllerCommandBase)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	api, err := newWalletAPIClient(apiRoot, client)
 	if err != nil {
 		return errors.Annotate(err, "failed to create an api client")
 	}
@@ -144,9 +149,8 @@ func (c *showWalletCommand) modelNameMap() (map[string]string, error) {
 
 var newWalletAPIClient = newWalletAPIClientImpl
 
-func newWalletAPIClientImpl(c *httpbakery.Client) (walletAPIClient, error) {
-	client := api.NewClient(c)
-	return client, nil
+func newWalletAPIClientImpl(apiRoot string, c *httpbakery.Client) (walletAPIClient, error) {
+	return api.NewClient(api.APIRoot(apiRoot), api.HTTPClient(c))
 }
 
 type walletAPIClient interface {

--- a/cmd/juju/romulus/showwallet/show_wallet_test.go
+++ b/cmd/juju/romulus/showwallet/show_wallet_test.go
@@ -14,7 +14,9 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/showwallet"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -36,6 +38,9 @@ func (s *showWalletSuite) SetUpTest(c *gc.C) {
 	s.mockAPI = &mockAPI{s.stub}
 	s.PatchValue(showwallet.NewWalletAPIClient, showwallet.WalletAPIClientFnc(s.mockWalletAPI))
 	s.PatchValue(showwallet.NewJujuclientStore, newMockClientStore)
+	s.PatchValue(&rcmd.GetMeteringURLForControllerCmd, func(c *modelcmd.ControllerCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s *showWalletSuite) TestShowWalletCommand(c *gc.C) {

--- a/cmd/juju/romulus/sla/sla.go
+++ b/cmd/juju/romulus/sla/sla.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/cmd/juju/common"
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
@@ -136,7 +137,11 @@ func (c *slaCommand) requestSupportCredentials(modelUUID string) (string, string
 	if err != nil {
 		return fail(errors.Trace(err))
 	}
-	authClient, err := c.newAuthorizationClient(sla.HTTPClient(hc))
+	apiRoot, err := rcmd.GetMeteringURLForModelCmd(&c.ModelCommandBase)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	authClient, err := c.newAuthorizationClient(sla.APIRoot(apiRoot), sla.HTTPClient(hc))
 	if err != nil {
 		return fail(errors.Trace(err))
 	}

--- a/cmd/juju/romulus/sla/sla_test.go
+++ b/cmd/juju/romulus/sla/sla_test.go
@@ -21,7 +21,9 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 
 	"github.com/juju/juju/api"
+	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/juju/romulus/sla"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -49,6 +51,9 @@ func (s *supportCommandSuite) SetUpTest(c *gc.C) {
 	s.modelUUID = utils.MustNewUUID().String()
 	s.fakeAPIRoot = &fakeAPIConnection{model: s.modelUUID}
 	s.PatchValue(sla.NewJujuClientStore, s.newMockClientStore)
+	s.PatchValue(&rcmd.GetMeteringURLForModelCmd, func(c *modelcmd.ModelCommandBase) (string, error) {
+		return "http://example.com", nil
+	})
 }
 
 func (s *supportCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {

--- a/controller/config.go
+++ b/controller/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/romulus"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	utilscert "github.com/juju/utils/cert"
@@ -172,6 +173,9 @@ const (
 
 	// Features allows a list of runtime changeable features to be updated.
 	Features = "features"
+
+	// MeteringURL is the key for the url to use for metrics
+	MeteringURL = "metering-url"
 )
 
 var (
@@ -202,6 +206,7 @@ var (
 		AuditLogExcludeMethods,
 		CAASOperatorImagePath,
 		Features,
+		MeteringURL,
 	}
 
 	// AllowedUpdateConfigAttributes contains all of the controller
@@ -498,6 +503,15 @@ func (c Config) CAASOperatorImagePath() string {
 	return c.asString(CAASOperatorImagePath)
 }
 
+// MeteringURL returns the URL to use for metering api calls.
+func (c Config) MeteringURL() string {
+	url := c.asString(MeteringURL)
+	if url == "" {
+		return romulus.DefaultAPIRoot
+	}
+	return url
+}
+
 // Validate ensures that config is a valid configuration.
 func Validate(c Config) error {
 	if v, ok := c[IdentityPublicKey].(string); ok {
@@ -682,6 +696,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	CAASOperatorImagePath:   schema.String(),
 	Features:                schema.List(schema.String()),
 	CharmStoreURL:           schema.String(),
+	MeteringURL:             schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
 	AuditingEnabled:         DefaultAuditingEnabled,
@@ -705,4 +720,5 @@ var configChecker = schema.FieldMap(schema.Fields{
 	CAASOperatorImagePath:   schema.Omit,
 	Features:                schema.Omit,
 	CharmStoreURL:           csclient.ServerURL,
+	MeteringURL:             romulus.DefaultAPIRoot,
 })

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
+	"github.com/juju/romulus"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	utilscert "github.com/juju/utils/cert"
@@ -458,4 +459,27 @@ func (s *ConfigSuite) TestCharmstoreURLSettingValue(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.CharmStoreURL(), gc.Equals, csURL)
+}
+
+func (s *ConfigSuite) TestMeteringURLDefault(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.MeteringURL(), gc.Equals, romulus.DefaultAPIRoot)
+}
+
+func (s *ConfigSuite) TestMeteringURLSettingValue(c *gc.C) {
+	mURL := "http://homestarrunner.com/metering"
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			controller.MeteringURL: mURL,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MeteringURL(), gc.Equals, mURL)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -58,7 +58,7 @@ github.com/juju/ratelimit	git	5b9ff866471762aa2ab2dced63c9fb6f53921342	2017-05-2
 github.com/juju/replicaset	git	86037679224858cd82666e4877a8ac4c42cbda8b	2018-04-17T12:35:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/rfc	git	b058ad085c9480f110200bfe2309189aff5780b8	2018-05-10T11:21:17Z
-github.com/juju/romulus	git	5b6f449d5c36ed6927c417c68379ab5acb7d7b46	2018-03-27T20:54:18Z
+github.com/juju/romulus	git	958d8b71e5ffa51212133b12a998ddf8362739df	2018-07-24T15:51:44Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	72703b1e95eb8ce4737fd8a3d8496c6b0be280a6	2018-05-17T13:41:05Z

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -39,6 +39,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.CAASOperatorImagePath,
 		controller.CharmStoreURL,
 		controller.Features,
+		controller.MeteringURL,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
## Description of change

Remove need for patching, set controller config. Similar to juju/juju#8896, for metering functionality in Juju.

## QA steps

`juju controller-config metering-url="https://api.staging.jujucharms.com/omnibus/v3" charmstore-url="https://api.staging.jujucharms.com/omnibus/v3"`

Deploy metered charm, set SLAs, plans, verify meter status is set. SLA, plan, budget commands should use controller-in-context for resolving APIs. Use --debug with all romulus commands to ensure the configured metering-url is used.

## Documentation changes

None at this time. Initial use case is supporting internal QA of Juju's integration with these APIs.

## Bug reference

None.