### PR TITLE
ec2 provider reacts to invalid credential.

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -331,8 +331,8 @@ func (v *ebsVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params 
 
 	instances := make(instanceCache)
 	if instanceIds.Size() > 1 {
-		if err := instances.update(v.env.ec2, instanceIds.Values()...); err != nil {
-			err := maybeConvertCredentialError(err)
+		if err := instances.update(v.env.ec2, ctx, instanceIds.Values()...); err != nil {
+			err := maybeConvertCredentialError(err, ctx)
 			logger.Debugf("querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
@@ -348,7 +348,7 @@ func (v *ebsVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params 
 		if results[i].Error != nil {
 			continue
 		}
-		volume, attachment, err := v.createVolume(p, instances)
+		volume, attachment, err := v.createVolume(ctx, p, instances)
 		if err != nil {
 			results[i].Error = err
 			continue
@@ -359,14 +359,14 @@ func (v *ebsVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params 
 	return results, nil
 }
 
-func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanceCache) (_ *storage.Volume, _ *storage.VolumeAttachment, err error) {
+func (v *ebsVolumeSource) createVolume(ctx context.ProviderCallContext, p storage.VolumeParams, instances instanceCache) (_ *storage.Volume, _ *storage.VolumeAttachment, err error) {
 	var volumeId string
 	defer func() {
 		if err == nil || volumeId == "" {
 			return
 		}
 		if _, err := v.env.ec2.DeleteVolume(volumeId); err != nil {
-			logger.Errorf("error cleaning up volume %v: %v", volumeId, maybeConvertCredentialError(err))
+			logger.Errorf("error cleaning up volume %v: %v", volumeId, maybeConvertCredentialError(err, ctx))
 		}
 	}()
 
@@ -377,20 +377,20 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 
 	// Create.
 	instId := string(p.Attachment.InstanceId)
-	if err := instances.update(v.env.ec2, instId); err != nil {
-		return nil, nil, errors.Trace(maybeConvertCredentialError(err))
+	if err := instances.update(v.env.ec2, ctx, instId); err != nil {
+		return nil, nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	inst, err := instances.get(instId)
 	if err != nil {
 		// Can't create the volume without the instance,
 		// because we need to know what its AZ is.
-		return nil, nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	vol, _ := parseVolumeOptions(p.Size, p.Attributes)
 	vol.AvailZone = inst.AvailZone
 	resp, err := v.env.ec2.CreateVolume(vol)
 	if err != nil {
-		return nil, nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	volumeId = resp.Id
 
@@ -400,7 +400,7 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 		resourceTags[k] = v
 	}
 	resourceTags[tagName] = resourceName(p.Tag, v.envName)
-	if err := tagResources(v.env.ec2, resourceTags, volumeId); err != nil {
+	if err := tagResources(v.env.ec2, ctx, resourceTags, volumeId); err != nil {
 		return nil, nil, errors.Annotate(err, "tagging volume")
 	}
 
@@ -419,13 +419,13 @@ func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanc
 func (v *ebsVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
 	filter := ec2.NewFilter()
 	filter.Add("tag:"+tags.JujuModel, v.modelUUID)
-	return listVolumes(v.env.ec2, filter, false)
+	return listVolumes(v.env.ec2, ctx, filter, false)
 }
 
-func listVolumes(client *ec2.EC2, filter *ec2.Filter, includeRootDisks bool) ([]string, error) {
+func listVolumes(client *ec2.EC2, ctx context.ProviderCallContext, filter *ec2.Filter, includeRootDisks bool) ([]string, error) {
 	resp, err := client.Volumes(nil, filter)
 	if err != nil {
-		return nil, maybeConvertCredentialError(err)
+		return nil, maybeConvertCredentialError(err, ctx)
 	}
 	volumeIds := make([]string, 0, len(resp.Volumes))
 	for _, vol := range resp.Volumes {
@@ -456,7 +456,7 @@ func (v *ebsVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volId
 	// be rare.
 	resp, err := v.env.ec2.Volumes(volIds, nil)
 	if err != nil {
-		return nil, maybeConvertCredentialError(err)
+		return nil, maybeConvertCredentialError(err, ctx)
 	}
 	byId := make(map[string]ec2.Volume)
 	for _, vol := range resp.Volumes {
@@ -486,22 +486,22 @@ func (v *ebsVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volId
 
 // DestroyVolumes is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
-	return foreachVolume(v.env.ec2, volIds, destroyVolume), nil
+	return foreachVolume(v.env.ec2, ctx, volIds, destroyVolume), nil
 }
 
 // ReleaseVolumes is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
-	return foreachVolume(v.env.ec2, volIds, releaseVolume), nil
+	return foreachVolume(v.env.ec2, ctx, volIds, releaseVolume), nil
 }
 
-func foreachVolume(client *ec2.EC2, volIds []string, f func(*ec2.EC2, string) error) []error {
+func foreachVolume(client *ec2.EC2, ctx context.ProviderCallContext, volIds []string, f func(*ec2.EC2, context.ProviderCallContext, string) error) []error {
 	var wg sync.WaitGroup
 	wg.Add(len(volIds))
 	results := make([]error, len(volIds))
 	for i, volumeId := range volIds {
 		go func(i int, volumeId string) {
 			defer wg.Done()
-			results[i] = f(client, volumeId)
+			results[i] = f(client, ctx, volumeId)
 		}(i, volumeId)
 	}
 	wg.Wait()
@@ -513,7 +513,7 @@ var destroyVolumeAttempt = utils.AttemptStrategy{
 	Delay: 5 * time.Second,
 }
 
-func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
+func destroyVolume(client *ec2.EC2, ctx context.ProviderCallContext, volumeId string) (err error) {
 	defer func() {
 		if err != nil {
 			if ec2ErrCode(err) == volumeNotFound || errors.IsNotFound(err) {
@@ -524,7 +524,7 @@ func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
 				logger.Tracef("Ignoring error destroying volume %q: %v", volumeId, err)
 				err = nil
 			} else {
-				err = maybeConvertCredentialError(err)
+				err = maybeConvertCredentialError(err, ctx)
 			}
 		}
 	}()
@@ -534,7 +534,7 @@ func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
 	// Volumes must not be in-use when destroying. A volume may
 	// still be in-use when the instance it is attached to is
 	// in the process of being terminated.
-	volume, err := waitVolume(client, volumeId, destroyVolumeAttempt, func(volume *ec2.Volume) (bool, error) {
+	volume, err := waitVolume(client, ctx, volumeId, destroyVolumeAttempt, func(volume *ec2.Volume) (bool, error) {
 		if volume.Status != volumeStatusInUse {
 			// Volume is not in use, it should be OK to destroy now.
 			return true, nil
@@ -595,7 +595,7 @@ func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
 		if len(args) == 0 {
 			return false, nil
 		}
-		results, err := detachVolumes(client, args)
+		results, err := detachVolumes(client, ctx, args)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
@@ -619,12 +619,12 @@ func destroyVolume(client *ec2.EC2, volumeId string) (err error) {
 		return nil
 	}
 	_, err = client.DeleteVolume(volumeId)
-	return errors.Annotatef(maybeConvertCredentialError(err), "destroying %q", volumeId)
+	return errors.Annotatef(maybeConvertCredentialError(err, ctx), "destroying %q", volumeId)
 }
 
-func releaseVolume(client *ec2.EC2, volumeId string) error {
+func releaseVolume(client *ec2.EC2, ctx context.ProviderCallContext, volumeId string) error {
 	logger.Debugf("releasing %q", volumeId)
-	_, err := waitVolume(client, volumeId, destroyVolumeAttempt, func(volume *ec2.Volume) (bool, error) {
+	_, err := waitVolume(client, ctx, volumeId, destroyVolumeAttempt, func(volume *ec2.Volume) (bool, error) {
 		if volume.Status == volumeStatusAvailable {
 			return true, nil
 		}
@@ -643,7 +643,7 @@ func releaseVolume(client *ec2.EC2, volumeId string) error {
 		if err == errWaitVolumeTimeout {
 			return errors.Errorf("timed out waiting for volume %v to become available", volumeId)
 		}
-		return errors.Annotatef(maybeConvertCredentialError(err), "cannot release volume %q", volumeId)
+		return errors.Annotatef(maybeConvertCredentialError(err, ctx), "cannot release volume %q", volumeId)
 	}
 	// Releasing the volume just means dropping the
 	// tags that associate it with the model and
@@ -652,7 +652,7 @@ func releaseVolume(client *ec2.EC2, volumeId string) error {
 		tags.JujuModel:      "",
 		tags.JujuController: "",
 	}
-	return errors.Annotate(tagResources(client, tags, volumeId), "tagging volume")
+	return errors.Annotate(tagResources(client, ctx, tags, volumeId), "tagging volume")
 }
 
 // ValidateVolumeParams is specified on the storage.VolumeSource interface.
@@ -704,8 +704,8 @@ func (v *ebsVolumeSource) AttachVolumes(ctx context.ProviderCallContext, attachP
 		instIds.Add(string(p.InstanceId))
 	}
 	instances := make(instanceCache)
-	if err := instances.update(v.env.ec2, instIds.Values()...); err != nil {
-		err := maybeConvertCredentialError(err)
+	if err := instances.update(v.env.ec2, ctx, instIds.Values()...); err != nil {
+		err := maybeConvertCredentialError(err, ctx)
 		logger.Debugf("querying running instances: %v", err)
 		// We ignore the error, because we don't want an invalid
 		// InstanceId reference from one VolumeParams to prevent
@@ -721,7 +721,7 @@ func (v *ebsVolumeSource) AttachVolumes(ctx context.ProviderCallContext, attachP
 		instId := string(params.InstanceId)
 		inst, err := instances.get(instId)
 		if err != nil {
-			results[i].Error = maybeConvertCredentialError(err)
+			results[i].Error = maybeConvertCredentialError(err, ctx)
 			continue
 		}
 
@@ -735,9 +735,9 @@ func (v *ebsVolumeSource) AttachVolumes(ctx context.ProviderCallContext, attachP
 		// must error if used with an "hvm" instance type.
 		const numbers = false
 		nextDeviceName := blockDeviceNamer(numbers)
-		_, deviceName, err := v.attachOneVolume(nextDeviceName, params.VolumeId, instId)
+		_, deviceName, err := v.attachOneVolume(ctx, nextDeviceName, params.VolumeId, instId)
 		if err != nil {
-			results[i].Error = maybeConvertCredentialError(err)
+			results[i].Error = maybeConvertCredentialError(err, ctx)
 			continue
 		}
 
@@ -773,13 +773,14 @@ func (v *ebsVolumeSource) AttachVolumes(ctx context.ProviderCallContext, attachP
 }
 
 func (v *ebsVolumeSource) attachOneVolume(
+	ctx context.ProviderCallContext,
 	nextDeviceName func() (string, string, error),
 	volumeId, instId string,
 ) (string, string, error) {
 	// Wait for the volume to move out of "creating".
-	volume, err := v.waitVolumeCreated(volumeId)
+	volume, err := v.waitVolumeCreated(ctx, volumeId)
 	if err != nil {
-		return "", "", errors.Trace(maybeConvertCredentialError(err))
+		return "", "", errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 
 	// Possible statuses:
@@ -832,19 +833,19 @@ func (v *ebsVolumeSource) attachOneVolume(
 			}
 		}
 		if err != nil {
-			return "", "", errors.Annotate(maybeConvertCredentialError(err), "attaching volume")
+			return "", "", errors.Annotate(maybeConvertCredentialError(err, ctx), "attaching volume")
 		}
 		return requestDeviceName, actualDeviceName, nil
 	}
 }
 
-func (v *ebsVolumeSource) waitVolumeCreated(volumeId string) (*ec2.Volume, error) {
+func (v *ebsVolumeSource) waitVolumeCreated(ctx context.ProviderCallContext, volumeId string) (*ec2.Volume, error) {
 	var attempt = utils.AttemptStrategy{
 		Total: 5 * time.Second,
 		Delay: 200 * time.Millisecond,
 	}
 	var lastStatus string
-	volume, err := waitVolume(v.env.ec2, volumeId, attempt, func(volume *ec2.Volume) (bool, error) {
+	volume, err := waitVolume(v.env.ec2, ctx, volumeId, attempt, func(volume *ec2.Volume) (bool, error) {
 		lastStatus = volume.Status
 		return volume.Status != volumeStatusCreating, nil
 	})
@@ -854,7 +855,7 @@ func (v *ebsVolumeSource) waitVolumeCreated(volumeId string) (*ec2.Volume, error
 			volumeId, lastStatus,
 		)
 	} else if err != nil {
-		return nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	return volume, nil
 }
@@ -863,12 +864,13 @@ var errWaitVolumeTimeout = errors.New("timed out")
 
 func waitVolume(
 	client *ec2.EC2,
+	ctx context.ProviderCallContext,
 	volumeId string,
 	attempt utils.AttemptStrategy,
 	pred func(v *ec2.Volume) (bool, error),
 ) (*ec2.Volume, error) {
 	for a := attempt.Start(); a.Next(); {
-		volume, err := describeVolume(client, volumeId)
+		volume, err := describeVolume(client, ctx, volumeId)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -883,10 +885,10 @@ func waitVolume(
 	return nil, errWaitVolumeTimeout
 }
 
-func describeVolume(client *ec2.EC2, volumeId string) (*ec2.Volume, error) {
+func describeVolume(client *ec2.EC2, ctx context.ProviderCallContext, volumeId string) (*ec2.Volume, error) {
 	resp, err := client.Volumes([]string{volumeId}, nil)
 	if err != nil {
-		return nil, errors.Annotate(maybeConvertCredentialError(err), "querying volume")
+		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "querying volume")
 	}
 	if len(resp.Volumes) == 0 {
 		return nil, errors.NotFoundf("%v", volumeId)
@@ -898,7 +900,7 @@ func describeVolume(client *ec2.EC2, volumeId string) (*ec2.Volume, error) {
 
 type instanceCache map[string]ec2.Instance
 
-func (c instanceCache) update(ec2client *ec2.EC2, ids ...string) error {
+func (c instanceCache) update(ec2client *ec2.EC2, ctx context.ProviderCallContext, ids ...string) error {
 	if len(ids) == 1 {
 		if _, ok := c[ids[0]]; ok {
 			return nil
@@ -908,7 +910,7 @@ func (c instanceCache) update(ec2client *ec2.EC2, ids ...string) error {
 	filter.Add("instance-state-name", "running")
 	resp, err := ec2client.Instances(ids, filter)
 	if err != nil {
-		return errors.Annotate(maybeConvertCredentialError(err), "querying instance details")
+		return errors.Annotate(maybeConvertCredentialError(err, ctx), "querying instance details")
 	}
 	for j := range resp.Reservations {
 		r := &resp.Reservations[j]
@@ -929,10 +931,10 @@ func (c instanceCache) get(id string) (ec2.Instance, error) {
 
 // DetachVolumes is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) DetachVolumes(ctx context.ProviderCallContext, attachParams []storage.VolumeAttachmentParams) ([]error, error) {
-	return detachVolumes(v.env.ec2, attachParams)
+	return detachVolumes(v.env.ec2, ctx, attachParams)
 }
 
-func detachVolumes(client *ec2.EC2, attachParams []storage.VolumeAttachmentParams) ([]error, error) {
+func detachVolumes(client *ec2.EC2, ctx context.ProviderCallContext, attachParams []storage.VolumeAttachmentParams) ([]error, error) {
 	results := make([]error, len(attachParams))
 	for i, params := range attachParams {
 		_, err := client.DetachVolume(params.VolumeId, string(params.InstanceId), "", false)
@@ -952,7 +954,7 @@ func detachVolumes(client *ec2.EC2, attachParams []storage.VolumeAttachmentParam
 		}
 		if err != nil {
 			results[i] = errors.Annotatef(
-				maybeConvertCredentialError(err), "detaching %s from %s",
+				maybeConvertCredentialError(err, ctx), "detaching %s from %s",
 				names.ReadableString(params.Volume),
 				names.ReadableString(params.Machine),
 			)
@@ -966,7 +968,7 @@ func (v *ebsVolumeSource) ImportVolume(ctx context.ProviderCallContext, volumeId
 	resp, err := v.env.ec2.Volumes([]string{volumeId}, nil)
 	if err != nil {
 		// TODO(axw) check for "not found" response, massage error message?
-		return storage.VolumeInfo{}, maybeConvertCredentialError(err)
+		return storage.VolumeInfo{}, maybeConvertCredentialError(err, ctx)
 	}
 	if len(resp.Volumes) != 1 {
 		return storage.VolumeInfo{}, errors.Errorf("expected 1 volume result, got %d", len(resp.Volumes))
@@ -975,7 +977,7 @@ func (v *ebsVolumeSource) ImportVolume(ctx context.ProviderCallContext, volumeId
 	if vol.Status != volumeStatusAvailable {
 		return storage.VolumeInfo{}, errors.Errorf("cannot import volume with status %q", vol.Status)
 	}
-	if err := tagResources(v.env.ec2, tags, volumeId); err != nil {
+	if err := tagResources(v.env.ec2, ctx, tags, volumeId); err != nil {
 		return storage.VolumeInfo{}, errors.Annotate(err, "tagging volume")
 	}
 	return storage.VolumeInfo{

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -252,7 +252,7 @@ func (s *ebsSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, instanc
 	c.Assert(ec2Vols.Volumes[4].Size, gc.Equals, 50)
 }
 
-var deleteSecurityGroupForTestFunc = func(inst ec2.SecurityGroupCleaner, group awsec2.SecurityGroup, _ clock.Clock) error {
+var deleteSecurityGroupForTestFunc = func(inst ec2.SecurityGroupCleaner, ctx context.ProviderCallContext, group awsec2.SecurityGroup, _ clock.Clock) error {
 	// With an exponential retry for deleting security groups,
 	// we never return from local live tests.
 	// No need to re-try in tests anyway - just call delete.

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -110,27 +110,30 @@ func (e *environ) Name() string {
 
 // PrepareForBootstrap is part of the Environ interface.
 func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	callCtx := context.NewCloudCallContext()
+	// Cannot really invalidate a credential here since nothing is bootstrapped yet.
+	callCtx.InvalidateCredentialFunc = func(string) error { return nil }
 	if ctx.ShouldVerifyCredentials() {
-		if err := verifyCredentials(env); err != nil {
+		if err := verifyCredentials(env, callCtx); err != nil {
 			return err
 		}
 	}
 	ecfg := env.ecfg()
 	vpcID, forceVPCID := ecfg.vpcID(), ecfg.forceVPCID()
-	if err := validateBootstrapVPC(env.ec2, env.cloud.Region, vpcID, forceVPCID, ctx); err != nil {
-		return errors.Trace(maybeConvertCredentialError(err))
+	if err := validateBootstrapVPC(env.ec2, callCtx, env.cloud.Region, vpcID, forceVPCID, ctx); err != nil {
+		return errors.Trace(maybeConvertCredentialError(err, callCtx))
 	}
 	return nil
 }
 
 // Create is part of the Environ interface.
 func (env *environ) Create(ctx context.ProviderCallContext, args environs.CreateParams) error {
-	if err := verifyCredentials(env); err != nil {
+	if err := verifyCredentials(env, ctx); err != nil {
 		return err
 	}
 	vpcID := env.ecfg().vpcID()
-	if err := validateModelVPC(env.ec2, env.name, vpcID); err != nil {
-		return errors.Trace(maybeConvertCredentialError(err))
+	if err := validateModelVPC(env.ec2, ctx, env.name, vpcID); err != nil {
+		return errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	// TODO(axw) 2016-08-04 #1609643
 	// Create global security group(s) here.
@@ -140,7 +143,7 @@ func (env *environ) Create(ctx context.ProviderCallContext, args environs.Create
 // Bootstrap is part of the Environ interface.
 func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	r, err := common.Bootstrap(ctx, e, callCtx, args)
-	return r, maybeConvertCredentialError(err)
+	return r, maybeConvertCredentialError(err, callCtx)
 }
 
 // SupportsSpaces is specified on environs.Networking.
@@ -172,7 +175,7 @@ func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 		[]string{constraints.InstanceType},
 		[]string{constraints.Mem, constraints.Cores, constraints.CpuPower})
 	validator.RegisterUnsupported(unsupportedConstraints)
-	instanceTypes, err := e.supportedInstanceTypes()
+	instanceTypes, err := e.supportedInstanceTypes(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -220,7 +223,7 @@ func (e *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.A
 		filter.Add("region-name", e.cloud.Region)
 		resp, err := ec2AvailabilityZones(e.ec2, filter)
 		if err != nil {
-			return nil, maybeConvertCredentialError(err)
+			return nil, maybeConvertCredentialError(err, ctx)
 		}
 		logger.Debugf("availability zones: %+v", resp)
 		e.availabilityZones = make([]common.AvailabilityZone, len(resp.Zones))
@@ -288,7 +291,7 @@ func (e *environ) parsePlacement(ctx context.ProviderCallContext, placement stri
 		matcher := CreateSubnetMatcher(value)
 		// Get all known subnets, look for a match
 		allSubnets := []string{}
-		subnetResp, vpcId, err := e.subnetsForVPC()
+		subnetResp, vpcId, err := e.subnetsForVPC(ctx)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -332,7 +335,7 @@ func (e *environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 		return nil
 	}
 	// Constraint has an instance-type constraint so let's see if it is valid.
-	instanceTypes, err := e.supportedInstanceTypes()
+	instanceTypes, err := e.supportedInstanceTypes(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -425,7 +428,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		// If there is a problem with authentication/authorisation,
 		// we want a correctly typed error.
 		annotatedErr := errors.Annotate(
-			maybeConvertCredentialError(received),
+			maybeConvertCredentialError(received, ctx),
 			annotation)
 		if common.IsCredentialNotValid(annotatedErr) {
 			return annotatedErr
@@ -455,7 +458,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 
 	arches := args.Tools.Arches()
 
-	instanceTypes, err := e.supportedInstanceTypes()
+	instanceTypes, err := e.supportedInstanceTypes(ctx)
 	if err != nil {
 		return nil, wrapError(err)
 	}
@@ -512,7 +515,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		apiPorts = append(apiPorts, args.InstanceConfig.APIInfo.Ports()[0])
 	}
 	callback(status.Allocating, "Setting up groups", nil)
-	groups, err := e.setUpGroups(args.ControllerUUID, args.InstanceConfig.MachineId, apiPorts)
+	groups, err := e.setUpGroups(ctx, args.ControllerUUID, args.InstanceConfig.MachineId, apiPorts)
 	if err != nil {
 		return nil, annotateWrapError(err, "cannot set up groups")
 	}
@@ -563,7 +566,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 				allowedSubnetIDs = append(allowedSubnetIDs, string(subnetID))
 			}
 		}
-		subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2, e.ecfg().vpcID(), availabilityZone, allowedSubnetIDs)
+		subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2, ctx, e.ecfg().vpcID(), availabilityZone, allowedSubnetIDs)
 	} else if args.Constraints.HaveSpaces() {
 		subnetIDsForZone, subnetErr = findSubnetIDsForAvailabilityZone(availabilityZone, args.SubnetsToZones)
 		if subnetErr == nil && placementSubnetID != "" {
@@ -581,7 +584,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	case subnetErr != nil && errors.IsNotFound(subnetErr):
 		return nil, errors.Trace(subnetErr)
 	case subnetErr != nil:
-		return nil, errors.Annotatef(maybeConvertCredentialError(subnetErr), "getting subnets for zone %q", availabilityZone)
+		return nil, errors.Annotatef(maybeConvertCredentialError(subnetErr, ctx), "getting subnets for zone %q", availabilityZone)
 	case len(subnetIDsForZone) > 1:
 		// With multiple equally suitable subnets, picking one at random
 		// will allow for better instance spread within the same zone, and
@@ -596,7 +599,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	}
 
 	callback(status.Allocating, fmt.Sprintf("Trying to start instance in availability zone %q", availabilityZone), nil)
-	instResp, err = runInstances(e.ec2, runArgs, callback)
+	instResp, err = runInstances(e.ec2, ctx, runArgs, callback)
 	if err != nil {
 		if !isZoneOrSubnetConstrainedError(err) {
 			err = annotateWrapError(err, "cannot run instances")
@@ -625,7 +628,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		names.NewMachineTag(args.InstanceConfig.MachineId), e.Config().Name(),
 	)
 	args.InstanceConfig.Tags[tagName] = instanceName
-	if err := tagResources(e.ec2, args.InstanceConfig.Tags, string(inst.Id())); err != nil {
+	if err := tagResources(e.ec2, ctx, args.InstanceConfig.Tags, string(inst.Id())); err != nil {
 		return nil, annotateWrapError(err, "tagging instance")
 	}
 
@@ -638,7 +641,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 			cfg,
 		)
 		tags[tagName] = instanceName + "-root"
-		if err := tagRootDisk(e.ec2, tags, inst.Instance); err != nil {
+		if err := tagRootDisk(e.ec2, ctx, tags, inst.Instance); err != nil {
 			return nil, annotateWrapError(err, "tagging root disk")
 		}
 	}
@@ -667,7 +670,7 @@ func (e *environ) deriveAvailabilityZoneAndSubnetID(ctx context.ProviderCallCont
 	// Determine the availability zones of existing volumes that are to be
 	// attached to the machine. They must all match, and must be the same
 	// as specified zone (if any).
-	volumeAttachmentsZone, err := volumeAttachmentsZone(e.ec2, args.VolumeAttachments)
+	volumeAttachmentsZone, err := volumeAttachmentsZone(e.ec2, ctx, args.VolumeAttachments)
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
@@ -740,7 +743,7 @@ func (e *environ) instancePlacementZone(ctx context.ProviderCallContext, placeme
 // volumeAttachmentsZone determines the availability zone for each volume
 // identified in the volume attachment parameters, checking that they are
 // all the same, and returns the availability zone name.
-func volumeAttachmentsZone(ec2 *ec2.EC2, attachments []storage.VolumeAttachmentParams) (string, error) {
+func volumeAttachmentsZone(ec2 *ec2.EC2, ctx context.ProviderCallContext, attachments []storage.VolumeAttachmentParams) (string, error) {
 	volumeIds := make([]string, 0, len(attachments))
 	for _, a := range attachments {
 		if a.Provider != EBS_ProviderType {
@@ -753,7 +756,7 @@ func volumeAttachmentsZone(ec2 *ec2.EC2, attachments []storage.VolumeAttachmentP
 	}
 	resp, err := ec2.Volumes(volumeIds, nil)
 	if err != nil {
-		return "", errors.Annotatef(maybeConvertCredentialError(err), "getting volume details (%s)", volumeIds)
+		return "", errors.Annotatef(maybeConvertCredentialError(err, ctx), "getting volume details (%s)", volumeIds)
 	}
 	if len(resp.Volumes) == 0 {
 		return "", nil
@@ -772,7 +775,7 @@ func volumeAttachmentsZone(ec2 *ec2.EC2, attachments []storage.VolumeAttachmentP
 // tagResources calls ec2.CreateTags, tagging each of the specified resources
 // with the given tags. tagResources will retry for a short period of time
 // if it receives a *.NotFound error response from EC2.
-func tagResources(e *ec2.EC2, tags map[string]string, resourceIds ...string) error {
+func tagResources(e *ec2.EC2, ctx context.ProviderCallContext, tags map[string]string, resourceIds ...string) error {
 	if len(tags) == 0 {
 		return nil
 	}
@@ -787,10 +790,10 @@ func tagResources(e *ec2.EC2, tags map[string]string, resourceIds ...string) err
 			return err
 		}
 	}
-	return maybeConvertCredentialError(err)
+	return maybeConvertCredentialError(err, ctx)
 }
 
-func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
+func tagRootDisk(e *ec2.EC2, ctx context.ProviderCallContext, tags map[string]string, inst *ec2.Instance) error {
 	if len(tags) == 0 {
 		return nil
 	}
@@ -814,7 +817,7 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 	for a := waitRootDiskAttempt.Start(); volumeId == "" && a.Next(); {
 		resp, err := e.Instances([]string{inst.InstanceId}, nil)
 		if err != nil {
-			err = errors.Annotate(maybeConvertCredentialError(err), "cannot fetch instance information")
+			err = errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot fetch instance information")
 			logger.Warningf("%v", err)
 			if a.HasNext() == false {
 				return err
@@ -830,7 +833,7 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 	if volumeId == "" {
 		return errors.New("timed out waiting for EBS volume to be associated")
 	}
-	return tagResources(e, tags, volumeId)
+	return tagResources(e, ctx, tags, volumeId)
 }
 
 var runInstances = _runInstances
@@ -838,7 +841,7 @@ var runInstances = _runInstances
 // runInstances calls ec2.RunInstances for a fixed number of attempts until
 // RunInstances returns an error code that does not indicate an error that
 // may be caused by eventual consistency.
-func _runInstances(e *ec2.EC2, ri *ec2.RunInstances, c environs.StatusCallbackFunc) (resp *ec2.RunInstancesResp, err error) {
+func _runInstances(e *ec2.EC2, ctx context.ProviderCallContext, ri *ec2.RunInstances, c environs.StatusCallbackFunc) (resp *ec2.RunInstancesResp, err error) {
 	try := 1
 	for a := shortAttempt.Start(); a.Next(); {
 		c(status.Allocating, fmt.Sprintf("Start instance attempt %d", try), nil)
@@ -848,7 +851,7 @@ func _runInstances(e *ec2.EC2, ri *ec2.RunInstances, c environs.StatusCallbackFu
 		}
 		try++
 	}
-	return resp, maybeConvertCredentialError(err)
+	return resp, maybeConvertCredentialError(err, ctx)
 }
 
 func (e *environ) StopInstances(ctx context.ProviderCallContext, ids ...instance.Id) error {
@@ -857,10 +860,10 @@ func (e *environ) StopInstances(ctx context.ProviderCallContext, ids ...instance
 
 // groupInfoByName returns information on the security group
 // with the given name including rules and other details.
-func (e *environ) groupInfoByName(groupName string) (ec2.SecurityGroupInfo, error) {
+func (e *environ) groupInfoByName(ctx context.ProviderCallContext, groupName string) (ec2.SecurityGroupInfo, error) {
 	resp, err := e.securityGroupsByNameOrID(groupName)
 	if err != nil {
-		return ec2.SecurityGroupInfo{}, maybeConvertCredentialError(err)
+		return ec2.SecurityGroupInfo{}, maybeConvertCredentialError(err, ctx)
 	}
 
 	if len(resp.Groups) != 1 {
@@ -873,8 +876,8 @@ func (e *environ) groupInfoByName(groupName string) (ec2.SecurityGroupInfo, erro
 }
 
 // groupByName returns the security group with the given name.
-func (e *environ) groupByName(groupName string) (ec2.SecurityGroup, error) {
-	groupInfo, err := e.groupInfoByName(groupName)
+func (e *environ) groupByName(ctx context.ProviderCallContext, groupName string) (ec2.SecurityGroup, error) {
+	groupInfo, err := e.groupInfoByName(ctx, groupName)
 	return groupInfo.SecurityGroup, err
 }
 
@@ -906,7 +909,7 @@ func (e *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 		filter.Add("instance-state-name", aliveInstanceStates...)
 		filter.Add("instance-id", need...)
 		e.addModelFilter(filter)
-		err = e.gatherInstances(ids, insts, filter)
+		err = e.gatherInstances(ctx, ids, insts, filter)
 		if err == nil || err != environs.ErrPartialInstances {
 			break
 		}
@@ -931,13 +934,14 @@ func (e *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 // This function returns environs.ErrPartialInstances if the
 // insts slice has not been completely filled.
 func (e *environ) gatherInstances(
+	ctx context.ProviderCallContext,
 	ids []instance.Id,
 	insts []instance.Instance,
 	filter *ec2.Filter,
 ) error {
 	resp, err := e.ec2.Instances(nil, filter)
 	if err != nil {
-		return maybeConvertCredentialError(err)
+		return maybeConvertCredentialError(err, ctx)
 	}
 	n := 0
 	// For each requested id, add it to the returned instances
@@ -977,7 +981,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, instId inst
 		networkInterfacesResp, err = e.ec2.NetworkInterfaces(nil, filter)
 		logger.Tracef("instance %q NICs: %#v (err: %v)", instId, networkInterfacesResp, err)
 		if err != nil {
-			err = maybeConvertCredentialError(err)
+			err = maybeConvertCredentialError(err, ctx)
 			if common.IsCredentialNotValid(err) {
 				// no need to re-try: there is a problem with credentials
 				break
@@ -1002,7 +1006,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, instId inst
 	for i, iface := range ec2Interfaces {
 		resp, err := e.ec2.Subnets([]string{iface.SubnetId}, nil)
 		if err != nil {
-			return nil, errors.Annotatef(maybeConvertCredentialError(err), "failed to retrieve subnet %q info", iface.SubnetId)
+			return nil, errors.Annotatef(maybeConvertCredentialError(err, ctx), "failed to retrieve subnet %q info", iface.SubnetId)
 		}
 		if len(resp.Subnets) != 1 {
 			return nil, errors.Errorf("expected 1 subnet, got %d", len(resp.Subnets))
@@ -1090,7 +1094,7 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, instId instance.Id, s
 			results = append(results, info)
 		}
 	} else {
-		resp, _, err := e.subnetsForVPC()
+		resp, _, err := e.subnetsForVPC(ctx)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to retrieve subnets")
 		}
@@ -1131,17 +1135,17 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, instId instance.Id, s
 	return results, nil
 }
 
-func (e *environ) subnetsForVPC() (resp *ec2.SubnetsResp, vpcId string, err error) {
+func (e *environ) subnetsForVPC(ctx context.ProviderCallContext) (resp *ec2.SubnetsResp, vpcId string, err error) {
 	filter := ec2.NewFilter()
 	vpcId = e.ecfg().vpcID()
 	if !isVPCIDSet(vpcId) {
-		if hasDefaultVPC, err := e.hasDefaultVPC(); err == nil && hasDefaultVPC {
+		if hasDefaultVPC, err := e.hasDefaultVPC(ctx); err == nil && hasDefaultVPC {
 			vpcId = e.defaultVPC.Id
 		}
 	}
 	filter.Add("vpc-id", vpcId)
 	resp, err = e.ec2.Subnets(nil, filter)
-	return resp, vpcId, maybeConvertCredentialError(err)
+	return resp, vpcId, maybeConvertCredentialError(err, ctx)
 }
 
 // AdoptResources is part of the Environ interface.
@@ -1154,11 +1158,11 @@ func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	// We want to update the controller tags on root disks even though
 	// they are destroyed automatically with the instance they're
 	// attached to.
-	volumeIds, err := e.allModelVolumes(true)
+	volumeIds, err := e.allModelVolumes(ctx, true)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	groupIds, err := e.modelSecurityGroupIDs()
+	groupIds, err := e.modelSecurityGroupIDs(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1171,7 +1175,7 @@ func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	resourceIds = append(resourceIds, groupIds...)
 
 	tags := map[string]string{tags.JujuController: controllerUUID}
-	return errors.Annotate(tagResources(e.ec2, tags, resourceIds...), "updating tags")
+	return errors.Annotate(tagResources(e.ec2, ctx, tags, resourceIds...), "updating tags")
 }
 
 // AllInstances is part of the environs.InstanceBroker interface.
@@ -1203,17 +1207,17 @@ func (e *environ) AllInstancesByState(ctx context.ProviderCallContext, states ..
 	// An EC2 API call is required to resolve the group name to an id, as
 	// VPC enabled accounts do not support name based filtering.
 	groupName := e.jujuGroupName()
-	group, err := e.groupByName(groupName)
+	group, err := e.groupByName(ctx, groupName)
 	if isNotFoundError(err) {
 		// If there's no group, then there cannot be any instances.
 		return nil, nil
 	} else if err != nil {
-		return nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	filter := ec2.NewFilter()
 	filter.Add("instance-state-name", states...)
 	filter.Add("instance.group-id", group.Id)
-	return e.allInstances(filter)
+	return e.allInstances(ctx, filter)
 }
 
 // ControllerInstances is part of the environs.Environ interface.
@@ -1222,9 +1226,9 @@ func (e *environ) ControllerInstances(ctx context.ProviderCallContext, controlle
 	filter.Add("instance-state-name", aliveInstanceStates...)
 	filter.Add(fmt.Sprintf("tag:%s", tags.JujuIsController), "true")
 	e.addControllerFilter(filter, controllerUUID)
-	ids, err := e.allInstanceIDs(filter)
+	ids, err := e.allInstanceIDs(ctx, filter)
 	if err != nil {
-		return nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	if len(ids) == 0 {
 		return nil, environs.ErrNotBootstrapped
@@ -1237,17 +1241,17 @@ func (e *environ) ControllerInstances(ctx context.ProviderCallContext, controlle
 //
 // Note that this requires that all instances are tagged; we cannot filter on
 // security groups, as we do not know the names of the models.
-func (e *environ) allControllerManagedInstances(controllerUUID string) ([]instance.Id, error) {
+func (e *environ) allControllerManagedInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
 	filter := ec2.NewFilter()
 	filter.Add("instance-state-name", aliveInstanceStates...)
 	e.addControllerFilter(filter, controllerUUID)
-	return e.allInstanceIDs(filter)
+	return e.allInstanceIDs(ctx, filter)
 }
 
-func (e *environ) allInstanceIDs(filter *ec2.Filter) ([]instance.Id, error) {
-	insts, err := e.allInstances(filter)
+func (e *environ) allInstanceIDs(ctx context.ProviderCallContext, filter *ec2.Filter) ([]instance.Id, error) {
+	insts, err := e.allInstances(ctx, filter)
 	if err != nil {
-		return nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	ids := make([]instance.Id, len(insts))
 	for i, inst := range insts {
@@ -1256,10 +1260,10 @@ func (e *environ) allInstanceIDs(filter *ec2.Filter) ([]instance.Id, error) {
 	return ids, nil
 }
 
-func (e *environ) allInstances(filter *ec2.Filter) ([]instance.Instance, error) {
+func (e *environ) allInstances(ctx context.ProviderCallContext, filter *ec2.Filter) ([]instance.Instance, error) {
 	resp, err := e.ec2.Instances(nil, filter)
 	if err != nil {
-		return nil, errors.Annotate(maybeConvertCredentialError(err), "listing instances")
+		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "listing instances")
 	}
 	var insts []instance.Instance
 	for _, r := range resp.Reservations {
@@ -1275,10 +1279,10 @@ func (e *environ) allInstances(filter *ec2.Filter) ([]instance.Instance, error) 
 // Destroy is part of the environs.Environ interface.
 func (e *environ) Destroy(ctx context.ProviderCallContext) error {
 	if err := common.Destroy(e, ctx); err != nil {
-		return errors.Trace(maybeConvertCredentialError(err))
+		return errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
-	if err := e.cleanEnvironmentSecurityGroups(); err != nil {
-		return errors.Annotate(maybeConvertCredentialError(err), "cannot delete environment security groups")
+	if err := e.cleanEnvironmentSecurityGroups(ctx); err != nil {
+		return errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot delete environment security groups")
 	}
 	return nil
 }
@@ -1299,7 +1303,7 @@ func (e *environ) DestroyController(ctx context.ProviderCallContext, controllerU
 func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallContext, controllerUUID string) error {
 
 	// Terminate all instances managed by the controller.
-	instIds, err := e.allControllerManagedInstances(controllerUUID)
+	instIds, err := e.allControllerManagedInstances(ctx, controllerUUID)
 	if err != nil {
 		return errors.Annotate(err, "listing instances")
 	}
@@ -1308,11 +1312,11 @@ func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 	}
 
 	// Delete all volumes managed by the controller. (No need to delete root disks manually.)
-	volIds, err := e.allControllerManagedVolumes(controllerUUID, false)
+	volIds, err := e.allControllerManagedVolumes(ctx, controllerUUID, false)
 	if err != nil {
 		return errors.Annotate(err, "listing volumes")
 	}
-	errs := foreachVolume(e.ec2, volIds, destroyVolume)
+	errs := foreachVolume(e.ec2, ctx, volIds, destroyVolume)
 	for i, err := range errs {
 		if err == nil {
 			continue
@@ -1324,12 +1328,12 @@ func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 	}
 
 	// Delete security groups managed by the controller.
-	groups, err := e.controllerSecurityGroups(controllerUUID)
+	groups, err := e.controllerSecurityGroups(ctx, controllerUUID)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	for _, g := range groups {
-		if err := deleteSecurityGroupInsistently(e.ec2, g, clock.WallClock); err != nil {
+		if err := deleteSecurityGroupInsistently(e.ec2, ctx, g, clock.WallClock); err != nil {
 			return errors.Annotatef(
 				err, "cannot delete security group %q (%q)",
 				g.Name, g.Id,
@@ -1339,16 +1343,16 @@ func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 	return nil
 }
 
-func (e *environ) allControllerManagedVolumes(controllerUUID string, includeRootDisks bool) ([]string, error) {
+func (e *environ) allControllerManagedVolumes(ctx context.ProviderCallContext, controllerUUID string, includeRootDisks bool) ([]string, error) {
 	filter := ec2.NewFilter()
 	e.addControllerFilter(filter, controllerUUID)
-	return listVolumes(e.ec2, filter, includeRootDisks)
+	return listVolumes(e.ec2, ctx, filter, includeRootDisks)
 }
 
-func (e *environ) allModelVolumes(includeRootDisks bool) ([]string, error) {
+func (e *environ) allModelVolumes(ctx context.ProviderCallContext, includeRootDisks bool) ([]string, error) {
 	filter := ec2.NewFilter()
 	e.addModelFilter(filter)
-	return listVolumes(e.ec2, filter, includeRootDisks)
+	return listVolumes(e.ec2, ctx, filter, includeRootDisks)
 }
 
 func rulesToIPPerms(rules []network.IngressRule) []ec2.IPPerm {
@@ -1369,12 +1373,12 @@ func rulesToIPPerms(rules []network.IngressRule) []ec2.IPPerm {
 	return ipPerms
 }
 
-func (e *environ) openPortsInGroup(name string, rules []network.IngressRule) error {
+func (e *environ) openPortsInGroup(ctx context.ProviderCallContext, name string, rules []network.IngressRule) error {
 	if len(rules) == 0 {
 		return nil
 	}
 	// Give permissions for anyone to access the given ports.
-	g, err := e.groupByName(name)
+	g, err := e.groupByName(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -1391,37 +1395,37 @@ func (e *environ) openPortsInGroup(name string, rules []network.IngressRule) err
 		for i := range ipPerms {
 			_, err := e.ec2.AuthorizeSecurityGroup(g, ipPerms[i:i+1])
 			if err != nil && ec2ErrCode(err) != "InvalidPermission.Duplicate" {
-				return errors.Annotatef(maybeConvertCredentialError(err), "cannot open port %v", ipPerms[i])
+				return errors.Annotatef(maybeConvertCredentialError(err, ctx), "cannot open port %v", ipPerms[i])
 			}
 		}
 		return nil
 	}
 	if err != nil {
-		return errors.Annotate(maybeConvertCredentialError(err), "cannot open ports")
+		return errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot open ports")
 	}
 	return nil
 }
 
-func (e *environ) closePortsInGroup(name string, rules []network.IngressRule) error {
+func (e *environ) closePortsInGroup(ctx context.ProviderCallContext, name string, rules []network.IngressRule) error {
 	if len(rules) == 0 {
 		return nil
 	}
 	// Revoke permissions for anyone to access the given ports.
 	// Note that ec2 allows the revocation of permissions that aren't
 	// granted, so this is naturally idempotent.
-	g, err := e.groupByName(name)
+	g, err := e.groupByName(ctx, name)
 	if err != nil {
 		return err
 	}
 	_, err = e.ec2.RevokeSecurityGroup(g, rulesToIPPerms(rules))
 	if err != nil {
-		return errors.Annotate(maybeConvertCredentialError(err), "cannot close ports")
+		return errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot close ports")
 	}
 	return nil
 }
 
-func (e *environ) ingressRulesInGroup(name string) (rules []network.IngressRule, err error) {
-	group, err := e.groupInfoByName(name)
+func (e *environ) ingressRulesInGroup(ctx context.ProviderCallContext, name string) (rules []network.IngressRule, err error) {
+	group, err := e.groupInfoByName(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1444,7 +1448,7 @@ func (e *environ) OpenPorts(ctx context.ProviderCallContext, rules []network.Ing
 	if e.Config().FirewallMode() != config.FwGlobal {
 		return errors.Errorf("invalid firewall mode %q for opening ports on model", e.Config().FirewallMode())
 	}
-	if err := e.openPortsInGroup(e.globalGroupName(), rules); err != nil {
+	if err := e.openPortsInGroup(ctx, e.globalGroupName(), rules); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Infof("opened ports in global group: %v", rules)
@@ -1455,7 +1459,7 @@ func (e *environ) ClosePorts(ctx context.ProviderCallContext, rules []network.In
 	if e.Config().FirewallMode() != config.FwGlobal {
 		return errors.Errorf("invalid firewall mode %q for closing ports on model", e.Config().FirewallMode())
 	}
-	if err := e.closePortsInGroup(e.globalGroupName(), rules); err != nil {
+	if err := e.closePortsInGroup(ctx, e.globalGroupName(), rules); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Infof("closed ports in global group: %v", rules)
@@ -1466,14 +1470,14 @@ func (e *environ) IngressRules(ctx context.ProviderCallContext) ([]network.Ingre
 	if e.Config().FirewallMode() != config.FwGlobal {
 		return nil, errors.Errorf("invalid firewall mode %q for retrieving ingress rules from model", e.Config().FirewallMode())
 	}
-	return e.ingressRulesInGroup(e.globalGroupName())
+	return e.ingressRulesInGroup(ctx, e.globalGroupName())
 }
 
 func (*environ) Provider() environs.EnvironProvider {
 	return &providerInstance
 }
 
-func (e *environ) instanceSecurityGroups(instIDs []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
+func (e *environ) instanceSecurityGroups(ctx context.ProviderCallContext, instIDs []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
 	strInstID := make([]string, len(instIDs))
 	for i := range instIDs {
 		strInstID[i] = string(instIDs[i])
@@ -1486,7 +1490,7 @@ func (e *environ) instanceSecurityGroups(instIDs []instance.Id, states ...string
 
 	resp, err := e.ec2.Instances(strInstID, filter)
 	if err != nil {
-		return nil, errors.Annotatef(maybeConvertCredentialError(err), "cannot retrieve instance information from aws to delete security groups")
+		return nil, errors.Annotatef(maybeConvertCredentialError(err, ctx), "cannot retrieve instance information from aws to delete security groups")
 	}
 
 	securityGroups := []ec2.SecurityGroup{}
@@ -1501,12 +1505,12 @@ func (e *environ) instanceSecurityGroups(instIDs []instance.Id, states ...string
 
 // controllerSecurityGroups returns the details of all security groups managed
 // by the environment's controller.
-func (e *environ) controllerSecurityGroups(controllerUUID string) ([]ec2.SecurityGroup, error) {
+func (e *environ) controllerSecurityGroups(ctx context.ProviderCallContext, controllerUUID string) ([]ec2.SecurityGroup, error) {
 	filter := ec2.NewFilter()
 	e.addControllerFilter(filter, controllerUUID)
 	resp, err := e.ec2.SecurityGroups(nil, filter)
 	if err != nil {
-		return nil, errors.Annotate(maybeConvertCredentialError(err), "listing security groups")
+		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "listing security groups")
 	}
 	groups := make([]ec2.SecurityGroup, len(resp.Groups))
 	for i, info := range resp.Groups {
@@ -1515,12 +1519,12 @@ func (e *environ) controllerSecurityGroups(controllerUUID string) ([]ec2.Securit
 	return groups, nil
 }
 
-func (e *environ) modelSecurityGroupIDs() ([]string, error) {
+func (e *environ) modelSecurityGroupIDs(ctx context.ProviderCallContext) ([]string, error) {
 	filter := ec2.NewFilter()
 	e.addModelFilter(filter)
 	resp, err := e.ec2.SecurityGroups(nil, filter)
 	if err != nil {
-		return nil, errors.Annotate(maybeConvertCredentialError(err), "listing security groups")
+		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "listing security groups")
 	}
 	groupIDs := make([]string, len(resp.Groups))
 	for i, info := range resp.Groups {
@@ -1531,16 +1535,16 @@ func (e *environ) modelSecurityGroupIDs() ([]string, error) {
 
 // cleanEnvironmentSecurityGroups attempts to delete all security groups owned
 // by the environment.
-func (e *environ) cleanEnvironmentSecurityGroups() error {
+func (e *environ) cleanEnvironmentSecurityGroups(ctx context.ProviderCallContext) error {
 	jujuGroup := e.jujuGroupName()
-	g, err := e.groupByName(jujuGroup)
+	g, err := e.groupByName(ctx, jujuGroup)
 	if isNotFoundError(err) {
 		return nil
 	}
 	if err != nil {
 		return errors.Annotatef(err, "cannot retrieve default security group: %q", jujuGroup)
 	}
-	if err := deleteSecurityGroupInsistently(e.ec2, g, clock.WallClock); err != nil {
+	if err := deleteSecurityGroupInsistently(e.ec2, ctx, g, clock.WallClock); err != nil {
 		return errors.Annotate(err, "cannot delete default security group")
 	}
 	return nil
@@ -1554,7 +1558,7 @@ func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	// TODO (anastasiamac 2016-04-11) Err if instances still have resources hanging around.
 	// LP#1568654
 	defer func() {
-		e.deleteSecurityGroupsForInstances(ids)
+		e.deleteSecurityGroupsForInstances(ctx, ids)
 	}()
 
 	// TODO (anastasiamac 2016-04-7) instance termination would benefit
@@ -1562,11 +1566,11 @@ func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	// in defer. Bug#1567179.
 	var err error
 	for a := shortAttempt.Start(); a.Next(); {
-		_, err = terminateInstancesById(e.ec2, ids...)
+		_, err = terminateInstancesById(e.ec2, ctx, ids...)
 		if err == nil || ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
 			// This will return either success at terminating all instances (1st condition) or
 			// encountered error as long as it's not NotFound (2nd condition).
-			return maybeConvertCredentialError(err)
+			return maybeConvertCredentialError(err, ctx)
 		}
 	}
 
@@ -1581,7 +1585,7 @@ func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	// So try each instance individually, ignoring a NotFound error this time.
 	deletedIDs := []instance.Id{}
 	for _, id := range ids {
-		_, err = terminateInstancesById(e.ec2, id)
+		_, err = terminateInstancesById(e.ec2, ctx, id)
 		if err == nil {
 			deletedIDs = append(deletedIDs, id)
 		}
@@ -1596,19 +1600,19 @@ func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	return nil
 }
 
-var terminateInstancesById = func(ec2inst *ec2.EC2, ids ...instance.Id) (*ec2.TerminateInstancesResp, error) {
+var terminateInstancesById = func(ec2inst *ec2.EC2, ctx context.ProviderCallContext, ids ...instance.Id) (*ec2.TerminateInstancesResp, error) {
 	strs := make([]string, len(ids))
 	for i, id := range ids {
 		strs[i] = string(id)
 	}
 	r, err := ec2inst.TerminateInstances(strs)
 	if err != nil {
-		return nil, maybeConvertCredentialError(err)
+		return nil, maybeConvertCredentialError(err, ctx)
 	}
 	return r, nil
 }
 
-func (e *environ) deleteSecurityGroupsForInstances(ids []instance.Id) {
+func (e *environ) deleteSecurityGroupsForInstances(ctx context.ProviderCallContext, ids []instance.Id) {
 	if len(ids) == 0 {
 		logger.Debugf("no need to delete security groups: no intances were terminated successfully")
 		return
@@ -1616,7 +1620,7 @@ func (e *environ) deleteSecurityGroupsForInstances(ids []instance.Id) {
 
 	// We only want to attempt deleting security groups for the
 	// instances that have been successfully terminated.
-	securityGroups, err := e.instanceSecurityGroups(ids, "shutting-down", "terminated")
+	securityGroups, err := e.instanceSecurityGroups(ctx, ids, "shutting-down", "terminated")
 	if err != nil {
 		logger.Errorf("cannot determine security groups to delete: %v", err)
 		return
@@ -1632,7 +1636,7 @@ func (e *environ) deleteSecurityGroupsForInstances(ids []instance.Id) {
 		if deletable.Name == jujuGroup {
 			continue
 		}
-		if err := deleteSecurityGroupInsistently(e.ec2, deletable, clock.WallClock); err != nil {
+		if err := deleteSecurityGroupInsistently(e.ec2, ctx, deletable, clock.WallClock); err != nil {
 			// In ideal world, we would err out here.
 			// However:
 			// 1. We do not know if all instances have been terminated.
@@ -1653,7 +1657,7 @@ type SecurityGroupCleaner interface {
 	DeleteSecurityGroup(group ec2.SecurityGroup) (resp *ec2.SimpleResp, err error)
 }
 
-var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, group ec2.SecurityGroup, clock clock.Clock) error {
+var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, ctx context.ProviderCallContext, group ec2.SecurityGroup, clock clock.Clock) error {
 	err := retry.Call(retry.CallArgs{
 		Attempts:    30,
 		Delay:       time.Second,
@@ -1666,7 +1670,7 @@ var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, group ec2.S
 				logger.Debugf("deleting security group %q", group.Name)
 				return nil
 			}
-			return errors.Trace(maybeConvertCredentialError(err))
+			return errors.Trace(maybeConvertCredentialError(err, ctx))
 		},
 		IsFatalError: func(err error) bool {
 			return common.IsCredentialNotValid(err)
@@ -1712,7 +1716,7 @@ func (e *environ) jujuGroupName() string {
 // other instances that might be running on the same EC2 account.  In
 // addition, a specific machine security group is created for each
 // machine, so that its firewall rules can be configured per machine.
-func (e *environ) setUpGroups(controllerUUID, machineId string, apiPorts []int) ([]ec2.SecurityGroup, error) {
+func (e *environ) setUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPorts []int) ([]ec2.SecurityGroup, error) {
 	perms := []ec2.IPPerm{{
 		Protocol:  "tcp",
 		FromPort:  22,
@@ -1741,7 +1745,7 @@ func (e *environ) setUpGroups(controllerUUID, machineId string, apiPorts []int) 
 		ToPort:   -1,
 	})
 	// Ensure there's a global group for Juju-related traffic.
-	jujuGroup, err := e.ensureGroup(controllerUUID, e.jujuGroupName(), perms)
+	jujuGroup, err := e.ensureGroup(ctx, controllerUUID, e.jujuGroupName(), perms)
 	if err != nil {
 		return nil, err
 	}
@@ -1749,9 +1753,9 @@ func (e *environ) setUpGroups(controllerUUID, machineId string, apiPorts []int) 
 	var machineGroup ec2.SecurityGroup
 	switch e.Config().FirewallMode() {
 	case config.FwInstance:
-		machineGroup, err = e.ensureGroup(controllerUUID, e.machineGroupName(machineId), nil)
+		machineGroup, err = e.ensureGroup(ctx, controllerUUID, e.machineGroupName(machineId), nil)
 	case config.FwGlobal:
-		machineGroup, err = e.ensureGroup(controllerUUID, e.globalGroupName(), nil)
+		machineGroup, err = e.ensureGroup(ctx, controllerUUID, e.globalGroupName(), nil)
 	}
 	if err != nil {
 		return nil, err
@@ -1786,7 +1790,7 @@ func (e *environ) securityGroupsByNameOrID(groupName string) (*ec2.SecurityGroup
 // If it exists, its permissions are set to perms.
 // Any entries in perms without SourceIPs will be granted for
 // the named group only.
-func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (g ec2.SecurityGroup, err error) {
+func (e *environ) ensureGroup(ctx context.ProviderCallContext, controllerUUID, name string, perms []ec2.IPPerm) (g ec2.SecurityGroup, err error) {
 	// Due to parallelization of the provisioner, it's possible that we try
 	// to create the model security group a second time before the first time
 	// is complete causing failures.
@@ -1803,7 +1807,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 
 	resp, err := e.ec2.CreateSecurityGroup(chosenVPCID, name, "juju group")
 	if err != nil && ec2ErrCode(err) != "InvalidGroup.Duplicate" {
-		err = errors.Annotatef(maybeConvertCredentialError(err), "creating security group %q%s", name, inVPCLogSuffix)
+		err = errors.Annotatef(maybeConvertCredentialError(err, ctx), "creating security group %q%s", name, inVPCLogSuffix)
 		return zeroGroup, err
 	}
 
@@ -1817,14 +1821,14 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 			names.NewControllerTag(controllerUUID),
 			cfg,
 		)
-		if err := tagResources(e.ec2, tags, g.Id); err != nil {
+		if err := tagResources(e.ec2, ctx, tags, g.Id); err != nil {
 			return g, errors.Annotate(err, "tagging security group")
 		}
 		logger.Debugf("created security group %q with ID %q%s", name, g.Id, inVPCLogSuffix)
 	} else {
 		resp, err := e.securityGroupsByNameOrID(name)
 		if err != nil {
-			return zeroGroup, errors.Annotatef(maybeConvertCredentialError(err), "fetching security group %q%s", name, inVPCLogSuffix)
+			return zeroGroup, errors.Annotatef(maybeConvertCredentialError(err, ctx), "fetching security group %q%s", name, inVPCLogSuffix)
 		}
 		if len(resp.Groups) == 0 {
 			return zeroGroup, errors.NotFoundf("security group %q%s", name, inVPCLogSuffix)
@@ -1848,7 +1852,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 	if len(revoke) > 0 {
 		_, err := e.ec2.RevokeSecurityGroup(g, revoke.ipPerms())
 		if err != nil {
-			return zeroGroup, errors.Annotatef(maybeConvertCredentialError(err), "revoking security group %q%s", g.Id, inVPCLogSuffix)
+			return zeroGroup, errors.Annotatef(maybeConvertCredentialError(err, ctx), "revoking security group %q%s", g.Id, inVPCLogSuffix)
 		}
 	}
 
@@ -1861,7 +1865,7 @@ func (e *environ) ensureGroup(controllerUUID, name string, perms []ec2.IPPerm) (
 	if len(add) > 0 {
 		_, err := e.ec2.AuthorizeSecurityGroup(g, add.ipPerms())
 		if err != nil {
-			return zeroGroup, errors.Annotatef(maybeConvertCredentialError(err), "authorizing security group %q%s", g.Id, inVPCLogSuffix)
+			return zeroGroup, errors.Annotatef(maybeConvertCredentialError(err, ctx), "authorizing security group %q%s", g.Id, inVPCLogSuffix)
 		}
 	}
 	return g, nil
@@ -1993,12 +1997,12 @@ func (e *environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, int
 	return errors.NotSupportedf("container address allocation")
 }
 
-func (e *environ) supportedInstanceTypes() ([]instances.InstanceType, error) {
+func (e *environ) supportedInstanceTypes(ctx context.ProviderCallContext) ([]instances.InstanceType, error) {
 	allInstanceTypes := ec2instancetypes.RegionInstanceTypes(e.cloud.Region)
 	if isVPCIDSet(e.ecfg().vpcID()) {
 		return allInstanceTypes, nil
 	}
-	hasDefaultVPC, err := e.hasDefaultVPC()
+	hasDefaultVPC, err := e.hasDefaultVPC(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2019,7 +2023,7 @@ func (e *environ) supportedInstanceTypes() ([]instances.InstanceType, error) {
 	return supportedInstanceTypes, nil
 }
 
-func (e *environ) hasDefaultVPC() (bool, error) {
+func (e *environ) hasDefaultVPC(ctx context.ProviderCallContext) (bool, error) {
 	e.defaultVPCMutex.Lock()
 	defer e.defaultVPCMutex.Unlock()
 	if !e.defaultVPCChecked {
@@ -2027,7 +2031,7 @@ func (e *environ) hasDefaultVPC() (bool, error) {
 		filter.Add("isDefault", "true")
 		resp, err := e.ec2.VPCs(nil, filter)
 		if err != nil {
-			return false, errors.Trace(maybeConvertCredentialError(err))
+			return false, errors.Trace(maybeConvertCredentialError(err, ctx))
 		}
 		if len(resp.VPCs) > 0 {
 			e.defaultVPC = &resp.VPCs[0]
@@ -2056,14 +2060,14 @@ func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses []networ
 func (e *environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	vpcId := e.ecfg().vpcID()
 	if !isVPCIDSet(vpcId) {
-		if hasDefaultVPC, err := e.hasDefaultVPC(); err == nil && hasDefaultVPC {
+		if hasDefaultVPC, err := e.hasDefaultVPC(ctx); err == nil && hasDefaultVPC {
 			vpcId = e.defaultVPC.Id
 		}
 	}
 	if !isVPCIDSet(vpcId) {
 		return nil, errors.NotSupportedf("Not a VPC environment")
 	}
-	cidr, err := getVPCCIDR(e.ec2, vpcId)
+	cidr, err := getVPCCIDR(e.ec2, ctx, vpcId)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/amz.v3/ec2"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -21,6 +22,8 @@ type vpcSuite struct {
 	testing.IsolationSuite
 
 	stubAPI *stubVPCAPIClient
+
+	cloudCallCtx context.ProviderCallContext
 }
 
 var _ = gc.Suite(&vpcSuite{})
@@ -29,12 +32,13 @@ func (s *vpcSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
 	s.stubAPI = &stubVPCAPIClient{Stub: &testing.Stub{}}
+	s.cloudCallCtx = context.NewCloudCallContext()
 }
 
 func (s *vpcSuite) TestValidateBootstrapVPCUnexpectedError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
-	err := validateBootstrapVPC(s.stubAPI, "region", anyVPCID, false, envtesting.BootstrapContext(c))
+	err := validateBootstrapVPC(s.stubAPI, s.cloudCallCtx, "region", anyVPCID, false, envtesting.BootstrapContext(c))
 	s.checkErrorMatchesCannotVerifyVPC(c, err)
 
 	s.stubAPI.CheckCallNames(c, "VPCs")
@@ -42,7 +46,7 @@ func (s *vpcSuite) TestValidateBootstrapVPCUnexpectedError(c *gc.C) {
 
 func (s *vpcSuite) TestValidateBootstrapVPCCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("AWS failed!"))
-	err := validateBootstrapVPC(s.stubAPI, "region", anyVPCID, false, envtesting.BootstrapContext(c))
+	err := validateBootstrapVPC(s.stubAPI, s.cloudCallCtx, "region", anyVPCID, false, envtesting.BootstrapContext(c))
 	s.checkErrorMatchesCannotVerifyVPC(c, err)
 	c.Check(err, jc.Satisfies, common.IsCredentialNotValid)
 }
@@ -55,7 +59,7 @@ func (*vpcSuite) checkErrorMatchesCannotVerifyVPC(c *gc.C, err error) {
 func (s *vpcSuite) TestValidateModelVPCUnexpectedError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
-	err := validateModelVPC(s.stubAPI, "model", anyVPCID)
+	err := validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", anyVPCID)
 	s.checkErrorMatchesCannotVerifyVPC(c, err)
 
 	s.stubAPI.CheckCallNames(c, "VPCs")
@@ -64,7 +68,7 @@ func (s *vpcSuite) TestValidateModelVPCUnexpectedError(c *gc.C) {
 func (s *vpcSuite) TestValidateModelVPCNotUsableError(c *gc.C) {
 	s.stubAPI.SetErrors(makeVPCNotFoundError("foo"))
 
-	err := validateModelVPC(s.stubAPI, "model", "foo")
+	err := validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", "foo")
 	expectedError := `Juju cannot use the given vpc-id for the model being added(.|\n)*vpc ID 'foo' does not exist.*`
 	c.Check(err, gc.ErrorMatches, expectedError)
 	c.Check(err, jc.Satisfies, isVPCNotUsableError)
@@ -74,7 +78,7 @@ func (s *vpcSuite) TestValidateModelVPCNotUsableError(c *gc.C) {
 
 func (s *vpcSuite) TestValidateModelVPCCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("foo"))
-	err := validateModelVPC(s.stubAPI, "model", "foo")
+	err := validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", "foo")
 	expectedError := `Juju could not verify whether the given vpc-id(.|\n)*`
 	c.Check(err, gc.ErrorMatches, expectedError)
 	c.Check(err, jc.Satisfies, common.IsCredentialNotValid)
@@ -82,10 +86,10 @@ func (s *vpcSuite) TestValidateModelVPCCredentialError(c *gc.C) {
 
 func (s *vpcSuite) TestValidateModelVPCIDNotSetOrNone(c *gc.C) {
 	const emptyVPCID = ""
-	err := validateModelVPC(s.stubAPI, "model", emptyVPCID)
+	err := validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", emptyVPCID)
 	c.Check(err, jc.ErrorIsNil)
 
-	err = validateModelVPC(s.stubAPI, "model", vpcIDNone)
+	err = validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", vpcIDNone)
 	c.Check(err, jc.ErrorIsNil)
 
 	s.stubAPI.CheckNoCalls(c)
@@ -96,10 +100,10 @@ func (s *vpcSuite) TestValidateModelVPCIDNotSetOrNone(c *gc.C) {
 // extensively tested separately below.
 
 func (s *vpcSuite) TestValidateVPCWithEmptyVPCIDOrNilAPIClient(c *gc.C) {
-	err := validateVPC(s.stubAPI, "")
+	err := validateVPC(s.stubAPI, s.cloudCallCtx, "")
 	c.Assert(err, gc.ErrorMatches, "invalid arguments: empty VPC ID or nil client")
 
-	err = validateVPC(nil, anyVPCID)
+	err = validateVPC(nil, s.cloudCallCtx, anyVPCID)
 	c.Assert(err, gc.ErrorMatches, "invalid arguments: empty VPC ID or nil client")
 
 	s.stubAPI.CheckNoCalls(c)
@@ -108,7 +112,7 @@ func (s *vpcSuite) TestValidateVPCWithEmptyVPCIDOrNilAPIClient(c *gc.C) {
 func (s *vpcSuite) TestValidateVPCWhenVPCIDNotFound(c *gc.C) {
 	s.stubAPI.SetErrors(makeVPCNotFoundError("foo"))
 
-	err := validateVPC(s.stubAPI, anyVPCID)
+	err := validateVPC(s.stubAPI, s.cloudCallCtx, anyVPCID)
 	c.Check(err, jc.Satisfies, isVPCNotUsableError)
 
 	s.stubAPI.CheckCallNames(c, "VPCs")
@@ -118,7 +122,7 @@ func (s *vpcSuite) TestValidateVPCWhenVPCHasNoSubnets(c *gc.C) {
 	s.stubAPI.SetVPCsResponse(1, availableState, notDefaultVPC)
 	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
 
-	err := validateVPC(s.stubAPI, anyVPCID)
+	err := validateVPC(s.stubAPI, s.cloudCallCtx, anyVPCID)
 	c.Check(err, jc.Satisfies, isVPCNotUsableError)
 
 	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets")
@@ -127,35 +131,35 @@ func (s *vpcSuite) TestValidateVPCWhenVPCNotAvailable(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetVPCsResponse(1, "bad-state", notDefaultVPC)
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "VPCs")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "VPCs")
 }
 
 func (s *vpcSuite) TestValidateVPCWhenVPCHasNoPublicSubnets(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetSubnetsResponse(1, anyZone, noPublicIPOnLaunch)
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "Subnets")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "Subnets")
 }
 
 func (s *vpcSuite) TestValidateVPCWhenVPCHasNoGateway(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetGatewaysResponse(noResults, anyState)
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "InternetGateways")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "InternetGateways")
 }
 
 func (s *vpcSuite) TestValidateVPCWhenVPCHasNoAttachedGateway(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetGatewaysResponse(1, "pending")
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "InternetGateways")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "InternetGateways")
 }
 
 func (s *vpcSuite) TestValidateVPCWhenVPCHasNoRouteTables(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetRouteTablesResponse() // no route tables at all
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "RouteTables")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "RouteTables")
 }
 
 func (s *vpcSuite) TestValidateVPCWhenVPCHasNoMainRouteTable(c *gc.C) {
@@ -164,7 +168,7 @@ func (s *vpcSuite) TestValidateVPCWhenVPCHasNoMainRouteTable(c *gc.C) {
 		makeEC2RouteTable(anyTableID, notMainRouteTable, nil, nil),
 	)
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "RouteTables")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "RouteTables")
 }
 
 func (s *vpcSuite) TestValidateVPCWhenVPCHasMainRouteTableWithoutRoutes(c *gc.C) {
@@ -173,13 +177,13 @@ func (s *vpcSuite) TestValidateVPCWhenVPCHasMainRouteTableWithoutRoutes(c *gc.C)
 		makeEC2RouteTable(anyTableID, mainRouteTable, nil, nil),
 	)
 
-	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, "RouteTables")
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c, s.cloudCallCtx, "RouteTables")
 }
 
 func (s *vpcSuite) TestValidateVPCSuccess(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 
-	err := validateVPC(s.stubAPI, anyVPCID)
+	err := validateVPC(s.stubAPI, s.cloudCallCtx, anyVPCID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets", "InternetGateways", "RouteTables")
@@ -188,7 +192,7 @@ func (s *vpcSuite) TestValidateVPCSuccess(c *gc.C) {
 func (s *vpcSuite) TestValidateModelVPCSuccess(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 
-	err := validateModelVPC(s.stubAPI, "model", anyVPCID)
+	err := validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", anyVPCID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets", "InternetGateways", "RouteTables")
@@ -199,7 +203,7 @@ func (s *vpcSuite) TestValidateModelVPCNotRecommendedStillOK(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetSubnetsResponse(1, anyZone, noPublicIPOnLaunch)
 
-	err := validateModelVPC(s.stubAPI, "model", anyVPCID)
+	err := validateModelVPC(s.stubAPI, s.cloudCallCtx, "model", anyVPCID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets")
@@ -212,7 +216,7 @@ func (s *vpcSuite) TestValidateModelVPCNotRecommendedStillOK(c *gc.C) {
 func (s *vpcSuite) TestGetVPCByIDWithMissingID(c *gc.C) {
 	s.stubAPI.SetErrors(makeVPCNotFoundError("foo"))
 
-	vpc, err := getVPCByID(s.stubAPI, "foo")
+	vpc, err := getVPCByID(s.stubAPI, s.cloudCallCtx, "foo")
 	c.Assert(err, gc.ErrorMatches, `The vpc ID 'foo' does not exist \(InvalidVpcID.NotFound\)`)
 	c.Check(err, jc.Satisfies, isVPCNotUsableError)
 	c.Check(vpc, gc.IsNil)
@@ -223,7 +227,7 @@ func (s *vpcSuite) TestGetVPCByIDWithMissingID(c *gc.C) {
 func (s *vpcSuite) TestGetVPCByIDUnexpectedAWSError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
-	vpc, err := getVPCByID(s.stubAPI, "bar")
+	vpc, err := getVPCByID(s.stubAPI, s.cloudCallCtx, "bar")
 	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting VPC "bar": AWS failed!`)
 	c.Check(vpc, gc.IsNil)
 
@@ -233,7 +237,7 @@ func (s *vpcSuite) TestGetVPCByIDUnexpectedAWSError(c *gc.C) {
 func (s *vpcSuite) TestGetVPCByIDCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("AWS failed!"))
 
-	vpc, err := getVPCByID(s.stubAPI, "bar")
+	vpc, err := getVPCByID(s.stubAPI, s.cloudCallCtx, "bar")
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Check(vpc, gc.IsNil)
 }
@@ -241,7 +245,7 @@ func (s *vpcSuite) TestGetVPCByIDCredentialError(c *gc.C) {
 func (s *vpcSuite) TestGetVPCByIDNoResults(c *gc.C) {
 	s.stubAPI.SetVPCsResponse(noResults, anyState, notDefaultVPC)
 
-	vpc, err := getVPCByID(s.stubAPI, "vpc-42")
+	vpc, err := getVPCByID(s.stubAPI, s.cloudCallCtx, "vpc-42")
 	c.Assert(err, gc.ErrorMatches, `VPC "vpc-42" not found`)
 	c.Check(err, jc.Satisfies, isVPCNotUsableError)
 	c.Check(vpc, gc.IsNil)
@@ -252,7 +256,7 @@ func (s *vpcSuite) TestGetVPCByIDNoResults(c *gc.C) {
 func (s *vpcSuite) TestGetVPCByIDMultipleResults(c *gc.C) {
 	s.stubAPI.SetVPCsResponse(5, anyState, notDefaultVPC)
 
-	vpc, err := getVPCByID(s.stubAPI, "vpc-33")
+	vpc, err := getVPCByID(s.stubAPI, s.cloudCallCtx, "vpc-33")
 	c.Assert(err, gc.ErrorMatches, "expected 1 result from AWS, got 5")
 	c.Check(vpc, gc.IsNil)
 
@@ -262,7 +266,7 @@ func (s *vpcSuite) TestGetVPCByIDMultipleResults(c *gc.C) {
 func (s *vpcSuite) TestGetVPCByIDSuccess(c *gc.C) {
 	s.stubAPI.SetVPCsResponse(1, anyState, notDefaultVPC)
 
-	vpc, err := getVPCByID(s.stubAPI, "vpc-1")
+	vpc, err := getVPCByID(s.stubAPI, s.cloudCallCtx, "vpc-1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(vpc, jc.DeepEquals, &s.stubAPI.vpcsResponse.VPCs[0])
 
@@ -300,7 +304,7 @@ func (s *vpcSuite) TestGetVPCSubnetUnexpectedAWSError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	subnets, err := getVPCSubnets(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting subnets of VPC "vpc-anything": AWS failed!`)
 	c.Check(subnets, gc.IsNil)
 
@@ -311,7 +315,7 @@ func (s *vpcSuite) TestGetVPCSubnetCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("AWS failed!"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	subnets, err := getVPCSubnets(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Check(subnets, gc.IsNil)
 }
@@ -320,7 +324,7 @@ func (s *vpcSuite) TestGetVPCSubnetsNoResults(c *gc.C) {
 	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	subnets, err := getVPCSubnets(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, `no subnets found for VPC "vpc-anything"`)
 	c.Check(err, jc.Satisfies, isVPCNotUsableError)
 	c.Check(subnets, gc.IsNil)
@@ -332,7 +336,7 @@ func (s *vpcSuite) TestGetVPCSubnetsSuccess(c *gc.C) {
 	s.stubAPI.SetSubnetsResponse(3, anyZone, noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	subnets, err := getVPCSubnets(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnets, jc.DeepEquals, s.stubAPI.subnetsResponse.Subnets)
 
@@ -361,7 +365,7 @@ func (s *vpcSuite) TestGetVPCInternetGatewayNoResults(c *gc.C) {
 	s.stubAPI.SetGatewaysResponse(noResults, anyState)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	gateway, err := getVPCInternetGateway(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, `VPC has no Internet Gateway attached`)
 	c.Check(err, jc.Satisfies, isVPCNotRecommendedError)
 	c.Check(gateway, gc.IsNil)
@@ -373,7 +377,7 @@ func (s *vpcSuite) TestGetVPCInternetGatewayUnexpectedAWSError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	gateway, err := getVPCInternetGateway(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting Internet Gateway of VPC "vpc-anything": AWS failed!`)
 	c.Check(gateway, gc.IsNil)
 
@@ -384,7 +388,7 @@ func (s *vpcSuite) TestGetVPCInternetGatewayCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("AWS failed!"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	gateway, err := getVPCInternetGateway(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Check(gateway, gc.IsNil)
 }
@@ -393,7 +397,7 @@ func (s *vpcSuite) TestGetVPCInternetGatewayMultipleResults(c *gc.C) {
 	s.stubAPI.SetGatewaysResponse(3, anyState)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	gateway, err := getVPCInternetGateway(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result from AWS, got 3")
 	c.Check(gateway, gc.IsNil)
 
@@ -404,7 +408,7 @@ func (s *vpcSuite) TestGetVPCInternetGatewaySuccess(c *gc.C) {
 	s.stubAPI.SetGatewaysResponse(1, anyState)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	gateway, err := getVPCInternetGateway(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(gateway, jc.DeepEquals, &s.stubAPI.gatewaysResponse.InternetGateways[0])
 
@@ -425,7 +429,7 @@ func (s *vpcSuite) TestGetVPCRouteTablesNoResults(c *gc.C) {
 	s.stubAPI.SetRouteTablesResponse() // no results
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	tables, err := getVPCRouteTables(s.stubAPI, anyVPC)
+	tables, err := getVPCRouteTables(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, `VPC has no route tables`)
 	c.Check(err, jc.Satisfies, isVPCNotRecommendedError)
 	c.Check(tables, gc.IsNil)
@@ -437,7 +441,7 @@ func (s *vpcSuite) TestGetVPCRouteTablesUnexpectedAWSError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	tables, err := getVPCRouteTables(s.stubAPI, anyVPC)
+	tables, err := getVPCRouteTables(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting route tables of VPC "vpc-anything": AWS failed!`)
 	c.Check(tables, gc.IsNil)
 
@@ -448,7 +452,7 @@ func (s *vpcSuite) TestGetVPCRouteTablesCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("AWS failed!"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	tables, err := getVPCRouteTables(s.stubAPI, anyVPC)
+	tables, err := getVPCRouteTables(s.stubAPI, s.cloudCallCtx, anyVPC)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	c.Check(tables, gc.IsNil)
 }
@@ -465,7 +469,7 @@ func (s *vpcSuite) TestGetVPCRouteTablesSuccess(c *gc.C) {
 		)),
 	)
 
-	tables, err := getVPCRouteTables(s.stubAPI, givenVPC)
+	tables, err := getVPCRouteTables(s.stubAPI, s.cloudCallCtx, givenVPC)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(tables, jc.DeepEquals, s.stubAPI.routeTablesResponse.Tables)
 
@@ -566,7 +570,7 @@ func (s *vpcSuite) TestCheckVPCRouteTableRoutesSuccess(c *gc.C) {
 func (s *vpcSuite) TestFindDefaultVPCIDUnexpectedAWSError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
-	vpcID, err := findDefaultVPCID(s.stubAPI)
+	vpcID, err := findDefaultVPCID(s.stubAPI, s.cloudCallCtx)
 	c.Assert(err, gc.ErrorMatches, "unexpected AWS response getting default-vpc account attribute: AWS failed!")
 	c.Check(vpcID, gc.Equals, "")
 
@@ -575,7 +579,7 @@ func (s *vpcSuite) TestFindDefaultVPCIDUnexpectedAWSError(c *gc.C) {
 
 func (s *vpcSuite) TestFindDefaultVPCIDCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("AWS failed!"))
-	_, err := findDefaultVPCID(s.stubAPI)
+	_, err := findDefaultVPCID(s.stubAPI, s.cloudCallCtx)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 }
 
@@ -583,7 +587,7 @@ func (s *vpcSuite) TestFindDefaultVPCIDNoAttributeOrNoValue(c *gc.C) {
 	s.stubAPI.SetAttributesResponse(nil) // no attributes at all
 
 	checkFailed := func() {
-		vpcID, err := findDefaultVPCID(s.stubAPI)
+		vpcID, err := findDefaultVPCID(s.stubAPI, s.cloudCallCtx)
 		c.Assert(err, gc.ErrorMatches, "default-vpc account attribute not found")
 		c.Check(err, jc.Satisfies, errors.IsNotFound)
 		c.Check(vpcID, gc.Equals, "")
@@ -618,7 +622,7 @@ func (s *vpcSuite) TestFindDefaultVPCIDWithExplicitNoneValue(c *gc.C) {
 		"default-vpc": {"none"},
 	})
 
-	vpcID, err := findDefaultVPCID(s.stubAPI)
+	vpcID, err := findDefaultVPCID(s.stubAPI, s.cloudCallCtx)
 	c.Assert(err, gc.ErrorMatches, "default VPC not found")
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(vpcID, gc.Equals, "")
@@ -631,7 +635,7 @@ func (s *vpcSuite) TestFindDefaultVPCIDSuccess(c *gc.C) {
 		"default-vpc": {"vpc-foo", "vpc-bar"},
 	})
 
-	vpcID, err := findDefaultVPCID(s.stubAPI)
+	vpcID, err := findDefaultVPCID(s.stubAPI, s.cloudCallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(vpcID, gc.Equals, "vpc-foo") // always the first value is used.
 
@@ -642,7 +646,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsError(c *gc.
 	s.stubAPI.SetErrors(errors.New("too cloudy"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone, nil)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, s.cloudCallCtx, anyVPC.Id, anyZone, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot get VPC "vpc-anything" subnets: unexpected AWS .*: too cloudy`)
 	c.Check(subnetIDs, gc.IsNil)
 
@@ -653,7 +657,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsCredentialEr
 	s.stubAPI.SetErrors(common.NewCredentialNotValid("too cloudy"))
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone, nil)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, s.cloudCallCtx, anyVPC.Id, anyZone, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot get VPC "vpc-anything" subnets: unexpected AWS .*: too cloudy`)
 	c.Check(subnetIDs, gc.IsNil)
 	c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
@@ -663,7 +667,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneNoSubnetsAtAll(c *gc.C)
 	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone, nil)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, s.cloudCallCtx, anyVPC.Id, anyZone, nil)
 	c.Assert(err, gc.ErrorMatches, `VPC "vpc-anything" has no subnets in AZ "any-zone": no subnets found for VPC.*`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(subnetIDs, gc.IsNil)
@@ -675,7 +679,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneNoSubnetsInAZ(c *gc.C) 
 	s.stubAPI.SetSubnetsResponse(3, "other-zone", noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "given-zone", nil)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, s.cloudCallCtx, anyVPC.Id, "given-zone", nil)
 	c.Assert(err, gc.ErrorMatches, `VPC "vpc-anything" has no subnets in AZ "given-zone"`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(subnetIDs, gc.IsNil)
@@ -691,7 +695,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsToZones(c *g
 	allowedSubnetIDs := []string{"subnet-1", "subnet-3"}
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone", allowedSubnetIDs)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, s.cloudCallCtx, anyVPC.Id, "my-zone", allowedSubnetIDs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnetIDs, jc.DeepEquals, []string{"subnet-1", "subnet-3"})
 
@@ -702,7 +706,7 @@ func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneSuccess(c *gc.C) {
 	s.stubAPI.SetSubnetsResponse(2, "my-zone", noPublicIPOnLaunch)
 
 	anyVPC := makeEC2VPC(anyVPCID, anyState)
-	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone", nil)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, s.cloudCallCtx, anyVPC.Id, "my-zone", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Result slice of IDs is always sorted.
 	c.Check(subnetIDs, jc.DeepEquals, []string{"subnet-0", "subnet-1"})
@@ -929,8 +933,8 @@ func (s *stubVPCAPIClient) PrepareValidateVPCResponses() {
 	)
 }
 
-func (s *stubVPCAPIClient) CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c *gc.C, lastExpectedCallName string) {
-	err := validateVPC(s, anyVPCID)
+func (s *stubVPCAPIClient) CallValidateVPCAndCheckCallsUpToExpectingVPCNotRecommendedError(c *gc.C, ctx context.ProviderCallContext, lastExpectedCallName string) {
+	err := validateVPC(s, ctx, anyVPCID)
 	c.Assert(err, jc.Satisfies, isVPCNotRecommendedError)
 
 	allCalls := []string{"VPCs", "Subnets", "InternetGateways", "RouteTables"}

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -42,16 +42,16 @@ func TerminatedInstances(e environs.Environ) ([]instance.Instance, error) {
 	return e.(*environ).AllInstancesByState(context.NewCloudCallContext(), "shutting-down", "terminated")
 }
 
-func InstanceSecurityGroups(e environs.Environ, ids []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
-	return e.(*environ).instanceSecurityGroups(ids, states...)
+func InstanceSecurityGroups(e environs.Environ, ctx context.ProviderCallContext, ids []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
+	return e.(*environ).instanceSecurityGroups(ctx, ids, states...)
 }
 
-func AllModelVolumes(e environs.Environ) ([]string, error) {
-	return e.(*environ).allModelVolumes(true)
+func AllModelVolumes(e environs.Environ, ctx context.ProviderCallContext) ([]string, error) {
+	return e.(*environ).allModelVolumes(ctx, true)
 }
 
-func AllModelGroups(e environs.Environ) ([]string, error) {
-	return e.(*environ).modelSecurityGroupIDs()
+func AllModelGroups(e environs.Environ, ctx context.ProviderCallContext) ([]string, error) {
+	return e.(*environ).modelSecurityGroupIDs(ctx)
 }
 
 var (
@@ -359,6 +359,6 @@ const testImageMetadataProduct = `
 }
 `
 
-func VerifyCredentials(env environs.Environ) error {
-	return verifyCredentials(env.(*environ))
+func VerifyCredentials(env environs.Environ, ctx context.ProviderCallContext) error {
+	return verifyCredentials(env.(*environ), ctx)
 }

--- a/provider/ec2/instance.go
+++ b/provider/ec2/instance.go
@@ -81,7 +81,7 @@ func (inst *ec2Instance) OpenPorts(ctx context.ProviderCallContext, machineId st
 			inst.e.Config().FirewallMode())
 	}
 	name := inst.e.machineGroupName(machineId)
-	if err := inst.e.openPortsInGroup(name, rules); err != nil {
+	if err := inst.e.openPortsInGroup(ctx, name, rules); err != nil {
 		return err
 	}
 	logger.Infof("opened ports in security group %s: %v", name, rules)
@@ -94,7 +94,7 @@ func (inst *ec2Instance) ClosePorts(ctx context.ProviderCallContext, machineId s
 			inst.e.Config().FirewallMode())
 	}
 	name := inst.e.machineGroupName(machineId)
-	if err := inst.e.closePortsInGroup(name, ports); err != nil {
+	if err := inst.e.closePortsInGroup(ctx, name, ports); err != nil {
 		return err
 	}
 	logger.Infof("closed ports in security group %s: %v", name, ports)
@@ -107,7 +107,7 @@ func (inst *ec2Instance) IngressRules(ctx context.ProviderCallContext, machineId
 			inst.e.Config().FirewallMode())
 	}
 	name := inst.e.machineGroupName(machineId)
-	ranges, err := inst.e.ingressRulesInGroup(name)
+	ranges, err := inst.e.ingressRulesInGroup(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/ec2/instance_information.go
+++ b/provider/ec2/instance_information.go
@@ -16,7 +16,7 @@ var _ environs.InstanceTypesFetcher = (*environ)(nil)
 
 // InstanceTypes implements InstanceTypesFetcher
 func (e *environ) InstanceTypes(ctx context.ProviderCallContext, c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
-	iTypes, err := e.supportedInstanceTypes()
+	iTypes, err := e.supportedInstanceTypes(ctx)
 	if err != nil {
 		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
 	}

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -54,7 +54,7 @@ func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error
 	var err error
 	e.ec2, err = awsClient(e.cloud)
 	if err != nil {
-		return nil, errors.Trace(maybeConvertCredentialError(err))
+		return nil, errors.Trace(err)
 	}
 
 	if err := e.SetConfig(args.Config); err != nil {
@@ -189,9 +189,9 @@ your details are being verified.`
 // verify the configured credentials. If verification fails, a user-friendly
 // error will be returned, and the original error will be logged at debug
 // level.
-var verifyCredentials = func(e *environ) error {
+var verifyCredentials = func(e *environ, ctx context.ProviderCallContext) error {
 	_, err := e.ec2.AccountAttributes()
-	return maybeConvertCredentialError(err)
+	return maybeConvertCredentialError(err, ctx)
 }
 
 // maybeConvertCredentialError examines the error received from the provider.
@@ -199,28 +199,38 @@ var verifyCredentials = func(e *environ) error {
 // Authorisation related errors are annotated with an additional
 // user-friendly explanation.
 // All other errors are returned un-wrapped and not annotated.
-var maybeConvertCredentialError = func(err error) error {
+var maybeConvertCredentialError = func(err error, ctx context.ProviderCallContext) error {
 	if err == nil {
 		return nil
+	}
+
+	convert := func(converted error) error {
+		logger.Errorf("XXXXXXXXXXXXXXXXXXX calling invalidate credential")
+		callbackErr := ctx.InvalidateCredential(converted.Error())
+		if callbackErr != nil {
+			// We want to proceed with the actual proessing but still keep a log of a problem.
+			logger.Infof("callback to invalidate model credential failed with %v", converted)
+		}
+		return converted
 	}
 
 	if err, ok := err.(*ec2.Error); ok {
 		// EC2 error codes are from https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.
 		switch err.Code {
 		case "AuthFailure":
-			return common.CredentialNotValidf(err, badKeys)
+			return convert(common.CredentialNotValidf(err, badKeys))
 		case "InvalidClientTokenId":
-			return common.CredentialNotValidf(err, badKeys)
+			return convert(common.CredentialNotValidf(err, badKeys))
 		case "MissingAuthenticationToken":
-			return common.CredentialNotValidf(err, badKeys)
+			return convert(common.CredentialNotValidf(err, badKeys))
 		case "Blocked":
-			return common.CredentialNotValidf(err, "\nYour Amazon account is currently blocked.")
+			return convert(common.CredentialNotValidf(err, "\nYour Amazon account is currently blocked."))
 		case "CustomerKeyHasBeenRevoked":
-			return common.CredentialNotValidf(err, "\nYour Amazon keys have been revoked.")
+			return convert(common.CredentialNotValidf(err, "\nYour Amazon keys have been revoked."))
 		case "PendingVerification":
-			return common.CredentialNotValidf(err, "\nYour account is pending verification by Amazon.")
+			return convert(common.CredentialNotValidf(err, "\nYour account is pending verification by Amazon."))
 		case "SignatureDoesNotMatch":
-			return common.CredentialNotValidf(err, badKeys)
+			return convert(common.CredentialNotValidf(err, badKeys))
 		case "OptInRequired":
 			return errors.Annotate(err, unauthorized)
 		case "UnauthorizedOperation":

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -205,7 +205,6 @@ var maybeConvertCredentialError = func(err error, ctx context.ProviderCallContex
 	}
 
 	convert := func(converted error) error {
-		logger.Errorf("XXXXXXXXXXXXXXXXXXX calling invalidate credential")
 		callbackErr := ctx.InvalidateCredential(converted.Error())
 		if callbackErr != nil {
 			// We want to proceed with the actual proessing but still keep a log of a problem.


### PR DESCRIPTION
## Description of change

This is the first of the providers to learn to react to invalid credential.

Essentially a successfully bootstrapped system might get the cloud credential it uses invalidated by the provider, say cloud credential gets expired... This event should pause all the interactions with the cloud api until the credential has been updated.

This PR ensures that this happens for aws.

## QA steps

* bootstrap
* add models, deploy applications
* invalidate cloud credential
* check that cannot deploy anything nor create anything that needs to also exist on the cloud
* check logs do not contain infinite number of "invalid credential" errors
* check that all workers that require valid credentials are stopped
* update credential or re-validate it
* check that everything is back to fully functional

