### PR TITLE
LXD availability zones

### DIFF
--- a/container/lxd/cluster.go
+++ b/container/lxd/cluster.go
@@ -3,6 +3,10 @@
 
 package lxd
 
+func (s *Server) ClusterSupported() bool {
+	return s.clusterAPISupport
+}
+
 // UseTargetServer returns a new Server based on the input target node name.
 // It is intended for use when operations must target specific nodes in a
 // cluster.

--- a/container/lxd/cluster.go
+++ b/container/lxd/cluster.go
@@ -11,5 +11,6 @@ func (s *Server) ClusterSupported() bool {
 // It is intended for use when operations must target specific nodes in a
 // cluster.
 func (s Server) UseTargetServer(name string) (*Server, error) {
+	logger.Debugf("creating LXD server for cluster node %q", name)
 	return NewServer(s.UseTarget(name))
 }

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -48,7 +48,7 @@ func (s *imageSuite) TestCopyImageUsesPassedCallback(c *gc.C) {
 		Image:     &image,
 		LXDServer: iSvr,
 	}
-	err = jujuSvr.CopyRemoteImage(sourced, []string{"local/image/alias"}, noOpCallback)
+	err = jujuSvr.CopyRemoteImage(sourced, []string{"local/image/alias"}, lxdtesting.NoOpCallback)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -116,8 +116,6 @@ func prepNetworkConfig() *container.NetworkConfig {
 	}})
 }
 
-var noOpCallback = func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
-
 func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -163,7 +161,7 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 	)
 
 	instance, hc, err := manager.CreateContainer(
-		iCfg, constraints.Value{}, "xenial", prepNetworkConfig(), &container.StorageConfig{}, noOpCallback,
+		iCfg, constraints.Value{}, "xenial", prepNetworkConfig(), &container.StorageConfig{}, lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -219,7 +217,7 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 		ParentInterfaceName: network.DefaultLXDBridge,
 	}})
 	_, _, err = manager.CreateContainer(
-		iCfg, constraints.Value{}, "xenial", netConfig, &container.StorageConfig{}, noOpCallback,
+		iCfg, constraints.Value{}, "xenial", netConfig, &container.StorageConfig{}, lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -249,7 +247,7 @@ func (s *managerSuite) TestCreateContainerCreateFailed(c *gc.C) {
 		"xenial",
 		prepNetworkConfig(),
 		&container.StorageConfig{},
-		noOpCallback,
+		lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, gc.ErrorMatches, ".*create failed")
 }
@@ -287,7 +285,7 @@ func (s *managerSuite) TestCreateContainerStartFailed(c *gc.C) {
 		"xenial",
 		prepNetworkConfig(),
 		&container.StorageConfig{},
-		noOpCallback,
+		lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, gc.ErrorMatches, ".*start failed")
 }

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -93,9 +93,6 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 	name := info.Environment.ServerName
 	clustered := info.Environment.ServerClustered
 	serverCertificate := info.Environment.Certificate
-	if clustered {
-		logger.Debugf("creating LXD server for cluster node %q", name)
-	}
 
 	return &Server{
 		ContainerServer:   svr,

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -105,6 +105,11 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 	}, nil
 }
 
+// Name returns the name of this LXD server.
+func (s *Server) Name() string {
+	return s.name
+}
+
 // UpdateServerConfig updates the server configuration with the input values.
 func (s *Server) UpdateServerConfig(cfg map[string]string) error {
 	svr, eTag, err := s.GetServer()

--- a/container/lxd/testing/suite.go
+++ b/container/lxd/testing/suite.go
@@ -2,14 +2,19 @@ package testing
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/utils/arch"
 	lxdapi "github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/utils/arch"
 )
 
 const ETag = "eTag"
+
+// NoOpCallback can be passed to methods that receive a callback for setting
+// status messages.
+var NoOpCallback = func(st status.Status, info string, data map[string]interface{}) error { return nil }
 
 // BaseSuite facilitates LXD testing.
 // Do not instantiate this suite directly.

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -165,7 +165,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
-		sExp.ClusterSupported().Return(true),
+		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
 	)
@@ -206,7 +206,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
-		sExp.ClusterSupported().Return(true),
+		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
 
@@ -240,7 +240,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
-		sExp.ClusterSupported().Return(true),
+		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
 

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -5,6 +5,7 @@ package lxd_test
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
@@ -17,7 +18,6 @@ import (
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
-	"reflect"
 )
 
 type environBrokerSuite struct {

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -4,18 +4,24 @@
 package lxd_test
 
 import (
-	gitjujutesting "github.com/juju/testing"
+	"fmt"
+
+	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/constraints"
 	containerlxd "github.com/juju/juju/container/lxd"
+	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
+	"reflect"
 )
 
 type environBrokerSuite struct {
-	lxd.BaseSuite
+	lxd.EnvironSuite
 
 	callCtx context.ProviderCallContext
 }
@@ -27,142 +33,409 @@ func (s *environBrokerSuite) SetUpTest(c *gc.C) {
 	s.callCtx = context.NewCloudCallContext()
 }
 
-func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
-	s.Client.Container = s.Container
-	s.Client.Profile.Devices = map[string]map[string]string{
-		"eth0": {},
+// containerSpecMatcher is a gomock matcher for testing a container spec
+// with a supplied validation func.
+type containerSpecMatcher struct {
+	check func(spec containerlxd.ContainerSpec) bool
+}
+
+func (m containerSpecMatcher) Matches(arg interface{}) bool {
+	if spec, ok := arg.(containerlxd.ContainerSpec); ok {
+		return m.check(spec)
 	}
+	return false
+}
 
+func (m containerSpecMatcher) String() string {
+	return fmt.Sprintf("%T", m.check)
+}
+
+func matchesContainerSpec(check func(spec containerlxd.ContainerSpec) bool) gomock.Matcher {
+	return containerSpecMatcher{check: check}
+}
+
+func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
-	result, err := s.Env.StartInstance(s.callCtx, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result.Instance, gc.DeepEquals, s.Instance)
-	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
-	c.Assert(s.StartInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.ARM64)
-
-	s.Stub.CheckCallNames(c, "FindImage", "GetNICsFromProfile", "CreateContainerFromSpec")
-	s.Stub.CheckCall(c, 0, "FindImage", "trusty", "arm64")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
 
 	// Check that no custom devices were passed - vanilla cloud-init.
-	spec := s.Stub.Calls()[2].Args[0].(containerlxd.ContainerSpec)
-	c.Check(spec.Devices, gc.IsNil)
-	c.Check(spec.Config[containerlxd.NetworkConfigKey], gc.Equals, "")
+	check := func(spec containerlxd.ContainerSpec) bool {
+		if spec.Config[containerlxd.NetworkConfigKey] != "" {
+			return false
+		}
+		return !(len(spec.Devices) > 0)
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
+	)
+
+	env := s.NewEnviron(c, svr, nil)
+	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c, "bionic"))
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
-	s.Client.Container = s.Container
-	s.Client.Profile.Devices = map[string]map[string]string{
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	nics := map[string]map[string]string{
 		"eno9": {
 			"name":    "eno9",
 			"mtu":     "9000",
 			"nictype": "bridged",
 			"parent":  "lxdbr0",
+			"hwaddr":  "00:00:00:00:00",
 		},
 	}
 
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-
-	result, err := s.Env.StartInstance(s.callCtx, s.StartInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result.Instance, gc.DeepEquals, s.Instance)
-	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
-	c.Assert(s.StartInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.ARM64)
-
-	s.Stub.CheckCallNames(c, "FindImage", "GetNICsFromProfile", "CreateContainerFromSpec")
-	s.Stub.CheckCall(c, 0, "FindImage", "trusty", "arm64")
-
-	// Check that the non-standard devices were passed explicitly.
-	spec := s.Stub.Calls()[2].Args[0].(containerlxd.ContainerSpec)
-	c.Check(spec.Devices, gc.HasLen, 1)
-	c.Check(spec.Devices["eno9"]["name"], gc.Equals, "eno9")
-	c.Check(spec.Config[containerlxd.NetworkConfigKey], gc.Equals, `network:
+	// Check that the non-standard devices were passed explicitly,
+	// And that we have disabled the standard network config.
+	check := func(spec containerlxd.ContainerSpec) bool {
+		if !reflect.DeepEqual(spec.Devices, nics) {
+			return false
+		}
+		return spec.Config[containerlxd.NetworkConfigKey] == `network:
   config: "disabled"
-`)
+`
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.GetNICsFromProfile("default").Return(nics, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
+	)
+
+	env := s.NewEnviron(c, svr, nil)
+	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c, "bionic"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	target := lxdtesting.NewMockContainerServer(ctrl)
+	tExp := target.EXPECT()
+	serverRet := &api.Server{}
+	tExp.GetServer().Return(serverRet, lxdtesting.ETag, nil)
+
+	jujuTarget, err := containerlxd.NewServer(target)
+	c.Assert(err, jc.ErrorIsNil)
+
+	image := containerlxd.SourcedImage{
+		Image: &api.Image{Filename: "container-image"},
+	}
+
+	members := []api.ClusterMember{
+		{
+			ServerName: "node01",
+			Status:     "ONLINE",
+		},
+		{
+			ServerName: "node02",
+			Status:     "ONLINE",
+		},
+	}
+
+	createOp := lxdtesting.NewMockRemoteOperation(ctrl)
+	createOp.EXPECT().Wait().Return(nil)
+	createOp.EXPECT().GetTarget().Return(&api.Operation{StatusCode: api.Success}, nil)
+
+	startOp := lxdtesting.NewMockOperation(ctrl)
+	startOp.EXPECT().Wait().Return(nil)
+
+	sExp := svr.EXPECT()
+	gomock.InOrder(
+		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
+		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.ClusterSupported().Return(true),
+		sExp.GetClusterMembers().Return(members, nil),
+		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
+	)
+
+	// CreateContainerFromSpec is tested in container/lxd.
+	// we don't bother with detailed parameter assertions here.
+	tExp.CreateContainerFromImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(createOp, nil)
+	tExp.UpdateContainerState(gomock.Any(), gomock.Any(), "").Return(startOp, nil)
+	tExp.GetContainer(gomock.Any()).Return(&api.Container{}, lxdtesting.ETag, nil)
+
+	env := s.NewEnviron(c, svr, nil)
+
+	args := s.GetStartInstanceArgs(c, "bionic")
+	args.Placement = "zone=node01"
+
+	_, err = env.StartInstance(s.callCtx, args)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	image := containerlxd.SourcedImage{
+		Image: &api.Image{Filename: "container-image"},
+	}
+
+	members := []api.ClusterMember{{
+		ServerName: "node01",
+		Status:     "ONLINE",
+	}}
+
+	sExp := svr.EXPECT()
+	gomock.InOrder(
+		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
+		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.ClusterSupported().Return(true),
+		sExp.GetClusterMembers().Return(members, nil),
+	)
+
+	env := s.NewEnviron(c, svr, nil)
+
+	args := s.GetStartInstanceArgs(c, "bionic")
+	args.Placement = "zone=node03"
+
+	_, err := env.StartInstance(s.callCtx, args)
+	c.Assert(err, gc.ErrorMatches, `availability zone "node03" not valid`)
+}
+
+func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C) {
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	image := containerlxd.SourcedImage{
+		Image: &api.Image{Filename: "container-image"},
+	}
+
+	members := []api.ClusterMember{{
+		ServerName: "node01",
+		Status:     "OFFLINE",
+	}}
+
+	sExp := svr.EXPECT()
+	gomock.InOrder(
+		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
+		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.ClusterSupported().Return(true),
+		sExp.GetClusterMembers().Return(members, nil),
+	)
+
+	env := s.NewEnviron(c, svr, nil)
+
+	args := s.GetStartInstanceArgs(c, "bionic")
+	args.Placement = "zone=node01"
+
+	_, err := env.StartInstance(s.callCtx, args)
+	c.Assert(err, gc.ErrorMatches, "availability zone \"node01\" is unavailable")
+}
+
+func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) {
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	image := containerlxd.SourcedImage{
+		Image: &api.Image{Filename: "container-image"},
+	}
+
+	sExp := svr.EXPECT()
+	gomock.InOrder(
+		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
+		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+	)
+	env := s.NewEnviron(c, svr, nil)
+
+	args := s.GetStartInstanceArgs(c, "bionic")
+	args.Placement = "breakfast=eggs"
+
+	_, err := env.StartInstance(s.callCtx, args)
+	c.Assert(err, gc.ErrorMatches, "unknown placement directive.*")
+}
+
+func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
+	// Patch the host's arch, so the broker will filter tools.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	// Check that the constraints were passed through to spec.Config.
+	check := func(spec containerlxd.ContainerSpec) bool {
+		cfg := spec.Config
+		if cfg["limits.cpu"] != "2" {
+			return false
+		}
+		if cfg["limits.memory"] != "2048MB" {
+			return false
+		}
+		return spec.InstanceType == "t2.micro"
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
+	)
+
+	args := s.GetStartInstanceArgs(c, "bionic")
+	cores := uint64(2)
+	mem := uint64(2048)
+	it := "t2.micro"
+	args.Constraints = constraints.Value{
+		CpuCores:     &cores,
+		Mem:          &mem,
+		InstanceType: &it,
+	}
+
+	env := s.NewEnviron(c, svr, nil)
+	_, err := env.StartInstance(s.callCtx, args)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {
-	s.Client.Container = s.Container
-
 	// Patch the host's arch, so the broker will filter tools.
 	s.PatchValue(&arch.HostArch, func() string { return arch.PPC64EL })
 
-	_, err := s.Env.StartInstance(s.callCtx, s.StartInstArgs)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	env := s.NewEnviron(c, svr, nil)
+	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c, "bionic"))
 	c.Assert(err, gc.ErrorMatches, "no matching agent binaries available")
 }
 
 func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
-	err := s.Env.StopInstances(s.callCtx, s.Instance.Id())
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	svr.EXPECT().RemoveContainers([]string{"juju-f75cba-1", "juju-f75cba-2"})
+
+	env := s.NewEnviron(c, svr, nil)
+	err := env.StopInstances(s.callCtx, "juju-f75cba-1", "juju-f75cba-2", "not-in-namespace-so-ignored")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environBrokerSuite) TestImageSourcesDefault(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	sources, err := lxd.GetImageSources(s.NewEnviron(c, svr, nil))
 	c.Assert(err, jc.ErrorIsNil)
 
-	// TODO (manadart 2018-06-25) This call has no IDs as arguments,
-	// because of filtering by the env namespace prefix.
-	// These tests will all be rewritten.
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "RemoveContainers",
-		Args: []interface{}{
-			[]string{},
-		},
-	}})
+	s.checkSources(c, sources, []string{
+		"https://streams.canonical.com/juju/images/releases/",
+		"https://cloud-images.ubuntu.com/releases/",
+	})
 }
 
 func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {
-	s.UpdateConfig(c, map[string]interface{}{
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	env := s.NewEnviron(c, svr, map[string]interface{}{
 		"image-metadata-url": "https://my-test.com/images/",
 	})
-	s.checkSources(c, []string{
+
+	sources, err := lxd.GetImageSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
 		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
 
-func (s *environBrokerSuite) TestImageMetadataURLMungesHTTP(c *gc.C) {
-	// LXD requires 'https://' hosts for simplestreams data.
-	// https://github.com/lxc/lxd/issues/1763
-	s.UpdateConfig(c, map[string]interface{}{
+func (s *environBrokerSuite) TestImageMetadataURLEnsuresHTTPS(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	// HTTP should be converted to HTTPS.
+	env := s.NewEnviron(c, svr, map[string]interface{}{
 		"image-metadata-url": "http://my-test.com/images/",
 	})
-	s.checkSources(c, []string{
-		"https://my-test.com/images/",
-		"https://streams.canonical.com/juju/images/releases/",
-		"https://cloud-images.ubuntu.com/releases/",
-	})
-}
 
-func (s *environBrokerSuite) TestImageStreamDefault(c *gc.C) {
-	s.checkSourcesFromStream(c, "", []string{
+	sources, err := lxd.GetImageSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkSources(c, sources, []string{
+		"https://my-test.com/images/",
 		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
 
 func (s *environBrokerSuite) TestImageStreamReleased(c *gc.C) {
-	s.checkSourcesFromStream(c, "released", []string{
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	env := s.NewEnviron(c, svr, map[string]interface{}{
+		"image-stream": "released",
+	})
+
+	sources, err := lxd.GetImageSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkSources(c, sources, []string{
 		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
 
 func (s *environBrokerSuite) TestImageStreamDaily(c *gc.C) {
-	s.checkSourcesFromStream(c, "daily", []string{
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	env := s.NewEnviron(c, svr, map[string]interface{}{
+		"image-stream": "daily",
+	})
+
+	sources, err := lxd.GetImageSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkSources(c, sources, []string{
 		"https://streams.canonical.com/juju/images/daily/",
 		"https://cloud-images.ubuntu.com/daily/",
 	})
 }
 
-func (s *environBrokerSuite) checkSourcesFromStream(c *gc.C, stream string, expectedURLs []string) {
-	if stream != "" {
-		s.UpdateConfig(c, map[string]interface{}{"image-stream": stream})
-	}
-	s.checkSources(c, expectedURLs)
-}
-
-func (s *environBrokerSuite) checkSources(c *gc.C, expectedURLs []string) {
-	sources, err := lxd.GetImageSources(s.Env)
-	c.Assert(err, jc.ErrorIsNil)
+func (s *environBrokerSuite) checkSources(c *gc.C, sources []containerlxd.ServerSpec, expectedURLs []string) {
 	var sourceURLs []string
 	for _, source := range sources {
 		sourceURLs = append(sourceURLs, source.Host)

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -113,16 +113,6 @@ func (env *environ) ControllerInstances(ctx context.ProviderCallContext, control
 	return results, nil
 }
 
-type instPlacement struct{}
-
-func (env *environ) parsePlacement(placement string) (*instPlacement, error) {
-	if placement == "" {
-		return &instPlacement{}, nil
-	}
-
-	return nil, errors.Errorf("unknown placement directive: %v", placement)
-}
-
 // AdoptResources updates the controller tags on all instances to have the
 // new controller id. It's part of the Environ interface.
 func (env *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -15,11 +15,8 @@ import (
 // PrecheckInstance verifies that the provided series and constraints
 // are valid for use in creating an instance in this environment.
 func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args environs.PrecheckInstanceParams) error {
-	if _, err := env.parsePlacement(args.Placement); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
+	_, err := env.parsePlacement(ctx, args.Placement)
+	return errors.Trace(err)
 }
 
 var unsupportedConstraints = []string{

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -57,7 +57,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=a-zone"
 	err := s.Env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: version.SupportedLTS(), Placement: placement})
 
-	c.Check(err, gc.ErrorMatches, `unknown placement directive: .*`)
+	c.Check(err, gc.ErrorMatches, `availability zone "a-zone" not valid`)
 }
 
 func (s *environPolSuite) TestConstraintsValidatorOkay(c *gc.C) {

--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -4,10 +4,12 @@
 package lxd
 
 import (
-	"github.com/juju/juju/environs"
+	"errors"
+
 	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/container/lxd"
+	"github.com/juju/juju/environs"
 )
 
 var (
@@ -69,6 +71,10 @@ func ExposeEnvServer(env *environ) Server {
 	return env.server
 }
 
-func GetImageSources(env *environ) ([]lxd.ServerSpec, error) {
-	return env.getImageSources()
+func GetImageSources(env environs.Environ) ([]lxd.ServerSpec, error) {
+	lxdEnv, ok := env.(*environ)
+	if !ok {
+		return nil, errors.New("not a LXD environ")
+	}
+	return lxdEnv.getImageSources()
 }

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -66,6 +66,9 @@ type Server interface {
 	ServerCertificate() string
 	EnableHTTPSListener() error
 	GetNICsFromProfile(profName string) (map[string]map[string]string, error)
+	ClusterSupported() bool
+	UseTargetServer(name string) (*lxd.Server, error)
+	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
 }
 
 // ServerFactory creates a new factory for creating servers that are required

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -234,9 +234,11 @@ func (s *serverFactory) initLocalServer() (Server, apiProfile, error) {
 		return nil, apiProfile{}, errors.Trace(err)
 	}
 
-	// If this is the LXD provider on the localhost, let's do an extra check to
-	// make sure the default profile has a correctly configured bridge, and
-	// which one is it.
+	// Ensure that the default profile has a network device, with a valid
+	// parent network.
+	//
+	// TODO (manadart 2018-07-18) Move this to just prior to instance creation.
+	// That is the only place it is relevant.
 	if err := svr.VerifyNetworkDevice(defaultProfile, profileETag); err != nil {
 		return nil, apiProfile{}, errors.Trace(err)
 	}
@@ -326,9 +328,11 @@ func (s *serverFactory) bootstrapRemoteServer(svr Server) error {
 		return errors.Trace(err)
 	}
 
-	// If this is the LXD provider on the localhost, let's do an extra check to
-	// make sure the default profile has a correctly configured bridge, and
-	// which one is it.
+	// Ensure that the default profile has a network device, with a valid
+	// parent network.
+	//
+	// TODO (manadart 2018-07-18) Move this to just prior to instance creation.
+	// That is the only place it is relevant.
 	if err := svr.VerifyNetworkDevice(defaultProfile, profileETag); err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -66,9 +66,10 @@ type Server interface {
 	ServerCertificate() string
 	EnableHTTPSListener() error
 	GetNICsFromProfile(profName string) (map[string]map[string]string, error)
-	ClusterSupported() bool
+	IsClustered() bool
 	UseTargetServer(name string) (*lxd.Server, error)
 	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
+	Name() string
 }
 
 // ServerFactory creates a new factory for creating servers that are required

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -50,6 +50,18 @@ func (mr *MockServerMockRecorder) AliveContainers(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliveContainers", reflect.TypeOf((*MockServer)(nil).AliveContainers), arg0)
 }
 
+// ClusterSupported mocks base method
+func (m *MockServer) ClusterSupported() bool {
+	ret := m.ctrl.Call(m, "ClusterSupported")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ClusterSupported indicates an expected call of ClusterSupported
+func (mr *MockServerMockRecorder) ClusterSupported() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterSupported", reflect.TypeOf((*MockServer)(nil).ClusterSupported))
+}
+
 // ContainerAddresses mocks base method
 func (m *MockServer) ContainerAddresses(arg0 string) ([]network.Address, error) {
 	ret := m.ctrl.Call(m, "ContainerAddresses", arg0)
@@ -227,6 +239,19 @@ func (m *MockServer) GetCertificate(arg0 string) (*api.Certificate, string, erro
 // GetCertificate indicates an expected call of GetCertificate
 func (mr *MockServerMockRecorder) GetCertificate(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertificate", reflect.TypeOf((*MockServer)(nil).GetCertificate), arg0)
+}
+
+// GetClusterMembers mocks base method
+func (m *MockServer) GetClusterMembers() ([]api.ClusterMember, error) {
+	ret := m.ctrl.Call(m, "GetClusterMembers")
+	ret0, _ := ret[0].([]api.ClusterMember)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMembers indicates an expected call of GetClusterMembers
+func (mr *MockServerMockRecorder) GetClusterMembers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMembers", reflect.TypeOf((*MockServer)(nil).GetClusterMembers))
 }
 
 // GetConnectionInfo mocks base method
@@ -444,6 +469,19 @@ func (m *MockServer) UpdateStoragePoolVolume(arg0, arg1, arg2 string, arg3 api.S
 // UpdateStoragePoolVolume indicates an expected call of UpdateStoragePoolVolume
 func (mr *MockServerMockRecorder) UpdateStoragePoolVolume(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStoragePoolVolume", reflect.TypeOf((*MockServer)(nil).UpdateStoragePoolVolume), arg0, arg1, arg2, arg3, arg4)
+}
+
+// UseTargetServer mocks base method
+func (m *MockServer) UseTargetServer(arg0 string) (*lxd.Server, error) {
+	ret := m.ctrl.Call(m, "UseTargetServer", arg0)
+	ret0, _ := ret[0].(*lxd.Server)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UseTargetServer indicates an expected call of UseTargetServer
+func (mr *MockServerMockRecorder) UseTargetServer(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseTargetServer", reflect.TypeOf((*MockServer)(nil).UseTargetServer), arg0)
 }
 
 // VerifyNetworkDevice mocks base method

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -50,18 +50,6 @@ func (mr *MockServerMockRecorder) AliveContainers(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliveContainers", reflect.TypeOf((*MockServer)(nil).AliveContainers), arg0)
 }
 
-// ClusterSupported mocks base method
-func (m *MockServer) ClusterSupported() bool {
-	ret := m.ctrl.Call(m, "ClusterSupported")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// ClusterSupported indicates an expected call of ClusterSupported
-func (mr *MockServerMockRecorder) ClusterSupported() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterSupported", reflect.TypeOf((*MockServer)(nil).ClusterSupported))
-}
-
 // ContainerAddresses mocks base method
 func (m *MockServer) ContainerAddresses(arg0 string) ([]network.Address, error) {
 	ret := m.ctrl.Call(m, "ContainerAddresses", arg0)
@@ -375,6 +363,18 @@ func (mr *MockServerMockRecorder) HasProfile(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProfile", reflect.TypeOf((*MockServer)(nil).HasProfile), arg0)
 }
 
+// IsClustered mocks base method
+func (m *MockServer) IsClustered() bool {
+	ret := m.ctrl.Call(m, "IsClustered")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsClustered indicates an expected call of IsClustered
+func (mr *MockServerMockRecorder) IsClustered() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClustered", reflect.TypeOf((*MockServer)(nil).IsClustered))
+}
+
 // LocalBridgeName mocks base method
 func (m *MockServer) LocalBridgeName() string {
 	ret := m.ctrl.Call(m, "LocalBridgeName")
@@ -385,6 +385,18 @@ func (m *MockServer) LocalBridgeName() string {
 // LocalBridgeName indicates an expected call of LocalBridgeName
 func (mr *MockServerMockRecorder) LocalBridgeName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalBridgeName", reflect.TypeOf((*MockServer)(nil).LocalBridgeName))
+}
+
+// Name mocks base method
+func (m *MockServer) Name() string {
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockServerMockRecorder) Name() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockServer)(nil).Name))
 }
 
 // RemoveContainer mocks base method

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -664,9 +664,14 @@ func (conn *StubClient) GetNICsFromProfile(profName string) (map[string]map[stri
 	return conn.Profile.Devices, conn.NextErr()
 }
 
-func (conn *StubClient) ClusterSupported() bool {
-	conn.AddCall("ClusterSupported")
+func (conn *StubClient) IsClustered() bool {
+	conn.AddCall("IsClustered")
 	return true
+}
+
+func (conn *StubClient) Name() string {
+	conn.AddCall("Name")
+	return "server"
 }
 
 // TODO (manadart 2018-07-20): This exists to satisfy the testing stub

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -664,6 +664,24 @@ func (conn *StubClient) GetNICsFromProfile(profName string) (map[string]map[stri
 	return conn.Profile.Devices, conn.NextErr()
 }
 
+func (conn *StubClient) ClusterSupported() bool {
+	conn.AddCall("ClusterSupported")
+	return true
+}
+
+// TODO (manadart 2018-07-20): This exists to satisfy the testing stub
+// interface. It is temporary, pending replacement with mocks and
+// should not be called in tests.
+func (conn *StubClient) UseTargetServer(name string) (*lxd.Server, error) {
+	conn.AddCall("UseTargetServer", name)
+	return nil, conn.NextErr()
+}
+
+func (conn *StubClient) GetClusterMembers() (members []api.ClusterMember, err error) {
+	conn.AddCall("GetClusterMembers")
+	return nil, conn.NextErr()
+}
+
 type MockClock struct {
 	clock.Clock
 	now time.Time
@@ -675,4 +693,59 @@ func (m *MockClock) Now() time.Time {
 
 func (m *MockClock) After(delay time.Duration) <-chan time.Time {
 	return time.After(time.Millisecond)
+}
+
+// TODO (manadart 2018-07-20): All of the above logic should ultimately be
+// replaced by what follows (in some form). The stub usage will be abandoned
+// and replaced by mocks.
+
+type EnvironSuite struct {
+	testing.BaseSuite
+}
+
+func (s *EnvironSuite) NewEnviron(c *gc.C, svr Server, cfgEdit map[string]interface{}) environs.Environ {
+	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	if cfgEdit != nil {
+		var err error
+		cfg, err = cfg.Apply(cfgEdit)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	eCfg, err := newValidConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	namespace, err := instance.NewNamespace(cfg.UUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	return &environ{
+		server:    svr,
+		ecfg:      eCfg,
+		namespace: namespace,
+	}
+}
+
+func (s *EnvironSuite) GetStartInstanceArgs(c *gc.C, series string) environs.StartInstanceParams {
+	tools := []*coretools.Tools{
+		{
+			Version: version.Binary{Arch: arch.AMD64, Series: series},
+			URL:     "https://example.org/amd",
+		},
+		{
+			Version: version.Binary{Arch: arch.ARM64, Series: series},
+			URL:     "https://example.org/arm",
+		},
+	}
+
+	cons := constraints.Value{}
+	iConfig, err := instancecfg.NewBootstrapInstanceConfig(testing.FakeControllerConfig(), cons, cons, series, "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	return environs.StartInstanceParams{
+		ControllerUUID: iConfig.Controller.Config.ControllerUUID(),
+		InstanceConfig: iConfig,
+		Tools:          tools,
+		Constraints:    cons,
+	}
 }


### PR DESCRIPTION
## Description of change

This patch adds initial support for "zone" placement directives in the LXD provider.

The notion of a zone is expected to evolve in the upstream LXD provider, but the current concept (and the one implemented here) is for a zone to be synonymous with a server name from the current list of LXD cluster members.

Supported syntax is "zone={zone}" or just "{zone}".

## QA steps

Supposing a LXD cluster cloud "lxd-guimaas" with nodes "nuc5" and "nuc6":
- `juju bootstrap lxd-guimaas zone-test --no-gui --debug --to zone=nuc5` and check that the controller is created on nuc5
- `juju deploy ubuntu --to zone=nuc6` and check that a new container is created on nuc6.
- `juju add-unit ubuntu --to nuc6` multiple times and check that a new container is always created on nuc6.

## Documentation changes

Yes.

## Bug reference

N/A
