### PR TITLE
Client Facade and CLI changes for export bundle

### DIFF
--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -42,5 +42,9 @@ func (c *Client) ExportBundle() (string, error) {
 		return "", errors.Trace(err)
 	}
 
+	if len(result.Result) == 0 {
+		return "", errors.Annotate(result.Error, "export failed")
+	}
+
 	return result.Result, nil
 }

--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package bundle provides access to the bundle api facade.
+// This facade contains api calls that are specific to bundles.
+
+package bundle
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var logger = loggo.GetLogger("juju.api.bundle")
+
+// Client allows access to the bundle API end point.
+type Client struct {
+	base.ClientFacade
+	st     base.APICallCloser
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new client for accessing the bundle api.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "Bundle")
+	return &Client{
+		ClientFacade: frontend,
+		st:           st,
+		facade:       backend}
+}
+
+// ExportBundle exports the current model configuration.
+func (c *Client) ExportBundle() (string, error) {
+	var result params.StringResult
+	if bestVer := c.BestAPIVersion(); bestVer < 2 {
+		return "", errors.Errorf("command not supported on v%d", bestVer)
+	}
+
+	if err := c.facade.FacadeCall("ExportBundle", nil, &result); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if len(result.Result) == 0 {
+		return "", errors.Errorf("result obtained is incorrect")
+	}
+	return result.Result, nil
+}

--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -34,11 +34,10 @@ func NewClient(st base.APICallCloser) *Client {
 func (c *Client) ExportBundle() (string, error) {
 	var result params.StringResult
 	if bestVer := c.BestAPIVersion(); bestVer < 2 {
-		return "", errors.Errorf("command not supported on v%d", bestVer)
+		return "", errors.Errorf("ExportBundle() on v%d is not supported", bestVer)
 	}
 
 	if err := c.facade.FacadeCall("ExportBundle", nil, &result); err != nil {
-		errors.Annotate(result.Error, "export failed")
 		return "", errors.Trace(err)
 	}
 

--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -19,7 +19,6 @@ var logger = loggo.GetLogger("juju.api.bundle")
 // Client allows access to the bundle API end point.
 type Client struct {
 	base.ClientFacade
-	st     base.APICallCloser
 	facade base.FacadeCaller
 }
 
@@ -28,7 +27,6 @@ func NewClient(st base.APICallCloser) *Client {
 	frontend, backend := base.NewClientFacade(st, "Bundle")
 	return &Client{
 		ClientFacade: frontend,
-		st:           st,
 		facade:       backend}
 }
 
@@ -40,11 +38,8 @@ func (c *Client) ExportBundle() (string, error) {
 	}
 
 	if err := c.facade.FacadeCall("ExportBundle", nil, &result); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotate(result.Error, "export failed")
 	}
 
-	if len(result.Result) == 0 {
-		return "", errors.Errorf("result obtained is incorrect")
-	}
 	return result.Result, nil
 }

--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -42,8 +42,8 @@ func (c *Client) ExportBundle() (string, error) {
 		return "", errors.Trace(err)
 	}
 
-	if len(result.Result) == 0 {
-		return "", errors.Annotate(result.Error, "export failed")
+	if result.Error != nil {
+		return "", errors.Trace(result.Error)
 	}
 
 	return result.Result, nil

--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -38,7 +38,8 @@ func (c *Client) ExportBundle() (string, error) {
 	}
 
 	if err := c.facade.FacadeCall("ExportBundle", nil, &result); err != nil {
-		return "", errors.Annotate(result.Error, "export failed")
+		errors.Annotate(result.Error, "export failed")
+		return "", errors.Trace(err)
 	}
 
 	return result.Result, nil

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -59,6 +59,7 @@ func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "ExportBundle")
 			c.Assert(args, gc.Equals, nil)
+			c.Assert(response, gc.FitsTypeOf, &params.StringResult{})
 			result := response.(*params.StringResult)
 			result.Result = "applications:\n  " +
 				"ubuntu:\n    " +
@@ -89,4 +90,28 @@ func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
 		"series: xenial\n"+
 		"relations:\n"+
 		"- []\n")
+}
+
+func (s *bundleMockSuite) TestExportBundleErrorv2(c *gc.C) {
+	client := newClient(
+		func(objType string, version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ExportBundle")
+			c.Assert(args, gc.Equals, nil)
+			c.Assert(response, gc.FitsTypeOf, &params.StringResult{})
+			result := response.(*params.StringResult)
+			result.Result = ""
+			return result.Error
+		}, 2,
+	)
+	result, err := client.ExportBundle()
+	c.Assert(err, gc.NotNil)
+	c.Assert(result, jc.DeepEquals, "")
+	c.Check(err.Error(), jc.Contains, "export failed")
 }

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -89,7 +89,7 @@ func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
 		"- []\n")
 }
 
-func (s *bundleMockSuite) TestExportBundleErrorv2(c *gc.C) {
+func (s *bundleMockSuite) TestExportBundleNotNilParamsErrorv2(c *gc.C) {
 	client := newClient(
 		func(objType string, version int,
 			id,
@@ -99,12 +99,32 @@ func (s *bundleMockSuite) TestExportBundleErrorv2(c *gc.C) {
 		) error {
 			result := response.(*params.StringResult)
 			result.Result = ""
-			*(response.(*params.StringResult)) = params.StringResult{Error: common.ServerError(errors.New("export failed"))}
+			*(response.(*params.StringResult)) = params.StringResult{Error: common.ServerError(
+				errors.New("export failed nothing to export as there are no applications"))}
 			return result.Error
 		}, 2,
 	)
 	result, err := client.ExportBundle()
 	c.Assert(err, gc.NotNil)
 	c.Assert(result, jc.DeepEquals, "")
-	c.Check(err.Error(), gc.Matches, "export failed")
+	c.Check(err.Error(), gc.Matches, "export failed nothing to export as there are no applications")
+}
+
+func (s *bundleMockSuite) TestExportBundleFailNoParamsErrorv2(c *gc.C) {
+	client := newClient(
+		func(objType string, version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			result := response.(*params.StringResult)
+			result.Result = ""
+			return errors.New("foo")
+		}, 2,
+	)
+	result, err := client.ExportBundle()
+	c.Assert(err, gc.NotNil)
+	c.Assert(result, jc.DeepEquals, "")
+	c.Check(err.Error(), gc.Matches, "foo")
 }

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -45,7 +45,8 @@ func (s *bundleMockSuite) TestFailExportBundlev1(c *gc.C) {
 		}, 1,
 	)
 	result, err := client.ExportBundle()
-	c.Assert(err, gc.ErrorMatches, "command not supported on v1")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err.Error(), gc.Equals, "ExportBundle() on v1 is not supported")
 	c.Assert(result, jc.DeepEquals, "")
 }
 

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bundle_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/bundle"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type bundleMockSuite struct {
+	coretesting.BaseSuite
+	bundleClient *bundle.Client
+}
+
+var _ = gc.Suite(&bundleMockSuite{})
+
+func newClient(f basetesting.APICallerFunc, ver int) *bundle.Client {
+	return bundle.NewClient(basetesting.BestVersionCaller{f, ver})
+}
+
+func (s *bundleMockSuite) TestFailExportBundlev1(c *gc.C) {
+	client := newClient(
+		func(objType string,
+			version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ExportBundle")
+			c.Assert(args, gc.Equals, nil)
+			result := response.(*params.StringResult)
+			result.Result = ""
+			return nil
+		}, 1,
+	)
+	result, err := client.ExportBundle()
+	c.Assert(err, gc.ErrorMatches, "command not supported on v1")
+	c.Assert(result, jc.DeepEquals, "")
+}
+
+func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
+	client := newClient(
+		func(objType string, version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ExportBundle")
+			c.Assert(args, gc.Equals, nil)
+			result := response.(*params.StringResult)
+			result.Result = "applications:\n  " +
+				"ubuntu:\n    " +
+				"charm: cs:trusty/ubuntu\n    " +
+				"series: trusty\n    " +
+				"num_units: 1\n    " +
+				"to:\n    " +
+				"- \"0\"\n    " +
+				"options:\n      " +
+				"key: value\n" +
+				"series: xenial\n" +
+				"relations:\n" +
+				"- []\n"
+			return nil
+		}, 2,
+	)
+	result, err := client.ExportBundle()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, "applications:\n  "+
+		"ubuntu:\n    "+
+		"charm: cs:trusty/ubuntu\n    "+
+		"series: trusty\n    "+
+		"num_units: 1\n    "+
+		"to:\n    "+
+		"- \"0\"\n    "+
+		"options:\n      "+
+		"key: value\n"+
+		"series: xenial\n"+
+		"relations:\n"+
+		"- []\n")
+}

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -4,11 +4,13 @@
 package bundle_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/bundle"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -55,11 +57,6 @@ func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
 			args,
 			response interface{},
 		) error {
-			c.Check(objType, gc.Equals, "Bundle")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ExportBundle")
-			c.Assert(args, gc.Equals, nil)
-			c.Assert(response, gc.FitsTypeOf, &params.StringResult{})
 			result := response.(*params.StringResult)
 			result.Result = "applications:\n  " +
 				"ubuntu:\n    " +
@@ -100,18 +97,14 @@ func (s *bundleMockSuite) TestExportBundleErrorv2(c *gc.C) {
 			args,
 			response interface{},
 		) error {
-			c.Check(objType, gc.Equals, "Bundle")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ExportBundle")
-			c.Assert(args, gc.Equals, nil)
-			c.Assert(response, gc.FitsTypeOf, &params.StringResult{})
 			result := response.(*params.StringResult)
 			result.Result = ""
+			*(response.(*params.StringResult)) = params.StringResult{Error: common.ServerError(errors.New("export failed"))}
 			return result.Error
 		}, 2,
 	)
 	result, err := client.ExportBundle()
 	c.Assert(err, gc.NotNil)
 	c.Assert(result, jc.DeepEquals, "")
-	c.Check(err.Error(), jc.Contains, "export failed")
+	c.Check(err.Error(), gc.Matches, "export failed")
 }

--- a/api/bundle/package_test.go
+++ b/api/bundle/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bundle_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -371,6 +371,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	if featureflag.Enabled(feature.DeveloperMode) {
 		r.Register(model.NewDumpCommand())
 		r.Register(model.NewDumpDBCommand())
+		r.Register(model.NewExportBundleCommand())
 	}
 
 	// Manage and control actions

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -67,7 +67,7 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 	return modelcmd.Wrap(cmd)
 }
 
-// NewDumpCommandForTest returns a DumpCommand with the api provided as specified.
+// NewExportBundleCommandForTest returns a ExportBundleCommand with the api provided as specified.
 func NewExportBundleCommandForTest(api ExportBundleAPI, store jujuclient.ClientStore) cmd.Command {
 	cmd := &exportBundleCommand{newAPIFunc: func() (ExportBundleAPI, error) {
 		return api, nil

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -68,8 +68,10 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 }
 
 // NewDumpCommandForTest returns a DumpCommand with the api provided as specified.
-func NewExportBundleCommandForTest(api ExportBundleModelAPI, store jujuclient.ClientStore) cmd.Command {
-	cmd := &exportBundleCommand{api: api}
+func NewExportBundleCommandForTest(api ExportBundleAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &exportBundleCommand{newAPIFunc: func() (ExportBundleAPI, error) {
+		return api, nil
+	}}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -67,6 +67,13 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 	return modelcmd.Wrap(cmd)
 }
 
+// NewDumpCommandForTest returns a DumpCommand with the api provided as specified.
+func NewExportBundleCommandForTest(api ExportBundleModelAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &exportBundleCommand{api: api}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
 func NewDestroyCommandForTest(
 	api DestroyModelAPI,

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -1,0 +1,117 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package model
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+
+	"github.com/juju/juju/api/bundle"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
+)
+
+// NewExportBundleCommand returns a fully constructed export bundle command.
+func NewExportBundleCommand() cmd.Command {
+	return modelcmd.Wrap(&exportBundleCommand{})
+}
+
+type exportBundleCommand struct {
+	modelcmd.ModelCommandBase
+	out cmd.Output
+	api ExportBundleModelAPI
+	// name of the charm bundle file.
+	Filename string
+}
+
+const exportBundleHelpDoc = `
+Exports the current model configuration into a YAML file.
+
+Examples:
+
+    juju export-bundle
+
+If --filename is not used, the bundle is displayed in stdout.
+`
+
+// Info implements Command.
+func (c *exportBundleCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "export-bundle",
+		Purpose: "Exports the current model configuration in a charm bundle.",
+		Doc:     exportBundleHelpDoc,
+	}
+}
+
+// SetFlags implements Command.
+func (c *exportBundleCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	f.StringVar(&c.Filename, "filename", "", "Export Model")
+}
+
+// Init implements Command.
+func (c *exportBundleCommand) Init(args []string) error {
+	return cmd.CheckEmpty(args)
+}
+
+// ExportBundleAPI specifies the used function calls of the ModelManager.
+type ExportBundleModelAPI interface {
+	Close() error
+	BestAPIVersion() int
+	ExportBundle() (string, error)
+}
+
+func (c *exportBundleCommand) getAPI() (ExportBundleModelAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return bundle.NewClient(api), nil
+}
+
+// Run implements Command.
+func (c *exportBundleCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var result string
+	if client.BestAPIVersion() > 1 {
+		result, err = client.ExportBundle()
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.Filename != "" {
+		filename := c.Filename + ".yaml"
+		file, err := os.Create(filename)
+		if err != nil {
+			return errors.Annotate(err, "while creating local file")
+		}
+		defer file.Close()
+
+		// Write out the result.
+		_, err = file.WriteString(result)
+		if err != nil {
+			return errors.Annotate(err, "while copying in local file")
+		}
+
+		// Print the local filename.
+		fmt.Fprintln(ctx.Stdout, "Bundle successfully exported to", filename)
+	} else {
+		c.out.Write(ctx, result)
+	}
+	return nil
+}

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -56,7 +56,7 @@ func (c *exportBundleCommand) Info() *cmd.Info {
 func (c *exportBundleCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
-	f.StringVar(&c.Filename, "filename", "", "bundle file")
+	f.StringVar(&c.Filename, "filename", "", "Bundle file")
 }
 
 // Init implements Command.

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -3,15 +3,16 @@
 package model
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
-	"fmt"
-	"github.com/juju/errors"
 	"github.com/juju/juju/api/bundle"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
-	"os"
 )
 
 // NewExportBundleCommand returns a fully constructed export bundle command.

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -34,7 +34,7 @@ type exportBundleCommand struct {
 const exportBundleHelpDoc = `
 Exports the current model configuration as bundle.
 
-If --filename is optional. The charm bundle is written in the filename provided as value.
+--filename specifies the file where bundle is written to. Its optional.
 If --filename is not used, the bundle is displayed in stdout.
 
 Examples:

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -34,8 +34,8 @@ type exportBundleCommand struct {
 const exportBundleHelpDoc = `
 Exports the current model configuration as bundle.
 
---filename specifies the file where bundle is written to. Its optional.
-If --filename is not used, the bundle is displayed in stdout.
+If --filename is not used, the configuration is printed to stdout.
+ --filename specifies an output file.
 
 Examples:
 

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -5,6 +5,7 @@ package model_test
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/testing"
@@ -15,7 +16,6 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
-	"os"
 )
 
 type ExportBundleCommandSuite struct {

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package model_test
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/model"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type ExportBundleCommandSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	fake  *fakeExportBundleClient
+	stub  *jujutesting.Stub
+	store *jujuclient.MemStore
+}
+
+var _ = gc.Suite(&ExportBundleCommandSuite{})
+
+type fakeExportBundleClient struct {
+	*jujutesting.Stub
+	bestAPIVersion int
+}
+
+func (f *fakeExportBundleClient) Close() error { return nil }
+
+func (f *fakeExportBundleClient) ExportBundle() (string, error) {
+	f.MethodCall(f, "ExportBundle")
+	if err := f.NextErr(); err != nil {
+		return "", err
+	}
+	return "applications:\n" +
+		"  mysql:\n" +
+		"    charm: \"\"\n" +
+		"    num_units: 1\n" +
+		"    to:\n" +
+		"    - \"0\"\n" +
+		"  wordpress:\n" +
+		"    charm: \"\"\n" +
+		"    num_units: 2\n" +
+		"    to:\n" +
+		"    - \"0\"\n" +
+		"    - \"1\"\n" +
+		"machines:\n" +
+		"  \"0\": {}\n" +
+		"  \"1\": {}\n" +
+		"series: xenial\n" +
+		"relations:\n" +
+		"- - wordpress:db\n" +
+		"  - mysql:mysql\n", f.NextErr()
+}
+
+func (f *fakeExportBundleClient) BestAPIVersion() int {
+	return f.bestAPIVersion
+}
+
+func (s *ExportBundleCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.stub = &jujutesting.Stub{}
+	s.fake = &fakeExportBundleClient{
+		Stub:           s.stub,
+		bestAPIVersion: 2,
+	}
+	s.store = jujuclient.NewMemStore()
+	s.store.CurrentControllerName = "testing"
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin",
+	}
+	err := s.store.UpdateModel("testing", "admin/mymodel", jujuclient.ModelDetails{
+		ModelUUID: testing.ModelTag.Id(),
+		ModelType: coremodel.IAAS,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.store.Models["testing"].CurrentModel = "admin/mymodel"
+}
+
+func (s *ExportBundleCommandSuite) TestExportBundleNoFilename(c *gc.C) {
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store))
+	c.Assert(err, jc.ErrorIsNil)
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
+		{"ExportBundle", nil},
+	})
+
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, "|\n"+
+		"  applications:\n"+
+		"    mysql:\n"+
+		"      charm: \"\"\n"+
+		"      num_units: 1\n"+
+		"      to:\n"+
+		"      - \"0\"\n"+
+		"    wordpress:\n"+
+		"      charm: \"\"\n"+
+		"      num_units: 2\n"+
+		"      to:\n"+
+		"      - \"0\"\n"+
+		"      - \"1\"\n"+
+		"  machines:\n"+
+		"    \"0\": {}\n"+
+		"    \"1\": {}\n"+
+		"  series: xenial\n"+
+		"  relations:\n"+
+		"  - - wordpress:db\n"+
+		"    - mysql:mysql\n")
+}

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -146,6 +146,29 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 		"- []\n")
 }
 
+func (s *ExportBundleCommandSuite) TestExportBundleFailNoFilename(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store), "--filename")
+	c.Assert(err, gc.NotNil)
+
+	c.Assert(err.Error(), gc.Equals, "flag needs an argument: --filename")
+}
+
+func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *gc.C) {
+	s.fake.filename = "mymodel"
+	s.fake.result = "fake-data"
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store), "--filename", s.fake.filename)
+	c.Assert(err, jc.ErrorIsNil)
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
+		{"ExportBundle", nil},
+	})
+
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, "Bundle successfully exported to mymodel.yaml\n")
+	output, err := ioutil.ReadFile("mymodel.yaml")
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(string(output), gc.Equals, "fake-data")
+}
+
 func (f *fakeExportBundleClient) Close() error { return nil }
 
 func (f *fakeExportBundleClient) ExportBundle() (string, error) {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:
This PR addresses CLI facade code changes required for export bundle command which exports the configuration of current model in a bundle.
## QA steps
juju  export-bundle --filename <filename>
(or)
juju export-bundle - the output is displayed in stdout.

## Documentation changes
Yes.
## Bug reference