### PR TITLE
LXD Network Checks and API Logging

### DIFF
--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -210,7 +210,7 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 			continue
 		}
 
-		logger.Infof("found usable network device %q with parent %q", name, netName)
+		logger.Debugf("found usable network device %q with parent %q", name, netName)
 		s.localBridgeName = netName
 		return nil
 	}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -122,6 +122,16 @@ func (env *environ) newContainer(
 	}
 	cleanupCallback() // Clean out any long line of completed download status
 
+	// Ensure that the default profile has a network configuration that will
+	// allow access to containers that we create.
+	profile, eTag, err := env.server.GetProfile("default")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := env.server.VerifyNetworkDevice(profile, eTag); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	cSpec, err := env.getContainerSpec(image, args)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -23,10 +23,22 @@ import (
 type environBrokerSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx        context.ProviderCallContext
+	defaultProfile *api.Profile
 }
 
 var _ = gc.Suite(&environBrokerSuite{})
+
+func (s *environBrokerSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.defaultProfile = &api.Profile{
+		ProfilePut: api.ProfilePut{
+			Devices: map[string]map[string]string{
+				"eth0": {},
+			},
+		},
+	}
+}
 
 func (s *environBrokerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
@@ -73,7 +85,9 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 	)
 
@@ -114,6 +128,8 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 	)
@@ -164,7 +180,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
@@ -205,7 +223,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
@@ -239,7 +259,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
@@ -268,7 +290,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 	)
 	env := s.NewEnviron(c, svr, nil)
 
@@ -302,7 +326,9 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 	)
 

--- a/provider/lxd/server_test.go
+++ b/provider/lxd/server_test.go
@@ -49,13 +49,12 @@ func (s *serverSuite) TestLocalServer(c *gc.C) {
 	factory, server, interfaceAddr := s.newLocalServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -91,17 +90,14 @@ func (s *serverSuite) TestLocalServerRetrySemantics(c *gc.C) {
 	factory, server, interfaceAddr := s.newLocalServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(emptyConnectionInfo, nil),
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -116,8 +112,6 @@ func (s *serverSuite) TestLocalServerRetrySemanticsFailure(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	profile := &api.Profile{}
-	etag := "etag"
 	bridgeName := "lxdbr0"
 	hostAddress := "192.168.0.1"
 	emptyConnectionInfo := &client.ConnectionInfo{
@@ -126,8 +120,6 @@ func (s *serverSuite) TestLocalServerRetrySemanticsFailure(c *gc.C) {
 
 	factory, server, interfaceAddr := s.newLocalServerFactory(ctrl)
 
-	server.EXPECT().GetProfile("default").Return(profile, etag, nil).Times(31)
-	server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil).Times(31)
 	server.EXPECT().EnableHTTPSListener().Return(nil).Times(31)
 	server.EXPECT().LocalBridgeName().Return(bridgeName)
 	interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil)
@@ -160,13 +152,12 @@ func (s *serverSuite) TestLocalServerWithInvalidAPIVersion(c *gc.C) {
 	factory, server, interfaceAddr := s.newLocalServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -297,7 +288,6 @@ func (s *serverSuite) TestLocalServerWithStorageNotSupported(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	profile := &api.Profile{}
 	etag := "etag"
 	bridgeName := "lxdbr0"
 	hostAddress := "192.168.0.1"
@@ -315,8 +305,6 @@ func (s *serverSuite) TestLocalServerWithStorageNotSupported(c *gc.C) {
 	factory, server, interfaceAddr := s.newLocalServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
@@ -354,13 +342,12 @@ func (s *serverSuite) TestRemoteServerWithEmptyEndpointYieldsLocalServer(c *gc.C
 	factory, server, interfaceAddr := s.newLocalServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -387,9 +374,8 @@ func (s *serverSuite) TestRemoteServer(c *gc.C) {
 	factory, server := s.newRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -414,7 +400,10 @@ func (s *serverSuite) TestRemoteServerWithProfileError(c *gc.C) {
 
 	factory, server := s.newRemoteServerFactory(ctrl)
 
-	server.EXPECT().GetProfile("default").Return(nil, "", errors.New("bad"))
+	gomock.InOrder(
+		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(nil, "", errors.New("bad")),
+	)
 
 	creds := cloud.NewCredential("any", map[string]string{
 		"client-cert": "client-cert",
@@ -432,7 +421,6 @@ func (s *serverSuite) TestRemoteServerWithNoStorage(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	profile := &api.Profile{}
 	etag := "etag"
 	serverInfo := &api.Server{
 		ServerUntrusted: api.ServerUntrusted{
@@ -443,8 +431,6 @@ func (s *serverSuite) TestRemoteServerWithNoStorage(c *gc.C) {
 	factory, server := s.newRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().StorageSupported().Return(false),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -482,13 +468,9 @@ func (s *serverSuite) TestRemoteServerWithGetServerError(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	profile := &api.Profile{}
-	etag := "etag"
 	factory, server := s.newRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().StorageSupported().Return(false),
 		server.EXPECT().GetServer().Return(nil, "", errors.New("bad")),
 	)


### PR DESCRIPTION
## Description of change

When observing controller logs, it became apparent that the info level logging was unnecessarily frequent for:
- Checks for usable network devices on the default profile.
- Logging the current LXD API version.

This PR does the following:
- Relocates the network device check to be done prior to container creation. This means that for all other instance checking, tear-down etc, the check is not made (or logged).
- Changes the API version logging level from "info" to "debug".

## QA steps

Bootstrap and add some machines. Tail the controller debug log and ensure that the logs indicate the changed level/frequency. Kill the controller and ensure that there are no network checks.

## Documentation changes

None.

## Bug reference

N/A
