### PR TITLE
Update help for credentials

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -39,6 +39,10 @@ credentials:
       application-id: <uuid1>
       application-password: <password>
       subscription-id: <uuid2>
+  lxd:
+    <credential name>:
+      auth-type: interactive
+      trust-password: <password>
 
 A "credential name" is arbitrary and is used solely to represent a set of
 credentials, of which there may be multiple per cloud.

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -64,7 +64,11 @@ OpenStack
   Credentials:
     1. On Linux, $HOME/.novarc
     2. Environment variables OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME,
-       OS_DOMAIN_NAME
+	   OS_DOMAIN_NAME
+
+LXD
+  Credentials:
+    1. On Linux, $HOME/.config/lxc/config.yml
 
 Example:
     juju autoload-credentials


### PR DESCRIPTION
## Description of change

The following adds better help messages for LXD credentials.

## QA steps

Run the following, should now show lxd credential information, that should 
help on board new/existing users.

```sh
juju autoload-credentials -h
juju add-credential -h
```

```
Usage: juju autoload-credentials

Summary:
Attempts to automatically add or replace credentials for a cloud.

Details:
Well known locations for specific clouds are searched and any found
information is presented interactively to the user.
An alternative to this command is `juju add-credential`
Below are the cloud types for which credentials may be autoloaded,
including the locations searched.

EC2
  Credentials and regions:
    1. On Linux, $HOME/.aws/credentials and $HOME/.aws/config
    2. Environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY

GCE
  Credentials:
    1. A JSON file whose path is specified by the
       GOOGLE_APPLICATION_CREDENTIALS environment variable
    2. On Linux, $HOME/.config/gcloud/application_default_credentials.json
       Default region is specified by the CLOUDSDK_COMPUTE_REGION environment
       variable.
    3. On Windows, %APPDATA%\gcloud\application_default_credentials.json

OpenStack
  Credentials:
    1. On Linux, $HOME/.novarc
    2. Environment variables OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME,
	   OS_DOMAIN_NAME

LXD
  Credentials:
    1. On Linux, $HOME/.config/lxc/config.yml

Example:
    juju autoload-credentials
   
See also:
    list-credentials
    remove-credential
    set-default-credential
    add-credential
```

```
Usage: juju add-credential [options] <cloud name>

Summary:
Adds or replaces credentials for a cloud, stored locally on this client.

Options:
-f (= "")
    The YAML file containing credentials to add
--replace  (= false)
    Overwrite existing credential information

Details:
The user is prompted to add credentials interactively if a YAML-formatted
credentials file is not specified. Here is a sample credentials file:

credentials:
  aws:
    <credential name>:
      auth-type: access-key
      access-key: <key>
      secret-key: <key>
  azure:
    <credential name>:
      auth-type: service-principal-secret
      application-id: <uuid1>
      application-password: <password>
      subscription-id: <uuid2>
  lxd:
    <credential name>:
      auth-type: interactive
      trust-password: <password>

A "credential name" is arbitrary and is used solely to represent a set of
credentials, of which there may be multiple per cloud.
The `--replace` option is required if credential information for the named
cloud already exists locally. All such information will be overwritten.
This command does not set default regions nor default credentials. Note
that if only one credential name exists, it will become the effective
default credential.
For credentials which are already in use by tools other than Juju, `juju 
autoload-credentials` may be used.
When Juju needs credentials for a cloud, i) if there are multiple
available; ii) there's no set default; iii) and one is not specified ('--
credential'), an error will be emitted.

Examples:
    juju add-credential google
    juju add-credential aws -f ~/credentials.yaml

See also: 
    credentials
    remove-credential
    set-default-credential
    autoload-credentials
```

## Documentation changes

Yes, the CLI should now provider better information about what is 
expected for the LXD credential yaml.

## Bug reference

N/A