### PR TITLE
Store registry and image path separately.

### DIFF
--- a/core/resources/resources.go
+++ b/core/resources/resources.go
@@ -21,7 +21,10 @@ type DockerImageDetails struct {
 	Password string `json:"Password,omitempty" yaml:"password"`
 }
 
-var validDockerImageRegExp = regexp.MustCompile(`^([A-Za-z\.]+/)?(([A-Za-z-_\.])+/?)+((@sha256){0,1}:[A-Za-z0-9-_\.]+)?$`)
+var (
+	validDockerImageRegExp = regexp.MustCompile(`^([A-Za-z\.]+/)?(([A-Za-z-_\.])+/?)+((@sha256){0,1}:[A-Za-z0-9-_\.]+)?$`)
+	registryPathSplit      = regexp.MustCompile(`^(?P<registryURL>([^.]+([.]+[^.\/]+)+))\/(?P<image>.*)$`)
+)
 
 // ValidateDockerRegistryPath ensures the registry path is valid (i.e. api.jujucharms.com@sha256:deadbeef)
 func ValidateDockerRegistryPath(path string) error {
@@ -32,7 +35,24 @@ func ValidateDockerRegistryPath(path string) error {
 }
 
 // CheckDockerDetails validates the provided resource is suitable for use.
-func CheckDockerDetails(name, value string) error {
+func CheckDockerDetails(name, registryPath string) error {
 	// TODO (veebers): Validate the URL actually works.
-	return ValidateDockerRegistryPath(value)
+	return ValidateDockerRegistryPath(registryPath)
+}
+
+// SplitRegistryPath extracts the repo and the image parts of a registry path.
+func SplitRegistryPath(registryPath string) (repo string, image string, err error) {
+	err = ValidateDockerRegistryPath(registryPath)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+
+	easySplit := registryPathSplit.MatchString(registryPath)
+	if easySplit {
+		repo = registryPathSplit.ReplaceAllString(registryPath, "$registryURL")
+		image = registryPathSplit.ReplaceAllString(registryPath, "$image")
+		return repo, image, nil
+	}
+
+	return "", registryPath, nil
 }

--- a/core/resources/resources_test.go
+++ b/core/resources/resources_test.go
@@ -17,7 +17,7 @@ type ResourceSuite struct{}
 var _ = gc.Suite(&ResourceSuite{})
 
 func (s *ResourceSuite) TestValidRegistryPath(c *gc.C) {
-	err := resources.ValidateDockerRegistryPath("registry.hub.docker.com/me/awesomeimage@sha256:deedbeaf")
+	err := resources.ValidateDockerRegistryPath("registry.hub.docker.io/me/awesomeimage@sha256:deedbeaf")
 	c.Assert(err, jc.ErrorIsNil)
 	err = resources.ValidateDockerRegistryPath("docker.io/me/mygitlab:latest")
 	c.Assert(err, jc.ErrorIsNil)
@@ -38,4 +38,35 @@ func (s *ResourceSuite) TestDockerImageDetailsUnmarshal(c *gc.C) {
 		Username:     "docker-registry",
 		Password:     "fragglerock",
 	})
+}
+
+func (s *ResourceSuite) TestSplitRegistryPathForValidPaths(c *gc.C) {
+	for _, registryTest := range []struct {
+		registryPath         string
+		expectedImagePath    string
+		expectedRegistryPath string
+	}{{
+		registryPath:         "registry.staging.charmstore.com/me/awesomeimage@sha256:deedbeaf",
+		expectedImagePath:    "me/awesomeimage@sha256:deedbeaf",
+		expectedRegistryPath: "registry.staging.charmstore.com",
+	}, {
+		registryPath:         "docker.io/me/mygitlab:latest",
+		expectedImagePath:    "me/mygitlab:latest",
+		expectedRegistryPath: "docker.io",
+	}, {
+		registryPath:         "me/mygitlab:latest",
+		expectedImagePath:    "me/mygitlab:latest",
+		expectedRegistryPath: "",
+	}} {
+		reg, image, err := resources.SplitRegistryPath(registryTest.registryPath)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(reg, gc.Equals, registryTest.expectedRegistryPath)
+		c.Assert(image, gc.Equals, registryTest.expectedImagePath)
+	}
+}
+
+func (s *ResourceSuite) TestSplitRegistryPathForInvalidPaths(c *gc.C) {
+	registryPath := "@sha256:deedbeaf"
+	_, _, err := resources.SplitRegistryPath(registryPath)
+	c.Assert(err, gc.ErrorMatches, "docker image path .* not valid")
 }


### PR DESCRIPTION
## Description of change

Splits registry and image data and stores it in the meta data for the docker image resource.
This is to move toward a stable data model for the docker resources with a mind on being able to do a resource-get on behalf of a charm so we can refresh secrets with new passwords.

## QA steps

Covered by unit tests, only data storage at this point.

## Documentation changes

None needed, internal data storage changes.
