### PR TITLE
Ignore missing config file

### DIFF
--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -387,8 +387,8 @@ type lxcConfigReader struct{}
 func (lxcConfigReader) ReadConfig(path string) (LXCConfig, error) {
 	configFile, err := ioutil.ReadFile(path)
 	if err != nil {
-		if cause := errors.Cause(err); !os.IsNotExist(cause) {
-			return LXCConfig{}, errors.Trace(err)
+		if cause := errors.Cause(err); os.IsNotExist(cause) {
+			return LXCConfig{}, nil
 		}
 		return LXCConfig{}, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

The following makes sure to ignore when a configuration file is
not there, so it doesn't throw an error when trying to read cloud
or credential information.

## QA steps

Ensure you don't have a `$HOME/.config/lxc/config.yml` file and
run the following:

```sh
juju autoload-credentials
```

## Documentation changes

N/A

## Bug reference

N/A