### PR TITLE
Drops logging level for LXD usable NIC device from Info to Trace.

### DIFF
--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -193,7 +193,7 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 			continue
 		}
 
-		logger.Infof("found usable network device %q with parent %q", name, netName)
+		logger.Tracef("found usable network device %q with parent %q", name, netName)
 		s.localBridgeName = netName
 		return nil
 	}


### PR DESCRIPTION
## Description of change

Since the post-LXD-refactor network checking has been recruited in the provider, we see the log entry for successful detection of NIC device config too frequently in the logs.

This notification is not particularly valuable for information or diagnostics, so we don't need to see it by default, particularly on every instantiation of LXD in the provider.

Change applied in 2.4 for later rolling into develop.

## QA steps

Bootstrap and add some machines. Tail the debug log and ensure that the logs indicate the changed level.

## Documentation changes

None.

## Bug reference

N/A
