### PR TITLE
LXD Host arch

### DIFF
--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -5,6 +5,7 @@ package lxd
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
@@ -94,7 +95,7 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 	name := info.Environment.ServerName
 	clustered := info.Environment.ServerClustered
 	serverCertificate := info.Environment.Certificate
-	hostArch := info.Environment.KernelArchitecture
+	hostArch := arch.NormaliseArch(info.Environment.KernelArchitecture)
 
 	return &Server{
 		ContainerServer:   svr,

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -34,6 +34,7 @@ type Server struct {
 	name              string
 	clustered         bool
 	serverCertificate string
+	hostArch          string
 
 	networkAPISupport bool
 	clusterAPISupport bool
@@ -93,12 +94,14 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 	name := info.Environment.ServerName
 	clustered := info.Environment.ServerClustered
 	serverCertificate := info.Environment.Certificate
+	hostArch := info.Environment.KernelArchitecture
 
 	return &Server{
 		ContainerServer:   svr,
 		name:              name,
 		clustered:         clustered,
 		serverCertificate: serverCertificate,
+		hostArch:          hostArch,
 		networkAPISupport: shared.StringInSlice("network", apiExt),
 		clusterAPISupport: shared.StringInSlice("clustering", apiExt),
 		storageAPISupport: shared.StringInSlice("storage", apiExt),
@@ -185,6 +188,11 @@ func (s *Server) CreateProfileWithConfig(name string, cfg map[string]string) err
 // ServerCertificate returns the current server environment certificate
 func (s *Server) ServerCertificate() string {
 	return s.serverCertificate
+}
+
+// HostArch returns the current host architecture
+func (s *Server) HostArch() string {
+	return s.hostArch
 }
 
 // IsLXDNotFound checks if an error from the LXD API indicates that a requested

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -298,7 +298,6 @@ func (env *environ) getHardwareCharacteristics(
 
 	archStr := container.Arch()
 	if archStr == "unknown" || !arch.IsSupportedArch(archStr) {
-		// TODO(ericsnow) This special-case should be improved.
 		archStr = env.server.HostArch()
 	}
 	cores := uint64(container.CPUs())

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -60,10 +60,7 @@ func (env *environ) StartInstance(
 }
 
 func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, error) {
-	// TODO(natefinch): This is only correct so long as the lxd is running on
-	// the local machine.  If/when we support a remote lxd environment, we'll
-	// need to change this to match the arch of the remote machine.
-	arch := arch.HostArch()
+	arch := env.server.HostArch()
 	tools, err := args.Tools.Match(tools.Filter{Arch: arch})
 	if err != nil {
 		return "", errors.Trace(err)
@@ -302,7 +299,7 @@ func (env *environ) getHardwareCharacteristics(
 	archStr := container.Arch()
 	if archStr == "unknown" || !arch.IsSupportedArch(archStr) {
 		// TODO(ericsnow) This special-case should be improved.
-		archStr = arch.HostArch()
+		archStr = env.server.HostArch()
 	}
 	cores := uint64(container.CPUs())
 	mem := uint64(container.Mem())

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -55,9 +55,6 @@ func matchesContainerSpec(check func(spec containerlxd.ContainerSpec) bool) gomo
 }
 
 func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -72,9 +69,11 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 
 	exp := svr.EXPECT()
 	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
+		exp.HostArch().Return(arch.AMD64),
 	)
 
 	env := s.NewEnviron(c, svr, nil)
@@ -83,9 +82,6 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -113,9 +109,11 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 
 	exp := svr.EXPECT()
 	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
+		exp.HostArch().Return(arch.AMD64),
 	)
 
 	env := s.NewEnviron(c, svr, nil)
@@ -124,9 +122,6 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -163,11 +158,13 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 
 	sExp := svr.EXPECT()
 	gomock.InOrder(
+		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
+		sExp.HostArch().Return(arch.AMD64),
 	)
 
 	// CreateContainerFromSpec is tested in container/lxd.
@@ -186,9 +183,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -204,6 +198,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 
 	sExp := svr.EXPECT()
 	gomock.InOrder(
+		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
 		sExp.IsClustered().Return(true),
@@ -220,9 +215,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -238,6 +230,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 
 	sExp := svr.EXPECT()
 	gomock.InOrder(
+		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
 		sExp.IsClustered().Return(true),
@@ -254,9 +247,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -267,6 +257,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 
 	sExp := svr.EXPECT()
 	gomock.InOrder(
+		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
 		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
 	)
@@ -280,9 +271,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -301,9 +289,11 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 
 	exp := svr.EXPECT()
 	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
+		exp.HostArch().Return(arch.AMD64),
 	)
 
 	args := s.GetStartInstanceArgs(c, "bionic")
@@ -322,12 +312,12 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {
-	// Patch the host's arch, so the broker will filter tools.
-	s.PatchValue(&arch.HostArch, func() string { return arch.PPC64EL })
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+
+	exp := svr.EXPECT()
+	exp.HostArch().Return(arch.PPC64EL)
 
 	env := s.NewEnviron(c, svr, nil)
 	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c, "bionic"))

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -5,7 +5,6 @@ package lxd
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -32,11 +31,7 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 	validator := constraints.NewValidator()
 
 	validator.RegisterUnsupported(unsupportedConstraints)
-
-	// TODO(natefinch): This is only correct so long as the lxd is running on
-	// the local machine.  If/when we support a remote lxd environment, we'll
-	// need to change this to match the arch of the remote machine.
-	validator.RegisterVocabulary(constraints.Arch, []string{arch.HostArch()})
+	validator.RegisterVocabulary(constraints.Arch, []string{env.server.HostArch()})
 
 	return validator, nil
 }

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -19,20 +19,20 @@ import (
 	"github.com/juju/juju/provider/lxd"
 )
 
-type environPolSuite struct {
+type environPolicySuite struct {
 	lxd.EnvironSuite
 
 	callCtx context.ProviderCallContext
 }
 
-var _ = gc.Suite(&environPolSuite{})
+var _ = gc.Suite(&environPolicySuite{})
 
-func (s *environPolSuite) SetUpTest(c *gc.C) {
+func (s *environPolicySuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.callCtx = context.NewCloudCallContext()
 }
 
-func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
+func (s *environPolicySuite) TestPrecheckInstanceDefaults(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -42,7 +42,7 @@ func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *environPolSuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
+func (s *environPolicySuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -55,7 +55,7 @@ func (s *environPolSuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
-func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
+func (s *environPolicySuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -68,7 +68,7 @@ func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
-func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
+func (s *environPolicySuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -81,7 +81,7 @@ func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
-func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
+func (s *environPolicySuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -111,7 +111,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `availability zone "a-zone" not valid`)
 }
 
-func (s *environPolSuite) TestConstraintsValidatorOkay(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorOkay(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -131,7 +131,7 @@ func (s *environPolSuite) TestConstraintsValidatorOkay(c *gc.C) {
 	c.Check(unsupported, gc.HasLen, 0)
 }
 
-func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorEmpty(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -150,7 +150,7 @@ func (s *environPolSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 	c.Check(unsupported, gc.HasLen, 0)
 }
 
-func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -183,7 +183,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	c.Check(unsupported, jc.SameContents, expected)
 }
 
-func (s *environPolSuite) TestConstraintsValidatorVocabArchKnown(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorVocabArchKnown(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -202,7 +202,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabArchKnown(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
-func (s *environPolSuite) TestConstraintsValidatorVocabArchUnknown(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorVocabArchUnknown(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -221,7 +221,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabArchUnknown(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "invalid constraint value: arch=ppc64el\nvalid values are: \\[amd64\\]")
 }
 
-func (s *environPolSuite) TestConstraintsValidatorVocabContainerUnknown(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorVocabContainerUnknown(c *gc.C) {
 	c.Skip("this will fail until we add a container vocabulary")
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -238,7 +238,7 @@ func (s *environPolSuite) TestConstraintsValidatorVocabContainerUnknown(c *gc.C)
 	c.Check(err, gc.ErrorMatches, "invalid constraint value: container=lxd\nvalid values are:.*")
 }
 
-func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -261,7 +261,7 @@ func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	c.Check(merged, jc.DeepEquals, expected)
 }
 
-func (s *environPolSuite) TestSupportNetworks(c *gc.C) {
+func (s *environPolicySuite) TestSupportNetworks(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -64,6 +64,7 @@ type Server interface {
 	UpdateStoragePoolVolume(pool string, volType string, name string, volume lxdapi.StorageVolumePut, ETag string) error
 	DeleteStoragePoolVolume(pool string, volType string, name string) (err error)
 	ServerCertificate() string
+	HostArch() string
 	EnableHTTPSListener() error
 	GetNICsFromProfile(profName string) (map[string]map[string]string, error)
 	IsClustered() bool

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -363,6 +363,18 @@ func (mr *MockServerMockRecorder) HasProfile(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProfile", reflect.TypeOf((*MockServer)(nil).HasProfile), arg0)
 }
 
+// HostArch mocks base method
+func (m *MockServer) HostArch() string {
+	ret := m.ctrl.Call(m, "HostArch")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// HostArch indicates an expected call of HostArch
+func (mr *MockServerMockRecorder) HostArch() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostArch", reflect.TypeOf((*MockServer)(nil).HostArch))
+}
+
 // IsClustered mocks base method
 func (m *MockServer) IsClustered() bool {
 	ret := m.ctrl.Call(m, "IsClustered")

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -434,6 +434,7 @@ type StubClient struct {
 	StorageIsSupported bool
 	Volumes            map[string][]api.StorageVolume
 	ServerCert         string
+	ServerHostArch     string
 }
 
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
@@ -652,6 +653,11 @@ func (conn *StubClient) CreateProfileWithConfig(name string, cfg map[string]stri
 func (conn *StubClient) ServerCertificate() string {
 	conn.AddCall("ServerCertificate")
 	return conn.ServerCert
+}
+
+func (conn *StubClient) HostArch() string {
+	conn.AddCall("HostArch")
+	return conn.ServerHostArch
 }
 
 func (conn *StubClient) EnableHTTPSListener() error {


### PR DESCRIPTION
## Description of change

HostArch from the server
The following ensures that the HostArch is from the LXD server and not from the local machine.

## QA steps

Bootstrap to different host architectures when bootstrapping.

## Documentation changes

N/A

## Bug reference

N/A