### PR TITLE
Model volume backed filesystem storage in k8s

### DIFF
--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -153,10 +153,6 @@ type storageFile interface {
 }
 
 var getStorageAccessor = func(st *state.State) (storageAccess, error) {
-	m, err := st.Model()
-	if err != nil {
-		return nil, err
-	}
 	sb, err := state.NewStorageBackend(st)
 	if err != nil {
 		return nil, err
@@ -165,10 +161,6 @@ var getStorageAccessor = func(st *state.State) (storageAccess, error) {
 		storageInterface: sb,
 		va:               sb,
 		fa:               sb,
-	}
-	// CAAS models don't support volume storage yet.
-	if m.Type() == state.ModelTypeCAAS {
-		storageAccess.va = nil
 	}
 	return storageAccess, nil
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -545,6 +545,7 @@ func createVolumeDetails(
 
 	if len(attachments) > 0 {
 		details.MachineAttachments = make(map[string]params.VolumeAttachmentDetails, len(attachments))
+		details.UnitAttachments = make(map[string]params.VolumeAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
 			attDetails := params.VolumeAttachmentDetails{
 				Life: params.Life(attachment.Life().String()),
@@ -554,7 +555,11 @@ func createVolumeDetails(
 					stateInfo,
 				)
 			}
-			details.MachineAttachments[attachment.Host().String()] = attDetails
+			if attachment.Host().Kind() == names.MachineTagKind {
+				details.MachineAttachments[attachment.Host().String()] = attDetails
+			} else {
+				details.UnitAttachments[attachment.Host().String()] = attDetails
+			}
 		}
 	}
 

--- a/apiserver/facades/client/storage/volumelist_test.go
+++ b/apiserver/facades/client/storage/volumelist_test.go
@@ -32,6 +32,7 @@ func (s *volumeSuite) expectedVolumeDetails() params.VolumeDetails {
 				Life: "alive",
 			},
 		},
+		UnitAttachments: map[string]params.VolumeAttachmentDetails{},
 		Storage: &params.StorageDetails{
 			StorageTag: "storage-data-0",
 			OwnerTag:   "unit-mysql-0",

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -227,6 +227,7 @@ func (m *mockUnit) DestroyOperation() *state.DestroyUnitOperation {
 type mockStorage struct {
 	testing.Stub
 	storageFilesystems map[names.StorageTag]names.FilesystemTag
+	storageVolumes     map[names.StorageTag]names.VolumeTag
 	storageAttachments map[names.UnitTag]names.StorageTag
 }
 
@@ -269,6 +270,25 @@ func (m *mockStorage) SetFilesystemInfo(fsTag names.FilesystemTag, fsInfo state.
 
 func (m *mockStorage) SetFilesystemAttachmentInfo(host names.Tag, fsTag names.FilesystemTag, info state.FilesystemAttachmentInfo) error {
 	m.MethodCall(m, "SetFilesystemAttachmentInfo", host, fsTag, info)
+	return nil
+}
+
+func (m *mockStorage) Volume(volTag names.VolumeTag) (state.Volume, error) {
+	m.MethodCall(m, "Volume", volTag)
+	return &mockVolume{Stub: &m.Stub, tag: volTag}, nil
+}
+
+func (m *mockStorage) StorageInstanceVolume(tag names.StorageTag) (state.Volume, error) {
+	return &mockVolume{Stub: &m.Stub, tag: m.storageVolumes[tag]}, nil
+}
+
+func (m *mockStorage) SetVolumeInfo(volTag names.VolumeTag, volInfo state.VolumeInfo) error {
+	m.MethodCall(m, "SetVolumeInfo", volTag, volInfo)
+	return nil
+}
+
+func (m *mockStorage) SetVolumeAttachmentInfo(host names.Tag, volTag names.VolumeTag, info state.VolumeAttachmentInfo) error {
+	m.MethodCall(m, "SetVolumeAttachmentInfo", host, volTag, info)
 	return nil
 }
 
@@ -324,7 +344,7 @@ func (f *mockFilesystem) FilesystemTag() names.FilesystemTag {
 }
 
 func (f *mockFilesystem) Volume() (names.VolumeTag, error) {
-	return names.VolumeTag{}, state.ErrNoBackingVolume
+	return names.NewVolumeTag("66"), nil
 }
 
 func (f *mockFilesystem) Params() (state.FilesystemParams, bool) {
@@ -352,6 +372,36 @@ func (f *mockFilesystemAttachment) Params() (state.FilesystemAttachmentParams, b
 		Location: "/path/to/here",
 		ReadOnly: true,
 	}, true
+}
+
+type mockVolume struct {
+	*testing.Stub
+	state.Volume
+	tag names.VolumeTag
+}
+
+func (v *mockVolume) Tag() names.Tag {
+	return v.VolumeTag()
+}
+
+func (v *mockVolume) VolumeTag() names.VolumeTag {
+	return v.tag
+}
+
+func (v *mockVolume) Params() (state.VolumeParams, bool) {
+	return state.VolumeParams{
+		Pool: "k8spool",
+		Size: 100,
+	}, true
+}
+
+func (v *mockVolume) SetStatus(statusInfo status.StatusInfo) error {
+	v.MethodCall(v, "SetStatus", statusInfo)
+	return nil
+}
+
+func (v *mockVolume) Info() (state.VolumeInfo, error) {
+	return state.VolumeInfo{}, errors.NotProvisionedf("volume")
 }
 
 type mockStorageProviderRegistry struct {

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -35,6 +35,10 @@ type StorageBackend interface {
 	UnitStorageAttachments(unit names.UnitTag) ([]state.StorageAttachment, error)
 	SetFilesystemInfo(names.FilesystemTag, state.FilesystemInfo) error
 	SetFilesystemAttachmentInfo(names.Tag, names.FilesystemTag, state.FilesystemAttachmentInfo) error
+	Volume(tag names.VolumeTag) (state.Volume, error)
+	StorageInstanceVolume(tag names.StorageTag) (state.Volume, error)
+	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
+	SetVolumeAttachmentInfo(names.Tag, names.VolumeTag, state.VolumeAttachmentInfo) error
 }
 
 // Model provides the subset of CAAS model state required

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -74,4 +74,17 @@ type KubernetesFilesystemInfo struct {
 	Status       string                 `json:"status"`
 	Info         string                 `json:"info"`
 	Data         map[string]interface{} `json:"data,omitempty"`
+	Volume       KubernetesVolumeInfo   `json:"volume"`
+}
+
+// Volume describes a storage volume in the cloud
+// as reported to the model.
+type KubernetesVolumeInfo struct {
+	VolumeId   string                 `json:"volume-id"`
+	Pool       string                 `json:"pool,omitempty"`
+	Size       uint64                 `json:"size"`
+	Persistent bool                   `json:"persistent"`
+	Status     string                 `json:"status"`
+	Info       string                 `json:"info"`
+	Data       map[string]interface{} `json:"data,omitempty"`
 }

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -632,6 +632,10 @@ type VolumeDetails struct {
 	// machine tag to volume attachment information.
 	MachineAttachments map[string]VolumeAttachmentDetails `json:"machine-attachments,omitempty"`
 
+	// UnitAttachments contains a mapping from
+	// unit tag to volume attachment information (CAAS models).
+	UnitAttachments map[string]VolumeAttachmentDetails `json:"unit-attachments,omitempty"`
+
 	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
 	Storage *StorageDetails `json:"storage,omitempty"`

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -145,6 +145,16 @@ type FilesystemInfo struct {
 	MountPoint   string
 	ReadOnly     bool
 	Status       status.StatusInfo
+	Volume       VolumeInfo
+}
+
+// VolumeInfo represents information about a volume
+// mounted by a unit.
+type VolumeInfo struct {
+	VolumeId   string
+	Size       uint64
+	Persistent bool
+	Status     status.StatusInfo
 }
 
 // Unit represents information about the status of a "pod".

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -394,13 +394,15 @@ func (k *kubernetesClient) ensureStorageClass(cfg *storageConfig) error {
 				cfg.storageClass))
 	}
 
+	reclaimPolicy := core.PersistentVolumeReclaimRetain
 	// Create the storage class with the specified provisioner.
 	_, err = storageClasses.Create(&k8sstorage.StorageClass{
 		ObjectMeta: v1.ObjectMeta{
 			Name: cfg.storageClass,
 		},
-		Provisioner: cfg.storageProvisioner,
-		Parameters:  cfg.parameters,
+		Provisioner:   cfg.storageProvisioner,
+		ReclaimPolicy: &reclaimPolicy,
+		Parameters:    cfg.parameters,
 	})
 	return errors.Trace(err)
 }
@@ -1051,6 +1053,7 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 		for _, pv := range p.Spec.Volumes {
 			volumesByName[pv.Name] = pv
 		}
+		pVolumes := k.CoreV1().PersistentVolumes()
 
 		// Gather info about how filesystems are attached/mounted to the pod.
 		// The mount name represents the filesystem tag name used by Juju.
@@ -1075,6 +1078,15 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 			pvc, err := pvClaims.Get(vol.PersistentVolumeClaim.ClaimName, v1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				// Ignore claims which don't exist (yet).
+				continue
+			}
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			pv, err := pVolumes.Get(pvc.Spec.VolumeName, v1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				// Ignore volumes which don't exist (yet).
 				continue
 			}
 			if err != nil {
@@ -1111,9 +1123,19 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 				MountPoint:   volMount.MountPath,
 				ReadOnly:     volMount.ReadOnly,
 				Status: status.StatusInfo{
-					Status:  k.jujuStorageStatus(pvc.Status.Phase),
+					Status:  k.jujuFilesystemStatus(pvc.Status.Phase),
 					Message: statusMessage,
 					Since:   &since,
+				},
+				Volume: caas.VolumeInfo{
+					VolumeId:   pv.Name,
+					Size:       uint64(pv.Size()),
+					Persistent: pv.Spec.PersistentVolumeReclaimPolicy == core.PersistentVolumeReclaimRetain,
+					Status: status.StatusInfo{
+						Status:  k.jujuVolumeStatus(pv.Status.Phase),
+						Message: pv.Status.Message,
+						Since:   &since,
+					},
 				},
 			})
 		}
@@ -1138,7 +1160,7 @@ func (k *kubernetesClient) jujuStatus(podPhase core.PodPhase, terminated bool) s
 	}
 }
 
-func (k *kubernetesClient) jujuStorageStatus(pvcPhase core.PersistentVolumeClaimPhase) status.Status {
+func (k *kubernetesClient) jujuFilesystemStatus(pvcPhase core.PersistentVolumeClaimPhase) status.Status {
 	switch pvcPhase {
 	case core.ClaimPending:
 		return status.Pending
@@ -1146,6 +1168,21 @@ func (k *kubernetesClient) jujuStorageStatus(pvcPhase core.PersistentVolumeClaim
 		return status.Attached
 	case core.ClaimLost:
 		return status.Detached
+	default:
+		return status.Unknown
+	}
+}
+
+func (k *kubernetesClient) jujuVolumeStatus(pvPhase core.PersistentVolumePhase) status.Status {
+	switch pvPhase {
+	case core.VolumePending:
+		return status.Pending
+	case core.VolumeBound:
+		return status.Attached
+	case core.VolumeAvailable, core.VolumeReleased:
+		return status.Detached
+	case core.VolumeFailed:
+		return status.Error
 	default:
 		return status.Unknown
 	}

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -105,22 +105,22 @@ func (g *storageProvider) ValidateConfig(cfg *storage.Config) error {
 
 // Supports is defined on the storage.Provider interface.
 func (g *storageProvider) Supports(k storage.StorageKind) bool {
-	return k == storage.StorageKindFilesystem
+	return k == storage.StorageKindBlock
 }
 
 // Scope is defined on the storage.Provider interface.
 func (g *storageProvider) Scope() storage.Scope {
-	return storage.ScopeMachine
+	return storage.ScopeEnviron
 }
 
 // Dynamic is defined on the storage.Provider interface.
 func (g *storageProvider) Dynamic() bool {
-	return false
+	return true
 }
 
 // Releasable is defined on the storage.Provider interface.
 func (e *storageProvider) Releasable() bool {
-	return false
+	return true
 }
 
 // DefaultPools is defined on the storage.Provider interface.

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -90,8 +90,8 @@ func (s *storageSuite) TestSupports(c *gc.C) {
 	defer ctrl.Finish()
 
 	p := s.k8sProvider(c, ctrl)
-	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsFalse)
-	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsTrue)
+	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsTrue)
+	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsFalse)
 }
 
 func (s *storageSuite) TestScope(c *gc.C) {
@@ -99,5 +99,5 @@ func (s *storageSuite) TestScope(c *gc.C) {
 	defer ctrl.Finish()
 
 	p := s.k8sProvider(c, ctrl)
-	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeEnviron)
 }

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/model"
 )
 
 // NewRemoveApplicationCommand returns a command which removes an application.
@@ -152,31 +151,6 @@ func (c *removeApplicationCommand) Run(ctx *cmd.Context) error {
 	}
 	if c.DestroyStorage && apiVersion < 5 {
 		return errors.New("--destroy-storage is not supported by this controller")
-	}
-	if !c.DestroyStorage {
-		mType, err := c.ModelType()
-		if err != nil {
-			return err
-		}
-		// TODO(caas) - this will change when volumes are managed separately to pods.
-		if mType == model.CAAS {
-			hasStorage, err := c.applicationsHaveStorage(c.ApplicationNames)
-			if err != nil {
-				return err
-			}
-			if hasStorage {
-				return errors.Errorf(`cannot destroy applications %q
-
-Destroying these kubernetes applications will destroy the storage,
-but you have not indicated that you want to do that.
-
-Please run the the command again with --destroy-storage
-to confirm that you want to destroy the storage along
-with the applications.
-
-`, c.ApplicationNames)
-			}
-		}
 	}
 	return c.removeApplications(ctx, client)
 }

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 type RemoveApplicationSuite struct {
@@ -140,28 +139,6 @@ func (s *RemoveApplicationSuite) TestInvalidArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `no application specified`)
 	_, err = runRemoveApplication(c, "invalid:name")
 	c.Assert(err, gc.ErrorMatches, `invalid application name "invalid:name"`)
-}
-
-func (s *RemoveApplicationSuite) TestRemoveCAASApplicationWithStorage(c *gc.C) {
-	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{Name: "caasmodel"})
-	s.AddCleanup(func(*gc.C) { st.Close() })
-
-	repo := testcharms.RepoForSeries("kubernetes")
-	ch := repo.CharmArchivePath(s.CharmsPath, "storage-filesystem")
-	err := runDeploy(c, ch, "-m", "caasmodel", "storage-filesystem", "--storage", "data=2")
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = runRemoveApplication(c, "-m", "caasmodel", "storage-filesystem")
-	c.Assert(err, gc.ErrorMatches, `cannot destroy applications \["storage-filesystem"\]
-
-Destroying these kubernetes applications will destroy the storage,
-but you have not indicated that you want to do that.
-
-Please run the the command again with --destroy-storage
-to confirm that you want to destroy the storage along
-with the applications.
-
-`)
 }
 
 type RemoveCharmStoreCharmsSuite struct {

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/api/storage"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/model"
 )
 
 // NewRemoveUnitCommand returns a command which removes an application's units.
@@ -137,31 +136,6 @@ func (c *removeUnitCommand) Run(ctx *cmd.Context) error {
 	}
 	if c.DestroyStorage && apiVersion < 5 {
 		return errors.New("--destroy-storage is not supported by this controller")
-	}
-	if !c.DestroyStorage {
-		mType, err := c.ModelType()
-		if err != nil {
-			return err
-		}
-		// TODO(caas) - this will change when volumes are managed separately to pods.
-		if mType == model.CAAS {
-			hasStorage, err := c.unitsHaveStorage(c.UnitNames)
-			if err != nil {
-				return err
-			}
-			if hasStorage {
-				return errors.Errorf(`cannot destroy units %q
-
-Destroying these kubernetes units will destroy the storage,
-but you have not indicated that you want to do that.
-
-Please run the the command again with --destroy-storage
-to confirm that you want to destroy the storage along
-with the units.
-
-`, c.UnitNames)
-			}
-		}
 	}
 	return c.removeUnits(ctx, client)
 }

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 type RemoveUnitSuite struct {
@@ -64,28 +63,6 @@ removing unit sillybilly/17 failed: unit "sillybilly/17" does not exist
 	for _, u := range units {
 		c.Assert(u.Life(), gc.Equals, state.Dying)
 	}
-}
-
-func (s *RemoveUnitSuite) TestRemoveCAASUnitWithStorage(c *gc.C) {
-	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{Name: "caasmodel"})
-	s.AddCleanup(func(*gc.C) { st.Close() })
-
-	repo := testcharms.RepoForSeries("kubernetes")
-	ch := repo.CharmArchivePath(s.CharmsPath, "storage-filesystem")
-	err := runDeploy(c, ch, "-m", "caasmodel", "storage-filesystem", "--storage", "data=2")
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = runRemoveUnit(c, "-m", "caasmodel", "storage-filesystem/0")
-	c.Assert(err, gc.ErrorMatches, `cannot destroy units \["storage-filesystem/0"\]
-
-Destroying these kubernetes units will destroy the storage,
-but you have not indicated that you want to do that.
-
-Please run the the command again with --destroy-storage
-to confirm that you want to destroy the storage along
-with the units.
-
-`)
 }
 
 func (s *RemoveUnitSuite) TestRemoveUnitDetachesStorage(c *gc.C) {

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -56,11 +56,12 @@ type EntityStatus struct {
 }
 
 type VolumeAttachments struct {
-	Machines map[string]MachineVolumeAttachment `yaml:"machines,omitempty" json:"machines,omitempty"`
-	Units    map[string]UnitStorageAttachment   `yaml:"units,omitempty" json:"units,omitempty"`
+	Machines   map[string]VolumeAttachment      `yaml:"machines,omitempty" json:"machines,omitempty"`
+	Containers map[string]VolumeAttachment      `yaml:"containers,omitempty" json:"containers,omitempty"`
+	Units      map[string]UnitStorageAttachment `yaml:"units,omitempty" json:"units,omitempty"`
 }
 
-type MachineVolumeAttachment struct {
+type VolumeAttachment struct {
 	DeviceName string `yaml:"device,omitempty" json:"device,omitempty"`
 	DeviceLink string `yaml:"device-link,omitempty" json:"device-link,omitempty"`
 	BusAddress string `yaml:"bus-address,omitempty" json:"bus-address,omitempty"`
@@ -134,14 +135,16 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 		common.FormatTime(details.Status.Since, false),
 	}
 
-	if len(details.MachineAttachments) > 0 {
-		machineAttachments := make(map[string]MachineVolumeAttachment)
-		for machineTag, attachment := range details.MachineAttachments {
-			machineId, err := idFromTag(machineTag)
+	attachmentsFromDetails := func(
+		in map[string]params.VolumeAttachmentDetails,
+		out map[string]VolumeAttachment,
+	) error {
+		for tag, attachment := range in {
+			id, err := idFromTag(tag)
 			if err != nil {
-				return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
+				return errors.Trace(err)
 			}
-			machineAttachments[machineId] = MachineVolumeAttachment{
+			out[id] = VolumeAttachment{
 				attachment.DeviceName,
 				attachment.DeviceLink,
 				attachment.BusAddress,
@@ -149,9 +152,28 @@ func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo
 				string(attachment.Life),
 			}
 		}
+		return nil
+	}
+
+	if len(details.MachineAttachments) > 0 {
+		machineAttachments := make(map[string]VolumeAttachment)
+		if err := attachmentsFromDetails(details.MachineAttachments, machineAttachments); err != nil {
+			return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
+		}
 		info.Attachments = &VolumeAttachments{
 			Machines: machineAttachments,
 		}
+	}
+
+	if len(details.UnitAttachments) > 0 {
+		unitAttachments := make(map[string]VolumeAttachment)
+		if err := attachmentsFromDetails(details.UnitAttachments, unitAttachments); err != nil {
+			return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
+		}
+		if info.Attachments == nil {
+			info.Attachments = &VolumeAttachments{}
+		}
+		info.Attachments.Containers = unitAttachments
 	}
 
 	if details.Storage != nil {

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -22,8 +22,8 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
 	print("[Volumes]")
-	print("Machine", "Unit", "Storage", "Id", "Provider Id", "Device", "Size", "State", "Message")
 
+	haveMachines := false
 	volumeAttachmentInfos := make(volumeAttachmentInfos, 0, len(infos))
 	for volumeId, info := range infos {
 		volumeAttachmentInfo := volumeAttachmentInfo{
@@ -42,9 +42,23 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 		for machineId, machineInfo := range info.Attachments.Machines {
 			volumeAttachmentInfo := volumeAttachmentInfo
 			volumeAttachmentInfo.MachineId = machineId
-			volumeAttachmentInfo.MachineVolumeAttachment = machineInfo
+			volumeAttachmentInfo.VolumeAttachment = machineInfo
 			for unitId, unitInfo := range info.Attachments.Units {
 				if unitInfo.MachineId == machineId {
+					volumeAttachmentInfo.UnitId = unitId
+					volumeAttachmentInfo.UnitStorageAttachment = unitInfo
+					break
+				}
+			}
+			haveMachines = true
+			volumeAttachmentInfos = append(volumeAttachmentInfos, volumeAttachmentInfo)
+		}
+
+		for hostId, containerInfo := range info.Attachments.Containers {
+			volumeAttachmentInfo := volumeAttachmentInfo
+			volumeAttachmentInfo.VolumeAttachment = containerInfo
+			for unitId, unitInfo := range info.Attachments.Units {
+				if hostId == unitId {
 					volumeAttachmentInfo.UnitId = unitId
 					volumeAttachmentInfo.UnitStorageAttachment = unitInfo
 					break
@@ -55,17 +69,31 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	}
 	sort.Sort(volumeAttachmentInfos)
 
+	if haveMachines {
+		print("Machine", "Unit", "Storage", "Id", "Provider Id", "Device", "Size", "State", "Message")
+	} else {
+		print("Unit", "Storage", "Id", "Provider Id", "Size", "State", "Message")
+	}
+
 	for _, info := range volumeAttachmentInfos {
 		var size string
 		if info.Size > 0 {
 			size = humanize.IBytes(info.Size * humanize.MiByte)
 		}
-		print(
-			info.MachineId, info.UnitId, info.Storage,
-			info.VolumeId, info.ProviderVolumeId,
-			info.DeviceName, size,
-			string(info.Status.Current), info.Status.Message,
-		)
+		if haveMachines {
+			print(
+				info.MachineId, info.UnitId, info.Storage,
+				info.VolumeId, info.ProviderVolumeId,
+				info.DeviceName, size,
+				string(info.Status.Current), info.Status.Message,
+			)
+		} else {
+			print(
+				info.UnitId, info.Storage,
+				info.VolumeId, info.ProviderVolumeId, size,
+				string(info.Status.Current), info.Status.Message,
+			)
+		}
 	}
 
 	return tw.Flush()
@@ -76,7 +104,7 @@ type volumeAttachmentInfo struct {
 	VolumeInfo
 
 	MachineId string
-	MachineVolumeAttachment
+	VolumeAttachment
 
 	UnitId string
 	UnitStorageAttachment

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -147,7 +147,7 @@ func (s *CAASModelSuite) TestDestroyModelDestroyStorage(c *gc.C) {
 	c.Assert(model.Life(), gc.Equals, state.Dying)
 
 	assertNeedsCleanup(c, st)
-	assertCleanupCount(c, st, 4)
+	assertCleanupCount(c, st, 5)
 
 	sb, err := state.NewStorageBackend(st)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -823,7 +823,7 @@ func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual boo
 				); err != nil {
 					return errors.Trace(err)
 				}
-				if err := updateStatus(); err != nil {
+				if err := updateStatus(); err != nil && !errors.IsNotFound(err) {
 					return errors.Trace(err)
 				}
 			}

--- a/state/volume.go
+++ b/state/volume.go
@@ -257,7 +257,7 @@ func (v *volumeAttachment) Volume() names.VolumeTag {
 
 // Host is required to implement VolumeAttachment.
 func (v *volumeAttachment) Host() names.Tag {
-	return names.NewMachineTag(v.doc.Host)
+	return storageAttachmentHost(v.doc.Host)
 }
 
 // Life is required to implement VolumeAttachment.
@@ -1018,12 +1018,14 @@ func (sb *storageBackend) SetVolumeAttachmentInfo(hostTag names.Tag, volumeTag n
 		return errors.Trace(err)
 	}
 	// Also ensure the machine is provisioned.
-	m, err := sb.machine(hostTag.Id())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if _, err := m.InstanceId(); err != nil {
-		return errors.Trace(err)
+	if _, ok := hostTag.(names.MachineTag); ok {
+		m, err := sb.machine(hostTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := m.InstanceId(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return sb.setVolumeAttachmentInfo(hostTag, volumeTag, info)
 }

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -188,6 +188,14 @@ func (aw *applicationWorker) loop() error {
 						Status:       info.Status.Status.String(),
 						Info:         info.Status.Message,
 						Data:         info.Status.Data,
+						Volume: params.KubernetesVolumeInfo{
+							VolumeId:   info.Volume.VolumeId,
+							Size:       info.Volume.Size,
+							Persistent: info.Volume.Persistent,
+							Status:     info.Volume.Status.Status.String(),
+							Info:       info.Volume.Status.Message,
+							Data:       info.Volume.Status.Data,
+						},
 					})
 
 				}

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -110,7 +110,10 @@ func (m *mockContainerBroker) Units(appName string) ([]caas.Unit, error) {
 				FilesystemInfo: []caas.FilesystemInfo{
 					{MountPoint: "/path-to-here", ReadOnly: true, StorageName: "database",
 						Size: 100, FilesystemId: "fs-id",
-						Status: status.StatusInfo{Status: status.Attaching, Message: "not ready"}},
+						Status: status.StatusInfo{Status: status.Attaching, Message: "not ready"},
+						Volume: caas.VolumeInfo{VolumeId: "vol-id", Size: 200, Persistent: true,
+							Status: status.StatusInfo{Status: status.Error, Message: "vol not ready"}},
+					},
 				},
 			},
 		},

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -580,6 +580,9 @@ func (s *WorkerSuite) assertUnitChange(c *gc.C, reported, expected status.Status
 					FilesystemInfo: []params.KubernetesFilesystemInfo{
 						{StorageName: "database", MountPoint: "/path-to-here", ReadOnly: true,
 							FilesystemId: "fs-id", Size: 100, Pool: "",
+							Volume: params.KubernetesVolumeInfo{
+								VolumeId: "vol-id", Size: 200,
+								Persistent: true, Status: "error", Info: "vol not ready"},
 							Status: "attaching", Info: "not ready"},
 					}},
 			},


### PR DESCRIPTION
## Description of change

The underlying pv used to host k8s filesystem storage is modelled. The main change is to pass the pv info from the k8s cluster back to Juju and store the info in the data model, plus tweak the storage provider setup to match that used by other clouds.
Because volumes are now tracked, we no longer need to enforce the use of the --destroy-storage flag when removing applications and units.

## QA steps

Deploy a k8s charm with storage.
Run juju storage --volume and check output.

