### PR TITLE
Bugfix for docker resource type and --resource.

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -158,10 +158,13 @@ func (h *ResourcesHandler) readResource(backend ResourcesBackend, req *http.Requ
 			return nil, errors.Errorf("incorrect extension on resource upload %q, expected %q", uReq.Filename, ext)
 		}
 	case charmresource.TypeDocker:
-		err := resources.CheckDockerDetails(res.Name, res.Path)
+		// Mapping the uploaded 'filename' which is actually the RegistryPath. There is no 'Path', it'll be written to file as content.yaml
+		err := resources.CheckDockerDetails(res.Name, uReq.Filename)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		// The uploaded finger print from the CLI will not match what comes in from the API request, do not store it.
+		uReq.Fingerprint = charmresource.Fingerprint{}
 	}
 
 	chRes, err := updateResource(res.Resource, uReq.Fingerprint, uReq.Size)

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -5,6 +5,7 @@ package resource
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	charmresource "gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/macaroon.v2-unstable"
-	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/charmstore"
 	resources "github.com/juju/juju/core/resources"
@@ -236,7 +236,10 @@ func (d deployUploader) uploadFile(resourcename, filename string) (id string, er
 }
 
 func (d deployUploader) uploadDockerDetails(resourcename, registryPath string) (id string, error error) {
-	data, err := yaml.Marshal(resources.DockerImageDetails{
+	// TODO (veebers): This will handle either a straight registryPath
+	// string (for public images) or a path to a file containing
+	// username/password details.
+	data, err := json.Marshal(resources.DockerImageDetails{
 		RegistryPath: registryPath,
 	})
 	if err != nil {

--- a/resource/context/internal/resource.go
+++ b/resource/context/internal/resource.go
@@ -35,7 +35,7 @@ func OpenResource(name string, client OpenedResourceClient) (*OpenedResource, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if info.Type == charmresource.TypeDocker && len(info.Path) == 0 {
+	if info.Type == charmresource.TypeDocker {
 		info.Path = "content.yaml"
 	}
 	or := &OpenedResource{

--- a/resource/resourcetesting/resource.go
+++ b/resource/resourcetesting/resource.go
@@ -18,13 +18,26 @@ import (
 	"github.com/juju/juju/resource"
 )
 
+type newCharmResourceFunc func(c *gc.C, name, content string) charmresource.Resource
+
 // NewResource produces full resource info for the given name and
 // content. The origin is set set to "upload". A reader is also returned
 // which contains the content.
 func NewResource(c *gc.C, stub *testing.Stub, name, applicationID, content string) resource.Opened {
 	username := "a-user"
 	return resource.Opened{
-		Resource:   newResource(c, name, applicationID, username, content),
+		Resource:   newResource(c, name, applicationID, username, content, NewCharmResource),
+		ReadCloser: newStubReadCloser(stub, content),
+	}
+}
+
+// NewDockerResource produces full resource info for the given name and
+// content. The origin is set set to "upload" (via resource created by  NewCharmDockerResource).
+// A reader is also returned which contains the content.
+func NewDockerResource(c *gc.C, stub *testing.Stub, name, applicationID, content string) resource.Opened {
+	username := "a-user"
+	return resource.Opened{
+		Resource:   newResource(c, name, applicationID, username, content, NewCharmDockerResource),
 		ReadCloser: newStubReadCloser(stub, content),
 	}
 }
@@ -52,23 +65,43 @@ func NewCharmResource(c *gc.C, name, content string) charmresource.Resource {
 	return res
 }
 
+// NewCharmDockerResource produces basic docker resource info for the given name
+// and content. The origin is set set to "upload".
+func NewCharmDockerResource(c *gc.C, name, content string) charmresource.Resource {
+	res := charmresource.Resource{
+		Meta: charmresource.Meta{
+			Name:        name,
+			Type:        charmresource.TypeDocker,
+			Description: name + " description",
+		},
+		Origin:      charmresource.OriginUpload,
+		Revision:    0,
+		Fingerprint: charmresource.Fingerprint{},
+		Size:        0,
+	}
+	err := res.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	return res
+}
+
 // NewPlaceholderResource returns resource info for a resource that
 // has not been uploaded or pulled from the charm store yet. The origin
 // is set to "upload".
 func NewPlaceholderResource(c *gc.C, name, applicationID string) resource.Resource {
-	res := newResource(c, name, applicationID, "", "")
+	res := newResource(c, name, applicationID, "", "", NewCharmResource)
 	res.Fingerprint = charmresource.Fingerprint{}
 	return res
 }
 
-func newResource(c *gc.C, name, applicationID, username, content string) resource.Resource {
+func newResource(c *gc.C, name, applicationID, username, content string, charmResourceFunc newCharmResourceFunc) resource.Resource {
 	var timestamp time.Time
 	if username != "" {
 		// TODO(perrito666) 2016-05-02 lp:1558657
 		timestamp = time.Now().UTC()
 	}
 	res := resource.Resource{
-		Resource:      NewCharmResource(c, name, content),
+		Resource:      charmResourceFunc(c, name, content),
 		ID:            applicationID + "/" + name,
 		PendingID:     "",
 		ApplicationID: applicationID,


### PR DESCRIPTION
## Description of change

This fixes using --resource to overwrite a docker image for a caas charm.

i.e. juju deploy cs:~veebers/caas-mysql --resource mysql_image=mysql/mysql-server:5.7

## QA steps

Unit test included for the docker image difference in read resources.

Manually verified as well:
  - Spin up k8s cluster (add-k8s k8s, add-model k8s etc.)
  - Bootstrap juju using staging charmstore
     ```juju bootstrap lxd/localhost resources --config charmstore-url=https://api.staging.jujucharms.com/charmstore```
  - Deploy charm using --resource to overwrite image:
     ```i.e. juju deploy cs:~veebers/caas-mysql --resource mysql_image=mysql/mysql-server:5.7```

## Documentation changes
No Documentation change needed, this fixes a bug.
