### PR TITLE
Credential override during bootstrap

### DIFF
--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -50,8 +50,11 @@ func GetOrDetectCredential(
 	// the environment.
 	ctx.Verbosef("no credentials found, checking environment")
 
-	detected, detectErr := modelcmd.DetectCredential(args.Cloud.Name, args.CredentialName, provider)
-	if err != nil && detectErr != nil && args.CredentialName != "" {
+	detected, selected, detectErr := modelcmd.DetectCredential(args.Cloud.Name, args.CredentialName, provider)
+	// Attempt to detect a credential if the credential name is not empty, but
+	// detect credential doesn't return a selected credential based on the
+	// credential name.
+	if !selected && args.CredentialName != "" {
 		return credential, chosenCredentialName, regionName, false, err
 	}
 	if errors.Cause(detectErr) == modelcmd.ErrMultipleCredentials {

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-// ErrMultipleCredentialsDetected is the error returned by
+// ErrMultipleDetectedCredentials is the error returned by
 // GetOrDetectCredential when multiple credentials are
 // detected, meaning Juju cannot choose one automatically.
 var ErrMultipleDetectedCredentials = errors.New("multiple detected credentials")
@@ -41,7 +41,7 @@ func GetOrDetectCredential(
 		return nil, "", "", false, err
 	}
 	credential, chosenCredentialName, regionName, err := modelcmd.GetCredentials(ctx, store, args)
-	if !errors.IsNotFound(err) || args.CredentialName != "" {
+	if !errors.IsNotFound(err) {
 		return credential, chosenCredentialName, regionName, false, err
 	}
 
@@ -50,11 +50,14 @@ func GetOrDetectCredential(
 	// the environment.
 	ctx.Verbosef("no credentials found, checking environment")
 
-	detected, err := modelcmd.DetectCredential(args.Cloud.Name, provider)
-	if errors.Cause(err) == modelcmd.ErrMultipleCredentials {
+	detected, detectErr := modelcmd.DetectCredential(args.Cloud.Name, args.CredentialName, provider)
+	if err != nil && detectErr != nil && args.CredentialName != "" {
+		return credential, chosenCredentialName, regionName, false, err
+	}
+	if errors.Cause(detectErr) == modelcmd.ErrMultipleCredentials {
 		return fail(ErrMultipleDetectedCredentials)
-	} else if err != nil {
-		return fail(errors.Trace(err))
+	} else if detectErr != nil {
+		return fail(errors.Trace(detectErr))
 	}
 
 	// We have one credential so extract it from the map.

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -54,6 +54,7 @@ type destroyCommand struct {
 	destroyModels  bool
 	destroyStorage bool
 	releaseStorage bool
+	credentialName string
 }
 
 // usageDetails has backticks which we want to keep for markdown processing.
@@ -139,6 +140,7 @@ func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.destroyModels, "destroy-all-models", false, "Destroy all hosted models in the controller")
 	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage instances managed by the controller")
 	f.BoolVar(&c.releaseStorage, "release-storage", false, "Release all storage instances from management of the controller, without destroying them")
+	f.StringVar(&c.credentialName, "credential", "", "Credentials to use when destroying")
 }
 
 // Init implements Command.Init.
@@ -213,7 +215,7 @@ upgrade the controller to version 2.3 or greater.
 	}
 
 	// Obtain controller environ so we can clean up afterwards.
-	controllerEnviron, err := c.getControllerEnviron(ctx, store, controllerName, api)
+	controllerEnviron, err := c.getControllerEnviron(ctx, store, controllerName, c.credentialName, api)
 	if err != nil {
 		return errors.Annotate(err, "getting controller environ")
 	}
@@ -527,10 +529,10 @@ func (c *destroyCommandBase) Init(args []string) error {
 func (c *destroyCommandBase) getControllerEnviron(
 	ctx *cmd.Context,
 	store jujuclient.ClientStore,
-	controllerName string,
+	controllerName, credentialName string,
 	sysAPI destroyControllerAPI,
 ) (environs.Environ, error) {
-	env, err := c.getControllerEnvironFromStore(ctx, store, controllerName)
+	env, err := c.getControllerEnvironFromStore(ctx, store, controllerName, credentialName)
 	if errors.IsNotFound(err) {
 		return c.getControllerEnvironFromAPI(sysAPI, controllerName)
 	} else if err != nil {
@@ -542,11 +544,11 @@ func (c *destroyCommandBase) getControllerEnviron(
 func (c *destroyCommandBase) getControllerEnvironFromStore(
 	ctx *cmd.Context,
 	store jujuclient.ClientStore,
-	controllerName string,
+	controllerName, credentialName string,
 ) (environs.Environ, error) {
 	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
 		ctx, store, environs.GlobalProviderRegistry(),
-	)(controllerName)
+	)(controllerName, credentialName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -63,8 +63,9 @@ func wrapKillCommand(kill *killCommand) modelcmd.Command {
 type killCommand struct {
 	destroyCommandBase
 
-	clock   clock.Clock
-	timeout time.Duration
+	clock          clock.Clock
+	timeout        time.Duration
+	credentialName string
 }
 
 // SetFlags implements Command.SetFlags.
@@ -72,6 +73,7 @@ func (c *killCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.destroyCommandBase.SetFlags(f)
 	f.Var(newDurationValue(time.Minute*5, &c.timeout), "t", "Timeout before direct destruction")
 	f.Var(newDurationValue(time.Minute*5, &c.timeout), "timeout", "")
+	f.StringVar(&c.credentialName, "credential", "", "Credentials to use for direct destruction")
 }
 
 // Info implements Command.Info.
@@ -116,7 +118,7 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Obtain controller environ so we can clean up afterwards.
-	controllerEnviron, err := c.getControllerEnviron(ctx, store, controllerName, api)
+	controllerEnviron, err := c.getControllerEnviron(ctx, store, controllerName, c.credentialName, api)
 	if err != nil {
 		return errors.Annotate(err, "getting controller environ")
 	}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -435,7 +435,7 @@ func NewGetBootstrapConfigParamsFunc(
 	ctx *cmd.Context,
 	store jujuclient.ClientStore,
 	providerRegistry environs.ProviderRegistry,
-) func(string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
+) func(string, string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
 	return bootstrapConfigGetter{ctx, store, providerRegistry}.getBootstrapConfigParams
 }
 
@@ -445,7 +445,7 @@ type bootstrapConfigGetter struct {
 	registry environs.ProviderRegistry
 }
 
-func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
+func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName, credentialName string) (*jujuclient.BootstrapConfig, *environs.PrepareConfigParams, error) {
 	controllerDetails, err := g.store.ControllerByName(controllerName)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "resolving controller name")
@@ -487,7 +487,11 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		cloudCredential, err := DetectCredential(bootstrapConfig.Cloud, provider)
+		detectCredential := credentialName
+		if detectCredential == "" {
+			detectCredential = bootstrapConfig.Credential
+		}
+		cloudCredential, err := DetectCredential(bootstrapConfig.Cloud, detectCredential, provider)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -491,7 +491,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName, credenti
 		if detectCredential == "" {
 			detectCredential = bootstrapConfig.Credential
 		}
-		cloudCredential, err := DetectCredential(bootstrapConfig.Cloud, detectCredential, provider)
+		cloudCredential, _, err := DetectCredential(bootstrapConfig.Cloud, detectCredential, provider)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -105,7 +105,31 @@ func (NewGetBootstrapConfigParamsFuncSuite) TestDetectCredentials(c *gc.C) {
 		clientStore,
 		&registry,
 	)
-	_, params, err := f("foo")
+	_, params, err := f("foo", "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(params.Cloud.Credential.Label, gc.Equals, "finalized")
+}
+
+func (NewGetBootstrapConfigParamsFuncSuite) TestDetectCredentialsWithOverride(c *gc.C) {
+	clientStore := jujuclient.NewMemStore()
+	clientStore.Controllers["foo"] = jujuclient.ControllerDetails{}
+	clientStore.BootstrapConfig["foo"] = jujuclient.BootstrapConfig{
+		Cloud:               "cloud",
+		CloudType:           "cloud-type",
+		ControllerModelUUID: coretesting.ModelTag.Id(),
+		Config: map[string]interface{}{
+			"name": "foo",
+			"type": "cloud-type",
+		},
+	}
+	var registry mockProviderRegistry
+
+	f := modelcmd.NewGetBootstrapConfigParamsFunc(
+		cmdtesting.Context(c),
+		clientStore,
+		&registry,
+	)
+	_, params, err := f("foo", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(params.Cloud.Credential.Label, gc.Equals, "finalized")
 }

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -169,16 +169,16 @@ func credentialByName(
 // If no credentials are detected, an error satisfying errors.IsNotFound will
 // be returned. If more than one credential is detected, ErrMultipleCredentials
 // will be returned.
-func DetectCredential(cloudName, credentialName string, provider environs.EnvironProvider) (*cloud.CloudCredential, error) {
+func DetectCredential(cloudName, credentialName string, provider environs.EnvironProvider) (cred *cloud.CloudCredential, selected bool, err error) {
 	detected, err := provider.DetectCredentials()
 	if err != nil {
-		return nil, errors.Annotatef(
+		return nil, false, errors.Annotatef(
 			err, "detecting credentials for %q cloud provider", cloudName,
 		)
 	}
 	logger.Tracef("provider detected credentials: %v", detected)
 	if len(detected.AuthCredentials) == 0 {
-		return nil, errors.NotFoundf("credentials for cloud %q", cloudName)
+		return nil, false, errors.NotFoundf("credentials for cloud %q", cloudName)
 	}
 
 	if len(detected.AuthCredentials) > 1 {
@@ -192,10 +192,10 @@ func DetectCredential(cloudName, credentialName string, provider environs.Enviro
 					AuthCredentials: map[string]cloud.Credential{
 						credentialName: cred,
 					},
-				}, nil
+				}, true, nil
 			}
 		}
-		return nil, ErrMultipleCredentials
+		return nil, false, ErrMultipleCredentials
 	}
-	return detected, nil
+	return detected, false, nil
 }

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -26,6 +26,8 @@ import (
 type imageMetadataCommandBase struct {
 	modelcmd.ModelCommandBase
 	modelcmd.IAASOnlyCommand
+
+	CredentialName string
 }
 
 func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Environ, error) {
@@ -38,7 +40,7 @@ func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Envir
 	// the specified environment.
 	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
 		context, c.ClientStore(), environs.GlobalProviderRegistry(),
-	)(controllerName)
+	)(controllerName, c.CredentialName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -69,15 +71,16 @@ func newImageMetadataCommand() cmd.Command {
 // imageMetadataCommand is used to write out simplestreams image metadata information.
 type imageMetadataCommand struct {
 	imageMetadataCommandBase
-	Dir            string
-	Series         string
-	Arch           string
-	ImageId        string
-	Region         string
-	Endpoint       string
-	Stream         string
-	VirtType       string
-	Storage        string
+	Dir      string
+	Series   string
+	Arch     string
+	ImageId  string
+	Region   string
+	Endpoint string
+	Stream   string
+	VirtType string
+	Storage  string
+
 	privateStorage string
 }
 
@@ -109,6 +112,7 @@ func (c *imageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Stream, "stream", imagemetadata.ReleasedStream, "the image stream")
 	f.StringVar(&c.VirtType, "virt-type", "", "the image virtualisation type")
 	f.StringVar(&c.Storage, "storage", "", "the type of root storage")
+	f.StringVar(&c.CredentialName, "credential", "", "the credentials type to use")
 }
 
 // setParams sets parameters based on the environment configuration


### PR DESCRIPTION
## Description of change

Background: with the introduction of `autoload-credential` improvements
to the LXD provider, it now makes it possible to be stuck in a situation where
by you can't launch the localhost lxd provider. This is because the logic
around bootstrap identifies (correctly!) that there are multiple credentials 
available to that one provider. The newly auto detected credentials and the
localhost or any other ones the user has successfully launched.

The problem is compounded more, by the fact that "localhost" for the LXD
provider is treated as a special case, as well as the fact that the LXD 
provider deals will different semantics; local vs remote/cluster servers.

So this PR aim to solve that by allowing the operator to specify the credential
to use at the right time.

```sh
juju bootstrap nuc5 --credential=nuc5
```

Note: this only happens when you have multiple credentials, for example
using the `autoload-credentials`

## QA steps

Setup your local lxc to add remote LXD server connections.

```sh
juju bootstrap nuc5 --credential=nuc5
```

Remove that remote LXD server connection from your local LXD setup
and test that it can connect to your localhost

```
juju bootstrap localhost lxd-test
```

## Documentation changes

Yes, that fact that `--credential=` argument is available.

## Bug reference

N/A