### PR TITLE
Make sure we set the default credential

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -163,7 +163,8 @@ func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 	}
 
 	return &cloud.CloudCredential{
-		AuthCredentials: authCredentials,
+		DefaultCredential: lxdnames.DefaultCloud,
+		AuthCredentials:   authCredentials,
 	}, nil
 }
 

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -107,6 +107,7 @@ func (s *credentialsSuite) TestDetectCredentialsUsesJujuCert(c *gc.C) {
 	expected.Label = `LXD credential "localhost"`
 
 	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: "localhost",
 		AuthCredentials: map[string]cloud.Credential{
 			"localhost": expected,
 		},
@@ -156,6 +157,7 @@ func (s *credentialsSuite) TestDetectCredentialsUsesLXCCert(c *gc.C) {
 	expected.Label = `LXD credential "localhost"`
 
 	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: "localhost",
 		AuthCredentials: map[string]cloud.Credential{
 			"localhost": expected,
 		},
@@ -210,6 +212,7 @@ func (s *credentialsSuite) TestDetectCredentialsGeneratesCert(c *gc.C) {
 	credentials, err := deps.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: "localhost",
 		AuthCredentials: map[string]cloud.Credential{
 			"localhost": credential,
 		},
@@ -309,6 +312,7 @@ func (s *credentialsSuite) TestRemoteDetectCredentials(c *gc.C) {
 	nuc1Credential.Label = `LXD credential "nuc1"`
 
 	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: "localhost",
 		AuthCredentials: map[string]cloud.Credential{
 			"localhost": localCredential,
 			"nuc1":      nuc1Credential,
@@ -340,6 +344,7 @@ func (s *credentialsSuite) TestRemoteDetectCredentialsWithConfigFailure(c *gc.C)
 	localCredential.Label = `LXD credential "localhost"`
 
 	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: "localhost",
 		AuthCredentials: map[string]cloud.Credential{
 			"localhost": localCredential,
 		},
@@ -381,6 +386,7 @@ func (s *credentialsSuite) TestRemoteDetectCredentialsWithCertFailure(c *gc.C) {
 	localCredential.Label = `LXD credential "localhost"`
 
 	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: "localhost",
 		AuthCredentials: map[string]cloud.Credential{
 			"localhost": localCredential,
 		},


### PR DESCRIPTION
## Description of change

Background: with the introduction of autoload-credential improvements
to the LXD provider, it now makes it possible to be stuck in a situation where
by you can't launch the localhost lxd provider. This is because the logic
around bootstrap identifies (correctly!) that there are multiple credentials
available to that one provider. The newly auto detected credentials and the
localhost or any other ones the user has successfully launched.

The problem is compounded more, by the fact that "localhost" for the LXD
provider is treated as a special case, as well as the fact that the LXD
provider deals will different semantics; local vs remote/cluster servers.

So this PR aim to solve that by making sure there is a default one.

```
juju autoload-credentials
juju bootstrap localhost
```

Note: this only happens when you have multiple credentials, for example
using the autoload-credentials

## QA steps

Setup your local lxc to add remote LXD server connections.

```sh
juju autoload-credentials
juju bootstrap localhost lxd-test
```

## Documentation changes

N/A

## Bug reference

N/A
