### PR TITLE
fix lp:1783633 juju destroy-controllers fails when using an Openstack with a self-signed certificate

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -530,6 +530,9 @@ func (c *destroyCommandBase) getControllerEnviron(
 	controllerName string,
 	sysAPI destroyControllerAPI,
 ) (environs.Environ, error) {
+	// TODO: (hml) 2018-08-01
+	// We should try to destroy via the API first, from store is a
+	// fall back position.
 	env, err := c.getControllerEnvironFromStore(ctx, store, controllerName)
 	if errors.IsNotFound(err) {
 		return c.getControllerEnvironFromAPI(sysAPI, controllerName)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -537,6 +537,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 			IdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
 			StorageEndpoint:  bootstrapConfig.CloudStorageEndpoint,
 			Credential:       credential,
+			CACertificates:   bootstrapConfig.CloudCACertificates,
 		},
 		Config: cfg,
 	}, nil

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -110,6 +110,32 @@ func (NewGetBootstrapConfigParamsFuncSuite) TestDetectCredentials(c *gc.C) {
 	c.Assert(params.Cloud.Credential.Label, gc.Equals, "finalized")
 }
 
+func (NewGetBootstrapConfigParamsFuncSuite) TestCloudCACert(c *gc.C) {
+	fakeCert := coretesting.CACert
+	clientStore := jujuclient.NewMemStore()
+	clientStore.Controllers["foo"] = jujuclient.ControllerDetails{}
+	clientStore.BootstrapConfig["foo"] = jujuclient.BootstrapConfig{
+		Cloud:               "cloud",
+		CloudType:           "cloud-type",
+		ControllerModelUUID: coretesting.ModelTag.Id(),
+		Config: map[string]interface{}{
+			"name": "foo",
+			"type": "cloud-type",
+		},
+		CloudCACertificates: []string{fakeCert},
+	}
+	var registry mockProviderRegistry
+
+	f := modelcmd.NewGetBootstrapConfigParamsFunc(
+		cmdtesting.Context(c),
+		clientStore,
+		&registry,
+	)
+	_, params, err := f("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(params.Cloud.CACertificates, jc.SameContents, []string{fakeCert})
+}
+
 type mockProviderRegistry struct {
 	environs.ProviderRegistry
 }

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -212,6 +212,7 @@ func prepare(
 	details.BootstrapConfig.CloudType = args.Cloud.Type
 	details.BootstrapConfig.Cloud = args.Cloud.Name
 	details.BootstrapConfig.CloudRegion = args.Cloud.Region
+	details.BootstrapConfig.CloudCACertificates = args.Cloud.CACertificates
 	details.CloudEndpoint = args.Cloud.Endpoint
 	details.CloudIdentityEndpoint = args.Cloud.IdentityEndpoint
 	details.CloudStorageEndpoint = args.Cloud.StorageEndpoint

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -57,11 +57,14 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 		controller.StatePort:               1234,
 		controller.SetNUMAControlPolicyKey: true,
 	}
+	fakeCert := testing.CACert
+	cloudSpec := dummy.SampleCloudSpec()
+	cloudSpec.CACertificates = []string{fakeCert}
 	_, err = bootstrap.Prepare(ctx, controllerStore, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
 		ModelConfig:      cfg.AllAttrs(),
-		Cloud:            dummy.SampleCloudSpec(),
+		Cloud:            cloudSpec,
 		AdminSecret:      "admin-secret",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -101,6 +104,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 		CloudEndpoint:         "dummy-endpoint",
 		CloudIdentityEndpoint: "dummy-identity-endpoint",
 		CloudStorageEndpoint:  "dummy-storage-endpoint",
+		CloudCACertificates:   []string{fakeCert},
 	})
 
 	// Check we cannot call Prepare again.

--- a/jujuclient/bootstrapconfigfile_test.go
+++ b/jujuclient/bootstrapconfigfile_test.go
@@ -47,7 +47,48 @@ controllers:
     cloud: maas
     type: maas
     region: 127.0.0.1
+    ca-certificates:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIC0DCCAbigAwIBAgIUeIj3r4ocrSubOmb1yPxmoiRfhO8wDQYJKoZIhvcNAQEL
+      BQAwDzENMAsGA1UEAwwET1NDSTAeFw0xODA3MTUxNjE2NTZaFw0xODEwMjQxNjE2
+      NTZaMA8xDTALBgNVBAMMBE9TQ0kwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+      AoIBAQCpCLMLGZpLojudOwrupsbk2ESCQO4/kEOF6L5YHxcUrRxcrxu0DmnwWYcK
+      pjKL9K3U7xSiSL+MtNff7MfBYbV0SOfjHR0/gqwio0JeYONABeeynUZkuXg1CXuG
+      uMHcmPjCAWnLyAnlF4Wwavv6pPdM4l1X4lt1b2ez8G6u4+UPg/zNt473aqOzwMzy
+      B3aToHSHOoDvXQDwtDkR0PimyEtHVz/17AcwSHzMqNGLgLFEx0SPuYJus8WJg1Sn
+      c9kqrvIUBnZzjtbCquCxLRxG2xHdvBxOesbRyJPO0ypqEcTMtrX9rmJce67HG+4h
+      EgLCEpcgfSVyH9PS3wdUAfkr9KE9AgMBAAGjJDAiMA8GA1UdEQQIMAaCBE9TQ0kw
+      DwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAFIYyqNayVFxZ1jcz
+      fdvEP2yVB9dq8vhSXU4lbkqlPw5q954bLURQzklqMfpXhhIbmrvq6LcLGaSkgmPp
+      CzlxMkjr8oTRVQUqNIfcJQKtwNOAGh7xZ77GPhBlfHJ8VhTFtDXPM/fj8GLr5Oav
+      gy9+QywhESKkwAn4+AubBRRtEDBX9zwc2hT5uqz1x1tcs16tKAZBIekwmMBJKkNs
+      61I+cRHoXtXFh8/upMC6eMAvv6eVHgqpcEWrVLvoBh7ivcsFuUD1IyuIlN4i6roh
+      xcSAzRCXqVe/BBsHqYyd8044vrIG7P7pYGaQm99nFGylTBfSh5g1LrYV7IJP6KkG
+      6JHZXg==
+      -----END CERTIFICATE-----
 `
+
+var fakecert = `
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAbigAwIBAgIUeIj3r4ocrSubOmb1yPxmoiRfhO8wDQYJKoZIhvcNAQEL
+BQAwDzENMAsGA1UEAwwET1NDSTAeFw0xODA3MTUxNjE2NTZaFw0xODEwMjQxNjE2
+NTZaMA8xDTALBgNVBAMMBE9TQ0kwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQCpCLMLGZpLojudOwrupsbk2ESCQO4/kEOF6L5YHxcUrRxcrxu0DmnwWYcK
+pjKL9K3U7xSiSL+MtNff7MfBYbV0SOfjHR0/gqwio0JeYONABeeynUZkuXg1CXuG
+uMHcmPjCAWnLyAnlF4Wwavv6pPdM4l1X4lt1b2ez8G6u4+UPg/zNt473aqOzwMzy
+B3aToHSHOoDvXQDwtDkR0PimyEtHVz/17AcwSHzMqNGLgLFEx0SPuYJus8WJg1Sn
+c9kqrvIUBnZzjtbCquCxLRxG2xHdvBxOesbRyJPO0ypqEcTMtrX9rmJce67HG+4h
+EgLCEpcgfSVyH9PS3wdUAfkr9KE9AgMBAAGjJDAiMA8GA1UdEQQIMAaCBE9TQ0kw
+DwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAFIYyqNayVFxZ1jcz
+fdvEP2yVB9dq8vhSXU4lbkqlPw5q954bLURQzklqMfpXhhIbmrvq6LcLGaSkgmPp
+CzlxMkjr8oTRVQUqNIfcJQKtwNOAGh7xZ77GPhBlfHJ8VhTFtDXPM/fj8GLr5Oav
+gy9+QywhESKkwAn4+AubBRRtEDBX9zwc2hT5uqz1x1tcs16tKAZBIekwmMBJKkNs
+61I+cRHoXtXFh8/upMC6eMAvv6eVHgqpcEWrVLvoBh7ivcsFuUD1IyuIlN4i6roh
+xcSAzRCXqVe/BBsHqYyd8044vrIG7P7pYGaQm99nFGylTBfSh5g1LrYV7IJP6KkG
+6JHZXg==
+-----END CERTIFICATE-----
+`[1:]
 
 var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 	"aws-test": {
@@ -79,6 +120,7 @@ var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 		Cloud:               "maas",
 		CloudType:           "maas",
 		CloudRegion:         "127.0.0.1",
+		CloudCACertificates: []string{fakecert},
 	},
 }
 

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -130,6 +130,10 @@ type BootstrapConfig struct {
 	// when communicating with the cloud's storage service. This will
 	// be empty for clouds that have no storage-specific API endpoint.
 	CloudStorageEndpoint string `yaml:"storage-endpoint,omitempty"`
+
+	// CloudCACertificates contains the CACertificates necessary to
+	// communicate with the cloud infrastructure.
+	CloudCACertificates []string `yaml:"ca-certificates,omitempty"`
 }
 
 // ControllerUpdater stores controller details.


### PR DESCRIPTION
## Description of change

Updated: Write cloud ca certs to the client store file bootstrap-config.yaml.  Add those certs to the bootstrap params used by destroy-controller.

## QA steps

Using an openstack deployment requiring a CACert for access:

1. juju add-cloud, the endpoint url should validate.
2. Add the ca cert to the clouds.yaml for the new cloud:
clouds:
openstack:
type: openstack
.....
ca-certificates:
|
-----BEGIN CERTIFICATE-----
.....
-----END CERTIFICATE-----
3. juju bootstrap; juju deploy ubuntu
4. juju destroy-controller --destroy-all-models --yes --destroy-storage <controller>

Step 4 no longer fails "ERROR destroying controller model: destroying instances: failed to get list of server details"

There should be no change when using other other OpenStack deployments.

## Documentation changes

not yet, there are a few more pieces of the feature to fix.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1783633