### PR TITLE
Azure reacts to invalid cloud credentials.

### DIFF
--- a/provider/azure/deployments.go
+++ b/provider/azure/deployments.go
@@ -7,10 +7,13 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
+	"github.com/juju/juju/provider/azure/internal/errorutils"
 )
 
 func createDeployment(
+	ctx context.ProviderCallContext,
 	client resources.DeploymentsClient,
 	resourceGroup string,
 	deploymentName string,
@@ -33,7 +36,7 @@ func createDeployment(
 		nil, // abort channel
 	)
 	if err := <-errChan; err != nil {
-		return errors.Annotatef(err, "creating deployment %q", deploymentName)
+		return errorutils.HandleCredentialError(errors.Annotatef(err, "creating deployment %q", deploymentName), ctx)
 	}
 	return nil
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1196,7 +1196,6 @@ func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.createSenderWithUnauthorisedStatusCode(c)
-	// s.sender = append(s.sender,s.initResourceGroupSenders())
 	s.sender = append(s.sender, s.startInstanceSenders(true)...)
 	s.requests = nil
 

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -116,7 +116,8 @@ type environSuite struct {
 	sshPublicKeys      []compute.SSHPublicKey
 	linuxOsProfile     compute.OSProfile
 
-	callCtx context.ProviderCallContext
+	callCtx               *context.CloudCallContext
+	invalidatedCredential bool
 }
 
 var _ = gc.Suite(&environSuite{})
@@ -239,7 +240,18 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
-	s.callCtx = context.NewCloudCallContext()
+
+	s.callCtx = &context.CloudCallContext{
+		InvalidateCredentialFunc: func(string) error {
+			s.invalidatedCredential = true
+			return nil
+		},
+	}
+}
+
+func (s *environSuite) TearDownTest(c *gc.C) {
+	s.invalidatedCredential = false
+	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *environSuite) openEnviron(c *gc.C, attrs ...testing.Attrs) environs.Environ {
@@ -492,6 +504,18 @@ func (s *environSuite) TestCloudEndpointManagementURI(c *gc.C) {
 	c.Assert(s.requests[0].URL.Host, gc.Equals, "api.azurestack.local")
 }
 
+func (s *environSuite) TestCloudEndpointManagementURIWithCredentialError(c *gc.C) {
+	env := s.openEnviron(c)
+	s.createSenderWithUnauthorisedStatusCode(c)
+	s.requests = nil
+
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	env.AllInstances(s.callCtx) // trigger a query
+	c.Assert(s.requests, gc.HasLen, 1)
+	c.Assert(s.requests[0].URL.Host, gc.Equals, "api.azurestack.local")
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
+}
+
 func (s *environSuite) TestStartInstance(c *gc.C) {
 	s.assertStartInstance(c, nil)
 }
@@ -568,6 +592,28 @@ func (s *environSuite) TestStartInstanceNoAuthorizedKeys(c *gc.C) {
 		osProfile:      &s.linuxOsProfile,
 		instanceType:   "Standard_A1",
 	})
+}
+
+func (s *environSuite) createSenderWithUnauthorisedStatusCode(c *gc.C) {
+	mockSender := mocks.NewSender()
+	mockSender.AppendResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
+	s.sender = azuretesting.Senders{mockSender}
+}
+
+func (s *environSuite) TestStartInstanceInvalidCredential(c *gc.C) {
+	env := s.openEnviron(c)
+	cfg, err := env.Config().Remove([]string{"authorized-keys"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.SetConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.createSenderWithUnauthorisedStatusCode(c)
+	s.requests = nil
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+
+	_, err = env.StartInstance(s.callCtx, makeStartInstanceParams(c, s.controllerUUID, "quantal"))
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
 }
 
 func (s *environSuite) TestStartInstanceWindowsMinRootDisk(c *gc.C) {
@@ -1143,6 +1189,33 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	})
 }
 
+func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
+	defer envtesting.DisableFinishBootstrap()()
+
+	ctx := envtesting.BootstrapContext(c)
+	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
+
+	s.createSenderWithUnauthorisedStatusCode(c)
+	// s.sender = append(s.sender,s.initResourceGroupSenders())
+	s.sender = append(s.sender, s.startInstanceSenders(true)...)
+	s.requests = nil
+
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	_, err := env.Bootstrap(
+		ctx, s.callCtx, environs.BootstrapParams{
+			ControllerConfig:     testing.FakeControllerConfig(),
+			AvailableTools:       makeToolsList("quantal"),
+			BootstrapSeries:      "quantal",
+			BootstrapConstraints: constraints.MustParse("mem=3.5G"),
+		},
+	)
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
+
+	// Successful bootstrap expects 4 but we expecte to bail out after getting an authorised error.
+	c.Assert(len(s.requests), gc.Equals, 1)
+}
+
 func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bootstrap not supported on Windows")
@@ -1277,6 +1350,21 @@ func (s *environSuite) TestStopInstancesNotFound(c *gc.C) {
 	s.sender = azuretesting.Senders{sender0, sender1}
 	err := env.StopInstances(s.callCtx, "a", "b")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environSuite) TestStopInstancesInvalidCredential(c *gc.C) {
+	env := s.openEnviron(c)
+	s.createSenderWithUnauthorisedStatusCode(c)
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	err := env.StopInstances(s.callCtx, "a", "b")
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
+	// This call is expected to have made 2 calls. Although we do undersntad that we could have gotten
+	// an invalid credential for one of the instances, the actual stop command to cloud api is done
+	// in a separate go routine for each instance. These goroutine do not really communicate with each other.
+	// There will be as many routines as there are instances and only once they all complete, will we have a chance to
+	// stop proceeding.
+	c.Assert(s.requests, gc.HasLen, 2)
 }
 
 func (s *environSuite) TestStopInstancesResourceGroupNotFound(c *gc.C) {
@@ -1498,6 +1586,17 @@ func (s *environSuite) TestDestroyHostedModel(c *gc.C) {
 	c.Assert(s.requests[0].Method, gc.Equals, "DELETE")
 }
 
+func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *gc.C) {
+	env := s.openEnviron(c, testing.Attrs{"controller-uuid": utils.MustNewUUID().String()})
+	s.createSenderWithUnauthorisedStatusCode(c)
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	err := env.Destroy(s.callCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
+	c.Assert(s.requests, gc.HasLen, 1)
+	c.Assert(s.requests[0].Method, gc.Equals, "DELETE")
+}
+
 func (s *environSuite) TestDestroyController(c *gc.C) {
 	groups := []resources.Group{{
 		Name: to.StringPtr("group1"),
@@ -1530,6 +1629,23 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 		path.Base(s.requests[2].URL.Path),
 	}
 	c.Assert(groupsDeleted, jc.SameContents, []string{"group1", "group2"})
+}
+
+func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *gc.C) {
+	env := s.openEnviron(c)
+	s.createSenderWithUnauthorisedStatusCode(c)
+
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	err := env.DestroyController(s.callCtx, s.controllerUUID)
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
+
+	c.Assert(s.requests, gc.HasLen, 1)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+		"tagname eq 'juju-controller-uuid' and tagvalue eq '%s'",
+		testing.ControllerTag.Id(),
+	))
 }
 
 func (s *environSuite) TestDestroyControllerErrors(c *gc.C) {
@@ -1588,6 +1704,16 @@ func (s *environSuite) TestInstanceInformation(c *gc.C) {
 	types, err = env.InstanceTypes(s.callCtx, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(types.InstanceTypes, gc.HasLen, 2)
+}
+
+func (s *environSuite) TestInstanceInformationWithInvalidCredential(c *gc.C) {
+	env := s.openEnviron(c)
+	s.createSenderWithUnauthorisedStatusCode(c)
+
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	_, err := env.InstanceTypes(s.callCtx, constraints.Value{})
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
 }
 
 func (s *environSuite) TestAdoptResources(c *gc.C) {
@@ -1787,6 +1913,16 @@ func (s *environSuite) TestAdoptResourcesErrorListingResources(c *gc.C) {
 	err := env.AdoptResources(s.callCtx, "new-controller", version.MustParse("1.0.0"))
 	c.Assert(err, gc.ErrorMatches, ".*ouch!$")
 	c.Assert(s.requests, gc.HasLen, 4)
+}
+
+func (s *environSuite) TestAdoptResourcesWithInvalidCredential(c *gc.C) {
+	env := s.openEnviron(c)
+	s.createSenderWithUnauthorisedStatusCode(c)
+
+	c.Assert(s.invalidatedCredential, jc.IsFalse)
+	err := env.AdoptResources(s.callCtx, "new-controller", version.MustParse("1.0.0"))
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.invalidatedCredential, jc.IsTrue)
 }
 
 func (s *environSuite) TestAdoptResourcesNoUpdateNeeded(c *gc.C) {

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
+	"github.com/juju/juju/provider/azure/internal/errorutils"
 )
 
 const (
@@ -171,7 +172,7 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 // verify the configured credentials. If verification fails, a user-friendly
 // error will be returned, and the original error will be logged at debug
 // level.
-var verifyCredentials = func(e *azureEnviron) error {
+var verifyCredentials = func(e *azureEnviron, ctx context.ProviderCallContext) error {
 	// TODO(axw) user-friendly error message
-	return e.authorizer.refresh()
+	return errorutils.HandleCredentialError(e.authorizer.refresh(), ctx)
 }

--- a/provider/azure/instance_information.go
+++ b/provider/azure/instance_information.go
@@ -16,7 +16,7 @@ var _ environs.InstanceTypesFetcher = (*azureEnviron)(nil)
 
 // InstanceTypes implements InstanceTypesFetcher
 func (env *azureEnviron) InstanceTypes(ctx context.ProviderCallContext, c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
-	types, err := env.getInstanceTypes()
+	types, err := env.getInstanceTypes(ctx)
 	if err != nil {
 		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
 	}

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -35,7 +35,8 @@ type instanceSuite struct {
 	networkInterfaces []network.Interface
 	publicIPAddresses []network.PublicIPAddress
 
-	callCtx context.ProviderCallContext
+	callCtx             *context.CloudCallContext
+	invalidteCredential bool
 }
 
 var _ = gc.Suite(&instanceSuite{})
@@ -58,7 +59,12 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 		makeDeployment("machine-0"),
 		makeDeployment("machine-1"),
 	}
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = &context.CloudCallContext{
+		InvalidateCredentialFunc: func(string) error {
+			s.invalidteCredential = true
+			return nil
+		},
+	}
 }
 
 func makeDeployment(name string) resources.DeploymentExtended {

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/azure/internal/imageutils"
+	"github.com/juju/juju/environs/context"
 )
 
 const defaultMem = 1024 // 1GiB
@@ -128,6 +129,7 @@ func mbToMib(mb uint64) uint64 {
 // NOTE(axw) for now we ignore simplestreams altogether, and go straight to
 // Azure's image registry.
 func findInstanceSpec(
+	ctx context.ProviderCallContext,
 	client compute.VirtualMachineImagesClient,
 	instanceTypesMap map[string]instances.InstanceType,
 	constraint *instances.InstanceConstraint,
@@ -139,7 +141,7 @@ func findInstanceSpec(
 		return nil, errors.NotFoundf("%s in arch constraints", arch.AMD64)
 	}
 
-	image, err := imageutils.SeriesImage(constraint.Series, imageStream, constraint.Region, client)
+	image, err := imageutils.SeriesImage(ctx, constraint.Series, imageStream, constraint.Region, client)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/azure/internal/imageutils"
-	"github.com/juju/juju/environs/context"
 )
 
 const defaultMem = 1024 // 1GiB

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -43,13 +43,13 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 // If it is, the credential is invalidated.
 // Original error is returned untouched.
 func HandleCredentialError(err error, ctx context.ProviderCallContext) error {
-	HasCredentialError(err, ctx)
+	MaybeHandleCredentialError(err, ctx)
 	return err
 }
 
-// HasCredentialError determines if given error has authorisation denial codes embedded.
+// MaybeHandleCredentialError determines if given error has authorisation denial codes embedded.
 // If a code related to an invalid credential is found, the credential is invalidated as well.
-func HasCredentialError(err error, ctx context.ProviderCallContext) bool {
+func MaybeHandleCredentialError(err error, ctx context.ProviderCallContext) bool {
 	if ctx == nil {
 		return false
 	}

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -43,13 +43,13 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 // If it is, the credential is invalidated.
 // Original error is returned untouched.
 func HandleCredentialError(err error, ctx context.ProviderCallContext) error {
-	MaybeHandleCredentialError(err, ctx)
+	MaybeInvalidateCredential(err, ctx)
 	return err
 }
 
-// MaybeHandleCredentialError determines if given error has authorisation denial codes embedded.
-// If a code related to an invalid credential is found, the credential is invalidated as well.
-func MaybeHandleCredentialError(err error, ctx context.ProviderCallContext) bool {
+// MaybeInvalidateCredential determines if given error is related to authentication/authorisation failures.
+// If an error is related to an invalid credential, then this call will try to invalidate that credential as well.
+func MaybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool {
 	if ctx == nil {
 		return false
 	}
@@ -59,7 +59,7 @@ func MaybeHandleCredentialError(err error, ctx context.ProviderCallContext) bool
 
 	invalidateErr := ctx.InvalidateCredential("azure cloud denied access")
 	if invalidateErr != nil {
-		logger.Infof("could not invalidate stored azure cloud credential on the controller")
+		logger.Warningf("could not invalidate stored azure cloud credential on the controller: %v", invalidateErr)
 	}
 	return true
 }

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -35,7 +35,7 @@ func (s *ErrorSuite) TestNilContext(c *gc.C) {
 	err := errorutils.HandleCredentialError(s.azureError, nil)
 	c.Assert(err, gc.DeepEquals, s.azureError)
 
-	invalidated := errorutils.HasCredentialError(s.azureError, nil)
+	invalidated := errorutils.MaybeHandleCredentialError(s.azureError, nil)
 	c.Assert(invalidated, jc.IsFalse)
 
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
@@ -46,7 +46,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
-	errorutils.HasCredentialError(s.azureError, ctx)
+	errorutils.MaybeHandleCredentialError(s.azureError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored azure cloud credential on the controller")
 }
 
@@ -64,7 +64,7 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	errorutils.HandleCredentialError(s.azureError, ctx)
 	c.Assert(called, jc.IsFalse)
 
-	for t, _ := range errorutils.AuthorisationFailureStatusCodes {
+	for t := range errorutils.AuthorisationFailureStatusCodes {
 		called = false
 		s.azureError.StatusCode = t
 		errorutils.HandleCredentialError(s.azureError, ctx)

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -1,0 +1,85 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errorutils_test
+
+import (
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/azure/internal/errorutils"
+	"github.com/juju/juju/testing"
+)
+
+type ErrorSuite struct {
+	testing.BaseSuite
+
+	azureError autorest.DetailedError
+}
+
+var _ = gc.Suite(&ErrorSuite{})
+
+func (s *ErrorSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.azureError = autorest.DetailedError{
+		StatusCode: http.StatusUnauthorized,
+	}
+}
+
+func (s *ErrorSuite) TestNilContext(c *gc.C) {
+	err := errorutils.HandleCredentialError(s.azureError, nil)
+	c.Assert(err, gc.DeepEquals, s.azureError)
+
+	invalidated := errorutils.HasCredentialError(s.azureError, nil)
+	c.Assert(invalidated, jc.IsFalse)
+
+	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
+}
+
+func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		return errors.New("kaboom")
+	}
+	errorutils.HasCredentialError(s.azureError, ctx)
+	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored azure cloud credential on the controller")
+}
+
+func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	called := false
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		c.Assert(msg, gc.DeepEquals, "azure cloud denied access")
+		called = true
+		return nil
+	}
+
+	// First test another status code.
+	s.azureError.StatusCode = http.StatusAccepted
+	errorutils.HandleCredentialError(s.azureError, ctx)
+	c.Assert(called, jc.IsFalse)
+
+	for t, _ := range errorutils.AuthorisationFailureStatusCodes {
+		called = false
+		s.azureError.StatusCode = t
+		errorutils.HandleCredentialError(s.azureError, ctx)
+		c.Assert(called, jc.IsTrue)
+	}
+}
+
+func (*ErrorSuite) TestNilAzureError(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	called := false
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		called = true
+		return nil
+	}
+	returnedErr := errorutils.HandleCredentialError(nil, ctx)
+	c.Assert(called, jc.IsFalse)
+	c.Assert(returnedErr, jc.ErrorIsNil)
+}

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -35,7 +35,7 @@ func (s *ErrorSuite) TestNilContext(c *gc.C) {
 	err := errorutils.HandleCredentialError(s.azureError, nil)
 	c.Assert(err, gc.DeepEquals, s.azureError)
 
-	invalidated := errorutils.MaybeHandleCredentialError(s.azureError, nil)
+	invalidated := errorutils.MaybeInvalidateCredential(s.azureError, nil)
 	c.Assert(invalidated, jc.IsFalse)
 
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
@@ -46,7 +46,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
-	errorutils.MaybeHandleCredentialError(s.azureError, ctx)
+	errorutils.MaybeInvalidateCredential(s.azureError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored azure cloud credential on the controller")
 }
 

--- a/provider/azure/internal/errorutils/package_test.go
+++ b/provider/azure/internal/errorutils/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errorutils_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -4,12 +4,15 @@
 package imageutils_test
 
 import (
+	"net/http"
+
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/go-autorest/autorest/mocks"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/azure/internal/imageutils"
 	"github.com/juju/juju/testing"
@@ -20,6 +23,7 @@ type imageutilsSuite struct {
 
 	mockSender *mocks.Sender
 	client     compute.VirtualMachineImagesClient
+	callCtx    *context.CloudCallContext
 }
 
 var _ = gc.Suite(&imageutilsSuite{})
@@ -29,13 +33,14 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 	s.mockSender = mocks.NewSender()
 	s.client.ManagementClient = compute.New("subscription-id")
 	s.client.Sender = s.mockSender
+	s.callCtx = context.NewCloudCallContext()
 }
 
 func (s *imageutilsSuite) TestSeriesImage(c *gc.C) {
 	s.mockSender.AppendResponse(mocks.NewResponseWithContent(
 		`[{"name": "14.04.3"}, {"name": "14.04.1-LTS"}, {"name": "12.04.5"}]`,
 	))
-	image, err := imageutils.SeriesImage("trusty", "released", "westus", s.client)
+	image, err := imageutils.SeriesImage(s.callCtx, "trusty", "released", "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -49,7 +54,7 @@ func (s *imageutilsSuite) TestSeriesImageInvalidSKU(c *gc.C) {
 	s.mockSender.AppendResponse(mocks.NewResponseWithContent(
 		`[{"name": "12.04.invalid"}, {"name": "12.04.5-LTS"}]`,
 	))
-	image, err := imageutils.SeriesImage("precise", "released", "westus", s.client)
+	image, err := imageutils.SeriesImage(s.callCtx, "precise", "released", "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -71,7 +76,7 @@ func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
 }
 
 func (s *imageutilsSuite) TestSeriesImageGenericLinux(c *gc.C) {
-	_, err := imageutils.SeriesImage("genericlinux", "released", "westus", s.client)
+	_, err := imageutils.SeriesImage(s.callCtx, "genericlinux", "released", "westus", s.client)
 	c.Assert(err, gc.ErrorMatches, "deploying GenericLinux not supported")
 }
 
@@ -84,19 +89,45 @@ func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {
 
 func (s *imageutilsSuite) TestSeriesImageNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(mocks.NewResponseWithContent(`[]`))
-	image, err := imageutils.SeriesImage("trusty", "released", "westus", s.client)
+	image, err := imageutils.SeriesImage(s.callCtx, "trusty", "released", "westus", s.client)
 	c.Assert(err, gc.ErrorMatches, "selecting SKU for trusty: Ubuntu SKUs not found")
 	c.Assert(image, gc.IsNil)
 }
 
 func (s *imageutilsSuite) TestSeriesImageStreamNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(mocks.NewResponseWithContent(`[{"name": "14.04-beta1"}]`))
-	_, err := imageutils.SeriesImage("trusty", "whatever", "westus", s.client)
+	_, err := imageutils.SeriesImage(s.callCtx, "trusty", "whatever", "westus", s.client)
 	c.Assert(err, gc.ErrorMatches, "selecting SKU for trusty: Ubuntu SKUs for whatever stream not found")
 }
 
+func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
+	s.mockSender.AppendResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
+	called := false
+	s.callCtx.InvalidateCredentialFunc = func(string) error {
+		called = true
+		return nil
+	}
+
+	_, err := imageutils.SeriesImage(s.callCtx, "trusty", "whatever", "westus", s.client)
+	c.Assert(err.Error(), jc.Contains, "StatusCode=401")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *imageutilsSuite) TestSeriesImageStreamThrewNonCredentialError(c *gc.C) {
+	s.mockSender.AppendResponse(mocks.NewResponseWithStatus("308 Permanent Redirect", http.StatusPermanentRedirect))
+	called := false
+	s.callCtx.InvalidateCredentialFunc = func(string) error {
+		called = true
+		return nil
+	}
+
+	_, err := imageutils.SeriesImage(s.callCtx, "trusty", "whatever", "westus", s.client)
+	c.Assert(err.Error(), jc.Contains, "StatusCode=308")
+	c.Assert(called, jc.IsFalse)
+}
+
 func (s *imageutilsSuite) assertImageId(c *gc.C, series, stream, id string) {
-	image, err := imageutils.SeriesImage(series, stream, "westus", s.client)
+	image, err := imageutils.SeriesImage(s.callCtx, series, stream, "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image.Id, gc.Equals, id)
 }

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -807,7 +807,7 @@ func (v *azureVolumeSource) updateVirtualMachines(
 			nil, // abort channel
 		)
 		if err := <-errCh; err != nil {
-			if errorutils.MaybeHandleCredentialError(err, ctx) {
+			if errorutils.MaybeInvalidateCredential(err, ctx) {
 				return nil, errors.Trace(err)
 			}
 			results[i] = err

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -807,7 +807,7 @@ func (v *azureVolumeSource) updateVirtualMachines(
 			nil, // abort channel
 		)
 		if err := <-errCh; err != nil {
-			if errorutils.HasCredentialError(err, ctx) {
+			if errorutils.MaybeHandleCredentialError(err, ctx) {
 				return nil, errors.Trace(err)
 			}
 			results[i] = err

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
+	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -30,7 +31,8 @@ type environUpgradeSuite struct {
 	provider environs.EnvironProvider
 	env      environs.Environ
 
-	callCtx context.ProviderCallContext
+	callCtx           *context.CloudCallContext
+	invalidCredential bool
 }
 
 var _ = gc.Suite(&environUpgradeSuite{})
@@ -46,7 +48,12 @@ func (s *environUpgradeSuite) SetUpTest(c *gc.C) {
 		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.env = openEnviron(c, s.provider, &s.sender)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = &context.CloudCallContext{
+		InvalidateCredentialFunc: func(string) error {
+			s.invalidCredential = true
+			return nil
+		},
+	}
 }
 
 func (s *environUpgradeSuite) TestEnvironImplementsUpgrader(c *gc.C) {
@@ -202,4 +209,24 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeploymentC
 
 	op0 := upgrader.UpgradeOperations(s.callCtx, environs.UpgradeOperationsParams{})[0]
 	c.Assert(op0.Steps[0].Run(s.callCtx), jc.ErrorIsNil)
+}
+
+func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeploymentControllerModelWithInvalidCredential(c *gc.C) {
+	s.sender = nil
+	s.requests = nil
+	env := openEnviron(c, s.provider, &s.sender, testing.Attrs{"name": "controller"})
+	upgrader := env.(environs.Upgrader)
+
+	controllerTags := make(map[string]*string)
+	trueString := "true"
+	controllerTags["juju-is-controller"] = &trueString
+
+	mockSender := mocks.NewSender()
+	mockSender.AppendResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
+	s.sender = append(s.sender, mockSender)
+
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	op0 := upgrader.UpgradeOperations(s.callCtx, environs.UpgradeOperationsParams{})[0]
+	c.Assert(op0.Steps[0].Run(s.callCtx), gc.NotNil)
+	c.Assert(s.invalidCredential, jc.IsTrue)
 }

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -13,6 +13,9 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/azure/internal/errorutils"
 )
 
 const (
@@ -61,13 +64,13 @@ func isNotFoundResponse(resp autorest.Response) bool {
 // Management API, because the API version requested must match the
 // type of the resource being manipulated through the API, rather than
 // the API version specified statically in the resource client code.
-func collectAPIVersions(client resources.ProvidersClient) (map[string]string, error) {
+func collectAPIVersions(ctx context.ProviderCallContext, client resources.ProvidersClient) (map[string]string, error) {
 	result := make(map[string]string)
 
 	var res resources.ProviderListResult
 	res, err := client.List(nil, "")
 	if err != nil {
-		return result, errors.Trace(err)
+		return result, errorutils.HandleCredentialError(errors.Trace(err), ctx)
 	}
 	for res.Value != nil {
 		for _, provider := range *res.Value {
@@ -86,7 +89,7 @@ func collectAPIVersions(client resources.ProvidersClient) (map[string]string, er
 		}
 		res, err = client.ListNextResults(res)
 		if err != nil {
-			return map[string]string{}, errors.Trace(err)
+			return map[string]string{}, errorutils.HandleCredentialError(errors.Trace(err), ctx)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
## Description of change

This PR ensures that juju azure provider is responsive to azure cloud un-happinness with provided credentials.

Both situations where an invalid credential and invalidated (say, expired) credential is used to communicate with azure cloud is catered for here. 

The most interesting bits are contained in ~/provider/azure/internal/errorutils package. This is the code that examines azure errors and determines whether the error is related to credential and worth reacting to.
All cloud calls that throw errors have now been modified to go through this logic to ensure that if the cloud complained about a credential, juju marks it as invalid.

Unit tests have been added to provide adequate initial coverage.

