### PR TITLE
Jujud Update-Series Creates exec-start.sh Pointing at the Wrong Tools Directory

### DIFF
--- a/cmd/jujud/updateseries/updateseries.go
+++ b/cmd/jujud/updateseries/updateseries.go
@@ -100,11 +100,8 @@ func (c *UpdateSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
-
-	var (
-		err              error
-		failedAgentNames []string
-	)
+	var err error
+	var failedAgentNames []string
 
 	if c.machineAgent, c.unitAgents, failedAgentNames, err = c.manager.FindAgents(c.dataDir); err != nil {
 		return err
@@ -163,7 +160,7 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 		startedSysdServiceNames, startedSymServiceNames, failedAgentNames, err := c.manager.WriteSystemdAgents(
 			c.machineAgent,
 			c.unitAgents,
-			service.SystemdDataDir,
+			c.dataDir,
 			systemdDir,
 			systemdMultiUserDir,
 			c.toSeries,

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -1,13 +1,15 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// This file has routines which can be used for agent specific functionalities related to service files:
+// This file has routines which can be used for agent specific functionality
+// related to service files:
 //	- finding all agents in the machine
 //	- create conf file using the machine details
 // 	- write systemd service file and setting links
 // 	- copy all tools and related to agents and setup the links
 // 	- start all the agents
-// These routines can be used by any tools/cmds trying to implement the above functionality as part of the process, eg. juju-updateseries command.
+// These routines can be used by any tools/cmds trying to implement the above
+// functionality as part of the process, eg. juju-updateseries command.
 
 package service
 
@@ -36,17 +38,22 @@ type SystemdServiceManager interface {
 	// FindAgents finds all the agents available in the machine.
 	FindAgents(dataDir string) (string, []string, []string, error)
 
-	// WriteSystemdAgents creates systemd files and create symlinks for the list of machine and units passed in the standard filepath.
-	WriteSystemdAgents(machineAgent string, unitAgents []string, dataDir string, symLinkSystemdDir string, symLinkSystemdMultiUserDir string, series string) ([]string, []string, []string, error)
+	// WriteSystemdAgents creates systemd files and create symlinks for the
+	// list of machine and units passed in the standard filepath.
+	WriteSystemdAgents(
+		machineAgent string, unitAgents []string, dataDir, symLinkSystemdDir, symLinkSystemdMultiUserDir, series string,
+	) ([]string, []string, []string, error)
 
-	//CreateAgentConf creates the configfile for specified agent running on a host with specified series.
+	//CreateAgentConf creates the configfile for specified agent running on a
+	// host with specified series.
 	CreateAgentConf(agentName string, dataDir string, series string) (common.Conf, error)
 
 	// CopyAgentBinary copies all the tools into the path specified for each agent.
-	CopyAgentBinary(machineAgent string, unitAgents []string, dataDir string, toSeries string, fromSeries string, jujuVersion version.Number) error
+	CopyAgentBinary(
+		machineAgent string, unitAgents []string, dataDir, toSeries, fromSeries string, jujuVersion version.Number) error
 
 	// StartAllAgents starts all the agents in the machine with specified series.
-	StartAllAgents(machineAgent string, unitAgents []string, dataDir string, series string) (string, []string, error)
+	StartAllAgents(machineAgent string, unitAgents []string, dataDir, series string) (string, []string, error)
 
 	// WriteServiceFile writes the service file in '/lib/systemd/system' path.
 	// this is done as part of upgrade step.
@@ -101,8 +108,12 @@ func (s *systemdServiceManager) FindAgents(dataDir string) (string, []string, []
 	return machineAgent, unitAgents, errAgentNames, nil
 }
 
-// WriteSystemdAgents creates systemd files and create symlinks for the list of machine and units passed in the standard filepath '/var/lib/juju' during the upgrade process.
-func (s *systemdServiceManager) WriteSystemdAgents(machineAgent string, unitAgents []string, dataDir string, symLinkSystemdDir string, symLinkSystemdMultiUserDir string, series string) ([]string, []string, []string, error) {
+// WriteSystemdAgents creates systemd files and create symlinks for the list of
+// machine and units passed in the standard filepath '/var/lib/juju' during the
+// upgrade process.
+func (s *systemdServiceManager) WriteSystemdAgents(
+	machineAgent string, unitAgents []string, dataDir, symLinkSystemdDir, symLinkSystemdMultiUserDir, series string,
+) ([]string, []string, []string, error) {
 
 	var (
 		startedSysServiceNames []string
@@ -219,8 +230,7 @@ func (s *systemdServiceManager) CopyAgentBinary(machineAgent string, unitAgents 
 		}
 	}()
 
-	// Setup new and old version.Binarys with only the series
-	// different.
+	// Setup new and old version.Binary instances with different series.
 	fromVers := version.Binary{
 		Number: jujuVersion,
 		Arch:   arch.HostArch(),

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -345,7 +345,7 @@ func (s *agentConfSuite) assertServiceSymLinks(c *gc.C) {
 		svcFileName := svcName + ".service"
 		result, err := os.Readlink(path.Join(s.systemdDir, svcFileName))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(result, gc.Equals, path.Join(s.systemdDataDir, svcName, svcFileName))
+		c.Assert(result, gc.Equals, path.Join(service.SystemdDataDir, svcName, svcFileName))
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -25,7 +25,7 @@ var (
 	renderer = shell.BashRenderer{}
 )
 
-// These are the names of the init systems regognized by juju.
+// These are the names of the init systems recognized by juju.
 const (
 	InitSystemSystemd = "systemd"
 	InitSystemUpstart = "upstart"

--- a/service/systemd/serialize.go
+++ b/service/systemd/serialize.go
@@ -23,7 +23,7 @@ import (
 
 // UnitSerialize encodes all of the given UnitOption objects into a unit file.
 // Renamed from Serialize from github.com/coreos/go-systemd/unit so as to not
-// confict with the exported internal function in export_test.go.
+// conflict with the exported internal function in export_test.go.
 func UnitSerialize(opts []*unit.UnitOption) io.Reader {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
## Description of change

The jujud _update-series_ command was causing the written _exec-start_ scripts to point at the wrong tools directory.

The solution is to pass the tools directory in the call to _WriteSystemdAgents_, as is done by the upgrade step that uses this method, but to explicitly use _/lib/systemd/system_ when systemd is not the running init system and service links must be created manually.

The first commit in the PR is formatting changes and can be discounted. Consider the second commit to ease review.

## QA steps

### Test _update-series_
- Bootstrap.
- Add a _Trusty_ machine.
- SSH to the machine and run `juju-update-series --from-series trusty --to-series xenial`.
- Check the service unit sym-links are correct and that _exec-start.sh_ points to the right tools directory.

### Regression test upgrade steps
- Bootstrap a 2.3 controller.
- Switch to the controller model and with the current dev HEAD juju upgrade-juju --debug --build-agent`. 
- Check the service unit sym-links are correct and that _exec-start.sh_ points to the right tools directory.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1783805
