### PR TITLE
Update cacert for the unresponsive controller case

### DIFF
--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -178,6 +178,13 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 		return nil, errors.Annotate(err, "cannot produce dial information")
 	}
 
+	// For the unresponsive controller case the oldAgentConfig and agentConfig
+	// have different certificates. MongoDB has been already started with a
+	// new certificate. Therefore all clients that would like to communicate
+	// with mongo should use the new certificate otherwise the
+	// "TLS handshake error" occurs. To avoid this error the old certificate
+	// should be replaced by the new one.
+	oldAgentConfig.SetCACert(agentConfig.CACert())
 	oldDialInfo, err := newDialInfo(args.PrivateAddress, oldAgentConfig)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot produce dial information for existing mongo")


### PR DESCRIPTION
## Description of change

For the unresponsive controller case the old and new agent configurations have different certificates. MongoDB is started with a new certificate after restoring procedure. Therefore all clients that would like to communicate with mongo should use the new certificate otherwise the "TLS handshake error" occurs.

## QA steps
To reproduce the bug follow the this procedure.

1. Bootstrap a new controller. 

$ juju bootstrap localhost lxd

2.  Deploy something there.

$ juju deploy nagios

3. create a backup 

$ juju create-backup -m lxd:controller --filename juju-backup.tgz

4. Simulate the unresponsive controller case. To do that remove the Juju lxc container.
5. Bootstrap another controller

$ juju bootstrap localhost lxd-1

6. Try to restore from a backup. This procure hangs.

$ juju restore-backup -m lxd-1:controller --file juju-backup.tgz

## Bug reference
https://bugs.launchpad.net/juju/+bug/1783340

