### PR TITLE
Fixes lp#1784701: Update helpdoc urls.

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -69,7 +69,7 @@ environment to match the restored database, e.g. no units, relations, nor
 machines will be added or removed during the restore process.
 
 Note: Extra care is needed to restore in an HA environment, please see
-https://docs.jujucharms.com/devel/en/controllers-backup for more information.
+https://docs.jujucharms.com/stable/controllers-backup for more information.
 
 If the provided state cannot be restored, this command will fail with
 an explanation.
@@ -166,7 +166,7 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	}
 	activeCount, _ := controller.ControllerMachineCounts(controllerModelUUID, modelStatus)
 	if activeCount > 1 {
-		return errors.Errorf("unable to restore backup in HA configuration.  For help see https://docs.jujucharms.com/devel/en/controllers-backup")
+		return errors.Errorf("unable to restore backup in HA configuration.  For help see https://docs.jujucharms.com/stable/controllers-backup")
 	}
 
 	var archive ArchiveReader

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -263,5 +263,5 @@ func (s *restoreSuite) TestRestoreFromBackupHAFail(c *gc.C) {
 		modelStatusClient.EXPECT().Close(),
 	)
 	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "restore", "--id", "an_id")
-	c.Assert(err, gc.ErrorMatches, "unable to restore backup in HA configuration.  For help see https://docs.jujucharms.com/devel/en/controllers-backup")
+	c.Assert(err, gc.ErrorMatches, "unable to restore backup in HA configuration.  For help see https://docs.jujucharms.com/stable/controllers-backup")
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -79,8 +79,8 @@ dictates what machine to use for the controller. This would typically be
 used with the MAAS provider ('--to <host>.maas').
 
 Available keys for use with --config can be found here:
-    https://jujucharms.com/docs/stable/controllers-config
-    https://jujucharms.com/docs/stable/models-config
+    https://jujucharms.com/stable/controllers-config
+    https://jujucharms.com/stable/models-config
 
 You can change the default timeout and retry delays used during the
 bootstrap by changing the following settings in your configuration

--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -50,7 +50,7 @@ file containing key values. Not all keys can be updated after
 bootstrap time.
 
 Available keys and values can be found here:
-https://jujucharms.com/docs/stable/controllers-config
+https://jujucharms.com/stable/controllers-config
 
 Examples:
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1857,7 +1857,7 @@ global or per instance security groups.`,
 	},
 	ProvisionerHarvestModeKey: {
 		// default: destroyed, but also depends on current setting of ProvisionerSafeModeKey
-		Description: "What to do with unknown machines. See https://jujucharms.com/docs/stable/config-general#juju-lifecycle-and-harvesting (default destroyed)",
+		Description: "What to do with unknown machines. See https://jujucharms.com/stable/config-general#juju-lifecycle-and-harvesting (default destroyed)",
 		Type:        environschema.Tstring,
 		Values:      []interface{}{"all", "none", "unknown", "destroyed"},
 		Group:       environschema.EnvironGroup,


### PR DESCRIPTION
## Description of change

Some commands were referring to the no-longer-existing manual pages. This PR updates these references to contain correct urls.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1784701
