### PR TITLE
Caas revert uneeded splitting and use existing functionality

### DIFF
--- a/caas/kubernetes/provider/dockerconfig.go
+++ b/caas/kubernetes/provider/dockerconfig.go
@@ -4,6 +4,9 @@
 package provider
 
 import (
+	// Import shas that are used for docker image validation.
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 	"encoding/json"
 
 	"github.com/docker/distribution/reference"

--- a/caas/kubernetes/provider/dockerconfig.go
+++ b/caas/kubernetes/provider/dockerconfig.go
@@ -5,14 +5,12 @@ package provider
 
 import (
 	"encoding/json"
-	"regexp"
+
+	"github.com/docker/distribution/reference"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/caas"
 )
-
-// Used to extract the registry from an Image Path.
-// i.e. registry.staging.jujucharms.com from registry.staging.jujucharms.com/tester/caas-mysql/mysql-image@sha256:dead-beef
-var dockerURLRegexp = regexp.MustCompile(`^(?P<registryURL>([^.]+([.]+[^.\/]+)+))\/.*$`)
 
 // These Docker Config datatypes have been pulled from
 // "k8s.io/kubernetes/pkg/credentialprovider".
@@ -40,7 +38,10 @@ func createDockerConfigJSON(imageDetails *caas.ImageDetails) ([]byte, error) {
 		Username: imageDetails.Username,
 		Password: imageDetails.Password,
 	}
-	registryURL := extractRegistryURL(imageDetails.ImagePath)
+	registryURL, err := extractRegistryURL(imageDetails.ImagePath)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	dockerConfig := DockerConfigJson{
 		Auths: map[string]DockerConfigEntry{
@@ -51,11 +52,10 @@ func createDockerConfigJSON(imageDetails *caas.ImageDetails) ([]byte, error) {
 }
 
 // extractRegistryName returns the registry URL part of an images path
-func extractRegistryURL(imagePath string) string {
-	registryURL := "docker.io"
-	hasRegistryURL := dockerURLRegexp.MatchString(imagePath)
-	if hasRegistryURL {
-		registryURL = dockerURLRegexp.ReplaceAllString(imagePath, "$registryURL")
+func extractRegistryURL(imagePath string) (string, error) {
+	imageNamed, err := reference.ParseNormalizedNamed(imagePath)
+	if err != nil {
+		return "", errors.Annotate(err, "extracting registry from path")
 	}
-	return registryURL
+	return reference.Domain(imageNamed), nil
 }

--- a/caas/kubernetes/provider/dockerconfig_test.go
+++ b/caas/kubernetes/provider/dockerconfig_test.go
@@ -21,20 +21,31 @@ type DockerConfigSuite struct {
 var _ = gc.Suite(&DockerConfigSuite{})
 
 func (s *DockerConfigSuite) TestExtractRegistryURL(c *gc.C) {
-	result := provider.ExtractRegistryURL("test")
-	c.Assert(result, gc.Equals, "docker.io")
-
-	result = provider.ExtractRegistryURL("tester/caas-mysql/mysql-image@sha256:dead-beef")
-	c.Assert(result, gc.Equals, "docker.io")
-
-	result = provider.ExtractRegistryURL("registry.staging.jujucharms.com/tester/caas-mysql/mysql-image@sha256:dead-beef")
-	c.Assert(result, gc.Equals, "registry.staging.jujucharms.com")
-
+	for _, registryTest := range []struct {
+		registryPath string
+		expectedURL  string
+	}{{
+		registryPath: "registry.staging.charmstore.com/me/awesomeimage@sha256:5e2c71d050bec85c258a31aa4507ca8adb3b2f5158a4dc919a39118b8879a5ce",
+		expectedURL:  "registry.staging.charmstore.com",
+	}, {
+		registryPath: "gcr.io/kubeflow/jupyterhub-k8s@sha256:5e2c71d050bec85c258a31aa4507ca8adb3b2f5158a4dc919a39118b8879a5ce",
+		expectedURL:  "gcr.io",
+	}, {
+		registryPath: "docker.io/me/mygitlab:latest",
+		expectedURL:  "docker.io",
+	}, {
+		registryPath: "me/mygitlab:latest",
+		expectedURL:  "docker.io",
+	}} {
+		result, err := provider.ExtractRegistryURL(registryTest.registryPath)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.Equals, registryTest.expectedURL)
+	}
 }
 
 func (s *DockerConfigSuite) TestCreateDockerConfigJSON(c *gc.C) {
 	imageDetails := caas.ImageDetails{
-		ImagePath: "registry.staging.jujucharms.com/tester/caas-mysql/mysql-image@sha256:dead-beef",
+		ImagePath: "registry.staging.jujucharms.com/tester/caas-mysql/mysql-image:5.7",
 		Username:  "docker-registry",
 		Password:  "hunter2",
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -163,7 +163,6 @@ func (k *kubernetesClient) EnsureSecret(imageSecretName, appName string, imageDe
 		return errors.Trace(err)
 	}
 	secrets := k.CoreV1().Secrets(k.namespace)
-	// imageSecretName := appSecretName(appName, containerSpec.Name)
 
 	newSecret := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{

--- a/core/resources/resources.go
+++ b/core/resources/resources.go
@@ -32,7 +32,7 @@ func ValidateDockerRegistryPath(path string) error {
 }
 
 // CheckDockerDetails validates the provided resource is suitable for use.
-func CheckDockerDetails(name, value string) error {
+func CheckDockerDetails(name, registryPath string) error {
 	// TODO (veebers): Validate the URL actually works.
-	return ValidateDockerRegistryPath(value)
+	return ValidateDockerRegistryPath(registryPath)
 }

--- a/core/resources/resources.go
+++ b/core/resources/resources.go
@@ -21,10 +21,7 @@ type DockerImageDetails struct {
 	Password string `json:"Password,omitempty" yaml:"password"`
 }
 
-var (
-	validDockerImageRegExp = regexp.MustCompile(`^([A-Za-z\.]+/)?(([A-Za-z-_\.])+/?)+((@sha256){0,1}:[A-Za-z0-9-_\.]+)?$`)
-	registryPathSplit      = regexp.MustCompile(`^(?P<registryURL>([^.]+([.]+[^.\/]+)+))\/(?P<image>.*)$`)
-)
+var validDockerImageRegExp = regexp.MustCompile(`^([A-Za-z\.]+/)?(([A-Za-z-_\.])+/?)+((@sha256){0,1}:[A-Za-z0-9-_\.]+)?$`)
 
 // ValidateDockerRegistryPath ensures the registry path is valid (i.e. api.jujucharms.com@sha256:deadbeef)
 func ValidateDockerRegistryPath(path string) error {
@@ -35,24 +32,7 @@ func ValidateDockerRegistryPath(path string) error {
 }
 
 // CheckDockerDetails validates the provided resource is suitable for use.
-func CheckDockerDetails(name, registryPath string) error {
+func CheckDockerDetails(name, value string) error {
 	// TODO (veebers): Validate the URL actually works.
-	return ValidateDockerRegistryPath(registryPath)
-}
-
-// SplitRegistryPath extracts the repo and the image parts of a registry path.
-func SplitRegistryPath(registryPath string) (repo string, image string, err error) {
-	err = ValidateDockerRegistryPath(registryPath)
-	if err != nil {
-		return "", "", errors.Trace(err)
-	}
-
-	easySplit := registryPathSplit.MatchString(registryPath)
-	if easySplit {
-		repo = registryPathSplit.ReplaceAllString(registryPath, "$registryURL")
-		image = registryPathSplit.ReplaceAllString(registryPath, "$image")
-		return repo, image, nil
-	}
-
-	return "", registryPath, nil
+	return ValidateDockerRegistryPath(value)
 }

--- a/core/resources/resources.go
+++ b/core/resources/resources.go
@@ -4,8 +4,11 @@
 package resources
 
 import (
-	"regexp"
+	// Import shas that are used for docker image validation.
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 
+	"github.com/docker/distribution/reference"
 	"github.com/juju/errors"
 )
 
@@ -21,11 +24,10 @@ type DockerImageDetails struct {
 	Password string `json:"Password,omitempty" yaml:"password"`
 }
 
-var validDockerImageRegExp = regexp.MustCompile(`^([A-Za-z\.]+/)?(([A-Za-z-_\.])+/?)+((@sha256){0,1}:[A-Za-z0-9-_\.]+)?$`)
-
 // ValidateDockerRegistryPath ensures the registry path is valid (i.e. api.jujucharms.com@sha256:deadbeef)
 func ValidateDockerRegistryPath(path string) error {
-	if ok := validDockerImageRegExp.MatchString(path); !ok {
+	_, err := reference.ParseNormalizedNamed(path)
+	if err != nil {
 		return errors.NotValidf("docker image path %q", path)
 	}
 	return nil

--- a/core/resources/resources_test.go
+++ b/core/resources/resources_test.go
@@ -17,7 +17,7 @@ type ResourceSuite struct{}
 var _ = gc.Suite(&ResourceSuite{})
 
 func (s *ResourceSuite) TestValidRegistryPath(c *gc.C) {
-	err := resources.ValidateDockerRegistryPath("registry.hub.docker.io/me/awesomeimage@sha256:deedbeaf")
+	err := resources.ValidateDockerRegistryPath("registry.hub.docker.com/me/awesomeimage@sha256:deedbeaf")
 	c.Assert(err, jc.ErrorIsNil)
 	err = resources.ValidateDockerRegistryPath("docker.io/me/mygitlab:latest")
 	c.Assert(err, jc.ErrorIsNil)
@@ -38,35 +38,4 @@ func (s *ResourceSuite) TestDockerImageDetailsUnmarshal(c *gc.C) {
 		Username:     "docker-registry",
 		Password:     "fragglerock",
 	})
-}
-
-func (s *ResourceSuite) TestSplitRegistryPathForValidPaths(c *gc.C) {
-	for _, registryTest := range []struct {
-		registryPath         string
-		expectedImagePath    string
-		expectedRegistryPath string
-	}{{
-		registryPath:         "registry.staging.charmstore.com/me/awesomeimage@sha256:deedbeaf",
-		expectedImagePath:    "me/awesomeimage@sha256:deedbeaf",
-		expectedRegistryPath: "registry.staging.charmstore.com",
-	}, {
-		registryPath:         "docker.io/me/mygitlab:latest",
-		expectedImagePath:    "me/mygitlab:latest",
-		expectedRegistryPath: "docker.io",
-	}, {
-		registryPath:         "me/mygitlab:latest",
-		expectedImagePath:    "me/mygitlab:latest",
-		expectedRegistryPath: "",
-	}} {
-		reg, image, err := resources.SplitRegistryPath(registryTest.registryPath)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(reg, gc.Equals, registryTest.expectedRegistryPath)
-		c.Assert(image, gc.Equals, registryTest.expectedImagePath)
-	}
-}
-
-func (s *ResourceSuite) TestSplitRegistryPathForInvalidPaths(c *gc.C) {
-	registryPath := "@sha256:deedbeaf"
-	_, _, err := resources.SplitRegistryPath(registryPath)
-	c.Assert(err, gc.ErrorMatches, "docker image path .* not valid")
 }

--- a/core/resources/resources_test.go
+++ b/core/resources/resources_test.go
@@ -17,7 +17,7 @@ type ResourceSuite struct{}
 var _ = gc.Suite(&ResourceSuite{})
 
 func (s *ResourceSuite) TestValidRegistryPath(c *gc.C) {
-	err := resources.ValidateDockerRegistryPath("registry.hub.docker.com/me/awesomeimage@sha256:deedbeaf")
+	err := resources.ValidateDockerRegistryPath("registry.hub.docker.io/me/awesomeimage@sha256:deedbeaf")
 	c.Assert(err, jc.ErrorIsNil)
 	err = resources.ValidateDockerRegistryPath("docker.io/me/mygitlab:latest")
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/resources/resources_test.go
+++ b/core/resources/resources_test.go
@@ -17,14 +17,24 @@ type ResourceSuite struct{}
 var _ = gc.Suite(&ResourceSuite{})
 
 func (s *ResourceSuite) TestValidRegistryPath(c *gc.C) {
-	err := resources.ValidateDockerRegistryPath("registry.hub.docker.io/me/awesomeimage@sha256:deedbeaf")
-	c.Assert(err, jc.ErrorIsNil)
-	err = resources.ValidateDockerRegistryPath("docker.io/me/mygitlab:latest")
-	c.Assert(err, jc.ErrorIsNil)
+	for _, registryTest := range []struct {
+		registryPath string
+	}{{
+		registryPath: "registry.staging.charmstore.com/me/awesomeimage@sha256:5e2c71d050bec85c258a31aa4507ca8adb3b2f5158a4dc919a39118b8879a5ce",
+	}, {
+		registryPath: "gcr.io/kubeflow/jupyterhub-k8s@sha256:5e2c71d050bec85c258a31aa4507ca8adb3b2f5158a4dc919a39118b8879a5ce",
+	}, {
+		registryPath: "docker.io/me/mygitlab:latest",
+	}, {
+		registryPath: "me/mygitlab:latest",
+	}} {
+		err := resources.ValidateDockerRegistryPath(registryTest.registryPath)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
 func (s *ResourceSuite) TestInvalidRegistryPath(c *gc.C) {
-	err := resources.ValidateDockerRegistryPath("sha256:deedbeaf")
+	err := resources.ValidateDockerRegistryPath("blah:sha256@")
 	c.Assert(err, gc.ErrorMatches, "docker image path .* not valid")
 }
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,6 +12,7 @@ github.com/cloud-green/monitoring	git	666e3beca3cb4f6b5c8f176ba80daf2b3adbd84e	2
 github.com/coreos/go-systemd	git	7b2428fec40033549c68f54e26e89e7ca9a9ce31	2016-02-02T21:14:25Z
 github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07-05T20:30:06Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
+github.com/docker/distribution	git	f0cc927784781fa395c06317c58dea2841ece3a9	2018-05-22T17:56:53Z
 github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T22:25:50Z
 github.com/golang/glog	git	44145f04b68cf362d9c4df2182967c2275eaefed	2014-11-05T02:39:35Z
 github.com/golang/mock	git	69521b3833175dfcfb1cc1fdb0c9be92e66faa81	2018-04-03T23:54:22Z

--- a/state/docker_resource.go
+++ b/state/docker_resource.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 
 	"github.com/juju/errors"
@@ -26,11 +25,8 @@ type dockerMetadataDoc struct {
 	// Id holds the resource ID
 	Id string `bson:"_id"`
 
-	// Registry holds the URI/URL of the registry where the image is stored.
-	Registry string `bson:"registry"`
-
-	// Image holds the image path part of the whole url, to be used with the registry URI.
-	Image string `bson:"image"`
+	// RegistryPath holds the image name (including host) of the image in the docker registry.
+	RegistryPath string `bson:"registry-path"`
 
 	// Username holds the password string for a non-private image.
 	Username string `bson:"username"`
@@ -55,17 +51,11 @@ func NewDockerMetadataStorage(st *State) DockerMetadataStorage {
 
 // Save creates a new record the a Docker resource.
 func (dr *dockerMetadataStorage) Save(resourceID string, drInfo resources.DockerImageDetails) error {
-
-	registry, image, err := resources.SplitRegistryPath(drInfo.RegistryPath)
-	if err != nil {
-		return errors.Annotate(err, "failed to extract repo and image")
-	}
 	doc := dockerMetadataDoc{
-		Id:       resourceID,
-		Registry: registry,
-		Image:    image,
-		Username: drInfo.Username,
-		Password: drInfo.Password,
+		Id:           resourceID,
+		RegistryPath: drInfo.RegistryPath,
+		Username:     drInfo.Username,
+		Password:     drInfo.Password,
 	}
 
 	buildTxn := func(int) ([]txn.Op, error) {
@@ -82,8 +72,7 @@ func (dr *dockerMetadataStorage) Save(resourceID string, drInfo resources.Docker
 				Update: bson.D{
 					{"$set",
 						bson.D{
-							{"registry", doc.Registry},
-							{"image", doc.Image},
+							{"registry-path", doc.RegistryPath},
 							{"username", doc.Username},
 							{"password", doc.Password},
 						},
@@ -100,7 +89,7 @@ func (dr *dockerMetadataStorage) Save(resourceID string, drInfo resources.Docker
 		}}, nil
 	}
 
-	err = dr.st.db().Run(buildTxn)
+	err := dr.st.db().Run(buildTxn)
 	return errors.Annotate(err, "failed to store Docker resource")
 }
 
@@ -121,13 +110,9 @@ func (dr *dockerMetadataStorage) Get(resourceID string) (io.ReadCloser, int64, e
 	if err != nil {
 		return nil, -1, errors.Trace(err)
 	}
-	separator := ""
-	if doc.Registry != "" {
-		separator = "/"
-	}
 	data, err := yaml.Marshal(
 		resources.DockerImageDetails{
-			RegistryPath: fmt.Sprintf("%s%s%s", doc.Registry, separator, doc.Image),
+			RegistryPath: doc.RegistryPath,
 			Username:     doc.Username,
 			Password:     doc.Password,
 		})


### PR DESCRIPTION
## Description of change

This branch reverts some validating and splitting of metadata. It instead uses the docker libraries to supply the image path validation.

It also fixes a bug where image names containing numbers wouldn't be considered valid.

## QA steps

Updated the unit tests
Deployed the caas charm that exhibited the validation error.
