### PR TITLE
Upgrade-Series API Server SeriesUpgradeStatus for Machine Entity

### DIFF
--- a/apiserver/common/mocks/mock_machine.go
+++ b/apiserver/common/mocks/mock_machine.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	common "github.com/juju/juju/apiserver/common"
 	state "github.com/juju/juju/state"
 	reflect "reflect"
 )
@@ -31,6 +32,19 @@ func NewMockUpgradeSeriesMachine(ctrl *gomock.Controller) *MockUpgradeSeriesMach
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockUpgradeSeriesMachine) EXPECT() *MockUpgradeSeriesMachineMockRecorder {
 	return m.recorder
+}
+
+// Units mocks base method
+func (m *MockUpgradeSeriesMachine) Units() ([]common.UpgradeSeriesUnit, error) {
+	ret := m.ctrl.Call(m, "Units")
+	ret0, _ := ret[0].([]common.UpgradeSeriesUnit)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Units indicates an expected call of Units
+func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Units))
 }
 
 // WatchUpgradeSeriesNotifications mocks base method

--- a/apiserver/common/mocks/mock_unit.go
+++ b/apiserver/common/mocks/mock_unit.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	model "github.com/juju/juju/core/model"
+	names_v2 "gopkg.in/juju/names.v2"
 	reflect "reflect"
 )
 
@@ -56,6 +57,18 @@ func (m *MockUpgradeSeriesUnit) SetUpgradeSeriesStatus(arg0 model.UnitSeriesUpgr
 // SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus
 func (mr *MockUpgradeSeriesUnitMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).SetUpgradeSeriesStatus), arg0, arg1)
+}
+
+// Tag mocks base method
+func (m *MockUpgradeSeriesUnit) Tag() names_v2.Tag {
+	ret := m.ctrl.Call(m, "Tag")
+	ret0, _ := ret[0].(names_v2.Tag)
+	return ret0
+}
+
+// Tag indicates an expected call of Tag
+func (mr *MockUpgradeSeriesUnitMockRecorder) Tag() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).Tag))
 }
 
 // UpgradeSeriesStatus mocks base method


### PR DESCRIPTION
## Description of change

Adds support for machine entities in the call to `SeriesUpgradeStatus` in the common API server.

The return represents the list of status values for all units managed by the machine.

## QA steps

Unit tests

## Documentation changes

None.

## Bug reference

N/A
