### PR TITLE
GCE reacts to invalid cloud credentials.

### DIFF
--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -88,7 +88,7 @@ func (g *storageProvider) VolumeSource(cfg *storage.Config) (storage.VolumeSourc
 
 type instanceCache map[string]google.Instance
 
-func (c instanceCache) update(gceClient gceConnection, ids ...string) error {
+func (c instanceCache) update(gceClient gceConnection, ctx context.ProviderCallContext, ids ...string) error {
 	if len(ids) == 1 {
 		if _, ok := c[ids[0]]; ok {
 			return nil
@@ -100,7 +100,7 @@ func (c instanceCache) update(gceClient gceConnection, ids ...string) error {
 	}
 	instances, err := gceClient.Instances("", google.StatusRunning)
 	if err != nil {
-		return errors.Annotate(err, "querying instance details")
+		return google.HandleCredentialError(errors.Annotate(err, "querying instance details"), ctx)
 	}
 	for _, instance := range instances {
 		if _, ok := idMap[instance.ID]; !ok {
@@ -132,11 +132,16 @@ func (v *volumeSource) CreateVolumes(ctx context.ProviderCallContext, params []s
 
 	instances := make(instanceCache)
 	if instanceIds.Size() > 1 {
-		if err := instances.update(v.gce, instanceIds.Values()...); err != nil {
+		if err := instances.update(v.gce, ctx, instanceIds.Values()...); err != nil {
 			logger.Debugf("querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
 			// the creation of another volume.
+			// ... Unless the error is due to an invalid credential, in which case, continuing with this call
+			// is pointless and creates an unnecessary churn: we know all calls will fail with the same error.
+			if google.HasDenialStatusCode(err) {
+				return results, err
+			}
 		}
 	}
 
@@ -144,10 +149,15 @@ func (v *volumeSource) CreateVolumes(ctx context.ProviderCallContext, params []s
 		if results[i].Error != nil {
 			continue
 		}
-		volume, attachment, err := v.createOneVolume(p, instances)
+		volume, attachment, err := v.createOneVolume(ctx, p, instances)
 		if err != nil {
 			results[i].Error = err
 			logger.Errorf("could not create one volume (or attach it): %v", err)
+			// ... Unless the error is due to an invalid credential, in which case, continuing with this call
+			// is pointless and creates an unnecessary churn: we know all calls will fail with the same error.
+			if google.HasDenialStatusCode(err) {
+				return results, err
+			}
 			continue
 		}
 		results[i].Volume = volume
@@ -173,19 +183,19 @@ func nameVolume(zone string) (string, error) {
 	return volumeName, nil
 }
 
-func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanceCache) (volume *storage.Volume, volumeAttachment *storage.VolumeAttachment, err error) {
+func (v *volumeSource) createOneVolume(ctx context.ProviderCallContext, p storage.VolumeParams, instances instanceCache) (volume *storage.Volume, volumeAttachment *storage.VolumeAttachment, err error) {
 	var volumeName, zone string
 	defer func() {
 		if err == nil || volumeName == "" {
 			return
 		}
 		if err := v.gce.RemoveDisk(zone, volumeName); err != nil {
-			logger.Errorf("error cleaning up volume %v: %v", volumeName, err)
+			logger.Errorf("error cleaning up volume %v: %v", volumeName, google.HandleCredentialError(err, ctx))
 		}
 	}()
 
 	instId := string(p.Attachment.InstanceId)
-	if err := instances.update(v.gce, instId); err != nil {
+	if err := instances.update(v.gce, ctx, instId); err != nil {
 		return nil, nil, errors.Annotatef(err, "cannot add %q to instance cache", instId)
 	}
 	inst, err := instances.get(instId)
@@ -215,14 +225,14 @@ func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanc
 
 	gceDisks, err := v.gce.CreateDisks(zone, []google.DiskSpec{disk})
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "cannot create disk")
+		return nil, nil, google.HandleCredentialError(errors.Annotate(err, "cannot create disk"), ctx)
 	}
 	if len(gceDisks) != 1 {
 		return nil, nil, errors.New(fmt.Sprintf("unexpected number of disks created: %d", len(gceDisks)))
 	}
 	gceDisk := gceDisks[0]
 
-	attachedDisk, err := v.attachOneVolume(gceDisk.Name, google.ModeRW, inst.ID)
+	attachedDisk, err := v.attachOneVolume(ctx, gceDisk.Name, google.ModeRW, inst.ID)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "attaching %q to %q", gceDisk.Name, instId)
 	}
@@ -251,21 +261,21 @@ func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanc
 }
 
 func (v *volumeSource) DestroyVolumes(ctx context.ProviderCallContext, volNames []string) ([]error, error) {
-	return v.foreachVolume(volNames, v.destroyOneVolume), nil
+	return v.foreachVolume(ctx, volNames, v.destroyOneVolume), nil
 }
 
 func (v *volumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volNames []string) ([]error, error) {
-	return v.foreachVolume(volNames, v.releaseOneVolume), nil
+	return v.foreachVolume(ctx, volNames, v.releaseOneVolume), nil
 }
 
-func (v *volumeSource) foreachVolume(volNames []string, f func(string) error) []error {
+func (v *volumeSource) foreachVolume(ctx context.ProviderCallContext, volNames []string, f func(context.ProviderCallContext, string) error) []error {
 	var wg sync.WaitGroup
 	wg.Add(len(volNames))
 	results := make([]error, len(volNames))
 	for i, volumeName := range volNames {
 		go func(i int, volumeName string) {
 			defer wg.Done()
-			results[i] = f(volumeName)
+			results[i] = f(ctx, volumeName)
 		}(i, volumeName)
 	}
 	wg.Wait()
@@ -287,25 +297,25 @@ func isValidVolume(volumeName string) bool {
 	return err == nil
 }
 
-func (v *volumeSource) destroyOneVolume(volName string) error {
+func (v *volumeSource) destroyOneVolume(ctx context.ProviderCallContext, volName string) error {
 	zone, _, err := parseVolumeId(volName)
 	if err != nil {
 		return errors.Annotatef(err, "invalid volume id %q", volName)
 	}
 	if err := v.gce.RemoveDisk(zone, volName); err != nil {
-		return errors.Annotatef(err, "cannot destroy volume %q", volName)
+		return google.HandleCredentialError(errors.Annotatef(err, "cannot destroy volume %q", volName), ctx)
 	}
 	return nil
 }
 
-func (v *volumeSource) releaseOneVolume(volName string) error {
+func (v *volumeSource) releaseOneVolume(ctx context.ProviderCallContext, volName string) error {
 	zone, _, err := parseVolumeId(volName)
 	if err != nil {
 		return errors.Annotatef(err, "invalid volume id %q", volName)
 	}
 	disk, err := v.gce.Disk(zone, volName)
 	if err != nil {
-		return errors.Trace(err)
+		return google.HandleCredentialError(errors.Trace(err), ctx)
 	}
 	switch disk.Status {
 	case google.StatusReady, google.StatusFailed:
@@ -324,7 +334,7 @@ func (v *volumeSource) releaseOneVolume(volName string) error {
 	delete(disk.Labels, tags.JujuController)
 	delete(disk.Labels, tags.JujuModel)
 	if err := v.gce.SetDiskLabels(zone, volName, disk.LabelFingerprint, disk.Labels); err != nil {
-		return errors.Annotatef(err, "cannot remove labels from volume %q", volName)
+		return google.HandleCredentialError(errors.Annotatef(err, "cannot remove labels from volume %q", volName), ctx)
 	}
 	return nil
 }
@@ -333,7 +343,7 @@ func (v *volumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, e
 	var volumes []string
 	disks, err := v.gce.Disks()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, google.HandleCredentialError(errors.Trace(err), ctx)
 	}
 	for _, disk := range disks {
 		if !isValidVolume(disk.Name) {
@@ -355,7 +365,7 @@ func (v *volumeSource) ImportVolume(ctx context.ProviderCallContext, volName str
 	}
 	disk, err := v.gce.Disk(zone, volName)
 	if err != nil {
-		return storage.VolumeInfo{}, errors.Annotatef(err, "cannot get volume %q", volName)
+		return storage.VolumeInfo{}, google.HandleCredentialError(errors.Annotatef(err, "cannot get volume %q", volName), ctx)
 	}
 	if disk.Status != google.StatusReady {
 		return storage.VolumeInfo{}, errors.Errorf(
@@ -370,7 +380,7 @@ func (v *volumeSource) ImportVolume(ctx context.ProviderCallContext, volName str
 		disk.Labels[k] = v
 	}
 	if err := v.gce.SetDiskLabels(zone, volName, disk.LabelFingerprint, disk.Labels); err != nil {
-		return storage.VolumeInfo{}, errors.Annotatef(err, "cannot update labels on volume %q", volName)
+		return storage.VolumeInfo{}, google.HandleCredentialError(errors.Annotatef(err, "cannot update labels on volume %q", volName), ctx)
 	}
 	return storage.VolumeInfo{
 		VolumeId:   disk.Name,
@@ -382,7 +392,7 @@ func (v *volumeSource) ImportVolume(ctx context.ProviderCallContext, volName str
 func (v *volumeSource) DescribeVolumes(ctx context.ProviderCallContext, volNames []string) ([]storage.DescribeVolumesResult, error) {
 	results := make([]storage.DescribeVolumesResult, len(volNames))
 	for i, vol := range volNames {
-		res, err := v.describeOneVolume(vol)
+		res, err := v.describeOneVolume(ctx, vol)
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot describe volumes")
 		}
@@ -391,14 +401,14 @@ func (v *volumeSource) DescribeVolumes(ctx context.ProviderCallContext, volNames
 	return results, nil
 }
 
-func (v *volumeSource) describeOneVolume(volName string) (storage.DescribeVolumesResult, error) {
+func (v *volumeSource) describeOneVolume(ctx context.ProviderCallContext, volName string) (storage.DescribeVolumesResult, error) {
 	zone, _, err := parseVolumeId(volName)
 	if err != nil {
 		return storage.DescribeVolumesResult{}, errors.Annotatef(err, "cannot describe %q", volName)
 	}
 	disk, err := v.gce.Disk(zone, volName)
 	if err != nil {
-		return storage.DescribeVolumesResult{}, errors.Annotatef(err, "cannot get volume %q", volName)
+		return storage.DescribeVolumesResult{}, google.HandleCredentialError(errors.Annotatef(err, "cannot get volume %q", volName), ctx)
 	}
 	desc := storage.DescribeVolumesResult{
 		&storage.VolumeInfo{
@@ -424,10 +434,15 @@ func (v *volumeSource) AttachVolumes(ctx context.ProviderCallContext, attachPara
 			mode = google.ModeRW
 		}
 		instanceId := attachment.InstanceId
-		attached, err := v.attachOneVolume(volumeName, mode, string(instanceId))
+		attached, err := v.attachOneVolume(ctx, volumeName, mode, string(instanceId))
 		if err != nil {
 			logger.Errorf("could not attach %q to %q: %v", volumeName, instanceId, err)
 			results[i].Error = err
+			// ... Unless the error is due to an invalid credential, in which case, continuing with this call
+			// is pointless and creates an unnecessary churn: we know all calls will fail with the same error.
+			if google.HasDenialStatusCode(err) {
+				return results, err
+			}
 			continue
 		}
 		results[i].VolumeAttachment = &storage.VolumeAttachment{
@@ -444,14 +459,14 @@ func (v *volumeSource) AttachVolumes(ctx context.ProviderCallContext, attachPara
 	return results, nil
 }
 
-func (v *volumeSource) attachOneVolume(volumeName string, mode google.DiskMode, instanceId string) (*google.AttachedDisk, error) {
+func (v *volumeSource) attachOneVolume(ctx context.ProviderCallContext, volumeName string, mode google.DiskMode, instanceId string) (*google.AttachedDisk, error) {
 	zone, _, err := parseVolumeId(volumeName)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid volume name")
 	}
 	instanceDisks, err := v.gce.InstanceDisks(zone, instanceId)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot verify if the disk is already in the instance")
+		return nil, google.HandleCredentialError(errors.Annotate(err, "cannot verify if the disk is already in the instance"), ctx)
 	}
 	// Is it already attached?
 	for _, disk := range instanceDisks {
@@ -462,7 +477,7 @@ func (v *volumeSource) attachOneVolume(volumeName string, mode google.DiskMode, 
 
 	attachment, err := v.gce.AttachDisk(zone, volumeName, instanceId, mode)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot attach volume")
+		return nil, google.HandleCredentialError(errors.Annotate(err, "cannot attach volume"), ctx)
 	}
 	return attachment, nil
 }
@@ -470,19 +485,24 @@ func (v *volumeSource) attachOneVolume(volumeName string, mode google.DiskMode, 
 func (v *volumeSource) DetachVolumes(ctx context.ProviderCallContext, attachParams []storage.VolumeAttachmentParams) ([]error, error) {
 	result := make([]error, len(attachParams))
 	for i, volumeAttachment := range attachParams {
-		result[i] = v.detachOneVolume(volumeAttachment)
+		err := v.detachOneVolume(ctx, volumeAttachment)
+		if err != nil && google.HasDenialStatusCode(err) {
+			// no need to continue as we'll keep getting the same invalid credential error.
+			return result, err
+		}
+		result[i] = err
 	}
 	return result, nil
 }
 
-func (v *volumeSource) detachOneVolume(attachParam storage.VolumeAttachmentParams) error {
+func (v *volumeSource) detachOneVolume(ctx context.ProviderCallContext, attachParam storage.VolumeAttachmentParams) error {
 	instId := attachParam.InstanceId
 	volumeName := attachParam.VolumeId
 	zone, _, err := parseVolumeId(volumeName)
 	if err != nil {
 		return errors.Annotatef(err, "%q is not a valid volume id", volumeName)
 	}
-	return v.gce.DetachDisk(zone, string(instId), volumeName)
+	return google.HandleCredentialError(v.gce.DetachDisk(zone, string(instId), volumeName), ctx)
 }
 
 // resourceTagsToDiskLabels translates a set of

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -486,7 +486,7 @@ func (v *volumeSource) DetachVolumes(ctx context.ProviderCallContext, attachPara
 	result := make([]error, len(attachParams))
 	for i, volumeAttachment := range attachParams {
 		err := v.detachOneVolume(ctx, volumeAttachment)
-		if err != nil && google.HasDenialStatusCode(err) {
+		if google.HasDenialStatusCode(err) {
 			// no need to continue as we'll keep getting the same invalid credential error.
 			return result, err
 		}

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -193,9 +193,9 @@ func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext) error {
 }
 
 // Create implements environs.Environ.
-func (env *environ) Create(context.ProviderCallContext, environs.CreateParams) error {
+func (env *environ) Create(ctx context.ProviderCallContext, p environs.CreateParams) error {
 	if err := env.gce.VerifyCredentials(); err != nil {
-		return errors.Trace(err)
+		return google.HandleCredentialError(errors.Trace(err), ctx)
 	}
 	return nil
 }
@@ -214,13 +214,13 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Pro
 		params.ControllerConfig.APIPort(),
 	)
 	if err := env.gce.OpenPorts(env.globalFirewallName(), rule); err != nil {
-		return nil, errors.Trace(err)
+		return nil, google.HandleCredentialError(errors.Trace(err), callCtx)
 	}
 	if params.ControllerConfig.AutocertDNSName() != "" {
 		// Open port 80 as well as it handles Let's Encrypt HTTP challenge.
 		rule = network.NewOpenIngressRule("tcp", 80, 80)
 		if err := env.gce.OpenPorts(env.globalFirewallName(), rule); err != nil {
-			return nil, errors.Trace(err)
+			return nil, google.HandleCredentialError(errors.Trace(err), callCtx)
 		}
 	}
 	return bootstrap(ctx, env, callCtx, params)

--- a/provider/gce/environ_availzones_test.go
+++ b/provider/gce/environ_availzones_test.go
@@ -19,6 +19,14 @@ type environAZSuite struct {
 
 var _ = gc.Suite(&environAZSuite{})
 
+func (s *environAZSuite) TestAvailabilityZonesInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	_, err := s.Env.AvailabilityZones(s.CallCtx)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
+}
+
 func (s *environAZSuite) TestAvailabilityZones(c *gc.C) {
 	s.FakeConn.Zones = []google.AvailabilityZone{
 		google.NewZone("a-zone", google.StatusUp, "", ""),
@@ -72,6 +80,15 @@ func (s *environAZSuite) TestInstanceAvailabilityZoneNamesAPIs(c *gc.C) {
 	s.FakeEnviron.CheckCalls(c, []gce.FakeCall{{
 		FuncName: "GetInstances", Args: gce.FakeCallArgs{"switch": s.Env},
 	}})
+}
+
+func (s *environAZSuite) TestDeriveAvailabilityZonesInvalidCredentialError(c *gc.C) {
+	s.StartInstArgs.Placement = "zone=test-available"
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	_, err := s.Env.DeriveAvailabilityZones(s.CallCtx, s.StartInstArgs)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
 
 func (s *environAZSuite) TestDeriveAvailabilityZones(c *gc.C) {

--- a/provider/gce/environ_firewall.go
+++ b/provider/gce/environ_firewall.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/provider/gce/google"
 )
 
 // globalFirewallName returns the name to use for the global firewall.
@@ -21,7 +22,7 @@ func (env *environ) globalFirewallName() string {
 // FwGlobal firewall mode.
 func (env *environ) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
 	err := env.gce.OpenPorts(env.globalFirewallName(), rules...)
-	return errors.Trace(err)
+	return google.HandleCredentialError(errors.Trace(err), ctx)
 }
 
 // ClosePorts closes the given port ranges for the whole environment.
@@ -29,7 +30,7 @@ func (env *environ) OpenPorts(ctx context.ProviderCallContext, rules []network.I
 // FwGlobal firewall mode.
 func (env *environ) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
 	err := env.gce.ClosePorts(env.globalFirewallName(), rules...)
-	return errors.Trace(err)
+	return google.HandleCredentialError(errors.Trace(err), ctx)
 }
 
 // IngressRules returns the ingress rules applicable for the whole environment.
@@ -37,5 +38,5 @@ func (env *environ) ClosePorts(ctx context.ProviderCallContext, rules []network.
 // FwGlobal firewall mode.
 func (env *environ) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
 	rules, err := env.gce.IngressRules(env.globalFirewallName())
-	return rules, errors.Trace(err)
+	return rules, google.HandleCredentialError(errors.Trace(err), ctx)
 }

--- a/provider/gce/environ_firewall_test.go
+++ b/provider/gce/environ_firewall_test.go
@@ -23,6 +23,14 @@ func (s *environFirewallSuite) TestGlobalFirewallName(c *gc.C) {
 	c.Check(fwname, gc.Equals, "juju-"+uuid)
 }
 
+func (s *environFirewallSuite) TestOpenPortsInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	err := s.Env.OpenPorts(s.CallCtx, s.Rules)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
+}
+
 func (s *environFirewallSuite) TestOpenPorts(c *gc.C) {
 	err := s.Env.OpenPorts(s.CallCtx, s.Rules)
 
@@ -46,6 +54,14 @@ func (s *environFirewallSuite) TestClosePorts(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
+func (s *environFirewallSuite) TestClosePortsInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	err := s.Env.ClosePorts(s.CallCtx, s.Rules)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
+}
+
 func (s *environFirewallSuite) TestClosePortsAPI(c *gc.C) {
 	fwname := gce.GlobalFirewallName(s.Env)
 	err := s.Env.ClosePorts(s.CallCtx, s.Rules)
@@ -64,6 +80,14 @@ func (s *environFirewallSuite) TestPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(ports, jc.DeepEquals, s.Rules)
+}
+
+func (s *environFirewallSuite) TestIngressRulesInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	_, err := s.Env.IngressRules(s.CallCtx)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
 
 func (s *environFirewallSuite) TestPortsAPI(c *gc.C) {

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -18,7 +18,7 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if _, err := env.instancePlacementZone(args.Placement, volumeAttachmentsZone); err != nil {
+	if _, err := env.instancePlacementZone(ctx, args.Placement, volumeAttachmentsZone); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -85,6 +85,17 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	c.Check(result.Finalize, gc.NotNil)
 }
 
+func (s *environSuite) TestBootstrapInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	params := environs.BootstrapParams{
+		ControllerConfig: testing.FakeControllerConfig(),
+	}
+	_, err := s.Env.Bootstrap(envtesting.BootstrapContext(c), s.CallCtx, params)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
+}
+
 func (s *environSuite) TestBootstrapOpensAPIPort(c *gc.C) {
 	config := testing.FakeControllerConfig()
 	s.checkAPIPorts(c, config, []int{config.APIPort()})
@@ -138,6 +149,22 @@ func (s *environSuite) TestBootstrapCommon(c *gc.C) {
 			"params": params,
 		},
 	}})
+}
+
+func (s *environSuite) TestCreateInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	err := s.Env.Create(s.CallCtx, environs.CreateParams{})
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
+}
+
+func (s *environSuite) TestDestroyInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	err := s.Env.Destroy(s.CallCtx)
+	c.Check(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
 
 func (s *environSuite) TestDestroy(c *gc.C) {

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -5,6 +5,7 @@ package gce
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/instance"
@@ -42,8 +43,8 @@ func GlobalFirewallName(env *environ) string {
 	return env.globalFirewallName()
 }
 
-func ParsePlacement(env *environ, placement string) (*instPlacement, error) {
-	return env.parsePlacement(placement)
+func ParsePlacement(env *environ, ctx context.ProviderCallContext, placement string) (*instPlacement, error) {
+	return env.parsePlacement(ctx, placement)
 }
 
 func FinishInstanceConfig(env *environ, args environs.StartInstanceParams, spec *instances.InstanceSpec) error {
@@ -62,14 +63,14 @@ func BuildInstanceSpec(env *environ, args environs.StartInstanceParams) (*instan
 	return env.buildInstanceSpec(args)
 }
 
-func NewRawInstance(env *environ, args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
-	return env.newRawInstance(args, spec)
+func NewRawInstance(env *environ, ctx context.ProviderCallContext, args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
+	return env.newRawInstance(ctx, args, spec)
 }
 
 func GetHardwareCharacteristics(env *environ, spec *instances.InstanceSpec, inst *environInstance) *instance.HardwareCharacteristics {
 	return env.getHardwareCharacteristics(spec, inst)
 }
 
-func GetInstances(env *environ) ([]instance.Instance, error) {
-	return env.instances()
+func GetInstances(env *environ, ctx context.ProviderCallContext) ([]instance.Instance, error) {
+	return env.instances(ctx)
 }

--- a/provider/gce/google/errors_test.go
+++ b/provider/gce/google/errors_test.go
@@ -1,0 +1,106 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package google_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/gce/google"
+	"github.com/juju/juju/testing"
+)
+
+type ErrorSuite struct {
+	testing.BaseSuite
+
+	googleError   *url.Error
+	internalError *googlyError
+}
+
+var _ = gc.Suite(&ErrorSuite{})
+
+func (s *ErrorSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.internalError = &googlyError{"400 Bad Request"}
+	s.googleError = &url.Error{"Get", "http://notforreal.com/", s.internalError}
+}
+
+func (s *ErrorSuite) TestNilContext(c *gc.C) {
+	err := google.HandleCredentialError(s.googleError, nil)
+	c.Assert(err, gc.DeepEquals, s.googleError)
+	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
+}
+
+func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		return errors.New("kaboom")
+	}
+	google.HandleCredentialError(s.googleError, ctx)
+	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored google cloud credential on the controller")
+}
+
+func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	called := false
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		c.Assert(msg, gc.DeepEquals, "google cloud denied access")
+		called = true
+		return nil
+	}
+
+	// First test another status code.
+	s.internalError.SetMessage(http.StatusAccepted, "Accepted")
+	google.HandleCredentialError(s.googleError, ctx)
+	c.Assert(called, jc.IsFalse)
+
+	for code, desc := range google.AuthorisationFailureStatusCodes {
+		called = false
+		s.internalError.SetMessage(code, desc)
+		google.HandleCredentialError(s.googleError, ctx)
+		c.Assert(called, jc.IsTrue)
+	}
+}
+
+func (*ErrorSuite) TestNilGoogleError(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	called := false
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		called = true
+		return nil
+	}
+	returnedErr := google.HandleCredentialError(nil, ctx)
+	c.Assert(called, jc.IsFalse)
+	c.Assert(returnedErr, jc.ErrorIsNil)
+}
+
+func (*ErrorSuite) TestAnyOtherError(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	called := false
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		called = true
+		return nil
+	}
+
+	notinterestingErr := errors.New("not kaboom")
+	returnedErr := google.HandleCredentialError(notinterestingErr, ctx)
+	c.Assert(called, jc.IsFalse)
+	c.Assert(returnedErr, gc.DeepEquals, notinterestingErr)
+}
+
+type googlyError struct {
+	msg string
+}
+
+func (e *googlyError) Error() string { return e.msg }
+
+func (e *googlyError) SetMessage(code int, desc string) {
+	e.msg = fmt.Sprintf("%v %v", code, desc)
+}

--- a/provider/gce/instance.go
+++ b/provider/gce/instance.go
@@ -77,7 +77,7 @@ func (inst *environInstance) OpenPorts(ctx context.ProviderCallContext, machineI
 		return errors.Trace(err)
 	}
 	err = inst.env.gce.OpenPorts(name, rules...)
-	return errors.Trace(err)
+	return google.HandleCredentialError(errors.Trace(err), ctx)
 }
 
 // ClosePorts closes the given ports on the instance, which
@@ -88,7 +88,7 @@ func (inst *environInstance) ClosePorts(ctx context.ProviderCallContext, machine
 		return errors.Trace(err)
 	}
 	err = inst.env.gce.ClosePorts(name, rules...)
-	return errors.Trace(err)
+	return google.HandleCredentialError(errors.Trace(err), ctx)
 }
 
 // IngressRules returns the set of ingress rules applicable to the instance, which
@@ -100,5 +100,5 @@ func (inst *environInstance) IngressRules(ctx context.ProviderCallContext, machi
 		return nil, errors.Trace(err)
 	}
 	ports, err := inst.env.gce.IngressRules(name)
-	return ports, errors.Trace(err)
+	return ports, google.HandleCredentialError(errors.Trace(err), ctx)
 }

--- a/provider/gce/instance_information.go
+++ b/provider/gce/instance_information.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/provider/gce/google"
 )
 
 var _ environs.InstanceTypesFetcher = (*environ)(nil)
@@ -26,7 +27,7 @@ func (env *environ) InstanceTypes(ctx context.ProviderCallContext, c constraints
 	}
 	zones, err := env.gce.AvailabilityZones(reg.Region)
 	if err != nil {
-		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+		return instances.InstanceTypesWithCostMetadata{}, google.HandleCredentialError(errors.Trace(err), ctx)
 	}
 	resultUnique := map[string]instances.InstanceType{}
 
@@ -36,7 +37,7 @@ func (env *environ) InstanceTypes(ctx context.ProviderCallContext, c constraints
 		}
 		machines, err := env.gce.ListMachineTypes(z.Name())
 		if err != nil {
-			return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
+			return instances.InstanceTypesWithCostMetadata{}, google.HandleCredentialError(errors.Trace(err), ctx)
 		}
 		for _, m := range machines {
 			i := instances.InstanceType{

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -5,8 +5,10 @@ package gce
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
@@ -309,7 +311,8 @@ type BaseSuite struct {
 	FakeCommon  *fakeCommon
 	FakeEnviron *fakeEnviron
 
-	CallCtx context.ProviderCallContext
+	CallCtx                *context.CloudCallContext
+	InvalidatedCredentials bool
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
@@ -333,7 +336,17 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&findInstanceSpec, s.FakeEnviron.FindInstanceSpec)
 	s.PatchValue(&getInstances, s.FakeEnviron.GetInstances)
 
-	s.CallCtx = context.NewCloudCallContext()
+	s.CallCtx = &context.CloudCallContext{
+		InvalidateCredentialFunc: func(string) error {
+			s.InvalidatedCredentials = true
+			return nil
+		},
+	}
+}
+
+func (s *BaseSuite) TearDownTest(c *gc.C) {
+	s.BaseSuiteUnpatched.TearDownTest(c)
+	s.InvalidatedCredentials = false
 }
 
 func (s *BaseSuite) CheckNoAPI(c *gc.C) {
@@ -422,7 +435,7 @@ type fakeEnviron struct {
 	Spec  *instances.InstanceSpec
 }
 
-func (fe *fakeEnviron) GetInstances(env *environ) ([]instance.Instance, error) {
+func (fe *fakeEnviron) GetInstances(env *environ, ctx context.ProviderCallContext) ([]instance.Instance, error) {
 	fe.addCall("GetInstances", FakeCallArgs{
 		"switch": env,
 	})
@@ -446,7 +459,7 @@ func (fe *fakeEnviron) GetHardwareCharacteristics(env *environ, spec *instances.
 	return fe.Hwc
 }
 
-func (fe *fakeEnviron) NewRawInstance(env *environ, args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
+func (fe *fakeEnviron) NewRawInstance(env *environ, ctx context.ProviderCallContext, args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
 	fe.addCall("NewRawInstance", FakeCallArgs{
 		"switch": env,
 		"args":   args,
@@ -718,3 +731,5 @@ func (fc *fakeConn) ListMachineTypes(zone string) ([]google.MachineType, error) 
 		{Name: "type-2", MemoryMb: 2048},
 	}, nil
 }
+
+var InvalidCredentialError = &url.Error{"Get", "testbad.com", errors.New("400 Bad Request")}

--- a/provider/gce/upgrades.go
+++ b/provider/gce/upgrades.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
+	"github.com/juju/juju/provider/gce/google"
 )
 
 // UpgradeOperations is part of the upgrades.OperationSource interface.
@@ -38,7 +39,7 @@ func (step diskLabelsUpgradeStep) Run(ctx context.ProviderCallContext) error {
 	env := step.env
 	disks, err := env.gce.Disks()
 	if err != nil {
-		return errors.Trace(err)
+		return google.HandleCredentialError(errors.Trace(err), ctx)
 	}
 	for _, disk := range disks {
 		if !isValidVolume(disk.Name) {
@@ -56,7 +57,7 @@ func (step diskLabelsUpgradeStep) Run(ctx context.ProviderCallContext) error {
 		disk.Labels[tags.JujuModel] = env.uuid
 		disk.Labels[tags.JujuController] = step.controllerUUID
 		if err := env.gce.SetDiskLabels(disk.Zone, disk.Name, disk.LabelFingerprint, disk.Labels); err != nil {
-			return errors.Annotatef(err, "cannot set labels on volume %q", disk.Name)
+			return google.HandleCredentialError(errors.Annotatef(err, "cannot set labels on volume %q", disk.Name), ctx)
 		}
 	}
 	return nil

--- a/provider/gce/upgrades_test.go
+++ b/provider/gce/upgrades_test.go
@@ -22,6 +22,15 @@ func (s *environUpgradeSuite) TestEnvironImplementsUpgrader(c *gc.C) {
 	c.Assert(s.Env, gc.Implements, new(environs.Upgrader))
 }
 
+func (s *environUpgradeSuite) TestEnvironUpgradeOperationsInvalidCredentialError(c *gc.C) {
+	s.FakeConn.Err = gce.InvalidCredentialError
+	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
+	ops := s.Env.UpgradeOperations(s.CallCtx, environs.UpgradeOperationsParams{})
+	err := ops[0].Steps[0].Run(s.CallCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
+}
+
 func (s *environUpgradeSuite) TestEnvironUpgradeOperations(c *gc.C) {
 	ops := s.Env.UpgradeOperations(s.CallCtx, environs.UpgradeOperationsParams{})
 	c.Assert(ops, gc.HasLen, 1)


### PR DESCRIPTION
## Description of change

This PR ensures that juju gce provider is responsive to google cloud un-happinness with provided credentials.

The most interesting bits are contained in ~/provider/gce/google/errors.go file. This is the code that examines google errors and determines whether the error is related to credential and worth reacting to.
All cloud calls that throw errors have now been modified to go through this logic to ensure that if the cloud complained about a credential, juju marks it as invalid.

Unit tests have been added to provide adequate initial coverage.
