### PR TITLE
leases: add raft-FSM lease store

### DIFF
--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/leadership"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/relation"
@@ -89,7 +90,8 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 }
 
 func (s *relationSuite) TestSetStatus(c *gc.C) {
-	err := s.State.LeadershipClaimer().ClaimLeadership("wordpress", "wordpress/0", time.Minute)
+	claimer := leadership.NewClient(s.st)
+	err := claimer.ClaimLeadership("wordpress", "wordpress/0", time.Minute)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.apiRelation.SetStatus(relation.Suspended)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/websocket"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/pubsub/apiserver"
 	"github.com/juju/juju/resource"
@@ -162,6 +163,10 @@ type ServerConfig struct {
 	// should be called every time a new login is handled.
 	GetAuditConfig func() auditlog.Config
 
+	// LeaseManager gives access to leadership and singular claimers
+	// and checkers for use in API facades.
+	LeaseManager lease.Manager
+
 	// PrometheusRegisterer registers Prometheus collectors.
 	PrometheusRegisterer prometheus.Registerer
 }
@@ -240,10 +245,11 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		cfg.RateLimitConfig.LoginRateLimit, cfg.RateLimitConfig.LoginMinPause,
 		cfg.RateLimitConfig.LoginMaxPause, clock.WallClock)
 	shared, err := newSharedServerContex(sharedServerConfig{
-		statePool:  cfg.StatePool,
-		centralHub: cfg.Hub,
-		presence:   cfg.Presence,
-		logger:     loggo.GetLogger("juju.apiserver"),
+		statePool:    cfg.StatePool,
+		centralHub:   cfg.Hub,
+		presence:     cfg.Presence,
+		leaseManager: cfg.LeaseManager,
+		logger:       loggo.GetLogger("juju.apiserver"),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/lease"
 )
 
 const (
@@ -83,6 +84,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 		LogDir:          c.MkDir(),
 		Hub:             centralhub.New(machineTag),
 		Presence:        presence.New(clock.WallClock),
+		LeaseManager:    &lease.Manager{},
 		Mux:             s.mux,
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -5,6 +5,8 @@ package facadetest
 
 import (
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/state"
 )
 
@@ -17,6 +19,10 @@ type Context struct {
 	State_     *state.State
 	StatePool_ *state.StatePool
 	ID_        string
+
+	LeadershipClaimer_ leadership.Claimer
+	LeadershipChecker_ leadership.Checker
+	SingularClaimer_   lease.Claimer
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
 	Identity string
@@ -66,4 +72,19 @@ func (context Context) Presence() facade.Presence {
 func (context Context) ModelPresence(modelUUID string) facade.ModelPresence {
 	// Potentially may need to add stuff here at some stage.
 	return nil
+}
+
+// LeadershipClaimer implements facade.Context.
+func (context Context) LeadershipClaimer() (leadership.Claimer, error) {
+	return context.LeadershipClaimer_, nil
+}
+
+// LeadershipChecker implements facade.Context.
+func (context Context) LeadershipChecker() (leadership.Checker, error) {
+	return context.LeadershipChecker_, nil
+}
+
+// SingularClaimer implements facade.Context.
+func (context Context) SingularClaimer() (lease.Claimer, error) {
+	return context.SingularClaimer_, nil
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -6,6 +6,8 @@ package facade
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -76,6 +78,15 @@ type Context interface {
 	// into Resources to get the watcher in play. This is not really
 	// a good idea; see Resources.
 	ID() string
+
+	// LeadershipClaimer returns a leadership.Claimer tied to the specific model for this context's model.
+	LeadershipClaimer() (leadership.Claimer, error)
+
+	// LeadershipChecker returns a leadership.Checker for this context's model.
+	LeadershipChecker() (leadership.Checker, error)
+
+	// SingularClaimer returns a lease.Claimer for singular leases for this context's model.
+	SingularClaimer() (lease.Claimer, error)
 }
 
 // Authorizer represents the authenticated entity using the API server.

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -34,7 +34,11 @@ const (
 // NewLeadershipServiceFacade constructs a new LeadershipService and presents
 // a signature that can be used for facade registration.
 func NewLeadershipServiceFacade(context facade.Context) (LeadershipService, error) {
-	return NewLeadershipService(context.State().LeadershipClaimer(), context.Auth())
+	claimer, err := context.LeadershipClaimer()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return NewLeadershipService(claimer, context.Auth())
 }
 
 // NewLeadershipService constructs a new LeadershipService.

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -12,6 +12,7 @@ import (
 	charm "gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -98,11 +99,12 @@ func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	uniterAPI, err := uniter.NewUniterAPI(
-		s.State,
-		s.resources,
-		s.authorizer,
-	)
+	uniterAPI, err := uniter.NewUniterAPI(facadetest.Context{
+		State_:             s.State,
+		Resources_:         s.resources,
+		Auth_:              s.authorizer,
+		LeadershipChecker_: s.State.LeadershipChecker(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.uniter = uniterAPI
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/charms"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/lease"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -38,6 +40,10 @@ func (ctx *charmsSuiteContext) StatePool() *state.StatePool { return nil }
 func (ctx *charmsSuiteContext) ID() string                  { return "" }
 func (ctx *charmsSuiteContext) Presence() facade.Presence   { return nil }
 func (ctx *charmsSuiteContext) Hub() facade.Hub             { return nil }
+
+func (ctx *charmsSuiteContext) LeadershipClaimer() (leadership.Claimer, error) { return nil, nil }
+func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error) { return nil, nil }
+func (ctx *charmsSuiteContext) SingularClaimer() (lease.Claimer, error)        { return nil, nil }
 
 func (s *charmsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -64,7 +64,10 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 
 func (s *statusSuite) TestFullStatusUnitLeadership(c *gc.C) {
 	u := s.Factory.MakeUnit(c, nil)
-	s.State.LeadershipClaimer().ClaimLeadership(u.ApplicationName(), u.Name(), time.Minute)
+	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	err = claimer.Claim(u.ApplicationName(), u.Name(), time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
 	client := s.APIState.Client()
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/singular/fixture_test.go
+++ b/apiserver/facades/controller/singular/fixture_test.go
@@ -45,11 +45,6 @@ func (mock *mockBackend) ModelTag() names.ModelTag {
 	return coretesting.ModelTag
 }
 
-// SingularClaimer is part of the singular.Backend interface.
-func (mock *mockBackend) SingularClaimer() lease.Claimer {
-	return mock
-}
-
 // Claim is part of the lease.Claimer interface.
 func (mock *mockBackend) Claim(lease, holder string, duration time.Duration) error {
 	mock.stub.AddCall("Claim", lease, holder, duration)

--- a/apiserver/facades/controller/singular/singular_test.go
+++ b/apiserver/facades/controller/singular/singular_test.go
@@ -31,14 +31,14 @@ var _ = gc.Suite(&SingularSuite{})
 
 func (s *SingularSuite) TestRequiresController(c *gc.C) {
 	auth := mockAuth{nonController: true}
-	facade, err := singular.NewFacade(nil, auth)
+	facade, err := singular.NewFacade(nil, nil, auth)
 	c.Check(facade, gc.IsNil)
 	c.Check(err, gc.Equals, common.ErrPerm)
 }
 
 func (s *SingularSuite) TestAcceptsController(c *gc.C) {
 	backend := &mockBackend{}
-	facade, err := singular.NewFacade(backend, mockAuth{})
+	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Check(facade, gc.NotNil)
 	c.Check(err, jc.ErrorIsNil)
 
@@ -69,7 +69,7 @@ func (s *SingularSuite) TestInvalidClaims(c *gc.C) {
 	}
 
 	backend := &mockBackend{}
-	facade, err := singular.NewFacade(backend, mockAuth{})
+	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
 	result := facade.Claim(claims)
 	c.Assert(result.Results, gc.HasLen, count)
@@ -124,7 +124,7 @@ func (s *SingularSuite) TestValidClaims(c *gc.C) {
 
 	backend := &mockBackend{}
 	backend.stub.SetErrors(errors...)
-	facade, err := singular.NewFacade(backend, mockAuth{})
+	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
 	result := facade.Claim(claims)
 	c.Assert(result.Results, gc.HasLen, count)
@@ -160,7 +160,7 @@ func (s *SingularSuite) TestWait(c *gc.C) {
 
 	backend := &mockBackend{}
 	backend.stub.SetErrors(errors.New("zap!"), nil)
-	facade, err := singular.NewFacade(backend, mockAuth{})
+	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
 	result := facade.Wait(context.TODO(), waits)
 	c.Assert(result.Results, gc.HasLen, count)
@@ -192,7 +192,7 @@ func (s *SingularSuite) TestWaitCancelled(c *gc.C) {
 	count := len(waits.Entities)
 
 	backend := &mockBackend{}
-	facade, err := singular.NewFacade(backend, mockAuth{})
+	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/lease"
+)
+
+// leadershipChecker implements leadership.Checker by wrapping a lease.Checker.
+type leadershipChecker struct {
+	checker lease.Checker
+}
+
+// LeadershipCheck is part of the leadership.Checker interface.
+func (m leadershipChecker) LeadershipCheck(applicationname, unitName string) leadership.Token {
+	token := m.checker.Token(applicationname, unitName)
+	return leadershipToken{
+		applicationname: applicationname,
+		unitName:        unitName,
+		token:           token,
+	}
+}
+
+// leadershipToken implements leadership.Token by wrapping a lease.Token.
+type leadershipToken struct {
+	applicationname string
+	unitName        string
+	token           lease.Token
+}
+
+// Check is part of the leadership.Token interface.
+func (t leadershipToken) Check(out interface{}) error {
+	err := t.token.Check(out)
+	if errors.Cause(err) == lease.ErrNotHeld {
+		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationname)
+	}
+	return errors.Trace(err)
+}
+
+// leadershipClaimer implements leadership.Claimer by wrappping a lease.Claimer.
+type leadershipClaimer struct {
+	claimer lease.Claimer
+}
+
+// ClaimLeadership is part of the leadership.Claimer interface.
+func (m leadershipClaimer) ClaimLeadership(applicationname, unitName string, duration time.Duration) error {
+	err := m.claimer.Claim(applicationname, unitName, duration)
+	if errors.Cause(err) == lease.ErrClaimDenied {
+		return leadership.ErrClaimDenied
+	}
+	return errors.Trace(err)
+}
+
+// BlockUntilLeadershipReleased is part of the leadership.Claimer interface.
+func (m leadershipClaimer) BlockUntilLeadershipReleased(applicationname string, cancel <-chan struct{}) error {
+	err := m.claimer.WaitUntilExpired(applicationname, cancel)
+	if errors.Cause(err) == lease.ErrWaitCancelled {
+		return leadership.ErrBlockCancelled
+	}
+	return errors.Trace(err)
+}

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/pubsub/controller"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/lease"
 )
 
 type sharedServerContextSuite struct {
@@ -35,10 +36,11 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 
 	s.hub = pubsub.NewStructuredHub(nil)
 	s.config = sharedServerConfig{
-		statePool:  s.StatePool,
-		centralHub: s.hub,
-		presence:   presence.New(clock.WallClock),
-		logger:     loggo.GetLogger("test"),
+		statePool:    s.StatePool,
+		centralHub:   s.hub,
+		presence:     presence.New(clock.WallClock),
+		leaseManager: &lease.Manager{},
+		logger:       loggo.GetLogger("test"),
 	}
 }
 
@@ -61,6 +63,13 @@ func (s *sharedServerContextSuite) TestConfigNoPresence(c *gc.C) {
 	err := s.config.validate()
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, "nil presence not valid")
+}
+
+func (s *sharedServerContextSuite) TestConfigNoLeaseManager(c *gc.C) {
+	s.config.leaseManager = nil
+	err := s.config.validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "nil leaseManager not valid")
 }
 
 func (s *sharedServerContextSuite) TestNewCallsConfigValidate(c *gc.C) {

--- a/apiserver/testserver/server.go
+++ b/apiserver/testserver/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/lease"
 )
 
 // DefaultServerConfig returns the default configuration for starting a test server.
@@ -38,6 +39,7 @@ func DefaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		LogDir:          c.MkDir(),
 		Hub:             hub,
 		Presence:        presence.New(clock.WallClock),
+		LeaseManager:    &lease.Manager{},
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{Enabled: false} },

--- a/cmd/jujud/agent/agenttest/engine.go
+++ b/cmd/jujud/agent/agenttest/engine.go
@@ -198,10 +198,17 @@ func AssertManifoldsDependencies(c *gc.C, manifolds dependency.Manifolds, expect
 		manifoldNames.Add(name)
 		dependencies[name] = ManifoldDependencies(manifolds, name, manifold).SortedValues()
 	}
-	c.Assert(len(dependencies), gc.Equals, len(expected))
+
+	empty := set.NewStrings()
+	names := set.NewStrings(keys(dependencies)...)
+	expectedNames := set.NewStrings(keys(expected)...)
+	// Unexpected names...
+	c.Assert(names.Difference(expectedNames), gc.DeepEquals, empty)
+	// Missing names...
+	c.Assert(expectedNames.Difference(names), gc.DeepEquals, empty)
 
 	for _, n := range manifoldNames.SortedValues() {
-		c.Assert(dependencies[n], jc.SameContents, expected[n], gc.Commentf("mismatched dependencies for worker %q", n))
+		c.Check(dependencies[n], jc.SameContents, expected[n], gc.Commentf("mismatched dependencies for worker %q", n))
 	}
 }
 
@@ -211,6 +218,14 @@ func ManifoldDependencies(all dependency.Manifolds, name string, manifold depend
 	for _, input := range manifold.Inputs {
 		result.Add(input)
 		result = result.Union(ManifoldDependencies(all, input, all[input]))
+	}
+	return result
+}
+
+func keys(items map[string][]string) []string {
+	result := make([]string, 0, len(items))
+	for key := range items {
+		result = append(result, key)
 	}
 	return result
 }

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -68,6 +68,8 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"http-server",
 		"is-controller-flag",
 		"is-primary-controller-flag",
+		"lease-clock-updater",
+		"lease-manager",
 		"log-pruner",
 		"log-sender",
 		"logging-config-updater",
@@ -86,6 +88,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"raft-backstop",
 		"raft-clusterer",
 		"raft-enabled-flag",
+		"raft-forwarder",
 		"raft-leader-flag",
 		"raft-transport",
 		"reboot-executor",
@@ -139,6 +142,8 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"http-server",
 		"is-controller-flag",
 		"is-primary-controller-flag",
+		"lease-clock-updater",
+		"lease-manager",
 		"log-forwarder",
 		"model-worker-manager",
 		"peer-grouper",
@@ -163,6 +168,7 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"raft-backstop",
 		"raft-clusterer",
 		"raft-enabled-flag",
+		"raft-forwarder",
 		"raft-leader-flag",
 		"raft-transport",
 		"valid-credential-flag",
@@ -188,6 +194,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"audit-config-updater",
 		"is-primary-controller-flag",
 		"raft-enabled-flag",
+		"lease-manager",
 	)
 	primaryControllerWorkers := set.NewStrings(
 		"external-controller-updater",
@@ -295,10 +302,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 	"api-server": {
 		"agent",
 		"audit-config-updater",
+		"central-hub",
 		"certificate-watcher",
 		"clock",
 		"http-server",
 		"is-controller-flag",
+		"lease-manager",
 		"restore-watcher",
 		"state",
 		"state-config-watcher",
@@ -402,6 +411,25 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"is-controller-flag",
 		"state",
 		"state-config-watcher"},
+
+	"lease-clock-updater": {
+		"agent",
+		"central-hub",
+		"clock",
+		"is-controller-flag",
+		"lease-manager",
+		"state",
+		"state-config-watcher",
+	},
+
+	"lease-manager": {
+		"agent",
+		"central-hub",
+		"clock",
+		"is-controller-flag",
+		"state",
+		"state-config-watcher",
+	},
 
 	"log-pruner": {
 		"agent",
@@ -592,6 +620,25 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"is-controller-flag",
 		"state",
 		"state-config-watcher"},
+
+	"raft-forwarder": {
+		"agent",
+		"central-hub",
+		"certificate-watcher",
+		"clock",
+		"http-server",
+		"is-controller-flag",
+		"raft",
+		"raft-enabled-flag",
+		"raft-leader-flag",
+		"raft-transport",
+		"state",
+		"state-config-watcher",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
 	"raft-leader-flag": {
 		"agent",

--- a/cmd/jujud/agent/machine_charms_test.go
+++ b/cmd/jujud/agent/machine_charms_test.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/charm.v6"
 
 	charmtesting "github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater/testing"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -35,6 +36,11 @@ func (s *MachineWithCharmsSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *MachineWithCharmsSuite) SetUpTest(c *gc.C) {
+	s.ControllerConfigAttrs = map[string]interface{}{
+		// TODO(raftlease): setting this temporarily until the startup
+		// issue is resolved.
+		controller.Features: []interface{}{"legacy-leases"},
+	}
 	s.commonMachineSuite.SetUpTest(c)
 	s.CharmSuite.SetUpTest(c)
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -77,6 +77,9 @@ func (s *MachineSuite) SetUpTest(c *gc.C) {
 	s.ControllerConfigAttrs = map[string]interface{}{
 		controller.AuditingEnabled: true,
 		controller.CharmStoreURL:   "staging.charmstore",
+		// TODO(raftlease): setting this temporarily until the startup
+		// issue is resolved.
+		controller.Features: []interface{}{"legacy-leases"},
 	}
 	s.commonMachineSuite.SetUpTest(c)
 	// Most of these tests normally finish sub-second on a fast machine.

--- a/core/globalclock/interface.go
+++ b/core/globalclock/interface.go
@@ -32,3 +32,9 @@ type Updater interface {
 	// general whether or not the database was updated.
 	Advance(d time.Duration) error
 }
+
+// IsConcurrentUpdate returns whether the specified error represents
+// ErrConcurrentUpdate (even if it's wrapped).
+func IsConcurrentUpdate(err error) bool {
+	return errors.Cause(err) == ErrConcurrentUpdate
+}

--- a/core/lease/claimer.go
+++ b/core/lease/claimer.go
@@ -9,6 +9,16 @@ import (
 	"github.com/juju/errors"
 )
 
+const (
+	// ApplicationLeadershipNamespace is the namespace used to manage
+	// leadership leases.
+	ApplicationLeadershipNamespace = "application-leadership"
+
+	// SingularControllerNamespace is the namespace used to manage
+	// controller leases.
+	SingularControllerNamespace = "singular-controller"
+)
+
 // ErrClaimDenied indicates that a Claimer.Claim() has been denied.
 var ErrClaimDenied = errors.New("lease claim denied")
 
@@ -58,4 +68,11 @@ type Token interface {
 	// particular Client you're using to determine what key should be passed and
 	// what errors that might induce.
 	Check(trapdoorKey interface{}) error
+}
+
+// Manager represents somewhere you can get Checkers and Claimers for
+// different models.
+type Manager interface {
+	Checker(namespace string, modelUUID string) (Checker, error)
+	Claimer(namespace string, modelUUID string) (Claimer, error)
 }

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -134,3 +134,15 @@ var (
 	// the operation should be retried.
 	ErrTimeout = errors.New("lease operation timed out")
 )
+
+// IsInvalid returns whether the specified error represents ErrInvalid
+// (even if it's wrapped).
+func IsInvalid(err error) bool {
+	return errors.Cause(err) == ErrInvalid
+}
+
+// IsTimeout returns whether the specified error represents ErrTimeout
+// (even if it's wrapped).
+func IsTimeout(err error) bool {
+	return errors.Cause(err) == ErrTimeout
+}

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -1,0 +1,413 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/core/globalclock"
+	"github.com/juju/juju/core/lease"
+)
+
+const (
+	// CommandVersion is the current version of the command format. If
+	// this changes then we need to be sure that reading and applying
+	// commands for previous versions still works.
+	CommandVersion = 1
+
+	// SnapshotVersion is the current version of the snapshot
+	// format. Similarly, changes to the snapshot representation need
+	// to be backward-compatible.
+	SnapshotVersion = 1
+
+	// OperationClaim denotes claiming a new lease.
+	OperationClaim = "claim"
+
+	// OperationExtend denotes extending an already-held lease.
+	OperationExtend = "extend"
+
+	// OperationExpire denotes removing a lease after its duration.
+	OperationExpire = "expire"
+
+	// OperationSetTime denotes updating stored global time.
+	OperationSetTime = "setTime"
+)
+
+// NewFSM returns a new FSM to store lease information.
+func NewFSM() *FSM {
+	return &FSM{
+		entries: make(map[lease.Key]*entry),
+	}
+}
+
+// FSM stores the state of leases in the system.
+type FSM struct {
+	mu         sync.Mutex
+	globalTime time.Time
+	entries    map[lease.Key]*entry
+}
+
+func (f *FSM) claim(key lease.Key, holder string, duration time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, found := f.entries[key]; found {
+		return lease.ErrInvalid
+	}
+	f.entries[key] = &entry{
+		holder:   holder,
+		start:    f.globalTime,
+		duration: duration,
+	}
+	return nil
+}
+
+func (f *FSM) extend(key lease.Key, holder string, duration time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entry, found := f.entries[key]
+	if !found {
+		return lease.ErrInvalid
+	}
+	if entry.holder != holder {
+		return lease.ErrInvalid
+	}
+	expiry := f.globalTime.Add(duration)
+	if !expiry.After(entry.start.Add(entry.duration)) {
+		// No extension needed - the lease already expires after the
+		// new time.
+		return nil
+	}
+	// entry is a pointer back into the f.entries map, so this update
+	// isn't lost.
+	entry.start = f.globalTime
+	entry.duration = duration
+	return nil
+}
+
+func (f *FSM) expire(key lease.Key) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entry, found := f.entries[key]
+	if !found {
+		return lease.ErrInvalid
+	}
+	expiry := entry.start.Add(entry.duration)
+	if !f.globalTime.After(expiry) {
+		return lease.ErrInvalid
+	}
+	delete(f.entries, key)
+	return nil
+}
+
+func (f *FSM) setTime(oldTime, newTime time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.globalTime != oldTime {
+		return globalclock.ErrConcurrentUpdate
+	}
+	f.globalTime = newTime
+	return nil
+}
+
+// GlobalTime returns the FSM's internal time.
+func (f *FSM) GlobalTime() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.globalTime
+}
+
+// Leases gets information about all of the leases in the system.
+func (f *FSM) Leases(localTime time.Time) map[lease.Key]lease.Info {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	results := make(map[lease.Key]lease.Info)
+	for key, entry := range f.entries {
+		globalExpiry := entry.start.Add(entry.duration)
+		remaining := globalExpiry.Sub(f.globalTime)
+		localExpiry := localTime.Add(remaining)
+		results[key] = lease.Info{
+			Holder: entry.holder,
+			Expiry: localExpiry,
+		}
+	}
+	return results
+}
+
+// entry holds the details of a lease.
+type entry struct {
+	// holder identifies the current holder of the lease.
+	holder string
+
+	// start is the global time at which the lease started.
+	start time.Time
+
+	// duration is the duration for which the lease is valid,
+	// from the start time.
+	duration time.Duration
+}
+
+// Apply is part of raft.FSM.
+func (f *FSM) Apply(log *raft.Log) interface{} {
+	var command Command
+	err := yaml.Unmarshal(log.Data, &command)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := command.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	switch command.Operation {
+	case OperationClaim:
+		return f.claim(command.LeaseKey(), command.Holder, command.Duration)
+	case OperationExtend:
+		return f.extend(command.LeaseKey(), command.Holder, command.Duration)
+	case OperationExpire:
+		return f.expire(command.LeaseKey())
+	case OperationSetTime:
+		return f.setTime(command.OldTime, command.NewTime)
+	default:
+		return errors.NotValidf("operation %q", command.Operation)
+	}
+}
+
+// Snapshot is part of raft.FSM.
+func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entries := make(map[SnapshotKey]SnapshotEntry, len(f.entries))
+	for key, entry := range f.entries {
+		entries[SnapshotKey{
+			Namespace: key.Namespace,
+			ModelUUID: key.ModelUUID,
+			Lease:     key.Lease,
+		}] = SnapshotEntry{
+			Holder:   entry.holder,
+			Start:    entry.start,
+			Duration: entry.duration,
+		}
+	}
+	return &Snapshot{
+		Version:    SnapshotVersion,
+		Entries:    entries,
+		GlobalTime: f.globalTime,
+	}, nil
+}
+
+// Restore is part of raft.FSM.
+func (f *FSM) Restore(reader io.ReadCloser) error {
+	defer reader.Close()
+	var snapshot Snapshot
+	decoder := yaml.NewDecoder(reader)
+	if err := decoder.Decode(&snapshot); err != nil {
+		return errors.Trace(err)
+	}
+	if snapshot.Version != SnapshotVersion {
+		return errors.NotValidf("snapshot version %d", snapshot.Version)
+	}
+	if snapshot.Entries == nil {
+		return errors.NotValidf("nil entries")
+	}
+
+	newEntries := make(map[lease.Key]*entry, len(snapshot.Entries))
+	for key, ssEntry := range snapshot.Entries {
+		newEntries[lease.Key{
+			Namespace: key.Namespace,
+			ModelUUID: key.ModelUUID,
+			Lease:     key.Lease,
+		}] = &entry{
+			holder:   ssEntry.Holder,
+			start:    ssEntry.Start,
+			duration: ssEntry.Duration,
+		}
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.globalTime = snapshot.GlobalTime
+	f.entries = newEntries
+
+	return nil
+}
+
+// Snapshot defines the format of the FSM snapshot.
+type Snapshot struct {
+	Version    int                           `yaml:"version"`
+	Entries    map[SnapshotKey]SnapshotEntry `yaml:"entries"`
+	GlobalTime time.Time                     `yaml:"global-time"`
+}
+
+// Persist is part of raft.FSMSnapshot.
+func (s *Snapshot) Persist(sink raft.SnapshotSink) (err error) {
+	defer func() {
+		if err != nil {
+			sink.Cancel()
+		}
+	}()
+
+	encoder := yaml.NewEncoder(sink)
+	if err := encoder.Encode(s); err != nil {
+		return errors.Trace(err)
+	}
+	if err := encoder.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	return sink.Close()
+}
+
+// Release is part of raft.FSMSnapshot.
+func (s *Snapshot) Release() {}
+
+// SnapshotKey defines the format of a lease key in a snapshot.
+type SnapshotKey struct {
+	Namespace string `yaml:"namespace"`
+	ModelUUID string `yaml:"model-uuid"`
+	Lease     string `yaml:"lease"`
+}
+
+// SnapshotEntry defines the format of a lease entry in a snapshot.
+type SnapshotEntry struct {
+	Holder   string        `yaml:"holder"`
+	Start    time.Time     `yaml:"start"`
+	Duration time.Duration `yaml:"duration"`
+}
+
+// Command captures the details of an operation to be run on the FSM.
+type Command struct {
+	// Version of the command format, in case it changes and we need
+	// to handle multiple formats.
+	Version int `yaml:"version"`
+
+	// Operation is one of claim, extend, expire or setTime.
+	Operation string `yaml:"operation"`
+
+	// Namespace is the kind of lease.
+	Namespace string `yaml:"namespace,omitempty"`
+
+	// ModelUUID identifies the model the lease belongs to.
+	ModelUUID string `yaml:"model-uuid,omitempty"`
+
+	// Lease is the name of the lease the command affects.
+	Lease string `yaml:"lease,omitempty"`
+
+	// Holder is the name of the party claiming or extending the
+	// lease.
+	Holder string `yaml:"holder,omitempty"`
+
+	// Duration is how long the lease should last.
+	Duration time.Duration `yaml:"duration,omitempty"`
+
+	// OldTime is the previous time for time updates (to avoid
+	// applying stale ones).
+	OldTime time.Time `yaml:"old-time,omitempty"`
+
+	// NewTime is the time to store as the global time.
+	NewTime time.Time `yaml:"new-time,omitempty"`
+}
+
+// Validate checks that the command describes a valid state change.
+func (c *Command) Validate() error {
+	var zeroTime time.Time
+	// For now there's only version 1.
+	if c.Version != 1 {
+		return errors.NotValidf("version %d", c.Version)
+	}
+	switch c.Operation {
+	case OperationClaim, OperationExtend:
+		if c.Holder == "" {
+			return errors.NotValidf("%s with empty holder", c.Operation)
+		}
+		if c.Duration == 0 {
+			return errors.NotValidf("%s with zero duration", c.Operation)
+		}
+		if c.Namespace == "" {
+			return errors.NotValidf("%s with empty namespace", c.Operation)
+		}
+		if c.ModelUUID == "" {
+			return errors.NotValidf("%s with empty model UUID", c.Operation)
+		}
+		if c.Lease == "" {
+			return errors.NotValidf("%s with empty lease", c.Operation)
+		}
+		if c.OldTime != zeroTime {
+			return errors.NotValidf("%s with old time", c.Operation)
+		}
+		if c.NewTime != zeroTime {
+			return errors.NotValidf("%s with new time", c.Operation)
+		}
+	case OperationExpire:
+		if c.Namespace == "" {
+			return errors.NotValidf("expire with empty namespace")
+		}
+		if c.ModelUUID == "" {
+			return errors.NotValidf("expire with empty model UUID")
+		}
+		if c.Lease == "" {
+			return errors.NotValidf("expire with empty lease")
+		}
+		if c.Holder != "" {
+			return errors.NotValidf("expire with holder")
+		}
+		if c.Duration != 0 {
+			return errors.NotValidf("expire with duration")
+		}
+		if c.OldTime != zeroTime {
+			return errors.NotValidf("expire with old time")
+		}
+		if c.NewTime != zeroTime {
+			return errors.NotValidf("expire with new time")
+		}
+	case OperationSetTime:
+		// An old time of 0 is valid when starting up.
+		if c.NewTime == zeroTime {
+			return errors.NotValidf("setTime with zero new time")
+		}
+		if c.Holder != "" {
+			return errors.NotValidf("setTime with holder")
+		}
+		if c.Duration != 0 {
+			return errors.NotValidf("setTime with duration")
+		}
+		if c.Namespace != "" {
+			return errors.NotValidf("setTime with namespace")
+		}
+		if c.ModelUUID != "" {
+			return errors.NotValidf("setTime with model UUID")
+		}
+		if c.Lease != "" {
+			return errors.NotValidf("setTime with lease")
+		}
+	default:
+		return errors.NotValidf("operation %q", c.Operation)
+	}
+	return nil
+}
+
+// LeaseKey makes a lease key from the fields in the command.
+func (c *Command) LeaseKey() lease.Key {
+	return lease.Key{
+		Namespace: c.Namespace,
+		ModelUUID: c.ModelUUID,
+		Lease:     c.Lease,
+	}
+}
+
+// Marshal converts this command to a byte slice.
+func (c *Command) Marshal() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// UnmarshalCommand converts a marshalled command []byte into a
+// command.
+func UnmarshalCommand(data []byte) (*Command, error) {
+	var result Command
+	err := yaml.Unmarshal(data, &result)
+	return &result, err
+}

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -1,0 +1,458 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease_test
+
+import (
+	"bytes"
+	"io"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/core/globalclock"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+)
+
+var zero time.Time
+
+type fsmSuite struct {
+	testing.IsolationSuite
+
+	fsm *raftlease.FSM
+}
+
+var _ = gc.Suite(&fsmSuite{})
+
+func (s *fsmSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.fsm = raftlease.NewFSM()
+}
+
+func (s *fsmSuite) apply(c *gc.C, command raftlease.Command) interface{} {
+	data, err := command.Marshal()
+	c.Assert(err, jc.ErrorIsNil)
+	result := s.fsm.Apply(&raft.Log{Data: data})
+	return result
+}
+
+func (s *fsmSuite) TestClaim(c *gc.C) {
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "me",
+		Duration:  time.Second,
+	}
+	err := s.apply(c, command)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fsm.Leases(zero), gc.DeepEquals,
+		map[lease.Key]lease.Info{
+			{"ns", "model", "lease"}: {
+				Holder: "me",
+				Expiry: offset(time.Second),
+			},
+		},
+	)
+
+	// Can't claim it again.
+	err = s.apply(c, command)
+	c.Assert(err, jc.Satisfies, lease.IsInvalid)
+
+	// Someone else trying to claim the lease.
+	command.Holder = "you"
+	err = s.apply(c, command)
+	c.Assert(err, jc.Satisfies, lease.IsInvalid)
+
+}
+
+func offset(d time.Duration) time.Time {
+	return zero.Add(d)
+}
+
+func (s *fsmSuite) TestExtend(c *gc.C) {
+	// Can't extend unless we've previously claimed.
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationExtend,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "me",
+		Duration:  time.Second,
+	}
+	c.Assert(s.apply(c, command), jc.Satisfies, lease.IsInvalid)
+
+	// Ok, so we'll claim it.
+	command.Operation = raftlease.OperationClaim
+	c.Assert(s.apply(c, command), jc.ErrorIsNil)
+
+	// Now we can extend it.
+	command.Operation = raftlease.OperationExtend
+	command.Duration = 2 * time.Second
+	c.Assert(s.apply(c, command), jc.ErrorIsNil)
+
+	c.Assert(s.fsm.Leases(zero), gc.DeepEquals,
+		map[lease.Key]lease.Info{
+			{"ns", "model", "lease"}: {
+				Holder: "me",
+				Expiry: offset(2 * time.Second),
+			},
+		},
+	)
+
+	// Extending by a time less than the remaining duration doesn't
+	// shorten the lease (but does succeed).
+	command.Duration = time.Millisecond
+	c.Assert(s.apply(c, command), jc.ErrorIsNil)
+
+	c.Assert(s.fsm.Leases(zero), gc.DeepEquals,
+		map[lease.Key]lease.Info{
+			{"ns", "model", "lease"}: {
+				Holder: "me",
+				Expiry: offset(2 * time.Second),
+			},
+		},
+	)
+
+	// Someone else can't extend it.
+	command.Holder = "you"
+	c.Assert(s.apply(c, command), jc.Satisfies, lease.IsInvalid)
+}
+
+func (s *fsmSuite) TestExpire(c *gc.C) {
+	// Can't expire a non-existent lease.
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationExpire,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+	}
+	c.Assert(s.apply(c, command), jc.Satisfies, lease.IsInvalid)
+
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "me",
+		Duration:  time.Second,
+	}), jc.ErrorIsNil)
+
+	// Not allowed to expire too early.
+	c.Assert(s.apply(c, command), jc.Satisfies, lease.IsInvalid)
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationSetTime,
+		OldTime:   s.fsm.GlobalTime(),
+		NewTime:   s.fsm.GlobalTime().Add(2 * time.Second),
+	}), jc.ErrorIsNil)
+
+	c.Assert(s.apply(c, command), jc.ErrorIsNil)
+	c.Assert(s.fsm.Leases(zero), gc.DeepEquals, map[lease.Key]lease.Info{})
+}
+
+func (s *fsmSuite) TestSetTime(c *gc.C) {
+	// Time always starts at 0.
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationSetTime,
+		OldTime:   zero,
+		NewTime:   zero.Add(2 * time.Second),
+	}), jc.ErrorIsNil)
+	c.Assert(s.fsm.GlobalTime(), gc.Equals, zero.Add(2*time.Second))
+
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationSetTime,
+		OldTime:   zero,
+		NewTime:   zero.Add(time.Second),
+	}), jc.Satisfies, globalclock.IsConcurrentUpdate)
+}
+
+func (s *fsmSuite) TestLeases(c *gc.C) {
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "me",
+		Duration:  time.Second,
+	}), jc.ErrorIsNil)
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns2",
+		ModelUUID: "model2",
+		Lease:     "lease",
+		Holder:    "you",
+		Duration:  4 * time.Second,
+	}), jc.ErrorIsNil)
+
+	c.Assert(s.fsm.Leases(zero), gc.DeepEquals,
+		map[lease.Key]lease.Info{
+			{"ns", "model", "lease"}: {
+				Holder: "me",
+				Expiry: offset(time.Second),
+			},
+			{"ns2", "model2", "lease"}: {
+				Holder: "you",
+				Expiry: offset(4 * time.Second),
+			},
+		},
+	)
+}
+
+func (s *fsmSuite) TestApplyInvalidCommand(c *gc.C) {
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   300,
+		Operation: raftlease.OperationSetTime,
+		OldTime:   zero,
+		NewTime:   zero.Add(2 * time.Second),
+	}), jc.Satisfies, errors.IsNotValid)
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: "libera-me",
+	}), jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *fsmSuite) TestSnapshot(c *gc.C) {
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "me",
+		Duration:  time.Second,
+	}), jc.ErrorIsNil)
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationSetTime,
+		OldTime:   zero,
+		NewTime:   zero.Add(2 * time.Second),
+	}), jc.ErrorIsNil)
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns2",
+		ModelUUID: "model2",
+		Lease:     "lease",
+		Holder:    "you",
+		Duration:  4 * time.Second,
+	}), jc.ErrorIsNil)
+
+	snapshot, err := s.fsm.Snapshot()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(snapshot, gc.DeepEquals, &raftlease.Snapshot{
+		Version: 1,
+		Entries: map[raftlease.SnapshotKey]raftlease.SnapshotEntry{
+			{"ns", "model", "lease"}: {
+				Holder:   "me",
+				Start:    zero,
+				Duration: time.Second,
+			},
+			{"ns2", "model2", "lease"}: {
+				Holder:   "you",
+				Start:    zero.Add(2 * time.Second),
+				Duration: 4 * time.Second,
+			},
+		},
+		GlobalTime: zero.Add(2 * time.Second),
+	})
+}
+
+func (s *fsmSuite) TestRestore(c *gc.C) {
+	c.Assert(s.apply(c, raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "ns",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "me",
+		Duration:  time.Second,
+	}), jc.ErrorIsNil)
+
+	// Restoring overwrites the state.
+	reader := closer{Reader: bytes.NewBuffer([]byte(snapshotYaml))}
+	err := s.fsm.Restore(&reader)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := &raftlease.Snapshot{
+		Version: 1,
+		Entries: map[raftlease.SnapshotKey]raftlease.SnapshotEntry{
+			{"ns", "model", "lease"}: {
+				Holder:   "me",
+				Start:    zero,
+				Duration: 5 * time.Second,
+			},
+			{"ns2", "model2", "lease"}: {
+				Holder:   "you",
+				Start:    zero.Add(2 * time.Second),
+				Duration: 10 * time.Second,
+			},
+		},
+		GlobalTime: zero.Add(3 * time.Second),
+	}
+
+	actual, err := s.fsm.Snapshot()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actual, gc.DeepEquals, expected)
+}
+
+func (s *fsmSuite) TestSnapshotPersist(c *gc.C) {
+	snapshot := &raftlease.Snapshot{
+		Version: 1,
+		Entries: map[raftlease.SnapshotKey]raftlease.SnapshotEntry{
+			{"ns", "model", "lease"}: {
+				Holder:   "me",
+				Start:    zero,
+				Duration: time.Second,
+			},
+			{"ns2", "model2", "lease"}: {
+				Holder:   "you",
+				Start:    zero.Add(2 * time.Second),
+				Duration: 4 * time.Second,
+			},
+		},
+		GlobalTime: zero.Add(2 * time.Second),
+	}
+	var buffer bytes.Buffer
+	sink := fakeSnapshotSink{Writer: &buffer}
+	err := snapshot.Persist(&sink)
+	c.Assert(err, gc.ErrorMatches, "quam olim abrahe")
+	c.Assert(sink.cancelled, gc.Equals, true)
+
+	// Don't compare buffer bytes in output yaml directly, it's
+	// dependent on map ordering.
+	decoder := yaml.NewDecoder(&buffer)
+	var loaded raftlease.Snapshot
+	err = decoder.Decode(&loaded)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(&loaded, gc.DeepEquals, snapshot)
+}
+
+func (s *fsmSuite) TestCommandValidationExpire(c *gc.C) {
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationExpire,
+		Namespace: "namespace",
+		ModelUUID: "model",
+		Lease:     "lease",
+	}
+	c.Assert(command.Validate(), gc.Equals, nil)
+	command.Holder = "me"
+	c.Assert(command.Validate(), gc.ErrorMatches, "expire with holder not valid")
+	command.Holder = ""
+	command.ModelUUID = ""
+	c.Assert(command.Validate(), gc.ErrorMatches, "expire with empty model UUID not valid")
+}
+
+func (s *fsmSuite) TestCommandValidationClaim(c *gc.C) {
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationClaim,
+		Namespace: "namespace",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "you",
+		Duration:  time.Second,
+	}
+	c.Assert(command.Validate(), gc.Equals, nil)
+	command.OldTime = time.Now()
+	c.Assert(command.Validate(), gc.ErrorMatches, "claim with old time not valid")
+	command.OldTime = time.Time{}
+	command.Lease = ""
+	c.Assert(command.Validate(), gc.ErrorMatches, "claim with empty lease not valid")
+}
+
+func (s *fsmSuite) TestCommandValidationExtend(c *gc.C) {
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationExtend,
+		Namespace: "namespace",
+		ModelUUID: "model",
+		Lease:     "lease",
+		Holder:    "you",
+		Duration:  time.Second,
+	}
+	c.Assert(command.Validate(), gc.Equals, nil)
+	command.NewTime = time.Now()
+	c.Assert(command.Validate(), gc.ErrorMatches, "extend with new time not valid")
+	command.OldTime = time.Time{}
+	command.Namespace = ""
+	c.Assert(command.Validate(), gc.ErrorMatches, "extend with empty namespace not valid")
+}
+
+func (s *fsmSuite) TestCommandValidationSetTime(c *gc.C) {
+	command := raftlease.Command{
+		Version:   1,
+		Operation: raftlease.OperationSetTime,
+		OldTime:   time.Now(),
+		NewTime:   time.Now(),
+	}
+	c.Assert(command.Validate(), gc.Equals, nil)
+	command.Duration = time.Minute
+	c.Assert(command.Validate(), gc.ErrorMatches, "setTime with duration not valid")
+	command.Duration = 0
+	command.NewTime = time.Time{}
+	c.Assert(command.Validate(), gc.ErrorMatches, "setTime with zero new time not valid")
+}
+
+type fakeSnapshotSink struct {
+	io.Writer
+	cancelled bool
+}
+
+func (s *fakeSnapshotSink) ID() string {
+	return "fakeSink"
+}
+
+func (s *fakeSnapshotSink) Cancel() error {
+	s.cancelled = true
+	return nil
+}
+
+func (s *fakeSnapshotSink) Close() error {
+	return errors.Errorf("quam olim abrahe")
+}
+
+type closer struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closer) Close() error {
+	c.closed = true
+	return nil
+}
+
+var snapshotYaml = `
+version: 1
+entries:
+  ? namespace: ns
+    model-uuid: model
+    lease: lease
+  : holder: me
+    start: 0001-01-01T00:00:00Z
+    duration: 5s
+  ? namespace: ns2
+    model-uuid: model2
+    lease: lease
+  : holder: you
+    start: 0001-01-01T00:00:02Z
+    duration: 10s
+global-time: 0001-01-01T00:00:03Z
+`[1:]

--- a/core/raftlease/package_test.go
+++ b/core/raftlease/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -1,0 +1,261 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+
+	"github.com/juju/juju/core/globalclock"
+	"github.com/juju/juju/core/lease"
+)
+
+// NotifyTarget defines methods needed to keep an external database
+// updated with who holds leases. (In non-test code the notify target
+// will generally be the state DB.)
+type NotifyTarget interface {
+	// Claimed will be called when a new lease has been claimed. Not
+	// allowed to return an error because this is purely advisory -
+	// the lease claim has still occurred, whether or not the callback
+	// succeeds.
+	Claimed(lease.Key, string)
+
+	// Expired will be called when an existing lease has expired. Not
+	// allowed to return an error because this is purely advisory.
+	Expired(lease.Key)
+
+	// Trapdoor returns a trapdoor to be attached to lease details for
+	// use by clients. This is intended to hold assertions that can be
+	// added to state transactions to ensure the lease is still held
+	// when the transaction is applied.
+	Trapdoor(lease.Key, string) lease.Trapdoor
+}
+
+// ReadonlyFSM defines the methods of the lease FSM the store can use
+// - any writes must go through the hub.
+type ReadonlyFSM interface {
+	Leases(time.Time) map[lease.Key]lease.Info
+	GlobalTime() time.Time
+}
+
+// StoreConfig holds resources and settings needed to run the Store.
+type StoreConfig struct {
+	FSM           ReadonlyFSM
+	Hub           *pubsub.StructuredHub
+	Target        NotifyTarget
+	RequestTopic  string
+	ResponseTopic func(requestID uint64) string
+
+	Clock          clock.Clock
+	ForwardTimeout time.Duration
+}
+
+// NewStore returns a core/lease.Store that manages leases in Raft.
+func NewStore(config StoreConfig) *Store {
+	return &Store{
+		fsm:      config.FSM,
+		hub:      config.Hub,
+		config:   config,
+		prevTime: config.FSM.GlobalTime(),
+	}
+}
+
+// Store manages a raft FSM and forwards writes through a pubsub hub.
+type Store struct {
+	fsm       ReadonlyFSM
+	hub       *pubsub.StructuredHub
+	requestID uint64
+	config    StoreConfig
+
+	prevTimeMu sync.Mutex
+	prevTime   time.Time
+}
+
+// ClaimLease is part of lease.Store.
+func (s *Store) ClaimLease(key lease.Key, req lease.Request) error {
+	err := s.runOnLeader(&Command{
+		Version:   CommandVersion,
+		Operation: OperationClaim,
+		Namespace: key.Namespace,
+		ModelUUID: key.ModelUUID,
+		Lease:     key.Lease,
+		Holder:    req.Holder,
+		Duration:  req.Duration,
+	})
+	if err == nil {
+		s.config.Target.Claimed(key, req.Holder)
+	}
+	return errors.Trace(err)
+}
+
+// ExtendLease is part of lease.Store.
+func (s *Store) ExtendLease(key lease.Key, req lease.Request) error {
+	return errors.Trace(s.runOnLeader(&Command{
+		Version:   CommandVersion,
+		Operation: OperationExtend,
+		Namespace: key.Namespace,
+		ModelUUID: key.ModelUUID,
+		Lease:     key.Lease,
+		Holder:    req.Holder,
+		Duration:  req.Duration,
+	}))
+}
+
+// ExpireLease is part of lease.Store.
+func (s *Store) ExpireLease(key lease.Key) error {
+	err := s.runOnLeader(&Command{
+		Version:   CommandVersion,
+		Operation: OperationExpire,
+		Namespace: key.Namespace,
+		ModelUUID: key.ModelUUID,
+		Lease:     key.Lease,
+	})
+	if err == nil {
+		s.config.Target.Expired(key)
+	}
+	return errors.Trace(err)
+}
+
+// Leases is part of lease.Store.
+func (s *Store) Leases() map[lease.Key]lease.Info {
+	leaseMap := s.fsm.Leases(s.config.Clock.Now())
+	result := make(map[lease.Key]lease.Info, len(leaseMap))
+	// Add trapdoors into the information from the FSM.
+	for k, v := range leaseMap {
+		v.Trapdoor = s.config.Target.Trapdoor(k, v.Holder)
+		result[k] = v
+	}
+	return result
+}
+
+// Refresh is part of lease.Store.
+func (s *Store) Refresh() error {
+	return nil
+}
+
+// Advance is part of globalclock.Updater.
+func (s *Store) Advance(duration time.Duration) error {
+	s.prevTimeMu.Lock()
+	defer s.prevTimeMu.Unlock()
+	newTime := s.prevTime.Add(duration)
+	err := s.runOnLeader(&Command{
+		Version:   CommandVersion,
+		Operation: OperationSetTime,
+		OldTime:   s.prevTime,
+		NewTime:   newTime,
+	})
+	if err == globalclock.ErrConcurrentUpdate {
+		// Someone else updated before us - get the new time.
+		s.prevTime = s.fsm.GlobalTime()
+	} else if err == nil {
+		s.prevTime = newTime
+	}
+	return errors.Trace(err)
+}
+
+func (s *Store) runOnLeader(command *Command) error {
+	bytes, err := command.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	requestID := atomic.AddUint64(&s.requestID, 1)
+	responseTopic := s.config.ResponseTopic(requestID)
+
+	responseChan := make(chan ForwardResponse, 1)
+	errChan := make(chan error)
+	unsubscribe, err := s.hub.Subscribe(
+		responseTopic,
+		func(_ string, resp ForwardResponse, err error) {
+			if err != nil {
+				errChan <- err
+				return
+			}
+			responseChan <- resp
+		},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer unsubscribe()
+
+	_, err = s.hub.Publish(s.config.RequestTopic, ForwardRequest{
+		Command:       bytes,
+		ResponseTopic: responseTopic,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	select {
+	case <-s.config.Clock.After(s.config.ForwardTimeout):
+		return lease.ErrTimeout
+	case err := <-errChan:
+		return errors.Trace(err)
+	case response := <-responseChan:
+		return RecoverError(response.Error)
+	}
+}
+
+// ForwardRequest is a message sent over the hub to the raft forwarder
+// (only running on the raft leader node).
+type ForwardRequest struct {
+	Command       []byte `yaml:"command"`
+	ResponseTopic string `yaml:"response-topic"`
+}
+
+// ForwardResponse is the response sent back from the raft forwarder.
+type ForwardResponse struct {
+	Error *ResponseError `yaml:"error"`
+}
+
+// ResponseError is used for sending error values back to the lease
+// store via the hub.
+type ResponseError struct {
+	Message string `yaml:"message"`
+	Code    string `yaml:"code"`
+}
+
+// AsResponseError returns a *ResponseError that can be sent back over
+// the hub in response to a forwarded FSM command.
+func AsResponseError(err error) *ResponseError {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	var code string
+	switch errors.Cause(err) {
+	case lease.ErrInvalid:
+		code = "invalid"
+	case globalclock.ErrConcurrentUpdate:
+		code = "concurrent-update"
+	default:
+		code = "error"
+	}
+	return &ResponseError{
+		Message: message,
+		Code:    code,
+	}
+}
+
+// RecoverError converts a ResponseError back into the specific error
+// it represents, or into a generic error if it wasn't one of the
+// singleton errors handled.
+func RecoverError(resp *ResponseError) error {
+	if resp == nil {
+		return nil
+	}
+	switch resp.Code {
+	case "invalid":
+		return lease.ErrInvalid
+	case "concurrent-update":
+		return globalclock.ErrConcurrentUpdate
+	default:
+		return errors.New(resp.Message)
+	}
+}

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -1,0 +1,470 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/globalclock"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type storeSuite struct {
+	testing.IsolationSuite
+
+	clock  *testclock.Clock
+	target *fakeTarget
+	fsm    *fakeFSM
+	hub    *pubsub.StructuredHub
+	store  *raftlease.Store
+}
+
+var _ = gc.Suite(&storeSuite{})
+
+func (s *storeSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	startTime, err := time.Parse(time.RFC3339, "2018-08-08T08:08:08+08:00")
+	c.Assert(err, jc.ErrorIsNil)
+	s.clock = testclock.NewClock(startTime)
+	s.target = &fakeTarget{}
+	s.fsm = &fakeFSM{
+		leases:     make(map[lease.Key]lease.Info),
+		globalTime: s.clock.Now(),
+	}
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.store = raftlease.NewStore(raftlease.StoreConfig{
+		FSM:          s.fsm,
+		Hub:          s.hub,
+		Target:       s.target,
+		RequestTopic: "lease.request",
+		ResponseTopic: func(reqID uint64) string {
+			return fmt.Sprintf("lease.request.%d", reqID)
+		},
+		Clock:          s.clock,
+		ForwardTimeout: time.Second,
+	})
+}
+
+func (s *storeSuite) TestClaim(c *gc.C) {
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.ClaimLease(
+				lease.Key{"warframe", "rhino", "prime"},
+				lease.Request{"lotus", time.Second},
+			)
+			c.Assert(err, jc.ErrorIsNil)
+		},
+
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationClaim,
+			Namespace: "warframe",
+			ModelUUID: "rhino",
+			Lease:     "prime",
+			Holder:    "lotus",
+			Duration:  time.Second,
+		},
+		func(req raftlease.ForwardRequest) {
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+	s.target.CheckCall(c, 0, "Claimed",
+		lease.Key{"warframe", "rhino", "prime"},
+		"lotus",
+	)
+}
+
+func (s *storeSuite) TestClaimTimeout(c *gc.C) {
+	s.handleHubRequest(c,
+		func() {
+			errChan := make(chan error)
+			go func() {
+				errChan <- s.store.ClaimLease(
+					lease.Key{"warframe", "vauban", "prime"},
+					lease.Request{"vor", time.Second},
+				)
+			}()
+			// Jump time forward further than the 1-second forward
+			// timeout.
+			s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1)
+			select {
+			case err := <-errChan:
+				c.Assert(err, jc.Satisfies, lease.IsTimeout)
+			case <-time.After(coretesting.LongWait):
+				c.Fatalf("timed out waiting for claim error")
+			}
+		},
+
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationClaim,
+			Namespace: "warframe",
+			ModelUUID: "vauban",
+			Lease:     "prime",
+			Holder:    "vor",
+			Duration:  time.Second,
+		},
+		func(req raftlease.ForwardRequest) {
+			// We never send a response, to trigger a timeout.
+		},
+	)
+	c.Assert(s.target.Calls(), gc.HasLen, 0)
+}
+
+func (s *storeSuite) TestClaimInvalid(c *gc.C) {
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.ClaimLease(
+				lease.Key{"warframe", "volt", "umbra"},
+				lease.Request{"maroo", 3 * time.Second},
+			)
+			c.Assert(err, jc.Satisfies, lease.IsInvalid)
+		},
+
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationClaim,
+			Namespace: "warframe",
+			ModelUUID: "volt",
+			Lease:     "umbra",
+			Holder:    "maroo",
+			Duration:  3 * time.Second,
+		},
+		func(req raftlease.ForwardRequest) {
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{
+					Error: &raftlease.ResponseError{
+						Code: "invalid",
+					},
+				},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+	c.Assert(s.target.Calls(), gc.HasLen, 0)
+}
+
+func (s *storeSuite) TestExtend(c *gc.C) {
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.ExtendLease(
+				lease.Key{"warframe", "frost", "prime"},
+				lease.Request{"konzu", time.Second},
+			)
+			c.Assert(err, jc.ErrorIsNil)
+		},
+
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationExtend,
+			Namespace: "warframe",
+			ModelUUID: "frost",
+			Lease:     "prime",
+			Holder:    "konzu",
+			Duration:  time.Second,
+		},
+		func(req raftlease.ForwardRequest) {
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+	c.Assert(s.target.Calls(), gc.HasLen, 0)
+}
+
+func (s *storeSuite) TestExpire(c *gc.C) {
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.ExpireLease(
+				lease.Key{"warframe", "oberon", "prime"},
+			)
+			c.Assert(err, jc.ErrorIsNil)
+		},
+
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationExpire,
+			Namespace: "warframe",
+			ModelUUID: "oberon",
+			Lease:     "prime",
+		},
+		func(req raftlease.ForwardRequest) {
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+	s.target.CheckCall(c, 0, "Expired",
+		lease.Key{"warframe", "oberon", "prime"},
+	)
+}
+
+func (s *storeSuite) TestLeases(c *gc.C) {
+	in5Seconds := s.clock.Now().Add(5 * time.Second)
+	in10Seconds := s.clock.Now().Add(10 * time.Second)
+	lease1 := lease.Key{"quam", "olim", "abrahe"}
+	lease2 := lease.Key{"la", "cry", "mosa"}
+	s.fsm.leases[lease1] = lease.Info{
+		Holder: "verdi",
+		Expiry: in10Seconds,
+	}
+	s.fsm.leases[lease2] = lease.Info{
+		Holder: "mozart",
+		Expiry: in5Seconds,
+	}
+	result := s.store.Leases()
+	c.Assert(len(result), gc.Equals, 2)
+
+	r1 := result[lease1]
+	c.Assert(r1.Holder, gc.Equals, "verdi")
+	c.Assert(r1.Expiry, gc.Equals, in10Seconds)
+
+	// Can't compare trapdoors directly.
+	var out string
+	err := r1.Trapdoor(&out)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, "{quam olim abrahe} held by verdi")
+
+	r2 := result[lease2]
+	c.Assert(r2.Holder, gc.Equals, "mozart")
+	c.Assert(r2.Expiry, gc.Equals, in5Seconds)
+
+	err = r2.Trapdoor(&out)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, gc.Equals, "{la cry mosa} held by mozart")
+}
+
+// handleHubRequest takes the action that triggers the request, the
+// expected command, and a function that will be run to make checks on
+// the request and send the response back.
+func (s *storeSuite) handleHubRequest(
+	c *gc.C,
+	action func(),
+	expectCommand raftlease.Command,
+	responder func(raftlease.ForwardRequest),
+) {
+	expectedBytes := marshal(c, expectCommand)
+	called := make(chan struct{})
+	unsubscribe, err := s.hub.Subscribe(
+		"lease.request",
+		func(_ string, req raftlease.ForwardRequest, err error) {
+			defer close(called)
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(req.Command, gc.DeepEquals, expectedBytes)
+			responder(req)
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	defer unsubscribe()
+
+	action()
+	select {
+	case <-called:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for hub message")
+	}
+}
+
+func (s *storeSuite) TestAdvance(c *gc.C) {
+	fromTime := s.clock.Now()
+
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.Advance(10 * time.Second)
+			c.Assert(err, jc.ErrorIsNil)
+		},
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationSetTime,
+			OldTime:   fromTime,
+			NewTime:   fromTime.Add(10 * time.Second),
+		},
+		func(req raftlease.ForwardRequest) {
+			c.Check(req.ResponseTopic, gc.Equals, "lease.request.1")
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+	// The store time advances, as seen in the next update.
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.Advance(5 * time.Second)
+			c.Assert(err, jc.ErrorIsNil)
+		},
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationSetTime,
+			OldTime:   fromTime.Add(10 * time.Second),
+			NewTime:   fromTime.Add(15 * time.Second),
+		},
+		func(req raftlease.ForwardRequest) {
+			c.Check(req.ResponseTopic, gc.Equals, "lease.request.2")
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+}
+
+func (s *storeSuite) TestAdvanceConcurrentUpdate(c *gc.C) {
+	fromTime := s.clock.Now()
+	plus5Sec := fromTime.Add(5 * time.Second)
+	plus10Sec := fromTime.Add(10 * time.Second)
+	s.fsm.globalTime = plus5Sec
+
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.Advance(10 * time.Second)
+			c.Assert(err, jc.Satisfies, globalclock.IsConcurrentUpdate)
+		},
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationSetTime,
+			OldTime:   fromTime,
+			NewTime:   plus10Sec,
+		},
+		func(req raftlease.ForwardRequest) {
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{
+					Error: &raftlease.ResponseError{
+						Code: "concurrent-update",
+					},
+				},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+
+	// Check that the store updates time from the FSM for when we try
+	// again.
+	s.handleHubRequest(c,
+		func() {
+			err := s.store.Advance(10 * time.Second)
+			c.Assert(err, jc.ErrorIsNil)
+		},
+		raftlease.Command{
+			Version:   1,
+			Operation: raftlease.OperationSetTime,
+			OldTime:   plus5Sec,
+			NewTime:   fromTime.Add(15 * time.Second),
+		},
+		func(req raftlease.ForwardRequest) {
+			c.Check(req.ResponseTopic, gc.Equals, "lease.request.2")
+			_, err := s.hub.Publish(
+				req.ResponseTopic,
+				raftlease.ForwardResponse{},
+			)
+			c.Check(err, jc.ErrorIsNil)
+		},
+	)
+}
+
+func (s *storeSuite) TestAsResponseError(c *gc.C) {
+	c.Assert(
+		raftlease.AsResponseError(lease.ErrInvalid),
+		gc.DeepEquals,
+		&raftlease.ResponseError{
+			"invalid lease operation",
+			"invalid",
+		},
+	)
+	c.Assert(
+		raftlease.AsResponseError(globalclock.ErrConcurrentUpdate),
+		gc.DeepEquals,
+		&raftlease.ResponseError{
+			"clock was updated concurrently, retry",
+			"concurrent-update",
+		},
+	)
+	c.Assert(
+		raftlease.AsResponseError(errors.Errorf("generic")),
+		gc.DeepEquals,
+		&raftlease.ResponseError{
+			"generic",
+			"error",
+		},
+	)
+}
+
+func (s *storeSuite) TestRecoverError(c *gc.C) {
+	c.Assert(raftlease.RecoverError(nil), gc.Equals, nil)
+	re := func(msg, code string) error {
+		return raftlease.RecoverError(&raftlease.ResponseError{
+			Message: msg,
+			Code:    code,
+		})
+	}
+	c.Assert(re("", "invalid"), jc.Satisfies, lease.IsInvalid)
+	c.Assert(re("", "concurrent-update"), jc.Satisfies, globalclock.IsConcurrentUpdate)
+	c.Assert(re("something", "else"), gc.ErrorMatches, "something")
+}
+
+type fakeFSM struct {
+	testing.Stub
+	leases     map[lease.Key]lease.Info
+	globalTime time.Time
+}
+
+func (f *fakeFSM) Leases(t time.Time) map[lease.Key]lease.Info {
+	f.AddCall("Leases", t)
+	return f.leases
+}
+
+func (f *fakeFSM) GlobalTime() time.Time {
+	return f.globalTime
+}
+
+type fakeTarget struct {
+	testing.Stub
+}
+
+func (t *fakeTarget) Claimed(key lease.Key, holder string) {
+	t.AddCall("Claimed", key, holder)
+}
+
+func (t *fakeTarget) Expired(key lease.Key) {
+	t.AddCall("Expired", key)
+}
+
+func (t *fakeTarget) Trapdoor(key lease.Key, holder string) lease.Trapdoor {
+	return func(out interface{}) error {
+		if s, ok := out.(*string); ok {
+			*s = fmt.Sprintf("%v held by %s", key, holder)
+			return nil
+		}
+		return errors.Errorf("bad input")
+	}
+}
+
+func marshal(c *gc.C, command raftlease.Command) []byte {
+	result, err := command.Marshal()
+	c.Assert(err, jc.ErrorIsNil)
+	return result
+}

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -51,3 +51,7 @@ const DisableRaft = "disable-raft"
 
 // UpgradeSeries is a development feature flag.
 const UpgradeSeries = "upgrade-series"
+
+// LegacyLeases will switch all lease management to be handled by the
+// Mongo-based lease store, rather than by the Raft FSM.
+const LegacyLeases = "legacy-leases"

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -105,6 +106,7 @@ type JujuConnSuite struct {
 	BackingState        *state.State          // The State being used by the API server
 	BackingStatePool    *state.StatePool      // The StatePool being used by the API server
 	Hub                 *pubsub.StructuredHub // The central hub being used by the API server.
+	LeaseManager        lease.Manager         // The lease manager being used by the API server.
 	RootDir             string                // The faked-up root directory.
 	LogDir              string
 	oldHome             string
@@ -402,6 +404,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.BackingState = getStater.GetStateInAPIServer()
 	s.BackingStatePool = getStater.GetStatePoolInAPIServer()
 	s.Hub = getStater.GetHubInAPIServer()
+	s.LeaseManager = getStater.GetLeaseManagerInAPIServer()
 
 	s.State, err = newState(s.ControllerConfig.ControllerUUID(), environ, s.MongoInfo(c))
 	c.Assert(err, jc.ErrorIsNil)
@@ -626,6 +629,7 @@ type GetStater interface {
 	GetStateInAPIServer() *state.State
 	GetStatePoolInAPIServer() *state.StatePool
 	GetHubInAPIServer() *pubsub.StructuredHub
+	GetLeaseManagerInAPIServer() lease.Manager
 }
 
 func (s *JujuConnSuite) tearDownConn(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -21,6 +21,7 @@ package dummy
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http/httptest"
 	"os"
@@ -44,6 +45,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -56,6 +58,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/auditlog"
+	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -74,6 +77,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/worker/lease"
 )
 
 var logger = loggo.GetLogger("juju.provider.dummy")
@@ -259,6 +263,7 @@ type environState struct {
 	apiStatePool   *state.StatePool
 	hub            *pubsub.StructuredHub
 	presence       *fakePresence
+	leaseManager   *lease.Manager
 	creator        string
 }
 
@@ -355,9 +360,11 @@ func (state *environState) destroyLocked() {
 	apiServer := state.apiServer
 	apiStatePool := state.apiStatePool
 	apiState := state.apiState
+	leaseManager := state.leaseManager
 	state.apiServer = nil
 	state.apiStatePool = nil
 	state.apiState = nil
+	state.leaseManager = nil
 	state.bootstrapped = false
 	state.hub = nil
 
@@ -370,6 +377,12 @@ func (state *environState) destroyLocked() {
 
 	if apiServer != nil {
 		if err := apiServer.Stop(); err != nil && mongoAlive() {
+			panic(err)
+		}
+	}
+
+	if leaseManager != nil {
+		if err := worker.Stop(leaseManager); err != nil && mongoAlive() {
 			panic(err)
 		}
 	}
@@ -428,6 +441,16 @@ func (e *environ) GetHubInAPIServer() *pubsub.StructuredHub {
 		panic(err)
 	}
 	return st.hub
+}
+
+// GetLeaseManagerInAPIServer returns the lease manager used by the
+// API server.
+func (e *environ) GetLeaseManagerInAPIServer() corelease.Manager {
+	st, err := e.state()
+	if err != nil {
+		panic(err)
+	}
+	return st.leaseManager
 }
 
 // newState creates the state for a new environment with the given name.
@@ -770,7 +793,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 	estate.bootstrapped = true
 	estate.ops <- OpBootstrap{Context: ctx, Env: e.name, Args: args}
 
-	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
+	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) (err error) {
 		if e.ecfg().controller() {
 			icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
 			if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
@@ -825,27 +848,28 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			if err != nil {
 				return err
 			}
+			defer func() {
+				if err != nil {
+					st.Close()
+				}
+			}()
 			ctlr.Close()
 			if err := st.SetModelConstraints(args.ModelConstraints); err != nil {
-				st.Close()
 				return err
 			}
+
 			if err := st.SetAdminMongoPassword(icfg.Controller.MongoInfo.Password); err != nil {
-				st.Close()
 				return err
 			}
 			if err := st.MongoSession().DB("admin").Login("admin", icfg.Controller.MongoInfo.Password); err != nil {
-				st.Close()
 				return err
 			}
 			env, err := st.Model()
 			if err != nil {
-				st.Close()
 				return err
 			}
 			owner, err := st.User(env.Owner())
 			if err != nil {
-				st.Close()
 				return err
 			}
 			// We log this out for test purposes only. No one in real life can use
@@ -858,7 +882,6 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			stateAuthenticator, err := stateauthenticator.NewAuthenticator(statePool, clock.WallClock)
 			if err != nil {
 				statePool.Close()
-				st.Close()
 				return err
 			}
 			stateAuthenticator.AddHandlers(estate.mux)
@@ -867,6 +890,16 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			estate.httpServer.StartTLS()
 			estate.presence = &fakePresence{make(map[string]presence.Status)}
 			estate.hub = centralhub.New(machineTag)
+
+			estate.leaseManager, err = leaseManager(
+				icfg.Controller.Config.ControllerUUID(),
+				st,
+			)
+			if err != nil {
+				statePool.Close()
+				return errors.Trace(err)
+			}
+
 			estate.apiServer, err = apiserver.NewServer(apiserver.ServerConfig{
 				StatePool:       statePool,
 				Authenticator:   stateAuthenticator,
@@ -878,6 +911,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 				Mux:             estate.mux,
 				Hub:             estate.hub,
 				Presence:        estate.presence,
+				LeaseManager:    estate.leaseManager,
 				NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 				RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 				PublicDNSName:   icfg.Controller.Config.AutocertDNSName(),
@@ -890,7 +924,6 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			})
 			if err != nil {
 				statePool.Close()
-				st.Close()
 				panic(err)
 			}
 			estate.apiState = st
@@ -914,6 +947,22 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 		Finalize: finalize,
 	}
 	return bsResult, nil
+}
+
+func leaseManager(controllerUUID string, st *state.State) (*lease.Manager, error) {
+	target := st.LeaseNotifyTarget(
+		ioutil.Discard,
+		loggo.GetLogger("juju.state.raftlease"),
+	)
+	dummyStore := newLeaseStore(clock.WallClock, target)
+	return lease.NewManager(lease.ManagerConfig{
+		Secretary:  lease.SecretaryFinder(controllerUUID),
+		Store:      dummyStore,
+		Logger:     loggo.GetLogger("juju.worker.lease.dummy"),
+		Clock:      clock.WallClock,
+		MaxSleep:   time.Minute,
+		EntityUUID: controllerUUID,
+	})
 }
 
 func (e *environ) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -1,0 +1,122 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dummy
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/clock"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+)
+
+// leaseStore implements lease.Store as simply as possible for use in
+// the dummy provider. Heavily cribbed from raftlease.FSM.
+type leaseStore struct {
+	mu      sync.Mutex
+	clock   clock.Clock
+	entries map[lease.Key]*entry
+	target  raftlease.NotifyTarget
+}
+
+// entry holds the details of a lease.
+type entry struct {
+	// holder identifies the current holder of the lease.
+	holder string
+
+	// start is the global time at which the lease started.
+	start time.Time
+
+	// duration is the duration for which the lease is valid,
+	// from the start time.
+	duration time.Duration
+}
+
+func newLeaseStore(clock clock.Clock, target raftlease.NotifyTarget) *leaseStore {
+	return &leaseStore{
+		clock:   clock,
+		entries: make(map[lease.Key]*entry),
+		target:  target,
+	}
+}
+
+// ClaimLease is part of lease.Store.
+func (s *leaseStore) ClaimLease(key lease.Key, req lease.Request) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, found := s.entries[key]; found {
+		return lease.ErrInvalid
+	}
+	s.entries[key] = &entry{
+		holder:   req.Holder,
+		start:    s.clock.Now(),
+		duration: req.Duration,
+	}
+	s.target.Claimed(key, req.Holder)
+	return nil
+}
+
+// ExtendLease is part of lease.Store.
+func (s *leaseStore) ExtendLease(key lease.Key, req lease.Request) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, found := s.entries[key]
+	if !found {
+		return lease.ErrInvalid
+	}
+	if entry.holder != req.Holder {
+		return lease.ErrInvalid
+	}
+	now := s.clock.Now()
+	expiry := now.Add(req.Duration)
+	if !expiry.After(entry.start.Add(entry.duration)) {
+		// No extension needed - the lease already expires after the
+		// new time.
+		return nil
+	}
+	// entry is a pointer back into the f.entries map, so this update
+	// isn't lost.
+	entry.start = now
+	entry.duration = req.Duration
+	return nil
+}
+
+// Expire is part of lease.Store.
+func (s *leaseStore) ExpireLease(key lease.Key) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, found := s.entries[key]
+	if !found {
+		return lease.ErrInvalid
+	}
+	expiry := entry.start.Add(entry.duration)
+	if !s.clock.Now().After(expiry) {
+		return lease.ErrInvalid
+	}
+	delete(s.entries, key)
+	s.target.Expired(key)
+	return nil
+}
+
+// Leases is part of lease.Store.
+func (s *leaseStore) Leases() map[lease.Key]lease.Info {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	results := make(map[lease.Key]lease.Info)
+	for key, entry := range s.entries {
+		results[key] = lease.Info{
+			Holder:   entry.holder,
+			Expiry:   entry.start.Add(entry.duration),
+			Trapdoor: s.target.Trapdoor(key, entry.holder),
+		}
+	}
+	return results
+}
+
+// Refresh is part of lease.Store.
+func (s *leaseStore) Refresh() error {
+	return nil
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -206,6 +206,16 @@ func allCollections() collectionSchema {
 			rawAccess: true,
 		},
 
+		// This collection tracks who holds which lease when the store
+		// is managed by raft - so that transactions can still make
+		// assertions about holding the lease.
+		leaseHoldersC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "namespace"},
+			}},
+		},
+
 		// This collection holds the last time the model user connected
 		// to the model.
 		modelUserLastConnectionC: {
@@ -536,6 +546,7 @@ const (
 	guisettingsC               = "guisettings"
 	instanceDataC              = "instanceData"
 	leasesC                    = "leases"
+	leaseHoldersC              = "leaseholders"
 	machinesC                  = "machines"
 	machineRemovalsC           = "machineremovals"
 	machineUpgradeSeriesLocksC = "machineUpgradeSeriesLocks"

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/leadership"
@@ -62,34 +61,6 @@ func buildTxnWithLeadership(buildTxn jujutxn.TransactionSource, token leadership
 		}
 		return append(prereqs, ops...), nil
 	}
-}
-
-// leadershipSecretary implements lease.Secretary; it checks that leases are
-// application names, and holders are unit names.
-type leadershipSecretary struct{}
-
-// CheckLease is part of the lease.Secretary interface.
-func (leadershipSecretary) CheckLease(name string) error {
-	if !names.IsValidApplication(name) {
-		return errors.NewNotValid(nil, "not an application name")
-	}
-	return nil
-}
-
-// CheckHolder is part of the lease.Secretary interface.
-func (leadershipSecretary) CheckHolder(name string) error {
-	if !names.IsValidUnit(name) {
-		return errors.NewNotValid(nil, "not a unit name")
-	}
-	return nil
-}
-
-// CheckDuration is part of the lease.Secretary interface.
-func (leadershipSecretary) CheckDuration(duration time.Duration) error {
-	if duration <= 0 {
-		return errors.NewNotValid(nil, "non-positive")
-	}
-	return nil
 }
 
 // leadershipChecker implements leadership.Checker by wrapping a lease.Checker.

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -204,6 +204,11 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		relationNetworksC,
 		firewallRulesC,
 		dockerResourcesC,
+		// TODO(raftlease)
+		// This collection shouldn't be migrated, but we need to make
+		// sure the leader units' leases are claimed in the target
+		// controller when leases are managed in raft.
+		leaseHoldersC,
 	)
 
 	modelCollections := set.NewStrings()

--- a/state/raftlease/package_test.go
+++ b/state/raftlease/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease_test
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}

--- a/state/raftlease/target.go
+++ b/state/raftlease/target.go
@@ -1,0 +1,256 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/mongo"
+)
+
+const (
+	// fieldNamespace identifies the namespace field in a leaseHolderDoc.
+	fieldNamespace = "namespace"
+
+	// fieldModelUUID identifies the model UUID field in a leaseHolderDoc.
+	fieldModelUUID = "model-uuid"
+
+	// fieldHolder identifies the holder field in a leaseHolderDoc.
+	fieldHolder = "holder"
+)
+
+// leaseHolderDoc is used to serialise lease holder info.
+type leaseHolderDoc struct {
+	Id        string `bson:"_id"`
+	Namespace string `bson:"namespace"`
+	ModelUUID string `bson:"model-uuid"`
+	Lease     string `bson:"lease"`
+	Holder    string `bson:"holder"`
+}
+
+// leaseHolderDocId returns the _id for the document holding details of the supplied
+// namespace and lease.
+func leaseHolderDocId(namespace, modelUUID, lease string) string {
+	return fmt.Sprintf("%s:%s#%s#", modelUUID, namespace, lease)
+}
+
+// validate returns an error if any fields are invalid or inconsistent.
+func (doc leaseHolderDoc) validate() error {
+	if doc.Id != leaseHolderDocId(doc.Namespace, doc.ModelUUID, doc.Lease) {
+		return errors.Errorf("inconsistent _id")
+	}
+	if err := lease.ValidateString(doc.Holder); err != nil {
+		return errors.Annotatef(err, "invalid holder")
+	}
+	return nil
+}
+
+// newLeaseHolderDoc returns a valid lease document encoding the supplied lease and
+// entry in the supplied namespace, or an error.
+func newLeaseHolderDoc(namespace, modelUUID, name, holder string) (*leaseHolderDoc, error) {
+	doc := &leaseHolderDoc{
+		Id:        leaseHolderDocId(namespace, modelUUID, name),
+		Namespace: namespace,
+		ModelUUID: modelUUID,
+		Lease:     name,
+		Holder:    holder,
+	}
+	if err := doc.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return doc, nil
+}
+
+// Mongo exposes MongoDB operations for use by the lease package.
+type Mongo interface {
+
+	// RunTransaction should probably delegate to a jujutxn.Runner's Run method.
+	RunTransaction(jujutxn.TransactionSource) error
+
+	// GetCollection should probably call the mongo.CollectionFromName func.
+	GetCollection(name string) (collection mongo.Collection, closer func())
+}
+
+// Logger allows us to report errors if we can't write to the database
+// for some reason.
+type Logger interface {
+	Errorf(string, ...interface{})
+}
+
+// NewNotifyTarget returns something that can be used to report lease
+// changes.
+func NewNotifyTarget(mongo Mongo, collection string, logDest io.Writer, errorLogger Logger) raftlease.NotifyTarget {
+	return &notifyTarget{
+		mongo:       mongo,
+		collection:  collection,
+		logger:      log.New(logDest, "", log.LstdFlags|log.Lmicroseconds|log.LUTC),
+		errorLogger: errorLogger,
+	}
+}
+
+// notifyTarget is a raftlease.NotifyTarget that updates the
+// information in mongo, as well as logging the lease changes.  Since
+// the callbacks it exposes aren't allowed to return errors, it takes
+// a logger for write errors as well as a destination for tracing
+// lease changes.
+type notifyTarget struct {
+	mongo       Mongo
+	collection  string
+	logger      *log.Logger
+	errorLogger Logger
+}
+
+func (t *notifyTarget) log(message string, args ...interface{}) {
+	err := t.logger.Output(2, fmt.Sprintf(message, args...))
+	if err != nil {
+		t.errorLogger.Errorf("couldn't write to lease log: %s", err.Error())
+	}
+}
+
+// Claimed is part of raftlease.NotifyTarget.
+func (t *notifyTarget) Claimed(key lease.Key, holder string) {
+	coll, closer := t.mongo.GetCollection(t.collection)
+	defer closer()
+	docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
+	err := t.mongo.RunTransaction(func(_ int) ([]txn.Op, error) {
+		existingDoc, err := getRecord(coll, docId)
+		switch {
+		case err == mgo.ErrNotFound:
+			doc, err := newLeaseHolderDoc(
+				key.Namespace,
+				key.ModelUUID,
+				key.Lease,
+				holder,
+			)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return []txn.Op{{
+				C:      t.collection,
+				Id:     docId,
+				Assert: txn.DocMissing,
+				Insert: doc,
+			}}, nil
+
+		case err != nil:
+			return nil, errors.Trace(err)
+
+		case existingDoc.Holder == holder:
+			return nil, jujutxn.ErrNoOperations
+
+		default:
+			return []txn.Op{{
+				C:  t.collection,
+				Id: docId,
+				Assert: bson.M{
+					fieldHolder: existingDoc.Holder,
+				},
+				Update: bson.M{
+					"$set": bson.M{
+						fieldHolder: holder,
+					},
+				},
+			}}, nil
+		}
+	})
+	if err != nil {
+		t.errorLogger.Errorf("couldn't claim lease %q for %q: %s", docId, holder, err.Error())
+		return
+	}
+	t.log("claimed %q for %q", docId, holder)
+}
+
+// Expired is part of raftlease.NotifyTarget.
+func (t *notifyTarget) Expired(key lease.Key) {
+	coll, closer := t.mongo.GetCollection(t.collection)
+	defer closer()
+	docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
+	err := t.mongo.RunTransaction(func(_ int) ([]txn.Op, error) {
+		existingDoc, err := getRecord(coll, docId)
+		if err == mgo.ErrNotFound {
+			return nil, jujutxn.ErrNoOperations
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return []txn.Op{{
+			C:  t.collection,
+			Id: docId,
+			Assert: bson.M{
+				fieldHolder: existingDoc.Holder,
+			},
+			Remove: true,
+		}}, nil
+	})
+
+	if err != nil {
+		t.errorLogger.Errorf("couldn't expire lease %q: %s", docId, err.Error())
+		return
+	}
+	t.log("expired %q", docId)
+}
+
+// Trapdoor is part of raftlease.NotifyTarget.
+func (t *notifyTarget) Trapdoor(key lease.Key, holder string) lease.Trapdoor {
+	op := txn.Op{
+		C: t.collection,
+		Id: leaseHolderDocId(
+			key.Namespace,
+			key.ModelUUID,
+			key.Lease,
+		),
+		Assert: bson.M{
+			fieldHolder: holder,
+		},
+	}
+	return func(out interface{}) error {
+		outPtr, ok := out.(*[]txn.Op)
+		if !ok {
+			return errors.NotValidf("expected *[]txn.Op; %T", out)
+		}
+		*outPtr = []txn.Op{op}
+		return nil
+	}
+}
+
+func getRecord(coll mongo.Collection, docId string) (leaseHolderDoc, error) {
+	var doc leaseHolderDoc
+	err := coll.FindId(docId).One(&doc)
+	if err != nil {
+		return leaseHolderDoc{}, err
+	}
+	return doc, nil
+}
+
+// LeaseHolders returns a map of each lease and the holder in the
+// specified namespace and model.
+func LeaseHolders(mongo Mongo, collection, namespace, modelUUID string) (map[string]string, error) {
+	coll, closer := mongo.GetCollection(collection)
+	defer closer()
+
+	iter := coll.Find(bson.M{
+		fieldNamespace: namespace,
+		fieldModelUUID: modelUUID,
+	}).Iter()
+	results := make(map[string]string)
+	var doc leaseHolderDoc
+	for iter.Next(&doc) {
+		results[doc.Lease] = doc.Holder
+	}
+
+	if err := iter.Close(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return results, nil
+}

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -1,0 +1,335 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease_test
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn"
+	txntesting "github.com/juju/txn/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/lease"
+	coreraftlease "github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state/raftlease"
+)
+
+const (
+	collection = "testleaseholders"
+	logPrefix  = `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{1,6} `
+)
+
+type targetSuite struct {
+	testing.IsolationSuite
+	testing.MgoSuite
+	db       *mgo.Database
+	mongo    *Mongo
+	errorLog loggo.Logger
+	leaseLog *bytes.Buffer
+}
+
+var _ = gc.Suite(&targetSuite{})
+
+func (s *targetSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	s.MgoSuite.SetUpSuite(c)
+}
+
+func (s *targetSuite) TearDownSuite(c *gc.C) {
+	s.MgoSuite.TearDownSuite(c)
+	s.IsolationSuite.TearDownSuite(c)
+}
+
+func (s *targetSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.MgoSuite.SetUpTest(c)
+	s.db = s.Session.DB("juju")
+	s.mongo = NewMongo(s.db)
+	s.errorLog = loggo.GetLogger("raftlease_test")
+	s.leaseLog = bytes.NewBuffer(nil)
+}
+
+func (s *targetSuite) TearDownTest(c *gc.C) {
+	s.MgoSuite.TearDownTest(c)
+	s.IsolationSuite.TearDownTest(c)
+}
+
+func (s *targetSuite) newTarget() coreraftlease.NotifyTarget {
+	return raftlease.NewNotifyTarget(s.mongo, collection, s.leaseLog, s.errorLog)
+}
+
+func (s *targetSuite) getRows(c *gc.C) []bson.M {
+	var results []bson.M
+	err := s.db.C(collection).Find(nil).Select(bson.M{
+		"namespace":  true,
+		"model-uuid": true,
+		"lease":      true,
+		"holder":     true,
+	}).All(&results)
+	c.Assert(err, jc.ErrorIsNil)
+	return results
+}
+
+func (s *targetSuite) TestClaimedNoRecord(c *gc.C) {
+	target := s.newTarget()
+	target.Claimed(lease.Key{"ns", "model", "ankles"}, "tailpipe")
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:ns#ankles#",
+		"namespace":  "ns",
+		"model-uuid": "model",
+		"lease":      "ankles",
+		"holder":     "tailpipe",
+	}})
+	s.assertLogMatches(c, `claimed "model:ns#ankles#" for "tailpipe"`)
+}
+
+func (s *targetSuite) TestClaimedAlreadyHolder(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:leadership#twin#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin",
+			"holder":     "voiid",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.newTarget().Claimed(
+		lease.Key{"leadership", "model", "twin"},
+		"voiid",
+	)
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:leadership#twin#",
+		"namespace":  "leadership",
+		"model-uuid": "model",
+		"lease":      "twin",
+		"holder":     "voiid",
+	}})
+	s.assertLogMatches(c, `claimed "model:leadership#twin#" for "voiid"`)
+}
+
+func (s *targetSuite) TestClaimedDifferentHolder(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:leadership#twin#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin",
+			"holder":     "shuffle",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.newTarget().Claimed(
+		lease.Key{"leadership", "model", "twin"},
+		"voiid",
+	)
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:leadership#twin#",
+		"namespace":  "leadership",
+		"model-uuid": "model",
+		"lease":      "twin",
+		"holder":     "voiid",
+	}})
+	s.assertLogMatches(c, `claimed "model:leadership#twin#" for "voiid"`)
+}
+
+func (s *targetSuite) TestClaimedRecordsChangeBetweenAttempts(c *gc.C) {
+	defer txntesting.SetBeforeHooks(c, s.mongo.runner, func() {
+		err := s.db.C(collection).Insert(
+			bson.M{
+				"_id":        "model:leadership#twin#",
+				"namespace":  "leadership",
+				"model-uuid": "model",
+				"lease":      "twin",
+				"holder":     "kitamura",
+			},
+		)
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+	s.newTarget().Claimed(
+		lease.Key{"leadership", "model", "twin"},
+		"voiid",
+	)
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:leadership#twin#",
+		"namespace":  "leadership",
+		"model-uuid": "model",
+		"lease":      "twin",
+		"holder":     "voiid",
+	}})
+	s.assertLogMatches(c, `claimed "model:leadership#twin#" for "voiid"`)
+}
+
+func (s *targetSuite) TestClaimedError(c *gc.C) {
+	var logWriter loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("raftlease-target-tests", &logWriter), jc.ErrorIsNil)
+	s.mongo.txnErr = errors.Errorf("oh no!")
+	s.newTarget().Claimed(lease.Key{"ns", "model", "lease"}, "me")
+	c.Assert(s.getRows(c), gc.HasLen, 0)
+	c.Assert(logWriter.Log(), jc.LogMatches, []string{
+		`couldn't claim lease "model:ns#lease#" for "me": oh no!`,
+	})
+}
+
+func (s *targetSuite) assertLogMatches(c *gc.C, expectLines ...string) {
+	lines := strings.Split(string(s.leaseLog.Bytes()), "\n")
+	c.Assert(lines, gc.HasLen, len(expectLines)+1)
+	for i, expected := range expectLines {
+		c.Assert(lines[i], gc.Matches, logPrefix+expected, gc.Commentf("line %d", i))
+	}
+	c.Assert(lines[len(expectLines)], gc.Equals, "")
+}
+
+func (s *targetSuite) TestExpired(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:leadership#twin#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin",
+			"holder":     "kitamura",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.newTarget().Expired(lease.Key{"leadership", "model", "twin"})
+	c.Assert(s.getRows(c), gc.HasLen, 0)
+	s.assertLogMatches(c, `expired "model:leadership#twin#"`)
+}
+
+func (s *targetSuite) TestExpiredNoRecord(c *gc.C) {
+	s.newTarget().Expired(lease.Key{"leadership", "model", "twin"})
+	c.Assert(s.getRows(c), gc.HasLen, 0)
+	s.assertLogMatches(c, `expired "model:leadership#twin#"`)
+}
+
+func (s *targetSuite) TestExpiredRemovedWhileRunning(c *gc.C) {
+	coll := s.db.C(collection)
+	err := coll.Insert(
+		bson.M{
+			"_id":        "model:leadership#twin#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin",
+			"holder":     "kitamura",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	defer txntesting.SetBeforeHooks(c, s.mongo.runner, func() {
+		c.Assert(coll.Remove(nil), jc.ErrorIsNil)
+	}).Check()
+	s.newTarget().Expired(lease.Key{"leadership", "model", "twin"})
+	c.Assert(s.getRows(c), gc.HasLen, 0)
+	s.assertLogMatches(c, `expired "model:leadership#twin#"`)
+}
+
+func (s *targetSuite) TestExpiredError(c *gc.C) {
+	var logWriter loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("raftlease-target-tests", &logWriter), jc.ErrorIsNil)
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:leadership#twin#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin",
+			"holder":     "kitamura",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.mongo.txnErr = errors.Errorf("oops!")
+	s.newTarget().Expired(lease.Key{"leadership", "model", "twin"})
+	c.Assert(logWriter.Log(), jc.LogMatches, []string{
+		`couldn't expire lease "model:leadership#twin#": oops!`,
+	})
+}
+
+func (s *targetSuite) TestTrapdoor(c *gc.C) {
+	trapdoor := s.newTarget().Trapdoor(lease.Key{"ns", "model", "landfall"}, "roy")
+	var result []txn.Op
+	err := trapdoor(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, []txn.Op{{
+		C:      collection,
+		Id:     "model:ns#landfall#",
+		Assert: bson.M{"holder": "roy"},
+	}})
+	var bad int
+	c.Assert(trapdoor(&bad), gc.ErrorMatches, `expected \*\[\]txn\.Op; \*int not valid`)
+}
+
+func (s *targetSuite) TestLeaseHolders(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"namespace":  "singular",
+			"model-uuid": "model",
+			"lease":      "cogitans",
+			"holder":     "planete",
+		},
+		bson.M{
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "cogitans",
+			"holder":     "res",
+		},
+		bson.M{
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin",
+			"holder":     "voiid",
+		},
+		bson.M{
+			"namespace":  "leadership",
+			"model-uuid": "model2",
+			"lease":      "thorn",
+			"holder":     "dornik",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	holders, err := raftlease.LeaseHolders(s.mongo, collection, "leadership", "model")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(holders, gc.DeepEquals, map[string]string{
+		"cogitans": "res",
+		"twin":     "voiid",
+	})
+}
+
+// Mongo exposes database operations. It uses a real database -- we can't mock
+// mongo out, we need to check it really actually works -- but it's good to
+// have the runner accessible for adversarial transaction tests.
+type Mongo struct {
+	database *mgo.Database
+	runner   jujutxn.Runner
+	txnErr   error
+}
+
+// NewMongo returns a *Mongo backed by the supplied database.
+func NewMongo(database *mgo.Database) *Mongo {
+	return &Mongo{
+		database: database,
+		runner: jujutxn.NewRunner(jujutxn.RunnerParams{
+			Database: database,
+		}),
+	}
+}
+
+// GetCollection is part of the lease.Mongo interface.
+func (m *Mongo) GetCollection(name string) (mongo.Collection, func()) {
+	return mongo.CollectionFromName(m.database, name)
+}
+
+// RunTransaction is part of the lease.Mongo interface.
+func (m *Mongo) RunTransaction(getTxn jujutxn.TransactionSource) error {
+	if m.txnErr != nil {
+		return m.txnErr
+	}
+	return m.runner.Run(getTxn)
+}

--- a/state/singular.go
+++ b/state/singular.go
@@ -4,51 +4,8 @@
 package state
 
 import (
-	"time"
-
-	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/juju/core/lease"
 )
-
-// singularSecretary implements lease.Secretary to restrict claims to either
-// a lease for the controller or a specific model, holdable only by machine-tag
-// strings.
-//
-// It would be nicer to have a single controller-level component managing all
-// singular leases for all models -- and thus be able to validate that
-// proposed holders really are env managers -- but the complexity of threading
-// data from *two* states through a single api connection is excessive by
-// comparison.
-type singularSecretary struct {
-	controllerUUID string
-	modelUUID      string
-}
-
-// CheckLease is part of the lease.Secretary interface.
-func (s singularSecretary) CheckLease(name string) error {
-	if name != s.controllerUUID && name != s.modelUUID {
-		return errors.New("expected controller or model UUID")
-	}
-	return nil
-}
-
-// CheckHolder is part of the lease.Secretary interface.
-func (s singularSecretary) CheckHolder(name string) error {
-	if _, err := names.ParseMachineTag(name); err != nil {
-		return errors.New("expected machine tag")
-	}
-	return nil
-}
-
-// CheckDuration is part of the lease.Secretary interface.
-func (s singularSecretary) CheckDuration(duration time.Duration) error {
-	if duration <= 0 {
-		return errors.NewNotValid(nil, "non-positive")
-	}
-	return nil
-}
 
 // SingularClaimer returns a lease.Claimer representing the exclusive right to
 // manage the model.

--- a/state/state.go
+++ b/state/state.go
@@ -8,6 +8,7 @@ package state
 
 import (
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strconv"
@@ -36,7 +37,9 @@ import (
 	"github.com/juju/juju/core/application"
 	coreglobalclock "github.com/juju/juju/core/globalclock"
 	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -45,6 +48,7 @@ import (
 	"github.com/juju/juju/state/globalclock"
 	statelease "github.com/juju/juju/state/lease"
 	"github.com/juju/juju/state/presence"
+	raftleasestore "github.com/juju/juju/state/raftlease"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
 	jujuversion "github.com/juju/juju/version"
@@ -419,6 +423,18 @@ func (st *State) start(controllerTag names.ControllerTag, hub *pubsub.SimpleHub)
 // ApplicationLeaders returns a map of the application name to the
 // unit name that is the current leader.
 func (st *State) ApplicationLeaders() (map[string]string, error) {
+	config, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !config.Features().Contains(feature.LegacyLeases) {
+		return raftleasestore.LeaseHolders(
+			&environMongo{st},
+			leaseHoldersC,
+			lease.ApplicationLeadershipNamespace,
+			st.ModelUUID(),
+		)
+	}
 	store, err := st.getLeadershipLeaseStore()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -432,11 +448,11 @@ func (st *State) ApplicationLeaders() (map[string]string, error) {
 }
 
 func (st *State) getLeadershipLeaseStore() (lease.Store, error) {
-	return st.getLeaseStore(applicationLeadershipNamespace)
+	return st.getLeaseStore(lease.ApplicationLeadershipNamespace)
 }
 
 func (st *State) getSingularLeaseStore() (lease.Store, error) {
-	return st.getLeaseStore(singularControllerNamespace)
+	return st.getLeaseStore(lease.SingularControllerNamespace)
 }
 
 func (st *State) getLeaseStore(namespace string) (lease.Store, error) {
@@ -467,6 +483,12 @@ func (st *State) getLeaseStore(namespace string) (lease.Store, error) {
 		return nil, errors.Annotatef(err, "cannot create %q lease store", namespace)
 	}
 	return store, nil
+}
+
+// LeaseNotifyTarget returns a raftlease.NotifyTarget for storing
+// lease changes in the database.
+func (st *State) LeaseNotifyTarget(logDest io.Writer, errorLogger raftleasestore.Logger) raftlease.NotifyTarget {
+	return raftleasestore.NewNotifyTarget(&environMongo{st}, leaseHoldersC, logDest, errorLogger)
 }
 
 // ModelUUID returns the model UUID for the model

--- a/state/workers.go
+++ b/state/workers.go
@@ -66,7 +66,7 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 		return presence.NewPingBatcher(st.getPresenceCollection(), pingFlushInterval), nil
 	})
 	ws.StartWorker(leadershipWorker, func() (worker.Worker, error) {
-		manager, err := st.newLeaseManager(st.getLeadershipLeaseStore, leadershipSecretary{}, st.ModelUUID())
+		manager, err := st.newLeaseManager(st.getLeadershipLeaseStore, lease.LeadershipSecretary{}, st.ModelUUID())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -74,9 +74,8 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 	})
 	ws.StartWorker(singularWorker, func() (worker.Worker, error) {
 		manager, err := st.newLeaseManager(st.getSingularLeaseStore,
-			singularSecretary{
-				controllerUUID: st.ControllerUUID(),
-				modelUUID:      st.ModelUUID(),
+			lease.SingularSecretary{
+				ControllerUUID: st.ControllerUUID(),
 			},
 			st.ControllerUUID(),
 		)
@@ -103,6 +102,7 @@ func (st *State) newLeaseManager(
 		},
 		Store:      store,
 		Clock:      st.clock(),
+		Logger:     loggo.GetLogger("juju.worker.lease.mongo"),
 		MaxSleep:   time.Minute,
 		EntityUUID: entityUUID,
 	})

--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common"
@@ -35,6 +36,7 @@ type ManifoldConfig struct {
 	StateName              string
 	UpgradeGateName        string
 	AuditConfigUpdaterName string
+	LeaseManagerName       string
 
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
@@ -70,6 +72,9 @@ func (config ManifoldConfig) Validate() error {
 	if config.AuditConfigUpdaterName == "" {
 		return errors.NotValidf("empty AuditConfigUpdaterName")
 	}
+	if config.LeaseManagerName == "" {
+		return errors.NotValidf("empty LeaseManagerName")
+	}
 	if config.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
 	}
@@ -102,6 +107,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.StateName,
 			config.UpgradeGateName,
 			config.AuditConfigUpdaterName,
+			config.LeaseManagerName,
 		},
 		Start: config.start,
 	}
@@ -152,6 +158,11 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
+	var leaseManager lease.Manager
+	if err := context.Get(config.LeaseManagerName, &leaseManager); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// Get the state pool after grabbing dependencies so we don't need
 	// to remember to call Done on it if they're not running yet.
 	statePool, err := stTracker.Use()
@@ -164,6 +175,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		Clock:                             clock,
 		Mux:                               mux,
 		StatePool:                         statePool,
+		LeaseManager:                      leaseManager,
 		PrometheusRegisterer:              config.PrometheusRegisterer,
 		RegisterIntrospectionHTTPHandlers: config.RegisterIntrospectionHTTPHandlers,
 		RestoreStatus:                     restoreStatus,

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 )
@@ -33,6 +34,7 @@ type Config struct {
 	Mux                               *apiserverhttp.Mux
 	Authenticator                     httpcontext.LocalMacaroonAuthenticator
 	StatePool                         *state.StatePool
+	LeaseManager                      lease.Manager
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
 	RestoreStatus                     func() state.RestoreStatus
@@ -67,6 +69,9 @@ func (config Config) Validate() error {
 	}
 	if config.Authenticator == nil {
 		return errors.NotValidf("nil Authenticator")
+	}
+	if config.LeaseManager == nil {
+		return errors.NotValidf("nil LeaseManager")
 	}
 	if config.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
@@ -138,6 +143,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		LogSinkConfig:                 &logSinkConfig,
 		PrometheusRegisterer:          config.PrometheusRegisterer,
 		GetAuditConfig:                config.GetAuditConfig,
+		LeaseManager:                  config.LeaseManager,
 	}
 	return config.NewServer(serverConfig)
 }

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -119,5 +119,6 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		RateLimitConfig:      rateLimitConfig,
 		LogSinkConfig:        &logSinkConfig,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		LeaseManager:         s.leaseManager,
 	})
 }

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,6 +17,7 @@ import (
 	dt "gopkg.in/juju/worker.v1/dependency/testing"
 	"gopkg.in/juju/worker.v1/workertest"
 
+	"github.com/juju/juju/core/globalclock"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/globalclockupdater"
@@ -27,6 +29,7 @@ type ManifoldSuite struct {
 	config       globalclockupdater.ManifoldConfig
 	stateTracker stubStateTracker
 	worker       worker.Worker
+	logger       loggo.Logger
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
@@ -34,12 +37,14 @@ var _ = gc.Suite(&ManifoldSuite{})
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.stub.ResetCalls()
+	s.logger = loggo.GetLogger("globalclockupdater_test")
 	s.config = globalclockupdater.ManifoldConfig{
 		ClockName:      "clock",
 		StateName:      "state",
 		NewWorker:      s.newWorker,
 		UpdateInterval: time.Second,
 		BackoffDelay:   time.Second,
+		Logger:         s.logger,
 	}
 	s.stateTracker = stubStateTracker{
 		done: make(chan struct{}),
@@ -62,6 +67,14 @@ func (s *ManifoldSuite) TestInputs(c *gc.C) {
 	c.Check(manifold.Inputs, jc.DeepEquals, expectInputs)
 }
 
+func (s *ManifoldSuite) TestLeaseManagerInputs(c *gc.C) {
+	s.config.StateName = ""
+	s.config.LeaseManagerName = "lease-manager"
+	manifold := globalclockupdater.Manifold(s.config)
+	expectInputs := []string{"clock", "lease-manager"}
+	c.Check(manifold.Inputs, jc.DeepEquals, expectInputs)
+}
+
 func (s *ManifoldSuite) TestStartValidateClockName(c *gc.C) {
 	s.config.ClockName = ""
 	s.testStartValidateConfig(c, "empty ClockName not valid")
@@ -69,7 +82,12 @@ func (s *ManifoldSuite) TestStartValidateClockName(c *gc.C) {
 
 func (s *ManifoldSuite) TestStartValidateStateName(c *gc.C) {
 	s.config.StateName = ""
-	s.testStartValidateConfig(c, "empty StateName not valid")
+	s.testStartValidateConfig(c, "both StateName and LeaseManagerName empty not valid")
+}
+
+func (s *ManifoldSuite) TestStartValidateNotBoth(c *gc.C) {
+	s.config.LeaseManagerName = "lease-manager"
+	s.testStartValidateConfig(c, "only one of StateName and LeaseManagerName can be set")
 }
 
 func (s *ManifoldSuite) TestStartValidateUpdateInterval(c *gc.C) {
@@ -97,6 +115,20 @@ func (s *ManifoldSuite) TestStartMissingClock(c *gc.C) {
 	manifold := globalclockupdater.Manifold(s.config)
 	context := dt.StubContext(nil, map[string]interface{}{
 		"clock": dependency.ErrMissing,
+	})
+
+	worker, err := manifold.Start(context)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartMissingLeaseManager(c *gc.C) {
+	s.config.StateName = ""
+	s.config.LeaseManagerName = "lease-manager"
+	manifold := globalclockupdater.Manifold(s.config)
+	context := dt.StubContext(nil, map[string]interface{}{
+		"clock":         fakeClock{},
+		"lease-manager": dependency.ErrMissing,
 	})
 
 	worker, err := manifold.Start(context)
@@ -144,6 +176,33 @@ func (s *ManifoldSuite) TestStartNewWorkerSuccess(c *gc.C) {
 		LocalClock:     fakeClock{},
 		UpdateInterval: s.config.UpdateInterval,
 		BackoffDelay:   s.config.BackoffDelay,
+		Logger:         s.logger,
+	})
+}
+
+func (s *ManifoldSuite) TestStartNewWorkerSuccessWithLeaseManager(c *gc.C) {
+	updater := fakeUpdater{}
+	s.config.StateName = ""
+	s.config.LeaseManagerName = "lease-manager"
+	worker, err := s.startManifoldWithContext(c, map[string]interface{}{
+		"clock":         fakeClock{},
+		"lease-manager": &updater,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, s.worker)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	config := s.stub.Calls()[0].Args[0].(globalclockupdater.Config)
+	c.Assert(config.NewUpdater, gc.NotNil)
+	actualUpdater, err := config.NewUpdater()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actualUpdater, gc.Equals, &updater)
+	config.NewUpdater = nil
+	c.Assert(config, jc.DeepEquals, globalclockupdater.Config{
+		LocalClock:     fakeClock{},
+		UpdateInterval: s.config.UpdateInterval,
+		BackoffDelay:   s.config.BackoffDelay,
+		Logger:         s.logger,
 	})
 }
 
@@ -168,12 +227,10 @@ func (s *ManifoldSuite) TestStoppingWorkerReleasesState(c *gc.C) {
 }
 
 func (s *ManifoldSuite) startManifold(c *gc.C) (worker.Worker, error) {
-	manifold := globalclockupdater.Manifold(s.config)
-	context := dt.StubContext(nil, map[string]interface{}{
+	worker, err := s.startManifoldWithContext(c, map[string]interface{}{
 		"clock": fakeClock{},
 		"state": &s.stateTracker,
 	})
-	worker, err := manifold.Start(context)
 	if err != nil {
 		return nil, err
 	}
@@ -183,11 +240,25 @@ func (s *ManifoldSuite) startManifold(c *gc.C) (worker.Worker, error) {
 		workertest.DirtyKill(c, worker)
 		s.stateTracker.waitDone(c)
 	})
+	return worker, err
+}
+
+func (s *ManifoldSuite) startManifoldWithContext(c *gc.C, data map[string]interface{}) (worker.Worker, error) {
+	manifold := globalclockupdater.Manifold(s.config)
+	context := dt.StubContext(nil, data)
+	worker, err := manifold.Start(context)
+	if err != nil {
+		return nil, err
+	}
 	return worker, nil
 }
 
 type fakeClock struct {
 	clock.Clock
+}
+
+type fakeUpdater struct {
+	globalclock.Updater
 }
 
 type stubStateTracker struct {

--- a/worker/globalclockupdater/worker.go
+++ b/worker/globalclockupdater/worker.go
@@ -8,14 +8,16 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/globalclock"
 )
 
-var logger = loggo.GetLogger("juju.worker.globalclockupdater")
+// Logger defines the methods we use from loggo.Logger.
+type Logger interface {
+	Tracef(string, ...interface{})
+}
 
 // Config contains the configuration for the global clock updater worker.
 type Config struct {
@@ -32,6 +34,9 @@ type Config struct {
 	// BackoffDelay is the amount of time to delay before attempting
 	// another update when a concurrent write is detected.
 	BackoffDelay time.Duration
+
+	// Logger determines where we write log messages.
+	Logger Logger
 }
 
 // Validate validates the configuration.
@@ -47,6 +52,9 @@ func (config Config) Validate() error {
 	}
 	if config.BackoffDelay <= 0 {
 		return errors.NotValidf("non-positive BackoffDelay")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
 	}
 	return nil
 }
@@ -104,15 +112,15 @@ func (w *updaterWorker) loop() error {
 			now := w.config.LocalClock.Now()
 			amount := now.Sub(last)
 			err := w.updater.Advance(amount)
-			if err == globalclock.ErrConcurrentUpdate {
-				logger.Tracef("concurrent update, backing off for %s", backoff)
+			if errors.Cause(err) == globalclock.ErrConcurrentUpdate {
+				w.config.Logger.Tracef("concurrent update, backing off for %s", backoff)
 				last = w.config.LocalClock.Now()
 				timer.Reset(backoff)
 				continue
 			} else if err != nil {
 				return errors.Annotate(err, "updating global clock")
 			}
-			logger.Tracef("incremented global time by %s", interval)
+			w.config.Logger.Tracef("incremented global time by %s", interval)
 			last = w.config.LocalClock.Now()
 			timer.Reset(interval)
 		}

--- a/worker/globalclockupdater/worker_test.go
+++ b/worker/globalclockupdater/worker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -43,6 +44,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		LocalClock:     s.localClock,
 		UpdateInterval: time.Second,
 		BackoffDelay:   time.Minute,
+		Logger:         loggo.GetLogger("globalclockupdater_test"),
 	}
 }
 
@@ -117,7 +119,7 @@ func (s *WorkerSuite) TestWorkerBackoffOnConcurrentUpdate(c *gc.C) {
 	c.Check(worker, gc.NotNil)
 	defer workertest.CleanKill(c, worker)
 
-	s.updater.SetErrors(globalclock.ErrConcurrentUpdate)
+	s.updater.SetErrors(errors.Annotate(globalclock.ErrConcurrentUpdate, "context info"))
 
 	s.localClock.WaitAdvance(time.Second, time.Second, 1)
 	select {

--- a/worker/lease/check.go
+++ b/worker/lease/check.go
@@ -29,7 +29,7 @@ func (t token) Check(trapdoorKey interface{}) error {
 	// factory.
 	//
 	// Fixing that would be great but seems out of scope.
-	if err := t.secretary.CheckLease(t.leaseKey.Lease); err != nil {
+	if err := t.secretary.CheckLease(t.leaseKey); err != nil {
 		return errors.Annotatef(err, "cannot check lease %q", t.leaseKey.Lease)
 	}
 	if err := t.secretary.CheckHolder(t.holderName); err != nil {

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -17,13 +17,20 @@ import (
 type Secretary interface {
 
 	// CheckLease returns an error if the supplied lease name is not valid.
-	CheckLease(name string) error
+	CheckLease(key lease.Key) error
 
 	// CheckHolder returns an error if the supplied holder name is not valid.
 	CheckHolder(name string) error
 
 	// CheckDuration returns an error if the supplied duration is not valid.
 	CheckDuration(duration time.Duration) error
+}
+
+// Logger represents the logging methods we use from a loggo.Logger.
+type Logger interface {
+	Tracef(string, ...interface{})
+	Debugf(string, ...interface{})
+	Errorf(string, ...interface{})
 }
 
 // ManagerConfig contains the resources and information required to create a
@@ -37,6 +44,10 @@ type ManagerConfig struct {
 
 	// Store is responsible for recording, retrieving, and expiring leases.
 	Store lease.Store
+
+	// Logger is used to report debugging/status information as the
+	// manager runs.
+	Logger Logger
 
 	// Clock is responsible for reporting the passage of time.
 	Clock clock.Clock
@@ -58,6 +69,9 @@ func (config ManagerConfig) Validate() error {
 	}
 	if config.Store == nil {
 		return errors.NotValidf("nil Store")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")

--- a/worker/lease/fixture_test.go
+++ b/worker/lease/fixture_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -92,6 +93,7 @@ func (fix *Fixture) RunTest(c *gc.C, test func(*lease.Manager, *testclock.Clock)
 			return Secretary{}, nil
 		},
 		MaxSleep: defaultMaxSleep,
+		Logger:   loggo.GetLogger("lease_test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -193,6 +194,7 @@ func (s *CrossSuite) TestDifferentNamespaceValidation(c *gc.C) {
 			}
 		},
 		MaxSleep: defaultMaxSleep,
+		Logger:   loggo.GetLogger("lease_test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
@@ -219,7 +221,7 @@ func (s *CrossSuite) TestDifferentNamespaceValidation(c *gc.C) {
 type OtherSecretary struct{}
 
 // CheckLease is part of the lease.Secretary interface.
-func (OtherSecretary) CheckLease(name string) error {
+func (OtherSecretary) CheckLease(key corelease.Key) error {
 	return errors.NotValidf("lease name")
 }
 

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -1,0 +1,261 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manifold
+
+// This needs to be in a different package from the lease manager
+// because it uses state (to construct the raftlease store), but the
+// lease manager also runs as a worker in state, so the state package
+// depends on worker/lease. Having it in worker/lease produces an
+// import cycle.
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"github.com/juju/utils"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/globalclock"
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/common"
+	"github.com/juju/juju/worker/lease"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+const (
+	// MaxSleep is the longest the manager will sleep before checking
+	// whether any leases should be expired. If it can see a lease
+	// expiring sooner than that it will still wake up earlier.
+	MaxSleep = time.Minute
+
+	// ForwardTimeout is how long the store should wait for a response
+	// after sending a lease operation over the hub.
+	ForwardTimeout = 200 * time.Millisecond
+
+	// maxLogs is the maximum number of backup store log files to keep.
+	maxLogs = 10
+
+	// maxLogSizeMB is the maximum size of the store log file on disk
+	// in megabytes.
+	maxLogSizeMB = 30
+)
+
+// TODO(raftlease): This manifold does too much - split out a worker
+// that holds the lease store and a manifold that creates it. Then
+// make this one depend on that.
+
+// ManifoldConfig holds the resources needed to start the lease
+// manager in a dependency engine.
+type ManifoldConfig struct {
+	AgentName      string
+	ClockName      string
+	StateName      string
+	CentralHubName string
+
+	FSM          *raftlease.FSM
+	RequestTopic string
+	Logger       lease.Logger
+	NewWorker    func(lease.ManagerConfig) (worker.Worker, error)
+	NewStore     func(raftlease.StoreConfig) *raftlease.Store
+	NewTarget    func(*state.State, io.Writer, lease.Logger) raftlease.NotifyTarget
+}
+
+// Validate checks that the config has all the required values.
+func (c ManifoldConfig) Validate() error {
+	if c.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if c.ClockName == "" {
+		return errors.NotValidf("empty ClockName")
+	}
+	if c.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if c.CentralHubName == "" {
+		return errors.NotValidf("empty CentralHubName")
+	}
+	if c.FSM == nil {
+		return errors.NotValidf("nil FSM")
+	}
+	if c.RequestTopic == "" {
+		return errors.NotValidf("empty RequestTopic")
+	}
+	if c.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if c.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if c.NewStore == nil {
+		return errors.NotValidf("nil NewStore")
+	}
+	if c.NewTarget == nil {
+		return errors.NotValidf("nil NewTarget")
+	}
+	return nil
+}
+
+type manifoldState struct {
+	config ManifoldConfig
+	store  *raftlease.Store
+}
+
+func (s *manifoldState) start(context dependency.Context) (worker.Worker, error) {
+	if err := s.config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(s.config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var clock clock.Clock
+	if err := context.Get(s.config.ClockName, &clock); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var hub *pubsub.StructuredHub
+	if err := context.Get(s.config.CentralHubName, &hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(s.config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	st := statePool.SystemState()
+
+	source := rand.NewSource(clock.Now().UnixNano())
+	runID := rand.New(source).Int31()
+
+	logPath := filepath.Join(agent.CurrentConfig().LogDir(), "lease.log")
+	if err := primeLogFile(logPath); err != nil {
+		// This isn't a fatal error, so log and continue if priming
+		// fails.
+		s.config.Logger.Errorf(
+			"unable to prime log file %q (proceeding anyway): %s",
+			logPath,
+			err.Error(),
+		)
+	}
+
+	notifyTarget := s.config.NewTarget(st, makeLogger(logPath), s.config.Logger)
+	s.store = s.config.NewStore(raftlease.StoreConfig{
+		FSM:          s.config.FSM,
+		Hub:          hub,
+		Target:       notifyTarget,
+		RequestTopic: s.config.RequestTopic,
+		ResponseTopic: func(requestID uint64) string {
+			return fmt.Sprintf("%s.%08x.%d", s.config.RequestTopic, runID, requestID)
+		},
+		Clock:          clock,
+		ForwardTimeout: ForwardTimeout,
+	})
+
+	controllerUUID := agent.CurrentConfig().Controller().Id()
+	w, err := s.config.NewWorker(lease.ManagerConfig{
+		Secretary:  lease.SecretaryFinder(controllerUUID),
+		Store:      s.store,
+		Clock:      clock,
+		Logger:     s.config.Logger,
+		MaxSleep:   MaxSleep,
+		EntityUUID: controllerUUID,
+	})
+	if err != nil {
+		stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+	return common.NewCleanupWorker(w, func() { stTracker.Done() }), nil
+}
+
+func (s *manifoldState) output(in worker.Worker, out interface{}) error {
+	if w, ok := in.(*common.CleanupWorker); ok {
+		in = w.Worker
+	}
+	manager, ok := in.(*lease.Manager)
+	if !ok {
+		return errors.Errorf("expected input of type *worker/lease.Manager, got %T", in)
+	}
+	switch out := out.(type) {
+	case *globalclock.Updater:
+		*out = s.store
+		return nil
+	case *corelease.Manager:
+		*out = manager
+		return nil
+	default:
+		return errors.Errorf("expected output of type *globalclock.Updater or *core/lease.Manager, got %T", out)
+	}
+}
+
+// Manifold builds a dependency.Manifold for running a lease manager.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	s := manifoldState{config: config}
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.ClockName,
+			config.StateName,
+			config.CentralHubName,
+		},
+		Start:  s.start,
+		Output: s.output,
+	}
+}
+
+// NewWorker wraps NewManager to return worker.Worker for testability.
+func NewWorker(config lease.ManagerConfig) (worker.Worker, error) {
+	return lease.NewManager(config)
+}
+
+// NewStore is a shim to make a raftlease.Store for testability.
+func NewStore(config raftlease.StoreConfig) *raftlease.Store {
+	return raftlease.NewStore(config)
+}
+
+// NewTarget is a shim to construct a raftlease.NotifyTarget for testability.
+func NewTarget(st *state.State, logFile io.Writer, errorLog lease.Logger) raftlease.NotifyTarget {
+	return st.LeaseNotifyTarget(logFile, errorLog)
+}
+
+func makeLogger(path string) *lumberjack.Logger {
+	return &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    maxLogSizeMB,
+		MaxBackups: maxLogs,
+		Compress:   true,
+	}
+}
+
+// primeLogFile ensures the lease log file is created with the
+// correct mode and ownership.
+func primeLogFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	err = utils.ChownPath(path, "syslog")
+	return errors.Trace(err)
+}

--- a/worker/lease/manifold/manifold_test.go
+++ b/worker/lease/manifold/manifold_test.go
@@ -1,0 +1,297 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manifold_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+	"gopkg.in/juju/worker.v1/workertest"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/globalclock"
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/common"
+	"github.com/juju/juju/worker/lease"
+	leasemanager "github.com/juju/juju/worker/lease/manifold"
+)
+
+type manifoldSuite struct {
+	testing.IsolationSuite
+
+	context  dependency.Context
+	manifold dependency.Manifold
+
+	agent        *mockAgent
+	clock        *testclock.Clock
+	stateTracker *stubStateTracker
+	hub          *pubsub.StructuredHub
+
+	fsm    *raftlease.FSM
+	logger loggo.Logger
+
+	worker worker.Worker
+	store  *raftlease.Store
+	target raftlease.NotifyTarget
+
+	logDir string
+	stub   testing.Stub
+}
+
+var _ = gc.Suite(&manifoldSuite{})
+
+func (s *manifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub.ResetCalls()
+
+	s.logDir = c.MkDir()
+	s.agent = &mockAgent{conf: mockAgentConfig{
+		logDir: s.logDir,
+		uuid:   "controller-uuid",
+	}}
+	s.clock = testclock.NewClock(time.Now())
+	s.stateTracker = &stubStateTracker{
+		done: make(chan struct{}),
+	}
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.fsm = raftlease.NewFSM()
+	s.logger = loggo.GetLogger("lease.manifold_test")
+
+	s.worker = &mockWorker{}
+	s.store = &raftlease.Store{}
+	s.target = &struct{ raftlease.NotifyTarget }{}
+
+	s.context = s.newContext(nil)
+	s.manifold = leasemanager.Manifold(leasemanager.ManifoldConfig{
+		AgentName:      "agent",
+		ClockName:      "clock",
+		StateName:      "state",
+		CentralHubName: "hub",
+		FSM:            s.fsm,
+		RequestTopic:   "lease.manifold_test",
+		Logger:         &s.logger,
+		NewWorker:      s.newWorker,
+		NewStore:       s.newStore,
+		NewTarget:      s.newTarget,
+	})
+}
+
+func (s *manifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"agent": s.agent,
+		"clock": s.clock,
+		"state": s.stateTracker,
+		"hub":   s.hub,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *manifoldSuite) newWorker(config lease.ManagerConfig) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+func (s *manifoldSuite) newStore(config raftlease.StoreConfig) *raftlease.Store {
+	s.stub.MethodCall(s, "NewStore", config)
+	return s.store
+}
+
+func (s *manifoldSuite) newTarget(st *state.State, logFile io.Writer, logger lease.Logger) raftlease.NotifyTarget {
+	s.stub.MethodCall(s, "NewTarget", st, logFile, logger)
+	return s.target
+}
+
+var expectedInputs = []string{
+	"agent", "clock", "state", "hub",
+}
+
+func (s *manifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *manifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *manifoldSuite) TestStart(c *gc.C) {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	cleanupW, ok := w.(*common.CleanupWorker)
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(cleanupW.Worker, gc.Equals, s.worker)
+
+	s.stub.CheckCallNames(c, "NewTarget", "NewStore", "NewWorker")
+
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 3)
+	c.Assert(args[0], gc.Equals, s.stateTracker.pool.SystemState())
+	c.Assert(args[1], gc.FitsTypeOf, &lumberjack.Logger{})
+
+	expectedPath := filepath.Join(s.logDir, "lease.log")
+	c.Assert(args[1].(*lumberjack.Logger).Filename, gc.Equals, expectedPath)
+	stat, err := os.Stat(expectedPath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stat.Mode(), gc.Equals, os.FileMode(0600))
+	c.Assert(args[2], gc.Equals, &s.logger)
+
+	args = s.stub.Calls()[1].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, raftlease.StoreConfig{})
+	storeConfig := args[0].(raftlease.StoreConfig)
+	c.Assert(storeConfig.ResponseTopic(1234), gc.Matches, "lease.manifold_test.[0-9a-f]{8}.1234")
+	storeConfig.ResponseTopic = nil
+	c.Assert(storeConfig, gc.DeepEquals, raftlease.StoreConfig{
+		FSM:            s.fsm,
+		Hub:            s.hub,
+		Target:         s.target,
+		RequestTopic:   "lease.manifold_test",
+		Clock:          s.clock,
+		ForwardTimeout: 200 * time.Millisecond,
+	})
+
+	args = s.stub.Calls()[2].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, lease.ManagerConfig{})
+	config := args[0].(lease.ManagerConfig)
+
+	secretary, err := config.Secretary(corelease.SingularControllerNamespace)
+	c.Assert(err, jc.ErrorIsNil)
+	// Check that this secretary knows the controller uuid.
+	err = secretary.CheckLease(corelease.Key{"", "", "controller-uuid"})
+	c.Assert(err, jc.ErrorIsNil)
+	config.Secretary = nil
+
+	c.Assert(config, jc.DeepEquals, lease.ManagerConfig{
+		Store:      s.store,
+		Clock:      s.clock,
+		Logger:     &s.logger,
+		MaxSleep:   time.Minute,
+		EntityUUID: "controller-uuid",
+	})
+}
+
+func (s *manifoldSuite) TestStoppingWorkerReleasesState(c *gc.C) {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stateTracker.CheckCallNames(c, "Use")
+	select {
+	case <-s.stateTracker.done:
+		c.Fatal("unexpected state release")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// Stopping the worker should cause the state to
+	// eventually be released.
+	workertest.CleanKill(c, w)
+
+	s.stateTracker.waitDone(c)
+	s.stateTracker.CheckCallNames(c, "Use", "Done")
+}
+
+func (s *manifoldSuite) TestOutput(c *gc.C) {
+	s.worker = &lease.Manager{}
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var updater globalclock.Updater
+	err = s.manifold.Output(w, &updater)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(updater, gc.Equals, s.store)
+
+	var manager corelease.Manager
+	err = s.manifold.Output(w, &manager)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(manager, gc.Equals, s.worker)
+
+	var other io.Writer
+	err = s.manifold.Output(w, &other)
+	c.Assert(err, gc.ErrorMatches, `expected output of type \*globalclock.Updater or \*core/lease.Manager, got \*io.Writer`)
+}
+
+type mockAgent struct {
+	agent.Agent
+	conf mockAgentConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+type mockAgentConfig struct {
+	agent.Config
+	logDir string
+	uuid   string
+}
+
+func (c *mockAgentConfig) LogDir() string {
+	return c.logDir
+}
+
+func (c *mockAgentConfig) Controller() names.ControllerTag {
+	return names.NewControllerTag(c.uuid)
+}
+
+type stubStateTracker struct {
+	testing.Stub
+	pool state.StatePool
+	done chan struct{}
+}
+
+func (s *stubStateTracker) Use() (*state.StatePool, error) {
+	s.MethodCall(s, "Use")
+	return &s.pool, s.NextErr()
+}
+
+func (s *stubStateTracker) Done() error {
+	s.MethodCall(s, "Done")
+	err := s.NextErr()
+	close(s.done)
+	return err
+}
+
+func (s *stubStateTracker) waitDone(c *gc.C) {
+	select {
+	case <-s.done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for state to be released")
+	}
+}
+
+type mockWorker struct{}
+
+func (w *mockWorker) Kill() {}
+func (w *mockWorker) Wait() error {
+	return nil
+}

--- a/worker/lease/manifold/package_test.go
+++ b/worker/lease/manifold/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manifold_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/lease/secretaries.go
+++ b/worker/lease/secretaries.go
@@ -1,0 +1,88 @@
+package lease
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/core/lease"
+)
+
+// SingularSecretary implements Secretary to restrict claims to either
+// a lease for the controller or the specific model it's asking for,
+// holdable only by machine-tag strings.
+type SingularSecretary struct {
+	ControllerUUID string
+}
+
+// CheckLease is part of the lease.Secretary interface.
+func (s SingularSecretary) CheckLease(key lease.Key) error {
+	if key.Lease != s.ControllerUUID && key.Lease != key.ModelUUID {
+		return errors.New("expected controller or model UUID")
+	}
+	return nil
+}
+
+// CheckHolder is part of the lease.Secretary interface.
+func (s SingularSecretary) CheckHolder(name string) error {
+	if _, err := names.ParseMachineTag(name); err != nil {
+		return errors.New("expected machine tag")
+	}
+	return nil
+}
+
+// CheckDuration is part of the lease.Secretary interface.
+func (s SingularSecretary) CheckDuration(duration time.Duration) error {
+	if duration <= 0 {
+		return errors.NewNotValid(nil, "non-positive")
+	}
+	return nil
+}
+
+// LeadershipSecretary implements Secretary; it checks that leases are
+// application names, and holders are unit names.
+type LeadershipSecretary struct{}
+
+// CheckLease is part of the lease.Secretary interface.
+func (LeadershipSecretary) CheckLease(key lease.Key) error {
+	if !names.IsValidApplication(key.Lease) {
+		return errors.NewNotValid(nil, "not an application name")
+	}
+	return nil
+}
+
+// CheckHolder is part of the lease.Secretary interface.
+func (LeadershipSecretary) CheckHolder(name string) error {
+	if !names.IsValidUnit(name) {
+		return errors.NewNotValid(nil, "not a unit name")
+	}
+	return nil
+}
+
+// CheckDuration is part of the lease.Secretary interface.
+func (LeadershipSecretary) CheckDuration(duration time.Duration) error {
+	if duration <= 0 {
+		return errors.NewNotValid(nil, "non-positive")
+	}
+	return nil
+}
+
+// SecretaryFinder returns a function to find the correct secretary to
+// use for validation for a specific lease namespace (or an error if
+// the namespace isn't valid).
+func SecretaryFinder(controllerUUID string) func(string) (Secretary, error) {
+	secretaries := map[string]Secretary{
+		lease.ApplicationLeadershipNamespace: LeadershipSecretary{},
+		lease.SingularControllerNamespace: SingularSecretary{
+			ControllerUUID: controllerUUID,
+		},
+	}
+	return func(namespace string) (Secretary, error) {
+		result, found := secretaries[namespace]
+		if !found {
+			return nil, errors.NotValidf("namespace %q", namespace)
+		}
+		return result, nil
+	}
+}

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -19,8 +19,8 @@ import (
 type Secretary struct{}
 
 // CheckLease is part of the lease.Secretary interface.
-func (Secretary) CheckLease(name string) error {
-	return checkName(name)
+func (Secretary) CheckLease(key lease.Key) error {
+	return checkName(key.Lease)
 }
 
 // CheckHolder is part of the lease.Secretary interface.

--- a/worker/raft/raftforwarder/manifold.go
+++ b/worker/raft/raftforwarder/manifold.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftforwarder
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+)
+
+// ManifoldConfig holds the resources needed to start a raft forwarder
+// worker in a dependency engine.
+type ManifoldConfig struct {
+	RaftName       string
+	CentralHubName string
+
+	RequestTopic string
+	Logger       Logger
+	NewWorker    func(Config) (worker.Worker, error)
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	var r *raft.Raft
+	if err := context.Get(config.RaftName, &r); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var hub *pubsub.StructuredHub
+	if err := context.Get(config.CentralHubName, &hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return config.NewWorker(Config{
+		Raft:   r,
+		Hub:    hub,
+		Logger: config.Logger,
+		Topic:  config.RequestTopic,
+	})
+}
+
+// Manifold builds a dependency.Manifold for running a raftforwarder
+// worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.RaftName,
+			config.CentralHubName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/raft/raftforwarder/manifold_test.go
+++ b/worker/raft/raftforwarder/manifold_test.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftforwarder_test
+
+import (
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+
+	"github.com/juju/juju/worker/raft/raftforwarder"
+)
+
+type manifoldSuite struct {
+	testing.IsolationSuite
+
+	context  dependency.Context
+	manifold dependency.Manifold
+	raft     *raft.Raft
+	hub      *pubsub.StructuredHub
+	logger   loggo.Logger
+	worker   worker.Worker
+	stub     testing.Stub
+}
+
+var _ = gc.Suite(&manifoldSuite{})
+
+func (s *manifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.raft = &raft.Raft{}
+	s.hub = &pubsub.StructuredHub{}
+
+	type mockWorker struct {
+		worker.Worker
+	}
+	s.worker = &mockWorker{}
+	s.logger = loggo.GetLogger("juju.worker.raftforwarder_test")
+
+	s.context = s.newContext(nil)
+	s.manifold = raftforwarder.Manifold(raftforwarder.ManifoldConfig{
+		RaftName:       "raft",
+		CentralHubName: "hub",
+		RequestTopic:   "test.request",
+		Logger:         &s.logger,
+		NewWorker:      s.newWorker,
+	})
+}
+
+func (s *manifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"raft": s.raft,
+		"hub":  s.hub,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *manifoldSuite) newWorker(config raftforwarder.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{
+	"raft", "hub",
+}
+
+func (s *manifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *manifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *manifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "NewWorker")
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, raftforwarder.Config{})
+	config := args[0].(raftforwarder.Config)
+
+	c.Assert(config, jc.DeepEquals, raftforwarder.Config{
+		Raft:   s.raft,
+		Hub:    s.hub,
+		Logger: &s.logger,
+		Topic:  "test.request",
+	})
+}
+
+func (s *manifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.Equals, s.worker)
+	return w
+}

--- a/worker/raft/raftforwarder/package_test.go
+++ b/worker/raft/raftforwarder/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftforwarder_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -1,0 +1,141 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftforwarder
+
+import (
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/catacomb"
+
+	"github.com/juju/juju/core/raftlease"
+)
+
+const applyTimeout = 5 * time.Second
+
+// This worker receives raft commands forwarded over the hub and
+// applies them to the raft node.
+
+// RaftApplier allows applying a command to the raft FSM.
+type RaftApplier interface {
+	Apply(cmd []byte, timeout time.Duration) raft.ApplyFuture
+}
+
+// Logger specifies the interface we use from loggo.Logger.
+type Logger interface {
+	Tracef(string, ...interface{})
+}
+
+// Config defines the resources the worker needs to run.
+type Config struct {
+	Hub    *pubsub.StructuredHub
+	Raft   RaftApplier
+	Logger Logger
+	Topic  string
+}
+
+// Validate checks that this config can be used.
+func (config Config) Validate() error {
+	if config.Hub == nil {
+		return errors.NotValidf("nil Hub")
+	}
+	if config.Raft == nil {
+		return errors.NotValidf("nil Raft")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.Topic == "" {
+		return errors.NotValidf("empty Topic")
+	}
+	return nil
+}
+
+// NewWorker creates and starts a worker that will forward leadership
+// claims from non-raft-leader machines.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &forwarder{
+		config: config,
+	}
+	unsubscribe, err := w.config.Hub.Subscribe(w.config.Topic, w.handleRequest)
+	if err != nil {
+		return nil, errors.Annotatef(err, "subscribing to %q", w.config.Topic)
+	}
+	w.unsubscribe = unsubscribe
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		unsubscribe()
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+type forwarder struct {
+	catacomb    catacomb.Catacomb
+	config      Config
+	unsubscribe func()
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *forwarder) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *forwarder) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *forwarder) loop() error {
+	defer w.unsubscribe()
+	<-w.catacomb.Dying()
+	return w.catacomb.ErrDying()
+}
+
+func (w *forwarder) handleRequest(_ string, req raftlease.ForwardRequest, err error) {
+	w.config.Logger.Tracef("received %#v, err: %s", req, err)
+	if err != nil {
+		// This should never happen, so treat it as fatal.
+		w.catacomb.Kill(errors.Annotate(err, "requests callback failed"))
+		return
+	}
+	response, err := w.processRequest(req.Command)
+	if err != nil {
+		w.catacomb.Kill(errors.Annotate(err, "applying command"))
+		return
+	}
+	_, err = w.config.Hub.Publish(req.ResponseTopic, response)
+	if err != nil {
+		w.catacomb.Kill(errors.Annotate(err, "publishing response"))
+		return
+	}
+}
+
+func (w *forwarder) processRequest(command []byte) (raftlease.ForwardResponse, error) {
+	var empty raftlease.ForwardResponse
+	future := w.config.Raft.Apply(command, applyTimeout)
+	if err := future.Error(); err != nil {
+		return empty, errors.Trace(err)
+	}
+	respValue := future.Response()
+	responseErr, ok := respValue.(error)
+	if respValue != nil && !ok {
+		return empty, errors.Errorf("FSM response must be an error or nil, got %#v", respValue)
+	}
+	return responseFromError(responseErr), nil
+}
+
+func responseFromError(err error) raftlease.ForwardResponse {
+	return raftlease.ForwardResponse{
+		Error: raftlease.AsResponseError(err),
+	}
+}

--- a/worker/raft/raftforwarder/worker_test.go
+++ b/worker/raft/raftforwarder/worker_test.go
@@ -1,0 +1,240 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftforwarder_test
+
+import (
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/pubsub/centralhub"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/raft/raftforwarder"
+)
+
+type workerFixture struct {
+	testing.IsolationSuite
+	raft   *mockRaft
+	hub    *pubsub.StructuredHub
+	config raftforwarder.Config
+}
+
+func (s *workerFixture) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	err := loggo.ConfigureLoggers("TRACE")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.raft = &mockRaft{af: &mockApplyFuture{}}
+	s.hub = centralhub.New(names.NewMachineTag("17"))
+	s.config = raftforwarder.Config{
+		Hub:    s.hub,
+		Raft:   s.raft,
+		Logger: loggo.GetLogger("raftforwarder_test"),
+		Topic:  "raftforwarder_test",
+	}
+}
+
+type workerValidationSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&workerValidationSuite{})
+
+func (s *workerValidationSuite) TestValidateErrors(c *gc.C) {
+	type test struct {
+		f      func(*raftforwarder.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *raftforwarder.Config) { cfg.Raft = nil },
+		"nil Raft not valid",
+	}, {
+		func(cfg *raftforwarder.Config) { cfg.Hub = nil },
+		"nil Hub not valid",
+	}, {
+		func(cfg *raftforwarder.Config) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *raftforwarder.Config) { cfg.Topic = "" },
+		"empty Topic not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		s.testValidateError(c, test.f, test.expect)
+	}
+}
+
+func (s *workerValidationSuite) testValidateError(c *gc.C, f func(*raftforwarder.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := raftforwarder.NewWorker(config)
+	if !c.Check(err, gc.NotNil) {
+		workertest.DirtyKill(c, w)
+		return
+	}
+	c.Check(w, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+type workerSuite struct {
+	workerFixture
+	worker worker.Worker
+	resps  chan raftlease.ForwardResponse
+}
+
+var _ = gc.Suite(&workerSuite{})
+
+func (s *workerSuite) SetUpTest(c *gc.C) {
+	s.workerFixture.SetUpTest(c)
+	s.resps = make(chan raftlease.ForwardResponse)
+
+	// Use a local variable to send to the channel in the callback, so
+	// we don't get races when a subsequent test overwrites s.resps
+	// with a new channel.
+	resps := s.resps
+	unsubscribe, err := s.hub.Subscribe(
+		"response",
+		func(_ string, resp raftlease.ForwardResponse, err error) {
+			c.Check(err, jc.ErrorIsNil)
+			resps <- resp
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { unsubscribe() })
+
+	worker, err := raftforwarder.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	s.worker = worker
+}
+
+func (s *workerSuite) TestCleanKill(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *workerSuite) TestSuccess(c *gc.C) {
+	_, err := s.hub.Publish("raftforwarder_test", raftlease.ForwardRequest{
+		Command:       []byte("myanmar"),
+		ResponseTopic: "response",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case resp := <-s.resps:
+		c.Assert(resp, gc.DeepEquals, raftlease.ForwardResponse{})
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for response")
+	}
+
+	s.raft.CheckCall(c, 0, "Apply", []byte("myanmar"), 5*time.Second)
+}
+
+func (s *workerSuite) TestApplyError(c *gc.C) {
+	s.raft.af.SetErrors(errors.Errorf("boom"))
+	_, err := s.hub.Publish("raftforwarder_test", raftlease.ForwardRequest{
+		Command:       []byte("france"),
+		ResponseTopic: "response",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = workertest.CheckKilled(c, s.worker)
+	c.Assert(err, gc.ErrorMatches, "applying command: boom")
+
+	select {
+	case <-s.resps:
+		c.Fatalf("unexpected response")
+	case <-time.After(coretesting.ShortWait):
+	}
+}
+
+func (s *workerSuite) TestBadResponseType(c *gc.C) {
+	s.raft.af.response = "23 skidoo!"
+	_, err := s.hub.Publish("raftforwarder_test", raftlease.ForwardRequest{
+		Command:       []byte("france"),
+		ResponseTopic: "response",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = workertest.CheckKilled(c, s.worker)
+	c.Assert(err, gc.ErrorMatches, `applying command: FSM response must be an error or nil, got "23 skidoo!"`)
+
+	select {
+	case <-s.resps:
+		c.Fatalf("unexpected response")
+	case <-time.After(coretesting.ShortWait):
+	}
+}
+
+func (s *workerSuite) TestResponseGenericError(c *gc.C) {
+	s.raft.af.response = errors.Errorf("help!")
+	_, err := s.hub.Publish("raftforwarder_test", raftlease.ForwardRequest{
+		Command:       []byte("france"),
+		ResponseTopic: "response",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case resp := <-s.resps:
+		c.Assert(resp, gc.DeepEquals, raftlease.ForwardResponse{
+			Error: &raftlease.ResponseError{"help!", "error"},
+		})
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for response")
+	}
+}
+
+func (s *workerSuite) TestResponseSingletonError(c *gc.C) {
+	s.raft.af.response = errors.Annotate(lease.ErrInvalid, "some context")
+	_, err := s.hub.Publish("raftforwarder_test", raftlease.ForwardRequest{
+		Command:       []byte("france"),
+		ResponseTopic: "response",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case resp := <-s.resps:
+		c.Assert(resp, gc.DeepEquals, raftlease.ForwardResponse{
+			Error: &raftlease.ResponseError{"some context: invalid lease operation", "invalid"},
+		})
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for response")
+	}
+}
+
+type mockRaft struct {
+	testing.Stub
+	af *mockApplyFuture
+}
+
+func (r *mockRaft) Apply(cmd []byte, timeout time.Duration) raft.ApplyFuture {
+	r.AddCall("Apply", cmd, timeout)
+	return r.af
+}
+
+type mockApplyFuture struct {
+	raft.IndexFuture
+	testing.Stub
+	response interface{}
+}
+
+func (f *mockApplyFuture) Error() error {
+	f.AddCall("Error")
+	return f.NextErr()
+}
+
+func (f *mockApplyFuture) Response() interface{} {
+	f.AddCall("Response")
+	return f.response
+}

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -196,7 +196,9 @@ func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
 func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
 	_, err := s.app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.LeadershipClaimer().ClaimLeadership("u", "u/0", time.Minute)
+	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	err = claimer.Claim("u", "u/0", time.Minute)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := context.NewContextRelation(s.apiRelUnit, nil)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -117,6 +117,7 @@ func (s *UniterSuite) runUniterTests(c *gc.C, uniterTests []uniterTest) {
 				path:                   s.unitDir,
 				dataDir:                s.dataDir,
 				charms:                 make(map[string][]byte),
+				leaseManager:           s.LeaseManager,
 				updateStatusHookTicker: s.updateStatusHookTicker,
 				charmDirGuard:          &mockCharmDirGuard{},
 			}
@@ -1543,6 +1544,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 		path:                   filepath.Join(s.dataDir, "agents", "unit-u-0"),
 		dataDir:                s.dataDir,
 		charms:                 make(map[string][]byte),
+		leaseManager:           s.LeaseManager,
 		updateStatusHookTicker: s.updateStatusHookTicker,
 		charmDirGuard:          &mockCharmDirGuard{},
 	}


### PR DESCRIPTION
## Description of change

Implements a new core/lease.Store as a raft FSM. Instead of running a lease manager for singular and leadership inside each state in the controller agent's state pool, we run one lease manager for the controller agent in the dependency engine. The manager now passes namespace and model uuid along with the lease name - together these are the lease key.

That manager talks to a lease store that reads data directly from the FSM, but all writes (claim, extend, expire) are sent over the pubsub hub to the raft leader to be applied there. We also run another global clock updater to increment the time in the raft lease store (using the same pubsub request mechanism) alongside the clock updater talking to mongo.

The raft lease store still updates the mongo database (the leaseholders collection, to avoid stepping on the toes of the state lease store), but only when leases are claimed or expired, which occur far less frequently than extensions (every 30 seconds).

Lease changes (claims and expiries) are also written to `/var/log/juju/lease.log`. In a multi-controller situation these will need to be combined to get a complete history of lease changes. These logs are rotated and compressed.

The two lease systems (mongo and raft) are both running - which one is in use is controlled by the `raft-leases` feature flag. This means it _can_ be switched on a running controller, although since the lease state isn't synchronised between them there's likely to be some fallout - it's possible for two units to both think they're the leader, for example. I'd advise not switching it on a controller you wouldn't be ok with throwing away for now.

## QA steps

* Bootstrap a controller with `--config="features=[raft-leases]"` and including `juju.worker.lease=TRACE` in `logging-config`.
* Enable HA.
* Deploy percona-cluster and 3 units of wordpress.
* See that one wordpress unit becomes the leader for the application (in status, in logging for `juju.worker.lease.raft` and in the mongo `leaseholders` collection).
* Remove that unit. Another wordpress unit should claim leadership when the original lease expires.
* Use `juju run -m controller <machine> juju-engine-report | less +/raft:` to determine the raft leader. Remove that machine. Once things stabilise, confirm that the lease operations are continuing in a two-controller voter/nonvoter configuration. 
* Add a new controller machine by running `enable-ha` again. The lease manager on that machine should join in with the normal lease operations.
