### PR TITLE
Allows upgrade-series API to return multiple status results

### DIFF
--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -8,7 +8,9 @@ import (
 
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -31,6 +33,10 @@ func PatchUnitResponse(p testing.Patcher, u *Unit, expectedRequest string, respo
 		}
 		return responseFunc(response)
 	})
+}
+
+func PatchUnitUpgradeSeriesFacade(u *Unit, facadeCaller base.FacadeCaller) {
+	u.st.UpgradeSeriesAPI = common.NewUpgradeSeriesAPI(facadeCaller, u.Tag())
 }
 
 // CreateUnit creates uniter.Unit for tests.

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -651,7 +651,14 @@ func (u *Unit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) 
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
 func (u *Unit) UpgradeSeriesStatus(statusType model.UpgradeSeriesStatusType) (string, error) {
-	return u.st.UpgradeSeriesStatus(statusType)
+	res, err := u.st.UpgradeSeriesStatus(statusType)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(res) != 1 {
+		return "", errors.Errorf("expected 1 result, got %d", len(res))
+	}
+	return res[0], nil
 }
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state


### PR DESCRIPTION
## Description of change

The upgrade-series worker needs to receive multiple statuses from `UpgradeSeriesStatus`.

This change removes the error condition when multiple status values are present in the return and moves the check for a single result to the unit API that wraps this call.

## QA steps

Unit tests.

## Documentation changes

None.

## Bug reference

N/A
