### PR TITLE
Exposes deployer method for mapping service names to units

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -127,6 +127,25 @@ func (s *serviceSuite) TestInstallAndStartFail(c *gc.C) {
 	s.Service.CheckCallNames(c, "Install", "Stop", "Start", "Stop", "Start", "Stop", "Start")
 }
 
+func (s *serviceSuite) TestFindUnitServiceNames(c *gc.C) {
+	names := []string{
+		"jujud-unit-ubuntu-lite-0",
+		"jujud-unit-wordpress-0",
+		"jujud-unit-wordpress-1",
+		"jujud-machine-0",
+		"not-a-juju-service",
+	}
+
+	expected := map[string]string{
+		"ubuntu-lite/0": "jujud-unit-ubuntu-lite-0",
+		"wordpress/0":   "jujud-unit-wordpress-0",
+		"wordpress/1":   "jujud-unit-wordpress-1",
+	}
+
+	services := service.FindUnitServiceNames(names)
+	c.Check(services, gc.DeepEquals, expected)
+}
+
 type restartSuite struct {
 	service.BaseSuite
 }

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -24,8 +24,6 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-// TODO(ericsnow) Use errors.Trace, etc. in this file.
-
 // APICalls defines the interface to the API that the simple context needs.
 type APICalls interface {
 	ConnectionInfo() (params.DeployerConnectionValues, error)
@@ -58,13 +56,13 @@ func recursiveChmod(path string, mode os.FileMode) error {
 		if _, err := os.Stat(p); err == nil {
 			errPerm := os.Chmod(p, mode)
 			if errPerm != nil {
-				return errPerm
+				return errors.Trace(errPerm)
 			}
 		}
 		return nil
 	}
 	if err := filepath.Walk(path, walker); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -158,7 +156,7 @@ func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err erro
 		return errors.Trace(err)
 	}
 	if err := conf.Write(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer removeOnErr(&err, conf.Dir())
 
@@ -205,49 +203,51 @@ func (ctx *SimpleContext) RecallUnit(unitName string) error {
 		return errors.Errorf("unit %q is not deployed", unitName)
 	}
 	if err := svc.Stop(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := svc.Remove(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	tag := names.NewUnitTag(unitName)
 	dataDir := ctx.agentConfig.DataDir()
 	agentDir := agent.Dir(dataDir, tag)
-	// Recursivley change mode to 777 on windows to avoid
+	// Recursively change mode to 777 on windows to avoid
 	// Operation not permitted errors when deleting the agentDir
 	err = recursiveChmod(agentDir, os.FileMode(0777))
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := os.RemoveAll(agentDir); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	// TODO(dfc) should take a Tag
 	toolsDir := tools.ToolsDir(dataDir, tag.String())
 	return os.Remove(toolsDir)
 }
 
-var deployedRe = regexp.MustCompile("^(jujud-.*unit-([a-z0-9-]+)-([0-9]+))$")
-
 func (ctx *SimpleContext) deployedUnitsInitSystemJobs() (map[string]string, error) {
-	fis, err := ctx.listServices()
+	svcNames, err := ctx.listServices()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	if err != nil {
-		return nil, err
-	}
-	installed := make(map[string]string)
-	for _, fi := range fis {
-		if groups := deployedRe.FindStringSubmatch(fi); len(groups) > 0 {
+	return FindUnitServiceNames(svcNames), nil
+}
+
+// FindUnitServiceNames accepts a collection of service names as managed by the
+// local init system. Any that are identified as being for unit agents are
+// returned, keyed on the unit name.
+func FindUnitServiceNames(svcNames []string) map[string]string {
+	unitMatcher := regexp.MustCompile("^(jujud-.*unit-([a-z0-9-]+)-([0-9]+))$")
+	unitServices := make(map[string]string)
+	for _, svc := range svcNames {
+		if groups := unitMatcher.FindStringSubmatch(svc); len(groups) > 0 {
 			unitName := groups[2] + "/" + groups[3]
-			if !names.IsValidUnit(unitName) {
-				continue
+			if names.IsValidUnit(unitName) {
+				unitServices[unitName] = groups[1]
 			}
-			installed[unitName] = groups[1]
 		}
 	}
-	return installed, nil
+	return unitServices
 }
 
 func (ctx *SimpleContext) DeployedUnits() ([]string, error) {

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/juju/errors"
 	"github.com/juju/os/series"
@@ -230,24 +229,7 @@ func (ctx *SimpleContext) deployedUnitsInitSystemJobs() (map[string]string, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return FindUnitServiceNames(svcNames), nil
-}
-
-// FindUnitServiceNames accepts a collection of service names as managed by the
-// local init system. Any that are identified as being for unit agents are
-// returned, keyed on the unit name.
-func FindUnitServiceNames(svcNames []string) map[string]string {
-	unitMatcher := regexp.MustCompile("^(jujud-.*unit-([a-z0-9-]+)-([0-9]+))$")
-	unitServices := make(map[string]string)
-	for _, svc := range svcNames {
-		if groups := unitMatcher.FindStringSubmatch(svc); len(groups) > 0 {
-			unitName := groups[2] + "/" + groups[3]
-			if names.IsValidUnit(unitName) {
-				unitServices[unitName] = groups[1]
-			}
-		}
-	}
-	return unitServices
+	return service.FindUnitServiceNames(svcNames), nil
 }
 
 func (ctx *SimpleContext) DeployedUnits() ([]string, error) {


### PR DESCRIPTION
## Description of change

Makes public a deployer worker method for mapping service names to known units. It is relocated to the service package for common usage. 

This will be recruited by the upgrade-series worker.

Includes a drive-by for the outstanding TODO, which is now gone.

## QA steps

- Deployer unit tests remain green.
- New unit test for extracted method.

## Documentation changes

None.

## Bug reference

N/A
