### PR TITLE
Bring in recent websocket with handshake timeout.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -621,8 +621,9 @@ func gorillaDialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Con
 			}
 			return netDialer.DialContext(ctx, netw, addr)
 		},
-		Proxy:           proxy.DefaultConfig.GetProxy,
-		TLSClientConfig: tlsConfig,
+		Proxy:            proxy.DefaultConfig.GetProxy,
+		HandshakeTimeout: 45 * time.Second,
+		TLSClientConfig:  tlsConfig,
 		// In order to deal with the remote side not handling message
 		// fragmentation, we default to largeish frames.
 		ReadBufferSize:  websocketFrameSize,

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -14,7 +14,7 @@ github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-
 github.com/google/go-querystring	git	9235644dd9e52eeae6fa48efd539fdc351a0af53	2016-04-01T23:30:42Z
 github.com/gorilla/handlers	git	13d73096a474cac93275c679c7b8a2dc17ddba82	2017-02-24T19:39:55Z
 github.com/gorilla/schema	git	08023a0215e7fc27a9aecd8b8c50913c40019478	2016-04-26T23:15:12Z
-github.com/gorilla/websocket	git	804cb600d06b10672f2fbc0a336a7bee507a428e	2017-02-14T17:41:18Z
+github.com/gorilla/websocket	git	5ed622c449da6d44c3c8329331ff47a9e5844f71	2018-06-05T20:25:52Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z
 github.com/joyent/gocommon	git	ade826b8b54e81a779ccb29d358a45ba24b7809c	2016-03-20T19:31:33Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z


### PR DESCRIPTION
There was a potential race condition on the agents when connecting to a controller if interrupted in the middle of the websocket protocol initiation handshake.

This is handled in a more recent version of the websocket library, so bring that in.

45 seconds is the default timeout from the upstream library, but we aren't using their default dialer.

## QA steps

I have not been successful in replicating the error conditions that we only see in very large deployments.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1732587