### PR TITLE
MAAS reacts to invalid cloud credentials.

### DIFF
--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -4,15 +4,13 @@
 package errorutils
 
 import (
-	"net/http"
-
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
 )
 
 var logger = loggo.GetLogger("juju.provider.azure")
@@ -30,14 +28,6 @@ func ServiceError(err error) (*azure.ServiceError, bool) {
 	}
 	return nil, false
 }
-
-// AuthorisationFailureStatusCodes contains http status code that signify authorisation difficulties.
-var AuthorisationFailureStatusCodes = set.NewInts(
-	http.StatusUnauthorized,
-	http.StatusPaymentRequired,
-	http.StatusForbidden,
-	http.StatusProxyAuthRequired,
-)
 
 // HandleCredentialError determines if given error relates to invalid credential.
 // If it is, the credential is invalidated.
@@ -71,9 +61,9 @@ func hasDenialStatusCode(err error) bool {
 
 	if d, ok := errors.Cause(err).(autorest.DetailedError); ok {
 		if d.Response != nil {
-			return AuthorisationFailureStatusCodes.Contains(d.Response.StatusCode)
+			return common.AuthorisationFailureStatusCodes.Contains(d.Response.StatusCode)
 		}
-		return AuthorisationFailureStatusCodes.Contains(d.StatusCode.(int))
+		return common.AuthorisationFailureStatusCodes.Contains(d.StatusCode.(int))
 	}
 	return false
 }

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/azure/internal/errorutils"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/testing"
 )
 
@@ -64,7 +65,7 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	errorutils.HandleCredentialError(s.azureError, ctx)
 	c.Assert(called, jc.IsFalse)
 
-	for t := range errorutils.AuthorisationFailureStatusCodes {
+	for t := range common.AuthorisationFailureStatusCodes {
 		called = false
 		s.azureError.StatusCode = t
 		errorutils.HandleCredentialError(s.azureError, ctx)

--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -3,7 +3,12 @@
 
 package common
 
-import "github.com/juju/errors"
+import (
+	"net/http"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
 
 // ZoneIndependentError wraps the given error such that it
 // satisfies environs.IsAvailabilityZoneIndependent.
@@ -67,3 +72,11 @@ func IsCredentialNotValid(err error) bool {
 	_, ok := err.(*credentialNotValid)
 	return ok
 }
+
+// AuthorisationFailureStatusCodes contains http status code that signify authorisation difficulties.
+var AuthorisationFailureStatusCodes = set.NewInts(
+	http.StatusUnauthorized,
+	http.StatusPaymentRequired,
+	http.StatusForbidden,
+	http.StatusProxyAuthRequired,
+)

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -27,7 +27,7 @@ var unsupportedConstraints = []string{
 func (environ *maasEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
-	supportedArches, err := environ.getSupportedArchitectures()
+	supportedArches, err := environ.getSupportedArchitectures(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/context"
 	envstorage "github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
@@ -218,7 +219,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 func (suite *environSuite) getInstance(systemId string) *maas1Instance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 

--- a/provider/maas/errors.go
+++ b/provider/maas/errors.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/gomaasapi"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
+)
+
+// MaybeHandleCredentialError determines if a given error relates to an invalid credential.
+//  If it is, the credential is invalidated and the return bool is true.
+// Original error is returned untouched.
+func MaybeHandleCredentialError(err error, ctx context.ProviderCallContext) (error, bool) {
+	denied := IsAuthorisationFailure(errors.Cause(err))
+	if ctx != nil && denied {
+		invalidateErr := ctx.InvalidateCredential("maas cloud denied access")
+		if invalidateErr != nil {
+			logger.Warningf("could not invalidate stored maas cloud credential on the controller: %v", invalidateErr)
+		}
+	}
+	return err, denied
+}
+
+// HandleCredentialError determines if a given error relates to an invalid credential.
+// If it is, the credential is invalidated. Original error is returned untouched.
+func HandleCredentialError(err error, ctx context.ProviderCallContext) error {
+	MaybeHandleCredentialError(err, ctx)
+	return err
+}
+
+// IsAuthorisationFailure determines if the given error has an authorisation failure.
+func IsAuthorisationFailure(err error) bool {
+	// This should cover most cases.
+	if gomaasapi.IsPermissionError(err) {
+		return true
+	}
+
+	// This should cover exceptional circumstances.
+	if maasErr, ok := err.(gomaasapi.ServerError); ok {
+		return common.AuthorisationFailureStatusCodes.Contains(maasErr.StatusCode)
+	}
+	return false
+}

--- a/provider/maas/errors_test.go
+++ b/provider/maas/errors_test.go
@@ -1,0 +1,93 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/gomaasapi"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/testing"
+)
+
+type ErrorSuite struct {
+	testing.BaseSuite
+
+	maasError error
+}
+
+var _ = gc.Suite(&ErrorSuite{})
+
+func (s *ErrorSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.maasError = gomaasapi.NewPermissionError("denial")
+}
+
+func (s *ErrorSuite) TestNilContext(c *gc.C) {
+	err, denied := MaybeHandleCredentialError(s.maasError, nil)
+	c.Assert(err, gc.DeepEquals, s.maasError)
+	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
+	c.Assert(denied, jc.IsTrue)
+}
+
+func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
+	ctx := context.NewCloudCallContext()
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		return errors.New("kaboom")
+	}
+	_, denied := MaybeHandleCredentialError(s.maasError, ctx)
+	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored maas cloud credential on the controller")
+	c.Assert(denied, jc.IsTrue)
+}
+
+func (s *ErrorSuite) TestHandleCredentialErrorPermissionError(c *gc.C) {
+	s.checkMaasPermissionHandling(c, true)
+
+	s.maasError = errors.Trace(s.maasError)
+	s.checkMaasPermissionHandling(c, true)
+
+	s.maasError = errors.Annotatef(s.maasError, "more and more")
+	s.checkMaasPermissionHandling(c, true)
+}
+
+func (s *ErrorSuite) TestHandleCredentialErrorAnotherError(c *gc.C) {
+	s.maasError = errors.New("fluffy")
+	s.checkMaasPermissionHandling(c, false)
+}
+
+func (s *ErrorSuite) TestNilError(c *gc.C) {
+	s.maasError = nil
+	s.checkMaasPermissionHandling(c, false)
+}
+
+func (s *ErrorSuite) TestGomaasError(c *gc.C) {
+	// check accepted status codes
+	s.maasError = gomaasapi.ServerError{StatusCode: http.StatusAccepted}
+	s.checkMaasPermissionHandling(c, false)
+
+	for t := range common.AuthorisationFailureStatusCodes {
+		s.maasError = gomaasapi.ServerError{StatusCode: t}
+		s.checkMaasPermissionHandling(c, true)
+	}
+}
+
+func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
+	ctx := context.NewCloudCallContext()
+	called := false
+	ctx.InvalidateCredentialFunc = func(msg string) error {
+		c.Assert(msg, gc.DeepEquals, "maas cloud denied access")
+		called = true
+		return nil
+	}
+
+	_, denied := MaybeHandleCredentialError(s.maasError, ctx)
+	c.Assert(called, gc.Equals, handled)
+	c.Assert(denied, gc.Equals, handled)
+
+}

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -29,7 +29,7 @@ type maasInstance interface {
 type maas1Instance struct {
 	maasObject   *gomaasapi.MAASObject
 	environ      *maasEnviron
-	statusGetter func(instance.Id) (string, string)
+	statusGetter func(context.ProviderCallContext, instance.Id) (string, string)
 }
 
 var _ maasInstance = (*maas1Instance)(nil)
@@ -87,7 +87,7 @@ func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance
 // Status returns a juju status based on the maas instance returned
 // status message.
 func (mi *maas1Instance) Status(ctx context.ProviderCallContext) instance.InstanceStatus {
-	statusMsg, substatus := mi.statusGetter(mi.Id())
+	statusMsg, substatus := mi.statusGetter(ctx, mi.Id())
 	return convertInstanceStatus(statusMsg, substatus, mi.Id())
 }
 
@@ -115,7 +115,7 @@ func (mi *maas1Instance) interfaceAddresses(ctx context.ProviderCallContext) ([]
 	// Fetch a fresh copy of the instance JSON first.
 	obj, err := refreshMAASObject(mi.maasObject)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting instance details")
+		return nil, HandleCredentialError(errors.Annotate(err, "getting instance details"), ctx)
 	}
 
 	subnetsMap, err := mi.environ.subnetToSpaceIds(ctx)

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
@@ -65,7 +66,7 @@ func (s *instanceTest) TestId(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
 	resourceURI, _ := obj.GetField("resource_uri")
 	// TODO(perrito666) make a decent mock status getter
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 	instance := maas1Instance{&obj, nil, statusGetter}
@@ -76,7 +77,7 @@ func (s *instanceTest) TestId(c *gc.C) {
 func (s *instanceTest) TestString(c *gc.C) {
 	jsonValue := `{"hostname": "thethingintheplace", "system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -91,7 +92,7 @@ func (s *instanceTest) TestStringWithoutHostname(c *gc.C) {
 	// For good measure, test what happens if we don't have a hostname.
 	jsonValue := `{"system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -130,7 +131,7 @@ func (s *instanceTest) TestAddressesViaInterfaces(c *gc.C) {
     "ip_addresses": [ "anything", "foo", "0.1.2.3" ]
 }`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -173,7 +174,7 @@ func (s *instanceTest) TestAddressesInvalid(c *gc.C) {
 		"ip_addresses": "incompatible"
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -190,7 +191,7 @@ func (s *instanceTest) TestAddressesInvalidContents(c *gc.C) {
 		"ip_addresses": [42]
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -209,7 +210,7 @@ func (s *instanceTest) TestHardwareCharacteristics(c *gc.C) {
         "memory": 16384
 	}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -230,7 +231,7 @@ func (s *instanceTest) TestHardwareCharacteristicsWithTags(c *gc.C) {
         "tag_names": ["a", "b"]
 	}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -260,7 +261,7 @@ func (s *instanceTest) TestHardwareCharacteristicsMissing(c *gc.C) {
 
 func (s *instanceTest) testHardwareCharacteristicsMissing(c *gc.C, json, expect string) {
 	obj := s.testMAASObject.TestServer.NewNode(json)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -143,6 +143,17 @@ func (suite *maas2EnvironSuite) TestInstances(c *gc.C) {
 	c.Assert(actualMachines, gc.DeepEquals, expectedMachines)
 }
 
+func (suite *maas2EnvironSuite) TestInstancesInvalidCredential(c *gc.C) {
+	controller := &fakeController{
+		machinesError: gomaasapi.NewPermissionError("fail auth here"),
+	}
+	env := suite.makeEnviron(c, controller)
+	c.Assert(suite.invalidCredential, jc.IsFalse)
+	_, err := env.Instances(suite.callCtx, []instance.Id{"jake", "bonnibel"})
+	c.Assert(err, gc.NotNil)
+	c.Assert(suite.invalidCredential, jc.IsTrue)
+}
+
 func (suite *maas2EnvironSuite) TestInstancesPartialResult(c *gc.C) {
 	env := suite.makeEnvironWithMachines(
 		c, []string{"jake", "bonnibel"}, []string{"tuco", "bonnibel"},
@@ -173,6 +184,17 @@ func (suite *maas2EnvironSuite) TestAvailabilityZonesError(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	_, err := env.AvailabilityZones(suite.callCtx)
 	c.Assert(err, gc.ErrorMatches, "a bad thing")
+}
+
+func (suite *maas2EnvironSuite) TestAvailabilityZonesInvalidCredential(c *gc.C) {
+	controller := &fakeController{
+		zonesError: gomaasapi.NewPermissionError("fail auth here"),
+	}
+	env := suite.makeEnviron(c, controller)
+	c.Assert(suite.invalidCredential, jc.IsFalse)
+	_, err := env.AvailabilityZones(suite.callCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(suite.invalidCredential, jc.IsTrue)
 }
 
 func (suite *maas2EnvironSuite) TestSpaces(c *gc.C) {
@@ -217,6 +239,17 @@ func (suite *maas2EnvironSuite) TestSpacesError(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	_, err := env.Spaces(suite.callCtx)
 	c.Assert(err, gc.ErrorMatches, "Joe Manginiello")
+}
+
+func (suite *maas2EnvironSuite) TestSpacesInvalidCredential(c *gc.C) {
+	controller := &fakeController{
+		spacesError: gomaasapi.NewPermissionError("fail auth here"),
+	}
+	env := suite.makeEnviron(c, controller)
+	c.Assert(suite.invalidCredential, jc.IsFalse)
+	_, err := env.Spaces(suite.callCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(suite.invalidCredential, jc.IsTrue)
 }
 
 func collectReleaseArgs(controller *fakeController) []gomaasapi.ReleaseMachinesArgs {
@@ -2244,6 +2277,18 @@ func (suite *maas2EnvironSuite) TestControllerInstances(c *gc.C) {
 	}
 }
 
+func (suite *maas2EnvironSuite) TestControllerInstancesInvalidCredential(c *gc.C) {
+	controller := &fakeController{
+		machinesError: gomaasapi.NewPermissionError("fail auth here"),
+	}
+	env := suite.makeEnviron(c, controller)
+
+	c.Assert(suite.invalidCredential, jc.IsFalse)
+	_, err := env.ControllerInstances(suite.callCtx, suite.controllerUUID)
+	c.Assert(err, gc.NotNil)
+	c.Assert(suite.invalidCredential, jc.IsTrue)
+}
+
 func (suite *maas2EnvironSuite) TestDestroy(c *gc.C) {
 	file1 := &fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"}
 	file2 := &fakeFile{name: coretesting.ModelTag.Id() + "-horace"}
@@ -2317,6 +2362,29 @@ func (suite *maas2EnvironSuite) TestConstraintsValidator(c *gc.C) {
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+}
+
+func (suite *maas2EnvironSuite) TestConstraintsValidatorInvalidCredential(c *gc.C) {
+	controller := &fakeController{
+		bootResources:      []gomaasapi.BootResource{&fakeBootResource{name: "trusty", architecture: "amd64"}},
+		bootResourcesError: gomaasapi.NewPermissionError("fail auth here"),
+	}
+	env := suite.makeEnviron(c, controller)
+	c.Assert(suite.invalidCredential, jc.IsFalse)
+	_, err := env.ConstraintsValidator(suite.callCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(suite.invalidCredential, jc.IsTrue)
+}
+
+func (suite *maas2EnvironSuite) TestDomainsInvalidCredential(c *gc.C) {
+	controller := &fakeController{
+		domainsError: gomaasapi.NewPermissionError("fail auth here"),
+	}
+	env := suite.makeEnviron(c, controller)
+	c.Assert(suite.invalidCredential, jc.IsFalse)
+	_, err := env.Domains(suite.callCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(suite.invalidCredential, jc.IsTrue)
 }
 
 func (suite *maas2EnvironSuite) TestConstraintsValidatorVocab(c *gc.C) {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -83,7 +83,8 @@ type fakeController struct {
 
 	files []gomaasapi.File
 
-	devices []gomaasapi.Device
+	devices      []gomaasapi.Device
+	domainsError error
 }
 
 func newFakeController() *fakeController {
@@ -137,7 +138,7 @@ func (c *fakeController) Machines(args gomaasapi.MachinesArgs) ([]gomaasapi.Mach
 }
 
 func (c *fakeController) Domains() ([]gomaasapi.Domain, error) {
-	return c.domains, nil
+	return c.domains, c.domainsError
 }
 
 func (c *fakeController) AllocateMachine(args gomaasapi.AllocateMachineArgs) (gomaasapi.Machine, gomaasapi.ConstraintMatches, error) {

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -104,6 +104,6 @@ func (mi *maas2Instance) ClosePorts(ctx context.ProviderCallContext, machineId s
 }
 
 func (mi *maas2Instance) IngressRules(ctx context.ProviderCallContext, machineId string) ([]network.IngressRule, error) {
-	logger.Debugf("unimplemented Rules() called")
+	logger.Debugf("unimplemented IngressRules() called")
 	return nil, nil
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -54,7 +54,8 @@ type baseProviderSuite struct {
 	envtesting.ToolsFixture
 	controllerUUID string
 
-	callCtx context.ProviderCallContext
+	callCtx           *context.CloudCallContext
+	invalidCredential bool
 }
 
 func (suite *baseProviderSuite) setupFakeTools(c *gc.C) {
@@ -81,10 +82,16 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	s.PatchValue(&series.MustHostSeries, func() string { return supportedversion.SupportedLTS() })
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = &context.CloudCallContext{
+		InvalidateCredentialFunc: func(string) error {
+			s.invalidCredential = true
+			return nil
+		},
+	}
 }
 
 func (s *baseProviderSuite) TearDownTest(c *gc.C) {
+	s.invalidCredential = false
 	s.ToolsFixture.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
@@ -159,7 +160,7 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(validVolumeJson)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -217,7 +218,7 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumesOldMass(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
-	statusGetter := func(instance.Id) (string, string) {
+	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
 		// status, substatus or status info.
 		return "provisioning", "substatus"
 	}


### PR DESCRIPTION
## Description of change

This PR ensures that juju maas provider is responsive to cloud denying access to a credential.

The most interesting bits are contained in ~/provider/maas/errors.go file. This is the code that examines maas errors and determines whether the error is related to credential and worth reacting to.
All cloud calls that throw errors have now been modified to go through this logic to ensure that if the cloud complained about a credential, juju marks it as invalid.

Unit tests have been added to provide adequate initial coverage.
Since this code also cater for maas v1 type errors which contain http Status Code, these codes have been moved to a common area.