### PR TITLE
Update resource usage of docker to container image.

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -157,7 +157,7 @@ func (h *ResourcesHandler) readResource(backend ResourcesBackend, req *http.Requ
 		if path.Ext(uReq.Filename) != ext {
 			return nil, errors.Errorf("incorrect extension on resource upload %q, expected %q", uReq.Filename, ext)
 		}
-	case charmresource.TypeDocker:
+	case charmresource.TypeContainerImage:
 		// Mapping the uploaded 'filename' which is actually the RegistryPath. There is no 'Path', it'll be written to file as content.yaml
 		err := resources.CheckDockerDetails(res.Name, uReq.Filename)
 		if err != nil {

--- a/charmstore/client_test.go
+++ b/charmstore/client_test.go
@@ -218,7 +218,7 @@ func (s *ClientSuite) TestGetResourceDockerType(c *gc.C) {
 	}
 	apiRes := params.Resource{
 		Name:        "mysql_image",
-		Type:        "docker",
+		Type:        "oci-image",
 		Description: "something",
 		Revision:    2,
 		Fingerprint: resource.Fingerprint{}.Bytes(),

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -122,7 +122,7 @@ func (d deployUploader) upload(resourceValues map[string]string, revisions map[s
 		switch d.resources[name].Type {
 		case charmresource.TypeFile:
 			id, err = d.uploadFile(name, resValue)
-		case charmresource.TypeDocker:
+		case charmresource.TypeContainerImage:
 			id, err = d.uploadDockerDetails(name, resValue)
 		default:
 			err = errors.New("unknown resource type to upload")
@@ -143,7 +143,7 @@ func (d deployUploader) validateResourceDetails(res map[string]string) error {
 		switch d.resources[name].Type {
 		case charmresource.TypeFile:
 			err = d.checkFile(name, value)
-		case charmresource.TypeDocker:
+		case charmresource.TypeContainerImage:
 			err = resources.CheckDockerDetails(name, value)
 		default:
 			return fmt.Errorf("unknown resource: %s", name)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -89,6 +89,7 @@ github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/matttproud/golang_protobuf_extensions	git	c12348ce28de40eed0136aa2b644d0ee0650e56c	2016-04-24T11:30:07Z
+github.com/ncw/swift	git	b2a7479cf26fa841ff90dd932d0221cb5c50782d	2018-03-27T20:33:07Z
 github.com/nu7hatch/gouuid	git	179d4d0c4d8d407a32af483c2354df1d2c91e6c3	2013-12-21T20:05:32Z
 github.com/oracle/oci-go-sdk	git	ad5c34ed0cf8169d6817e2a37ec3e4521f856368	2018-04-05T22:36:05Z
 github.com/pkg/errors	git	839d9e913e063e28dfd0e6c7b7512793e0a48be9	2016-10-02T05:25:12Z
@@ -113,10 +114,10 @@ gopkg.in/goose.v2	git	9cc2ac8f3ac3904725fe9bef85d30b53713b3be9	2018-07-31T15:26:
 gopkg.in/httprequest.v1	git	1a21782420ea13c3c6fb1d03578f446b3248edb1	2018-03-08T16:26:44Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6	git	52d8af8e45d911a36f072826d1229d83ecdb958d	2018-07-15T21:39:02Z
+gopkg.in/juju/charm.v6	git	abaa717bc6ed4f694281737cb01f32f7de7ea357	2018-08-03T03:00:15Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
-gopkg.in/juju/charmrepo.v3	git	8bb46aa94f3c679069e80fe35aac6d0581096d65	2018-06-29T07:07:28Z
-gopkg.in/juju/charmstore.v5	git	d93d0fd2b81b8230bdf9b1be91b50538dd8782fa	2018-06-28T08:11:03Z
+gopkg.in/juju/charmrepo.v3	git	7778a447283bd71109671c20818544514e16e9d9	2018-08-03T04:37:37Z
+gopkg.in/juju/charmstore.v5	git	743b5ab3209d901b82aaa6594c405e017e0761a9	2018-08-03T04:08:00Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v3	git	1ebf5c5481e815de683e57e0f46705ac567e4e58	2018-06-29T06:57:38Z
 gopkg.in/juju/names.v2	git	fd59336b4621bc2a70bf96d9e2f49954115ad19b	2018-06-21T09:39:30Z

--- a/resource/context/internal/resource.go
+++ b/resource/context/internal/resource.go
@@ -35,7 +35,7 @@ func OpenResource(name string, client OpenedResourceClient) (*OpenedResource, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if info.Type == charmresource.TypeDocker {
+	if info.Type == charmresource.TypeContainerImage {
 		info.Path = "content.yaml"
 	}
 	or := &OpenedResource{

--- a/resource/resourcetesting/resource.go
+++ b/resource/resourcetesting/resource.go
@@ -71,7 +71,7 @@ func NewCharmDockerResource(c *gc.C, name, content string) charmresource.Resourc
 	res := charmresource.Resource{
 		Meta: charmresource.Meta{
 			Name:        name,
-			Type:        charmresource.TypeDocker,
+			Type:        charmresource.TypeContainerImage,
 			Description: name + " description",
 		},
 		Origin:      charmresource.OriginUpload,

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -283,7 +283,7 @@ func (st resourceState) storeResource(res resource.Resource, r io.Reader) error 
 	switch res.Type {
 	case charmresource.TypeFile:
 		err = st.storage.PutAndCheckHash(storagePath, r, res.Size, hash)
-	case charmresource.TypeDocker:
+	case charmresource.TypeContainerImage:
 		var dockerDetails resources.DockerImageDetails
 		respBuf := new(bytes.Buffer)
 		_, err := respBuf.ReadFrom(r)
@@ -336,7 +336,7 @@ func (st resourceState) OpenResource(applicationID, name string) (resource.Resou
 	var resourceReader io.ReadCloser
 	var resSize int64
 	switch resourceInfo.Type {
-	case charmresource.TypeDocker:
+	case charmresource.TypeContainerImage:
 		resourceReader, resSize, err = st.dockerMetadataStorage.Get(resourceInfo.ID)
 	case charmresource.TypeFile:
 		resourceReader, resSize, err = st.storage.Get(storagePath)
@@ -347,7 +347,7 @@ func (st resourceState) OpenResource(applicationID, name string) (resource.Resou
 		return resource.Resource{}, nil, errors.Annotate(err, "while retrieving resource data")
 	}
 	switch resourceInfo.Type {
-	case charmresource.TypeDocker:
+	case charmresource.TypeContainerImage:
 		// Resource size only found at this stage in time as it's a response from the charmstore, not a stored file.
 		// Store it as it's used later for verification (in a separate call than this one)
 		resourceInfo.Size = resSize


### PR DESCRIPTION
## Description of change

This updates the use of TypeDocker to TypeContainerImage. It reflects the use of "oci-image" instead of "docker" in a charms metadata.yaml.

## QA steps

Unit tests updated and a manual deploy of a caas charm (local charm as staging charmstore wasn't been updated yet, also needed to use --resource for that same reason).
