### PR TITLE
Should fix intermittent and puzzling test failure in cmd/machine.

### DIFF
--- a/cmd/juju/machine/package_test.go
+++ b/cmd/juju/machine/package_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 // None of the tests in this package require mongo.
-// Full command integration tests are found in cmd/juju/machine_test.go
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)


### PR DESCRIPTION
## Description of change

This failure is observed only in develop, so newly added tests were suspect.
The failure was puzzling because it would not actually produce a trace and will look like this http://ci.jujucharms.com/job/github-check-merge-juju/2693/testReport/junit/github/com_juju_juju_cmd_juju_machine/TestPackage/
Absence of any form of a stack trace is concerning and pointed to a failure outside of juju codebase, specifically a failure in gomocks as the external library used by this tests. Upon further investigation, the tests here construct mock controller in setuptest using gc.C (our custom equivalent of testing.T). However, we know that the instance of gc.C at test setup is different to the instance used by any one test. See also https://github.com/golang/mock/issues/51

As a consequence, this PR ensures that mock controller is constructed by each test with correct gc.C instance.

I will build this PR several times as the problem seems to be more apparent on CI machines. 

Run 1: Pass
Run 2: Pass
Run 3: Pass
Run 4: Pass
   
## Bug reference

https://bugs.launchpad.net/juju/+bug/1783284
