### PR TITLE
Add UnitIds Method to Upgrade-Series API

### DIFF
--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -121,3 +121,27 @@ func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(status string, statusType mode
 	}
 	return nil
 }
+
+func (u *UpgradeSeriesAPI) UnitIds() ([]string, error) {
+	var results params.StringResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: u.tag.String()}},
+	}
+
+	err := u.facade.FacadeCall("UnitIds", args, &results)
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := make([]string, len(results.Results))
+	for i, res := range results.Results {
+		if res.Error != nil {
+			if params.IsCodeNotFound(res.Error) {
+				return nil, errors.NewNotFound(res.Error, "")
+			}
+			return nil, res.Error
+		}
+		statuses[i] = res.Result
+	}
+	return statuses, nil
+}

--- a/api/common/upgradeseries_test.go
+++ b/api/common/upgradeseries_test.go
@@ -209,3 +209,25 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusResultError(c *gc.C) {
 	err := api.SetUpgradeSeriesStatus(string(model.UnitErrored), model.PrepareStatus)
 	c.Assert(err, gc.ErrorMatches, "error in call")
 }
+
+func (s *upgradeSeriesSuite) TestUnitIds(c *gc.C) {
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		c.Assert(name, gc.Equals, "UnitIds")
+		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
+			{Tag: s.tag.String()},
+		}})
+		*(response.(*params.StringResults)) = params.StringResults{
+			Results: []params.StringResult{
+				{Result: "ubuntu-lite/0"},
+				{Result: "wordpress/0"},
+				{Result: "wordpress/1"},
+			},
+		}
+		return nil
+	}
+	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
+	watchResult, err := api.UnitIds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watchResult, gc.DeepEquals, []string{"ubuntu-lite/0", "wordpress/0", "wordpress/1"})
+}

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -220,14 +220,38 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMachineTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{
-			{
-				Status: string(model.UnitStarted),
-				Error:  nil,
-			},
-			{
-				Status: string(model.UnitCompleted),
-				Error:  nil,
-			},
+			{Status: string(model.UnitStarted)},
+			{Status: string(model.UnitCompleted)},
+		},
+	})
+}
+
+func (s *upgradeSeriesSuite) TestUnitIds(c *gc.C) {
+	api, ctrl, mockBackend := s.assertBackendApi(c, s.machineTag1)
+	defer ctrl.Finish()
+
+	mockApplication := mocks.NewMockUpgradeSeriesMachine(ctrl)
+	mockUnit1 := mocks.NewMockUpgradeSeriesUnit(ctrl)
+	mockUnit2 := mocks.NewMockUpgradeSeriesUnit(ctrl)
+
+	mockBackend.EXPECT().Machine(s.machineTag1.Id()).Return(mockApplication, nil)
+
+	mockApplication.EXPECT().Units().Return([]common.UpgradeSeriesUnit{mockUnit1, mockUnit2}, nil)
+	mockUnit1.EXPECT().Tag().Return(s.unitTag1)
+	mockUnit2.EXPECT().Tag().Return(s.unitTag2)
+
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: s.machineTag1.String()},
+		},
+	}
+
+	results, err := api.UnitIds(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Result: s.unitTag1.Id()},
+			{Result: s.unitTag2.Id()},
 		},
 	})
 }


### PR DESCRIPTION
## Description of change

Adds `UnitIds` method to upgrade-series API and API server, required by the upgrade-series worker.

## QA steps

Unit tests

## Documentation changes

None.

## Bug reference

N/A
