### PR TITLE
update openstack cloud schema to include os_cacert

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -77,6 +77,11 @@ const (
 	// RegionsKey is the name of the key in a cloud schema that holds the list
 	// of regions a cloud supports.
 	RegionsKey = "regions"
+
+	// CertFilenameKey is the name of the key in a cloud schema that holds
+	// the filename of a CA Certificate to be used to access the cloud, in conjunction
+	// with an auth type.
+	CertFilenameKey = "certfilename"
 )
 
 // Attrs serves as a map to hold regions specific configuration attributes.

--- a/cloud/validations.go
+++ b/cloud/validations.go
@@ -58,6 +58,10 @@ var cloudSchema = map[string]interface{}{
 		"config":            map[string]interface{}{"type": "object"},
 		"regions":           regionsSchema,
 		"region-config":     map[string]interface{}{"type": "object"},
+		"ca-certificates": map[string]interface{}{
+			"type":  "array",
+			"items": map[string]interface{}{"type": "string"},
+		},
 	},
 	"additionalProperties": false,
 }

--- a/cloud/validations_test.go
+++ b/cloud/validations_test.go
@@ -24,7 +24,11 @@ func (s *cloudSuite) TestValidateValidCloud(c *gc.C) {
                 http-proxy: http://10.245.200.27:8000/
               regions:
                 dev1:
-                  endpoint: https://openstack.example.com:35574/v3.0/`
+                  endpoint: https://openstack.example.com:35574/v3.0/
+              ca-certificates:
+              - |-
+                -----BEGIN CERTIFICATE-----
+                -----END CERTIFICATE-----`
 
 	yaml := []byte(validCloud)
 	err := cloud.ValidateCloudSet(yaml)

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -5,23 +5,27 @@ package cloud_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	cloudfile "github.com/juju/juju/cloud"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
-	cloudfile "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/testing"
 )
 
 type addSuite struct {
@@ -61,6 +65,10 @@ func (f *fakeCloudMetadataStore) WritePersonalCloudMetadata(cloudsMap map[string
 
 func (f *fakeCloudMetadataStore) ParseOneCloud(data []byte) (cloudfile.Cloud, error) {
 	results := f.MethodCall(f, "ParseOneCloud", data)
+	if len(results) != 2 {
+		fmt.Printf("ParseOneCloud()\n(%s)\n", string(data))
+		return cloudfile.Cloud{}, errors.New("ParseOneCloud failed, not enough results")
+	}
 	return results[0].(cloudfile.Cloud), jujutesting.TypeAssertError(results[1])
 }
 
@@ -324,61 +332,6 @@ func (*addSuite) TestInteractive(c *gc.C) {
 	)
 }
 
-func (*addSuite) TestInteractiveOpenstack(c *gc.C) {
-	fake := newFakeCloudMetadataStore()
-	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
-	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
-	myOpenstack := cloudfile.Cloud{
-		Name:      "os1",
-		Type:      "openstack",
-		AuthTypes: []cloudfile.AuthType{"userpass", "access-key"},
-		Endpoint:  "http://myopenstack",
-		Regions: []cloudfile.Region{
-			{
-				Name:     "regionone",
-				Endpoint: "http://boston/1.0",
-			},
-		},
-	}
-	const expectedYAMLarg = "" +
-		"auth-types:\n" +
-		"- userpass\n" +
-		"- access-key\n" +
-		"endpoint: http://myopenstack\n" +
-		"regions:\n" +
-		"  regionone:\n" +
-		"    endpoint: http://boston/1.0\n"
-	fake.Call("ParseOneCloud", []byte(expectedYAMLarg)).Returns(myOpenstack, nil)
-	m1Metadata := map[string]cloudfile.Cloud{"os1": myOpenstack}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
-
-	command := cloud.NewAddCloudCommand(fake)
-	command.Ping = func(environs.EnvironProvider, string) error {
-		return nil
-	}
-	err := cmdtesting.InitCommand(command, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	ctx := &cmd.Context{
-		Stdout: ioutil.Discard,
-		Stderr: ioutil.Discard,
-		Stdin: strings.NewReader("" +
-			"openstack\n" +
-			"os1\n" +
-			"http://myopenstack\n" +
-			"userpass,access-key\n" +
-			"regionone\n" +
-			"http://boston/1.0\n" +
-			"n\n",
-		),
-	}
-
-	err = command.Run(ctx)
-	c.Check(err, jc.ErrorIsNil)
-
-	c.Check(numCallsToWrite(), gc.Equals, 1)
-}
-
 func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	fake := newFakeCloudMetadataStore()
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
@@ -496,9 +449,9 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 			/* Enter a name for the cloud: */ "mvs\n" +
 			/* Enter the vCenter address or URL: */ "192.168.1.6\n" +
 			/* Enter datacenter name: */ "foo\n" +
-			/* Enter another datacenter? (Y/n): */ "y\n" +
+			/* Enter another datacenter? (y/N): */ "y\n" +
 			/* Enter datacenter name: */ "bar\n" +
-			/* Enter another datacenter? (Y/n): */ "n\n",
+			/* Enter another datacenter? (y/N): */ "n\n",
 		),
 	}
 
@@ -511,9 +464,9 @@ Select cloud type:
 Enter a name for your vsphere cloud: 
 Enter the vCenter address or URL: 
 Enter datacenter name: 
-Enter another datacenter\? \(Y/n\): 
+Enter another datacenter\? \(y/N\): 
 Enter datacenter name: 
-Enter another datacenter\? \(Y/n\): 
+Enter another datacenter\? \(y/N\): 
 `[1:]+"(.|\n)*")
 }
 
@@ -756,4 +709,214 @@ func (s *addSuite) TestInvalidCredentialMessage(c *gc.C) {
 	err := command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, "Cloud credential is not accepted by cloud provider: running test")
+}
+
+func (*addSuite) TestInteractiveOpenstackNoCloudCert(c *gc.C) {
+	myOpenstack := cloudfile.Cloud{
+		Name:      "os1",
+		Type:      "openstack",
+		AuthTypes: []cloudfile.AuthType{"userpass", "access-key"},
+		Endpoint:  "http://myopenstack",
+		Regions: []cloudfile.Region{
+			{
+				Name:     "regionone",
+				Endpoint: "http://boston/1.0",
+			},
+		},
+	}
+
+	var expectedYAMLarg = "" +
+		"auth-types:\n" +
+		"- userpass\n" +
+		"- access-key\n" +
+		"certfilename: \"\"\n" +
+		"endpoint: http://myopenstack\n" +
+		"regions:\n" +
+		"  regionone:\n" +
+		"    endpoint: http://boston/1.0\n"
+
+	var input = "" +
+		/* Select cloud type: */ "openstack\n" +
+		/* Enter a name for your openstack cloud: */ "os1\n" +
+		/* Enter the API endpoint url for the cloud []: */ "http://myopenstack\n" +
+		/* Enter ta path to the CA certificate for your cloud if one is required to access it. (optional) [none] */ "\n" +
+		/* Select one or more auth types separated by commas: */ "userpass,access-key\n" +
+		/* Enter region name: */ "regionone\n" +
+		/* Enter the API endpoint url for the region [use cloud api url]: */ "http://boston/1.0\n" +
+		/* Enter another region? (Y/n): */ "n\n"
+
+	testInteractiveOpenstack(c, myOpenstack, expectedYAMLarg, input, "", "")
+}
+
+// Note: The first %s is filled with a string containing a newline
+var expectedCloudYAMLarg = `
+auth-types:
+- userpass
+- access-key
+%scertfilename: %s
+endpoint: http://myopenstack
+regions:
+  regionone:
+    endpoint: ""
+`[1:]
+
+func (*addSuite) TestInteractiveOpenstackCloudCertFail(c *gc.C) {
+	fakeCertDir := c.MkDir()
+	fakeCertFilename := path.Join(fakeCertDir, "cloudcert.crt")
+
+	invalidCertFilename := path.Join(fakeCertDir, "invalid.crt")
+	ioutil.WriteFile(invalidCertFilename, []byte("testing certification validation"), 0666)
+
+	input := fmt.Sprintf(""+
+		/* Select cloud type: */ "openstack\n"+
+		/* Enter a name for your openstack cloud: */ "os1\n"+
+		/* Enter the API endpoint url for the cloud []: */ "http://myopenstack\n"+
+		/* Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none] */ "%s\n"+
+		/* Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none] */ "%s\n"+
+		/* Select one or more auth types separated by commas: */ "userpass,access-key\n"+
+		/* Enter region name: */ "regionone\n"+
+		/* Enter the API endpoint url for the region [use cloud api url]: */ "\n"+
+		/* Enter another region? (Y/n): */ "n\n", invalidCertFilename, fakeCertFilename)
+
+	testInteractiveOpenstackCloudCert(c, fakeCertFilename, input,
+		fmt.Sprintf("Successfully read CA Certificate from %s\n", fakeCertFilename),
+		fmt.Sprintf("Can't validate CA Certificate %s: no certificates found", invalidCertFilename))
+}
+
+func (*addSuite) TestInteractiveOpenstackCloudCertReadFailRetry(c *gc.C) {
+	var invalidCertFilename = "/tmp/no-such-file"
+	fakeCertDir := c.MkDir()
+	fakeCertFilename := path.Join(fakeCertDir, "cloudcert.crt")
+
+	input := fmt.Sprintf(""+
+		/* Select cloud type: */ "openstack\n"+
+		/* Enter a name for your openstack cloud: */ "os1\n"+
+		/* Enter the API endpoint url for the cloud []: */ "http://myopenstack\n"+
+		/* Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none] */ "%s\n"+
+		/* Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none] */ "%s\n"+
+		/* Select one or more auth types separated by commas: */ "userpass,access-key\n"+
+		/* Enter region name: */ "regionone\n"+
+		/* Enter the API endpoint url for the region [use cloud api url]: */ "\n"+
+		/* Enter another region? (Y/n): */ "n\n", invalidCertFilename, fakeCertFilename)
+
+	testInteractiveOpenstackCloudCert(c,
+		fakeCertFilename,
+		input,
+		fmt.Sprintf("Successfully read CA Certificate from %s\n", fakeCertFilename),
+		fmt.Sprintf("Can't validate CA Certificate file: open %s: no such file or directory", invalidCertFilename),
+	)
+}
+
+func (*addSuite) TestInteractiveOpenstackCloudCert(c *gc.C) {
+	fakeCertFilename := path.Join(c.MkDir(), "cloudcert.crt")
+
+	input := fmt.Sprintf(""+
+		/* Select cloud type: */ "openstack\n"+
+		/* Enter a name for your openstack cloud: */ "os1\n"+
+		/* Enter the API endpoint url for the cloud []: */ "http://myopenstack\n"+
+		/* Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none] */ "%s\n"+
+		/* Select one or more auth types separated by commas: */ "userpass,access-key\n"+
+		/* Enter region name: */ "regionone\n"+
+		/* Enter the API endpoint url for the region [use cloud api url]: */ "\n"+
+		/* Enter another region? (Y/n): */ "n\n", fakeCertFilename)
+
+	testInteractiveOpenstackCloudCert(c, fakeCertFilename, input,
+		fmt.Sprintf("Successfully read CA Certificate from %s\n", fakeCertFilename), "")
+}
+
+type addOpenStackSuite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&addOpenStackSuite{})
+
+func (s *addOpenStackSuite) TearDownTest(c *gc.C) {
+	s.IsolationSuite.TearDownTest(c)
+	os.Unsetenv("OS_CACERT")
+	os.Unsetenv("OS_AUTH_URL")
+}
+
+func (*addOpenStackSuite) TestInteractiveOpenstackCloudCertEnvVar(c *gc.C) {
+	fakeCertFilename := path.Join(c.MkDir(), "cloudcert.crt")
+
+	input := "" +
+		/* Select cloud type: */ "openstack\n" +
+		/* Enter a name for your openstack cloud: */ "os1\n" +
+		/* Enter the API endpoint url for the cloud [$OS_AUTH_URL]: */ "\n" +
+		/* Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [$OS_CACERT] */ "\n" +
+		/* Select one or more auth types separated by commas: */ "userpass,access-key\n" +
+		/* Enter region name: */ "regionone\n" +
+		/* Enter the API endpoint url for the region [use cloud api url]: */ "\n" +
+		/* Enter another region? (Y/n): */ "n\n"
+
+	os.Setenv("OS_CACERT", fakeCertFilename)
+	os.Setenv("OS_AUTH_URL", "http://myopenstack")
+
+	testInteractiveOpenstackCloudCert(c, fakeCertFilename, input,
+		fmt.Sprintf("Successfully read CA Certificate from %s\n", fakeCertFilename), "")
+}
+
+func testInteractiveOpenstackCloudCert(c *gc.C, fakeCertFilename, input, addStdErrMsg, stdOutMsg string) {
+	fakeCert := testing.CACert
+	ioutil.WriteFile(fakeCertFilename, []byte(fakeCert), 0666)
+
+	myOpenstack := cloudfile.Cloud{
+		Name:      "os1",
+		Type:      "openstack",
+		AuthTypes: []cloudfile.AuthType{"userpass", "access-key"},
+		Endpoint:  "http://myopenstack",
+		Regions: []cloudfile.Region{
+			{
+				Name:     "regionone",
+				Endpoint: "http://myopenstack",
+			},
+		},
+		CACertificates: []string{fakeCert},
+	}
+
+	fakeCertMap := map[string]interface{}{
+		"ca-certificates": []string{fakeCert},
+	}
+	fakeCertYaml, err := yaml.Marshal(fakeCertMap)
+	c.Assert(err, gc.IsNil)
+
+	expectedYAMLarg := fmt.Sprintf(expectedCloudYAMLarg, fakeCertYaml, fakeCertFilename)
+
+	testInteractiveOpenstack(c, myOpenstack, expectedYAMLarg, input, addStdErrMsg, stdOutMsg)
+}
+
+func testInteractiveOpenstack(c *gc.C, myOpenstack cloudfile.Cloud, expectedYAMLarg, input, addStdErrMsg, stdOutMsg string) {
+	fake := newFakeCloudMetadataStore()
+	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloudfile.Cloud{}, false, nil)
+	fake.Call("PersonalCloudMetadata").Returns(map[string]cloudfile.Cloud{}, nil)
+
+	fake.Call("ParseOneCloud", []byte(expectedYAMLarg)).Returns(myOpenstack, nil)
+	m1Metadata := map[string]cloudfile.Cloud{"os1": myOpenstack}
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
+
+	command := cloud.NewAddCloudCommand(fake)
+	command.Ping = func(environs.EnvironProvider, string) error {
+		return nil
+	}
+	err := cmdtesting.InitCommand(command, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = strings.NewReader(input)
+
+	err = command.Run(ctx)
+
+	if err != nil {
+		fmt.Printf("expectedYAML\n(%s)\n", expectedYAMLarg)
+	}
+
+	c.Check(err, jc.ErrorIsNil)
+	var output = addStdErrMsg +
+		"Cloud \"os1\" successfully added\n" +
+		"You may need to `juju add-credential os1' if your cloud needs additional credentials\n" +
+		"Then you can bootstrap with 'juju bootstrap os1'\n"
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, output)
+	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, stdOutMsg)
+
+	c.Check(numCallsToWrite(), gc.Equals, 1)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
+	"github.com/juju/juju/cmd/juju/interact"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -83,12 +84,22 @@ var providerInstance *EnvironProvider = &EnvironProvider{
 var cloudSchema = &jsonschema.Schema{
 	Type:     []jsonschema.Type{jsonschema.ObjectType},
 	Required: []string{cloud.EndpointKey, cloud.AuthTypesKey, cloud.RegionsKey},
-	Order:    []string{cloud.EndpointKey, cloud.AuthTypesKey, cloud.RegionsKey},
+	Order:    []string{cloud.EndpointKey, cloud.CertFilenameKey, cloud.AuthTypesKey, cloud.RegionsKey},
 	Properties: map[string]*jsonschema.Schema{
 		cloud.EndpointKey: {
 			Singular: "the API endpoint url for the cloud",
 			Type:     []jsonschema.Type{jsonschema.StringType},
 			Format:   jsonschema.FormatURI,
+			Default:  "",
+			EnvVars:  []string{"OS_AUTH_URL"},
+		},
+		cloud.CertFilenameKey: {
+			Singular:      "a path to the CA certificate for your cloud if one is required to access it. (optional)",
+			Type:          []jsonschema.Type{jsonschema.StringType},
+			Format:        interact.FormatCertFilename,
+			Default:       "",
+			PromptDefault: "none",
+			EnvVars:       []string{"OS_CACERT"},
 		},
 		cloud.AuthTypesKey: {
 			Singular:    "auth type",
@@ -109,6 +120,10 @@ var cloudSchema = &jsonschema.Schema{
 			Type:     []jsonschema.Type{jsonschema.ObjectType},
 			Singular: "region",
 			Plural:   "regions",
+			Default:  "",
+			// TODO (hml) 2018-08-02
+			// It'd be nice to have the EnvVars work with ObjectTypes, like they do for StringType.
+			// EnvVars:  []string{"OS_REGION_NAME"},
 			AdditionalProperties: &jsonschema.Schema{
 				Type:          []jsonschema.Type{jsonschema.ObjectType},
 				Required:      []string{cloud.EndpointKey},


### PR DESCRIPTION
## Description of change

Update add-cloud to allow default values of the cloud schema's to get
values from environment variables.  Add environment variables and a new
get cloud ca certificate to the openstack cloud schema.  Add ca-certificates
to cloud schema use for validation.

## QA steps

Run juju add-cloud for openstack.  Should query for an optional cloud ca cert.
1. try without a cert
2. try with a good cert file
3. try with a bad cert file - should create the cloud but Ignore the cert.

Source a novarc file, including a OS_CACERT definition, run juju add-cloud for openstack.
1. notice that the auth url is now a default option.
2. notice that the os cacert is now a default option.

Check that the new cloud definition in ~/.local/share/juju/clouds.yaml contains  ca-certificates: ...

Try juju add-cloud -f with a yaml definition including the ca-certificates, no schema validation error should be printed on the name.

## Documentation changes

Not yet, a discourse update will happen with all of the OS_CACERT changes are made.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1777897
Partially addresses https://bugs.launchpad.net/juju/+bug/1722580