### PR TITLE
Sort API Host Ports by server too

### DIFF
--- a/network/hostport.go
+++ b/network/hostport.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
@@ -131,6 +132,27 @@ func SortHostPorts(hps []HostPort, preferIPv6 bool) {
 	} else {
 		sort.Sort(hostPortsPreferringIPv4Slice(hps))
 	}
+}
+
+// Slice of HostPort slices (for example, API Servers' HostPorts).
+type hostPortsSlicesSlice [][]HostPort
+
+func (hpss hostPortsSlicesSlice) Len() int      { return len(hpss) }
+func (hpss hostPortsSlicesSlice) Swap(i, j int) { hpss[i], hpss[j] = hpss[j], hpss[i] }
+func (hpss hostPortsSlicesSlice) Less(i, j int) bool {
+	// Convert the HostPort slices to strings and compare.
+	hps1 := strings.Join(HostPortsToStrings(hpss[i]), ",")
+	hps2 := strings.Join(HostPortsToStrings(hpss[j]), ",")
+	return hps1 < hps2
+}
+
+// SortHostPortsServers sorts the outer slice in the given
+// slice of HostPort slices according to converted strings
+// (that is, it sorts the servers based on their hostports).
+// It doesn't sort the inner slices (do with SortHostPorts()).
+// One should sort the inner slices before the outer slice.
+func SortHostPortsServers(hpss [][]HostPort) {
+	sort.Sort(hostPortsSlicesSlice(hpss))
 }
 
 var netLookupIP = net.LookupIP

--- a/worker/peergrouper/publish.go
+++ b/worker/peergrouper/publish.go
@@ -43,6 +43,9 @@ func (pub *publisher) publishAPIServers(apiServers [][]network.HostPort, instanc
 		sortedAPIServers[i] = append([]network.HostPort{}, hostPorts...)
 		network.SortHostPorts(sortedAPIServers[i], pub.preferIPv6)
 	}
+	logger.Debugf("Sort API host ports by server (before): %v", sortedAPIServers)
+	network.SortHostPortsServers(sortedAPIServers)
+	logger.Debugf("Sort API host ports by server (after): %v", sortedAPIServers)
 	if apiServersEqual(sortedAPIServers, pub.lastAPIServers) {
 		logger.Debugf("API host ports have not changed")
 		return nil


### PR DESCRIPTION
Currently the API Servers are sorted by HostPort for each server
(ie, inner slice) but not by server (ie, outer slice).

This allows for unnecessary updates of API servers (and triggers
of rsyslog restarts, for example) in case the servers and their
hostports have _not_ changed but the _order_ of servers changed.

It happens because publishAPIServers()'s apiServers parameter is
obtained from pgWorker.apiPublishInfo(), which iterates over the
pgWorker.machines _map_ with 'for/range'.

However, the iteration order over maps is _not_ specified and
_not_ guaranteed to be the same from one iteration to the next
(Go spec, section 'For statements', subsection 'For statement
 with range clause', note 3 [1]); apparently the runtime even
randomizes the map iteration order.

So, sort the API servers host ports by server as well, so that
the order of the servers does not change if the servers do not
change. This uses String sort on the host ports of each server.

[1] https://golang.org/ref/spec#For_statements

Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>

## Please provide the following details to expedite Pull Request review:

----

## Description of change

Currently the API servers are periodically published in _random_ order, which triggers _excessive_ restarts of the `rsyslog` service on bootstrap nodes.

The randomness happens because the list of servers to publish is obtained from a `map` with `for/range`, and in this case the iteration order is not specified/guaranteed by `go`.

The `rsyslog` restart happens because the `rsyslog` worker watches for changes in the API servers to reload the `rsyslog` configuration -- and a different _order_ of the servers is detected as change (even if all per-server content did not change).

Since the API servers are published often, and apparently may be published by any bootstrap node (which increases the chance of different order from the previously published value, possibly by another bootstrap node), the situation gets worse w/ the number bootstrap nodes.

This change simply sorts the API servers by server for publishing (after the existing sort by hostport for each server). This ensures the order of the servers is consistent, and does not change unless there are changes in the servers.

## QA steps

It's possible to verify this change observing messages in `all-machines.log` in _debug_ level; specifically:
- number of times API servers change did not happen: `API host ports have not changed`
- number of times API servers change did happen: `setting API hostPorts`
- number of times the rsyslog config is reloaded: `Reloading rsyslog configuration`
- new debug messages:  `Sort API host ports by server (before/after)`

e.g.,
`$ juju set-environment logging-config="<root>=DEBUG;unit=DEBUG"`

**Before**

```
In approx. 7hour 25mins (445 minutes)

# sed -n '1p;$p' /var/log/juju/all-machines.log.PROBLEM | cut -d' ' -f2-3
2018-07-18 05:04:49
2018-07-18 12:29:05

The number of rsyslog config reloads/service restarts 
in 3 bootstrap nodes is: 257 + 290 + 334 (each server) = 881 times (total).

The number of times the API host ports have not changed is much lower.

Observe the `setting API hostPorts` message, which happens for 
the 3 possible permutations of the 3 bootstrap nodes.

# cat /var/log/juju/all-machines.log.PROBLEM \
  | grep -e 'Sort API host ports' \
         -e 'setting API hostPorts' \
         -e 'API host ports have not changed' \
         -e 'Reloading rsyslog configuration' \
  | grep -v 'message repeated' \
  | cut -d' ' -f1,7- \
  | sort \
  | uniq -c 

    138 machine-0: API host ports have not changed
    257 machine-0: Reloading rsyslog configuration
     23 machine-0: setting API hostPorts: [[os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     23 machine-0: setting API hostPorts: [[os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070]]
     33 machine-0: setting API hostPorts: [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070]]

    173 machine-1: API host ports have not changed
    290 machine-1: Reloading rsyslog configuration
     32 machine-1: setting API hostPorts: [[os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     35 machine-1: setting API hostPorts: [[os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070]]
     63 machine-1: setting API hostPorts: [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070]]

    198 machine-2: API host ports have not changed
    334 machine-2: Reloading rsyslog configuration
     35 machine-2: setting API hostPorts: [[os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     35 machine-2: setting API hostPorts: [[os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070]]
     61 machine-2: setting API hostPorts: [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 127.0.0.1:17070 [::1]:17070]]
```

**After**

```
In this case, the period is ~5 hours, and no rsyslog restarts were needed.
Notice the number of times the API servers have not changed (high).

# grep -m1 2018-08 /var/log/juju/all-machines.log* | cut -d' ' -f2-3
2018-08-03 11:42:38
2018-08-03 10:17:49
2018-08-03 08:52:55

# date
Fri Aug  3 12:57:37 UTC 2018

# cat /var/log/juju/all-machines.log* \
  | grep -e 'Sort API host ports' \
         -e 'setting API hostPorts' \
         -e 'API host ports have not changed' \
  | grep -v 'message repeated' \
  | cut -d' ' -f1,7- \
  | sort \
  | uniq -c 

    222 machine-0: API host ports have not changed
    222 machine-0: Sort API host ports by server (after): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     28 machine-0: Sort API host ports by server (before): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     23 machine-0: Sort API host ports by server (before): [[os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070]]
    171 machine-0: Sort API host ports by server (before): [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070]]


    223 machine-1: API host ports have not changed
    223 machine-1: Sort API host ports by server (after): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     30 machine-1: Sort API host ports by server (before): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     25 machine-1: Sort API host ports by server (before): [[os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070]]
    169 machine-1: Sort API host ports by server (before): [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070]]


    223 machine-2: API host ports have not changed
    223 machine-2: Sort API host ports by server (after): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     45 machine-2: Sort API host ports by server (before): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070]]
     23 machine-2: Sort API host ports by server (before): [[os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070]]
    155 machine-2: Sort API host ports by server (before): [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070]]

```
**After (another)**

```
Here in ~2 hours usually 1 rsyslog restart happened per server:

     66 machine-0: API host ports have not changed
      2 machine-0: Reloading rsyslog configuration
      2 machine-0: setting API hostPorts: [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.
0.1:17070 [::1]:17070]]
     67 machine-0: Sort API host ports by server (after): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.
210:17070 127.0.0.1:17070 [::1]:17070]]
      7 machine-0: Sort API host ports by server (before): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10
.210:17070 127.0.0.1:17070 [::1]:17070]]
      3 machine-0: Sort API host ports by server (before): [[os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.1
22.1:17070 127.0.0.1:17070 [::1]:17070]]
     57 machine-0: Sort API host ports by server (before): [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.1
22.1:17070 127.0.0.1:17070 [::1]:17070]]


     67 machine-1: API host ports have not changed
      1 machine-1: Reloading rsyslog configuration
      1 machine-1: setting API hostPorts: [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.
0.1:17070 [::1]:17070]]
     68 machine-1: Sort API host ports by server (after): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.
210:17070 127.0.0.1:17070 [::1]:17070]]
      5 machine-1: Sort API host ports by server (before): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10
.210:17070 127.0.0.1:17070 [::1]:17070]]
      6 machine-1: Sort API host ports by server (before): [[os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.1
22.1:17070 127.0.0.1:17070 [::1]:17070]]
     57 machine-1: Sort API host ports by server (before): [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.1
22.1:17070 127.0.0.1:17070 [::1]:17070]]


     67 machine-2: API host ports have not changed
      1 machine-2: Reloading rsyslog configuration
      1 machine-2: setting API hostPorts: [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.
0.1:17070 [::1]:17070]]
     68 machine-2: Sort API host ports by server (after): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.
210:17070 127.0.0.1:17070 [::1]:17070]]
      7 machine-2: Sort API host ports by server (before): [[os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10
.210:17070 127.0.0.1:17070 [::1]:17070]]
      6 machine-2: Sort API host ports by server (before): [[os-compute03.maas:17070 192.168.10.211:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.1
22.1:17070 127.0.0.1:17070 [::1]:17070]]
     55 machine-2: Sort API host ports by server (before): [[os-juju01.maas:17070 192.168.10.210:17070 127.0.0.1:17070 [::1]:17070] [os-compute02.maas:17070 192.168.10.214:17070 192.168.122.1:17070 127.0.0.1:17070 [::1]:17070] [os-compute03.maas:17070 192.168.10.211:17070 192.168.1
22.1:17070 127.0.0.1:17070 [::1]:17070]]
```

## Documentation changes

This should not change workflow/anything user-visible.

## Bug reference

- SF#162291 (Canonical)

