### PR TITLE
add ca-certificates to the output of show-cloud

### DIFF
--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -115,9 +115,10 @@ type cloudDetails struct {
 	// Regions is for when we want to print regions in order for yaml output.
 	Regions yaml.MapSlice `yaml:"regions,omitempty" json:"-"`
 	// Regions map is for json marshalling where format is important but not order.
-	RegionsMap   map[string]regionDetails `yaml:"-" json:"regions,omitempty"`
-	Config       map[string]interface{}   `yaml:"config,omitempty" json:"config,omitempty"`
-	RegionConfig jujucloud.RegionConfig   `yaml:"region-config,omitempty" json:"region-config,omitempty"`
+	RegionsMap    map[string]regionDetails `yaml:"-" json:"regions,omitempty"`
+	Config        map[string]interface{}   `yaml:"config,omitempty" json:"config,omitempty"`
+	RegionConfig  jujucloud.RegionConfig   `yaml:"region-config,omitempty" json:"region-config,omitempty"`
+	CACredentials []string                 `yaml:"ca-credentials,omitempty" json:"ca-credentials,omitempty"`
 }
 
 func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
@@ -130,6 +131,7 @@ func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 		Config:           cloud.Config,
 		RegionConfig:     cloud.RegionConfig,
 		CloudDescription: cloud.Description,
+		CACredentials:    cloud.CACertificates,
 	}
 	result.AuthTypes = make([]string, len(cloud.AuthTypes))
 	for i, at := range cloud.AuthTypes {

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -171,3 +171,73 @@ regions:
     endpoint: https://us-west-1.api.joyentcloud.com
 `[1:])
 }
+
+var yamlWithCert = `
+clouds:
+  homestack:
+    type: openstack
+    auth-types: [userpass]
+    endpoint: https://homestack:5000/v2.0
+    regions:
+      RegionOne:
+        endpoint: https://homestack:5000/v2.0
+    ca-certificates:
+    - |-
+      -----BEGIN CERTIFICATE-----
+      MIIC0DCCAbigAwIBAgIUeIj3r4ocrSubOmb1yPxmoiRfhO8wDQYJKoZIhvcNAQEL
+      BQAwDzENMAsGA1UEAwwET1NDSTAeFw0xODA3MTUxNjE2NTZaFw0xODEwMjQxNjE2
+      NTZaMA8xDTALBgNVBAMMBE9TQ0kwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+      AoIBAQCpCLMLGZpLojudOwrupsbk2ESCQO4/kEOF6L5YHxcUrRxcrxu0DmnwWYcK
+      pjKL9K3U7xSiSL+MtNff7MfBYbV0SOfjHR0/gqwio0JeYONABeeynUZkuXg1CXuG
+      uMHcmPjCAWnLyAnlF4Wwavv6pPdM4l1X4lt1b2ez8G6u4+UPg/zNt473aqOzwMzy
+      B3aToHSHOoDvXQDwtDkR0PimyEtHVz/17AcwSHzMqNGLgLFEx0SPuYJus8WJg1Sn
+      c9kqrvIUBnZzjtbCquCxLRxG2xHdvBxOesbRyJPO0ypqEcTMtrX9rmJce67HG+4h
+      EgLCEpcgfSVyH9PS3wdUAfkr9KE9AgMBAAGjJDAiMA8GA1UdEQQIMAaCBE9TQ0kw
+      DwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAFIYyqNayVFxZ1jcz
+      fdvEP2yVB9dq8vhSXU4lbkqlPw5q954bLURQzklqMfpXhhIbmrvq6LcLGaSkgmPp
+      CzlxMkjr8oTRVQUqNIfcJQKtwNOAGh7xZ77GPhBlfHJ8VhTFtDXPM/fj8GLr5Oav
+      gy9+QywhESKkwAn4+AubBRRtEDBX9zwc2hT5uqz1x1tcs16tKAZBIekwmMBJKkNs
+      61I+cRHoXtXFh8/upMC6eMAvv6eVHgqpcEWrVLvoBh7ivcsFuUD1IyuIlN4i6roh
+      xcSAzRCXqVe/BBsHqYyd8044vrIG7P7pYGaQm99nFGylTBfSh5g1LrYV7IJP6KkG
+      6JHZXg==
+      -----END CERTIFICATE-----
+`[1:]
+
+var resultWithCert = `
+defined: local
+type: openstack
+description: Openstack Cloud
+auth-types: [userpass]
+endpoint: https://homestack:5000/v2.0
+regions:
+  RegionOne: {}
+ca-credentials:
+- |-
+  -----BEGIN CERTIFICATE-----
+  MIIC0DCCAbigAwIBAgIUeIj3r4ocrSubOmb1yPxmoiRfhO8wDQYJKoZIhvcNAQEL
+  BQAwDzENMAsGA1UEAwwET1NDSTAeFw0xODA3MTUxNjE2NTZaFw0xODEwMjQxNjE2
+  NTZaMA8xDTALBgNVBAMMBE9TQ0kwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+  AoIBAQCpCLMLGZpLojudOwrupsbk2ESCQO4/kEOF6L5YHxcUrRxcrxu0DmnwWYcK
+  pjKL9K3U7xSiSL+MtNff7MfBYbV0SOfjHR0/gqwio0JeYONABeeynUZkuXg1CXuG
+  uMHcmPjCAWnLyAnlF4Wwavv6pPdM4l1X4lt1b2ez8G6u4+UPg/zNt473aqOzwMzy
+  B3aToHSHOoDvXQDwtDkR0PimyEtHVz/17AcwSHzMqNGLgLFEx0SPuYJus8WJg1Sn
+  c9kqrvIUBnZzjtbCquCxLRxG2xHdvBxOesbRyJPO0ypqEcTMtrX9rmJce67HG+4h
+  EgLCEpcgfSVyH9PS3wdUAfkr9KE9AgMBAAGjJDAiMA8GA1UdEQQIMAaCBE9TQ0kw
+  DwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAFIYyqNayVFxZ1jcz
+  fdvEP2yVB9dq8vhSXU4lbkqlPw5q954bLURQzklqMfpXhhIbmrvq6LcLGaSkgmPp
+  CzlxMkjr8oTRVQUqNIfcJQKtwNOAGh7xZ77GPhBlfHJ8VhTFtDXPM/fj8GLr5Oav
+  gy9+QywhESKkwAn4+AubBRRtEDBX9zwc2hT5uqz1x1tcs16tKAZBIekwmMBJKkNs
+  61I+cRHoXtXFh8/upMC6eMAvv6eVHgqpcEWrVLvoBh7ivcsFuUD1IyuIlN4i6roh
+  xcSAzRCXqVe/BBsHqYyd8044vrIG7P7pYGaQm99nFGylTBfSh5g1LrYV7IJP6KkG
+  6JHZXg==
+  -----END CERTIFICATE-----
+`[1:]
+
+func (s *showSuite) TestShowWithCACertificate(c *gc.C) {
+	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(yamlWithCert), 0600)
+
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack")
+	c.Assert(err, jc.ErrorIsNil)
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, resultWithCert)
+}


### PR DESCRIPTION
## Description of change

Add ca-certificates to the list of cloud details displayed via show-cloud.

## QA steps

With a ca-cert specified in a cloud, run juju show-cloud, the ca-certificates should now be shown. 

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?* 

## Bug reference

N/A