### PR TITLE
Prevent false negative with go vet

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1492,10 +1492,10 @@ func mergeDeviceConstraints(device devices.KubernetesDeviceParams, resources *co
 
 	resourceName := core.ResourceName(device.Type)
 	if v, ok := resources.Limits[resourceName]; ok {
-		return errors.NotValidf("resource limit for %q has already been set to %d! Unexpected!", resourceName, v)
+		return errors.NotValidf("resource limit for %q has already been set to %v! resource limit %q", resourceName, v, resourceName)
 	}
 	if v, ok := resources.Requests[resourceName]; ok {
-		return errors.NotValidf("resource request for %q has already been set to %d! Unexpected!", resourceName, v)
+		return errors.NotValidf("resource request for %q has already been set to %v! resource limit %q", resourceName, v, resourceName)
 	}
 	// GPU request/limit have to be set to same value equals to the Count.
 	// - https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#clusters-containing-different-types-of-nvidia-gpus


### PR DESCRIPTION
## Description of change

The following error message has been updated to read correctly when
it is outputted to a user at some point (logs/CLI).

NotValidf will insert a " not valid" as the suffix to the error
message and because of that, the error message shown, is non-sensical

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A
