### PR TITLE
Ensure the model owner set in the params for the list offers api call

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -59,6 +59,7 @@ func (c *Client) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]*cr
 	var paramsFilter params.OfferFilters
 	for _, f := range filters {
 		filterTerm := params.OfferFilter{
+			OwnerName:           f.OwnerName,
 			ModelName:           f.ModelName,
 			OfferName:           f.OfferName,
 			ApplicationName:     f.ApplicationName,

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -105,6 +105,8 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 	relations := []jujucrossmodel.EndpointFilterTerm{{Name: "endPointA", Interface: "http"}}
 
 	filter := jujucrossmodel.ApplicationOfferFilter{
+		OwnerName:        "fred",
+		ModelName:        "prod",
 		OfferName:        offerName,
 		Endpoints:        relations,
 		ApplicationName:  "mysql",
@@ -128,6 +130,8 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.Filters, gc.HasLen, 1)
 			c.Assert(args.Filters[0], jc.DeepEquals, params.OfferFilter{
+				OwnerName:       "fred",
+				ModelName:       "prod",
 				OfferName:       filter.OfferName,
 				ApplicationName: filter.ApplicationName,
 				Endpoints: []params.EndpointFilterAttributes{{

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -82,6 +82,32 @@ varnish:
 `[1:])
 }
 
+func (s *crossmodelSuite) TestListEndpointsOtherModel(c *gc.C) {
+	s.addOtherModelApplication(c)
+
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewListEndpointsCommand(),
+		"-m", "otheruser/othermodel", "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
+hosted-mysql:
+  application: mysql
+  store: kontroll
+  charm: local:quantal/mysql-1
+  offer-url: otheruser/othermodel.hosted-mysql
+  endpoints:
+    database:
+      interface: mysql
+      role: provider
+  users:
+    admin:
+      display-name: admin
+      access: admin
+    otheruser:
+      display-name: Other
+      access: admin
+`[1:])
+}
+
 func (s *crossmodelSuite) TestRemove(c *gc.C) {
 	ch := s.AddTestingCharm(c, "riak")
 	s.AddTestingApplication(c, "riakservice", ch)
@@ -376,7 +402,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
 }
 
 func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
-	otherOwner := s.Factory.MakeUser(c, &factory.UserParams{Name: "otheruser"})
+	otherOwner := s.Factory.MakeUser(c, &factory.UserParams{Name: "otheruser", DisplayName: "Other"})
 	otherModel := s.Factory.MakeModel(c, &factory.ModelParams{Name: "othermodel", Owner: otherOwner.Tag()})
 	s.AddCleanup(func(*gc.C) { otherModel.Close() })
 


### PR DESCRIPTION
## Description of change

When making a ListOffers api call, ensure the model owner attribute is set in the passed params.

## QA steps

Deploy an offer. Grant access to a user.
As that user in another session, juju offers <controller>:<model>
Ensure that any offers are shown.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1785223
