### PR TITLE
Make juju_engine_report more useful

### DIFF
--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -170,6 +170,8 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		WorstError:  cmdutil.MoreImportantError,
 		ErrorDelay:  3 * time.Second,
 		BounceDelay: 10 * time.Millisecond,
+		Clock:       clock.WallClock,
+		Logger:      loggo.GetLogger("juju.worker.dependency"),
 	}
 	engine, err := dependency.NewEngine(config)
 	if err != nil {

--- a/cmd/jujud/agent/introspection_test.go
+++ b/cmd/jujud/agent/introspection_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
@@ -73,6 +75,8 @@ func (s *introspectionSuite) TestStartSuccess(c *gc.C) {
 	config := dependency.EngineConfig{
 		IsFatal:    cmdutil.IsFatal,
 		WorstError: cmdutil.MoreImportantError,
+		Clock:      clock.WallClock,
+		Logger:     loggo.GetLogger("juju.worker.dependency"),
 	}
 	engine, err := dependency.NewEngine(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/introspection_test.go
+++ b/cmd/jujud/agent/introspection_test.go
@@ -7,11 +7,11 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -503,6 +503,8 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			WorstError:  cmdutil.MoreImportantError,
 			ErrorDelay:  3 * time.Second,
 			BounceDelay: 10 * time.Millisecond,
+			Clock:       clock.WallClock,
+			Logger:      loggo.GetLogger("juju.worker.dependency"),
 		}
 		engine, err := dependency.NewEngine(config)
 		if err != nil {
@@ -999,6 +1001,8 @@ func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.Model
 		Filter:      model.IgnoreErrRemoved,
 		ErrorDelay:  3 * time.Second,
 		BounceDelay: 10 * time.Millisecond,
+		Clock:       clock.WallClock,
+		Logger:      loggo.GetLogger("juju.worker.dependency"),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -212,6 +212,8 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		WorstError:  cmdutil.MoreImportantError,
 		ErrorDelay:  3 * time.Second,
 		BounceDelay: 10 * time.Millisecond,
+		Clock:       clock.WallClock,
+		Logger:      loggo.GetLogger("juju.worker.dependency"),
 	}
 	engine, err := dependency.NewEngine(config)
 	if err != nil {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -30,6 +30,7 @@ github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/bundlechanges	git	5b8dee6ac69a0b40649795140afbad0396d1c96a	2018-05-14T04:51:38Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
+github.com/juju/clock	git	d293bb356ca441f16b59562295cca74478966757	2018-05-24T02:22:03Z
 github.com/juju/collections	git	9be91dc79b7c185fa8b08e7ceceee40562055c83	2018-07-17T17:15:55Z
 github.com/juju/description	git	25349c35a6b1c9244c24045c9b5faab5932eae63	2018-05-30T03:17:50Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
@@ -118,7 +119,7 @@ gopkg.in/juju/charmstore.v5	git	0d59319d1dba8418eaa72667f3ef447561aaefee	2018-02
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v3	git	6f7342099e20c84f560bd9fc8afe96ff7486613e	2017-11-14T17:07:01Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
-gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
+gopkg.in/juju/worker.v1	git	fece57956a1a0faa71a0a3898606a8f2fdb29ddd	2018-08-06T22:30:48Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon-bakery.v2	git	ec9d2ad6796100720c154f614b6dea8798ec1181	2017-11-03T09:26:24Z
 gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf0	2016-06-23T14:27:47Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -119,7 +119,7 @@ gopkg.in/juju/charmstore.v5	git	0d59319d1dba8418eaa72667f3ef447561aaefee	2018-02
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v3	git	6f7342099e20c84f560bd9fc8afe96ff7486613e	2017-11-14T17:07:01Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
-gopkg.in/juju/worker.v1	git	fece57956a1a0faa71a0a3898606a8f2fdb29ddd	2018-08-06T22:30:48Z
+gopkg.in/juju/worker.v1	git	4c0526ed627c30f4445496875e48d2e3aca890ec	2018-08-07T03:01:48Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon-bakery.v2	git	ec9d2ad6796100720c154f614b6dea8798ec1181	2017-11-03T09:26:24Z
 gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf0	2016-06-23T14:27:47Z

--- a/watcher/notify.go
+++ b/watcher/notify.go
@@ -5,6 +5,7 @@ package watcher
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/worker/catacomb"
 )
@@ -138,13 +139,9 @@ func (nw *NotifyWorker) Wait() error {
 	return nw.catacomb.Wait()
 }
 
-type reporter interface {
-	Report() map[string]interface{}
-}
-
 // Report implements dependency.Reporter.
 func (nw *NotifyWorker) Report() map[string]interface{} {
-	if r, ok := nw.config.Handler.(reporter); ok {
+	if r, ok := nw.config.Handler.(worker.Reporter); ok {
 		return r.Report()
 	}
 	return nil

--- a/watcher/notify.go
+++ b/watcher/notify.go
@@ -137,3 +137,15 @@ func (nw *NotifyWorker) Kill() {
 func (nw *NotifyWorker) Wait() error {
 	return nw.catacomb.Wait()
 }
+
+type reporter interface {
+	Report() map[string]interface{}
+}
+
+// Report implements dependency.Reporter.
+func (nw *NotifyWorker) Report() map[string]interface{} {
+	if r, ok := nw.config.Handler.(reporter); ok {
+		return r.Report()
+	}
+	return nil
+}

--- a/watcher/notify_test.go
+++ b/watcher/notify_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v2"
 
 	coretesting "github.com/juju/juju/testing"
@@ -101,6 +101,12 @@ func (nh *notifyHandler) CheckActions(c *gc.C, actions ...string) {
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
 	c.Check(nh.actions, gc.DeepEquals, actions)
+}
+
+func (nh *notifyHandler) Report() map[string]interface{} {
+	return map[string]interface{}{
+		"test": true,
+	}
 }
 
 // During teardown we try to stop the worker, but don't hang the test suite if
@@ -307,4 +313,14 @@ func (s *notifyWorkerSuite) TestErrorsOnClosedChannel(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "change channel closed")
 	s.actor.CheckActions(c, "setup", "teardown")
 	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestWorkerReport(c *gc.C) {
+	// Check that the worker has a report method, and it calls through to the
+	// handler.
+	reporter, ok := s.worker.(worker.Reporter)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(reporter.Report(), jc.DeepEquals, map[string]interface{}{
+		"test": true,
+	})
 }

--- a/worker/agent/manifold.go
+++ b/worker/agent/manifold.go
@@ -61,3 +61,12 @@ func (w *agentWorker) Kill() {
 func (w *agentWorker) Wait() error {
 	return w.tomb.Wait()
 }
+
+// Report shows up in the dependency engine report.
+func (w *agentWorker) Report() map[string]interface{} {
+	cfg := w.agent.CurrentConfig()
+	return map[string]interface{}{
+		"model-uuid": cfg.Model().Id(),
+		"agent":      cfg.Tag().String(),
+	}
+}

--- a/worker/common/cleanup.go
+++ b/worker/common/cleanup.go
@@ -34,13 +34,9 @@ func (w *CleanupWorker) Wait() error {
 	return err
 }
 
-type reporter interface {
-	Report() map[string]interface{}
-}
-
 // Report implements dependency.Reporter.
 func (w *CleanupWorker) Report() map[string]interface{} {
-	if r, ok := w.Worker.(reporter); ok {
+	if r, ok := w.Worker.(worker.Reporter); ok {
 		return r.Report()
 	}
 	return nil

--- a/worker/common/cleanup.go
+++ b/worker/common/cleanup.go
@@ -33,3 +33,15 @@ func (w *CleanupWorker) Wait() error {
 	w.cleanupOnce.Do(w.cleanup)
 	return err
 }
+
+type reporter interface {
+	Report() map[string]interface{}
+}
+
+// Report implements dependency.Reporter.
+func (w *CleanupWorker) Report() map[string]interface{} {
+	if r, ok := w.Worker.(reporter); ok {
+		return r.Report()
+	}
+	return nil
+}

--- a/worker/common/cleanup_test.go
+++ b/worker/common/cleanup_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/common"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type cleanupSuite struct {
@@ -33,6 +35,18 @@ func (s *cleanupSuite) TestCleansUpOnce(c *gc.C) {
 	w.stub.CheckCallNames(c, "Wait", "cleanup", "Wait")
 }
 
+func (s *cleanupSuite) TestReport(c *gc.C) {
+	var w fakeWorker
+	cw := common.NewCleanupWorker(&w, func() {})
+	defer workertest.CleanKill(c, cw)
+
+	reporter, ok := cw.(worker.Reporter)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(reporter.Report(), jc.DeepEquals, map[string]interface{}{
+		"fake": true,
+	})
+}
+
 type fakeWorker struct {
 	stub testing.Stub
 }
@@ -44,4 +58,10 @@ func (w *fakeWorker) Kill() {
 func (w *fakeWorker) Wait() error {
 	w.stub.AddCall("Wait")
 	return w.stub.NextErr()
+}
+
+func (w *fakeWorker) Report() map[string]interface{} {
+	return map[string]interface{}{
+		"fake": true,
+	}
 }

--- a/worker/dependency/context.go
+++ b/worker/dependency/context.go
@@ -31,6 +31,8 @@ type context struct {
 	// accessLog holds the names and types of resource requests, and any error
 	// encountered. It does not include requests made after expiry.
 	accessLog []resourceAccess
+
+	logger Logger
 }
 
 // Abort is part of the Context interface.
@@ -40,7 +42,7 @@ func (ctx *context) Abort() <-chan struct{} {
 
 // Get is part of the Context interface.
 func (ctx *context) Get(resourceName string, out interface{}) error {
-	logger.Tracef("%q manifold requested %q resource", ctx.clientName, resourceName)
+	ctx.logger.Tracef("%q manifold requested %q resource", ctx.clientName, resourceName)
 	select {
 	case <-ctx.expired:
 		return errors.New("expired context: cannot be used outside Start func")

--- a/worker/dependency/doc.go
+++ b/worker/dependency/doc.go
@@ -3,7 +3,7 @@
 
 /*
 
-The dependency package exists to address a general problem with shared resources
+Package dependency exists to address a general problem with shared resources
 and the management of their lifetimes. Many kinds of software handle these issues
 with more or less felicity, but it's particularly important that juju (which is
 a distributed system that needs to be very fault-tolerant) handle them clearly

--- a/worker/dependency/engine_test.go
+++ b/worker/dependency/engine_test.go
@@ -6,7 +6,9 @@ package dependency_test
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -687,6 +689,14 @@ func (s *EngineSuite) TestConfigValidate(c *gc.C) {
 		func(config *dependency.EngineConfig) {
 			config.BounceDelay = -time.Second
 		}, "BounceDelay is negative",
+	}, {
+		func(config *dependency.EngineConfig) {
+			config.Clock = nil
+		}, "missing Clock not valid",
+	}, {
+		func(config *dependency.EngineConfig) {
+			config.Logger = nil
+		}, "missing Logger not valid",
 	}}
 
 	for i, test := range tests {
@@ -696,6 +706,8 @@ func (s *EngineSuite) TestConfigValidate(c *gc.C) {
 			WorstError:  firstError,
 			ErrorDelay:  time.Second,
 			BounceDelay: time.Second,
+			Clock:       clock.WallClock,
+			Logger:      loggo.GetLogger("test"),
 		}
 		test.breakConfig(&config)
 

--- a/worker/dependency/reporter.go
+++ b/worker/dependency/reporter.go
@@ -63,4 +63,10 @@ const (
 	// KeyType holds a string representation of the type by which a resource
 	// was accessed.
 	KeyType = "type"
+
+	// KeyStartCount holds the number of times the worker has been started.
+	KeyStartCount = "start-count"
+
+	// KeyLastStart holds the time of when the worker was last started.
+	KeyLastStart = "started"
 )

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -214,6 +214,10 @@ type mockClock struct {
 	c    *gc.C
 }
 
+func (m *mockClock) Now() time.Time {
+	return time.Now()
+}
+
 func (m *mockClock) After(duration time.Duration) <-chan time.Time {
 	m.wait = duration
 	return time.After(time.Millisecond)

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -182,3 +182,8 @@ func neverImportant(error, error) bool {
 func isModelActive(m Model) bool {
 	return m.MigrationMode() != state.MigrationModeImporting
 }
+
+// Report shows up in the dependency engine report.
+func (m *modelWorkerManager) Report() map[string]interface{} {
+	return m.runner.Report()
+}

--- a/worker/modelworkermanager/modelworkermanager_test.go
+++ b/worker/modelworkermanager/modelworkermanager_test.go
@@ -144,6 +144,24 @@ func (s *suite) TestNoStartingWorkersForImportingModel(c *gc.C) {
 	})
 }
 
+func (s *suite) TestReport(c *gc.C) {
+	s.runTest(c, func(w worker.Worker, mw *mockModelWatcher, _ *mockModelGetter) {
+		mw.sendModelChange("uuid")
+		s.assertStarts(c, "uuid")
+
+		reporter, ok := w.(worker.Reporter)
+		c.Assert(ok, jc.IsTrue)
+		report := reporter.Report()
+		c.Assert(report, gc.NotNil)
+		// TODO: pass a clock through in the worker config so it can be passed
+		// to the worker.Runner used in the model to control time.
+		// For now, we just look at the started state.
+		workers := report["workers"].(map[string]interface{})
+		modelWorker := workers["uuid"].(map[string]interface{})
+		c.Assert(modelWorker["state"], gc.Equals, "started")
+	})
+}
+
 type testFunc func(worker.Worker, *mockModelWatcher, *mockModelGetter)
 type killFunc func(*gc.C, worker.Worker)
 


### PR DESCRIPTION
The engine report that is available through the introspection endpoint had limited usefulness.

The engine now keeps a count of the number of times a worker has started, and also the time at which the worker was started.

This branch also hooks up the Report method for a number of workers. In particular the model worker, as it has the nested dependency engine.

## QA steps

- bootstrap a controller
- deploy something in the default model
- juju ssh -m controller 0
- juju_engine_report
