### PR TITLE
Fixes lp1780711: hard-coding yaml formatter for filtered output.

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -358,13 +358,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		if !found {
 			return errors.Errorf("key %q not found in %q application config or charm settings.", key, c.applicationName)
 		}
-		out := &bytes.Buffer{}
-		err := cmd.FormatYaml(out, info["value"])
-		if err != nil {
-			return err
-		}
-		fmt.Fprint(ctx.Stdout, out.String())
-		return nil
+		return c.out.Write(ctx, info["value"])
 	}
 
 	resultsMap := map[string]interface{}{

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -47,6 +47,11 @@ var charmSettings = map[string]interface{}{
 		"type":        "string",
 		"value":       "Nearly There",
 	},
+	"multiline-value": map[string]interface{}{
+		"description": "Specifies title",
+		"type":        "string",
+		"value":       "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ",
+	},
 	"skill-level": map[string]interface{}{
 		"description": "Specifies skill-level",
 		"value":       100,
@@ -98,10 +103,11 @@ var getTests = []struct {
 func (s *configCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.defaultCharmValues = map[string]interface{}{
-		"title":       "Nearly There",
-		"skill-level": 100,
-		"username":    "admin001",
-		"outlook":     "true",
+		"title":           "Nearly There",
+		"skill-level":     100,
+		"username":        "admin001",
+		"outlook":         "true",
+		"multiline-value": "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ",
 	}
 	s.defaultAppValues = map[string]interface{}{
 		"juju-external-hostname": "ext-host",
@@ -172,6 +178,22 @@ func (s *configCommandSuite) TestGetCharmConfigKey(c *gc.C) {
 	c.Check(code, gc.Equals, 0)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "Nearly There\n")
+}
+
+func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value"})
+	c.Check(code, gc.Equals, 0)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "'The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the\n  lazy dog\" \"The quick brown fox jumps over the lazy dog\" '\n")
+}
+
+func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value", "--format", "json"})
+	c.Check(code, gc.Equals, 0)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "\"The quick brown fox jumps over the lazy dog. \\\"The quick brown fox jumps over the lazy dog\\\" \\\"The quick brown fox jumps over the lazy dog\\\" \"\n")
 }
 
 func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -42,15 +42,15 @@ var (
 )
 
 var charmSettings = map[string]interface{}{
+	"multiline-value": map[string]interface{}{
+		"description": "Specifies multiline-value",
+		"type":        "string",
+		"value":       "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ",
+	},
 	"title": map[string]interface{}{
 		"description": "Specifies title",
 		"type":        "string",
 		"value":       "Nearly There",
-	},
-	"multiline-value": map[string]interface{}{
-		"description": "Specifies title",
-		"type":        "string",
-		"value":       "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ",
 	},
 	"skill-level": map[string]interface{}{
 		"description": "Specifies skill-level",


### PR DESCRIPTION
## Description of change

'juju config <application name> <settings key>' was hardcoding the output to yaml format.

This PR removes hardcoding and adds couple of tests.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1780711
