### PR TITLE
Add support for autocert new TLS-ALPN challenge

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -290,9 +290,9 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 	srv.logSinkWriter = logSinkWriter
 
 	if cfg.PrometheusRegisterer != nil {
-		apiserverCollectior := NewMetricsCollector(&metricAdaptor{srv})
-		cfg.PrometheusRegisterer.Unregister(apiserverCollectior)
-		if err := cfg.PrometheusRegisterer.Register(apiserverCollectior); err != nil {
+		apiserverCollector := NewMetricsCollector(&metricAdaptor{srv})
+		cfg.PrometheusRegisterer.Unregister(apiserverCollector)
+		if err := cfg.PrometheusRegisterer.Register(apiserverCollector); err != nil {
 			return nil, errors.Annotate(err, "registering apiserver metrics collector")
 		}
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -11,8 +11,8 @@ github.com/boltdb/bolt	git	e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd	2017-01-31T1
 github.com/cloud-green/monitoring	git	666e3beca3cb4f6b5c8f176ba80daf2b3adbd84e	2017-11-27T13:22:20Z
 github.com/coreos/go-systemd	git	7b2428fec40033549c68f54e26e89e7ca9a9ce31	2016-02-02T21:14:25Z
 github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07-05T20:30:06Z
-github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
 github.com/docker/distribution	git	f0cc927784781fa395c06317c58dea2841ece3a9	2018-05-22T17:56:53Z
+github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
 github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T22:25:50Z
 github.com/golang/glog	git	44145f04b68cf362d9c4df2182967c2275eaefed	2014-11-05T02:39:35Z
 github.com/golang/mock	git	69521b3833175dfcfb1cc1fdb0c9be92e66faa81	2018-04-03T23:54:22Z
@@ -100,13 +100,12 @@ github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-0
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 github.com/satori/uuid	git	5bf94b69c6b68ee1b541973bb8e1144db23a194b	2017-03-21T23:07:31Z
 github.com/vmware/govmomi	git	05504416e95561e1478196d7058721c827a7bb8c	2018-03-06T20:02:55Z
-golang.org/x/crypto	git	49796115aa4b964c318aad4f3084fdb41e9aa067	2018-02-22T18:24:04Z
+golang.org/x/crypto	git	f027049dab0ad238e394a753dba2d14753473a04	2018-08-07T10:46:21Z
 golang.org/x/net	git	61147c48b25b599e5b561d2e9c4f3e1ef489ca41	2018-04-06T21:48:16Z
 golang.org/x/oauth2	git	a6bd8cefa1811bd24b86f8902872e4e8225f74c4	2017-04-12T23:27:59Z
 golang.org/x/sys	git	37707fdb30a5b38865cfb95e5aab41707daec7fd	2018-02-02T13:58:01Z
 golang.org/x/text	git	b19bf474d317b857955b12035d2c5acb57ce8b01	2017-08-10T15:42:03Z
 google.golang.org/api	git	ed10e890a8366167a7ce33fac2b12447987bcb1c	2017-08-17T20:34:27Z
-google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T22:36:35Z
 gopkg.in/amz.v3	git	8c3190dff075bf5442c9eedbf8f8ed6144a099e7	2016-12-15T13:08:49Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z

--- a/worker/httpserver/cert_test.go
+++ b/worker/httpserver/cert_test.go
@@ -32,7 +32,7 @@ var _ = gc.Suite(&certSuite{})
 
 func (s *certSuite) SetUpTest(c *gc.C) {
 	s.workerFixture.SetUpTest(c)
-	tlsConfig, _ := httpserver.InternalNewTLSConfig(
+	tlsConfig := httpserver.InternalNewTLSConfig(
 		"",
 		"https://0.1.2.3/no-autocert-here",
 		nil,
@@ -111,7 +111,7 @@ func (s *certSuite) TestAutocertFailure(c *gc.C) {
 
 	// Dropping the handler returned here disables the challenge
 	// listener.
-	tlsConfig, _ := httpserver.InternalNewTLSConfig(
+	tlsConfig := httpserver.InternalNewTLSConfig(
 		"somewhere.example",
 		"https://0.1.2.3/no-autocert-here",
 		nil,
@@ -148,7 +148,7 @@ func (s *certSuite) TestAutocertFailure(c *gc.C) {
 }
 
 func (s *certSuite) TestAutocertNameMismatch(c *gc.C) {
-	tlsConfig, _ := httpserver.InternalNewTLSConfig(
+	tlsConfig := httpserver.InternalNewTLSConfig(
 		"somewhere.example",
 		"https://0.1.2.3/no-autocert-here",
 		nil,

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -5,8 +5,6 @@ package httpserver_test
 
 import (
 	"crypto/tls"
-	"net"
-	"net/http"
 	"time"
 
 	"github.com/juju/errors"
@@ -93,26 +91,12 @@ func (s *ManifoldSuite) newStateAuthenticator(
 	return &s.authenticator, nil
 }
 
-func (s *ManifoldSuite) newTLSConfig(
-	st *state.State,
-	getCertificate func() *tls.Certificate,
-) (*tls.Config, http.Handler, error) {
+func (s *ManifoldSuite) newTLSConfig(st *state.State, getCertificate func() *tls.Certificate) (*tls.Config, error) {
 	s.stub.MethodCall(s, "NewTLSConfig", st)
 	if err := s.stub.NextErr(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return s.tlsConfig, autocertHandler, nil
-}
-
-func (s *ManifoldSuite) newTLSConfigNoHandler(
-	st *state.State,
-	getCertificate func() *tls.Certificate,
-) (*tls.Config, http.Handler, error) {
-	s.stub.MethodCall(s, "NewTLSConfig", st)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, nil, err
-	}
-	return s.tlsConfig, nil, nil
+	return s.tlsConfig, nil
 }
 
 func (s *ManifoldSuite) newWorker(config httpserver.Config) (worker.Worker, error) {
@@ -151,47 +135,12 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(newWorkerArgs[0], gc.FitsTypeOf, httpserver.Config{})
 	config := newWorkerArgs[0].(httpserver.Config)
 
-	// We should get a non-nil autocert listener.
-	c.Assert(config.AutocertListener, gc.NotNil)
-	_, port, err := net.SplitHostPort(config.AutocertListener.Addr().String())
-	c.Assert(err, jc.ErrorIsNil)
-	// Sanity check - in tests we won't be running as root so won't be
-	// able to bind port 80.
-	c.Assert(port, gc.Not(gc.Equals), "80")
-	err = config.AutocertListener.Close()
-	c.Assert(err, jc.ErrorIsNil)
-	config.AutocertListener = nil
-
 	c.Assert(config, jc.DeepEquals, httpserver.Config{
 		AgentConfig:          &s.agent.conf,
 		PrometheusRegisterer: &s.prometheusRegisterer,
 		TLSConfig:            s.tlsConfig,
-		AutocertHandler:      autocertHandler,
 		Mux:                  apiserverhttp.NewMux(),
 	})
-}
-
-func (s *ManifoldSuite) TestStartNoAutocert(c *gc.C) {
-	s.manifold = httpserver.Manifold(httpserver.ManifoldConfig{
-		AgentName:             "agent",
-		CertWatcherName:       "cert-watcher",
-		ClockName:             "clock",
-		StateName:             "state",
-		PrometheusRegisterer:  &s.prometheusRegisterer,
-		NewStateAuthenticator: s.newStateAuthenticator,
-		NewTLSConfig:          s.newTLSConfigNoHandler,
-		NewWorker:             s.newWorker,
-	})
-	w := s.startWorkerClean(c)
-	defer workertest.CleanKill(c, w)
-	s.stub.CheckCallNames(c, "NewTLSConfig", "NewStateAuthenticator", "NewWorker")
-	newWorkerArgs := s.stub.Calls()[2].Args
-	c.Assert(newWorkerArgs, gc.HasLen, 1)
-	c.Assert(newWorkerArgs[0], gc.FitsTypeOf, httpserver.Config{})
-	config := newWorkerArgs[0].(httpserver.Config)
-
-	c.Assert(config.AutocertHandler, gc.IsNil)
-	c.Assert(config.AutocertListener, gc.IsNil)
 }
 
 func (s *ManifoldSuite) TestStopWorkerClosesState(c *gc.C) {
@@ -234,9 +183,3 @@ func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
 	workertest.CheckAlive(c, w)
 	return w
 }
-
-type mockHandler struct{}
-
-func (*mockHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
-
-var autocertHandler = &mockHandler{}

--- a/worker/httpserver/tls_state_test.go
+++ b/worker/httpserver/tls_state_test.go
@@ -6,7 +6,6 @@ package httpserver_test
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -44,7 +43,7 @@ type TLSStateSuite struct {
 var _ = gc.Suite(&TLSStateSuite{})
 
 func (s *TLSStateSuite) TestNewTLSConfig(c *gc.C) {
-	tlsConfig, handler, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
+	tlsConfig, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{
@@ -52,8 +51,6 @@ func (s *TLSStateSuite) TestNewTLSConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cert, gc.Equals, s.cert)
-
-	c.Assert(handler, gc.Equals, nil)
 }
 
 type TLSStateAutocertSuite struct {
@@ -82,48 +79,35 @@ func (s *TLSStateAutocertSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *TLSStateAutocertSuite) TestAutocertExceptions(c *gc.C) {
-	tlsConfig, handler, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
+	tlsConfig, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "127.0.0.1")
 	s.testGetCertificate(c, tlsConfig, "juju-apiserver")
 	s.testGetCertificate(c, tlsConfig, "testing1.invalid")
 	c.Assert(s.autocertQueried, jc.IsFalse)
-	s.testHandler(c, handler)
 }
 
 func (s *TLSStateAutocertSuite) TestAutocert(c *gc.C) {
-	tlsConfig, handler, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
+	tlsConfig, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "public.invalid")
 	c.Assert(s.autocertQueried, jc.IsTrue)
-	s.testHandler(c, handler)
 }
 
 func (s *TLSStateAutocertSuite) TestAutocertHostPolicy(c *gc.C) {
-	tlsConfig, handler, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
+	tlsConfig, err := httpserver.NewTLSConfig(s.State, s.getCertificate)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "always.invalid")
 	c.Assert(s.autocertQueried, jc.IsFalse)
-	s.testHandler(c, handler)
 }
 
 func (s *TLSStateAutocertSuite) testGetCertificate(c *gc.C, tlsConfig *tls.Config, serverName string) {
-	cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{ServerName: serverName})
+	cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{
+		ServerName: serverName,
+	})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("server name %q", serverName))
 	// NOTE(axw) we always expect to get back s.cert, because we don't have
 	// a functioning autocert test server. We do check that we attempt to
 	// query the autocert server, but that's as far as we test here.
 	c.Assert(cert, gc.Equals, s.cert, gc.Commentf("server name %q", serverName))
-}
-
-func (s *TLSStateAutocertSuite) testHandler(c *gc.C, handler http.Handler) {
-	// Just check enough to see that it's the autocert handler.
-	request := httptest.NewRequest("GET", "http://public.invalid/.well-known/acme-challenge/", nil)
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, request)
-	response := recorder.Result()
-	c.Assert(response.StatusCode, gc.Equals, http.StatusNotFound)
-	content, err := ioutil.ReadAll(response.Body)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(content), gc.Equals, "acme/autocert: certificate cache miss\n")
 }

--- a/worker/httpserver/tls_state_test.go
+++ b/worker/httpserver/tls_state_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/worker/httpserver"
 	jc "github.com/juju/testing/checkers"
+	"golang.org/x/crypto/acme"
 	gc "gopkg.in/check.v1"
 )
 
@@ -92,6 +93,7 @@ func (s *TLSStateAutocertSuite) TestAutocert(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "public.invalid")
 	c.Assert(s.autocertQueried, jc.IsTrue)
+	c.Assert(tlsConfig.NextProtos, jc.DeepEquals, []string{"h2", "http/1.1", acme.ALPNProto})
 }
 
 func (s *TLSStateAutocertSuite) TestAutocertHostPolicy(c *gc.C) {


### PR DESCRIPTION
Rather than using the HTTP challenge, requiring port 80 to be open, and therefore an additional handler, we use the new TLS-ALPN challenge, which works using the TLS handshake on 443.

**QA:**
Assuming $DNSNAME is a DNS name that you control:
- bootstrap juju with `--config autocert-dns-name=$DNSNAME`; 
- when the bootstrap process completes, point $DNSNAME to the ip address of the controller;
- wait for the change to propagate;
- run `juju gui`: the output should suggest a URL to visit which includes $DNSNAME;
- visit the GUI at that URL, and it should work;
- deploying charms, running `juju status`, i.e. accessing the API should work.
