### PR TITLE
Fixes lp#1779337: Local charms must have hooks to be valid.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -4,12 +4,14 @@
 package api
 
 import (
+	"archive/zip"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -329,11 +331,50 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, err
 		return nil, errors.Errorf("unknown charm type %T", ch)
 	}
 
-	curl, err := c.UploadCharm(curl, archive)
+	anyHooks, err := hasHooks(archive.Name())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !anyHooks {
+		return nil, errors.Errorf("invalid charm %q: has no hooks", curl.Name)
+	}
+
+	curl, err = c.UploadCharm(curl, archive)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return curl, nil
+}
+
+var hasHooks = hasHooksFolder
+
+func hasHooksFolder(name string) (bool, error) {
+	zipr, err := zip.OpenReader(name)
+	if err != nil {
+		return false, err
+	}
+	defer zipr.Close()
+
+	count := 0
+	// Cater for file separator differences between operating systems.
+	hooksPath := filepath.FromSlash("hooks/")
+	for _, f := range zipr.File {
+		if strings.Contains(f.Name, hooksPath) {
+			count++
+		}
+		if count > 1 {
+			// 1 is the magic number here.
+			// Charm zip archive is expected to contain several files and folders.
+			// All properly built charms will have a non-empty "hooks" folders.
+			// File names in the archive will be of the form "hooks/" - for hooks folder; and
+			// "hooks/*" for the actual charm hooks implementations.
+			// For example, install hook may have a file with a name "hooks/install".
+			// Once we know that there are, at least, 2 files that have names that start with "hooks/", we
+			// know for sure that the charm has a non-empty hooks folder.
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // UploadCharm sends the content to the API server using an HTTP post.

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -108,7 +108,7 @@ func (s *clientSuite) TestZipHasHooks(c *gc.C) {
 }
 
 func (s *clientSuite) TestZipHasNoHooks(c *gc.C) {
-	ch := testcharms.Repo.CharmDir("riak") // has no hooks
+	ch := testcharms.Repo.CharmDir("category") // has no hooks
 
 	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -119,6 +119,48 @@ func (s *clientSuite) TestAddLocalCharm(c *gc.C) {
 	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
 }
 
+func (s *clientSuite) TestAddLocalCharmFindingHooksError(c *gc.C) {
+	s.assertAddLocalCharmFailed(c,
+		func(string) (bool, error) {
+			return true, fmt.Errorf("bad zip")
+		},
+		`bad zip`)
+}
+
+func (s *clientSuite) TestAddLocalCharmNoHooks(c *gc.C) {
+	s.assertAddLocalCharmFailed(c,
+		func(string) (bool, error) {
+			return false, nil
+		},
+		`invalid charm \"dummy\": has no hooks`)
+}
+
+func (s *clientSuite) assertAddLocalCharmFailed(c *gc.C, f func(string) (bool, error), msg string) {
+	curl, ch := s.testCharm(c)
+	s.PatchValue(api.HasHooks, f)
+	_, err := s.APIState.Client().AddLocalCharm(curl, ch)
+	c.Assert(err, gc.ErrorMatches, msg)
+}
+
+func (s *clientSuite) TestAddLocalCharmDefinetelyWithHooks(c *gc.C) {
+	curl, ch := s.testCharm(c)
+	s.PatchValue(api.HasHooks, func(string) (bool, error) {
+		return true, nil
+	})
+
+	savedCURL, err := s.APIState.Client().AddLocalCharm(curl, ch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(savedCURL.String(), gc.Equals, curl.String())
+}
+
+func (s *clientSuite) testCharm(c *gc.C) (*charm.URL, charm.Charm) {
+	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	curl := charm.MustParseURL(
+		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
+	)
+	return curl, charmArchive
+}
+
 func (s *clientSuite) TestAddLocalCharmOtherModel(c *gc.C) {
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -24,6 +24,7 @@ var (
 	SlideAddressToFront = slideAddressToFront
 	BestVersion         = bestVersion
 	FacadeVersions      = &facadeVersions
+	HasHooks            = &hasHooks
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {

--- a/featuretests/cmd_juju_deploy_test.go
+++ b/featuretests/cmd_juju_deploy_test.go
@@ -6,12 +6,12 @@ package featuretests
 import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/juju/testcharms"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testcharms"
 )
 
 type cmdDeploySuite struct {

--- a/featuretests/cmd_juju_deploy_test.go
+++ b/featuretests/cmd_juju_deploy_test.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	"github.com/juju/juju/testcharms"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/juju/testing"
+)
+
+type cmdDeploySuite struct {
+	testing.JujuConnSuite
+}
+
+func (s *cmdUpdateSeriesSuite) TestLocalDeploySuccess(c *gc.C) {
+	ch := testcharms.Repo.CharmDir("storage-filesystem-subordinate") // has hooks
+
+	ctx, err := runCommand(c, "deploy", ch.Path, "--series", "quantal")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Deploying charm "local:quantal/storage-filesystem-subordinate-1"`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	savedCh, err := s.State.Charm(charm.MustParseURL("local:quantal/storage-filesystem-subordinate-1"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(savedCh, gc.NotNil)
+}
+
+func (s *cmdUpdateSeriesSuite) TestLocalDeployFailNoHook(c *gc.C) {
+	ch := testcharms.Repo.CharmDir("riak") // has no hooks
+
+	ctx, err := runCommand(c, "deploy", ch.Path, "--series", "quantal")
+	c.Assert(err, gc.NotNil)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `invalid charm "riak": has no hooks`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	_, err = s.State.Charm(charm.MustParseURL("local:quantal/riak"))
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/featuretests/cmd_juju_deploy_test.go
+++ b/featuretests/cmd_juju_deploy_test.go
@@ -32,13 +32,13 @@ func (s *cmdUpdateSeriesSuite) TestLocalDeploySuccess(c *gc.C) {
 }
 
 func (s *cmdUpdateSeriesSuite) TestLocalDeployFailNoHook(c *gc.C) {
-	ch := testcharms.Repo.CharmDir("riak") // has no hooks
+	ch := testcharms.Repo.CharmDir("category") // has no hooks
 
 	ctx, err := runCommand(c, "deploy", ch.Path, "--series", "quantal")
 	c.Assert(err, gc.NotNil)
-	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `invalid charm "riak": has no hooks`)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `invalid charm "category": has no hooks`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
-	_, err = s.State.Charm(charm.MustParseURL("local:quantal/riak"))
+	_, err = s.State.Charm(charm.MustParseURL("local:quantal/category"))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -59,6 +59,7 @@ func init() {
 	gc.Suite(&cmdUpdateSeriesSuite{})
 	gc.Suite(&FirewallRulesSuite{})
 	gc.Suite(&StatusSuite{})
+	gc.Suite(&cmdDeploySuite{})
 
 	// TODO (anastasiamac 2016-07-19) Bug#1603585
 	// These tests cannot run on windows - they require a bootstrapped controller.

--- a/testcharms/charm-repo/quantal/dummy-resource/hooks/config-changed
+++ b/testcharms/charm-repo/quantal/dummy-resource/hooks/config-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/dummy-resource/hooks/hooks
+++ b/testcharms/charm-repo/quantal/dummy-resource/hooks/hooks
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/dummy-resource/hooks/install
+++ b/testcharms/charm-repo/quantal/dummy-resource/hooks/install
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="install-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/dummy-resource/hooks/update-status
+++ b/testcharms/charm-repo/quantal/dummy-resource/hooks/update-status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="upload-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/metered-multi-series/hooks/config-changed
+++ b/testcharms/charm-repo/quantal/metered-multi-series/hooks/config-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/metered-multi-series/hooks/hooks
+++ b/testcharms/charm-repo/quantal/metered-multi-series/hooks/hooks
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/metered-multi-series/hooks/install
+++ b/testcharms/charm-repo/quantal/metered-multi-series/hooks/install
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="install-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/metered-multi-series/hooks/update-status
+++ b/testcharms/charm-repo/quantal/metered-multi-series/hooks/update-status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="upload-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/multi-series/hooks/config-changed
+++ b/testcharms/charm-repo/quantal/multi-series/hooks/config-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/multi-series/hooks/hooks
+++ b/testcharms/charm-repo/quantal/multi-series/hooks/hooks
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/multi-series/hooks/install
+++ b/testcharms/charm-repo/quantal/multi-series/hooks/install
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="install-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/multi-series/hooks/update-status
+++ b/testcharms/charm-repo/quantal/multi-series/hooks/update-status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="upload-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/mysql/hooks/config-changed
+++ b/testcharms/charm-repo/quantal/mysql/hooks/config-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/mysql/hooks/hooks
+++ b/testcharms/charm-repo/quantal/mysql/hooks/hooks
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/mysql/hooks/install
+++ b/testcharms/charm-repo/quantal/mysql/hooks/install
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="install-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/mysql/hooks/update-status
+++ b/testcharms/charm-repo/quantal/mysql/hooks/update-status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="upload-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/riak/hooks/config-changed
+++ b/testcharms/charm-repo/quantal/riak/hooks/config-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/riak/hooks/hooks
+++ b/testcharms/charm-repo/quantal/riak/hooks/hooks
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Do nothing!

--- a/testcharms/charm-repo/quantal/riak/hooks/install
+++ b/testcharms/charm-repo/quantal/riak/hooks/install
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="install-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)

--- a/testcharms/charm-repo/quantal/riak/hooks/update-status
+++ b/testcharms/charm-repo/quantal/riak/hooks/update-status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RES_NAME="upload-resource"
+RES_PATH=$(2>&1 resource-get $RES_NAME)
+if [ $? -ne 0 ]; then
+    RES_GET_STDERR=$RES_PATH
+    status-set blocked "[resource "'"'"$RES_NAME"'"'"] $RES_GET_STDERR"
+    exit 0
+fi
+
+set -e
+
+status-set maintenance "path: $RES_PATH"
+status-set maintenance $(cat $RES_PATH)


### PR DESCRIPTION
## Description of change

As per linked bug, users may easily attempt to deploy local charms that have not been built. Well-built charms have non-empty hooks directory.

This PR checks that local charms are well-built.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1779337
