### PR TITLE
Fix machine-lock issue with container initialisation.

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -88,6 +88,10 @@ type StartInstanceParams struct {
 	// changes in status. Its signature is consistent with other
 	// status-related functions to allow them to be used as callbacks.
 	StatusCallback StatusCallbackFunc
+
+	// Abort is a channel that will be closed to indicate that the command
+	// should be aborted.
+	Abort <-chan struct{}
 }
 
 // StartInstanceResult holds the result of an

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -207,7 +207,7 @@ func (f *fakeAPI) HostChangesForContainer(machineTag names.MachineTag) ([]networ
 	return []network.DeviceToBridge{f.fakeDeviceToBridge}, 0, nil
 }
 
-func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger) error {
+func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error {
 	// This is not actually part of the API, however it is something that the
 	// Brokers should be calling, and putting it here means we get a wholistic
 	// view of when what function is getting called.
@@ -216,7 +216,7 @@ func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger) e
 		return err
 	}
 	if f.fakePreparer != nil {
-		return f.fakePreparer(containerTag, log)
+		return f.fakePreparer(containerTag, log, abort)
 	}
 	return nil
 }

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -268,18 +268,15 @@ func defaultBridger() (network.Bridger, error) {
 	}
 }
 
-func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.Logger) error {
+func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error {
 	preparer := NewHostPreparer(HostPreparerParams{
 		API:                cs.provisioner,
 		ObserveNetworkFunc: cs.observeNetwork,
 		AcquireLockFunc:    cs.acquireLock,
 		CreateBridger:      defaultBridger,
-		// TODO(jam): 2017-02-08 figure out how to thread catacomb.Dying() into
-		// this function, so that we can stop trying to acquire the lock if we
-		// are stopping.
-		AbortChan:  nil,
-		MachineTag: cs.machine.MachineTag(),
-		Logger:     log,
+		AbortChan:          abort,
+		MachineTag:         cs.machine.MachineTag(),
+		Logger:             log,
 	})
 	return preparer.Prepare(containerTag)
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -70,7 +70,7 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, err
 	}
 
-	err = broker.prepareHost(names.NewMachineTag(containerMachineID), kvmLogger)
+	err = broker.prepareHost(names.NewMachineTag(containerMachineID), kvmLogger, args.Abort)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -400,7 +400,7 @@ func (s *kvmProvisionerSuite) TearDownTest(c *gc.C) {
 	s.CommonProvisionerSuite.TearDownTest(c)
 }
 
-func noopPrepareHostFunc(names.MachineTag, loggo.Logger) error {
+func noopPrepareHostFunc(names.MachineTag, loggo.Logger, <-chan struct{}) error {
 	return nil
 }
 

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -19,7 +19,7 @@ import (
 
 var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
 
-type PrepareHostFunc func(containerTag names.MachineTag, log loggo.Logger) error
+type PrepareHostFunc func(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error
 
 // NewLXDBroker creates a Broker that can be used to start LXD containers in a
 // similar fashion to normal StartInstance requests.
@@ -61,7 +61,7 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, err
 	}
 
-	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger)
+	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger, args.Abort)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -709,6 +709,7 @@ func (task *provisionerTask) constructStartInstanceParams(
 		EndpointBindings:  endpointBindings,
 		ImageMetadata:     possibleImageMetadata,
 		StatusCallback:    machine.SetInstanceStatus,
+		Abort:             task.catacomb.Dying(),
 	}
 
 	return startInstanceParams, nil


### PR DESCRIPTION
With the recent changes in the machine lock, the cancel channel became non-optional. There was the ability to explicitly say "there is no cancel", but we don't want to use that for the container initialisation as it should be cancelled when the provisioner is being shut down.

This branch adds an abort channel to the StartInstanceParams. This is constructed by the provisioner and passed down through the broker calls, which both the KVM and LXD brokers support. This channel is then passed through to the machine lock call.

## QA steps

I tried to replicate on EC2 but it seems the problem occurs more in MAAS and the bridging code.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1786099