### PR TITLE
Ensure the most up-to-date resource info is used.

### DIFF
--- a/resource/charmstore/cache.go
+++ b/resource/charmstore/cache.go
@@ -70,7 +70,8 @@ func (cfo cacheForOperations) set(chRes charmresource.Resource, reader io.ReadCl
 		return resource.Resource{}, nil, errors.Trace(err)
 	}
 
-	_, reader, err = cfo.OpenResource(res.Name)
+	// Make sure to use the potentially updated resource details.
+	res, reader, err = cfo.OpenResource(res.Name)
 	if err != nil {
 		return resource.Resource{}, nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Fixes issue where initial resource-get request for a oci-image fails (as the io.Copy erroneously  thinks it's 0 Size) resulting in an error message and forcing another attempt.

## QA steps

Manually deploying a caas charm and monitoring logs.
