### PR TITLE
Default Constraints Checker

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -271,7 +271,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, callCtx 
 	// The follow is used to determine if we should apply the default
 	// constraints when we bootstrap. Generally speaking this should always be
 	// applied, but there are exceptions to the rule e.g. local LXD
-	if checker, ok := environ.(environs.DefaultConstraintsChecker); !ok || checker.ShouldUseDefaultConstraints() {
+	if checker, ok := environ.(environs.DefaultConstraintsChecker); !ok || checker.ShouldApplyControllerConstraints() {
 		bootstrapConstraints = withDefaultControllerConstraints(bootstrapConstraints)
 	}
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -268,7 +268,12 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, callCtx 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	bootstrapConstraints = withDefaultControllerConstraints(bootstrapConstraints)
+	// The follow is used to determine if we should apply the default
+	// constraints when we bootstrap. Generally speaking this should always be
+	// applied, but there are exceptions to the rule e.g. local LXD
+	if checker, ok := environ.(environs.DefaultConstraintsChecker); !ok || checker.ShouldUseDefaultConstraints() {
+		bootstrapConstraints = withDefaultControllerConstraints(bootstrapConstraints)
+	}
 
 	// The arch we use to find tools isn't the boostrapConstraints arch.
 	// We copy the constraints arch to a separate variable and

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -498,7 +498,7 @@ type UpgradeStep interface {
 // constraints should be applied for the Environ provider when bootstrapping
 // the provider.
 type DefaultConstraintsChecker interface {
-	// ShouldUseDefaultConstraints returns if bootstrapping logic should use
-	// default constraints
-	ShouldUseDefaultConstraints() bool
+	// ShouldApplyControllerConstraints returns if bootstrapping logic should
+	// use default constraints
+	ShouldApplyControllerConstraints() bool
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -493,3 +493,12 @@ type UpgradeStep interface {
 	// Run executes the upgrade business logic.
 	Run(ctx context.ProviderCallContext) error
 }
+
+// DefaultConstraintsChecker defines an interface for checking if the default
+// constraints should be applied for the Environ provider when bootstrapping
+// the provider.
+type DefaultConstraintsChecker interface {
+	// ShouldUseDefaultConstraints returns if bootstrapping logic should use
+	// default constraints
+	ShouldUseDefaultConstraints() bool
+}

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -36,9 +36,9 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 	return validator, nil
 }
 
-// ShouldUseDefaultConstraints returns if bootstrapping logic should use
+// ShouldApplyControllerConstraints returns if bootstrapping logic should use
 // default constraints
-func (env *environ) ShouldUseDefaultConstraints() bool {
+func (env *environ) ShouldApplyControllerConstraints() bool {
 	return false
 }
 

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -36,6 +36,12 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 	return validator, nil
 }
 
+// ShouldUseDefaultConstraints returns if bootstrapping logic should use
+// default constraints
+func (env *environ) ShouldUseDefaultConstraints() bool {
+	return false
+}
+
 // SupportNetworks returns whether the environment has support to
 // specify networks for applications and machines.
 func (env *environ) SupportNetworks(ctx context.ProviderCallContext) bool {


### PR DESCRIPTION
## Description of change

The following commit ensures that when we bootstrap, we only apply
the default constraints for providers that require it. This is an
opt-out method and not an opt-in and should be backwards compatible
for all existing providers.

The reason for this change is to allow some providers (think LXD),
to opt out of using default constraints, without inserting magic
numbers/strings into the constraints vocabulary/logic, which could
cause potential bugs down the line. With this method of change, we
are asking if the Environ is a type and if the environ implements
the type, asking if we should use the default constraints. This
logic is simple and doesn't tie any provider to the bootstrap
directly and feels less hacky than other ideas floating around.

If there are better ways to solve this, then I'm more than happy
to change this.

## QA steps

```sh
juju bootstrap --no-gui localhost lxd1
lxc config get juju-944bca-0 limits.memory
```
Should return nothing...

## Documentation changes

The following ensures that we don't limit the LXD controller with
default memory constraints.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1784075
