### PR TITLE
lp: 1784018 update more lxd network verification error messages

### DIFF
--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -146,9 +146,10 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *gc.C) {
 
 	err = jujuSvr.VerifyNetworkDevice(profile, "")
 	c.Assert(err, gc.ErrorMatches,
-		`profile "default": no network device found with nictype "bridged" or "macvlan", `+
-			`and without IPv6 configured.\n`+
-			`\tthe following devices were checked: \[eth0\]`)
+		`profile "default": no network device found with nictype "bridged" or "macvlan"\n`+
+			`\tthe following devices were checked: eth0\n`+
+			`Note: juju does not support IPv6.\n`+
+			`Reconfigure lxd to use a network of type "bridged" or "macvlan", disabling IPv6.`)
 }
 
 func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
@@ -172,9 +173,9 @@ func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
 
 	err = jujuSvr.VerifyNetworkDevice(defaultProfile(), "")
 	c.Assert(err, gc.ErrorMatches,
-		`profile "default": no network device found with nictype "bridged" or "macvlan", `+
-			`and without IPv6 configured.\n`+
-			`\tthe following devices were checked: \[eth0\]`)
+		`profile "default": juju does not support IPv6. Disable IPv6 in LXD via:\n`+
+			`\tlxc network set lxdbr0 ipv6.address none\n`+
+			`and run the command again`)
 }
 
 func (s *networkSuite) TestVerifyNetworkDeviceNotPresentCreated(c *gc.C) {


### PR DESCRIPTION
## Description of change

The current error message on lxd network verification when failing due to IPv6 being enabled is unclear as to what the real problem is.  Clarify error messages from verifyNICsWithAPI(), to include that juju does not support IPv6.

## QA steps

On a fresh install of lxd, enable IPv6 when running lxd init.  Try to juju bootstrap.  It will fail, but the error message should mention that IPv6 is not supported and how to fix the lxd network config.  Run the juju suggested command and attempt to bootstrap again.  This time it should succeed.

## Documentation changes

juju docs regarding configuration of lxd should say to disable IPv6 has juju doesn't support it at this time.  lxd init defaults to enabling IPv6.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1784018
