### PR TITLE
makefile: Reduce the noise from `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(GOPATH)/bin/dep:
 
 # populate vendor/ from Gopkg.lock without updating it first (lock file is the single source of truth for machine).
 dep: $(GOPATH)/bin/dep
-	$(GOPATH)/bin/dep ensure -v -vendor-only
+	$(GOPATH)/bin/dep ensure -vendor-only
 else
 dep:
 	@echo "skipping dep"
@@ -78,7 +78,8 @@ clean:
 	go clean -n -r --cache --testcache $(PROJECT_PACKAGES)
 
 go-install:
-	go install -ldflags "-s -w" -v $(PROJECT_PACKAGES)
+	@echo 'go install -ldflags "-s -w" -v $$PROJECT_PACKAGES'
+	@go install -ldflags "-s -w" -v $(PROJECT_PACKAGES)
 
 go-build:
 	go build $(PROJECT_PACKAGES)


### PR DESCRIPTION
## Description of change

Now that dep is working, remove the verbose flag to reduce the output from running `make install`. Also, since we now need to explicitly list packages in the `go install` command to avoid the vendored packages, echo a sanitised version of the command, rather than the real (very long) one.

These tweaks reduce the output from a nothing-changed build from 38k to about 3 lines.

## QA steps

Run `make install` - output is mostly restricted to listing packages as they are being built.
