### PR TITLE
Fixes lp#1786061: added uuid back for backward compatibility.

### DIFF
--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -139,6 +139,7 @@ controllers:
     current-model: controller
     user: admin
     recent-server: this-is-aws-test-of-many-api-endpoints
+    uuid: this-is-the-aws-test-uuid
     controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
@@ -155,6 +156,7 @@ controllers:
     user: admin
     access: superuser
     recent-server: this-is-another-of-many-api-endpoints
+    uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -168,6 +170,7 @@ controllers:
   mark-test-prodstack:
     user: admin
     recent-server: this-is-one-of-many-api-endpoints
+    uuid: this-is-a-uuid
     controller-uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -29,10 +29,13 @@ type ControllerMachines struct {
 
 // ControllerItem defines the serialization behaviour of controller information.
 type ControllerItem struct {
-	ModelName          string              `yaml:"current-model,omitempty" json:"current-model,omitempty"`
-	User               string              `yaml:"user,omitempty" json:"user,omitempty"`
-	Access             string              `yaml:"access,omitempty" json:"access,omitempty"`
-	Server             string              `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
+	ModelName string `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+	User      string `yaml:"user,omitempty" json:"user,omitempty"`
+	Access    string `yaml:"access,omitempty" json:"access,omitempty"`
+	Server    string `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
+	// TODO(anastasiamac 2018-08-10) This is a deprecated property, see lp#1596607.
+	// It was added for backward compatibility, lp#1786061, to be removed for Juju 3.
+	OldControllerUUID  string              `yaml:"uuid" json:"-"`
 	ControllerUUID     string              `yaml:"controller-uuid" json:"uuid"`
 	APIEndpoints       []string            `yaml:"api-endpoints,flow" json:"api-endpoints"`
 	CACert             string              `yaml:"ca-cert" json:"ca-cert"`
@@ -104,16 +107,17 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 		modelCount := len(models)
 
 		item := ControllerItem{
-			ModelName:      modelName,
-			User:           userName,
-			Access:         access,
-			Server:         serverName,
-			APIEndpoints:   details.APIEndpoints,
-			ControllerUUID: details.ControllerUUID,
-			CACert:         details.CACert,
-			Cloud:          details.Cloud,
-			CloudRegion:    details.CloudRegion,
-			AgentVersion:   details.AgentVersion,
+			ModelName:         modelName,
+			User:              userName,
+			Access:            access,
+			Server:            serverName,
+			APIEndpoints:      details.APIEndpoints,
+			ControllerUUID:    details.ControllerUUID,
+			OldControllerUUID: details.ControllerUUID,
+			CACert:            details.CACert,
+			Cloud:             details.Cloud,
+			CloudRegion:       details.CloudRegion,
+			AgentVersion:      details.AgentVersion,
 		}
 		if details.MachineCount != nil && *details.MachineCount > 0 {
 			item.MachineCount = details.MachineCount

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -240,6 +240,10 @@ type ShowControllerDetails struct {
 
 // ControllerDetails holds details of a controller to show.
 type ControllerDetails struct {
+	// TODO(anastasiamac 2018-08-10) This is a deprecated property, see lp#1596607.
+	// It was added for backward compatibility, lp#1786061, to be removed for Juju 3.
+	OldControllerUUID string `yaml:"uuid" json:"-"`
+
 	// ControllerUUID is the unique ID for the controller.
 	ControllerUUID string `yaml:"controller-uuid" json:"uuid"`
 
@@ -276,6 +280,10 @@ type MachineDetails struct {
 
 // ModelDetails holds details of a model to show.
 type ModelDetails struct {
+	// TODO(anastasiamac 2018-08-10) This is a deprecated property, see lp#1596607.
+	// It was added for backward compatibility, lp#1786061, to be removed for Juju 3.
+	OldModelUUID string `yaml:"uuid" json:"-"`
+
 	// ModelUUID holds the details of a model.
 	ModelUUID string `yaml:"model-uuid" json:"uuid"`
 
@@ -308,12 +316,13 @@ func (c *showControllerCommand) convertControllerForShow(
 ) {
 
 	controller.Details = ControllerDetails{
-		ControllerUUID: details.ControllerUUID,
-		APIEndpoints:   details.APIEndpoints,
-		CACert:         details.CACert,
-		Cloud:          details.Cloud,
-		CloudRegion:    details.CloudRegion,
-		AgentVersion:   details.AgentVersion,
+		ControllerUUID:    details.ControllerUUID,
+		OldControllerUUID: details.ControllerUUID,
+		APIEndpoints:      details.APIEndpoints,
+		CACert:            details.CACert,
+		Cloud:             details.Cloud,
+		CloudRegion:       details.CloudRegion,
+		AgentVersion:      details.AgentVersion,
 	}
 	c.convertModelsForShow(controllerName, controller, allModels, modelStatusResults)
 	c.convertAccountsForShow(controllerName, controller, access)
@@ -371,7 +380,7 @@ func (c *showControllerCommand) convertModelsForShow(
 ) {
 	controller.Models = make(map[string]ModelDetails)
 	for i, model := range models {
-		modelDetails := ModelDetails{ModelUUID: model.UUID}
+		modelDetails := ModelDetails{ModelUUID: model.UUID, OldModelUUID: model.UUID}
 		result := modelStatus[i]
 		if result.Error != nil {
 			if !errors.IsNotFound(result.Error) {

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -61,6 +61,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
 	s.expectedOutput = `
 mallards:
   details:
+    uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -68,10 +69,12 @@ mallards:
     agent-version: 999.99.99
   models:
     controller:
+      uuid: abc
       model-uuid: abc
       machine-count: 2
       core-count: 4
     my-model:
+      uuid: def
       model-uuid: def
       machine-count: 2
       core-count: 4
@@ -98,6 +101,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
 	s.expectedOutput = `
 mallards:
   details:
+    uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -105,10 +109,12 @@ mallards:
     agent-version: 999.99.99
   models:
     controller:
+      uuid: abc
       model-uuid: abc
       machine-count: 2
       core-count: 4
     my-model:
+      uuid: def
       model-uuid: def
       machine-count: 2
       core-count: 4
@@ -149,6 +155,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	s.expectedOutput = `
 mallards:
   details:
+    uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -157,10 +164,12 @@ mallards:
     agent-version: 999.99.99
   models:
     controller:
+      uuid: abc
       model-uuid: abc
       machine-count: 2
       core-count: 4
     my-model:
+      uuid: def
       model-uuid: def
       machine-count: 2
       core-count: 4
@@ -179,6 +188,7 @@ func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {
 	s.expectedOutput = `
 aws-test:
   details:
+    uuid: this-is-the-aws-test-uuid
     controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
@@ -197,6 +207,7 @@ aws-test:
       ha-status: ha-enabled
   models:
     controller:
+      uuid: ghi
       model-uuid: ghi
       machine-count: 2
       core-count: 4
@@ -213,6 +224,7 @@ func (s *ShowControllerSuite) TestShowSomeControllerMoreInStore(c *gc.C) {
 	s.expectedOutput = `
 aws-test:
   details:
+    uuid: this-is-the-aws-test-uuid
     controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
@@ -231,6 +243,7 @@ aws-test:
       ha-status: ha-enabled
   models:
     controller:
+      uuid: ghi
       model-uuid: ghi
       machine-count: 2
       core-count: 4
@@ -240,6 +253,7 @@ aws-test:
     access: superuser
 mark-test-prodstack:
   details:
+    uuid: this-is-a-uuid
     controller-uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert


### PR DESCRIPTION
## Description of change

As per linked bug, some scripts may be broken due to a property rename in yaml output.

This PR adds back old names: uuid' for controller on both 'controllers' and 'show-controller' command as well as 'uuid' for model in 'show-controller' command.

Note that it means that both new and old properties are now part of the output - 'controller-uuid' and 'model-uuid' as well as the old 'uuid' for both controller and model, respectively.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1786061
