### PR TITLE
Fixes lp#1786253: backup create help and result messaging.

### DIFF
--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -27,16 +27,17 @@ const createDoc = `
 This command requests that Juju creates a backup of its state and prints the
 backup's unique ID.  You may provide a note to associate with the backup.
 
-By default, the backup archive and associated metadata are downloaded without keeping a copy remotely on the controller.
+By default, the backup archive and associated metadata are downloaded 
+without keeping a copy remotely on the controller.
 
-Use --no-download to avoid getting a local copy of the backup downloaded at the end of the backup process. 
+Use --no-download to avoid getting a local copy of the backup downloaded
+at the end of the backup process. 
 
-Use --keep-copy option to store a copy of this backup remotely on the controller. Ignored when --no-download is used.
-
+Use --keep-copy option to store a copy of backup remotely on the controller. 
 
 Use --verbose to see extra information about backup.
 
-To access the remote backups stored on the controller, see 'juju download-backup'.
+To access remote backups stored on the controller, see 'juju download-backup'.
 
 Examples:
     juju create-backup 

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -249,6 +249,12 @@ func (s *createSuite) TestKeepCopy(c *gc.C) {
 	s.checkDownload(c, ctx)
 }
 
+func (s *createSuite) TestFailKeepCopyNoDownload(c *gc.C) {
+	s.setDownload()
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--keep-copy", "--no-download")
+	c.Check(err, gc.ErrorMatches, "cannot mix --no-download and --keep-copy")
+}
+
 func (s *createSuite) TestKeepCopyV1Fail(c *gc.C) {
 	s.apiVersion = 1
 	s.setDownload()

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -5,7 +5,9 @@ package backups_test
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -33,6 +35,16 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 	s.defaultFilename = "juju-backup-<date>-<time>.tar.gz"
 }
 
+func (s *createSuite) TearDownTest(c *gc.C) {
+	// We do not need to cater here for s.BaseBackupsSuite.filename as it will be deleted by the base suite.
+	// However, in situations where s.command.Filename is defined, we want to remove it as well.
+	if s.command.Filename != backups.NotSet && s.command.Filename != s.filename {
+		err := os.Remove(s.command.Filename)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	s.BaseBackupsSuite.TearDownTest(c)
+}
+
 func (s *createSuite) setSuccess() *fakeAPIClient {
 	client := &fakeAPIClient{metaresult: s.metaresult}
 	s.patchGetAPI(client)
@@ -52,25 +64,22 @@ func (s *createSuite) setDownload() *fakeAPIClient {
 }
 
 func (s *createSuite) checkDownloadStd(c *gc.C, ctx *cmd.Context) {
-	c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, MetaResultString)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, MetaResultString)
 
-	out := ctx.Stderr.(*bytes.Buffer).String()
-
+	out := cmdtesting.Stderr(ctx)
 	parts := strings.Split(out, "\n")
-	i := 0
+	c.Assert(parts, gc.HasLen, 3)
 	if s.command.KeepCopy {
-		c.Assert(parts, gc.HasLen, 3)
-		c.Check(parts[0], gc.Equals, s.metaresult.ID)
-		i = 1
+		c.Check(parts[0], gc.Equals, fmt.Sprintf("Remote backup stored on the controller as %v.", s.metaresult.ID))
 	} else {
-		c.Assert(parts, gc.HasLen, 2)
+		c.Check(parts[0], gc.Equals, "Remote backup was not created.")
 	}
 
 	// Check the download message.
-	parts = strings.Split(parts[i], "downloading to ")
+	parts = strings.Split(parts[1], "Downloaded to ")
 	c.Assert(parts, gc.HasLen, 2)
 	c.Assert(parts[0], gc.Equals, "")
-	s.filename = parts[1]
+	s.filename = parts[1][:len(parts[1])-1]
 }
 
 func (s *createSuite) checkDownload(c *gc.C, ctx *cmd.Context) {
@@ -224,7 +233,8 @@ func (s *createSuite) TestNoDownload(c *gc.C) {
 	client.CheckCalls(c, "Create")
 	client.CheckArgs(c, "", "true", "true")
 	out := MetaResultString
-	s.checkStd(c, ctx, out, "WARNING "+backups.DownloadWarning+"\n"+s.metaresult.ID+"\n")
+	expectedMsg := fmt.Sprintf("WARNING %v\nRemote backup stored on the controller as %v.\n", backups.DownloadWarning, s.metaresult.ID)
+	s.checkStd(c, ctx, out, expectedMsg)
 	c.Check(s.command.Filename, gc.Equals, backups.NotSet)
 }
 

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -117,6 +117,14 @@ func (s *BaseBackupsSuite) checkArchive(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer archive.Close()
 
+	// Test file created successfully. Clean it up after the test is run.
+	s.AddCleanup(func(c *gc.C) {
+		err := os.Remove(s.filename)
+		if !os.IsNotExist(err) {
+			c.Fatalf("could not remove test file %v: %v", s.filename, err)
+		}
+	})
+
 	data, err := ioutil.ReadAll(archive)
 	c.Check(string(data), gc.Equals, s.data)
 }


### PR DESCRIPTION
## Description of change

From 2.4 we have introduced a slight change in the way that 'create-backup' command was run - backups are now downloaded to the client by default instead of the old way where we stored them remotely by default.

This PR updates help text for the command.
But also ensures that the operator is clear whether the backup is available remotely or not. 

Whilst running unit tests locally, I have also noticed that we were not removing test-generated files. I have adjusted tests' cleanup.

## Documentation changes

@juju/docs I *think* this has been covered when the original behavior change was done to resolve https://bugs.launchpad.net/juju/+bug/1749300 in https://github.com/juju/juju/pull/8663. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1786253
