### PR TITLE
Default lxd region

### DIFF
--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -399,7 +399,25 @@ func (p *Pollster) queryAdditionalProps(vals map[string]interface{}, schema *jso
 		// We assume that the name of the schema is the name of the object the
 		// schema describes, and for additional properties the property name
 		// (i.e. map key) is the "name" of the thing.
-		name, err := p.EnterVerify(schema.Singular+" name", verifyName)
+		var name string
+		var err error
+		if schema.Default != nil {
+			var def string
+			if schema.PromptDefault != nil {
+				def = fmt.Sprintf("%v", schema.PromptDefault)
+			} else {
+				def = fmt.Sprintf("%v", schema.Default)
+			}
+			name, err = p.EnterVerifyDefault(schema.Singular+" name", verifyName, def)
+
+			// If we set a prompt default, that'll get returned as the value,
+			// but it's not the actual value that is the default, so fix that.
+			if err == nil && name == def && schema.PromptDefault != nil {
+				name = fmt.Sprintf("%v", schema.Default)
+			}
+		} else {
+			name, err = p.EnterVerify(schema.Singular+" name", verifyName)
+		}
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -118,6 +118,10 @@ func (s *providerSuite) TestRemoteDetectClouds(c *gc.C) {
 			AuthTypes: []cloud.AuthType{
 				cloud.CertificateAuthType,
 			},
+			Regions: []cloud.Region{{
+				Name:     "default",
+				Endpoint: "https://10.0.0.1:8443",
+			}},
 			Description: "LXD Container Hypervisor",
 		},
 	})
@@ -181,6 +185,10 @@ func (s *providerSuite) TestRemoteDetectCloud(c *gc.C) {
 		AuthTypes: []cloud.AuthType{
 			cloud.CertificateAuthType,
 		},
+		Regions: []cloud.Region{{
+			Name:     "default",
+			Endpoint: "https://10.0.0.1:8443",
+		}},
 		Description: "LXD Container Hypervisor",
 	})
 }


### PR DESCRIPTION
## Description of change

Update the pollster interaction so that we can have default naming
for object key names. To improve the UI/UX for adding a LXD cloud
interactively we want to state that there can be a region and that
it can be default, we do allow you to override this when adding a
cloud, but a sane default should suffice.

## QA steps

```sh
juju add-cloud lxd-remote2
Cloud Types
  lxd
  maas
  manual
  oci
  openstack
  oracle
  vsphere

Select cloud type: lxd

Enter the API endpoint url for the remote LXD server: https://10.0.0.225:8443

Auth Types
  certificate
  interactive

Select one or more auth types separated by commas: interactive

Enter region name [use default]: 

Enter the API endpoint url for the region [use cloud api url]: 

Enter another region? (Y/n): n

Cloud "lxd-remote2" successfully added
You may need to `juju add-credential lxd-remote2' if your cloud needs additional credentials
Then you can bootstrap with 'juju bootstrap lxd-remote2'
```
Then verify with:

```sh
juju clouds
Cloud        Regions  Default          Type        Description
aws               15  us-east-1        ec2         Amazon Web Services
aws-china          1  cn-north-1       ec2         Amazon China
aws-gov            1  us-gov-west-1    ec2         Amazon (USA Government)
azure             26  centralus        azure       Microsoft Azure
azure-china        2  chinaeast        azure       Microsoft Azure China
cloudsigma         5  hnl              cloudsigma  CloudSigma Cloud
google            13  us-east1         gce         Google Cloud Platform
joyent             6  eu-ams-1         joyent      Joyent Cloud
oracle             5  uscom-central-1  oracle      Oracle Cloud
rackspace          6  dfw              rackspace   Rackspace Cloud
localhost          1  localhost        lxd         LXD Container Hypervisor
lxd                1  default          lxd         LXD Container Hypervisor
lxd-remote         0                   lxd         LXD Container Hypervisor
lxd-remote2        1  default          lxd         LXD Container Hypervisor
```

## Documentation changes

Allows you to set a default region when adding a cloud, so that when
calling `juju clouds` the default region is correctly set.

## Bug reference

N/A
