### PR TITLE
Openstack default fix

### DIFF
--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -409,7 +409,17 @@ func (p *Pollster) queryAdditionalProps(vals map[string]interface{}, schema *jso
 			var def string
 			if schema.PromptDefault != nil {
 				def = fmt.Sprintf("%v", schema.PromptDefault)
-			} else {
+			}
+			if len(schema.EnvVars) > 0 {
+				for _, envVar := range schema.EnvVars {
+					value, ok := os.LookupEnv(envVar)
+					if ok && value != "" {
+						def = value
+						break
+					}
+				}
+			}
+			if def == "" {
 				def = fmt.Sprintf("%v", schema.Default)
 			}
 			name, err = p.EnterVerifyDefault(schema.Singular+" name", verifyName, def)

--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -405,7 +405,7 @@ func (p *Pollster) queryAdditionalProps(vals map[string]interface{}, schema *jso
 		// (i.e. map key) is the "name" of the thing.
 		var name string
 		var err error
-		if schema.Default != nil {
+		if schema.Default != nil && schema.Default != "" {
 			var def string
 			if schema.PromptDefault != nil {
 				def = fmt.Sprintf("%v", schema.PromptDefault)

--- a/cmd/juju/interact/pollster_test.go
+++ b/cmd/juju/interact/pollster_test.go
@@ -795,3 +795,54 @@ func (PollsterSuite) TestQueryObjectSchemaWithDefault(c *gc.C) {
 		},
 	})
 }
+
+func (PollsterSuite) TestQueryObjectSchemaWithDefaultEnvVars(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Type:  []jsonschema.Type{jsonschema.ObjectType},
+		Order: []string{"name", "nested"},
+		Properties: map[string]*jsonschema.Schema{
+			"nested": {
+				Singular:      "nested",
+				Default:       "default",
+				PromptDefault: "use default value",
+				EnvVars:       []string{"TEST_ENV_VAR_NESTED"},
+				Type:          []jsonschema.Type{jsonschema.ObjectType},
+				AdditionalProperties: &jsonschema.Schema{
+					Type:          []jsonschema.Type{jsonschema.ObjectType},
+					Required:      []string{"name"},
+					MaxProperties: jsonschema.Int(1),
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Singular:      "the name",
+							Type:          []jsonschema.Type{jsonschema.StringType},
+							Default:       "",
+							PromptDefault: "use name",
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     []jsonschema.Type{jsonschema.StringType},
+				Singular: "the name",
+			},
+		},
+	}
+	// queries should be alphabetical without an order specified, so name then
+	// number.
+	os.Setenv("TEST_ENV_VAR_NESTED", "baz")
+	defer os.Unsetenv("TEST_ENV_VAR_NESTED")
+
+	r := strings.NewReader("Bill\n\n\n\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, jc.DeepEquals, map[string]interface{}{
+		"name": "Bill",
+		"nested": map[string]interface{}{
+			"baz": map[string]interface{}{
+				"name": "",
+			},
+		},
+	})
+}

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -66,8 +66,6 @@ var cloudSchema = &jsonschema.Schema{
 	Type:     []jsonschema.Type{jsonschema.ObjectType},
 	Required: []string{cloud.EndpointKey, cloud.AuthTypesKey},
 	Order:    []string{cloud.EndpointKey, cloud.AuthTypesKey, cloud.RegionsKey},
-	// Order doesn't matter since there's only one thing to ask about.  Add
-	// order if this changes.
 	Properties: map[string]*jsonschema.Schema{
 		cloud.EndpointKey: {
 			Singular: "the API endpoint url for the remote LXD server",
@@ -90,11 +88,10 @@ var cloudSchema = &jsonschema.Schema{
 			},
 		},
 		cloud.RegionsKey: {
-			Type:          []jsonschema.Type{jsonschema.ObjectType},
-			Singular:      "region",
-			Plural:        "regions",
-			Default:       "default",
-			PromptDefault: "use default",
+			Type:     []jsonschema.Type{jsonschema.ObjectType},
+			Singular: "region",
+			Plural:   "regions",
+			Default:  "default",
 			AdditionalProperties: &jsonschema.Schema{
 				Type:          []jsonschema.Type{jsonschema.ObjectType},
 				Required:      []string{cloud.EndpointKey},

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -121,9 +121,7 @@ var cloudSchema = &jsonschema.Schema{
 			Singular: "region",
 			Plural:   "regions",
 			Default:  "",
-			// TODO (hml) 2018-08-02
-			// It'd be nice to have the EnvVars work with ObjectTypes, like they do for StringType.
-			// EnvVars:  []string{"OS_REGION_NAME"},
+			EnvVars:  []string{"OS_REGION_NAME"},
 			AdditionalProperties: &jsonschema.Schema{
 				Type:          []jsonschema.Type{jsonschema.ObjectType},
 				Required:      []string{cloud.EndpointKey},


### PR DESCRIPTION
## Description of change

The following also checks for empty default string, so that we're
backwards compatible with other providers like openstack. Openstack
here adds a default of "" and if a provider sets the default to ""
we skip it, like it was equal to nil.

Also updated to include drive by comment removal and better default
wording for LXD provider.

## QA steps

```sh
juju add-cloud
Cloud Types
  lxd
  maas
  manual
  oci
  openstack
  oracle
  vsphere

Select cloud type: openstack

Enter a name for your openstack cloud: os1 

Enter the API endpoint url for the cloud []: https://os1.com 

Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none]: 

Auth Types
  access-key
  userpass

Select one or more auth types separated by commas: userpass

Enter region name: 

Enter region name: default

Enter the API endpoint url for the region [use cloud api url]: https://region.os1.com

Enter another region? (y/N): n

Cloud "os1" successfully added
You may need to `juju add-credential os1' if your cloud needs additional credentials
Then you can bootstrap with 'juju bootstrap os1'
```

## Documentation changes

N/A

## Bug reference

N/A
