### PR TITLE
fix lp: 1783407 fix interactive credentials type for lxd

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -62,6 +62,12 @@ const (
 	// https://tools.ietf.org/html/draft-cavage-http-signatures-06
 	HTTPSigAuthType AuthType = "httpsig"
 
+	// interactiveAuthType is a credential auth-type provided as an option to
+	// "juju add-credential", which takes the user through the process of
+	// adding credentials.  e.g. for lxd: generating a certificate credential.
+	// This authType should used in a CredentialSchema, not a CloudSchema.
+	InteractiveAuthType = "interactive"
+
 	// EmptyAuthType is the authentication type used for providers
 	// that require no credentials, e.g. "lxd", and "manual".
 	EmptyAuthType AuthType = "empty"

--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -530,10 +530,22 @@ func (p *Pollster) queryArray(schema *jsonschema.Schema) (interface{}, error) {
 		}
 		return nil, errors.Errorf("unsupported schema for an array: %s", b)
 	}
+	var def string
+	if schema.Default != nil {
+		def = schema.Default.(string)
+	}
+	if schema.PromptDefault != nil {
+		def = schema.PromptDefault.(string)
+	}
+	var array []string
+	if def != "" {
+		array = []string{def}
+	}
 	return p.MultiSelect(MultiList{
 		Singular: schema.Singular,
 		Plural:   schema.Plural,
 		Options:  optFromEnum(schema.Items.Schemas[0]),
+		Default:  array,
 	})
 }
 

--- a/cmd/juju/interact/pollster_test.go
+++ b/cmd/juju/interact/pollster_test.go
@@ -504,6 +504,76 @@ Select one or more numbers separated by commas:
 	c.Check(s, jc.SameContents, []string{"one", "three"})
 }
 
+func (PollsterSuite) TestQueryArraySchemaDefault(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Singular: "number",
+		Plural:   "numbers",
+		Type:     []jsonschema.Type{jsonschema.ArrayType},
+		Default:  "two",
+		Items: &jsonschema.ItemSpec{
+			Schemas: []*jsonschema.Schema{{
+				Type: []jsonschema.Type{jsonschema.StringType},
+				Enum: []interface{}{
+					"one",
+					"two",
+					"three",
+				},
+			}},
+		},
+	}
+	r := strings.NewReader("\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(w.String(), gc.Equals, `
+Numbers
+  one
+  two
+  three
+
+Select one or more numbers separated by commas [two]: 
+`[1:])
+	s, ok := v.([]string)
+	c.Check(ok, jc.IsTrue)
+	c.Check(s, jc.SameContents, []string{"two"})
+}
+
+func (PollsterSuite) TestQueryArraySchemaNotDefault(c *gc.C) {
+	schema := &jsonschema.Schema{
+		Singular: "number",
+		Plural:   "numbers",
+		Type:     []jsonschema.Type{jsonschema.ArrayType},
+		Default:  "two",
+		Items: &jsonschema.ItemSpec{
+			Schemas: []*jsonschema.Schema{{
+				Type: []jsonschema.Type{jsonschema.StringType},
+				Enum: []interface{}{
+					"one",
+					"two",
+					"three",
+				},
+			}},
+		},
+	}
+	r := strings.NewReader("three")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	v, err := p.QuerySchema(schema)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(w.String(), gc.Equals, `
+Numbers
+  one
+  two
+  three
+
+Select one or more numbers separated by commas [two]: 
+`[1:])
+	s, ok := v.([]string)
+	c.Check(ok, jc.IsTrue)
+	c.Check(s, jc.SameContents, []string{"three"})
+}
+
 func (PollsterSuite) TestQueryEnum(c *gc.C) {
 	schema := &jsonschema.Schema{
 		Singular: "number",

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -30,7 +30,7 @@ const (
 
 	// deviceCodeAuthType is the auth-type for the interactive
 	// "device code" OAuth flow.
-	deviceCodeAuthType cloud.AuthType = "interactive"
+	deviceCodeAuthType cloud.AuthType = cloud.InteractiveAuthType
 )
 
 type ServicePrincipalCreator interface {

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -31,11 +31,6 @@ const (
 	credAttrClientCert    = "client-cert"
 	credAttrClientKey     = "client-key"
 	credAttrTrustPassword = "trust-password"
-
-	// interactiveAuthType is a credential auth-type provided as an option to
-	// "juju add-credential", which takes the user through the process of
-	// generating a certificate credential.
-	interactiveAuthType = "interactive"
 )
 
 // CertificateReadWriter groups methods that is required to read and write
@@ -103,7 +98,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 				},
 			},
 		},
-		interactiveAuthType: {
+		cloud.InteractiveAuthType: {
 			{
 				Name: credAttrTrustPassword,
 				CredentialAttr: cloud.CredentialAttr{
@@ -273,7 +268,7 @@ func (p environProviderCredentials) FinalizeCredential(
 	args environs.FinalizeCredentialParams,
 ) (*cloud.Credential, error) {
 	switch authType := args.Credential.AuthType(); authType {
-	case interactiveAuthType:
+	case cloud.InteractiveAuthType:
 		credAttrs := args.Credential.Attributes()
 		// We don't care if the password is empty, just that it exists. Empty
 		// passwords can be valid ones...

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -79,12 +79,12 @@ var cloudSchema = &jsonschema.Schema{
 			Plural:      "auth types",
 			Type:        []jsonschema.Type{jsonschema.ArrayType},
 			UniqueItems: jsonschema.Bool(true),
+			Default:     string(cloud.CertificateAuthType),
 			Items: &jsonschema.ItemSpec{
 				Schemas: []*jsonschema.Schema{{
 					Type: []jsonschema.Type{jsonschema.StringType},
 					Enum: []interface{}{
 						string(cloud.CertificateAuthType),
-						string(interactiveAuthType),
 					},
 				}},
 			},
@@ -345,7 +345,6 @@ var localhostCloud = cloud.Cloud{
 	Type: lxdnames.ProviderType,
 	AuthTypes: []cloud.AuthType{
 		cloud.CertificateAuthType,
-		interactiveAuthType,
 	},
 	Endpoint: "",
 	Regions: []cloud.Region{{
@@ -385,7 +384,7 @@ func (p *environProvider) validateCloudSpec(spec environs.CloudSpec) error {
 		return errors.Trace(err)
 	}
 	switch authType := spec.Credential.AuthType(); authType {
-	case cloud.CertificateAuthType, interactiveAuthType:
+	case cloud.CertificateAuthType:
 		if spec.Credential == nil {
 			return errors.NotFoundf("credentials")
 		}

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -104,7 +104,6 @@ func (s *providerSuite) TestRemoteDetectClouds(c *gc.C) {
 			Type: "lxd",
 			AuthTypes: []cloud.AuthType{
 				cloud.CertificateAuthType,
-				"interactive",
 			},
 			Regions: []cloud.Region{{
 				Name: "localhost",
@@ -225,7 +224,6 @@ func (s *providerSuite) assertLocalhostCloud(c *gc.C, found cloud.Cloud) {
 		Type: "lxd",
 		AuthTypes: []cloud.AuthType{
 			cloud.CertificateAuthType,
-			"interactive",
 		},
 		Regions: []cloud.Region{{
 			Name: "localhost",


### PR DESCRIPTION
## Description of change

Allow for interactive authtype in CredentialSchemas,that isn't in the CloudSchema. If specified will be the default for add-credential.

Allow for a Default to be used in pollster for Schema ArrayTypes.

## QA steps

1. juju add-cloud for lxd with a remote.  The default auth type should be "certificates".
2. juju add-credential for the new lxd cloud should mention auth types of both certificate and interactive.  Interactive being the default.
3. juju add-credential -f <file> for the new lxd cloud with an authtype of interactive should work.
4. juju bootstrap the new lxd cloud should succeed.
3. no change to juju add-credential for azure.

## Documentation changes

Not clear.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1783407