### PR TITLE
Change default presense implementation to core/presence.

### DIFF
--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -406,10 +406,11 @@ func (ctx *facadeContext) Presence() facade.Presence {
 
 // ModelPresence implements facade.ModelPresence.
 func (ctx *facadeContext) ModelPresence(modelUUID string) facade.ModelPresence {
-	if ctx.r.shared.featureEnabled(feature.NewPresence) {
-		return ctx.r.shared.presence.Connections().ForModel(modelUUID)
+	if ctx.r.shared.featureEnabled(feature.OldPresence) {
+		// Used in presence.go in this package to determine which code path to follow.
+		return nil
 	}
-	return nil
+	return ctx.r.shared.presence.Connections().ForModel(modelUUID)
 }
 
 // Hub implements facade.Context.

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/migration"
-	corepresence "github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
 	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
@@ -38,7 +38,6 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -99,21 +98,17 @@ type stepper interface {
 //
 
 func newContext(st *state.State, env environs.Environ, presenceSetter presenceSetter, adminUserTag string) *context {
-	// We make changes in the API server's state so that
-	// our changes to presence are immediately noticed
-	// in the status.
 	return &context{
 		st:             st,
 		env:            env,
 		presenceSetter: presenceSetter,
 		charms:         make(map[string]*state.Charm),
-		pingers:        make(map[string]*presence.Pinger),
 		adminUserTag:   adminUserTag,
 	}
 }
 
 type presenceSetter interface {
-	SetAgentPresence(agent string, status corepresence.Status)
+	SetAgentPresence(agent string, status presence.Status)
 }
 
 type context struct {
@@ -121,16 +116,8 @@ type context struct {
 	env            environs.Environ
 	presenceSetter presenceSetter
 	charms         map[string]*state.Charm
-	pingers        map[string]*presence.Pinger
 	adminUserTag   string // A string repr of the tag.
 	expectIsoTime  bool
-}
-
-func (ctx *context) reset(c *gc.C) {
-	for _, up := range ctx.pingers {
-		err := up.KillForTesting()
-		c.Check(err, jc.ErrorIsNil)
-	}
 }
 
 func (ctx *context) run(c *gc.C, steps []stepper) {
@@ -141,29 +128,20 @@ func (ctx *context) run(c *gc.C, steps []stepper) {
 	}
 }
 
-func (ctx *context) setAgentPresence(c *gc.C, p presence.Agent) *presence.Pinger {
-	pinger, err := p.SetAgentPresence()
-	c.Assert(err, jc.ErrorIsNil)
-	ctx.st.StartSync()
-	err = p.WaitAgentPresence(coretesting.LongWait)
-	c.Assert(err, jc.ErrorIsNil)
-	agentPresence, err := p.AgentPresence()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentPresence, jc.IsTrue)
-	return pinger
+func (ctx *context) setAgentAlive(tag names.Tag) {
+	ctx.presenceSetter.SetAgentPresence(tag.String(), presence.Alive)
+}
+
+func (ctx *context) setAgentMissing(tag names.Tag) {
+	ctx.presenceSetter.SetAgentPresence(tag.String(), presence.Missing)
 }
 
 func (s *StatusSuite) newContext(c *gc.C) *context {
 	st := s.Environ.(testing.GetStater).GetStateInAPIServer()
-
-	// We make changes in the API server's state so that
-	// our changes to presence are immediately noticed
-	// in the status.
 	return newContext(st, s.Environ, s, s.AdminUserTag(c).String())
 }
 
 func (s *StatusSuite) resetContext(c *gc.C, ctx *context) {
-	ctx.reset(c)
 	s.JujuConnSuite.Reset(c)
 }
 
@@ -3567,7 +3545,7 @@ type startMachine struct {
 func (sm startMachine) step(c *gc.C, ctx *context) {
 	m, err := ctx.st.Machine(sm.machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.presenceSetter.SetAgentPresence(m.Tag().String(), corepresence.Missing)
+	ctx.setAgentMissing(m.Tag())
 	cons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
@@ -3584,7 +3562,7 @@ type startMissingMachine struct {
 func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 	m, err := ctx.st.Machine(sm.machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.presenceSetter.SetAgentPresence(m.Tag().String(), corepresence.Missing)
+	ctx.setAgentMissing(m.Tag())
 	cons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
@@ -3610,8 +3588,7 @@ type startAliveMachine struct {
 func (sam startAliveMachine) step(c *gc.C, ctx *context) {
 	m, err := ctx.st.Machine(sam.machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.presenceSetter.SetAgentPresence(m.Tag().String(), corepresence.Alive)
-	pinger := ctx.setAgentPresence(c, m)
+	ctx.setAgentAlive(m.Tag())
 	cons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
@@ -3619,7 +3596,6 @@ func (sam startAliveMachine) step(c *gc.C, ctx *context) {
 	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned(inst.Id(), "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.pingers[m.Id()] = pinger
 }
 
 type startMachineWithHardware struct {
@@ -3630,8 +3606,7 @@ type startMachineWithHardware struct {
 func (sm startMachineWithHardware) step(c *gc.C, ctx *context) {
 	m, err := ctx.st.Machine(sm.machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.presenceSetter.SetAgentPresence(m.Tag().String(), corepresence.Alive)
-	pinger := ctx.setAgentPresence(c, m)
+	ctx.setAgentAlive(m.Tag())
 	cons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
@@ -3639,7 +3614,6 @@ func (sm startMachineWithHardware) step(c *gc.C, ctx *context) {
 	inst, _ := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned(inst.Id(), "fake_nonce", &sm.hc)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.pingers[m.Id()] = pinger
 }
 
 type setMachineInstanceStatus struct {
@@ -3932,7 +3906,7 @@ func (au addUnit) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := s.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.presenceSetter.SetAgentPresence(u.Tag().String(), corepresence.Missing)
+	ctx.setAgentMissing(u.Tag())
 	m, err := ctx.st.Machine(au.machineId)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
@@ -3949,13 +3923,11 @@ func (aau addAliveUnit) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := s.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.presenceSetter.SetAgentPresence(u.Tag().String(), corepresence.Alive)
-	pinger := ctx.setAgentPresence(c, u)
+	ctx.setAgentAlive(u.Tag())
 	m, err := ctx.st.Machine(aau.machineId)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.pingers[u.Name()] = pinger
 }
 
 type setUnitsAlive struct {
@@ -3968,8 +3940,7 @@ func (sua setUnitsAlive) step(c *gc.C, ctx *context) {
 	us, err := s.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	for _, u := range us {
-		ctx.presenceSetter.SetAgentPresence(u.Tag().String(), corepresence.Alive)
-		ctx.pingers[u.Name()] = ctx.setAgentPresence(c, u)
+		ctx.setAgentAlive(u.Tag())
 	}
 }
 

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -38,10 +38,10 @@ const DeveloperMode = "developer-mode"
 // values for annotations, status, status history, or settings.
 const StrictMigration = "strict-migration"
 
-// NewPresence indicates that the new in-memory presence implementation
+// OldPresence indicates that the old database presence implementation
 // should be used by the API server to determine agent presence.
 // This value is only checked using the controller config "features" attrubite.
-const NewPresence = "new-presence"
+const OldPresence = "old-presence"
 
 // DisableRaft will prevent the raft workers from running. At the
 // moment the raft cluster isn't managing leadership, so we want the

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -753,4 +754,12 @@ func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSe
 func (s *JujuConnSuite) AssertConfigParameterUpdated(c *gc.C, key string, value interface{}) {
 	err := s.Model.UpdateModelConfig(map[string]interface{}{key: value}, nil)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+type agentStatusSetter interface {
+	SetAgentStatus(agent string, status presence.Status)
+}
+
+func (s *JujuConnSuite) SetAgentPresence(agent string, status presence.Status) {
+	s.Environ.(agentStatusSetter).SetAgentStatus(agent, status)
 }


### PR DESCRIPTION
In 2.4 we added the core/presence package running in tandem with the existing state/presence implementation. The new presence checks could be turned on with a controller freature flag.

This branch changes the default to be the new presence, with the old presence implementation available as a feature flag.

## QA steps

The unit tests passing, followed by CI.
