### PR TITLE
Version bionic 2.4 backport

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1440,7 +1440,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitColocationWithUnit(c *
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc.C) {
-	testcharms.UploadCharm(c, s.client, "xenial/django-42", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/django-42", "dummy")
 	err := s.DeployBundleYAML(c, `
         applications:
             django:
@@ -1470,17 +1470,17 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *gc.C) {
-	testcharms.UploadCharm(c, s.client, "xenial/django-42", "dummy")
-	testcharms.UploadCharm(c, s.client, "xenial/mem-47", "dummy")
-	testcharms.UploadCharm(c, s.client, "xenial/rails-0", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/django-42", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/mem-47", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/rails-0", "dummy")
 	err := s.DeployBundleYAML(c, `
         applications:
             memcached:
-                charm: cs:xenial/mem-47
+                charm: cs:bionic/mem-47
                 num_units: 3
                 to: [1, 2, 3]
             django:
-                charm: cs:xenial/django-42
+                charm: cs:bionic/django-42
                 num_units: 4
                 to:
                     - 1
@@ -1516,17 +1516,17 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	content := `
         applications:
             memcached:
-                charm: cs:xenial/mem-47
+                charm: cs:bionic/mem-47
                 num_units: 3
                 to: [1, 2, 3]
             django:
-                charm: cs:xenial/django-42
+                charm: cs:bionic/django-42
                 num_units: 4
                 to:
                     - 1
                     - lxd:memcached
             node:
-                charm: cs:xenial/django-42
+                charm: cs:bionic/django-42
                 num_units: 1
                 to:
                     - lxd:memcached
@@ -1539,7 +1539,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- deploy application node on xenial using cs:xenial/django-42\n"+
+		"- deploy application node on bionic using cs:bionic/django-42\n"+
 		"- add unit node/0 to 0/lxd/0 to satisfy [lxd:memcached]",
 	)
 
@@ -1563,8 +1563,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCorrect(c *gc.C) {
-	testcharms.UploadCharm(c, s.client, "xenial/django-42", "dummy")
-	testcharms.UploadCharm(c, s.client, "xenial/mem-47", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/django-42", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/mem-47", "dummy")
 	stdOut, stdErr, err := s.DeployBundleYAMLWithOutput(c, `
         applications:
             django:
@@ -1575,7 +1575,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCo
                     key2: value2
                 to: [1]
             memcached:
-                charm: xenial/mem-47
+                charm: bionic/mem-47
                 num_units: 1
         machines:
             1:
@@ -1585,11 +1585,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCo
 
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/django-42 for series xenial\n"+
-		"- deploy application django on xenial using cs:xenial/django-42\n"+
+		"- upload charm cs:bionic/django-42 for series bionic\n"+
+		"- deploy application django on bionic using cs:bionic/django-42\n"+
 		"- set annotations for django\n"+
-		"- upload charm cs:xenial/mem-47 for series xenial\n"+
-		"- deploy application memcached on xenial using cs:xenial/mem-47\n"+
+		"- upload charm cs:bionic/mem-47 for series bionic\n"+
+		"- deploy application memcached on bionic using cs:bionic/mem-47\n"+
 		"- add new machine 0 (bundle machine 1)\n"+
 		"- set annotations for new machine 0\n"+
 		"- add unit django/0 to new machine 0\n"+
@@ -1597,14 +1597,14 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCo
 	)
 	c.Check(stdErr, gc.Equals, ""+
 		"Resolving charm: cs:django\n"+
-		"Resolving charm: xenial/mem-47\n"+
+		"Resolving charm: bionic/mem-47\n"+
 		"Deploy of bundle completed.",
 	)
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleAnnotations(c *gc.C) {
-	testcharms.UploadCharm(c, s.client, "xenial/django-42", "dummy")
-	testcharms.UploadCharm(c, s.client, "xenial/mem-47", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/django-42", "dummy")
+	testcharms.UploadCharm(c, s.client, "bionic/mem-47", "dummy")
 	err := s.DeployBundleYAML(c, `
         applications:
             django:
@@ -1615,7 +1615,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleAnnotations(c *gc.C) {
                     key2: value2
                 to: [1]
             memcached:
-                charm: xenial/mem-47
+                charm: bionic/mem-47
                 num_units: 1
         machines:
             1:

--- a/cmd/juju/application/series_selector_test.go
+++ b/cmd/juju/application/series_selector_test.go
@@ -58,12 +58,12 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 		},
 		expectedSeries: "precise",
 	}, {
-		title: "juju deploy simple --force   # no default series, no supported series, use LTS (xenial)",
+		title: "juju deploy simple --force   # no default series, no supported series, use LTS (bionic)",
 		seriesSelector: seriesSelector{
 			force: true,
 			conf:  defaultSeries{},
 		},
-		expectedSeries: "xenial",
+		expectedSeries: "bionic",
 	}, {
 		// Now charms with supported series.
 
@@ -150,8 +150,8 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 		expectedSeries: "precise",
 	}}
 
-	// Use xenial for LTS for all calls.
-	previous := series.SetLatestLtsForTesting("xenial")
+	// Use bionic for LTS for all calls.
+	previous := series.SetLatestLtsForTesting("bionic")
 	defer series.SetLatestLtsForTesting(previous)
 
 	for i, test := range deploySeriesTests {

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -61,6 +61,7 @@ var seriesVersions map[string]string = map[string]string{
 	"raring":  "13.04",
 	"trusty":  "14.04",
 	"xenial":  "16.04",
+	"bionic":  "18.04",
 }
 
 type expectedMetadata struct {
@@ -147,7 +148,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesDefaultArch(c *gc.C) {
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)
 }
 
-func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLts(c *gc.C) {
+func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLTS(c *gc.C) {
 	ec2Config, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":            "ec2-latest-lts",
 		"type":            "ec2",

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -82,7 +82,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			controller.SetNUMAControlPolicyKey: true,
 		},
 		Config: map[string]interface{}{
-			"default-series":            "xenial",
+			"default-series":            "bionic",
 			"firewall-mode":             "instance",
 			"ssl-hostname-verification": true,
 			"logging-config":            "<root>=DEBUG;unit=DEBUG",

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -71,7 +71,7 @@ func (s *CmdExportBundleSuite) TestExportBundle(c *gc.C) {
 		"      charm: cs:quantal/logging-43\n"+
 		"    wordpress:\n"+
 		"      charm: cs:quantal/wordpress-23\n"+
-		"  series: xenial\n"+
+		"  series: bionic\n"+
 		"  relations:\n"+
 		"  - - wordpress:juju-info\n"+
 		"    - logging:info\n"+

--- a/juju/version/version.go
+++ b/juju/version/version.go
@@ -4,9 +4,9 @@
 // Package version contains versioning information about packages that juju supports.
 package version
 
-// SupportedLts returns the latest LTS that Juju supports and is compatible with.
+// SupportedLTS returns the latest LTS that Juju supports and is compatible with.
 // For example, Juju 2.3.x series cannot be run on "bionic"
 // as mongo version that it depends on (3.2 and less) is not packaged for bionic.
 func SupportedLTS() string {
-	return "xenial"
+	return "bionic"
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -110,6 +110,11 @@ func makeImage(id, storage, virtType, arch, version, region string) *imagemetada
 
 var TestImageMetadata = []*imagemetadata.ImageMetadata{
 	// LTS-dependent requires new entries upon new LTS release.
+	// 18.04:amd64
+	makeImage("ami-00001133", "ssd", "hvm", "amd64", "18.04", "test"),
+	makeImage("ami-00001139", "ebs", "hvm", "amd64", "18.04", "test"),
+	makeImage("ami-00001135", "ssd", "pv", "amd64", "18.04", "test"),
+
 	// 16.04:amd64
 	makeImage("ami-00000133", "ssd", "hvm", "amd64", "16.04", "test"),
 	makeImage("ami-00000139", "ebs", "hvm", "amd64", "16.04", "test"),
@@ -157,6 +162,7 @@ const testImageMetadataIndex = `
    "datatype": "image-ids",
    "format": "products:1.0",
    "products": [
+    "com.ubuntu.cloud:server:18.04:amd64",
     "com.ubuntu.cloud:server:16.04:amd64",
     "com.ubuntu.cloud:server:14.04:amd64",
     "com.ubuntu.cloud:server:14.04:i386",
@@ -174,6 +180,61 @@ const testImageMetadataProduct = `
 {
  "content_id": "com.ubuntu.cloud:released:aws",
  "products": {
+    "com.ubuntu.cloud:server:18.04:amd64": {
+      "release": "trusty",
+      "version": "18.04",
+      "arch": "amd64",
+      "versions": {
+        "20121218": {
+          "items": {
+            "usee1pi": {
+              "root_store": "instance",
+              "virt": "pv",
+              "region": "us-east-1",
+              "id": "ami-00001111"
+            },
+            "usww1pe": {
+              "root_store": "ssd",
+              "virt": "pv",
+              "region": "eu-west-1",
+              "id": "ami-00001116"
+            },
+            "apne1pe": {
+              "root_store": "ssd",
+              "virt": "pv",
+              "region": "ap-northeast-1",
+              "id": "ami-00001126"
+            },
+            "apne1he": {
+              "root_store": "ssd",
+              "virt": "hvm",
+              "region": "ap-northeast-1",
+              "id": "ami-00001187"
+            },
+            "test1peebs": {
+              "root_store": "ssd",
+              "virt": "pv",
+              "region": "test",
+              "id": "ami-00001133"
+            },
+            "test1pessd": {
+              "root_store": "ebs",
+              "virt": "pv",
+              "region": "test",
+              "id": "ami-00001139"
+            },
+            "test1he": {
+              "root_store": "ssd",
+              "virt": "hvm",
+              "region": "test",
+              "id": "ami-00001135"
+            }
+          },
+          "pubname": "ubuntu-trusty-16.04-amd64-server-20121218",
+          "label": "release"
+        }
+      }
+    },
    "com.ubuntu.cloud:server:16.04:amd64": {
      "release": "trusty",
      "version": "16.04",

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1559,7 +1559,7 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	image_ids, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(image_ids)
-	c.Assert(image_ids, gc.DeepEquals, []string{"ami-00000133", "ami-00000135", "ami-00000139"})
+	c.Assert(image_ids, gc.DeepEquals, []string{"ami-00001133", "ami-00001135", "ami-00001139"})
 }
 
 func (t *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -47,6 +47,7 @@ var indexData = `
 		   "datatype": "image-ids",
 		   "format": "products:1.0",
 		   "products": [
+      "com.ubuntu.cloud:server:18.04:amd64",
 			"com.ubuntu.cloud:server:16.04:amd64",
 			"com.ubuntu.cloud:server:14.04:amd64",
 			"com.ubuntu.cloud:server:12.10:amd64",
@@ -67,6 +68,24 @@ var imagesData = `
   "updated": "Fri, 14 Feb 2014 13:39:35 +0000",
   "datatype": "image-ids",
   "products": {
+    "com.ubuntu.cloud:server:18.04:amd64": {
+      "release": "trusty",
+      "version": "18.04",
+      "arch": "amd64",
+      "versions": {
+        "20160216": {
+          "items": {
+            "11223344-0a0a-ff99-11bb-0a1b2c3d4e5f": {
+              "region": "some-region",
+              "id": "11223344-0a0a-ff99-11bb-0a1b2c3d4e5f",
+              "virt": "kvm"
+            }
+          },
+          "pubname": "ubuntu-trusty-16.04-amd64-server-20160216",
+          "label": "release"
+        }
+      }
+    },
     "com.ubuntu.cloud:server:16.04:amd64": {
       "release": "trusty",
       "version": "16.04",

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -115,6 +115,10 @@ var indexData = `
 		   "datatype": "image-ids",
 		   "format": "products:1.0",
 		   "products": [
+      "com.ubuntu.cloud:server:18.04:s390x",
+      "com.ubuntu.cloud:server:18.04:amd64",
+      "com.ubuntu.cloud:server:18.04:arm64",
+      "com.ubuntu.cloud:server:18.04:ppc64el",
 			"com.ubuntu.cloud:server:16.04:s390x",
 			"com.ubuntu.cloud:server:16.04:amd64",
 			"com.ubuntu.cloud:server:16.04:arm64",
@@ -138,6 +142,81 @@ var imagesData = `
 {
  "content_id": "com.ubuntu.cloud:released:openstack",
  "products": {
+   "com.ubuntu.cloud:server:18.04:amd64": {
+     "release": "trusty",
+     "version": "18.04",
+     "arch": "amd64",
+     "versions": {
+       "20121218": {
+         "items": {
+           "inst1": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "1"
+           },
+           "inst2": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "another-region",
+             "id": "2"
+           }
+         },
+         "pubname": "ubuntu-trusty-18.04-amd64-server-20121218",
+         "label": "release"
+       },
+       "20121111": {
+         "items": {
+           "inst3": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "3"
+           }
+         },
+         "pubname": "ubuntu-trusty-18.04-amd64-server-20121111",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:18.04:arm64": {
+     "release": "xenial",
+     "version": "18.04",
+     "arch": "arm64",
+     "versions": {
+       "20121111": {
+         "items": {
+           "inst1604arm64": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-1604arm64"
+           }
+         },
+         "pubname": "ubuntu-xenial-18.04-arm64-server-20121111",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:18.04:ppc64el": {
+     "release": "xenial",
+     "version": "18.04",
+     "arch": "ppc64el",
+     "versions": {
+       "20121111": {
+         "items": {
+           "inst1604ppc64el": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-1604ppc64el"
+           }
+         },
+         "pubname": "ubuntu-xenial-18.04-ppc64el-server-20121111",
+         "label": "release"
+       }
+     }
+   },
    "com.ubuntu.cloud:server:16.04:amd64": {
      "release": "trusty",
      "version": "16.04",

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -514,7 +514,7 @@ func (s *factorySuite) TestMakeModelNil(c *gc.C) {
 
 	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "xenial")
+	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "bionic")
 }
 
 func (s *factorySuite) TestMakeModel(c *gc.C) {


### PR DESCRIPTION
## Description of change

This makes sure that all LXD images by default are Bionic for 2.4
release. The issue with this is that it can cause issues from this,
because we're now bumping the LTS version for EVERYTHING.

A lot of testing should be done to ensure that we don't cause other
issues for other parts of the system.

## QA steps

Test that launching LXD providers is possible AND that other 
providers/machines aren't broken in changing this.

## Documentation changes

The default LTS for juju is changing from Xenial to Bionic. You can still
over ride this using the series flag if required.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1785124