### PR TITLE
Upgrade yaml to latest version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1042,7 +1042,7 @@
   revision = "05504416e95561e1478196d7058721c827a7bb8c"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:53c4b75f22ea7757dea07eae380ea42de547ae6865a5e3b41866754a8a8219c9"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
@@ -1471,11 +1471,11 @@
   revision = "14b3d72120e8d10ea6e6b7f87f7175734b1faab8"
 
 [[projects]]
-  digest = "1:fb5632d5b9b7d7b28498017fd6535c22075b27511273f3f6bcaf8eee29875b5b"
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = ""
-  revision = "1be3d31502d6eabc0dd7ce5b0daab022e14a5538"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
 
 [[projects]]
   digest = "1:09ea5dbe52206b2d102fe418b840ca297f63883101c596039d68391596fe9bf1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -514,7 +514,7 @@
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"
-  revision = "1be3d31502d6eabc0dd7ce5b0daab022e14a5538"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
 
 [[constraint]]
   name = "github.com/docker/distribution"

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -186,7 +186,7 @@ func GenerateNetplan(interfaces []network.InterfaceInfo) (string, error) {
 		}
 		netPlan.Network.Ethernets[info.InterfaceName] = iface
 	}
-	out, err := netplan.Marshal(netPlan)
+	out, err := netplan.Marshal(&netPlan)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -263,7 +263,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 		withArgs: []string{validUnitId, "some-action",
 			"--params", s.dir + "/" + "invalidParams.yml",
 		},
-		expectedErr: "yaml: line 3: mapping values are not allowed in this context",
+		expectedErr: "yaml: line 4: mapping values are not allowed in this context",
 	}, {
 		should: "fail with invalid UTF in file",
 		withArgs: []string{validUnitId, "some-action",

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -654,7 +654,7 @@ charm path in application "mysql" does not exist: .*mysql`,
 }, {
 	about:   "invalid bundle content",
 	content: "!",
-	err:     `cannot unmarshal bundle data: yaml: .*`,
+	err:     `(?s)cannot unmarshal bundle data: yaml: .*`,
 }, {
 	about: "invalid bundle data",
 	content: `
@@ -1977,7 +1977,7 @@ func (s *ProcessBundleOverlaySuite) TestBadFile(c *gc.C) {
 func (s *ProcessBundleOverlaySuite) TestGoodYAML(c *gc.C) {
 	filename := s.writeFile(c, "bad:\n\tindent")
 	err := processBundleOverlay(s.bundleData, filename)
-	c.Assert(err, gc.ErrorMatches, `unable to read bundle overlay file ".*": cannot unmarshal bundle data: yaml: line 1: found character that cannot start any token`)
+	c.Assert(err, gc.ErrorMatches, `unable to read bundle overlay file ".*": cannot unmarshal bundle data: yaml: line 2: found character that cannot start any token`)
 }
 
 func (s *ProcessBundleOverlaySuite) TestReplaceZeroValues(c *gc.C) {

--- a/cmd/juju/common/flags_test.go
+++ b/cmd/juju/common/flags_test.go
@@ -50,7 +50,7 @@ func (*FlagsSuite) TestConfigFlagSet(c *gc.C) {
 func (*FlagsSuite) TestConfigFlagSetErrors(c *gc.C) {
 	var f ConfigFlag
 	c.Assert(f.Set(""), gc.ErrorMatches, "empty string not valid")
-	c.Assert(f.Set("x=!"), gc.ErrorMatches, "yaml: did not find URI escaped octet")
+	c.Assert(f.Set("x=%"), gc.ErrorMatches, "yaml: could not find expected directive name")
 }
 
 func (*FlagsSuite) TestConfigFlagString(c *gc.C) {

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -599,7 +599,7 @@ models:
   users:
     admin:
       access: read
-      last-connection: 2015-03-20
+      last-connection: "2015-03-20"
   agent-version: 2.55.5
 - name: carlotta/test-model2
   short-name: test-model2
@@ -615,7 +615,7 @@ models:
   users:
     admin:
       access: write
-      last-connection: 2015-03-01
+      last-connection: "2015-03-01"
   agent-version: 2.55.5
 - name: daiwik@external/test-model3
   short-name: test-model3
@@ -692,7 +692,7 @@ models:
   status:
     current: active
   access: read
-  last-connection: 2015-03-20
+  last-connection: "2015-03-20"
   agent-version: 2.55.5
 - name: carlotta/test-model2
   short-name: test-model2
@@ -710,7 +710,7 @@ models:
   status:
     current: active
   access: write
-  last-connection: 2015-03-01
+  last-connection: "2015-03-01"
   agent-version: 2.55.5
 - name: daiwik@external/test-model3
   short-name: test-model3

--- a/cmd/juju/user/info_test.go
+++ b/cmd/juju/user/info_test.go
@@ -73,8 +73,8 @@ func (s *UserInfoCommandSuite) TestUserInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: current-user
 access: add-model
-date-created: 1981-02-27
-last-connection: 2014-01-01
+date-created: "1981-02-27"
+last-connection: "2014-01-01"
 `)
 }
 
@@ -94,8 +94,8 @@ func (s *UserInfoCommandSuite) TestUserInfoWithUsername(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: foobar
 display-name: Foo Bar
 access: login
-date-created: 1981-02-27
-last-connection: 2014-01-01
+date-created: "1981-02-27"
+last-connection: "2014-01-01"
 `)
 }
 
@@ -134,8 +134,8 @@ func (s *UserInfoCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `user-name: current-user
 access: add-model
-date-created: 1981-02-27
-last-connection: 2014-01-01
+date-created: "1981-02-27"
+last-connection: "2014-01-01"
 `)
 }
 

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -125,38 +125,44 @@ func (s *UserListCommandSuite) SetUpTest(c *gc.C) {
 func (s *UserListCommandSuite) TestUserInfo(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newUserListCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: testing\n\n"+
-		"Name     Display name    Access     Date created  Last connection\n"+
-		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
-		"barbara  Barbara Yellow  add-model  2013-05-02    just now\n"+
-		"charlie  Charlie Xavier  superuser  6 hours ago   never connected\n"+
-		"\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+Controller: testing
+
+Name     Display name    Access     Date created  Last connection
+adam*    Adam Zulu       login      2012-10-08    2014-01-01
+barbara  Barbara Yellow  add-model  2013-05-02    just now
+charlie  Charlie Xavier  superuser  6 hours ago   never connected
+
+`[1:])
 }
 
 func (s *UserListCommandSuite) TestUserInfoWithDisabled(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--all")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: testing\n\n"+
-		"Name     Display name    Access     Date created  Last connection\n"+
-		"adam*    Adam Zulu       login      2012-10-08    2014-01-01\n"+
-		"barbara  Barbara Yellow  add-model  2013-05-02    just now\n"+
-		"charlie  Charlie Xavier  superuser  6 hours ago   never connected\n"+
-		"davey    Davey Willow               2014-10-09    35 minutes ago (disabled)\n"+
-		"\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+Controller: testing
+
+Name     Display name    Access     Date created  Last connection
+adam*    Adam Zulu       login      2012-10-08    2014-01-01
+barbara  Barbara Yellow  add-model  2013-05-02    just now
+charlie  Charlie Xavier  superuser  6 hours ago   never connected
+davey    Davey Willow               2014-10-09    35 minutes ago (disabled)
+
+`[1:])
 }
 
 func (s *UserListCommandSuite) TestUserInfoExactTime(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--exact-time")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Controller: testing\n\n"+
-		"Name     Display name    Access     Date created                   Last connection\n"+
-		"adam*    Adam Zulu       login      2012-10-08 00:00:00 +0000 UTC  2014-01-01 00:00:00 +0000 UTC\n"+
-		"barbara  Barbara Yellow  add-model  2013-05-02 00:00:00 +0000 UTC  2016-09-15 12:00:00 +0000 UTC\n"+
-		"charlie  Charlie Xavier  superuser  2016-09-15 06:00:00 +0000 UTC  never connected\n"+
-		"\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+Controller: testing
+
+Name     Display name    Access     Date created                   Last connection
+adam*    Adam Zulu       login      2012-10-08 00:00:00 +0000 UTC  2014-01-01 00:00:00 +0000 UTC
+barbara  Barbara Yellow  add-model  2013-05-02 00:00:00 +0000 UTC  2016-09-15 12:00:00 +0000 UTC
+charlie  Charlie Xavier  superuser  2016-09-15 06:00:00 +0000 UTC  never connected
+
+`[1:])
 }
 
 func (s *UserListCommandSuite) TestUserInfoFormatJson(c *gc.C) {
@@ -172,33 +178,35 @@ func (s *UserListCommandSuite) TestUserInfoFormatJson(c *gc.C) {
 func (s *UserListCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"- user-name: adam\n"+
-		"  display-name: Adam Zulu\n"+
-		"  access: login\n"+
-		"  date-created: \"2012-10-08\"\n"+
-		"  last-connection: \"2014-01-01\"\n"+
-		"- user-name: barbara\n"+
-		"  display-name: Barbara Yellow\n"+
-		"  access: add-model\n"+
-		"  date-created: \"2013-05-02\"\n"+
-		"  last-connection: just now\n"+
-		"- user-name: charlie\n"+
-		"  display-name: Charlie Xavier\n"+
-		"  access: superuser\n"+
-		"  date-created: 6 hours ago\n"+
-		"  last-connection: never connected\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+- user-name: adam
+  display-name: Adam Zulu
+  access: login
+  date-created: "2012-10-08"
+  last-connection: "2014-01-01"
+- user-name: barbara
+  display-name: Barbara Yellow
+  access: add-model
+  date-created: "2013-05-02"
+  last-connection: just now
+- user-name: charlie
+  display-name: Charlie Xavier
+  access: superuser
+  date-created: 6 hours ago
+  last-connection: never connected
+`[1:])
 }
 
 func (s *UserListCommandSuite) TestModelUsers(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "admin")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Name                Display name  Access  Last connection\n"+
-		"adam*               Adam          read    2015-03-01\n"+
-		"admin                             write   2015-03-20\n"+
-		"charlie@ubuntu.com  Charlie       read    never connected\n"+
-		"\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+Name                Display name  Access  Last connection
+adam*               Adam          read    2015-03-01
+admin                             write   2015-03-20
+charlie@ubuntu.com  Charlie       read    never connected
+
+`[1:])
 }
 
 func (s *UserListCommandSuite) TestModelUsersFormatJson(c *gc.C) {
@@ -214,18 +222,19 @@ func (s *UserListCommandSuite) TestModelUsersFormatJson(c *gc.C) {
 func (s *UserListCommandSuite) TestModelUsersInfoFormatYaml(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newUserListCommand(), "admin", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"adam:\n"+
-		"  display-name: Adam\n"+
-		"  access: read\n"+
-		"  last-connection: \"2015-03-01\"\n"+
-		"admin:\n"+
-		"  access: write\n"+
-		"  last-connection: \"2015-03-20\"\n"+
-		"charlie@ubuntu.com:\n"+
-		"  display-name: Charlie\n"+
-		"  access: read\n"+
-		"  last-connection: never connected\n")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
+adam:
+  display-name: Adam
+  access: read
+  last-connection: "2015-03-01"
+admin:
+  access: write
+  last-connection: "2015-03-20"
+charlie@ubuntu.com:
+  display-name: Charlie
+  access: read
+  last-connection: never connected
+`[1:])
 }
 
 func (s *UserListCommandSuite) TestTooManyArgs(c *gc.C) {

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -176,12 +176,12 @@ func (s *UserListCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 		"- user-name: adam\n"+
 		"  display-name: Adam Zulu\n"+
 		"  access: login\n"+
-		"  date-created: 2012-10-08\n"+
-		"  last-connection: 2014-01-01\n"+
+		"  date-created: \"2012-10-08\"\n"+
+		"  last-connection: \"2014-01-01\"\n"+
 		"- user-name: barbara\n"+
 		"  display-name: Barbara Yellow\n"+
 		"  access: add-model\n"+
-		"  date-created: 2013-05-02\n"+
+		"  date-created: \"2013-05-02\"\n"+
 		"  last-connection: just now\n"+
 		"- user-name: charlie\n"+
 		"  display-name: Charlie Xavier\n"+
@@ -218,10 +218,10 @@ func (s *UserListCommandSuite) TestModelUsersInfoFormatYaml(c *gc.C) {
 		"adam:\n"+
 		"  display-name: Adam\n"+
 		"  access: read\n"+
-		"  last-connection: 2015-03-01\n"+
+		"  last-connection: \"2015-03-01\"\n"+
 		"admin:\n"+
 		"  access: write\n"+
-		"  last-connection: 2015-03-20\n"+
+		"  last-connection: \"2015-03-20\"\n"+
 		"charlie@ubuntu.com:\n"+
 		"  display-name: Charlie\n"+
 		"  access: read\n"+

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -283,11 +283,69 @@ func (np *Netplan) createBridgeFromInterface(bridgeName, deviceId string, intf *
 	*intf = Interface{MTU: intf.MTU}
 }
 
-func Unmarshal(in []byte, out interface{}) (err error) {
-	return goyaml.UnmarshalStrict(in, out)
+func (np *Netplan) merge(other *Netplan) {
+	// Only copy attributes that would be unmarshalled from yaml.
+	// This blithely replaces keys in the maps (eg. Ethernets or
+	// Wifis) if they're set in both np and other - it's not clear
+	// from the reference whether this is the right thing to do.
+	// See https://bugs.launchpad.net/juju/+bug/1701429 and
+	// https://netplan.io/reference#general-structure
+	np.Network.Version = other.Network.Version
+	np.Network.Renderer = other.Network.Renderer
+	np.Network.Routes = other.Network.Routes
+	if np.Network.Ethernets == nil {
+		np.Network.Ethernets = other.Network.Ethernets
+	} else {
+		for key, val := range other.Network.Ethernets {
+			np.Network.Ethernets[key] = val
+		}
+	}
+	if np.Network.Wifis == nil {
+		np.Network.Wifis = other.Network.Wifis
+	} else {
+		for key, val := range other.Network.Wifis {
+			np.Network.Wifis[key] = val
+		}
+	}
+	if np.Network.Bridges == nil {
+		np.Network.Bridges = other.Network.Bridges
+	} else {
+		for key, val := range other.Network.Bridges {
+			np.Network.Bridges[key] = val
+		}
+	}
+	if np.Network.Bonds == nil {
+		np.Network.Bonds = other.Network.Bonds
+	} else {
+		for key, val := range other.Network.Bonds {
+			np.Network.Bonds[key] = val
+		}
+	}
+	if np.Network.VLANs == nil {
+		np.Network.VLANs = other.Network.VLANs
+	} else {
+		for key, val := range other.Network.VLANs {
+			np.Network.VLANs[key] = val
+		}
+	}
 }
 
-func Marshal(in interface{}) (out []byte, err error) {
+func Unmarshal(in []byte, out *Netplan) error {
+	if out == nil {
+		return errors.NotValidf("nil out Netplan")
+	}
+	// Use UnmarshalStrict because we want errors for unknown
+	// attributes. This also refuses to overwrite keys (which we need)
+	// so unmarshal locally and copy across.
+	var local Netplan
+	if err := goyaml.UnmarshalStrict(in, &local); err != nil {
+		return errors.Trace(err)
+	}
+	out.merge(&local)
+	return nil
+}
+
+func Marshal(in *Netplan) (out []byte, err error) {
 	return goyaml.Marshal(in)
 }
 

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/network/netplan"
 	coretesting "github.com/juju/juju/testing"
@@ -42,7 +43,7 @@ func checkNetplanRoundTrips(c *gc.C, input string) {
 	var np netplan.Netplan
 	err := netplan.Unmarshal([]byte(input), &np)
 	c.Assert(err, jc.ErrorIsNil)
-	out, err := netplan.Marshal(np)
+	out, err := netplan.Marshal(&np)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(out), gc.Equals, input)
 }
@@ -888,7 +889,7 @@ network:
     id0:
       match:
         macaddress: "00:11:22:33:44:55"
-    id0:
+    id1:
       match:
         macaddress: "00:11:22:33:44:66"
   vlans:
@@ -1301,7 +1302,7 @@ network:
 	np, err := netplan.ReadDirectory("testdata/TestReadDirectory")
 	c.Assert(err, jc.ErrorIsNil)
 
-	out, err := netplan.Marshal(np)
+	out, err := netplan.Marshal(&np)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(out), gc.Equals, expected)
 }
@@ -1340,7 +1341,7 @@ network:
 	np, err := netplan.ReadDirectory("testdata/TestReadDirectory")
 	c.Assert(err, jc.ErrorIsNil)
 
-	out, err := netplan.Marshal(np)
+	out, err := netplan.Marshal(&np)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(out), gc.Equals, expected)
 }
@@ -1588,7 +1589,7 @@ func (s *NetplanSuite) TestNetplanExamples(c *gc.C) {
 	for _, example := range examples {
 		c.Logf("example: %s", example.filename)
 		var orig map[interface{}]interface{}
-		err := netplan.Unmarshal([]byte(example.content), &orig)
+		err := yaml.UnmarshalStrict([]byte(example.content), &orig)
 		c.Assert(err, jc.ErrorIsNil, gc.Commentf("failed to unmarshal as map %s", example.filename))
 		var np netplan.Netplan
 		err = netplan.Unmarshal([]byte(example.content), &np)
@@ -1596,10 +1597,10 @@ func (s *NetplanSuite) TestNetplanExamples(c *gc.C) {
 		// We don't assert that we exactly match the serialized form (we may output fields in a different order),
 		// but we do check that if we Marshal and then Unmarshal again, we get the same map contents.
 		// (We might also change boolean 'no' to 'false', etc.
-		out, err := netplan.Marshal(np)
+		out, err := netplan.Marshal(&np)
 		c.Check(err, jc.ErrorIsNil, gc.Commentf("failed to marshal %s", example.filename))
 		var roundtripped map[interface{}]interface{}
-		err = netplan.Unmarshal(out, &roundtripped)
+		err = yaml.UnmarshalStrict(out, &roundtripped)
 		if !reflect.DeepEqual(orig, roundtripped) {
 			pretty.Ldiff(c, orig, roundtripped)
 			c.Errorf("marshalling and unmarshalling %s did not contain the same content", example.filename)

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -275,10 +275,10 @@ var relationSetInitTests = []relationSetInitTest{
 		content: "[haha]",
 		err:     "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!seq into map.*",
 	}, {
-		summary: "multiple maps",
-		args:    []string{"--file", "spam"},
-		content: "{a: b}\n{c: d}",
-		err:     `.*yaml: .*`,
+		summary:  "multiple maps",
+		args:     []string{"--file", "spam"},
+		content:  "{a: b}\n{c: d}",
+		settings: map[string]string{"a": "b"},
 	}, {
 		summary:  "value with a space",
 		args:     []string{"--file", "spam"},


### PR DESCRIPTION
## Description of change

This updates our yaml dependency to the latest version. This provides Encoder and Decoder types will be used in the Raft lease implementation (and other places, I'm sure).

It's backwards compatible but has some slight behaviour changes that meant some tests needed to change. Most of these are differences in error messages. 

The one behaviour change that affects code is that `yaml.UnmarshalStrict` has become stricter - as well as checking for unknown field names it also refuses to overwrite map keys in the destination struct. The netplan code was relying on being able to overwrite keys to load multiple configuration files into one struct. I've changed the netplan unmarshalling code to load each file in a new struct and then merge the data into the old one. 

At the moment this just preserves the old behaviour, but there is mention in the tests of [this bug](https://bugs.launchpad.net/juju/+bug/1701429) that suggests the merge shouldn't overwrite keys but should merge the objects instead. That said, the bug is closed-wontfix, so maybe this behaviour is what we want? I couldn't tell from the [netplan documentation](https://netplan.io/reference#general-structure) I could see.

## QA steps

All unit tests pass, smoke-test bootstrap on bionic and spinning up some units in lxd containers worked. I'm not sure how else to exercise netplan handling.
