### PR TITLE
Avoid starting presence pingers unless needed.

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -462,26 +463,32 @@ func (shim presenceShim) Start() (presence.Pinger, error) {
 }
 
 func startPingerIfAgent(clock clock.Clock, root *apiHandler, entity state.Entity) error {
-	// worker runs presence.Pingers -- absence of which will cause
-	// embarrassing "agent is lost" messages to show up in status --
-	// until it's stopped. It's stored in resources purely for the
-	// side effects: we don't record its id, and nobody else
-	// retrieves it -- we just expect it to be stopped when the
-	// connection is shut down.
-	agent, ok := entity.(statepresence.Agent)
-	if !ok {
+	tag := entity.Tag()
+	if tag.Kind() == names.UserTagKind {
 		return nil
 	}
-	worker, err := presence.New(presence.Config{
-		Identity:   entity.Tag(),
-		Start:      presenceShim{agent}.Start,
-		Clock:      clock,
-		RetryDelay: 3 * time.Second,
-	})
-	if err != nil {
-		return err
+	if root.shared.featureEnabled(feature.OldPresence) {
+		// worker runs presence.Pingers -- absence of which will cause
+		// embarrassing "agent is lost" messages to show up in status --
+		// until it's stopped. It's stored in resources purely for the
+		// side effects: we don't record its id, and nobody else
+		// retrieves it -- we just expect it to be stopped when the
+		// connection is shut down.
+		agent, ok := entity.(statepresence.Agent)
+		if !ok {
+			return nil
+		}
+		worker, err := presence.New(presence.Config{
+			Identity:   tag,
+			Start:      presenceShim{agent}.Start,
+			Clock:      clock,
+			RetryDelay: 3 * time.Second,
+		})
+		if err != nil {
+			return err
+		}
+		root.getResources().Register(worker)
 	}
-	root.getResources().Register(worker)
 
 	// pingTimeout, by contrast, *is* used by the Pinger facade to
 	// stave off the call to action() that will shut down the agent

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -89,6 +89,7 @@ func (s *pingerSuite) TestClientNoNeedToPing(c *gc.C) {
 	time.Sleep(coretesting.ShortWait)
 
 	clock.Advance(apiserver.MaxClientPingInterval * 2)
+	time.Sleep(coretesting.ShortWait)
 	c.Assert(pingConn(conn), jc.ErrorIsNil)
 }
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -46,6 +46,15 @@ type serverSuite struct {
 
 var _ = gc.Suite(&serverSuite{})
 
+func (s *serverSuite) SetUpTest(c *gc.C) {
+	// Tests here check that pingers are started. We need to inject
+	// the feature flags into the controller very early.
+	s.ControllerConfigAttrs = map[string]interface{}{
+		"features": []string{feature.OldPresence},
+	}
+	s.JujuConnSuite.SetUpTest(c)
+}
+
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
@@ -211,12 +220,6 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 }
 
 func (s *serverSuite) TestMachineLoginStartsPinger(c *gc.C) {
-	// The pingers that are created here are the old presence pingers
-	// and only created when the feature flag is set.
-	err := s.State.UpdateControllerConfig(map[string]interface{}{
-		"features": []string{feature.OldPresence},
-	}, nil)
-	c.Assert(err, jc.ErrorIsNil)
 	// This is the same steps as OpenAPIAsNewMachine but we need to assert
 	// the agent is not alive before we actually open the API.
 	// Create a new machine to verify "agent alive" behavior.
@@ -238,12 +241,6 @@ func (s *serverSuite) TestMachineLoginStartsPinger(c *gc.C) {
 }
 
 func (s *serverSuite) TestUnitLoginStartsPinger(c *gc.C) {
-	// The pingers that are created here are the old presence pingers
-	// and only created when the feature flag is set.
-	err := s.State.UpdateControllerConfig(map[string]interface{}{
-		"features": []string{feature.OldPresence},
-	}, nil)
-	c.Assert(err, jc.ErrorIsNil)
 	// Create a new application and unit to verify "agent alive" behavior.
 	unit, password := s.Factory.MakeUnitReturningPassword(c, nil)
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testserver"
+	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -210,6 +211,12 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 }
 
 func (s *serverSuite) TestMachineLoginStartsPinger(c *gc.C) {
+	// The pingers that are created here are the old presence pingers
+	// and only created when the feature flag is set.
+	err := s.State.UpdateControllerConfig(map[string]interface{}{
+		"features": []string{feature.OldPresence},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	// This is the same steps as OpenAPIAsNewMachine but we need to assert
 	// the agent is not alive before we actually open the API.
 	// Create a new machine to verify "agent alive" behavior.
@@ -231,6 +238,12 @@ func (s *serverSuite) TestMachineLoginStartsPinger(c *gc.C) {
 }
 
 func (s *serverSuite) TestUnitLoginStartsPinger(c *gc.C) {
+	// The pingers that are created here are the old presence pingers
+	// and only created when the feature flag is set.
+	err := s.State.UpdateControllerConfig(map[string]interface{}{
+		"features": []string{feature.OldPresence},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	// Create a new application and unit to verify "agent alive" behavior.
 	unit, password := s.Factory.MakeUnitReturningPassword(c, nil)
 

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -90,3 +90,11 @@ type PresenceResponse struct {
 // OriginTarget represents the data for the connect and disconnect
 // topics.
 type OriginTarget common.OriginTarget
+
+// RestartTopic is used by the API server to listen for events that should
+// cause the API server to be bounced.
+const RestartTopic = "apiserver.restart"
+
+// Restart message only contains the local-only indicator as the restart
+// is only ever for the same agent.
+type Restart common.LocalOnly

--- a/pubsub/common/messages.go
+++ b/pubsub/common/messages.go
@@ -13,3 +13,9 @@ type OriginTarget struct {
 	// messages to.
 	Target string `yaml:"target"`
 }
+
+// LocalOnly represents a common structure where the subject is the
+// primary indicator and the message is local.
+type LocalOnly struct {
+	LocalOnly bool `yaml:"local-only"`
+}


### PR DESCRIPTION
With the new presence code now being the default in 2.5, we want to avoid starting presence pingers.

If the operator does set the old-presence feature flag, the api server will start presence pingers for the agents. However to ensure that we get all the agents, we restart the apiserver when the old-presence feature flag is either set or unset. This will force disconnect all the agents, and they will reconnect and start the pingers if necessary.

I did start exposing the hub for the JujuConnSuite only to not actually need it. But there is no harm now in leaving it there.