### PR TITLE
2.3 try stopped 1785623

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -675,7 +675,6 @@ func dialWebsocketMulti(ctx context.Context, addrs []string, path string, opts d
 			// the addresses are checked with Info.Validate
 			// beforehand.
 			err := errors.Errorf("invalid address %q: %v", addr, err)
-			logger.Criticalf("dialWebsocketMulti got: %v", err)
 			recordTryError(try, err)
 			continue
 		}
@@ -689,7 +688,6 @@ func dialWebsocketMulti(ctx context.Context, addrs []string, path string, opts d
 			ips, err = lookupIPAddr(ctx, host, opts.IPAddrResolver)
 			if err != nil {
 				err := errors.Errorf("cannot resolve %q: %v", host, err)
-				logger.Criticalf("lookupIPAddr got: %v", err)
 				recordTryError(try, err)
 				continue
 			}
@@ -704,11 +702,9 @@ func dialWebsocketMulti(ctx context.Context, addrs []string, path string, opts d
 			tried[ipStr] = true
 			err := startDialWebsocket(ctx, try, ipStr, addr, path, opts)
 			if err == parallel.ErrStopped {
-				logger.Criticalf("startDialWebsocket return ErrStopped")
 				break
 			}
 			if err != nil {
-				logger.Criticalf("startDialWebsocket failed with got: %v", err)
 				return nil, errors.Trace(err)
 			}
 			select {
@@ -720,7 +716,6 @@ func dialWebsocketMulti(ctx context.Context, addrs []string, path string, opts d
 	try.Close()
 	result, err := try.Result()
 	if err != nil {
-		logger.Criticalf("try.Result returned error: %v", err)
 		return nil, errors.Trace(err)
 	}
 	return result.(*dialResult), nil
@@ -848,13 +843,11 @@ func (d dialer) dial1() (jsoncodec.JSONConn, *tls.Config, error) {
 	} else {
 		tlsConfig.ServerName = d.serverName
 	}
-	logger.Criticalf("dialing %v", d.urlStr)
 	conn, err := d.opts.DialWebsocket(d.ctx, d.urlStr, tlsConfig, d.ipAddr)
 	if err == nil {
 		logger.Debugf("successfully dialed %q", d.urlStr)
 		return conn, tlsConfig, nil
 	}
-	logger.Criticalf("dial errored: %v", err)
 	if !isX509Error(err) {
 		return nil, nil, errors.Trace(err)
 	}

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -1,0 +1,56 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"context"
+	"net"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jtesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
+)
+
+type apiclientWhiteboxSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&apiclientWhiteboxSuite{})
+
+func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiTimeout(c *gc.C) {
+	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(ctx)
+	started := make(chan struct{})
+	go func() {
+		select {
+		case <-started:
+		case <-time.After(jtesting.LongWait):
+			c.Fatalf("timed out waiting %s for started", jtesting.LongWait)
+		}
+		<-time.After(10 * time.Millisecond)
+		if cancel != nil {
+			c.Logf("cancelling")
+			cancel()
+		}
+	}()
+	listen, err := net.Listen("tcp4", ":0")
+	c.Assert(err, jc.ErrorIsNil)
+	defer listen.Close()
+	addr := listen.Addr().String()
+	c.Logf("listening at: %s", addr)
+	// Note that we Listen, but we never Accept
+	close(started)
+	info := &Info{
+		Addrs: []string{addr},
+	}
+	opts := DialOpts{
+		Timeout:     10 * time.Millisecond,
+		DialTimeout: 5 * time.Millisecond,
+	}
+	_, err = dialAPI(ctx, info, opts)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"time"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	jtesting "github.com/juju/juju/testing"
-	"github.com/juju/testing"
 )
 
 type apiclientWhiteboxSuite struct {
@@ -56,7 +57,7 @@ func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiCancelled(c *gc.C) {
 	// Close before we connect
 	listen.Close()
 	_, err = dialAPI(ctx, info, opts)
-	c.Check(err.Error(), gc.Equals, fmt.Sprintf("dial tcp %s: operation was canceled", addr))
+	c.Check(err, gc.ErrorMatches, fmt.Sprintf("dial tcp %s:.*", regexp.QuoteMeta(addr)))
 }
 
 func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiClosed(c *gc.C) {
@@ -76,5 +77,5 @@ func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiClosed(c *gc.C) {
 	}
 	listen.Close()
 	_, _, err = DialAPI(info, opts)
-	c.Check(err.Error(), gc.Equals, fmt.Sprintf("unable to connect to API: dial tcp %s:.*", addr))
+	c.Check(err, gc.ErrorMatches, fmt.Sprintf("unable to connect to API: dial tcp %s:.*", regexp.QuoteMeta(addr)))
 }

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package api
@@ -48,8 +48,10 @@ func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiTimeout(c *gc.C) {
 		Addrs: []string{addr},
 	}
 	opts := DialOpts{
-		Timeout:     10 * time.Millisecond,
-		DialTimeout: 5 * time.Millisecond,
+		DialAddressInterval: 1 * time.Millisecond,
+		RetryDelay:          1 * time.Millisecond,
+		Timeout:             10 * time.Millisecond,
+		DialTimeout:         5 * time.Millisecond,
 	}
 	_, err = dialAPI(ctx, info, opts)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

In bug #1785623 when a controller was failing to connect, all we were getting was an unhelpful "try was stopped". I was able to reproduce that with a socket that did not have a valid server running. This just changes the error code path to return the last known error when connecting.

## QA steps

See the associated whitebox tests. Without this, you get "try was stopped" as the error.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1785623