### PR TITLE
lp 1781450, change juju deploy to not allow --to lxd with storage

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/storage"
 )
@@ -739,6 +740,15 @@ func (c *DeployCommand) deployCharm(
 		return errors.New("this juju controller does not support --attach-storage")
 	}
 
+	// Storage cannot be added to a container.
+	if len(c.Storage) > 0 || len(c.AttachStorage) > 0 {
+		for _, placement := range c.Placement {
+			if t, err := instance.ParseContainerType(placement.Scope); err == nil {
+				return errors.NotSupportedf("adding storage to %s container", string(t))
+			}
+		}
+	}
+
 	numUnits := c.NumUnits
 	if charmInfo.Meta.Subordinate {
 		if !constraints.IsEmpty(&c.Constraints) {
@@ -870,6 +880,7 @@ func (c *DeployCommand) deployCharm(
 	if len(appConfig) == 0 {
 		appConfig = nil
 	}
+
 	args := application.DeployArgs{
 		CharmID:          id,
 		Cons:             c.Constraints,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -421,6 +421,15 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 	})
 }
 
+func (s *DeploySuite) TestDeployStorageFailContainer(c *gc.C) {
+	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
+	machine, err := s.State.AddMachine(version.SupportedLTS(), state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	container := "lxd:" + machine.Id()
+	err = runDeploy(c, ch, "--to", container, "--storage", "data=machinescoped,1G")
+	c.Assert(err, gc.ErrorMatches, "adding storage to lxd container not supported")
+}
+
 func (s *DeploySuite) TestPlacement(c *gc.C) {
 	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "dummy")
 	// Add a machine that will be ignored due to placement directive.
@@ -1623,6 +1632,30 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorage(c *gc.C) {
 		"--attach-storage", "bar/1,baz/2",
 	)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *DeployUnitTestSuite) TestDeployAttachStorageFailContainer(c *gc.C) {
+	charmsPath := c.MkDir()
+	charmDir := testcharms.Repo.ClonedDir(charmsPath, "dummy")
+
+	fakeAPI := vanillaFakeModelAPI(map[string]interface{}{
+		"name": "name",
+		"uuid": "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"type": "foo",
+	})
+
+	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
+	withCharmDeployable(
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
+	)
+
+	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
+	cmd.SetClientStore(jujuclienttesting.MinimalStore())
+	_, err := cmdtesting.RunCommand(c, cmd, dummyURL.String(),
+		"--attach-storage", "foo/0", "--to", "lxd",
+	)
+	c.Assert(err, gc.ErrorMatches, "adding storage to lxd container not supported")
 }
 
 func (s *DeployUnitTestSuite) TestDeployAttachStorageNotSupported(c *gc.C) {


### PR DESCRIPTION
## Description of change

Change juju deploy to not allow --to lxd with --storage or --attach-storage, known failure.  This already happens with juju add-storage and juju add-unit

## QA steps

1. juju bootstrap aws
2. juju create-storage-pool iops ebs volume-type=provisioned-iops iops=30
3. juju deploy postgresql --storage pgdata=iops,10G --to lxd  <-- fails cleanly
4. juju add-machine
5. juju deploy postgresql --storage pgdata=iops,10G --to lxd:0 <-- fails cleanly

Do the same with --attach-storage after creating a juju storage device.

## Documentation changes

n/a 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1781450

