### PR TITLE
More accurate create backup option check.

### DIFF
--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -97,8 +97,8 @@ func (c *createCommand) Init(args []string) error {
 	// all the backup will not be stored anywhere.
 	if c.NoDownload {
 		keepCopySet := false
-		c.fs.Visit(func(blah *gnuflag.Flag) {
-			if blah.Name == "keep-copy" {
+		c.fs.Visit(func(flag *gnuflag.Flag) {
+			if flag.Name == "keep-copy" {
 				keepCopySet = true
 			}
 		})

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -252,7 +252,13 @@ func (s *createSuite) TestKeepCopy(c *gc.C) {
 func (s *createSuite) TestFailKeepCopyNoDownload(c *gc.C) {
 	s.setDownload()
 	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--keep-copy", "--no-download")
-	c.Check(err, gc.ErrorMatches, "cannot mix --no-download and --keep-copy")
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *createSuite) TestFailKeepCopyFalseNoDownload(c *gc.C) {
+	s.setDownload()
+	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "--keep-copy=false", "--no-download")
+	c.Check(err, gc.ErrorMatches, "--no-download cannot be set when --keep-copy is not: the backup will not be created")
 }
 
 func (s *createSuite) TestKeepCopyV1Fail(c *gc.C) {


### PR DESCRIPTION
## Description of change

When requesting a backup, it is possible for user to specify not to download created backup file at the same time as instructing Juju not to keep a remote copy, '--no-download --keep-copy=false'. This would mean that we will do a lot of work but there will be no output. Of course, '--no-download --keep-copy' whilst redundant, is actually ok.

This PR tightens this check and ensures that there are unit tests.