### PR TITLE
Corrected the help for exportbundle command

### DIFF
--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -34,7 +34,7 @@ func NewClient(st base.APICallCloser) *Client {
 func (c *Client) ExportBundle() (string, error) {
 	var result params.StringResult
 	if bestVer := c.BestAPIVersion(); bestVer < 2 {
-		return "", errors.Errorf("ExportBundle() on v%d is not supported", bestVer)
+		return "", errors.Errorf("this controller version does not support bundle export feature.")
 	}
 
 	if err := c.facade.FacadeCall("ExportBundle", nil, &result); err != nil {

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -46,7 +46,7 @@ func (s *bundleMockSuite) TestFailExportBundlev1(c *gc.C) {
 	)
 	result, err := client.ExportBundle()
 	c.Assert(err, gc.NotNil)
-	c.Assert(err.Error(), gc.Equals, "ExportBundle() on v1 is not supported")
+	c.Assert(err.Error(), gc.Equals, "this controller version does not support bundle export feature.")
 	c.Assert(result, jc.DeepEquals, "")
 }
 

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/api/bundle"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/cmd/output"
 )
 
 // NewExportBundleCommand returns a fully constructed export bundle command.
@@ -32,7 +31,7 @@ type exportBundleCommand struct {
 }
 
 const exportBundleHelpDoc = `
-Exports the current model configuration as bundle.
+Exports the current model configuration as a reusable bundle.
 
 If --filename is not used, the configuration is printed to stdout.
  --filename specifies an output file.
@@ -40,14 +39,15 @@ If --filename is not used, the configuration is printed to stdout.
 Examples:
 
     juju export-bundle
-	juju export-bundle --filename mymodel
+	juju export-bundle --filename mymodel.yaml
+
 `
 
 // Info implements Command.
 func (c *exportBundleCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "export-bundle",
-		Purpose: "Exports the current model configuration as bundle.",
+		Purpose: "Exports the current model configuration as a reusable bundle.",
 		Doc:     exportBundleHelpDoc,
 	}
 }
@@ -55,7 +55,6 @@ func (c *exportBundleCommand) Info() *cmd.Info {
 // SetFlags implements Command.
 func (c *exportBundleCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.StringVar(&c.Filename, "filename", "", "Bundle file")
 }
 
@@ -93,9 +92,10 @@ func (c *exportBundleCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if c.Filename == "" {
-		return c.out.Write(ctx, result)
+		_, err := fmt.Fprintf(ctx.Stdout, "%v", result)
+		return err
 	}
-	filename := c.Filename + ".yaml"
+	filename := c.Filename
 	file, err := os.Create(filename)
 	if err != nil {
 		return errors.Annotate(err, "while creating local file")

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -86,26 +86,26 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
 	})
 
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, "|\n"+
-		"  applications:\n"+
-		"    mysql:\n"+
-		"      charm: \"\"\n"+
-		"      num_units: 1\n"+
-		"      to:\n"+
-		"      - \"0\"\n"+
-		"    wordpress:\n"+
-		"      charm: \"\"\n"+
-		"      num_units: 2\n"+
-		"      to:\n"+
-		"      - \"0\"\n"+
-		"      - \"1\"\n"+
-		"  machines:\n"+
-		"    \"0\": {}\n"+
-		"    \"1\": {}\n"+
-		"  series: xenial\n"+
-		"  relations:\n"+
-		"  - - wordpress:db\n"+
-		"    - mysql:mysql\n")
+	c.Assert(out, gc.Equals, ""+
+		"applications:\n"+
+		"  mysql:\n"+
+		"    charm: \"\"\n"+
+		"    num_units: 1\n"+
+		"    to:\n"+
+		"    - \"0\"\n"+
+		"  wordpress:\n"+
+		"    charm: \"\"\n"+
+		"    num_units: 2\n"+
+		"    to:\n"+
+		"    - \"0\"\n"+
+		"    - \"1\"\n"+
+		"machines:\n"+
+		"  \"0\": {}\n"+
+		"  \"1\": {}\n"+
+		"series: xenial\n"+
+		"relations:\n"+
+		"- - wordpress:db\n"+
+		"  - mysql:mysql\n")
 }
 
 func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
@@ -129,8 +129,8 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 	})
 
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, "Bundle successfully exported to mymodel.yaml\n")
-	output, err := ioutil.ReadFile("mymodel.yaml")
+	c.Assert(out, gc.Equals, "Bundle successfully exported to mymodel\n")
+	output, err := ioutil.ReadFile("mymodel")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "applications:\n"+
 		"  magic:\n"+
@@ -163,8 +163,8 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *
 	})
 
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, "Bundle successfully exported to mymodel.yaml\n")
-	output, err := ioutil.ReadFile("mymodel.yaml")
+	c.Assert(out, gc.Equals, "Bundle successfully exported to mymodel\n")
+	output, err := ioutil.ReadFile("mymodel")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "fake-data")
 }

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -65,16 +65,15 @@ func (s *CmdExportBundleSuite) TestExportBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stdout(ctx)
 	c.Assert(output, gc.Equals, ""+
-		"|\n"+
-		"  applications:\n"+
-		"    logging:\n"+
-		"      charm: cs:quantal/logging-43\n"+
-		"    wordpress:\n"+
-		"      charm: cs:quantal/wordpress-23\n"+
-		"  series: bionic\n"+
-		"  relations:\n"+
-		"  - - wordpress:juju-info\n"+
-		"    - logging:info\n"+
-		"  - - wordpress:logging-dir\n"+
-		"    - logging:logging-directory\n")
+		"applications:\n"+
+		"  logging:\n"+
+		"    charm: cs:quantal/logging-43\n"+
+		"  wordpress:\n"+
+		"    charm: cs:quantal/wordpress-23\n"+
+		"series: bionic\n"+
+		"relations:\n"+
+		"- - wordpress:juju-info\n"+
+		"  - logging:info\n"+
+		"- - wordpress:logging-dir\n"+
+		"  - logging:logging-directory\n")
 }


### PR DESCRIPTION
This PR has code changes that fix the help for export bundle command. 
There shouldn't be --output and --format options in thge help menu. 

## QA steps
execute juju export-bundle --help command.