### PR TITLE
Fixes lp#1787200: Remove new lines from summary.

### DIFF
--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -20,9 +20,7 @@ import (
 	"github.com/juju/juju/instance"
 )
 
-var usageAddUnitSummary = `
-Adds one or more units to a deployed application.
-`[1:]
+var usageAddUnitSummary = `Adds one or more units to a deployed application.`
 
 var usageAddUnitDetails = `
 The add-unit is used to scale out an application for improved performance or


### PR DESCRIPTION
## Description of change

Extra newlines in commands summary cause havoc in 'juju help commands'. This PR removes newlines in 'add-unit' summary, reported in linked bug.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1787200
