### PR TITLE
Fixes lp#1780711: Ignore all formatting when only one output is desired.

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -355,7 +355,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		return err
 	}
 	if len(c.keys) == 1 {
-		ctx.Infof("format %v is ignored", c.out.Name())
+		logger.Infof("format %v is ignored", c.out.Name())
 		key := c.keys[0]
 		info, found := results.CharmConfig[key].(map[string]interface{})
 		if !found && len(results.ApplicationConfig) > 0 {

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -34,6 +34,11 @@ Output includes the name of the charm used to deploy the application and a
 listing of the application-specific configuration settings.
 See ` + "`juju status`" + ` for application names.
 
+When only one configuration value is desired, the command will ignore --format
+option and will output the value unformatted. This is provided to support 
+scripts where the output of "juju config <application name> <setting name>" 
+can be used as an input to an expression or a function.
+
 Examples:
     juju config apache2
     juju config --format=json apache2
@@ -350,6 +355,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		return err
 	}
 	if len(c.keys) == 1 {
+		ctx.Infof("format %v is ignored", c.out.Name())
 		key := c.keys[0]
 		info, found := results.CharmConfig[key].(map[string]interface{})
 		if !found && len(results.ApplicationConfig) > 0 {
@@ -358,7 +364,8 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		if !found {
 			return errors.Errorf("key %q not found in %q application config or charm settings.", key, c.applicationName)
 		}
-		return c.out.Write(ctx, info["value"])
+		fmt.Fprintln(ctx.Stdout, info["value"])
+		return nil
 	}
 
 	resultsMap := map[string]interface{}{

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -176,32 +176,32 @@ func (s *configCommandSuite) TestGetCharmConfigKey(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "title"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "Nearly There\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format yaml is ignored\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Nearly There\n")
 }
 
 func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "'The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the\n  lazy dog\" \"The quick brown fox jumps over the lazy dog\" '\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format yaml is ignored\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
 func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value", "--format", "json"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "\"The quick brown fox jumps over the lazy dog. \\\"The quick brown fox jumps over the lazy dog\\\" \\\"The quick brown fox jumps over the lazy dog\\\" \"\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format json is ignored\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
 func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "juju-external-hostname"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "ext-host\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format yaml is ignored\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host\n")
 }
 
 func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -176,7 +176,7 @@ func (s *configCommandSuite) TestGetCharmConfigKey(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "title"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format yaml is ignored\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Nearly There\n")
 }
 
@@ -184,7 +184,7 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format yaml is ignored\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
@@ -192,7 +192,7 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value", "--format", "json"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format json is ignored\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
@@ -200,7 +200,7 @@ func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "juju-external-hostname"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "format yaml is ignored\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host\n")
 }
 


### PR DESCRIPTION
## Description of change

Application configuration string options may contain multi-lined values. When formatted these values get un-desired newlines which are supposedly helpful for human readers and are supplied by json and ymal formatters. However, these newlines are highly undesired when scripting.

As per suggestion in the linked bug, this PR ensures that a single-value output is not formatted. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1780711
