### PR TITLE
provider/oci: Fix data race in terminateInstances

### DIFF
--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -632,7 +632,7 @@ func (e *environSuite) TestStopInstancesMultipleFail(c *gc.C) {
 	}
 	err := e.env.StopInstances(nil, ids...)
 	// order in which the instances are returned or fail is not guaranteed
-	c.Assert(err, gc.ErrorMatches, "failed to stop instances \\[fakeInstance[24] fakeInstance[24]\\]: \\[I failed to terminate fakeInstance[24] I failed to terminate fakeInstance[24]\\]")
+	c.Assert(err, gc.ErrorMatches, `failed to stop instances \[fakeInstance[24] fakeInstance[24]\]: \[I failed to terminate fakeInstance[24] I failed to terminate fakeInstance[24]\]`)
 
 }
 


### PR DESCRIPTION
## Description of change
`terminateInstances` was appending to the errs and instIds slices from different goroutines in a waitgroup, so `environSuite.TestStopInstancesMultipleFail` would sometimes fail because one of the errors was dropped. I've changed it to send ids and errors down one buffered channel (in a struct so the right id is associated with each error), and then read from the channel after the waitgroup is finished.

## QA steps

Running `environSuite.TestStopInstancesMultipleFail` under the race detector no longer complains, and the test still passes.
