### PR TITLE
Initial cloud container status storage

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -488,44 +488,49 @@ func (a *Facade) UpdateApplicationsUnits(args params.UpdateApplicationUnitArgs) 
 	return result, nil
 }
 
-// updateStatus constructs the unit and agent status values based on the pod status.
+// updateStatus constructs the agent and cloud container status values.
 func (a *Facade) updateStatus(params params.ApplicationUnitParams) (
 	agentStatus *status.StatusInfo,
-	unitStatus *status.StatusInfo,
-	_ error,
+	cloudContainerStatus *status.StatusInfo,
 ) {
+	var containerStatus status.Status
 	switch status.Status(params.Status) {
 	case status.Unknown:
 		// The container runtime can spam us with unimportant
 		// status updates, so ignore any irrelevant ones.
-		return nil, nil, nil
+		return nil, nil
 	case status.Allocating:
 		// The container runtime has decided to restart the pod.
 		agentStatus = &status.StatusInfo{
 			Status:  status.Allocating,
 			Message: params.Info,
 		}
-		unitStatus = &status.StatusInfo{
-			Status:  status.Waiting,
-			Message: status.MessageWaitForContainer,
-		}
+		containerStatus = status.Waiting
 	case status.Running:
 		// A pod has finished starting so the workload is now active.
 		agentStatus = &status.StatusInfo{
 			Status: status.Idle,
 		}
-		unitStatus = &status.StatusInfo{
-			Status:  status.Active,
-			Message: params.Info,
-		}
+		containerStatus = status.Running
 	case status.Error:
 		agentStatus = &status.StatusInfo{
 			Status:  status.Error,
 			Message: params.Info,
 			Data:    params.Data,
 		}
+		containerStatus = status.Error
+	case status.Blocked:
+		containerStatus = status.Blocked
+		agentStatus = &status.StatusInfo{
+			Status: status.Idle,
+		}
 	}
-	return agentStatus, unitStatus, nil
+	cloudContainerStatus = &status.StatusInfo{
+		Status:  containerStatus,
+		Message: params.Info,
+		Data:    params.Data,
+	}
+	return agentStatus, cloudContainerStatus
 }
 
 // updateUnitsFromCloud takes a slice of unit information provided by an external
@@ -719,7 +724,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 		// occur when a pod is restarted external to Juju, or permanent if the pod has
 		// been deleted external to Juju. In the latter case, juju remove-unit will be
 		// need to clean things up on the Juju side.
-		unitStatus := &status.StatusInfo{
+		cloudContainerStatus := &status.StatusInfo{
 			Status:  status.Terminated,
 			Message: "unit stopped by the cloud",
 		}
@@ -727,25 +732,22 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 			Status: status.Idle,
 		}
 		updateProps := state.UnitUpdateProperties{
-			UnitStatus:  unitStatus,
-			AgentStatus: agentStatus,
+			CloudContainerStatus: cloudContainerStatus,
+			AgentStatus:          agentStatus,
 		}
 		unitUpdate.Updates = append(unitUpdate.Updates,
 			u.UpdateOperation(updateProps))
 	}
 
-	processUnitParams := func(unitParams params.ApplicationUnitParams) (*state.UnitUpdateProperties, error) {
-		agentStatus, unitStatus, err := a.updateStatus(unitParams)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+	processUnitParams := func(unitParams params.ApplicationUnitParams) *state.UnitUpdateProperties {
+		agentStatus, cloudContainerStatus := a.updateStatus(unitParams)
 		return &state.UnitUpdateProperties{
-			ProviderId:  &unitParams.ProviderId,
-			Address:     &unitParams.Address,
-			Ports:       &unitParams.Ports,
-			AgentStatus: agentStatus,
-			UnitStatus:  unitStatus,
-		}, nil
+			ProviderId:           &unitParams.ProviderId,
+			Address:              &unitParams.Address,
+			Ports:                &unitParams.Ports,
+			AgentStatus:          agentStatus,
+			CloudContainerStatus: cloudContainerStatus,
+		}
 	}
 
 	processFilesystemParams := func(processedFilesystemIds set.Strings, unitTag names.UnitTag, unitParams params.ApplicationUnitParams) error {
@@ -848,10 +850,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 			logger.Warningf("unexpected unit parameters %+v not in state", unitParams)
 			continue
 		}
-		updateProps, err := processUnitParams(unitParams)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		updateProps := processUnitParams(unitParams)
 		if len(unitParams.FilesystemInfo) > 0 {
 			unitParamsWithFilesystemInfo = append(unitParamsWithFilesystemInfo, unitParams)
 		}
@@ -866,10 +865,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 	for _, unitParams := range unitInfo.addedCloudPods {
 		if idx < len(unitInfo.unassociatedUnits) {
 			u := unitInfo.unassociatedUnits[idx]
-			updateProps, err := processUnitParams(unitParams)
-			if err != nil {
-				return errors.Trace(err)
-			}
+			updateProps := processUnitParams(unitParams)
 			unitUpdate.Updates = append(unitUpdate.Updates,
 				u.UpdateOperation(*updateProps))
 			idx += 1
@@ -880,10 +876,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 		}
 
 		// Process units added directly in the cloud instead of via Juju.
-		updateProps, err := processUnitParams(unitParams)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		updateProps := processUnitParams(unitParams)
 		if len(unitParams.FilesystemInfo) > 0 {
 			unitParamsWithFilesystemInfo = append(unitParamsWithFilesystemInfo, unitParams)
 		}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -311,7 +311,7 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnits(c *gc.C) {
 	s.st.application.CheckCall(c, 1, "AddOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("really-new-uuid"),
 		Address:    strPtr("really-new-address"), Ports: &[]string{"really-new-port"},
-		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "really new message"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "really new message"},
 		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[0].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
@@ -339,7 +339,7 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnits(c *gc.C) {
 	s.st.application.units[3].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("new-uuid"),
 		Address:    strPtr("new-address"), Ports: &[]string{"new-port"},
-		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "new message"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "new message"},
 		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 }
@@ -433,14 +433,14 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithStorage(c *gc.C) {
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("uuid"),
 		Address:    strPtr("address"), Ports: &[]string{"port"},
-		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "message"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "message"},
 		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("another-uuid"),
 		Address:    strPtr("another-address"), Ports: &[]string{"another-port"},
-		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "another message"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "another message"},
 		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 	s.storage.CheckCallNames(c,

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -311,34 +311,36 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnits(c *gc.C) {
 	s.st.application.CheckCall(c, 1, "AddOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("really-new-uuid"),
 		Address:    strPtr("really-new-address"), Ports: &[]string{"really-new-port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "really new message"},
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "really new message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[0].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
+	// CloudContainer message is not overwritten based on agent status
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("uuid"),
 		Address:    strPtr("address"), Ports: &[]string{"port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Waiting, Message: "waiting for container"},
-		AgentStatus: &status.StatusInfo{Status: status.Allocating},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Waiting, Message: ""},
+		AgentStatus:          &status.StatusInfo{Status: status.Allocating},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
+	// CloudContainer message is not overwritten based on agent status
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("another-uuid"),
 		Address:    strPtr("another-address"), Ports: &[]string{"another-port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Waiting, Message: "waiting for container"},
-		AgentStatus: &status.StatusInfo{Status: status.Allocating, Message: "another message"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Waiting, Message: "another message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Allocating, Message: "another message"},
 	})
 	s.st.application.units[2].(*mockUnit).CheckCallNames(c, "Life", "DestroyOperation", "UpdateOperation")
 	s.st.application.units[2].(*mockUnit).CheckCall(c, 2, "UpdateOperation", state.UnitUpdateProperties{
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
-		UnitStatus:  &status.StatusInfo{Status: status.Terminated, Message: "unit stopped by the cloud"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Terminated, Message: "unit stopped by the cloud"},
 	})
 	s.st.application.units[3].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[3].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("new-uuid"),
 		Address:    strPtr("new-address"), Ports: &[]string{"new-port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "new message"},
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "new message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 }
 
@@ -431,15 +433,15 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsUnitsWithStorage(c *gc.C) {
 	s.st.application.units[0].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("uuid"),
 		Address:    strPtr("address"), Ports: &[]string{"port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "message"},
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 	s.st.application.units[1].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	s.st.application.units[1].(*mockUnit).CheckCall(c, 1, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("another-uuid"),
 		Address:    strPtr("another-address"), Ports: &[]string{"another-port"},
-		UnitStatus:  &status.StatusInfo{Status: status.Active, Message: "another message"},
-		AgentStatus: &status.StatusInfo{Status: status.Idle},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Active, Message: "another message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
 	})
 	s.storage.CheckCallNames(c,
 		"UnitStorageAttachments", "UnitStorageAttachments", "StorageInstance",

--- a/state/application.go
+++ b/state/application.go
@@ -2545,6 +2545,17 @@ func (op *AddUnitOperation) Done(err error) error {
 		}
 	}
 	if op.props.CloudContainerStatus != nil {
+		doc := statusDoc{
+			Status:     op.props.CloudContainerStatus.Status,
+			StatusInfo: op.props.CloudContainerStatus.Message,
+			StatusData: mgoutils.EscapeKeys(op.props.CloudContainerStatus.Data),
+			Updated:    timeOrNow(op.props.CloudContainerStatus.Since, u.st.clock()).UnixNano(),
+		}
+		_, err := probablyUpdateStatusHistory(op.application.st.db(), globalCloudContainerKey(op.unitName), doc)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
 		// Ensure unit history is updated correctly
 		unitStatus, err := getStatus(op.application.st.db(), unitGlobalKey(op.unitName), "unit")
 		if err != nil {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3606,6 +3606,13 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	c.Assert(unitHistory[0].Status, gc.Equals, status.Running)
 	c.Assert(unitHistory[0].Message, gc.Equals, "new container running")
 
+	// check cloud container status history is stored.
+	containerStatusHistory, err := state.GetCloudContainerStatusHistory(s.caasSt, u.Name(), status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(containerStatusHistory, gc.HasLen, 1)
+	c.Assert(containerStatusHistory[0].Status, gc.Equals, status.Running)
+	c.Assert(containerStatusHistory[0].Message, gc.Equals, "new container running")
+
 	err = removedUnit.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -388,7 +388,7 @@ func (s *CAASModelSuite) TestCloudContainerHistoryOverwrite(c *gc.C) {
 	// Now that status is stored as Active, but displayed (and in history)
 	// as waiting for container, once we set cloud container status as active
 	// it must show active from the unit (incl. history)
-	setCloudContainerStatus(c, unit, status.Active, "Container Active")
+	setCloudContainerStatus(c, unit, status.Running, "Container Active")
 	workloadStatus = unitWorkloadStatus(c, m, unit.Name())
 	c.Assert(workloadStatus.Message, gc.Equals, "Unit Active")
 	c.Assert(workloadStatus.Status, gc.Equals, status.Active)

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -312,4 +313,127 @@ func (s *CAASModelSuite) TestContainers(c *gc.C) {
 		unitNames = append(unitNames, c.Unit())
 	}
 	c.Assert(unitNames, jc.SameContents, []string{app.Name() + "/0", app.Name() + "/1"})
+}
+
+func (s *CAASModelSuite) TestCloudContainerStatus(c *gc.C) {
+	m, st := s.newCAASModel(c)
+	f := factory.NewFactory(st, s.StatePool)
+	unit := f.MakeUnit(c, &factory.UnitParams{
+		Status: &status.StatusInfo{
+			Status:  status.Active,
+			Message: "Unit Active",
+		},
+	})
+
+	// Cloud container overrides Allocating unit
+	setCloudContainerStatus(c, unit, status.Allocating, "k8s allocating")
+	msWorkload := unitWorkloadStatus(c, m, unit.Name())
+	c.Check(msWorkload.Message, gc.Equals, "k8s allocating")
+	c.Check(msWorkload.Status, gc.Equals, status.Allocating)
+
+	// Cloud container error overrides unit status
+	setCloudContainerStatus(c, unit, status.Error, "k8s charm error")
+	msWorkload = unitWorkloadStatus(c, m, unit.Name())
+	c.Check(msWorkload.Message, gc.Equals, "k8s charm error")
+	c.Check(msWorkload.Status, gc.Equals, status.Error)
+
+	// Unit status must be used.
+	setCloudContainerStatus(c, unit, status.Running, "k8s idle")
+	msWorkload = unitWorkloadStatus(c, m, unit.Name())
+	c.Check(msWorkload.Message, gc.Equals, "Unit Active")
+	c.Check(msWorkload.Status, gc.Equals, status.Active)
+
+	// Cloud container overrides
+	setCloudContainerStatus(c, unit, status.Blocked, "POD storage issue")
+	msWorkload = unitWorkloadStatus(c, m, unit.Name())
+	c.Check(msWorkload.Message, gc.Equals, "POD storage issue")
+	c.Check(msWorkload.Status, gc.Equals, status.Blocked)
+
+	// Cloud container overrides
+	setCloudContainerStatus(c, unit, status.Waiting, "Building the bits")
+	msWorkload = unitWorkloadStatus(c, m, unit.Name())
+	c.Check(msWorkload.Message, gc.Equals, "Building the bits")
+	c.Check(msWorkload.Status, gc.Equals, status.Waiting)
+
+	// Cloud container overrides
+	setCloudContainerStatus(c, unit, status.Running, "Bits have been built")
+	msWorkload = unitWorkloadStatus(c, m, unit.Name())
+	c.Check(msWorkload.Message, gc.Equals, "Unit Active")
+	c.Check(msWorkload.Status, gc.Equals, status.Active)
+}
+
+func (s *CAASModelSuite) TestCloudContainerHistoryOverwrite(c *gc.C) {
+	m, st := s.newCAASModel(c)
+	f := factory.NewFactory(st, s.StatePool)
+	unit := f.MakeUnit(c, &factory.UnitParams{})
+
+	unit.SetStatus(status.StatusInfo{
+		Status:  status.Active,
+		Message: "Unit Active",
+	})
+
+	unitStatus, err := unit.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitStatus.Message, gc.Equals, "Unit Active")
+	c.Assert(unitStatus.Status, gc.Equals, status.Active)
+	workloadStatus := unitWorkloadStatus(c, m, unit.Name())
+	c.Assert(workloadStatus.Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(workloadStatus.Status, gc.Equals, status.Waiting)
+	statusHistory, err := unit.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusHistory, gc.HasLen, 1)
+	c.Assert(statusHistory[0].Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(statusHistory[0].Status, gc.Equals, status.Waiting)
+
+	// Now that status is stored as Active, but displayed (and in history)
+	// as waiting for container, once we set cloud container status as active
+	// it must show active from the unit (incl. history)
+	setCloudContainerStatus(c, unit, status.Active, "Container Active")
+	workloadStatus = unitWorkloadStatus(c, m, unit.Name())
+	c.Assert(workloadStatus.Message, gc.Equals, "Unit Active")
+	c.Assert(workloadStatus.Status, gc.Equals, status.Active)
+	statusHistory, err = unit.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusHistory, gc.HasLen, 2)
+	c.Assert(statusHistory[0].Message, gc.Equals, "Unit Active")
+	c.Assert(statusHistory[0].Status, gc.Equals, status.Active)
+	c.Assert(statusHistory[1].Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(statusHistory[1].Status, gc.Equals, status.Waiting)
+
+	unit.SetStatus(status.StatusInfo{
+		Status:  status.Waiting,
+		Message: "This is a different message",
+	})
+	workloadStatus = unitWorkloadStatus(c, m, unit.Name())
+	c.Assert(workloadStatus.Message, gc.Equals, "This is a different message")
+	c.Assert(workloadStatus.Status, gc.Equals, status.Waiting)
+	statusHistory, err = unit.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusHistory, gc.HasLen, 3)
+	c.Assert(statusHistory[0].Message, gc.Equals, "This is a different message")
+	c.Assert(statusHistory[0].Status, gc.Equals, status.Waiting)
+	c.Assert(statusHistory[1].Message, gc.Equals, "Unit Active")
+	c.Assert(statusHistory[1].Status, gc.Equals, status.Active)
+	c.Assert(statusHistory[2].Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(statusHistory[2].Status, gc.Equals, status.Waiting)
+}
+
+func unitWorkloadStatus(c *gc.C, model *state.CAASModel, unitName string) status.StatusInfo {
+	ms, err := model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	msWorkload, err := ms.UnitWorkload(unitName)
+	c.Assert(err, jc.ErrorIsNil)
+	return msWorkload
+}
+
+func setCloudContainerStatus(c *gc.C, unit *state.Unit, statusCode status.Status, message string) {
+	var updateUnits state.UpdateUnitsOperation
+	updateUnits.Updates = []*state.UpdateUnitOperation{
+		unit.UpdateOperation(state.UnitUpdateProperties{
+			CloudContainerStatus: &status.StatusInfo{Status: statusCode, Message: message},
+		})}
+	app, err := unit.Application()
+	c.Assert(err, jc.ErrorIsNil)
+	err = app.UpdateUnits(&updateUnits)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -74,6 +74,12 @@ func (c *cloudContainer) Ports() []string {
 	return c.doc.Ports
 }
 
+// globalCloudContainerKey returns the global database key for the
+// cloud container status key for this unit.
+func globalCloudContainerKey(name string) string {
+	return unitGlobalKey(name) + "#container"
+}
+
 func (u *Unit) cloudContainer() (*cloudContainerDoc, error) {
 	coll, closer := u.st.db().GetCollection(cloudContainersC)
 	defer closer()

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -836,6 +836,15 @@ func GetCloudContainerStatus(st *State, name string) (status.StatusInfo, error) 
 	return getStatus(st.db(), globalCloudContainerKey(name), "unit")
 }
 
+func GetCloudContainerStatusHistory(st *State, name string, filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		db:        st.db(),
+		globalKey: globalCloudContainerKey(name),
+		filter:    filter,
+	}
+	return statusHistory(args)
+}
+
 func CaasUnitDisplayStatus(unitStatus status.StatusInfo, cloudContainerStatus status.StatusInfo) status.StatusInfo {
 	return caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -831,3 +831,11 @@ func (st *State) ModelQueryForUser(user names.UserTag, isSuperuser bool) (mongo.
 func UnitsHaveChanged(m *Machine, unitNames []string) (bool, error) {
 	return m.unitsHaveChanged(unitNames)
 }
+
+func GetCloudContainerStatus(st *State, name string) (status.StatusInfo, error) {
+	return getStatus(st.db(), globalCloudContainerKey(name), "unit")
+}
+
+func CaasUnitDisplayStatus(unitStatus status.StatusInfo, cloudContainerStatus status.StatusInfo) status.StatusInfo {
+	return caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
+}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -815,6 +815,17 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 				SHA256:  tools.SHA256,
 				Size:    tools.Size,
 			})
+		} else {
+			// TODO(caas) - Actually use the exported cloud container details and status history.
+			// Currently these are only grabbed to make the MigrationExportSuite tests happy.
+			globalCCKey := unit.globalCloudContainerKey()
+			_, err = e.statusArgs(globalCCKey)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					return errors.Annotatef(err, "cloud container workload status for unit %s", unit.Name())
+				}
+			}
+			e.statusHistoryArgs(globalCCKey)
 		}
 		exUnit.SetAnnotations(e.getAnnotations(globalKey))
 

--- a/state/status.go
+++ b/state/status.go
@@ -180,6 +180,9 @@ func caasUnitDisplayStatus(unitStatus status.StatusInfo, containerStatus status.
 	if unitStatus.Status == status.Terminated {
 		return unitStatus
 	}
+	if containerStatus.Status == status.Terminated {
+		return containerStatus
+	}
 	if containerStatus.Status == "" {
 		// No container update received from k8s yet,
 		// so we have to assume it's still allocating.

--- a/state/status.go
+++ b/state/status.go
@@ -157,7 +157,75 @@ func (m *ModelStatus) UnitWorkload(unitName string) (status.StatusInfo, error) {
 		return info, nil
 	}
 
-	return m.getStatus(unitGlobalKey(unitName), "workload")
+	// (for CAAS models) Use cloud container status over unit if the cloud
+	// container status is error or active or the unit status hasn't shifted
+	// from 'allocating'
+	info, err = m.getStatus(unitGlobalKey(unitName), "workload")
+	if err != nil {
+		return info, errors.Trace(err)
+	}
+
+	if m.model.Type() == ModelTypeIAAS {
+		return info, nil
+	}
+
+	containerInfo, err := m.getStatus(globalCloudContainerKey(unitName), "cloud container")
+	if err != nil && !errors.IsNotFound(err) {
+		return info, err
+	}
+	return caasUnitDisplayStatus(info, containerInfo), nil
+}
+
+func caasUnitDisplayStatus(unitStatus status.StatusInfo, containerStatus status.StatusInfo) status.StatusInfo {
+	if unitStatus.Status == status.Terminated {
+		return unitStatus
+	}
+	if containerStatus.Status == "" {
+		// No container update received from k8s yet,
+		// so we have to assume it's still allocating.
+		return status.StatusInfo{
+			Status:  status.Waiting,
+			Message: status.MessageWaitForContainer,
+		}
+	}
+	if unitStatus.Status != status.Active && unitStatus.Status != status.Waiting && unitStatus.Status != status.Blocked {
+		// Charm has said that there's a problem (error) or
+		// it's doing something (maintenance) so we'll stick with that.
+		return unitStatus
+	}
+
+	// Charm may think it's active, but as yet there's no way for it to
+	// query the workload state, so we'll ensure that we only say that
+	// it's active if the pod is reported as running. If not, we'll report
+	// any pod error.
+	switch containerStatus.Status {
+	case status.Error, status.Blocked, status.Allocating:
+		return containerStatus
+	case status.Waiting:
+		if unitStatus.Status == status.Active {
+			return containerStatus
+		}
+	case status.Running:
+		// Unit hasn't moved from initial state.
+		if unitStatus.Status == status.Waiting && unitStatus.Message == status.MessageWaitForContainer {
+			return containerStatus
+		}
+	}
+	return unitStatus
+}
+
+// caasHistoryRewriteDoc determines which status should be stored as history.
+func caasHistoryRewriteDoc(unitStatus, cloudContainerStatus status.StatusInfo, clock clock.Clock) (*statusDoc, error) {
+	modifiedStatus := caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
+	if modifiedStatus.Status == unitStatus.Status && modifiedStatus.Message == unitStatus.Message {
+		return nil, nil
+	}
+	return &statusDoc{
+		Status:     modifiedStatus.Status,
+		StatusInfo: modifiedStatus.Message,
+		StatusData: utils.EscapeKeys(modifiedStatus.Data),
+		Updated:    timeOrNow(modifiedStatus.Since, clock).UnixNano(),
+	}, nil
 }
 
 type statusDocWithID struct {
@@ -278,6 +346,13 @@ type setStatusParams struct {
 
 	// updated, the time the status was set.
 	updated *time.Time
+
+	// historyOverwrite provides an optional ability to write a different
+	// version of status as history (vs. what status actually gets set.)
+	// Used only with caas models as there is currently no way for a charm
+	// to query its' workload and the cloud container status might contradict
+	// what it thinks it is.
+	historyOverwrite *statusDoc
 }
 
 func timeOrNow(t *time.Time, clock clock.Clock) *time.Time {
@@ -302,8 +377,13 @@ func setStatus(db Database, params setStatusParams) (err error) {
 		Updated:    params.updated.UnixNano(),
 	}
 
-	newStatus, historyErr := probablyUpdateStatusHistory(db, params.globalKey, doc)
-	if !newStatus && historyErr == nil {
+	historyDoc := &doc
+	if params.historyOverwrite != nil {
+		historyDoc = params.historyOverwrite
+	}
+
+	newStatus, historyErr := probablyUpdateStatusHistory(db, params.globalKey, *historyDoc)
+	if params.historyOverwrite == nil && (!newStatus && historyErr == nil) {
 		// If this status is not new (i.e. it is exactly the same as
 		// our last status), there is no need to update the record.
 		// Update here will only reset the 'Since' field.
@@ -401,10 +481,39 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (
 	history, closer := db.GetCollection(statusesHistoryC)
 	defer closer()
 
+	exists, currentID := statusHistoryExists(db, historyDoc)
+	if exists {
+		// If the status values have not changed since the last run,
+		// update history record with this timestamp
+		// to keep correct track of when SetStatus ran.
+		historyW := history.Writeable()
+		err := historyW.Update(
+			bson.D{{"_id", currentID}},
+			bson.D{{"$set", bson.D{{"updated", doc.Updated}}}})
+		if err != nil {
+			logger.Errorf("failed to update status history: %v", err)
+			return false, err
+		}
+		return false, nil
+	}
+
+	historyW := history.Writeable()
+	err := historyW.Insert(historyDoc)
+	if err != nil {
+		logger.Errorf("failed to write status history: %v", err)
+		return false, err
+	}
+	return true, nil
+}
+
+func statusHistoryExists(db Database, historyDoc *historicalStatusDoc) (bool, bson.ObjectId) {
 	// Find the current value to see if it is worthwhile adding the new
 	// status value.
+	history, closer := db.GetCollection(statusesHistoryC)
+	defer closer()
+
 	var latest []recordedHistoricalStatusDoc
-	query := history.Find(bson.D{{globalKeyField, globalKey}})
+	query := history.Find(bson.D{{globalKeyField, historyDoc.GlobalKey}})
 	query = query.Sort("-updated").Limit(1)
 	err := query.All(&latest)
 	if err == nil && len(latest) == 1 {
@@ -425,31 +534,13 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (
 		}
 		// Check the data last as the short circuit evaluation may mean
 		// we rarely need to drop down into the reflect library.
-		if current.Status == doc.Status &&
-			current.StatusInfo == doc.StatusInfo &&
-			dataSame(current.StatusData, doc.StatusData) {
-			// If the status values have not changed since the last run,
-			// update history record with this timestamp
-			// to keep correct track of when SetStatus ran.
-			historyW := history.Writeable()
-			err = historyW.Update(
-				bson.D{{"_id", current.ID}},
-				bson.D{{"$set", bson.D{{"updated", doc.Updated}}}})
-			if err != nil {
-				logger.Errorf("failed to update status history: %v", err)
-				return false, err
-			}
-			return false, nil
+		if current.Status == historyDoc.Status &&
+			current.StatusInfo == historyDoc.StatusInfo &&
+			dataSame(current.StatusData, historyDoc.StatusData) {
+			return true, current.ID
 		}
 	}
-
-	historyW := history.Writeable()
-	err = historyW.Insert(historyDoc)
-	if err != nil {
-		logger.Errorf("failed to write status history: %v", err)
-		return false, err
-	}
-	return true, nil
+	return false, ""
 }
 
 // eraseStatusHistory removes all status history documents for

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -3262,8 +3262,8 @@ func (w *containerAddressesWatcher) Changes() <-chan struct{} {
 
 func (w *containerAddressesWatcher) loop() error {
 	id := w.backend.docID(w.unit.globalKey())
-	continers, closer := w.db.GetCollection(cloudContainersC)
-	revno, err := getTxnRevno(continers, id)
+	containers, closer := w.db.GetCollection(cloudContainersC)
+	revno, err := getTxnRevno(containers, id)
 	closer()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description of change

Initial plumbing to allow Caas charms to expose status information from within a pod
