### PR TITLE
2.3 txn prune batches 1771906

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ TAGS
 parts/
 prime/
 stage/
+vendor/
+_vendor/
 *.snap
 .emacs.desktop
 .emacs.desktop.lock

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -263,7 +263,7 @@ func (s *restoreSuite) TestRestoreReboostrapWritesUpdatedControllerInfo(c *gc.C)
 	})
 }
 
-func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
+func (s *restoreSuite) TestRestoreRebootstrapControllerConfigDefaults(c *gc.C) {
 	metadata := params.BackupsMetadataResult{
 		CACert:       testing.CACert,
 		CAPrivateKey: testing.CAKey,
@@ -292,6 +292,8 @@ func (s *restoreSuite) TestRestoreReboostrapControllerConfigDefaults(c *gc.C) {
 			"max-logs-age":              "72h",
 			"max-logs-size":             "4096M",
 			"max-txn-log-size":          "10M",
+			"max-prune-txn-batch-size":  1000000,
+			"max-prune-txn-passes":      100,
 			"auditing-enabled":          true,
 			"audit-log-capture-args":    false,
 			"audit-log-max-size":        "300M",

--- a/controller/config.go
+++ b/controller/config.go
@@ -206,6 +206,8 @@ var (
 		AuditingEnabled,
 		AuditLogCaptureArgs,
 		AuditLogExcludeMethods,
+		MaxPruneTxnBatchSize,
+		MaxPruneTxnPasses,
 	)
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -204,6 +204,27 @@ func (s *ConfigSuite) TestTxnLogConfigValue(c *gc.C) {
 	c.Assert(cfg.MaxTxnLogSizeMB(), gc.Equals, 8192)
 }
 
+func (s *ConfigSuite) TestMaxPruneTxnConfigDefault(c *gc.C) {
+	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.MaxPruneTxnBatchSize(), gc.Equals, 1*1000*1000)
+	c.Check(cfg.MaxPruneTxnPasses(), gc.Equals, 100)
+}
+
+func (s *ConfigSuite) TestMaxPruneTxnConfigValue(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"max-prune-txn-batch-size": "12345678",
+			"max-prune-txn-passes":     "10",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.MaxPruneTxnBatchSize(), gc.Equals, 12345678)
+	c.Check(cfg.MaxPruneTxnPasses(), gc.Equals, 10)
+}
+
 func (s *ConfigSuite) TestAuditLogDefaults(c *gc.C) {
 	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -54,7 +54,7 @@ github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	72703b1e95eb8ce4737fd8a3d8496c6b0be280a6	2018-05-17T13:41:05Z
-github.com/juju/txn	git	5e2800621a9aa9d31d0e0bfc5859ef62d40d2e5b	2018-08-16T14:20:22Z
+github.com/juju/txn	git	43be63df1fb67abe617877d8fbe7238344f1f820	2018-08-20T12:57:51Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -32,7 +32,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	abe11904dd8cd40f0777b7704ae60348a876542e	2018-05-21T08:20:44Z
+github.com/juju/gomaasapi	git	abe11904dd8cd40f0777b7704ae60348a876542e	2018-05-21T08:04:29Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z
@@ -54,7 +54,7 @@ github.com/juju/romulus	git	624b9e2be59f28601b29652ca710e21d51e51949	2018-01-03T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	72703b1e95eb8ce4737fd8a3d8496c6b0be280a6	2018-05-17T13:41:05Z
-github.com/juju/txn	git	f50b17d1ff3c31b7ea1c70e0d38a83f19af6d334	2018-04-06T04:58:51Z
+github.com/juju/txn	git	5e2800621a9aa9d31d0e0bfc5859ef62d40d2e5b	2018-08-16T14:20:22Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -33,6 +33,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AllowModelAccessKey,
 		controller.MongoMemoryProfile,
 		controller.AuditLogExcludeMethods,
+		controller.MaxPruneTxnBatchSize,
+		controller.MaxPruneTxnPasses,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)

--- a/state/txns.go
+++ b/state/txns.go
@@ -52,7 +52,7 @@ func (st *State) MaybePruneTransactions() error {
 		MinNewTransactions:   1000,
 		MaxNewTransactions:   100000,
 		MaxTime:              time.Now().Add(-time.Hour),
-		MaxBatchTransactions: uint64(maxBatchSize),
+		MaxBatchTransactions: maxBatchSize,
 		MaxBatches:           maxPasses,
 	})
 }


### PR DESCRIPTION
## Description of change

Brings in the latest txn pruner changes (to only prune in batches), and provides controller config knobs to allow for them to be tuned live, in case 1M batches is not ideal.

## QA steps

```
$ juju bootstrap lxd --debug
# Post bootstrap, you should be able to set the config
$ juju controller-config max-prune-txn-batch-size=10000
# Deploy a lot of applications, so we end up with lots of lease txn churn
$ for k in `seq 0 2` do; for j in `seq 0 9`; do echo $j; for i in `seq 0 9`; do juju deploy cs:~jameinel/ubuntu-lite u$k$j$i --to 0 & done; time wait ; done ; done
# Watch the log for prune events:
$ juju debug-log -m controller --include-module juju.txn --replay
```

It takes 1hr before the first prune event, which shouldn't do much because we don't clean txns that are <1hr old. The second one should end with something like:
```
machine-0: 11:40:19 INFO juju.txn txn pruning complete after 6.766794665s in 5 batches. txns now: 52058, inspected 336 collections, 9420 docs (0 cleaned)
   removed 0 stash docs and 52058 txn docs
```

It should take 5 batches of 10,000 to clean out 50k transactions. You can also trap for max passes with:
```
$ juju controller-config max-prune-txn-batch-size=1000 max-prune-txn-passes=10
```

## Documentation changes

@pmatulis, we probably need to document the new controller config entries well. (`max-prune-txn-batch-size` and `max-prune-txn-passes`)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1771906