### PR TITLE
Ensure test storage charms have at least one hook

### DIFF
--- a/acceptancetests/assess_constraints.py
+++ b/acceptancetests/assess_constraints.py
@@ -192,6 +192,10 @@ def deploy_charm_constraint(client, constraints, charm_name, charm_series,
     constraints_charm = Charm(charm_name,
                               'Test charm for constraints',
                               series=[charm_series])
+    # Valid charms require at least one hook.
+    # Add a dummy install hook.
+    install = '#!/bin/sh\necho install'
+    constraints_charm.add_hook_script('install', install)    
     charm_root = constraints_charm.to_repo_dir(charm_dir)
     platform = 'ubuntu'
     charm = local_charm_path(charm=charm_name,

--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -186,6 +186,10 @@ def storage_pool_list(client):
 def create_storage_charm(charm_dir, name, summary, storage):
     """Manually create a temporary charm to test with storage."""
     storage_charm = Charm(name, summary, storage=storage, series=['trusty'])
+    # Valid charms require at least one hook.
+    # Add a dummy install hook.
+    install = '#!/bin/sh\necho install'
+    storage_charm.add_hook_script('install', install)
     charm_root = storage_charm.to_repo_dir(charm_dir)
     return charm_root
 

--- a/api/client.go
+++ b/api/client.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -360,8 +359,8 @@ func hasHooksFolder(name string) (bool, error) {
 	}
 	defer zipr.Close()
 	count := 0
-	// Cater for file separator differences between operating systems.
-	hooksPath := filepath.FromSlash("hooks/")
+	// zip file spec 4.4.17.1 says that separators are always "/" even on Windows.
+	hooksPath := "hooks/"
 	for _, f := range zipr.File {
 		if strings.Contains(f.Name, hooksPath) {
 			count++


### PR DESCRIPTION
## Description of change

Juju now refuses to install charms without at least one hook.
Fix the generated storage test charms to allow acceptance tests to pass.

## QA steps

Run assess_storage.py
