### PR TITLE
Check cloud credential works for a model.

### DIFF
--- a/apiserver/common/credentialcommon/backend.go
+++ b/apiserver/common/credentialcommon/backend.go
@@ -29,9 +29,9 @@ type Machine interface {
 	Id() string
 }
 
-// PersistedCloudEntitiesBackend defines what cloud entities where persisted in state
+// CloudEntitiesBackend defines what cloud entities where persisted in state
 // and will be accessed during the check.
-type PersistedCloudEntitiesBackend interface {
+type CloudEntitiesBackend interface {
 	// AllMachines returns all machines in the model.
 	AllMachines() ([]Machine, error)
 }
@@ -48,10 +48,10 @@ type Model interface {
 	Config() (*config.Config, error)
 }
 
-// PersistedModelBackend defines what model specific properties where persisted in state
+// ModelBackend defines what model specific properties where persisted in state
 // and will be accessed during the check.
-type PersistedModelBackend interface {
-	PersistedCloudEntitiesBackend
+type ModelBackend interface {
+	CloudEntitiesBackend
 
 	// Model returns the model entity.
 	Model() (Model, error)
@@ -64,8 +64,8 @@ type stateShim struct {
 	*state.State
 }
 
-// NewPersistedCloudEntitiesBackend creates a backend to use based on state.State.
-func NewPersistedCloudEntitiesBackend(p *state.State) PersistedCloudEntitiesBackend {
+// NewCloudEntitiesBackend creates a backend to use based on state.State.
+func NewCloudEntitiesBackend(p *state.State) CloudEntitiesBackend {
 	return stateShim{p}
 }
 

--- a/apiserver/common/credentialcommon/backend.go
+++ b/apiserver/common/credentialcommon/backend.go
@@ -1,0 +1,95 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialcommon
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+)
+
+// Machine defines machine methods needed for the check.
+type Machine interface {
+	// IsManual returns true if the machine was manually provisioned.
+	IsManual() (bool, error)
+
+	// IsContainer returns true if the machine is a container.
+	IsContainer() bool
+
+	// InstanceId returns the provider specific instance id for this
+	// machine, or a NotProvisionedError, if not set.
+	InstanceId() (instance.Id, error)
+
+	// Id returns the machine id.
+	Id() string
+}
+
+// PersistedCloudEntitiesBackend defines what cloud entities where persisted in state
+// and will be accessed during the check.
+type PersistedCloudEntitiesBackend interface {
+	// AllMachines returns all machines in the model.
+	AllMachines() ([]Machine, error)
+}
+
+// Model defines model methods needed for the check.
+type Model interface {
+	// Cloud returns the name of the cloud to which the model is deployed.
+	Cloud() string
+
+	// CloudRegion returns the name of the cloud region to which the model is deployed.
+	CloudRegion() string
+
+	// Config returns the config for the model.
+	Config() (*config.Config, error)
+}
+
+// PersistedModelBackend defines what model specific properties where persisted in state
+// and will be accessed during the check.
+type PersistedModelBackend interface {
+	PersistedCloudEntitiesBackend
+
+	// Model returns the model entity.
+	Model() (Model, error)
+
+	// Cloud returns the controller's cloud definition.
+	Cloud(name string) (cloud.Cloud, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+// NewPersistedCloudEntitiesBackend creates a backend to use based on state.State.
+func NewPersistedCloudEntitiesBackend(p *state.State) PersistedCloudEntitiesBackend {
+	return stateShim{p}
+}
+
+// AllMachines implements PersistedBackend.AllMachines.
+func (st stateShim) AllMachines() ([]Machine, error) {
+	machines, err := st.State.AllMachines()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]Machine, len(machines))
+	for i, m := range machines {
+		result[i] = m
+	}
+	return result, nil
+}
+
+// Model implements PersistedBackend.Model.
+func (st stateShim) Model() (Model, error) {
+	m, err := st.State.Model()
+	return m, err
+}
+
+// CloudProvider defines methods needed from the cloud provider to perform the check.
+type CloudProvider interface {
+	// AllInstances returns all instances currently known to the cloud provider.
+	AllInstances(ctx context.ProviderCallContext) ([]instance.Instance, error)
+}

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ValidateModelCredential checks if a cloud credential is valid for a model.
-func ValidateModelCredential(persisted PersistedCloudEntitiesBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+func ValidateModelCredential(persisted CloudEntitiesBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
 	// We only check persisted machines vs known cloud instances.
 	// In the future, this check may be extended to other cloud resources,
 	// entities and operation-level authorisations such as interfaces,
@@ -26,7 +26,7 @@ func ValidateModelCredential(persisted PersistedCloudEntitiesBackend, provider C
 // ValidateNewModelCredential checks if a new cloud credential can be valid
 // for a given model.
 // Note that this call does not validate credential against the cloud of the model.
-func ValidateNewModelCredential(backend PersistedModelBackend, newEnv NewEnvironFunc, callCtx context.ProviderCallContext, credential *cloud.Credential) (params.ErrorResults, error) {
+func ValidateNewModelCredential(backend ModelBackend, newEnv NewEnvironFunc, callCtx context.ProviderCallContext, credential *cloud.Credential) (params.ErrorResults, error) {
 	model, err := backend.Model()
 	if err != nil {
 		return failCredentialValidation(errors.Trace(err))
@@ -59,7 +59,7 @@ func ValidateNewModelCredential(backend PersistedModelBackend, newEnv NewEnviron
 
 // CheckMachineInstances compares model machines from state with
 // the ones reported by the provider using supplied credential.
-func CheckMachineInstances(backend PersistedCloudEntitiesBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+func CheckMachineInstances(backend CloudEntitiesBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
 	// Get machines from state
 	machines, err := backend.AllMachines()
 	if err != nil {

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -1,0 +1,124 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialcommon
+
+import (
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+)
+
+// ValidateModelCredential checks if a cloud credential is valid for a model.
+func ValidateModelCredential(persisted PersistedCloudEntitiesBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+	// We only check persisted machines vs known cloud instances.
+	// In the future, this check may be extended to other cloud resources,
+	// entities and operation-level authorisations such as interfaces,
+	// ability to CRUD storage, etc.
+	return CheckMachineInstances(persisted, provider, callCtx)
+}
+
+// ValidateNewModelCredential checks if a new cloud credential can be valid
+// for a given model.
+// Note that this call does not validate credential against the cloud of the model.
+func ValidateNewModelCredential(backend PersistedModelBackend, newEnv NewEnvironFunc, callCtx context.ProviderCallContext, credential *cloud.Credential) (params.ErrorResults, error) {
+	model, err := backend.Model()
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+
+	modelCloud, err := backend.Cloud(model.Cloud())
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+	tempCloudSpec, err := environs.MakeCloudSpec(modelCloud, model.CloudRegion(), credential)
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+
+	cfg, err := model.Config()
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+	tempOpenParams := environs.OpenParams{
+		Cloud:  tempCloudSpec,
+		Config: cfg,
+	}
+	env, err := newEnv(tempOpenParams)
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+
+	return ValidateModelCredential(backend, env, callCtx)
+}
+
+// CheckMachineInstances compares model machines from state with
+// the ones reported by the provider using supplied credential.
+func CheckMachineInstances(backend PersistedCloudEntitiesBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+	// Get machines from state
+	machines, err := backend.AllMachines()
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+	machinesByInstance := make(map[string]string)
+	for _, machine := range machines {
+		if machine.IsContainer() {
+			// Containers don't correspond to instances at the
+			// provider level.
+			continue
+		}
+		if manual, err := machine.IsManual(); err != nil {
+			return failCredentialValidation(errors.Trace(err))
+		} else if manual {
+			continue
+		}
+		instanceId, err := machine.InstanceId()
+		if err != nil {
+			// TODO (anastasiamac 2018-08-21) do we really want to fail all processing here or just an error result against this machine and keep going?
+			return failCredentialValidation(errors.Annotatef(err, "getting instance id for machine %s", machine.Id()))
+		}
+		machinesByInstance[string(instanceId)] = machine.Id()
+	}
+
+	// Check can see all machines' instances
+	instances, err := provider.AllInstances(callCtx)
+	if err != nil {
+		return failCredentialValidation(errors.Trace(err))
+	}
+
+	var results []params.ErrorResult
+
+	errorResult := func(format string, args ...interface{}) params.ErrorResult {
+		return params.ErrorResult{Error: common.ServerError(errors.Errorf(format, args...))}
+	}
+
+	instanceIds := set.NewStrings()
+	for _, instance := range instances {
+		id := string(instance.Id())
+		instanceIds.Add(id)
+		if _, found := machinesByInstance[id]; !found {
+			results = append(results, errorResult("no machine with instance %q", id))
+		}
+	}
+
+	for instanceId, name := range machinesByInstance {
+		if !instanceIds.Contains(instanceId) {
+			results = append(results, errorResult(
+				"couldn't find instance %q for machine %s", instanceId, name))
+		}
+	}
+
+	return params.ErrorResults{Results: results}, nil
+}
+
+func failCredentialValidation(original error) (params.ErrorResults, error) {
+	return params.ErrorResults{}, original
+}
+
+// NewEnvironFunc defines function that obtains new Environ.
+type NewEnvironFunc func(args environs.OpenParams) (environs.Environ, error)

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -1,0 +1,348 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credentialcommon_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common/credentialcommon"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/instance"
+)
+
+type ModelCredentialSuite struct {
+	testing.IsolationSuite
+
+	provider           *mockProvider
+	instance           *mockInstance
+	callContext        context.ProviderCallContext
+	testNewEnvironFunc credentialcommon.NewEnvironFunc
+
+	backend *mockBackend
+	machine *mockMachine
+}
+
+var _ = gc.Suite(&ModelCredentialSuite{})
+
+func (s *ModelCredentialSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	// This is what the test gets from the state.
+	s.machine = createTestMachine("1", "wind-up")
+	s.backend = &mockBackend{
+		Stub: &testing.Stub{},
+		allMachinesFunc: func() ([]credentialcommon.Machine, error) {
+			return []credentialcommon.Machine{s.machine}, nil
+		},
+	}
+
+	// This is what the test gets from the cloud.
+	s.instance = &mockInstance{id: "wind-up"}
+	s.provider = &mockProvider{
+		Stub: &testing.Stub{},
+		allInstancesFunc: func(ctx context.ProviderCallContext) ([]instance.Instance, error) {
+			return []instance.Instance{s.instance}, nil
+		},
+	}
+
+	s.testNewEnvironFunc = func(args environs.OpenParams) (environs.Environ, error) {
+		return &mockEnviron{mockProvider: s.provider}, nil
+	}
+	s.callContext = context.NewCloudCallContext()
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesSuccess(c *gc.C) {
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
+	machine1 := createTestMachine("2", "birds")
+	s.backend.allMachinesFunc = func() ([]credentialcommon.Machine, error) {
+		return []credentialcommon.Machine{s.machine, machine1}, nil
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `couldn't find instance "birds" for machine 2`)
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesExtraInstances(c *gc.C) {
+	instance2 := &mockInstance{id: "analyse"}
+	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instance.Instance, error) {
+		return []instance.Instance{s.instance, instance2}, nil
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `no machine with instance "analyse"`)
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesErrorGettingMachines(c *gc.C) {
+	s.backend.allMachinesFunc = func() ([]credentialcommon.Machine, error) {
+		return nil, errors.New("boom")
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesErrorGettingInstances(c *gc.C) {
+	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instance.Instance, error) {
+		return nil, errors.New("kaboom")
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, gc.ErrorMatches, "kaboom")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
+	machine1 := createTestMachine("1", "")
+	machine1.container = true
+	s.backend.allMachinesFunc = func() ([]credentialcommon.Machine, error) {
+		return []credentialcommon.Machine{s.machine, machine1}, nil
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesHandlesManual(c *gc.C) {
+	machine1 := createTestMachine("2", "")
+	machine1.manualFunc = func() (bool, error) { return false, errors.New("manual retrieval failure") }
+	s.backend.allMachinesFunc = func() ([]credentialcommon.Machine, error) {
+		return []credentialcommon.Machine{s.machine, machine1}, nil
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+
+	machine1.manualFunc = func() (bool, error) { return true, nil }
+	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *gc.C) {
+	machine1 := createTestMachine("2", "")
+	machine1.instanceIdFunc = func() (instance.Id, error) { return "", errors.New("retrieval failure") }
+	s.backend.allMachinesFunc = func() ([]credentialcommon.Machine, error) {
+		return []credentialcommon.Machine{s.machine, machine1}, nil
+	}
+
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, gc.ErrorMatches, "getting instance id for machine 2: retrieval failure")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestValidateModelCredential(c *gc.C) {
+	results, err := credentialcommon.ValidateModelCredential(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestValidateNewModelCredentialErrorGettingModel(c *gc.C) {
+	s.backend.SetErrors(errors.New("get model error"))
+	results, err := credentialcommon.ValidateNewModelCredential(s.createModelBackend(c), s.testNewEnvironFunc, s.callContext, nil)
+	c.Assert(err, gc.ErrorMatches, "get model error")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestValidateNewModelCredentialErrorGettingCloud(c *gc.C) {
+	s.backend.SetErrors(
+		nil, // getting model
+		errors.New("get cloud error"),
+	)
+	results, err := credentialcommon.ValidateNewModelCredential(s.createModelBackend(c), s.testNewEnvironFunc, s.callContext, nil)
+	c.Assert(err, gc.ErrorMatches, "get cloud error")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestValidateNewModelCredentialErrorGettingModelConfig(c *gc.C) {
+	model := createTestModel()
+	model.configFunc = func() (*config.Config, error) {
+		return nil, errors.New("get model config error")
+	}
+
+	backend := s.createModelBackend(c)
+	backend.modelFunc = func() (credentialcommon.Model, error) {
+		return model, nil
+	}
+
+	results, err := credentialcommon.ValidateNewModelCredential(backend, s.testNewEnvironFunc, s.callContext, nil)
+	c.Assert(err, gc.ErrorMatches, "get model config error")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestValidateNewModelCredentialErrorOpenEnviron(c *gc.C) {
+	failNewEnvironFunc := func(args environs.OpenParams) (environs.Environ, error) {
+		return nil, errors.New("new environ error")
+	}
+	results, err := credentialcommon.ValidateNewModelCredential(s.createModelBackend(c), failNewEnvironFunc, s.callContext, nil)
+	c.Assert(err, gc.ErrorMatches, "new environ error")
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) TestValidateNewModelCredentialSuccess(c *gc.C) {
+	results, err := credentialcommon.ValidateNewModelCredential(s.createModelBackend(c), s.testNewEnvironFunc, s.callContext, &testCredential)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ModelCredentialSuite) createModelBackend(c *gc.C) *mockModelBackend {
+	return &mockModelBackend{
+		mockBackend: s.backend,
+		modelFunc: func() (credentialcommon.Model, error) {
+			return createTestModel(), s.backend.NextErr()
+		},
+		cloudFunc: func(name string) (cloud.Cloud, error) {
+			return cloud.Cloud{
+				Name:      "nuage",
+				Type:      "dummy",
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+				Regions:   []cloud.Region{{Name: "nine", Endpoint: "endpoint"}},
+			}, s.backend.NextErr()
+		},
+	}
+}
+
+type mockBackend struct {
+	*testing.Stub
+	allMachinesFunc func() ([]credentialcommon.Machine, error)
+}
+
+func (m *mockBackend) AllMachines() ([]credentialcommon.Machine, error) {
+	m.MethodCall(m, "AllMachines")
+	return m.allMachinesFunc()
+}
+
+type mockProvider struct {
+	*testing.Stub
+	allInstancesFunc func(ctx context.ProviderCallContext) ([]instance.Instance, error)
+}
+
+func (m *mockProvider) AllInstances(ctx context.ProviderCallContext) ([]instance.Instance, error) {
+	m.MethodCall(m, "AllInstances", ctx)
+	return m.allInstancesFunc(ctx)
+}
+
+type mockInstance struct {
+	instance.Instance
+	id string
+}
+
+func (i *mockInstance) Id() instance.Id {
+	return instance.Id(i.id)
+}
+
+type mockMachine struct {
+	id             string
+	container      bool
+	manualFunc     func() (bool, error)
+	instanceIdFunc func() (instance.Id, error)
+}
+
+func (m *mockMachine) IsManual() (bool, error) {
+	return m.manualFunc()
+}
+
+func (m *mockMachine) IsContainer() bool {
+	return m.container
+}
+
+func (m *mockMachine) InstanceId() (instance.Id, error) {
+	return m.instanceIdFunc()
+}
+
+func (m *mockMachine) Id() string {
+	return m.id
+}
+
+func createTestMachine(id, instanceId string) *mockMachine {
+	return &mockMachine{
+		id:             id,
+		manualFunc:     func() (bool, error) { return false, nil },
+		instanceIdFunc: func() (instance.Id, error) { return instance.Id(instanceId), nil },
+	}
+}
+
+type mockModelBackend struct {
+	*mockBackend
+
+	modelFunc func() (credentialcommon.Model, error)
+	cloudFunc func(name string) (cloud.Cloud, error)
+}
+
+func (m *mockModelBackend) Model() (credentialcommon.Model, error) {
+	m.MethodCall(m, "Model")
+	return m.modelFunc()
+}
+
+func (m *mockModelBackend) Cloud(name string) (cloud.Cloud, error) {
+	m.MethodCall(m, "Cloud", name)
+	return m.cloudFunc(name)
+}
+
+type mockModel struct {
+	cloudFunc       func() string
+	cloudRegionFunc func() string
+	configFunc      func() (*config.Config, error)
+}
+
+func (m *mockModel) Cloud() string {
+	return m.cloudFunc()
+}
+
+func (m *mockModel) CloudRegion() string {
+	return m.cloudRegionFunc()
+}
+
+func (m *mockModel) Config() (*config.Config, error) {
+	return m.configFunc()
+}
+
+func createTestModel() *mockModel {
+	return &mockModel{
+		cloudFunc:       func() string { return "nuage" },
+		cloudRegionFunc: func() string { return "nine" },
+		configFunc: func() (*config.Config, error) {
+			return nil, nil
+		},
+	}
+}
+
+var (
+	testCredential = cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"username": "user",
+			"password": "password",
+		},
+	)
+)
+
+type mockEnviron struct {
+	environs.Environ
+	*mockProvider
+}
+
+func (m *mockEnviron) AllInstances(ctx context.ProviderCallContext) ([]instance.Instance, error) {
+	return m.mockProvider.AllInstances(ctx)
+}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -255,7 +255,7 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 	}
 
 	return credentialcommon.ValidateModelCredential(
-		credentialcommon.NewPersistedCloudEntitiesBackend(st.State),
+		credentialcommon.NewCloudEntitiesBackend(st.State),
 		env,
 		api.callContext,
 	)


### PR DESCRIPTION
## Description of change

We need to be able to determine if a cloud credential is valid for a model. At this stage, this means "the cloud instances that this credential lists are the same that this model has as machine instances".

This check can be performed using the credential that a model already references. This section of PR is re-factored from migrationtarget facade. We re-factor it to be used both from migrationtarget as well as the update-credential-content functional path.
This check can also be performed using a credential that is not yet referenced by the model. This is the new logical path that this PR introduces. This will be used when we want to replace model credential, i.e. allow models to set a new credential.


