### PR TITLE
Bring in newer juju/os.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -529,14 +529,14 @@
   revision = "5b81707e882b8293e6cf77854b4cd49f29776e11"
 
 [[projects]]
-  digest = "1:e4e4534b39a567c609e143b6720487bd5f671875c35ffb9d1a46d0ca364d645b"
+  digest = "1:fba7e98f7a8ac8d332b2d74b782be1fcb14593b298ffe5f16cc8aea6ef9fc243"
   name = "github.com/juju/os"
   packages = [
     ".",
     "series",
   ]
   pruneopts = ""
-  revision = "325989f58c78b64db349b60742495b48e5468ec1"
+  revision = "6ce4bcbabcd28979bffb62d0e11bf17aab9bcfb4"
 
 [[projects]]
   digest = "1:8fd6c21ba9a864b949672e63800d1bd71a3d8ac8e085cc22143b97f1261ad634"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,7 +89,7 @@
   name = "github.com/juju/naturalsort"
 
 [[constraint]]
-  revision = "325989f58c78b64db349b60742495b48e5468ec1"
+  revision = "6ce4bcbabcd28979bffb62d0e11bf17aab9bcfb4"
   name = "github.com/juju/os"
 
 [[constraint]]


### PR DESCRIPTION
A forward-port of https://github.com/juju/juju/pull/9095.

However, since we have moved from godeps to dep in between these branch, this will need a review.
