### PR TITLE
Error on upgrade from older series.

### DIFF
--- a/apiserver/facades/client/machinemanager/export_test.go
+++ b/apiserver/facades/client/machinemanager/export_test.go
@@ -4,3 +4,4 @@
 package machinemanager
 
 var InstanceTypes = instanceTypes
+var IsSeriesLessThan = isSeriesLessThan

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -495,15 +495,11 @@ func (mm *MachineManagerAPI) validateSeries(argumentSeries, currentSeries string
 	return nil
 }
 
-// IsSeriesLessThan returns a bool indicating whether the first argument's
+// isSeriesLessThan returns a bool indicating whether the first argument's
 // version is lexicographically less than the second argument's, thus indicating
 // that the series represents an older version of the operating system. The
 // output is only valid for Ubuntu series.
 func isSeriesLessThan(series1, series2 string) (bool, error) {
-	return seriesLessThan(series1, series2)
-}
-
-func seriesLessThan(series1, series2 string) (bool, error) {
 	version1, err := series.SeriesVersion(series1)
 	if err != nil {
 		return false, err

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -495,7 +495,7 @@ func (mm *MachineManagerAPI) validateSeries(argumentSeries, currentSeries string
 	return nil
 }
 
-// Is series less than return a bool indicating whether the first argument's
+// IsSeriesLessThan returns a bool indicating whether the first argument's
 // version is lexicographically less than the second argument's, thus indicating
 // that the series represents an older version of the operating system. The
 // output is only valid for Ubuntu series.

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/os/series"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -71,6 +72,7 @@ func NewFacadeV4(ctx facade.Context) (*MachineManagerAPIV4, error) {
 	return &MachineManagerAPIV4{machineManagerAPIV5}, nil
 }
 
+// NewFacadeV5 creates a new server-side MachineManager API facade.
 func NewFacadeV5(ctx facade.Context) (*MachineManagerAPIV5, error) {
 	machineManagerAPI, err := NewFacade(ctx)
 	if err != nil {
@@ -358,11 +360,16 @@ func (mm *MachineManagerAPI) updateSeriesPrepare(arg params.UpdateSeriesArg) err
 	if err != nil {
 		return errors.Trace(err)
 	}
-
 	if arg.Series == machine.Series() {
 		return errors.Errorf("%s is already running series %s", machineTag, arg.Series)
 	}
-
+	isOlderSeries, err := isSeriesLessThan(arg.Series, machine.Series())
+	if err != nil {
+		return err
+	}
+	if isOlderSeries {
+		return errors.Errorf("machine %s is running %s which is a newer series than %s", machineTag, machine.Series(), arg.Series)
+	}
 	principals := machine.Principals()
 	units, err := machine.VerifyUnitsSeries(principals, arg.Series, arg.Force)
 	if err != nil {
@@ -477,4 +484,24 @@ func (mm *MachineManagerAPI) removeUpgradeSeriesLock(arg params.UpdateSeriesArg)
 		return errors.Trace(err)
 	}
 	return machine.RemoveUpgradeSeriesLock()
+}
+
+// Is series less than return a bool indicating whether the first argument's
+// version is lexicographically less than the second argument's, thus indicating
+// that the series represents an older version of the operating system. The
+// output is only valid for Ubuntu series.
+func isSeriesLessThan(series1, series2 string) (bool, error) {
+	return seriesLessThan(series1, series2)
+}
+
+func seriesLessThan(series1, series2 string) (bool, error) {
+	version1, err := series.SeriesVersion(series1)
+	if err != nil {
+		return false, err
+	}
+	version2, err := series.SeriesVersion(series2)
+	if err != nil {
+		return false, err
+	}
+	return version2 > version1, nil
 }

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -489,7 +489,7 @@ func (mm *MachineManagerAPI) validateSeries(argumentSeries, currentSeries string
 		return err
 	}
 	if isOlderSeries {
-		return errors.Errorf("machine %s is running %s which is a newer series than %s", machineTag, currentSeries, argumentSeries)
+		return errors.Errorf("machine %s is running %s which is a newer series than %s.", machineTag, currentSeries, argumentSeries)
 	}
 
 	return nil

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -465,7 +465,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareOlderSeriesShouldError(c *
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.ErrorMatches, "machine machine-1 is running trusty which is a newer series than precise")
+	c.Assert(result.Error, gc.ErrorMatches, "machine machine-1 is running trusty which is a newer series than precise.")
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareRemoveLockAfterFail(c *gc.C) {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -4,7 +4,10 @@
 package machinemanager_test
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
+	"github.com/juju/os/series"
 	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -450,6 +453,21 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	})
 }
 
+func (s *MachineManagerSuite) TestUpgradeSeriesPrepareOlderSeriesShouldError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	machineTag := names.NewMachineTag("1")
+	result, err := apiV5.UpgradeSeriesPrepare(
+		params.UpdateSeriesArg{
+			Entity: params.Entity{
+				Tag: machineTag.String()},
+			Series: "precise",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.ErrorMatches, "machine machine-1 is running trusty which is a newer series than precise")
+}
+
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareRemoveLockAfterFail(c *gc.C) {
 	// TODO managed upgrade series
 }
@@ -463,6 +481,44 @@ func (s *MachineManagerSuite) TestUpgradeSeriesComplete(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestIsSeriesLessThan tests a validation method which is not very complicated
+// but complex enough to warrant being exported from an export test package for
+// testing.
+func (s *MachineManagerSuite) TestIsSeriesLessThan(c *gc.C) {
+	ss := series.SupportedSeries()
+
+	// get the series versions
+	vs := make([]string, 0, len(ss))
+	for _, ser := range ss {
+		ver, err := series.SeriesVersion(ser)
+		c.Assert(err, jc.ErrorIsNil)
+		vs = append(vs, ver)
+	}
+
+	// sort the values, so the lexicographical order is determined
+	sort.Strings(vs)
+
+	// check that the IsSeriesLessThan works for all supported series
+	for i := range vs {
+
+		// We need both the series and the next series in the list. So
+		// we provide a check here to prevent going out of bounds.
+		if i+1 > len(vs)-1 {
+			break
+		}
+
+		// get the series for the specified version
+		s1, err := series.VersionSeries(vs[i])
+		c.Assert(err, jc.ErrorIsNil)
+		s2, err := series.VersionSeries(vs[i+1])
+		c.Assert(err, jc.ErrorIsNil)
+
+		isLessThan, err := machinemanager.IsSeriesLessThan(s1, s2)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(isLessThan, jc.IsTrue)
+	}
 }
 
 type mockState struct {


### PR DESCRIPTION
When running `juju upgrade-series prepare` a user should NOT be able to upgrade from a newer version to an older version.