### PR TITLE
Better recovery from multi-controller cmr errors

### DIFF
--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -69,7 +69,11 @@ func (w *relationUnitsWorker) Kill() {
 
 // Wait is defined on worker.Worker
 func (w *relationUnitsWorker) Wait() error {
-	return w.catacomb.Wait()
+	err := w.catacomb.Wait()
+	if err != nil {
+		logger.Errorf("error in relation units worker for %v: %v", w.relationTag.Id(), err)
+	}
+	return err
 }
 
 func (w *relationUnitsWorker) loop() error {

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -507,14 +507,21 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 	c.Assert(s.stub.Calls(), gc.HasLen, 0)
 	s.config.Clock.(*testing.Clock).WaitAdvance(10*time.Second, coretesting.LongWait, 1)
 
-	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
-	relWatcher.changes <- []string{"db2:db django:db"}
-	relTag := names.NewRelationTag("db2:db django:db")
 	mac, err := macaroon.New(nil, "test", "")
 	c.Assert(err, jc.ErrorIsNil)
 	expected = []jujutesting.StubCall{
+		{"WatchRemoteApplicationRelations", []interface{}{"db2"}},
 		{"ControllerAPIInfoForModel", []interface{}{"remote-model-uuid"}},
 		{"WatchOfferStatus", []interface{}{"offer-db2-uuid", macaroon.Slice{mac}}},
+	}
+	// After the worker resumes, normal processing happens.
+	s.waitForWorkerStubCalls(c, expected)
+
+	s.stub.ResetCalls()
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
+	relTag := names.NewRelationTag("db2:db django:db")
+	expected = []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 		{"ExportEntities", []interface{}{
 			[]names.Tag{names.NewApplicationTag("django"), relTag}}},
@@ -537,7 +544,6 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 		{"WatchRelationUnits", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 	}
-	// After the worker resumes, normal processing happens.
 	s.waitForWorkerStubCalls(c, expected)
 }
 


### PR DESCRIPTION
## Description of change

If a cross model relation is created between controllers and the offering controller is offline, the consumer can't create the relation which is expected. But when the offering controller comes back online, the processing doesn't resume. This is because a key watcher is not restarted.
This PR moves the watcher creation to the worker which uses it which fixes the issue.

Also add some logging so that child worker errors are exposed.

## QA steps

Create an offer and firewall off the controller
bootstrap another controller and relate to the offer
restore connectivity and the relation should be created

## Bug reference

https://bugs.launchpad.net/juju/2.3/+bug/1788554
