### PR TITLE
Upgrade Series Refactoring for Consistency

### DIFF
--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -49,14 +49,14 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications() (watcher.NotifyWatc
 	return w, nil
 }
 
-// UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
-func (u *UpgradeSeriesAPI) UpgradeSeriesStatus() ([]model.UpgradeSeriesStatus, error) {
+// UnitStatus returns the upgrade series status of a unit from remote state.
+func (u *UpgradeSeriesAPI) UnitStatus() ([]model.UpgradeSeriesStatus, error) {
 	var results params.UpgradeSeriesStatusResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
 
-	err := u.facade.FacadeCall("GetUpgradeSeriesStatus", args, &results)
+	err := u.facade.FacadeCall("UnitStatus", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +78,8 @@ func (u *UpgradeSeriesAPI) UpgradeSeriesStatus() ([]model.UpgradeSeriesStatus, e
 	return statuses, nil
 }
 
-// SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
-func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
+// SetUnitStatus sets the upgrade series status of the unit in the remote state.
+func (u *UpgradeSeriesAPI) SetUnitStatus(status model.UpgradeSeriesStatus) error {
 	var results params.ErrorResults
 	args := params.UpgradeSeriesStatusParams{
 		Params: []params.UpgradeSeriesStatusParam{{
@@ -87,7 +87,7 @@ func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(status model.UpgradeSeriesStat
 			Status: status,
 		}},
 	}
-	err := u.facade.FacadeCall("SetUpgradeSeriesStatus", args, &results)
+	err := u.facade.FacadeCall("SetUnitStatus", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -49,14 +49,15 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications() (watcher.NotifyWatc
 	return w, nil
 }
 
-// UnitStatus returns the upgrade series status of a unit from remote state.
-func (u *UpgradeSeriesAPI) UnitStatus() ([]model.UpgradeSeriesStatus, error) {
+// UpgradeSeriesUnitStatus returns the upgrade series status of a
+// unit from remote state.
+func (u *UpgradeSeriesAPI) UpgradeSeriesUnitStatus() ([]model.UpgradeSeriesStatus, error) {
 	var results params.UpgradeSeriesStatusResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
 
-	err := u.facade.FacadeCall("UnitStatus", args, &results)
+	err := u.facade.FacadeCall("UpgradeSeriesUnitStatus", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +79,9 @@ func (u *UpgradeSeriesAPI) UnitStatus() ([]model.UpgradeSeriesStatus, error) {
 	return statuses, nil
 }
 
-// SetUnitStatus sets the upgrade series status of the unit in the remote state.
-func (u *UpgradeSeriesAPI) SetUnitStatus(status model.UpgradeSeriesStatus) error {
+// SetUpgradeSeriesUnitStatus sets the upgrade series status of the
+// unit in the remote state.
+func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(status model.UpgradeSeriesStatus) error {
 	var results params.ErrorResults
 	args := params.UpgradeSeriesStatusParams{
 		Params: []params.UpgradeSeriesStatusParam{{
@@ -87,7 +89,7 @@ func (u *UpgradeSeriesAPI) SetUnitStatus(status model.UpgradeSeriesStatus) error
 			Status: status,
 		}},
 	}
-	err := u.facade.FacadeCall("SetUnitStatus", args, &results)
+	err := u.facade.FacadeCall("SetUpgradeSeriesUnitStatus", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -49,7 +50,7 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications() (watcher.NotifyWatc
 }
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
-func (u *UpgradeSeriesAPI) UpgradeSeriesStatus() ([]string, error) {
+func (u *UpgradeSeriesAPI) UpgradeSeriesStatus() ([]model.UpgradeSeriesStatus, error) {
 	var results params.UpgradeSeriesStatusResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
@@ -60,7 +61,7 @@ func (u *UpgradeSeriesAPI) UpgradeSeriesStatus() ([]string, error) {
 		return nil, err
 	}
 
-	statuses := make([]string, len(results.Results))
+	statuses := make([]model.UpgradeSeriesStatus, len(results.Results))
 	for i, res := range results.Results {
 		if res.Error != nil {
 			// TODO (externalreality) The code to convert api errors (with
@@ -74,17 +75,14 @@ func (u *UpgradeSeriesAPI) UpgradeSeriesStatus() ([]string, error) {
 		}
 		statuses[i] = res.Status
 	}
-	// TODO (manadart 2018-08-02) Should we be converting these back to
-	// model.UnitSeriesUpgradeStatus and reporting an error if that fails?
-	// (externalreality): validation does take place a few levels down.
 	return statuses, nil
 }
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
-func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(status string) error {
+func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
 	var results params.ErrorResults
-	args := params.SetUpgradeSeriesStatusParams{
-		Params: []params.SetUpgradeSeriesStatusParam{{
+	args := params.UpgradeSeriesStatusParams{
+		Params: []params.UpgradeSeriesStatusParam{{
 			Entity: params.Entity{Tag: u.tag.String()},
 			Status: status,
 		}},

--- a/api/common/upgradeseries_test.go
+++ b/api/common/upgradeseries_test.go
@@ -65,7 +65,7 @@ func (s *upgradeSeriesSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusPrepare(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "GetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "UnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -75,7 +75,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusPrepare(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UpgradeSeriesStatus()
+	watchResult, err := api.UnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []model.UpgradeSeriesStatus{model.UpgradeSeriesCompleted}
@@ -85,7 +85,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusPrepare(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "GetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "UnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -95,7 +95,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UpgradeSeriesStatus()
+	watchResult, err := api.UnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []model.UpgradeSeriesStatus{model.UpgradeSeriesCompleted}
@@ -105,7 +105,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "GetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "UnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -120,7 +120,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UpgradeSeriesStatus()
+	watchResult, err := api.UnitStatus()
 	c.Assert(err, gc.ErrorMatches, "testing")
 	c.Check(errors.IsNotFound(err), jc.IsTrue)
 	c.Check(watchResult, gc.HasLen, 0)
@@ -129,7 +129,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "GetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "UnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -142,7 +142,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UpgradeSeriesStatus()
+	watchResult, err := api.UnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []model.UpgradeSeriesStatus{model.UpgradeSeriesPrepareStarted, model.UpgradeSeriesPrepareCompleted}
@@ -152,7 +152,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "SetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "SetUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.UpgradeSeriesStatusParams{
 			Params: []params.UpgradeSeriesStatusParam{{
 				Entity: params.Entity{Tag: s.tag.String()},
@@ -167,14 +167,14 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUpgradeSeriesStatus(model.UpgradeSeriesError)
+	err := api.SetUnitStatus(model.UpgradeSeriesError)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusNotOne(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "SetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "SetUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.UpgradeSeriesStatusParams{
 			Params: []params.UpgradeSeriesStatusParam{{
 				Entity: params.Entity{Tag: s.tag.String()},
@@ -187,14 +187,14 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusNotOne(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUpgradeSeriesStatus(model.UpgradeSeriesError)
+	err := api.SetUnitStatus(model.UpgradeSeriesError)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
 
 func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusResultError(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "SetUpgradeSeriesStatus")
+		c.Assert(name, gc.Equals, "SetUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.UpgradeSeriesStatusParams{
 			Params: []params.UpgradeSeriesStatusParam{{
 				Entity: params.Entity{Tag: s.tag.String()},
@@ -209,6 +209,6 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusResultError(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUpgradeSeriesStatus(model.UpgradeSeriesError)
+	err := api.SetUnitStatus(model.UpgradeSeriesError)
 	c.Assert(err, gc.ErrorMatches, "error in call")
 }

--- a/api/common/upgradeseries_test.go
+++ b/api/common/upgradeseries_test.go
@@ -65,7 +65,7 @@ func (s *upgradeSeriesSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusPrepare(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "UnitStatus")
+		c.Assert(name, gc.Equals, "UpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -75,7 +75,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusPrepare(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UnitStatus()
+	watchResult, err := api.UpgradeSeriesUnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []model.UpgradeSeriesStatus{model.UpgradeSeriesCompleted}
@@ -85,7 +85,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusPrepare(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "UnitStatus")
+		c.Assert(name, gc.Equals, "UpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -95,7 +95,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UnitStatus()
+	watchResult, err := api.UpgradeSeriesUnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []model.UpgradeSeriesStatus{model.UpgradeSeriesCompleted}
@@ -105,7 +105,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "UnitStatus")
+		c.Assert(name, gc.Equals, "UpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -120,7 +120,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UnitStatus()
+	watchResult, err := api.UpgradeSeriesUnitStatus()
 	c.Assert(err, gc.ErrorMatches, "testing")
 	c.Check(errors.IsNotFound(err), jc.IsTrue)
 	c.Check(watchResult, gc.HasLen, 0)
@@ -129,7 +129,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "UnitStatus")
+		c.Assert(name, gc.Equals, "UpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
 			{Tag: s.tag.String()},
 		}})
@@ -142,7 +142,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	watchResult, err := api.UnitStatus()
+	watchResult, err := api.UpgradeSeriesUnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []model.UpgradeSeriesStatus{model.UpgradeSeriesPrepareStarted, model.UpgradeSeriesPrepareCompleted}
@@ -152,7 +152,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "SetUnitStatus")
+		c.Assert(name, gc.Equals, "SetUpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.UpgradeSeriesStatusParams{
 			Params: []params.UpgradeSeriesStatusParam{{
 				Entity: params.Entity{Tag: s.tag.String()},
@@ -167,14 +167,14 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUnitStatus(model.UpgradeSeriesError)
+	err := api.SetUpgradeSeriesUnitStatus(model.UpgradeSeriesError)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusNotOne(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "SetUnitStatus")
+		c.Assert(name, gc.Equals, "SetUpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.UpgradeSeriesStatusParams{
 			Params: []params.UpgradeSeriesStatusParam{{
 				Entity: params.Entity{Tag: s.tag.String()},
@@ -187,14 +187,14 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusNotOne(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUnitStatus(model.UpgradeSeriesError)
+	err := api.SetUpgradeSeriesUnitStatus(model.UpgradeSeriesError)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
 
 func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusResultError(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "SetUnitStatus")
+		c.Assert(name, gc.Equals, "SetUpgradeSeriesUnitStatus")
 		c.Assert(args, jc.DeepEquals, params.UpgradeSeriesStatusParams{
 			Params: []params.UpgradeSeriesStatusParam{{
 				Entity: params.Entity{Tag: s.tag.String()},
@@ -209,6 +209,6 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusResultError(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUnitStatus(model.UpgradeSeriesError)
+	err := api.SetUpgradeSeriesUnitStatus(model.UpgradeSeriesError)
 	c.Assert(err, gc.ErrorMatches, "error in call")
 }

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -651,7 +651,7 @@ func (u *Unit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) 
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
 func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	res, err := u.st.UnitStatus()
+	res, err := u.st.UpgradeSeriesUnitStatus()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -663,7 +663,7 @@ func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
 func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
-	return u.st.SetUnitStatus(status)
+	return u.st.SetUpgradeSeriesUnitStatus(status)
 }
 
 // RequestReboot sets the reboot flag for its machine agent

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -649,7 +650,7 @@ func (u *Unit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) 
 }
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
-func (u *Unit) UpgradeSeriesStatus() (string, error) {
+func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	res, err := u.st.UpgradeSeriesStatus()
 	if err != nil {
 		return "", errors.Trace(err)
@@ -661,7 +662,7 @@ func (u *Unit) UpgradeSeriesStatus() (string, error) {
 }
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
-func (u *Unit) SetUpgradeSeriesStatus(status string) error {
+func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
 	return u.st.SetUpgradeSeriesStatus(status)
 }
 

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -649,7 +649,7 @@ func (u *Unit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) 
 	return u.st.WatchUpgradeSeriesNotifications()
 }
 
-// UnitStatus returns the upgrade series status of a unit from remote state
+// UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
 func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	res, err := u.st.UnitStatus()
 	if err != nil {
@@ -661,7 +661,7 @@ func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	return res[0], nil
 }
 
-// SetUnitStatus sets the upgrade series status of the unit in the remote state
+// SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
 func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
 	return u.st.SetUnitStatus(status)
 }

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -649,9 +649,9 @@ func (u *Unit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) 
 	return u.st.WatchUpgradeSeriesNotifications()
 }
 
-// UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
+// UnitStatus returns the upgrade series status of a unit from remote state
 func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	res, err := u.st.UpgradeSeriesStatus()
+	res, err := u.st.UnitStatus()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -661,9 +661,9 @@ func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	return res[0], nil
 }
 
-// SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
+// SetUnitStatus sets the upgrade series status of the unit in the remote state
 func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
-	return u.st.SetUpgradeSeriesStatus(status)
+	return u.st.SetUnitStatus(status)
 }
 
 // RequestReboot sets the reboot flag for its machine agent

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -716,18 +716,18 @@ func (s *unitSuite) TestUpgradeSeriesStatusIsInitializedToUnitStarted(c *gc.C) {
 	// assigned units.
 	status, err := s.apiUnit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, string(model.UpgradeSeriesPrepareStarted))
+	c.Assert(status, gc.Equals, model.UpgradeSeriesPrepareStarted)
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusFailsIfNoLockExists(c *gc.C) {
-	arbitraryStatus := string(model.UpgradeSeriesNotStarted)
+	arbitraryStatus := model.UpgradeSeriesNotStarted
 
 	err := s.apiUnit.SetUpgradeSeriesStatus(arbitraryStatus)
 	c.Assert(err, gc.ErrorMatches, "machine \"[0-9]*\" is not locked for upgrade")
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {
-	arbitraryNonDefaultStatus := string(model.UpgradeSeriesNotStarted)
+	arbitraryNonDefaultStatus := model.UpgradeSeriesNotStarted
 
 	// First we create the prepare lock or the required state will not exists
 	s.CreateUpgradeSeriesLock(c)
@@ -984,24 +984,23 @@ func (s *unitSuite) TestUpgradeSeriesStatusMultipleReturnsError(c *gc.C) {
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		*(response.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
 			Results: []params.UpgradeSeriesStatusResult{
-				{Status: "Started"},
-				{Status: "UpgradeSeriesCompleted"},
+				{Status: "prepare started"},
+				{Status: "completed"},
 			},
 		}
 		return nil
 	}
 	uniter.PatchUnitUpgradeSeriesFacade(s.apiUnit, &facadeCaller)
 
-	sts, err := s.apiUnit.UpgradeSeriesStatus()
+	_, err := s.apiUnit.UpgradeSeriesStatus()
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
-	c.Check(sts, gc.Equals, "")
 }
 
 func (s *unitSuite) TestUpgradeSeriesStatusSingleResult(c *gc.C) {
 	facadeCaller := testing.StubFacadeCaller{Stub: &coretesting.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		*(response.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
-			Results: []params.UpgradeSeriesStatusResult{{Status: "UpgradeSeriesCompleted"}},
+			Results: []params.UpgradeSeriesStatusResult{{Status: "completed"}},
 		}
 		return nil
 	}
@@ -1009,7 +1008,7 @@ func (s *unitSuite) TestUpgradeSeriesStatusSingleResult(c *gc.C) {
 
 	sts, err := s.apiUnit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(sts, gc.Equals, "UpgradeSeriesCompleted")
+	c.Check(sts, gc.Equals, model.UpgradeSeriesCompleted)
 }
 
 type unitMetricBatchesSuite struct {

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -716,23 +716,23 @@ func (s *unitSuite) TestUpgradeSeriesStatusIsInitializedToUnitStarted(c *gc.C) {
 	// assigned units.
 	status, err := s.apiUnit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, string(model.PrepareStarted))
+	c.Assert(status, gc.Equals, string(model.UpgradeSeriesPrepareStarted))
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusFailsIfNoLockExists(c *gc.C) {
-	arbitraryStatus := string(model.NotStarted)
+	arbitraryStatus := string(model.UpgradeSeriesNotStarted)
 
 	err := s.apiUnit.SetUpgradeSeriesStatus(arbitraryStatus)
 	c.Assert(err, gc.ErrorMatches, "machine \"[0-9]*\" is not locked for upgrade")
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {
-	arbitraryNonDefaultStatus := string(model.NotStarted)
+	arbitraryNonDefaultStatus := string(model.UpgradeSeriesNotStarted)
 
 	// First we create the prepare lock or the required state will not exists
 	s.CreateUpgradeSeriesLock(c)
 
-	// Change the state to something other than the default remote state of PrepareStarted
+	// Change the state to something other than the default remote state of UpgradeSeriesPrepareStarted
 	err := s.apiUnit.SetUpgradeSeriesStatus(arbitraryNonDefaultStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -754,13 +754,13 @@ func (s *unitSuite) TestSetUpgradeSeriesStatusShouldOnlySetSpecifiedUnit(c *gc.C
 	s.CreateUpgradeSeriesLock(c, unit2.Name())
 
 	// Complete one unit
-	err = unit2.SetUpgradeSeriesStatus(model.PrepareCompleted)
+	err = unit2.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The other unit should still be in the started state
 	status, err := s.wordpressUnit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, model.PrepareStarted)
+	c.Assert(status, gc.Equals, model.UpgradeSeriesPrepareStarted)
 }
 
 func (s *unitSuite) CreateUpgradeSeriesLock(c *gc.C, additionalUnits ...string) {
@@ -985,7 +985,7 @@ func (s *unitSuite) TestUpgradeSeriesStatusMultipleReturnsError(c *gc.C) {
 		*(response.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
 			Results: []params.UpgradeSeriesStatusResult{
 				{Status: "Started"},
-				{Status: "Completed"},
+				{Status: "UpgradeSeriesCompleted"},
 			},
 		}
 		return nil
@@ -1001,7 +1001,7 @@ func (s *unitSuite) TestUpgradeSeriesStatusSingleResult(c *gc.C) {
 	facadeCaller := testing.StubFacadeCaller{Stub: &coretesting.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
 		*(response.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
-			Results: []params.UpgradeSeriesStatusResult{{Status: "Completed"}},
+			Results: []params.UpgradeSeriesStatusResult{{Status: "UpgradeSeriesCompleted"}},
 		}
 		return nil
 	}
@@ -1009,7 +1009,7 @@ func (s *unitSuite) TestUpgradeSeriesStatusSingleResult(c *gc.C) {
 
 	sts, err := s.apiUnit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(sts, gc.Equals, "Completed")
+	c.Check(sts, gc.Equals, "UpgradeSeriesCompleted")
 }
 
 type unitMetricBatchesSuite struct {

--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -39,7 +39,7 @@ func NewClient(caller base.APICaller, authTag names.Tag) *Client {
 
 // Machine status retrieves the machine status from remote state.
 func (s *Client) MachineStatus() (model.UpgradeSeriesStatus, error) {
-	var results params.UpgradeSeriesStatusResultsNew
+	var results params.UpgradeSeriesStatusResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.authTag.String()}},
 	}
@@ -54,7 +54,7 @@ func (s *Client) MachineStatus() (model.UpgradeSeriesStatus, error) {
 
 	r := results.Results[0]
 	if r.Error == nil {
-		return r.Status.Status, nil
+		return r.Status, nil
 	}
 
 	if params.IsCodeNotFound(r.Error) {
@@ -111,7 +111,7 @@ func (s *Client) unitsInState(facadeMethod string) ([]names.UnitTag, error) {
 func (s *Client) SetMachineStatus(status model.UpgradeSeriesStatus) error {
 	var results params.ErrorResults
 	args := params.UpgradeSeriesStatusParams{
-		Params: []params.UpgradeSeriesStatus{{
+		Params: []params.UpgradeSeriesStatusParam{{
 			Entity: params.Entity{Tag: s.authTag.String()},
 			Status: status,
 		}},
@@ -131,7 +131,7 @@ func (s *Client) SetMachineStatus(status model.UpgradeSeriesStatus) error {
 func (s *Client) StartUnitCompletion() error {
 	var results params.ErrorResults
 	args := params.UpgradeSeriesStatusParams{
-		Params: []params.UpgradeSeriesStatus{{
+		Params: []params.UpgradeSeriesStatusParam{{
 			Entity: params.Entity{Tag: s.authTag.String()},
 		}},
 	}

--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -96,7 +96,11 @@ func (s *Client) unitsInState(facadeMethod string) ([]names.UnitTag, error) {
 	if r.Error == nil {
 		tags := make([]names.UnitTag, len(r.Entities))
 		for i, e := range r.Entities {
-			tags[i] = names.NewUnitTag(e.Tag)
+			tag, err := names.ParseUnitTag(e.Tag)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			tags[i] = tag
 		}
 		return tags, nil
 	}

--- a/api/upgradeseries/upgradeseries_test.go
+++ b/api/upgradeseries/upgradeseries_test.go
@@ -100,13 +100,13 @@ func (s *upgradeSeriesSuite) TestUnitsPrepared(c *gc.C) {
 
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
-	r0 := "redis/0"
-	r1 := "redis/1"
+	r0 := names.NewUnitTag("redis/0")
+	r1 := names.NewUnitTag("redis/1")
 
 	resultSource := params.EntitiesResults{
 		Results: []params.EntitiesResult{{Entities: []params.Entity{
-			{Tag: r0},
-			{Tag: r1},
+			{Tag: r0.String()},
+			{Tag: r1.String()},
 		}}},
 	}
 	fCaller.EXPECT().FacadeCall("UnitsPrepared", s.args, gomock.Any()).SetArg(2, resultSource)
@@ -115,7 +115,7 @@ func (s *upgradeSeriesSuite) TestUnitsPrepared(c *gc.C) {
 	units, err := api.UnitsPrepared()
 	c.Assert(err, gc.IsNil)
 
-	expected := []names.UnitTag{names.NewUnitTag(r0), names.NewUnitTag(r1)}
+	expected := []names.UnitTag{r0, r1}
 	c.Check(units, jc.SameContents, expected)
 }
 
@@ -125,15 +125,15 @@ func (s *upgradeSeriesSuite) TestUnitsCompleted(c *gc.C) {
 
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
-	p0 := "postgres/0"
-	p1 := "postgres/1"
-	p2 := "postgres/2"
+	p0 := names.NewUnitTag("postgres/0")
+	p1 := names.NewUnitTag("postgres/1")
+	p2 := names.NewUnitTag("postgres/2")
 
 	resultSource := params.EntitiesResults{
 		Results: []params.EntitiesResult{{Entities: []params.Entity{
-			{Tag: p0},
-			{Tag: p1},
-			{Tag: p2},
+			{Tag: p0.String()},
+			{Tag: p1.String()},
+			{Tag: p2.String()},
 		}}},
 	}
 	fCaller.EXPECT().FacadeCall("UnitsCompleted", s.args, gomock.Any()).SetArg(2, resultSource)
@@ -142,7 +142,7 @@ func (s *upgradeSeriesSuite) TestUnitsCompleted(c *gc.C) {
 	units, err := api.UnitsCompleted()
 	c.Assert(err, gc.IsNil)
 
-	expected := []names.UnitTag{names.NewUnitTag(p0), names.NewUnitTag(p1), names.NewUnitTag(p2)}
+	expected := []names.UnitTag{p0, p1, p2}
 	c.Check(units, jc.SameContents, expected)
 }
 

--- a/api/upgradeseries/upgradeseries_test.go
+++ b/api/upgradeseries/upgradeseries_test.go
@@ -39,9 +39,9 @@ func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
-	resultSource := params.UpgradeSeriesStatusResultsNew{
-		Results: []params.UpgradeSeriesStatusResultNew{{
-			Status: params.UpgradeSeriesStatus{Status: model.PrepareStarted, Entity: s.args.Entities[0]}},
+	resultSource := params.UpgradeSeriesStatusResults{
+		Results: []params.UpgradeSeriesStatusResult{{
+			Status: model.UpgradeSeriesPrepareStarted},
 		},
 	}
 	fCaller.EXPECT().FacadeCall("MachineStatus", s.args, gomock.Any()).SetArg(2, resultSource)
@@ -49,7 +49,7 @@ func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
 	status, err := api.MachineStatus()
 	c.Assert(err, gc.IsNil)
-	c.Check(status, gc.Equals, model.PrepareStarted)
+	c.Check(status, gc.Equals, model.UpgradeSeriesPrepareStarted)
 }
 
 func (s *upgradeSeriesSuite) TestMachineStatusNotFound(c *gc.C) {
@@ -58,8 +58,8 @@ func (s *upgradeSeriesSuite) TestMachineStatusNotFound(c *gc.C) {
 
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
-	resultSource := params.UpgradeSeriesStatusResultsNew{
-		Results: []params.UpgradeSeriesStatusResultNew{{
+	resultSource := params.UpgradeSeriesStatusResults{
+		Results: []params.UpgradeSeriesStatusResult{{
 			Error: &params.Error{
 				Code:    params.CodeNotFound,
 				Message: "did not find",
@@ -82,15 +82,15 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
 	args := params.UpgradeSeriesStatusParams{
-		Params: []params.UpgradeSeriesStatus{
-			{Status: model.CompleteStarted, Entity: s.args.Entities[0]},
+		Params: []params.UpgradeSeriesStatusParam{
+			{Status: model.UpgradeSeriesCompleteStarted, Entity: s.args.Entities[0]},
 		},
 	}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}}}
 	fCaller.EXPECT().FacadeCall("SetMachineStatus", args, gomock.Any()).SetArg(2, resultSource)
 
 	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
-	err := api.SetMachineStatus(model.CompleteStarted)
+	err := api.SetMachineStatus(model.UpgradeSeriesCompleteStarted)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -153,7 +153,7 @@ func (s *upgradeSeriesSuite) TestStartUnitCompletion(c *gc.C) {
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
 	args := params.UpgradeSeriesStatusParams{
-		Params: []params.UpgradeSeriesStatus{
+		Params: []params.UpgradeSeriesStatusParam{
 			{Entity: s.args.Entities[0]},
 		},
 	}

--- a/apiserver/common/mocks/mock_upgradeseries.go
+++ b/apiserver/common/mocks/mock_upgradeseries.go
@@ -85,29 +85,16 @@ func (m *MockUpgradeSeriesMachine) EXPECT() *MockUpgradeSeriesMachineMockRecorde
 	return m.recorder
 }
 
-// MachineUpgradeSeriesStatus mocks base method
-func (m *MockUpgradeSeriesMachine) MachineUpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	ret := m.ctrl.Call(m, "MachineUpgradeSeriesStatus")
-	ret0, _ := ret[0].(model.UpgradeSeriesStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MachineUpgradeSeriesStatus indicates an expected call of MachineUpgradeSeriesStatus
-func (mr *MockUpgradeSeriesMachineMockRecorder) MachineUpgradeSeriesStatus() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).MachineUpgradeSeriesStatus))
-}
-
-// SetMachineUpgradeSeriesStatus mocks base method
-func (m *MockUpgradeSeriesMachine) SetMachineUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus) error {
-	ret := m.ctrl.Call(m, "SetMachineUpgradeSeriesStatus", arg0)
+// SetUpgradeSeriesStatus mocks base method
+func (m *MockUpgradeSeriesMachine) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus) error {
+	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetMachineUpgradeSeriesStatus indicates an expected call of SetMachineUpgradeSeriesStatus
-func (mr *MockUpgradeSeriesMachineMockRecorder) SetMachineUpgradeSeriesStatus(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMachineUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetMachineUpgradeSeriesStatus), arg0)
+// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus
+func (mr *MockUpgradeSeriesMachineMockRecorder) SetUpgradeSeriesStatus(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetUpgradeSeriesStatus), arg0)
 }
 
 // StartUpgradeSeriesUnitCompletion mocks base method
@@ -133,6 +120,19 @@ func (m *MockUpgradeSeriesMachine) Units() ([]common.UpgradeSeriesUnit, error) {
 // Units indicates an expected call of Units
 func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Units))
+}
+
+// UpgradeSeriesStatus mocks base method
+func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
+	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")
+	ret0, _ := ret[0].(model.UpgradeSeriesStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus
+func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesStatus() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesStatus))
 }
 
 // UpgradeSeriesUnitStatuses mocks base method

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -24,8 +24,8 @@ type UpgradeSeriesBackend interface {
 type UpgradeSeriesMachine interface {
 	WatchUpgradeSeriesNotifications() (state.NotifyWatcher, error)
 	Units() ([]UpgradeSeriesUnit, error)
-	MachineUpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
-	SetMachineUpgradeSeriesStatus(model.UpgradeSeriesStatus) error
+	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
+	SetUpgradeSeriesStatus(model.UpgradeSeriesStatus) error
 	StartUpgradeSeriesUnitCompletion() error
 	UpgradeSeriesUnitStatuses() (map[string]state.UpgradeSeriesUnitStatus, error)
 }
@@ -141,17 +141,18 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications(args params.Entities)
 	return result, nil
 }
 
-// UpgradeSeriesStatus returns the current preparation status of an upgrading
-// unit. If no series upgrade is in progress an error is returned instead.
-func (u *UpgradeSeriesAPI) GetUpgradeSeriesStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
-	return u.upgradeSeriesStatus(args)
+// UnitStatus returns the current preparation status of an upgrading unit.
+// If no series upgrade is in progress an error is returned instead.
+func (u *UpgradeSeriesAPI) UnitStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
+	u.logger.Tracef("Starting UnitStatus with %+v", args)
+	return u.unitStatus(args)
 }
 
-// SetUpgradeSeriesStatus sets the upgrade series status of the unit.
+// SetUnitStatus sets the upgrade series status of the unit.
 // If no upgrade is in progress an error is returned instead.
-func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
-	u.logger.Tracef("Starting SetUpgradeSeriesStatus with %+v", args)
-	return u.setUpgradeSeriesStatus(args)
+func (u *UpgradeSeriesAPI) SetUnitStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
+	u.logger.Tracef("Starting SetUnitStatus with %+v", args)
+	return u.setUnitStatus(args)
 }
 
 func (u *UpgradeSeriesAPI) GetMachine(tag names.Tag) (UpgradeSeriesMachine, error) {
@@ -189,7 +190,7 @@ func NewExternalUpgradeSeriesAPI(
 	return NewUpgradeSeriesAPI(UpgradeSeriesState{st}, resources, authorizer, accessMachine, accessUnit, logger)
 }
 
-func (u *UpgradeSeriesAPI) setUpgradeSeriesStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
+func (u *UpgradeSeriesAPI) setUnitStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Params)),
 	}
@@ -227,9 +228,7 @@ func (u *UpgradeSeriesAPI) setUpgradeSeriesStatus(args params.UpgradeSeriesStatu
 	return result, nil
 }
 
-func (u *UpgradeSeriesAPI) upgradeSeriesStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
-	u.logger.Tracef("Starting GetUpgradeSeriesStatus with %+v", args)
-
+func (u *UpgradeSeriesAPI) unitStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.UpgradeSeriesStatusResults{}, err

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -149,7 +149,7 @@ func (u *UpgradeSeriesAPI) GetUpgradeSeriesStatus(args params.Entities) (params.
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit.
 // If no upgrade is in progress an error is returned instead.
-func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(args params.SetUpgradeSeriesStatusParams) (params.ErrorResults, error) {
+func (u *UpgradeSeriesAPI) SetUpgradeSeriesStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	u.logger.Tracef("Starting SetUpgradeSeriesStatus with %+v", args)
 	return u.setUpgradeSeriesStatus(args)
 }
@@ -189,7 +189,7 @@ func NewExternalUpgradeSeriesAPI(
 	return NewUpgradeSeriesAPI(UpgradeSeriesState{st}, resources, authorizer, accessMachine, accessUnit, logger)
 }
 
-func (u *UpgradeSeriesAPI) setUpgradeSeriesStatus(args params.SetUpgradeSeriesStatusParams) (params.ErrorResults, error) {
+func (u *UpgradeSeriesAPI) setUpgradeSeriesStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Params)),
 	}
@@ -256,7 +256,7 @@ func (u *UpgradeSeriesAPI) upgradeSeriesStatus(args params.Entities) (params.Upg
 			results[i].Error = ServerError(err)
 			continue
 		}
-		results[i].Status = string(status)
+		results[i].Status = status
 	}
 	return params.UpgradeSeriesStatusResults{Results: results}, nil
 }

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -141,17 +141,20 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications(args params.Entities)
 	return result, nil
 }
 
-// UnitStatus returns the current preparation status of an upgrading unit.
+// UpgradeSeriesUnitStatus returns the current preparation status of an
+// upgrading unit.
 // If no series upgrade is in progress an error is returned instead.
-func (u *UpgradeSeriesAPI) UnitStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
-	u.logger.Tracef("Starting UnitStatus with %+v", args)
+func (u *UpgradeSeriesAPI) UpgradeSeriesUnitStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
+	u.logger.Tracef("Starting UpgradeSeriesUnitStatus with %+v", args)
 	return u.unitStatus(args)
 }
 
-// SetUnitStatus sets the upgrade series status of the unit.
+// SetUpgradeSeriesUnitStatus sets the upgrade series status of the unit.
 // If no upgrade is in progress an error is returned instead.
-func (u *UpgradeSeriesAPI) SetUnitStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
-	u.logger.Tracef("Starting SetUnitStatus with %+v", args)
+func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(
+	args params.UpgradeSeriesStatusParams,
+) (params.ErrorResults, error) {
+	u.logger.Tracef("Starting SetUpgradeSeriesUnitStatus with %+v", args)
 	return u.setUnitStatus(args)
 }
 

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -150,7 +150,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTag(c *gc.C) {
 			},
 		},
 	}
-	watches, err := api.SetUpgradeSeriesStatus(args)
+	watches, err := api.SetUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(watches, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -176,7 +176,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 		},
 	}
 
-	results, err := api.GetUpgradeSeriesStatus(args)
+	results, err := api.UnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -62,7 +62,8 @@ func (s *upgradeSeriesSuite) assertBackendApi(c *gc.C, tag names.Tag) (*common.U
 		}, nil
 	}
 
-	api := common.NewUpgradeSeriesAPI(mockBackend, resources, authorizer, machineAuthFunc, unitAuthFunc, loggo.GetLogger("juju.apiserver.common"))
+	api := common.NewUpgradeSeriesAPI(
+		mockBackend, resources, authorizer, machineAuthFunc, unitAuthFunc, loggo.GetLogger("juju.apiserver.common"))
 	return api, ctrl, mockBackend
 }
 
@@ -135,17 +136,17 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTag(c *gc.C) {
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().SetUpgradeSeriesStatus(model.PrepareCompleted).Return(nil)
+	mockUnit.EXPECT().SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted).Return(nil)
 
-	args := params.SetUpgradeSeriesStatusParams{
-		Params: []params.SetUpgradeSeriesStatusParam{
+	args := params.UpgradeSeriesStatusParams{
+		Params: []params.UpgradeSeriesStatusParam{
 			{
 				Entity: params.Entity{Tag: s.unitTag1.String()},
-				Status: string(model.PrepareCompleted),
+				Status: model.UpgradeSeriesPrepareCompleted,
 			},
 			{
 				Entity: params.Entity{Tag: names.NewUnitTag("mysql/2").String()},
-				Status: string(model.PrepareCompleted),
+				Status: model.UpgradeSeriesPrepareCompleted,
 			},
 		},
 	}
@@ -166,7 +167,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.PrepareCompleted, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
 
 	args := params.Entities{
 		Entities: []params.Entity{
@@ -179,14 +180,8 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{
-			{
-				Status: string(model.PrepareCompleted),
-				Error:  nil,
-			},
-			{
-				Status: "",
-				Error:  &params.Error{Message: "permission denied", Code: "unauthorized access"},
-			},
+			{Status: model.UpgradeSeriesPrepareCompleted},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -150,7 +150,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTag(c *gc.C) {
 			},
 		},
 	}
-	watches, err := api.SetUnitStatus(args)
+	watches, err := api.SetUpgradeSeriesUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(watches, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -176,7 +176,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 		},
 	}
 
-	results, err := api.UnitStatus(args)
+	results, err := api.UpgradeSeriesUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -79,7 +79,7 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		status, err := machine.MachineUpgradeSeriesStatus()
+		status, err := machine.UpgradeSeriesStatus()
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -107,7 +107,7 @@ func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.Er
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		err = machine.SetMachineUpgradeSeriesStatus(param.Status)
+		err = machine.SetUpgradeSeriesStatus(param.Status)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 		}

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -64,15 +64,15 @@ func NewUpgradeSeriesAPI(st State, resources facade.Resources, authorizer facade
 }
 
 // MachineStatus gets the current upgrade-series status of a machine.
-func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusResultsNew, error) {
-	result := params.UpgradeSeriesStatusResultsNew{}
+func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
+	result := params.UpgradeSeriesStatusResults{}
 
 	canAccess, err := a.AccessMachine()
 	if err != nil {
 		return result, err
 	}
 
-	results := make([]params.UpgradeSeriesStatusResultNew, len(args.Entities))
+	results := make([]params.UpgradeSeriesStatusResult, len(args.Entities))
 	for i, entity := range args.Entities {
 		machine, err := a.authAndMachine(entity, canAccess)
 		if err != nil {
@@ -84,7 +84,7 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		results[i].Status = params.UpgradeSeriesStatus{Status: status, Entity: entity}
+		results[i].Status = status
 	}
 
 	result.Results = results
@@ -119,7 +119,7 @@ func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.Er
 
 // CompleteStatus starts the upgrade series completion phase for all subordinate
 // units of a given machine.
-func (a *API) StartUnitCompletion(args params.SetUpgradeSeriesStatusParams) (params.ErrorResults, error) {
+func (a *API) StartUnitCompletion(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Params)),
 	}
@@ -146,14 +146,14 @@ func (a *API) StartUnitCompletion(args params.SetUpgradeSeriesStatusParams) (par
 // their upgrade-series preparation, and are ready to be stopped and have their
 // unit agent services converted for the target series.
 func (a *API) UnitsPrepared(args params.Entities) (params.EntitiesResults, error) {
-	result, err := a.unitsInState(args, model.PrepareCompleted)
+	result, err := a.unitsInState(args, model.UpgradeSeriesPrepareCompleted)
 	return result, errors.Trace(err)
 }
 
 // UnitsCompleted returns the units running on this machine that have completed
 // the upgrade-series workflow and are in their normal running state.
 func (a *API) UnitsCompleted(args params.Entities) (params.EntitiesResults, error) {
-	result, err := a.unitsInState(args, model.Completed)
+	result, err := a.unitsInState(args, model.UpgradeSeriesCompleted)
 	return result, errors.Trace(err)
 }
 

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -43,7 +43,7 @@ func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 	machine := mocks.NewMockUpgradeSeriesMachine(ctrl)
 
 	backend.EXPECT().Machine(s.machineTag.Id()).Return(machine, nil)
-	machine.EXPECT().MachineUpgradeSeriesStatus().Return(model.PrepareCompleted, nil)
+	machine.EXPECT().MachineUpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
 
 	entity := params.Entity{Tag: s.machineTag.String()}
 	args := params.Entities{
@@ -52,12 +52,8 @@ func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 
 	results, err := api.MachineStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResultsNew{
-		Results: []params.UpgradeSeriesStatusResultNew{
-			{
-				Status: params.UpgradeSeriesStatus{Entity: entity, Status: model.PrepareCompleted},
-			},
-		},
+	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
+		Results: []params.UpgradeSeriesStatusResult{{Status: model.UpgradeSeriesPrepareCompleted}},
 	})
 }
 
@@ -69,11 +65,11 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 	machine := mocks.NewMockUpgradeSeriesMachine(ctrl)
 
 	backend.EXPECT().Machine(s.machineTag.Id()).Return(machine, nil)
-	machine.EXPECT().SetMachineUpgradeSeriesStatus(model.PrepareCompleted).Return(nil)
+	machine.EXPECT().SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted).Return(nil)
 
 	entity := params.Entity{Tag: s.machineTag.String()}
 	args := params.UpgradeSeriesStatusParams{
-		Params: []params.UpgradeSeriesStatus{{Entity: entity, Status: model.PrepareCompleted}},
+		Params: []params.UpgradeSeriesStatusParam{{Entity: entity, Status: model.UpgradeSeriesPrepareCompleted}},
 	}
 
 	results, err := api.SetMachineStatus(args)
@@ -92,8 +88,8 @@ func (s *upgradeSeriesSuite) TestUnitsPrepared(c *gc.C) {
 
 	backend.EXPECT().Machine(s.machineTag.Id()).Return(machine, nil)
 	machine.EXPECT().UpgradeSeriesUnitStatuses().Return(map[string]state.UpgradeSeriesUnitStatus{
-		"redis/0": {Status: model.PrepareCompleted},
-		"redis/1": {Status: model.PrepareStarted},
+		"redis/0": {Status: model.UpgradeSeriesPrepareCompleted},
+		"redis/1": {Status: model.UpgradeSeriesPrepareStarted},
 	}, nil)
 
 	args := params.Entities{Entities: []params.Entity{{Tag: s.machineTag.String()}}}
@@ -114,8 +110,8 @@ func (s *upgradeSeriesSuite) TestUnitsCompleted(c *gc.C) {
 
 	backend.EXPECT().Machine(s.machineTag.Id()).Return(machine, nil)
 	machine.EXPECT().UpgradeSeriesUnitStatuses().Return(map[string]state.UpgradeSeriesUnitStatus{
-		"redis/0": {Status: model.Completed},
-		"redis/1": {Status: model.CompleteStarted},
+		"redis/0": {Status: model.UpgradeSeriesCompleted},
+		"redis/1": {Status: model.UpgradeSeriesCompleteStarted},
 	}, nil)
 
 	args := params.Entities{Entities: []params.Entity{{Tag: s.machineTag.String()}}}

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -43,7 +43,7 @@ func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 	machine := mocks.NewMockUpgradeSeriesMachine(ctrl)
 
 	backend.EXPECT().Machine(s.machineTag.Id()).Return(machine, nil)
-	machine.EXPECT().MachineUpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
+	machine.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
 
 	entity := params.Entity{Tag: s.machineTag.String()}
 	args := params.Entities{
@@ -65,7 +65,7 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 	machine := mocks.NewMockUpgradeSeriesMachine(ctrl)
 
 	backend.EXPECT().Machine(s.machineTag.Id()).Return(machine, nil)
-	machine.EXPECT().SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted).Return(nil)
+	machine.EXPECT().SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted).Return(nil)
 
 	entity := params.Entity{Tag: s.machineTag.String()}
 	args := params.UpgradeSeriesStatusParams{

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1314,50 +1314,19 @@ type DumpModelRequest struct {
 }
 
 type UpgradeSeriesStatusResult struct {
-	Error  *Error `json:"error,omitempty"`
-	Status string `json:"status,omitempty"`
+	Error  *Error                    `json:"error,omitempty"`
+	Status model.UpgradeSeriesStatus `json:"status,omitempty"`
 }
 
 type UpgradeSeriesStatusResults struct {
 	Results []UpgradeSeriesStatusResult `json:"results,omitempty"`
 }
 
-type SetUpgradeSeriesStatusParams struct {
-	Params []SetUpgradeSeriesStatusParam `json:"params"`
+type UpgradeSeriesStatusParams struct {
+	Params []UpgradeSeriesStatusParam `json:"params"`
 }
 
-type SetUpgradeSeriesStatusParam struct {
-	Entity Entity `json:"entity"`
-	Status string `json:"status"`
-}
-
-// UpgradeSeriesStatus is a transport for the status of a unit or machine
-// who's host OS is being upgraded.
-// Used as both an argument and a return.
-// TODO (manadart 2018-08-07) Replace SetUpgradeSeriesStatusParam usage
-// with this and use in place of UpgradeSeriesStatusResult.Status.
-type UpgradeSeriesStatus struct {
+type UpgradeSeriesStatusParam struct {
 	Entity Entity                    `json:"entity"`
 	Status model.UpgradeSeriesStatus `json:"status"`
-}
-
-// UpgradeSeriesStatusResultNew transports the upgrade-series status of a
-// single entity.
-// TODO (manadart 2018-08-07) Remove UpgradeSeriesStatusResult and
-// rename this.
-type UpgradeSeriesStatusResultNew struct {
-	Error  *Error              `json:"error,omitempty"`
-	Status UpgradeSeriesStatus `json:"status,omitempty"`
-}
-
-// UpgradeSeriesStatusResultsNew transports the upgrade series statuses
-// for a collection of entities.
-// TODO (manadart 2018-08-07) Remove UpgradeSeriesStatusResults and
-// rename this.
-type UpgradeSeriesStatusResultsNew struct {
-	Results []UpgradeSeriesStatusResultNew `json:"results,omitempty"`
-}
-
-type UpgradeSeriesStatusParams struct {
-	Params []UpgradeSeriesStatus `json:"params"`
 }

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -7,27 +7,26 @@ import (
 	"github.com/juju/errors"
 )
 
-//UpgradeSeriesStatus is the current status of a series upgrade for units
+// UpgradeSeriesStatus is the current status of a series upgrade for units
 type UpgradeSeriesStatus string
 
 const (
-	NotStarted       UpgradeSeriesStatus = "not started"
-	PrepareStarted   UpgradeSeriesStatus = "prepare started"
-	PrepareMachine   UpgradeSeriesStatus = "prepare machine"
-	PrepareCompleted UpgradeSeriesStatus = "prepare completed"
-	CompleteStarted  UpgradeSeriesStatus = "complete started"
-	Completed        UpgradeSeriesStatus = "completed"
-	UnitErrored      UpgradeSeriesStatus = "error"
+	UpgradeSeriesNotStarted       UpgradeSeriesStatus = "not started"
+	UpgradeSeriesPrepareStarted   UpgradeSeriesStatus = "prepare started"
+	UpgradeSeriesPrepareMachine   UpgradeSeriesStatus = "prepare machine"
+	UpgradeSeriesPrepareCompleted UpgradeSeriesStatus = "prepare completed"
+	UpgradeSeriesCompleteStarted  UpgradeSeriesStatus = "complete started"
+	UpgradeSeriesCompleted        UpgradeSeriesStatus = "completed"
+	UpgradeSeriesError            UpgradeSeriesStatus = "error"
 )
 
 // ValidateUnitSeriesUpgradeStatus validates a string returning an
 // UpgradeSeriesStatus, if valid, or an error.
-func ValidateUnitSeriesUpgradeStatus(series string) (UpgradeSeriesStatus, error) {
-	unCheckedStatus := UpgradeSeriesStatus(series)
-	switch unCheckedStatus {
-	case NotStarted, PrepareStarted, PrepareCompleted, CompleteStarted, Completed, UnitErrored:
-		return unCheckedStatus, nil
+func ValidateUnitSeriesUpgradeStatus(status UpgradeSeriesStatus) (UpgradeSeriesStatus, error) {
+	switch status {
+	case UpgradeSeriesNotStarted, UpgradeSeriesPrepareStarted, UpgradeSeriesPrepareCompleted,
+		UpgradeSeriesCompleteStarted, UpgradeSeriesCompleted, UpgradeSeriesError:
+		return status, nil
 	}
-
-	return NotStarted, errors.Errorf("encountered invalid unit upgrade series status of %q", series)
+	return UpgradeSeriesNotStarted, errors.NotValidf("unit upgrade series status of %q", status)
 }

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -20,8 +20,8 @@ const (
 	UpgradeSeriesError            UpgradeSeriesStatus = "error"
 )
 
-// ValidateUnitSeriesUpgradeStatus validates a string returning an
-// UpgradeSeriesStatus, if valid, or an error.
+// ValidateUnitSeriesUpgradeStatus validates a the input status as valid for a
+// unit, returning the valid status or an error.
 func ValidateUnitSeriesUpgradeStatus(status UpgradeSeriesStatus) (UpgradeSeriesStatus, error) {
 	switch status {
 	case UpgradeSeriesNotStarted, UpgradeSeriesPrepareStarted, UpgradeSeriesPrepareCompleted,

--- a/core/model/upgradeseries_test.go
+++ b/core/model/upgradeseries_test.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/testing"
+)
+
+type upgradeSeriesSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&upgradeSeriesSuite{})
+
+func (*upgradeSeriesSuite) TestValidateUnitUpgradeSeriesStatus(c *gc.C) {
+	for _, t := range []struct {
+		expected model.UpgradeSeriesStatus
+		name     string
+		valid    bool
+	}{
+		{model.UpgradeSeriesPrepareStarted, "prepare started", true},
+		{model.UpgradeSeriesNotStarted, "GTFO", false},
+	} {
+		status, err := model.ValidateUnitSeriesUpgradeStatus(model.UpgradeSeriesStatus(t.name))
+		if t.valid {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, jc.Satisfies, errors.IsNotValid)
+		}
+		c.Check(status, gc.Equals, t.expected)
+	}
+}

--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -65,7 +65,7 @@ func (s *MachineInternalSuite) TestRemoveUpgradeLockTxnAssertsDocExists(c *gc.C)
 func (s *MachineInternalSuite) TestsetUpgradeSeriesTxnOpsBuildsCorrectUnitTransaction(c *gc.C) {
 	arbitraryMachineID := "id"
 	arbitraryUnitName := "application/0"
-	arbitraryStatus := model.PrepareStarted
+	arbitraryStatus := model.UpgradeSeriesPrepareStarted
 	arbitraryUpdateTime := bson.Now()
 	expectedOp := txn.Op{
 		C:  machineUpgradeSeriesLocksC,
@@ -85,7 +85,7 @@ func (s *MachineInternalSuite) TestsetUpgradeSeriesTxnOpsBuildsCorrectUnitTransa
 
 func (s *MachineInternalSuite) TestsetUpgradeSeriesTxnOpsShouldAssertAssignedMachineIsAlive(c *gc.C) {
 	arbitraryMachineID := "id"
-	arbitraryStatus := model.PrepareStarted
+	arbitraryStatus := model.UpgradeSeriesPrepareStarted
 	arbitraryUnitName := "application/0"
 	arbitraryUpdateTime := bson.Now()
 	expectedOp := txn.Op{
@@ -113,7 +113,7 @@ func (s *MachineInternalSuite) TestStartUpgradeSeriesUnitCompletionTxnOps(c *gc.
 		{
 			C:      machineUpgradeSeriesLocksC,
 			Id:     arbitraryMachineID,
-			Assert: bson.D{{"machine-status", model.CompleteStarted}},
+			Assert: bson.D{{"machine-status", model.UpgradeSeriesCompleteStarted}},
 			Update: bson.D{{"$set", bson.D{{"unit-statuses", arbitraryUnitStatuses}}}},
 		},
 	}

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -284,12 +284,7 @@ func removeUpgradeSeriesLockTxnOps(machineDocId string) []txn.Op {
 	}
 }
 
-// MachineUpgradeSeriesStatus returns the upgrade-series status of a machine.
-// TODO (manadart 2018-08-07) This should be renamed to UpgradeSeriesStatus,
-// and the unit-based methods renamed to indicate their context.
-// The translation code can be removed once the old->new bootstrap is no
-// longer required.
-func (m *Machine) MachineUpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
+func (m *Machine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
 	defer closer()
 
@@ -305,8 +300,8 @@ func (m *Machine) MachineUpgradeSeriesStatus() (model.UpgradeSeriesStatus, error
 	return lock.MachineStatus, errors.Trace(err)
 }
 
-// UpgradeSeriesStatus returns the series upgrade status for the input unit.
-func (m *Machine) UpgradeSeriesStatus(unitName string) (model.UpgradeSeriesStatus, error) {
+// UnitStatus returns the series upgrade status for the input unit.
+func (m *Machine) UpgradeSeriesUnitStatus(unitName string) (model.UpgradeSeriesStatus, error) {
 	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
 	defer closer()
 
@@ -325,7 +320,7 @@ func (m *Machine) UpgradeSeriesStatus(unitName string) (model.UpgradeSeriesStatu
 	return lock.UnitStatuses[unitName].Status, nil
 }
 
-// UpgradeSeriesStatus returns the unit statuses from the upgrade-series lock
+// UnitStatus returns the unit statuses from the upgrade-series lock
 // for this machine.
 func (m *Machine) UpgradeSeriesUnitStatuses() (map[string]UpgradeSeriesUnitStatus, error) {
 	lock, err := m.getUpgradeSeriesLock()
@@ -335,8 +330,8 @@ func (m *Machine) UpgradeSeriesUnitStatuses() (map[string]UpgradeSeriesUnitStatu
 	return lock.UnitStatuses, nil
 }
 
-// SetUpgradeSeriesStatus sets the status of a series upgrade for a unit.
-func (m *Machine) SetUpgradeSeriesStatus(unitName string, status model.UpgradeSeriesStatus) error {
+// SetUpgradeSeriesUnitStatus sets the status of a series upgrade for a unit.
+func (m *Machine) SetUpgradeSeriesUnitStatus(unitName string, status model.UpgradeSeriesStatus) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := m.Refresh(); err != nil {
@@ -400,12 +395,9 @@ func setUpgradeSeriesTxnOps(
 	}, nil
 }
 
-// SetUpgradeSeriesStatus sets the machine status of a series upgrade.
-// TODO (manadart 2018-08-07) This should be renamed to UpgradeSeriesStatus,
-// and the unit-based methods renamed to indicate their context.
-// The translation code can be removed once the old->new bootstrap is no
-// longer required.
-func (m *Machine) SetMachineUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
+// SetUpgradeSeriesStatus sets the status of the machine in
+// the upgrade-series lock.
+func (m *Machine) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := m.Refresh(); err != nil {

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -122,7 +122,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareI
 	err := s.machine.CreateUpgradeSeriesLock([]string{unit0.Name()}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetMachineUpgradeSeriesStatus(model.PrepareCompleted)
+	err = s.machine.SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()
@@ -133,7 +133,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSetCompleteStatusOfMachine
 	err := s.machine.CreateUpgradeSeriesLock([]string{}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetMachineUpgradeSeriesStatus(model.PrepareCompleted)
+	err = s.machine.SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()
@@ -142,7 +142,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSetCompleteStatusOfMachine
 	sts, err := s.machine.MachineUpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(sts, gc.Equals, model.CompleteStarted)
+	c.Assert(sts, gc.Equals, model.UpgradeSeriesCompleteStarted)
 }
 
 func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailIfAlreadyInCompleteState(c *gc.C) {
@@ -150,7 +150,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailIfAlreadyInCompleteSta
 	err := s.machine.CreateUpgradeSeriesLock([]string{unit0.Name()}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetMachineUpgradeSeriesStatus(model.PrepareCompleted)
+	err = s.machine.SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -122,7 +122,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSucceedWhenMachinePrepareI
 	err := s.machine.CreateUpgradeSeriesLock([]string{unit0.Name()}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
+	err = s.machine.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()
@@ -133,13 +133,13 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSetCompleteStatusOfMachine
 	err := s.machine.CreateUpgradeSeriesLock([]string{}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
+	err = s.machine.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()
 	c.Assert(err, jc.ErrorIsNil)
 
-	sts, err := s.machine.MachineUpgradeSeriesStatus()
+	sts, err := s.machine.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(sts, gc.Equals, model.UpgradeSeriesCompleteStarted)
@@ -150,7 +150,7 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailIfAlreadyInCompleteSta
 	err := s.machine.CreateUpgradeSeriesLock([]string{unit0.Name()}, "cosmic")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetMachineUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
+	err = s.machine.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.CompleteUpgradeSeries()

--- a/state/unit.go
+++ b/state/unit.go
@@ -2870,20 +2870,20 @@ func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
 	return boundSpace, nil
 }
 
-// UpgradeSeriesStatus returns the upgrade status of the units assigned machine.
+// UnitStatus returns the upgrade status of the units assigned machine.
 func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	machine, err := u.machine()
 	if err != nil {
 		return "", err
 	}
-	return machine.UpgradeSeriesStatus(u.Name())
+	return machine.UpgradeSeriesUnitStatus(u.Name())
 }
 
-// SetUpgradeSeriesStatus sets the upgrade status of the units assigned machine.
+// SetUnitStatus sets the upgrade status of the units assigned machine.
 func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
 	machine, err := u.machine()
 	if err != nil {
 		return err
 	}
-	return machine.SetUpgradeSeriesStatus(u.Name(), status)
+	return machine.SetUpgradeSeriesUnitStatus(u.Name(), status)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -2870,7 +2870,7 @@ func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
 	return boundSpace, nil
 }
 
-// UnitStatus returns the upgrade status of the units assigned machine.
+// UpgradeSeriesStatus returns the upgrade status of the units assigned machine.
 func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	machine, err := u.machine()
 	if err != nil {
@@ -2879,7 +2879,7 @@ func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	return machine.UpgradeSeriesUnitStatus(u.Name())
 }
 
-// SetUnitStatus sets the upgrade status of the units assigned machine.
+// SetUpgradeSeriesStatus sets the upgrade status of the units assigned machine.
 func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {
 	machine, err := u.machine()
 	if err != nil {

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -35,7 +35,7 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 	}
 }
 
-// setUpgradeSeriesStatus sets the upgrade series status
+// setUpgradeSeriesStatus sets the upgrade series status.
 func setUpgradeSeriesStatus(u *Uniter, status model.UpgradeSeriesStatus) error {
-	return u.unit.SetUpgradeSeriesStatus(string(status))
+	return u.unit.SetUpgradeSeriesStatus(status)
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -124,7 +124,7 @@ func (opc *operationCallbacks) SetExecutingStatus(message string) error {
 	return setAgentStatus(opc.u, status.Executing, message, nil)
 }
 
-// SetUnitStatus is part of the operation.Callbacks interface.
+// SetUpgradeSeriesStatus is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetUpgradeSeriesStatus(upgradeSeriesStatus model.UpgradeSeriesStatus) error {
 	return setUpgradeSeriesStatus(opc.u, upgradeSeriesStatus)
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -124,7 +124,7 @@ func (opc *operationCallbacks) SetExecutingStatus(message string) error {
 	return setAgentStatus(opc.u, status.Executing, message, nil)
 }
 
-// SetUpgradeSeriesStatus is part of the operation.Callbacks interface.
+// SetUnitStatus is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetUpgradeSeriesStatus(upgradeSeriesStatus model.UpgradeSeriesStatus) error {
 	return setUpgradeSeriesStatus(opc.u, upgradeSeriesStatus)
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -204,10 +204,10 @@ func (rh *runHook) afterHook(state State) (_ bool, err error) {
 		}
 	case hooks.PreSeriesUpgrade:
 		logger.Debugf("completing pre upgrade series hook. updating state of series upgrade.")
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.PrepareCompleted)
+		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted)
 	case hooks.PostSeriesUpgrade:
 		logger.Debugf("completing post upgrade series hook. updating state of series upgrade.")
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.Completed)
+		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted)
 	}
 	return hasRunStatusSet && err == nil, err
 }

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -267,7 +267,7 @@ func (u *mockUnit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, err
 }
 
 func (u *mockUnit) UpgradeSeriesStatus() (string, error) {
-	return string(model.PrepareStarted), nil
+	return string(model.UpgradeSeriesPrepareStarted), nil
 }
 
 func (m *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -266,8 +266,8 @@ func (u *mockUnit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, err
 	return u.upgradeSeriesWatcher, nil
 }
 
-func (u *mockUnit) UpgradeSeriesStatus() (string, error) {
-	return string(model.UpgradeSeriesPrepareStarted), nil
+func (u *mockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
+	return model.UpgradeSeriesPrepareStarted, nil
 }
 
 func (m *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -48,7 +49,7 @@ type Unit interface {
 	// WatchRelation returns a watcher that fires when relations
 	// relevant for this unit change.
 	WatchRelations() (watcher.StringsWatcher, error)
-	UpgradeSeriesStatus() (string, error)
+	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
 }
 
 type Application interface {

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -205,8 +205,8 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 		Leader:                true,
 		Series:                "",
 		//The mock remotes state watcher always delivers Started for the upgrade statuses
-		UpgradeSeriesPrepareStatus:  model.PrepareStarted,
-		UpgradeSeriesCompleteStatus: model.PrepareStarted,
+		UpgradeSeriesPrepareStatus:  model.UpgradeSeriesPrepareStarted,
+		UpgradeSeriesCompleteStatus: model.UpgradeSeriesPrepareStarted,
 	})
 }
 

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -56,8 +56,8 @@ func (s *uniterResolver) NextOp(
 	// state) then the uniter should idle in the face of all remote state
 	// changes accept for those which indicate termination - the unit is
 	// waiting to be shutdown.
-	if localState.UpgradeSeriesPrepareStatus == model.PrepareCompleted &&
-		remoteState.UpgradeSeriesPrepareStatus == model.PrepareCompleted {
+	if localState.UpgradeSeriesPrepareStatus == model.UpgradeSeriesPrepareCompleted &&
+		remoteState.UpgradeSeriesPrepareStatus == model.UpgradeSeriesPrepareCompleted {
 		logger.Criticalf("We hit here were we are supposed to idle when shutting down.")
 		//return nil, resolver.ErrNoOperation
 	}
@@ -288,15 +288,15 @@ func (s *uniterResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 
-	if localState.UpgradeSeriesPrepareStatus == model.NotStarted &&
-		remoteState.UpgradeSeriesPrepareStatus == model.PrepareStarted {
+	if localState.UpgradeSeriesPrepareStatus == model.UpgradeSeriesNotStarted &&
+		remoteState.UpgradeSeriesPrepareStatus == model.UpgradeSeriesPrepareStarted {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
 	}
 
-	if localState.UpgradeSeriesCompleteStatus == model.NotStarted &&
-		// localState.UpgradeSeriesPrepareStatus == model.PrepareCompleted &&  //these checks ensure that the uniter is not stuck in its idle state after the prepare phase
-		// remoteState.UpgradeSeriesPrepareStatus == model.PrepareCompleted
-		remoteState.UpgradeSeriesCompleteStatus == model.CompleteStarted {
+	if localState.UpgradeSeriesCompleteStatus == model.UpgradeSeriesNotStarted &&
+		// localState.UpgradeSeriesPrepareStatus == model.UpgradeSeriesPrepareCompleted &&  //these checks ensure that the uniter is not stuck in its idle state after the prepare phase
+		// remoteState.UpgradeSeriesPrepareStatus == model.UpgradeSeriesPrepareCompleted
+		remoteState.UpgradeSeriesCompleteStatus == model.UpgradeSeriesCompleteStarted {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.PostSeriesUpgrade})
 	}
 

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -70,8 +70,8 @@ func (s *ResolverOpFactorySuite) TestUpgradeSeriesStatusChanged(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
 
 	// The initial state
-	f.LocalState.UpgradeSeriesPrepareStatus = model.NotStarted
-	f.RemoteState.UpgradeSeriesPrepareStatus = model.PrepareStarted
+	f.LocalState.UpgradeSeriesPrepareStatus = model.UpgradeSeriesNotStarted
+	f.RemoteState.UpgradeSeriesPrepareStatus = model.UpgradeSeriesPrepareStarted
 
 	op, err := f.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
 	c.Assert(err, jc.ErrorIsNil)
@@ -79,13 +79,13 @@ func (s *ResolverOpFactorySuite) TestUpgradeSeriesStatusChanged(c *gc.C) {
 	_, err = op.Prepare(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(f.LocalState.UpgradeSeriesPrepareStatus, gc.Equals, model.PrepareStarted)
-	f.RemoteState.UpgradeSeriesPrepareStatus = model.PrepareCompleted
+	c.Assert(f.LocalState.UpgradeSeriesPrepareStatus, gc.Equals, model.UpgradeSeriesPrepareStarted)
+	f.RemoteState.UpgradeSeriesPrepareStatus = model.UpgradeSeriesPrepareCompleted
 
 	_, err = op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(f.LocalState.UpgradeSeriesPrepareStatus, gc.Equals, model.PrepareCompleted)
+	c.Assert(f.LocalState.UpgradeSeriesPrepareStatus, gc.Equals, model.UpgradeSeriesPrepareCompleted)
 }
 
 func (s *ResolverOpFactorySuite) TestNewHookError(c *gc.C) {

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -152,7 +152,7 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 		CharmModifiedVersion: s.charmModifiedVersion,
 		CharmURL:             s.charmURL,
 		Series:               s.charmURL.Series,
-		UpgradeSeriesPrepareStatus: model.NotStarted,
+		UpgradeSeriesPrepareStatus: model.UpgradeSeriesNotStarted,
 		State: operation.State{
 			Kind:      operation.Continue,
 			Installed: true,
@@ -160,7 +160,7 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 		},
 	}
 	s.remoteState.Series = s.charmURL.Series
-	s.remoteState.UpgradeSeriesPrepareStatus = model.PrepareStarted
+	s.remoteState.UpgradeSeriesPrepareStatus = model.UpgradeSeriesPrepareStarted
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run pre-series-upgrade hook")
@@ -171,8 +171,8 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 		CharmModifiedVersion: s.charmModifiedVersion,
 		CharmURL:             s.charmURL,
 		Series:               s.charmURL.Series,
-		UpgradeSeriesCompleteStatus: model.NotStarted,
-		//		UpgradeSeriesPrepareStatus:  model.PrepareCompleted,
+		UpgradeSeriesCompleteStatus: model.UpgradeSeriesNotStarted,
+		//		UpgradeSeriesPrepareStatus:  model.UpgradeSeriesPrepareCompleted,
 		State: operation.State{
 			Kind:      operation.Continue,
 			Installed: true,
@@ -180,8 +180,8 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 		},
 	}
 	s.remoteState.Series = s.charmURL.Series
-	s.remoteState.UpgradeSeriesCompleteStatus = model.CompleteStarted
-	//	s.remoteState.UpgradeSeriesPrepareStatus = model.PrepareCompleted
+	s.remoteState.UpgradeSeriesCompleteStatus = model.UpgradeSeriesCompleteStarted
+	//	s.remoteState.UpgradeSeriesPrepareStatus = model.UpgradeSeriesPrepareCompleted
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run post-series-upgrade hook")
@@ -190,19 +190,19 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 func (s *iaasResolverSuite) TestUpgradeSeriesStatusIdlesUniterOnUpggradeSeriesCompletion(c *gc.C) {
 	c.Skip("This test should be skipped unitl machine agent can shutdown the uniter for a series upgrade.")
 	localState := resolver.LocalState{
-		UpgradeSeriesPrepareStatus: model.PrepareCompleted,
+		UpgradeSeriesPrepareStatus: model.UpgradeSeriesPrepareCompleted,
 		State: operation.State{
 			Kind:      operation.Continue,
 			Installed: true,
 		},
 	}
-	s.remoteState.UpgradeSeriesPrepareStatus = model.PrepareCompleted
+	s.remoteState.UpgradeSeriesPrepareStatus = model.UpgradeSeriesPrepareCompleted
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 
 	// changing the series would normally fire a config-changed hook but
 	// since the uniter does not respond to state changes after reaching a
-	// UpgradeSeriesPrepareStatus of "Completed" no operation should take place.
+	// UpgradeSeriesPrepareStatus of "UpgradeSeriesCompleted" no operation should take place.
 	s.remoteState.Series = "NewSeries"
 	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -342,8 +342,8 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		localState := resolver.LocalState{
 			CharmURL:                    charmURL,
 			CharmModifiedVersion:        charmModifiedVersion,
-			UpgradeSeriesPrepareStatus:  model.NotStarted,
-			UpgradeSeriesCompleteStatus: model.NotStarted,
+			UpgradeSeriesPrepareStatus:  model.UpgradeSeriesNotStarted,
+			UpgradeSeriesCompleteStatus: model.UpgradeSeriesNotStarted,
 		}
 		for err == nil {
 			err = resolver.Loop(resolver.LoopConfig{

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -144,11 +144,11 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 	w.logger.Debugf("series upgrade lock changed")
 
 	switch machineStatus {
-	case model.PrepareStarted:
+	case model.UpgradeSeriesPrepareStarted:
 		err = w.handlePrepareStarted()
-	case model.PrepareMachine:
+	case model.UpgradeSeriesPrepareMachine:
 		err = w.handlePrepareMachine()
-	case model.CompleteStarted:
+	case model.UpgradeSeriesCompleteStarted:
 		err = w.handleCompleteStarted()
 	default:
 		w.logger.Debugf("machine series upgrade status is %q", machineStatus)
@@ -157,9 +157,9 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 }
 
 // handlePrepareStarted handles workflow for the machine with an upgrade-series
-// lock status of "PrepareStarted"
+// lock status of "UpgradeSeriesPrepareStarted"
 func (w *upgradeSeriesWorker) handlePrepareStarted() error {
-	w.logger.Debugf("machine series upgrade status is %q", model.PrepareStarted)
+	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesPrepareStarted)
 
 	units, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
 	if err != nil {
@@ -201,15 +201,15 @@ func (w *upgradeSeriesWorker) transitionPrepareMachine(unitServices map[string]s
 		}
 	}
 
-	return errors.Trace(w.SetMachineStatus(model.PrepareMachine))
+	return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesPrepareMachine))
 }
 
 // handlePrepareMachine handles workflow for the machine with an upgrade-series
-// lock status of "PrepareMachine".
+// lock status of "UpgradeSeriesPrepareMachine".
 // TODO (manadart 2018-08-09): Rename when a better name is contrived for
 // "UpgradeSeriesPrepareMachine".
 func (w *upgradeSeriesWorker) handlePrepareMachine() error {
-	w.logger.Debugf("machine series upgrade status is %q", model.PrepareMachine)
+	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesPrepareMachine)
 
 	// This is a sanity check.
 	// The units should all still be in the "PrepareComplete" state.
@@ -236,11 +236,11 @@ func (w *upgradeSeriesWorker) transitionPrepareComplete(unitServices map[string]
 
 	// TODO (manadart 2018-08-09): Unit file wrangling to come.
 	// For now we just update the machine status to progress the workflow.
-	return errors.Trace(w.SetMachineStatus(model.PrepareCompleted))
+	return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesPrepareCompleted))
 }
 
 func (w *upgradeSeriesWorker) handleCompleteStarted() error {
-	w.logger.Debugf("machine series upgrade status is %q", model.CompleteStarted)
+	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesCompleteStarted)
 
 	// If the units are still all in the "PrepareComplete" state, then the
 	// manual tasks have been run and an operator has executed the
@@ -262,7 +262,7 @@ func (w *upgradeSeriesWorker) handleCompleteStarted() error {
 	}
 	if allConfirmed {
 		w.logger.Infof("series upgrade complete")
-		return errors.Trace(w.SetMachineStatus(model.Completed))
+		return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesCompleted))
 	}
 
 	return nil
@@ -331,7 +331,7 @@ func (w *upgradeSeriesWorker) compareUnitAgentServices(getUnits unitsInState) (m
 }
 
 func unitsCompleted(statuses []string) bool {
-	return unitsAllWithStatus(statuses, model.Completed)
+	return unitsAllWithStatus(statuses, model.UpgradeSeriesCompleted)
 }
 
 func unitsAllWithStatus(statuses []string, status model.UpgradeSeriesStatus) bool {

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -75,7 +75,7 @@ func (s *workerSuite) TestCompleteNoAction(c *gc.C) {
 
 	// If the workflow is completed, no further processing occurs.
 	// This is the only call we expect to see.
-	s.facade.EXPECT().MachineStatus().Return(model.PrepareCompleted, nil)
+	s.facade.EXPECT().MachineStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
 
 	w := s.newWorker(c, ctrl, ignoreLogging(c), notify(1))
 	s.cleanKill(c, w)
@@ -87,7 +87,7 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c
 	s.setupMocks(ctrl)
 
 	exp := s.facade.EXPECT()
-	exp.MachineStatus().Return(model.PrepareStarted, nil)
+	exp.MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
 	// Only one of the two units has completed preparation.
 	exp.UnitsPrepared().Return([]names.UnitTag{names.NewUnitTag("wordpress/0")}, nil)
 
@@ -105,13 +105,13 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsStoppedProgressPrepareMachin
 	s.setupMocks(ctrl)
 
 	exp := s.facade.EXPECT()
-	exp.MachineStatus().Return(model.PrepareStarted, nil)
+	exp.MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
 	// All known units have completed preparation - the workflow progresses.
 	exp.UnitsPrepared().Return([]names.UnitTag{
 		names.NewUnitTag("wordpress/0"),
 		names.NewUnitTag("mysql/0"),
 	}, nil)
-	exp.SetMachineStatus(model.PrepareMachine).Return(nil)
+	exp.SetMachineStatus(model.UpgradeSeriesPrepareMachine).Return(nil)
 
 	s.expectServiceDiscovery(true)
 
@@ -130,7 +130,7 @@ func (s *workerSuite) TestMachinePrepareMachineUnitFilesWrittenProgressPrepareCo
 	s.setupMocks(ctrl)
 
 	exp := s.facade.EXPECT()
-	exp.MachineStatus().Return(model.PrepareMachine, nil)
+	exp.MachineStatus().Return(model.UpgradeSeriesPrepareMachine, nil)
 	exp.UnitsPrepared().Return([]names.UnitTag{
 		names.NewUnitTag("wordpress/0"),
 		names.NewUnitTag("mysql/0"),
@@ -138,7 +138,7 @@ func (s *workerSuite) TestMachinePrepareMachineUnitFilesWrittenProgressPrepareCo
 
 	// TODO (manadart 2018-08-09): Assertions for service unit manipulation.
 
-	exp.SetMachineStatus(model.PrepareCompleted).Return(nil)
+	exp.SetMachineStatus(model.UpgradeSeriesPrepareCompleted).Return(nil)
 
 	s.expectServiceDiscovery(false)
 
@@ -152,7 +152,7 @@ func (s *workerSuite) TestMachineCompleteStartedUnitsPrepareCompleteUnitsStarted
 	s.setupMocks(ctrl)
 
 	exp := s.facade.EXPECT()
-	exp.MachineStatus().Return(model.CompleteStarted, nil)
+	exp.MachineStatus().Return(model.UpgradeSeriesCompleteStarted, nil)
 	exp.UnitsPrepared().Return([]names.UnitTag{
 		names.NewUnitTag("wordpress/0"),
 		names.NewUnitTag("mysql/0"),
@@ -176,7 +176,7 @@ func (s *workerSuite) TestMachineCompleteStartedUnitsCompleteProgressComplete(c 
 	s.setupMocks(ctrl)
 
 	exp := s.facade.EXPECT()
-	exp.MachineStatus().Return(model.CompleteStarted, nil)
+	exp.MachineStatus().Return(model.UpgradeSeriesCompleteStarted, nil)
 	// No units are in the prepare-complete state.
 	// They have completed their workflow.
 	exp.UnitsPrepared().Return([]names.UnitTag{}, nil)
@@ -184,7 +184,7 @@ func (s *workerSuite) TestMachineCompleteStartedUnitsCompleteProgressComplete(c 
 		names.NewUnitTag("wordpress/0"),
 		names.NewUnitTag("mysql/0"),
 	}, nil)
-	exp.SetMachineStatus(model.Completed).Return(nil)
+	exp.SetMachineStatus(model.UpgradeSeriesCompleted).Return(nil)
 
 	// TODO (manadart 2018-08-22): Modify the tested code so that the services
 	// are detected just the one time.


### PR DESCRIPTION
## Description of change

Almost entirely mechanical:

- Prefixes status constants in the model package with "UpgradeSeries" to disambiguate them from future potential exports.
- Renames API methods for consistency, removing unnecessary "UpgradeSeries" sub-strings implied by the API scope.
- Removes previously added DTO structs and makes status get/set consistent for unit and machine.
- Uses `model.UpgradeSeriesStatus` everywhere instead of strings that are cast back and forward.
- Renames methods on `state.Machine` that deal with series upgrades; unit-based methods are indicated, machine-based methods are implied.
- Fixes panic in upgrade-series API due to errant unit tag creation.

## QA steps

Green unit tests.
End-to-end work-flow continues to work.

## Documentation changes

None.

## Bug reference

N/A
