### PR TITLE
Improve k8s storage class lookup

### DIFF
--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -36,6 +36,10 @@ func StorageClass(cfg *storageConfig) string {
 	return cfg.storageClass
 }
 
+func ExistingStorageClass(cfg *storageConfig) string {
+	return cfg.existingStorageClass
+}
+
 func StorageProvisioner(cfg *storageConfig) string {
 	return cfg.storageProvisioner
 }

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -60,13 +60,13 @@ func (s *storageSuite) TestValidateConfigError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "storage-class must be specified if storage-provisioner is specified")
 }
 
-func (s *storageSuite) TestValidateConfigDefaultStorageClass(c *gc.C) {
+func (s *storageSuite) TestValidateConfigExistingStorageClass(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	cfg, err := provider.NewStorageConfig(map[string]interface{}{"storage-provisioner": "ebs"})
+	cfg, err := provider.NewStorageConfig(map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(provider.StorageClass(cfg), gc.Equals, "juju-unit-storage")
+	c.Assert(provider.ExistingStorageClass(cfg), gc.Equals, "juju-unit-storage")
 }
 
 func (s *storageSuite) TestNewStorageConfig(c *gc.C) {


### PR DESCRIPTION
## Description of change

When the k8s provisioner looks up what storage class to use, we now supply a fallback class which will be used if present, but won't result in a not found error if it doesn't exist. This is so that we can properly allow operator storage to be configured.

## QA steps

deploy a k8s model
deploy a charm and ensure that the operator comes up but with no storage used
set up a storage class called juju-operator-volume
deploy a charm and ensure that the operator storage is created

