### PR TITLE
Bootstraping to LXD 2.0.x

### DIFF
--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -238,7 +238,7 @@ func (s *Server) verifyNICsWithConfigFile(nics map[string]device, reader func(st
 			continue
 		}
 
-		logger.Debugf("found usable network device %q with parent %q", name, netName)
+		logger.Tracef("found usable network device %q with parent %q", name, netName)
 		s.localBridgeName = netName
 		return nil
 	}

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -180,10 +180,9 @@ func (s *Server) ensureDefaultNetworking(profile *api.Profile, eTag string) erro
 
 	if err := s.UpdateProfile(profile.Name, profile.Writable(), eTag); err != nil {
 		return errors.Trace(err)
-	} else {
-		logger.Debugf("created new nic device %q in profile %q", nicName, profile.Name)
-		return nil
 	}
+	logger.Debugf("created new nic device %q in profile %q", nicName, profile.Name)
+	return nil
 }
 
 // verifyNICsWithAPI uses the LXD network API to check if one of the input NIC
@@ -239,7 +238,7 @@ func (s *Server) verifyNICsWithConfigFile(nics map[string]device, reader func(st
 			continue
 		}
 
-		logger.Infof("found usable network device %q with parent %q", name, netName)
+		logger.Debugf("found usable network device %q with parent %q", name, netName)
 		s.localBridgeName = netName
 		return nil
 	}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -119,6 +119,16 @@ func (env *environ) newContainer(
 	}
 	cleanupCallback() // Clean out any long line of completed download status
 
+	// Ensure that the default profile has a network configuration that will
+	// allow access to containers that we create.
+	profile, eTag, err := env.server.GetProfile("default")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := env.server.VerifyNetworkDevice(profile, eTag); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	cSpec, err := env.getContainerSpec(image, args)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -23,7 +23,8 @@ import (
 type environBrokerSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx        context.ProviderCallContext
+	defaultProfile *api.Profile
 }
 
 var _ = gc.Suite(&environBrokerSuite{})
@@ -31,6 +32,13 @@ var _ = gc.Suite(&environBrokerSuite{})
 func (s *environBrokerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.callCtx = context.NewCloudCallContext()
+	s.defaultProfile = &api.Profile{
+		ProfilePut: api.ProfilePut{
+			Devices: map[string]map[string]string{
+				"eth0": {},
+			},
+		},
+	}
 }
 
 // containerSpecMatcher is a gomock matcher for testing a container spec
@@ -71,7 +79,9 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
 	)
@@ -111,6 +121,8 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -160,7 +172,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
@@ -200,7 +214,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
@@ -232,7 +248,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
@@ -259,7 +277,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 	)
 	env := s.NewEnviron(c, svr, nil)
 
@@ -291,7 +311,9 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetNICsFromProfile("default").Return(map[string]map[string]string{"eth0": {}}, nil),
+		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
+		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
+		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
 	)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -89,7 +89,7 @@ type ServerFactory interface {
 	RemoteServer(environs.CloudSpec) (Server, error)
 
 	// InsecureRemoteServer creates a new server that connect to a remote lxd
-	// server in a insecure mannor.
+	// server in a insecure manner.
 	// If the cloudSpec endpoint is nil or empty, it will assume that you want
 	// to connection to a local server and will instead use that one.
 	InsecureRemoteServer(environs.CloudSpec) (Server, error)
@@ -145,7 +145,7 @@ func (s *serverFactory) LocalServer() (Server, error) {
 	}
 
 	// initialize a new local server
-	svr, profile, err := s.initLocalServer()
+	svr, err := s.initLocalServer()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -153,7 +153,7 @@ func (s *serverFactory) LocalServer() (Server, error) {
 	// bootstrap a new local server, this ensures that all connections to and
 	// from the local server are connected and setup correctly.
 	var hostName string
-	svr, hostName, err = s.bootstrapLocalServer(svr, profile)
+	svr, hostName, err = s.bootstrapLocalServer(svr)
 	if err == nil {
 		s.localServer = svr
 		s.localServerAddress = hostName
@@ -221,46 +221,29 @@ func (s *serverFactory) InsecureRemoteServer(spec environs.CloudSpec) (Server, e
 	return svr, errors.Trace(err)
 }
 
-type apiProfile struct {
-	Profile *lxdapi.Profile
-	ETag    string
-}
-
-func (s *serverFactory) initLocalServer() (Server, apiProfile, error) {
+func (s *serverFactory) initLocalServer() (Server, error) {
 	svr, err := s.newLocalServerFunc()
 	if err != nil {
-		return nil, apiProfile{}, errors.Trace(hoistLocalConnectErr(err))
+		return nil, errors.Trace(hoistLocalConnectErr(err))
 	}
 
-	// We need to get a default profile, so that the local bridge name
-	// can be discovered correctly to then get the host address.
 	defaultProfile, profileETag, err := svr.GetProfile("default")
 	if err != nil {
-		return nil, apiProfile{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-
-	// Ensure that the default profile has a network device, with a valid
-	// parent network.
-	//
-	// TODO (manadart 2018-07-18) Move this to just prior to instance creation.
-	// That is the only place it is relevant.
 	if err := svr.VerifyNetworkDevice(defaultProfile, profileETag); err != nil {
-		return nil, apiProfile{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	// LXD itself reports the host:ports that it listens on.
 	// Cross-check the address we have with the values reported by LXD.
-	err = svr.EnableHTTPSListener()
-	if err != nil {
-		return nil, apiProfile{}, errors.Annotate(err, "enabling HTTPS listener")
+	if err := svr.EnableHTTPSListener(); err != nil {
+		return nil, errors.Annotate(err, "enabling HTTPS listener")
 	}
-	return svr, apiProfile{
-		Profile: defaultProfile,
-		ETag:    profileETag,
-	}, nil
+	return svr, nil
 }
 
-func (s *serverFactory) bootstrapLocalServer(svr Server, profile apiProfile) (Server, string, error) {
+func (s *serverFactory) bootstrapLocalServer(svr Server) (Server, string, error) {
 	// select the server bridge name, so that we can then try and select
 	// the hostAddress from the current interfaceAddress
 	bridgeName := svr.LocalBridgeName()
@@ -300,7 +283,7 @@ func (s *serverFactory) bootstrapLocalServer(svr Server, profile apiProfile) (Se
 			// Requesting a NewLocalServer forces a new connection, so that when
 			// we GetConnectionInfo it gets the required addresses.
 			// Note: this modifies the outer svr server.
-			if svr, profile, err = s.initLocalServer(); err != nil {
+			if svr, err = s.initLocalServer(); err != nil {
 				return errors.Trace(err)
 			}
 
@@ -318,7 +301,7 @@ func (s *serverFactory) bootstrapLocalServer(svr Server, profile apiProfile) (Se
 
 	// If the server is not a simple simple stream server, don't check the
 	// API version, but do report for other scenarios
-	if err := s.validateServer(svr, profile); err != nil {
+	if err := s.validateServer(svr); err != nil {
 		return nil, "", errors.Trace(err)
 	}
 
@@ -326,37 +309,22 @@ func (s *serverFactory) bootstrapLocalServer(svr Server, profile apiProfile) (Se
 }
 
 func (s *serverFactory) bootstrapRemoteServer(svr Server) error {
-	// We need to get a default profile, so that the local bridge name
-	// can be discovered correctly to then get the host address.
-	defaultProfile, profileETag, err := svr.GetProfile("default")
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Ensure that the default profile has a network device, with a valid
-	// parent network.
-	//
-	// TODO (manadart 2018-07-18) Move this to just prior to instance creation.
-	// That is the only place it is relevant.
-	if err := svr.VerifyNetworkDevice(defaultProfile, profileETag); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := s.validateServer(svr, apiProfile{
-		Profile: defaultProfile,
-		ETag:    profileETag,
-	}); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
+	err := s.validateServer(svr)
+	return errors.Trace(err)
 }
 
-func (s *serverFactory) validateServer(svr Server, profile apiProfile) error {
+func (s *serverFactory) validateServer(svr Server) error {
 	// If the storage API is supported, let's make sure the LXD has a
 	// default pool; we'll just use dir backend for now.
 	if svr.StorageSupported() {
-		if err := svr.EnsureDefaultStorage(profile.Profile, profile.ETag); err != nil {
+		// Ensure that the default profile has a network configuration that will
+		// allow access to containers that we create.
+		profile, eTag, err := svr.GetProfile("default")
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		if err := svr.EnsureDefaultStorage(profile, eTag); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -373,7 +341,7 @@ func (s *serverFactory) validateServer(svr Server, profile apiProfile) error {
 		logger.Warningf(msg)
 		logger.Warningf("trying to use unsupported LXD API version %q", apiVersion)
 	} else {
-		logger.Infof("using LXD API version %q", apiVersion)
+		logger.Debugf("using LXD API version %q", apiVersion)
 	}
 
 	return nil

--- a/provider/lxd/server_test.go
+++ b/provider/lxd/server_test.go
@@ -56,6 +56,7 @@ func (s *serverSuite) TestLocalServer(c *gc.C) {
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -102,6 +103,7 @@ func (s *serverSuite) TestLocalServerRetrySemantics(c *gc.C) {
 		server.EXPECT().EnableHTTPSListener().Return(nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -167,6 +169,7 @@ func (s *serverSuite) TestLocalServerWithInvalidAPIVersion(c *gc.C) {
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -308,7 +311,7 @@ func (s *serverSuite) TestLocalServerWithStorageNotSupported(c *gc.C) {
 	}
 	serverInfo := &api.Server{
 		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "a.b",
+			APIVersion: "2.2",
 		},
 	}
 
@@ -361,6 +364,7 @@ func (s *serverSuite) TestRemoteServerWithEmptyEndpointYieldsLocalServer(c *gc.C
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -387,9 +391,8 @@ func (s *serverSuite) TestRemoteServer(c *gc.C) {
 	factory, server := s.newRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().StorageSupported().Return(true),
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -408,31 +411,10 @@ func (s *serverSuite) TestRemoteServer(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *serverSuite) TestRemoteServerWithProfileError(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	factory, server := s.newRemoteServerFactory(ctrl)
-
-	server.EXPECT().GetProfile("default").Return(nil, "", errors.New("bad"))
-
-	creds := cloud.NewCredential("any", map[string]string{
-		"client-cert": "client-cert",
-		"client-key":  "client-key",
-		"server-cert": "server-cert",
-	})
-	_, err := factory.RemoteServer(environs.CloudSpec{
-		Endpoint:   "https://10.0.0.9:8443",
-		Credential: &creds,
-	})
-	c.Assert(errors.Cause(err).Error(), gc.Matches, "bad")
-}
-
 func (s *serverSuite) TestRemoteServerWithNoStorage(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	profile := &api.Profile{}
 	etag := "etag"
 	serverInfo := &api.Server{
 		ServerUntrusted: api.ServerUntrusted{
@@ -443,8 +425,6 @@ func (s *serverSuite) TestRemoteServerWithNoStorage(c *gc.C) {
 	factory, server := s.newRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().StorageSupported().Return(false),
 		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
 	)
@@ -482,13 +462,9 @@ func (s *serverSuite) TestRemoteServerWithGetServerError(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	profile := &api.Profile{}
-	etag := "etag"
 	factory, server := s.newRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
-		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
-		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().StorageSupported().Return(false),
 		server.EXPECT().GetServer().Return(nil, "", errors.New("bad")),
 	)


### PR DESCRIPTION
## Description of change

When using lxd 2.0.x that doesn't support api network extensions, 
the latest juju will fail because it can't find the configuration file 
inside the container. 

In current develop for Juju LXD 2.0.x will not bootstrap, the following
code will now bootstrap to LXD 2.0.x.

## QA steps

Install lxd 2.0 either via snap or apt-get, making sure that
you remove your current lxd 3.0 and your current lxd 2.0
setup. (this only presents itself on a clean install).

Installing lxd 2.0 for xenial:

```sh
sudo apt-get install lxd=2.0.11-0ubuntu1~16.04.4
```

```sh
juju bootstrap localhost test
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1788805

## Notes

This PR supersedes https://github.com/juju/juju/pull/8964