### PR TITLE
add newline to juju add-cloud success output

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -258,6 +258,7 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	ctxt.Infof("Cloud %q successfully added", name)
+	ctxt.Infof("")
 	ctxt.Infof("You may need to `juju add-credential %s' if your cloud needs additional credentials", name)
 	ctxt.Infof("Then you can bootstrap with 'juju bootstrap %s'", name)
 

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -913,6 +913,7 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack cloudfile.Cloud, expectedYAML
 	c.Check(err, jc.ErrorIsNil)
 	var output = addStdErrMsg +
 		"Cloud \"os1\" successfully added\n" +
+		"\n" +
 		"You may need to `juju add-credential os1' if your cloud needs additional credentials\n" +
 		"Then you can bootstrap with 'juju bootstrap os1'\n"
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, output)


### PR DESCRIPTION
## Description of change

add newline to juju add-cloud success output

## QA steps

Run 'juju add-cloud'.  The success message at the end should have a new line between the lines starting with "Cloud" and "You may need".

## Documentation changes

N/A

## Bug reference

N/A