### PR TITLE
leases: Don't crash the lease manager on timeouts

### DIFF
--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -30,6 +30,7 @@ type Secretary interface {
 type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
 	Errorf(string, ...interface{})
 }
 

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/workertest"
 
 	corelease "github.com/juju/juju/core/lease"
 	coretesting "github.com/juju/juju/testing"
@@ -217,8 +218,7 @@ func (s *AsyncSuite) TestExpiryRepeatedTimeout(c *gc.C) {
 			}
 			delay *= 2
 		}
-		err := manager.Wait()
-		c.Assert(errors.Cause(err), gc.Equals, corelease.ErrTimeout)
+		workertest.CheckAlive(c, manager)
 	})
 }
 
@@ -501,7 +501,6 @@ func (s *AsyncSuite) TestClaimRepeatedTimeout(c *gc.C) {
 			c.Fatalf("timed out waiting for result")
 		}
 
-		err = manager.Wait()
-		c.Assert(errors.Cause(err), gc.Equals, corelease.ErrTimeout)
+		workertest.CheckAlive(c, manager)
 	})
 }


### PR DESCRIPTION
## Description of change

At startup there's a period where the lease manager is running but raft isn't yet. We get timeouts when workers try to claim singular leases in  that time, but if the lease manager bounces because of them it causes a lot of fallout because that also bounces the API server, breaking API connections and invalidating watchers.

Instead we log the timeout error, as well as responding to the client in the case of claims/extensions timing out. 

## QA steps

* Bootstrap a controller and deploy an application immediately when the bootstrap finishes (ie `juju bootstrap ...  && juju deploy ...`. The deploy should succeed - previously it would complain that the API connection was closed.
