### PR TITLE
Cloud credential validation against model's cloud.

### DIFF
--- a/apiserver/common/credentialcommon/backend.go
+++ b/apiserver/common/credentialcommon/backend.go
@@ -5,6 +5,7 @@ package credentialcommon
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
@@ -46,6 +47,9 @@ type Model interface {
 
 	// Config returns the config for the model.
 	Config() (*config.Config, error)
+
+	// ValidateCloudCredential validates new cloud credential for this model.
+	ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error
 }
 
 // ModelBackend defines what model specific properties where persisted in state

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/credentialcommon"
@@ -17,7 +18,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
-	"gopkg.in/juju/names.v2"
 )
 
 type ModelCredentialSuite struct {

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -200,7 +200,7 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C
 	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
 	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
 	err = s.State.UpdateCloudCredential(tag, cred)
-	c.Assert(err, gc.ErrorMatches, `updating cloud credentials: validating cloud credentials: credential "stratus/bob/foobar" with auth-type "userpass" is not supported \(expected one of \["access-key"\]\)`)
+	c.Assert(err, gc.ErrorMatches, `updating cloud credentials: validating credential "stratus/bob/foobar" for cloud "stratus": supported auth-types \["access-key"\], "userpass" not supported`)
 }
 
 func (s *CloudCredentialsSuite) TestCloudCredentialsEmpty(c *gc.C) {

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -98,7 +98,7 @@ func (p InitializeParams) Validate() error {
 		credentials[tag] = convertCloudCredentialToState(tag, cred)
 	}
 	if _, err := validateCloudCredentials(p.Cloud, credentials); err != nil {
-		return errors.Annotate(err, "validating cloud credentials")
+		return errors.Trace(err)
 	}
 	creds := make(map[string]Credential, len(credentials))
 	for tag, cred := range credentials {

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -245,7 +245,7 @@ func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {
 		AdminPassword: "dummy-secret",
 	})
 	c.Assert(err, gc.ErrorMatches,
-		`validating initialization args: validating cloud credentials: credential "dummy/initialize-admin/borken" with auth-type "userpass" is not supported \(expected one of \["access-key" "oauth1"\]\)`,
+		`validating initialization args: validating credential "dummy/initialize-admin/borken" for cloud "dummy": supported auth-types \["access-key" "oauth1"\], "userpass" not supported`,
 	)
 }
 

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -5,6 +5,9 @@ package state
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/cloud"
 )
 
 // InvalidateModelCredential invalidate cloud credential for the model
@@ -22,4 +25,18 @@ func (st *State) InvalidateModelCredential(reason string) error {
 	}
 
 	return errors.Trace(st.InvalidateCloudCredential(tag, reason))
+}
+
+// ValidateCloudCredential validates new cloud credential for this model.
+func (m *Model) ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
+	cloud, err := m.st.Cloud(m.Cloud())
+	if err != nil {
+		return errors.Annotatef(err, "getting cloud %q", m.Cloud())
+	}
+
+	err = validateCredentialForCloud(cloud, tag, convertCloudCredentialToState(tag, credential))
+	if err != nil {
+		return errors.Annotatef(err, "validating credential %q for cloud %q", tag.Id(), cloud.Name)
+	}
+	return nil
 }

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -59,6 +59,33 @@ func (s *ModelCredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 	c.Assert(invalidated.InvalidReason, gc.DeepEquals, reason)
 }
 
+func (s *ModelCredentialSuite) TestValidateCloudCredentialWrongCloud(c *gc.C) {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
+	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
+	err = m.ValidateCloudCredential(tag, cred)
+	c.Assert(err, gc.ErrorMatches, `validating credential "stratus/bob/foobar" for cloud "dummy": cloud "stratus" not valid`)
+}
+
+func (s *ModelCredentialSuite) TestValidateCloudCredentialWrongAuthType(c *gc.C) {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	tag := names.NewCloudCredentialTag("dummy/bob/foobar")
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, nil)
+	err = m.ValidateCloudCredential(tag, cred)
+	c.Assert(err, gc.ErrorMatches, `validating credential "dummy/bob/foobar" for cloud "dummy": supported auth-types \["empty"\], "access-key" not supported`)
+}
+
+func (s *ModelCredentialSuite) TestValidateCloudCredentialModel(c *gc.C) {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	tag := names.NewCloudCredentialTag("dummy/bob/foobar")
+	cred := cloud.NewCredential(cloud.EmptyAuthType, nil)
+	err = m.ValidateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ModelCredentialSuite) createCloudCredential(c *gc.C, credentialName string) names.CloudCredentialTag {
 	// Cloud name is always "dummy" as deep within the testing infrastructure,
 	// we create a testing controller on a cloud "dummy".


### PR DESCRIPTION
## Description of change

When validating a cloud credential for a model, we need to ensure that the credential is valid for the cloud, for example that it is of auth-type that the cloud supports.

Most of this functionality has been written in state. This PR re-factors it for common use, exposes it and uses it in the apiserver call.

