### PR TITLE
ensure ResourceVersion for updating existing CRD

### DIFF
--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -136,6 +136,10 @@ func (s *BaseSuite) k8sNotFoundError() *k8serrors.StatusError {
 	return k8serrors.NewNotFound(schema.GroupResource{}, "test")
 }
 
+func (s *BaseSuite) k8sAlreadyExists() *k8serrors.StatusError {
+	return k8serrors.NewAlreadyExists(schema.GroupResource{}, "test")
+}
+
 func (s *BaseSuite) deleteOptions(policy v1.DeletionPropagation) *v1.DeleteOptions {
 	return &v1.DeleteOptions{PropagationPolicy: &policy}
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -371,7 +371,6 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionCreate(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockCustomResourceDefinition.EXPECT().Update(crd).Times(1).Return(nil, s.k8sNotFoundError()),
 		s.mockCustomResourceDefinition.EXPECT().Create(crd).Times(1).Return(crd, nil),
 	)
 	err := s.broker.EnsureCustomResourceDefinition("test", podSpec)
@@ -475,6 +474,8 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionUpdate(c *gc.C) {
 		},
 	}
 	gomock.InOrder(
+		s.mockCustomResourceDefinition.EXPECT().Create(crd).Times(1).Return(crd, s.k8sAlreadyExists()),
+		s.mockCustomResourceDefinition.EXPECT().Get("tfjobs.kubeflow.org", v1.GetOptions{}).Times(1).Return(crd, nil),
 		s.mockCustomResourceDefinition.EXPECT().Update(crd).Times(1).Return(crd, nil),
 	)
 	err := s.broker.EnsureCustomResourceDefinition("test", podSpec)

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -147,11 +147,11 @@ func (w *deploymentWorker) loop() error {
 			return errors.Annotate(err, "cannot parse pod spec")
 		}
 		if len(spec.CustomResourceDefinitions) > 0 {
-			logger.Debugf("created/updated custom resource definition for %q.", w.application)
 			err = w.broker.EnsureCustomResourceDefinition(w.application, spec)
 			if err != nil {
 				return errors.Trace(err)
 			}
+			logger.Debugf("created/updated custom resource definition for %q.", w.application)
 		}
 		serviceParams := &caas.ServiceParams{
 			PodSpec:      spec,


### PR DESCRIPTION
## Description of change

Now, Juju can update existing CRD correctly.
fix: Get `ResourceVersion` first then inject it into `CRD` `Update` payload

## QA steps

```
juju deploy cs:~kelvin.liu/kubeflow-tf-job-operator-6  # ensure an existing CRD

juju add-model k2 k8s  # create a new CAAS model

juju deploy cs:~kelvin.liu/kubeflow-tf-job-operator-6  # deploy the same charm into the same k8s cluster

juju debug-log -m controller --color --include-module juju.workers.caasunitprovisioner --include-module juju.kubernetes.provider --replay  # see logs
```
