### PR TITLE
k8s operators as deployed as statefulsets and use storage correctly

### DIFF
--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/storage"
 )
 
 // Client allows access to the CAAS operator provisioner API endpoint.
@@ -105,8 +106,9 @@ func (c *Client) Life(appName string) (life.Value, error) {
 
 // OperatorProvisioningInfo holds the info needed to provision an operator.
 type OperatorProvisioningInfo struct {
-	ImagePath string
-	Version   version.Number
+	ImagePath    string
+	Version      version.Number
+	CharmStorage storage.KubernetesFilesystemParams
 }
 
 // OperatorProvisioningInfo returns the info needed to provision an operator.
@@ -115,8 +117,20 @@ func (c *Client) OperatorProvisioningInfo() (OperatorProvisioningInfo, error) {
 	if err := c.facade.FacadeCall("OperatorProvisioningInfo", nil, &result); err != nil {
 		return OperatorProvisioningInfo{}, err
 	}
-	return OperatorProvisioningInfo{
-		ImagePath: result.ImagePath,
-		Version:   result.Version,
-	}, nil
+	info := OperatorProvisioningInfo{
+		ImagePath:    result.ImagePath,
+		Version:      result.Version,
+		CharmStorage: filesystemFromParams(result.CharmStorage),
+	}
+	return info, nil
+}
+
+func filesystemFromParams(in params.KubernetesFilesystemParams) storage.KubernetesFilesystemParams {
+	return storage.KubernetesFilesystemParams{
+		StorageName:  in.StorageName,
+		Provider:     storage.ProviderType(in.Provider),
+		Size:         in.Size,
+		Attributes:   in.Attributes,
+		ResourceTags: in.Tags,
+	}
 }

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/caasoperatorprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/storage"
 )
 
 type provisionerSuite struct {
@@ -165,6 +166,13 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 		*(result.(*params.OperatorProvisioningInfo)) = params.OperatorProvisioningInfo{
 			ImagePath: "juju-operator-image",
 			Version:   vers,
+			CharmStorage: params.KubernetesFilesystemParams{
+				Size:        10,
+				Provider:    "kubernetes",
+				StorageName: "stor",
+				Tags:        map[string]string{"model": "mode-tag"},
+				Attributes:  map[string]interface{}{"key": "value"},
+			},
 		}
 		return nil
 	})
@@ -173,5 +181,12 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 	c.Assert(info, jc.DeepEquals, caasoperatorprovisioner.OperatorProvisioningInfo{
 		ImagePath: "juju-operator-image",
 		Version:   vers,
+		CharmStorage: storage.KubernetesFilesystemParams{
+			Size:         10,
+			Provider:     "kubernetes",
+			StorageName:  "stor",
+			ResourceTags: map[string]string{"model": "mode-tag"},
+			Attributes:   map[string]interface{}{"key": "value"},
+		},
 	})
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -6,6 +6,7 @@ package caasoperatorprovisioner_test
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -24,10 +25,12 @@ var _ = gc.Suite(&CAASProvisionerSuite{})
 type CAASProvisionerSuite struct {
 	coretesting.BaseSuite
 
-	resources  *common.Resources
-	authorizer *apiservertesting.FakeAuthorizer
-	api        *caasoperatorprovisioner.API
-	st         *mockState
+	resources               *common.Resources
+	authorizer              *apiservertesting.FakeAuthorizer
+	api                     *caasoperatorprovisioner.API
+	st                      *mockState
+	storageProviderRegistry *mockStorageProviderRegistry
+	storagePoolManager      *mockStoragePoolManager
 }
 
 func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
@@ -42,7 +45,9 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	api, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st)
+	s.storageProviderRegistry = &mockStorageProviderRegistry{}
+	s.storagePoolManager = &mockStoragePoolManager{}
+	api, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st, s.storageProviderRegistry, s.storagePoolManager)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -51,7 +56,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: names.NewMachineTag("0"),
 	}
-	_, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st)
+	_, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st, s.storageProviderRegistry, s.storagePoolManager)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -122,6 +127,11 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
 		ImagePath: fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
 		Version:   version.Current,
+		CharmStorage: params.KubernetesFilesystemParams{
+			Size:       uint64(1024),
+			Provider:   "kubernetes",
+			Attributes: map[string]interface{}{"foo": "bar"},
+		},
 	})
 }
 
@@ -132,6 +142,25 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
 		ImagePath: s.st.operatorImage,
 		Version:   version.Current,
+		CharmStorage: params.KubernetesFilesystemParams{
+			Size:       uint64(1024),
+			Provider:   "kubernetes",
+			Attributes: map[string]interface{}{"foo": "bar"},
+		},
+	})
+}
+
+func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
+	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
+	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	result, err := s.api.OperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
+		ImagePath: s.st.operatorImage,
+		Version:   version.Current,
+		CharmStorage: params.KubernetesFilesystemParams{
+			Size: uint64(1024),
+		},
 	})
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -481,8 +481,9 @@ type ConfigResult struct {
 
 // OperatorProvisioningInfo holds info need to provision an operator.
 type OperatorProvisioningInfo struct {
-	ImagePath string         `json:"image-path"`
-	Version   version.Number `json:"version"`
+	ImagePath    string                     `json:"image-path"`
+	Version      version.Number             `json:"version"`
+	CharmStorage KubernetesFilesystemParams `json:"charm-storage"`
 }
 
 // PublicAddress holds parameters for the PublicAddress call.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -174,6 +174,24 @@ type Unit struct {
 	FilesystemInfo []FilesystemInfo
 }
 
+// CharmStorageParams defines parameters used to create storage
+// for operators to use for charm state.
+type CharmStorageParams struct {
+	// Size is the minimum size of the filesystem in MiB.
+	Size uint64
+
+	// The provider type for this filesystem.
+	Provider storage.ProviderType
+
+	// Attributes is a set of provider-specific options for storage creation,
+	// as defined in a storage pool.
+	Attributes map[string]interface{}
+
+	// ResourceTags is a set of tags to set on the created filesystem, if the
+	// storage provider supports tags.
+	ResourceTags map[string]string
+}
+
 // OperatorConfig is the config to use when creating an operator.
 type OperatorConfig struct {
 	// OperatorImagePath is the docker registry URL for the image.
@@ -181,6 +199,10 @@ type OperatorConfig struct {
 
 	// Version is the Juju version of the operator image.
 	Version version.Number
+
+	// CharmStorage defines parameters used to create storage
+	// for operators to use for charm state.
+	CharmStorage CharmStorageParams
 
 	// AgentConf is the contents of the agent.conf file.
 	AgentConf []byte

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -12,10 +12,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/retry"
 	"gopkg.in/juju/names.v2"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -52,10 +50,9 @@ const (
 	labelStorage     = "juju-storage"
 	labelVersion     = "juju-version"
 	labelApplication = "juju-application"
+	labelModel       = "juju-model"
 
-	operatorStorageClassName = "juju-operator-storage"
-	// TODO(caas) - make this configurable using application config
-	operatorStorageSize = "10Mi"
+	defaultOperatorStorageClassName = "juju-operator-storage"
 
 	gpuAffinityNodeSelectorKey = "gpu"
 )
@@ -217,61 +214,84 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		return errors.Annotate(err, "creating or updating ConfigMap")
 	}
 
-	// Attempt to get a persistent volume to store charm state etc.
-	// If there are none, that's ok, we'll just use ephemeral storage.
+	// Set up the parameters for creating charm storage.
 	volStorageLabel := fmt.Sprintf("%s-operator-storage", appName)
 	params := volumeParams{
-		storageConfig:       &storageConfig{existingStorageClass: operatorStorageClassName},
+		storageConfig:       &storageConfig{existingStorageClass: defaultOperatorStorageClassName},
 		storageLabels:       []string{volStorageLabel, k.namespace, "default"},
 		pvcName:             operatorVolumeClaim(appName),
-		requestedVolumeSize: operatorStorageSize,
-		labels:              map[string]string{labelApplication: appName},
+		requestedVolumeSize: fmt.Sprintf("%dMi", config.CharmStorage.Size),
+		labels:              map[string]string{labelOperator: appName},
 	}
-	var (
-		storageVol *core.Volume
-		pvc        *core.PersistentVolumeClaim
-	)
-	pvcSpec, exists, err := k.maybeGetVolumeClaimSpec(params)
+	// If there's been a storage pool created for operator storage, use it.
+	if config.CharmStorage.Provider == K8s_ProviderType {
+		if storageLabel, ok := config.CharmStorage.Attributes[storageLabel]; ok {
+			params.storageLabels = append([]string{fmt.Sprintf("%v", storageLabel)}, params.storageLabels...)
+		}
+		var err error
+		params.storageConfig, err = newStorageConfig(config.CharmStorage.Attributes, defaultOperatorStorageClassName)
+		if err != nil {
+			return errors.Annotatef(err, "invalid storage configuration for %v operator", appName)
+		}
+	}
+	logger.Debugf("operator storage config %#v", *params.storageConfig)
+
+	// Attempt to get a persistent volume to store charm state etc.
+	// If there are none, that's ok, we'll just use ephemeral storage.
+	var pvc *core.PersistentVolumeClaim
+	pvcSpec, err := k.maybeGetVolumeClaimSpec(params)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Annotate(err, "finding operator volume claim")
 	} else if err == nil {
-		volName := pvcSpec.VolumeName
-		if !exists {
-			pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
-			pvc, err = pvClaims.Create(&core.PersistentVolumeClaim{
-				ObjectMeta: v1.ObjectMeta{
-					Name:   params.pvcName,
-					Labels: params.labels},
-				Spec: *pvcSpec,
-			})
-			if err != nil {
-				return errors.Trace(err)
-			}
-			logger.Debugf("created new pvc: %+v", pvc)
-			volName = pvc.Spec.VolumeName
-		}
-		storageVol = &core.Volume{Name: volName}
-		storageVol.PersistentVolumeClaim = &core.PersistentVolumeClaimVolumeSource{
-			ClaimName: params.pvcName,
+		pvc = &core.PersistentVolumeClaim{
+			ObjectMeta: v1.ObjectMeta{
+				Name:   params.pvcName,
+				Labels: params.labels},
+			Spec: *pvcSpec,
 		}
 	}
 	pod := operatorPod(appName, agentPath, config.OperatorImagePath, config.Version.String())
-	if storageVol != nil {
-		// TODO(caas) - if claim is pending, backoff until it is ready
-		logger.Debugf("using persistent volume for operator: %+v", storageVol)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, *storageVol)
+	// Take a copy for use with statefulset.
+	podWithoutStorage := pod
+
+	numPods := int32(1)
+	labels := map[string]string{labelOperator: appName}
+	if pvc != nil {
+		// Storage has been set up for this operator so use a statefulset.
+		logger.Debugf("using persistent volume claim for operator %s: %+v", appName, pvc)
+		statefulset := &apps.StatefulSet{
+			ObjectMeta: v1.ObjectMeta{
+				Name:   operatorName(appName),
+				Labels: labels},
+			Spec: apps.StatefulSetSpec{
+				Replicas: &numPods,
+				Selector: &v1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: core.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: labels,
+					},
+				},
+				PodManagementPolicy:  apps.ParallelPodManagement,
+				VolumeClaimTemplates: []core.PersistentVolumeClaim{*pvc},
+			},
+		}
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, core.VolumeMount{
-			Name:      storageVol.Name,
+			Name:      pvc.Name,
 			MountPath: agent.BaseDir(agentPath),
 		})
-	}
 
-	// See if we are able to just update the pod image, otherwise we'll need to
-	// delete and create as without deployment controller that's all we can do.
-	// TODO(caas) - consider using a deployment controller for operator for easier management
-	if err := k.maybeUpdatePodImage(
-		operatorSelector(appName), config.Version.String(), pod.Spec.Containers[0].Image); err != nil {
-		return k.ensurePod(pod)
+		statefulset.Spec.Template.Spec = pod.Spec
+		if err := k.ensureStatefulSet(statefulset, podWithoutStorage.Spec); err != nil {
+			return errors.Annotatef(err, "creating or updating %v operator StatefulSet", appName)
+		}
+	} else {
+		// No storage has been set up for this operator so use a deployment.
+		operatorSpec := &unitSpec{Pod: pod.Spec}
+		if err := k.configureDeployment(appName, operatorName(appName), labels, operatorSpec, nil, &numPods); err != nil {
+			return errors.Annotatef(err, "creating or updating %v operator DeploymentController", appName)
+		}
 	}
 	return nil
 }
@@ -282,11 +302,26 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 func (k *kubernetesClient) maybeGetStorageClass(labels ...string) (*k8sstorage.StorageClass, error) {
 	// First try looking for a storage class with a Juju label.
 	selector := fmt.Sprintf("%v in (%v)", labelStorage, strings.Join(labels, ", "))
+	modelTerm := fmt.Sprintf("%s==%s", labelModel, k.namespace)
+	modelSelector := selector + "," + modelTerm
+
+	// Attempt to get a storage class tied to this model.
 	storageClasses, err := k.StorageV1().StorageClasses().List(v1.ListOptions{
-		LabelSelector: selector,
+		LabelSelector: modelSelector,
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "looking for existing storage class with selector %q", modelSelector)
+	}
+
+	// If no storage classes tied to this model, look for a non-model specific
+	// storage class with the relevant labels.
+	if len(storageClasses.Items) == 0 {
+		storageClasses, err = k.StorageV1().StorageClasses().List(v1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return nil, errors.Annotatef(err, "looking for existing storage class with selector %q", modelSelector)
+		}
 	}
 	logger.Debugf("available storage classes: %v", storageClasses.Items)
 	// For now, pick the first matching storage class.
@@ -297,7 +332,7 @@ func (k *kubernetesClient) maybeGetStorageClass(labels ...string) (*k8sstorage.S
 	// Second look for the cluster default storage class, if defined.
 	storageClasses, err = k.StorageV1().StorageClasses().List(v1.ListOptions{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "listing storage classes")
 	}
 	for _, sc := range storageClasses.Items {
 		if v, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && v != "false" {
@@ -321,34 +356,18 @@ type volumeParams struct {
 	accessMode          core.PersistentVolumeAccessMode
 }
 
-// maybeGetVolumeClaimSpec returns a persistent volume claim spec, and a bool indicating
-// if the claim exists.
-func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.PersistentVolumeClaimSpec, bool, error) {
-	// We create a volume using a persistent volume claim.
-	// First, attempt to get any previously created claim for this app.
-	pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
-	pvc, err := pvClaims.Get(params.pvcName, v1.GetOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil, false, errors.Trace(err)
-	}
-	if err == nil {
-		logger.Debugf("using existing pvc %s for %v", pvc.Name, pvc.Spec.VolumeName)
-		return &pvc.Spec, true, nil
-	}
-
-	// We need to create a new claim.
-	logger.Debugf("creating new persistent volume claim for %v", params.pvcName)
-
+// maybeGetVolumeClaimSpec returns a persistent volume claim spec for the given
+// parameters. If no suitable storage class is available, return a NotFound error.
+func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.PersistentVolumeClaimSpec, error) {
 	storageClassName := params.storageConfig.storageClass
 	existingStorageClassName := params.storageConfig.existingStorageClass
 	haveStorageClass := false
 	// If no specific storage class has been specified but there's a default
 	// fallback one, try and look for that first.
 	if storageClassName == "" && existingStorageClassName != "" {
-		storageClasses := k.StorageV1().StorageClasses()
-		sc, err := storageClasses.Get(existingStorageClassName, v1.GetOptions{})
+		sc, err := k.getStorageClass(existingStorageClassName)
 		if err != nil && !k8serrors.IsNotFound(err) {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Annotatef(err, "looking for existing storage class %q", existingStorageClassName)
 		}
 		if err == nil {
 			haveStorageClass = true
@@ -360,7 +379,7 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.P
 	if storageClassName == "" && !haveStorageClass {
 		sc, err := k.maybeGetStorageClass(params.storageLabels...)
 		if err != nil && !errors.IsNotFound(err) {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 		if err == nil {
 			haveStorageClass = true
@@ -369,14 +388,18 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.P
 	}
 	// If a specific storage class has been requested, make sure it exists.
 	if storageClassName != "" && !haveStorageClass {
-		err := k.ensureStorageClass(params.storageConfig)
+		params.storageConfig.storageClass = storageClassName
+		sc, err := k.ensureStorageClass(params.storageConfig)
 		if err != nil && !errors.IsNotFound(err) {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
-		haveStorageClass = err == nil
+		if err == nil {
+			haveStorageClass = true
+			storageClassName = sc.Name
+		}
 	}
 	if !haveStorageClass {
-		return nil, false, errors.NewNotFound(nil, fmt.Sprintf(
+		return nil, errors.NewNotFound(nil, fmt.Sprintf(
 			"cannot create persistent volume as no storage class matching %q exists and no default storage class is defined",
 			params.storageLabels))
 	}
@@ -386,7 +409,7 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.P
 	}
 	fsSize, err := resource.ParseQuantity(params.requestedVolumeSize)
 	if err != nil {
-		return nil, false, errors.Annotatef(err, "invalid volume size %v", params.requestedVolumeSize)
+		return nil, errors.Annotatef(err, "invalid volume size %v", params.requestedVolumeSize)
 	}
 	return &core.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClassName,
@@ -396,56 +419,61 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.P
 			},
 		},
 		AccessModes: []core.PersistentVolumeAccessMode{accessMode},
-	}, false, nil
+	}, nil
 }
 
-func (k *kubernetesClient) ensureStorageClass(cfg *storageConfig) error {
-	// First see if the named storage class exists.
+// getStorageClass returns a named storage class, first looking for
+// one which is qualified by the current namespace if it's available.
+func (k *kubernetesClient) getStorageClass(name string) (*k8sstorage.StorageClass, error) {
 	storageClasses := k.StorageV1().StorageClasses()
-	_, err := storageClasses.Get(cfg.storageClass, v1.GetOptions{})
+	qualifiedName := qualifiedStorageClassName(k.namespace, name)
+	sc, err := storageClasses.Get(qualifiedName, v1.GetOptions{})
 	if err == nil {
-		return nil
+		return sc, nil
 	}
-
 	if !k8serrors.IsNotFound(err) {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
+	}
+	return storageClasses.Get(name, v1.GetOptions{})
+}
+
+func (k *kubernetesClient) ensureStorageClass(cfg *storageConfig) (*k8sstorage.StorageClass, error) {
+	// First see if the named storage class exists.
+	sc, err := k.getStorageClass(cfg.storageClass)
+	if err == nil {
+		return sc, nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return nil, errors.Annotatef(err, "getting storage class %q", cfg.storageClass)
 	}
 	// If it's not found but there's no provisioner specified, we can't
 	// create it so just return not found.
 	if err != nil && cfg.storageProvisioner == "" {
-		return errors.NewNotFound(nil,
+		return nil, errors.NewNotFound(nil,
 			fmt.Sprintf("storage class %q doesn't exist, but no storage provisioner has been specified",
 				cfg.storageClass))
 	}
 
 	reclaimPolicy := core.PersistentVolumeReclaimRetain
 	// Create the storage class with the specified provisioner.
-	_, err = storageClasses.Create(&k8sstorage.StorageClass{
+	storageClasses := k.StorageV1().StorageClasses()
+	sc, err = storageClasses.Create(&k8sstorage.StorageClass{
 		ObjectMeta: v1.ObjectMeta{
-			Name: cfg.storageClass,
+			Name:   qualifiedStorageClassName(k.namespace, cfg.storageClass),
+			Labels: map[string]string{labelModel: k.namespace},
 		},
 		Provisioner:   cfg.storageProvisioner,
 		ReclaimPolicy: &reclaimPolicy,
 		Parameters:    cfg.parameters,
 	})
-	return errors.Trace(err)
+	return sc, errors.Annotatef(err, "creating storage class %q", cfg.storageClass)
 }
 
 // DeleteOperator deletes the specified operator.
 func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 	logger.Debugf("deleting %s operator", appName)
 
-	// First delete any persistent volume claim.
-	pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
-	pvcName := operatorVolumeClaim(appName)
-	err = pvClaims.Delete(pvcName, &v1.DeleteOptions{
-		PropagationPolicy: &defaultPropagationPolicy,
-	})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil
-	}
-
-	// Then delete the config map.
+	// First delete the config map.
 	configMaps := k.CoreV1().ConfigMaps(k.namespace)
 	configMapName := operatorConfigMapName(appName)
 	err = configMaps.Delete(configMapName, &v1.DeleteOptions{
@@ -455,9 +483,24 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 		return nil
 	}
 
-	// Finally the pod itself.
-	podName := operatorPodName(appName)
-	return k.deletePod(podName)
+	// Finally the operator itself.
+	operatorName := operatorName(appName)
+	if err := k.deleteStatefulSet(operatorName); err != nil {
+		return errors.Trace(err)
+	}
+	pods := k.CoreV1().Pods(k.namespace)
+	podsList, err := pods.List(v1.ListOptions{
+		LabelSelector: operatorSelector(appName),
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, p := range podsList.Items {
+		if err := k.deleteVolumeClaims(&p); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return errors.Trace(k.deleteDeployment(operatorName))
 }
 
 // Service returns the service for the specified application.
@@ -507,7 +550,8 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 	if err := k.deleteService(appName); err != nil {
 		return errors.Trace(err)
 	}
-	if err := k.deleteStatefulSet(appName); err != nil {
+	deploymentName := deploymentName(appName)
+	if err := k.deleteStatefulSet(deploymentName); err != nil {
 		return errors.Trace(err)
 	}
 	pods := k.CoreV1().Pods(k.namespace)
@@ -522,7 +566,7 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 			return errors.Trace(err)
 		}
 	}
-	return errors.Trace(k.deleteDeployment(appName))
+	return errors.Trace(k.deleteDeployment(deploymentName))
 }
 
 // EnsureCustomResourceDefinition creates or updates a custom resource definition resource.
@@ -638,13 +682,14 @@ func (k *kubernetesClient) EnsureService(
 	}
 
 	numPods := int32(numUnits)
+	labels := map[string]string{labelApplication: appName}
 	if useStatefulSet {
-		if err := k.configureStatefulSet(appName, unitSpec, params.PodSpec.Containers, &numPods, params.Filesystems); err != nil {
+		if err := k.configureStatefulSet(appName, labels, unitSpec, params.PodSpec.Containers, &numPods, params.Filesystems); err != nil {
 			return errors.Annotate(err, "creating or updating StatefulSet")
 		}
 		cleanups = append(cleanups, func() { k.deleteDeployment(appName) })
 	} else {
-		if err := k.configureDeployment(appName, unitSpec, params.PodSpec.Containers, &numPods); err != nil {
+		if err := k.configureDeployment(appName, deploymentName(appName), labels, unitSpec, params.PodSpec.Containers, &numPods); err != nil {
 			return errors.Annotate(err, "creating or updating DeploymentController")
 		}
 		cleanups = append(cleanups, func() { k.deleteDeployment(appName) })
@@ -725,12 +770,12 @@ func (k *kubernetesClient) configureStorage(
 		if storageLabel, ok := fs.Attributes[storageLabel]; ok {
 			params.storageLabels = append([]string{fmt.Sprintf("%v", storageLabel)}, params.storageLabels...)
 		}
-		params.storageConfig, err = newStorageConfig(fs.Attributes)
+		params.storageConfig, err = newStorageConfig(fs.Attributes, defaultStorageClass)
 		if err != nil {
 			return errors.Annotatef(err, "invalid storage configuration for %v", fs.StorageName)
 		}
 
-		pvcSpec, _, err := k.maybeGetVolumeClaimSpec(params)
+		pvcSpec, err := k.maybeGetVolumeClaimSpec(params)
 		if err != nil {
 			return errors.Annotatef(err, "finding volume for %s", fs.StorageName)
 		}
@@ -796,7 +841,9 @@ func (k *kubernetesClient) configurePodFiles(podSpec *core.PodSpec, containers [
 	return nil
 }
 
-func (k *kubernetesClient) configureDeployment(appName string, unitSpec *unitSpec, containers []caas.ContainerSpec, replicas *int32) error {
+func (k *kubernetesClient) configureDeployment(
+	appName, deploymentName string, labels map[string]string, unitSpec *unitSpec, containers []caas.ContainerSpec, replicas *int32,
+) error {
 	logger.Debugf("creating/updating deployment for %s", appName)
 
 	// Add the specified file to the pod spec.
@@ -808,20 +855,19 @@ func (k *kubernetesClient) configureDeployment(appName string, unitSpec *unitSpe
 		return errors.Trace(err)
 	}
 
-	namePrefix := resourceNamePrefix(appName)
 	deployment := &apps.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   deploymentName(appName),
-			Labels: map[string]string{labelApplication: appName}},
+			Name:   deploymentName,
+			Labels: labels},
 		Spec: apps.DeploymentSpec{
 			Replicas: replicas,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{labelApplication: appName},
+				MatchLabels: labels,
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					GenerateName: namePrefix,
-					Labels:       map[string]string{labelApplication: appName},
+					GenerateName: deploymentName + "-",
+					Labels:       labels,
 				},
 				Spec: podSpec,
 			},
@@ -839,9 +885,9 @@ func (k *kubernetesClient) ensureDeployment(spec *apps.Deployment) error {
 	return errors.Trace(err)
 }
 
-func (k *kubernetesClient) deleteDeployment(appName string) error {
+func (k *kubernetesClient) deleteDeployment(name string) error {
 	deployments := k.AppsV1().Deployments(k.namespace)
-	err := deployments.Delete(deploymentName(appName), &v1.DeleteOptions{
+	err := deployments.Delete(name, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
 	if k8serrors.IsNotFound(err) {
@@ -851,7 +897,7 @@ func (k *kubernetesClient) deleteDeployment(appName string) error {
 }
 
 func (k *kubernetesClient) configureStatefulSet(
-	appName string, unitSpec *unitSpec, containers []caas.ContainerSpec, replicas *int32, filesystems []storage.KubernetesFilesystemParams,
+	appName string, labels map[string]string, unitSpec *unitSpec, containers []caas.ContainerSpec, replicas *int32, filesystems []storage.KubernetesFilesystemParams,
 ) error {
 	logger.Debugf("creating/updating stateful set for %s", appName)
 
@@ -862,15 +908,15 @@ func (k *kubernetesClient) configureStatefulSet(
 	statefulset := &apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   deploymentName(appName),
-			Labels: map[string]string{labelApplication: appName}},
+			Labels: labels},
 		Spec: apps.StatefulSetSpec{
 			Replicas: replicas,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{labelApplication: appName},
+				MatchLabels: labels,
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{labelApplication: appName},
+					Labels: labels,
 				},
 			},
 			PodManagementPolicy: apps.ParallelPodManagement,
@@ -914,9 +960,9 @@ func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPod
 	return errors.Trace(err)
 }
 
-func (k *kubernetesClient) deleteStatefulSet(appName string) error {
+func (k *kubernetesClient) deleteStatefulSet(name string) error {
 	deployments := k.AppsV1().StatefulSets(k.namespace)
-	err := deployments.Delete(deploymentName(appName), &v1.DeleteOptions{
+	err := deployments.Delete(name, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
 	if k8serrors.IsNotFound(err) {
@@ -1357,85 +1403,10 @@ func (k *kubernetesClient) ensureConfigMap(configMap *core.ConfigMap) error {
 	return errors.Trace(err)
 }
 
-// maybeUpdatePodImage updates the pod image for the selector so long as its Juju version
-// label matches the given version.
-func (k *kubernetesClient) maybeUpdatePodImage(selector, jujuVersion, image string) error {
-	pods := k.CoreV1().Pods(k.namespace)
-	podList, err := pods.List(v1.ListOptions{
-		LabelSelector: selector,
-	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(podList.Items) == 0 {
-		return errors.NotFoundf("pod %q", selector)
-	}
-	pod := podList.Items[0]
-
-	// If the pod is for the same Juju version, we know the pod spec
-	// will not have changed so can just update the image.
-	// TODO(caas) - we should compare the old and new pod specs
-	if pod.Labels[jujuVersion] != jujuVersion {
-		return errors.New("version mismatch")
-	}
-	pod.Spec.Containers[0].Image = image
-	_, err = pods.Update(&pod)
-	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) ensurePod(pod *core.Pod) error {
-	// Kubernetes doesn't support updating a pod except under specific
-	// circumstances so we need to delete and create.
-	pods := k.CoreV1().Pods(k.namespace)
-	if err := k.deletePod(pod.Name); err != nil {
-		return errors.Trace(err)
-	}
-	_, err := pods.Create(pod)
-	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) deletePod(podName string) error {
-	pods := k.CoreV1().Pods(k.namespace)
-	err := pods.Delete(podName, &v1.DeleteOptions{
-		PropagationPolicy: &defaultPropagationPolicy,
-	})
-	if k8serrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Wait for pod to be deleted.
-	//
-	// TODO(caas) if we even need to wait,
-	// consider using pods.Watch.
-	errExists := errors.New("exists")
-	retryArgs := retry.CallArgs{
-		Clock: clock.WallClock,
-		IsFatalError: func(err error) bool {
-			return errors.Cause(err) != errExists
-		},
-		Func: func() error {
-			_, err := pods.Get(podName, v1.GetOptions{})
-			if err == nil {
-				return errExists
-			}
-			if k8serrors.IsNotFound(err) {
-				return nil
-			}
-			return errors.Trace(err)
-		},
-		Delay:       5 * time.Second,
-		MaxDuration: 2 * time.Minute,
-	}
-	return retry.Call(retryArgs)
-}
-
 // operatorPod returns a *core.Pod for the operator pod
 // of the specified application.
 func operatorPod(appName, agentPath, operatorImagePath, version string) *core.Pod {
-	podName := operatorPodName(appName)
+	podName := operatorName(appName)
 	configMapName := operatorConfigMapName(appName)
 	configVolName := configMapName + "-volume"
 
@@ -1574,12 +1545,12 @@ func makeUnitSpec(appName string, podSpec *caas.PodSpec) (*unitSpec, error) {
 	return &unitSpec, nil
 }
 
-func operatorPodName(appName string) string {
+func operatorName(appName string) string {
 	return "juju-operator-" + appName
 }
 
 func operatorConfigMapName(appName string) string {
-	return operatorPodName(appName) + "-config"
+	return operatorName(appName) + "-config"
 }
 
 func applicationConfigMapName(appName, fileSetName string) string {
@@ -1590,13 +1561,13 @@ func deploymentName(appName string) string {
 	return "juju-" + appName
 }
 
-func resourceNamePrefix(appName string) string {
-	return "juju-" + names.NewApplicationTag(appName).String() + "-"
-}
-
 func appSecretName(appName, containerName string) string {
 	// A pod may have multiple containers with different images and thus different secrets
 	return "juju-" + appName + "-" + containerName + "-secret"
+}
+
+func qualifiedStorageClassName(namespace, storageClass string) string {
+	return namespace + "-" + storageClass
 }
 
 func mergeDeviceConstraints(device devices.KubernetesDeviceParams, resources *core.ResourceRequirements) error {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -6,6 +6,7 @@ package provider_test
 import (
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	apps "k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -97,6 +98,39 @@ var basicPodspec = &caas.PodSpec{
 	}},
 }
 
+var operatorPodspec = core.PodSpec{
+	Containers: []core.Container{{
+		Name:            "juju-operator",
+		ImagePullPolicy: core.PullIfNotPresent,
+		Image:           "/path/to/image",
+		Env: []core.EnvVar{
+			{Name: "JUJU_APPLICATION", Value: "test"},
+		},
+		VolumeMounts: []core.VolumeMount{{
+			Name:      "juju-operator-test-config-volume",
+			MountPath: "path/to/agent/agents/application-test/agent.conf",
+			SubPath:   "agent.conf",
+		}, {
+			Name:      "test-operator-volume",
+			MountPath: "path/to/agent/agents",
+		}},
+	}},
+	Volumes: []core.Volume{{
+		Name: "juju-operator-test-config-volume",
+		VolumeSource: core.VolumeSource{
+			ConfigMap: &core.ConfigMapVolumeSource{
+				LocalObjectReference: core.LocalObjectReference{
+					Name: "juju-operator-test-config",
+				},
+				Items: []core.KeyToPath{{
+					Key:  "agent.conf",
+					Path: "agent.conf",
+				}},
+			},
+		},
+	}},
+}
+
 func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 	spec, err := provider.MakeUnitSpec("app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
@@ -158,6 +192,96 @@ func (s *K8sBrokerSuite) TestEnsureNamespace(c *gc.C) {
 
 	// Check idempotent.
 	err = s.broker.EnsureNamespace()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestDeleteOperator(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	// Delete operations below return a not found to ensure it's treated as a no-op.
+	gomock.InOrder(
+		s.mockConfigMaps.EXPECT().Delete("juju-operator-test-config", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
+			Return(s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Delete("juju-operator-test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
+			Return(s.k8sNotFoundError()),
+		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).
+			Return(&core.PodList{Items: []core.Pod{}}, nil),
+		s.mockDeployments.EXPECT().Delete("juju-operator-test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
+			Return(s.k8sNotFoundError()),
+	)
+
+	err := s.broker.DeleteOperator("test")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestEnsureOperator(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	numUnits := int32(1)
+	configMapArg := &core.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "juju-operator-test-config",
+		},
+		Data: map[string]string{
+			"agent.conf": "agent-conf-data",
+		},
+	}
+
+	scName := "test-juju-operator-storage"
+	statefulSetArg := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "juju-operator-test",
+			Labels: map[string]string{"juju-operator": "test"}},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &numUnits,
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"juju-operator": "test"},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"juju-operator": "test"},
+				},
+				Spec: operatorPodspec,
+			},
+			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   "test-operator-volume",
+					Labels: map[string]string{"juju-operator": "test"}},
+				Spec: core.PersistentVolumeClaimSpec{
+					StorageClassName: &scName,
+					AccessModes:      []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+					Resources: core.ResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("10Mi"),
+						},
+					},
+				},
+			}},
+			PodManagementPolicy: apps.ParallelPodManagement,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockNamespaces.EXPECT().Update(&core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}}).Times(1),
+		s.mockConfigMaps.EXPECT().Update(configMapArg).Times(1),
+		s.mockStorageClass.EXPECT().Get("test-juju-operator-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-juju-operator-storage"}}, nil),
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+			Return(nil, nil),
+	)
+
+	err := s.broker.EnsureOperator("test", "path/to/agent", &caas.OperatorConfig{
+		OperatorImagePath: "/path/to/image",
+		Version:           version.MustParse("2.99.0"),
+		AgentConf:         []byte("agent-conf-data"),
+		CharmStorage: caas.CharmStorageParams{
+			Size: uint64(10),
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -224,7 +348,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					GenerateName: "juju-application-test-",
+					GenerateName: "juju-test-",
 					Labels:       map[string]string{"juju-application": "test"},
 				},
 				Spec: podSpec,
@@ -544,7 +668,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockPersistentVolumeClaims.EXPECT().Get("juju-database-0", v1.GetOptions{}).
+		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "juju-unit-storage"}}, nil),
@@ -610,7 +734,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					GenerateName: "juju-application-test-",
+					GenerateName: "juju-test-",
 					Labels:       map[string]string{"juju-application": "test"},
 				},
 				Spec: podSpec,
@@ -740,7 +864,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockPersistentVolumeClaims.EXPECT().Get("juju-database-0", v1.GetOptions{}).
+		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "juju-unit-storage"}}, nil),

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -89,7 +89,7 @@ type storageConfig struct {
 	storageLabels []string
 }
 
-func newStorageConfig(attrs map[string]interface{}) (*storageConfig, error) {
+func newStorageConfig(attrs map[string]interface{}, defaultStorageClass string) (*storageConfig, error) {
 	out, err := storageConfigChecker.Coerce(attrs, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "validating storage config")
@@ -121,7 +121,7 @@ func newStorageConfig(attrs map[string]interface{}) (*storageConfig, error) {
 
 // ValidateConfig is defined on the storage.Provider interface.
 func (g *storageProvider) ValidateConfig(cfg *storage.Config) error {
-	_, err := newStorageConfig(cfg.Attrs())
+	_, err := newStorageConfig(cfg.Attrs(), defaultStorageClass)
 	return errors.Trace(err)
 }
 

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -64,7 +64,7 @@ func (s *storageSuite) TestValidateConfigExistingStorageClass(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	cfg, err := provider.NewStorageConfig(map[string]interface{}{})
+	cfg, err := provider.NewStorageConfig(map[string]interface{}{}, "juju-unit-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.ExistingStorageClass(cfg), gc.Equals, "juju-unit-storage")
 }
@@ -77,10 +77,11 @@ func (s *storageSuite) TestNewStorageConfig(c *gc.C) {
 		"storage-class":       "juju-ebs",
 		"storage-provisioner": "ebs",
 		"parameters.type":     "gp2",
-	})
+	}, "juju-unit-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.StorageClass(cfg), gc.Equals, "juju-ebs")
 	c.Assert(provider.StorageProvisioner(cfg), gc.Equals, "ebs")
+	c.Assert(provider.ExistingStorageClass(cfg), gc.Equals, "juju-unit-storage")
 	c.Assert(provider.StorageParameters(cfg), jc.DeepEquals, map[string]string{"type": "gp2"})
 }
 

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -6,6 +6,7 @@ package caasoperatorprovisioner_test
 import (
 	"sync"
 
+	"github.com/juju/juju/storage"
 	"github.com/juju/testing"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
@@ -58,6 +59,12 @@ func (m *mockProvisionerFacade) OperatorProvisioningInfo() (apicaasprovisioner.O
 	return apicaasprovisioner.OperatorProvisioningInfo{
 		ImagePath: "juju-operator-image",
 		Version:   version.MustParse("2.99.0"),
+		CharmStorage: storage.KubernetesFilesystemParams{
+			Provider:     "kubernetes",
+			Size:         uint64(1024),
+			ResourceTags: map[string]string{"foo": "bar"},
+			Attributes:   map[string]interface{}{"key": "value"},
+		},
 	}, nil
 }
 

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/storage"
 )
 
 var logger = loggo.GetLogger("juju.workers.caasprovisioner")
@@ -237,5 +238,15 @@ func (p *provisioner) newOperatorConfig(appName string, password string) (*caas.
 		AgentConf:         confBytes,
 		OperatorImagePath: info.ImagePath,
 		Version:           info.Version,
+		CharmStorage:      charmStorageParams(info.CharmStorage),
 	}, nil
+}
+
+func charmStorageParams(in storage.KubernetesFilesystemParams) caas.CharmStorageParams {
+	return caas.CharmStorageParams{
+		Provider:     in.Provider,
+		Size:         in.Size,
+		Attributes:   in.Attributes,
+		ResourceTags: in.ResourceTags,
+	}
 }

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -102,6 +102,12 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C) {
 	config := args[2].(*caas.OperatorConfig)
 	c.Assert(config.OperatorImagePath, gc.Equals, "juju-operator-image")
 	c.Assert(config.Version, gc.Equals, version.MustParse("2.99.0"))
+	c.Assert(config.CharmStorage, jc.DeepEquals, caas.CharmStorageParams{
+		Provider:     "kubernetes",
+		Size:         uint64(1024),
+		ResourceTags: map[string]string{"foo": "bar"},
+		Attributes:   map[string]interface{}{"key": "value"},
+	})
 
 	agentFile := filepath.Join(c.MkDir(), "agent.config")
 	err := ioutil.WriteFile(agentFile, []byte(config.AgentConf), 0644)


### PR DESCRIPTION
## Description of change

This PR fixes a number of aspects of k8s operator deployments.

k8s application operators now are deployed using either a deployment controller or statefulset (depending on if storage is used).
The operator provisioning api has been extended to provide the necessary storage information. juju will look for a storage-pool called "operator-storage" and use that if defined.
storage classes are now prefixed with the model name when created since they are global entities. juju will look first for the model class, and then for a global class.

## QA steps

Create a k8s model on aws.

Create a juju operator storage class:
$ juju create-storage-pool operator-storage kubernetes storage-class=juju-operator-storage storage-provisioner=kubernetes.io/aws-ebs parameters.type=gp2

Deploy a charm and see that the operator is deployed as a statefulset and that an ebs volume has been provisioned and used for operator storage.

