### PR TITLE
LXD: Set default server name

### DIFF
--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -99,6 +99,7 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 		// likely that we're on an older version of LXD. So in that case we
 		// need to set the name to something and internally LXD sets this type
 		// of node to "none".
+		// LP:#1786309
 		name = "none"
 	}
 	serverCertificate := info.Environment.Certificate

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -94,6 +94,13 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 
 	name := info.Environment.ServerName
 	clustered := info.Environment.ServerClustered
+	if name == "" && !clustered {
+		// If the name is set to empty and clustering is false, then it's highly
+		// likely that we're on an older version of LXD. So in that case we
+		// need to set the name to something and internally LXD sets this type
+		// of node to "none".
+		name = "none"
+	}
 	serverCertificate := info.Environment.Certificate
 	hostArch := arch.NormaliseArch(info.Environment.KernelArchitecture)
 

--- a/container/lxd/server_test.go
+++ b/container/lxd/server_test.go
@@ -94,6 +94,53 @@ func (s *serverSuite) TestCreateProfileWithConfig(c *gc.C) {
 	cSvr.EXPECT().CreateProfile(req).Return(nil)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
 	err = jujuSvr.CreateProfileWithConfig("custom", map[string]string{"boot.autostart": "false"})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serverSuite) TestGetServerName(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	serverName := "nuc8"
+	mutate := func(s *api.Server) {
+		s.Environment.ServerClustered = false
+		s.Environment.ServerName = serverName
+	}
+
+	cSvr := s.NewMockServer(ctrl, mutate)
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(jujuSvr.Name(), gc.Equals, serverName)
+}
+
+func (s *serverSuite) TestGetServerNameReturnsNoneIfServerNameIsEmpty(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mutate := func(s *api.Server) {
+		s.Environment.ServerClustered = false
+		s.Environment.ServerName = ""
+	}
+
+	cSvr := s.NewMockServer(ctrl, mutate)
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(jujuSvr.Name(), gc.Equals, "none")
+}
+
+func (s *serverSuite) TestGetServerNameReturnsEmptyIfServerNameIsEmptyAndClustered(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mutate := func(s *api.Server) {
+		s.Environment.ServerClustered = true
+		s.Environment.ServerName = ""
+	}
+
+	cSvr := s.NewMockServer(ctrl, mutate)
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(jujuSvr.Name(), gc.Equals, "")
 }

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -253,6 +253,11 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common
 func (env *environ) InstanceAvailabilityZoneNames(
 	ctx context.ProviderCallContext, ids []instance.Id,
 ) ([]string, error) {
+	instances, err := env.Instances(ctx, ids)
+	if err != nil && err != environs.ErrPartialInstances {
+		return nil, err
+	}
+
 	// If not clustered, just report all input IDs as being in the zone
 	// represented by the single server.
 	if !env.server.IsClustered() {
@@ -262,11 +267,6 @@ func (env *environ) InstanceAvailabilityZoneNames(
 			zones[i] = n
 		}
 		return zones, nil
-	}
-
-	instances, err := env.Instances(ctx, ids)
-	if err != nil && err != environs.ErrPartialInstances {
-		return nil, err
 	}
 
 	zones := make([]string, len(instances))

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -119,16 +119,6 @@ func (env *environ) newContainer(
 	}
 	cleanupCallback() // Clean out any long line of completed download status
 
-	// Ensure that the default profile has a network configuration that will
-	// allow access to containers that we create.
-	profile, eTag, err := env.server.GetProfile("default")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := env.server.VerifyNetworkDevice(profile, eTag); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	cSpec, err := env.getContainerSpec(image, args)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -79,8 +79,6 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -121,8 +119,6 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -172,8 +168,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
@@ -214,8 +208,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
@@ -248,8 +240,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
@@ -277,8 +267,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		sExp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 	)
 	env := s.NewEnviron(c, svr, nil)
@@ -311,8 +299,6 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.GetProfile("default").Return(s.defaultProfile, lxdtesting.ETag, nil),
-		exp.VerifyNetworkDevice(s.defaultProfile, lxdtesting.ETag).Return(nil),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -341,7 +341,7 @@ func (s *serverFactory) validateServer(svr Server) error {
 		logger.Warningf(msg)
 		logger.Warningf("trying to use unsupported LXD API version %q", apiVersion)
 	} else {
-		logger.Debugf("using LXD API version %q", apiVersion)
+		logger.Tracef("using LXD API version %q", apiVersion)
 	}
 
 	return nil


### PR DESCRIPTION
## Description of change

So the idea of the following is to set a default server name, so
that when we come to fill in the zones later on, the code in
question can identify it correctly.

From the code:
```
// If the name is set to empty and clustering is false, then it's highly
// likely that we're on an older version of LXD. So in that case we
// need to set the name to something and internally LXD sets this type
// of node to "none".
```

## QA steps

Ensure that you've got LXD 2.0 installed (snap is the easiest way, removing
LXD 3.0.x from your system).

```
juju bootstrap localhost test
juju deploy mysql
```

The following should not fail with the error 
> suitable availability zone for machine 0 not found

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1786309