### PR TITLE
Only show meter status for models under SLA.

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -413,9 +413,12 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 		Since:  status.Since,
 		Data:   status.Data,
 	}
-	ms := m.MeterStatus()
-	if isColorStatus(ms.Code) {
-		info.MeterStatus = params.MeterStatus{Color: strings.ToLower(ms.Code.String()), Message: ms.Info}
+
+	if info.SLA != "unsupported" {
+		ms := m.MeterStatus()
+		if isColorStatus(ms.Code) {
+			info.MeterStatus = params.MeterStatus{Color: strings.ToLower(ms.Code.String()), Message: ms.Info}
+		}
 	}
 
 	return info, nil

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -41,7 +41,8 @@ func (s *statusSuite) addMachine(c *gc.C) *state.Machine {
 
 func (s *statusSuite) TestFullStatus(c *gc.C) {
 	machine := s.addMachine(c)
-	s.State.SetSLA("essential", "test-user", []byte(""))
+	c.Assert(s.State.SetSLA("essential", "test-user", []byte("")), jc.ErrorIsNil)
+	c.Assert(s.State.SetModelMeterStatus("GREEN", "goo"), jc.ErrorIsNil)
 	client := s.APIState.Client()
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -49,6 +50,8 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	c.Check(status.Model.Type, gc.Equals, "iaas")
 	c.Check(status.Model.CloudTag, gc.Equals, "cloud-dummy")
 	c.Check(status.Model.SLA, gc.Equals, "essential")
+	c.Check(status.Model.MeterStatus.Color, gc.Equals, "green")
+	c.Check(status.Model.MeterStatus.Message, gc.Equals, "goo")
 	c.Check(status.Applications, gc.HasLen, 0)
 	c.Check(status.RemoteApplications, gc.HasLen, 0)
 	c.Check(status.Offers, gc.HasLen, 0)
@@ -60,6 +63,18 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	}
 	c.Check(resultMachine.Id, gc.Equals, machine.Id())
 	c.Check(resultMachine.Series, gc.Equals, machine.Series())
+}
+
+func (s *statusSuite) TestUnsupportedNoModelMeterStatus(c *gc.C) {
+	s.addMachine(c)
+	c.Assert(s.State.SetSLA("unsupported", "test-user", []byte("")), jc.ErrorIsNil)
+	c.Assert(s.State.SetModelMeterStatus("RED", "nope"), jc.ErrorIsNil)
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(status.Model.SLA, gc.Equals, "unsupported")
+	c.Check(status.Model.MeterStatus.Color, gc.Equals, "")
+	c.Check(status.Model.MeterStatus.Message, gc.Equals, "")
 }
 
 func (s *statusSuite) TestFullStatusUnitLeadership(c *gc.C) {
@@ -142,7 +157,8 @@ var testUnits = []struct {
 }
 
 func (s *statusUnitTestSuite) TestModelMeterStatus(c *gc.C) {
-	s.State.SetModelMeterStatus("RED", "thing")
+	c.Assert(s.State.SetSLA("advanced", "test-user", nil), jc.ErrorIsNil)
+	c.Assert(s.State.SetModelMeterStatus("RED", "thing"), jc.ErrorIsNil)
 
 	client := s.APIState.Client()
 	status, err := client.Status(nil)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3125,6 +3125,7 @@ var statusTests = []testCase{
 	),
 	test( // 24
 		"set meter status on the model",
+		setSLA{"advanced"},
 		setModelMeterStatus{"RED", "status message"},
 		expect{
 			what: "simulate just the two applications and a bootstrap node",
@@ -3144,7 +3145,7 @@ var statusTests = []testCase{
 						"color":   "red",
 						"message": "status message",
 					},
-					"sla": "unsupported",
+					"sla": "advanced",
 				},
 				"machines":     M{},
 				"applications": M{},


### PR DESCRIPTION
Fixes LP:#1779175

## Description of change

Only display model meter status when an SLA is set.

## QA steps

Deploy a model that collects metrics like cs:canonical-kubernetes or cs:kubernetes-core. Do not set an SLA. `juju status` should no longer display model meter status.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1779175