### PR TITLE
Allow the hubwatcher to die even if it has pending events to send.

### DIFF
--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -199,7 +199,12 @@ func (w *HubWatcher) loop() error {
 			w.handle(req)
 		}
 		for (len(w.syncEvents) + len(w.requestEvents)) > 0 {
-			w.flush()
+			select {
+			case <-w.tomb.Dying():
+				return errors.Trace(tomb.ErrDying)
+			default:
+				w.flush()
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes an infinite loop in shutdown of the hubwatcher where the hubwatcher wouldn't stop if there were pending messages to send.

## QA steps

Due to the inherent racy nature of this bug, it is very hard to trigger.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1789510