### PR TITLE
Notify users of units affected by machine series upgrade.

### DIFF
--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -19,10 +19,15 @@ type Client struct {
 	facade base.FacadeCaller
 }
 
+// MakeClient is a constructor function for a machine manager client
+func MakeClient(clientFacade base.ClientFacade, facadeCaller base.FacadeCaller) *Client {
+	return &Client{ClientFacade: clientFacade, facade: facadeCaller}
+}
+
 // NewClient returns a new machinemanager client.
 func NewClient(st base.APICallCloser) *Client {
 	frontend, backend := base.NewClientFacade(st, machineManagerFacade)
-	return &Client{ClientFacade: frontend, facade: backend}
+	return MakeClient(frontend, backend)
 }
 
 // AddMachines adds new machines with the supplied parameters, creating any requested disks.
@@ -166,7 +171,7 @@ func (client *Client) UpgradeSeriesPrepare(machineName, series string, force boo
 // successfully completed the managed series upgrade process.
 func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	if client.BestAPIVersion() < 5 {
-		return errors.NotSupportedf("upgrade-series complete")
+		return errors.NotSupportedf("UpgradeSeriesComplete")
 	}
 	args := params.UpdateSeriesArg{
 		Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},
@@ -181,4 +186,29 @@ func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	}
 
 	return nil
+}
+
+func (client *Client) UnitsToUpgrade(machineName string) ([]string, error) {
+	if client.BestAPIVersion() < 5 {
+		return nil, errors.NotSupportedf("UnitsToUpgrade")
+	}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{
+			{
+				Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},
+			},
+		},
+	}
+	results := new(params.UpgradeSeriesUnitsResults)
+	err := client.facade.FacadeCall("UnitsToUpgrade", args, results)
+	if err != nil {
+		return nil, err
+	}
+	if n := len(results.Results); n != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", n)
+	}
+	if results.Results[0].Error != nil {
+		return nil, results.Results[0].Error
+	}
+	return results.Results[0].UnitNames, nil
 }

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -19,15 +19,15 @@ type Client struct {
 	facade base.FacadeCaller
 }
 
-// MakeClient is a constructor function for a machine manager client
-func MakeClient(clientFacade base.ClientFacade, facadeCaller base.FacadeCaller) *Client {
+// ConstructClient is a constructor function for a machine manager client
+func ConstructClient(clientFacade base.ClientFacade, facadeCaller base.FacadeCaller) *Client {
 	return &Client{ClientFacade: clientFacade, facade: facadeCaller}
 }
 
 // NewClient returns a new machinemanager client.
 func NewClient(st base.APICallCloser) *Client {
 	frontend, backend := base.NewClientFacade(st, machineManagerFacade)
-	return MakeClient(frontend, backend)
+	return ConstructClient(frontend, backend)
 }
 
 // AddMachines adds new machines with the supplied parameters, creating any requested disks.

--- a/api/machinemanager/machinemanagernew_test.go
+++ b/api/machinemanager/machinemanagernew_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager_test
+
+import (
+	"github.com/golang/mock/gomock"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base/mocks"
+	"github.com/juju/juju/api/machinemanager"
+	"github.com/juju/juju/apiserver/params"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&NewMachineManagerSuite{})
+
+type NewMachineManagerSuite struct {
+	jujutesting.BaseSuite
+
+	tag  names.Tag
+	args params.Entities
+}
+
+func (s *NewMachineManagerSuite) SetUpTest(c *gc.C) {
+
+	s.tag = names.NewMachineTag("0")
+	s.args = params.Entities{Entities: []params.Entity{{Tag: s.tag.String()}}}
+
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *NewMachineManagerSuite) TestUnitsToUpgrade(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	fFacade := mocks.NewMockClientFacade(ctrl)
+	fCaller := mocks.NewMockFacadeCaller(ctrl)
+	arbitraryName := "machine-0"
+
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{
+			{
+				Entity: params.Entity{Tag: names.NewMachineTag(arbitraryName).String()},
+			},
+		},
+	}
+	result := params.UpgradeSeriesUnitsResult{
+		UnitNames: []string{"ubuntu/0", "ubuntu/1"},
+	}
+
+	results := params.UpgradeSeriesUnitsResults{[]params.UpgradeSeriesUnitsResult{result}}
+
+	fFacade.EXPECT().BestAPIVersion().Return(5)
+	fCaller.EXPECT().FacadeCall("UnitsToUpgrade", args, gomock.Any()).SetArg(2, results)
+	client := machinemanager.MakeClient(fFacade, fCaller)
+
+	unitNames, err := client.UnitsToUpgrade(arbitraryName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(unitNames, gc.DeepEquals, result.UnitNames)
+}

--- a/api/machinemanager/machinemanagernew_test.go
+++ b/api/machinemanager/machinemanagernew_test.go
@@ -1,6 +1,15 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+/*
+The existing machinemanager_test.go uses a home grown mocking mechanism. I wanted to establish the new suffixed file to have a place to start systematically moving those tests to use gomock. There are two benefits to this
+
+1) We can work piecemeal
+2) We don't have to mix two mocking styles (in attempt to preserve one file) when transitioning between mocking styles
+
+The plan is to start moving those old style tests and when finished delete the old file and mv the new file.
+*/
+
 package machinemanager_test
 
 import (

--- a/api/machinemanager/machinemanagernew_test.go
+++ b/api/machinemanager/machinemanagernew_test.go
@@ -63,7 +63,7 @@ func (s *NewMachineManagerSuite) TestUnitsToUpgrade(c *gc.C) {
 
 	fFacade.EXPECT().BestAPIVersion().Return(5)
 	fCaller.EXPECT().FacadeCall("UnitsToUpgrade", args, gomock.Any()).SetArg(2, results)
-	client := machinemanager.MakeClient(fFacade, fCaller)
+	client := machinemanager.ConstructClient(fFacade, fCaller)
 
 	unitNames, err := client.UnitsToUpgrade(arbitraryName)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -220,12 +220,12 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		return nil, errors.Trace(err)
 	}
 	template := state.MachineTemplate{
-		Series:                  p.Series,
-		Constraints:             p.Constraints,
-		Volumes:                 volumes,
-		InstanceId:              p.InstanceId,
-		Jobs:                    jobs,
-		Nonce:                   p.Nonce,
+		Series:      p.Series,
+		Constraints: p.Constraints,
+		Volumes:     volumes,
+		InstanceId:  p.InstanceId,
+		Jobs:        jobs,
+		Nonce:       p.Nonce,
 		HardwareCharacteristics: p.HardwareCharacteristics,
 		Addresses:               params.NetworkAddresses(p.Addrs...),
 		Placement:               placementDirective,

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -220,12 +220,12 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		return nil, errors.Trace(err)
 	}
 	template := state.MachineTemplate{
-		Series:      p.Series,
-		Constraints: p.Constraints,
-		Volumes:     volumes,
-		InstanceId:  p.InstanceId,
-		Jobs:        jobs,
-		Nonce:       p.Nonce,
+		Series:                  p.Series,
+		Constraints:             p.Constraints,
+		Volumes:                 volumes,
+		InstanceId:              p.InstanceId,
+		Jobs:                    jobs,
+		Nonce:                   p.Nonce,
 		HardwareCharacteristics: p.HardwareCharacteristics,
 		Addresses:               params.NetworkAddresses(p.Addrs...),
 		Placement:               placementDirective,
@@ -426,14 +426,17 @@ func (mm *MachineManagerAPI) UnitsToUpgrade(args params.UpdateSeriesArgs) (param
 		machineTag, err := names.ParseMachineTag(arg.Entity.Tag)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
+			continue
 		}
 		machine, err := mm.st.Machine(machineTag.Id())
 		if err != nil {
 			results[i].Error = common.ServerError(err)
+			continue
 		}
 		units, err := machine.Units()
 		if err != nil {
 			results[i].Error = common.ServerError(err)
+			continue
 		}
 		unitNames := []string{}
 		for _, unit := range units {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -483,6 +483,31 @@ func (s *MachineManagerSuite) TestUpgradeSeriesComplete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *MachineManagerSuite) TestUnitsToUpgrade(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{
+			{
+				Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
+			},
+		},
+	}
+	results, err := apiV5.UnitsToUpgrade(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	units, err := s.st.machines["0"].Units()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedUnitNames := []string{}
+	for _, unit := range units {
+		expectedUnitNames = append(expectedUnitNames, unit.Name())
+	}
+	actualUnitNames := results.Results[0].UnitNames
+
+	c.Assert(actualUnitNames, gc.DeepEquals, expectedUnitNames)
+}
+
 // TestIsSeriesLessThan tests a validation method which is not very complicated
 // but complex enough to warrant being exported from an export test package for
 // testing.
@@ -712,6 +737,10 @@ type mockUnit struct {
 
 func (u *mockUnit) UnitTag() names.UnitTag {
 	return u.tag
+}
+
+func (u *mockUnit) Name() string {
+	return u.tag.String()
 }
 
 type mockStorage struct {

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -97,6 +97,7 @@ func (m machineShim) Units() ([]Unit, error) {
 
 type Unit interface {
 	UnitTag() names.UnitTag
+	Name() string
 }
 
 func (m machineShim) VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error) {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1314,20 +1314,41 @@ type DumpModelRequest struct {
 	Simplified bool     `json:"simplified"`
 }
 
+// UpgradeSeriesStatusResult contains the upgrade series status result for an upgrading
+// machine or unit
 type UpgradeSeriesStatusResult struct {
 	Error  *Error                    `json:"error,omitempty"`
 	Status model.UpgradeSeriesStatus `json:"status,omitempty"`
 }
 
+// UpgradeSeriesStatusResults contains the upgrade series status results for
+// upgrading machines or units.
 type UpgradeSeriesStatusResults struct {
 	Results []UpgradeSeriesStatusResult `json:"results,omitempty"`
 }
 
+// UpgradeSeriesStatusParams contains the entities and desired statuses for
+// those entities.
 type UpgradeSeriesStatusParams struct {
 	Params []UpgradeSeriesStatusParam `json:"params"`
 }
 
+// UpgradeSeriesStatusParam contains the entity and desired status for
+// that entity.
 type UpgradeSeriesStatusParam struct {
 	Entity Entity                    `json:"entity"`
 	Status model.UpgradeSeriesStatus `json:"status"`
+}
+
+// UpgradeSeriesUnitsResults contains the units affected by a series per
+// machine entity.
+type UpgradeSeriesUnitsResults struct {
+	Results []UpgradeSeriesUnitsResult
+}
+
+// UpgradeSeriesUnitsResults contains the units affected by a series for
+// a given machine.
+type UpgradeSeriesUnitsResult struct {
+	Error     *Error   `json:"error,omitempty"`
+	UnitNames []string `json:"unit-names"`
 }

--- a/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
+++ b/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
@@ -56,6 +56,19 @@ func (mr *MockUpgradeMachineSeriesAPIMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).Close))
 }
 
+// UnitsToUpgrade mocks base method
+func (m *MockUpgradeMachineSeriesAPI) UnitsToUpgrade(arg0 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "UnitsToUpgrade", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnitsToUpgrade indicates an expected call of UnitsToUpgrade
+func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UnitsToUpgrade(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitsToUpgrade", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UnitsToUpgrade), arg0)
+}
+
 // UpgradeSeriesComplete mocks base method
 func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesComplete(arg0 string) error {
 	ret := m.ctrl.Call(m, "UpgradeSeriesComplete", arg0)

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -190,11 +190,6 @@ func (c *upgradeSeriesCommand) Run(ctx *cmd.Context) error {
 // dependency this function should contain minimal logic other than gathering an
 // API handle and making the API call.
 func (c *upgradeSeriesCommand) UpgradeSeriesPrepare(ctx *cmd.Context) error {
-	err := c.promptConfirmation(ctx)
-	if err != nil {
-		return err
-	}
-
 	var apiRoot api.Connection
 
 	// If the upgradeMachineSeries is nil then we collect a handle to the
@@ -208,6 +203,11 @@ func (c *upgradeSeriesCommand) UpgradeSeriesPrepare(ctx *cmd.Context) error {
 		}
 		defer apiRoot.Close()
 		c.upgradeMachineSeriesClient = machinemanager.NewClient(apiRoot)
+	}
+
+	err := c.promptConfirmation(ctx)
+	if err != nil {
+		return err
 	}
 
 	err = c.upgradeMachineSeriesClient.UpgradeSeriesPrepare(c.machineNumber, c.series, c.force)


### PR DESCRIPTION
## Description of change

When running `upgrade-series prepare` users should be notified of the units that are affected by the upgrade.

## QA steps

* `upgrade-series prepare <machine>`
* You should be notified of the units that would be changed by the issuing of the above command.

## Documentation changes

N/A (Perhaps some Discourse changes at first) 

## Bug reference

N/A
