### PR TITLE
raftleases: Increase the raft-forward timeout threshold to 5s

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -565,11 +565,11 @@
   revision = "5f8741c297b47cba29f747c67f2e31e7c2a36ecb"
 
 [[projects]]
-  digest = "1:f156d17854ec35dd41a88a507103cb0f703f62332fa31315779a303c565667c9"
+  digest = "1:76068d833db78ba2419f72e5efd91d1d4ab5e8ffca1f61c5b5a724795fea6572"
   name = "github.com/juju/pubsub"
   packages = ["."]
   pruneopts = ""
-  revision = "091412f84753115324ce870066ffbb6bb55c4ef4"
+  revision = "ad5dc02599e01a8409f9b1144e4d759baafd01dc"
 
 [[projects]]
   digest = "1:fbafcd485d270fc069d738bdcbfa3e03676936f837d4b2708f7ba80fa90e1c5a"
@@ -1817,6 +1817,7 @@
     "gopkg.in/goose.v2/swift",
     "gopkg.in/goose.v2/testservices/hook",
     "gopkg.in/goose.v2/testservices/identityservice",
+    "gopkg.in/goose.v2/testservices/neutronmodel",
     "gopkg.in/goose.v2/testservices/neutronservice",
     "gopkg.in/goose.v2/testservices/novaservice",
     "gopkg.in/goose.v2/testservices/openstackservice",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -318,7 +318,7 @@
 
 [[constraint]]
   name = "github.com/juju/pubsub"
-  revision = "091412f84753115324ce870066ffbb6bb55c4ef4"
+  revision = "ad5dc02599e01a8409f9b1144e4d759baafd01dc"
 
 [[constraint]]
   name = "github.com/juju/ratelimit"

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -42,8 +42,11 @@ const (
 	MaxSleep = time.Minute
 
 	// ForwardTimeout is how long the store should wait for a response
-	// after sending a lease operation over the hub.
-	ForwardTimeout = 200 * time.Millisecond
+	// after sending a lease operation over the hub before deciding a
+	// a response is never coming back (for example if we send the
+	// request during a raft-leadership election). This should be long
+	// enough that we can be very confident the request was missed.
+	ForwardTimeout = 5 * time.Second
 
 	// maxLogs is the maximum number of backup store log files to keep.
 	maxLogs = 10

--- a/worker/lease/manifold/manifold_test.go
+++ b/worker/lease/manifold/manifold_test.go
@@ -177,7 +177,7 @@ func (s *manifoldSuite) TestStart(c *gc.C) {
 		Target:         s.target,
 		RequestTopic:   "lease.manifold_test",
 		Clock:          s.clock,
-		ForwardTimeout: 200 * time.Millisecond,
+		ForwardTimeout: 5 * time.Second,
 	})
 
 	args = s.stub.Calls()[2].Args


### PR DESCRIPTION
## Description of change
The raft forward timeout needs to be high enough that when we see it we can be very confident that it happened because there was no raft-forwarder listening on the hub. The old value was low enough that we'd sometimes see false reports of timeouts even though the request was actually received and applied to raft. This would mean that the notify target wouldn't be sent the update if a lease was claimed or expired, for example.

There's not much downside to having a high-ish value - the caller will be blocked waiting for a response, but other lease operations aren't queued behind this one.

Also update the pubsub dependency so we don't see debug logging every time a clock update is sent.

## QA steps

* Tests pass, bootstrapping and deploying a set of applications with multiple units, watching the logs for timeout messages (none should happen once the system has started up - some are acceptable while raft is waiting for the peergrouper to publish api details).
