### PR TITLE
Remove newline after value when output is for a single setting.

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -345,7 +345,9 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 		if !ok || v == nil {
 			v = ""
 		}
-		fmt.Fprintln(ctx.Stdout, v)
+		// TODO (anastasiamac 2018-08-29) We want to have a new line after here (fmt.Fprintln).
+		// However, it will break all existing scripts and should be done as part of Juju 3.x work.
+		fmt.Fprint(ctx.Stdout, v)
 		return nil
 	}
 

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -140,17 +140,16 @@ func (s *ApplicationConfigSuite) TestConfigNoValueSingleSetting(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	var options []string
-	for k, _ := range charm.Config().Options {
-		options = append(options, k)
+	// use 'juju config foo' to see values
+	for option := range charm.Config().Options {
+		output := s.configCommandOutput(c, appName, option)
+		c.Assert(output, gc.Equals, "")
 	}
 
-	for i, option := range options {
-		c.Logf("case %d: 'juju config %v %v'", i, appName, option)
-		// use 'juju config foo' to see values
-		output := s.configCommandOutput(c, appName, option)
-		c.Assert(output, gc.Equals, "\n")
-	}
+	// set value to be something so that we can check newline added
+	s.configCommandOutput(c, appName, "stremptydefault=a")
+	output := s.configCommandOutput(c, appName, "stremptydefault")
+	c.Assert(output, gc.Equals, "a")
 }
 
 func (s *ApplicationConfigSuite) assertSameConfigOutput(c *gc.C, expectedValues settingsMap) {


### PR DESCRIPTION
## Description of change

We have previously introduced a newline when returning a value for a single application setting, see 'juju config'.
However, it can break existing scripts and should be held off as a breaking change until Juju 3.x.
