### PR TITLE
worker/lease: Ensure the lease manager waits for child goroutines

### DIFF
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -6,6 +6,7 @@ package lease
 import (
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/clock"
@@ -113,6 +114,10 @@ type Manager struct {
 	// errors is used to send errors from background claim or tick
 	// goroutines back to the main loop.
 	errors chan error
+
+	// wg is used to ensure that all child goroutines are finished
+	// before we stop.
+	wg sync.WaitGroup
 }
 
 // Kill is part of the worker.Worker interface.
@@ -127,6 +132,7 @@ func (manager *Manager) Wait() error {
 
 // loop runs until the manager is stopped.
 func (manager *Manager) loop() error {
+	defer manager.wg.Wait()
 	blocks := make(blocks)
 	for {
 		if err := manager.choose(blocks); err != nil {
@@ -153,8 +159,10 @@ func (manager *Manager) choose(blocks blocks) error {
 	case check := <-manager.checks:
 		return manager.handleCheck(check)
 	case manager.now = <-manager.nextTick(manager.now):
+		manager.wg.Add(1)
 		go manager.retryingTick(manager.now)
 	case claim := <-manager.claims:
+		manager.wg.Add(1)
 		go manager.retryingClaim(claim)
 	case block := <-manager.blocks:
 		// TODO(raftlease): Include the other key items.
@@ -191,6 +199,7 @@ func (manager *Manager) Claimer(namespace, modelUUID string) (lease.Claimer, err
 // claiming party when it eventually succeeds or fails, or if it times
 // out after a number of retries.
 func (manager *Manager) retryingClaim(claim claim) {
+	defer manager.wg.Done()
 	var (
 		err     error
 		success bool
@@ -324,6 +333,7 @@ func (manager *Manager) nextTick(lastTick time.Time) <-chan time.Time {
 
 // retryingTick runs tick and retries any timeouts.
 func (manager *Manager) retryingTick(now time.Time) {
+	defer manager.wg.Done()
 	var err error
 	for a := manager.startRetry(); a.Next(); {
 		err = manager.tick(now)


### PR DESCRIPTION
## Description of change

We were seeing errors in test teardown caused by a state-lease store operation trying to use a closed session. The tests will avoid closing the session until the state workers are stopped, but the lease manager would stop before its goroutines were finished. Use a waitgroup to prevent the manager from stopping until in-flight requests have finished or timed out.

## QA steps

* Added a test to verify that the manager waits until the child goroutines are finished. Ran state tests under stress to try to reproduce the error but couldn't.
