### PR TITLE
Fix charm version string

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1266,7 +1266,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:2cf3af3fdf2f8243de033c450c9749e68114b7edc11507a92e138d490e4ba555"
+  digest = "1:c59c19158813d727bc3b98225a3189c62db975279d4c74ea2886fe4c4c748ce4"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1274,7 +1274,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "abaa717bc6ed4f694281737cb01f32f7de7ea357"
+  revision = "c254caf8b8704ff71a10c552fa9e6f5df981ad06"
 
 [[projects]]
   digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -145,7 +145,7 @@
   name = "gopkg.in/juju/blobstore.v2"
 
 [[constraint]]
-  revision = "abaa717bc6ed4f694281737cb01f32f7de7ea357"
+  revision = "c254caf8b8704ff71a10c552fa9e6f5df981ad06"
   name = "gopkg.in/juju/charm.v6"
 
 [[constraint]]

--- a/testcharms/charm-repo/quantal/dummy/version
+++ b/testcharms/charm-repo/quantal/dummy/version
@@ -1,1 +1,1 @@
-dummy-146-g725cfd3-dirty
+revision-id: dummy-146-g725cfd3-dirty


### PR DESCRIPTION
## Description of change

When deploying a local charm, there was a warning generating the git version string if no tags were available. Bring in a new charm.v6 to fix this issue.
Also, the charm version string was not being correctly processed if there was no newline in the file. Use a Scanner to be more robust.
As a driveby, strip the useless revision-id: prefix from bzr revisions.

## QA steps

deploy a local charm with a bzr revision and check juju status

## Bug reference

https://bugs.launchpad.net/bugs/1789447
