### PR TITLE
Systemd Service Manager Refactoring

### DIFF
--- a/cmd/jujud/updateseries/updateseries.go
+++ b/cmd/jujud/updateseries/updateseries.go
@@ -17,7 +17,6 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/systemd"
 )
 
 var logger = loggo.GetLogger("juju.cmd.jujud.updateseries")
@@ -86,7 +85,7 @@ func (c *UpdateSeriesCommand) Init(args []string) error {
 	}
 
 	if c.manager == nil {
-		c.manager = service.NewSystemdServiceManager(systemd.IsRunning)
+		c.manager = service.NewServiceManagerWithDefaults()
 	}
 	return c.CommandBase.Init(args)
 }
@@ -139,12 +138,7 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 			break
 		}
 
-		startedMachineName, startedUnitNames, err := c.manager.StartAllAgents(
-			c.machineAgent,
-			c.unitAgents,
-			c.dataDir,
-			c.toSeries,
-		)
+		startedMachineName, startedUnitNames, err := c.manager.StartAllAgents(c.machineAgent, c.unitAgents, c.dataDir)
 		if err != nil {
 			return err
 		} else {
@@ -163,7 +157,6 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 			c.dataDir,
 			systemdDir,
 			systemdMultiUserDir,
-			c.toSeries,
 		)
 		if err != nil {
 			for _, agentName := range failedAgentNames {
@@ -198,7 +191,6 @@ func (c *UpdateSeriesCommand) Run(ctx *cmd.Context) error {
 				c.machineAgent,
 				c.unitAgents,
 				c.dataDir,
-				c.toSeries,
 			)
 			if err != nil {
 				return err

--- a/cmd/jujud/updateseries/updateseries_test.go
+++ b/cmd/jujud/updateseries/updateseries_test.go
@@ -5,7 +5,6 @@ package updateseries
 
 import (
 	"bytes"
-	"github.com/juju/juju/service/systemd"
 	"os"
 	"path"
 	"runtime"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	svctesting "github.com/juju/juju/service/common/testing"
+	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/testing"
 	coretest "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"

--- a/cmd/jujud/updateseries/updateseries_test.go
+++ b/cmd/jujud/updateseries/updateseries_test.go
@@ -5,6 +5,7 @@ package updateseries
 
 import (
 	"bytes"
+	"github.com/juju/juju/service/systemd"
 	"os"
 	"path"
 	"runtime"
@@ -67,8 +68,11 @@ func (s *updateSeriesCmdSuite) SetUpTest(c *gc.C) {
 	s.machineName = "machine-0"
 	s.unitNames = []string{"unit-ubuntu-0", "unit-mysql-0"}
 
-	// Equalivent to reboot after upgrade
-	s.manager = service.NewSystemdServiceManager(func() (bool, error) { return true, nil })
+	// Equivalent to reboot after upgrade.
+	s.manager = service.NewServiceManager(
+		func() (bool, error) { return true, nil },
+		s.newService,
+	)
 
 	s.assertSetupAgentsForTest(c)
 	s.setUpAgentConf(c)
@@ -110,12 +114,11 @@ func (s *updateSeriesCmdSuite) setUpServices(c *gc.C) {
 	for _, fake := range append(s.unitNames, s.machineName) {
 		s.addService("jujud-" + fake)
 	}
-	s.PatchValue(&service.NewService, s.newService)
 	s.PatchValue(&service.ListServices, s.listServices)
 }
 
 func (s *updateSeriesCmdSuite) addService(name string) {
-	svc, _ := s.newService(name, common.Conf{}, "")
+	svc, _ := s.newService(name, common.Conf{})
 	svc.Install()
 	svc.Start()
 }
@@ -124,7 +127,7 @@ func (s *updateSeriesCmdSuite) listServices() ([]string, error) {
 	return s.serviceData.InstalledNames(), nil
 }
 
-func (s *updateSeriesCmdSuite) newService(name string, conf common.Conf, series string) (service.Service, error) {
+func (s *updateSeriesCmdSuite) newService(name string, conf common.Conf) (service.Service, error) {
 	for _, svc := range s.services {
 		if svc.Name() == name {
 			return svc, nil
@@ -268,7 +271,11 @@ func (s *updateSeriesCmdSuite) assertSetupAgentsForTest(c *gc.C) {
 }
 
 func (s *updateSeriesCmdSuite) TestRunPreUpstartToSystemdUpgradeReboot(c *gc.C) {
-	s.manager = service.NewSystemdServiceManager(func() (bool, error) { return false, nil })
+	s.manager = service.NewServiceManager(
+		func() (bool, error) { return false, nil },
+		s.newService,
+	)
+
 	s.assertRunTest(c)
 	s.assertServiceSymLinks(c)
 	// Check idempotence
@@ -338,7 +345,11 @@ func (s *updateSeriesCmdSuite) TestSystemdToSystemdUpgradeStartAllAgents(c *gc.C
 }
 
 func (s *updateSeriesCmdSuite) TestRunTwiceFailFirstSystemdWriteService(c *gc.C) {
-	s.manager = service.NewSystemdServiceManager(func() (bool, error) { return false, nil })
+	s.manager = service.NewServiceManager(
+		func() (bool, error) { return false, nil },
+		s.newService,
+	)
+
 	s.services[0].SetErrors(
 		errors.New("fail me"),
 	)
@@ -391,7 +402,11 @@ func (s *updateSeriesCmdSuite) TestRunTwiceFailFirstWriteService(c *gc.C) {
 }
 
 func (s *updateSeriesCmdSuite) TestRunTwiceRewriteToolsLink(c *gc.C) {
-	s.manager = service.NewSystemdServiceManager(func() (bool, error) { return false, nil })
+	s.manager = service.NewServiceManager(
+		func() (bool, error) { return false, nil },
+		s.newService,
+	)
+
 	s.assertRunTest(c)
 	s.assertServiceSymLinks(c)
 
@@ -447,12 +462,12 @@ func (s *updateSeriesCmdSuite) assertToolsCopySymlink(c *gc.C, series string) {
 }
 
 func (s *updateSeriesCmdSuite) assertServiceSymLinks(c *gc.C) {
-	for _, agent := range append(s.unitNames, s.machineName) {
-		svcName := "jujud-" + agent
+	for _, name := range append(s.unitNames, s.machineName) {
+		svcName := "jujud-" + name
 		svcFileName := svcName + ".service"
 		result, err := os.Readlink(path.Join(systemdDir, svcFileName))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(result, gc.Equals, path.Join(service.SystemdDataDir, svcName, svcFileName))
+		c.Assert(result, gc.Equals, path.Join(systemd.DataDir, svcName, svcFileName))
 	}
 }
 

--- a/cmd/jujud/updateseries/updateseries_test.go
+++ b/cmd/jujud/updateseries/updateseries_test.go
@@ -467,7 +467,7 @@ func (s *updateSeriesCmdSuite) assertServiceSymLinks(c *gc.C) {
 		svcFileName := svcName + ".service"
 		result, err := os.Readlink(path.Join(systemdDir, svcFileName))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(result, gc.Equals, path.Join(systemd.DataDir, svcName, svcFileName))
+		c.Assert(result, gc.Equals, path.Join(systemd.LibSystemdDir, svcName, svcFileName))
 	}
 }
 

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -28,10 +28,18 @@ const (
 	cloudInitCfgDir
 )
 
+const (
+	// NixDataDir is location for agent binaries on *nix operating systems.
+	NixDataDir = "/var/lib/juju"
+
+	// NixDataDir is location for Juju logs on *nix operating systems.
+	NixLogDir = "/var/log"
+)
+
 var nixVals = map[osVarType]string{
 	tmpDir:               "/tmp",
-	logDir:               "/var/log",
-	dataDir:              "/var/lib/juju",
+	logDir:               NixLogDir,
+	dataDir:              NixDataDir,
 	storageDir:           "/var/lib/juju/storage",
 	confDir:              "/etc/juju",
 	jujuRun:              "/usr/bin/juju-run",

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -90,7 +90,8 @@ func NewServiceManager(
 	}
 }
 
-// WriteServiceFiles writes the service life in standard '/lib/systemd/system' path.
+// WriteServiceFiles writes service files to the standard
+// "/lib/systemd/system" path.
 func (s *systemdServiceManager) WriteServiceFiles() error {
 	machineAgent, unitAgents, _, err := s.FindAgents(paths.NixDataDir)
 	if err != nil {
@@ -215,13 +216,13 @@ func (s *systemdServiceManager) WriteSystemdAgents(
 
 		// Otherwise we need to manually ensure the service unit links.
 		svcFileName := svcName + ".service"
-		if err = os.Symlink(path.Join(systemd.DataDir, svcName, svcFileName),
+		if err = os.Symlink(path.Join(systemd.LibSystemdDir, svcName, svcFileName),
 			path.Join(symLinkSystemdDir, svcFileName)); err != nil && !os.IsExist(err) {
 			return nil, nil, nil, errors.Errorf(
 				"failed to link service file (%s) in systemd dir: %s\n", svcFileName, err)
 		}
 
-		if err = os.Symlink(path.Join(systemd.DataDir, svcName, svcFileName),
+		if err = os.Symlink(path.Join(systemd.LibSystemdDir, svcName, svcFileName),
 			path.Join(symLinkSystemdMultiUserDir, svcFileName)); err != nil && !os.IsExist(err) {
 			return nil, nil, nil, errors.Errorf(
 				"failed to link service file (%s) in multi-user.target.wants dir: %s\n", svcFileName, err)

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -355,7 +355,7 @@ func (s *agentConfSuite) assertServiceSymLinks(c *gc.C) {
 		svcFileName := svcName + ".service"
 		result, err := os.Readlink(path.Join(s.systemdDir, svcFileName))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(result, gc.Equals, path.Join(systemd.DataDir, svcName, svcFileName))
+		c.Assert(result, gc.Equals, path.Join(systemd.LibSystemdDir, svcName, svcFileName))
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -12,27 +12,21 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/os/series"
 	"github.com/juju/utils"
-	"github.com/juju/utils/shell"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
 	"github.com/juju/juju/service/windows"
 )
 
-var (
-	logger   = loggo.GetLogger("juju.service")
-	renderer = shell.BashRenderer{}
-)
+var logger = loggo.GetLogger("juju.service")
 
 // These are the names of the init systems recognized by juju.
 const (
 	InitSystemSystemd = "systemd"
 	InitSystemUpstart = "upstart"
 	InitSystemWindows = "windows"
-	SystemdDataDir    = "/lib/systemd/system"
 )
 
 // linuxInitSystems lists the names of the init systems that juju might
@@ -134,17 +128,7 @@ func newService(name string, conf common.Conf, initSystem, series string) (Servi
 	case InitSystemUpstart:
 		return upstart.NewService(name, conf), nil
 	case InitSystemSystemd:
-		dataDir, err := paths.DataDir(series)
-		if err != nil {
-			return nil, err
-		}
-		svc, err := systemd.NewService(
-			name,
-			conf,
-			SystemdDataDir,
-			systemd.NewDBusAPI,
-			renderer.Join(dataDir, "init"),
-		)
+		svc, err := systemd.NewServiceWithDefaults(name, conf)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to wrap service %q", name)
 		}

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/juju/service/common"
 )
 
-const DataDir = "/lib/systemd/system"
+const LibSystemdDir = "/lib/systemd/system"
 
 var (
 	logger = loggo.GetLogger("juju.service.systemd")
@@ -79,7 +79,7 @@ type Service struct {
 // NewServiceWithDefaults returns a new systemd service reference populated
 // with sensible defaults.
 func NewServiceWithDefaults(name string, conf common.Conf) (*Service, error) {
-	svc, err := NewService(name, conf, DataDir, NewDBusAPI, renderer.Join(paths.NixDataDir, "init"))
+	svc, err := NewService(name, conf, LibSystemdDir, NewDBusAPI, renderer.Join(paths.NixDataDir, "init"))
 	return svc, errors.Trace(err)
 }
 

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -4,6 +4,7 @@
 package systemd
 
 import (
+	"github.com/juju/juju/juju/paths"
 	"io/ioutil"
 	"os"
 	"path"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/juju/juju/service/common"
 )
+
+const DataDir = "/lib/systemd/system"
 
 var (
 	logger = loggo.GetLogger("juju.service.systemd")
@@ -73,8 +76,18 @@ type Service struct {
 	newDBus DBusAPIFactory
 }
 
-// NewService returns a new value that implements Service for systemd.
-func NewService(name string, conf common.Conf, dataDir string, newDBus DBusAPIFactory, fallBackDirName string) (*Service, error) {
+// NewServiceWithDefaults returns a new systemd service reference populated
+// with sensible defaults.
+func NewServiceWithDefaults(name string, conf common.Conf) (*Service, error) {
+	svc, err := NewService(name, conf, DataDir, NewDBusAPI, renderer.Join(paths.NixDataDir, "init"))
+	return svc, errors.Trace(err)
+}
+
+// NewService returns a new reference to an object that implements the Service
+// interface for systemd.
+func NewService(
+	name string, conf common.Conf, dataDir string, newDBus DBusAPIFactory, fallBackDirName string,
+) (*Service, error) {
 	confName := name + ".service"
 	var volName string
 	if conf.ExecStart != "" {

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -4,7 +4,6 @@
 package systemd
 
 import (
-	"github.com/juju/juju/juju/paths"
 	"io/ioutil"
 	"os"
 	"path"
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/shell"
 
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service/common"
 )
 

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/systemd"
 )
 
 // stateStepsFor24 returns upgrade steps for Juju 2.4.0 that manipulate state directly.
@@ -84,8 +83,8 @@ func installServiceFile(context Context) error {
 				oldDataDir := context.AgentConfig().DataDir()
 				oldInitDataDir := filepath.Join(oldDataDir, "init")
 
-				sysdManager := service.NewSystemdServiceManager(systemd.IsRunning)
-				err = sysdManager.WriteServiceFile()
+				sysdManager := service.NewServiceManagerWithDefaults()
+				err = sysdManager.WriteServiceFiles()
 				if err != nil {
 					logger.Errorf("unsuccessful writing the service files in /lib/systemd/system path")
 					return err


### PR DESCRIPTION
## Description of change

Several of the methods on `SystemdServiceManager` accept "series" as an argument. This is misleading, because it is used to determine the OS and from there, the init system. **We already know it is systemd**.

The implementation of this logic is also under the _service_ package, but being specific to systemd, it should be under the _systemd_ package. It is currently not possible to lift this and move it because of cyclic dependencies it introduces.

This patch does the following:
- Instead of requesting service instances from the service package, systemd services are instantiated directly.
- Series arguments are removed where they were for the purpose of passing to `service.NewService` (see item above).
- Some new constructors are added to facilitate the changes above and for separation of concerns.
- Test changes to remove old patching and to initialise service implementations for testing.

Overall, it is a simplification of the implementation, and a progression towards locating this concern under the _systemd_ package.

## QA steps

- Tests for _service_, _updateseries_ and _upgrades_ are all green.
- Running the jujud updateseries command works.
- Upgrading from a version prior to 2.4 works.

## Documentation changes

None

## Bug reference

N/A