### PR TITLE
Allow OpenPorts/ClosePorts if we don't have an external network.

### DIFF
--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -86,7 +86,10 @@ func (inst *environInstance) IngressRules(machineID string) ([]network.IngressRu
 
 func (inst *environInstance) changeIngressRules(insert bool, rules []network.IngressRule) error {
 	if inst.env.ecfg.externalNetwork() == "" {
-		return errors.New("Can't close/open ports without external network")
+		// Open/Close port without an externalNetwork defined is treated as a no-op.
+		// We don't firewall the internal network, and without an external network we don't have any iptables rules
+		// to define.
+		return nil
 	}
 	addresses, client, err := inst.getInstanceConfigurator()
 	if err != nil {

--- a/provider/vsphere/instance_test.go
+++ b/provider/vsphere/instance_test.go
@@ -108,3 +108,34 @@ func (s *InstanceSuite) TestControllerInstances(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids, jc.DeepEquals, []instance.Id{"inst-1"})
 }
+
+func (s *InstanceSuite) TestOpenPortNoExternalNetwork(c *gc.C) {
+	s.client.virtualMachines = []*mo.VirtualMachine{
+		buildVM("inst-0").vm(),
+	}
+	instances, err := s.env.Instances([]instance.Id{"inst-0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instances, gc.HasLen, 1)
+	inst0 := instances[0]
+	firewaller, ok := inst0.(instance.InstanceFirewaller)
+	c.Assert(ok, jc.IsTrue)
+	// machineID is ignored in per-instance firewallers
+	err = firewaller.OpenPorts("", []network.IngressRule{{
+		PortRange: network.PortRange{
+			Protocol: "tcp",
+			FromPort: 10,
+			ToPort:   10,
+		},
+		SourceCIDRs: []string{"0.0.0.0/0"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	err = firewaller.ClosePorts("", []network.IngressRule{{
+		PortRange: network.PortRange{
+			Protocol: "tcp",
+			FromPort: 10,
+			ToPort:   10,
+		},
+		SourceCIDRs: []string{"0.0.0.0/0"},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
## Description of change

We just treat them as no-op, since we don't have any firewalls to
actually apply. Arguably users shouldn't be exposing in places that
don't have an external network, but they wouldn't be able to unexpose
(and thus close the ports) unless we treat both Open and Close as a
no-op.

## QA steps

I have not yet done manual QA. I think to do a proper job it would be something like:
```
$ juju bootstrap vmware # no --config external-network set
$ juju deploy mysql
$ juju expose mysql
$ juju debug-log
```
Without this fix we should expect to see a lot of errors in the logs around
```
2018-08-24 14:19:26 ERROR juju.worker.dependency engine.go:551 "firewaller" manifold worker returned unexpected error: cannot respond to units changes for "machine-9": Can't close/open ports without external network
```

With this fix, it should ignore the 'juju expose' call, since it has nowhere to expose the instance to.

Note that if you could
```
$ juju unexpose mysql
```
we could probably be ok, but because that involves a `ClosePort()` call that would run into the same failure.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1789211