### PR TITLE
Fixes lp#1788401: intermittent "charm not a valid zip". 

### DIFF
--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -23,59 +23,55 @@ var _ = gc.Suite(&clientMacaroonSuite{})
 // macaroon authentication.
 type clientMacaroonSuite struct {
 	apitesting.MacaroonSuite
-	client    *api.Client
-	cookieJar *apitesting.ClearableCookieJar
 }
 
-func (s *clientMacaroonSuite) SetUpTest(c *gc.C) {
-	s.MacaroonSuite.SetUpTest(c)
-	const username = "testuser@somewhere"
+func (s *clientMacaroonSuite) createTestClient(c *gc.C) *api.Client {
+	username := "testuser@somewhere"
 	s.AddModelUser(c, username)
 	s.AddControllerUser(c, username, permission.LoginAccess)
-	s.cookieJar = apitesting.NewClearableCookieJar()
+	cookieJar := apitesting.NewClearableCookieJar()
 	s.DischargerLogin = func() string { return username }
-	s.client = s.OpenAPI(c, nil, s.cookieJar).Client()
+	client := s.OpenAPI(c, nil, cookieJar).Client()
 
 	// Even though we've logged into the API, we want
 	// the tests below to exercise the discharging logic
 	// so we clear the cookies.
-	s.cookieJar.Clear()
-}
-
-func (s *clientMacaroonSuite) TearDownTest(c *gc.C) {
-	s.client.Close()
-	s.MacaroonSuite.TearDownTest(c)
+	cookieJar.Clear()
+	return client
 }
 
 func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {
+	client := s.createTestClient(c)
 	s.DischargerLogin = func() string { return "" }
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
-	savedURL, err := s.client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive)
 	c.Assert(err, gc.ErrorMatches, `POST https://.+: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
 	c.Assert(savedURL, gc.IsNil)
 }
 
 func (s *clientMacaroonSuite) TestAddLocalCharmSuccess(c *gc.C) {
+	client := s.createTestClient(c)
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
 	// Upload an archive with its original revision.
-	savedURL, err := s.client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 }
 
 func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
+	client := s.createTestClient(c)
 	s.DischargerLogin = func() string { return "baduser" }
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
 	// Upload an archive with its original revision.
-	_, err := s.client.AddLocalCharm(curl, charmArchive)
+	_, err := client.AddLocalCharm(curl, charmArchive)
 	c.Assert(err, gc.ErrorMatches, `.*invalid entity name or password$`)
 }


### PR DESCRIPTION
## Description of change

I cannot reproduce this locally at all.

However, I believe since CI runs tests in parallel, there could be a discrepancy between client creation at SetUpTest and client closure in TearDownTest.

This PR ensures that client is created within the test. Also everywhere else, unless we are explicitly testing for client closure, we do not close client in tests. So, this PR also removes closing code. 

The failure has been occurring fairly frequently in CI, so I want to build couple of times to see whether this PR is a fix.
Example check-merge failures:
http://ci.jujucharms.com/job/github-check-merge-juju/3267/
http://ci.jujucharms.com/job/github-check-merge-juju/3255/

github-check-merge-juju runs:
1 - Pass
2 - Pass for the test of interest, failed with other intermittent failures http://ci.jujucharms.com/job/github-check-merge-juju/3275/
3 - same as 2 passed for my test but other intertmittents - http://ci.jujucharms.com/job/github-check-merge-juju/3276/
4 - again my test passes, but another intermittent failure - http://ci.jujucharms.com/job/github-check-merge-juju/3277/
5 - Pass
6 - pass for my test, but another intermittent failure elsewhere: http://ci.jujucharms.com/job/github-check-merge-juju/3280/
7 - pass, with unrelated intermittent failure elsewhere: http://ci.jujucharms.com/job/github-check-merge-juju/3281
8- pass for my tests but another unrelated provisioner failure - http://ci.jujucharms.com/job/github-check-merge-juju/3282
9 - pass

## Bug reference

https://bugs.launchpad.net/juju/+bug/1788401
