### PR TITLE
migrations: Ensure leadership is claimed when importing a model

### DIFF
--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -75,7 +75,7 @@ func (context Context) ModelPresence(modelUUID string) facade.ModelPresence {
 }
 
 // LeadershipClaimer implements facade.Context.
-func (context Context) LeadershipClaimer() (leadership.Claimer, error) {
+func (context Context) LeadershipClaimer(modelUUID string) (leadership.Claimer, error) {
 	return context.LeadershipClaimer_, nil
 }
 

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -79,13 +79,16 @@ type Context interface {
 	// a good idea; see Resources.
 	ID() string
 
-	// LeadershipClaimer returns a leadership.Claimer tied to the specific model for this context's model.
-	LeadershipClaimer() (leadership.Claimer, error)
+	// LeadershipClaimer returns a leadership.Claimer tied to a
+	// specific model.
+	LeadershipClaimer(modelUUID string) (leadership.Claimer, error)
 
-	// LeadershipChecker returns a leadership.Checker for this context's model.
+	// LeadershipChecker returns a leadership.Checker for this
+	// context's model.
 	LeadershipChecker() (leadership.Checker, error)
 
-	// SingularClaimer returns a lease.Claimer for singular leases for this context's model.
+	// SingularClaimer returns a lease.Claimer for singular leases for
+	// this context's model.
 	SingularClaimer() (lease.Claimer, error)
 }
 

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -34,7 +34,7 @@ const (
 // NewLeadershipServiceFacade constructs a new LeadershipService and presents
 // a signature that can be used for facade registration.
 func NewLeadershipServiceFacade(context facade.Context) (LeadershipService, error) {
-	claimer, err := context.LeadershipClaimer()
+	claimer, err := context.LeadershipClaimer(context.State().ModelUUID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -41,9 +41,9 @@ func (ctx *charmsSuiteContext) ID() string                  { return "" }
 func (ctx *charmsSuiteContext) Presence() facade.Presence   { return nil }
 func (ctx *charmsSuiteContext) Hub() facade.Hub             { return nil }
 
-func (ctx *charmsSuiteContext) LeadershipClaimer() (leadership.Claimer, error) { return nil, nil }
-func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error) { return nil, nil }
-func (ctx *charmsSuiteContext) SingularClaimer() (lease.Claimer, error)        { return nil, nil }
+func (ctx *charmsSuiteContext) LeadershipClaimer(string) (leadership.Claimer, error) { return nil, nil }
+func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error)       { return nil, nil }
+func (ctx *charmsSuiteContext) SingularClaimer() (lease.Claimer, error)              { return nil, nil }
 
 func (s *charmsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -31,6 +31,7 @@ type API struct {
 	authorizer  facade.Authorizer
 	resources   facade.Resources
 	presence    facade.Presence
+	getClaimer  migration.ClaimerFunc
 	getEnviron  stateenvirons.NewEnvironFunc
 	callContext context.ProviderCallContext
 }
@@ -54,6 +55,7 @@ func NewAPI(ctx facade.Context, getEnviron stateenvirons.NewEnvironFunc, callCtx
 		authorizer:  auth,
 		resources:   ctx.Resources(),
 		presence:    ctx.Presence(),
+		getClaimer:  ctx.LeadershipClaimer,
 		getEnviron:  getEnviron,
 		callContext: callCtx,
 	}, nil
@@ -107,7 +109,7 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 // recreates it in the receiving controller.
 func (api *API) Import(serialized params.SerializedModel) error {
 	controller := state.NewController(api.pool)
-	_, st, err := migration.ImportModel(controller, serialized.Bytes)
+	_, st, err := migration.ImportModel(controller, api.getClaimer, serialized.Bytes)
 	if err != nil {
 		return err
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -16,7 +16,9 @@ import (
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
@@ -53,10 +55,14 @@ type StateImporter interface {
 	Import(model description.Model) (*state.Model, *state.State, error)
 }
 
+// ClaimerFunc is a function that returns a leadership claimer for the
+// model UUID passed.
+type ClaimerFunc func(string) (leadership.Claimer, error)
+
 // ImportModel deserializes a model description from the bytes, transforms
 // the model config based on information from the controller model, and then
 // imports that as a new database model.
-func ImportModel(importer StateImporter, bytes []byte) (*state.Model, *state.State, error) {
+func ImportModel(importer StateImporter, getClaimer ClaimerFunc, bytes []byte) (*state.Model, *state.State, error) {
 	model, err := description.Deserialize(bytes)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -66,6 +72,54 @@ func ImportModel(importer StateImporter, bytes []byte) (*state.Model, *state.Sta
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+
+	config, err := dbState.ControllerConfig()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// If we're using legacy-leases we get the claimer from the new
+	// state - otherwise use the function passed in.
+	//
+	var claimer leadership.Claimer
+	if config.Features().Contains(feature.LegacyLeases) {
+		claimer = dbState.LeadershipClaimer()
+	} else {
+		claimer, err = getClaimer(dbModel.UUID())
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "getting leadership claimer")
+		}
+	}
+
+	logger.Debugf("importing leadership")
+	for _, application := range model.Applications() {
+		if application.Leader() == "" {
+			continue
+		}
+		// When we import a new model, we need to give the leaders
+		// some time to settle. We don't want to have leader switches
+		// just because we migrated a model, so this time needs to be
+		// long enough to make sure we cover the time taken to migrate
+		// a reasonable sized model. We don't yet know how long this
+		// is going to be, but we need something.
+		// TODO(babbageclunk): Handle this better - maybe a way to
+		// suppress leadership expiries for a model until it's
+		// finished importing?
+		logger.Debugf("%q is the leader for %q", application.Leader(), application.Name())
+		err := claimer.ClaimLeadership(
+			application.Name(),
+			application.Leader(),
+			state.InitialLeaderClaimTime,
+		)
+		if err != nil {
+			return nil, nil, errors.Annotatef(
+				err,
+				"claiming leadership for %q",
+				application.Leader(),
+			)
+		}
+	}
+
 	return dbModel, dbState, nil
 }
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -9,9 +9,12 @@ import (
 	"io"
 	"io/ioutil"
 	"net/url"
+	"time"
 
 	"github.com/juju/description"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/version"
@@ -19,7 +22,10 @@ import (
 	"gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/component/all"
+	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/lease"
 	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/dummy"
@@ -27,7 +33,8 @@ import (
 	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/tools"
 )
 
@@ -45,26 +52,27 @@ type ImportSuite struct {
 var _ = gc.Suite(&ImportSuite{})
 
 func (s *ImportSuite) SetUpTest(c *gc.C) {
-	// Specify the config to use for the controller model before calling
-	// SetUpTest of the StateSuite, otherwise we get testing.ModelConfig(c).
-	// The default provider type specified in the testing.ModelConfig function
-	// is one that isn't registered as a valid provider. For our tests here we
+	// Specify the config to use for the controller model before
+	// calling SetUpTest of the StateSuite, otherwise we get
+	// coretesting.ModelConfig(c). The default provider type
+	// specified in the coretesting.ModelConfig function is one that
+	// isn't registered as a valid provider. For our tests here we
 	// need a real registered provider, so we use the dummy provider.
 	// NOTE: make a better test provider.
-	s.InitialConfig = testing.CustomModelConfig(c, dummy.SampleConfig())
+	s.InitialConfig = coretesting.CustomModelConfig(c, dummy.SampleConfig())
 	s.StateSuite.SetUpTest(c)
 }
 
 func (s *ImportSuite) TestBadBytes(c *gc.C) {
 	bytes := []byte("not a model")
 	controller := state.NewController(s.StatePool)
-	model, st, err := migration.ImportModel(controller, bytes)
+	model, st, err := migration.ImportModel(controller, fakeGetClaimer, bytes)
 	c.Check(st, gc.IsNil)
 	c.Check(model, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "yaml: unmarshal errors:\n.*")
 }
 
-func (s *ImportSuite) TestImportModel(c *gc.C) {
+func (s *ImportSuite) exportImport(c *gc.C, getClaimer migration.ClaimerFunc) *state.State {
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -81,14 +89,87 @@ func (s *ImportSuite) TestImportModel(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 
 	controller := state.NewController(s.StatePool)
-	dbModel, dbState, err := migration.ImportModel(controller, bytes)
+	dbModel, dbState, err := migration.ImportModel(controller, getClaimer, bytes)
 	c.Assert(err, jc.ErrorIsNil)
-	defer dbState.Close()
+	s.AddCleanup(func(*gc.C) { dbState.Close() })
 
 	dbConfig, err := dbModel.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dbConfig.UUID(), gc.Equals, uuid)
 	c.Assert(dbConfig.Name(), gc.Equals, "new-model")
+	return dbState
+}
+
+func (s *ImportSuite) TestImportModel(c *gc.C) {
+	s.exportImport(c, fakeGetClaimer)
+}
+
+func (s *ImportSuite) TestImportsLeadership(c *gc.C) {
+	s.makeApplicationWithUnits(c, "wordpress", 3)
+	s.makeUnitApplicationLeader(c, "wordpress/1", "wordpress")
+	s.makeApplicationWithUnits(c, "mysql", 2)
+
+	var (
+		claimer   fakeClaimer
+		modelUUID string
+	)
+	dbState := s.exportImport(c, func(uuid string) (leadership.Claimer, error) {
+		modelUUID = uuid
+		return &claimer, nil
+	})
+	c.Assert(modelUUID, gc.Equals, dbState.ModelUUID())
+	c.Assert(claimer.stub.Calls(), gc.HasLen, 1)
+	claimer.stub.CheckCall(c, 0, "ClaimLeadership", "wordpress", "wordpress/1", time.Minute)
+}
+
+func (s *ImportSuite) TestImportsLeadershipLegacy(c *gc.C) {
+	err := s.State.UpdateControllerConfig(map[string]interface{}{
+		"features": []interface{}{feature.LegacyLeases},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.makeApplicationWithUnits(c, "wordpress", 3)
+	s.makeUnitApplicationLeaderLegacy(c, "wordpress/1", "wordpress")
+	s.makeApplicationWithUnits(c, "mysql", 2)
+
+	dbState := s.exportImport(c, nil)
+
+	leaders, err := dbState.ApplicationLeaders()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(leaders, gc.DeepEquals, map[string]string{"wordpress": "wordpress/1"})
+}
+
+func (s *ImportSuite) makeApplicationWithUnits(c *gc.C, applicationname string, count int) {
+	units := make([]*state.Unit, count)
+	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: applicationname,
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
+			Name: applicationname,
+		}),
+	})
+	for i := 0; i < count; i++ {
+		units[i] = s.Factory.MakeUnit(c, &factory.UnitParams{
+			Application: application,
+		})
+	}
+}
+
+func (s *ImportSuite) makeUnitApplicationLeader(c *gc.C, unitName, applicationName string) {
+	target := s.State.LeaseNotifyTarget(
+		ioutil.Discard,
+		loggo.GetLogger("migration_import_test"),
+	)
+	target.Claimed(
+		lease.Key{"application-leadership", s.State.ModelUUID(), applicationName},
+		unitName,
+	)
+}
+
+func (s *ImportSuite) makeUnitApplicationLeaderLegacy(c *gc.C, unitName, applicationName string) {
+	err := s.State.LeadershipClaimer().ClaimLeadership(
+		applicationName,
+		unitName,
+		time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ImportSuite) TestUploadBinariesConfigValidate(c *gc.C) {
@@ -301,4 +382,18 @@ func (s *ExportSuite) TestExportModel(c *gc.C) {
 	modelDesc, err := description.Deserialize(bytes)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelDesc.Validate(), jc.ErrorIsNil)
+}
+
+func fakeGetClaimer(string) (leadership.Claimer, error) {
+	return &fakeClaimer{}, nil
+}
+
+type fakeClaimer struct {
+	leadership.Claimer
+	stub testing.Stub
+}
+
+func (c *fakeClaimer) ClaimLeadership(application, unit string, duration time.Duration) error {
+	c.stub.AddCall("ClaimLeadership", application, unit, duration)
+	return c.stub.NextErr()
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -33,13 +33,6 @@ import (
 	"github.com/juju/juju/tools"
 )
 
-// When we import a new model, we need to give the leaders some time to
-// settle. We don't want to have leader switches just because we migrated an
-// model, so this time needs to be long enough to make sure we cover
-// the time taken to migration a reasonable sized model. We don't yet
-// know how long this is going to be, but we need something.
-var initialLeaderClaimTime = time.Minute
-
 // Import the database agnostic model representation into the database.
 func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err error) {
 	st := ctrl.pool.SystemState()
@@ -818,15 +811,6 @@ func (i *importer) application(a description.Application) error {
 
 	for _, unit := range a.Units() {
 		if err := i.unit(a, unit); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	if a.Leader() != "" {
-		if err := i.st.LeadershipClaimer().ClaimLeadership(
-			a.Name(),
-			a.Leader(),
-			initialLeaderClaimTime); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/permission"
@@ -582,33 +581,6 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudService.ProviderId(), gc.Equals, "provider-id")
 	c.Assert(cloudService.Addresses(), jc.DeepEquals, []network.Address{addr})
-}
-
-func (s *MigrationImportSuite) TestApplicationLeadersLegacy(c *gc.C) {
-	// TODO(raftlease): handle application leaders in migrations.
-	err := s.State.UpdateControllerConfig(map[string]interface{}{
-		"features": []interface{}{feature.LegacyLeases},
-	}, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.makeApplicationWithUnits(c, "mysql", 2)
-	s.makeUnitApplicationLeaderLegacy(c, "mysql/1", "mysql")
-
-	s.makeApplicationWithUnits(c, "wordpress", 4)
-	s.makeUnitApplicationLeaderLegacy(c, "wordpress/2", "wordpress")
-
-	_, newSt := s.importModel(c, s.State)
-
-	leaders := make(map[string]string)
-	leases, err := state.LeadershipLeases(newSt)
-	c.Assert(err, jc.ErrorIsNil)
-	for key, value := range leases {
-		leaders[key.Lease] = value.Holder
-	}
-	c.Assert(leaders, jc.DeepEquals, map[string]string{
-		"mysql":     "mysql/1",
-		"wordpress": "wordpress/2",
-	})
 }
 
 func (s *MigrationImportSuite) TestCharmRevSequencesNotImported(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -1272,6 +1273,8 @@ func MigrateLeasesToGlobalTime(pool *StatePool) error {
 	return runForAllModelStates(pool, migrateModelLeasesToGlobalTime)
 }
 
+const InitialLeaderClaimTime = time.Minute
+
 func migrateModelLeasesToGlobalTime(st *State) error {
 	coll, closer := st.db().GetCollection(leasesC)
 	defer closer()
@@ -1324,7 +1327,7 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 				doc.Writer,
 				coll.Name(),
 				globalclock.GlobalEpoch(),
-				initialLeaderClaimTime,
+				InitialLeaderClaimTime,
 			)
 			if err != nil {
 				return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

With raft-based leases, the import code that claims leadership for applications in the incoming model needs to move out of state - the global lease manager isn't accessible from there. We now claim leadership in `migration.Import`, passing in a function to get the leadership claimer from the API facade.

This required changing facade context.LeadershipClaimer to accept a model uuid - migrationtarget is a controller facade, so the model being imported isn't the one that we're connected to (since it doesn't exist when the connection is made).

The other wrinkle is that we can't get the legacy leadership claimer from the facade context, because we'd need to get it from the state pool, which in turn would require that we either return a LeadershipClaimer extended with a Close to release the pooled state, or a closer function. It seemed simpler just to check the feature flag and get the claimer from the state we have after importing if LegacyLeases is set. 

## QA steps

* Bootstrap 2 controllers (A and B) and deploy 5 or 6 units of an application in a model on A.
* Migrate the model from A to B.
* After the migration is finished, verify that the leader has been maintained correctly.
* In debug logging for juju.migration check that the leadership was claimed for the right unit during import (so it wasn't just chance that the leadership was carried over).
