### PR TITLE
Fixes part lp#1790424: provisioner keep machine on remove.

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -285,7 +285,7 @@ func (task *provisionerTask) processMachines(ids []string) error {
 	}
 
 	if len(stopping) > 0 {
-		logger.Infof("stopping known instances %v", stopping)
+		logger.Infof("stopping known instances %v", instanceIds(stopping))
 	}
 	if len(unknown) > 0 {
 		logger.Infof("stopping unknown instances %v", instanceIds(unknown))

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1469,7 +1469,6 @@ func (s *ProvisionerSuite) TestHarvestAllReapsAllTheThings(c *gc.C) {
 }
 
 func (s *ProvisionerSuite) TestStopInstancesIgnoresMachinesWithKeep(c *gc.C) {
-
 	task := s.newProvisionerTask(c,
 		config.HarvestAll,
 		s.Environ,
@@ -1488,6 +1487,9 @@ func (s *ProvisionerSuite) TestStopInstancesIgnoresMachinesWithKeep(c *gc.C) {
 	i1 := s.checkStartInstance(c, m1)
 	err = m1.SetKeepInstance(true)
 	c.Assert(err, jc.ErrorIsNil)
+	// we must ensure that m1's harvest mode is set correctly
+	// before proceeding with the test.
+	s.BackingState.StartSync()
 
 	// Mark them both as dead.
 	c.Assert(m0.EnsureDead(), gc.IsNil)


### PR DESCRIPTION
## Description of change

TestStopInstancesIgnoresMachinesWithKeep started failing more frequently with the recent change that made Juju watcher more responsive.

The problem was with the test that have assumed that machine records were in particular state but has not done anything to ensure that it is so. Specifically we were adding a machine and setting it's haverstmode to keep after removal. The test that would proceed to remove the machine and check that it has been kept. However, with the new watcher, sometimes, the command to remove the machine came before the harvest mode was set causing test to fail. This PR adds a database sync before issuing removal of machine call.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1790424

The other part of this bug is related to another provisioner test failure which I am still chasing locally, and cannot reproduce. However, I wanted to propose this fix as TestStopInstancesIgnoresMachinesWithKeep fails frequently.
