### PR TITLE
Upgrade-Series Worker - Copy and Link Agent Binaries

### DIFF
--- a/worker/upgradeseries/upgrader_test.go
+++ b/worker/upgradeseries/upgrader_test.go
@@ -5,12 +5,13 @@ package upgradeseries_test
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/juju/juju/juju/paths"
-	"github.com/juju/juju/service/systemd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/upgradeseries"
 	. "github.com/juju/juju/worker/upgradeseries/mocks"
 )
@@ -34,27 +35,33 @@ func (s *upgraderSuite) SetUpTest(c *gc.C) {
 	s.unitServices = []string{"jujud-unit-ubuntu-0", "jujud-unit-redis-0"}
 }
 
-func (s *upgraderSuite) TestNotToSystemdNoAction(c *gc.C) {
+func (s *upgraderSuite) TestNotToSystemdCopyToolsOnly(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	s.setupMocks(ctrl)
 
 	s.patchFrom("precise")
 
-	// No expectations.
+	// No systemd file changes; just the new tools for the target series.
+	s.manager.EXPECT().CopyAgentBinary(
+		s.machineService, s.unitServices, paths.NixDataDir, "trusty", "precise", version.Current,
+	).Return(nil)
 
 	upg := s.newUpgrader(c, "trusty")
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
 }
 
-func (s *upgraderSuite) TestFromSystemdNoAction(c *gc.C) {
+func (s *upgraderSuite) TestFromSystemdCopyToolsOnly(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	s.setupMocks(ctrl)
 
 	s.patchFrom("xenial")
 
-	// No expectations.
+	// No systemd file changes; just the new tools for the target series.
+	s.manager.EXPECT().CopyAgentBinary(
+		s.machineService, s.unitServices, paths.NixDataDir, "bionic", "xenial", version.Current,
+	).Return(nil)
 
 	upg := s.newUpgrader(c, "bionic")
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
@@ -70,6 +77,10 @@ func (s *upgraderSuite) TestToSystemdServicesWritten(c *gc.C) {
 	s.manager.EXPECT().WriteSystemdAgents(
 		s.machineService, s.unitServices, paths.NixDataDir, systemd.EtcSystemdDir, systemd.EtcSystemdMultiUserDir,
 	).Return(append(s.unitServices, s.machineService), nil, nil, nil)
+
+	s.manager.EXPECT().CopyAgentBinary(
+		s.machineService, s.unitServices, paths.NixDataDir, "xenial", "trusty", version.Current,
+	).Return(nil)
 
 	upg := s.newUpgrader(c, "xenial")
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

Adds a step to the upgrade-series worker that copies and links agent binaries to a new directory for the target series and the current Juju version.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`
- Bootstrap
- Deploy a Trusty charm (Ubuntu or Redis will work)
- `juju upgrade-series prepare 0 xenial`
- SSH on to the machine and check that there is a tools directory for the target series, and that the agent links point to this location.

## Documentation changes

None.

## Bug reference

N/A
