### PR TITLE
Upgrade-Series Worker Tests Refining the Behaviour Idea

### DIFF
--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -98,6 +98,11 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c
 func (s *workerSuite) TestFullWorkflow(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	// TODO (manadart 2018-09-05): The idea of passing behaviours into a
+	// scenario (as below) evolved so as to make itself redundant.
+	// All of the anonymous funcs passed could be called directly on the suite
+	// here, with the same effect and greater clarity.
+
 	w := s.workerForScenario(c, s.ignoreLogging(c), s.notify(4),
 		s.expectMachinePrepareStartedUnitsStoppedProgressPrepareMachine,
 		s.expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete,

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -58,35 +58,29 @@ func (s *workerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *workerSuite) TestLockNotFoundNoAction(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
 	// If the lock is not found, no further processing occurs.
 	// This is the only call we expect to see.
 	s.facade.EXPECT().MachineStatus().Return(model.UpgradeSeriesStatus(""), errors.NewNotFound(nil, "nope"))
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1))
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1))
 	s.cleanKill(c, w)
 }
 
 func (s *workerSuite) TestCompleteNoAction(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
 	// If the workflow is completed, no further processing occurs.
 	// This is the only call we expect to see.
 	s.facade.EXPECT().MachineStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1))
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1))
 	s.cleanKill(c, w)
 }
 
 func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
 	s.facade.EXPECT().MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
 	// Only one of the two units has completed preparation.
@@ -96,16 +90,14 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c
 	// no further action is taken.
 	s.expectServiceDiscovery(false)
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1))
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1))
 	s.cleanKill(c, w)
 }
 
 func (s *workerSuite) TestFullWorkflow(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(4),
+	w := s.workerForScenario(c, ignoreLogging(c), notify(4),
 		expectMachinePrepareStartedUnitsStoppedProgressPrepareMachine,
 		expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete,
 		expectMachineCompleteStartedUnitsPrepareCompleteUnitsStarted,
@@ -115,11 +107,9 @@ func (s *workerSuite) TestFullWorkflow(c *gc.C) {
 }
 
 func (s *workerSuite) TestMachinePrepareStartedUnitsStoppedProgressPrepareMachine(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1),
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1),
 		expectMachinePrepareStartedUnitsStoppedProgressPrepareMachine)
 
 	s.cleanKill(c, w)
@@ -140,11 +130,9 @@ func expectMachinePrepareStartedUnitsStoppedProgressPrepareMachine(s *workerSuit
 }
 
 func (s *workerSuite) TestMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1),
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1),
 		expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete)
 	s.cleanKill(c, w)
 }
@@ -164,11 +152,9 @@ func expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete(s *worke
 }
 
 func (s *workerSuite) TestMachineCompleteStartedUnitsPrepareCompleteUnitsStarted(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1),
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1),
 		expectMachineCompleteStartedUnitsPrepareCompleteUnitsStarted)
 	s.cleanKill(c, w)
 }
@@ -187,9 +173,7 @@ func expectMachineCompleteStartedUnitsPrepareCompleteUnitsStarted(s *workerSuite
 }
 
 func (s *workerSuite) TestMachineCompleteStartedNoUnitsProgressComplete(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
 	exp := s.facade.EXPECT()
 	exp.MachineStatus().Return(model.UpgradeSeriesCompleteStarted, nil)
@@ -202,16 +186,14 @@ func (s *workerSuite) TestMachineCompleteStartedNoUnitsProgressComplete(c *gc.C)
 	// Progress directly to completed.
 	exp.SetMachineStatus(model.UpgradeSeriesCompleted).Return(nil)
 
-	w := s.newWorker(c, ctrl, ignoreLogging(c), notify(1))
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1))
 	s.cleanKill(c, w)
 }
 
 func (s *workerSuite) TestMachineCompleteStartedUnitsCompleteProgressComplete(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
-	w := s.workerForScenario(c, ctrl, ignoreLogging(c), notify(1),
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1),
 		expectMachineCompleteStartedUnitsCompleteProgressComplete)
 	s.cleanKill(c, w)
 }
@@ -236,9 +218,7 @@ func expectMachineCompleteStartedUnitsCompleteProgressComplete(s *workerSuite) {
 }
 
 func (s *workerSuite) TestMachineCompletedFinishUpgradeSeries(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	s.setupMocks(ctrl)
+	defer s.setupMocks(c).Finish()
 
 	s.patchHost("xenial")
 
@@ -246,11 +226,13 @@ func (s *workerSuite) TestMachineCompletedFinishUpgradeSeries(c *gc.C) {
 	exp.MachineStatus().Return(model.UpgradeSeriesCompleted, nil)
 	exp.FinishUpgradeSeries("xenial").Return(nil)
 
-	w := s.newWorker(c, ctrl, ignoreLogging(c), notify(1))
+	w := s.workerForScenario(c, ignoreLogging(c), notify(1))
 	s.cleanKill(c, w)
 }
 
-func (s *workerSuite) setupMocks(ctrl *gomock.Controller) {
+func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
 	s.logger = NewMockLogger(ctrl)
 	s.facade = NewMockFacade(ctrl)
 	s.notifyWorker = NewMockWorker(ctrl)
@@ -258,12 +240,14 @@ func (s *workerSuite) setupMocks(ctrl *gomock.Controller) {
 	s.upgrader = NewMockUpgrader(ctrl)
 	s.wordPressAgent = NewMockAgentService(ctrl)
 	s.mySQLAgent = NewMockAgentService(ctrl)
+
+	return ctrl
 }
 
 // workerForScenario creates worker dependency mocks using the input controller.
 // Any supplied behaviour functions are applied to the suite, then a new worker
 // is started and returned.
-func (s *workerSuite) workerForScenario(c *gc.C, ctrl *gomock.Controller, behaviours ...suiteBehaviour) worker.Worker {
+func (s *workerSuite) workerForScenario(c *gc.C, behaviours ...suiteBehaviour) worker.Worker {
 	cfg := upgradeseries.Config{
 		Logger:          s.logger,
 		FacadeFactory:   func(_ names.Tag) upgradeseries.Facade { return s.facade },

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -94,6 +94,9 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c
 	s.cleanKill(c, w)
 }
 
+// TestFullWorkflow uses the the expectation scenarios from each of the tests
+// below to compose a test of the whole upgrade-series scenario, from start
+// to finish.
 func (s *workerSuite) TestFullWorkflow(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
## Description of change

This patch makes changes to the upgrade-series worker tests that:
- Extract the mock expectations for each scenario into stand-alone methods.
- Include these as behaviours when creating a worker for the test.
- Add a new test that demonstrates composing all of the behaviours into a single test or the full upgrade series work-flow from the worker's perspective.

Proposing this patch is to solicit review more than it is to get the logic into Juju. The main question is whether it is understandable and whether it could be considered for testing other worker scenarios.

## QA steps

The same test suite remains green.

## Documentation changes

None

## Bug reference

N/A
