### PR TITLE
Fix intermittent test failure.

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -582,9 +582,14 @@ func (app *backingRemoteApplication) updated(st *State, store *multiwatcherStore
 			Since:   appStatus.Since,
 		}
 		logger.Debugf("remote application status %#v", info.Status)
-	}
-	if store.Get(info.EntityId()) == nil {
-		logger.Debugf("new remote application %q added to backing state", app.Name)
+	} else {
+		logger.Debugf("use status from existing app")
+		switch t := oldInfo.(type) {
+		case *multiwatcher.RemoteApplicationInfo:
+			info.Status = t.Status
+		default:
+			logger.Debugf("unexpected type %t", t)
+		}
 	}
 	store.Update(info)
 	return nil

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -51,6 +51,12 @@ options:
 
 type allWatcherBaseSuite struct {
 	internalStateSuite
+	currentTime time.Time
+}
+
+func (s *allWatcherBaseSuite) SetUpTest(c *gc.C) {
+	s.internalStateSuite.SetUpTest(c)
+	s.currentTime = s.state.clock().Now()
 }
 
 // setUpScenario adds some entities to the state so that
@@ -63,6 +69,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	add := func(e multiwatcher.EntityInfo) {
 		entities = append(entities, e)
 	}
+	now := s.currentTime
 	m, err := st.AddMachine("quantal", JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, names.NewMachineTag("0"))
@@ -92,10 +99,12 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 		AgentStatus: multiwatcher.StatusInfo{
 			Current: status.Pending,
 			Data:    map[string]interface{}{},
+			Since:   &now,
 		},
 		InstanceStatus: multiwatcher.StatusInfo{
 			Current: status.Pending,
 			Data:    map[string]interface{}{},
+			Since:   &now,
 		},
 		Life:                    multiwatcher.Life("alive"),
 		Series:                  "quantal",
@@ -128,6 +137,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Current: "waiting",
 			Message: "waiting for machine",
 			Data:    map[string]interface{}{},
+			Since:   &now,
 		},
 	})
 	pairs := map[string]string{"x": "12", "y": "99"}
@@ -151,6 +161,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Current: "waiting",
 			Message: "waiting for machine",
 			Data:    map[string]interface{}{},
+			Since:   &now,
 		},
 	})
 
@@ -188,11 +199,13 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: "allocating",
 				Message: "",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 		})
 		pairs := map[string]string{"name": fmt.Sprintf("bar %d", i)}
@@ -206,7 +219,6 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 
 		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
-		now := testing.ZeroTime()
 		sInfo := status.StatusInfo{
 			Status:  status.Error,
 			Message: m.Tag().String(),
@@ -224,10 +236,12 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 				Current: status.Error,
 				Message: m.Tag().String(),
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			Life:                    multiwatcher.Life("alive"),
 			Series:                  "quantal",
@@ -269,11 +283,13 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: "allocating",
 				Message: "",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 		})
 	}
@@ -295,6 +311,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Current: "waiting",
 			Message: "waiting for machine",
 			Data:    map[string]interface{}{},
+			Since:   &now,
 		},
 	})
 
@@ -372,21 +389,24 @@ func addTestingRemoteApplication(
 		IsConsumerProxy: isProxy,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	status, err := rs.Status()
-	c.Assert(err, jc.ErrorIsNil)
-
+	var appStatus multiwatcher.StatusInfo
+	if !isProxy {
+		status, err := rs.Status()
+		c.Assert(err, jc.ErrorIsNil)
+		appStatus = multiwatcher.StatusInfo{
+			Current: status.Status,
+			Message: status.Message,
+			Data:    status.Data,
+			Since:   status.Since,
+		}
+	}
 	return rs, multiwatcher.RemoteApplicationInfo{
 		ModelUUID: st.ModelUUID(),
 		Name:      name,
 		OfferUUID: offerUUID,
 		OfferURL:  url,
 		Life:      multiwatcher.Life(rs.Life().String()),
-		Status: multiwatcher.StatusInfo{
-			Current: status.Status,
-			Message: status.Message,
-			Data:    status.Data,
-			Since:   status.Since,
-		},
+		Status:    appStatus,
 	}
 }
 
@@ -481,7 +501,6 @@ func (s *allWatcherStateSuite) checkGetAll(c *gc.C, expectEntities entityInfoSli
 	var gotEntities entityInfoSlice = all.All()
 	sort.Sort(gotEntities)
 	sort.Sort(expectEntities)
-	substNilSinceTimeForEntities(c, gotEntities)
 	assertEntitiesEqual(c, gotEntities, expectEntities)
 }
 
@@ -521,69 +540,6 @@ type changeTestCase struct {
 	expectContents []multiwatcher.EntityInfo
 }
 
-func substNilSinceTimeForStatus(c *gc.C, sInfo *multiwatcher.StatusInfo) {
-	if sInfo.Current != "" {
-		c.Assert(sInfo.Since, gc.NotNil) // TODO(dfc) WTF does this check do ? separation of concerns much
-	}
-	sInfo.Since = nil
-}
-
-// substNilSinceTimeForEntities zeros out any updated timestamps for unit
-// or application status values so we can easily check the results.
-func substNilSinceTimeForEntities(c *gc.C, entities []multiwatcher.EntityInfo) {
-	// Zero out any updated timestamps for unit or application status values
-	// so we can easily check the results.
-	for i := range entities {
-		switch e := entities[i].(type) {
-		case *multiwatcher.UnitInfo:
-			unitInfo := *e // must copy because this entity came out of the multiwatcher cache.
-			substNilSinceTimeForStatus(c, &unitInfo.WorkloadStatus)
-			substNilSinceTimeForStatus(c, &unitInfo.AgentStatus)
-			entities[i] = &unitInfo
-		case *multiwatcher.ApplicationInfo:
-			applicationInfo := *e // must copy because this entity came out of the multiwatcher cache.
-			substNilSinceTimeForStatus(c, &applicationInfo.Status)
-			entities[i] = &applicationInfo
-		case *multiwatcher.RemoteApplicationInfo:
-			remoteApplicationInfo := *e // must copy because this entity came out of the multiwatcher cache.
-			substNilSinceTimeForStatus(c, &remoteApplicationInfo.Status)
-			entities[i] = &remoteApplicationInfo
-		case *multiwatcher.MachineInfo:
-			machineInfo := *e // must copy because this entity came out of the multiwatcher cache.
-			substNilSinceTimeForStatus(c, &machineInfo.AgentStatus)
-			substNilSinceTimeForStatus(c, &machineInfo.InstanceStatus)
-			entities[i] = &machineInfo
-		}
-	}
-}
-
-func substNilSinceTimeForEntityNoCheck(entity multiwatcher.EntityInfo) multiwatcher.EntityInfo {
-	// Zero out any updated timestamps for unit or application status values
-	// so we can easily check the results.
-	switch e := entity.(type) {
-	case *multiwatcher.UnitInfo:
-		unitInfo := *e // must copy because this entity came out of the multiwatcher cache.
-		unitInfo.WorkloadStatus.Since = nil
-		unitInfo.AgentStatus.Since = nil
-		return &unitInfo
-	case *multiwatcher.ApplicationInfo:
-		applicationInfo := *e // must copy because this entity came out of the multiwatcher cache.
-		applicationInfo.Status.Since = nil
-		return &applicationInfo
-	case *multiwatcher.RemoteApplicationInfo:
-		remoteApplicationInfo := *e // must copy because this entity came out of the multiwatcher cache.
-		remoteApplicationInfo.Status.Since = nil
-		return &remoteApplicationInfo
-	case *multiwatcher.MachineInfo:
-		machineInfo := *e // must copy because we this entity came out of the multiwatcher cache.
-		machineInfo.AgentStatus.Since = nil
-		machineInfo.InstanceStatus.Since = nil
-		return &machineInfo
-	default:
-		return entity
-	}
-}
-
 // changeTestFunc is a function for the preparation of a test and
 // the creation of the according case.
 type changeTestFunc func(c *gc.C, st *State) changeTestCase
@@ -602,7 +558,6 @@ func (s *allWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFuncs [
 		err := b.Changed(all, test.change)
 		c.Assert(err, jc.ErrorIsNil)
 		entities := all.All()
-		substNilSinceTimeForEntities(c, entities)
 		assertEntitiesEqual(c, entities, test.expectContents)
 		s.reset(c)
 	}
@@ -781,7 +736,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	entities := all.All()
-	substNilSinceTimeForEntities(c, entities)
+	now := s.currentTime
 	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
 		&multiwatcher.UnitInfo{
 			ModelUUID:      s.state.ModelUUID(),
@@ -797,10 +752,12 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: "allocating",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 		},
 		&multiwatcher.MachineInfo{
@@ -817,7 +774,6 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	entities = all.All()
-	substNilSinceTimeForEntities(c, entities)
 	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
 		&multiwatcher.UnitInfo{
 			ModelUUID:      s.state.ModelUUID(),
@@ -833,10 +789,12 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: "allocating",
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 		},
 		&multiwatcher.MachineInfo{
@@ -865,7 +823,6 @@ func (s *allWatcherStateSuite) TestApplicationSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	entities := all.All()
-	substNilSinceTimeForEntities(c, entities)
 	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
 		&multiwatcher.ApplicationInfo{
 			ModelUUID: s.state.ModelUUID(),
@@ -909,7 +866,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 
 	// Expect to see events for the already created machines first.
 	deltas := tw.All(2)
-	now := testing.ZeroTime()
+	now := s.currentTime
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: s.state.ModelUUID(),
@@ -959,7 +916,6 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	deltas = tw.All(1)
-	zeroOutTimestampsForDeltas(c, deltas)
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: s.state.ModelUUID(),
@@ -987,7 +943,6 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	deltas = tw.All(1)
-	zeroOutTimestampsForDeltas(c, deltas)
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: s.state.ModelUUID(),
@@ -1033,11 +988,10 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = wu.AssignToMachine(m2)
 	c.Assert(err, jc.ErrorIsNil)
+	wpTime := s.state.clock().Now()
 
 	// Look for the state changes from the allwatcher.
 	deltas = tw.All(5)
-
-	zeroOutTimestampsForDeltas(c, deltas)
 
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
@@ -1075,12 +1029,12 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
-				Since:   &now,
+				Since:   &wpTime,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
-				Since:   &now,
+				Since:   &wpTime,
 			},
 			Life:      multiwatcher.Life("alive"),
 			Series:    "quantal",
@@ -1100,6 +1054,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &wpTime,
 			},
 		},
 	}, {
@@ -1113,11 +1068,13 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &wpTime,
 			},
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: "allocating",
 				Message: "",
 				Data:    map[string]interface{}{},
+				Since:   &wpTime,
 			},
 		},
 	}})
@@ -1354,7 +1311,6 @@ func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFu
 			err := b.Changed(all, test0.change)
 			c.Assert(err, jc.ErrorIsNil)
 			var entities entityInfoSlice = all.All()
-			substNilSinceTimeForEntities(c, entities)
 			assertEntitiesEqual(c, entities, test0.expectContents)
 
 			// Now do the same updates for a second model.
@@ -1374,12 +1330,6 @@ func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFu
 			sort.Sort(entities)
 			sort.Sort(expectedEntities)
 
-			// for some reason substNilSinceTimeForStatus cares if the Current is not blank
-			// and will abort if it is. Apparently this happens and it's totally fine. So we
-			// must use the NoCheck variant, rather than substNilSinceTimeForEntities(c, entities)
-			for i := range entities {
-				entities[i] = substNilSinceTimeForEntityNoCheck(entities[i])
-			}
 			assertEntitiesEqual(c, entities, expectedEntities)
 		}()
 	}
@@ -1645,7 +1595,6 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 	var gotEntities entityInfoSlice = all.All()
 	sort.Sort(gotEntities)
 	sort.Sort(expectedEntities)
-	substNilSinceTimeForEntities(c, gotEntities)
 	assertEntitiesEqual(c, gotEntities, expectedEntities)
 }
 
@@ -1751,6 +1700,8 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m10.Id(), gc.Equals, "0")
 
+	now := st0.clock().Now()
+
 	backing := s.NewAllModelWatcherStateBacking()
 	tw := newTestWatcher(backing, st0, c)
 	defer tw.Stop()
@@ -1801,10 +1752,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			Life:      multiwatcher.Life("alive"),
 			Series:    "trusty",
@@ -1820,10 +1773,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			Life:      multiwatcher.Life("alive"),
 			Series:    "saucy",
@@ -1839,7 +1794,6 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	deltas = tw.All(1)
-	zeroOutTimestampsForDeltas(c, deltas)
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: st1.ModelUUID(),
@@ -1847,10 +1801,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			Life:      multiwatcher.Life("dying"),
 			Series:    "saucy",
@@ -1865,7 +1821,6 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	deltas = tw.All(1)
-	zeroOutTimestampsForDeltas(c, deltas)
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: st1.ModelUUID(),
@@ -1873,10 +1828,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			Life:      multiwatcher.Life("dead"),
 			Series:    "saucy",
@@ -1915,8 +1872,8 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(m20.Id(), gc.Equals, "0")
 
 	// Look for the state changes from the allwatcher.
+	later := st2.clock().Now()
 	deltas = tw.All(7)
-	zeroOutTimestampsForDeltas(c, deltas)
 
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
@@ -1926,10 +1883,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &now,
 			},
 			Life:                    multiwatcher.Life("alive"),
 			Series:                  "trusty",
@@ -1952,10 +1911,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 			Life:      multiwatcher.Life("alive"),
 			Series:    "quantal",
@@ -1975,6 +1936,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 		},
 	}, {
@@ -1988,11 +1950,13 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Current: "waiting",
 				Message: "waiting for machine",
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: "allocating",
 				Message: "",
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 		},
 	}, {
@@ -2007,6 +1971,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Current: "available",
 				Message: "",
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 			SLA: multiwatcher.ModelSLAInfo{
 				Level: "unsupported",
@@ -2019,10 +1984,12 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			AgentStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 			InstanceStatus: multiwatcher.StatusInfo{
 				Current: status.Pending,
 				Data:    map[string]interface{}{},
+				Since:   &later,
 			},
 			Life:      multiwatcher.Life("alive"),
 			Series:    "trusty",
@@ -2032,31 +1999,6 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			WantsVote: false,
 		},
 	}})
-}
-
-func zeroOutTimestampsForDeltas(c *gc.C, deltas []multiwatcher.Delta) {
-	for i, delta := range deltas {
-		switch e := delta.Entity.(type) {
-		case *multiwatcher.UnitInfo:
-			unitInfo := *e // must copy, we may not own this reference
-			substNilSinceTimeForStatus(c, &unitInfo.WorkloadStatus)
-			substNilSinceTimeForStatus(c, &unitInfo.AgentStatus)
-			delta.Entity = &unitInfo
-		case *multiwatcher.ModelInfo:
-			modelInfo := *e // must copy, we may not own this reference
-			substNilSinceTimeForStatus(c, &modelInfo.Status)
-			delta.Entity = &modelInfo
-		case *multiwatcher.ApplicationInfo:
-			applicationInfo := *e // must copy, we may not own this reference
-			substNilSinceTimeForStatus(c, &applicationInfo.Status)
-			delta.Entity = &applicationInfo
-		case *multiwatcher.RemoteApplicationInfo:
-			remoteApplicationInfo := *e // must copy, we may not own this reference
-			substNilSinceTimeForStatus(c, &remoteApplicationInfo.Status)
-			delta.Entity = &remoteApplicationInfo
-		}
-		deltas[i] = delta
-	}
 }
 
 // The testChange* funcs are extracted so the test cases can be used
@@ -2146,7 +2088,6 @@ func testChangeAnnotations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 }
 
 func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
-	now := testing.ZeroTime()
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
@@ -2179,7 +2120,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "failure",
@@ -2202,10 +2143,12 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Current: status.Error,
 							Message: "failure",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
 							Current: status.Pending,
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						Life:      multiwatcher.Life("alive"),
 						Series:    "quantal",
@@ -2225,7 +2168,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 
 			err = m.SetAgentVersion(version.MustParseBinary("2.4.1-bionic-amd64"))
 			c.Assert(err, jc.ErrorIsNil)
-
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "machine is updated if it's in backing and in Store",
 				initialContents: []multiwatcher.EntityInfo{
@@ -2259,10 +2202,12 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Message: "another failure",
 							Data:    map[string]interface{}{},
 							Version: "2.4.1",
+							Since:   &now,
 						},
 						InstanceStatus: multiwatcher.StatusInfo{
 							Current: status.Pending,
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						Life:                     multiwatcher.Life("alive"),
 						Series:                   "trusty",
@@ -2274,6 +2219,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "no change if status is not in backing",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.MachineInfo{
@@ -2298,13 +2244,14 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Current: status.Error,
 							Message: "failure",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Started,
 				Message: "",
@@ -2336,6 +2283,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: status.Started,
 							Data:    make(map[string]interface{}),
+							Since:   &now,
 						},
 					}}}
 		},
@@ -2424,7 +2372,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 			c.Assert(err, jc.ErrorIsNil)
 			err = wordpress.SetMinUnits(42)
 			c.Assert(err, jc.ErrorIsNil)
-
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "application is added if it's in backing but not in Store",
 				change: watcher.Change{
@@ -2444,6 +2392,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -2482,7 +2431,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 			c.Assert(err, jc.ErrorIsNil)
 			err = unit.SetWorkloadVersion("42.47")
 			c.Assert(err, jc.ErrorIsNil)
-
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "workload version is updated when set on a unit",
 				initialContents: []multiwatcher.EntityInfo{
@@ -2508,6 +2457,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					},
 					&multiwatcher.ApplicationInfo{
@@ -2519,6 +2469,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					},
 				},
@@ -2530,7 +2481,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 			c.Assert(err, jc.ErrorIsNil)
 			err = unit.SetWorkloadVersion("")
 			c.Assert(err, jc.ErrorIsNil)
-
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "workload version is not updated when empty",
 				initialContents: []multiwatcher.EntityInfo{
@@ -2557,6 +2508,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					},
 					&multiwatcher.ApplicationInfo{
@@ -2568,6 +2520,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					},
 				},
@@ -2805,7 +2758,6 @@ func testChangeApplicationsConstraints(c *gc.C, owner names.UserTag, runChangeTe
 }
 
 func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []changeTestFunc)) {
-	now := testing.ZeroTime()
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
@@ -2843,7 +2795,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPorts("tcp", 5555, 5558)
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "failure",
@@ -2882,11 +2834,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "error",
 							Message: "failure",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -2902,6 +2856,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.SetAgentVersion(version.MustParseBinary("2.4.1-bionic-amd64"))
 			c.Assert(err, jc.ErrorIsNil)
+			now := st.clock().Now()
 
 			return changeTestCase{
 				about: "unit is updated if it's in backing and in multiwatcher.Store",
@@ -2941,11 +2896,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Message: "",
 							Data:    map[string]interface{}{},
 							Version: "2.4.1",
+							Since:   &now,
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "error",
 							Message: "another failure",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -2999,7 +2956,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPorts("tcp", 21, 22)
 			c.Assert(err, jc.ErrorIsNil)
-
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "unit is created if a port is opened on the machine it is placed in",
 				initialContents: []multiwatcher.EntityInfo{
@@ -3023,10 +2980,12 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "allocating",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						Ports:      []multiwatcher.Port{{"tcp", 21}, {"tcp", 22}},
 						PortRanges: []multiwatcher.PortRange{{21, 22, "tcp"}},
@@ -3051,7 +3010,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			privateAddress := network.NewScopedAddress("private", network.ScopeCloudLocal)
 			err = m.SetProviderAddresses(publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "failure",
@@ -3081,11 +3040,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "error",
 							Message: "failure",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -3098,6 +3059,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "no change if status is not in backing",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
@@ -3130,11 +3092,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "error",
 							Message: "failure",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -3144,7 +3108,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.AssignToNewMachine()
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Idle,
 				Message: "",
@@ -3185,11 +3149,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "maintenance",
 							Message: "working",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -3197,7 +3163,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Idle,
 				Message: "",
@@ -3247,11 +3213,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "maintenance",
 							Message: "doing work",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -3259,7 +3227,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit(AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
 				Message: "hook error",
@@ -3307,11 +3275,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 								"2nd-key": 2,
 								"3rd-key": true,
 							},
+							Since: &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -3321,7 +3291,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.AssignToNewMachine()
 			c.Assert(err, jc.ErrorIsNil)
-			now := testing.ZeroTime()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Active,
 				Message: "",
@@ -3374,11 +3344,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "active",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "idle",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					},
 					&multiwatcher.ApplicationInfo{
@@ -3388,6 +3360,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Current: "active",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					},
 				}}
@@ -3441,7 +3414,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 	changeTestFuncs := []changeTestFunc{
 		func(c *gc.C, st *State) changeTestCase {
 			initModel(c, st, assignUnit)
-
+			now := st.clock().Now()
 			return changeTestCase{
 				about: "don't open ports on unit",
 				change: watcher.Change{
@@ -3461,16 +3434,19 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "allocating",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			initModel(c, st, assignUnit|openPorts)
+			now := st.clock().Now()
 
 			return changeTestCase{
 				about: "open a port on unit",
@@ -3493,16 +3469,19 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "allocating",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			initModel(c, st, assignUnit|openPorts|closePorts)
+			now := st.clock().Now()
 
 			return changeTestCase{
 				about: "open a port on unit and close it again",
@@ -3525,16 +3504,19 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "allocating",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			initModel(c, st, openPorts)
+			now := st.clock().Now()
 
 			return changeTestCase{
 				about: "open ports on an unassigned unit",
@@ -3554,11 +3536,13 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 							Current: "waiting",
 							Message: "waiting for machine",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "allocating",
 							Message: "",
 							Data:    map[string]interface{}{},
+							Since:   &now,
 						},
 					}}}
 		},
@@ -3595,8 +3579,6 @@ func testChangeRemoteApplications(c *gc.C, runChangeTests func(*gc.C, []changeTe
 		func(c *gc.C, st *State) changeTestCase {
 			_, remoteApplicationInfo := addTestingRemoteApplication(
 				c, st, "remote-mysql2", "me/model.mysql", "remote-mysql2-uuid", mysqlRelations, false)
-			// Zero out the since time in the status entry.
-			remoteApplicationInfo.Status.Since = nil
 			return changeTestCase{
 				about: "remote application is added if it's in backing but not in Store",
 				change: watcher.Change{
@@ -3637,13 +3619,14 @@ func testChangeRemoteApplications(c *gc.C, runChangeTests func(*gc.C, []changeTe
 			err = mysql.Destroy()
 			c.Assert(err, jc.ErrorIsNil)
 
+			now := st.clock().Now()
 			initialRemoteApplicationInfo := remoteApplicationInfo
 			remoteApplicationInfo.Life = "dying"
 			remoteApplicationInfo.Status = multiwatcher.StatusInfo{
 				Current: status.Status,
 				Message: status.Message,
 				Data:    status.Data,
-				// We replace Since with zero, so no time expected.
+				Since:   &now,
 			}
 			return changeTestCase{
 				about:           "remote application is updated if it's in backing and in multiwatcher.Store",
@@ -3659,7 +3642,7 @@ func testChangeRemoteApplications(c *gc.C, runChangeTests func(*gc.C, []changeTe
 			mysql, remoteApplicationInfo := addTestingRemoteApplication(
 				c, st, "remote-mysql2", "me/model.mysql", "remote-mysql2-uuid", mysqlRelations, false,
 			)
-			now := time.Now()
+			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Active,
 				Message: "running",
@@ -3673,6 +3656,7 @@ func testChangeRemoteApplications(c *gc.C, runChangeTests func(*gc.C, []changeTe
 				Current: "active",
 				Message: "running",
 				Data:    map[string]interface{}{"foo": "bar"},
+				Since:   &now,
 			}
 			return changeTestCase{
 				about:           "remote application status is updated if it's in backing and in multiwatcher.Store",
@@ -3944,7 +3928,7 @@ func deltaMap(deltas []multiwatcher.Delta) map[interface{}]multiwatcher.EntityIn
 		if d.Removed {
 			m[id] = nil
 		} else {
-			m[id] = substNilSinceTimeForEntityNoCheck(d.Entity)
+			m[id] = d.Entity
 		}
 	}
 	return m

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -59,7 +59,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	modelCfg := testing.ModelConfig(c)
 	controllerCfg := testing.FakeControllerConfig()
 	ctlr, err := Initialize(InitializeParams{
-		Clock:            testclock.NewClock(testing.NonZeroTime()), //  clock.WallClock,
+		Clock:            testclock.NewClock(testing.NonZeroTime()),
 		ControllerConfig: controllerCfg,
 		ControllerModelArgs: ModelArgs{
 			Type:        ModelTypeIAAS,

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -730,7 +729,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 			statusDoc := statusDoc{
 				ModelUUID: st.ModelUUID(),
 				Status:    status.Unknown,
-				Updated:   time.Now().UnixNano(),
+				Updated:   st.clock().Now().UnixNano(),
 			}
 			ops = append(ops, createStatusOp(st, app.globalKey(), statusDoc))
 		}


### PR DESCRIPTION
The TestClientWatchAllAdminPermission from apiserver/facades/client/client failed intermittently.

When run locally it would fail about 50% of the time. After much digging, I found that this was a race in the underlying multiwatcher code. If the intial GetAll was processed and the underlying changes from the document watchers hadn't been processed, the test would pass, but if the change for the remote application was processed before Next was called in the test, it would fail.

This was due to the entity being assigned into the multiwatcher state was missing the status value. To handle this, if the entity isn't new, we get the status from the old value.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1790548
