### PR TITLE
Set Machine Series When Series Upgrade is Complete

### DIFF
--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -198,5 +198,10 @@ func (s *Client) FinishUpgradeSeries() error {
 	if len(results.Results) != 1 {
 		return errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
-	return results.Results[0].Error
+
+	result := results.Results[0]
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
 }

--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -184,13 +184,16 @@ func (s *Client) StartUnitCompletion() error {
 }
 
 // FinishUpgradeSeries notifies the controller that the upgrade process is
-// completely finished. We use the name "Finish" to distinguish this method from
-// the various "Complete" phases.
-func (s *Client) FinishUpgradeSeries() error {
+// completely finished, passing the current host OS series.
+// We use the name "Finish" to distinguish this method from the various
+// "Complete" phases.
+func (s *Client) FinishUpgradeSeries(hostSeries string) error {
 	var results params.ErrorResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: s.authTag.String()}},
-	}
+	args := params.UpdateSeriesArgs{Args: []params.UpdateSeriesArg{{
+		Entity: params.Entity{Tag: s.authTag.String()},
+		Series: hostSeries,
+	}}}
+
 	err := s.facade.FacadeCall("FinishUpgradeSeries", args, &results)
 	if err != nil {
 		return err

--- a/api/upgradeseries/upgradeseries_test.go
+++ b/api/upgradeseries/upgradeseries_test.go
@@ -185,10 +185,15 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeries(c *gc.C) {
 
 	fCaller := mocks.NewMockFacadeCaller(ctrl)
 
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{
+			{Series: "xenial", Entity: s.args.Entities[0]},
+		},
+	}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}}}
-	fCaller.EXPECT().FacadeCall("FinishUpgradeSeries", s.args, gomock.Any()).SetArg(2, resultSource)
+	fCaller.EXPECT().FacadeCall("FinishUpgradeSeries", args, gomock.Any()).SetArg(2, resultSource)
 
 	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
-	err := api.FinishUpgradeSeries()
+	err := api.FinishUpgradeSeries("xenial")
 	c.Assert(err, gc.IsNil)
 }

--- a/apiserver/common/mocks/mock_upgradeseries.go
+++ b/apiserver/common/mocks/mock_upgradeseries.go
@@ -134,6 +134,18 @@ func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Units))
 }
 
+// UpdateMachineSeries mocks base method
+func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string, arg1 bool) error {
+	ret := m.ctrl.Call(m, "UpdateMachineSeries", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMachineSeries indicates an expected call of UpdateMachineSeries
+func (mr *MockUpgradeSeriesMachineMockRecorder) UpdateMachineSeries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMachineSeries", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpdateMachineSeries), arg0, arg1)
+}
+
 // UpgradeSeriesStatus mocks base method
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")

--- a/apiserver/common/mocks/mock_upgradeseries.go
+++ b/apiserver/common/mocks/mock_upgradeseries.go
@@ -97,6 +97,18 @@ func (mr *MockUpgradeSeriesMachineMockRecorder) RemoveUpgradeSeriesLock() *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeSeriesLock", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).RemoveUpgradeSeriesLock))
 }
 
+// Series mocks base method
+func (m *MockUpgradeSeriesMachine) Series() string {
+	ret := m.ctrl.Call(m, "Series")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Series indicates an expected call of Series
+func (mr *MockUpgradeSeriesMachineMockRecorder) Series() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Series))
+}
+
 // SetUpgradeSeriesStatus mocks base method
 func (m *MockUpgradeSeriesMachine) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus) error {
 	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0)

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -32,6 +32,7 @@ type UpgradeSeriesMachine interface {
 	UpgradeSeriesUnitStatuses() (map[string]state.UpgradeSeriesUnitStatus, error)
 	RemoveUpgradeSeriesLock() error
 	UpgradeSeriesTarget() (string, error)
+	UpdateMachineSeries(series string, force bool) error
 }
 
 // UpgradeSeriesUnit describes unit-receiver state methods

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -32,6 +32,7 @@ type UpgradeSeriesMachine interface {
 	UpgradeSeriesUnitStatuses() (map[string]state.UpgradeSeriesUnitStatus, error)
 	RemoveUpgradeSeriesLock() error
 	UpgradeSeriesTarget() (string, error)
+	Series() string
 	UpdateMachineSeries(series string, force bool) error
 }
 

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -127,15 +127,39 @@ func (s *upgradeSeriesSuite) TestUnitsCompleted(c *gc.C) {
 	})
 }
 
-func (s *upgradeSeriesSuite) TestFinishUpgradeSeries(c *gc.C) {
+func (s *upgradeSeriesSuite) TestFinishUpgradeSeriesUpgraded(c *gc.C) {
 	defer s.arrangeTest(c).Finish()
 
 	exp := s.machine.EXPECT()
-	exp.UpgradeSeriesTarget().Return("xenial", nil)
+	exp.Series().Return("trusty")
 	exp.UpdateMachineSeries("xenial", true).Return(nil)
 	exp.RemoveUpgradeSeriesLock().Return(nil)
 
-	results, err := s.api.FinishUpgradeSeries(s.entityArgs)
+	entity := params.Entity{Tag: s.machineTag.String()}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{Entity: entity, Series: "xenial"}},
+	}
+
+	results, err := s.api.FinishUpgradeSeries(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+
+func (s *upgradeSeriesSuite) TestFinishUpgradeSeriesNotUpgraded(c *gc.C) {
+	defer s.arrangeTest(c).Finish()
+
+	exp := s.machine.EXPECT()
+	exp.Series().Return("trusty")
+	exp.RemoveUpgradeSeriesLock().Return(nil)
+
+	entity := params.Entity{Tag: s.machineTag.String()}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{Entity: entity, Series: "trusty"}},
+	}
+
+	results, err := s.api.FinishUpgradeSeries(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}},

--- a/worker/upgradeseries/mocks/package_mock.go
+++ b/worker/upgradeseries/mocks/package_mock.go
@@ -37,15 +37,15 @@ func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 }
 
 // FinishUpgradeSeries mocks base method
-func (m *MockFacade) FinishUpgradeSeries() error {
-	ret := m.ctrl.Call(m, "FinishUpgradeSeries")
+func (m *MockFacade) FinishUpgradeSeries(arg0 string) error {
+	ret := m.ctrl.Call(m, "FinishUpgradeSeries", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FinishUpgradeSeries indicates an expected call of FinishUpgradeSeries
-func (mr *MockFacadeMockRecorder) FinishUpgradeSeries() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishUpgradeSeries", reflect.TypeOf((*MockFacade)(nil).FinishUpgradeSeries))
+func (mr *MockFacadeMockRecorder) FinishUpgradeSeries(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishUpgradeSeries", reflect.TypeOf((*MockFacade)(nil).FinishUpgradeSeries), arg0)
 }
 
 // MachineStatus mocks base method

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -20,7 +20,7 @@ type Facade interface {
 	UnitsCompleted() ([]names.UnitTag, error)
 	StartUnitCompletion() error
 	SetMachineStatus(status model.UpgradeSeriesStatus) error
-	FinishUpgradeSeries() error
+	FinishUpgradeSeries(string) error
 	TargetSeries() (string, error)
 }
 

--- a/worker/upgradeseries/upgrader.go
+++ b/worker/upgradeseries/upgrader.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service"
@@ -21,8 +20,6 @@ var (
 	systemdDir          = systemd.EtcSystemdDir
 	systemdMultiUserDir = systemd.EtcSystemdMultiUserDir
 )
-
-var hostSeries = series.HostSeries
 
 // Upgrader describes methods required to perform file-system manipulation in
 // preparation for upgrading the host Ubuntu version.

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -261,24 +261,36 @@ func (w *upgradeSeriesWorker) transitionPrepareComplete(unitServices map[string]
 func (w *upgradeSeriesWorker) handleCompleteStarted() error {
 	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesCompleteStarted)
 
+	// TODO (manadart 2018-09-04): We should check the actual series here to
+	// ensure that it has actually been upgraded before advancing this
+	// workflow any further.
+
 	// If the units are still all in the "PrepareComplete" state, then the
 	// manual tasks have been run and an operator has executed the
 	// upgrade-series completion command; start all the unit agents,
 	// and progress the workflow.
-	units, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
+	unitServices, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if allConfirmed {
-		return errors.Trace(w.transitionUnitsStarted(units))
+	servicesPresent := len(unitServices) > 0
+
+	// allConfirmed returns true when there are no units, so we only need this
+	// transition when there are services to start.
+	// If there are none, just proceed to the completed stage.
+	if allConfirmed && servicesPresent {
+		return errors.Trace(w.transitionUnitsStarted(unitServices))
 	}
 
-	// If the units have all completed their workflow, then we are done.
-	// Make the final update to the lock to say the machine is completed.
-	units, allConfirmed, err = w.compareUnitAgentServices(w.UnitsCompleted)
-	if err != nil {
-		return errors.Trace(err)
+	if servicesPresent {
+		// If the units have all completed their workflow, then we are done.
+		// Make the final update to the lock to say the machine is completed.
+		unitServices, allConfirmed, err = w.compareUnitAgentServices(w.UnitsCompleted)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
+
 	if allConfirmed {
 		w.logger.Infof("series upgrade complete")
 		return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesCompleted))

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -281,13 +281,11 @@ func (w *upgradeSeriesWorker) handleCompleteStarted() error {
 		return errors.Trace(w.transitionUnitsStarted(unitServices))
 	}
 
-	if servicesPresent {
-		// If the units have all completed their workflow, then we are done.
-		// Make the final update to the lock to say the machine is completed.
-		unitServices, allConfirmed, err = w.compareUnitAgentServices(w.UnitsCompleted)
-		if err != nil {
-			return errors.Trace(err)
-		}
+	// If the units have all completed their workflow, then we are done.
+	// Make the final update to the lock to say the machine is completed.
+	unitServices, allConfirmed, err = w.compareUnitAgentServices(w.UnitsCompleted)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	if allConfirmed {
@@ -363,6 +361,9 @@ func (w *upgradeSeriesWorker) compareUnitAgentServices(
 	}
 
 	unitServices := service.FindUnitServiceNames(services)
+	if len(unitServices) == 0 {
+		w.logger.Debugf("no unit agent services found")
+	}
 	if len(units) != len(unitServices) {
 		return unitServices, false, nil
 	}

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -317,9 +317,10 @@ func (w *upgradeSeriesWorker) transitionUnitsStarted(unitServices map[string]str
 // post upgrade routine.
 func (w *upgradeSeriesWorker) handleCompleted() error {
 	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesCompleted)
+
 	err := w.FinishUpgradeSeries()
 	if err != nil {
-		errors.Trace(err)
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -173,19 +173,19 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 func (w *upgradeSeriesWorker) handlePrepareStarted() error {
 	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesPrepareStarted)
 
-	units, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
+	unitServices, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if !allConfirmed {
 		w.logger.Debugf(
-			"still waiting for units to complete series upgrade preparation; known unit agent services:\n\t%s",
-			unitNames(units),
+			"still waiting for units to complete series upgrade preparation; known unit agent services: %s",
+			unitNames(unitServices),
 		)
 		return nil
 	}
 
-	return errors.Trace(w.transitionPrepareMachine(units))
+	return errors.Trace(w.transitionPrepareMachine(unitServices))
 }
 
 // transitionPrepareMachine stops all unit agents on this machine and updates
@@ -225,19 +225,19 @@ func (w *upgradeSeriesWorker) handlePrepareMachine() error {
 
 	// This is a sanity check.
 	// The units should all still be in the "PrepareComplete" state.
-	units, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
+	unitServices, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if !allConfirmed {
-		w.logger.Debugf(
+		w.logger.Warningf(
 			"units are not all in the expected state for series upgrade preparation (complete); "+
-				"known unit agent services:\n\t%s",
-			unitNames(units),
+				"known unit agent services: %s",
+			unitNames(unitServices),
 		)
 	}
 
-	return errors.Trace(w.transitionPrepareComplete(units))
+	return errors.Trace(w.transitionPrepareComplete(unitServices))
 }
 
 // transitionPrepareComplete rewrites service unit files for unit agents running

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -183,7 +183,8 @@ func (s *workerSuite) TestMachineCompleteStartedNoUnitsProgressComplete(c *gc.C)
 
 	// Machine with no units - API calls return none, no services discovered.
 	exp.UnitsPrepared().Return(nil, nil)
-	s.service.EXPECT().ListServices().Return(nil, nil)
+	exp.UnitsCompleted().Return(nil, nil)
+	s.service.EXPECT().ListServices().Return(nil, nil).Times(2)
 
 	// Progress directly to completed.
 	exp.SetMachineStatus(model.UpgradeSeriesCompleted).Return(nil)


### PR DESCRIPTION
## Description of change

When the upgrade-series workflow has completed, and prior to removing the upgrade lock, the machine's series is updated to match the host Ubuntu series if they differ.

Also included:
- Fix for error checking when calling `FinishUpgradeSeries`.
- Fix for work-flow looping when attempting to _complete_ a machine with no units. 

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`
- Bootstrap
- Deploy a Trusty charm (Ubuntu or Redis will work)
  - `juju upgrade-series prepare 0 xenial`
  - `juju upgrade-series complete 0`
  - Check that `juju status` shows the machine series as "trusty".
- `juju add-machine --series trusty` (no units)
  - `juju upgrade-series prepare 1 xenial`
  - SSH to the machine and run `do-release-upgrade`, following defaults.
  - `juju upgrade-series complete 1`
  - Check that `juju status` shows the machine series as "xenial".

## Documentation changes

None

## Bug reference

N/A
