### PR TITLE
Upgrade Series Ensure Before Completion.

### DIFF
--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -198,5 +198,10 @@ func (s *Client) FinishUpgradeSeries() error {
 	if len(results.Results) != 1 {
 		return errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
-	return results.Results[0].Error
+
+	result := results.Results[0]
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
 }

--- a/apiserver/common/mocks/mock_upgradeseries.go
+++ b/apiserver/common/mocks/mock_upgradeseries.go
@@ -134,6 +134,18 @@ func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Units))
 }
 
+// UpdateMachineSeries mocks base method
+func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string, arg1 bool) error {
+	ret := m.ctrl.Call(m, "UpdateMachineSeries", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMachineSeries indicates an expected call of UpdateMachineSeries
+func (mr *MockUpgradeSeriesMachineMockRecorder) UpdateMachineSeries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMachineSeries", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpdateMachineSeries), arg0, arg1)
+}
+
 // UpgradeSeriesStatus mocks base method
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -32,6 +32,7 @@ type UpgradeSeriesMachine interface {
 	UpgradeSeriesUnitStatuses() (map[string]state.UpgradeSeriesUnitStatus, error)
 	RemoveUpgradeSeriesLock() error
 	UpgradeSeriesTarget() (string, error)
+	UpdateMachineSeries(series string, force bool) error
 }
 
 // UpgradeSeriesUnit describes unit-receiver state methods

--- a/worker/upgradeseries/upgrader.go
+++ b/worker/upgradeseries/upgrader.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service"
@@ -21,8 +20,6 @@ var (
 	systemdDir          = systemd.EtcSystemdDir
 	systemdMultiUserDir = systemd.EtcSystemdMultiUserDir
 )
-
-var hostSeries = series.HostSeries
 
 // Upgrader describes methods required to perform file-system manipulation in
 // preparation for upgrading the host Ubuntu version.

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -261,24 +261,36 @@ func (w *upgradeSeriesWorker) transitionPrepareComplete(unitServices map[string]
 func (w *upgradeSeriesWorker) handleCompleteStarted() error {
 	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesCompleteStarted)
 
+	// TODO (manadart 2018-09-04): We should check the actual series here to
+	// ensure that it has actually been upgraded before advancing this
+	// workflow any further.
+
 	// If the units are still all in the "PrepareComplete" state, then the
 	// manual tasks have been run and an operator has executed the
 	// upgrade-series completion command; start all the unit agents,
 	// and progress the workflow.
-	units, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
+	unitServices, allConfirmed, err := w.compareUnitAgentServices(w.UnitsPrepared)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if allConfirmed {
-		return errors.Trace(w.transitionUnitsStarted(units))
+	servicesPresent := len(unitServices) > 0
+
+	// allConfirmed returns true when there are no units, so we only need this
+	// transition when there are services to start.
+	// If there are none, just proceed to the completed stage.
+	if allConfirmed && servicesPresent {
+		return errors.Trace(w.transitionUnitsStarted(unitServices))
 	}
 
-	// If the units have all completed their workflow, then we are done.
-	// Make the final update to the lock to say the machine is completed.
-	units, allConfirmed, err = w.compareUnitAgentServices(w.UnitsCompleted)
-	if err != nil {
-		return errors.Trace(err)
+	if servicesPresent {
+		// If the units have all completed their workflow, then we are done.
+		// Make the final update to the lock to say the machine is completed.
+		unitServices, allConfirmed, err = w.compareUnitAgentServices(w.UnitsCompleted)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
+
 	if allConfirmed {
 		w.logger.Infof("series upgrade complete")
 		return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesCompleted))

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -317,9 +317,10 @@ func (w *upgradeSeriesWorker) transitionUnitsStarted(unitServices map[string]str
 // post upgrade routine.
 func (w *upgradeSeriesWorker) handleCompleted() error {
 	w.logger.Debugf("machine series upgrade status is %q", model.UpgradeSeriesCompleted)
+
 	err := w.FinishUpgradeSeries()
 	if err != nil {
-		errors.Trace(err)
+		return errors.Trace(err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

Depends on https://github.com/juju/juju/pull/9157

This prevents the possibility of going through the series upgrade work-flow without actually upgrading the OS.

Upon detecting the lock change to "complete started", the machine worker compares the upgrade target series to the host series. If the host has not been upgraded, an error is returned.

Once the upgrade has been run, the work-flow progression resumes.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`
- Bootstrap
- Deploy a Trusty charm (Ubuntu or Redis will work)
- `juju upgrade-series prepare 0 xenial`
- After prepare is completed, `juju upgrade-series complete 0`
  - Units should remain unstarted.
  - Machine series should remain unchanged.
  - Log should show an error for the mismatched target and host series.
- SSH on to the machine and run `do-release-upgrade`, accepting defaults.
- Units should start and the machine's series should update.

## Documentation changes

None.

## Bug reference

N/A.
