### PR TITLE
Handle if collStats returns an int64 for size.

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -61,6 +61,7 @@ var (
 	ModelGlobalKey                       = modelGlobalKey
 	MergeBindings                        = mergeBindings
 	UpgradeInProgressError               = errUpgradeInProgress
+	DBCollectionSizeToInt                = dbCollectionSizeToInt
 )
 
 type (

--- a/state/logs.go
+++ b/state/logs.go
@@ -864,12 +864,18 @@ func dbCollectionSizeToInt(result bson.M, collectionName string) (int, error) {
 		return 0, nil
 	}
 	if asint, ok := size.(int); ok {
+		if asint < 0 {
+			return 0, errors.Errorf("mongo collStats for %q returned a negative value: %v", collectionName, size)
+		}
 		return asint, nil
 	}
 	if asint64, ok := size.(int64); ok {
 		// 2billion megabytes is 2 petabytes, which is outside our range anyway.
 		if asint64 > math.MaxInt32 {
 			return math.MaxInt32, nil
+		}
+		if asint64 < 0 {
+			return 0, errors.Errorf("mongo collStats for %q returned a negative value: %v", collectionName, size)
 		}
 		return int(asint64), nil
 	}

--- a/state/logs.go
+++ b/state/logs.go
@@ -8,6 +8,7 @@ package state
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -854,6 +855,29 @@ func initLogsSession(st ModelSessioner) (*mgo.Session, *mgo.Collection) {
 	return session, db.C(logCollectionName(st.ModelUUID()))
 }
 
+// dbCollectionSizeToInt processes the result of Database.collStats()
+func dbCollectionSizeToInt(result bson.M, collectionName string) (int, error) {
+	size, ok := result["size"]
+	if !ok {
+		logger.Warningf("mongo collStats did not return a size field for %q", collectionName)
+		// this wasn't considered an error in the past, just treat it as size 0
+		return 0, nil
+	}
+	if asint, ok := size.(int); ok {
+		return asint, nil
+	}
+	if asint64, ok := size.(int64); ok {
+		// 2billion megabytes is 2 petabytes, which is outside our range anyway.
+		if asint64 > math.MaxInt32 {
+			return math.MaxInt32, nil
+		}
+		return int(asint64), nil
+	}
+	return 0, errors.Errorf(
+		"mongo collStats for %q did not return an int or int64 for size, returned %T: %v",
+		collectionName, size, size)
+}
+
 // getCollectionMB returns the size of a MongoDB collection (in
 // bytes), excluding space used by indexes.
 func getCollectionMB(coll *mgo.Collection) (int, error) {
@@ -865,7 +889,7 @@ func getCollectionMB(coll *mgo.Collection) (int, error) {
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	return result["size"].(int), nil
+	return dbCollectionSizeToInt(result, coll.Name)
 }
 
 // getCollectionTotalMB returns the total size of the log collections

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -962,6 +962,13 @@ func (*DBLogSizeSuite) TestDBLogSizeInt64SizeOverflow(c *gc.C) {
 	c.Check(res, gc.Equals, int((1<<31)-1))
 }
 
+func (*DBLogSizeSuite) TestDBLogSizeNegativeSize(c *gc.C) {
+	_, err := state.DBCollectionSizeToInt(bson.M{"size": int(-10)}, "coll-name")
+	c.Check(err, gc.ErrorMatches, `mongo collStats for "coll-name" returned a negative value: -10`)
+	_, err = state.DBCollectionSizeToInt(bson.M{"size": int64(-10)}, "coll-name")
+	c.Check(err, gc.ErrorMatches, `mongo collStats for "coll-name" returned a negative value: -10`)
+}
+
 func (*DBLogSizeSuite) TestDBLogSizeUnknownType(c *gc.C) {
 	_, err := state.DBCollectionSizeToInt(bson.M{"size": float64(12345)}, "coll-name")
 	c.Check(err, gc.ErrorMatches, `mongo collStats for "coll-name" did not return an int or int64 for size, returned float64: 12345`)

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -927,3 +927,42 @@ func (s *LogTailerSuite) assertTailer(c *gc.C, tailer state.LogTailer, expectedC
 		}
 	}
 }
+
+type DBLogSizeSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&DBLogSizeSuite{})
+
+func (*DBLogSizeSuite) TestDBLogSizeIntSize(c *gc.C) {
+	res, err := state.DBCollectionSizeToInt(bson.M{"size": int(12345)}, "coll-name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.Equals, int(12345))
+}
+
+func (*DBLogSizeSuite) TestDBLogSizeNoSize(c *gc.C) {
+	res, err := state.DBCollectionSizeToInt(bson.M{}, "coll-name")
+	// Old code didn't treat this as an error, if we know it doesn't happen often, we could start changing it to be an error.
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.Equals, int(0))
+}
+
+func (*DBLogSizeSuite) TestDBLogSizeInt64Size(c *gc.C) {
+	// Production results have shown that sometimes collStats can return an int64.
+	// See https://bugs.launchpad.net/juju/+bug/1790626 in case we ever figure out why
+	res, err := state.DBCollectionSizeToInt(bson.M{"size": int64(12345)}, "coll-name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.Equals, int(12345))
+}
+
+func (*DBLogSizeSuite) TestDBLogSizeInt64SizeOverflow(c *gc.C) {
+	// Just in case, it is unlikely this ever actually happens
+	res, err := state.DBCollectionSizeToInt(bson.M{"size": int64(12345678901)}, "coll-name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.Equals, int((1<<31)-1))
+}
+
+func (*DBLogSizeSuite) TestDBLogSizeUnknownType(c *gc.C) {
+	_, err := state.DBCollectionSizeToInt(bson.M{"size": float64(12345)}, "coll-name")
+	c.Check(err, gc.ErrorMatches, `mongo collStats for "coll-name" did not return an int or int64 for size, returned float64: 12345`)
+}


### PR DESCRIPTION
## Description of change

In production, we ran into panic() because Mongo was returning an int64 for a size field instead of an int. We don't have full understanding of how it was happening, but this should at least cover the issue.

Add some testing for how we handle the bson.M result and allow it to be
int or int64 and generate an error rather than panic if it isn't.

## QA steps

Tests added to cover the new code path which was factored out so that it could be directly testable. We don't have exact reproduction for how to get Mongo to behave in this way. One possibility is to just create a logs table that is very very large (>2GB?) and see if it panics without this change.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1790626