### PR TITLE
use sed -E instead of -r for portability in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PROJECT_DIR := $(shell go list -e -f '{{.Dir}}' $(PROJECT))
 PROJECT_PACKAGES := $(shell go list $(PROJECT)/... | grep -v /vendor/)
 
 # Allow the tests to take longer on arm platforms.
-ifeq ($(shell uname -p | sed -r 's/.*(armel|armhf|aarch64).*/golang/'), golang)
+ifeq ($(shell uname -p | sed -E 's/.*(armel|armhf|aarch64).*/golang/'), golang)
 	TEST_TIMEOUT := 2400s
 else
 	TEST_TIMEOUT := 1500s


### PR DESCRIPTION
## Description of change

Use sed -E instead of -r for portability in Makefile.  Per sed man page they are interchangeable.

## QA steps

make juju on an osx machine, "sed: illegal option -- r" should not appear.
make juju on ubuntu, no change.

## Documentation changes

n/a

## Bug reference

n/a