### PR TITLE
raftlease.FSM autoexpires leases when time is updated

### DIFF
--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -106,14 +106,9 @@ func (s *Store) ExtendLease(key lease.Key, req lease.Request) error {
 
 // ExpireLease is part of lease.Store.
 func (s *Store) ExpireLease(key lease.Key) error {
-	err := s.runOnLeader(&Command{
-		Version:   CommandVersion,
-		Operation: OperationExpire,
-		Namespace: key.Namespace,
-		ModelUUID: key.ModelUUID,
-		Lease:     key.Lease,
-	})
-	return errors.Trace(err)
+	// It's always an invalid operation - expiration happens
+	// automatically when time is advanced.
+	return lease.ErrInvalid
 }
 
 // Leases is part of lease.Store.

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -183,29 +183,10 @@ func (s *storeSuite) TestExtend(c *gc.C) {
 }
 
 func (s *storeSuite) TestExpire(c *gc.C) {
-	s.handleHubRequest(c,
-		func() {
-			err := s.store.ExpireLease(
-				lease.Key{"warframe", "oberon", "prime"},
-			)
-			c.Assert(err, jc.ErrorIsNil)
-		},
-
-		raftlease.Command{
-			Version:   1,
-			Operation: raftlease.OperationExpire,
-			Namespace: "warframe",
-			ModelUUID: "oberon",
-			Lease:     "prime",
-		},
-		func(req raftlease.ForwardRequest) {
-			_, err := s.hub.Publish(
-				req.ResponseTopic,
-				raftlease.ForwardResponse{},
-			)
-			c.Check(err, jc.ErrorIsNil)
-		},
+	err := s.store.ExpireLease(
+		lease.Key{"warframe", "oberon", "prime"},
 	)
+	c.Assert(err, jc.Satisfies, lease.IsInvalid)
 }
 
 func (s *storeSuite) TestLeases(c *gc.C) {


### PR DESCRIPTION
## Description of change
When the time is updated in the FSM, it expires all leases that should be expired. (This means that store.ExpireLeases doesn't do anything anymore.) The expired leases are returned in the response for the setTime operation so the database can be kept in sync. 

This will reduce the number of commands that need to be fed through the raft system (since time updates need to happen anyway).

## QA steps

* Bootstrap a controller and deploy an application with a number of units, kill off the leader and see that leadership expires and is claimed by another unit, check in the database that the change is reflected in the leaseholders collection.
