### PR TITLE
Add stanza for 18.04:s390x to openstack test image metadata

### DIFF
--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -217,6 +217,25 @@ var imagesData = `
        }
      }
    },
+   "com.ubuntu.cloud:server:18.04:s390x": {
+     "release": "xenial",
+     "version": "18.04",
+     "arch": "s390x",
+     "versions": {
+       "20121111": {
+         "items": {
+           "inst1604s390x": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-1604s390x"
+           }
+         },
+         "pubname": "ubuntu-xenial-18.04-s390x-server-20121111",
+         "label": "release"
+       }
+     }
+   },
    "com.ubuntu.cloud:server:16.04:amd64": {
      "release": "trusty",
      "version": "16.04",


### PR DESCRIPTION
## Description of change

The index entry for 18.04:s390x was added when the default series was bumped to bionic, and image metadata was added for the other architectures, but it seems like s390x was missed. This was preventing the s390x unit test job from passing.

(Backported to 2.4 from #9165 - I'd have just made the change in 2.4 and left it for merging, but the test data has been moved out of export_test in develop.)

## QA steps

* I removed the corresponding section for 18.04:amd64 and saw that the test failed in the same way when run locally.