### PR TITLE
Fix for racy TestRemoveApplicationStopsWatchingApplication

### DIFF
--- a/worker/caasfirewaller/worker_test.go
+++ b/worker/caasfirewaller/worker_test.go
@@ -197,6 +197,11 @@ func (s *WorkerSuite) TestWatchApplicationDead(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
+	// Set up the errors before triggering any events to avoid racing
+	// with the worker loop. First time around the loop the
+	// application's alive, then it's gone.
+	s.lifeGetter.SetErrors(nil, errors.NotFoundf("application"))
+
 	w, err := caasfirewaller.NewWorker(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -207,7 +212,6 @@ func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
 		c.Fatal("timed out sending applications change")
 	}
 
-	s.lifeGetter.SetErrors(errors.NotFoundf("application"))
 	select {
 	case s.applicationChanges <- []string{"gitlab"}:
 	case <-time.After(coretesting.LongWait):


### PR DESCRIPTION
## Description of change

This would fail occasionally because the worker loop hadn't had time to get the life for gitlab before the test would set the notfound error - in that case it would never start the watcher for gitlab, and never kill it.

Fix this by setting errors (starting with a nil) before firing any change events.

## QA steps

* Before this change the test would fail about 1 in 5 runs under stress-race, after the change I haven't seen it fail.
