### PR TITLE
Fixes lp#1790424: new provisioner retries and keep machine tests.

### DIFF
--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
@@ -182,8 +181,6 @@ func (s *ProvisionerTaskSuite) waitForTask(c *gc.C, expectedCalls []string) {
 }
 
 func (s *ProvisionerTaskSuite) TestProvisionerRetries(c *gc.C) {
-	logger := loggo.GetLogger("juju.provisioner")
-	logger.SetLogLevel(loggo.TRACE)
 	s.instanceBrocker.SetErrors(
 		errors.New("errors 1"),
 		errors.New("errors 2"),


### PR DESCRIPTION
## Description of change

This PR re-write two unit tests that fail the most frequently for worker provisioner.
Previously, these tests were part of JujuConnSuite. They are no more.

The difficulty with provisioner task tests is that we need to know when to stop the worker. This PR uses calls chan to detect when the expected calls have been made.

Run with 'stress' checker for an hour without a problem.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1790424
