### PR TITLE
Upgrade-Series Worker Report

### DIFF
--- a/worker/upgradeseries/export_test.go
+++ b/worker/upgradeseries/export_test.go
@@ -3,28 +3,10 @@
 
 package upgradeseries
 
-import (
-	"github.com/juju/juju/core/model"
-	"gopkg.in/juju/names.v2"
-	"gopkg.in/juju/worker.v1"
-)
-
 type patcher interface {
 	PatchValue(interface{}, interface{})
 }
 
 func PatchHostSeries(patcher patcher, series string) {
 	patcher.PatchValue(&hostSeries, func() (string, error) { return series, nil })
-}
-
-func MachineStatus(w worker.Worker) model.UpgradeSeriesStatus {
-	return w.(*upgradeSeriesWorker).machineStatus
-}
-
-func PreparedUnits(w worker.Worker) []names.UnitTag {
-	return w.(*upgradeSeriesWorker).preparedUnits
-}
-
-func CompletedUnits(w worker.Worker) []names.UnitTag {
-	return w.(*upgradeSeriesWorker).completedUnits
 }

--- a/worker/upgradeseries/export_test.go
+++ b/worker/upgradeseries/export_test.go
@@ -3,10 +3,28 @@
 
 package upgradeseries
 
+import (
+	"github.com/juju/juju/core/model"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+)
+
 type patcher interface {
 	PatchValue(interface{}, interface{})
 }
 
 func PatchHostSeries(patcher patcher, series string) {
 	patcher.PatchValue(&hostSeries, func() (string, error) { return series, nil })
+}
+
+func MachineStatus(w worker.Worker) model.UpgradeSeriesStatus {
+	return w.(*upgradeSeriesWorker).machineStatus
+}
+
+func PreparedUnits(w worker.Worker) []names.UnitTag {
+	return w.(*upgradeSeriesWorker).preparedUnits
+}
+
+func CompletedUnits(w worker.Worker) []names.UnitTag {
+	return w.(*upgradeSeriesWorker).completedUnits
 }

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -157,7 +157,7 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 			// No upgrade-series lock. This can happen when:
 			// - The first watch call is made.
 			// - The lock is removed after a completed upgrade.
-			w.logger.Warningf("no series upgrade lock present")
+			w.logger.Infof("no series upgrade lock present")
 			w.machineStatus = model.UpgradeSeriesNotStarted
 			w.preparedUnits = nil
 			w.completedUnits = nil
@@ -165,7 +165,7 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 		}
 		return errors.Trace(err)
 	}
-	w.logger.Debugf("machine series upgrade status changed to %q", w.machineStatus)
+	w.logger.Infof("machine series upgrade status changed to %q", w.machineStatus)
 
 	switch w.machineStatus {
 	case model.UpgradeSeriesPrepareStarted:

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -348,7 +348,6 @@ func (w *upgradeSeriesWorker) transitionUnitsStarted(unitServices map[string]str
 
 // handleCompleted notifies the server that it has completed the upgrade
 // workflow, passing back the current host OS series.
-// It then clears relevant internal state.
 func (w *upgradeSeriesWorker) handleCompleted() error {
 	s, err := hostSeries()
 	if err != nil {

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -159,6 +159,8 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 			// - The lock is removed after a completed upgrade.
 			w.logger.Warningf("no series upgrade lock present")
 			w.machineStatus = model.UpgradeSeriesNotStarted
+			w.preparedUnits = nil
+			w.completedUnits = nil
 			return nil
 		}
 		return errors.Trace(err)
@@ -356,10 +358,6 @@ func (w *upgradeSeriesWorker) handleCompleted() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	w.machineStatus = model.UpgradeSeriesNotStarted
-	w.preparedUnits = nil
-	w.completedUnits = nil
 
 	return nil
 }

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -111,6 +111,9 @@ func (s *workerSuite) TestFullWorkflow(c *gc.C) {
 		s.expectMachineCompletedFinishUpgradeSeries)
 
 	s.cleanKill(c, w)
+	c.Check(upgradeseries.MachineStatus(w), gc.Equals, model.UpgradeSeriesNotStarted)
+	c.Check(upgradeseries.PreparedUnits(w), gc.IsNil)
+	c.Check(upgradeseries.CompletedUnits(w), gc.IsNil)
 }
 
 func (s *workerSuite) TestMachinePrepareStartedUnitsStoppedProgressPrepareMachine(c *gc.C) {
@@ -120,6 +123,12 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsStoppedProgressPrepareMachin
 		s.expectMachinePrepareStartedUnitsStoppedProgressPrepareMachine)
 
 	s.cleanKill(c, w)
+	expected := []names.UnitTag{
+		names.NewUnitTag("wordpress/0"),
+		names.NewUnitTag("mysql/0"),
+	}
+	c.Check(upgradeseries.PreparedUnits(w), jc.SameContents, expected)
+	c.Check(upgradeseries.CompletedUnits(w), gc.IsNil)
 }
 
 func (s *workerSuite) expectMachinePrepareStartedUnitsStoppedProgressPrepareMachine() {
@@ -143,6 +152,12 @@ func (s *workerSuite) TestMachinePrepareMachineUnitFilesWrittenProgressPrepareCo
 		s.expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete)
 
 	s.cleanKill(c, w)
+	expected := []names.UnitTag{
+		names.NewUnitTag("wordpress/0"),
+		names.NewUnitTag("mysql/0"),
+	}
+	c.Check(upgradeseries.PreparedUnits(w), jc.SameContents, expected)
+	c.Check(upgradeseries.CompletedUnits(w), gc.IsNil)
 }
 
 func (s *workerSuite) expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete() {
@@ -166,6 +181,12 @@ func (s *workerSuite) TestMachineCompleteStartedUnitsPrepareCompleteUnitsStarted
 		s.expectMachineCompleteStartedUnitsPrepareCompleteUnitsStarted)
 
 	s.cleanKill(c, w)
+	expected := []names.UnitTag{
+		names.NewUnitTag("wordpress/0"),
+		names.NewUnitTag("mysql/0"),
+	}
+	c.Check(upgradeseries.PreparedUnits(w), jc.SameContents, expected)
+	c.Check(upgradeseries.CompletedUnits(w), gc.IsNil)
 }
 
 func (s *workerSuite) expectMachineCompleteStartedUnitsPrepareCompleteUnitsStarted() {
@@ -196,7 +217,10 @@ func (s *workerSuite) TestMachineCompleteStartedNoUnitsProgressComplete(c *gc.C)
 	exp.SetMachineStatus(model.UpgradeSeriesCompleted).Return(nil)
 
 	w := s.workerForScenario(c, s.ignoreLogging(c), s.notify(1))
+
 	s.cleanKill(c, w)
+	c.Check(upgradeseries.PreparedUnits(w), gc.IsNil)
+	c.Check(upgradeseries.CompletedUnits(w), gc.IsNil)
 }
 
 func (s *workerSuite) TestMachineCompleteStartedUnitsCompleteProgressComplete(c *gc.C) {
@@ -206,6 +230,12 @@ func (s *workerSuite) TestMachineCompleteStartedUnitsCompleteProgressComplete(c 
 		s.expectMachineCompleteStartedUnitsCompleteProgressComplete)
 
 	s.cleanKill(c, w)
+	c.Check(upgradeseries.PreparedUnits(w), gc.HasLen, 0)
+	expected := []names.UnitTag{
+		names.NewUnitTag("wordpress/0"),
+		names.NewUnitTag("mysql/0"),
+	}
+	c.Check(upgradeseries.CompletedUnits(w), jc.SameContents, expected)
 }
 
 func (s *workerSuite) expectMachineCompleteStartedUnitsCompleteProgressComplete() {


### PR DESCRIPTION
## Description of change

Implements `worker.Reporter` in the upgrade-series worker, so that pertinent information is included in the Juju engine report.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`.
- Bootstrap.
- Deploy a Trusty charm (Ubuntu or Redis will work).
- `juju ssh 0` then `juju_engine_report`.
- Check that the upgrade-series worker shows a machine status of "not started".
- `juju upgrade-series prepare 0 xenial`.
- After units are completed, running the report again should show:
  - Machine status "prepare completed".
  - Whatever unit was deployed listed under "prepared units".

## Documentation changes

None.

## Bug reference

N/A
