### PR TITLE
Fixed typo in help text

### DIFF
--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -88,7 +88,7 @@ If you need to pass flags to the command being run, you must precede the
 command and its arguments with "--", to tell "juju run" to stop processing
 those arguments. For example:
 
-    juju run --all --hostname -f
+    juju run --all -- hostname -f
 `
 
 func (c *runCommand) Info() *cmd.Info {


### PR DESCRIPTION
## Description of change

The example command is incorrect

## QA steps

run `juju run -h` and confirm the last line says `-- hostname` instead of `--hostname`

## Documentation changes

None

## Bug reference

None
