### PR TITLE
Improvements to caas operator password/storage/config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -533,7 +533,7 @@ func ReadConfig(configFilePath string) (ConfigSetterWriter, error) {
 	)
 	configData, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read agent config %q: %v", configFilePath, err)
+		return nil, errors.Annotatef(err, "cannot read agent config %q: %v", configFilePath)
 	}
 	format, config, err = parseConfigData(configData)
 	if err != nil {

--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -22,13 +22,15 @@ import (
 // Client allows access to the CAAS operator API endpoint.
 type Client struct {
 	facade base.FacadeCaller
+	*common.APIAddresser
 }
 
 // NewClient returns a client used to access the CAAS Operator API.
 func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, "CAASOperator")
 	return &Client{
-		facade: facadeCaller,
+		facade:       facadeCaller,
+		APIAddresser: common.NewAPIAddresser(facadeCaller),
 	}
 }
 

--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
@@ -19,7 +18,6 @@ import (
 
 // Client allows access to the CAAS operator provisioner API endpoint.
 type Client struct {
-	*common.APIAddresser
 	facade base.FacadeCaller
 }
 
@@ -27,8 +25,7 @@ type Client struct {
 func NewClient(caller base.APICaller) *Client {
 	facadeCaller := base.NewFacadeCaller(caller, "CAASOperatorProvisioner")
 	return &Client{
-		facade:       facadeCaller,
-		APIAddresser: common.NewAPIAddresser(facadeCaller),
+		facade: facadeCaller,
 	}
 }
 
@@ -108,6 +105,7 @@ func (c *Client) Life(appName string) (life.Value, error) {
 type OperatorProvisioningInfo struct {
 	ImagePath    string
 	Version      version.Number
+	APIAddresses []string
 	CharmStorage storage.KubernetesFilesystemParams
 }
 
@@ -120,6 +118,7 @@ func (c *Client) OperatorProvisioningInfo() (OperatorProvisioningInfo, error) {
 	info := OperatorProvisioningInfo{
 		ImagePath:    result.ImagePath,
 		Version:      result.Version,
+		APIAddresses: result.APIAddresses,
 		CharmStorage: filesystemFromParams(result.CharmStorage),
 	}
 	return info, nil

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -164,8 +164,9 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 		c.Assert(a, gc.IsNil)
 		c.Assert(result, gc.FitsTypeOf, &params.OperatorProvisioningInfo{})
 		*(result.(*params.OperatorProvisioningInfo)) = params.OperatorProvisioningInfo{
-			ImagePath: "juju-operator-image",
-			Version:   vers,
+			ImagePath:    "juju-operator-image",
+			Version:      vers,
+			APIAddresses: []string{"10.0.0.1:1"},
 			CharmStorage: params.KubernetesFilesystemParams{
 				Size:        10,
 				Provider:    "kubernetes",
@@ -179,8 +180,9 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 	info, err := client.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, caasoperatorprovisioner.OperatorProvisioningInfo{
-		ImagePath: "juju-operator-image",
-		Version:   vers,
+		ImagePath:    "juju-operator-image",
+		Version:      vers,
+		APIAddresses: []string{"10.0.0.1:1"},
 		CharmStorage: storage.KubernetesFilesystemParams{
 			Size:         10,
 			Provider:     "kubernetes",

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -10,10 +10,13 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
 	_ "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -22,6 +25,7 @@ import (
 
 type mockState struct {
 	testing.Stub
+	common.AddressAndCertGetter
 	entities map[string]state.Entity
 	app      mockApplication
 	unit     mockUnit
@@ -51,6 +55,16 @@ func newMockState() *mockState {
 	st.entities[st.app.Tag().String()] = &st.app
 	st.entities[st.unit.Tag().String()] = &st.unit
 	return st
+}
+
+func (st *mockState) APIHostPortsForAgents() ([][]network.HostPort, error) {
+	st.MethodCall(st, "APIHostPortsForAgents")
+	return nil, nil
+}
+
+func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	st.MethodCall(st, "WatchAPIHostPortsForAgents")
+	return apiservertesting.NewFakeNotifyWatcher()
 }
 
 func (st *mockState) Application(id string) (caasoperator.Application, error) {

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -24,6 +24,7 @@ type Facade struct {
 	*common.AgentEntityWatcher
 	*common.Remover
 	*common.ToolsSetter
+	*common.APIAddresser
 
 	model Model
 }
@@ -79,6 +80,7 @@ func NewFacade(
 	}
 	return &Facade{
 		LifeGetter:         common.NewLifeGetter(st, canRead),
+		APIAddresser:       common.NewAPIAddresser(st, resources),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, resources, canRead),
 		Remover:            common.NewRemover(st, true, accessUnit),
 		ToolsSetter:        common.NewToolsSetter(st, common.AuthFuncForTag(authorizer.GetAuthTag())),

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -320,3 +320,15 @@ func (s *CAASOperatorSuite) TestSetTools(c *gc.C) {
 	})
 	s.st.app.CheckCall(c, 0, "SetAgentVersion", vers)
 }
+
+func (s *CAASOperatorSuite) TestAddresses(c *gc.C) {
+	_, err := s.facade.APIAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "Model", "APIHostPortsForAgents")
+}
+
+func (s *CAASOperatorSuite) TestWatchAPIHostPorts(c *gc.C) {
+	_, err := s.facade.WatchAPIHostPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "Model", "WatchAPIHostPortsForAgents")
+}

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -17,7 +18,11 @@ import (
 type CAASOperatorState interface {
 	Application(string) (Application, error)
 	Model() (Model, error)
+	ModelUUID() string
 	FindEntity(names.Tag) (state.Entity, error)
+	APIHostPortsForAgents() ([][]network.HostPort, error)
+	Addresses() ([]string, error)
+	WatchAPIHostPortsForAgents() state.NotifyWatcher
 }
 
 // Model provides the subset of CAAS model state required

--- a/apiserver/facades/agent/logger/logger.go
+++ b/apiserver/facades/agent/logger/logger.go
@@ -39,7 +39,7 @@ func NewLoggerAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*LoggerAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthUnitAgent() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthUnitAgent() && !authorizer.AuthApplicationAgent() {
 		return nil, common.ErrPerm
 	}
 	m, err := st.Model()

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -66,6 +66,14 @@ func (s *loggerSuite) TestNewLoggerAPIAcceptsUnitAgent(c *gc.C) {
 	c.Assert(endPoint, gc.NotNil)
 }
 
+func (s *loggerSuite) TestNewLoggerAPIAcceptsApplicationAgent(c *gc.C) {
+	anAuthorizer := s.authorizer
+	anAuthorizer.Tag = names.NewApplicationTag("germany")
+	endPoint, err := logger.NewLoggerAPI(s.State, s.resources, anAuthorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(endPoint, gc.NotNil)
+}
+
 func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 	// Not an error to watch nothing
 	results := s.logger.WatchLoggingConfig(params.Entities{})

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -33,9 +33,11 @@ import (
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 	statestorage "github.com/juju/juju/state/storage"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -92,6 +94,8 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv8 {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(s.State)
+	registry := stateenvirons.NewStorageProviderRegistry(s.Environ)
+	pm := poolmanager.New(state.NewStateSettings(s.State), registry)
 	api, err := application.NewAPIBase(
 		application.GetState(s.State),
 		storageAccess,
@@ -101,6 +105,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv8 {
 		model.Type(),
 		application.CharmToStateCharm,
 		application.DeployApplication,
+		pm,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return &application.APIv8{api}

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -55,6 +55,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		model.Type(),
 		application.CharmToStateCharm,
 		application.DeployApplication,
+		&mockStoragePoolManager{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.applicationAPI = &application.APIv8{api}
@@ -192,6 +193,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 		state.ModelTypeCAAS,
 		application.CharmToStateCharm,
 		application.DeployApplication,
+		&mockStoragePoolManager{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{api}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/schema"
 	jtesting "github.com/juju/testing"
 	"gopkg.in/juju/charm.v6"
@@ -27,6 +28,8 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -671,4 +674,22 @@ func (s *recordingStorage) Remove(path string) error {
 	}
 	s.blobs.Remove(path)
 	return nil
+}
+
+type mockStoragePoolManager struct {
+	jtesting.Stub
+	poolmanager.PoolManager
+	storageType storage.ProviderType
+}
+
+func (m *mockStoragePoolManager) Get(name string) (*storage.Config, error) {
+	m.MethodCall(m, "Get", name)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	storageType := m.storageType
+	if name == "db" {
+		storageType = provider.RootfsProviderType
+	}
+	return storage.NewConfig(name, storageType, map[string]interface{}{"foo": "bar"})
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/apiserver/common"
-	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/network"
@@ -54,12 +53,9 @@ func (st *mockState) ControllerConfig() (controller.Config, error) {
 
 func (st *mockState) APIHostPortsForAgents() ([][]network.HostPort, error) {
 	st.MethodCall(st, "APIHostPortsForAgents")
-	return nil, nil
-}
-
-func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
-	st.MethodCall(st, "WatchAPIHostPortsForAgents")
-	return apiservertesting.NewFakeNotifyWatcher()
+	return [][]network.HostPort{
+		network.NewHostPorts(1, "10.0.0.1"),
+	}, nil
 }
 
 type mockStorageProviderRegistry struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -125,8 +125,9 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath: fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
-		Version:   version.Current,
+		ImagePath:    fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
+		Version:      version.Current,
+		APIAddresses: []string{"10.0.0.1:1"},
 		CharmStorage: params.KubernetesFilesystemParams{
 			Size:       uint64(1024),
 			Provider:   "kubernetes",
@@ -140,8 +141,9 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath: s.st.operatorImage,
-		Version:   version.Current,
+		ImagePath:    s.st.operatorImage,
+		Version:      version.Current,
+		APIAddresses: []string{"10.0.0.1:1"},
 		CharmStorage: params.KubernetesFilesystemParams{
 			Size:       uint64(1024),
 			Provider:   "kubernetes",
@@ -153,25 +155,12 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
 	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
-	result, err := s.api.OperatorProvisioningInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath: s.st.operatorImage,
-		Version:   version.Current,
-		CharmStorage: params.KubernetesFilesystemParams{
-			Size: uint64(1024),
-		},
-	})
+	_, err := s.api.OperatorProvisioningInfo()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *CAASProvisionerSuite) TestAddresses(c *gc.C) {
 	_, err := s.api.APIAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c, "APIHostPortsForAgents")
-}
-
-func (s *CAASProvisionerSuite) TestWatchAPIHostPorts(c *gc.C) {
-	_, err := s.api.WatchAPIHostPorts()
-	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "WatchAPIHostPortsForAgents")
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -483,6 +483,7 @@ type ConfigResult struct {
 type OperatorProvisioningInfo struct {
 	ImagePath    string                     `json:"image-path"`
 	Version      version.Number             `json:"version"`
+	APIAddresses []string                   `json:"api-addresses"`
 	CharmStorage KubernetesFilesystemParams `json:"charm-storage"`
 }
 

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -27,6 +27,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"FilesystemAttachmentsWatcher",
 	"LeadershipService",
 	"LifeFlag",
+	"Logger",
 	"MeterStatus",
 	"MigrationFlag",
 	"MigrationMaster",

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -103,6 +103,10 @@ type Broker interface {
 	// a charm for the specified application.
 	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
 
+	// OperatorExists returns true if the operator for the specified
+	// application exists.
+	OperatorExists(appName string) (bool, error)
+
 	// DeleteOperator deletes the specified operator.
 	DeleteOperator(appName string) error
 

--- a/caas/config.go
+++ b/caas/config.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	// OperatorStoragePoolName is the storage pool used to define
+	// storage for application operators.
+	OperatorStoragePoolName = "operator-storage"
+
 	// JujuExternalHostNameKey specifies the hostname of a CAAS application.
 	JujuExternalHostNameKey = "juju-external-hostname"
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -19,8 +19,12 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/state/stateenvirons"
+	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -488,6 +492,12 @@ func (s *CAASDeploySuite) TestInitErrorsCaasModel(c *gc.C) {
 }
 
 func (s *CAASDeploySuite) TestDevices(c *gc.C) {
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(broker)
+	storagePoolManager := poolmanager.New(state.NewStateSettings(s.State), storageProviderRegistry)
+	_, err = storagePoolManager.Create("operator-storage", provider.K8s_ProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -34,11 +34,13 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	manifolds := caasoperator.Manifolds(config)
 	expectedKeys := []string{
 		"agent",
+		"api-address-updater",
 		"api-caller",
 		"charm-dir",
 		"clock",
 		"hook-retry-strategy",
 		"operator",
+		"logging-config-updater",
 		"migration-fortress",
 		"migration-minion",
 		"migration-inactive-flag",

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -123,8 +123,10 @@ func TrackCAASOperator(c *gc.C, tracker *agenttest.EngineTracker, inner CAASOper
 var (
 	alwaysCAASWorkers = []string{
 		"agent",
+		"api-address-updater",
 		"api-caller",
 		"clock",
+		"logging-config-updater",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"migration-minion",

--- a/worker/apiaddressupdater/manifold.go
+++ b/worker/apiaddressupdater/manifold.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
@@ -37,6 +38,8 @@ var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, er
 	switch apiTag := tag.(type) {
 	case names.UnitTag:
 		facade = uniter.NewState(apiCaller, apiTag)
+	case names.ApplicationTag:
+		facade = caasoperator.NewClient(apiCaller)
 	case names.MachineTag:
 		facade = machiner.NewState(apiCaller)
 	default:

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -334,7 +334,7 @@ func (op *caasOperator) loop() (err error) {
 		case <-watcher.RemoteStateChanged():
 			snap := watcher.Snapshot()
 			if charmModified(localState, snap) {
-				// Charm changed so download and install the ne version.
+				// Charm changed so download and install the new version.
 				charmURL, charmModifiedVersion, err := op.ensureCharm()
 				if err != nil {
 					return errors.Annotatef(err, "error downloading updated charm %v", charmURL.String())
@@ -406,6 +406,10 @@ func charmModified(local LocalState, remote remotestate.Snapshot) bool {
 	// CAAS models may not yet have read the charm url from state.
 	if remote.CharmURL == nil {
 		return false
+	}
+	if local.CharmURL == nil {
+		logger.Warningf("unexpected nil local charm URL")
+		return true
 	}
 	if *local.CharmURL != *remote.CharmURL {
 		logger.Debugf("upgrade from %v to %v", local.CharmURL, remote.CharmURL)

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -17,6 +17,7 @@ import (
 	apicaasprovisioner "github.com/juju/juju/api/caasoperatorprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/storage"
@@ -30,8 +31,6 @@ type CAASProvisionerFacade interface {
 	WatchApplications() (watcher.StringsWatcher, error)
 	SetPasswords([]apicaasprovisioner.ApplicationPassword) (params.ErrorResults, error)
 	Life(string) (life.Value, error)
-	WatchAPIHostPorts() (watcher.NotifyWatcher, error)
-	APIAddresses() ([]string, error)
 }
 
 // Config defines the operation of a Worker.
@@ -49,7 +48,6 @@ func NewProvisionerWorker(config Config) (worker.Worker, error) {
 		broker:            config.Broker,
 		modelTag:          config.ModelTag,
 		agentConfig:       config.AgentConfig,
-		appPasswords:      make(map[string]string),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &p.catacomb,
@@ -65,8 +63,6 @@ type provisioner struct {
 
 	modelTag    names.ModelTag
 	agentConfig agent.Config
-
-	appPasswords map[string]string
 }
 
 // Kill is part of the worker.Worker interface.
@@ -93,38 +89,17 @@ func (p *provisioner) loop() error {
 		return errors.Trace(err)
 	}
 
-	apiAddressWatcher, err := p.provisionerFacade.WatchAPIHostPorts()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := p.catacomb.Add(apiAddressWatcher); err != nil {
-		return errors.Trace(err)
-	}
-
-	var apiAddressChanged watcher.NotifyChannel
 	for {
 		select {
 		case <-p.catacomb.Dying():
 			return p.catacomb.ErrDying()
-
-		// API addresses have changed so we need to update
-		// each operator pod so it has the new addresses.
-		case _, ok := <-apiAddressChanged:
-			if !ok {
-				return errors.New("api watcher closed channel")
-			}
-			for app, password := range p.appPasswords {
-				if err := p.ensureOperator(app, password); err != nil {
-					return errors.Annotatef(err, "updating operator for q with new api addresses", app)
-				}
-			}
 
 		// CAAS applications changed so either create or remove pods as appropriate.
 		case apps, ok := <-appWatcher.Changes():
 			if !ok {
 				return errors.New("app watcher closed channel")
 			}
-			var newApps []apicaasprovisioner.ApplicationPassword
+			var newApps []string
 			for _, app := range apps {
 				appLife, err := p.provisionerFacade.Life(app)
 				if errors.IsNotFound(err) || appLife == life.Dead {
@@ -132,18 +107,12 @@ func (p *provisioner) loop() error {
 					if err := p.broker.DeleteOperator(app); err != nil {
 						return errors.Annotatef(err, "failed to stop operator for %q", app)
 					}
-					delete(p.appPasswords, app)
 					continue
 				}
 				if appLife != life.Alive {
 					continue
 				}
-
-				password, err := utils.RandomPassword()
-				if err != nil {
-					return errors.Trace(err)
-				}
-				newApps = append(newApps, apicaasprovisioner.ApplicationPassword{Name: app, Password: password})
+				newApps = append(newApps, app)
 			}
 			if len(newApps) == 0 {
 				continue
@@ -151,46 +120,64 @@ func (p *provisioner) loop() error {
 			if err := p.ensureOperators(newApps); err != nil {
 				return errors.Trace(err)
 			}
-			// Store the apps we have just added.
-			for _, ap := range newApps {
-				p.appPasswords[ap.Name] = ap.Password
-			}
-
-			// Now we have been through all the applications at least once, we can
-			// listen for api address changes.
-			apiAddressChanged = apiAddressWatcher.Changes()
 		}
 	}
 }
 
 // ensureOperators creates operator pods for the specified app names -> api passwords.
-func (p *provisioner) ensureOperators(appPasswords []apicaasprovisioner.ApplicationPassword) error {
-	errorResults, err := p.provisionerFacade.SetPasswords(appPasswords)
-	if err != nil {
-		return errors.Annotate(err, "failed to set application api passwords")
-	}
-	var errorStrings []string
-	for i, r := range errorResults.Results {
-		if r.Error != nil {
-			errorStrings = append(errorStrings, r.Error.Error())
-			continue
+func (p *provisioner) ensureOperators(apps []string) error {
+	var appPasswords []apicaasprovisioner.ApplicationPassword
+	operatorConfig := make([]*caas.OperatorConfig, len(apps))
+	for i, app := range apps {
+		exists, err := p.broker.OperatorExists(app)
+		if err != nil {
+			return errors.Annotatef(err, "failed to find operator for %q", app)
 		}
-		if err := p.ensureOperator(appPasswords[i].Name, appPasswords[i].Password); err != nil {
-			return errors.Trace(err)
+		// If the operator does not exist already, we need to create an initial
+		// password for it.
+		var password string
+		if !exists {
+			if password, err = utils.RandomPassword(); err != nil {
+				return errors.Trace(err)
+			}
+			appPasswords = append(appPasswords, apicaasprovisioner.ApplicationPassword{Name: app, Password: password})
+		}
+
+		config, err := p.makeOperatorConfig(app, password)
+		if err != nil {
+			return errors.Annotatef(err, "failed to generate operator config for %q", app)
+		}
+		operatorConfig[i] = config
+	}
+	// If we did create any passwords for new operators, first they need
+	// to be saved so the agent can login when it starts up.
+	if len(appPasswords) > 0 {
+		errorResults, err := p.provisionerFacade.SetPasswords(appPasswords)
+		if err != nil {
+			return errors.Annotate(err, "failed to set application api passwords")
+		}
+		if err := errorResults.Combine(); err != nil {
+			return errors.Annotate(err, "failed to set application api passwords")
+		}
+	}
+
+	// Now that any new config/passwords are done, create or update
+	// the operators themselves.
+	var errorStrings []string
+	for i, app := range apps {
+		if err := p.ensureOperator(app, operatorConfig[i]); err != nil {
+			errorStrings = append(errorStrings, err.Error())
+			continue
 		}
 	}
 	if errorStrings != nil {
 		err := errors.New(strings.Join(errorStrings, "\n"))
-		return errors.Annotate(err, "failed to set application api passwords")
+		return errors.Annotate(err, "failed to provision all operators")
 	}
 	return nil
 }
 
-func (p *provisioner) ensureOperator(app, password string) error {
-	config, err := p.newOperatorConfig(app, password)
-	if err != nil {
-		return errors.Trace(err)
-	}
+func (p *provisioner) ensureOperator(app string, config *caas.OperatorConfig) error {
 	if err := p.broker.EnsureOperator(app, p.agentConfig.DataDir(), config); err != nil {
 		return errors.Annotatef(err, "failed to start operator for %q", app)
 	}
@@ -198,30 +185,50 @@ func (p *provisioner) ensureOperator(app, password string) error {
 	return nil
 }
 
-func (p *provisioner) newOperatorConfig(appName string, password string) (*caas.OperatorConfig, error) {
+func (p *provisioner) makeOperatorConfig(appName, password string) (*caas.OperatorConfig, error) {
 	appTag := names.NewApplicationTag(appName)
-	apiAddrs, err := p.provisionerFacade.APIAddresses()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	info, err := p.provisionerFacade.OperatorProvisioningInfo()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// All operators must have storage configured because charms
+	// have persistent state which must be preserved between any
+	// operator restarts.
+	if info.CharmStorage.Provider != provider.K8s_ProviderType {
+		if spType := info.CharmStorage.Provider; spType == "" {
+			return nil, errors.NotValidf("missing operator storage provider")
+		} else {
+			return nil, errors.NotSupportedf("operator storage provider %q", spType)
+		}
+	}
+	logger.Debugf("using caas operator info %+v", info)
+
+	cfg := &caas.OperatorConfig{
+		OperatorImagePath: info.ImagePath,
+		Version:           info.Version,
+		CharmStorage:      charmStorageParams(info.CharmStorage),
+	}
+	// If no password required, we leave the agent conf empty.
+	if password == "" {
+		return cfg, nil
+	}
+
 	conf, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{
 			Paths: agent.Paths{
 				DataDir: p.agentConfig.DataDir(),
 				LogDir:  p.agentConfig.LogDir(),
 			},
+			Tag:          appTag,
+			Controller:   p.agentConfig.Controller(),
+			Model:        p.modelTag,
+			APIAddresses: info.APIAddresses,
+			CACert:       p.agentConfig.CACert(),
+			Password:     password,
+
+			// UpgradedToVersion is mandatory but not used by caas operator agents as they
+			// are not upgraded insitu.
 			UpgradedToVersion: info.Version,
-			Tag:               appTag,
-			Password:          password,
-			Controller:        p.agentConfig.Controller(),
-			Model:             p.modelTag,
-			APIAddresses:      apiAddrs,
-			CACert:            p.agentConfig.CACert(),
 		},
 	)
 	if err != nil {
@@ -232,14 +239,8 @@ func (p *provisioner) newOperatorConfig(appName string, password string) (*caas.
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	logger.Debugf("using caas operator info %+v", info)
-	return &caas.OperatorConfig{
-		AgentConf:         confBytes,
-		OperatorImagePath: info.ImagePath,
-		Version:           info.Version,
-		CharmStorage:      charmStorageParams(info.CharmStorage),
-	}, nil
+	cfg.AgentConf = confBytes
+	return cfg, nil
 }
 
 func charmStorageParams(in storage.KubernetesFilesystemParams) caas.CharmStorageParams {


### PR DESCRIPTION
## Description of change

When deploying a k8s charm, it is now mandatory that a storage pool for operator storage be configured - operators require storage for charm state etc. This change also allows us to provide a writable agent config file. The file is provided read-only in a config map and copied to the writable filesystem. This then allows password and logging config to be properly managed.

Part of the change is that the address watcher plugin is removed from the caas operator provisioner worker and facades and moved across to the caas operator itself (and associated facades). Also, the api addresses are returned as part of the caas operator provisioning info call.

The deploy command has checks added to ensure that the required storage setup is all in place.

## QA steps

deploy a k8s charm with storage
ensure the necessary checks are done and errors if no storage pools are configured
ensure that the charm deploys ok when all necessary storage config is in place

## Documentation changes

discourse post will be updated
