### PR TITLE
Upgrade Early Machine Validation

### DIFF
--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -188,19 +188,20 @@ func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	return nil
 }
 
-func (client *Client) UnitsToUpgrade(machineName string) ([]string, error) {
+func (client *Client) UpgradeSeriesValidate(machineName, series string) ([]string, error) {
 	if client.BestAPIVersion() < 5 {
-		return nil, errors.NotSupportedf("UnitsToUpgrade")
+		return nil, errors.NotSupportedf("UpgradeSeriesValidate")
 	}
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{
 			{
 				Entity: params.Entity{Tag: names.NewMachineTag(machineName).String()},
+				Series: series,
 			},
 		},
 	}
 	results := new(params.UpgradeSeriesUnitsResults)
-	err := client.facade.FacadeCall("UnitsToUpgrade", args, results)
+	err := client.facade.FacadeCall("UpgradeSeriesValidate", args, results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/machinemanager/machinemanager_test.go
+++ b/api/machinemanager/machinemanager_test.go
@@ -149,7 +149,7 @@ func (s *MachinemanagerSuite) testDestroyMachines(
 		})
 		c.Assert(response, gc.FitsTypeOf, &params.DestroyMachineResults{})
 		out := response.(*params.DestroyMachineResults)
-		*out = params.DestroyMachineResults{expectedResults}
+		*out = params.DestroyMachineResults{Results: expectedResults}
 		return nil
 	})
 	results, err := method(client, "0", "0/lxd/1")
@@ -173,7 +173,7 @@ func (s *MachinemanagerSuite) TestDestroyMachinesInvalidIds(c *gc.C) {
 	}}
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		out := response.(*params.DestroyMachineResults)
-		*out = params.DestroyMachineResults{expectedResults[1:]}
+		*out = params.DestroyMachineResults{Results: expectedResults[1:]}
 		return nil
 	})
 	results, err := client.DestroyMachines("!", "0")
@@ -203,7 +203,7 @@ func (s *MachinemanagerSuite) TestDestroyMachinesWithParams(c *gc.C) {
 		})
 		c.Assert(response, gc.FitsTypeOf, &params.DestroyMachineResults{})
 		out := response.(*params.DestroyMachineResults)
-		*out = params.DestroyMachineResults{expectedResults}
+		*out = params.DestroyMachineResults{Results: expectedResults}
 		return nil
 	})
 	results, err := client.DestroyMachinesWithParams(true, true, "0", "0/lxd/1")

--- a/api/machinemanager/machinemanagernew_test.go
+++ b/api/machinemanager/machinemanagernew_test.go
@@ -41,7 +41,7 @@ func (s *NewMachineManagerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 }
 
-func (s *NewMachineManagerSuite) TestUnitsToUpgrade(c *gc.C) {
+func (s *NewMachineManagerSuite) UpgradeSeriesValidate(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	fFacade := mocks.NewMockClientFacade(ctrl)
@@ -59,13 +59,13 @@ func (s *NewMachineManagerSuite) TestUnitsToUpgrade(c *gc.C) {
 		UnitNames: []string{"ubuntu/0", "ubuntu/1"},
 	}
 
-	results := params.UpgradeSeriesUnitsResults{[]params.UpgradeSeriesUnitsResult{result}}
+	results := params.UpgradeSeriesUnitsResults{Results: []params.UpgradeSeriesUnitsResult{result}}
 
 	fFacade.EXPECT().BestAPIVersion().Return(5)
-	fCaller.EXPECT().FacadeCall("UnitsToUpgrade", args, gomock.Any()).SetArg(2, results)
+	fCaller.EXPECT().FacadeCall("UpgradeSeriesValidate", args, gomock.Any()).SetArg(2, results)
 	client := machinemanager.ConstructClient(fFacade, fCaller)
 
-	unitNames, err := client.UnitsToUpgrade(arbitraryName)
+	unitNames, err := client.UpgradeSeriesVerify(arbitraryName)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(unitNames, gc.DeepEquals, result.UnitNames)

--- a/apiserver/facades/client/machinemanager/export_test.go
+++ b/apiserver/facades/client/machinemanager/export_test.go
@@ -3,5 +3,11 @@
 
 package machinemanager
 
+import "gopkg.in/juju/names.v2"
+
 var InstanceTypes = instanceTypes
 var IsSeriesLessThan = isSeriesLessThan
+
+func (mm *MachineManagerAPI) ValidateSeries(argumentSeries, currentSeries string, machineTag names.MachineTag) error {
+	return mm.validateSeries(argumentSeries, currentSeries, machineTag)
+}

--- a/apiserver/facades/client/machinemanager/export_test.go
+++ b/apiserver/facades/client/machinemanager/export_test.go
@@ -3,11 +3,5 @@
 
 package machinemanager
 
-import "gopkg.in/juju/names.v2"
-
 var InstanceTypes = instanceTypes
 var IsSeriesLessThan = isSeriesLessThan
-
-func (mm *MachineManagerAPI) ValidateSeries(argumentSeries, currentSeries string, machineTag names.MachineTag) error {
-	return mm.validateSeries(argumentSeries, currentSeries, machineTag)
-}

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -188,6 +188,7 @@ func (s *MachineManagerSuite) setupUpdateMachineSeries(c *gc.C) {
 	s.st.machines = map[string]*mockMachine{
 		"0": {series: "trusty", units: []string{"foo/0", "test/0"}},
 		"1": {series: "trusty", units: []string{"foo/1", "test/1"}},
+		"2": {series: "centos7", units: []string{"foo/1", "test/1"}},
 	}
 }
 
@@ -324,6 +325,105 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesPermissionDenied(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateOK(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
+			Series: "xenial",
+		}},
+	}
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result := results.Results[0]
+	c.Assert(result.Error, gc.IsNil)
+
+	var expectedUnitNames []string
+	for _, unit := range s.st.machines["0"].Principals() {
+		expectedUnitNames = append(expectedUnitNames, unit)
+	}
+	c.Assert(result.UnitNames, gc.DeepEquals, expectedUnitNames)
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateNoSeriesError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
+		}},
+	}
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, "series missing from args")
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateNotFromUbuntuError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("2").String()},
+			Series: "bionic",
+		}},
+	}
+
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches,
+		"machine-2 is running CentOS and is not valid for Ubuntu series upgrade")
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateNotToUbuntuError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
+			Series: "centos7",
+		}},
+	}
+
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches,
+		`series "centos7" is from OS "CentOS" and is not a valid upgrade target`)
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateAlreadyRunningSeriesError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
+			Series: "trusty",
+		}},
+	}
+
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, "machine-1 is already running series trusty")
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateOlderSeriesError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
+			Series: "precise",
+		}},
+	}
+
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches,
+		"machine machine-1 is running trusty which is a newer series than precise.")
+}
+
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 	s.setupUpdateMachineSeries(c)
 	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
@@ -337,26 +437,11 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
+
 	mach := s.st.machines["0"]
-	c.Assert(len(mach.Calls()), gc.Equals, 4)
-	mach.CheckCallNames(c, "Series", "Principals", "VerifyUnitsSeries", "CreateUpgradeSeriesLock")
-	mach.CheckCall(c, 3, "CreateUpgradeSeriesLock", []string{"foo/0", "test/0"}, "xenial")
-
-}
-
-func (s *MachineManagerSuite) TestUpgradeSeriesPrepareAlreadyRunningSeries(c *gc.C) {
-	s.setupUpdateMachineSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
-	machineTag := names.NewMachineTag("1")
-	result, err := apiV5.UpgradeSeriesPrepare(
-		params.UpdateSeriesArg{
-			Entity: params.Entity{
-				Tag: machineTag.String()},
-			Series: "trusty",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.ErrorMatches, "machine-1 is already running series trusty")
+	c.Assert(len(mach.Calls()), gc.Equals, 3)
+	mach.CheckCallNames(c, "Principals", "VerifyUnitsSeries", "CreateUpgradeSeriesLock")
+	mach.CheckCall(c, 2, "CreateUpgradeSeriesLock", []string{"foo/0", "test/0"}, "xenial")
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareMachineNotFound(c *gc.C) {
@@ -459,21 +544,6 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	})
 }
 
-func (s *MachineManagerSuite) TestUpgradeSeriesPrepareOlderSeriesShouldError(c *gc.C) {
-	s.setupUpdateMachineSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
-	machineTag := names.NewMachineTag("1")
-	result, err := apiV5.UpgradeSeriesPrepare(
-		params.UpdateSeriesArg{
-			Entity: params.Entity{
-				Tag: machineTag.String()},
-			Series: "precise",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.ErrorMatches, "machine machine-1 is running trusty which is a newer series than precise.")
-}
-
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareRemoveLockAfterFail(c *gc.C) {
 	// TODO managed upgrade series
 }
@@ -486,41 +556,6 @@ func (s *MachineManagerSuite) TestUpgradeSeriesComplete(c *gc.C) {
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
 		},
 	)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *MachineManagerSuite) TestUnitsToUpgrade(c *gc.C) {
-	s.setupUpdateMachineSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
-	args := params.UpdateSeriesArgs{
-		Args: []params.UpdateSeriesArg{
-			{
-				Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
-			},
-		},
-	}
-	results, err := apiV5.UnitsToUpgrade(args)
-	c.Assert(err, jc.ErrorIsNil)
-
-	units, err := s.st.machines["0"].Units()
-	c.Assert(err, jc.ErrorIsNil)
-
-	var expectedUnitNames []string
-	for _, unit := range units {
-		expectedUnitNames = append(expectedUnitNames, unit.Name())
-	}
-	actualUnitNames := results.Results[0].UnitNames
-
-	c.Assert(actualUnitNames, gc.DeepEquals, expectedUnitNames)
-}
-
-func (s *MachineManagerSuite) TestValidateSeriesNotUbuntuError(c *gc.C) {
-	err := machinemanager.MachineManagerAPIV5{}.ValidateSeries("xenial", "centos7", names.NewMachineTag("0"))
-	c.Assert(err, gc.ErrorMatches, "machine-0 is running CentOS and is not valid for Ubuntu series upgrade")
-}
-
-func (s *MachineManagerSuite) TestValidateSeriesUbuntuLessThanCurrentOK(c *gc.C) {
-	err := machinemanager.MachineManagerAPIV5{}.ValidateSeries("xenial", "trusty", names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
+++ b/cmd/juju/machine/mocks/upgradeMachineSeriesAPI_mock.go
@@ -56,19 +56,6 @@ func (mr *MockUpgradeMachineSeriesAPIMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).Close))
 }
 
-// UnitsToUpgrade mocks base method
-func (m *MockUpgradeMachineSeriesAPI) UnitsToUpgrade(arg0 string) ([]string, error) {
-	ret := m.ctrl.Call(m, "UnitsToUpgrade", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UnitsToUpgrade indicates an expected call of UnitsToUpgrade
-func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UnitsToUpgrade(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitsToUpgrade", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UnitsToUpgrade), arg0)
-}
-
 // UpgradeSeriesComplete mocks base method
 func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesComplete(arg0 string) error {
 	ret := m.ctrl.Call(m, "UpgradeSeriesComplete", arg0)
@@ -91,4 +78,17 @@ func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesPrepare(arg0, arg1 string, ar
 // UpgradeSeriesPrepare indicates an expected call of UpgradeSeriesPrepare
 func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UpgradeSeriesPrepare(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesPrepare", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UpgradeSeriesPrepare), arg0, arg1, arg2)
+}
+
+// UpgradeSeriesValidate mocks base method
+func (m *MockUpgradeMachineSeriesAPI) UpgradeSeriesValidate(arg0, arg1 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "UpgradeSeriesValidate", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeSeriesValidate indicates an expected call of UpgradeSeriesValidate
+func (mr *MockUpgradeMachineSeriesAPIMockRecorder) UpgradeSeriesValidate(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesValidate", reflect.TypeOf((*MockUpgradeMachineSeriesAPI)(nil).UpgradeSeriesValidate), arg0, arg1)
 }

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -44,9 +44,9 @@ func NewUpgradeSeriesCommand() cmd.Command {
 type UpgradeMachineSeriesAPI interface {
 	BestAPIVersion() int
 	Close() error
+	UpgradeSeriesValidate(string, string) ([]string, error)
 	UpgradeSeriesPrepare(string, string, bool) error
 	UpgradeSeriesComplete(string) error
-	UnitsToUpgrade(string) ([]string, error)
 }
 
 // upgradeSeriesCommand is responsible for updating the series of an application or machine.
@@ -248,7 +248,7 @@ func (c *upgradeSeriesCommand) promptConfirmation(ctx *cmd.Context) error {
 		return nil
 	}
 
-	affectedUnits, err := c.upgradeMachineSeriesClient.UnitsToUpgrade(c.machineNumber)
+	affectedUnits, err := c.upgradeMachineSeriesClient.UpgradeSeriesValidate(c.machineNumber, c.series)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -270,13 +270,14 @@ func checkPrepCommands(prepCommands []string, argCommand string) (string, error)
 		}
 	}
 
-	return "", errors.Errorf("%q is an invalid upgrade-series command; valid commands are: %s.", argCommand, strings.Join(prepCommands, ", "))
+	return "", errors.Errorf("%q is an invalid upgrade-series command; valid commands are: %s.",
+		argCommand, strings.Join(prepCommands, ", "))
 }
 
 func checkSeries(supportedSeries []string, seriesArgument string) (string, error) {
-	for _, series := range supportedSeries {
-		if series == strings.ToLower(seriesArgument) {
-			return series, nil
+	for _, s := range supportedSeries {
+		if s == strings.ToLower(seriesArgument) {
+			return s, nil
 		}
 	}
 


### PR DESCRIPTION
## Description of change

This patch introduces some additional validation steps:
- The machine to be upgraded must be running a series from Ubuntu.
- The target series must be from Ubuntu.

The validation now occurs before the use is shown the affected units and prompted for confirmation. To this end, the API method `UnitsToUpgrade` is replaced with the new `UpgradeSeriesValidate` method. Some of the validation previously under `UpgradeSeriesPrepare moves to the new method. Some is duplicated, but acceptably so.

## QA steps

- Bootstrap
- Deploy a "Trusty" charm (Ubuntu or Redis will work).
- `juju upgradeseries prepare 0 precise` and check that the error is shown instead of confirmation.
- `juju upgradeseries prepare 0 centos7` and check that the error is shown instead of confirmation.
- `juju upgradeseries prepare 0 ""` and check that the error is shown instead of confirmation.
- `juju upgradeseries prepare 1 xenial` and check that the error is shown instead of confirmation.
- `juju upgradeseries prepare  xenial` the confirmation shows with the deployed unit listed.

## Documentation changes

None.

## Bug reference

N/A
