### PR TITLE
2.4: fix build errors found with go 1.11 test

### DIFF
--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -116,7 +116,7 @@ func getMachineData(series, file string) (map[string]interface{}, error) {
 	}
 	data, err := ioutil.ReadFile(filepath.Join(dir, file))
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannot read %q from machine (%s)", file)
+		return nil, errors.Annotatef(err, "cannot read %q from machine", file)
 	}
 
 	if len(data) == 0 {

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -118,7 +118,7 @@ func (s *fromHostSuite) TestMissingVendorDataFile(c *gc.C) {
 	dir := c.MkDir()
 	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return dir, nil })
 	obtained, err := cloudconfig.GetMachineData("xenial", "vendor-data.txt")
-	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine .*")
+	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine.*")
 	c.Assert(obtained, gc.IsNil)
 }
 

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -243,7 +243,7 @@ func (inst *azureInstance) OpenPorts(ctx context.ProviderCallContext, machineId 
 
 		priority, err := nextSecurityRulePriority(nsg, securityRuleInternalMax+1, securityRuleMax)
 		if err != nil {
-			return errors.Annotatef(err, "getting security rule priority for %s", rule)
+			return errors.Annotatef(err, "getting security rule priority for %q", rule)
 		}
 
 		var protocol network.SecurityRuleProtocol
@@ -283,7 +283,7 @@ func (inst *azureInstance) OpenPorts(ctx context.ProviderCallContext, machineId 
 			nil, // abort channel
 		)
 		if err := <-errCh; err != nil {
-			return errors.Annotatef(err, "creating security rule for %s", securityRule)
+			return errors.Annotatef(err, "creating security rule for %q", ruleName)
 		}
 		securityRules = append(securityRules, securityRule)
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1320,7 +1320,7 @@ func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 		// (anastasiamac 2018-03-21) This is strange - we do try
 		// to destroy all volumes but afterwards, if we have encountered any errors,
 		// we will return first one...The same logic happens on detach..?...
-		return errors.Annotatef(err, "destroying volume %q", volIds[i], err)
+		return errors.Annotatef(err, "destroying volume %q", volIds[i])
 	}
 
 	// Delete security groups managed by the controller.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1723,7 +1723,7 @@ func (environ *maasEnviron) filteredSubnets(ctx context.ProviderCallContext, nod
 		}
 		subnetIdFloat, err := fields["id"].GetFloat64()
 		if err != nil {
-			return nil, errors.Annotatef(err, "cannot get subnet Id: %v")
+			return nil, errors.Annotate(err, "cannot get subnet Id")
 		}
 		subnetId := strconv.Itoa(int(subnetIdFloat))
 		// If we're filtering by subnet id check if this subnet is one
@@ -1738,7 +1738,7 @@ func (environ *maasEnviron) filteredSubnets(ctx context.ProviderCallContext, nod
 		}
 		cidr, err := fields["cidr"].GetString()
 		if err != nil {
-			return nil, errors.Annotatef(err, "cannot get subnet Id")
+			return nil, errors.Annotatef(err, "cannot get subnet %q cidr", subnetId)
 		}
 		spaceId, ok := subnetsMap[cidr]
 		if !ok {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1229,7 +1229,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 			}
 			return nil, common.ZoneIndependentError(errors.Annotatef(err,
 				"cannot assign public address %s to instance %q",
-				publicIP, inst.Id(),
+				*publicIP, inst.Id(),
 			))
 		}
 		inst.floatingIP = publicIP
@@ -1629,7 +1629,7 @@ func (e *Environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 			if err == nil {
 				continue
 			}
-			return errors.Annotatef(err, "destroying volume %q", volIds[i], err)
+			return errors.Annotatef(err, "destroying volume %q", volIds[i])
 		}
 	} else if !errors.IsNotSupported(err) {
 		return errors.Trace(err)

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -114,7 +114,7 @@ func (p *provisioner) loop() error {
 			}
 			for app, password := range p.appPasswords {
 				if err := p.ensureOperator(app, password); err != nil {
-					return errors.Annotatef(err, "updating operator for q with new api addresses", app)
+					return errors.Annotatef(err, "updating operator for %q with new api addresses", app)
 				}
 			}
 

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -483,7 +483,7 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 	// Ensure the relation is exported first up.
 	results, err := w.localModelFacade.ExportEntities([]names.Tag{applicationTag, relationTag})
 	if err != nil {
-		return fail(errors.Annotatef(err, "exporting relation %v and application", relationTag, applicationTag))
+		return fail(errors.Annotatef(err, "exporting relation %v and application %v", relationTag, applicationTag))
 	}
 	if results[0].Error != nil && !params.IsCodeAlreadyExists(results[0].Error) {
 		return fail(errors.Annotatef(err, "exporting application %v", applicationTag))


### PR DESCRIPTION
## Description of change

Fix build errors found with running go test with go version 1.11. 

## QA steps

Have branch downloaded and dependencies setup.
Install go 1.11
Edit Makefile to not run pre-check when check is run.
make check   <-- intermittent unit test failures are possible, but no build failures should be logged.
