### PR TITLE
fix build errors found with go 1.11 test

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -533,7 +533,7 @@ func ReadConfig(configFilePath string) (ConfigSetterWriter, error) {
 	)
 	configData, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannot read agent config %q: %v", configFilePath)
+		return nil, errors.Annotatef(err, "cannot read agent config %q", configFilePath)
 	}
 	format, config, err = parseConfigData(configData)
 	if err != nil {

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -116,7 +116,7 @@ func getMachineData(series, file string) (map[string]interface{}, error) {
 	}
 	data, err := ioutil.ReadFile(filepath.Join(dir, file))
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannot read %q from machine (%s)", file)
+		return nil, errors.Annotatef(err, "cannot read %q from machine", file)
 	}
 
 	if len(data) == 0 {

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -118,7 +118,7 @@ func (s *fromHostSuite) TestMissingVendorDataFile(c *gc.C) {
 	dir := c.MkDir()
 	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return dir, nil })
 	obtained, err := cloudconfig.GetMachineData("xenial", "vendor-data.txt")
-	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine .*")
+	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine.*")
 	c.Assert(obtained, gc.IsNil)
 }
 

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -247,7 +247,7 @@ func (inst *azureInstance) OpenPorts(ctx context.ProviderCallContext, machineId 
 
 		priority, err := nextSecurityRulePriority(nsg, securityRuleInternalMax+1, securityRuleMax)
 		if err != nil {
-			return errors.Annotatef(err, "getting security rule priority for %s", rule)
+			return errors.Annotatef(err, "getting security rule priority for %q", rule)
 		}
 
 		var protocol network.SecurityRuleProtocol
@@ -287,7 +287,7 @@ func (inst *azureInstance) OpenPorts(ctx context.ProviderCallContext, machineId 
 			nil, // abort channel
 		)
 		if err := <-errCh; err != nil {
-			return errorutils.HandleCredentialError(errors.Annotatef(err, "creating security rule for %s", securityRule), ctx)
+			return errorutils.HandleCredentialError(errors.Annotatef(err, "creating security rule for %q", ruleName), ctx)
 		}
 		securityRules = append(securityRules, securityRule)
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1324,7 +1324,7 @@ func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 		// (anastasiamac 2018-03-21) This is strange - we do try
 		// to destroy all volumes but afterwards, if we have encountered any errors,
 		// we will return first one...The same logic happens on detach..?...
-		return errors.Annotatef(err, "destroying volume %q", volIds[i], err)
+		return errors.Annotatef(err, "destroying volume %q", volIds[i])
 	}
 
 	// Delete security groups managed by the controller.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1741,7 +1741,7 @@ func (environ *maasEnviron) filteredSubnets(ctx context.ProviderCallContext, nod
 		}
 		subnetIdFloat, err := fields["id"].GetFloat64()
 		if err != nil {
-			return nil, errors.Annotatef(err, "cannot get subnet Id: %v")
+			return nil, errors.Annotate(err, "cannot get subnet Id")
 		}
 		subnetId := strconv.Itoa(int(subnetIdFloat))
 		// If we're filtering by subnet id check if this subnet is one
@@ -1756,7 +1756,7 @@ func (environ *maasEnviron) filteredSubnets(ctx context.ProviderCallContext, nod
 		}
 		cidr, err := fields["cidr"].GetString()
 		if err != nil {
-			return nil, errors.Annotatef(err, "cannot get subnet Id")
+			return nil, errors.Annotatef(err, "cannot get subnet %q cidr", subnetId)
 		}
 		spaceId, ok := subnetsMap[cidr]
 		if !ok {

--- a/provider/oci/provider.go
+++ b/provider/oci/provider.go
@@ -284,7 +284,7 @@ func (e *EnvironProvider) Open(params environs.OpenParams) (environs.Environ, er
 	if _, ipNET, err := net.ParseCIDR(*addressSpace); err == nil {
 		size, _ := ipNET.Mask.Size()
 		if size > 16 {
-			return nil, errors.Errorf("configured subnet (%q) is not large enough. Please use a prefix length in the range /8 to /16. Current prefix length is /%d", addressSpace, size)
+			return nil, errors.Errorf("configured subnet (%q) is not large enough. Please use a prefix length in the range /8 to /16. Current prefix length is /%d", *addressSpace, size)
 		}
 	} else {
 		return nil, errors.Trace(err)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1259,7 +1259,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 			}
 			return nil, common.ZoneIndependentError(errors.Annotatef(err,
 				"cannot assign public address %s to instance %q",
-				publicIP, inst.Id(),
+				*publicIP, inst.Id(),
 			))
 		}
 		inst.floatingIP = publicIP
@@ -1659,7 +1659,7 @@ func (e *Environ) destroyControllerManagedEnvirons(controllerUUID string) error 
 			if err == nil {
 				continue
 			}
-			return errors.Annotatef(err, "destroying volume %q", volIds[i], err)
+			return errors.Annotatef(err, "destroying volume %q", volIds[i])
 		}
 	} else if !errors.IsNotSupported(err) {
 		return errors.Trace(err)

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -453,7 +453,7 @@ func (m *Machine) getUpgradeSeriesLock() (*upgradeSeriesLockDoc, error) {
 		return nil, errors.BadRequestf("machine %q is not locked for upgrade", m)
 	}
 	if err != nil {
-		return nil, errors.Annotatef(err, "retrieving upgrade series lock for machine %v: %v", m.Id())
+		return nil, errors.Annotatef(err, "retrieving upgrade series lock for machine %v", m.Id())
 	}
 	return &lock, nil
 }

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -469,7 +469,7 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 	// Ensure the relation is exported first up.
 	results, err := w.localModelFacade.ExportEntities([]names.Tag{applicationTag, relationTag})
 	if err != nil {
-		return fail(errors.Annotatef(err, "exporting relation %v and application", relationTag, applicationTag))
+		return fail(errors.Annotatef(err, "exporting relation %v and application %v", relationTag, applicationTag))
 	}
 	if results[0].Error != nil && !params.IsCodeAlreadyExists(results[0].Error) {
 		return fail(errors.Annotatef(err, "exporting application %v", applicationTag))


### PR DESCRIPTION
## Description of change

Fix build errors found with running go test with go version 1.11. 

## QA steps

Have branch downloaded and dependencies setup.
Install go 1.11
Edit Makefile to not run pre-check when check is run.
make check   <-- intermittent unit test failures are possible, but no build failures should be logged.