### PR TITLE
upgrader: Check available space before downloading binaries

### DIFF
--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -45,10 +45,10 @@ var MinDiskSpaceMib = uint64(250)
 // containing dir.
 func CheckFreeDiskSpace(dir string, thresholdMib uint64) error {
 	usage := du.NewDiskUsage(dir)
-	free := usage.Free()
-	if free < thresholdMib*humanize.MiByte {
-		return errors.Errorf("not enough free disk space for upgrade at %q: %s available, require %dMiB",
-			dir, humanize.IBytes(free), thresholdMib)
+	available := usage.Available()
+	if available < thresholdMib*humanize.MiByte {
+		return errors.Errorf("not enough free disk space on %q for upgrade: %s available, require %dMiB",
+			dir, humanize.IBytes(available), thresholdMib)
 	}
 	return nil
 }

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -22,7 +22,7 @@ type PreUpgradeStepsFunc func(_ *state.State, _ agent.Config, isController, isMa
 // PreUpgradeSteps runs various checks and prepares for performing an upgrade.
 // If any check fails, an error is returned which aborts the upgrade.
 func PreUpgradeSteps(st *state.State, agentConf agent.Config, isController, isMaster bool) error {
-	if err := checkDiskSpace(agentConf.DataDir()); err != nil {
+	if err := CheckFreeDiskSpace(agentConf.DataDir(), MinDiskSpaceMib); err != nil {
 		return errors.Trace(err)
 	}
 	if isController {
@@ -36,15 +36,19 @@ func PreUpgradeSteps(st *state.State, agentConf agent.Config, isController, isMa
 	return nil
 }
 
-// We'll be conservative and require at least 250MiB of disk space for an upgrade.
+// MinDiskSpaceMib is the standard amount of disk space free (in MiB)
+// we'll require before downloading a binary or starting an upgrade.
 var MinDiskSpaceMib = uint64(250)
 
-func checkDiskSpace(dir string) error {
+// CheckFreeDiskSpace returns a helpful error if there isn't at
+// least thresholdMib MiB of free space available on the volume
+// containing dir.
+func CheckFreeDiskSpace(dir string, thresholdMib uint64) error {
 	usage := du.NewDiskUsage(dir)
 	free := usage.Free()
-	if free < uint64(MinDiskSpaceMib*humanize.MiByte) {
-		return errors.Errorf("not enough free disk space for upgrade: %s available, require %dMiB",
-			humanize.IBytes(free), MinDiskSpaceMib)
+	if free < thresholdMib*humanize.MiByte {
+		return errors.Errorf("not enough free disk space for upgrade at %q: %s available, require %dMiB",
+			dir, humanize.IBytes(free), thresholdMib)
 	}
 	return nil
 }

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -25,7 +25,7 @@ func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
 	// Expect an impossibly large amount of free disk.
 	s.PatchValue(&upgrades.MinDiskSpaceMib, uint64(humanize.PiByte/humanize.MiByte))
 	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false, false)
-	c.Assert(err, gc.ErrorMatches, `not enough free disk space for upgrade at "/": .* available, require 1073741824MiB`)
+	c.Assert(err, gc.ErrorMatches, `not enough free disk space on "/" for upgrade: .* available, require 1073741824MiB`)
 }
 
 func (s *preupgradechecksSuite) TestUpdateDistroInfo(c *gc.C) {

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -25,7 +25,7 @@ func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
 	// Expect an impossibly large amount of free disk.
 	s.PatchValue(&upgrades.MinDiskSpaceMib, uint64(humanize.PiByte/humanize.MiByte))
 	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false, false)
-	c.Assert(err, gc.ErrorMatches, "not enough free disk space for upgrade: .*")
+	c.Assert(err, gc.ErrorMatches, `not enough free disk space for upgrade at "/": .* available, require 1073741824MiB`)
 }
 
 func (s *preupgradechecksSuite) TestUpdateDistroInfo(c *gc.C) {

--- a/worker/upgrader/manifold.go
+++ b/worker/upgrader/manifold.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/upgrader"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/gate"
 )
@@ -83,6 +84,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				OrigAgentVersion:            config.PreviousAgentVersion,
 				UpgradeStepsWaiter:          upgradeStepsWaiter,
 				InitialUpgradeCheckComplete: initialCheckUnlocker,
+				CheckDiskSpace:              upgrades.CheckFreeDiskSpace,
 			})
 		},
 	}

--- a/worker/upgrader/manifold.go
+++ b/worker/upgrader/manifold.go
@@ -77,13 +77,13 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				}
 			}
 
-			return NewAgentUpgrader(
-				upgraderFacade,
-				currentConfig,
-				config.PreviousAgentVersion,
-				upgradeStepsWaiter,
-				initialCheckUnlocker,
-			)
+			return NewAgentUpgrader(Config{
+				State:                       upgraderFacade,
+				AgentConfig:                 currentConfig,
+				OrigAgentVersion:            config.PreviousAgentVersion,
+				UpgradeStepsWaiter:          upgradeStepsWaiter,
+				InitialUpgradeCheckComplete: initialCheckUnlocker,
+			})
 		},
 	}
 }

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -99,13 +99,13 @@ func agentConfig(tag names.Tag, datadir string) agent.Config {
 }
 
 func (s *UpgraderSuite) makeUpgrader(c *gc.C) *upgrader.Upgrader {
-	w, err := upgrader.NewAgentUpgrader(
-		s.state.Upgrader(),
-		agentConfig(s.machine.Tag(), s.DataDir()),
-		s.confVersion,
-		s.upgradeStepsComplete,
-		s.initialCheckComplete,
-	)
+	w, err := upgrader.NewAgentUpgrader(upgrader.Config{
+		State:                       s.state.Upgrader(),
+		AgentConfig:                 agentConfig(s.machine.Tag(), s.DataDir()),
+		OrigAgentVersion:            s.confVersion,
+		UpgradeStepsWaiter:          s.upgradeStepsComplete,
+		InitialUpgradeCheckComplete: s.initialCheckComplete,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return w
 }


### PR DESCRIPTION
## Description of change

If the disk was full when trying to download the agent binary for an upgrade, Juju would log fairly cryptic errors that didn't clearly spell out the problem. Instead of allowing the download or unpacking to just fail, we now check for 250MiB available space before beginning. If there's not enough space the error message logged is:
```
not enough free disk space on "/var/lib/juju" for upgrade: 103MiB available, require 250MiB
```

The free space check is done for the Juju data directory as well as wherever the OS temp storage is (for unpacking).

This exposes and uses `upgrades.CheckFreeDiskSpace` so it can be used from the worker. The function now uses `DiskUsage.Available()`, because in manual testing I couldn't ever get the disk space check to fail using `.Free()` and after some research Available seems like the right choice. I had trouble finding information about the difference between the fields in the underlying `statfs` syscall - the man page just says `f_bfree: free blocks in filesystem` versus `f_bavail: free blocks available to unprivileged user` without any indication of why or in what circumstances you'd use one over the other. [This discussion](https://unix.stackexchange.com/questions/7950/reserved-space-for-root-on-a-filesystem-why) has some detail about superuser-reserved space that suggests it's really/mostly for emergency recovery in nearly-full disk situations. That indicates that Available is the right field for this check - we shouldn't be filling up emergency space with downloaded agent binaries just because the agent is running as root.

## QA steps

* Deploy an application, on a machine in the application use `fallocate -l <size> bigfile` to create a file that fills *almost* all the available space reported by `df -h` - so that there's less than 250MiB free.
* Run `juju upgrade-juju -m controller --build-agent && sleep 20 && juju upgrade-juju ` to upgrade the model.
* Look in the model log, you should see the uniter on the full machine complaining that there's not enough space in /var/lib/juju.
* Delete bigfile; the upgrade should continue and succeed.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1782367
