### PR TITLE
Fix error copying agent conf file template on startup

### DIFF
--- a/cmd/jujud/agent/caasoperator_test.go
+++ b/cmd/jujud/agent/caasoperator_test.go
@@ -4,15 +4,22 @@
 package agent
 
 import (
+	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
 	coretesting "github.com/juju/juju/testing"
+	jujuworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/logsender"
 )
 
@@ -97,6 +104,7 @@ func (s *CAASOperatorSuite) TestLogStderr(c *gc.C) {
 		AgentConf:       FakeAgentConfig{},
 		ctx:             ctx,
 		ApplicationName: "mysql",
+		dead:            make(chan struct{}),
 	}
 
 	err = a.Init(nil)
@@ -104,4 +112,61 @@ func (s *CAASOperatorSuite) TestLogStderr(c *gc.C) {
 
 	_, ok := ctx.Stderr.(*lumberjack.Logger)
 	c.Assert(ok, jc.IsFalse)
+}
+
+var agentConfigContents = `
+# format 2.0
+controller: controller-deadbeef-1bad-500d-9000-4b1d0d06f00d
+model: model-deadbeef-0bad-400d-8000-4b1d0d06f00d
+tag: machine-0
+datadir: /home/user/.local/share/juju/local
+logdir: /var/log/juju-user-local
+upgradedToVersion: 1.2.3
+apiaddresses:
+- localhost:17070
+apiport: 17070
+`[1:]
+
+func (s *CAASOperatorSuite) TestRunCopiesConfigTemplate(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+	dataDir := c.MkDir()
+	agentDir := filepath.Join(dataDir, "agents", "application-mysql")
+	err = os.MkdirAll(agentDir, 0700)
+	c.Assert(err, gc.IsNil)
+	templateFile := filepath.Join(agentDir, "template-agent.conf")
+
+	err = ioutil.WriteFile(templateFile, []byte(agentConfigContents), 0600)
+	c.Assert(err, gc.IsNil)
+
+	a := &CaasOperatorAgent{
+		AgentConf:       NewAgentConf(dataDir),
+		ctx:             ctx,
+		ApplicationName: "mysql",
+		bufferedLogger:  s.newBufferedLogWriter(),
+		dead:            make(chan struct{}),
+	}
+
+	dummy := jujuworker.NewSimpleWorker(func(stopCh <-chan struct{}) error {
+		return jujuworker.ErrTerminateAgent
+	})
+	s.PatchValue(&CaasOperatorManifolds, func(config caasoperator.ManifoldsConfig) dependency.Manifolds {
+		return dependency.Manifolds{"test": dependency.Manifold{
+			Start: func(context dependency.Context) (worker.Worker, error) {
+				return dummy, nil
+			},
+		}}
+	})
+
+	err = a.Init(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = a.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+
+	agentConfig := a.CurrentConfig()
+	c.Assert(agentConfig.Controller(), gc.Equals, names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d"))
+	addr, err := agentConfig.APIAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr, jc.SameContents, []string{"localhost:17070"})
 }


### PR DESCRIPTION
## Description of change

When the operator starts, it copies an agent conf template to the real agent conf file. There were 2 problems:
- the copied file was done using a utils method that used the wrong permissions
- the copied file was not read in afterwards to initialise the agent data

The utils method is replaced with a small bit of code to do the job. Also add a unit test.

## QA steps

bootstrap a k8s model and deploy k8s charm
