### PR TITLE
Wire up caas operator logging to controller

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -480,14 +480,14 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	logStreamHandler := newLogStreamEndpointHandler(httpCtxt)
 	debugLogHandler := newDebugLogDBHandler(
 		httpCtxt, srv.authenticator,
-		tagKindAuthorizer{names.MachineTagKind, names.UserTagKind})
+		tagKindAuthorizer{names.MachineTagKind, names.UserTagKind, names.ApplicationTagKind})
 	pubsubHandler := newPubSubHandler(httpCtxt, srv.shared.centralHub)
 	logSinkHandler := logsink.NewHTTPHandler(
 		newAgentLogWriteCloserFunc(httpCtxt, srv.logSinkWriter, &srv.dbloggers),
 		httpCtxt.stop(),
 		&srv.logsinkRateLimitConfig,
 	)
-	logSinkAuthorizer := tagKindAuthorizer{names.MachineTagKind, names.UnitTagKind}
+	logSinkAuthorizer := tagKindAuthorizer{names.MachineTagKind, names.UnitTagKind, names.ApplicationTagKind}
 	logTransferHandler := logsink.NewHTTPHandler(
 		// We don't need to save the migrated logs
 		// to a logfile as well as to the DB.

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -130,7 +130,7 @@ func (ctxt *httpContext) stateAndEntityForRequestAuthenticatedUser(r *http.Reque
 func (ctxt *httpContext) stateForRequestAuthenticatedAgent(r *http.Request) (
 	*state.PooledState, state.Entity, error,
 ) {
-	return ctxt.stateForRequestAuthenticatedTag(r, names.MachineTagKind, names.UnitTagKind)
+	return ctxt.stateForRequestAuthenticatedTag(r, names.MachineTagKind, names.UnitTagKind, names.ApplicationTagKind)
 }
 
 // stateForRequestAuthenticatedTag checks that the request is

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -93,6 +93,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		clockName: clockManifold(config.Clock),
 
+		// The log sender is a leaf worker that sends log messages to some
+		// API server, when configured so to do. We should only need one of
+		// these in a consolidated agent.
+		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
+			APICallerName: apiCallerName,
+			LogSource:     config.LogSource,
+		}),
+
 		// The upgrade steps gate is used to coordinate workers which
 		// shouldn't do anything until the upgrade-steps worker has
 		// finished running any required upgrade steps. The flag of
@@ -215,6 +223,7 @@ const (
 	apiCallerName = "api-caller"
 	clockName     = "clock"
 	operatorName  = "operator"
+	logSenderName = "log-sender"
 
 	charmDirName          = "charm-dir"
 	hookRetryStrategyName = "hook-retry-strategy"

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -41,6 +41,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"hook-retry-strategy",
 		"operator",
 		"logging-config-updater",
+		"log-sender",
 		"migration-fortress",
 		"migration-minion",
 		"migration-inactive-flag",

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -127,6 +127,7 @@ var (
 		"api-caller",
 		"clock",
 		"logging-config-updater",
+		"log-sender",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"migration-minion",

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/symlink"
 	"github.com/juju/version"
-	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
@@ -31,6 +30,7 @@ import (
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/caasoperator/remotestate"
 	"github.com/juju/juju/worker/uniter"
+	jujucharm "github.com/juju/juju/worker/uniter/charm"
 )
 
 var logger = loggo.GetLogger("juju.worker.caasoperator")
@@ -40,10 +40,12 @@ var logger = loggo.GetLogger("juju.worker.caasoperator")
 // delegated to Mode values, which are expected to react to events and direct
 // the caasoperator's responses to them.
 type caasOperator struct {
-	catacomb catacomb.Catacomb
-	config   Config
-	paths    Paths
-	runner   *worker.Runner
+	catacomb  catacomb.Catacomb
+	config    Config
+	paths     Paths
+	runner    *worker.Runner
+	deployer  jujucharm.Deployer
+	stateFile *StateFile
 }
 
 // Config hold the configuration for a caasoperator worker.
@@ -161,9 +163,20 @@ func NewWorker(config Config) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	paths := NewPaths(config.DataDir, names.NewApplicationTag(config.Application))
+	deployer, err := jujucharm.NewDeployer(
+		paths.State.CharmDir,
+		paths.State.DeployerDir,
+		jujucharm.NewBundlesDir(paths.State.BundlesDir, config.Downloader),
+	)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot create deployer")
+	}
+
 	op := &caasOperator{
-		config: config,
-		paths:  NewPaths(config.DataDir, names.NewApplicationTag(config.Application)),
+		config:   config,
+		paths:    paths,
+		deployer: deployer,
 		runner: worker.NewRunner(worker.RunnerParams{
 			Clock: config.Clock,
 
@@ -247,27 +260,40 @@ func toBinaryVersion(vers version.Number) version.Binary {
 	return outVers
 }
 
-func (op *caasOperator) loop() (err error) {
-	// Start by reporting current tools (which includes arch/series).
-	if err := op.config.VersionSetter.SetVersion(
-		op.config.Application, toBinaryVersion(jujuversion.Current)); err != nil {
-		return errors.Annotate(err, "cannot set agent version")
+func (op *caasOperator) init() (*LocalState, error) {
+	if err := jujucharm.ClearDownloads(op.paths.State.BundlesDir); err != nil {
+		logger.Warningf(err.Error())
 	}
 
-	charmURL, charmModifiedVersion, err := op.ensureCharm()
-	if err != nil {
+	op.stateFile = NewStateFile(op.paths.State.OperationsFile)
+	localState, err := op.stateFile.Read()
+	if err == ErrNoStateFile {
+		localState = &LocalState{}
+	}
+
+	if err := op.ensureCharm(localState); err != nil {
 		if err == jworker.ErrTerminateAgent {
-			return err
+			return nil, err
 		}
-		return errors.Annotatef(err,
+		return nil, errors.Annotatef(err,
 			"failed to initialize caasoperator for %q",
 			op.config.Application,
 		)
 	}
-	// Take note of the current charm version attributes.
-	localState := LocalState{
-		CharmURL:             charmURL,
-		CharmModifiedVersion: charmModifiedVersion,
+	return localState, nil
+}
+
+func (op *caasOperator) loop() (err error) {
+	localState, err := op.init()
+	if err != nil {
+		return err
+	}
+	logger.Infof("operator %q started", op.config.Application)
+
+	// Start by reporting current tools (which includes arch/series).
+	if err := op.config.VersionSetter.SetVersion(
+		op.config.Application, toBinaryVersion(jujuversion.Current)); err != nil {
+		return errors.Annotate(err, "cannot set agent version")
 	}
 
 	var (
@@ -335,12 +361,10 @@ func (op *caasOperator) loop() (err error) {
 			snap := watcher.Snapshot()
 			if charmModified(localState, snap) {
 				// Charm changed so download and install the new version.
-				charmURL, charmModifiedVersion, err := op.ensureCharm()
+				err := op.ensureCharm(localState)
 				if err != nil {
-					return errors.Annotatef(err, "error downloading updated charm %v", charmURL.String())
+					return errors.Annotatef(err, "error downloading updated charm %v", localState.CharmURL)
 				}
-				localState.CharmURL = charmURL
-				localState.CharmModifiedVersion = charmModifiedVersion
 				// Notify all uniters of the change so they run the upgrade-charm hook.
 				for unitId, changedChan := range aliveUnits {
 					logger.Debugf("trigger upgrade charm for caas unit %v", unitId)
@@ -402,12 +426,12 @@ func (op *caasOperator) loop() (err error) {
 	}
 }
 
-func charmModified(local LocalState, remote remotestate.Snapshot) bool {
+func charmModified(local *LocalState, remote remotestate.Snapshot) bool {
 	// CAAS models may not yet have read the charm url from state.
 	if remote.CharmURL == nil {
 		return false
 	}
-	if local.CharmURL == nil {
+	if local == nil || local.CharmURL == nil {
 		logger.Warningf("unexpected nil local charm URL")
 		return true
 	}
@@ -425,28 +449,6 @@ func charmModified(local LocalState, remote remotestate.Snapshot) bool {
 		return true
 	}
 	return false
-}
-
-func (op *caasOperator) ensureCharm() (*charm.URL, int, error) {
-	charmDir := op.paths.GetCharmDir()
-	if _, err := os.Stat(charmDir); !os.IsNotExist(err) {
-		return nil, 0, errors.Trace(err)
-	}
-	curl, _, sha256, vers, err := op.config.CharmGetter.Charm(op.config.Application)
-	if err != nil {
-		return nil, 0, errors.Trace(err)
-	}
-	if op.setStatus(status.Maintenance, "downloading charm (%s)", curl); err != nil {
-		return nil, 0, errors.Trace(err)
-	}
-	if err := downloadCharm(
-		op.config.Downloader,
-		curl, sha256, charmDir,
-		op.catacomb.Dying(),
-	); err != nil {
-		return nil, 0, errors.Trace(err)
-	}
-	return curl, vers, nil
 }
 
 func (op *caasOperator) setStatus(status status.Status, message string, args ...interface{}) error {

--- a/worker/caasoperator/download.go
+++ b/worker/caasoperator/download.go
@@ -4,14 +4,12 @@
 package caasoperator
 
 import (
-	"net/url"
-	"os"
-
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6"
 
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/downloader"
+	jujucharm "github.com/juju/juju/worker/uniter/charm"
 )
 
 // Downloader provides an interface for downloading files to disk.
@@ -21,76 +19,44 @@ type Downloader interface {
 	Download(downloader.Request) (string, error)
 }
 
-func downloadCharm(
-	dl Downloader,
-	curl *charm.URL,
-	sha256 string,
-	charmDir string,
-	abort <-chan struct{},
-) error {
-	curlURL, err := url.Parse(curl.String())
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	charmDirDownload := charmDir + ".dl"
-	if err := os.RemoveAll(charmDirDownload); err != nil {
-		return errors.Trace(err)
-	}
-	if err := os.MkdirAll(charmDirDownload, 0755); err != nil {
-		return errors.Trace(err)
-	}
-	defer os.RemoveAll(charmDirDownload)
-
-	verify := func(f *os.File) error {
-		digest, _, err := utils.ReadSHA256(f)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if digest == sha256 {
-			return nil
-		}
-		return errors.New("SHA256 hash mismatch")
-	}
-
-	logger.Debugf("downloading %q to %s...", curlURL, charmDirDownload)
-	charmArchivePath, err := dl.Download(downloader.Request{
-		URL:       curlURL,
-		TargetDir: charmDirDownload,
-		Verify:    verify,
-		Abort:     abort,
-	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Unpack the archive to a temporary directory,
-	// and then atomically rename that to the target
-	// directory.
-	charmDirUnpack := charmDir + ".tmp"
-	logger.Debugf("unpacking charm into %s...", charmDirUnpack)
-	if err := os.RemoveAll(charmDirUnpack); err != nil {
-		return errors.Trace(err)
-	}
-	if err := os.MkdirAll(charmDirUnpack, 0755); err != nil {
-		return errors.Trace(err)
-	}
-	if err := unpackCharm(charmArchivePath, charmDirUnpack); err != nil {
-		os.RemoveAll(charmDirUnpack)
-		return errors.Trace(err)
-	}
-	if err := os.Rename(charmDirUnpack, charmDir); err != nil {
-		os.RemoveAll(charmDirUnpack)
-		return errors.Trace(err)
-	}
-	logger.Debugf("charm is ready at %s", charmDir)
-	return nil
+type charmInfo struct {
+	curl   *charm.URL
+	sha256 string
 }
 
-func unpackCharm(charmArchivePath, dir string) error {
-	charmArchive, err := charm.ReadCharmArchive(charmArchivePath)
+func (c *charmInfo) URL() *charm.URL {
+	return c.curl
+}
+
+func (c *charmInfo) ArchiveSha256() (string, error) {
+	return c.sha256, nil
+}
+
+func (op *caasOperator) ensureCharm(localState *LocalState) error {
+	curl, _, sha256, vers, err := op.config.CharmGetter.Charm(op.config.Application)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return charmArchive.ExpandTo(dir)
+	localState.CharmModifiedVersion = vers
+	if localState.CharmURL == curl {
+		logger.Debugf("charm %s already downloaded", curl)
+		return nil
+	}
+	if err := op.setStatus(status.Maintenance, "downloading charm (%s)", curl); err != nil {
+		return errors.Trace(err)
+	}
+
+	info := &charmInfo{curl: curl, sha256: sha256}
+	if err := op.deployer.Stage(info, op.catacomb.Dying()); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := op.deployer.Deploy(); err != nil {
+		if err == jujucharm.ErrConflict {
+			err = op.setStatus(status.Error, "upgrade failed", nil)
+		}
+		return errors.Trace(err)
+	}
+	localState.CharmURL = curl
+	return op.stateFile.Write(localState)
 }

--- a/worker/caasoperator/localstate_test.go
+++ b/worker/caasoperator/localstate_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator_test
+
+import (
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
+
+	"github.com/juju/juju/worker/caasoperator"
+)
+
+type LocalStateFileSuite struct{}
+
+var _ = gc.Suite(&LocalStateFileSuite{})
+
+func (s *LocalStateFileSuite) TestState(c *gc.C) {
+	path := filepath.Join(c.MkDir(), "operator")
+	file := caasoperator.NewStateFile(path)
+	_, err := file.Read()
+	c.Assert(err, gc.Equals, caasoperator.ErrNoStateFile)
+
+	localSt := caasoperator.LocalState{
+		CharmURL:             charm.MustParseURL("cs:quantal/application-name-123"),
+		CharmModifiedVersion: 123,
+	}
+	err = file.Write(&localSt)
+	c.Assert(err, jc.ErrorIsNil)
+	st, err := file.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(st, jc.DeepEquals, &localSt)
+}

--- a/worker/caasoperator/paths.go
+++ b/worker/caasoperator/paths.go
@@ -73,6 +73,17 @@ type StatePaths struct {
 	// CharmDir is the directory to which the charm the operator runs is deployed.
 	CharmDir string
 
+	// OperationsFile holds information about what the operator is doing
+	// and/or has done.
+	OperationsFile string
+
+	// BundlesDir holds downloaded charms.
+	BundlesDir string
+
+	// DeployerDir holds metadata about charms that are installing or have
+	// been installed.
+	DeployerDir string
+
 	// RelationsDir holds relation-specific information about what the
 	// operator is doing and/or has done.
 	RelationsDir string
@@ -107,7 +118,10 @@ func NewPaths(dataDir string, applicationTag names.ApplicationTag) Paths {
 		State: StatePaths{
 			BaseDir:         baseDir,
 			CharmDir:        join(baseDir, "charm"),
+			BundlesDir:      join(stateDir, "bundles"),
+			DeployerDir:     join(stateDir, "deployer"),
 			RelationsDir:    join(stateDir, "relations"),
+			OperationsFile:  join(stateDir, "operator"),
 			MetricsSpoolDir: join(stateDir, "spool", "metrics"),
 		},
 	}

--- a/worker/caasoperator/paths_test.go
+++ b/worker/caasoperator/paths_test.go
@@ -43,6 +43,9 @@ func (s *PathsSuite) TestPaths(c *gc.C) {
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
 			RelationsDir:    relAgent("state", "relations"),
+			BundlesDir:      relAgent("state", "bundles"),
+			DeployerDir:     relAgent("state", "deployer"),
+			OperationsFile:  relAgent("state", "operator"),
 			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})


### PR DESCRIPTION
## Description of change

As well as logging to standard k8s logger, we also send logs to the controller. This conforms with how other agents are expected to operate.

## QA steps

deploy k8s charm
run juju debug-log on the k8s model

