### PR TITLE
Upgrade Series - Ensure Valid State for Units

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -6,8 +6,6 @@ package machinemanager
 import (
 	"fmt"
 
-	"github.com/juju/juju/core/status"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/os"
@@ -18,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -516,8 +516,9 @@ func (mm *MachineManagerAPI) validateSeries(argumentSeries, currentSeries string
 }
 
 // verifiedUnits verifies that the machine units and their tree of subordinates
-// all support the input series.
-// If they do the unit names are all returned; if not, an error results.
+// all support the input series. If not, an error is returned.
+// If they do, the agent statuses are checked to ensure that they are all in
+// the idle state i.e. not installing, running hooks, or needing intervention.
 func (mm *MachineManagerAPI) verifiedUnits(machine Machine, series string, force bool) ([]string, error) {
 	principals := machine.Principals()
 	units, err := machine.VerifyUnitsSeries(principals, series, force)

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -4,10 +4,11 @@
 package machinemanager
 
 import (
-	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
@@ -98,6 +99,7 @@ func (m machineShim) Units() ([]Unit, error) {
 type Unit interface {
 	UnitTag() names.UnitTag
 	Name() string
+	AgentStatus() (status.StatusInfo, error)
 }
 
 func (m machineShim) VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error) {


### PR DESCRIPTION
## Description of change

Depends on https://github.com/juju/juju/pull/9176

This patch adds logic to the _prepare_ validation step to ensure that unit agents on the target machine are in the "idle" state. This should be sufficient to indicate the units are not:
- Waiting for allocation.
- Running hooks (including install).
- In an error state. 
- Otherwise down or disconnected.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`.
- Bootstrap
- Deploy a "Trusty" charm (Redis is ideal).
- Immediately run `juju upgradeseries prepare 0 xenial`
- Keep running the command. There should be a transition through:
  - Error message for the "allocating" state.
  - Error message for the "executing" state (install hook).
  - Error message for the "executing" state (config changed hook).
  - Valid prompt to proceed, listing the unit.

## Documentation changes

None. 

## Bug reference

N/A
