### PR TITLE
Add support for deploying k8s charms with constraints

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
 	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
@@ -160,6 +161,10 @@ func (m *mockApplication) DeviceConstraints() (map[string]state.DeviceConstraint
 			Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
 		},
 	}, nil
+}
+
+func (m *mockApplication) Constraints() (constraints.Value, error) {
+	return constraints.MustParse("mem=64G"), nil
 }
 
 func (m *mockApplication) UpdateCloudService(providerId string, addreses []network.Address) error {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -294,11 +294,16 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	cons, err := app.Constraints()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	return &params.KubernetesProvisioningInfo{
 		PodSpec:     podSpec,
 		Filesystems: filesystemParams,
 		Devices:     devices,
+		Constraints: cons,
 	}, nil
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -196,6 +197,7 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 						Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
 					},
 				},
+				Constraints: constraints.MustParse("mem=64G"),
 			},
 		}, {
 			Error: &params.Error{

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
@@ -75,6 +76,7 @@ type Application interface {
 	DeviceConstraints() (map[string]state.DeviceConstraints, error)
 	Life() state.Life
 	Name() string
+	Constraints() (constraints.Value, error)
 }
 
 type stateShim struct {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -139,6 +139,9 @@ type Broker interface {
 
 	// ProviderRegistry is an interface for obtaining storage providers.
 	storage.ProviderRegistry
+
+	// ConstraintsChecker provides a means to check that constraints are valid.
+	environs.ConstraintsChecker
 }
 
 // Service represents information about the status of a caas service entity.

--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/context"
+)
+
+var unsupportedConstraints = []string{
+	constraints.Cores,
+	constraints.Tags,
+	constraints.VirtType,
+	constraints.Container,
+	constraints.Arch,
+	constraints.RootDisk,
+	constraints.InstanceType,
+	constraints.Spaces,
+}
+
+// ConstraintsValidator returns a Validator value which is used to
+// validate and merge constraints.
+func (k *kubernetesClient) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+	validator := constraints.NewValidator()
+	validator.RegisterUnsupported(unsupportedConstraints)
+	return validator, nil
+}

--- a/caas/kubernetes/provider/constraints_test.go
+++ b/caas/kubernetes/provider/constraints_test.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/context"
+)
+
+type ConstraintsSuite struct {
+	BaseSuite
+
+	callCtx context.ProviderCallContext
+}
+
+var _ = gc.Suite(&ConstraintsSuite{})
+
+func (s *ConstraintsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.callCtx = context.NewCloudCallContext()
+}
+
+func (s *ConstraintsSuite) TestConstraintsValidatorOkay(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	validator, err := s.broker.ConstraintsValidator(context.NewCloudCallContext())
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons := constraints.MustParse("mem=64G")
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(unsupported, gc.HasLen, 0)
+}
+
+func (s *ConstraintsSuite) TestConstraintsValidatorEmpty(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	validator, err := s.broker.ConstraintsValidator(context.NewCloudCallContext())
+	c.Assert(err, jc.ErrorIsNil)
+
+	unsupported, err := validator.Validate(constraints.Value{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(unsupported, gc.HasLen, 0)
+}
+
+func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	validator, err := s.broker.ConstraintsValidator(context.NewCloudCallContext())
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons := constraints.MustParse(strings.Join([]string{
+		"arch=amd64",
+		"tags=foo",
+		"mem=3",
+		"instance-type=some-type",
+		"cores=2",
+		"cpu-power=250",
+		"virt-type=kvm",
+		"root-disk=10M",
+		"spaces=foo",
+		"container=kvm",
+	}, " "))
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := []string{
+		"tags",
+		"cores",
+		"virt-type",
+		"arch",
+		"instance-type",
+		"root-disk",
+		"spaces",
+		"container",
+	}
+	c.Check(unsupported, jc.SameContents, expected)
+}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/environs/context"
@@ -970,6 +971,113 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 				Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
 			},
 		},
+	}
+	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
+		"kubernetes-service-externalname":    "ext-name",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	numUnits := int32(2)
+	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	c.Assert(err, jc.ErrorIsNil)
+	podSpec := provider.PodSpec(unitSpec)
+	podSpec.Containers[0].VolumeMounts = []core.VolumeMount{{
+		Name:      "juju-database-0",
+		MountPath: "path/to/here",
+	}}
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].Resources = core.ResourceRequirements{
+			Limits: core.ResourceList{
+				"memory": resource.MustParse("64Mi"),
+				"cpu":    resource.MustParse("500m"),
+			},
+		}
+	}
+
+	scName := "juju-unit-storage"
+	statefulSetArg := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "juju-test",
+			Labels: map[string]string{"juju-application": "test"}},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &numUnits,
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"juju-application": "test"},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"juju-application": "test"},
+				},
+				Spec: podSpec,
+			},
+			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   "juju-database-0",
+					Labels: map[string]string{"juju-application": "test"}},
+				Spec: core.PersistentVolumeClaimSpec{
+					StorageClassName: &scName,
+					AccessModes:      []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+					Resources: core.ResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("100Mi"),
+						},
+					},
+				},
+			}},
+			PodManagementPolicy: apps.ParallelPodManagement,
+		},
+	}
+	serviceArg := &core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "juju-test",
+			Labels: map[string]string{"juju-application": "test"}},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"juju-application": "test"},
+			Type:     "nodeIP",
+			Ports: []core.ServicePort{
+				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
+				{Port: 8080, Protocol: "TCP", Name: "fred"},
+			},
+			LoadBalancerIP: "10.0.0.1",
+			ExternalName:   "ext-name",
+		},
+	}
+
+	gomock.InOrder(
+		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStorageClass.EXPECT().Get("juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "juju-unit-storage"}}, nil),
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+			Return(nil, nil),
+		s.mockServices.EXPECT().Get("juju-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+			Return(nil, nil),
+	)
+
+	params := &caas.ServiceParams{
+		PodSpec: basicPodspec,
+		Filesystems: []storage.KubernetesFilesystemParams{{
+			StorageName: "database",
+			Size:        100,
+			Provider:    "kubernetes",
+			Attachment: &storage.KubernetesFilesystemAttachmentParams{
+				Path: "path/to/here",
+			},
+		}},
+		Constraints: constraints.MustParse("mem=64 cpu-power=500"),
 	}
 	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -344,9 +344,8 @@ type Environ interface {
 	// ConfigGetter allows the retrieval of the configuration data.
 	ConfigGetter
 
-	// ConstraintsValidator returns a Validator instance which
-	// is used to validate and merge constraints.
-	ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error)
+	// ConstraintsChecker provides a means to check that constraints are valid.
+	ConstraintsChecker
 
 	// SetConfig updates the Environ's configuration.
 	//
@@ -386,6 +385,13 @@ type Environ interface {
 	// InstanceTypesFetcher represents an environment that can return
 	// information about the available instance types.
 	InstanceTypesFetcher
+}
+
+// ConstraintsChecker provides a means to check that constraints are valid.
+type ConstraintsChecker interface {
+	// ConstraintsValidator returns a Validator instance which
+	// is used to validate and merge constraints.
+	ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error)
 }
 
 // InstancePrechecker provides a means of "prechecking" instance

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -228,9 +228,10 @@ func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModelsWithResources(c
 	otherModel, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab"})
-	ch, _, err := application.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
+	f := factory.NewFactory(otherSt, s.StatePool)
+	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
 	args := state.AddApplicationArgs{
 		Name:   application.Name(),
 		Series: "kubernetes",

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -89,16 +89,19 @@ func (p environStatePolicy) ConstraintsValidator(ctx context.ProviderCallContext
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if model.Type() != state.ModelTypeIAAS {
-		// TODO(caas) CAAS providers should also provide
-		// constraints validation.
-		return nil, errors.NotImplementedf("ConstraintsValidator")
+
+	if model.Type() == state.ModelTypeIAAS {
+		env, err := p.getEnviron(p.st)
+		if err != nil {
+			return nil, err
+		}
+		return env.ConstraintsValidator(ctx)
 	}
-	env, err := p.getEnviron(p.st)
+	broker, err := p.getBroker(p.st)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	return env.ConstraintsValidator(ctx)
+	return broker.ConstraintsValidator(ctx)
 }
 
 // InstanceDistributor implements state.Policy.


### PR DESCRIPTION
## Description of change

Deploying k8s charms now supports using constraints. The supported constraints are "mem" and "cpu-power". cpu-power is milli-cpu units.

As a driveby, consolidate the checking logic in state to validate deployment args for iaas and caas models.

## QA steps

juju deploy a k8s charm with constrains, eg --constraints "mem=1G cpu-power=500"
look at the pod and check that the resource limits are correctly applied

