### PR TITLE
Pass through the task abort channel.

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -87,6 +87,10 @@ type StartInstanceParams struct {
 	// changes in status. Its signature is consistent with other
 	// status-related functions to allow them to be used as callbacks.
 	StatusCallback StatusCallbackFunc
+
+	// Abort is a channel that will be closed to indicate that the command
+	// should be aborted.
+	Abort <-chan struct{}
 }
 
 // StartInstanceResult holds the result of an

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -206,7 +206,7 @@ func (f *fakeAPI) HostChangesForContainer(machineTag names.MachineTag) ([]networ
 	return []network.DeviceToBridge{f.fakeDeviceToBridge}, 0, nil
 }
 
-func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger) error {
+func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error {
 	// This is not actually part of the API, however it is something that the
 	// Brokers should be calling, and putting it here means we get a wholistic
 	// view of when what function is getting called.
@@ -215,7 +215,7 @@ func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger) e
 		return err
 	}
 	if f.fakePreparer != nil {
-		return f.fakePreparer(containerTag, log)
+		return f.fakePreparer(containerTag, log, abort)
 	}
 	return nil
 }

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -220,18 +220,15 @@ func defaultBridger() (network.Bridger, error) {
 	}
 }
 
-func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.Logger) error {
+func (cs *ContainerSetup) prepareHost(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error {
 	preparer := NewHostPreparer(HostPreparerParams{
 		API:                cs.provisioner,
 		ObserveNetworkFunc: observeNetwork,
 		AcquireLockFunc:    cs.acquireLock,
 		CreateBridger:      defaultBridger,
-		// TODO(jam): 2017-02-08 figure out how to thread catacomb.Dying() into
-		// this function, so that we can stop trying to acquire the lock if we
-		// are stopping.
-		AbortChan:  nil,
-		MachineTag: cs.machine.MachineTag(),
-		Logger:     log,
+		AbortChan:          abort,
+		MachineTag:         cs.machine.MachineTag(),
+		Logger:             log,
 	})
 	return preparer.Prepare(containerTag)
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -69,7 +69,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	err = broker.prepareHost(names.NewMachineTag(containerMachineID), kvmLogger)
+	err = broker.prepareHost(names.NewMachineTag(containerMachineID), kvmLogger, args.Abort)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -405,7 +405,7 @@ func (s *kvmProvisionerSuite) TearDownTest(c *gc.C) {
 	s.CommonProvisionerSuite.TearDownTest(c)
 }
 
-func noopPrepareHostFunc(names.MachineTag, loggo.Logger) error {
+func noopPrepareHostFunc(names.MachineTag, loggo.Logger, <-chan struct{}) error {
 	return nil
 }
 

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -17,7 +17,7 @@ import (
 
 var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
 
-type PrepareHostFunc func(containerTag names.MachineTag, log loggo.Logger) error
+type PrepareHostFunc func(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error
 
 // NewLXDBroker creates a Broker that can be used to start LXD containers in a
 // similar fashion to normal StartInstance requests.
@@ -59,7 +59,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger)
+	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger, args.Abort)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -695,6 +695,7 @@ func (task *provisionerTask) constructStartInstanceParams(
 		EndpointBindings:  endpointBindings,
 		ImageMetadata:     possibleImageMetadata,
 		StatusCallback:    machine.SetInstanceStatus,
+		Abort:             task.catacomb.Dying(),
 	}
 
 	return startInstanceParams, nil


### PR DESCRIPTION
This is a backport of the 2.4 fix for the container initialization problem.

See PR #9041.