### PR TITLE
Support --to placement for k8s charms

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -145,6 +145,7 @@ func (c *Client) WatchPodSpec(application string) (watcher.NotifyWatcher, error)
 // ProvisioningInfo holds unit provisioning info.
 type ProvisioningInfo struct {
 	PodSpec     string
+	Placement   string
 	Constraints constraints.Value
 	Filesystems []storage.KubernetesFilesystemParams
 	Devices     []devices.KubernetesDeviceParams
@@ -173,6 +174,7 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 	result := results.Results[0].Result
 	info := &ProvisioningInfo{
 		PodSpec:     result.PodSpec,
+		Placement:   result.Placement,
 		Constraints: result.Constraints,
 		Tags:        result.Tags,
 	}

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -47,6 +47,7 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 				Result: &params.KubernetesProvisioningInfo{
 					PodSpec:     "foo",
 					Tags:        map[string]string{"foo": "bar"},
+					Placement:   "a=b,c=d",
 					Constraints: constraints.MustParse("mem=4G"),
 					Filesystems: []params.KubernetesFilesystemParams{{
 						StorageName: "database",
@@ -79,6 +80,7 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(info, jc.DeepEquals, &caasunitprovisioner.ProvisioningInfo{
 		PodSpec:     "foo",
 		Tags:        map[string]string{"foo": "bar"},
+		Placement:   "a=b,c=d",
 		Constraints: constraints.MustParse("mem=4G"),
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName:  "database",

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -416,10 +416,11 @@ func deployApplication(
 				modelType,
 			)
 		}
-		if len(args.Placement) > 0 {
+		if len(args.Placement) > 1 {
 			return errors.Errorf(
-				"Placement may not be specified for %s models",
+				"only 1 placement directive is supported for %s models, got %d",
 				modelType,
+				len(args.Placement),
 			)
 		}
 		for storageName, cons := range args.Storage {
@@ -1038,10 +1039,11 @@ func addApplicationUnits(backend Backend, modelType state.ModelType, args params
 				modelType,
 			)
 		}
-		if len(args.Placement) > 0 {
+		if len(args.Placement) > 1 {
 			return nil, errors.Errorf(
-				"Placement may not be specified for %s models",
+				"only 1 placement directive is supported for %s models, got %d",
 				modelType,
+				len(args.Placement),
 			)
 		}
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -490,7 +490,7 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 			ApplicationName: "baz",
 			CharmURL:        "local:baz-0",
 			NumUnits:        1,
-			Placement:       []*instance.Placement{{}},
+			Placement:       []*instance.Placement{{}, {}},
 		}},
 	}
 	results, err := s.api.Deploy(args)
@@ -498,7 +498,7 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	c.Assert(results.Results[1].Error, gc.ErrorMatches, "AttachStorage may not be specified for caas models")
-	c.Assert(results.Results[2].Error, gc.ErrorMatches, "Placement may not be specified for caas models")
+	c.Assert(results.Results[2].Error, gc.ErrorMatches, "only 1 placement directive is supported for caas models, got 2")
 }
 
 func (s *ApplicationSuite) TestDeployCAASModelNoOperatorStorage(c *gc.C) {

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -140,6 +140,11 @@ func (a *mockApplication) GetScale() int {
 	return 5
 }
 
+func (a *mockApplication) GetPlacement() string {
+	a.MethodCall(a, "GetPlacement")
+	return "placement"
+}
+
 func (a *mockApplication) ApplicationConfig() (application.ConfigAttributes, error) {
 	a.MethodCall(a, "ApplicationConfig")
 	return application.ConfigAttributes{"foo": "bar"}, a.NextErr()

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -304,6 +304,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		Filesystems: filesystemParams,
 		Devices:     devices,
 		Constraints: cons,
+		Placement:   app.GetPlacement(),
 	}, nil
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -197,6 +197,7 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 						Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
 					},
 				},
+				Placement:   "placement",
 				Constraints: constraints.MustParse("mem=64G"),
 			},
 		}, {

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -77,6 +77,7 @@ type Application interface {
 	Life() state.Life
 	Name() string
 	Constraints() (constraints.Value, error)
+	GetPlacement() string
 }
 
 type stateShim struct {

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -11,6 +11,7 @@ import (
 type KubernetesProvisioningInfo struct {
 	PodSpec     string                       `json:"pod-spec"`
 	Constraints constraints.Value            `json:"constraints"`
+	Placement   string                       `json:"placement,omitempty"`
 	Tags        map[string]string            `json:"tags,omitempty"`
 	Filesystems []KubernetesFilesystemParams `json:"filesystems,omitempty"`
 	Volumes     []KubernetesVolumeParams     `json:"volumes,omitempty"`

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -77,6 +77,9 @@ type ServiceParams struct {
 	// ResourceTags is a set of tags to set on the created service.
 	ResourceTags map[string]string
 
+	// Placement defines node affinity rules.
+	Placement string
+
 	// Constraints is a set of constraints on
 	// the pod to create.
 	Constraints constraints.Value
@@ -142,6 +145,10 @@ type Broker interface {
 
 	// ConstraintsChecker provides a means to check that constraints are valid.
 	environs.ConstraintsChecker
+
+	// InstancePrechecker provides a means of "prechecking" placement
+	// arguments before recording them in state.
+	environs.InstancePrechecker
 }
 
 // Service represents information about the status of a caas service entity.

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/keyvalues"
 	"gopkg.in/juju/names.v2"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -707,6 +708,13 @@ func (k *kubernetesClient) EnsureService(
 		if err = k.configureConstraint(unitSpec, "cpu", fmt.Sprintf("%dm", *cpu)); err != nil {
 			return errors.Annotatef(err, "configuring cpu constraint for %s", appName)
 		}
+	}
+	if params.Placement != "" {
+		affinityLabels, err := keyvalues.Parse(strings.Split(params.Placement, ","), false)
+		if err != nil {
+			return errors.Annotatef(err, "invalid placement directive %q", params.Placement)
+		}
+		unitSpec.Pod.NodeSelector = affinityLabels
 	}
 
 	for _, c := range params.PodSpec.Containers {

--- a/caas/kubernetes/provider/precheck.go
+++ b/caas/kubernetes/provider/precheck.go
@@ -1,0 +1,55 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/utils/keyvalues"
+)
+
+// PrecheckInstance performs a preflight check on the specified
+// series and constraints, ensuring that they are possibly valid for
+// creating an instance in this model.
+//
+// PrecheckInstance is best effort, and not guaranteed to eliminate
+// all invalid parameters. If PrecheckInstance returns nil, it is not
+// guaranteed that the constraints are valid; if a non-nil error is
+// returned, then the constraints are definitely invalid.
+func (k *kubernetesClient) PrecheckInstance(ctx context.ProviderCallContext, params environs.PrecheckInstanceParams) error {
+	// Ensure there are no unsupported constraints.
+	// Clouds generally don't enforce this but we will
+	// for Kubernetes deployments.
+	validator, err := k.ConstraintsValidator(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	unsupported, err := validator.Validate(params.Constraints)
+	if err != nil {
+		return errors.NotValidf("constraints %q", params.Constraints.String())
+	}
+	if len(unsupported) > 0 {
+		return errors.NotSupportedf("constraints %v", strings.Join(unsupported, ","))
+	}
+
+	if params.Series != "kubernetes" {
+		return errors.NotValidf("series %q", params.Series)
+	}
+
+	if params.Placement == "" {
+		return nil
+	}
+
+	// Check placement is valid.
+	// TODO(caas) - check for valid node labels?
+	// Placement is a comma separated list of key-value pairs (node labels).
+	_, err = keyvalues.Parse(strings.Split(params.Placement, ","), false)
+	if err != nil {
+		return errors.NotValidf("placement directive %q", params.Placement)
+	}
+	return nil
+}

--- a/caas/kubernetes/provider/precheck_test.go
+++ b/caas/kubernetes/provider/precheck_test.go
@@ -1,0 +1,70 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+)
+
+type PrecheckSuite struct {
+	BaseSuite
+
+	callCtx context.ProviderCallContext
+}
+
+var _ = gc.Suite(&PrecheckSuite{})
+
+func (s *PrecheckSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.callCtx = context.NewCloudCallContext()
+}
+
+func (s *PrecheckSuite) TestSuccess(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+		Series:      "kubernetes",
+		Constraints: constraints.MustParse("mem=4G"),
+		Placement:   "a=b",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *PrecheckSuite) TestWrongSeries(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+		Series: "quantal",
+	})
+	c.Assert(err, gc.ErrorMatches, `series "quantal" not valid`)
+}
+
+func (s *PrecheckSuite) TestUnsupportedConstraints(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+		Series:      "kubernetes",
+		Constraints: constraints.MustParse("instance-type=foo"),
+	})
+	c.Assert(err, gc.ErrorMatches, `constraints instance-type not supported`)
+}
+
+func (s *PrecheckSuite) TestBadPlacement(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+		Series:    "kubernetes",
+		Placement: "a",
+	})
+	c.Assert(err, gc.ErrorMatches, `placement directive "a" not valid`)
+}

--- a/state/application.go
+++ b/state/application.go
@@ -58,11 +58,15 @@ type applicationDoc struct {
 	RelationCount        int          `bson:"relationcount"`
 	Exposed              bool         `bson:"exposed"`
 	MinUnits             int          `bson:"minunits"`
-	DesiredScale         int          `bson:"scale"`
 	Tools                *tools.Tools `bson:",omitempty"`
 	TxnRevno             int64        `bson:"txn-revno"`
 	MetricCredentials    []byte       `bson:"metric-credentials"`
-	PasswordHash         string       `bson:"passwordhash"`
+
+	// CAAS related attributes.
+	DesiredScale int    `bson:"scale"`
+	PasswordHash string `bson:"passwordhash"`
+	// Placement is the placement directive that should be used allocating units/pods.
+	Placement string `bson:"placement,omitempty"`
 }
 
 func newApplication(st *State, doc *applicationDoc) *Application {
@@ -1274,12 +1278,20 @@ func (a *Application) Refresh() error {
 	return nil
 }
 
+// GetPlacement returns the application's placement directive.
+// This is used on CAAS models.
+func (a *Application) GetPlacement() string {
+	return a.doc.Placement
+}
+
 // GetScale returns the application's desired scale value.
+// This is used on CAAS models.
 func (a *Application) GetScale() int {
 	return a.doc.DesiredScale
 }
 
 // Scale sets the application's desired scale value.
+// This is used on CAAS models.
 func (a *Application) Scale(scale int) error {
 	if scale < 0 {
 		return errors.NotValidf("application scale %d", scale)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -379,6 +379,7 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"RelationCount",
 		// TODO(caas)
 		"DesiredScale",
+		"Placement",
 	)
 	migrated := set.NewStrings(
 		"Name",

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -40,12 +40,10 @@ func (p environStatePolicy) Prechecker() (environs.InstancePrechecker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if model.Type() != state.ModelTypeIAAS {
-		// Only IAAS models support machines, hence prechecking.
-		return nil, errors.NotImplementedf("Prechecker")
+	if model.Type() == state.ModelTypeIAAS {
+		return p.getEnviron(p.st)
 	}
-	// Environ implements environs.InstancePrechecker.
-	return p.getEnviron(p.st)
+	return p.getBroker(p.st)
 }
 
 // ConfigValidator implements state.Policy.

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -156,6 +156,7 @@ func (w *deploymentWorker) loop() error {
 		serviceParams := &caas.ServiceParams{
 			PodSpec:      spec,
 			Constraints:  info.Constraints,
+			Placement:    info.Placement,
 			ResourceTags: info.Tags,
 			Filesystems:  info.Filesystems,
 			Devices:      info.Devices,

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -85,6 +85,7 @@ containers:
 	expectedServiceParams = &caas.ServiceParams{
 		PodSpec:      &parsedSpec,
 		ResourceTags: map[string]string{"foo": "bar"},
+		Placement:    "placement",
 		Constraints:  constraints.MustParse("mem=4G"),
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
@@ -118,6 +119,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.podSpecGetter.setProvisioningInfo(apicaasunitprovisioner.ProvisioningInfo{
 		PodSpec:     containerSpec,
 		Tags:        map[string]string{"foo": "bar"},
+		Placement:   "placement",
 		Constraints: constraints.MustParse("mem=4G"),
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",


### PR DESCRIPTION
## Description of change

Add placement support for k8s charms. Initially only node selectors are supported since affinity is still in beta.
The k8s tests have also been tweaked to reduce the cut and paste of code.

## QA steps

deploy a k8s charm with placement, eg deploy mariadb-k8s --to kubernetes.io/hostname=host
check the pod is started and the nodeSelector is correctly set

