### PR TITLE
raftlease: Upgrade step to migrate legacy leases into raft store

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo/utils"
@@ -1716,4 +1717,56 @@ func migrateStorageMachineIds(st *State) error {
 		return errors.Trace(st.db().RunTransaction(ops))
 	}
 	return nil
+}
+
+// LegacyLeases returns information about all of the leases in the
+// state-based lease store.
+func LegacyLeases(pool *StatePool, localTime time.Time) (map[corelease.Key]corelease.Info, error) {
+	st := pool.SystemState()
+	reader, err := globalclock.NewReader(globalclock.ReaderConfig{
+		Config: globalclock.Config{
+			Collection: globalClockC,
+			Mongo:      &environMongo{state: st},
+		},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	globalTime, err := reader.Now()
+
+	// This needs to be the raw collection so we see all leases across
+	// models.
+	leaseCollection, closer := st.db().GetRawCollection(leasesC)
+	defer closer()
+	iter := leaseCollection.Find(nil).Iter()
+	results := make(map[corelease.Key]corelease.Info)
+
+	var doc struct {
+		Namespace string        `bson:"namespace"`
+		ModelUUID string        `bson:"model-uuid"`
+		Name      string        `bson:"name"`
+		Holder    string        `bson:"holder"`
+		Start     int64         `bson:"start"`
+		Duration  time.Duration `bson:"duration"`
+	}
+
+	for iter.Next(&doc) {
+		startTime := time.Unix(0, doc.Start)
+		globalExpiry := startTime.Add(doc.Duration)
+		remaining := globalExpiry.Sub(globalTime)
+		localExpiry := localTime.Add(remaining)
+		results[corelease.Key{
+			Namespace: doc.Namespace,
+			ModelUUID: doc.ModelUUID,
+			Lease:     doc.Name,
+		}] = corelease.Info{
+			Holder:   doc.Holder,
+			Expiry:   localExpiry,
+			Trapdoor: corelease.LockedTrapdoor,
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return results, nil
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1755,14 +1755,15 @@ func LegacyLeases(pool *StatePool, localTime time.Time) (map[corelease.Key]corel
 		globalExpiry := startTime.Add(doc.Duration)
 		remaining := globalExpiry.Sub(globalTime)
 		localExpiry := localTime.Add(remaining)
-		results[corelease.Key{
+		key := corelease.Key{
 			Namespace: doc.Namespace,
 			ModelUUID: doc.ModelUUID,
 			Lease:     doc.Name,
-		}] = corelease.Info{
+		}
+		results[key] = corelease.Info{
 			Holder:   doc.Holder,
 			Expiry:   localExpiry,
-			Trapdoor: corelease.LockedTrapdoor,
+			Trapdoor: nil,
 		}
 	}
 	if err := iter.Close(); err != nil {

--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -4,15 +4,22 @@
 package upgrades
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
+	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/replicaset"
 
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/feature"
 	raftworker "github.com/juju/juju/worker/raft"
 )
 
@@ -24,7 +31,7 @@ const jujuMachineKey = "juju-machine-id"
 // being upgraded.
 func BootstrapRaft(context Context) error {
 	agentConfig := context.AgentConfig()
-	storageDir := filepath.Join(agentConfig.DataDir(), "raft")
+	storageDir := raftDir(agentConfig)
 	_, err := os.Stat(storageDir)
 	// If the storage dir already exists we shouldn't run again. (If
 	// we statted the dir successfully, this will return nil.)
@@ -71,6 +78,10 @@ func BootstrapRaft(context Context) error {
 	return errors.Annotate(err, "bootstrapping raft cluster")
 }
 
+func raftDir(agentConfig agent.ConfigSetter) string {
+	return filepath.Join(agentConfig.DataDir(), "raft")
+}
+
 func makeRaftServers(members []replicaset.Member, apiPort int) (raft.Configuration, error) {
 	var empty raft.Configuration
 	var servers []raft.Server
@@ -96,4 +107,167 @@ func makeRaftServers(members []replicaset.Member, apiPort int) (raft.Configurati
 		servers = append(servers, server)
 	}
 	return raft.Configuration{Servers: servers}, nil
+}
+
+// MigrateLegacyLeases converts leases in the legacy store into
+// corresponding ones in the raft store.
+func MigrateLegacyLeases(context Context) error {
+	// We know at this point in time that the raft workers aren't
+	// running - they're all guarded by the upgrade-steps gate.
+
+	// We need to migrate leases if:
+	// * legacy-leases is off,
+	// * there are some legacy leases,
+	// * and there are no snapshots in the snapshot store (which shows
+	//   that the raft-lease store is already in use).
+	st := context.State()
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return errors.Annotate(err, "getting controller config")
+	}
+	if controllerConfig.Features().Contains(feature.LegacyLeases) {
+		logger.Debugf("legacy-leases flag is set, not migrating leases")
+		return nil
+	}
+
+	var zero time.Time
+	legacyLeases, err := st.LegacyLeases(zero)
+	if err != nil {
+		return errors.Annotate(err, "getting legacy leases")
+	}
+	if len(legacyLeases) == 0 {
+		logger.Debugf("no legacy leases to migrate")
+		return nil
+	}
+
+	storageDir := raftDir(context.AgentConfig())
+	snapshotStore, err := raftworker.NewSnapshotStore(
+		storageDir, 2, logger)
+	if err != nil {
+		return errors.Annotate(err, "opening snapshot store")
+	}
+	snapshots, err := snapshotStore.List()
+	if err != nil {
+		return errors.Annotate(err, "listing snapshots")
+	}
+	if len(snapshots) != 0 {
+		logger.Debugf("snapshots found in store - raft leases in use")
+		return nil
+	}
+
+	// We need the last term and index, latest configuration and
+	// configuration index from the log store.
+	logStore, err := raftworker.NewLogStore(storageDir)
+	if err != nil {
+		return errors.Annotate(err, "opening log store")
+	}
+	defer logStore.Close()
+
+	latest, configEntry, err := collectLogEntries(logStore)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	configuration, err := decodeConfiguration(configEntry.Data)
+	if err != nil {
+		return errors.Annotate(err, "decoding configuration")
+	}
+
+	entries := make(map[raftlease.SnapshotKey]raftlease.SnapshotEntry, len(legacyLeases))
+	target := st.LeaseNotifyTarget(ioutil.Discard, logger)
+
+	// Populate the snapshot and the leaseholders collection.
+	for key, info := range legacyLeases {
+		entries[raftlease.SnapshotKey{
+			Namespace: key.Namespace,
+			ModelUUID: key.ModelUUID,
+			Lease:     key.Lease,
+		}] = raftlease.SnapshotEntry{
+			Holder:   info.Holder,
+			Start:    zero,
+			Duration: info.Expiry.Sub(zero),
+		}
+		target.Claimed(key, info.Holder)
+	}
+
+	newSnapshot := raftlease.Snapshot{
+		Version:    raftlease.SnapshotVersion,
+		Entries:    entries,
+		GlobalTime: zero,
+	}
+	// Store the snapshot.
+	_, transport := raft.NewInmemTransport(raft.ServerAddress("notused"))
+	defer transport.Close()
+	sink, err := snapshotStore.Create(
+		raft.SnapshotVersionMax,
+		latest.Index,
+		latest.Term,
+		configuration,
+		configEntry.Index,
+		transport,
+	)
+	if err != nil {
+		return errors.Annotate(err, "creating snapshot sink")
+	}
+	defer sink.Close()
+	err = newSnapshot.Persist(sink)
+	if err != nil {
+		sink.Cancel()
+		return errors.Annotate(err, "persisting snapshot")
+	}
+
+	return nil
+}
+
+// collectLogEntries returns two log entries: the latest one, and the
+// most recent configuration entry. (These might be the same.)
+func collectLogEntries(store raft.LogStore) (*raft.Log, *raft.Log, error) {
+	var latest raft.Log
+
+	lastIndex, err := store.LastIndex()
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "getting last index")
+	}
+
+	if lastIndex == 0 {
+		return nil, nil, errors.Errorf("no log entries, expected at least one for configuration")
+	}
+
+	err = store.GetLog(lastIndex, &latest)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "getting last log entry")
+	}
+
+	if latest.Type == raft.LogConfiguration {
+		return &latest, &latest, nil
+	}
+
+	firstIndex, err := store.FirstIndex()
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "getting first index`")
+	}
+	current := lastIndex
+	for current > firstIndex {
+		current--
+		var entry raft.Log
+		err := store.GetLog(current, &entry)
+		if errors.Cause(err) == raft.ErrLogNotFound {
+			continue
+		} else if err != nil {
+			return nil, nil, errors.Annotatef(err, "getting log index %d", current)
+		}
+		if entry.Type == raft.LogConfiguration {
+			return &latest, &entry, nil
+		}
+	}
+
+	return nil, nil, errors.Errorf("no configuration entry in log")
+}
+
+func decodeConfiguration(data []byte) (raft.Configuration, error) {
+	var hd codec.MsgpackHandle
+	dec := codec.NewDecoder(bytes.NewBuffer(data), &hd)
+	var config raft.Configuration
+	err := dec.Decode(&config)
+	return config, errors.Trace(err)
 }

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -4,8 +4,11 @@
 package upgrades_test
 
 import (
+	"io"
 	"log"
 	"path/filepath"
+	"reflect"
+	"time"
 
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/raft-boltdb"
@@ -15,7 +18,11 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
 	"github.com/juju/juju/state"
+	raftleasestore "github.com/juju/juju/state/raftlease"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 	raftworker "github.com/juju/juju/worker/raft"
@@ -67,7 +74,7 @@ func (s *raftSuite) TestBootstrapRaft(c *gc.C) {
 	checkRaftConfiguration(c, dataDir)
 }
 
-func checkRaftConfiguration(c *gc.C, dataDir string) {
+func withRaft(c *gc.C, dataDir string, fsm raft.FSM, checkFunc func(*raft.Raft)) {
 	// Capture logging to include in test output.
 	output := captureWriter{c}
 	config := raft.DefaultConfig()
@@ -88,7 +95,7 @@ func checkRaftConfiguration(c *gc.C, dataDir string) {
 
 	r, err := raft.NewRaft(
 		config,
-		&raftworker.SimpleFSM{},
+		fsm,
 		logStore,
 		logStore,
 		snapshotStore,
@@ -98,20 +105,133 @@ func checkRaftConfiguration(c *gc.C, dataDir string) {
 	defer func() {
 		c.Assert(r.Shutdown().Error(), jc.ErrorIsNil)
 	}()
+	checkFunc(r)
+}
 
-	rafttest.CheckConfiguration(c, r, []raft.Server{{
-		ID:       "42",
-		Address:  "somewhere.else:1234",
-		Suffrage: raft.Voter,
-	}, {
-		ID:       "23",
-		Address:  "nowhere.else:1234",
-		Suffrage: raft.Voter,
-	}, {
-		ID:       "7",
-		Address:  "everywhere.else:1234",
-		Suffrage: raft.Nonvoter,
-	}})
+func checkRaftConfiguration(c *gc.C, dataDir string) {
+	withRaft(c, dataDir, &raftworker.SimpleFSM{},
+		func(r *raft.Raft) {
+			rafttest.CheckConfiguration(c, r, []raft.Server{{
+				ID:       "42",
+				Address:  "somewhere.else:1234",
+				Suffrage: raft.Voter,
+			}, {
+				ID:       "23",
+				Address:  "nowhere.else:1234",
+				Suffrage: raft.Voter,
+			}, {
+				ID:       "7",
+				Address:  "everywhere.else:1234",
+				Suffrage: raft.Nonvoter,
+			}})
+		},
+	)
+}
+
+func (s *raftSuite) TestMigrateLegacyLeases(c *gc.C) {
+	dataDir := c.MkDir()
+	context := &mockContext{
+		agentConfig: &mockAgentConfig{
+			tag:     names.NewMachineTag("23"),
+			dataDir: dataDir,
+		},
+		state: &mockState{
+			members: []replicaset.Member{{
+				Address: "somewhere.else:37012",
+				Tags:    map[string]string{"juju-machine-id": "42"},
+			}},
+			info: state.StateServingInfo{APIPort: 1234},
+		},
+	}
+	err := upgrades.BootstrapRaft(context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var zero time.Time
+
+	// Now we migrate some leases...
+	config, err := controller.NewConfig(
+		coretesting.ControllerTag.Id(),
+		coretesting.CACert,
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	var target mockTarget
+	context.state = &mockState{
+		config: config,
+		leases: map[lease.Key]lease.Info{
+			{"nonagon", "m1", "gamma"}: {
+				Holder: "knife",
+				Expiry: zero.Add(30 * time.Second),
+			},
+			{"reyne", "m2", "keening"}: {
+				Holder: "jordan",
+				Expiry: zero.Add(45 * time.Second),
+			},
+		},
+		target: &target,
+	}
+
+	err = upgrades.MigrateLegacyLeases(context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	target.assertClaimed(c, map[lease.Key]string{
+		{"nonagon", "m1", "gamma"}: "knife",
+		{"reyne", "m2", "keening"}: "jordan",
+	})
+
+	expectedLeases := context.state.(*mockState).leases
+
+	// Start up raft with the leases in the snapshot.
+	fsm := raftlease.NewFSM()
+	withRaft(c, dataDir, fsm, func(r *raft.Raft) {
+		// Once the snapshot is loaded the leases should be in the
+		// FSM.
+		var leases map[lease.Key]lease.Info
+		for a := coretesting.LongAttempt.Start(); a.Next(); {
+			leases = fsm.Leases(zero)
+			if reflect.DeepEqual(leases, expectedLeases) {
+				return
+			}
+		}
+		c.Assert(leases, gc.DeepEquals, expectedLeases,
+			gc.Commentf("waited %s but didn't see expected leases",
+				coretesting.LongAttempt.Total))
+	})
+
+	// Check that running the step again works, but doesn't migrate
+	// more leases.
+	context.state = &mockState{
+		config: config,
+		leases: map[lease.Key]lease.Info{
+			{"songs", "m3", "ferryman"}: {
+				Holder: "jordan",
+				Expiry: zero.Add(30 * time.Second),
+			},
+		},
+		target: &target,
+	}
+	target.stub.ResetCalls()
+
+	err = upgrades.MigrateLegacyLeases(context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(target.stub.Calls(), gc.HasLen, 0)
+
+	fsm = raftlease.NewFSM()
+	withRaft(c, dataDir, fsm, func(r *raft.Raft) {
+		var leases map[lease.Key]lease.Info
+		for a := coretesting.LongAttempt.Start(); a.Next(); {
+			leases = fsm.Leases(zero)
+			// The leases haven't been updated with the changed one.
+			if reflect.DeepEqual(leases, expectedLeases) {
+				return
+			}
+		}
+		c.Assert(leases, gc.DeepEquals, expectedLeases,
+			gc.Commentf("waited %s but didn't see expected leases",
+				coretesting.LongAttempt.Total))
+	})
+
 }
 
 type mockState struct {
@@ -119,6 +239,9 @@ type mockState struct {
 	stub    testing.Stub
 	members []replicaset.Member
 	info    state.StateServingInfo
+	config  controller.Config
+	leases  map[lease.Key]lease.Info
+	target  *mockTarget
 }
 
 func (s *mockState) ReplicaSetMembers() ([]replicaset.Member, error) {
@@ -127,6 +250,45 @@ func (s *mockState) ReplicaSetMembers() ([]replicaset.Member, error) {
 
 func (s *mockState) StateServingInfo() (state.StateServingInfo, error) {
 	return s.info, s.stub.NextErr()
+}
+
+func (s *mockState) ControllerConfig() (controller.Config, error) {
+	return s.config, s.stub.NextErr()
+}
+
+func (s *mockState) LegacyLeases(localTime time.Time) (map[lease.Key]lease.Info, error) {
+	s.stub.AddCall("LegacyLeases", localTime)
+	return s.leases, s.stub.NextErr()
+}
+
+func (s *mockState) LeaseNotifyTarget(log io.Writer, errorLog raftleasestore.Logger) raftlease.NotifyTarget {
+	s.stub.AddCall("LeaseNotifyTarget", log, errorLog)
+	return s.target
+}
+
+type mockTarget struct {
+	raftlease.NotifyTarget
+	stub testing.Stub
+}
+
+func (t *mockTarget) Claimed(key lease.Key, holder string) {
+	t.stub.AddCall("Claimed", key, holder)
+}
+
+func (t *mockTarget) assertClaimed(c *gc.C, claims map[lease.Key]string) {
+	c.Assert(t.stub.Calls(), gc.HasLen, len(claims))
+	for _, call := range t.stub.Calls() {
+		c.Assert(call.FuncName, gc.Equals, "Claimed")
+		c.Assert(call.Args, gc.HasLen, 2)
+		key, ok := call.Args[0].(lease.Key)
+		c.Assert(ok, gc.Equals, true)
+		holder, ok := call.Args[1].(string)
+		c.Assert(ok, gc.Equals, true)
+		expectedHolder, found := claims[key]
+		c.Assert(found, gc.Equals, true)
+		c.Assert(holder, gc.Equals, expectedHolder)
+		delete(claims, key)
+	}
 }
 
 type captureWriter struct {

--- a/upgrades/steps_25.go
+++ b/upgrades/steps_25.go
@@ -13,5 +13,10 @@ func stateStepsFor25() []Step {
 				return context.State().MigrateStorageMachineIdFields()
 			},
 		},
+		&upgradeStep{
+			description: "migrate legacy leases into raft",
+			targets:     []Target{Controller},
+			run:         MigrateLegacyLeases,
+		},
 	}
 }

--- a/upgrades/steps_25_test.go
+++ b/upgrades/steps_25_test.go
@@ -25,3 +25,9 @@ func (s *steps25Suite) TestMigrateMachineIdField(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps25Suite) TestMigrateLegacyLeases(c *gc.C) {
+	step := findStateStep(c, v25, `migrate legacy leases into raft`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.Controller})
+}


### PR DESCRIPTION
## Description of change

When upgrading from 2.4.x to 2.5, the existing leases in the mongo store need to be copied into the raft store so that unit leadership will be the same after the upgrade. We read the legacy leases from the mongo store and construct a snapshot with those leases in raftlease.FSM format and write that into the raft snapshot store. When the raft nodes start the snapshot is loaded and the lease state matches what it was before the upgrade. We also update the leaseholders collection in mongo so that the DB is consistent.

## QA steps

* Bootstrap a 2.4 controller. 
* Deploy several application with multiple units. 
* Remove the /0 unit for each application so that the leadership isn't the default (just in case).
* Upgrade to 2.5 with this change.
* Application leadership should stay the same across the upgrade.
* Upgrade again to 2.5 to ensure that the upgrade step is idempotent.
