### PR TITLE
Use resource tags to add to labels on deployed pods etc

### DIFF
--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -106,6 +106,7 @@ type OperatorProvisioningInfo struct {
 	ImagePath    string
 	Version      version.Number
 	APIAddresses []string
+	Tags         map[string]string
 	CharmStorage storage.KubernetesFilesystemParams
 }
 
@@ -119,6 +120,7 @@ func (c *Client) OperatorProvisioningInfo() (OperatorProvisioningInfo, error) {
 		ImagePath:    result.ImagePath,
 		Version:      result.Version,
 		APIAddresses: result.APIAddresses,
+		Tags:         result.Tags,
 		CharmStorage: filesystemFromParams(result.CharmStorage),
 	}
 	return info, nil

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -167,11 +167,12 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 			ImagePath:    "juju-operator-image",
 			Version:      vers,
 			APIAddresses: []string{"10.0.0.1:1"},
+			Tags:         map[string]string{"foo": "bar"},
 			CharmStorage: params.KubernetesFilesystemParams{
 				Size:        10,
 				Provider:    "kubernetes",
 				StorageName: "stor",
-				Tags:        map[string]string{"model": "mode-tag"},
+				Tags:        map[string]string{"model": "model-tag"},
 				Attributes:  map[string]interface{}{"key": "value"},
 			},
 		}
@@ -183,11 +184,12 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 		ImagePath:    "juju-operator-image",
 		Version:      vers,
 		APIAddresses: []string{"10.0.0.1:1"},
+		Tags:         map[string]string{"foo": "bar"},
 		CharmStorage: storage.KubernetesFilesystemParams{
 			Size:         10,
 			Provider:     "kubernetes",
 			StorageName:  "stor",
-			ResourceTags: map[string]string{"model": "mode-tag"},
+			ResourceTags: map[string]string{"model": "model-tag"},
 			Attributes:   map[string]interface{}{"key": "value"},
 		},
 	})

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -128,10 +128,16 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 		ImagePath:    fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
+		Tags: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		CharmStorage: params.KubernetesFilesystemParams{
 			Size:       uint64(1024),
 			Provider:   "kubernetes",
 			Attributes: map[string]interface{}{"foo": "bar"},
+			Tags: map[string]string{
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		},
 	})
 }
@@ -144,10 +150,16 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 		ImagePath:    s.st.operatorImage,
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
+		Tags: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		CharmStorage: params.KubernetesFilesystemParams{
 			Size:       uint64(1024),
 			Provider:   "kubernetes",
 			Attributes: map[string]interface{}{"foo": "bar"},
+			Tags: map[string]string{
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		},
 	})
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
@@ -19,6 +20,24 @@ type CAASOperatorProvisionerState interface {
 	FindEntity(tag names.Tag) (state.Entity, error)
 	Addresses() ([]string, error)
 	ModelUUID() string
+	Model() (Model, error)
 	APIHostPortsForAgents() ([][]network.HostPort, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
+}
+
+type Model interface {
+	UUID() string
+	ModelConfig() (*config.Config, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) Model() (Model, error) {
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, err
+	}
+	return model.CAASModel()
 }

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -199,6 +199,9 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 				},
 				Placement:   "placement",
 				Constraints: constraints.MustParse("mem=64G"),
+				Tags: map[string]string{
+					"juju-model-uuid":      coretesting.ModelTag.Id(),
+					"juju-controller-uuid": coretesting.ControllerTag.Id()},
 			},
 		}, {
 			Error: &params.Error{

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -484,6 +484,7 @@ type OperatorProvisioningInfo struct {
 	ImagePath    string                     `json:"image-path"`
 	Version      version.Number             `json:"version"`
 	APIAddresses []string                   `json:"api-addresses"`
+	Tags         map[string]string          `json:"tags,omitempty"`
 	CharmStorage KubernetesFilesystemParams `json:"charm-storage"`
 }
 

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -126,7 +126,7 @@ type Broker interface {
 	DeleteService(appName string) error
 
 	// ExposeService sets up external access to the specified service.
-	ExposeService(appName string, config application.ConfigAttributes) error
+	ExposeService(appName string, resourceTags map[string]string, config application.ConfigAttributes) error
 
 	// UnexposeService removes external access to the specified service.
 	UnexposeService(appName string) error
@@ -220,4 +220,7 @@ type OperatorConfig struct {
 
 	// AgentConf is the contents of the agent.conf file.
 	AgentConf []byte
+
+	// ResourceTags is a set of tags to set on the operator pod.
+	ResourceTags map[string]string
 }

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -429,8 +429,10 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 		caasFirewallerName: ifNotMigrating(caasfirewaller.Manifold(
 			caasfirewaller.ManifoldConfig{
-				APICallerName: apiCallerName,
-				BrokerName:    caasBrokerTrackerName,
+				APICallerName:  apiCallerName,
+				BrokerName:     caasBrokerTrackerName,
+				ControllerUUID: agentConfig.Controller().Id(),
+				ModelUUID:      agentConfig.Model().Id(),
 				NewClient: func(caller base.APICaller) caasfirewaller.Client {
 					return caasfirewallerapi.NewClient(caller)
 				},

--- a/worker/caasfirewaller/broker.go
+++ b/worker/caasfirewaller/broker.go
@@ -6,6 +6,6 @@ package caasfirewaller
 import "github.com/juju/juju/core/application"
 
 type ServiceExposer interface {
-	ExposeService(appName string, config application.ConfigAttributes) error
+	ExposeService(appName string, resourceTags map[string]string, config application.ConfigAttributes) error
 	UnexposeService(appName string) error
 }

--- a/worker/caasfirewaller/manifold.go
+++ b/worker/caasfirewaller/manifold.go
@@ -17,6 +17,9 @@ type ManifoldConfig struct {
 	APICallerName string
 	BrokerName    string
 
+	ControllerUUID string
+	ModelUUID      string
+
 	NewClient func(base.APICaller) Client
 	NewWorker func(Config) (worker.Worker, error)
 }
@@ -34,6 +37,12 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 
 // Validate is called by start to check for bad configuration.
 func (config ManifoldConfig) Validate() error {
+	if config.ControllerUUID == "" {
+		return errors.NotValidf("empty ControllerUUID")
+	}
+	if config.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
 	if config.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
 	}
@@ -67,6 +76,8 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	client := config.NewClient(apiCaller)
 	w, err := config.NewWorker(Config{
+		ControllerUUID:    config.ControllerUUID,
+		ModelUUID:         config.ModelUUID,
 		ApplicationGetter: client,
 		LifeGetter:        client,
 		ServiceExposer:    broker,

--- a/worker/caasfirewaller/mock_test.go
+++ b/worker/caasfirewaller/mock_test.go
@@ -33,8 +33,8 @@ type mockServiceExposer struct {
 	unexposed chan<- struct{}
 }
 
-func (m *mockServiceExposer) ExposeService(appName string, config application.ConfigAttributes) error {
-	m.MethodCall(m, "ExposeService", appName, config)
+func (m *mockServiceExposer) ExposeService(appName string, resourceTags map[string]string, config application.ConfigAttributes) error {
+	m.MethodCall(m, "ExposeService", appName, resourceTags, config)
 	m.exposed <- struct{}{}
 	return m.NextErr()
 }

--- a/worker/caasfirewaller/worker.go
+++ b/worker/caasfirewaller/worker.go
@@ -16,6 +16,8 @@ var logger = loggo.GetLogger("juju.workers.caasfirewaller")
 
 // Config holds configuration for the CAAS unit firewaller worker.
 type Config struct {
+	ControllerUUID    string
+	ModelUUID         string
 	ApplicationGetter ApplicationGetter
 	LifeGetter        LifeGetter
 	ServiceExposer    ServiceExposer
@@ -23,6 +25,12 @@ type Config struct {
 
 // Validate validates the worker configuration.
 func (config Config) Validate() error {
+	if config.ControllerUUID == "" {
+		return errors.NotValidf("missing ControllerUUID")
+	}
+	if config.ModelUUID == "" {
+		return errors.NotValidf("missing ModelUUID")
+	}
 	if config.ApplicationGetter == nil {
 		return errors.NotValidf("missing ApplicationGetter")
 	}
@@ -102,6 +110,8 @@ func (p *firewaller) loop() error {
 					continue
 				}
 				w, err := newApplicationWorker(
+					p.config.ControllerUUID,
+					p.config.ModelUUID,
 					appId,
 					p.config.ApplicationGetter,
 					p.config.ServiceExposer,

--- a/worker/caasfirewaller/worker_test.go
+++ b/worker/caasfirewaller/worker_test.go
@@ -58,6 +58,8 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.config = caasfirewaller.Config{
+		ControllerUUID:    coretesting.ControllerTag.Id(),
+		ModelUUID:         coretesting.ModelTag.Id(),
 		ApplicationGetter: &s.applicationGetter,
 		ServiceExposer:    &s.serviceExposer,
 		LifeGetter:        &s.lifeGetter,
@@ -73,6 +75,14 @@ func (s *WorkerSuite) sendApplicationExposedChange(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
+	s.testValidateConfig(c, func(config *caasfirewaller.Config) {
+		config.ControllerUUID = ""
+	}, `missing ControllerUUID not valid`)
+
+	s.testValidateConfig(c, func(config *caasfirewaller.Config) {
+		config.ModelUUID = ""
+	}, `missing ModelUUID not valid`)
+
 	s.testValidateConfig(c, func(config *caasfirewaller.Config) {
 		config.ApplicationGetter = nil
 	}, `missing ApplicationGetter not valid`)
@@ -137,6 +147,9 @@ func (s *WorkerSuite) TestExposedChange(c *gc.C) {
 	}
 	s.serviceExposer.CheckCallNames(c, "UnexposeService", "ExposeService")
 	s.serviceExposer.CheckCall(c, 1, "ExposeService", "gitlab",
+		map[string]string{
+			"juju-controller-uuid": coretesting.ControllerTag.Id(),
+			"juju-model-uuid":      coretesting.ModelTag.Id()},
 		application.ConfigAttributes{"juju-external-hostname": "exthost"})
 }
 

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -60,6 +60,7 @@ func (m *mockProvisionerFacade) OperatorProvisioningInfo() (apicaasprovisioner.O
 		ImagePath:    "juju-operator-image",
 		Version:      version.MustParse("2.99.0"),
 		APIAddresses: []string{"10.0.0.1:17070", "192.18.1.1:17070"},
+		Tags:         map[string]string{"fred": "mary"},
 		CharmStorage: storage.KubernetesFilesystemParams{
 			Provider:     "kubernetes",
 			Size:         uint64(1024),

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -206,6 +206,7 @@ func (p *provisioner) makeOperatorConfig(appName, password string) (*caas.Operat
 	cfg := &caas.OperatorConfig{
 		OperatorImagePath: info.ImagePath,
 		Version:           info.Version,
+		ResourceTags:      info.Tags,
 		CharmStorage:      charmStorageParams(info.CharmStorage),
 	}
 	// If no password required, we leave the agent conf empty.

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -105,6 +105,7 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists bool) {
 	config := args[2].(*caas.OperatorConfig)
 	c.Assert(config.OperatorImagePath, gc.Equals, "juju-operator-image")
 	c.Assert(config.Version, gc.Equals, version.MustParse("2.99.0"))
+	c.Assert(config.ResourceTags, jc.DeepEquals, map[string]string{"fred": "mary"})
 	c.Assert(config.CharmStorage, jc.DeepEquals, caas.CharmStorageParams{
 		Provider:     "kubernetes",
 		Size:         uint64(1024),


### PR DESCRIPTION
## Description of change

Add the content of the juju resource tags to the labels on pods, secrets, and other resources created in k8s. This mirrors the functionality for cloud based models.

Also, remove code which used a deployment controller for the operator as that's no longer supported.

## QA steps

deploy a k8s model
add some resource tags
deploy a k8s charm
inspect the pods and see that the labels are correctly set

