### PR TITLE
Local Charm lxdprofile validation

### DIFF
--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -38,12 +38,13 @@ func (c *Client) IsMetered(charmURL string) (bool, error) {
 
 // CharmInfo holds information about a charm.
 type CharmInfo struct {
-	Revision int
-	URL      string
-	Config   *charm.Config
-	Meta     *charm.Meta
-	Actions  *charm.Actions
-	Metrics  *charm.Metrics
+	Revision   int
+	URL        string
+	Config     *charm.Config
+	Meta       *charm.Meta
+	Actions    *charm.Actions
+	Metrics    *charm.Metrics
+	LXDProfile *charm.LXDProfile
 }
 
 // CharmInfo returns information about the requested charm.
@@ -58,12 +59,13 @@ func (c *Client) CharmInfo(charmURL string) (*CharmInfo, error) {
 		return nil, errors.Trace(err)
 	}
 	result := &CharmInfo{
-		Revision: info.Revision,
-		URL:      info.URL,
-		Config:   convertCharmConfig(info.Config),
-		Meta:     meta,
-		Actions:  convertCharmActions(info.Actions),
-		Metrics:  convertCharmMetrics(info.Metrics),
+		Revision:   info.Revision,
+		URL:        info.URL,
+		Config:     convertCharmConfig(info.Config),
+		Meta:       meta,
+		Actions:    convertCharmActions(info.Actions),
+		Metrics:    convertCharmMetrics(info.Metrics),
+		LXDProfile: convertCharmLXDProfile(info.LXDProfile),
 	}
 	return result, nil
 }
@@ -282,6 +284,37 @@ func convertCharmExtraBindingMap(bindings map[string]string) map[string]charm.Ex
 	result := make(map[string]charm.ExtraBinding)
 	for key, value := range bindings {
 		result[key] = charm.ExtraBinding{value}
+	}
+	return result
+}
+
+func convertCharmLXDProfile(lxdProfile *params.CharmLXDProfile) *charm.LXDProfile {
+	if lxdProfile == nil {
+		return nil
+	}
+	return &charm.LXDProfile{
+		Description: lxdProfile.Description,
+		Config:      convertCharmLXDProfileConfigMap(lxdProfile.Config),
+		Devices:     convertCharmLXDProfileDevicesMap(lxdProfile.Devices),
+	}
+}
+
+func convertCharmLXDProfileConfigMap(config map[string]string) map[string]string {
+	result := make(map[string]string, len(config))
+	for k, v := range config {
+		result[k] = v
+	}
+	return result
+}
+
+func convertCharmLXDProfileDevicesMap(devices map[string]map[string]string) map[string]map[string]string {
+	result := make(map[string]map[string]string, len(devices))
+	for k, v := range devices {
+		nested := make(map[string]string, len(v))
+		for nk, nv := range v {
+			nested[nk] = nv
+		}
+		result[k] = nested
 	}
 	return result
 }

--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -50,8 +50,8 @@ type CharmInfo struct {
 // CharmInfo returns information about the requested charm.
 func (c *Client) CharmInfo(charmURL string) (*CharmInfo, error) {
 	args := params.CharmURL{URL: charmURL}
-	info := new(params.CharmInfo)
-	if err := c.facade.FacadeCall("CharmInfo", args, info); err != nil {
+	var info params.CharmInfo
+	if err := c.facade.FacadeCall("CharmInfo", args, &info); err != nil {
 		return nil, errors.Trace(err)
 	}
 	meta, err := convertCharmMeta(info.Meta)

--- a/api/charms/export_test.go
+++ b/api/charms/export_test.go
@@ -1,0 +1,7 @@
+package charms
+
+import "github.com/juju/juju/api/base"
+
+func NewClientWithFacade(facade base.FacadeCaller) *Client {
+	return &Client{facade: facade}
+}

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -126,12 +126,13 @@ type CharmMeta struct {
 // CharmInfo holds all the charm data that the client needs.
 // To be honest, it probably returns way more than what is actually needed.
 type CharmInfo struct {
-	Revision int                    `json:"revision"`
-	URL      string                 `json:"url"`
-	Config   map[string]CharmOption `json:"config"`
-	Meta     *CharmMeta             `json:"meta,omitempty"`
-	Actions  *CharmActions          `json:"actions,omitempty"`
-	Metrics  *CharmMetrics          `json:"metrics,omitempty"`
+	Revision   int                    `json:"revision"`
+	URL        string                 `json:"url"`
+	Config     map[string]CharmOption `json:"config"`
+	Meta       *CharmMeta             `json:"meta,omitempty"`
+	Actions    *CharmActions          `json:"actions,omitempty"`
+	Metrics    *CharmMetrics          `json:"metrics,omitempty"`
+	LXDProfile *CharmLXDProfile       `json:"lxd-profile,omitempty"`
 }
 
 // CharmActions mirrors charm.Actions.
@@ -160,4 +161,11 @@ type CharmPlan struct {
 type CharmMetrics struct {
 	Metrics map[string]CharmMetric `json:"metrics"`
 	Plan    CharmPlan              `json:"plan"`
+}
+
+// CharmLXDProfile mirrors charm.LXDProfile
+type CharmLXDProfile struct {
+	Config      map[string]string            `json:"config"`
+	Description string                       `json:"description"`
+	Devices     map[string]map[string]string `json:"devices"`
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1127,9 +1127,11 @@ func (c *DeployCommand) validateCharmLXDProfile(ch charm.Charm) error {
 }
 
 func (c *DeployCommand) validateCharmInfoLXDProfile(info *apicharms.CharmInfo) error {
-	if profile := info.LXDProfile; profile != nil {
-		err := profile.ValidateConfigDevices()
-		return errors.Trace(err)
+	if featureflag.Enabled(feature.LXDProfile) {
+		if profile := info.LXDProfile; profile != nil {
+			err := profile.ValidateConfigDevices()
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -858,6 +858,13 @@ func (c *DeployCommand) deployCharm(
 		applicationName = charmInfo.Meta.Name
 	}
 
+	// LXDProfile validation
+	if profile := charmInfo.LXDProfile; profile != nil {
+		if err := profile.ValidateConfigDevices(); err != nil {
+			return err
+		}
+	}
+
 	// Process the --config args.
 	// We may have a single file arg specified, in which case
 	// it points to a YAML file keyed on the charm name and

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -414,6 +414,12 @@ func (s *DeploySuite) TestLXDProfileLocalCharm(c *gc.C) {
 	s.AssertApplication(c, "lxd-profile", curl, 1, 0)
 }
 
+func (s *DeploySuite) TestLXDProfileLocalCharmFails(c *gc.C) {
+	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile-fail")
+	err := runDeploy(c, path)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, `invalid lxd-profile.yaml: contains device type "unix-disk"`)
+}
+
 // TODO(ericsnow) Add tests for charmstore-based resources once the
 // endpoints are implemented.
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/storage/poolmanager"
@@ -30,6 +31,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charmrepo.v3"
@@ -54,6 +56,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/juju/version"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -407,16 +410,26 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 }
 
 func (s *DeploySuite) TestLXDProfileLocalCharm(c *gc.C) {
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile")
-	err := runDeploy(c, path)
+	err = runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:bionic/lxd-profile-0")
 	s.AssertApplication(c, "lxd-profile", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestLXDProfileLocalCharmFails(c *gc.C) {
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile-fail")
-	err := runDeploy(c, path)
+	err = runDeploy(c, path)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, `invalid lxd-profile.yaml: contains device type "unix-disk"`)
 }
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -406,6 +406,14 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 	})
 }
 
+func (s *DeploySuite) TestLXDProfileLocalCharm(c *gc.C) {
+	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile")
+	err := runDeploy(c, path)
+	c.Assert(err, jc.ErrorIsNil)
+	curl := charm.MustParseURL("local:bionic/lxd-profile-0")
+	s.AssertApplication(c, "lxd-profile", curl, 1, 0)
+}
+
 // TODO(ericsnow) Add tests for charmstore-based resources once the
 // endpoints are implemented.
 

--- a/state/charm.go
+++ b/state/charm.go
@@ -126,7 +126,7 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 	if featureflag.Enabled(feature.LXDProfile) {
 		lpc, ok := info.Charm.(charm.LXDProfiler)
 		if !ok {
-			return nil, errors.New("charm does no implment LXDProfiler")
+			return nil, errors.New("charm does no implement LXDProfiler")
 		}
 		doc.LXDProfile = safeLXDProfile(lpc.LXDProfile())
 	}
@@ -226,18 +226,12 @@ func updateCharmOps(mb modelBackend, info CharmInfo, assert bson.D) ([]txn.Op, e
 	}
 	op.Assert = append(lifeAssert, assert...)
 
-	var lxdProfile *charm.LXDProfile
-	if profiler, ok := info.Charm.(charm.LXDProfiler); ok {
-		lxdProfile = profiler.LXDProfile()
-	}
-
 	data := bson.D{
 		{"charm-version", info.Version},
 		{"meta", info.Charm.Meta()},
 		{"config", safeConfig(info.Charm)},
 		{"actions", info.Charm.Actions()},
 		{"metrics", info.Charm.Metrics()},
-		{"lxd-profile", safeLXDProfile(lxdProfile)},
 		{"storagepath", info.StoragePath},
 		{"bundlesha256", info.SHA256},
 		{"pendingupload", false},

--- a/state/charm.go
+++ b/state/charm.go
@@ -107,8 +107,10 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 	}
 
 	var lxdProfile *charm.LXDProfile
-	if profiler, ok := info.Charm.(charm.LXDProfiler); ok {
-		lxdProfile = profiler.LXDProfile()
+	if featureflag.Enabled(feature.LXDProfile) {
+		if profiler, ok := info.Charm.(charm.LXDProfiler); ok {
+			lxdProfile = profiler.LXDProfile()
+		}
 	}
 
 	doc := charmDoc{

--- a/state/charm.go
+++ b/state/charm.go
@@ -106,13 +106,6 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 		return nil, errors.New("*charm.URL was nil")
 	}
 
-	var lxdProfile *charm.LXDProfile
-	if featureflag.Enabled(feature.LXDProfile) {
-		if profiler, ok := info.Charm.(charm.LXDProfiler); ok {
-			lxdProfile = profiler.LXDProfile()
-		}
-	}
-
 	doc := charmDoc{
 		DocID:        info.ID.String(),
 		URL:          info.ID,
@@ -121,7 +114,6 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 		Config:       safeConfig(info.Charm),
 		Metrics:      info.Charm.Metrics(),
 		Actions:      info.Charm.Actions(),
-		LXDProfile:   safeLXDProfile(lxdProfile),
 		BundleSha256: info.SHA256,
 		StoragePath:  info.StoragePath,
 	}

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -100,6 +100,12 @@ func (s *ConnSuite) AddActionsCharm(c *gc.C, name, actionsYaml string, revision 
 	return state.AddCustomCharm(c, s.State, name, "actions.yaml", actionsYaml, "quantal", revision)
 }
 
+// AddLXDProfileCharm clones a testing charm, replaces its lxd profile schema with
+// the given YAML, and adds it to the state, using the given revision.
+func (s *ConnSuite) AddLXDProfileCharm(c *gc.C, name, lxdProfileYaml string, revision int) *state.Charm {
+	return state.AddCustomCharm(c, s.State, name, "lxd-profile.yaml", lxdProfileYaml, "quantal", revision)
+}
+
 // AddMetaCharm clones a testing charm, replaces its metadata with the
 // given YAML string and adds it to the state, using the given revision.
 func (s *ConnSuite) AddMetaCharm(c *gc.C, name, metaYaml string, revision int) *state.Charm {

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -100,7 +100,7 @@ func (s *ConnSuite) AddActionsCharm(c *gc.C, name, actionsYaml string, revision 
 	return state.AddCustomCharm(c, s.State, name, "actions.yaml", actionsYaml, "quantal", revision)
 }
 
-// AddLXDProfileCharm clones a testing charm, replaces its lxd profile schema with
+// AddLXDProfileCharm clones a testing charm, replaces its lxd profile config with
 // the given YAML, and adds it to the state, using the given revision.
 func (s *ConnSuite) AddLXDProfileCharm(c *gc.C, name, lxdProfileYaml string, revision int) *state.Charm {
 	return state.AddCustomCharm(c, s.State, name, "lxd-profile.yaml", lxdProfileYaml, "quantal", revision)


### PR DESCRIPTION
## Description of change

The following allows the validation of a LXDProfile against a local
deployment of a charm.

## QA steps

```
juju boostrap localhost lxd
JUJU_DEV_FEATURE_FLAGS=lxd-profile juju deploy --debug ./testcharms/charm-repo/quantal/lxd-profile 
```

Failure case:

```
juju boostrap localhost lxd
JUJU_DEV_FEATURE_FLAGS=lxd-profile juju deploy --debug ./testcharms/charm-repo/quantal/lxd-profile-fail
```

## Documentation changes

The following changes prevents charms from being deployed with invalid profile yamls.

## Bug reference

N/A
