### PR TITLE
No longer copy across public-clouds from cloud-city to JUJU_DATA

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -223,11 +223,6 @@ class JujuData:
             shutil.rmtree(home_path)
         os.makedirs(home_path)
         self.dump_yaml(home_path)
-        # For extention: Add all files carried over to the list.
-        for file_name in ['public-clouds.yaml']:
-            src_path = os.path.join(juju_home, file_name)
-            with skip_on_missing_file():
-                shutil.copy(src_path, home_path)
         yield home_path
 
     def update_config(self, new_config):


### PR DESCRIPTION
## Description of change

Functional tests would copy a public-clouds.yaml across the to the created JUJU_DATA (for some unknown reasons).
This would override the actually up-to-date clouds compiled within the juju under test.