### PR TITLE
Fixes win failure in cmd/juju/cloud.

### DIFF
--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -803,7 +803,7 @@ func (*addSuite) TestInteractiveOpenstackCloudCertReadFailRetry(c *gc.C) {
 		fakeCertFilename,
 		input,
 		fmt.Sprintf("Successfully read CA Certificate from %s\n", fakeCertFilename),
-		fmt.Sprintf("Can't validate CA Certificate file: open %s: no such file or directory", invalidCertFilename),
+		fmt.Sprintf("Can't validate CA Certificate file: open %s:", invalidCertFilename),
 	)
 }
 


### PR DESCRIPTION
## Description of change

We check for an exact error message wording. However, different OS word their errors differently.
This PR fixes the error message comparison when looking for a file while adding a cloud.

Failure seen in
http://10.125.0.203:8080/view/Unit%20tests/job/RunUnittests-win2012/lastCompletedBuild/testReport/github/com_juju_juju_cmd_juju_cloud/TestPackage/
