### PR TITLE
New Interfaces for Pinning Leadership

### DIFF
--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -38,6 +38,19 @@ type Claimer interface {
 	BlockUntilLeadershipReleased(applicationId string, cancel <-chan struct{}) (err error)
 }
 
+// Pinner describes methods used to manage suspension of application leadership
+// expiry.
+type Pinner interface {
+
+	// PinLeadership ensures that until "unpinned", the leadership of the input
+	// application will not change.
+	PinLeadership(applicationId string) error
+
+	// UnpinLeadership reverses the PinLeadership operation, restoring the
+	// usual leadership expiry behaviour for input the application.
+	UnpinLeadership(applicationId string) error
+}
+
 // Token represents a unit's leadership of its application.
 type Token interface {
 

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -43,7 +43,7 @@ type Claimer interface {
 type Pinner interface {
 
 	// PinLeadership ensures that until "unpinned", the leadership of the input
-	// application will not change.
+	// application will not expire.
 	PinLeadership(applicationId string) error
 
 	// UnpinLeadership reverses the PinLeadership operation, restoring the

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -46,6 +46,20 @@ type Claimer interface {
 	WaitUntilExpired(leaseName string, cancel <-chan struct{}) error
 }
 
+// Pinner describes methods used to manage suspension of lease expiry.
+type Pinner interface {
+
+	// Pin ensures that the current holder of input lease name will not loose
+	// the lease to expiry until Unpin is called for the same lease name.
+	// If there is no current holder of the lease, the next claimant will be
+	// the recipient of the pin behaviour.
+	Pin(leaseName string) error
+
+	// Unpin ensures that the current or future holders of the input lease name
+	// are subject to normal lease expiry behaviour.
+	Unpin(leaseName string) error
+}
+
 // Checker exposes facts about lease ownership.
 type Checker interface {
 

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -49,7 +49,7 @@ type Claimer interface {
 // Pinner describes methods used to manage suspension of lease expiry.
 type Pinner interface {
 
-	// Pin ensures that the current holder of input lease name will not loose
+	// Pin ensures that the current holder of input lease name will not lose
 	// the lease to expiry until Unpin is called for the same lease name.
 	// If there is no current holder of the lease, the next claimant will be
 	// the recipient of the pin behaviour.


### PR DESCRIPTION
## Description of change

This patch adds new interfaces that describe methods used for pinning leadership through lease management.

## QA steps

N/A

## Documentation changes

None yet, but the behaviour when implemented will need to be documented for commands that recruit it.

## Bug reference

N/A
