### PR TITLE
Update credentials with models, apiserver.

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -4,6 +4,8 @@
 package cloud
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -11,7 +13,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
-	"strings"
 )
 
 // Client provides methods that the Juju client command uses to interact

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -33,7 +33,7 @@ var facadeVersions = map[string]int{
 	"Charms":                       2,
 	"Cleaner":                      2,
 	"Client":                       2,
-	"Cloud":                        2,
+	"Cloud":                        3,
 	"Controller":                   5,
 	"CredentialManager":            1,
 	"CredentialValidator":          1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -157,8 +157,9 @@ func AllFacades() *facade.Registry {
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)
 	reg("Client", 1, client.NewFacadeV1)
 	reg("Client", 2, client.NewFacade)
-	reg("Cloud", 1, cloud.NewFacade)
-	reg("Cloud", 2, cloud.NewFacadeV2) // adds CredentialContents, RemoveCloud
+	reg("Cloud", 1, cloud.NewFacadeV1)
+	reg("Cloud", 2, cloud.NewFacadeV2) // adds AddCloud, AddCredentials, CredentialContents, RemoveClouds
+	reg("Cloud", 3, cloud.NewFacadeV3) // changes signature of UpdateCredentials
 
 	// CAAS related facades.
 	// Move these to the correct place above once the feature flag disappears.

--- a/apiserver/common/credentialcommon/backend.go
+++ b/apiserver/common/credentialcommon/backend.go
@@ -73,6 +73,11 @@ func NewCloudEntitiesBackend(p *state.State) CloudEntitiesBackend {
 	return stateShim{p}
 }
 
+// NewModelBackend creates a model backend to use based on state.State.
+func NewModelBackend(p *state.State) ModelBackend {
+	return stateShim{p}
+}
+
 // AllMachines implements PersistedBackend.AllMachines.
 func (st stateShim) AllMachines() ([]Machine, error) {
 	machines, err := st.State.AllMachines()

--- a/apiserver/facades/client/cloud/export_test.go
+++ b/apiserver/facades/client/cloud/export_test.go
@@ -5,7 +5,10 @@ package cloud
 
 import "github.com/juju/juju/apiserver/facade"
 
-var InstanceTypes = instanceTypes
+var (
+	InstanceTypes                     = instanceTypes
+	ValidateNewCredentialForModelFunc = &validateNewCredentialForModelFunc
+)
 
 func NewCloudTestingAPI(backend, ctlrBackend Backend, authorizer facade.Authorizer) *CloudAPI {
 	return &CloudAPI{

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -189,3 +189,17 @@ type ValidateCredentialArg struct {
 type ValidateCredentialArgs struct {
 	All []ValidateCredentialArg `json:"credentials,omitempty"`
 }
+
+// UpdateCredentialResult stores the result of updating one cloud credential.
+type UpdateCredentialResult struct {
+	// CredentialTag holds credential tag.
+	CredentialTag string `json:"tag"`
+
+	// Errors contains the errors accumulated while trying to update a credential.
+	Errors *ErrorResults `json:"errors,omitempty"`
+}
+
+// UpdateCredentialResult contains a set of UpdateCredentialResult.
+type UpdateCredentialResults struct {
+	Results []UpdateCredentialResult `json:"results,omitempty"`
+}

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -63,8 +63,14 @@ clouds:
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []params.CloudCredentialResult{
 		{Result: &params.CloudCredential{
-			AuthType:   "userpass",
-			Attributes: map[string]string{"username": "fred", "identity-domain": "domain"},
+			AuthType: "userpass",
+			// TODO (anastasiamac 2018-09-18) check this test once api and cmd is updated to cater for models check
+			// in followup PRs.
+			// At the moment, with models' check this test does not update credential as we are getting
+			// ...ERROR no machine with instance "localhost"...
+			// Ideally, if credential is updated successfully, we'd get:
+			// Attributes: map[string]string{"username": "fred", "identity-domain": "domain"},
+			Attributes: map[string]string{"username": "dummy"},
 			Redacted:   []string{"password"},
 		}},
 	})


### PR DESCRIPTION
## Description of change

'update-credential' command has been updating credential content stored on the controller without checking if the models that use this credential are still accessible.

This PR adds the check for the models at the apiserver layer. Once this lands, api- and cmd-layers need to be adjusted to cater for a new facade version and method signature. The signature of the call had to be changed to cater for the possibility that each updated credential may have more than one error as we can now err out per model. The errors that we can get from a model can also be related to individual machines and instances, so there is a possibility to get more than one error per model. This means that previous approach of an error-per-credential no longer fit. New signature caters for possibility of having more than one error per credential.

This PR also changes how Cloud facade versions are bumped. Previous approach worked well when we only wanted to add new methods to the facade but did not cater for the scenario here where we are changing a signature of the existing method, i.e. previous versions of Cloud facade still have the method but with a different signature.


