### PR TITLE
Fix racy caasoperator test

### DIFF
--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -224,7 +224,14 @@ func (s *WorkerSuite) TestWorkerDownloadsCharm(c *gc.C) {
 		c.Fatal("timed out waiting for application to be watched")
 	}
 
-	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm")
+	// Sometimes loop is fast enough to call Life before we get to
+	// here - just check the first 7 calls match the ones we expect.
+	names := make([]string, 7)
+	calls := s.client.Calls()[:7]
+	for i, call := range calls {
+		names[i] = call.FuncName
+	}
+	c.Assert(names, gc.DeepEquals, []string{"Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm"})
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
 	s.client.CheckCall(c, 2, "SetVersion", "gitlab", version.Binary{
 		Number: jujuversion.Current,


### PR DESCRIPTION
## Description of change

About 1 run in 5 TestWorkerDownloadsCharm fails because there's an extra call to Life in the recorded calls - change the test to only consider the first 7 calls.

[Example of a failure in CI](http://10.125.0.203:8080/job/RunUnittests-amd64/903/testReport/junit/github/com_juju_juju_worker_caasoperator/TestPackage/)

```
PASS: caasoperator_test.go:347: WorkerSuite.TestWatcherFailureStopsWorker	0.004s

----------------------------------------------------------------------
FAIL: caasoperator_test.go:199: WorkerSuite.TestWorkerDownloadsCharm

[LOG] 0:00.000 DEBUG juju.charm charm is not in revision control directory
[LOG] 0:00.008 INFO juju.worker.uniter.charm downloading cs:gitlab-1 from API server
[LOG] 0:00.014 DEBUG juju.worker.uniter.charm preparing to deploy charm "cs:gitlab-1"
[LOG] 0:00.014 DEBUG juju.worker.uniter.charm deploying charm "cs:gitlab-1"
[LOG] 0:00.020 DEBUG juju.worker.uniter.charm finishing deploy of charm "cs:gitlab-1"
[LOG] 0:00.021 INFO juju.worker.caasoperator operator "gitlab" started
[LOG] 0:00.021 DEBUG juju.worker.caasoperator.remotestate got application change
caasoperator_test.go:227:
    s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm")
/workspace/_build/src/github.com/juju/juju/vendor/github.com/juju/testing/stub.go:248:
    return c.Check(funcNames, jc.DeepEquals, expected)
... obtained []string = []string{"Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm", "Life"}
... expected []string = []string{"Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm"}
... mismatch at top level: length mismatch, 8 vs 7; obtained []string{"Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm", "Life"}; expected []string{"Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm"}


----------------------------------------------------------------------
PASS: caasoperator_test.go:338: WorkerSuite.TestWorkerSetsStatus	0.017s
``` 

## QA steps

Ran the updated test under stress-race for a longish time with no failures.
