### PR TITLE
Add some synchronisation points for the JujuConnSuite.

### DIFF
--- a/state/watcher/export_text.go
+++ b/state/watcher/export_text.go
@@ -20,6 +20,6 @@ func NewTestWatcher(changelog *mgo.Collection, iteratorFunc func() mongo.Iterato
 	return newWatcher(changelog, iteratorFunc)
 }
 
-func NewTestHubWatcher(hub HubSource, logger Logger) (*HubWatcher, <-chan struct{}) {
-	return newHubWatcher(hub, logger)
+func NewTestHubWatcher(hub HubSource, clock Clock, modelUUID string, logger Logger) (*HubWatcher, <-chan struct{}) {
+	return newHubWatcher(hub, clock, modelUUID, logger)
 }

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -6,6 +6,7 @@ package watcher_test
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	jc "github.com/juju/testing/checkers"
@@ -36,7 +37,7 @@ func (s *HubWatcherSuite) SetUpTest(c *gc.C) {
 	s.hub = pubsub.NewSimpleHub(nil)
 	s.ch = make(chan watcher.Change)
 	var started <-chan struct{}
-	s.w, started = watcher.NewTestHubWatcher(s.hub, logger)
+	s.w, started = watcher.NewTestHubWatcher(s.hub, clock.WallClock, "model-uuid", logger)
 	s.AddCleanup(func(c *gc.C) {
 		worker.Stop(s.w)
 	})

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -74,10 +75,13 @@ func (s *TxnWatcherSuite) advanceTime(c *gc.C, d time.Duration) {
 
 func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, *fakeHub) {
 	hub := newFakeHub(c, expect)
+	logger := loggo.GetLogger("test")
+	logger.SetLogLevel(loggo.TRACE)
 	w, err := watcher.NewTxnWatcher(watcher.TxnWatcherConfig{
 		ChangeLog: s.log,
 		Hub:       hub,
 		Clock:     s.clock,
+		Logger:    logger,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// Wait for the main loop to have started.

--- a/state/workers.go
+++ b/state/workers.go
@@ -56,7 +56,12 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 		})
 	} else {
 		ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
-			return watcher.NewHubWatcher(hub, loggo.GetLogger("juju.state.watcher")), nil
+			return watcher.NewHubWatcher(watcher.HubWatcherConfig{
+				Hub:       hub,
+				Clock:     st.clock(),
+				ModelUUID: st.modelUUID(),
+				Logger:    loggo.GetLogger("juju.state.watcher"),
+			})
 		})
 	}
 	ws.StartWorker(presenceWorker, func() (worker.Worker, error) {


### PR DESCRIPTION
Since the JujuConnSuite uses a wall clock to drive the txn poller, the StartSync method now does nothing to the txn poller. There are some tests though that still need to await for txn polling to have been completed before continuing.  This branch adds two different synchronisation methods to the base JujuConnSuite.

`WaitForNextSync` will return when the txn poller has next finished a pass over the txns.logs collection.
`WaitForModelWatchersIdle` waits for all the current watchers on the specified State object for the model to have finished processing any events that had been sent from the txn poller.