### PR TITLE
Network Health Acceptance Tests Network Binding for MAAS

### DIFF
--- a/acceptancetests/repository/network-health-2-machines-bind.yaml
+++ b/acceptancetests/repository/network-health-2-machines-bind.yaml
@@ -1,10 +1,10 @@
 # network-health-2-machines:
 machines:
   '0':
-    series: bionic
+    series: xenial
   '1':
-    series: bionic
-series: bionic
+    series: xenial
+series: xenial
 services:
   dummy-source-a:
     charm: ~juju-qa/dummy-source

--- a/acceptancetests/repository/network-health-2-machines-bind.yaml
+++ b/acceptancetests/repository/network-health-2-machines-bind.yaml
@@ -1,0 +1,84 @@
+# network-health-2-machines:
+machines:
+  '0':
+    series: bionic
+  '1':
+    series: bionic
+series: bionic
+services:
+  dummy-source-a:
+    charm: ~juju-qa/dummy-source
+    num_units: 1
+    expose: false
+    options:
+      token: 'true'
+    to:
+    - '0'
+  dummy-source-b:
+    charm: ~juju-qa/dummy-source
+    num_units: 1
+    expose: false
+    options:
+      token: 'true'
+    to:
+    - lxd:0
+    bindings:
+      "": space-0
+  dummy-source-c:
+    charm: ~juju-qa/dummy-source
+    num_units: 1
+    expose: false
+    options:
+      token: 'true'
+    to:
+    - lxd:1
+    bindings:
+      "": space-0
+  dummy-sink-a:
+    charm: ~juju-qa/dummy-sink
+    num_units: 1
+    expose: false
+    options:
+      token: 'true'
+    to:
+    - lxd:0
+    bindings:
+      "": space-0
+  dummy-sink-b:
+    charm: ~juju-qa/dummy-sink
+    num_units: 1
+    expose: false
+    options:
+      token: 'true'
+    to:
+    - '1'
+    bindings:
+      "": space-0
+  dummy-sink-c:
+    charm: ~juju-qa/dummy-sink
+    num_units: 1
+    expose: false
+    options:
+      token: 'true'
+    to:
+    - lxd:1
+    bindings:
+      "": space-0
+  dummy-subordinate:
+    charm: ~juju-qa/dummy-subordinate
+    expose: false
+    options:
+      token: 'true'
+relations:
+- - dummy-source-a
+  - dummy-sink-b
+- - dummy-source-b
+  - dummy-sink-a
+- - dummy-source-b
+  - dummy-sink-c
+- - dummy-source-c
+  - dummy-sink-a
+- - dummy-subordinate
+  - dummy-sink-b
+- - dummy-subordinate
+  - dummy-sink-c

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -36,3 +36,4 @@ ipaddress>=1.0.16
 python-novaclient>=6.0.2
 pyOpenSSL>=17.5.0
 boto3>=1.5.18
+pyaml>=17.12.1


### PR DESCRIPTION
## Description of change

This patch adds a new bundle for use by MAAS network health acceptance tests. This bundle includes bindings intended to select the correct network space on the _finfolk_ MAAS environment.

It is intended for use with a corresponding change to the Jenkins job definition.

Includes an additional Python dependency for YAML.

## QA steps

Running the test using this bundle deploys without space errors.

## Documentation changes

None

## Bug reference

N/A
