### PR TITLE
Make sure we don't ignore the error

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1448,7 +1448,7 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 		// We check this first before possibly suggesting --force.
 		if err == nil {
 			if err2 := c.validateCharmSeries(series); err2 != nil {
-				return errors.Trace(err)
+				return errors.Trace(err2)
 			}
 		}
 


### PR DESCRIPTION
## Description of change

This is a drive by fix, whilst creating another PR (to follow)

The following just makes sure that we highlight the error when we
validate the series when deploying. As the err in here would be
nil, so err2 should be outputted instead of a nil err.

## QA steps

N/A
