### PR TITLE
Idle uniter based on remote upgrade status alone.

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -557,13 +557,6 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 	}
 }
 
-// [TODO] externalreality: upgradeSeriesStatusChanged makes two remote calls,
-// one for each type of state. Perhaps we should make one call collect both.
-// However, the remote state watcher is only ever interested in at most one of
-// the states at a time(basically only one of the states should ever update when
-// this function is called). Is it worth keeping track of which one is of
-// interest instead of checking for both?
-
 // upgradeSeriesStatusChanged is called when the remote status of a series
 // upgrade changes.
 func (w *RemoteStateWatcher) upgradeSeriesStatusChanged() error {

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -56,8 +56,7 @@ func (s *uniterResolver) NextOp(
 	// state) then the uniter should idle in the face of all remote state
 	// changes accept for those which indicate termination - the unit is
 	// waiting to be shutdown.
-	if localState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareCompleted &&
-		remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareCompleted {
+	if remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareCompleted {
 		return nil, resolver.ErrNoOperation
 	}
 
@@ -236,7 +235,6 @@ func (s *uniterResolver) nextOp(
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
-
 	switch remoteState.Life {
 	case params.Alive:
 	case params.Dying:

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -204,9 +204,9 @@ func (s *iaasResolverSuite) TestRunsOperationToResetLocalUpgradeSeriesStateWhenC
 	c.Assert(op.String(), gc.Equals, "complete upgrade series")
 }
 
-func (s *iaasResolverSuite) TestUpgradeSeriesStatusIdlesUniterOnUpggradeSeriesCompletion(c *gc.C) {
+func (s *iaasResolverSuite) TestUniterIdlesWhenRemoteStateIsUpgradeSeriesCompleted(c *gc.C) {
 	localState := resolver.LocalState{
-		UpgradeSeriesStatus: model.UpgradeSeriesPrepareCompleted,
+		UpgradeSeriesStatus: model.UpgradeSeriesNotStarted,
 		CharmURL:            s.charmURL,
 		State: operation.State{
 			Kind:      operation.Continue,
@@ -215,13 +215,6 @@ func (s *iaasResolverSuite) TestUpgradeSeriesStatusIdlesUniterOnUpggradeSeriesCo
 	}
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareCompleted
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
-	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-
-	// changing the series would normally fire a config-changed hook but
-	// since the uniter does not respond to state changes after reaching a
-	// UpgradeSeriesStatus of "UpgradeSeriesCompleted" no operation should take place.
-	s.remoteState.Series = "NewSeries"
-	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 


### PR DESCRIPTION
## Description of change

After an invocation of `upgrade-series prepare` the Uniter should idle (not run any subsequent operations) and then shutdown. If the Uniter should start back up before an `upgrade-series complete` command finishes then it should still be in an idle state and not run operations. This was not happening. This patch fixes that.

## Description of change

The Uniter was determining whether to idle based on volatile state. When it started back up that state would be reset and the Uniter would not be in an idle state. The Uniter now idles on persistent state only.

## QA steps

1. Run an upgrade-series prepare command. You should be notified that units are shut down.
2. Restart the units by hand
3. Check the unit logs - no hooks should be run