### PR TITLE
Use charm defined lxd profile when starting lxd machine

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -86,8 +86,9 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine, env environs.Envi
 	// TODO: lxd-profile 2018-09-18
 	// Add withoutControllerSuite.TestProvisioningInfoWithLXDProfile when
 	// lxd profiles added to ProvisioningInfo.
+	var pNames []string
 	if featureflag.Enabled(feature.LXDProfile) {
-		_, err = p.machineLXDProfiles(m, env)
+		pNames, err = p.machineLXDProfiles(m, env)
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot write lxd profiles")
 		}
@@ -121,6 +122,7 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine, env environs.Envi
 		ImageMetadata:     imageMetadata,
 		ControllerConfig:  controllerCfg,
 		CloudInitUserData: env.Config().CloudInitUserData(),
+		CharmLXDProfiles:  pNames,
 	}, nil
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -688,6 +688,7 @@ type ProvisioningInfo struct {
 	EndpointBindings  map[string]string         `json:"endpoint-bindings,omitempty"`
 	ControllerConfig  map[string]interface{}    `json:"controller-config,omitempty"`
 	CloudInitUserData map[string]interface{}    `json:"cloudinit-userdata,omitempty"`
+	CharmLXDProfiles  []string                  `json:"charm-lxd-profiles,omitempty"`
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -92,6 +92,11 @@ type StartInstanceParams struct {
 	// Abort is a channel that will be closed to indicate that the command
 	// should be aborted.
 	Abort <-chan struct{}
+
+	// CharmLXDProfiles is a slice of names of lxd profiles to be used creating
+	// the LXD container, if specified and an LXD container.  The profiles
+	// come from charms deployed on the machine.
+	CharmLXDProfiles []string
 }
 
 // StartInstanceResult holds the result of an

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/jsonschema"
 	"github.com/juju/version"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
@@ -520,4 +521,11 @@ type DefaultConstraintsChecker interface {
 	// ShouldApplyControllerConstraints returns if bootstrapping logic should
 	// use default constraints
 	ShouldApplyControllerConstraints() bool
+}
+
+// LXDProfiler defines an interface for dealing with lxd profiles used to
+// deploy juju machines.
+type LXDProfiler interface {
+	// MaybeWriteLXDProfile, write given LXDProfile to if not already there.
+	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -43,6 +43,7 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
@@ -1842,6 +1843,11 @@ func (*environ) ProviderSpaceInfo(ctx context.ProviderCallContext, space *networ
 // AreSpacesRoutable implements NetworkingEnviron.
 func (*environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
 	return false, nil
+}
+
+// MaybeWriteLXDProfile implements environs.LXDProfiler.
+func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+	return nil
 }
 
 // SSHAddresses implements environs.SSHAddresses.

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -179,7 +179,7 @@ func (env *environ) getContainerSpec(
 	}
 	cSpec := lxd.ContainerSpec{
 		Name:     hostname,
-		Profiles: []string{"default", env.profileName()},
+		Profiles: append([]string{"default", env.profileName()}, args.CharmLXDProfiles...),
 		Image:    image,
 		Config:   make(map[string]string),
 	}

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -227,7 +227,7 @@ func (s *environProfileSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 	)
 
 	env := s.NewEnviron(c, svr, nil)
-	lxdEnv, ok := env.(lxd.LXDProfiler)
+	lxdEnv, ok := env.(environs.LXDProfiler)
 	c.Assert(ok, jc.IsTrue)
 	err := lxdEnv.MaybeWriteLXDProfile("testname", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -52,6 +52,7 @@ type Server interface {
 	CreateProfileWithConfig(string, map[string]string) error
 	GetProfile(string) (*lxdapi.Profile, string, error)
 	HasProfile(string) (bool, error)
+	CreateProfile(post lxdapi.ProfilesPost) (err error)
 	VerifyNetworkDevice(*lxdapi.Profile, string) error
 	EnsureDefaultStorage(*lxdapi.Profile, string) error
 	StorageSupported() bool

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -112,18 +112,6 @@ func (mr *MockServerMockRecorder) CreatePool(arg0, arg1, arg2 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePool", reflect.TypeOf((*MockServer)(nil).CreatePool), arg0, arg1, arg2)
 }
 
-// CreateProfileWithConfig mocks base method
-func (m *MockServer) CreateProfileWithConfig(arg0 string, arg1 map[string]string) error {
-	ret := m.ctrl.Call(m, "CreateProfileWithConfig", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateProfileWithConfig indicates an expected call of CreateProfileWithConfig
-func (mr *MockServerMockRecorder) CreateProfileWithConfig(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfileWithConfig", reflect.TypeOf((*MockServer)(nil).CreateProfileWithConfig), arg0, arg1)
-}
-
 // CreateProfile mocks base method
 func (m *MockServer) CreateProfile(arg0 api.ProfilesPost) error {
 	ret := m.ctrl.Call(m, "CreateProfile", arg0)
@@ -134,6 +122,18 @@ func (m *MockServer) CreateProfile(arg0 api.ProfilesPost) error {
 // CreateProfile indicates an expected call of CreateProfile
 func (mr *MockServerMockRecorder) CreateProfile(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfile", reflect.TypeOf((*MockServer)(nil).CreateProfile), arg0)
+}
+
+// CreateProfileWithConfig mocks base method
+func (m *MockServer) CreateProfileWithConfig(arg0 string, arg1 map[string]string) error {
+	ret := m.ctrl.Call(m, "CreateProfileWithConfig", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateProfileWithConfig indicates an expected call of CreateProfileWithConfig
+func (mr *MockServerMockRecorder) CreateProfileWithConfig(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfileWithConfig", reflect.TypeOf((*MockServer)(nil).CreateProfileWithConfig), arg0, arg1)
 }
 
 // CreateVolume mocks base method

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -124,6 +124,18 @@ func (mr *MockServerMockRecorder) CreateProfileWithConfig(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfileWithConfig", reflect.TypeOf((*MockServer)(nil).CreateProfileWithConfig), arg0, arg1)
 }
 
+// CreateProfile mocks base method
+func (m *MockServer) CreateProfile(arg0 api.ProfilesPost) error {
+	ret := m.ctrl.Call(m, "CreateProfile", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateProfile indicates an expected call of CreateProfile
+func (mr *MockServerMockRecorder) CreateProfile(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfile", reflect.TypeOf((*MockServer)(nil).CreateProfile), arg0)
+}
+
 // CreateVolume mocks base method
 func (m *MockServer) CreateVolume(arg0, arg1 string, arg2 map[string]string) error {
 	ret := m.ctrl.Call(m, "CreateVolume", arg0, arg1, arg2)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -650,6 +650,11 @@ func (conn *StubClient) CreateProfileWithConfig(name string, cfg map[string]stri
 	return conn.NextErr()
 }
 
+func (conn *StubClient) CreateProfile(post api.ProfilesPost) error {
+	conn.AddCall("CreateProfile", post)
+	return conn.NextErr()
+}
+
 func (conn *StubClient) ServerCertificate() string {
 	conn.AddCall("ServerCertificate")
 	return conn.ServerCert

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -710,6 +710,7 @@ func (task *provisionerTask) constructStartInstanceParams(
 		ImageMetadata:     possibleImageMetadata,
 		StatusCallback:    machine.SetInstanceStatus,
 		Abort:             task.catacomb.Dying(),
+		CharmLXDProfiles:  provisioningInfo.CharmLXDProfiles,
 	}
 
 	return startInstanceParams, nil


### PR DESCRIPTION
## Description of change

Use charm defined lxd profile when starting lxd machine

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=lxd-profile
2. juju bootstrap localhost
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile
4. wait for deploy to finish, get container name
4. lxc profile show juju-default-lxd-profile-0-0
profile should exist and be a superset (without comments) as what's in ./testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml, adding name and used_by.  Container name from step above should be listed in used_by.
5. unit should deploy per normal, charm profile is used.

