### PR TITLE
Fix the race in the JujuConnSuite.

### DIFF
--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -119,7 +119,7 @@ type JujuConnSuite struct {
 
 	txnSyncNotify     chan struct{}
 	modelWatcherIdle  chan string
-	modelWatcherMutex sync.Mutex
+	modelWatcherMutex *sync.Mutex
 }
 
 const AdminSecret = "dummy-secret"
@@ -144,6 +144,7 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 
 	s.txnSyncNotify = make(chan struct{})
 	s.modelWatcherIdle = nil
+	s.modelWatcherMutex = &sync.Mutex{}
 	s.PatchValue(&statewatcher.TxnPollNotifyFunc, s.txnNotifyFunc)
 	s.PatchValue(&statewatcher.HubWatcherIdleFunc, s.hubWatcherIdleFunc)
 	s.setUpConn(c)


### PR DESCRIPTION
Latest CI run showed some very weird data races in tests that looked very unrelated to recent changes.

The cause was the addition of the sync.Mutex to the JujuConnSuite. It appears that gocheck is taking a copy of the Suite somewhere. To avoid the data race we make the mutex a pointer and set it in the setup test.