### PR TITLE
Also fix featuretest for metrics.

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -942,38 +942,6 @@ func (s *unitSuite) TestMeterStatusResultError(c *gc.C) {
 	c.Assert(statusInfo, gc.Equals, "")
 }
 
-func (s *unitSuite) TestWatchMeterStatus(c *gc.C) {
-	// This test is really testing the apiserver code, and the
-	// state code, not really the API client.
-	// The watcher gets notified when either the unit meter status
-	// changes, or the metrics manager changes.
-	w, err := s.apiUnit.WatchMeterStatus()
-	wc := watchertest.NewNotifyWatcherC(c, w, s.BackingState.StartSync)
-	defer wc.AssertStops()
-
-	// Initial event.
-	wc.AssertOneChange()
-
-	err = s.wordpressUnit.SetMeterStatus("AMBER", "ok")
-	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertOneChange()
-
-	// Non-change is not reported.
-	err = s.wordpressUnit.SetMeterStatus("AMBER", "ok")
-	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertNoChange()
-
-	mm, err := s.State.MetricsManager()
-	c.Assert(err, jc.ErrorIsNil)
-	err = mm.SetLastSuccessfulSend(time.Now())
-	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertOneChange()
-
-	err = mm.IncrementConsecutiveErrors()
-	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertOneChange()
-}
-
 func (s *unitSuite) TestUpgradeSeriesStatusMultipleReturnsError(c *gc.C) {
 	facadeCaller := testing.StubFacadeCaller{Stub: &coretesting.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {

--- a/featuretests/api_meterstatus_test.go
+++ b/featuretests/api_meterstatus_test.go
@@ -57,10 +57,9 @@ func (s *meterStatusIntegrationSuite) TestWatchMeterStatus(c *gc.C) {
 	wc := watchertest.NewNotifyWatcherC(c, w, s.BackingState.StartSync)
 	defer wc.AssertStops()
 
+	// Initial event.
 	wc.AssertOneChange()
 
-	err = s.unit.SetMeterStatus("GREEN", "ok")
-	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.SetMeterStatus("AMBER", "ok")
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
@@ -74,11 +73,9 @@ func (s *meterStatusIntegrationSuite) TestWatchMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = mm.SetLastSuccessfulSend(time.Now())
 	c.Assert(err, jc.ErrorIsNil)
-	for i := 0; i < 3; i++ {
-		err := mm.IncrementConsecutiveErrors()
-		c.Assert(err, jc.ErrorIsNil)
-	}
-	status := mm.MeterStatus()
-	c.Assert(status.Code, gc.Equals, state.MeterAmber) // Confirm meter status has changed
+	wc.AssertOneChange()
+
+	err = mm.IncrementConsecutiveErrors()
+	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }


### PR DESCRIPTION
The meterstatus watcher was also tested in the featuretests area, which is the right place to do the integration tests. Removed the test from the api uniter test.