### PR TITLE
Add bundleURL annotation to applications deployed from bundles in the charmstore.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -357,11 +357,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:9e1a3f4b4c8767468be887871a2bf2a2103306ab83b10277c3b17c0c6b9a228b"
+  digest = "1:5641f505a7a414a741bad62acaaa089609a14c344ec1205958b5181ea888a0c2"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "735c14e2335ad2d8112482794d69629c0517476c"
+  revision = "3bc35d40e54c9d6436c9eaa69fca228afdef9016"
 
 [[projects]]
   digest = "1:3d4df54c1d5e1be4d7aab3e6e3a3807b4ddbeebd0bf7a87ea363fe41e6aec0ac"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "735c14e2335ad2d8112482794d69629c0517476c"
+  revision = "3bc35d40e54c9d6436c9eaa69fca228afdef9016"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -181,8 +181,9 @@ func getChanges(
 	}
 	changes, err := bundlechanges.FromData(
 		bundlechanges.ChangesConfig{
-			Bundle: data,
-			Logger: loggo.GetLogger("juju.apiserver.bundlechanges"),
+			Bundle:    data,
+			BundleURL: args.BundleURL,
+			Logger:    loggo.GetLogger("juju.apiserver.bundlechanges"),
 		})
 	if err != nil {
 		return results, err

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1107,6 +1107,7 @@ type BundleChangesParams struct {
 	// BundleDataYAML is the YAML-encoded charm bundle data
 	// (see "github.com/juju/charm.BundleData").
 	BundleDataYAML string `json:"yaml"`
+	BundleURL      string
 }
 
 // BundleChangesResults holds results of the Bundle.GetChanges call.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1107,7 +1107,7 @@ type BundleChangesParams struct {
 	// BundleDataYAML is the YAML-encoded charm bundle data
 	// (see "github.com/juju/charm.BundleData").
 	BundleDataYAML string `json:"yaml"`
-	BundleURL      string
+	BundleURL      string `json:"bundleURL"`
 }
 
 // BundleChangesResults holds results of the Bundle.GetChanges call.

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -338,11 +338,16 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 }
 
 func (h *bundleHandler) getChanges() error {
+	bundleURL := ""
+	if h.bundleURL != nil {
+		bundleURL = h.bundleURL.String()
+	}
 	changes, err := bundlechanges.FromData(
 		bundlechanges.ChangesConfig{
-			Bundle: h.data,
-			Model:  h.model,
-			Logger: logger,
+			Bundle:    h.data,
+			BundleURL: bundleURL,
+			Model:     h.model,
+			Logger:    logger,
 		})
 	if err != nil {
 		return errors.Trace(err)
@@ -618,18 +623,6 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	}
 	h.writeAddedResources(resNames2IDs)
 
-	if h.bundleURL == nil {
-		return nil
-	}
-
-	tag := names.NewApplicationTag(p.Application).String()
-	result, err := h.api.SetAnnotation(map[string]map[string]string{tag: {"bundleURL": h.bundleURL.String()}})
-	if err == nil && len(result) > 0 {
-		err = result[0].Error
-	}
-	if err != nil {
-		logger.Debugf("error setting bundleURL annotation for %q: %s", p.Application, err)
-	}
 	return nil
 }
 

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -185,7 +185,8 @@ type bundleHandler struct {
 	// data is the original bundle data that we want to deploy.
 	data *charm.BundleData
 
-	// The bundle URL from the charmstore.
+	// bundleURL is the URL of the bundle when deploying a bundle from the
+	// charmstore, nil otherwise.
 	bundleURL *charm.URL
 
 	// unitStatus reflects the environment status and maps unit names to their
@@ -617,15 +618,18 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	}
 	h.writeAddedResources(resNames2IDs)
 
-	if h.bundleURL != nil {
-		tag := names.NewApplicationTag(p.Application).String()
-		result, err := h.api.SetAnnotation(map[string]map[string]string{tag: {"bundleURL": h.bundleURL.String()}})
-		if err == nil && len(result) > 0 {
-			err = result[0].Error
+	if h.bundleURL == nil {
+		return nil
+	}
+
+	tag := names.NewApplicationTag(p.Application).String()
+	result, err := h.api.SetAnnotation(map[string]map[string]string{tag: {"bundleURL": h.bundleURL.String()}})
+	if err == nil && len(result) > 0 {
+		err = result[0].Error
+		if err != nil {
 			logger.Debugf("error setting bundleURL annotation for %q: %s", p.Application, err)
 		}
 	}
-
 	return nil
 }
 

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -626,9 +626,9 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	result, err := h.api.SetAnnotation(map[string]map[string]string{tag: {"bundleURL": h.bundleURL.String()}})
 	if err == nil && len(result) > 0 {
 		err = result[0].Error
-		if err != nil {
-			logger.Debugf("error setting bundleURL annotation for %q: %s", p.Application, err)
-		}
+	}
+	if err != nil {
+		logger.Debugf("error setting bundleURL annotation for %q: %s", p.Application, err)
 	}
 	return nil
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1061,6 +1061,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSetAnnotations(c *gc.C) {
 	ann, err := s.Model.Annotations(application)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ann, jc.DeepEquals, map[string]string{"bundleURL": "cs:bundle/wordpress-simple-1"})
+	application2, err := s.State.Application("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	ann2, err := s.Model.Annotations(application2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ann2, jc.DeepEquals, map[string]string{"bundleURL": "cs:bundle/wordpress-simple-1"})
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C) {

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -286,8 +286,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 		"Executing changes:\n"+
 		"- upload charm cs:xenial/mysql-42 for series xenial\n"+
 		"- deploy application mysql on xenial using cs:xenial/mysql-42\n"+
+		"- set annotations for mysql\n"+
 		"- upload charm cs:xenial/wordpress-47 for series xenial\n"+
 		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n"+
+		"- set annotations for wordpress\n"+
 		"- add relation wordpress:db - mysql:server\n"+
 		"- add unit mysql/0 to new machine 0\n"+
 		"- add unit wordpress/0 to new machine 1",
@@ -325,8 +327,10 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunTwice(c *gc.C) {
 		"Changes to deploy bundle:\n" +
 		"- upload charm cs:xenial/mysql-42 for series xenial\n" +
 		"- deploy application mysql on xenial using cs:xenial/mysql-42\n" +
+		"- set annotations for mysql\n" +
 		"- upload charm cs:xenial/wordpress-47 for series xenial\n" +
 		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n" +
+		"- set annotations for wordpress\n" +
 		"- add relation wordpress:db - mysql:server\n" +
 		"- add unit mysql/0 to new machine 0\n" +
 		"- add unit wordpress/0 to new machine 1"
@@ -363,8 +367,10 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunExistingModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := "" +
 		"Changes to deploy bundle:\n" +
+		"- set annotations for mysql\n" +
 		"- upload charm cs:xenial/wordpress-47 for series xenial\n" +
 		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n" +
+		"- set annotations for wordpress\n" +
 		"- add relation wordpress:db - mysql:server\n" +
 		"- add unit wordpress/0 to new machine 1"
 

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1050,6 +1050,19 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstraints(c *
 	})
 }
 
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleSetAnnotations(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "xenial/mysql-42", "mysql")
+	testcharms.UploadCharm(c, s.client, "xenial/wordpress-47", "wordpress")
+	testcharms.UploadBundle(c, s.client, "bundle/wordpress-simple-1", "wordpress-simple")
+	err := runDeploy(c, "bundle/wordpress-simple")
+	c.Assert(err, jc.ErrorIsNil)
+	application, err := s.State.Application("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	ann, err := s.Model.Annotations(application)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ann, jc.DeepEquals, map[string]string{"bundleURL": "cs:bundle/wordpress-simple-1"})
+}
+
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C) {
 	_, wpch := testcharms.UploadCharm(c, s.client, "xenial/wordpress-42", "wordpress")
 	testcharms.UploadCharm(c, s.client, "vivid/upgrade-1", "upgrade1")

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -773,6 +773,7 @@ func (c *DeployCommand) deployBundle(
 	ctx *cmd.Context,
 	filePath string,
 	data *charm.BundleData,
+	bundleURL *charm.URL,
 	channel params.Channel,
 	apiRoot DeployAPI,
 	bundleStorage map[string]map[string]storage.Constraints,
@@ -825,6 +826,7 @@ func (c *DeployCommand) deployBundle(
 	if _, err := deployBundle(
 		filePath,
 		data,
+		bundleURL,
 		c.BundleOverlayFile,
 		channel,
 		apiRoot,
@@ -1226,6 +1228,7 @@ func (c *DeployCommand) maybeReadLocalBundle() (deployFn, error) {
 			ctx,
 			bundleDir,
 			bundleData,
+			nil,
 			c.Channel,
 			apiRoot,
 			c.BundleStorage,
@@ -1366,6 +1369,7 @@ func (c *DeployCommand) maybeReadCharmstoreBundleFn(apiRoot DeployAPI) func() (d
 				ctx,
 				"", // filepath
 				data,
+				storeCharmOrBundleURL,
 				channel,
 				apiRoot,
 				c.BundleStorage,

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -425,9 +425,9 @@ be used to override configurations or devices when creating the containers for
 LXD. LXD Profiles are validated against a allow/deny list, using '--force' flag
 can bypass the validation.
 
-Using the '--force' flag for LXD Profiles is not generally recommended when 
-deploying an application; overriding profiles on the container may cause 
-unexpected behavior. 
+Using the '--force' flag for LXD Profiles is not generally recommended when
+deploying an application; overriding profiles on the container may cause
+unexpected behavior.
 
 Local bundles are specified with a direct path to a bundle.yaml file.
 For example:

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1788,6 +1788,16 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		error(nil),
 	)
 
+	fakeAPI.Call("SetAnnotation", map[string]map[string]string{"application-wordpress": {"bundleURL": "cs:bundle/wordpress-simple"}}).Returns(
+		[]params.ErrorResult{},
+		error(nil),
+	)
+
+	fakeAPI.Call("SetAnnotation", map[string]map[string]string{"application-mysql": {"bundleURL": "cs:bundle/wordpress-simple"}}).Returns(
+		[]params.ErrorResult{},
+		error(nil),
+	)
+
 	deployCmd := NewDeployCommandForTest(func() (DeployAPI, error) {
 		return fakeAPI, nil
 	}, nil)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1816,8 +1816,10 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		"Executing changes:\n"+
 		"- upload charm cs:mysql\n"+
 		"- deploy application mysql using cs:mysql\n"+
+		"- set annotations for mysql\n"+
 		"- upload charm cs:wordpress\n"+
 		"- deploy application wordpress using cs:wordpress\n"+
+		"- set annotations for wordpress\n"+
 		"- add relation wordpress:db - mysql:server\n"+
 		"- add unit mysql/0 to new machine 0\n"+
 		"- add unit wordpress/0 to new machine 1\n",


### PR DESCRIPTION
The Juju GUI will group applications together in the inspector that have been deployed via bundles from the charmstore. To do this it relies on an application annotation `bundleURL`. This branch adds that value when a bundle is deployed via the CLI from the charmstore.