### PR TITLE
Fix race in caasoperatorprovisioner test

### DIFF
--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -87,11 +87,12 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists bool) {
 	s.provisionerFacade.applicationsWatcher.changes <- []string{"myapp"}
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		if len(s.caasClient.Calls()) > 0 {
+		if len(s.caasClient.Calls()) == 2 {
 			break
 		}
 	}
 	s.caasClient.CheckCallNames(c, "OperatorExists", "EnsureOperator")
+	c.Assert(s.caasClient.Calls(), gc.HasLen, 2)
 
 	args := s.caasClient.Calls()[0].Args
 	c.Assert(args, gc.HasLen, 1)


### PR DESCRIPTION
## Description of change

Previously the test would wait until there was at least one call on the caasClient stub but then check for two calls. Most of the time the two calls would happen in quick enough succession that the test would pass, but sometimes (especially under load), it would check the calls before the second one was made. 

Change it to wait for two calls - if they never show up it will still fail in the same way. Also add an assertion on the Calls() length to avoid the test panicking (since the CheckCallNames doesn't stop it).

## QA steps

Reran under stress-race with other load on the machine, didn't see the failure again.
