### PR TITLE
Fix uniter apiserver facade intermittent test failure.

### DIFF
--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1074,7 +1074,7 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 	}}
 
-	s.State.StartSync()
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	results, err := s.uniter.WatchActionNotifications(args)
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
Same as other places. StartSync now does nothing on the JujuConnSuite, so we call the other method added for synchronisation.