### PR TITLE
Remove intermittently failing test and test case explicitly at lower …

### DIFF
--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -101,6 +101,6 @@ type LocalState struct {
 	Series string
 
 	// UpgradeSeriesStatus is the current state of any currently running
-	// upgrade series or the empty string if no upgrade series has been started.
+	// upgrade series.
 	UpgradeSeriesStatus model.UpgradeSeriesStatus
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -669,33 +669,6 @@ func (s *UniterSuite) TestUniterSteadyStateUpgradeRetry(c *gc.C) {
 	})
 }
 
-func (s *UniterSuite) TestUniterSteadyStateUpgradeRelations(c *gc.C) {
-	s.runUniterTests(c, []uniterTest{
-		ut(
-			// This test does an add-relation as quickly as possible
-			// after an upgrade-charm, in the hope that the scheduler will
-			// deliver the events in the wrong order. The observed
-			// behaviour should be the same in either case.
-			"ignore unknown relations until upgrade is done",
-			quickStart{},
-			createCharm{
-				revision: 2,
-				customize: func(c *gc.C, ctx *context, path string) {
-					renameRelation(c, path, "db", "db2")
-					hpath := filepath.Join(path, "hooks", "db2-relation-joined")
-					ctx.writeHook(c, hpath, true)
-				},
-			},
-			serveCharm{},
-			upgradeCharm{revision: 2},
-			addRelation{},
-			addRelationUnit{},
-			waitHooks{"upgrade-charm", "config-changed", "db2-relation-joined mysql/0 db2:0"},
-			verifyCharm{revision: 2},
-		),
-	})
-}
-
 func (s *UniterSuite) TestUpdateResourceCausesUpgrade(c *gc.C) {
 	// appendStorageMetadata customises the wordpress charm's metadata,
 	// adding a "wp-content" filesystem store. We do it here rather

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -238,7 +238,7 @@ action-reboot:
 func (ctx *context) matchHooks(c *gc.C) (match bool, overshoot bool) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
-	c.Logf("  actual hooks: %#v", ctx.hooksCompleted)
+	c.Logf("actual hooks: %#v", ctx.hooksCompleted)
 	c.Logf("expected hooks: %#v", ctx.hooks)
 	if len(ctx.hooksCompleted) < len(ctx.hooks) {
 		return false, false


### PR DESCRIPTION
…level.

## Description of change

A test was removed that intentionally flexed two cases in a non-deterministic fashion - one of which fails and should not pass. This test was replaced by a resolver test that specifically tests the correct behavior at a lower level (i.e. in the uniter's resolver tests). 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1778986