### PR TITLE
enhance certificate auth type for k8s

### DIFF
--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	CredAttrUsername = "username"
-	CredAttrPassword = "password"
+	CredAttrUsername      = "username"
+	CredAttrPassword      = "password"
+	CredAttrClientCertificateData = "ClientCertificateData"
+	CredAttrClientKeyData         = "ClientKeyData"
 )
 
 type environProviderCredentials struct{}
@@ -27,6 +29,21 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 			}, {
 				CredAttrPassword, cloud.CredentialAttr{
 					Description: "The password for the specified username.",
+					Hidden:      true,
+				},
+			},
+		},
+		cloud.CertificateAuthType: {
+			{
+				Name: CredAttrClientCertificateData,
+				CredentialAttr: cloud.CredentialAttr{
+					Description: "the kubernetes certificate data",
+				},
+			},
+			{
+				Name: CredAttrClientKeyData,
+				CredentialAttr: cloud.CredentialAttr{
+					Description: "the kubernetes private key data",
 					Hidden:      true,
 				},
 			},

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	CredAttrUsername      = "username"
-	CredAttrPassword      = "password"
+	CredAttrUsername              = "username"
+	CredAttrPassword              = "password"
 	CredAttrClientCertificateData = "ClientCertificateData"
 	CredAttrClientKeyData         = "ClientKeyData"
 )

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -32,7 +32,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "userpass")
+	envtesting.AssertProviderAuthTypes(c, s.provider, "userpass", "certificate")
 }
 
 func (s *credentialsSuite) TestCredentialsValid(c *gc.C) {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -114,8 +114,8 @@ func newK8sConfig(cloudSpec environs.CloudSpec) (*rest.Config, error) {
 		Username: credentialAttrs[CredAttrUsername],
 		Password: credentialAttrs[CredAttrPassword],
 		TLSClientConfig: rest.TLSClientConfig{
-			CertData: []byte(credentialAttrs["ClientCertificateData"]),
-			KeyData:  []byte(credentialAttrs["ClientKeyData"]),
+			CertData: []byte(credentialAttrs[CredAttrClientCertificateData]),
+			KeyData:  []byte(credentialAttrs[CredAttrClientKeyData]),
 			CAData:   CAData,
 		},
 	}, nil

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -114,7 +114,7 @@ func validateCloudSpec(spec environs.CloudSpec) error {
 	if spec.Credential == nil {
 		return errors.NotValidf("missing credential")
 	}
-	if authType := spec.Credential.AuthType(); authType != cloud.UserPassAuthType {
+	if authType := spec.Credential.AuthType(); authType != cloud.UserPassAuthType && authType != cloud.CertificateAuthType {
 		return errors.NotSupportedf("%q auth-type", authType)
 	}
 	return nil


### PR DESCRIPTION
## Description of change

- Enhance k8s credentials of `ClientData` auth type

## QA steps

- prepare a kubeconfig file with `clientKey` auth type

```bash
gcloud config set container/use_client_certificate True
gcloud container clusters get-credentials <cluster-name> --zone <zone>

gcloud config set container/use_client_certificate False
gcloud container clusters get-credentials <cluster-name> --zone <zone>

kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account) --user client  --context <cluster-context-name>

gcloud config set container/use_client_certificate True
gcloud container clusters get-credentials <cluster-name> --zone <zone>
```

- add ur cluster using add-k8s

```bash
kubectl config view --raw | juju add-k8s <your-cloud-name> --cluster-name=<ur-cluster-name>
```
- add k8s model to the cloud

```bash
juju add-model <your-k8s-model> <your-cloud-name>
```
- ensure storage pool for operator pod
```bash
juju create-storage-pool operator-storage kubernetes storage-class=juju-operator-storage storage-provisioner=kubernetes.io/gce-pd parameters.type=pd-standard
```

- deploy caas app to test authentication of the credentials imported

```bash
juju deploy cs:~kelvin.liu/kubeflow-tf-job-operator-6
```
