### PR TITLE
Add support using the newest gomaasapi to support handling partitions result from a storage constraint.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -32,7 +32,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	abe11904dd8cd40f0777b7704ae60348a876542e	2018-05-21T08:04:29Z
+github.com/juju/gomaasapi	git	8a8cec793ba70659ba95f1b9a491ba807169bfc3	2018-09-20T03:00:11Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	4dc25171f675da4206b71695d3fd80e519ad05c1	2017-02-09T16:27:49Z

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -80,7 +80,7 @@ func (suite *maas2EnvironSuite) injectControllerWithSpacesAndCheck(c *gc.C, spac
 		allocateMachineArgsCheck: check,
 		allocateMachine:          newFakeMachine("Bruce Sterling", arch.HostArch(), ""),
 		allocateMachineMatches: gomaasapi.ConstraintMatches{
-			Storage: map[string][]gomaasapi.BlockDevice{},
+			Storage: map[string][]gomaasapi.StorageDevice{},
 		},
 		spaces: spaces,
 	}
@@ -341,7 +341,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceParams(c *gc.C) {
 		},
 		allocateMachine: newFakeMachine("Bruce Sterling", arch.HostArch(), ""),
 		allocateMachineMatches: gomaasapi.ConstraintMatches{
-			Storage: map[string][]gomaasapi.BlockDevice{},
+			Storage: map[string][]gomaasapi.StorageDevice{},
 		},
 		zones: []gomaasapi.Zone{&fakeZone{name: "foo"}},
 	})
@@ -672,7 +672,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	controller := newFakeController()
 	controller.allocateMachine = machine
 	controller.allocateMachineMatches = gomaasapi.ConstraintMatches{
-		Storage: map[string][]gomaasapi.BlockDevice{},
+		Storage: map[string][]gomaasapi.StorageDevice{},
 	}
 	controller.machines = []gomaasapi.Machine{machine}
 	suite.injectController(controller)
@@ -691,7 +691,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentRetry(c *gc.C) {
 	controller := newFakeController()
 	controller.allocateMachine = machine
 	controller.allocateMachineMatches = gomaasapi.ConstraintMatches{
-		Storage: map[string][]gomaasapi.BlockDevice{},
+		Storage: map[string][]gomaasapi.StorageDevice{},
 	}
 	controller.machines = []gomaasapi.Machine{}
 	suite.injectController(controller)
@@ -710,7 +710,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	controller := newFakeController()
 	controller.allocateMachine = machine
 	controller.allocateMachineMatches = gomaasapi.ConstraintMatches{
-		Storage: map[string][]gomaasapi.BlockDevice{},
+		Storage: map[string][]gomaasapi.StorageDevice{},
 	}
 	controller.machines = []gomaasapi.Machine{machine}
 	suite.injectController(controller)
@@ -893,7 +893,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 	controller := &fakeController{
 		allocateMachine: machine,
 		allocateMachineMatches: gomaasapi.ConstraintMatches{
-			Storage: map[string][]gomaasapi.BlockDevice{},
+			Storage: map[string][]gomaasapi.StorageDevice{},
 		},
 	}
 	suite.injectController(controller)
@@ -2148,7 +2148,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	controller.machines = []gomaasapi.Machine{machine}
 	controller.allocateMachine = machine
 	controller.allocateMachineMatches = gomaasapi.ConstraintMatches{
-		Storage: make(map[string][]gomaasapi.BlockDevice),
+		Storage: make(map[string][]gomaasapi.StorageDevice),
 	}
 
 	env := suite.makeEnviron(c, controller)

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -574,23 +574,123 @@ func (f *fakeFile) ReadAll() ([]byte, error) {
 }
 
 type fakeBlockDevice struct {
-	gomaasapi.BlockDevice
+	id     int
+	uuid   string
 	name   string
+	path   string
 	idPath string
+	model  string
+	serial string
 	size   uint64
+}
+
+func (bd fakeBlockDevice) Type() string {
+	return "blockdevice"
+}
+
+func (bd fakeBlockDevice) ID() int {
+	return bd.id
+}
+
+func (bd fakeBlockDevice) UUID() string {
+	return bd.uuid
 }
 
 func (bd fakeBlockDevice) Name() string {
 	return bd.name
 }
 
+func (bd fakeBlockDevice) Path() string {
+	return bd.path
+}
+
 func (bd fakeBlockDevice) IDPath() string {
 	return bd.idPath
+}
+
+func (bd fakeBlockDevice) Model() string {
+	return bd.model
+}
+
+func (bd fakeBlockDevice) Serial() string {
+	return bd.serial
 }
 
 func (bd fakeBlockDevice) Size() uint64 {
 	return bd.size
 }
+
+func (bd fakeBlockDevice) UsedSize() uint64 {
+	return 0
+}
+
+func (bd fakeBlockDevice) BlockSize() uint64 {
+	return 512
+}
+
+func (bd fakeBlockDevice) Tags() []string {
+	return []string{}
+}
+
+func (bd fakeBlockDevice) UsedFor() string {
+	return ""
+}
+
+func (bd fakeBlockDevice) FileSystem() gomaasapi.FileSystem {
+	return nil
+}
+
+func (bd fakeBlockDevice) Partitions() []gomaasapi.Partition {
+	return []gomaasapi.Partition{}
+}
+
+var _ gomaasapi.BlockDevice = (*fakeBlockDevice)(nil)
+
+type fakePartition struct {
+	id   int
+	uuid string
+	name string
+	path string
+	size uint64
+}
+
+func (part fakePartition) Type() string {
+	return "partition"
+}
+
+func (part fakePartition) ID() int {
+	return part.id
+}
+
+func (part fakePartition) UUID() string {
+	return part.uuid
+}
+
+func (part fakePartition) Name() string {
+	return part.name
+}
+
+func (part fakePartition) Path() string {
+	return part.path
+}
+
+func (part fakePartition) Size() uint64 {
+	return part.size
+}
+
+func (part fakePartition) UsedFor() string {
+	return ""
+}
+
+func (part fakePartition) Tags() []string {
+	return []string{}
+}
+
+func (part fakePartition) FileSystem() gomaasapi.FileSystem {
+	return nil
+}
+
+var _ gomaasapi.Partition = (*fakePartition)(nil)
 
 type fakeDevice struct {
 	*testing.Stub

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -574,96 +574,31 @@ func (f *fakeFile) ReadAll() ([]byte, error) {
 }
 
 type fakeBlockDevice struct {
-	id     int
-	uuid   string
+	gomaasapi.BlockDevice
+
 	name   string
-	path   string
 	idPath string
-	model  string
-	serial string
 	size   uint64
-}
-
-func (bd fakeBlockDevice) Type() string {
-	return "blockdevice"
-}
-
-func (bd fakeBlockDevice) ID() int {
-	return bd.id
-}
-
-func (bd fakeBlockDevice) UUID() string {
-	return bd.uuid
 }
 
 func (bd fakeBlockDevice) Name() string {
 	return bd.name
 }
 
-func (bd fakeBlockDevice) Path() string {
-	return bd.path
-}
-
 func (bd fakeBlockDevice) IDPath() string {
 	return bd.idPath
-}
-
-func (bd fakeBlockDevice) Model() string {
-	return bd.model
-}
-
-func (bd fakeBlockDevice) Serial() string {
-	return bd.serial
 }
 
 func (bd fakeBlockDevice) Size() uint64 {
 	return bd.size
 }
 
-func (bd fakeBlockDevice) UsedSize() uint64 {
-	return 0
-}
-
-func (bd fakeBlockDevice) BlockSize() uint64 {
-	return 512
-}
-
-func (bd fakeBlockDevice) Tags() []string {
-	return []string{}
-}
-
-func (bd fakeBlockDevice) UsedFor() string {
-	return ""
-}
-
-func (bd fakeBlockDevice) FileSystem() gomaasapi.FileSystem {
-	return nil
-}
-
-func (bd fakeBlockDevice) Partitions() []gomaasapi.Partition {
-	return []gomaasapi.Partition{}
-}
-
-var _ gomaasapi.BlockDevice = (*fakeBlockDevice)(nil)
-
 type fakePartition struct {
-	id   int
-	uuid string
+	gomaasapi.Partition
+
 	name string
 	path string
 	size uint64
-}
-
-func (part fakePartition) Type() string {
-	return "partition"
-}
-
-func (part fakePartition) ID() int {
-	return part.id
-}
-
-func (part fakePartition) UUID() string {
-	return part.uuid
 }
 
 func (part fakePartition) Name() string {
@@ -677,20 +612,6 @@ func (part fakePartition) Path() string {
 func (part fakePartition) Size() uint64 {
 	return part.size
 }
-
-func (part fakePartition) UsedFor() string {
-	return ""
-}
-
-func (part fakePartition) Tags() []string {
-	return []string{}
-}
-
-func (part fakePartition) FileSystem() gomaasapi.FileSystem {
-	return nil
-}
-
-var _ gomaasapi.Partition = (*fakePartition)(nil)
 
 type fakeDevice struct {
 	*testing.Stub

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -78,7 +78,7 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 	instance := maas2Instance{
 		machine: &fakeMachine{},
 		constraintMatches: gomaasapi.ConstraintMatches{
-			Storage: map[string][]gomaasapi.BlockDevice{
+			Storage: map[string][]gomaasapi.StorageDevice{
 				"root": {&fakeBlockDevice{name: "sda", idPath: "/dev/disk/by-dname/sda", size: 250059350016}},
 				"1":    {&fakeBlockDevice{name: "sdb", idPath: "/dev/sdb", size: 500059350016}},
 				"2":    {&fakeBlockDevice{name: "sdc", idPath: "/dev/disk/by-id/foo", size: 250362438230}},
@@ -90,6 +90,9 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 					&fakeBlockDevice{name: "sdf", idPath: "/dev/disk/by-id/wwn-drbr", size: 280362438231},
 				},
 				"5": {
+					&fakePartition{name: "sde-part1", path: "/dev/disk/by-dname/sde-part1", size: 280362438231},
+				},
+				"6": {
 					&fakeBlockDevice{name: "sdg", idPath: "/dev/disk/by-dname/sdg", size: 280362438231},
 				},
 			},
@@ -101,12 +104,13 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 		names.NewVolumeTag("2"),
 		names.NewVolumeTag("3"),
 		names.NewVolumeTag("4"),
+		names.NewVolumeTag("5"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// Expect 4 volumes - root volume is ignored, as are volumes
 	// with tags we did not request.
-	c.Assert(volumes, gc.HasLen, 4)
-	c.Assert(attachments, gc.HasLen, 4)
+	c.Assert(volumes, gc.HasLen, 5)
+	c.Assert(attachments, gc.HasLen, 5)
 	c.Check(volumes, jc.SameContents, []storage.Volume{{
 		names.NewVolumeTag("1"),
 		storage.VolumeInfo{
@@ -133,6 +137,12 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 			Size:     267374,
 			WWN:      "drbr",
 		},
+	}, {
+		names.NewVolumeTag("5"),
+		storage.VolumeInfo{
+			VolumeId: "volume-5",
+			Size:     267374,
+		},
 	}})
 	c.Assert(attachments, jc.SameContents, []storage.VolumeAttachment{{
 		names.NewVolumeTag("1"),
@@ -154,6 +164,12 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 		names.NewVolumeTag("4"),
 		mTag,
 		storage.VolumeAttachmentInfo{},
+	}, {
+		names.NewVolumeTag("5"),
+		mTag,
+		storage.VolumeAttachmentInfo{
+			DeviceLink: "/dev/disk/by-dname/sde-part1",
+		},
 	}})
 }
 
@@ -303,14 +319,23 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB",
             "block_size": 4096,
             "serial": "S21NNSAFC388888L",
-            "size": 250362438230
-        }
+			"size": 250362438230,
+			"partitions": [
+				{
+					"id": 1,
+					"name": "sde-part1",
+					"path": "/dev/disk/by-dname/sde-part1",
+					"size": 280362438231
+				}
+			]
+		}
     ],
     "constraint_map": {
         "1": "root",
         "2": "1",
         "3": "2",
-        "4": "3"
+		"4": "3",
+		"5": "partition:1"
     }
 }
 `[1:]

--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -28,6 +28,7 @@ const (
 
 	typeDisk = "disk"
 	typeLoop = "loop"
+	typePart = "part"
 )
 
 func init() {
@@ -101,6 +102,7 @@ func listBlockDevices() ([]storage.BlockDevice, error) {
 		// for now.
 		switch deviceType {
 		case typeLoop:
+		case typePart:
 		case typeDisk:
 			// Floppy disks, which have major device number 2,
 			// should be ignored.
@@ -176,7 +178,7 @@ func addHardwareInfo(dev *storage.BlockDevice) error {
 	output, err := exec.Command(
 		"udevadm", "info",
 		"-q", "property",
-		"--path", "/block/"+dev.DeviceName,
+		"--name", dev.DeviceName,
 	).Output()
 	if err != nil {
 		msg := "udevadm failed"

--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -40,10 +40,10 @@ func (s *ListBlockDevicesSuite) TestListBlockDevices(c *gc.C) {
 	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
 cat <<EOF
 KNAME="sda" SIZE="240057409536" LABEL="" UUID="" TYPE="disk"
-KNAME="sda1" SIZE="254803968" LABEL="" UUID="7a62bd85-a350-4c09-8944-5b99bf2080c6" MOUNTPOINT="/tmp" TYPE="disk"
-KNAME="sda2" SIZE="1024" LABEL="boot" UUID="" TYPE="disk"
+KNAME="sda1" SIZE="254803968" LABEL="" UUID="7a62bd85-a350-4c09-8944-5b99bf2080c6" MOUNTPOINT="/tmp" TYPE="part"
+KNAME="sda2" SIZE="1024" LABEL="boot" UUID="" TYPE="part"
 KNAME="sdb" SIZE="32017047552" LABEL="" UUID="" TYPE="disk"
-KNAME="sdb1" SIZE="32015122432" LABEL="media" UUID="2c1c701d-f2ce-43a4-b345-33e2e39f9503" FSTYPE="ext4" TYPE="disk"
+KNAME="sdb1" SIZE="32015122432" LABEL="media" UUID="2c1c701d-f2ce-43a4-b345-33e2e39f9503" FSTYPE="ext4" TYPE="part"
 KNAME="fd0" SIZE="1024" TYPE="disk" MAJ:MIN="2:0"
 KNAME="fd1" SIZE="1024" TYPE="disk" MAJ:MIN="2:1"
 EOF`)
@@ -235,6 +235,9 @@ EOF`)
 	c.Assert(devices, jc.DeepEquals, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       228936,
+	}, {
+		DeviceName: "sda1",
+		Size:       243,
 	}, {
 		DeviceName: "loop0",
 		Size:       243,


### PR DESCRIPTION
## Description of change

MAAS 2.5 added support for a storage constraint to reference a partition. Previous versions of MAAS always only referenced a block device.

## QA steps

First add the `part` tag to a partition in MAAS:
```
maas admin partition add-tag gadex8 6 10 tag=part
```

Bootstrap Juju on MAAS
```
juju add-cloud maas ...
juju add-credential maas ...
```

Add the storage pool with required partition tag and the created `part` tag.
```
juju create-storage-pool maas-part maas tags=partition,part
juju deploy postgresql --storage pgdata=maas-part,1G
```

Wait for the magic!

## Documentation changes

Maybe explain that to get a storage pool to match a partition you need to ensure that `partition` is included as a tag in the storage pool creation.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1713239
