### PR TITLE
Fix 'not locked' error after complete

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -724,7 +724,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatusFailsIfNoLockExists(c *gc.C) {
 	arbitraryReason := ""
 
 	err := s.apiUnit.SetUpgradeSeriesStatus(arbitraryStatus, arbitraryReason)
-	c.Assert(err, gc.ErrorMatches, "machine \"[0-9]*\" is not locked for upgrade")
+	c.Assert(err, gc.ErrorMatches, "upgrade lock for machine \"[0-9]*\" not found")
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -106,7 +106,7 @@ func (m *Machine) IsLocked() (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if errors.IsBadRequest(err) {
+	if errors.IsNotFound(err) {
 		return false, nil
 	}
 	return false, errors.Trace(err)

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -571,7 +571,7 @@ func (m *Machine) getUpgradeSeriesLock() (*upgradeSeriesLockDoc, error) {
 	var lock upgradeSeriesLockDoc
 	err := coll.FindId(m.Id()).One(&lock)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("machine %q is not locked for upgrade", m)
+		return nil, errors.NotFoundf("upgrade lock for machine %q", m)
 	}
 	if err != nil {
 		return nil, errors.Annotatef(err, "retrieving upgrade series lock for machine %v", m.Id())

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -217,6 +217,12 @@ func (s *MachineSuite) TestGetUpgradeSeriesMessagesMissingLockMeansFinished(c *g
 	c.Assert(finished, jc.IsTrue)
 }
 
+func (s *MachineSuite) TestIsLockedIndicatesUnlockedWhenNoLockDocIsFound(c *gc.C) {
+	locked, err := s.machine.IsLocked()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(locked, jc.IsFalse)
+}
+
 func AssertMachineLockedForPrepare(c *gc.C, mach *state.Machine) {
 	locked, err := mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -211,6 +211,12 @@ func (s *MachineSuite) TestUnitsHaveChangedFalseNoUnits(c *gc.C) {
 	c.Assert(changed, jc.IsFalse)
 }
 
+func (s *MachineSuite) TestGetUpgradeSeriesMessagesMissingLockMeansFinished(c *gc.C) {
+	_, finished, err := s.machine.GetUpgradeSeriesMessages()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(finished, jc.IsTrue)
+}
+
 func AssertMachineLockedForPrepare(c *gc.C, mach *state.Machine) {
 	locked, err := mach.IsLocked()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

The removal of an `UpgradeSeries` lock is considered a change to the mechanisms that watch for such things. If that change solicits a request to fetch context messages from the controller before the change triggers the message channel's closure, then CLI will attempt to fetch more messages only to find no lock and signal an error.

Here we fix this issue by changing the semantics of ` GetUpgradeSeriesLock` to signal "finished" or "no more messages available" when no lock is found rather than an error.

## QA steps

```bash
for (( ; ; ))
do
   juju upgrade-series prepare <machine> <series>
   juju upgrade-series complete <machine>
done
```

When you are satisfied the race no longer occurs press Ctrl+c to exit the loop.