### PR TITLE
Fix watcher expectation in api/watcher.

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -481,10 +481,7 @@ func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 	assertChange, stop := s.setupOfferStatusWatch(c)
 	defer stop()
 
-	// We only want the most recent change.
-	err := mysql.SetStatus(status.StatusInfo{Status: status.Blocked, Message: "message"})
-	c.Assert(err, jc.ErrorIsNil)
-	err = mysql.SetStatus(status.StatusInfo{Status: status.Waiting, Message: "another message"})
+	err := mysql.SetStatus(status.StatusInfo{Status: status.Waiting, Message: "another message"})
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(status.Waiting, "another message")
 


### PR DESCRIPTION
Can't rely on squishing events.
I swear we had fixed this one already, but I guess not.