### PR TITLE
'update-credential' checks models. 

### DIFF
--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type cloudSuite struct {
@@ -163,46 +164,300 @@ func (s *cloudSuite) TestUserCredentials(c *gc.C) {
 	})
 }
 
-func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
+func (s *cloudSuite) TestUpdateCredentialV2(c *gc.C) {
 	var called bool
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Cloud")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "UpdateCredentials")
-			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			c.Assert(a, jc.DeepEquals, params.TaggedCredentials{
-				Credentials: []params.TaggedCredential{{
-					Tag: "cloudcred-foo_bob_bar",
-					Credential: params.CloudCredential{
-						AuthType: "userpass",
-						Attributes: map[string]string{
-							"username": "admin",
-							"password": "adm1n",
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "UpdateCredentials")
+				c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+				c.Assert(a, jc.DeepEquals, params.TaggedCredentials{
+					Credentials: []params.TaggedCredential{{
+						Tag: "cloudcred-foo_bob_bar",
+						Credential: params.CloudCredential{
+							AuthType: "userpass",
+							Attributes: map[string]string{
+								"username": "admin",
+								"password": "adm1n",
+							},
 						},
-					},
-				}}})
-			*result.(*params.ErrorResults) = params.ErrorResults{
-				Results: []params.ErrorResult{{}},
-			}
-			called = true
-			return nil
-		},
-	)
-
+					}}})
+				*result.(*params.ErrorResults) = params.ErrorResults{
+					Results: []params.ErrorResult{{}},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
 	client := cloudapi.NewClient(apiCaller)
-	tag := names.NewCloudCredentialTag("foo/bob/bar")
-	err := client.UpdateCredential(tag, cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-		"username": "admin",
-		"password": "adm1n",
-	}))
+	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.IsNil)
 	c.Assert(called, jc.IsTrue)
 }
+
+func (s *cloudSuite) TestUpdateCredential(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
+				c.Assert(result, gc.FitsTypeOf, &params.UpdateCredentialResults{})
+				c.Assert(a, jc.DeepEquals, params.TaggedCredentials{
+					Credentials: []params.TaggedCredential{{
+						Tag: "cloudcred-foo_bob_bar",
+						Credential: params.CloudCredential{
+							AuthType: "userpass",
+							Attributes: map[string]string{
+								"username": "admin",
+								"password": "adm1n",
+							},
+						},
+					}}})
+				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
+					Results: []params.UpdateCredentialResult{{}},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 3,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialErrorV2(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentials")
+				*result.(*params.ErrorResults) = params.ErrorResults{
+					Results: []params.ErrorResult{{common.ServerError(errors.New("validation failure"))}},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	errs, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, gc.ErrorMatches, "validation failure")
+	c.Assert(errs, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialError(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
+				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
+					Results: []params.UpdateCredentialResult{
+						{CredentialTag: "cloudcred-foo_bob_bar",
+							Error: common.ServerError(errors.New("validation failure")),
+						},
+					},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 3,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	errs, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, gc.ErrorMatches, "validation failure")
+	c.Assert(errs, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialCallErrorV2(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentials")
+				called = true
+				return errors.New("scary but true")
+			},
+		),
+		BestVersion: 2,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, gc.ErrorMatches, "scary but true")
+	c.Assert(result, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialCallError(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
+				called = true
+				return errors.New("scary but true")
+			},
+		),
+		BestVersion: 3,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, gc.ErrorMatches, "scary but true")
+	c.Assert(result, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialManyResultsV2(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentials")
+				*result.(*params.ErrorResults) = params.ErrorResults{
+					Results: []params.ErrorResult{
+						{},
+						{},
+					},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, gc.ErrorMatches, `expected 1 result for when updating credential "bar", got 2`)
+	c.Assert(result, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialManyResults(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
+				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
+					Results: []params.UpdateCredentialResult{
+						{},
+						{},
+					}}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 3,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, gc.ErrorMatches, `expected 1 result for when updating credential "bar", got 2`)
+	c.Assert(result, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestUpdateCredentialModelErrors(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
+				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
+					Results: []params.UpdateCredentialResult{
+						{
+							CredentialTag: testCredentialTag.String(),
+							Models: []params.UpdateCredentialModelResult{
+								{
+									ModelUUID: coretesting.ModelTag.Id(),
+									ModelName: "test-model",
+									Errors: []params.ErrorResult{
+										{common.ServerError(errors.New("validation failure one"))},
+										{common.ServerError(errors.New("validation failure two"))},
+									},
+								},
+							},
+						},
+					}}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 3,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	errs, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.DeepEquals, []params.UpdateCredentialModelResult{
+		{
+			ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			ModelName: "test-model",
+			Errors: []params.ErrorResult{
+				{Error: &params.Error{Message: "validation failure one", Code: ""}},
+				{Error: &params.Error{Message: "validation failure two", Code: ""}},
+			},
+		},
+	})
+	c.Assert(called, jc.IsTrue)
+}
+
+var (
+	testCredentialTag = names.NewCloudCredentialTag("foo/bob/bar")
+	testCredential    = cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"username": "admin",
+		"password": "adm1n",
+	})
+)
 
 func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 	var called bool

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	"github.com/juju/txn"
 	"gopkg.in/juju/names.v2"
 
@@ -34,7 +35,7 @@ type CloudV3 interface {
 	AddCloud(cloudArgs params.AddCloudArgs) error
 	AddCredentials(args params.TaggedCredentials) (params.ErrorResults, error)
 	CredentialContents(credentialArgs params.CloudCredentialArgs) (params.CredentialContentResults, error)
-	UpdateCredentials(args params.TaggedCredentials) (params.UpdateCredentialResults, error)
+	UpdateCredentialsCheckModels(args params.TaggedCredentials) (params.UpdateCredentialResults, error)
 	ModifyCloudAccess(args params.ModifyCloudAccessRequest) (params.ErrorResults, error)
 }
 
@@ -283,11 +284,11 @@ func (api *CloudAPI) AddCredentials(args params.TaggedCredentials) (params.Error
 	return results, nil
 }
 
-// UpdateCredentials updates a set of cloud credentials' content.
+// UpdateCredentialsCheckModels updates a set of cloud credentials' content.
 // If there are any models that are using a credential and these models
 // are not going to be visible with updated credential content,
 // there will be detailed validation errors per model.
-func (api *CloudAPI) UpdateCredentials(args params.TaggedCredentials) (params.UpdateCredentialResults, error) {
+func (api *CloudAPI) UpdateCredentialsCheckModels(args params.TaggedCredentials) (params.UpdateCredentialResults, error) {
 	return api.commonUpdateCredentials(args)
 }
 
@@ -297,26 +298,18 @@ func (api *CloudAPI) commonUpdateCredentials(args params.TaggedCredentials) (par
 		return params.UpdateCredentialResults{}, err
 	}
 
-	credentialError := func(oneError error) *params.ErrorResults {
-		return &params.ErrorResults{
-			Results: []params.ErrorResult{
-				{common.ServerError(oneError)},
-			},
-		}
-	}
-
 	results := make([]params.UpdateCredentialResult, len(args.Credentials))
 	for i, arg := range args.Credentials {
 		results[i].CredentialTag = arg.Tag
 		tag, err := names.ParseCloudCredentialTag(arg.Tag)
 		if err != nil {
-			results[i].Errors = credentialError(err)
+			results[i].Error = common.ServerError(err)
 			continue
 		}
 		// NOTE(axw) if we add ACLs for cloud credentials, we'll need
 		// to change this auth check.
 		if !authFunc(tag.Owner()) {
-			results[i].Errors = credentialError(common.ErrPerm)
+			results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
 		in := cloud.NewCredential(
@@ -327,20 +320,34 @@ func (api *CloudAPI) commonUpdateCredentials(args params.TaggedCredentials) (par
 		credentialModels, err := api.backend.CredentialModels(tag)
 		if err != nil && !errors.IsNotFound(err) {
 			// Could not determine if credential has models - do not continue updating this credential...
-			results[i].Errors = credentialError(err)
+			results[i].Error = common.ServerError(err)
 			continue
 		}
 
-		var modelsErrors []params.ErrorResult
-		for modelUUID := range credentialModels {
-			modelErrors := api.validateCredentialForModel(modelUUID, tag, &in)
-			if len(modelErrors) > 0 {
-				modelsErrors = append(modelsErrors, modelErrors...)
+		modelsVisible := true
+		if len(credentialModels) > 0 {
+			// since we get a map here, for consistency ensure that models are added
+			// sorted by model uuid.
+			var uuids []string
+			for uuid := range credentialModels {
+				uuids = append(uuids, uuid)
 			}
+			naturalsort.Sort(uuids)
+			var models []params.UpdateCredentialModelResult
+			for _, uuid := range uuids {
+				model := params.UpdateCredentialModelResult{ModelUUID: uuid, ModelName: credentialModels[uuid]}
+				model.Errors = api.validateCredentialForModel(uuid, tag, &in)
+				models = append(models, model)
+				if len(model.Errors) > 0 {
+					modelsVisible = false
+				}
+			}
+			results[i].Models = models
 		}
-		if len(modelsErrors) > 0 {
+
+		if !modelsVisible {
 			// Some models that use this credential do not like the new content, do not update the credential...
-			results[i].Errors = &params.ErrorResults{Results: modelsErrors}
+			results[i].Error = common.ServerError(errors.New("some models are no longer visible"))
 			continue
 		}
 
@@ -350,7 +357,7 @@ func (api *CloudAPI) commonUpdateCredentials(args params.TaggedCredentials) (par
 					"cannot update credential %q: controller does not manage cloud %q",
 					tag.Name(), tag.Cloud().Id())
 			}
-			results[i].Errors = credentialError(err)
+			results[i].Error = common.ServerError(err)
 			continue
 		}
 	}
@@ -384,31 +391,47 @@ func (api *CloudAPI) validateCredentialForModel(modelUUID string, tag names.Clou
 
 var validateNewCredentialForModelFunc = credentialcommon.ValidateNewModelCredential
 
+// Mask out old methods from the new API versions. The API reflection
+// code in rpc/rpcreflect/type.go:newMethod skips 2-argument methods,
+// so this removes the method as far as the RPC machinery is concerned.
+// UpdateCredentials was dropped in V3, replaced with UpdateCredentialsCheckModels.
+func (*CloudAPI) UpdateCredentials(_, _ struct{}) {}
+
 // UpdateCredentials updates a set of cloud credentials' content.
-// This method is provided here for back-compatibility.
-// If there are any models that are using a credential and these models
-// are not going to be visible with updated credential content,
-// there will be detailed validation errors per model.
-// However, old return parameter structure could not hold this much detail and,
-// thus, per-model-per-credential errors are squashed into per-credential errors.
 func (api *CloudAPIV2) UpdateCredentials(args params.TaggedCredentials) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Credentials)),
 	}
-	errors, err := api.commonUpdateCredentials(args)
+	updateResults, err := api.commonUpdateCredentials(args)
 	if err != nil {
 		return results, err
 	}
 
-	for i, credErrs := range errors.Results {
-		if credErrs.Errors == nil {
+	// If there are any models that are using a credential and these models
+	// are not going to be visible with updated credential content,
+	// there will be detailed validation errors per model.
+	// However, old return parameter structure could not hold this much detail and,
+	// thus, per-model-per-credential errors are squashed into per-credential errors.
+	for i, result := range updateResults.Results {
+		var resultErrors []params.ErrorResult
+		if result.Error != nil {
+			resultErrors = append(resultErrors, params.ErrorResult{result.Error})
+		}
+		for _, m := range result.Models {
+			if len(m.Errors) > 0 {
+				modelErors := params.ErrorResults{m.Errors}
+				combined := errors.Annotatef(modelErors.Combine(), "model %q (uuid %v)", m.ModelName, m.ModelUUID)
+				resultErrors = append(resultErrors, params.ErrorResult{common.ServerError(combined)})
+			}
+		}
+		if len(resultErrors) == 1 {
+			results.Results[i].Error = resultErrors[0].Error
 			continue
 		}
-		if len(credErrs.Errors.Results) == 1 {
-			results.Results[i].Error = common.ServerError(credErrs.Errors.OneError())
-			continue
+		if len(resultErrors) > 1 {
+			credentialError := params.ErrorResults{resultErrors}
+			results.Results[i].Error = common.ServerError(credentialError.Combine())
 		}
-		results.Results[i].Error = common.ServerError(credErrs.Errors.Combine())
 	}
 	return results, nil
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -324,7 +324,7 @@ func (api *CloudAPI) commonUpdateCredentials(args params.TaggedCredentials) (par
 			continue
 		}
 
-		modelsVisible := true
+		var modelsErred bool
 		if len(credentialModels) > 0 {
 			// since we get a map here, for consistency ensure that models are added
 			// sorted by model uuid.
@@ -339,13 +339,13 @@ func (api *CloudAPI) commonUpdateCredentials(args params.TaggedCredentials) (par
 				model.Errors = api.validateCredentialForModel(uuid, tag, &in)
 				models = append(models, model)
 				if len(model.Errors) > 0 {
-					modelsVisible = false
+					modelsErred = true
 				}
 			}
 			results[i].Models = models
 		}
 
-		if !modelsVisible {
+		if modelsErred {
 			// Some models that use this credential do not like the new content, do not update the credential...
 			results[i].Error = common.ServerError(errors.New("some models are no longer visible"))
 			continue

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/common/credentialcommon"
 	cloudfacade "github.com/juju/juju/apiserver/facades/client/cloud"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -22,6 +23,7 @@ import (
 	_ "github.com/juju/juju/provider/maas"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&cloudSuiteV2{})
@@ -84,10 +86,33 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 				{ModelName: "whynotmodel", OwnerAccess: permission.NoAccess},
 			},
 		},
+		credentialModelsF: func(tag names.CloudCredentialTag) (map[string]string, error) {
+			return nil, nil
+		},
 	}
 
 	s.setTestAPIForUser(c, owner)
-	s.statePool = &mockStatePool{}
+	pooledModel := &mockPooledModel{
+		model: &mockModelBackend{
+			model: &mockModel{
+				cloud:       "dummy",
+				cloudRegion: "nether",
+				cfg:         coretesting.ModelConfig(c),
+			},
+			cloud: cloud.Cloud{
+				Name:      "dummy",
+				Type:      "dummy",
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+				Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+			},
+		},
+		release: true,
+	}
+	s.statePool = &mockStatePool{
+		getF: func(modelUUID string) (cloudfacade.PooledModelBackend, error) {
+			return pooledModel, nil
+		},
+	}
 }
 
 func (s *cloudSuiteV2) setTestAPIForUser(c *gc.C, user names.UserTag) {
@@ -302,6 +327,42 @@ func (s *cloudSuiteV2) TestUpdateCredentialsAdminAccess(c *gc.C) {
 	c.Assert(results.Results[0].Error, gc.IsNil)
 }
 
+func (s *cloudSuiteV2) TestUpdateCredentialsWithBrokenModels(c *gc.C) {
+	s.backend.SetErrors(nil, errors.NotFoundf("cloud"))
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return map[string]string{
+			coretesting.ModelTag.Id():              "testModel1",
+			"deadbeef-2f18-4fd2-967d-db9663db7bea": "testModel2",
+		}, nil
+	}
+	calls := 0
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.ModelBackend, newEnv credentialcommon.NewEnvironFunc, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+		calls++
+		if calls == 1 {
+			return params.ErrorResults{[]params.ErrorResult{
+				{&params.Error{Message: "not valid for model"}},
+				{&params.Error{Message: "cannot find machine failure"}},
+			}}, nil
+		}
+		return params.ErrorResults{[]params.ErrorResult{}}, nil
+	})
+	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
+	results, err := s.apiv2.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+		Tag: "cloudcred-meep_bruce_three",
+		Credential: params.CloudCredential{
+			AuthType:   "oauth1",
+			Attributes: map[string]string{"token": "foo:bar:baz"},
+		},
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results.Results, gc.DeepEquals, []params.ErrorResult{
+		{Error: &params.Error{
+			Message: "some models are no longer visible\nmodel \"testModel1\" (uuid deadbeef-0bad-400d-8000-4b1d0d06f00d): not valid for model\ncannot find machine failure"},
+		},
+	})
+}
+
 var cloudTypes = map[string]string{
 	"aws":   "ec2",
 	"dummy": "dummy",
@@ -311,8 +372,9 @@ var cloudTypes = map[string]string{
 type mockBackendV2 struct {
 	gitjujutesting.Stub
 	cloudfacade.Backend
-	credentials []state.Credential
-	models      map[names.CloudCredentialTag][]state.CredentialOwnerModelAccess
+	credentials       []state.Credential
+	models            map[names.CloudCredentialTag][]state.CredentialOwnerModelAccess
+	credentialModelsF func(tag names.CloudCredentialTag) (map[string]string, error)
 }
 
 func (st *mockBackendV2) AllCloudCredentials(user names.UserTag) ([]state.Credential, error) {
@@ -417,5 +479,5 @@ func (st *mockBackendV2) ModelConfig() (*config.Config, error) {
 
 func (st *mockBackendV2) CredentialModels(tag names.CloudCredentialTag) (map[string]string, error) {
 	st.MethodCall(st, "CredentialModels", tag)
-	return nil, nil
+	return st.credentialModelsF(tag)
 }

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -177,7 +177,7 @@ func (s *cloudSuite) TestUserCredentialsAdminAccess(c *gc.C) {
 func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 	s.backend.SetErrors(nil, errors.NotFoundf("cloud"))
 	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag: "machine-0",
 	}, {
 		Tag: "cloudcred-meep_admin_whatever",
@@ -201,16 +201,16 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 		Results: []params.UpdateCredentialResult{
 			{
 				CredentialTag: "machine-0",
-				Errors:        oneErrorResult(&params.Error{Message: `"machine-0" is not a valid cloudcred tag`}),
+				Error:         &params.Error{Message: `"machine-0" is not a valid cloudcred tag`},
 			},
 			{
 				CredentialTag: "cloudcred-meep_admin_whatever",
-				Errors:        oneErrorResult(&params.Error{Message: "permission denied", Code: params.CodeUnauthorized}),
+				Error:         &params.Error{Message: "permission denied", Code: params.CodeUnauthorized},
 			},
 			{CredentialTag: "cloudcred-meep_bruce_three"},
 			{
 				CredentialTag: "cloudcred-badcloud_bruce_three",
-				Errors:        oneErrorResult(&params.Error{Message: `cannot update credential "three": controller does not manage cloud "badcloud"`}),
+				Error:         &params.Error{Message: `cannot update credential "three": controller does not manage cloud "badcloud"`},
 			},
 		},
 	})
@@ -226,7 +226,7 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 }
 
 func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
@@ -240,7 +240,7 @@ func (s *cloudSuite) TestUpdateCredentialsNoModelsFound(c *gc.C) {
 	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
 		return nil, errors.NotFoundf("how about it")
 	}
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
@@ -252,9 +252,9 @@ func (s *cloudSuite) TestUpdateCredentialsNoModelsFound(c *gc.C) {
 
 func (s *cloudSuite) TestUpdateCredentialsModelsError(c *gc.C) {
 	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
-		return nil, errors.New("how about it")
+		return nil, errors.New("cannot get models")
 	}
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
@@ -264,7 +264,7 @@ func (s *cloudSuite) TestUpdateCredentialsModelsError(c *gc.C) {
 		Results: []params.UpdateCredentialResult{
 			{
 				CredentialTag: "cloudcred-meep_julia_three",
-				Errors:        oneErrorResult(&params.Error{Message: "how about it"}),
+				Error:         &params.Error{Message: "cannot get models"},
 			},
 		}})
 }
@@ -280,14 +280,23 @@ func (s *cloudSuite) TestUpdateCredentialsOneModelSuccess(c *gc.C) {
 		return params.ErrorResults{}, nil
 	})
 
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
-		Results: []params.UpdateCredentialResult{{CredentialTag: "cloudcred-meep_julia_three"}}})
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+					ModelName: "testModel1",
+				},
+			},
+		}},
+	})
 }
 
 func (s *cloudSuite) TestUpdateCredentialsModelGetError(c *gc.C) {
@@ -297,10 +306,10 @@ func (s *cloudSuite) TestUpdateCredentialsModelGetError(c *gc.C) {
 		}, nil
 	}
 	s.statePool.getF = func(modelUUID string) (cloudfacade.PooledModelBackend, error) {
-		return nil, errors.New("test dreaming")
+		return nil, errors.New("cannot get a model")
 	}
 
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
@@ -309,8 +318,16 @@ func (s *cloudSuite) TestUpdateCredentialsModelGetError(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Errors:        oneErrorResult(&params.Error{Message: "test dreaming"}),
-		}}})
+			Error:         &params.Error{Message: "some models are no longer visible"},
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "cannot get a model", Code: ""}}},
+				},
+			},
+		}},
+	})
 }
 
 func (s *cloudSuite) TestUpdateCredentialsModelFailedValidation(c *gc.C) {
@@ -324,7 +341,7 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidation(c *gc.C) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
@@ -333,8 +350,16 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidation(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Errors:        oneErrorResult(&params.Error{Message: "not valid for model"}),
-		}}})
+			Error:         &params.Error{Message: "some models are no longer visible"},
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: coretesting.ModelTag.Id(),
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model", Code: ""}}},
+				},
+			},
+		}},
+	})
 }
 
 func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) {
@@ -354,17 +379,31 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) {
 		return params.ErrorResults{[]params.ErrorResult{}}, nil
 	})
 
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
-		Results: []params.UpdateCredentialResult{{
-			CredentialTag: "cloudcred-meep_julia_three",
-			Errors:        oneErrorResult(&params.Error{Message: "not valid for model"}),
-		}}})
+		Results: []params.UpdateCredentialResult{
+			{
+				CredentialTag: "cloudcred-meep_julia_three",
+				Error:         &params.Error{Message: "some models are no longer visible"},
+				Models: []params.UpdateCredentialModelResult{
+					{
+						ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+						ModelName: "testModel1",
+						Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model", Code: ""}}},
+					},
+					{
+						ModelUUID: "deadbeef-2f18-4fd2-967d-db9663db7bea",
+						ModelName: "testModel2",
+					},
+				},
+			},
+		},
+	})
 }
 
 func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidation(c *gc.C) {
@@ -379,20 +418,30 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidation(c *gc.C) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
-	results, err := s.api.UpdateCredentials(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag:        "cloudcred-meep_julia_three",
 		Credential: params.CloudCredential{},
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
-	oneError := &params.Error{Message: "not valid for model"}
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Errors: &params.ErrorResults{Results: []params.ErrorResult{
-				{oneError},
-				{oneError},
-			}}}}})
+			Error:         &params.Error{Message: "some models are no longer visible"},
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: coretesting.ModelTag.Id(),
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}},
+				},
+				{
+					ModelUUID: "deadbeef-2f18-4fd2-967d-db9663db7bea",
+					ModelName: "testModel2",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}},
+				},
+			},
+		}}},
+	)
 }
 
 func (s *cloudSuite) TestRevokeCredentials(c *gc.C) {

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -212,13 +212,30 @@ type ValidateCredentialArgs struct {
 	All []ValidateCredentialArg `json:"credentials,omitempty"`
 }
 
+// UpdateCredentialModelResult contains results for a model credential validation check
+// from a cloud credential update.
+type UpdateCredentialModelResult struct {
+
+	// ModelUUID contains model's UUID.
+	ModelUUID string `json:"uuid"`
+
+	// ModelName contains model name.
+	ModelName string `json:"name"`
+
+	// Errors contains the errors accumulated while trying to update a credential.
+	Errors []ErrorResult `json:"errors,omitempty"`
+}
+
 // UpdateCredentialResult stores the result of updating one cloud credential.
 type UpdateCredentialResult struct {
 	// CredentialTag holds credential tag.
 	CredentialTag string `json:"tag"`
 
-	// Errors contains the errors accumulated while trying to update a credential.
-	Errors *ErrorResults `json:"errors,omitempty"`
+	// Errors contains an error that may have occurred while trying to update a credential.
+	Error *Error `json:"error,omitempty"`
+
+	// Models contains results of credential check against models that use this cloud credential.
+	Models []UpdateCredentialModelResult `json:"models,omitempty"`
 }
 
 // UpdateCredentialResult contains a set of UpdateCredentialResult.

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	apicloud "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -83,7 +84,7 @@ func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 type credentialAPI interface {
-	UpdateCredential(tag names.CloudCredentialTag, credential jujucloud.Credential) error
+	UpdateCredentialsCheckModels(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error)
 	Close() error
 }
 
@@ -131,8 +132,25 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	if err := client.UpdateCredential(credentialTag, *credToUpdate); err != nil {
-		return err
+	models, err := client.UpdateCredentialsCheckModels(credentialTag, *credToUpdate)
+	if err != nil {
+		ctx.Infof("Could not update credential %q for user %q on cloud %q: %v", c.credential, accountDetails.User, c.cloud, err)
+	}
+	for _, m := range models {
+		if len(m.Errors) == 0 {
+			ctx.Infof("Model %q is visible.", m.ModelName)
+			continue
+		} else {
+			ctx.Infof("Model %q is not visible:", m.ModelName)
+			for _, anErr := range m.Errors {
+				// This will allows to determine the last error.
+				ctx.Infof("  %v", errors.Trace(anErr.Error))
+			}
+		}
+	}
+	if err != nil {
+		// We do not want to return err here as we have already displayed it on the console.
+		return cmd.ErrSilent
 	}
 	ctx.Infof("Updated credential %q for user %q on cloud %q.", c.credential, accountDetails.User, c.cloud)
 	return nil

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -8,11 +8,15 @@ import (
 	"os"
 	"strings"
 
+	jujucmd "github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/jujuclient"
@@ -77,36 +81,20 @@ func (s *updateCredentialSuite) TestBadCloudName(c *gc.C) {
 }
 
 func (s *updateCredentialSuite) TestUpdate(c *gc.C) {
-	authCreds := map[string]string{"access-key": "key", "secret-key": "secret"}
-	store := &jujuclient.MemStore{
-		Controllers: map[string]jujuclient.ControllerDetails{
-			"controller": {},
-		},
-		CurrentControllerName: "controller",
-		Accounts: map[string]jujuclient.AccountDetails{
-			"controller": {
-				User: "admin@local",
-			},
-		},
-		Credentials: map[string]jujucloud.CloudCredential{
-			"aws": {
-				AuthCredentials: map[string]jujucloud.Credential{
-					"my-credential":      jujucloud.NewCredential(jujucloud.AccessKeyAuthType, authCreds),
-					"another-credential": jujucloud.NewCredential(jujucloud.UserPassAuthType, authCreds),
-				},
-			},
+	fake := &fakeUpdateCredentialAPI{
+		updateCredentialsCheckModelsF: func(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error) {
+			c.Assert(tag, gc.DeepEquals, names.NewCloudCredentialTag("aws/admin@local/my-credential"))
+			c.Assert(credential, jc.DeepEquals, jujucloud.NewCredential(jujucloud.AccessKeyAuthType, map[string]string{"access-key": "key", "secret-key": "secret"}))
+			return nil, nil
 		},
 	}
-	fake := &fakeUpdateCredentialAPI{}
-	cmd := cloud.NewUpdateCredentialCommandForTest(store, fake)
+
+	cmd := cloud.NewUpdateCredentialCommandForTest(s.store(c), fake)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "my-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
 	c.Assert(output, gc.Equals, `Updated credential "my-credential" for user "admin@local" on cloud "aws".`)
-	c.Assert(fake.creds, jc.DeepEquals, map[names.CloudCredentialTag]jujucloud.Credential{
-		names.NewCloudCredentialTag("aws/admin@local/my-credential"): jujucloud.NewCredential(jujucloud.AccessKeyAuthType, map[string]string{"access-key": "key", "secret-key": "secret"}),
-	})
 }
 
 func (s *updateCredentialSuite) TestUpdateCredentialWithFilePath(c *gc.C) {
@@ -144,26 +132,96 @@ func (s *updateCredentialSuite) TestUpdateCredentialWithFilePath(c *gc.C) {
 	err = ioutil.WriteFile(tmpFile.Name(), contents, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	fake := &fakeUpdateCredentialAPI{}
+	fake := &fakeUpdateCredentialAPI{
+		updateCredentialsCheckModelsF: func(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error) {
+			c.Assert(tag, gc.DeepEquals, names.NewCloudCredentialTag("google/admin@local/gce"))
+			c.Assert(credential.Attributes()["file"], gc.Equals, string(contents))
+			return nil, nil
+		},
+	}
 	cmd := cloud.NewUpdateCredentialCommandForTest(store, fake)
 	_, err = cmdtesting.RunCommand(c, cmd, "google", "gce")
 	c.Assert(err, jc.ErrorIsNil)
+}
 
-	tag := names.NewCloudCredentialTag("google/admin@local/gce")
-	expectedFileContents := fake.creds[tag].Attributes()["file"]
-	c.Assert(expectedFileContents, gc.Equals, string(contents))
+func (s *updateCredentialSuite) store(c *gc.C) jujuclient.ClientStore {
+	authCreds := map[string]string{"access-key": "key", "secret-key": "secret"}
+	return &jujuclient.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+		Accounts: map[string]jujuclient.AccountDetails{
+			"controller": {
+				User: "admin@local",
+			},
+		},
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"my-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, authCreds),
+				},
+			},
+		},
+	}
+}
+
+func (s *updateCredentialSuite) TestUpdateResultError(c *gc.C) {
+	fake := &fakeUpdateCredentialAPI{
+		updateCredentialsCheckModelsF: func(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error) {
+			return nil, errors.New("kaboom")
+		},
+	}
+	cmd := cloud.NewUpdateCredentialCommandForTest(s.store(c), fake)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "my-credential")
+	c.Assert(err, gc.NotNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Could not update credential \"my-credential\" for user \"admin@local\" on cloud \"aws\": kaboom\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+}
+func (s *updateCredentialSuite) TestUpdateWithModels(c *gc.C) {
+	fake := &fakeUpdateCredentialAPI{
+		updateCredentialsCheckModelsF: func(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error) {
+			return []params.UpdateCredentialModelResult{
+				{
+					ModelName: "model-a",
+					Errors: []params.ErrorResult{
+						{common.ServerError(errors.New("kaboom"))},
+						{common.ServerError(errors.New("kaboom 2"))},
+					},
+				},
+				{
+					ModelName: "model-b",
+					Errors: []params.ErrorResult{
+						{common.ServerError(errors.New("one failure"))},
+					},
+				},
+				{
+					ModelName: "model-c",
+				},
+			}, errors.New("models issues")
+		},
+	}
+	cmd := cloud.NewUpdateCredentialCommandForTest(s.store(c), fake)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws", "my-credential")
+	c.Assert(err, gc.DeepEquals, jujucmd.ErrSilent)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+Could not update credential "my-credential" for user "admin@local" on cloud "aws": models issues
+Model "model-a" is not visible:
+  kaboom
+  kaboom 2
+Model "model-b" is not visible:
+  one failure
+Model "model-c" is visible.
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }
 
 type fakeUpdateCredentialAPI struct {
-	creds map[names.CloudCredentialTag]jujucloud.Credential
+	updateCredentialsCheckModelsF func(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error)
 }
 
-func (f *fakeUpdateCredentialAPI) UpdateCredential(tag names.CloudCredentialTag, credential jujucloud.Credential) error {
-	if f.creds == nil {
-		f.creds = make(map[names.CloudCredentialTag]jujucloud.Credential)
-	}
-	f.creds[tag] = credential
-	return nil
+func (f *fakeUpdateCredentialAPI) UpdateCredentialsCheckModels(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error) {
+	return f.updateCredentialsCheckModelsF(tag, credential)
 }
 
 func (*fakeUpdateCredentialAPI) Close() error {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -153,7 +153,7 @@ type CloudAPI interface {
 	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
 	Cloud(names.CloudTag) (jujucloud.Cloud, error)
 	UserCredentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error)
-	UpdateCredential(names.CloudCredentialTag, jujucloud.Credential) error
+	UpdateCredentialsCheckModels(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error)
 }
 
 func (c *addModelCommand) newAPIRoot() (api.Connection, error) {
@@ -223,7 +223,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	// Upload the credential if it was found locally.
 	if credential != nil {
 		ctx.Infof("Uploading credential '%s' to controller", credentialTag.Id())
-		if err := cloudClient.UpdateCredential(credentialTag, *credential); err != nil {
+		if _, err := cloudClient.UpdateCredentialsCheckModels(credentialTag, *credential); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -293,8 +293,8 @@ func (s *AddModelSuite) TestCredentialsDetected(c *gc.C) {
 	credential.Label = "finalized"
 
 	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
-	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials", "UpdateCredential")
-	s.fakeCloudAPI.CheckCall(c, 3, "UpdateCredential", credentialTag, credential)
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials", "UpdateCredentialsCheckModels")
+	s.fakeCloudAPI.CheckCall(c, 3, "UpdateCredentialsCheckModels", credentialTag, credential)
 }
 
 func (s *AddModelSuite) TestCredentialsDetectedAmbiguous(c *gc.C) {
@@ -671,9 +671,9 @@ func (c *fakeCloudAPI) UserCredentials(user names.UserTag, cloud names.CloudTag)
 	return c.credentials, c.NextErr()
 }
 
-func (c *fakeCloudAPI) UpdateCredential(credentialTag names.CloudCredentialTag, credential cloud.Credential) error {
-	c.MethodCall(c, "UpdateCredential", credentialTag, credential)
-	return c.NextErr()
+func (c *fakeCloudAPI) UpdateCredentialsCheckModels(tag names.CloudCredentialTag, credential cloud.Credential) ([]params.UpdateCredentialModelResult, error) {
+	c.MethodCall(c, "UpdateCredentialsCheckModels", tag, credential)
+	return nil, c.NextErr()
 }
 
 type fakeProviderRegistry struct {

--- a/featuretests/api_cloud_test.go
+++ b/featuretests/api_cloud_test.go
@@ -58,7 +58,7 @@ func (s *CloudAPISuite) TestCloudAPI(c *gc.C) {
 
 func (s *CloudAPISuite) TestCredentialsAPI(c *gc.C) {
 	tag := names.NewCloudCredentialTag("dummy/admin/default")
-	err := s.client.UpdateCredential(tag, cloud.NewCredential(
+	_, err := s.client.UpdateCredentialsCheckModels(tag, cloud.NewCredential(
 		cloud.UserPassAuthType,
 		map[string]string{"username": "fred", "password": "secret"},
 	))


### PR DESCRIPTION
## Description of change

Updating credential content on the controller, 'update-credential' command, now also checks the models that use this credential.

We provide more detailed output - what models have been checked? are they visible? if not visible, why?

The PR updates adds new facade call - UpdateCredentialsCheckModels - to version 3 of "Cloud" facade, removing "UpdateCredentials".
