### PR TITLE
Make quiet flag work

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -238,7 +238,7 @@ func (c *upgradeSeriesCommand) UpgradeSeriesPrepare(ctx *cmd.Context) error {
 	}
 
 	m := UpgradeSeriesPrepareFinishedMessage + "\n"
-	fmt.Fprintf(ctx.Stdout, m, c.machineNumber)
+	ctx.Infof(m, c.machineNumber)
 
 	return nil
 }
@@ -301,10 +301,7 @@ func (c *upgradeSeriesCommand) handleUpgradeSeriesChange(ctx *cmd.Context, wid s
 	if len(messages) == 0 {
 		return nil
 	}
-	_, err = fmt.Fprintln(ctx.Stdout, strings.Join(messages, "\n"))
-	if err != nil {
-		errors.Trace(err)
-	}
+	ctx.Infof(strings.Join(messages, "\n"))
 	return nil
 }
 
@@ -336,7 +333,7 @@ func (c *upgradeSeriesCommand) UpgradeSeriesComplete(ctx *cmd.Context) error {
 	}
 
 	m := UpgradeSeriesCompleteFinishedMessage + "\n"
-	fmt.Fprintf(ctx.Stdout, m, c.machineNumber)
+	ctx.Infof(m, c.machineNumber)
 
 	return nil
 }

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -5,7 +5,6 @@ package machine_test
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -75,9 +74,6 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(
 	if err != nil {
 		return nil, err
 	}
-	if stderr.String() != "" {
-		return nil, errors.New(stderr.String())
-	}
 	return ctx, nil
 }
 
@@ -142,9 +138,7 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c
 	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machine.PrepareCommand, machineArg, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
 	confirmationMsg := fmt.Sprintf(machine.UpgradeSeriesConfirmationMsg, machineArg, seriesArg, machineArg, unitsString)
-	finishedMessage := fmt.Sprintf(machine.UpgradeSeriesPrepareFinishedMessage, machineArg)
-	displayedMessage := strings.Join([]string{confirmationMsg, finishedMessage}, "") + "\n"
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, displayedMessage)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, confirmationMsg)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeAndNotPrompt(c *gc.C) {
@@ -153,8 +147,8 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeAndNotPrompt(c *
 	confirmationMessage := "" //There is no confirmation message since the `--agree` flag is being used to avoid the prompt
 	finishedMessage := fmt.Sprintf(machine.UpgradeSeriesPrepareFinishedMessage, machineArg)
 	displayedMessage := strings.Join([]string{confirmationMessage, finishedMessage}, "") + "\n"
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, displayedMessage)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, displayedMessage)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, displayedMessage)
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, displayedMessage)
 }
 
 type upgradeSeriesPrepareExpectation struct {


### PR DESCRIPTION
## Description of change

`juju upgrade-prepare` writes output directly to standard out stream instead of using the command context's writer. This prevents the '--quiet' flag from working. This patch fixes the issue.

## QA steps

`juju upgrade-series prepare <machine> <series> --agree --quiet` should display no output.
`juju upgrade-series complete <machine> --quiet` should display no output.

