### PR TITLE
Add callback to set status of operator during provisioning

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/storage"
 )
@@ -297,4 +298,17 @@ func (c *Client) UpdateApplicationService(arg params.UpdateApplicationServiceArg
 		return nil
 	}
 	return maybeNotFound(result.Results[0].Error)
+}
+
+// SetOperatorStatus updates the provisioning status of an operator.
+func (c *Client) SetOperatorStatus(appName string, status status.Status, message string, data map[string]interface{}) error {
+	var result params.ErrorResults
+	args := params.SetStatus{Entities: []params.EntityStatusArgs{
+		{Tag: names.NewApplicationTag(appName).String(), Status: status.String(), Info: message, Data: data},
+	}}
+	err := c.facade.FacadeCall("SetOperatorStatus", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
 }

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -185,6 +185,11 @@ func (m *mockApplication) AddOperation(props state.UnitUpdateProperties) *state.
 	return addOp
 }
 
+func (m *mockApplication) SetOperatorStatus(sInfo status.StatusInfo) error {
+	m.MethodCall(m, "SetOperatorStatus", sInfo)
+	return nil
+}
+
 type mockContainerInfo struct {
 	state.CloudContainer
 	providerId string

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -78,6 +78,7 @@ type Application interface {
 	Name() string
 	Constraints() (constraints.Value, error)
 	GetPlacement() string
+	SetOperatorStatus(sInfo status.StatusInfo) error
 }
 
 type stateShim struct {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -69,6 +69,9 @@ func Open(p environs.EnvironProvider, args environs.OpenParams) (Broker, error) 
 // NewContainerBrokerFunc returns a Container Broker.
 type NewContainerBrokerFunc func(args environs.OpenParams) (Broker, error)
 
+// StatusCallbackFunc represents a function that can be called to report a status.
+type StatusCallbackFunc func(appName string, settableStatus status.Status, info string, data map[string]interface{}) error
+
 // ServiceParams defines parameters used to create a service.
 type ServiceParams struct {
 	// PodSpec is the spec used to configure a pod.
@@ -114,7 +117,7 @@ type Broker interface {
 	DeleteOperator(appName string) error
 
 	// EnsureService creates or updates a service for pods with the given params.
-	EnsureService(appName string, params *ServiceParams, numUnits int, config application.ConfigAttributes) error
+	EnsureService(appName string, statusCallback StatusCallbackFunc, params *ServiceParams, numUnits int, config application.ConfigAttributes) error
 
 	// EnsureCustomResourceDefinition creates or updates a custom resource definition resource.
 	EnsureCustomResourceDefinition(appName string, podSpec *PodSpec) error

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -658,8 +658,14 @@ func (k *kubernetesClient) ensureCustomResourceDefinitionTemplate(t *caas.Custom
 
 // EnsureService creates or updates a service for pods with the given params.
 func (k *kubernetesClient) EnsureService(
-	appName string, params *caas.ServiceParams, numUnits int, config application.ConfigAttributes,
+	appName string, statusCallback caas.StatusCallbackFunc, params *caas.ServiceParams, numUnits int, config application.ConfigAttributes,
 ) (err error) {
+	defer func() {
+		if err != nil {
+			statusCallback(appName, status.Error, err.Error(), nil)
+		}
+	}()
+
 	logger.Debugf("creating/updating application %s", appName)
 
 	if numUnits < 0 {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -469,7 +469,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoUnits(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{}
-	err := s.broker.EnsureService("test", params, 0, nil)
+	err := s.broker.EnsureService("test", nil, params, 0, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -544,7 +544,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 		PodSpec:      basicPodspec,
 		ResourceTags: map[string]string{"fred": "mary"},
 	}
-	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+	err = s.broker.EnsureService("test", nil, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
@@ -803,7 +803,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 			ResourceTags: map[string]string{"foo": "bar"},
 		}},
 	}
-	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+	err = s.broker.EnsureService("test", nil, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
@@ -875,7 +875,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 			},
 		},
 	}
-	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+	err = s.broker.EnsureService("test", nil, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
@@ -943,7 +943,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 			},
 		},
 	}
-	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+	err = s.broker.EnsureService("test", nil, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
@@ -1002,7 +1002,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		}},
 		Constraints: constraints.MustParse("mem=64 cpu-power=500"),
 	}
-	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+	err = s.broker.EnsureService("test", nil, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
@@ -1054,7 +1054,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithPlacement(c *gc.C) {
 		}},
 		Placement: "a=b",
 	}
-	err = s.broker.EnsureService("test", params, 2, application.ConfigAttributes{
+	err = s.broker.EnsureService("test", nil, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -848,3 +848,7 @@ func GetCloudContainerStatusHistory(st *State, name string, filter status.Status
 func CaasUnitDisplayStatus(unitStatus status.StatusInfo, cloudContainerStatus status.StatusInfo) status.StatusInfo {
 	return caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
 }
+
+func ApplicationOperatorStatus(st *State, appName string) (status.StatusInfo, error) {
+	return getStatus(st.db(), applicationGlobalOperatorKey(appName), "operator")
+}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -734,6 +734,17 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	exApplication.SetStatusHistory(e.statusHistoryArgs(globalKey))
 	exApplication.SetAnnotations(e.getAnnotations(globalKey))
 
+	// TODO(caas) - Actually use the exported application operator details and status history.
+	// Currently these are only grabbed to make the MigrationExportSuite tests happy.
+	globalAppWorkloadKey := applicationGlobalOperatorKey(appName)
+	_, err = e.statusArgs(globalAppWorkloadKey)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.Annotatef(err, "application operator status for applucation %s", appName)
+		}
+	}
+	e.statusHistoryArgs(globalAppWorkloadKey)
+
 	constraintsArgs, err := e.constraintsArgs(globalKey)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -23,29 +23,32 @@ type applicationWorker struct {
 	serviceBroker   ServiceBroker
 	containerBroker ContainerBroker
 
-	provisioningInfoGetter ProvisioningInfoGetter
-	applicationGetter      ApplicationGetter
-	applicationUpdater     ApplicationUpdater
-	unitUpdater            UnitUpdater
+	provisioningStatusSetter ProvisioningStatusSetter
+	provisioningInfoGetter   ProvisioningInfoGetter
+	applicationGetter        ApplicationGetter
+	applicationUpdater       ApplicationUpdater
+	unitUpdater              UnitUpdater
 }
 
 func newApplicationWorker(
 	application string,
 	serviceBroker ServiceBroker,
 	containerBroker ContainerBroker,
+	provisioningStatusSetter ProvisioningStatusSetter,
 	provisioningInfoGetter ProvisioningInfoGetter,
 	applicationGetter ApplicationGetter,
 	applicationUpdater ApplicationUpdater,
 	unitUpdater UnitUpdater,
 ) (*applicationWorker, error) {
 	w := &applicationWorker{
-		application:            application,
-		serviceBroker:          serviceBroker,
-		containerBroker:        containerBroker,
-		provisioningInfoGetter: provisioningInfoGetter,
-		applicationGetter:      applicationGetter,
-		applicationUpdater:     applicationUpdater,
-		unitUpdater:            unitUpdater,
+		application:              application,
+		serviceBroker:            serviceBroker,
+		containerBroker:          containerBroker,
+		provisioningStatusSetter: provisioningStatusSetter,
+		provisioningInfoGetter:   provisioningInfoGetter,
+		applicationGetter:        applicationGetter,
+		applicationUpdater:       applicationUpdater,
+		unitUpdater:              unitUpdater,
 	}
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -69,6 +72,7 @@ func (aw *applicationWorker) Wait() error {
 func (aw *applicationWorker) loop() error {
 	deploymentWorker, err := newDeploymentWorker(
 		aw.application,
+		aw.provisioningStatusSetter,
 		aw.serviceBroker,
 		aw.provisioningInfoGetter,
 		aw.applicationGetter,

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -19,7 +19,7 @@ type ContainerBroker interface {
 
 type ServiceBroker interface {
 	Provider() caas.ContainerEnvironProvider
-	EnsureService(appName string, params *caas.ServiceParams, numUnits int, config application.ConfigAttributes) error
+	EnsureService(appName string, statusCallback caas.StatusCallbackFunc, params *caas.ServiceParams, numUnits int, config application.ConfigAttributes) error
 	EnsureCustomResourceDefinition(appName string, podSpec *caas.PodSpec) error
 	Service(appName string) (*caas.Service, error)
 	DeleteService(appName string) error

--- a/worker/caasunitprovisioner/client.go
+++ b/worker/caasunitprovisioner/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -20,6 +21,7 @@ type Client interface {
 	ProvisioningInfoGetter
 	LifeGetter
 	UnitUpdater
+	ProvisioningStatusSetter
 }
 
 // ApplicationGetter provides an interface for
@@ -57,4 +59,11 @@ type LifeGetter interface {
 // Juju units from changes in the cloud.
 type UnitUpdater interface {
 	UpdateUnits(arg params.UpdateApplicationUnits) error
+}
+
+// ProvisioningStatusSetter provides an interface for
+// setting status information.
+type ProvisioningStatusSetter interface {
+	// SetOperatorStatus sets the status for the application operator.
+	SetOperatorStatus(appName string, status status.Status, message string, data map[string]interface{}) error
 }

--- a/worker/caasunitprovisioner/manifold.go
+++ b/worker/caasunitprovisioner/manifold.go
@@ -61,9 +61,10 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ServiceBroker:   broker,
 		ContainerBroker: broker,
 
-		ProvisioningInfoGetter: client,
-		LifeGetter:             client,
-		UnitUpdater:            client,
+		ProvisioningInfoGetter:   client,
+		ProvisioningStatusSetter: client,
+		LifeGetter:               client,
+		UnitUpdater:              client,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/caasunitprovisioner/manifold_test.go
+++ b/worker/caasunitprovisioner/manifold_test.go
@@ -127,12 +127,13 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config := args[0].(caasunitprovisioner.Config)
 
 	c.Assert(config, jc.DeepEquals, caasunitprovisioner.Config{
-		ApplicationGetter:      &s.client,
-		ApplicationUpdater:     &s.client,
-		ServiceBroker:          &s.broker,
-		ContainerBroker:        &s.broker,
-		ProvisioningInfoGetter: &s.client,
-		LifeGetter:             &s.client,
-		UnitUpdater:            &s.client,
+		ApplicationGetter:        &s.client,
+		ApplicationUpdater:       &s.client,
+		ServiceBroker:            &s.broker,
+		ContainerBroker:          &s.broker,
+		ProvisioningInfoGetter:   &s.client,
+		ProvisioningStatusSetter: &s.client,
+		LifeGetter:               &s.client,
+		UnitUpdater:              &s.client,
 	})
 }

--- a/worker/caasunitprovisioner/worker.go
+++ b/worker/caasunitprovisioner/worker.go
@@ -22,10 +22,11 @@ type Config struct {
 	ApplicationUpdater ApplicationUpdater
 	ServiceBroker      ServiceBroker
 
-	ContainerBroker        ContainerBroker
-	ProvisioningInfoGetter ProvisioningInfoGetter
-	LifeGetter             LifeGetter
-	UnitUpdater            UnitUpdater
+	ContainerBroker          ContainerBroker
+	ProvisioningInfoGetter   ProvisioningInfoGetter
+	ProvisioningStatusSetter ProvisioningStatusSetter
+	LifeGetter               LifeGetter
+	UnitUpdater              UnitUpdater
 }
 
 // Validate validates the worker configuration.
@@ -50,6 +51,9 @@ func (config Config) Validate() error {
 	}
 	if config.UnitUpdater == nil {
 		return errors.NotValidf("missing UnitUpdater")
+	}
+	if config.ProvisioningStatusSetter == nil {
+		return errors.NotValidf("missing ProvisioningStatusSetter")
 	}
 	return nil
 }
@@ -169,6 +173,7 @@ func (p *provisioner) loop() error {
 					appId,
 					p.config.ServiceBroker,
 					p.config.ContainerBroker,
+					p.config.ProvisioningStatusSetter,
 					p.config.ProvisioningInfoGetter,
 					p.config.ApplicationGetter,
 					p.config.ApplicationUpdater,


### PR DESCRIPTION
## Description of change

IAAS providers have a callback they can use to set the status of a machine during provisioning.
This PR provides the same mechanism to record status during the provisioning of an operator.
It currently reports any error resulting from EnsureService. The error is recorded as an application operator status value. A future PR will expose this in juju status.

## QA steps

Just a smoke test at this stage.

