### PR TITLE
Add new list cloud apis

### DIFF
--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -19,6 +19,7 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	Model() (Model, error)
 	ModelConfig() (*config.Config, error)
+	User(tag names.UserTag) (User, error)
 
 	CloudCredentials(user names.UserTag, cloudName string) (map[string]state.Credential, error)
 	UpdateCloudCredential(names.CloudCredentialTag, cloud.Credential) error
@@ -31,9 +32,11 @@ type Backend interface {
 
 	ControllerInfo() (*state.ControllerInfo, error)
 	GetCloudAccess(cloud string, user names.UserTag) (permission.Access, error)
+	GetCloudUsers(cloud string) (map[string]permission.Access, error)
 	CreateCloudAccess(cloud string, user names.UserTag, access permission.Access) error
 	UpdateCloudAccess(cloud string, user names.UserTag, access permission.Access) error
 	RemoveCloudAccess(cloud string, user names.UserTag) error
+	CloudsForUser(user names.UserTag, all bool) ([]state.CloudInfo, error)
 }
 
 type stateShim struct {
@@ -116,4 +119,12 @@ func NewPooledModelBackend(st *state.PooledState) PooledModelBackend {
 // Model implements PooledModelBackend.Model.
 func (s modelShim) Model() credentialcommon.ModelBackend {
 	return credentialcommon.NewModelBackend(s.PooledState.State)
+}
+
+type User interface {
+	DisplayName() string
+}
+
+func (s stateShim) User(tag names.UserTag) (User, error) {
+	return s.State.User(tag)
 }

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -45,6 +45,71 @@ type CloudsResult struct {
 	Clouds map[string]Cloud `json:"clouds,omitempty"`
 }
 
+// CloudUserInfo holds information on a user who has access to a
+// cloud. Cloud admins can see this information for all users
+// who have access, so it should not include sensitive information.
+type CloudUserInfo struct {
+	UserName    string `json:"user"`
+	DisplayName string `json:"display-name"`
+	Access      string `json:"access"`
+}
+
+// CloudDetails holds information about a cloud.
+type CloudDetails struct {
+	Type             string        `json:"type"`
+	AuthTypes        []string      `json:"auth-types,omitempty"`
+	Endpoint         string        `json:"endpoint,omitempty"`
+	IdentityEndpoint string        `json:"identity-endpoint,omitempty"`
+	StorageEndpoint  string        `json:"storage-endpoint,omitempty"`
+	Regions          []CloudRegion `json:"regions,omitempty"`
+}
+
+// CloudInfo holds information about a cloud and user who can access it.
+type CloudInfo struct {
+	CloudDetails `json:",inline"`
+
+	// Users contains information about the users that have access
+	// to the cloud. Administrators can see all users that have access;
+	// other users can only see their own details.
+	Users []CloudUserInfo `json:"users"`
+}
+
+// CloudInfoResult holds the result of a CloudInfo call.
+type CloudInfoResult struct {
+	Result *CloudInfo `json:"result,omitempty"`
+	Error  *Error     `json:"error,omitempty"`
+}
+
+// CloudInfoResults holds the result of a bulk CloudInfo call.
+type CloudInfoResults struct {
+	Results []CloudInfoResult `json:"results"`
+}
+
+// ListCloudsRequest encapsulates how we request a list of cloud details for a user.
+type ListCloudsRequest struct {
+	UserTag string `json:"user-tag"`
+	All     bool   `json:"all,omitempty"`
+}
+
+// ListCloudInfo holds information about a cloud for a user.
+type ListCloudInfo struct {
+	CloudDetails `json:",inline"`
+
+	// Access is the access level for the user.
+	Access string `json:"user-access"`
+}
+
+// ListCloudInfoResult holds the result of a ListCloudInfo call.
+type ListCloudInfoResult struct {
+	Result *ListCloudInfo `json:"result,omitempty"`
+	Error  *Error         `json:"error,omitempty"`
+}
+
+// ListCloudInfoResults holds the result of a bulk ListCloudInfo call.
+type ListCloudInfoResults struct {
+	Results []ListCloudInfoResult `json:"results"`
+}
+
 // ModifyCloudAccessRequest holds the parameters for making grant and revoke cloud calls.
 type ModifyCloudAccessRequest struct {
 	Changes []ModifyCloudAccess `json:"changes"`

--- a/state/clouduser.go
+++ b/state/clouduser.go
@@ -4,10 +4,16 @@
 package state
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/permission"
 )
 
@@ -91,4 +97,119 @@ func (st *State) RemoveCloudAccess(cloud string, user names.UserTag) error {
 
 	err := st.db().Run(buildTxn)
 	return errors.Trace(err)
+}
+
+// CloudInfo describes interesting information for a given cloud.
+type CloudInfo struct {
+	cloud.Cloud
+
+	// Access is the access level the supplied user has on this cloud.
+	Access permission.Access
+}
+
+// CloudsForUser returns details including access level of clouds which can
+// be seen by the specified user, or all users if the caller is a superuser.
+func (st *State) CloudsForUser(user names.UserTag, all bool) ([]CloudInfo, error) {
+	// We only treat the user as a superuser if they pass --all
+	isControllerSuperuser := false
+	if all {
+		var err error
+		isControllerSuperuser, err = st.isUserSuperuser(user)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	clouds, closer := st.db().GetCollection(cloudsC)
+	defer closer()
+
+	var cloudQuery mongo.Query
+	if isControllerSuperuser {
+		// Fast path, we just get all the clouds.
+		cloudQuery = clouds.Find(nil)
+	} else {
+		cloudNames, err := st.cloudNamesForUser(user)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cloudQuery = clouds.Find(bson.M{
+			"_id": bson.M{"$in": cloudNames},
+		})
+	}
+	cloudQuery = cloudQuery.Sort("name")
+
+	var cloudDocs []cloudDoc
+	if err := cloudQuery.All(&cloudDocs); err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]CloudInfo, len(cloudDocs))
+	for i, c := range cloudDocs {
+		result[i] = CloudInfo{
+			Cloud: c.toCloud(),
+		}
+	}
+	if err := st.fillInCloudUserAccess(user, result); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result, nil
+}
+
+// cloudNamesForUser returns the cloud names a user can see.
+func (st *State) cloudNamesForUser(user names.UserTag) ([]string, error) {
+	// Start by looking up cloud names that the user has access to, and then load only the records that are
+	// included in that set
+	permissions, permCloser := st.db().GetRawCollection(permissionsC)
+	defer permCloser()
+
+	findExpr := fmt.Sprintf("^.*#%s$", userGlobalKey(user.Id()))
+	query := permissions.Find(
+		bson.D{{"_id", bson.D{{"$regex", findExpr}}}},
+	).Batch(100)
+
+	var doc permissionDoc
+	iter := query.Iter()
+	var cloudNames []string
+	for iter.Next(&doc) {
+		cloudName := strings.TrimPrefix(doc.ObjectGlobalKey, "cloud#")
+		cloudNames = append(cloudNames, cloudName)
+	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cloudNames, nil
+}
+
+// fillInCloudUserAccess fills in the Access rights for this user on the clouds (but not other users).
+func (st *State) fillInCloudUserAccess(user names.UserTag, cloudInfo []CloudInfo) error {
+	// Note: Even for Superuser we track the individual Access for each model.
+	username := strings.ToLower(user.Name())
+	var permissionIds []string
+	for _, info := range cloudInfo {
+		permId := permissionID(cloudGlobalKey(info.Name), userGlobalKey(username))
+		permissionIds = append(permissionIds, permId)
+	}
+
+	// Record index by name so we can fill access details below.
+	indexByName := make(map[string]int, len(cloudInfo))
+	for i, info := range cloudInfo {
+		indexByName[info.Name] = i
+	}
+
+	perms, closer := st.db().GetCollection(permissionsC)
+	defer closer()
+	query := perms.Find(bson.M{"_id": bson.M{"$in": permissionIds}}).Batch(100)
+	iter := query.Iter()
+
+	var doc permissionDoc
+	for iter.Next(&doc) {
+		cloudName := strings.TrimPrefix(doc.ObjectGlobalKey, "cloud#")
+		cloudIdx := indexByName[cloudName]
+
+		details := &cloudInfo[cloudIdx]
+		access := permission.Access(doc.Access)
+		if err := access.Validate(); err == nil {
+			details.Access = access
+		}
+	}
+	return iter.Close()
 }

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -212,6 +212,11 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// Ensure the controller cloud owner has admin.
+	cloudPermissionOps := createPermissionOp(
+		cloudGlobalKey(args.Cloud.Name),
+		userGlobalKey(userAccessID(args.ControllerModelArgs.Owner)),
+		permission.AdminAccess)
 
 	ops = append(ops,
 		txn.Op{
@@ -224,6 +229,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 			},
 		},
 		createCloudOp(args.Cloud),
+		cloudPermissionOps,
 		cloudRefCountOp,
 		txn.Op{
 			C:      controllersC,

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
@@ -207,6 +208,11 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 		"dummy/initialize-admin/some-credential":  expectedUserpassCredential,
 		"dummy/initialize-admin/empty-credential": expectedEmptyCredential,
 	})
+
+	// Check that the cloud owner has admin access.
+	access, err := s.State.GetCloudAccess("dummy", owner)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(access, gc.Equals, permission.AdminAccess)
 
 	// Check that the cloud's model count is initially 1.
 	cloud, err := s.State.Cloud("dummy")

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -250,7 +250,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainPermissions(c *gc.C) {
 	var initialPermissions []bson.M
 	err := coll.Find(nil).Sort("_id").All(&initialPermissions)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(initialPermissions, gc.HasLen, 2)
+	c.Assert(initialPermissions, gc.HasLen, 3)
 
 	err = coll.Insert(
 		permissionDoc{
@@ -275,7 +275,7 @@ func (s *upgradesSuite) TestStripLocalUserDomainPermissions(c *gc.C) {
 		initialPermissions[i] = perm
 	}
 
-	expected := []bson.M{initialPermissions[0], initialPermissions[1], {
+	expected := []bson.M{initialPermissions[0], initialPermissions[1], initialPermissions[2], {
 		"_id":                "uuid#fred",
 		"object-global-key":  "c#uuid",
 		"subject-global-key": "fred",
@@ -365,7 +365,7 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 	var initialPermissions []bson.M
 	err := coll.Find(nil).Sort("_id").All(&initialPermissions)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(initialPermissions, gc.HasLen, 2)
+	c.Assert(initialPermissions, gc.HasLen, 3)
 
 	err = coll.Insert(
 		permissionDoc{
@@ -390,7 +390,7 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 		initialPermissions[i] = perm
 	}
 
-	expected := []bson.M{initialPermissions[0], initialPermissions[1], {
+	expected := []bson.M{initialPermissions[0], initialPermissions[1], initialPermissions[2], {
 		"_id":                "uuid#fred",
 		"object-global-key":  "c#uuid",
 		"subject-global-key": "fred",
@@ -2799,6 +2799,11 @@ func (s *upgradesSuite) TestMigrateAddModelPermissions(c *gc.C) {
 		"_id":                permissionID(modelKey, "us#test-admin"),
 		"object-global-key":  modelKey,
 		"subject-global-key": "us#test-admin",
+		"access":             "admin",
+	}, {
+		"_id":                permissionID("cloud#dummy", "us#test-admin"),
+		"subject-global-key": "us#test-admin",
+		"object-global-key":  "cloud#dummy",
 		"access":             "admin",
 	}, {
 		"_id":                permissionID(controllerKey, "us#bob"),


### PR DESCRIPTION
## Description of change

Add new APIs to the cloud facade:
CloudInfo
ListCloudInfo

These are used to get info and access details for clouds. The implementation is based on what was done previously for models. These will be used later when the CLI is updated.

As a driveby, ensure the controller owner is granted explicit admin access to the controller cloud.

## QA steps

APIs not used yet. Basic smoke test.