### PR TITLE
Upgrade-Series Validation Checks that Units are not in an Error State.

### DIFF
--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -102,6 +102,7 @@ type Unit interface {
 	UnitTag() names.UnitTag
 	Name() string
 	AgentStatus() (status.StatusInfo, error)
+	Status() (status.StatusInfo, error)
 }
 
 func (m machineShim) VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error) {


### PR DESCRIPTION
## Description of change

This modifies the previous addition of unit validation to include a check that the units do not have a status of "error"

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`.
- Bootstrap
- Deploy a that results in the unit being in an error state. What works for me is:  `juju deploy redis --series xenial --force
- Once the error state is observed, `juju upgradeseries prepare 0 xenial` and receive the error message.

## Documentation changes

None.

## Bug reference

N/A
