### PR TITLE
Add back the state of each unit in a relation to goal state

### DIFF
--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -189,11 +189,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelation(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expectedUnitWordpress,
 					Relations: map[string]params.UnitsGoalState{
-						"db": params.UnitsGoalState{
-							"wordpress": expectedRelationStatus,
-						},
-						"server": params.UnitsGoalState{
-							"mysql": expectedRelationStatus,
+						"server": {
+							"mysql":   expectedRelationStatus,
+							"mysql/0": expectedUnitStatus,
 						},
 					},
 				},
@@ -224,11 +222,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsWordPress,
 					Relations: map[string]params.UnitsGoalState{
-						"db": params.UnitsGoalState{
-							"wordpress": expectedRelationStatus,
-						},
-						"server": params.UnitsGoalState{
-							"mysql": expectedRelationStatus,
+						"server": {
+							"mysql":   expectedRelationStatus,
+							"mysql/0": expectedUnitStatus,
 						},
 					},
 				},
@@ -246,11 +242,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 						"wordpress/0": expectedUnitStatus,
 					},
 					Relations: map[string]params.UnitsGoalState{
-						"db": params.UnitsGoalState{
-							"wordpress": expectedRelationStatus,
-						},
-						"server": params.UnitsGoalState{
-							"mysql": expectedRelationStatus,
+						"server": {
+							"mysql":   expectedRelationStatus,
+							"mysql/0": expectedUnitStatus,
 						},
 					},
 				},
@@ -301,11 +295,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsWordPress,
 					Relations: map[string]params.UnitsGoalState{
-						"db": params.UnitsGoalState{
-							"wordpress": expectedRelationStatus,
-						},
-						"server": params.UnitsGoalState{
-							"mysql": expectedRelationStatus,
+						"server": {
+							"mysql":   expectedRelationStatus,
+							"mysql/0": expectedUnitStatus,
 						},
 					},
 				},
@@ -328,11 +320,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 						},
 					},
 					Relations: map[string]params.UnitsGoalState{
-						"db": params.UnitsGoalState{
-							"wordpress": expectedRelationStatus,
-						},
-						"server": params.UnitsGoalState{
-							"mysql": expectedRelationStatus,
+						"server": {
+							"mysql":   expectedRelationStatus,
+							"mysql/0": expectedUnitStatus,
 						},
 					},
 				},
@@ -356,11 +346,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesCrossModelRelation(c *gc.C) {
 					"wordpress/0": expectedUnitStatus,
 				},
 				Relations: map[string]params.UnitsGoalState{
-					"db": params.UnitsGoalState{
-						"wordpress": expectedRelationStatus,
-					},
-					"server": params.UnitsGoalState{
-						"mysql": expectedRelationStatus,
+					"server": {
+						"mysql":   expectedRelationStatus,
+						"mysql/0": expectedUnitStatus,
 					},
 				},
 			},
@@ -389,11 +377,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesCrossModelRelation(c *gc.C) {
 					"wordpress/0": expectedUnitStatus,
 				},
 				Relations: map[string]params.UnitsGoalState{
-					"db": params.UnitsGoalState{
-						"wordpress": expectedRelationStatus,
-					},
-					"server": params.UnitsGoalState{
+					"server": {
 						"mysql":                     expectedRelationStatus,
+						"mysql/0":                   expectedUnitStatus,
 						"ctrl1:admin/default.mysql": expectedRelationStatus,
 					},
 				},
@@ -440,12 +426,11 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsWordPress,
 					Relations: map[string]params.UnitsGoalState{
-						"db": params.UnitsGoalState{
-							"wordpress": expectedRelationStatus,
-						},
-						"server": params.UnitsGoalState{
-							"mysql":  expectedRelationStatus,
-							"mysql1": expectedRelationStatus,
+						"server": {
+							"mysql":    expectedRelationStatus,
+							"mysql/0":  expectedUnitStatus,
+							"mysql1":   expectedRelationStatus,
+							"mysql1/0": expectedUnitStatus,
 						},
 					},
 				},

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2559,7 +2559,7 @@ func (u *UniterAPI) goalStateResult(application *state.Application) (*params.Goa
 		return nil, err
 	}
 	if allRelations != nil {
-		gs.Relations, err = u.goalStateRelations(allRelations)
+		gs.Relations, err = u.goalStateRelations(application.Name(), allRelations)
 		if err != nil {
 			return nil, err
 		}
@@ -2568,11 +2568,15 @@ func (u *UniterAPI) goalStateResult(application *state.Application) (*params.Goa
 }
 
 // goalStateRelations creates the structure with all the relations between endpoints in an application.
-func (u *UniterAPI) goalStateRelations(allRelations []*state.Relation) (map[string]params.UnitsGoalState, error) {
+func (u *UniterAPI) goalStateRelations(appName string, allRelations []*state.Relation) (map[string]params.UnitsGoalState, error) {
 
 	result := map[string]params.UnitsGoalState{}
 
 	for _, r := range allRelations {
+		statusInfo, err := r.Status()
+		if err != nil {
+			return nil, errors.Annotate(err, "getting relation status")
+		}
 		endPoints := r.Endpoints()
 		for _, e := range endPoints {
 			if e.Relation.Role == "peer" {
@@ -2598,11 +2602,13 @@ func (u *UniterAPI) goalStateRelations(allRelations []*state.Relation) (map[stri
 			} else {
 				return nil, err
 			}
-			goalState := params.GoalStateStatus{}
-			statusInfo, err := r.Status()
-			if err != nil {
-				return nil, errors.Annotate(err, "getting relation status")
+
+			// We don't show units for the same application as we are currently processing.
+			if key == appName {
+				continue
 			}
+
+			goalState := params.GoalStateStatus{}
 			goalState.Status = statusInfo.Status.String()
 			goalState.Since = statusInfo.Since
 			relationGoalState := result[e.Name]
@@ -2610,6 +2616,18 @@ func (u *UniterAPI) goalStateRelations(allRelations []*state.Relation) (map[stri
 				relationGoalState = params.UnitsGoalState{}
 			}
 			relationGoalState[key] = goalState
+
+			// For local applications, add in the status of units as well.
+			if application != nil {
+				units, err := u.goalStateUnits(application)
+				if err != nil {
+					return nil, err
+				}
+				for unitName, unitGS := range units {
+					relationGoalState[unitName] = unitGS
+				}
+			}
+
 			result[e.Name] = relationGoalState
 		}
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -252,13 +252,7 @@ func (s *InterfaceSuite) TestGoalState(c *gc.C) {
 			},
 		},
 		Relations: map[string]application.UnitsGoalState{
-			"db": application.UnitsGoalState{
-				"u": application.GoalStateStatus{
-					Status: "joining",
-					Since:  &timestamp,
-				},
-			},
-			"server": application.UnitsGoalState{
+			"server": {
 				"db0": application.GoalStateStatus{
 					Status: "joining",
 					Since:  &timestamp,
@@ -281,7 +275,7 @@ func (s *InterfaceSuite) TestGoalState(c *gc.C) {
 	}
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(goalState, gc.DeepEquals, &goalStateCheck)
+	c.Assert(goalState, jc.DeepEquals, &goalStateCheck)
 }
 
 // TestNonActionCallsToActionMethodsFail does exactly what its name says:

--- a/worker/uniter/runner/jujuc/jujuctesting/suite.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/suite.go
@@ -47,10 +47,10 @@ func (s *ContextSuite) NewInfo() *ContextInfo {
 			"mysql/0": gsStatus,
 		},
 		Relations: map[string]application.UnitsGoalState{
-			"db": application.UnitsGoalState{
+			"db": {
 				"mysql/0": gsStatus,
 			},
-			"server": application.UnitsGoalState{
+			"server": {
 				"wordpress/0": gsStatus,
 			},
 		},


### PR DESCRIPTION
## Description of change

Goal state output was changed to adhere to spec but in so doing lost some status that people ended up relying on. So we add that back in. The "relations" block now shows relation status plus the status of each unit in the relation. Also, we were showing peer units in the relation section as well as the units section - this has been fixed as well.

## QA steps

Deploy mediawiki and mariadb and relate.

`$ juju run --unit mariadb/0 goal-state`
``` yaml
units:
  mariadb/0:
    status: active
    since: 2018-09-28 00:59:42Z
relations:
  db:
    mediawiki:
      status: joined
      since: 2018-09-28 01:21:25Z
    mediawiki/0:
      status: active
      since: 2018-09-28 01:33:30Z
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1794739