### PR TITLE
Runs upgrade-series completion hook before others.

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -269,6 +269,13 @@ func (s *uniterResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.Install})
 	}
 
+	// This is checked early so that after a series upgrade, it is the first
+	// hook to be run.
+	if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
+		remoteState.UpgradeSeriesStatus == model.UpgradeSeriesCompleteStarted {
+		return opFactory.NewRunHook(hook.Info{Kind: hooks.PostSeriesUpgrade})
+	}
+
 	// Only IAAS models will react to a charm modified change.
 	// For CAAS models, the operator will unpack the new charm and
 	// inform the uniter workers to run the upgrade hook.
@@ -288,11 +295,6 @@ func (s *uniterResolver) nextOp(
 	if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
 		remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareStarted {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
-	}
-
-	if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
-		remoteState.UpgradeSeriesStatus == model.UpgradeSeriesCompleteStarted {
-		return opFactory.NewRunHook(hook.Info{Kind: hooks.PostSeriesUpgrade})
 	}
 
 	// If the local state is completed but the remote state is not started,

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -194,6 +194,7 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 		CharmURL:             s.charmURL,
 		Series:               s.charmURL.Series,
 		UpgradeSeriesStatus:  model.UpgradeSeriesNotStarted,
+		ConfigVersion:        1,
 		State: operation.State{
 			Kind:      operation.Continue,
 			Installed: true,
@@ -202,6 +203,11 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 	}
 	s.remoteState.Series = s.charmURL.Series
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesCompleteStarted
+
+	// Bumping the remote state config version checks that the upgrade-series
+	// completion hook takes precedence.
+	s.remoteState.ConfigVersion = 2
+
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run post-series-upgrade hook")


### PR DESCRIPTION
## Description of change

A bug was reported whereby `upgrade-series complete` hung due to the first hook executed being a config-changed event, which resulted in an error.

https://paste.ubuntu.com/p/HknV4JVVBj/

This patch simply moves the check for running the upgrade-series completion hook earlier in the workflow.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=upgrade-series`.
- Bootstrap
- `juju deploy --series xenial cs:~gnuoy/aodh-14`
- `juju upgrade-series prepare 0`
- When prepared, run `do-release-upgrade` on the machine. Choose to use the (new) mantainer's version of files when prompted.
- `juju upgrade-series complete 0`
- The command will not hang and there is a window where the complete hook can be seen running.

Note that this particular charm ends up blocked waiting for other applications. It was used because it exhibited the bug behaviour and could be used to determine rectification.

## Documentation changes

None.

## Bug reference

N/A
