### PR TITLE
Improve final guiding text for `add-cloud` invocation

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -259,8 +259,8 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 	}
 	ctxt.Infof("Cloud %q successfully added", name)
 	ctxt.Infof("")
-	ctxt.Infof("You may need to `juju add-credential %s' if your cloud needs additional credentials", name)
-	ctxt.Infof("Then you can bootstrap with 'juju bootstrap %s'", name)
+	ctxt.Infof("You will need to add credentials for this cloud (`juju add-credential %s`)", name)
+	ctxt.Infof("before creating a controller (`juju bootstrap %s`).", name)
 
 	return nil
 }

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -914,8 +914,8 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack cloudfile.Cloud, expectedYAML
 	var output = addStdErrMsg +
 		"Cloud \"os1\" successfully added\n" +
 		"\n" +
-		"You may need to `juju add-credential os1' if your cloud needs additional credentials\n" +
-		"Then you can bootstrap with 'juju bootstrap os1'\n"
+		"You will need to add credentials for this cloud (`juju add-credential os1`)\n" +
+		"before creating a controller (`juju bootstrap os1`).\n"
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, output)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, stdOutMsg)
 


### PR DESCRIPTION
## Description of change

Improve the text that the user sees once they successfully add a cloud with the `add-cloud` command.

## QA steps

Add a cloud and look at the text printed at the very end. It should say, assuming a given cloud name of 'lxd-remote':

```
You will need to add credentials for this cloud (`juju add-credential lxd-remote`)
before creating a controller (`juju bootstrap lxd-remote`).
```

## Documentation changes

Inspect any `add-cloud` example sessions and make the necessary changes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1794353
