### PR TITLE
LXD: Ensure target is defined firstly.

### DIFF
--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -113,18 +113,18 @@ func (env *environ) newContainer(
 	}
 	defer cleanupCallback()
 
-	image, err := env.server.FindImage(args.InstanceConfig.Series, arch, imageSources, true, statusCallback)
+	target, err := env.getTargetServer(ctx, args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	image, err := target.FindImage(args.InstanceConfig.Series, arch, imageSources, true, statusCallback)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	cleanupCallback() // Clean out any long line of completed download status
 
 	cSpec, err := env.getContainerSpec(image, args)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	target, err := env.getTargetServer(ctx, args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -137,14 +137,14 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	target := lxdtesting.NewMockContainerServer(ctrl)
 	tExp := target.EXPECT()
 	serverRet := &api.Server{}
+	image := &api.Image{Filename: "container-image"}
+
 	tExp.GetServer().Return(serverRet, lxdtesting.ETag, nil)
+	tExp.GetImageAlias("juju/bionic/amd64").Return(&api.ImageAliasesEntry{}, lxdtesting.ETag, nil)
+	tExp.GetImage("").Return(image, lxdtesting.ETag, nil)
 
 	jujuTarget, err := containerlxd.NewServer(target)
 	c.Assert(err, jc.ErrorIsNil)
-
-	image := containerlxd.SourcedImage{
-		Image: &api.Image{Filename: "container-image"},
-	}
 
 	members := []api.ClusterMember{
 		{
@@ -167,11 +167,10 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
-		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
+		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.HostArch().Return(arch.AMD64),
 	)
 
@@ -195,10 +194,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
 
-	image := containerlxd.SourcedImage{
-		Image: &api.Image{Filename: "container-image"},
-	}
-
 	members := []api.ClusterMember{{
 		ServerName: "node01",
 		Status:     "ONLINE",
@@ -207,8 +202,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
-		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
@@ -227,10 +220,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
 
-	image := containerlxd.SourcedImage{
-		Image: &api.Image{Filename: "container-image"},
-	}
-
 	members := []api.ClusterMember{{
 		ServerName: "node01",
 		Status:     "OFFLINE",
@@ -239,8 +228,6 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
-		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
 	)
@@ -259,15 +246,9 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
 
-	image := containerlxd.SourcedImage{
-		Image: &api.Image{Filename: "container-image"},
-	}
-
 	sExp := svr.EXPECT()
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
-		sExp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(image, nil),
-		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 	)
 	env := s.NewEnviron(c, svr, nil)
 


### PR DESCRIPTION
## Description of change

The following patch is required when attempting to bootstrap into
a lxd cluster, but the container image isn't found. We believe that
the happens because of an optimisation[1] with in lxd which assumes
the instance is the same as the source. Because of the way the methods
are invoked in juju, can lead to the prior bug[2].

[1] https://github.com/lxc/lxd/blob/c3de74dc45c23c177328a8d7c2a197ebcd521b42/client/lxd_containers.go#L176
[2] https://bugs.launchpad.net/juju/+bug/1793291

## QA steps

This assumes you have a cluster setup of at least 3 nodes and that you can 
communicate between them with a trust password. 

You can follow this [documentation](https://discourse.jujucharms.com/t/setting-up-lxd-cluster-as-a-juju-cloud/73)

```
juju bootstrap lxd-cluster --to zone=node3
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1793291
