### PR TITLE
Stop units from getting shut down.

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -270,8 +270,12 @@ func (s *uniterResolver) nextOp(
 	}
 
 	// This is checked early so that after a series upgrade, it is the first
-	// hook to be run.
-	if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
+	// hook to be run. The uniter's local state will be in the "not started" state
+	// if the uniter was stopped, for whatever reason, when performing a
+	// series upgrade. If the uniter was not stopped then it will be in the
+	// "prepare completed" state and should fire the hook likewise.
+	if (localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted ||
+		localState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareCompleted) &&
 		remoteState.UpgradeSeriesStatus == model.UpgradeSeriesCompleteStarted {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.PostSeriesUpgrade})
 	}

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -200,31 +200,8 @@ func (w *upgradeSeriesWorker) handlePrepareStarted() error {
 	return errors.Trace(w.transitionPrepareMachine(unitServices))
 }
 
-// transitionPrepareMachine stops all unit agents on this machine and updates
-// the upgrade-series status lock to indicate that upgrade work can proceed.
-// TODO (manadart 2018-08-09): Rename when a better name is contrived for
-// "UpgradeSeriesPrepareMachine".
 func (w *upgradeSeriesWorker) transitionPrepareMachine(unitServices map[string]string) error {
-	w.logger.Infof("stopping units for series upgrade")
-
-	for unit, serviceName := range unitServices {
-		svc, err := w.service.DiscoverService(serviceName)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		running, err := svc.Running()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !running {
-			continue
-		}
-
-		if err := svc.Stop(); err != nil {
-			return errors.Annotatef(err, "stopping %q unit agent for series upgrade", unit)
-		}
-	}
-	return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesPrepareMachine, "all units stopped for series upgrade"))
+	return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesPrepareMachine, "all unit prepare hooks completed"))
 }
 
 // handlePrepareMachine handles workflow for the machine with an upgrade-series

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -68,8 +68,8 @@ func (s *workerSuite) TestFullWorkflow(c *gc.C) {
 	// here, with the same effect and greater clarity.
 
 	w := s.workerForScenario(c, s.ignoreLogging(c), s.notify(6),
-		s.expectMachineUnitServiceDiscovery,
-		s.expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete,
+		s.expectMachinePrepareStartedUnitsNotPrepareCompleteNoAction,
+		s.expectMachinePrepareStartedUnitFilesWrittenProgressPrepareComplete,
 		s.expectMachineCompleteStartedUnitsPrepareCompleteUnitsStarted,
 		s.expectMachineCompleteStartedUnitsCompleteProgressComplete,
 		s.expectMachineCompletedFinishUpgradeSeries,
@@ -120,15 +120,7 @@ func (s *workerSuite) TestCompleteNoAction(c *gc.C) {
 func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.facade.EXPECT().MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
-	// Only one of the two units has completed preparation.
-	s.expectUnitsPrepared("wordpress/0")
-
-	// After comparing the prepare-complete units with the services,
-	// no further action is taken.
-	s.expectServiceDiscovery(false)
-
-	w := s.workerForScenario(c, s.ignoreLogging(c), s.notify(1))
+	w := s.workerForScenario(c, s.ignoreLogging(c), s.notify(1), s.expectMachinePrepareStartedUnitsNotPrepareCompleteNoAction)
 
 	s.cleanKill(c, w)
 	expected := map[string]interface{}{
@@ -138,33 +130,34 @@ func (s *workerSuite) TestMachinePrepareStartedUnitsNotPrepareCompleteNoAction(c
 	c.Check(w.(worker.Reporter).Report(), gc.DeepEquals, expected)
 }
 
-func (s *workerSuite) expectMachineUnitServiceDiscovery() {
+func (s *workerSuite) expectMachinePrepareStartedUnitsNotPrepareCompleteNoAction() {
 	s.facade.EXPECT().MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
-	// All known units have completed preparation - the workflow progresses.
-	s.expectUnitsPrepared("wordpress/0", "mysql/0")
-	s.facade.EXPECT().SetMachineStatus(model.UpgradeSeriesPrepareMachine, gomock.Any()).Return(nil)
+	// Only one of the two units has completed preparation.
+	s.expectUnitsPrepared("wordpress/0")
 
+	// After comparing the prepare-complete units with the services,
+	// no further action is taken.
 	s.expectServiceDiscovery(false)
 }
 
-func (s *workerSuite) TestMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete(c *gc.C) {
+func (s *workerSuite) TestMachinePrepareStartedUnitFilesWrittenProgressPrepareComplete(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	w := s.workerForScenario(c, s.ignoreLogging(c), s.notify(1),
-		s.expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete)
+		s.expectMachinePrepareStartedUnitFilesWrittenProgressPrepareComplete)
 
 	s.cleanKill(c, w)
 	expected := map[string]interface{}{
-		"machine status": model.UpgradeSeriesPrepareMachine,
+		"machine status": model.UpgradeSeriesPrepareStarted,
 		"prepared units": []string{"wordpress/0", "mysql/0"},
 	}
 	c.Check(w.(worker.Reporter).Report(), gc.DeepEquals, expected)
 }
 
-func (s *workerSuite) expectMachinePrepareMachineUnitFilesWrittenProgressPrepareComplete() {
+func (s *workerSuite) expectMachinePrepareStartedUnitFilesWrittenProgressPrepareComplete() {
 	exp := s.facade.EXPECT()
 
-	exp.MachineStatus().Return(model.UpgradeSeriesPrepareMachine, nil)
+	exp.MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
 	s.expectUnitsPrepared("wordpress/0", "mysql/0")
 	exp.TargetSeries().Return("xenial", nil)
 


### PR DESCRIPTION
## Description of change

Units should no longer be shut down during an `upgrade-series prepare`

