### PR TITLE
credentialsFromConfig returns errors for invalid k8s credentails rather than ignore

### DIFF
--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -136,7 +136,7 @@ func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Creden
 		var authType cloud.AuthType
 		if user.Token != "" {
 			if user.Username != "" || user.Password != "" {
-				return nil, errors.NotValidf("AuthInfo: %q has both Token and User/Pass", name)
+				return nil, errors.NotValidf("AuthInfo: %q with both Token and User/Pass", name)
 			}
 			attrs["Token"] = user.Token
 			if hasCert {
@@ -158,10 +158,10 @@ func credentialsFromConfig(config *clientcmdapi.Config) (map[string]cloud.Creden
 		} else if hasCert {
 			authType = cloud.CertificateAuthType
 			if len(user.ClientKeyData) == 0 {
-				return nil, errors.NotValidf("ClientKeyData is empty for %q AuthInfo %q", authType, name)
+				return nil, errors.NotValidf("empty ClientKeyData for %q with auth type %q", name, authType)
 			}
 		} else {
-			return nil, errors.NotValidf("unsupported configuration for AuthInfo %q", name)
+			return nil, errors.NotSupportedf("configuration for %q", name)
 		}
 
 		cred := cloud.NewCredential(authType, attrs)

--- a/caas/kubernetes/clientconfig/k8s_test.go
+++ b/caas/kubernetes/clientconfig/k8s_test.go
@@ -25,17 +25,7 @@ type k8sConfigSuite struct {
 var _ = gc.Suite(&k8sConfigSuite{})
 
 var (
-	emptyConfigYAML = `
-apiVersion: v1
-kind: Config
-clusters: []
-contexts: []
-current-context: ""
-preferences: {}
-users: []
-`
-
-	singleConfigYAML = `
+	prefixConfigYAML = `
 apiVersion: v1
 kind: Config
 clusters:
@@ -51,6 +41,18 @@ contexts:
 current-context: the-context
 preferences: {}
 users:
+`
+	emptyConfigYAML = `
+apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+current-context: ""
+preferences: {}
+users: []
+`
+
+	singleConfigYAML = prefixConfigYAML + `
 - name: the-user
   user:
     password: thepassword
@@ -102,32 +104,6 @@ users:
     client-key-data: Qg==
     username: "fifth-user"
     password: "userpasscertpass"
-`
-	notSupportedAuthProviderTypeConfigYAML = `
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: https://1.1.1.1:8888
-    certificate-authority-data: QQ==
-  name: the-cluster
-contexts:
-- context:
-    cluster: the-cluster
-    user: the-user
-  name: the-context
-current-context: the-context
-preferences: {}
-users:
-- name: gke_gothic-list-89514_us-central1-a_kubeflow-codelab
-  user:
-    auth-provider:
-      config:
-        cmd-args: config config-helper --format=json
-        cmd-path: /usr/lib/google-cloud-sdk/bin/gcloud
-        expiry-key: '{.credential.token_expiry}'
-        token-key: '{.credential.access_token}'
-      name: gcp
 `
 )
 
@@ -201,13 +177,56 @@ func (s *k8sConfigSuite) assertSingleConfig(c *gc.C, f *os.File) {
 		})
 }
 
-func (s *k8sConfigSuite) TestAuthProviderTypeConfigError(c *gc.C) {
-	f, err := s.writeTempKubeConfig(c, "notSupportedAuthProviderTypeConfig", notSupportedAuthProviderTypeConfigYAML)
-	defer f.Close()
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = clientconfig.NewK8sClientConfig(f)
-	c.Assert(err, gc.ErrorMatches,
-		`failed to read credentials from kubernetes config: unsupported configuration for AuthInfo "gke_gothic-list-89514_us-central1-a_kubeflow-codelab" not valid`)
+func (s *k8sConfigSuite) TestConfigErrors(c *gc.C) {
+	for i, test := range []struct {
+		title          string
+		userConfigYAML string
+		errMatch       string
+	}{
+		{
+			title: "notSupportedAuthProviderTypeConfig",
+			userConfigYAML: `
+- name: the-user
+  user:
+    auth-provider:
+      config:
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/lib/google-cloud-sdk/bin/gcloud
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+`,
+			errMatch: `failed to read credentials from kubernetes config: configuration for "the-user" not supported`,
+		},
+		{
+			title: "tokenWithUsernameInvalidConfig",
+			userConfigYAML: `
+- name: the-user
+  user:
+    password: defaultpassword
+    username: defaultuser
+    token: nonEmptyToken
+`,
+			errMatch: `failed to read credentials from kubernetes config: AuthInfo: "the-user" with both Token and User/Pass not valid`,
+		},
+		{
+			title: "emptyClientKeyDataInvalidConfig",
+			userConfigYAML: `
+- name: the-user
+  user:
+    client-certificate-data: QQ==
+    client-key-data:
+`,
+			errMatch: `failed to read credentials from kubernetes config: empty ClientKeyData for \"the-user\" with auth type \"certificate\" not valid`,
+		},
+	} {
+		c.Logf("test %d", i)
+		f, err := s.writeTempKubeConfig(c, test.title, prefixConfigYAML+test.userConfigYAML)
+		defer f.Close()
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = clientconfig.NewK8sClientConfig(f)
+		c.Check(err, gc.ErrorMatches, test.errMatch)
+	}
 }
 
 func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {


### PR DESCRIPTION
## Description of change

returns error for invalid/unsupported k8s credentials

## QA steps

- prepare auth-provider k8s credentials like:
```yaml
- name: gke_gothic-list-89514_us-central1-a_kubeflow-codelab
  user:
    auth-provider:
      config:
        cmd-args: config config-helper --format=json
        cmd-path: /usr/lib/google-cloud-sdk/bin/gcloud
        expiry-key: '{.credential.token_expiry}'
        token-key: '{.credential.access_token}'
      name: gcp
```
- juju add-k8s should complain about it;
```
kubectl config view --raw | juju add-k8s <cloud-name> --cluster-name=<cluster-name>  --debug
```

## Documentation changes

N/A

## Bug reference

N/A
