### PR TITLE
Implement Lease Pinning in Store and Worker

### DIFF
--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -40,11 +40,11 @@ type ReleaseLeadershipBulkParams struct {
 // leadership claim.
 type ReleaseLeadershipParams struct {
 
-	// ApplicationTag is the application for which you want to make a
+	// ApplicationTag is the application for which you want to release the
 	// leadership claim.
 	ApplicationTag string `json:"application-tag"`
 
-	// UnitTag is the unit which is making the leadership claim.
+	// UnitTag is the unit which is releasing the leadership claim.
 	UnitTag string `json:"unit-tag"`
 }
 

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -30,28 +30,6 @@ type ClaimLeadershipParams struct {
 // leadership claim.
 type ClaimLeadershipBulkResults ErrorResults
 
-// ReleaseLeadershipBulkParams is a collection of parameters needed to
-// make a bulk release leadership call.
-type ReleaseLeadershipBulkParams struct {
-	Params []ReleaseLeadershipParams `json:"params"`
-}
-
-// ReleaseLeadershipParams are the parameters needed to release a
-// leadership claim.
-type ReleaseLeadershipParams struct {
-
-	// ApplicationTag is the application for which you want to release the
-	// leadership claim.
-	ApplicationTag string `json:"application-tag"`
-
-	// UnitTag is the unit which is releasing the leadership claim.
-	UnitTag string `json:"unit-tag"`
-}
-
-// ReleaseLeadershipBulkResults is a type which contains results from
-// a bulk leadership call.
-type ReleaseLeadershipBulkResults ErrorResults
-
 // GetLeadershipSettingsBulkResults is the collection of results from
 // a bulk request for leadership settings.
 type GetLeadershipSettingsBulkResults struct {

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -36,7 +36,7 @@ type Store interface {
 	// expressed according to the Clock the store was configured with.
 	Leases() map[Key]Info
 
-	// TODO (jam) 2017-10-31: Many callers of Leases() actually only tant
+	// TODO (jam) 2017-10-31: Many callers of Leases() actually only want
 	// exactly 1 lease, we should have a way to do a query to return exactly
 	// that lease, instead of having to read all of them to pull one out of the
 	// map. (Worst case it is implemented as exactly this, best case avoids
@@ -44,6 +44,17 @@ type Store interface {
 
 	// Refresh reads all lease state from the database.
 	Refresh() error
+
+	// PinLease ensures that the holder of the input lease will not have its
+	// claim expired until UnpinLease is called for the same key.
+	// A current lease holder is not required for this operation to succeed.
+	// If there is no holder, the next claimant of the lease will hold it at
+	// least until Unpin is called.
+	PinLease(lease Key) error
+
+	// UnpinLease removes the pin from the input lease,
+	// restoring normal expiry behaviour.
+	UnpinLease(lease Key) error
 }
 
 // Key fully identifies a lease, including the namespace and

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -128,6 +128,26 @@ func (s *Store) Refresh() error {
 	return nil
 }
 
+// PinLease is part of lease.Store.
+func (s *Store) PinLease(key lease.Key) error {
+	return errors.Trace(s.pinOp(key, OperationPin))
+}
+
+// UnpinLease is part of lease.Store.
+func (s *Store) UnpinLease(key lease.Key) error {
+	return errors.Trace(s.pinOp(key, OperationUnpin))
+}
+
+func (s *Store) pinOp(key lease.Key, operation string) error {
+	return errors.Trace(s.runOnLeader(&Command{
+		Version:   CommandVersion,
+		Operation: operation,
+		Namespace: key.Namespace,
+		ModelUUID: key.ModelUUID,
+		Lease:     key.Lease,
+	}))
+}
+
 // Advance is part of globalclock.Updater.
 func (s *Store) Advance(duration time.Duration) error {
 	s.prevTimeMu.Lock()

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/raftlease"
@@ -121,4 +122,14 @@ func (s *leaseStore) Leases() map[lease.Key]lease.Info {
 // Refresh is part of lease.Store.
 func (s *leaseStore) Refresh() error {
 	return nil
+}
+
+// PinLease is part of lease.Store.
+func (s *leaseStore) PinLease(key lease.Key) error {
+	return errors.NotImplementedf("pinning for legacy leases")
+}
+
+// UnpinLease is part of lease.Store.
+func (s *leaseStore) UnpinLease(key lease.Key) error {
+	return errors.NotImplementedf("unpinning for legacy leases")
 }

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -69,10 +69,10 @@ type leadershipChecker struct {
 }
 
 // LeadershipCheck is part of the leadership.Checker interface.
-func (m leadershipChecker) LeadershipCheck(applicationname, unitName string) leadership.Token {
-	token := m.checker.Token(applicationname, unitName)
+func (m leadershipChecker) LeadershipCheck(applicationName, unitName string) leadership.Token {
+	token := m.checker.Token(applicationName, unitName)
 	return leadershipToken{
-		applicationname: applicationname,
+		applicationName: applicationName,
 		unitName:        unitName,
 		token:           token,
 	}
@@ -80,7 +80,7 @@ func (m leadershipChecker) LeadershipCheck(applicationname, unitName string) lea
 
 // leadershipToken implements leadership.Token by wrapping a lease.Token.
 type leadershipToken struct {
-	applicationname string
+	applicationName string
 	unitName        string
 	token           lease.Token
 }
@@ -89,12 +89,12 @@ type leadershipToken struct {
 func (t leadershipToken) Check(out interface{}) error {
 	err := t.token.Check(out)
 	if errors.Cause(err) == lease.ErrNotHeld {
-		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationname)
+		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
 	}
 	return errors.Trace(err)
 }
 
-// leadershipClaimer implements leadership.Claimer by wrappping a lease.Claimer.
+// leadershipClaimer implements leadership.Claimer by wrapping a lease.Claimer.
 type leadershipClaimer struct {
 	claimer lease.Claimer
 }

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -188,6 +188,16 @@ func (store *store) ExpireLease(key lease.Key) error {
 	return nil
 }
 
+// PinLease is part of the Store interface.
+func (store *store) PinLease(key lease.Key) error {
+	return errors.NotImplementedf("pinning for legacy leases")
+}
+
+// UnpinLease is part of the Store interface.
+func (store *store) UnpinLease(key lease.Key) error {
+	return errors.NotImplementedf("unpinning for legacy leases")
+}
+
 // Refresh is part of the Store interface.
 func (store *store) Refresh() error {
 	store.mu.Lock()

--- a/worker/lease/bound.go
+++ b/worker/lease/bound.go
@@ -11,15 +11,15 @@ import (
 	"github.com/juju/juju/core/lease"
 )
 
-// checkerClaimer combines the lease.Checker and lease.Claimer
-// interfaces.
-type checkerClaimer interface {
+// broker describes methods for manipulating and checking leases.
+type broker interface {
 	lease.Checker
 	lease.Claimer
+	lease.Pinner
 }
 
-// boundManager implements lease.Claimer and lease.Checker - it
-// represents a lease manager for a specific namespace and model.
+// boundManager implements the broker interface.
+// It represents a lease manager for a specific namespace and model.
 type boundManager struct {
 	manager   *Manager
 	secretary Secretary
@@ -29,11 +29,7 @@ type boundManager struct {
 
 // Claim is part of the lease.Claimer interface.
 func (b *boundManager) Claim(leaseName, holderName string, duration time.Duration) error {
-	key := lease.Key{
-		Namespace: b.namespace,
-		ModelUUID: b.modelUUID,
-		Lease:     leaseName,
-	}
+	key := b.leaseKey(leaseName)
 	if err := b.secretary.CheckLease(key); err != nil {
 		return errors.Annotatef(err, "cannot claim lease %q", leaseName)
 	}
@@ -43,6 +39,7 @@ func (b *boundManager) Claim(leaseName, holderName string, duration time.Duratio
 	if err := b.secretary.CheckDuration(duration); err != nil {
 		return errors.Annotatef(err, "cannot claim lease for %s", duration)
 	}
+
 	return claim{
 		leaseKey:   key,
 		holderName: holderName,
@@ -54,14 +51,11 @@ func (b *boundManager) Claim(leaseName, holderName string, duration time.Duratio
 
 // WaitUntilExpired is part of the lease.Claimer interface.
 func (b *boundManager) WaitUntilExpired(leaseName string, cancel <-chan struct{}) error {
-	key := lease.Key{
-		Namespace: b.namespace,
-		ModelUUID: b.modelUUID,
-		Lease:     leaseName,
-	}
+	key := b.leaseKey(leaseName)
 	if err := b.secretary.CheckLease(key); err != nil {
 		return errors.Annotatef(err, "cannot wait for lease %q expiry", leaseName)
 	}
+
 	return block{
 		leaseKey: key,
 		unblock:  make(chan struct{}),
@@ -72,16 +66,40 @@ func (b *boundManager) WaitUntilExpired(leaseName string, cancel <-chan struct{}
 
 // Token is part of the lease.Checker interface.
 func (b *boundManager) Token(leaseName, holderName string) lease.Token {
-	key := lease.Key{
-		Namespace: b.namespace,
-		ModelUUID: b.modelUUID,
-		Lease:     leaseName,
-	}
 	return token{
-		leaseKey:   key,
+		leaseKey:   b.leaseKey(leaseName),
 		holderName: holderName,
 		secretary:  b.secretary,
 		checks:     b.manager.checks,
 		stop:       b.manager.catacomb.Dying(),
+	}
+}
+
+// Pin (lease.Pinner) sends a pin message to the worker loop.
+func (b *boundManager) Pin(leaseName string) error {
+	return errors.Trace(b.pinOp(leaseName, b.manager.pins))
+}
+
+// Unpin (lease.Pinner) sends an unpin message to the worker loop.
+func (b *boundManager) Unpin(leaseName string) error {
+	return errors.Trace(b.pinOp(leaseName, b.manager.unpins))
+}
+
+// pinOp creates a pin instance from the input lease name,
+// then sends it on the input channel.
+func (b *boundManager) pinOp(leaseName string, ch chan pin) error {
+	return errors.Trace(pin{
+		leaseKey: b.leaseKey(leaseName),
+		response: make(chan error),
+		stop:     b.manager.catacomb.Dying(),
+	}.invoke(ch))
+}
+
+// leaseKey returns a key for the manager's binding and the input lease name.
+func (b *boundManager) leaseKey(leaseName string) lease.Key {
+	return lease.Key{
+		Namespace: b.namespace,
+		ModelUUID: b.modelUUID,
+		Lease:     leaseName,
 	}
 }

--- a/worker/lease/dead_manager_test.go
+++ b/worker/lease/dead_manager_test.go
@@ -52,6 +52,16 @@ func (s *deadManagerSuite) TestChecker(c *gc.C) {
 	checkMethods(c, checker)
 }
 
+// And Pinner.
+func (s *deadManagerSuite) TestPinner(c *gc.C) {
+	deadManagerErr := deadManagerError{}
+	deadManager := lease.NewDeadManager(&deadManagerErr)
+
+	checker, err := deadManager.Pinner("namespace", "model")
+	c.Assert(err, jc.ErrorIsNil)
+	checkMethods(c, checker)
+}
+
 func checkMethods(c *gc.C, manager interface{}) {
 	managerType := reflect.TypeOf(manager)
 	managerValue := reflect.ValueOf(manager)

--- a/worker/lease/manager_pin_test.go
+++ b/worker/lease/manager_pin_test.go
@@ -1,0 +1,94 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/worker/lease"
+)
+
+type PinSuite struct {
+	testing.IsolationSuite
+	keyArgs []interface{}
+}
+
+func (s *PinSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.keyArgs = []interface{}{
+		corelease.Key{
+			Namespace: "namespace",
+			ModelUUID: "modelUUID",
+			Lease:     "redis",
+		},
+	}
+}
+
+var _ = gc.Suite(&PinSuite{})
+
+func (s *PinSuite) TestPinLease_Success(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "PinLease",
+			args:   s.keyArgs,
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
+		err := getPinner(c, manager).Pin("redis")
+		c.Assert(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *PinSuite) TestPinLease_Error(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "PinLease",
+			args:   s.keyArgs,
+			err:    errors.New("boom"),
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
+		err := getPinner(c, manager).Pin("redis")
+		c.Check(err, gc.ErrorMatches, "boom")
+	})
+}
+
+func (s *PinSuite) TestUnpinLease_Success(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "UnpinLease",
+			args:   s.keyArgs,
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
+		err := getPinner(c, manager).Unpin("redis")
+		c.Assert(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *PinSuite) TestUnpinLease_Error(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "UnpinLease",
+			args:   s.keyArgs,
+			err:    errors.New("boom"),
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
+		err := getPinner(c, manager).Unpin("redis")
+		c.Check(err, gc.ErrorMatches, "boom")
+	})
+}
+
+func getPinner(c *gc.C, manager *lease.Manager) corelease.Pinner {
+	pinner, err := manager.Pinner("namespace", "modelUUID")
+	c.Assert(err, jc.ErrorIsNil)
+	return pinner
+}

--- a/worker/lease/pin.go
+++ b/worker/lease/pin.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"github.com/juju/juju/core/lease"
+)
+
+// pin is used to deliver lease pinning and unpinning requests to a manager's
+// worker loop on behalf of PinLeadership and UnpinLeadership.
+type pin struct {
+	leaseKey lease.Key
+	response chan error
+	stop     <-chan struct{}
+}
+
+// invoke sends the claim on the supplied channel and waits for a response.
+func (c pin) invoke(ch chan<- pin) error {
+	for {
+		select {
+		case <-c.stop:
+			return errStopped
+		case ch <- c:
+			ch = nil
+		case err := <-c.response:
+			return err
+		}
+	}
+}
+
+// respond causes the supplied success value to be sent back to invoke.
+func (c pin) respond(err error) {
+	select {
+	case <-c.stop:
+	case c.response <- err:
+	}
+}

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -171,6 +171,16 @@ func (store *Store) Refresh() error {
 	return store.call("Refresh", nil)
 }
 
+// PinLease is part of the corelease.Store interface.
+func (store *Store) PinLease(key lease.Key) error {
+	return store.call("PinLease", []interface{}{key})
+}
+
+// UnpinLease is part of the corelease.Store interface.
+func (store *Store) UnpinLease(key lease.Key) error {
+	return store.call("UnpinLease", []interface{}{key})
+}
+
 // call defines a expected method call on a Store; it encodes:
 type call struct {
 


### PR DESCRIPTION
## Description of change

This patch builds on previous modifications to support the "pinning" of leadership via leases. In particular:
- The new lease _Pinner_ interface is implemented by all lease stores, but throws `NotImplemented` on all but the Raft store.
-  The lease worker handles pin and unpin operations.

## QA steps

New unit tests.

## Documentation changes

There will be an ultimate client-facing exposure of this facility, but not yet.

## Bug reference

N/A
