### PR TITLE
Fix uniter crash edge case

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -723,7 +723,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatusFailsIfNoLockExists(c *gc.C) {
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatusUpdatesStatus(c *gc.C) {
-	arbitraryNonDefaultStatus := model.UpgradeSeriesNotStarted
+	arbitraryNonDefaultStatus := model.UpgradeSeriesPrepareRunning
 	arbitraryReason := ""
 
 	// First we create the prepare lock or the required state will not exists

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -225,7 +225,7 @@ func (u *UpgradeSeriesAPI) setUnitStatus(args params.UpgradeSeriesStatusParams) 
 			result.Results[i].Error = ServerError(err)
 			continue
 		}
-		status, err := model.ValidateUnitSeriesUpgradeStatus(p.Status)
+		status, err := model.ValidateUpgradeSeriesStatus(p.Status)
 		if err != nil {
 			result.Results[i].Error = ServerError(err)
 			continue

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -14,12 +14,11 @@ var UpgradeSeriesStatusOrder map[UpgradeSeriesStatus]int = map[UpgradeSeriesStat
 	UpgradeSeriesNotStarted:       0,
 	UpgradeSeriesPrepareStarted:   1,
 	UpgradeSeriesPrepareRunning:   2,
-	UpgradeSeriesPrepareMachine:   3,
-	UpgradeSeriesPrepareCompleted: 4,
-	UpgradeSeriesCompleteStarted:  5,
-	UpgradeSeriesCompleteRunning:  6,
-	UpgradeSeriesCompleted:        7,
-	UpgradeSeriesError:            8,
+	UpgradeSeriesPrepareCompleted: 3,
+	UpgradeSeriesCompleteStarted:  4,
+	UpgradeSeriesCompleteRunning:  5,
+	UpgradeSeriesCompleted:        6,
+	UpgradeSeriesError:            7,
 }
 
 const (
@@ -34,9 +33,9 @@ const (
 	UpgradeSeriesError            UpgradeSeriesStatus = "error"
 )
 
-// ValidateUnitSeriesUpgradeStatus validates a the input status as valid for a
+// ValidateUpgradeSeriesStatus validates a the input status as valid for a
 // unit, returning the valid status or an error.
-func ValidateUnitSeriesUpgradeStatus(status UpgradeSeriesStatus) (UpgradeSeriesStatus, error) {
+func ValidateUpgradeSeriesStatus(status UpgradeSeriesStatus) (UpgradeSeriesStatus, error) {
 	if _, ok := UpgradeSeriesStatusOrder[status]; !ok {
 		return UpgradeSeriesNotStarted, errors.NotValidf("upgrade series status of %q is", status)
 	}
@@ -48,8 +47,8 @@ func ValidateUnitSeriesUpgradeStatus(status UpgradeSeriesStatus) (UpgradeSeriesS
 // returned; 1 is returned otherwise.
 func CompareUpgradeSeriesStatus(status1 UpgradeSeriesStatus, status2 UpgradeSeriesStatus) (int, error) {
 	var err error
-	st1, err := ValidateUnitSeriesUpgradeStatus(status1)
-	st2, err := ValidateUnitSeriesUpgradeStatus(status2)
+	st1, err := ValidateUpgradeSeriesStatus(status1)
+	st2, err := ValidateUpgradeSeriesStatus(status2)
 	if err != nil {
 		return 0, err
 	}

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -37,24 +37,28 @@ const (
 // ValidateUnitSeriesUpgradeStatus validates a the input status as valid for a
 // unit, returning the valid status or an error.
 func ValidateUnitSeriesUpgradeStatus(status UpgradeSeriesStatus) (UpgradeSeriesStatus, error) {
-	switch status {
-	case UpgradeSeriesNotStarted, UpgradeSeriesPrepareStarted, UpgradeSeriesPrepareCompleted,
-		UpgradeSeriesCompleteStarted, UpgradeSeriesCompleted, UpgradeSeriesError,
-		UpgradeSeriesPrepareRunning, UpgradeSeriesCompleteRunning:
-		return status, nil
+	if _, ok := UpgradeSeriesStatusOrder[status]; !ok {
+		return UpgradeSeriesNotStarted, errors.NotValidf("upgrade series status of %q is", status)
 	}
-	return UpgradeSeriesNotStarted, errors.NotValidf("unit upgrade series status of %q", status)
+	return status, nil
 }
 
 // CompareUpgradeSeriesStatus compares two upgrade series statuses and returns and integer; if the first
 // argument equals the second then 0 is returned; if the second is greater -1 is
 // returned; 1 is returned otherwise.
-func CompareUpgradeSeriesStatus(status1 UpgradeSeriesStatus, status2 UpgradeSeriesStatus) int {
-	if UpgradeSeriesStatusOrder[status1] == UpgradeSeriesStatusOrder[status2] {
-		return 0
+func CompareUpgradeSeriesStatus(status1 UpgradeSeriesStatus, status2 UpgradeSeriesStatus) (int, error) {
+	var err error
+	st1, err := ValidateUnitSeriesUpgradeStatus(status1)
+	st2, err := ValidateUnitSeriesUpgradeStatus(status2)
+	if err != nil {
+		return 0, err
 	}
-	if UpgradeSeriesStatusOrder[status1] < UpgradeSeriesStatusOrder[status2] {
-		return -1
+
+	if UpgradeSeriesStatusOrder[st1] == UpgradeSeriesStatusOrder[st2] {
+		return 0, nil
 	}
-	return 1
+	if UpgradeSeriesStatusOrder[st1] < UpgradeSeriesStatusOrder[st2] {
+		return -1, nil
+	}
+	return 1, nil
 }

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -10,6 +10,18 @@ import (
 // UpgradeSeriesStatus is the current status of a series upgrade for units
 type UpgradeSeriesStatus string
 
+var UpgradeSeriesStatusOrder map[UpgradeSeriesStatus]int = map[UpgradeSeriesStatus]int{
+	UpgradeSeriesNotStarted:       0,
+	UpgradeSeriesPrepareStarted:   1,
+	UpgradeSeriesPrepareRunning:   2,
+	UpgradeSeriesPrepareMachine:   3,
+	UpgradeSeriesPrepareCompleted: 4,
+	UpgradeSeriesCompleteStarted:  5,
+	UpgradeSeriesCompleteRunning:  6,
+	UpgradeSeriesCompleted:        7,
+	UpgradeSeriesError:            8,
+}
+
 const (
 	UpgradeSeriesNotStarted       UpgradeSeriesStatus = "not started"
 	UpgradeSeriesPrepareStarted   UpgradeSeriesStatus = "prepare started"
@@ -32,4 +44,17 @@ func ValidateUnitSeriesUpgradeStatus(status UpgradeSeriesStatus) (UpgradeSeriesS
 		return status, nil
 	}
 	return UpgradeSeriesNotStarted, errors.NotValidf("unit upgrade series status of %q", status)
+}
+
+// CompareUpgradeSeriesStatus compares two upgrade series statuses and returns and integer; if the first
+// argument equals the second then 0 is returned; if the second is greater -1 is
+// returned; 1 is returned otherwise.
+func CompareUpgradeSeriesStatus(status1 UpgradeSeriesStatus, status2 UpgradeSeriesStatus) int {
+	if UpgradeSeriesStatusOrder[status1] == UpgradeSeriesStatusOrder[status2] {
+		return 0
+	}
+	if UpgradeSeriesStatusOrder[status1] < UpgradeSeriesStatusOrder[status2] {
+		return -1
+	}
+	return 1
 }

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -42,9 +42,10 @@ func ValidateUpgradeSeriesStatus(status UpgradeSeriesStatus) (UpgradeSeriesStatu
 	return status, nil
 }
 
-// CompareUpgradeSeriesStatus compares two upgrade series statuses and returns and integer; if the first
-// argument equals the second then 0 is returned; if the second is greater -1 is
-// returned; 1 is returned otherwise.
+// CompareUpgradeSeriesStatus compares two upgrade series statuses and returns
+// an integer; if the first argument equals the second then 0 is returned; if
+// the second is greater -1 is returned; 1 is returned otherwise. An error is
+// returned if either argument is an invalid status.
 func CompareUpgradeSeriesStatus(status1 UpgradeSeriesStatus, status2 UpgradeSeriesStatus) (int, error) {
 	var err error
 	st1, err := ValidateUpgradeSeriesStatus(status1)

--- a/core/model/upgradeseries_test.go
+++ b/core/model/upgradeseries_test.go
@@ -27,7 +27,7 @@ func (*upgradeSeriesSuite) TestValidateUnitUpgradeSeriesStatus(c *gc.C) {
 		{model.UpgradeSeriesPrepareStarted, "prepare started", true},
 		{model.UpgradeSeriesNotStarted, "GTFO", false},
 	} {
-		status, err := model.ValidateUnitSeriesUpgradeStatus(model.UpgradeSeriesStatus(t.name))
+		status, err := model.ValidateUpgradeSeriesStatus(model.UpgradeSeriesStatus(t.name))
 		if t.valid {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/core/model/upgradeseries_test.go
+++ b/core/model/upgradeseries_test.go
@@ -36,3 +36,21 @@ func (*upgradeSeriesSuite) TestValidateUnitUpgradeSeriesStatus(c *gc.C) {
 		c.Check(status, gc.Equals, t.expected)
 	}
 }
+
+func (*upgradeSeriesSuite) TestUpgradeSeriesStatusOrderComparison(c *gc.C) {
+	for status1, i := range model.UpgradeSeriesStatusOrder {
+		for status2, j := range model.UpgradeSeriesStatusOrder {
+			comp := model.CompareUpgradeSeriesStatus(status1, status2)
+			if status1 == status2 {
+				c.Check(comp, gc.Equals, 0)
+			} else {
+				sig := i - j
+				c.Check(sameSign(comp, sig), jc.IsTrue)
+			}
+		}
+	}
+}
+
+func sameSign(x, y int) bool {
+	return (x >= 0) != (y < 0)
+}

--- a/core/model/upgradeseries_test.go
+++ b/core/model/upgradeseries_test.go
@@ -40,7 +40,8 @@ func (*upgradeSeriesSuite) TestValidateUnitUpgradeSeriesStatus(c *gc.C) {
 func (*upgradeSeriesSuite) TestUpgradeSeriesStatusOrderComparison(c *gc.C) {
 	for status1, i := range model.UpgradeSeriesStatusOrder {
 		for status2, j := range model.UpgradeSeriesStatusOrder {
-			comp := model.CompareUpgradeSeriesStatus(status1, status2)
+			comp, err := model.CompareUpgradeSeriesStatus(status1, status2)
+			c.Check(err, jc.ErrorIsNil)
 			if status1 == status2 {
 				c.Check(comp, gc.Equals, 0)
 			} else {
@@ -49,6 +50,11 @@ func (*upgradeSeriesSuite) TestUpgradeSeriesStatusOrderComparison(c *gc.C) {
 			}
 		}
 	}
+}
+
+func (*upgradeSeriesSuite) TestUpgradeSeriesStatusOrderComparisonVlidatesStatuses(c *gc.C) {
+	_, err := model.CompareUpgradeSeriesStatus(model.UpgradeSeriesNotStarted, "bad status")
+	c.Check(err.Error(), gc.Equals, "upgrade series status of \"bad status\" is not valid")
 }
 
 func sameSign(x, y int) bool {

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -423,7 +423,12 @@ func (m *Machine) verifyUnitUpgradeSeriesStatus(unitName string, status model.Up
 	if !ok {
 		return false, errors.NotFoundf(unitName)
 	}
-	return model.CompareUpgradeSeriesStatus(us.Status, status) == -1
+
+	comp, err := model.CompareUpgradeSeriesStatus(us.Status, status)
+	if err != nil {
+		return false, err
+	}
+	return comp == -1, nil
 }
 
 // [TODO](externalreality): move some/all of these parameters into an argument structure.

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -423,7 +423,7 @@ func (m *Machine) verifyUnitUpgradeSeriesStatus(unitName string, status model.Up
 	if !ok {
 		return false, errors.NotFoundf(unitName)
 	}
-	return model.CompareUpgradeSeriesStatus(us.Status, status) == -1, nil
+	return model.CompareUpgradeSeriesStatus(us.Status, status) == -1
 }
 
 // [TODO](externalreality): move some/all of these parameters into an argument structure.

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -206,12 +206,6 @@ func (rh *runHook) afterHook(state State) (_ bool, err error) {
 		if rErr == nil && rel.Suspended() {
 			err = rel.SetStatus(relation.Suspended)
 		}
-	case hooks.PreSeriesUpgrade:
-		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted, message)
-	case hooks.PostSeriesUpgrade:
-		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, message)
 	}
 	return hasRunStatusSet && err == nil, err
 }
@@ -262,6 +256,12 @@ func (rh *runHook) Commit(state State) (*State, error) {
 		newState.Started = true
 	case hooks.Stop:
 		newState.Stopped = true
+	case hooks.PreSeriesUpgrade:
+		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
+		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted, message)
+	case hooks.PostSeriesUpgrade:
+		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
+		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, message)
 	}
 
 	return newState, nil

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -582,7 +582,7 @@ func (w *RemoteStateWatcher) upgradeSeriesStatus() (model.UpgradeSeriesStatus, e
 	if err != nil {
 		return "", err
 	}
-	status, err := model.ValidateUnitSeriesUpgradeStatus(rawStatus)
+	status, err := model.ValidateUpgradeSeriesStatus(rawStatus)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR fixes an edge case with the `upgrade-series` command. 

If the `uniter` should stop while running its hooks then when it is restarted by the `complete` sub command the uniter would rerun the interrupted hook which would regresses the units state and halt the machine's agent's `upgrade-series` workflow.

Like any program, we cannot prevent the `uniter` form being stopped by outside forces, the only thing we can do is have it recover gracefully when it is restarted. We take two measures to do this:

1. We ensure a unit's remote `upgrade series` state cannot be regressed by the `upgrade-series` hooks
2. We ensure that the hooks update the state as late in the hooks running process as possible to increase the probability that the `uniter` will not fail or be stopped before completing its hook but after updating its remote state.

## QA

run a script like the following for 45 minutes to an hour:

```bash
#!/bin/bash
while :
do
    juju upgrade-series prepare $1 bionic --agree
    juju upgrade-series complete $1
done
```
Its should not encounter the infinite loop condition and get stuck on a `complete` sub command.

If you trust that the issue is caused by the above you can crash the `uniter` with a panic after its state gets updated but before the hook completes - then restart it and see if the workflow recovers properly.


