### PR TITLE
LXD Profile force

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -311,9 +311,7 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bool) (*ch
 		return nil, errors.Trace(err)
 	}
 	if err := lxdprofile.ValidateCharmLXDProfile(ch); err != nil {
-		if force {
-			logger.Debugf("force flag used to override validation error %v", err)
-		} else {
+		if !force {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -302,7 +302,7 @@ func (c *Client) FindTools(majorVersion, minorVersion int, series, arch, agentSt
 // AddLocalCharm prepares the given charm with a local: schema in its
 // URL, and uploads it via the API server, returning the assigned
 // charm URL.
-func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, error) {
+func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bool) (*charm.URL, error) {
 	if curl.Schema != "local" {
 		return nil, errors.Errorf("expected charm URL with local: schema, got %q", curl.String())
 	}
@@ -311,7 +311,11 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, err
 		return nil, errors.Trace(err)
 	}
 	if err := lxdprofile.ValidateCharmLXDProfile(ch); err != nil {
-		return nil, errors.Trace(err)
+		if force {
+			logger.Infof("force flag used to override validation error %v", err)
+		} else {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	// Package the charm for uploading.
@@ -462,11 +466,14 @@ func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel) error {
 // If the AddCharmWithAuthorization API call fails because of an
 // authorization error when retrieving the charm from the charm store,
 // an error satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon) error {
+// Force is used to overload any validation errors that could occur during
+// a
+func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, force bool) error {
 	args := params.AddCharmWithAuthorization{
 		URL:                curl.String(),
 		Channel:            string(channel),
 		CharmStoreMacaroon: csMac,
+		Force:              force,
 	}
 	if err := c.facade.FacadeCall("AddCharmWithAuthorization", args, nil); err != nil {
 		return errors.Trace(err)

--- a/api/client.go
+++ b/api/client.go
@@ -312,7 +312,7 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bool) (*ch
 	}
 	if err := lxdprofile.ValidateCharmLXDProfile(ch); err != nil {
 		if force {
-			logger.Infof("force flag used to override validation error %v", err)
+			logger.Debugf("force flag used to override validation error %v", err)
 		} else {
 			return nil, errors.Trace(err)
 		}
@@ -468,7 +468,7 @@ func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel, force bool)
 // authorization error when retrieving the charm from the charm store,
 // an error satisfying params.IsCodeUnauthorized will be returned.
 // Force is used to overload any validation errors that could occur during
-// a
+// a deploy
 func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, force bool) error {
 	args := params.AddCharmWithAuthorization{
 		URL:                curl.String(),

--- a/api/client.go
+++ b/api/client.go
@@ -446,10 +446,11 @@ func (c *Client) validateCharmVersion(ch charm.Charm) error {
 // If the AddCharm API call fails because of an authorization error
 // when retrieving the charm from the charm store, an error
 // satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel) error {
+func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel, force bool) error {
 	args := params.AddCharm{
 		URL:     curl.String(),
 		Channel: string(channel),
+		Force:   force,
 	}
 	if err := c.facade.FacadeCall("AddCharm", args, nil); err != nil {
 		return errors.Trace(err)

--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -47,7 +47,7 @@ func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
-	savedURL, err := client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, gc.ErrorMatches, `POST https://.+: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
 	c.Assert(savedURL, gc.IsNil)
 }
@@ -61,7 +61,7 @@ func (s *clientMacaroonSuite) TestAddLocalCharmSuccess(c *gc.C) {
 	testcharms.CheckCharmReady(c, charmArchive)
 
 	// Upload an archive with its original revision.
-	savedURL, err := client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 }
@@ -74,6 +74,6 @@ func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
 	// Upload an archive with its original revision.
-	_, err := client.AddLocalCharm(curl, charmArchive)
+	_, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, gc.ErrorMatches, `.*invalid entity name or password$`)
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -217,32 +217,15 @@ func (s *clientSuite) TestAddLocalCharmWithInvalidLXDProfile(c *gc.C) {
 }
 
 func (s *clientSuite) TestAddLocalCharmWithValidLXDProfileWithForceSucceeds(c *gc.C) {
-	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "lxd-profile")
-	curl := charm.MustParseURL(
-		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
-	)
-	client := s.APIState.Client()
-
-	// Upload an archive with its original revision.
-	savedURL, err := client.AddLocalCharm(curl, charmArchive, true)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(savedURL.String(), gc.Equals, curl.String())
-
-	// Upload a charm directory with changed revision.
-	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "lxd-profile")
-	charmDir.SetDiskRevision(42)
-	savedURL, err = client.AddLocalCharm(curl, charmDir, true)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(savedURL.Revision, gc.Equals, 42)
-
-	// Upload a charm directory again, revision should be bumped.
-	savedURL, err = client.AddLocalCharm(curl, charmDir, true)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
+	s.testAddLocalCharmWithWithForceSucceeds("lxd-profile", c)
 }
 
 func (s *clientSuite) TestAddLocalCharmWithInvalidLXDProfileWithForceSucceeds(c *gc.C) {
-	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "lxd-profile-fail")
+	s.testAddLocalCharmWithWithForceSucceeds("lxd-profile-fail", c)
+}
+
+func (s *clientSuite) testAddLocalCharmWithWithForceSucceeds(name string, c *gc.C) {
+	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), name)
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
@@ -254,7 +237,7 @@ func (s *clientSuite) TestAddLocalCharmWithInvalidLXDProfileWithForceSucceeds(c 
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 
 	// Upload a charm directory with changed revision.
-	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "lxd-profile-fail")
+	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), name)
 	charmDir.SetDiskRevision(42)
 	savedURL, err = client.AddLocalCharm(curl, charmDir, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -134,23 +134,23 @@ func (s *clientSuite) TestAddLocalCharm(c *gc.C) {
 	client := s.APIState.Client()
 
 	// Test the sanity checks first.
-	_, err := client.AddLocalCharm(charm.MustParseURL("cs:quantal/wordpress-1"), nil)
+	_, err := client.AddLocalCharm(charm.MustParseURL("cs:quantal/wordpress-1"), nil, false)
 	c.Assert(err, gc.ErrorMatches, `expected charm URL with local: schema, got "cs:quantal/wordpress-1"`)
 
 	// Upload an archive with its original revision.
-	savedURL, err := client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 
 	// Upload a charm directory with changed revision.
 	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy")
 	charmDir.SetDiskRevision(42)
-	savedURL, err = client.AddLocalCharm(curl, charmDir)
+	savedURL, err = client.AddLocalCharm(curl, charmDir, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.Revision, gc.Equals, 42)
 
 	// Upload a charm directory again, revision should be bumped.
-	savedURL, err = client.AddLocalCharm(curl, charmDir)
+	savedURL, err = client.AddLocalCharm(curl, charmDir, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
 }
@@ -184,19 +184,19 @@ func (s *clientSuite) TestAddLocalCharmWithLXDProfile(c *gc.C) {
 	client := s.APIState.Client()
 
 	// Upload an archive with its original revision.
-	savedURL, err := client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 
 	// Upload a charm directory with changed revision.
 	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "lxd-profile")
 	charmDir.SetDiskRevision(42)
-	savedURL, err = client.AddLocalCharm(curl, charmDir)
+	savedURL, err = client.AddLocalCharm(curl, charmDir, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.Revision, gc.Equals, 42)
 
 	// Upload a charm directory again, revision should be bumped.
-	savedURL, err = client.AddLocalCharm(curl, charmDir)
+	savedURL, err = client.AddLocalCharm(curl, charmDir, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
 }
@@ -214,14 +214,14 @@ func (s *clientSuite) TestAddLocalCharmWithInvalidLXDProfile(c *gc.C) {
 	client := s.APIState.Client()
 
 	// Upload an archive with its original revision.
-	_, err = client.AddLocalCharm(curl, charmArchive)
+	_, err = client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, gc.ErrorMatches, "invalid lxd-profile.yaml: contains device type \"unix-disk\"")
 }
 
 func (s *clientSuite) assertAddLocalCharmFailed(c *gc.C, f func(string) (bool, error), msg string) {
 	curl, ch := s.testCharm(c)
 	s.PatchValue(api.HasHooks, f)
-	_, err := s.APIState.Client().AddLocalCharm(curl, ch)
+	_, err := s.APIState.Client().AddLocalCharm(curl, ch, false)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
@@ -230,7 +230,7 @@ func (s *clientSuite) TestAddLocalCharmDefinetelyWithHooks(c *gc.C) {
 	s.PatchValue(api.HasHooks, func(string) (bool, error) {
 		return true, nil
 	})
-	savedCURL, err := s.APIState.Client().AddLocalCharm(curl, ch)
+	savedCURL, err := s.APIState.Client().AddLocalCharm(curl, ch, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedCURL.String(), gc.Equals, curl.String())
 }
@@ -255,7 +255,7 @@ func (s *clientSuite) TestAddLocalCharmOtherModel(c *gc.C) {
 	client := otherAPISt.Client()
 
 	// Upload an archive
-	savedURL, err := client.AddLocalCharm(curl, charmArchive)
+	savedURL, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 
@@ -294,7 +294,7 @@ func (s *clientSuite) TestAddLocalCharmError(c *gc.C) {
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
 
-	_, err := client.AddLocalCharm(curl, charmArchive)
+	_, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, gc.ErrorMatches, `.*the POST method is not allowed$`)
 }
 
@@ -346,7 +346,7 @@ func testMinVer(client *api.Client, t minverTest, c *gc.C) {
 	)
 	charmArchive.Meta().MinJujuVersion = charmMinVer
 
-	_, err := client.AddLocalCharm(curl, charmArchive)
+	_, err := client.AddLocalCharm(curl, charmArchive, false)
 
 	if t.ok {
 		if err != nil {
@@ -410,7 +410,7 @@ func (s *clientSuite) TestOpenCharmMissing(c *gc.C) {
 func addLocalCharm(c *gc.C, client *api.Client, name string) (*charm.URL, *charm.CharmArchive) {
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), name)
 	curl := charm.MustParseURL(fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()))
-	_, err := client.AddLocalCharm(curl, charmArchive)
+	_, err := client.AddLocalCharm(curl, charmArchive, false)
 	c.Assert(err, jc.ErrorIsNil)
 	return curl, charmArchive
 }

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -629,7 +629,7 @@ func (s *charmsSuite) TestGetWorksForControllerMachines(c *gc.C) {
 
 	curl := charm.MustParseURL("local:quantal/dummy-1")
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := jujutesting.AddCharm(newSt, curl, ch)
+	_, err := jujutesting.AddCharm(newSt, curl, ch, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Controller machine should be able to download the charm from
@@ -686,7 +686,7 @@ func (s *charmsSuite) TestGetAllowsOtherEnvironment(c *gc.C) {
 
 	curl := charm.MustParseURL("local:quantal/dummy-1")
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := jujutesting.AddCharm(newSt, curl, ch)
+	_, err := jujutesting.AddCharm(newSt, curl, ch, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	url := s.charmsURL("url=" + curl.String() + "&file=revision")

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -6,6 +6,7 @@ package application_test
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"sync"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	charmresource "gopkg.in/juju/charm.v6/resource"
@@ -30,7 +32,9 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -79,6 +83,11 @@ func (s *applicationSuite) SetUpTest(c *gc.C) {
 		Tag: s.AdminUserTag(c),
 	}
 	s.applicationAPI = s.makeAPI(c)
+
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *applicationSuite) TearDownTest(c *gc.C) {
@@ -1389,6 +1398,99 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	c.Assert(mid, gc.Equals, machine.Id())
 }
 
+func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C) {
+	curl, ch := s.UploadCharm(c, "quantal/lxd-profile-0", "lxd-profile")
+	err := application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{{
+			CharmURL:        curl.String(),
+			ApplicationName: "application-name",
+			NumUnits:        1,
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	application, err := s.State.Application("application-name")
+	c.Assert(err, jc.ErrorIsNil)
+	expected, force, err := application.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(force, jc.IsFalse)
+	c.Assert(expected.URL(), gc.DeepEquals, curl)
+	c.Assert(expected.Meta(), gc.DeepEquals, ch.Meta())
+	c.Assert(expected.Config(), gc.DeepEquals, ch.Config())
+	c.Assert(expected.LXDProfile(), gc.DeepEquals, ch.(charm.LXDProfiler).LXDProfile())
+
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
+	c.Assert(errs, gc.DeepEquals, []error{nil})
+	c.Assert(err, jc.ErrorIsNil)
+
+	units, err := application.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 1)
+
+	mid, err := units[0].AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mid, gc.Equals, machine.Id())
+}
+
+func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfile(c *gc.C) {
+	curl, _ := s.UploadCharm(c, "quantal/lxd-profile-fail-0", "lxd-profile-fail")
+	err := application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
+	c.Assert(err, gc.ErrorMatches, `.*invalid lxd-profile.yaml: contains device type "unix-disk"`)
+}
+
+func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAndForceStillSucceeds(c *gc.C) {
+	curl, ch := s.UploadCharm(c, "quantal/lxd-profile-fail-0", "lxd-profile-fail")
+	err := application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
+		URL:   curl.String(),
+		Force: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{{
+			CharmURL:        curl.String(),
+			ApplicationName: "application-name",
+			NumUnits:        1,
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	application, err := s.State.Application("application-name")
+	c.Assert(err, jc.ErrorIsNil)
+	expected, force, err := application.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(force, jc.IsFalse)
+	c.Assert(expected.URL(), gc.DeepEquals, curl)
+	c.Assert(expected.Meta(), gc.DeepEquals, ch.Meta())
+	c.Assert(expected.Config(), gc.DeepEquals, ch.Config())
+	c.Assert(expected.LXDProfile(), gc.DeepEquals, ch.(charm.LXDProfiler).LXDProfile())
+
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
+	c.Assert(errs, gc.DeepEquals, []error{nil})
+	c.Assert(err, jc.ErrorIsNil)
+
+	units, err := application.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 1)
+
+	mid, err := units[0].AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mid, gc.Equals, machine.Id())
+}
+
 func (s *applicationSuite) TestApplicationDeployToMachineNotFound(c *gc.C) {
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
@@ -1540,6 +1642,38 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnits(c *gc.C) {
 	// Ensure the minimum number of units has been set.
 	c.Assert(application.Refresh(), gc.IsNil)
 	c.Assert(application.MinUnits(), gc.Equals, minUnits)
+}
+
+func (s *applicationSuite) TestApplicationUpdateSetMinUnitsWithLXDProfile(c *gc.C) {
+	application := s.AddTestingApplication(c, "lxd-profile", s.AddTestingCharm(c, "lxd-profile"))
+
+	// Set minimum units for the application.
+	minUnits := 2
+	args := params.ApplicationUpdate{
+		ApplicationName: "lxd-profile",
+		MinUnits:        &minUnits,
+	}
+	err := s.applicationAPI.Update(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the minimum number of units has been set.
+	c.Assert(application.Refresh(), gc.IsNil)
+	c.Assert(application.MinUnits(), gc.Equals, minUnits)
+}
+
+func (s *applicationSuite) TestApplicationUpdateDoesNotSetMinUnitsWithLXDProfile(c *gc.C) {
+	series := "quantal"
+	repo := testcharms.RepoForSeries(series)
+	ch := repo.CharmDir("lxd-profile-fail")
+	ident := fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/%s", series, ident))
+	storerepo, err := charmrepo.InferRepository(
+		curl,
+		charmrepo.NewCharmStoreParams{},
+		repo.Path())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = jujutesting.PutCharm(s.State, curl, storerepo, false, false)
+	c.Assert(err, gc.ErrorMatches, `invalid lxd-profile.yaml: contains device type "unix-disk"`)
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetMinUnitsError(c *gc.C) {

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -674,11 +674,11 @@ func (s *applicationSuite) TestAddCharm(c *gc.C) {
 
 	client := s.APIState.Client()
 	// First test the sanity checks.
-	err := client.AddCharm(&charm.URL{Name: "nonsense"}, csparams.StableChannel)
+	err := client.AddCharm(&charm.URL{Name: "nonsense"}, csparams.StableChannel, false)
 	c.Assert(err, gc.ErrorMatches, `cannot parse charm or bundle URL: ":nonsense-0"`)
-	err = client.AddCharm(charm.MustParseURL("local:precise/dummy"), csparams.StableChannel)
+	err = client.AddCharm(charm.MustParseURL("local:precise/dummy"), csparams.StableChannel, false)
 	c.Assert(err, gc.ErrorMatches, "only charm store charm URLs are supported, with cs: schema")
-	err = client.AddCharm(charm.MustParseURL("cs:precise/wordpress"), csparams.StableChannel)
+	err = client.AddCharm(charm.MustParseURL("cs:precise/wordpress"), csparams.StableChannel, false)
 	c.Assert(err, gc.ErrorMatches, "charm URL must include revision")
 
 	// Add a charm, without uploading it to storage, to
@@ -696,14 +696,14 @@ func (s *applicationSuite) TestAddCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// AddCharm should see the charm in state and not upload it.
-	err = client.AddCharm(sch.URL(), csparams.StableChannel)
+	err = client.AddCharm(sch.URL(), csparams.StableChannel, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(blobs.m, gc.HasLen, 0)
 
 	// Now try adding another charm completely.
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err = client.AddCharm(curl, csparams.StableChannel)
+	err = client.AddCharm(curl, csparams.StableChannel, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify it's in state and it got uploaded.
@@ -725,7 +725,7 @@ func (s *applicationSuite) TestAddCharmWithAuthorization(c *gc.C) {
 
 	// Try to add a charm to the model without authorization.
 	s.DischargeUser = ""
-	err = s.APIState.Client().AddCharm(curl, csparams.StableChannel)
+	err = s.APIState.Client().AddCharm(curl, csparams.StableChannel, false)
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: discharge denied \(unauthorized access\)`)
 
 	tryAs := func(user string) error {
@@ -782,7 +782,7 @@ func (s *applicationSuite) TestAddCharmConcurrently(c *gc.C) {
 		go func(index int) {
 			defer wg.Done()
 
-			c.Assert(client.AddCharm(curl, csparams.StableChannel), gc.IsNil, gc.Commentf("goroutine %d", index))
+			c.Assert(client.AddCharm(curl, csparams.StableChannel, false), gc.IsNil, gc.Commentf("goroutine %d", index))
 			sch, err := s.State.Charm(curl)
 			c.Assert(err, gc.IsNil, gc.Commentf("goroutine %d", index))
 			c.Assert(sch.URL(), jc.DeepEquals, curl, gc.Commentf("goroutine %d", index))
@@ -831,7 +831,7 @@ func (s *applicationSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 
 	// Now try to add the charm, which will convert the placeholder to
 	// a pending charm.
-	err = client.AddCharm(curl, csparams.StableChannel)
+	err = client.AddCharm(curl, csparams.StableChannel, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Make sure the document's flags were reset as expected.
@@ -1204,7 +1204,7 @@ func (s *applicationSuite) TestSpecializeStoreOnDeployApplicationSetCharmAndAddC
 
 	// Check that the store's test mode is enabled when calling AddCharm.
 	curl, _ = s.UploadCharm(c, "utopic/riak-42", "riak")
-	err = s.APIState.Client().AddCharm(curl, csparams.StableChannel)
+	err = s.APIState.Client().AddCharm(curl, csparams.StableChannel, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(repo.testMode, jc.IsTrue)
 }

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -141,7 +141,7 @@ func AddCharmWithAuthorizationAndRepo(st State, args params.AddCharmWithAuthoriz
 	// Validate the charm lxd profile once we've downloaded it.
 	if err := lxdprofile.ValidateCharmLXDProfile(downloadedCharm); err != nil {
 		if args.Force {
-			logger.Infof("force flag used to override validation error %v", err)
+			logger.Debugf("force flag used to override validation error %v", err)
 		} else {
 			return errors.Annotate(err, "cannot add charm")
 		}

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -140,7 +140,11 @@ func AddCharmWithAuthorizationAndRepo(st State, args params.AddCharmWithAuthoriz
 
 	// Validate the charm lxd profile once we've downloaded it.
 	if err := lxdprofile.ValidateCharmLXDProfile(downloadedCharm); err != nil {
-		return errors.Annotate(err, "cannot add charm")
+		if args.Force {
+			logger.Infof("force flag used to override validation error %v", err)
+		} else {
+			return errors.Annotate(err, "cannot add charm")
+		}
 	}
 
 	// Clean up the downloaded charm - we don't need to cache it in

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -140,9 +140,7 @@ func AddCharmWithAuthorizationAndRepo(st State, args params.AddCharmWithAuthoriz
 
 	// Validate the charm lxd profile once we've downloaded it.
 	if err := lxdprofile.ValidateCharmLXDProfile(downloadedCharm); err != nil {
-		if args.Force {
-			logger.Debugf("force flag used to override validation error %v", err)
-		} else {
+		if !args.Force {
 			return errors.Annotate(err, "cannot add charm")
 		}
 	}

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -43,7 +43,7 @@ func (s *DeployLocalSuite) SetUpSuite(c *gc.C) {
 func (s *DeployLocalSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	curl := charm.MustParseURL("local:quantal/dummy")
-	charm, err := testing.PutCharm(s.State, curl, s.repo, false)
+	charm, err := testing.PutCharm(s.State, curl, s.repo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	s.charm = charm
 }
@@ -115,7 +115,7 @@ func (s *DeployLocalSuite) addWordpressCharmWithExtraBindings(c *gc.C) *state.Ch
 }
 
 func (s *DeployLocalSuite) addWordpressCharmFromURL(c *gc.C, charmURL *charm.URL) *state.Charm {
-	wordpressCharm, err := testing.PutCharm(s.State, charmURL, s.repo, false)
+	wordpressCharm, err := testing.PutCharm(s.State, charmURL, s.repo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	return wordpressCharm
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -156,6 +156,11 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 						"misc",
 						"application_development",
 					},
+					Series: []string{
+						"bionic",
+						"xenial",
+						"quantal",
+					},
 				},
 				Actions: &params.CharmActions{},
 				LXDProfile: &params.CharmLXDProfile{

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -670,6 +670,7 @@ func (c *Client) AddCharm(args params.AddCharm) error {
 	return application.AddCharmWithAuthorization(shim, params.AddCharmWithAuthorization{
 		URL:     args.URL,
 		Channel: args.Channel,
+		Force:   args.Force,
 	})
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -165,6 +165,7 @@ type RelationSuspendedArg struct {
 type AddCharm struct {
 	URL     string `json:"url"`
 	Channel string `json:"channel"`
+	Force   bool   `json:"force"`
 }
 
 // AddCharmWithAuthorization holds the arguments for making an AddCharmWithAuthorization API call.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -172,6 +172,7 @@ type AddCharmWithAuthorization struct {
 	URL                string             `json:"url"`
 	Channel            string             `json:"channel"`
 	CharmStoreMacaroon *macaroon.Macaroon `json:"macaroon"`
+	Force              bool               `json:"force"`
 }
 
 // AddMachineParams encapsulates the parameters used to create a new machine.

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -443,7 +443,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 					return errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
 				}
 			}
-			if curl, err = h.api.AddLocalCharm(curl, ch); err != nil {
+			if curl, err = h.api.AddLocalCharm(curl, ch, h.force); err != nil {
 				return err
 			}
 			logger.Debugf("added charm %s", curl)
@@ -466,7 +466,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Errorf("expected charm URL, got bundle URL %q", p.Charm)
 	}
 	var macaroon *macaroon.Macaroon
-	url, macaroon, err = addCharmFromURL(h.api, url, channel)
+	url, macaroon, err = addCharmFromURL(h.api, url, channel, h.force)
 	if err != nil {
 		return errors.Annotatef(err, "cannot add charm %q", p.Charm)
 	}

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -438,7 +438,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		if err == nil {
 			if err := lxdprofile.ValidateCharmLXDProfile(ch); err != nil {
 				if h.force {
-					logger.Infof("force flag used to override validation error %v", err)
+					logger.Debugf("force flag used to override validation error %v", err)
 				} else {
 					return errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
 				}
@@ -572,7 +572,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 
 	if err := lxdprofile.ValidateCharmInfoLXDProfile(charmInfo); err != nil {
 		if h.force {
-			logger.Infof("force flag used to override validation error %v", err)
+			logger.Debugf("force flag used to override validation error %v", err)
 		} else {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	charmresource "gopkg.in/juju/charm.v6/resource"
@@ -29,6 +30,8 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -591,6 +594,11 @@ func (s *BundleDeployCharmStoreSuite) SetUpTest(c *gc.C) {
 
 	s.charmStoreSuite.SetUpTest(c)
 	logger.SetLogLevel(loggo.TRACE)
+
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *BundleDeployCharmStoreSuite) TearDownTest(c *gc.C) {
@@ -865,6 +873,41 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadConfig(c
 	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: unable to read bundle overlay file .*")
 }
 
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(c *gc.C) {
+	charmsPath := c.MkDir()
+	lxdProfilePath := testcharms.Repo.ClonedDirPath(charmsPath, "lxd-profile")
+	err := s.DeployBundleYAML(c, fmt.Sprintf(`
+        series: bionic
+        services:
+            lxd-profile:
+                charm: %s
+                num_units: 1
+    `, lxdProfilePath))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertCharmsUploaded(c, "local:bionic/lxd-profile-0")
+	lxdProfile, err := s.State.Charm(charm.MustParseURL("local:bionic/lxd-profile-0"))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertApplicationsDeployed(c, map[string]applicationInfo{
+		"lxd-profile": {charm: "local:bionic/lxd-profile-0", config: lxdProfile.Config().DefaultSettings()},
+	})
+	s.assertUnitsCreated(c, map[string]string{
+		"lxd-profile/0": "0",
+	})
+}
+
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfile(c *gc.C) {
+	charmsPath := c.MkDir()
+	lxdProfilePath := testcharms.Repo.ClonedDirPath(charmsPath, "lxd-profile-fail")
+	err := s.DeployBundleYAML(c, fmt.Sprintf(`
+        series: bionic
+        services:
+            lxd-profile-fail:
+                charm: %s
+                num_units: 1
+    `, lxdProfilePath))
+	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: cannot deploy local charm at .*: invalid lxd-profile.yaml: contains device type \"unix-disk\"")
+}
+
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentWithBundleOverlay(c *gc.C) {
 	configDir := c.MkDir()
 	configFile := filepath.Join(configDir, "config.yaml")
@@ -975,7 +1018,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationOptions(c *gc.C
 	})
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstrants(c *gc.C) {
+func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstraints(c *gc.C) {
 	_, wpch := testcharms.UploadCharm(c, s.client, "xenial/wordpress-42", "wordpress")
 	_, dch := testcharms.UploadCharm(c, s.client, "precise/dummy-0", "dummy")
 	err := s.DeployBundleYAML(c, `

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -910,25 +910,16 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfi
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfileWithForce(c *gc.C) {
 	charmsPath := c.MkDir()
-	lxdProfilePath := testcharms.Repo.ClonedDirPath(charmsPath, "lxd-profile")
+	lxdProfilePath := testcharms.Repo.ClonedDirPath(charmsPath, "lxd-profile-fail")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
         services:
-            lxd-profile:
+            lxd-profile-fail:
                 charm: %s
                 num_units: 1
     `, lxdProfilePath),
 		"--force")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCharmsUploaded(c, "local:bionic/lxd-profile-0")
-	lxdProfile, err := s.State.Charm(charm.MustParseURL("local:bionic/lxd-profile-0"))
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"lxd-profile": {charm: "local:bionic/lxd-profile-0", config: lxdProfile.Config().DefaultSettings()},
-	})
-	s.assertUnitsCreated(c, map[string]string{
-		"lxd-profile/0": "0",
-	})
+	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: cannot deploy local charm at .*: invalid lxd-profile.yaml: contains device type \"unix-disk\"")
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentWithBundleOverlay(c *gc.C) {

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -908,20 +908,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfi
 	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: cannot deploy local charm at .*: invalid lxd-profile.yaml: contains device type \"unix-disk\"")
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfileWithForce(c *gc.C) {
-	charmsPath := c.MkDir()
-	lxdProfilePath := testcharms.Repo.ClonedDirPath(charmsPath, "lxd-profile-fail")
-	err := s.DeployBundleYAML(c, fmt.Sprintf(`
-        series: bionic
-        services:
-            lxd-profile-fail:
-                charm: %s
-                num_units: 1
-    `, lxdProfilePath),
-		"--force")
-	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: cannot deploy local charm at .*: invalid lxd-profile.yaml: contains device type \"unix-disk\"")
-}
-
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentWithBundleOverlay(c *gc.C) {
 	configDir := c.MkDir()
 	configFile := filepath.Join(configDir, "config.yaml")

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -663,9 +663,6 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *DeployCommand) Init(args []string) error {
-	if c.Force && c.Series == "" && c.PlacementSpec == "" {
-		return errors.New("--force is only used with --series")
-	}
 	modelType, err := c.ModelType()
 	if err != nil {
 		return err

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -624,7 +624,7 @@ var (
 // whether we are deploying a charm or a bundle.
 func charmOnlyFlags() []string {
 	charmOnlyFlags := []string{
-		"bind", "config", "constraints", "force", "n", "num-units",
+		"bind", "config", "constraints", "n", "num-units",
 		"series", "to", "resource", "attach-storage",
 	}
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -820,6 +820,8 @@ func (c *DeployCommand) deployBundle(
 	}
 
 	// TODO(ericsnow) Do something with the CS macaroons that were returned?
+	// Deploying bundles does not allow the use force, it's expected that the
+	// bundle is correct and therefore the charms are also.
 	if _, err := deployBundle(
 		filePath,
 		data,
@@ -830,7 +832,6 @@ func (c *DeployCommand) deployBundle(
 		bundleStorage,
 		bundleDevices,
 		c.DryRun,
-		c.Force,
 		c.UseExisting,
 		c.BundleMachines,
 	); err != nil {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -601,6 +601,7 @@ type DeploymentInfo struct {
 	ModelUUID       string
 	CharmInfo       *apicharms.CharmInfo
 	ApplicationPlan string
+	Force           bool
 }
 
 func (c *DeployCommand) Info() *cmd.Info {
@@ -794,6 +795,7 @@ func (c *DeployCommand) deployBundle(
 					ApplicationName: application,
 					ApplicationPlan: applicationSpec.Plan,
 					ModelUUID:       modelUUID,
+					Force:           c.Force,
 				}
 
 				err = s.RunPre(apiRoot, bakeryClient, ctx, deployInfo)
@@ -950,6 +952,7 @@ func (c *DeployCommand) deployCharm(
 		ApplicationName: applicationName,
 		ModelUUID:       uuid,
 		CharmInfo:       charmInfo,
+		Force:           c.Force,
 	}
 
 	for _, step := range c.Steps {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -821,6 +821,7 @@ func (c *DeployCommand) deployBundle(
 		bundleStorage,
 		bundleDevices,
 		c.DryRun,
+		c.Force,
 		c.UseExisting,
 		c.BundleMachines,
 	); err != nil {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -47,7 +47,7 @@ import (
 
 type CharmAdder interface {
 	AddLocalCharm(*charm.URL, charm.Charm, bool) (*charm.URL, error)
-	AddCharm(*charm.URL, params.Channel) error
+	AddCharm(*charm.URL, params.Channel, bool) error
 	AddCharmWithAuthorization(*charm.URL, params.Channel, *macaroon.Macaroon, bool) error
 	AuthorizeCharmstoreEntity(*charm.URL) (*macaroon.Macaroon, error)
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -420,6 +420,15 @@ unless '--force' is used.
 
   juju deploy /path/to/charm --series wily --force
 
+Charms can also utilise LXD Profiles when deploying a charm. LXD Profiles can
+be used to override configurations or devices when creating the containers for
+LXD. LXD Profiles are validated against a allow/deny list, using '--force' flag
+can bypass the validation.
+
+Using the '--force' flag for LXD Profiles is not generally recommended when 
+deploying an application; overriding profiles on the container may cause 
+unexpected behavior. 
+
 Local bundles are specified with a direct path to a bundle.yaml file.
 For example:
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -633,7 +633,7 @@ var (
 // whether we are deploying a charm or a bundle.
 func charmOnlyFlags() []string {
 	charmOnlyFlags := []string{
-		"bind", "config", "constraints", "n", "num-units",
+		"bind", "config", "constraints", "force", "n", "num-units",
 		"series", "to", "resource", "attach-storage",
 	}
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -83,6 +83,15 @@ type DeploySuite struct {
 
 var _ = gc.Suite(&DeploySuite{})
 
+func (s *DeploySuite) SetUpTest(c *gc.C) {
+	s.DeploySuiteBase.SetUpTest(c)
+
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+}
+
 // runDeploy executes the deploy command in order to deploy the given
 // charm or bundle. The deployment stderr output and error are returned.
 func runDeployWithOutput(c *gc.C, args ...string) (string, string, error) {
@@ -415,26 +424,16 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 }
 
 func (s *DeploySuite) TestLXDProfileLocalCharm(c *gc.C) {
-	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
-	c.Assert(err, jc.ErrorIsNil)
-	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile")
-	err = runDeploy(c, path)
+	err := runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:bionic/lxd-profile-0")
 	s.AssertApplication(c, "lxd-profile", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestLXDProfileLocalCharmFails(c *gc.C) {
-	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
-	c.Assert(err, jc.ErrorIsNil)
-	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
 	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile-fail")
-	err = runDeploy(c, path)
+	err := runDeploy(c, path)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, `invalid lxd-profile.yaml: contains device type "unix-disk"`)
 }
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -120,7 +120,7 @@ var initErrorTests = []struct {
 		err:  `invalid --to parameter "#:foo"`,
 	}, {
 		args: []string{"charm", "application", "--force"},
-		err:  `--force is only used with --series`,
+		err:  "",
 	}, {
 		args: []string{"charm", "--attach-storage", "foo/0", "-n", "2"},
 		err:  `--attach-storage cannot be used with -n`,
@@ -134,7 +134,11 @@ func (s *DeploySuite) TestInitErrors(c *gc.C) {
 	for i, t := range initErrorTests {
 		c.Logf("test %d", i)
 		err := cmdtesting.InitCommand(NewDeployCommand(), t.args)
-		c.Check(err, gc.ErrorMatches, t.err)
+		if t.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.err)
+		}
 	}
 }
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1200,7 +1200,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	fakeAPI.planURL = server.URL
-	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, nil)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1251,7 +1251,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 	meteredURL := charm.MustParseURL("cs:quantal/metered-1")
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	fakeAPI.planURL = server.URL
-	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, nil)
+	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1298,7 +1298,7 @@ func (s *DeployCharmStoreSuite) TestSetMetricCredentialsNotCalledForUnmeteredCha
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, charmURL, cfg)
-	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, nil)
+	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	deploy := &DeployCommand{
 		Steps: []DeployStep{&RegisterMeteredCharm{}},
@@ -1343,7 +1343,7 @@ summary: summary
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, url, cfg)
-	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil, nil)
+	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, false, 1, nil, nil)
 
 	stub := &jujutesting.Stub{}
 	handler := &testMetricsRegistrationHandler{Stub: stub}
@@ -1393,7 +1393,7 @@ summary: summary
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, url, cfg)
-	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, 1, nil, nil)
+	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, false, 1, nil, nil)
 
 	deploy := &DeployCommand{
 		Steps: []DeployStep{&RegisterMeteredCharm{PlanURL: server.URL}},
@@ -1466,7 +1466,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 	cfg, err := config.New(config.NoDefaults, cfgAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	withCharmRepoResolvable(fakeAPI, meteredCharmURL, cfg)
-	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, nil)
+	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 
 	// `"hello registration"\n` (quotes and newline from json
 	// encoding) is returned by the fake http server. This is binary64
@@ -1651,13 +1651,14 @@ func (s *DeployUnitTestSuite) TestDeployApplicationConfig(c *gc.C) {
 	})
 
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
-	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir, false)
 	withCharmDeployable(
 		fakeAPI,
 		dummyURL,
 		"trusty",
 		charmDir.Meta(),
 		charmDir.Metrics(),
+		false,
 		false,
 		1,
 		nil,
@@ -1677,8 +1678,8 @@ func (s *DeployUnitTestSuite) TestDeployLocalWithBundleOverlay(c *gc.C) {
 	fakeAPI := s.fakeAPI()
 
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
-	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, nil)
+	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir, false)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	_, err := s.runDeploy(c, fakeAPI, charmDir.Path, "--overlay", "somefile")
 	c.Check(err, gc.ErrorMatches, "flags provided but not supported when deploying a charm: --overlay")
@@ -1690,8 +1691,8 @@ func (s *DeployUnitTestSuite) TestDeployLocalCharmGivesCorrectUserMessage(c *gc.
 	fakeAPI := s.fakeAPI()
 
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
-	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, nil)
+	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir, false)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	context, err := s.runDeploy(c, fakeAPI, charmDir.Path, "--series", "trusty")
 	c.Check(err, jc.ErrorIsNil)
@@ -1702,8 +1703,8 @@ func (s *DeployUnitTestSuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c
 	charmDir := s.makeCharmDir(c, "multi-series")
 	multiSeriesURL := charm.MustParseURL("local:trusty/multi-series-1")
 	fakeAPI := s.fakeAPI()
-	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir)
-	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, 1, nil, nil)
+	withLocalCharmDeployable(fakeAPI, multiSeriesURL, charmDir, false)
+	withCharmDeployable(fakeAPI, multiSeriesURL, "trusty", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 
 	_, err := s.runDeploy(c, fakeAPI, charmDir.Path, "--series", "trusty")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1720,8 +1721,8 @@ func (s *DeployUnitTestSuite) TestRedeployLocalCharmSucceedsWhenDeployed(c *gc.C
 	charmDir := s.makeCharmDir(c, "dummy")
 	fakeAPI := s.fakeAPI()
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
-	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
-	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, nil, nil)
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir, false)
+	withCharmDeployable(fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	context, err := s.runDeploy(c, fakeAPI, dummyURL.String())
 	c.Assert(err, jc.ErrorIsNil)
@@ -1753,6 +1754,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		&charm.Meta{Series: []string{"quantal"}},
 		&charm.Metrics{},
 		false,
+		false,
 		0,
 		nil,
 		nil,
@@ -1770,6 +1772,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 		"quantal",
 		&charm.Meta{Series: []string{"quantal"}},
 		&charm.Metrics{},
+		false,
 		false,
 		0,
 		nil,
@@ -1822,9 +1825,9 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorage(c *gc.C) {
 	})
 
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
-	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir, false)
 	withCharmDeployable(
-		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
@@ -1847,9 +1850,9 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorageFailContainer(c *gc.C) {
 	})
 
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
-	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir, false)
 	withCharmDeployable(
-		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
@@ -1871,9 +1874,9 @@ func (s *DeployUnitTestSuite) TestDeployAttachStorageNotSupported(c *gc.C) {
 	})
 	fakeAPI.Call("BestFacadeVersion", "Application").Returns(4) // v4 doesn't support attach-storage
 	dummyURL := charm.MustParseURL("local:trusty/dummy-0")
-	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir)
+	withLocalCharmDeployable(fakeAPI, dummyURL, charmDir, false)
 	withCharmDeployable(
-		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
+		fakeAPI, dummyURL, "trusty", charmDir.Meta(), charmDir.Metrics(), false, false, 1, []string{"foo/0", "bar/1", "baz/2"}, nil,
 	)
 
 	cmd := NewDeployCommandForTest(func() (DeployAPI, error) { return fakeAPI, nil }, nil)
@@ -1949,13 +1952,13 @@ func (f *fakeDeployAPI) ModelUUID() (string, bool) {
 	return results[0].(string), results[1].(bool)
 }
 
-func (f *fakeDeployAPI) AddLocalCharm(url *charm.URL, ch charm.Charm) (*charm.URL, error) {
-	results := f.MethodCall(f, "AddLocalCharm", url, ch)
+func (f *fakeDeployAPI) AddLocalCharm(url *charm.URL, ch charm.Charm, force bool) (*charm.URL, error) {
+	results := f.MethodCall(f, "AddLocalCharm", url, ch, force)
 	return results[0].(*charm.URL), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) AddCharm(url *charm.URL, channel csclientparams.Channel) error {
-	results := f.MethodCall(f, "AddCharm", url, channel)
+func (f *fakeDeployAPI) AddCharm(url *charm.URL, channel csclientparams.Channel, force bool) error {
+	results := f.MethodCall(f, "AddCharm", url, channel, force)
 	return jujutesting.TypeAssertError(results[0])
 }
 
@@ -1963,8 +1966,9 @@ func (f *fakeDeployAPI) AddCharmWithAuthorization(
 	url *charm.URL,
 	channel csclientparams.Channel,
 	macaroon *macaroon.Macaroon,
+	force bool,
 ) error {
-	results := f.MethodCall(f, "AddCharmWithAuthorization", url, channel, macaroon)
+	results := f.MethodCall(f, "AddCharmWithAuthorization", url, channel, macaroon, force)
 	return jujutesting.TypeAssertError(results[0])
 }
 
@@ -2079,8 +2083,9 @@ func withLocalCharmDeployable(
 	fakeAPI *fakeDeployAPI,
 	url *charm.URL,
 	c charm.Charm,
+	force bool,
 ) {
-	fakeAPI.Call("AddLocalCharm", url, c).Returns(url, error(nil))
+	fakeAPI.Call("AddLocalCharm", url, c, force).Returns(url, error(nil))
 }
 
 func withCharmDeployable(
@@ -2090,11 +2095,12 @@ func withCharmDeployable(
 	meta *charm.Meta,
 	metrics *charm.Metrics,
 	metered bool,
+	force bool,
 	numUnits int,
 	attachStorage []string,
 	config map[string]string,
 ) {
-	fakeAPI.Call("AddCharm", url, csclientparams.Channel("")).Returns(error(nil))
+	fakeAPI.Call("AddCharm", url, csclientparams.Channel(""), force).Returns(error(nil))
 	fakeAPI.Call("CharmInfo", url.String()).Returns(
 		&charms.CharmInfo{
 			URL:     url.String(),

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -764,7 +764,7 @@ func (s *DeploySuite) TestDeployFlags(c *gc.C) {
 	c.Assert(command.flagSet, jc.DeepEquals, flagSet)
 	// Add to the slice below if a new flag is introduced which is valid for
 	// both charms and bundles.
-	charmAndBundleFlags := []string{"channel", "storage", "device", "force"}
+	charmAndBundleFlags := []string{"channel", "storage", "device"}
 	var allFlags []string
 	flagSet.VisitAll(func(flag *gnuflag.Flag) {
 		allFlags = append(allFlags, flag.Name)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -764,7 +764,7 @@ func (s *DeploySuite) TestDeployFlags(c *gc.C) {
 	c.Assert(command.flagSet, jc.DeepEquals, flagSet)
 	// Add to the slice below if a new flag is introduced which is valid for
 	// both charms and bundles.
-	charmAndBundleFlags := []string{"channel", "storage", "device"}
+	charmAndBundleFlags := []string{"channel", "storage", "device", "force"}
 	var allFlags []string
 	flagSet.VisitAll(func(flag *gnuflag.Flag) {
 		allFlags = append(allFlags, flag.Name)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -119,9 +119,6 @@ var initErrorTests = []struct {
 		args: []string{"craziness", "burble1", "--to", "#:foo"},
 		err:  `invalid --to parameter "#:foo"`,
 	}, {
-		args: []string{"charm", "application", "--force"},
-		err:  "",
-	}, {
 		args: []string{"charm", "--attach-storage", "foo/0", "-n", "2"},
 		err:  `--attach-storage cannot be used with -n`,
 	}, {
@@ -134,11 +131,7 @@ func (s *DeploySuite) TestInitErrors(c *gc.C) {
 	for i, t := range initErrorTests {
 		c.Logf("test %d", i)
 		err := cmdtesting.InitCommand(NewDeployCommand(), t.args)
-		if t.err == "" {
-			c.Check(err, jc.ErrorIsNil)
-		} else {
-			c.Check(err, gc.ErrorMatches, t.err)
-		}
+		c.Check(err, gc.ErrorMatches, t.err)
 	}
 }
 
@@ -259,6 +252,14 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:quantal/multi-series-1")
 	s.AssertApplication(c, "multi-series", curl, 1, 0)
+}
+
+func (s *DeploySuite) TestDeployFromPathUnsupportedLXDProfileForce(c *gc.C) {
+	path := testcharms.Repo.ClonedDirPath(s.CharmsPath, "lxd-profile-fail")
+	err := runDeploy(c, path, "--series", "quantal", "--force")
+	c.Assert(err, jc.ErrorIsNil)
+	curl := charm.MustParseURL("local:quantal/lxd-profile-fail-0")
+	s.AssertApplication(c, "lxd-profile-fail", curl, 1, 0)
 }
 
 func (s *DeploySuite) TestUpgradeCharmDir(c *gc.C) {

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -80,7 +80,7 @@ func resolveCharm(
 // given charm URL to state. For non-public charm URLs, this function also
 // handles the macaroon authorization process using the given csClient.
 // The resulting charm URL of the added charm is displayed on stdout.
-func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channel) (*charm.URL, *macaroon.Macaroon, error) {
+func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channel, force bool) (*charm.URL, *macaroon.Macaroon, error) {
 	var csMac *macaroon.Macaroon
 	if err := client.AddCharm(curl, channel); err != nil {
 		if !params.IsCodeUnauthorized(err) {
@@ -90,7 +90,7 @@ func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channe
 		if err != nil {
 			return nil, nil, common.MaybeTermsAgreementError(err)
 		}
-		if err := client.AddCharmWithAuthorization(curl, channel, m); err != nil {
+		if err := client.AddCharmWithAuthorization(curl, channel, m, force); err != nil {
 			return nil, nil, errors.Trace(err)
 		}
 		csMac = m

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -82,7 +82,7 @@ func resolveCharm(
 // The resulting charm URL of the added charm is displayed on stdout.
 func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channel, force bool) (*charm.URL, *macaroon.Macaroon, error) {
 	var csMac *macaroon.Macaroon
-	if err := client.AddCharm(curl, channel); err != nil {
+	if err := client.AddCharm(curl, channel, force); err != nil {
 		if !params.IsCodeUnauthorized(err) {
 			return nil, nil, errors.Trace(err)
 		}

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -105,12 +105,14 @@ type upgradeCharmCommand struct {
 	CharmStoreURLGetter   func(api.Connection) (string, error)
 
 	ApplicationName string
-	Force           bool
-	ForceUnits      bool
-	ForceSeries     bool
-	SwitchURL       string
-	CharmPath       string
-	Revision        int // defaults to -1 (latest)
+	// Force should be ubiquitous and we should eventually deprecate both
+	// ForceUnits and ForceSeries; instead just using "force"
+	Force       bool
+	ForceUnits  bool
+	ForceSeries bool
+	SwitchURL   string
+	CharmPath   string
+	Revision    int // defaults to -1 (latest)
 
 	// Resources is a map of resource name to filename to be uploaded on upgrade.
 	Resources map[string]string
@@ -199,6 +201,10 @@ would specify revision number 5 of the wordpress charm.
 Use of the --force-units flag is not generally recommended; units upgraded while in an
 error state will not have upgrade-charm hooks executed, and may cause unexpected
 behavior.
+
+--force flag for LXD Profiles is not generally recommended when upgrading an 
+application; overriding profiles on the container may cause unexpected 
+behavior. 
 `
 
 func (c *upgradeCharmCommand) Info() *cmd.Info {
@@ -212,7 +218,7 @@ func (c *upgradeCharmCommand) Info() *cmd.Info {
 
 func (c *upgradeCharmCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.Force, "force", false, "Allow a charm to be deployed which bypasses for LXD profile allow list")
+	f.BoolVar(&c.Force, "force", false, "Allow a charm to be upgraded which bypasses LXD profile allow list")
 	f.BoolVar(&c.ForceUnits, "force-units", false, "Upgrade all units immediately, even if in error state")
 	f.StringVar((*string)(&c.Channel), "channel", "", "Channel to use when getting the charm or bundle from the charm store")
 	f.BoolVar(&c.ForceSeries, "force-series", false, "Upgrade even if series of deployed applications are not supported by the new charm")

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -733,8 +733,8 @@ type mockCharmAdder struct {
 	testing.Stub
 }
 
-func (m *mockCharmAdder) AddCharm(curl *charm.URL, channel csclientparams.Channel) error {
-	m.MethodCall(m, "AddCharm", curl, channel)
+func (m *mockCharmAdder) AddCharm(curl *charm.URL, channel csclientparams.Channel, force bool) error {
+	m.MethodCall(m, "AddCharm", curl, channel, force)
 	return m.NextErr()
 }
 

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
@@ -35,6 +36,8 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
@@ -379,6 +382,11 @@ func (s *UpgradeCharmSuccessStateSuite) SetUpTest(c *gc.C) {
 	s.CmdBlockHelper = coretesting.NewCmdBlockHelper(s.APIState)
 	c.Assert(s.CmdBlockHelper, gc.NotNil)
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+
+	err = os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.LXDProfile)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *UpgradeCharmSuccessStateSuite) assertLocalRevision(c *gc.C, revision int, path string) {
@@ -461,6 +469,53 @@ func (s *UpgradeCharmSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	ch, force, err := application.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(ch.Revision(), gc.Equals, 2)
+	c.Check(force, gc.Equals, false)
+}
+
+func (s *UpgradeCharmSuccessStateSuite) TestForcedLXDProfileUpgrade(c *gc.C) {
+	path := testcharms.Repo.ClonedDirPath(c.MkDir(), "lxd-profile")
+	err := runDeploy(c, path, "lxd-profile")
+	c.Assert(err, jc.ErrorIsNil)
+	application, err := s.State.Application("lxd-profile")
+	c.Assert(err, jc.ErrorIsNil)
+	ch, _, err := application.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.Revision(), gc.Equals, 0)
+
+	// Overwrite the lxd-profile.yaml to change the supported series.
+	lxdProfilePath := filepath.Join(path, "lxd-profile.yaml")
+	file, err := os.OpenFile(lxdProfilePath, os.O_TRUNC|os.O_RDWR, 0666)
+	if err != nil {
+		c.Fatal(errors.Annotate(err, "cannot open lxd-profile.yaml for overwriting"))
+	}
+	defer file.Close()
+
+	lxdProfile := `
+description: lxd profile for testing
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+  environment.http_proxy: ""
+  limits.memory: "256MB"
+devices: {}
+`
+	if _, err := file.WriteString(lxdProfile); err != nil {
+		c.Fatal(errors.Annotate(err, "cannot write to lxd-profile.yaml"))
+	}
+
+	err = runUpgradeCharm(c, "lxd-profile", "--path", path)
+	c.Assert(err, gc.ErrorMatches, `invalid lxd-profile.yaml: contains config value "limits.memory"`)
+
+	err = runUpgradeCharm(c, "lxd-profile", "--path", path, "--force")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = application.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	ch, force, err := application.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(ch.Revision(), gc.Equals, 1)
 	c.Check(force, gc.Equals, false)
 }
 

--- a/cmd/juju/application/validate.go
+++ b/cmd/juju/application/validate.go
@@ -36,7 +36,7 @@ func (r *ValidateLXDProfileCharm) RunPre(api DeployStepAPI, bakeryClient *httpba
 			if deployInfo.Force {
 				// TODO (stickupkid): should we consider raising this to the user
 				// so they're aware of potential pitfalls?
-				logger.Infof("force flag used to override validation error %v", err)
+				logger.Debugf("force flag used to override validation error %v", err)
 				return nil
 			}
 			return errors.Trace(err)

--- a/cmd/juju/application/validate.go
+++ b/cmd/juju/application/validate.go
@@ -34,8 +34,6 @@ func (r *ValidateLXDProfileCharm) RunPre(api DeployStepAPI, bakeryClient *httpba
 			// The force flag was provided, but we should let the user know that
 			// this could deliver some unexpected results.
 			if deployInfo.Force {
-				// TODO (stickupkid): should we consider raising this to the user
-				// so they're aware of potential pitfalls?
 				logger.Debugf("force flag used to override validation error %v", err)
 				return nil
 			}

--- a/cmd/juju/application/validate_test.go
+++ b/cmd/juju/application/validate_test.go
@@ -91,3 +91,63 @@ func (*ValidateLXDProfileCharmSuite) TestRunPreWithInvalidLXDProfile(c *gc.C) {
 	err := validate.RunPre(mockDeployStepAPI, nil, nil, deployInfo)
 	c.Assert(err, gc.ErrorMatches, "invalid lxd-profile.yaml: contains config value \"boot.autostart\"")
 }
+
+func (*ValidateLXDProfileCharmSuite) TestRunPreWithNoLXDProfileAndForce(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	deployInfo := application.DeploymentInfo{
+		CharmInfo: &apicharms.CharmInfo{},
+		Force:     true,
+	}
+
+	mockDeployStepAPI := mocks.NewMockDeployStepAPI(ctrl)
+
+	validate := &application.ValidateLXDProfileCharm{}
+	err := validate.RunPre(mockDeployStepAPI, nil, nil, deployInfo)
+	c.Assert(err, gc.IsNil)
+}
+
+func (*ValidateLXDProfileCharmSuite) TestRunPreWithLXDProfileAndForce(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	deployInfo := application.DeploymentInfo{
+		CharmInfo: &apicharms.CharmInfo{
+			LXDProfile: &charm.LXDProfile{
+				Config: map[string]string{
+					"security.nesting": "true",
+				},
+			},
+		},
+		Force: true,
+	}
+
+	mockDeployStepAPI := mocks.NewMockDeployStepAPI(ctrl)
+
+	validate := &application.ValidateLXDProfileCharm{}
+	err := validate.RunPre(mockDeployStepAPI, nil, nil, deployInfo)
+	c.Assert(err, gc.IsNil)
+}
+
+func (*ValidateLXDProfileCharmSuite) TestRunPreWithInvalidLXDProfileAndForce(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	deployInfo := application.DeploymentInfo{
+		CharmInfo: &apicharms.CharmInfo{
+			LXDProfile: &charm.LXDProfile{
+				Config: map[string]string{
+					"boot.autostart": "true",
+				},
+			},
+		},
+		Force: true,
+	}
+
+	mockDeployStepAPI := mocks.NewMockDeployStepAPI(ctrl)
+
+	validate := &application.ValidateLXDProfileCharm{}
+	err := validate.RunPre(mockDeployStepAPI, nil, nil, deployInfo)
+	c.Assert(err, gc.IsNil)
+}

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -679,7 +679,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	c.Logf("deploying application")
 	repoDir := c.MkDir()
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
-	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
+	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := st.AddApplication(state.AddApplicationArgs{Name: "dummy", Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -383,7 +383,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerSameOwner(c *gc.C) {
 		charmrepo.NewCharmStoreParams{},
 		testcharms.Repo.Path())
 	c.Assert(err, jc.ErrorIsNil)
-	ch, err = jujutesting.PutCharm(otherModel, curl, repo, false)
+	ch, err = jujutesting.PutCharm(otherModel, curl, repo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",
@@ -414,7 +414,7 @@ func (s *crossmodelSuite) addOtherModelApplication(c *gc.C) *state.State {
 		charmrepo.NewCharmStoreParams{},
 		testcharms.Repo.Path())
 	c.Assert(err, jc.ErrorIsNil)
-	ch, err := jujutesting.PutCharm(otherModel, curl, repo, false)
+	ch, err := jujutesting.PutCharm(otherModel, curl, repo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = otherModel.AddApplication(state.AddApplicationArgs{
 		Name:  "mysql",

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/juju/core/lxdprofile"
+
 	"github.com/juju/clock"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
@@ -612,7 +614,7 @@ func newState(controllerUUID string, environ environs.Environ, mongoInfo *mongo.
 // the same URL already exists in the state.
 // If bumpRevision is true, the charm must be a local directory,
 // and the revision number will be incremented before pushing.
-func PutCharm(st *state.State, curl *charm.URL, repo charmrepo.Interface, bumpRevision bool) (*state.Charm, error) {
+func PutCharm(st *state.State, curl *charm.URL, repo charmrepo.Interface, bumpRevision, force bool) (*state.Charm, error) {
 	if curl.Revision == -1 {
 		var err error
 		curl, _, err = repo.Resolve(curl)
@@ -637,11 +639,11 @@ func PutCharm(st *state.State, curl *charm.URL, repo charmrepo.Interface, bumpRe
 	if sch, err := st.Charm(curl); err == nil {
 		return sch, nil
 	}
-	return AddCharm(st, curl, ch)
+	return AddCharm(st, curl, ch, force)
 }
 
 // AddCharm adds the charm to state and storage.
-func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm) (*state.Charm, error) {
+func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm, force bool) (*state.Charm, error) {
 	var f *os.File
 	name := charm.Quote(curl.String())
 	switch ch := ch.(type) {
@@ -673,6 +675,10 @@ func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm) (*state.Charm, e
 		return nil, err
 	}
 	if _, err := f.Seek(0, 0); err != nil {
+		return nil, err
+	}
+
+	if err := lxdprofile.ValidateCharmLXDProfile(ch); err != nil && !force {
 		return nil, err
 	}
 
@@ -781,7 +787,7 @@ func (s *JujuConnSuite) AddTestingCharmForSeries(c *gc.C, name, series string) *
 		charmrepo.NewCharmStoreParams{},
 		repo.Path())
 	c.Assert(err, jc.ErrorIsNil)
-	sch, err := PutCharm(s.State, curl, storerepo, false)
+	sch, err := PutCharm(s.State, curl, storerepo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	return sch
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/core/lxdprofile"
-
 	"github.com/juju/clock"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
@@ -37,6 +35,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -678,6 +677,8 @@ func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm, force bool) (*st
 		return nil, err
 	}
 
+	// ValidateCharmLXDProfile is used here to replicate the same flow as the
+	// not testing version.
 	if err := lxdprofile.ValidateCharmLXDProfile(ch); err != nil && !force {
 		return nil, err
 	}

--- a/testcharms/charm-repo/quantal/lxd-profile-fail/lxd-profile.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-fail/lxd-profile.yaml
@@ -5,6 +5,7 @@ config:
   linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
   # boot.* keys are blacklisted by juju.
   boot.autostart: "true"
+  limits.memory: 256mb
 devices:
   tun:
     path: /dev/net/tun

--- a/testcharms/charm-repo/quantal/lxd-profile-fail/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-fail/metadata.yaml
@@ -14,3 +14,7 @@ tags:
   - misc
   - application_development
 subordinate: false
+series:
+  - quantal
+  - xenial
+  - bionic

--- a/testcharms/charm-repo/quantal/lxd-profile-fail/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-fail/metadata.yaml
@@ -15,6 +15,6 @@ tags:
   - application_development
 subordinate: false
 series:
-  - quantal
-  - xenial
   - bionic
+  - xenial
+  - quantal

--- a/testcharms/charm-repo/quantal/lxd-profile-subordinate-fail/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-subordinate-fail/metadata.yaml
@@ -16,6 +16,6 @@ requires:
     interface: juju-info
     scope: container
 series:
-  - quantal
-  - xenial
   - bionic
+  - xenial
+  - quantal

--- a/testcharms/charm-repo/quantal/lxd-profile-subordinate/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-subordinate/metadata.yaml
@@ -16,6 +16,6 @@ requires:
     interface: juju-info
     scope: container
 series:
-  - quantal
-  - xenial
   - bionic
+  - xenial
+  - quantal

--- a/testcharms/charm-repo/quantal/lxd-profile/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile/metadata.yaml
@@ -14,6 +14,6 @@ tags:
   - application_development
 subordinate: false
 series:
-  - quantal
-  - xenial
   - bionic
+  - xenial
+  - quantal

--- a/testcharms/charm-repo/quantal/lxd-profile/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile/metadata.yaml
@@ -13,3 +13,7 @@ tags:
   - misc
   - application_development
 subordinate: false
+series:
+  - quantal
+  - xenial
+  - bionic

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -69,7 +69,7 @@ func (s *BundlesDirSuite) TearDownTest(c *gc.C) {
 func (s *BundlesDirSuite) AddCharm(c *gc.C) (charm.BundleInfo, *state.Charm) {
 	curl := corecharm.MustParseURL("cs:quantal/dummy-1")
 	bun := testcharms.Repo.CharmDir("dummy")
-	sch, err := testing.AddCharm(s.State, curl, bun)
+	sch, err := testing.AddCharm(s.State, curl, bun, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiCharm, err := s.uniter.Charm(sch.URL())


### PR DESCRIPTION
## Description of change

The following passes force as an option to the deployment info, so
that we can verify if we need to show an error or not when
validating a deploy.

The force flag overrides the error, but still validates the charm,
with the aim to improve error messages when attempting to debug
a deployment from the logs.

## QA steps

```sh
juju bootstrap lxd-test
juju deploy cs:~juju-qa/bionic/lxd-profile-fail-0 --force
```

## Documentation changes

TBA

## Bug reference

N/A