### PR TITLE
trigger new modelmachinesprofileswatcher during charm upgrade if charm contains a profile

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -850,3 +850,17 @@ func (c *Client) ResolveUnitErrors(units []string, all, retry bool) error {
 	}
 	return errors.Trace(results.Combine())
 }
+
+// SetCharmProfile a new charm's url on deployed machines for changing the profile used
+// on those machine.
+func (c *Client) SetCharmProfile(applicationName string, charmID charmstore.CharmID) error {
+	if c.BestAPIVersion() < 8 {
+		return errors.NotSupportedf("SetCharmProfile not supported by this version of Juju")
+	}
+	args := params.ApplicationSetCharmProfile{
+		ApplicationName: applicationName,
+		CharmURL:        charmID.URL.String(),
+	}
+	var results params.ErrorResults
+	return c.facade.FacadeCall("SetCharmProfile", args, &results)
+}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1221,3 +1221,18 @@ func (s *applicationSuite) TestScaleApplicationCallError(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
+
+func (s *applicationSuite) TestSetCharmProfileError(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			c.Assert(request, gc.Equals, "SetCharmProfile")
+			return errors.New("boom")
+		},
+	)
+	//client := application.NewClient(apiCaller)
+	client := newClient(apiCaller)
+	err := client.SetCharmProfile("foo", charmstore.CharmID{
+		URL: charm.MustParseURL("local:testing-1"),
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1229,7 +1229,6 @@ func (s *applicationSuite) TestSetCharmProfileError(c *gc.C) {
 			return errors.New("boom")
 		},
 	)
-	//client := application.NewClient(apiCaller)
 	client := newClient(apiCaller)
 	err := client.SetCharmProfile("foo", charmstore.CharmID{
 		URL: charm.MustParseURL("local:testing-1"),

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -81,7 +81,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  6,
+	"Provisioner":                  7,
 	"ProxyUpdater":                 2,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -135,6 +135,21 @@ func (st *State) WatchMachineErrorRetry() (watcher.NotifyWatcher, error) {
 	return w, nil
 }
 
+// WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
+// changes to the upgrade charm profile charm url for a machine.
+func (st *State) WatchModelMachinesCharmProfiles() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	err := st.facade.FacadeCall("WatchModelMachinesCharmProfiles", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	if err := result.Error; err != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	return w, nil
+}
+
 // StateAddresses returns the list of addresses used to connect to the state.
 func (st *State) StateAddresses() ([]string, error) {
 	var result params.StringsResult

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -247,6 +247,7 @@ func AllFacades() *facade.Registry {
 	reg("Provisioner", 4, provisioner.NewProvisionerAPIV4)
 	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5) // v5 adds DistributionGroupByMachineId()
 	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6) // v6 adds more proxy settings
+	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7) // v7 adds charm profile watcher
 
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)
 	reg("ProxyUpdater", 2, proxyupdater.NewFacadeV2)

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -74,6 +74,7 @@ type Application interface {
 	SetCharm(state.SetCharmConfig) error
 	SetConstraints(constraints.Value) error
 	SetExposed() error
+	SetCharmProfile(string) error
 	SetMetricCredentials([]byte) error
 	SetMinUnits(int) error
 	UpdateApplicationSeries(string, bool) error

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -389,6 +389,16 @@ type ApplicationSetCharm struct {
 	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
 }
 
+// ApplicationSetCharmProfile holds the parameters for making the
+// application SetCharmProfile call.
+type ApplicationSetCharmProfile struct {
+	// ApplicationName is the name of the application to set the profile on.
+	ApplicationName string `json:"application"`
+
+	// CharmURL is the new charm's url.
+	CharmURL string `json:"charm-url"`
+}
+
 // ApplicationExpose holds the parameters for making the application Expose call.
 type ApplicationExpose struct {
 	ApplicationName string `json:"application"`

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -68,6 +68,7 @@ type CharmUpgradeClient interface {
 	GetCharmURL(string) (*charm.URL, error)
 	Get(string) (*params.ApplicationGetResults, error)
 	SetCharm(application.SetCharmConfig) error
+	SetCharmProfile(string, charmstore.CharmID) error
 }
 
 // CharmClient defines a subset of the charms facade, as required
@@ -342,6 +343,12 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	ids, err := c.upgradeResources(apiRoot, charmsClient, resourceLister, chID, csMac)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Next, upgrade the lxd-profile if appropriate.
+	err = charmUpgradeClient.SetCharmProfile(c.ApplicationName, chID)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -1114,7 +1114,10 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		return errors.Annotate(err, "validating config settings")
 	}
 
-	// TODO validate lxd profile?
+	// TODO (hml) lxd-profile 15-oct-2018
+	// Do we need to validate the lxd profile here?
+	// Need force threaded thru in state.SetCharmConfig &
+	// params.ApplicationSetCharm
 
 	var newCharmModifiedVersion int
 	channel := string(cfg.Channel)

--- a/state/application.go
+++ b/state/application.go
@@ -868,6 +868,26 @@ func (a *Application) changeCharmOps(
 	return append(ops, decOps...), nil
 }
 
+// SetCharmProfile updates each machine the application is deployed
+// on with the name and charm url for a profile update of that machine.
+func (a *Application) SetCharmProfile(charmURL string) error {
+	units, err := a.AllUnits()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, u := range units {
+		m, err := u.machine()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = m.SetUpgradeCharmProfile(a.Name(), charmURL)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
 func (a *Application) newCharmStorageOps(
 	ch *Charm,
 	units []*Unit,
@@ -1093,6 +1113,8 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 	if err != nil {
 		return errors.Annotate(err, "validating config settings")
 	}
+
+	// TODO validate lxd profile?
 
 	var newCharmModifiedVersion int
 	channel := string(cfg.Channel)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -316,6 +316,10 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 		// Ignored at this stage, could be an issue if mongo 3.0 isn't
 		// available.
 		"StopMongoUntilVersion",
+		// Ignore at this stage.  Depends on how we handle the machine charm
+		// profile watcher if this is a good idea.
+		"UpgradeCharmProfileApplication",
+		"UpgradeCharmProfileCharmURL",
 	)
 	migrated := set.NewStrings(
 		"Addresses",

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -864,7 +864,7 @@ func (w *modelMachinesProfileWatcher) merge(machineIds set.Strings, change watch
 	return nil
 }
 
-func (w *modelMachinesProfileWatcher) loop() (err error) {
+func (w *modelMachinesProfileWatcher) loop() error {
 	ch := make(chan watcher.Change)
 	w.watcher.WatchCollectionWithFilter(machinesC, ch, isLocalID(w.backend))
 	defer w.watcher.UnwatchCollection(machinesC, ch)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -251,6 +251,12 @@ func (s *containerSetupSuite) stubOutProvisioner(ctrl *gomock.Controller) {
 	}}}
 	fExp.FacadeCall("WatchContainers", gomock.Any(), gomock.Any()).SetArg(2, watchSource).Return(nil).AnyTimes()
 
+	watchOneSource := params.StringsWatchResult{
+		StringsWatcherId: "something",
+		Changes:          []string{},
+	}
+	fExp.FacadeCall("WatchModelMachinesCharmProfiles", gomock.Any(), gomock.Any()).SetArg(2, watchOneSource).Return(nil).AnyTimes()
+
 	controllerCfgSource := params.ControllerConfigResult{
 		Config: map[string]interface{}{"controller-uuid": s.controllerUUID.String()},
 	}

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -403,3 +403,7 @@ func (p *containerProvisioner) getMachineWatcher() (watcher.StringsWatcher, erro
 func (p *containerProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
 	return nil, errors.NotImplementedf("getRetryWatcher")
 }
+
+func (p *containerProvisioner) getProfileWatcher() (watcher.StringsWatcher, error) {
+	return p.st.WatchModelMachinesCharmProfiles()
+}

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -40,6 +40,7 @@ type Provisioner interface {
 	worker.Worker
 	getMachineWatcher() (watcher.StringsWatcher, error)
 	getRetryWatcher() (watcher.NotifyWatcher, error)
+	getProfileWatcher() (watcher.StringsWatcher, error)
 }
 
 // environProvisioner represents a running provisioning worker for machine nodes
@@ -150,6 +151,10 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 	if err != nil && !errors.IsNotImplemented(err) {
 		return nil, err
 	}
+	profileWatcher, err := p.getProfileWatcher()
+	if err != nil && !errors.IsNotImplemented(err) {
+		return nil, err
+	}
 	tag := p.agentConfig.Tag()
 	machineTag, ok := tag.(names.MachineTag)
 	if !ok {
@@ -175,6 +180,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		p.toolsFinder,
 		machineWatcher,
 		retryWatcher,
+		profileWatcher,
 		p.broker,
 		auth,
 		modelCfg.ImageStream(),
@@ -271,6 +277,10 @@ func (p *environProvisioner) getMachineWatcher() (watcher.StringsWatcher, error)
 
 func (p *environProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
 	return p.st.WatchMachineErrorRetry()
+}
+
+func (p *environProvisioner) getProfileWatcher() (watcher.StringsWatcher, error) {
+	return p.st.WatchModelMachinesCharmProfiles()
 }
 
 // setConfig updates the environment configuration and notifies

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -78,6 +78,7 @@ func NewProvisionerTask(
 	toolsFinder ToolsFinder,
 	machineWatcher watcher.StringsWatcher,
 	retryWatcher watcher.NotifyWatcher,
+	profileWatcher watcher.StringsWatcher,
 	broker environs.InstanceBroker,
 	auth authentication.AuthenticationProvider,
 	imageStream string,
@@ -91,6 +92,7 @@ func NewProvisionerTask(
 		retryChanges = retryWatcher.Changes()
 		workers = append(workers, retryWatcher)
 	}
+	profileChanges := profileWatcher.Changes()
 	task := &provisionerTask{
 		controllerUUID:             controllerUUID,
 		machineTag:                 machineTag,
@@ -99,6 +101,7 @@ func NewProvisionerTask(
 		toolsFinder:                toolsFinder,
 		machineChanges:             machineChanges,
 		retryChanges:               retryChanges,
+		profileChanges:             profileChanges,
 		broker:                     broker,
 		auth:                       auth,
 		harvestMode:                harvestMode,
@@ -134,6 +137,7 @@ type provisionerTask struct {
 	toolsFinder                ToolsFinder
 	machineChanges             watcher.StringsChannel
 	retryChanges               watcher.NotifyChannel
+	profileChanges             watcher.StringsChannel
 	broker                     environs.InstanceBroker
 	catacomb                   catacomb.Catacomb
 	auth                       authentication.AuthenticationProvider
@@ -201,6 +205,13 @@ func (task *provisionerTask) loop() error {
 		case <-task.retryChanges:
 			if err := task.processMachinesWithTransientErrors(); err != nil {
 				return errors.Annotate(err, "failed to process machines with transient errors")
+			}
+		case ids, ok := <-task.profileChanges:
+			if !ok {
+				return errors.New("profile watcher closed channel")
+			}
+			if err := task.processProfileChanges(ids); err != nil {
+				return errors.Annotate(err, "failed to process updated charm profiles")
 			}
 		}
 	}
@@ -315,6 +326,13 @@ func (task *provisionerTask) processMachines(ids []string) error {
 
 	// Start an instance for the pending ones
 	return task.startMachines(pending)
+}
+
+func (task *provisionerTask) processProfileChanges(ids []string) error {
+	// TODO hml 2018-10-10
+	// Change to Tracef when function implemented
+	logger.Debugf("processProfileChanges(%v)", ids)
+	return nil
 }
 
 func instanceIds(instances []instance.Instance) []string {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -69,8 +69,8 @@ func (s *ProvisionerTaskSuite) SetUpTest(c *gc.C) {
 	s.machineErrorRetryChanges = make(chan struct{})
 	s.machineErrorRetryWatcher = watchertest.NewMockNotifyWatcher(s.machineErrorRetryChanges)
 
-	s.modelMachinesChanges = make(chan []string)
-	s.modelMachinesWatcher = watchertest.NewMockStringsWatcher(s.modelMachinesProfileChanges)
+	s.modelMachinesProfileChanges = make(chan []string)
+	s.modelMachinesProfileWatcher = watchertest.NewMockStringsWatcher(s.modelMachinesProfileChanges)
 
 	s.machinesResults = []apiprovisioner.MachineResult{}
 	s.machineStatusResults = []apiprovisioner.MachineStatusResult{}

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -42,6 +42,9 @@ type ProvisionerTaskSuite struct {
 	machineErrorRetryChanges chan struct{}
 	machineErrorRetryWatcher watcher.NotifyWatcher
 
+	modelMachinesProfileChanges chan []string
+	modelMachinesProfileWatcher watcher.StringsWatcher
+
 	machinesResults      []apiprovisioner.MachineResult
 	machineStatusResults []apiprovisioner.MachineStatusResult
 	machineGetter        *testMachineGetter
@@ -65,6 +68,9 @@ func (s *ProvisionerTaskSuite) SetUpTest(c *gc.C) {
 
 	s.machineErrorRetryChanges = make(chan struct{})
 	s.machineErrorRetryWatcher = watchertest.NewMockNotifyWatcher(s.machineErrorRetryChanges)
+
+	s.modelMachinesChanges = make(chan []string)
+	s.modelMachinesWatcher = watchertest.NewMockStringsWatcher(s.modelMachinesProfileChanges)
 
 	s.machinesResults = []apiprovisioner.MachineResult{}
 	s.machineStatusResults = []apiprovisioner.MachineStatusResult{}
@@ -256,6 +262,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithRetry(
 		toolsFinder,
 		s.modelMachinesWatcher,
 		s.machineErrorRetryWatcher,
+		s.modelMachinesProfileWatcher,
 		s.instanceBrocker,
 		s.auth,
 		imagemetadata.ReleasedStream,

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1346,6 +1346,8 @@ func (s *ProvisionerSuite) newProvisionerTaskWithRetryStrategy(
 	c.Assert(err, jc.ErrorIsNil)
 	retryWatcher, err := s.provisioner.WatchMachineErrorRetry()
 	c.Assert(err, jc.ErrorIsNil)
+	machineProfileWatcher, err := s.provisioner.WatchModelMachinesCharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
 	auth, err := authentication.NewAPIAuthenticator(s.provisioner)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1358,6 +1360,7 @@ func (s *ProvisionerSuite) newProvisionerTaskWithRetryStrategy(
 		toolsFinder,
 		machineWatcher,
 		retryWatcher,
+		machineProfileWatcher,
 		broker,
 		auth,
 		imagemetadata.ReleasedStream,


### PR DESCRIPTION
## Description of change

Part of upgrade charm with lxd profile work: trigger new modelmachinesprofileswatcher, for each lxd unit of the application, during charm upgrade if charm contains a profile.  

## QA steps

1. `export JUJU_DEV_FEATURE_FLAGS=lxd-profile`
2. `juju bootstrap localhost --config  logging-config='<root>=DEBUG;unit=DEBUG'`
3. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-profile-local`
     Once deploy is complete, upgrade the charm
4. `juju upgrade-charm lxd-profile-local --path ./testcharms/charm-repo/quantal/lxd-profile`
5. run `juju debug-log -m controller --include-module juju.provisioner` watch for debug msg about "processProfileChanges"