### PR TITLE
Improve help text printed by `list-clouds`

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -6,7 +6,6 @@ package cloud
 import (
 	"io"
 	"sort"
-	"strings"
 
 	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
@@ -204,18 +203,11 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 	printClouds(clouds.builtin, nil)
 	printClouds(clouds.personal, ansiterm.Foreground(ansiterm.BrightBlue))
 
-	// Get other provider types supported by add-cloud.
-	// These will typically be for private clouds like maas etc.
-	providers, _, err := addableCloudProviders()
-	if err != nil {
-		return errors.Trace(err)
-	}
+	w.Println("\n - Import a cloud credential with `add-credential <cloud>`.")
+	w.Println(" - List a cloud's regions and endpoints with `show-cloud <cloud>`.")
+	w.Println(" - Add a cloud to Juju with `add-cloud`.")
+	w.Println(" - Update cloud metadata with `update-clouds`.")
 
-	w.Println("\nTry 'list-regions <cloud>' to see available regions.")
-	w.Println("'show-cloud <cloud>' or 'regions --format yaml <cloud>' can be used to see region endpoints.")
-	w.Println("Update the known public clouds with 'update-clouds'.")
-	w.Println("'add-cloud' can add private or custom clouds / infrastructure built for the following provider types:")
-	w.Printf("  - %s\n", strings.Join(providers, ", "))
 	tw.Flush()
 	return nil
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -203,11 +203,6 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 	printClouds(clouds.builtin, nil)
 	printClouds(clouds.personal, ansiterm.Foreground(ansiterm.BrightBlue))
 
-	w.Println("\n - Import a cloud credential with `add-credential <cloud>`.")
-	w.Println(" - List a cloud's regions and endpoints with `show-cloud <cloud>`.")
-	w.Println(" - Add a cloud to Juju with `add-cloud`.")
-	w.Println(" - Update cloud metadata with `update-clouds`.")
-
 	tw.Flush()
 	return nil
 }

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -33,8 +33,6 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	c.Assert(out, gc.Matches, `.*aws-china[ ]*1[ ]*cn-north-1[ ]*ec2.*`)
 	// LXD should be there too.
 	c.Assert(out, gc.Matches, `.*localhost[ ]*1[ ]*localhost[ ]*lxd.*`)
-	// The private provider types should be there also.
-	c.Assert(out, gc.Matches, `.*maas, manual, oci, openstack, oracle, vsphere.*`)
 }
 
 func (s *listSuite) TestListPublicAndPersonal(c *gc.C) {


### PR DESCRIPTION
## Description of change

This improves the help text printed after the table of known clouds (`list-clouds`). It is simpler and easier to read.

I removed the list and explanation of non-baked-in clouds as I found that level of detail out of place in this context. I hope I didn't overstep my bounds there. Anyway, I do believe `add-cloud` can add any cloud type (e.g. 'localhost') so the existing text is misleading.

## QA steps

List clouds (`juju clouds`) and look at the text printed at the very end. It should say:

```
 - Import a cloud credential with `add-credential <cloud>`.
 - List a cloud's regions and endpoints with `show-cloud <cloud>`.
 - Add a cloud to Juju with `add-cloud`.
 - Update cloud metadata with `update-clouds`.
```

Instead of:

```
Try 'list-regions <cloud>' to see available regions.
'show-cloud <cloud>' or 'regions --format yaml <cloud>' can be used to see region endpoints.
Update the known public clouds with 'update-clouds'.
'add-cloud' can add private or custom clouds / infrastructure built for the following provider types:
  - lxd, maas, manual, oci, openstack, oracle, vsphere
```

## Documentation changes

Inspect any `list-clouds` (or `clouds`) example sessions and make the necessary changes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1795996