### PR TITLE
Intermittent failure for cloud info output

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -7,6 +7,7 @@ package cloud
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
@@ -353,6 +354,10 @@ func (api *CloudAPI) getCloudInfo(tag names.CloudTag) (*params.CloudInfo, error)
 		// have access to the cloud.
 		return nil, errors.Trace(common.ErrPerm)
 	}
+	// Make sure that the slice is sorted in a predictable manor
+	sort.Slice(info.Users, func(i, j int) bool {
+		return info.Users[i].UserName < info.Users[j].UserName
+	})
 	return &info, nil
 }
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -7,7 +7,6 @@ package cloud
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
@@ -354,10 +353,6 @@ func (api *CloudAPI) getCloudInfo(tag names.CloudTag) (*params.CloudInfo, error)
 		// have access to the cloud.
 		return nil, errors.Trace(common.ErrPerm)
 	}
-	// Make sure that the slice is sorted in a predictable manor
-	sort.Slice(info.Users, func(i, j int) bool {
-		return info.Users[i].UserName < info.Users[j].UserName
-	})
 	return &info, nil
 }
 

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -4,6 +4,8 @@
 package cloud_test
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 	"github.com/juju/juju/permission"
 	gitjujutesting "github.com/juju/testing"
@@ -135,6 +137,12 @@ func (s *cloudSuite) TestCloudInfoAdmin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "Cloud", "User", "User")
 	s.ctlrBackend.CheckCallNames(c, "ControllerTag", "GetCloudUsers")
+
+	// Make sure that the slice is sorted in a predictable manor
+	sort.Slice(result.Results[0].Result.Users, func(i, j int) bool {
+		return result.Results[0].Result.Users[i].UserName < result.Results[0].Result.Users[j].UserName
+	})
+
 	c.Assert(result.Results, jc.DeepEquals, []params.CloudInfoResult{
 		{
 			Result: &params.CloudInfo{


### PR DESCRIPTION
## Description of change

The following output is never predictable because the results from
an api call is a map[string]... and the loop over the map never
orders the output. The tests then expects the result of the test
to be the same order, this is never the case as a map is used.

## Bug Link

https://bugs.launchpad.net/juju/+bug/1795742