### PR TITLE
Rework --help for `clouds` command

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -29,19 +29,18 @@ type listCloudsCommand struct {
 // commands for ease in markdown.
 var listCloudsDoc = "" +
         "Output includes fundamental properties for each cloud known to the\n" +
-        "current Juju client. These are: name, number of regions, default region,\n" +
-	"type, and description.\n" +
-        "\nThe cloud name is what's used to refer to a cloud in any Juju command.\n" +
-        "\nThe default output shows public clouds known to Juju out of the box\n" +
-	"(these may change between Juju versions). In addition to these public\n" +
+        "current Juju client: name, number of regions, default region, type,\n" +
+	"and description.\n" +
+        "\nThe default output shows public clouds known to Juju out of the box.\n" +
+	"These may change between Juju versions. In addition to these public\n" +
 	"clouds, the 'localhost' cloud (local LXD) is also listed.\n" +
         "\nThis command's default output format is 'tabular'.\n" +
         "\nCloud metadata sometimes changes, e.g. AWS adds a new region. Use the\n" +
 	"`update-clouds` command to update the current Juju client accordingly.\n" +
-	"\nUse the `add-cloud` command to add a private cloud to the list of clouds\n" +
-	"known to the current Juju client.\n" +
-        "\nUse the `regions` command to list a cloud's regions and the `show-cloud`\n" +
-	"command to get more detail, such as regions and endpoints.\n" +
+	"\nUse the `add-cloud` command to add a private cloud to the list of\n" +
+	"clouds known to the current Juju client.\n" +
+        "\nUse the `regions` command to list a cloud's regions. Use the\n" +
+	"`show-cloud` command to get more detail, such as regions and endpoints.\n" +
         "\nFurther reading: https://docs.jujucharms.com/stable/clouds\n" + listCloudsDocExamples
 
 var listCloudsDocExamples = `

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -28,20 +28,20 @@ type listCloudsCommand struct {
 // listCloudsDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 var listCloudsDoc = "" +
-        "Output includes fundamental properties for each cloud known to Juju.\n" +
-        "These are: name, number of regions, default region, type, and description.\n" +
+        "Output includes fundamental properties for each cloud known to the\n" +
+        "current Juju client. These are: name, number of regions, default region,\n" +
+	"type, and description.\n" +
         "\nThe cloud name is what's used to refer to a cloud in any Juju command.\n" +
-        "\nThe `regions` command lists a cloud's regions. Both regions and endpoints\n" +
-	"are exposed with `show-cloud`.\n" +
-        "\nThe default output shows those clouds known to Juju out of the box (the\n" +
-	"\"baked in\" clouds). With the exception of the 'localhost' cloud, these\n" +
-	"are all the supported public clouds. Other (private) clouds need to be\n" +
-	"added via the `add-cloud` command. These are 'lxd' (remote), 'maas',\n" +
-	"'manual', 'openstack', and 'vsphere'.\n" +
-        "\nCloud metadata sometimes changes (e.g. AWS adds a new region). To\n" +
-	"synchronise Juju with the \"baked in\" clouds the `update-clouds` command\n" +
-	"is used.\n" +
+        "\nThe default output shows public clouds known to Juju out of the box\n" +
+	"(these may change between Juju versions). In addition to these public\n" +
+	"clouds, the 'localhost' cloud (local LXD) is also listed.\n" +
         "\nThis command's default output format is 'tabular'.\n" +
+        "\nCloud metadata sometimes changes, e.g. AWS adds a new region. Use the\n" +
+	"`update-clouds` command to update the current Juju client accordingly.\n" +
+	"\nUse the `add-cloud` command to add a private cloud to the list of clouds\n" +
+	"known to the current Juju client.\n" +
+        "\nUse the `regions` command to list a cloud's regions and the `show-cloud`\n" +
+	"command to get more detail, such as regions and endpoints.\n" +
         "\nFurther reading: https://docs.jujucharms.com/stable/clouds\n" + listCloudsDocExamples
 
 var listCloudsDocExamples = `

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -28,17 +28,27 @@ type listCloudsCommand struct {
 // listCloudsDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 var listCloudsDoc = "" +
-	"Provided information includes 'cloud' (as understood by Juju), cloud\n" +
-	"'type', and cloud 'regions'.\n" +
-	"The listing will consist of public clouds and any custom clouds made\n" +
-	"available through the `juju add-cloud` command. The former can be updated\n" +
-	"via the `juju update-clouds` command.\n" +
-	"By default, the tabular format is used.\n" + listCloudsDocExamples
+        "Output includes fundamental properties for each cloud known to Juju.\n" +
+        "These are: name, number of regions, default region, type, and description.\n" +
+        "\nThe cloud name is what's used to refer to a cloud in any Juju command.\n" +
+        "\nThe `regions` command lists a cloud's regions. Both regions and endpoints\n" +
+	"are exposed with `show-cloud`.\n" +
+        "\nThe default output shows those clouds known to Juju out of the box (the\n" +
+	"\"baked in\" clouds). With the exception of the 'localhost' cloud, these\n" +
+	"are all the supported public clouds. Other (private) clouds need to be\n" +
+	"added via the `add-cloud` command. These are 'lxd' (remote), 'maas',\n" +
+	"'manual', 'openstack', and 'vsphere'.\n" +
+        "\nCloud metadata sometimes changes (e.g. AWS adds a new region). To\n" +
+	"synchronise Juju with the \"baked in\" clouds the `update-clouds` command\n" +
+	"is used.\n" +
+        "\nThis command's default output format is 'tabular'.\n" +
+        "\nFurther reading: https://docs.jujucharms.com/stable/clouds\n" + listCloudsDocExamples
 
 var listCloudsDocExamples = `
 Examples:
 
     juju clouds
+    juju clouds --format yaml
 
 See also:
     add-cloud

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -28,20 +28,20 @@ type listCloudsCommand struct {
 // listCloudsDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 var listCloudsDoc = "" +
-        "Output includes fundamental properties for each cloud known to the\n" +
-        "current Juju client: name, number of regions, default region, type,\n" +
+	"Output includes fundamental properties for each cloud known to the\n" +
+	"current Juju client: name, number of regions, default region, type,\n" +
 	"and description.\n" +
-        "\nThe default output shows public clouds known to Juju out of the box.\n" +
+	"\nThe default output shows public clouds known to Juju out of the box.\n" +
 	"These may change between Juju versions. In addition to these public\n" +
 	"clouds, the 'localhost' cloud (local LXD) is also listed.\n" +
-        "\nThis command's default output format is 'tabular'.\n" +
-        "\nCloud metadata sometimes changes, e.g. AWS adds a new region. Use the\n" +
+	"\nThis command's default output format is 'tabular'.\n" +
+	"\nCloud metadata sometimes changes, e.g. AWS adds a new region. Use the\n" +
 	"`update-clouds` command to update the current Juju client accordingly.\n" +
 	"\nUse the `add-cloud` command to add a private cloud to the list of\n" +
 	"clouds known to the current Juju client.\n" +
-        "\nUse the `regions` command to list a cloud's regions. Use the\n" +
+	"\nUse the `regions` command to list a cloud's regions. Use the\n" +
 	"`show-cloud` command to get more detail, such as regions and endpoints.\n" +
-        "\nFurther reading: https://docs.jujucharms.com/stable/clouds\n" + listCloudsDocExamples
+	"\nFurther reading: https://docs.jujucharms.com/stable/clouds\n" + listCloudsDocExamples
 
 var listCloudsDocExamples = `
 Examples:


### PR DESCRIPTION
## Description of change

This improves the help output for the `clouds` command.

I hardcoded the supported private clouds. I did not include 'oci' nor 'oracle' in that list since the latter should soon be gone and the former will soon be baked in.

See #9280.

## QA steps

View the help (`juju help clouds`) and see the revised output:

```
Details:
Output includes fundamental properties for each cloud known to Juju.
These are: name, number of regions, default region, type, and description.

The cloud name is what's used to refer to a cloud in any Juju command.

The `regions` command lists a cloud's regions. Both regions and endpoints
are exposed with `show-cloud`.

The default output shows those clouds known to Juju out of the box (the
"baked in" clouds). With the exception of the 'localhost' cloud, these
are all the supported public clouds. Other (private) clouds need to be
added via the `add-cloud` command. These are 'lxd' (remote), 'maas',
'manual', 'openstack', and 'vsphere'.

Cloud metadata sometimes changes (e.g. AWS adds a new region). To
synchronise Juju with the "baked in" clouds the `update-clouds` command
is used.

This command's default output format is 'tabular'.

Further reading: https://docs.jujucharms.com/stable/clouds
```

Instead of:

```
Details:
Provided information includes 'cloud' (as understood by Juju), cloud
'type', and cloud 'regions'.
The listing will consist of public clouds and any custom clouds made
available through the `juju add-cloud` command. The former can be updated
via the `juju update-clouds` command.
By default, the tabular format is used.
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1796149
