### PR TITLE
Fixes lp#1795495: credential check excludes dead models.

### DIFF
--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -353,8 +353,13 @@ func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]stri
 	coll, cleanup := st.db().GetCollection(modelsC)
 	defer cleanup()
 
+	sel := bson.D{
+		{"cloud-credential", tag.Id()},
+		{"life", bson.D{{"$ne", Dead}}},
+	}
+
 	var docs []modelDoc
-	err := coll.Find(bson.D{{"cloud-credential", tag.Id()}}).All(&docs)
+	err := coll.Find(sel).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting models that use cloud credential %q", tag.Id())
 	}


### PR DESCRIPTION
## Description of change

There is no need to check whether a cloud credential works for a dead model. By extension, it is also not correct to consider that a dead model is part of the model credential collection. This collection should only contain non-dead models.

This PR fixes cloud credential models query and adds a test to verify that a model that became dead is excluded form the result.  

## Bug reference

https://bugs.launchpad.net/juju/+bug/1795495
