### PR TITLE
Fix multiwatcher waitgroup goroutines

### DIFF
--- a/apiserver/common/watch.go
+++ b/apiserver/common/watch.go
@@ -108,11 +108,10 @@ func NewMultiNotifyWatcher(w ...state.NotifyWatcher) *MultiNotifyWatcher {
 	for _, w := range w {
 		// Consume the first event of each watcher.
 		<-w.Changes()
-		wCopy := w
-		m.tomb.Go(func() error {
+		go func(wCopy state.NotifyWatcher) {
 			defer wg.Done()
-			return wCopy.Wait()
-		})
+			wCopy.Wait()
+		}(w)
 		// Copy events from the watcher to the staging channel.
 		go copyEvents(staging, w.Changes(), &m.tomb)
 	}


### PR DESCRIPTION
tomb.Go shouldn't be called multiple times from a non-tomb managed goroutine.

Since the watcher is just interested the goroutine to decrement the wait group, it doesn't need the tomb.

## QA steps

unit tests should still pass

## Documentation changes

No doc changes needed

## Bug reference
partial fix for https://bugs.launchpad.net/juju/+bug/1792299
