### PR TITLE
2.4 - Containers on Manually Provisioned Machines, on Providers Supporting Container Networking

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -864,7 +864,9 @@ func (ctx *prepareOrGetContext) SetError(idx int, err *params.Error) {
 	ctx.result.Results[idx].Error = err
 }
 
-func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, callContext context.ProviderCallContext, idx int, host, container *state.Machine) error {
+func (ctx *prepareOrGetContext) ProcessOneContainer(
+	env environs.Environ, callContext context.ProviderCallContext, idx int, host, container *state.Machine,
+) error {
 	containerId, err := container.InstanceId()
 	if ctx.maintain {
 		if err == nil {
@@ -876,10 +878,9 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, callCo
 	}
 	// The only error we allow is NotProvisioned
 	if err != nil && !errors.IsNotProvisioned(err) {
-		return err
+		return errors.Trace(err)
 	}
 
-	supportContainerAddresses := environs.SupportsContainerAddresses(callContext, env)
 	bridgePolicy := containerizer.BridgePolicy{
 		NetBondReconfigureDelay:   env.Config().NetBondReconfigureDelay(),
 		ContainerNetworkingMethod: env.Config().ContainerNetworkingMethod(),
@@ -890,13 +891,21 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, callCo
 	// into things we'd like to tell the Host machine to create, and then *it*
 	// reports back what actually exists when its done.
 	if err := bridgePolicy.PopulateContainerLinkLayerDevices(host, container); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	containerDevices, err := container.AllLinkLayerDevices()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
+
+	// We do not ask the provider to allocate addresses for manually provisioned
+	// machines as we do not expect such machines to be recognised (LP:1796106).
+	hostIsManual, err := host.IsManual()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	supportContainerAddresses := environs.SupportsContainerAddresses(callContext, env) && !hostIsManual
 
 	preparedInfo := make([]network.InterfaceInfo, len(containerDevices))
 	for j, device := range containerDevices {
@@ -909,7 +918,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, callCo
 		}
 		parentAddrs, err := parentDevice.Addresses()
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 
 		info := network.InterfaceInfo{
@@ -961,15 +970,17 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(env environs.Environ, callCo
 	hostInstanceId, err := host.InstanceId()
 	if err != nil {
 		// this should have already been checked in the processEachContainer helper
-		return err
+		return errors.Trace(err)
 	}
+
 	allocatedInfo := preparedInfo
 	if supportContainerAddresses {
 		// supportContainerAddresses already checks that we can cast to an environ.Networking
 		networking := env.(environs.Networking)
-		allocatedInfo, err = networking.AllocateContainerAddresses(callContext, hostInstanceId, container.MachineTag(), preparedInfo)
+		allocatedInfo, err = networking.AllocateContainerAddresses(
+			callContext, hostInstanceId, container.MachineTag(), preparedInfo)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		logger.Debugf("got allocated info from provider: %+v", allocatedInfo)
 	} else {


### PR DESCRIPTION
## Description of change

When adding a container to a manually provisioned machine on a provider that supports container networking, such as MAAS, provisioning fails because the machine is not recognised.

This patch adds an additional check when allocating container addresses. If the machine is manually provisioned, we just fall back to DHCP without asking the provider for an address.

*Note for reviewers*: The functional change is in the second commit (https://github.com/juju/juju/pull/9287/commits/8ba8c82307e7841b430d28d4fb7a65fa30c7076d). The first commit includes receiver renamings that add mostly noise, for which the submitter apologises.

## QA steps

There are no unit tests covering this change because the functionality in question is tested using the dummy provider, which does not support container networking. The QA steps confirm desired operation.

- Bootstrap to MAAS.
- Deploy a Xenial machine that uses DHCP. Note the address it receives.
- Add manually provisioned machine, for example `juju add-machine ssh:ubuntu@10.0.0.76`
- `juju add-machine lxd:0` and ensure that there is no error.
- `juju add-machine`
- `juju add-machine lxd:1` and check that normal container machine provisioning works`

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1796106
