### PR TITLE
write used charm profile names to instanceData for machine

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -394,11 +394,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:6d6c5ad4b8e4aa201d33fc1afafa5f0fcc9e4b14cca84a8fab16b156a65a4fd3"
+  digest = "1:897190ff1d32412aa4e298f4f04d4ae6d5d1f18df16bb4f2bedb347a97d085bd"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "1f9306d91eb3958fef5c2c8741e7049d1dda08b6"
+  revision = "40b9e213be66cd7fcd4eba2448a73188e405a1c8"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "1f9306d91eb3958fef5c2c8741e7049d1dda08b6"
+  revision = "40b9e213be66cd7fcd4eba2448a73188e405a1c8"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -91,7 +91,7 @@ type MachineProvisioner interface {
 	SetInstanceInfo(
 		id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
 		networkConfig []params.NetworkConfig, volumes []params.Volume,
-		volumeAttachments map[string]params.VolumeAttachmentInfo,
+		volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
 	) error
 
 	// InstanceId returns the provider specific instance id for the
@@ -367,7 +367,7 @@ func (m *Machine) DistributionGroup() ([]instance.Id, error) {
 func (m *Machine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
 	networkConfig []params.NetworkConfig, volumes []params.Volume,
-	volumeAttachments map[string]params.VolumeAttachmentInfo,
+	volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
 ) error {
 	var result params.ErrorResults
 	args := params.InstancesInfo{
@@ -379,6 +379,7 @@ func (m *Machine) SetInstanceInfo(
 			Volumes:           volumes,
 			VolumeAttachments: volumeAttachments,
 			NetworkConfig:     networkConfig,
+			CharmProfiles:     charmProfiles,
 		}},
 	}
 	err := m.st.facade.FacadeCall("SetInstanceInfo", args, &result)

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -228,15 +228,15 @@ func (mr *MockMachineProvisionerMockRecorder) Series() *gomock.Call {
 }
 
 // SetInstanceInfo mocks base method
-func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1 string, arg2 *instance.HardwareCharacteristics, arg3 []params.NetworkConfig, arg4 []params.Volume, arg5 map[string]params.VolumeAttachmentInfo) error {
-	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5)
+func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1 string, arg2 *instance.HardwareCharacteristics, arg3 []params.NetworkConfig, arg4 []params.Volume, arg5 map[string]params.VolumeAttachmentInfo, arg6 []string) error {
+	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo
-func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5)
+func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // SetInstanceStatus mocks base method

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -63,7 +63,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetInstanceInfo("i-manager", "fake_nonce", nil, nil, nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-manager", "fake_nonce", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.machine.Tag(), password, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)
@@ -296,7 +296,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	}
 
 	err = apiMachine.SetInstanceInfo(
-		"i-will", "fake_nonce", &hwChars, nil, volumes, volumeAttachments,
+		"i-will", "fake_nonce", &hwChars, nil, volumes, volumeAttachments, nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -305,7 +305,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(instanceId, gc.Equals, instance.Id("i-will"))
 
 	// Try it again - should fail.
-	err = apiMachine.SetInstanceInfo("i-wont", "fake", nil, nil, nil, nil)
+	err = apiMachine.SetInstanceInfo("i-wont", "fake", nil, nil, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot record provisioning info for "i-wont": cannot set instance data for machine "1": already set`)
 
 	// Now try to get machine 0's instance id.
@@ -373,13 +373,44 @@ func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 	hwChars := instance.MustParseHardware(fmt.Sprintf("availability-zone=%s", availabilityZone))
 
 	err = apiMachine.SetInstanceInfo(
-		"azinst", "nonce", &hwChars, nil, nil, nil,
+		"azinst", "nonce", &hwChars, nil, nil, nil, nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	retAvailabilityZone, err := apiMachine.AvailabilityZone()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(availabilityZone, gc.Equals, retAvailabilityZone)
+}
+
+func (s *provisionerSuite) TestSetInstanceInfoProfiles(c *gc.C) {
+	// Create a fresh machine, since machine 0 is already provisioned.
+	template := state.MachineTemplate{
+		Series: "xenial",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	}
+	notProvisionedMachine, err := s.State.AddOneMachine(template)
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiMachine := s.assertGetOneMachine(c, notProvisionedMachine.MachineTag())
+
+	instanceId, err := apiMachine.InstanceId()
+	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
+	c.Assert(err, gc.ErrorMatches, "machine 1 not provisioned")
+	c.Assert(instanceId, gc.Equals, instance.Id(""))
+
+	hwChars := instance.MustParseHardware("cores=123", "mem=4G")
+
+	profiles := []string{"juju-default-profile-0", "juju-default-lxd-2"}
+	err = apiMachine.SetInstanceInfo(
+		"profileinst", "nonce", &hwChars, nil, nil, nil, profiles,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mach, err := s.State.Machine(apiMachine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedProfiles, err := mach.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(profiles, jc.SameContents, obtainedProfiles)
 }
 
 func (s *provisionerSuite) TestKeepInstance(c *gc.C) {
@@ -402,7 +433,7 @@ func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 	apiMachine = s.assertGetOneMachine(c, machine1.MachineTag())
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	err = apiMachine.SetInstanceInfo("i-d", "fake", nil, nil, nil, nil)
+	err = apiMachine.SetInstanceInfo("i-d", "fake", nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	instances, err = apiMachine.DistributionGroup()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -46,7 +46,7 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
 
-	err = s.machine.SetInstanceInfo("i-foo", "FAKE_NONCE", nil, nil, nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-foo", "FAKE_NONCE", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	observedConfig := []params.NetworkConfig{{
@@ -101,7 +101,7 @@ func (s *networkConfigSuite) TestSetProviderNetworkConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
 
-	err = s.machine.SetInstanceInfo("i-foo", "FAKE_NONCE", nil, nil, nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-foo", "FAKE_NONCE", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -699,7 +699,7 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 		err = machine.SetInstanceInfo(
 			arg.InstanceId, arg.Nonce, arg.Characteristics,
 			devicesArgs, devicesAddrs,
-			volumes, volumeAttachments,
+			volumes, volumeAttachments, arg.CharmProfiles,
 		)
 		if err != nil {
 			return errors.Annotatef(err, "cannot record provisioning info for %q", arg.InstanceId)

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1176,7 +1176,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 
 	// Provision machine 0 first.
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err = s.machines[0].SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, nil, nil)
+	err = s.machines[0].SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	volumesMachine, err := s.State.AddOneMachine(state.MachineTemplate{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3354,7 +3354,7 @@ func (s *uniterNetworkConfigSuite) addProvisionedMachineWithDevicesAndAddresses(
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	devicesArgs, devicesAddrs := s.makeMachineDevicesAndAddressesArgs(addrSuffix)
-	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil)
+	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineAddrs, err := machine.AllAddresses()
@@ -3610,7 +3610,7 @@ func (s *uniterNetworkInfoSuite) addProvisionedMachineWithDevicesAndAddresses(c 
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	devicesArgs, devicesAddrs := s.makeMachineDevicesAndAddressesArgs(addrSuffix)
-	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil)
+	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineAddrs, err := machine.AllAddresses()

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -397,6 +397,7 @@ type InstanceInfo struct {
 	VolumeAttachments map[string]VolumeAttachmentInfo `json:"volume-attachments"`
 
 	NetworkConfig []NetworkConfig `json:"network-config"`
+	CharmProfiles []string        `json:"charm-profiles"`
 }
 
 // InstancesInfo holds the parameters for making a SetInstanceInfo

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -130,6 +130,20 @@ func (s *MachineSuite) TestSetKeepInstance(c *gc.C) {
 	c.Assert(keep, jc.IsTrue)
 }
 
+func (s *MachineSuite) TestSetCharmProfile(c *gc.C) {
+	err := s.machine.SetProvisioned("1234", "nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedProfiles := []string{"juju-default-lxd-profile-0", "juju-default-lxd-sub-0"}
+	err = s.machine.SetCharmProfiles(expectedProfiles)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Machine(s.machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedProfiles, err := m.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(expectedProfiles, jc.SameContents, obtainedProfiles)
+}
+
 func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -977,14 +991,14 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{
 		names.NewVolumeTag("1065"): {VolumeId: "vol-ume"},
 	}
-	err := s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
+	err := s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume \"1065\": volume \"1065\" not found`)
 	assertNotProvisioned()
 
 	invalidVolumes = map[names.VolumeTag]state.VolumeInfo{
 		names.NewVolumeTag("1065"): {},
 	}
-	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
+	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume \"1065\": volume ID not set`)
 	assertNotProvisioned()
 
@@ -1017,7 +1031,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 		Size:     1234,
 	}
 	volumes := map[names.VolumeTag]state.VolumeInfo{volumeTag: volumeInfo}
-	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, volumes, nil)
+	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, volumes, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.machine.CheckProvisioned("fake_nonce"), jc.IsTrue)
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -410,6 +410,7 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 		return nil, errors.NotValidf("missing instance data for machine %s", machine.Id())
 	}
 	exMachine.SetInstance(e.newCloudInstanceArgs(instData))
+
 	instance := exMachine.Instance()
 	instanceKey := machine.globalInstanceKey()
 	statusArgs, err := e.statusArgs(instanceKey)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -525,6 +525,9 @@ func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudIns
 	if az := inst.AvailabilityZone(); az != "" {
 		doc.AvailZone = &az
 	}
+	if profiles := inst.CharmProfiles(); len(profiles) > 0 {
+		doc.CharmProfiles = profiles
+	}
 
 	return txn.Op{
 		C:      instanceDataC,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -361,6 +361,7 @@ func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
 		"CpuPower",
 		"Tags",
 		"AvailZone",
+		"CharmProfiles",
 	)
 	s.AssertExportedFields(c, instanceData{}, migrated.Union(ignored))
 }

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -333,19 +333,19 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	c.Assert(m0.Life(), gc.Equals, state.Alive)
 	err = m0.SetInstanceInfo("i-12345", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &onecore,
-	}, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	m1, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m1.SetInstanceInfo("i-45678", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &twocores,
-	}, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	m2, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m2.SetInstanceInfo("i-78901", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &threecores,
-	}, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// No instance
 	_, err = shared.AddMachine("quantal", state.JobHostUnits)
@@ -355,7 +355,7 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = mDying.SetInstanceInfo("i-78901", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &threecores,
-	}, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mDying.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -365,7 +365,7 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	arch := "amd64"
 	err = m4.SetInstanceInfo("i-78901", "nonce", &instance.HardwareCharacteristics{
 		Arch: &arch,
-	}, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	summaries, err := s.State.ModelSummariesForUser(names.NewUserTag("user1write"), false)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1140,6 +1140,7 @@ func (task *provisionerTask) startMachine(
 		networkConfig,
 		volumes,
 		volumeNameToAttachmentInfo,
+		startInstanceParams.CharmLXDProfiles,
 	); err != nil {
 		// We need to stop the instance right away here, set error status and go on.
 		if err2 := task.setErrorStatus("cannot register instance for machine %v: %v", machine, err); err2 != nil {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -387,7 +387,7 @@ func (m *testMachine) ModelAgentVersion() (*version.Number, error) {
 func (m *testMachine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
 	networkConfig []params.NetworkConfig, volumes []params.Volume,
-	volumeAttachments map[string]params.VolumeAttachmentInfo,
+	volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
 ) error {
 	return nil
 }


### PR DESCRIPTION
## Description of change

Once a "machine" using an LXD profile from a charm is started, write the name of the profiles to the machine's instanceData.

## QA steps

1. `export JUJU_DEV_FEATURE_FLAGS=lxd-profile`
2. `juju bootstrap localhost`
3. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile`
4. check the mongo db for profiles names in the instanceDataC:
juju:PRIMARY> db.instanceData.find({},{"machineid":1,"charm-profiles":1})
5. bootstrap a new controller
6. migrate the model over to the new controller
7. check the new controller's mongo db for profiles names in the instanceDataC: