### PR TITLE
Model credential setter and watcher.

### DIFF
--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -5,7 +5,10 @@ package state
 
 import (
 	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
 )
@@ -39,4 +42,71 @@ func (m *Model) ValidateCloudCredential(tag names.CloudCredentialTag, credential
 		return errors.Annotatef(err, "validating credential %q for cloud %q", tag.Id(), cloud.Name)
 	}
 	return nil
+}
+
+// SetCloudCredential sets new cloud credential for this model.
+// Returned bool indicates if model credential was set.
+func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
+	cloud, err := m.st.Cloud(m.Cloud())
+	if err != nil {
+		return false, errors.Annotatef(err, "getting cloud %q", m.Cloud())
+	}
+	updating := true
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := m.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		if tag.Id() == m.doc.CloudCredential {
+			updating = false
+			return nil, jujutxn.ErrNoOperations
+		}
+		// Must be a valid credential that is already on the controller.
+		credential, err := m.st.CloudCredential(tag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !credential.IsValid() {
+			return nil, errors.NotValidf("credential %q", tag.Id())
+		}
+		if err := validateCredentialForCloud(cloud, tag, credential); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return []txn.Op{{
+			C:      modelsC,
+			Id:     m.doc.UUID,
+			Assert: txn.DocExists,
+			Update: bson.D{{"$set", bson.D{{"cloud-credential", tag.Id()}}}},
+		}}, nil
+	}
+	if err := m.st.db().Run(buildTxn); err != nil {
+		return false, errors.Trace(err)
+	}
+	return updating, m.Refresh()
+}
+
+// WatchModelCredential returns a new NotifyWatcher that watches
+// a model reference to a cloud credential.
+func (m *Model) WatchModelCredential() NotifyWatcher {
+	current := m.doc.CloudCredential
+	filter := func(id interface{}) bool {
+		id, ok := id.(string)
+		if !ok || id != m.doc.UUID {
+			return false
+		}
+
+		models, closer := m.st.db().GetCollection(modelsC)
+		defer closer()
+
+		var doc *modelDoc
+		if err := models.FindId(id).One(&doc); err != nil {
+			return false
+		}
+
+		match := current != doc.CloudCredential
+		current = doc.CloudCredential
+		return match
+	}
+	return newNotifyCollWatcher(m.st, modelsC, filter)
 }

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -172,14 +172,12 @@ func (s *ModelCredentialSuite) TestWatchModelCredential(c *gc.C) {
 
 	// Initial event.
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	// Check the watcher reacts to credential reference changes.
 	set, err := m.SetCloudCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(set, jc.IsTrue)
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	// Check the watcher does not react to other changes on this model.
 	err = m.SetDead()

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
@@ -85,6 +86,137 @@ func (s *ModelCredentialSuite) TestValidateCloudCredentialModel(c *gc.C) {
 	cred := cloud.NewCredential(cloud.EmptyAuthType, nil)
 	err = m.ValidateCloudCredential(tag, cred)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ModelCredentialSuite) TestSetCloudCredential(c *gc.C) {
+	s.assertSetCloudCredential(c,
+		names.NewCloudCredentialTag("dummy/bob/foobar"),
+		cloud.NewCredential(cloud.EmptyAuthType, nil),
+	)
+}
+
+func (s *ModelCredentialSuite) TestSetCloudCredentialNoUpdate(c *gc.C) {
+	tag := names.NewCloudCredentialTag("dummy/bob/foobar")
+	m := s.assertSetCloudCredential(c,
+		tag,
+		cloud.NewCredential(cloud.EmptyAuthType, nil),
+	)
+
+	set, err := m.SetCloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	// This should be false as cloud credential change was an no-op.
+	c.Assert(set, jc.IsFalse)
+
+	// Check credential is still set.
+	credentialTag, credentialSet := m.CloudCredential()
+	c.Assert(credentialTag, gc.DeepEquals, tag)
+	c.Assert(credentialSet, jc.IsTrue)
+}
+
+func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c *gc.C) {
+	tag := names.NewCloudCredentialTag("dummy/bob/foobar")
+	credential := cloud.NewCredential(cloud.EmptyAuthType, nil)
+	err := s.State.UpdateCloudCredential(tag, credential)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.InvalidateCloudCredential(tag, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	set, err := m.SetCloudCredential(tag)
+	c.Assert(err, gc.ErrorMatches, `credential "dummy/bob/foobar" not valid`)
+	c.Assert(set, jc.IsFalse)
+
+	credentialTag, credentialSet := m.CloudCredential()
+	// Make sure no credential is set.
+	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+}
+
+func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialForModel(c *gc.C) {
+	err := s.State.AddCloud(lowCloud, s.Owner.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	tag := names.NewCloudCredentialTag("stratus/bob/foobar")
+	credential := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"access-key": "someverysecretaccesskey",
+		"secret-key": "someverysercretplainkey",
+	})
+	err = s.State.UpdateCloudCredential(tag, credential)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	set, err := m.SetCloudCredential(tag)
+	c.Assert(err, gc.ErrorMatches, `cloud "stratus" not valid`)
+	c.Assert(set, jc.IsFalse)
+
+	credentialTag, credentialSet := m.CloudCredential()
+	// Make sure no credential is set.
+	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+}
+
+func (s *ModelCredentialSuite) TestWatchModelCredential(c *gc.C) {
+	// Credential to use in this test.
+	tag := names.NewCloudCredentialTag("dummy/bob/foobar")
+	credential := cloud.NewCredential(cloud.EmptyAuthType, nil)
+	err := s.State.UpdateCloudCredential(tag, credential)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Model with credential watcher for this test.
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	w := m.WatchModelCredential()
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+
+	// Initial event.
+	wc.AssertOneChange()
+	wc.AssertNoChange()
+
+	// Check the watcher reacts to credential reference changes.
+	set, err := m.SetCloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(set, jc.IsTrue)
+	wc.AssertOneChange()
+	wc.AssertNoChange()
+
+	// Check the watcher does not react to other changes on this model.
+	err = m.SetDead()
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+
+	// Check that changes on another model do not affect this watcher.
+	st := s.addModel(c, "abcmodel", s.credentialTag)
+	defer st.Close()
+	anotherM, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	set, err = anotherM.SetCloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(set, jc.IsTrue)
+	wc.AssertNoChange()
+}
+
+func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.CloudCredentialTag, credential cloud.Credential) *state.Model {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	credentialTag, credentialSet := m.CloudCredential()
+	// Make sure no credential is set.
+	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+
+	err = s.State.UpdateCloudCredential(tag, credential)
+	c.Assert(err, jc.ErrorIsNil)
+
+	set, err := m.SetCloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(set, jc.IsTrue)
+
+	// Check credential is set.
+	credentialTag, credentialSet = m.CloudCredential()
+	c.Assert(credentialTag, gc.DeepEquals, tag)
+	c.Assert(credentialSet, jc.IsTrue)
+	return m
 }
 
 func (s *ModelCredentialSuite) createCloudCredential(c *gc.C, credentialName string) names.CloudCredentialTag {


### PR DESCRIPTION
## Description of change

We need the ability to replace model credential reference to allow users to change model credentials.
This PR introduces model credential setter and its watcher in state layer.
