### PR TITLE
deploy: Fix bundle panic from inconsistent machine map

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -61,7 +61,7 @@ func (b *bundleAPI) GetChanges(args params.BundleChangesParams) (params.BundleCh
 		_, err := storage.ParseConstraints(s)
 		return err
 	}
-	if err := data.Verify(verifyConstraints, verifyStorage); err != nil {
+	if err := data.Verify(verifyConstraints, verifyStorage, nil); err != nil {
 		if err, ok := err.(*charm.VerificationError); ok {
 			results.Errors = make([]string, len(err.Errors))
 			for i, e := range err.Errors {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -601,8 +601,13 @@ func (h *bundleHandler) addMachine(change *bundlechanges.AddMachineChange) error
 
 	deployedApps := func() string {
 		apps := h.applicationsForMachineChange(change.Id())
-		// Note that we always have at least one application that justifies the
-		// creation of this machine.
+		// Note that we *should* always have at least one application
+		// that justifies the creation of this machine. But just in
+		// case, check (see https://pad.lv/1773357).
+		if len(apps) == 0 {
+			h.ctx.Warningf("no applications found for machine change %q", change.Id())
+			return "nothing"
+		}
 		msg := apps[0] + " unit"
 
 		if count := len(apps); count != 1 {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -88,13 +88,13 @@ func deployBundle(
 		if err := processBundleIncludes(ctx.Dir, data); err != nil {
 			return nil, errors.Annotate(err, "unable to process includes")
 		}
-		verifyError = data.Verify(verifyConstraints, verifyStorage)
+		verifyError = data.Verify(verifyConstraints, verifyStorage, nil)
 	} else {
 		// Process includes in the bundle data.
 		if err := processBundleIncludes(bundleDir, data); err != nil {
 			return nil, errors.Annotate(err, "unable to process includes")
 		}
-		verifyError = data.VerifyLocal(bundleDir, verifyConstraints, verifyStorage)
+		verifyError = data.VerifyLocal(bundleDir, verifyConstraints, verifyStorage, nil)
 	}
 	if verifyError != nil {
 		if verr, ok := verifyError.(*charm.VerificationError); ok {

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -121,7 +121,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
-	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
+	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed post-series-upgrade pre-series-upgrade server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
 }, {
 	info:  `no args at all`,
 	args:  nil,

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
-github.com/juju/bundlechanges	git	5b8dee6ac69a0b40649795140afbad0396d1c96a	2018-05-14T04:51:38Z
+github.com/juju/bundlechanges	git	735c14e2335ad2d8112482794d69629c0517476c	2018-10-09T01:45:39Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
 github.com/juju/collections	git	9be91dc79b7c185fa8b08e7ceceee40562055c83	2018-07-17T17:15:55Z
 github.com/juju/description	git	7ee30d2bc01ef20938adea2efeb991eb817c1f2a	2018-02-21T00:58:49Z
@@ -92,7 +92,6 @@ github.com/vmware/govmomi	git	05504416e95561e1478196d7058721c827a7bb8c	2018-03-0
 golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
-golang.org/x/sync	git	f52d1811a62927559de87708c8913c1650ce4f26	2017-05-17T21:12:32Z
 golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:45Z
 golang.org/x/text	git	2910a502d2bf9e43193af9d68ca516529614eed3	2016-07-26T16:48:57Z
 google.golang.org/api	git	ed10e890a8366167a7ce33fac2b12447987bcb1c	2017-08-17T20:34:27Z
@@ -103,7 +102,7 @@ gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:
 gopkg.in/goose.v2	git	36df5d12fc6d0ef1c102e1c18a22ddf345b18821	2018-03-22T12:54:45Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
-gopkg.in/juju/charm.v6	git	d93cf8b75cf4017ace4b3bf6af3bd03003e11cfa	2017-11-14T08:46:58Z
+gopkg.in/juju/charm.v6	git	2ca384ecdc5353e6e76b51f0bf996bbc1a06aa74	2018-09-04T14:33:06Z
 gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-28T19:41:00Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7	2016-11-17T15:25:28Z

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -6,9 +6,9 @@ package charm
 import (
 	"errors"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
-	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
 )
 

--- a/worker/uniter/charm/charm_test.go
+++ b/worker/uniter/charm/charm_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	corecharm "gopkg.in/juju/charm.v6"
 

--- a/worker/uniter/charm/manifest_deployer.go
+++ b/worker/uniter/charm/manifest_deployer.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/utils"
-	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
 )
 

--- a/worker/uniter/charm/manifest_deployer_test.go
+++ b/worker/uniter/charm/manifest_deployer_test.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -11,13 +11,6 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
-// TODO(fwereade): move these definitions to juju/charm/hooks.
-const (
-	LeaderElected         hooks.Kind = "leader-elected"
-	LeaderDeposed         hooks.Kind = "leader-deposed"
-	LeaderSettingsChanged hooks.Kind = "leader-settings-changed"
-)
-
 // Info holds details required to execute a hook. Not all fields are
 // relevant to all Kind values.
 type Info struct {
@@ -48,7 +41,8 @@ func (hi Info) Validate() error {
 		}
 		fallthrough
 	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken,
-		hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus:
+		hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus, hooks.LeaderElected, hooks.LeaderDeposed,
+		hooks.LeaderSettingsChanged, hooks.PreSeriesUpgrade, hooks.PostSeriesUpgrade:
 		return nil
 	case hooks.Action:
 		return fmt.Errorf("hooks.Kind Action is deprecated")
@@ -56,9 +50,6 @@ func (hi Info) Validate() error {
 		if !names.IsValidStorage(hi.StorageId) {
 			return fmt.Errorf("invalid storage ID %q", hi.StorageId)
 		}
-		return nil
-	// TODO(fwereade): define these in charm/hooks...
-	case LeaderElected, LeaderDeposed, LeaderSettingsChanged:
 		return nil
 	}
 	return fmt.Errorf("unknown hook kind %q", hi.Kind)

--- a/worker/uniter/leadership/resolver.go
+++ b/worker/uniter/leadership/resolver.go
@@ -5,6 +5,7 @@ package leadership
 
 import (
 	"github.com/juju/loggo"
+	"gopkg.in/juju/charm.v6/hooks"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/hook"
@@ -63,7 +64,7 @@ func (l *leadershipResolver) NextOp(
 		// We want to run the leader settings hook if we're
 		// not the leader and the settings have changed.
 		if !localState.Leader && localState.LeaderSettingsVersion != remoteState.LeaderSettingsVersion {
-			return opFactory.NewRunHook(hook.Info{Kind: hook.LeaderSettingsChanged})
+			return opFactory.NewRunHook(hook.Info{Kind: hooks.LeaderSettingsChanged})
 		}
 	}
 

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -48,7 +48,7 @@ func (opc *operationCallbacks) PrepareHook(hi hook.Info) (string, error) {
 	case hi.Kind == hooks.ConfigChanged:
 		// TODO(axw)
 		//opc.u.f.DiscardConfigEvent()
-	case hi.Kind == hook.LeaderSettingsChanged:
+	case hi.Kind == hooks.LeaderSettingsChanged:
 		// TODO(axw)
 		//opc.u.f.DiscardLeaderSettingsEvent()
 	}

--- a/worker/uniter/operation/leader.go
+++ b/worker/uniter/operation/leader.go
@@ -5,6 +5,7 @@ package operation
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6/hooks"
 
 	"github.com/juju/juju/worker/uniter/hook"
 )
@@ -45,7 +46,7 @@ func (al *acceptLeadership) Commit(state State) (*State, error) {
 	newState := stateChange{
 		Kind: RunHook,
 		Step: Queued,
-		Hook: &hook.Info{Kind: hook.LeaderElected},
+		Hook: &hook.Info{Kind: hooks.LeaderElected},
 	}.apply(state)
 	newState.Leader = true
 	return newState, nil

--- a/worker/uniter/operation/leader_test.go
+++ b/worker/uniter/operation/leader_test.go
@@ -70,7 +70,7 @@ func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_BlankSlate(c *gc.C) 
 	c.Check(newState, gc.DeepEquals, &operation.State{
 		Kind:   operation.RunHook,
 		Step:   operation.Queued,
-		Hook:   &hook.Info{Kind: hook.LeaderElected},
+		Hook:   &hook.Info{Kind: hooks.LeaderElected},
 		Leader: true,
 	})
 }
@@ -91,7 +91,7 @@ func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_Preserve(c *gc.C) {
 	c.Check(newState, gc.DeepEquals, &operation.State{
 		Kind:    operation.RunHook,
 		Step:    operation.Queued,
-		Hook:    &hook.Info{Kind: hook.LeaderElected},
+		Hook:    &hook.Info{Kind: hooks.LeaderElected},
 		Leader:  true,
 		Started: true,
 	})


### PR DESCRIPTION
## Description of change

If `--map-machines=existing` is used when deploying a bundle you can get a state where the bundle and model machines are inconsistent, which caused the old version of the bundlechanges package to emit an add-machine change without putting any units on it (because the application has enough units already). This caused a panic in the deploy code, which expected there'd always be an application for an added machine.

Update the bundlechanges package to a new version which detects this inconsistency and reports an error that hopefully explains the problem and what should be done about it - it looks like this:
```
$ juju deploy bundle.yaml --dry-run --map-machines=existing
ERROR cannot deploy bundle: bundle and machine mapping are inconsistent: need an explicit entry mapping bundle machine "1", perhaps to one of model machines ["36", "37"] - the target should host [grafana]
```

Also add a belt-and-suspenders check so we won't panic in the future if for some reason there's still a machine added with no units.

## QA steps

* Run `juju deploy bundle.yaml --map-machines=existing` with a bundle and model in this state (machines in the bundle missing from the model, but all applications having enough units). See the error.
* Add explicit mapping to `map-machines`, error goes away and deploy continues correctly.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1773357
