### PR TITLE
deploy: Fix bundle panic from inconsistent machine map

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -601,8 +601,13 @@ func (h *bundleHandler) addMachine(change *bundlechanges.AddMachineChange) error
 
 	deployedApps := func() string {
 		apps := h.applicationsForMachineChange(change.Id())
-		// Note that we always have at least one application that justifies the
-		// creation of this machine.
+		// Note that we *should* always have at least one application
+		// that justifies the creation of this machine. But just in
+		// case, check (see https://pad.lv/1773357).
+		if len(apps) == 0 {
+			h.ctx.Warningf("no applications found for machine change %q", change.Id())
+			return "nothing"
+		}
 		msg := apps[0] + " unit"
 
 		if count := len(apps); count != 1 {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/joyent/gocommon	git	ade826b8b54e81a779ccb29d358a45ba24b7809c	2016-03-
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
-github.com/juju/bundlechanges	git	bc5b7e5db16683db8ddffa7eef67b53706a4618a	2018-07-18T04:39:43Z
+github.com/juju/bundlechanges	git	735c14e2335ad2d8112482794d69629c0517476c	2018-10-09T01:45:39Z
 github.com/juju/clock	git	d293bb356ca441f16b59562295cca74478966757	2018-05-24T02:22:03Z
 github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
 github.com/juju/collections	git	9be91dc79b7c185fa8b08e7ceceee40562055c83	2018-07-17T17:15:55Z


### PR DESCRIPTION
## Description of change

If `--map-machines=existing` is used when deploying a bundle you can get a state where the bundle and model machines are inconsistent, which caused the old version of the bundlechanges package to emit an add-machine change without putting any units on it (because the application has enough units already). This caused a panic in the deploy code, which expected there'd always be an application for an added machine.

Update the bundlechanges package to a new version which detects this inconsistency and reports an error that hopefully explains the problem and what should be done about it - it looks like this:
```
$ juju deploy bundle.yaml --dry-run --map-machines=existing
ERROR cannot deploy bundle: bundle and machine mapping are inconsistent: need an explicit entry mapping bundle machine "1", perhaps to one of model machines ["36", "37"] - the target should host [grafana]
```

Also add a belt-and-suspenders check so we won't panic in the future if for some reason there's still a machine added with no units.

This is a mostly-trivial forward-port of #9291 - it's simpler than the 2.3 change because the `gopkg.in/juju/charm.v6` dependency didn't need to be upgraded (which had a few knock-on effects).

## QA steps

* Run `juju deploy bundle.yaml --map-machines=existing` with a bundle and model in this state (machines in the bundle missing from the model, but all applications having enough units). See the error.
* Add explicit mapping to `map-machines`, error goes away and deploy continues correctly.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1773357
