### PR TITLE
Fixes lp#1779677: Add more info to 'settings not found' error & log message. 

### DIFF
--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2156,7 +2156,7 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 	result, err := s.uniter.ReadRemoteSettings(args)
 
 	// We don't set the remote unit settings on purpose to test the error.
-	expectErr := `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": settings`
+	expectErr := `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": settings for "r#0#provider#mysql/0"`
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2156,7 +2156,7 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 	result, err := s.uniter.ReadRemoteSettings(args)
 
 	// We don't set the remote unit settings on purpose to test the error.
-	expectErr := `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": settings for "r#0#provider#mysql/0"`
+	expectErr := `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": unit "mysql/0": settings`
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -491,7 +491,7 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 	if needConfig {
 		doc, err := readSettingsDoc(st.db(), settingsC, applicationSettingsKey(app.Name, app.CharmURL))
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Annotatef(err, "application %q", app.Name)
 		}
 		info.Config = doc.Settings
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -642,7 +642,7 @@ func (a *Application) changeCharmOps(
 		// No old settings, start with the updated settings.
 		newSettings = updatedSettings
 	} else {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "application %q", a.doc.Name)
 	}
 
 	// Create or replace application settings.
@@ -652,7 +652,7 @@ func (a *Application) changeCharmOps(
 		// No settings for this key yet, create it.
 		settingsOp = createSettingsOp(settingsC, newSettingsKey, newSettings)
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "application %q", a.doc.Name)
 	} else {
 		// Settings exist, just replace them with the new ones.
 		settingsOp, _, err = replaceSettingsOp(a.st.db(), settingsC, newSettingsKey, newSettings)
@@ -1659,7 +1659,7 @@ func applicationRelations(st *State, name string) (relations []*Relation, err er
 func (a *Application) ConfigSettings() (charm.Settings, error) {
 	settings, err := readSettings(a.st.db(), settingsC, a.settingsKey())
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotatef(err, "application %q", a.doc.Name)
 	}
 	return settings.Map(), nil
 }
@@ -1681,7 +1681,7 @@ func (a *Application) UpdateConfigSettings(changes charm.Settings) error {
 	// name, so the actual impact of a race is non-threatening.
 	node, err := readSettings(a.st.db(), settingsC, a.settingsKey())
 	if err != nil {
-		return err
+		return errors.Annotatef(err, "application %q", a.doc.Name)
 	}
 	for name, value := range changes {
 		if value == nil {
@@ -1703,9 +1703,9 @@ func (a *Application) LeaderSettings() (map[string]string, error) {
 
 	doc, err := readSettingsDoc(a.st.db(), settingsC, leadershipSettingsKey(a.doc.Name))
 	if errors.IsNotFound(err) {
-		return nil, errors.NotFoundf("application")
+		return nil, errors.NotFoundf("application %q", a.doc.Name)
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "application %q", a.doc.Name)
 	}
 	result := make(map[string]string)
 	for escapedKey, interfaceValue := range doc.Settings {
@@ -1765,9 +1765,9 @@ func (a *Application) UpdateLeaderSettings(token leadership.Token, updates map[s
 		// on it and prevent these settings from landing late.
 		doc, err := readSettingsDoc(a.st.db(), settingsC, key)
 		if errors.IsNotFound(err) {
-			return nil, errors.NotFoundf("application")
+			return nil, errors.NotFoundf("application %q", a.doc.Name)
 		} else if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "application %q", a.doc.Name)
 		}
 		if isNullChange(doc.Settings) {
 			return nil, jujutxn.ErrNoOperations

--- a/state/application_leader_test.go
+++ b/state/application_leader_test.go
@@ -124,7 +124,7 @@ func (s *ServiceLeaderSuite) TestReadRemoved(c *gc.C) {
 	s.destroyService(c)
 
 	actual, err := s.service.LeaderSettings()
-	c.Check(err, gc.ErrorMatches, "application not found")
+	c.Check(err, gc.ErrorMatches, `application "mysql" not found`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(actual, gc.IsNil)
 }
@@ -135,7 +135,7 @@ func (s *ServiceLeaderSuite) TestWriteRemoved(c *gc.C) {
 	err := s.service.UpdateLeaderSettings(&fakeToken{}, map[string]string{
 		"should": "fail",
 	})
-	c.Check(err, gc.ErrorMatches, "application not found")
+	c.Check(err, gc.ErrorMatches, `application "mysql" not found`)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -290,7 +290,7 @@ func (s *CleanupSuite) TestCleanupRelationSettings(c *gc.C) {
 	// ...but they are on cleanup.
 	s.assertCleanupCount(c, 1)
 	_, err = pr.ru1.ReadSettings("riak/0")
-	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": settings not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": unit "riak/0": settings not found`)
 }
 
 func (s *CleanupSuite) TestForceDestroyMachineErrors(c *gc.C) {

--- a/state/controller.go
+++ b/state/controller.go
@@ -83,7 +83,7 @@ func (ctlr *Controller) Ping() error {
 func (st *State) ControllerConfig() (jujucontroller.Config, error) {
 	settings, err := readSettings(st.db(), controllersC, controllerSettingsGlobalKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "controller %q", st.ControllerUUID())
 	}
 	return settings.Map(), nil
 }
@@ -100,7 +100,7 @@ func (st *State) UpdateControllerConfig(updateAttrs map[string]interface{}, remo
 
 	settings, err := readSettings(st.db(), controllersC, controllerSettingsGlobalKey)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "controller %q", st.ControllerUUID())
 	}
 	for _, r := range removeAttrs {
 		settings.Delete(r)

--- a/state/model.go
+++ b/state/model.go
@@ -684,7 +684,7 @@ func (m *Model) StatusHistory(filter status.StatusHistoryFilter) ([]status.Statu
 
 // Config returns the config for the model.
 func (m *Model) Config() (*config.Config, error) {
-	return getModelConfig(m.st.db())
+	return getModelConfig(m.st.db(), m.UUID())
 }
 
 // UpdateLatestToolsVersion looks up for the latest available version of

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -21,13 +21,13 @@ var disallowedModelConfigAttrs = [...]string{
 
 // ModelConfig returns the complete config for the model
 func (m *Model) ModelConfig() (*config.Config, error) {
-	return getModelConfig(m.st.db())
+	return getModelConfig(m.st.db(), m.UUID())
 }
 
-func getModelConfig(db Database) (*config.Config, error) {
+func getModelConfig(db Database, uuid string) (*config.Config, error) {
 	modelSettings, err := readSettings(db, settingsC, modelGlobalKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "model %q", uuid)
 	}
 	return config.New(config.NoDefaults, modelSettings.Map())
 }
@@ -148,12 +148,12 @@ func (model *Model) UpdateModelConfigDefaultValues(attrs map[string]interface{},
 	settings, err := readSettings(model.st.db(), globalSettingsC, key)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return errors.Trace(err)
+			return errors.Annotatef(err, "model %q", model.UUID())
 		}
 		// We haven't created settings for this region yet.
 		_, err := createSettings(model.st.db(), globalSettingsC, key, attrs)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Annotatef(err, "model %q", model.UUID())
 		}
 		return nil
 	}
@@ -315,7 +315,7 @@ func (m *Model) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttr
 
 	modelSettings, err := readSettings(st.db(), settingsC, modelGlobalKey)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "model %q", m.UUID())
 	}
 
 	oldConfig, err := m.ModelConfig()
@@ -400,7 +400,7 @@ func (st *State) defaultInheritedConfig() (attrValues, error) {
 func (st *State) controllerInheritedConfig() (attrValues, error) {
 	settings, err := readSettings(st.db(), globalSettingsC, controllerInheritedSettingsGlobalKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "controller %q", st.ControllerUUID())
 	}
 	return settings.Map(), nil
 }
@@ -427,7 +427,7 @@ func (st *State) regionInheritedConfig(regionSpec *environs.RegionSpec) func() (
 			regionSettingsGlobalKey(regionSpec.Cloud, regionSpec.Region),
 		)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "region %q on %q cloud", regionSpec.Region, regionSpec.Cloud)
 		}
 		return settings.Map(), nil
 	}

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -451,7 +451,11 @@ func watchRelationScope(
 // Settings returns a Settings which allows access to the unit's settings
 // within the relation.
 func (ru *RelationUnit) Settings() (*Settings, error) {
-	return readSettings(ru.st.db(), settingsC, ru.key())
+	s, err := readSettings(ru.st.db(), settingsC, ru.key())
+	if err != nil {
+		return nil, errors.Annotatef(err, "unit %q", ru.unitName)
+	}
+	return s, nil
 }
 
 // ReadSettings returns a map holding the settings of the unit with the
@@ -472,7 +476,7 @@ func (ru *RelationUnit) ReadSettings(uname string) (m map[string]interface{}, er
 	}
 	node, err := readSettings(ru.st.db(), settingsC, key)
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotatef(err, "unit %q", uname)
 	}
 	return node.Map(), nil
 }

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -76,7 +76,7 @@ func (s *RelationUnitSuite) TestReadSettingsErrors(c *gc.C) {
 	_, err = ru0.ReadSettings("riak/pressure")
 	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/pressure" in relation "riak:ring": "riak/pressure" is not a valid unit name`)
 	_, err = ru0.ReadSettings("riak/1")
-	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/1" in relation "riak:ring": settings not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/1" in relation "riak:ring": unit "riak/1": settings not found`)
 }
 
 func (s *RelationUnitSuite) TestPeerSettings(c *gc.C) {
@@ -208,7 +208,7 @@ func (s *RelationUnitSuite) testProReqSettings(c *gc.C, pru0, pru1, rru0, rru1 *
 	// Check missing settings cannot be read by any RU.
 	for _, ru := range rus {
 		_, err := ru.ReadSettings("mysql/0")
-		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": settings not found`)
+		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": unit "mysql/0": settings not found`)
 	}
 
 	// Add settings for one RU.
@@ -238,7 +238,7 @@ func (s *RelationUnitSuite) TestContainerSettings(c *gc.C) {
 	// Check missing settings cannot be read by any RU.
 	for _, ru := range rus {
 		_, err := ru.ReadSettings("logging/0")
-		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "logging/0" in relation "logging:info mysql:juju-info": settings not found`)
+		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "logging/0" in relation "logging:info mysql:juju-info": unit "logging/0": settings not found`)
 	}
 
 	// Add settings for one RU.
@@ -373,7 +373,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 
 	// Check that we created no settings for the unit we failed to add.
 	_, err = pr.ru0.ReadSettings("riak/2")
-	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/2" in relation "riak:ring": settings not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/2" in relation "riak:ring": unit "riak/2": settings not found`)
 
 	// ru0 leaves the scope; check that service Destroy is still a no-op.
 	assertJoined(c, pr.ru0)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -86,7 +86,7 @@ func (s *RelationUnitSuite) TestPeerSettings(c *gc.C) {
 	// Check missing settings cannot be read by any RU.
 	for _, ru := range rus {
 		_, err := ru.ReadSettings("riak/0")
-		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": settings not found`)
+		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": unit "riak/0": settings not found`)
 	}
 
 	// Add settings for one RU.
@@ -265,7 +265,7 @@ func (s *RelationUnitSuite) TestContainerSettings(c *gc.C) {
 	rus1 := RUs{prr.pru1, prr.rru1}
 	for _, ru := range rus1 {
 		_, err := ru.ReadSettings("mysql/0")
-		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "mysql/0" in relation "logging:info mysql:juju-info": settings not found`)
+		c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "mysql/0" in relation "logging:info mysql:juju-info": unit "mysql/0": settings not found`)
 	}
 }
 
@@ -409,7 +409,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 	err = s.State.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = pr.ru1.ReadSettings("riak/0")
-	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": settings not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": unit "riak/0": settings not found`)
 }
 
 func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {

--- a/state/settings.go
+++ b/state/settings.go
@@ -300,7 +300,7 @@ func readSettingsDocInto(db Database, collection, key string, out interface{}) e
 
 	err := settings.FindId(key).One(out)
 	if err == mgo.ErrNotFound {
-		err = errors.NotFoundf("settings")
+		err = errors.NotFoundf("settings for key %q in %q", key, collection)
 	}
 	return err
 }
@@ -352,7 +352,7 @@ func createSettings(db Database, collection, key string, values map[string]inter
 func removeSettings(db Database, collection, key string) error {
 	err := db.RunTransaction([]txn.Op{removeSettingsOp(collection, key)})
 	if err == txn.ErrAborted {
-		return errors.NotFoundf("settings")
+		return errors.NotFoundf("settings for key %q in %q", key, collection)
 	} else if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/settings.go
+++ b/state/settings.go
@@ -300,7 +300,7 @@ func readSettingsDocInto(db Database, collection, key string, out interface{}) e
 
 	err := settings.FindId(key).One(out)
 	if err == mgo.ErrNotFound {
-		err = errors.NotFoundf("settings for key %q in %q", key, collection)
+		err = errors.NotFoundf("settings")
 	}
 	return err
 }
@@ -352,7 +352,7 @@ func createSettings(db Database, collection, key string, values map[string]inter
 func removeSettings(db Database, collection, key string) error {
 	err := db.RunTransaction([]txn.Op{removeSettingsOp(collection, key)})
 	if err == txn.ErrAborted {
-		return errors.NotFoundf("settings for key %q in %q", key, collection)
+		return errors.NotFoundf("settings")
 	} else if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -699,7 +699,7 @@ func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVers
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		settings, err := readSettings(st.db(), settingsC, modelGlobalKey)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "model %q", st.modelTag.Id())
 		}
 		agentVersion, ok := settings.Get("agent-version")
 		if !ok {

--- a/state/unit.go
+++ b/state/unit.go
@@ -123,7 +123,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	}
 	settings, err := readSettings(u.st.db(), settingsC, applicationSettingsKey(u.doc.Application, u.doc.CharmURL))
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotatef(err, "unit %q", u.Name())
 	}
 	chrm, err := u.st.Charm(u.doc.CharmURL)
 	if err != nil {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1012,7 +1012,7 @@ func (w *relationUnitsWatcher) mergeScope(changes *params.RelationUnitsChange, c
 		docID := w.backend.docID(key)
 		revno, err := w.mergeSettings(changes, key)
 		if err != nil {
-			return err
+			return errors.Annotatef(err, "while merging settings for %q entering relation scope", name)
 		}
 		changes.Departed = remove(changes.Departed, name)
 		w.watcher.Watch(settingsC, docID, revno, w.updates)
@@ -1082,7 +1082,7 @@ func (w *relationUnitsWatcher) loop() (err error) {
 				logger.Warningf("ignoring bad relation scope id: %#v", c.Id)
 			}
 			if _, err := w.mergeSettings(&changes, id); err != nil {
-				return err
+				return errors.Annotatef(err, "relation scope id %q", id)
 			}
 			out = w.out
 		case out <- changes:


### PR DESCRIPTION
## Description of change

When things go wrong, the more information we can provide the better.
One of the most common error that we see is 'settings not found'. It is a symptom of a variety of different failures, for example failed model destruction. The message of an error does not convey what settings were not found, for what entity.

This PR adds this information.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1779677
