### PR TITLE
Add robustness around controller connectivity issues for cmr

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -104,6 +104,10 @@ type Relation interface {
 	// with the supplied ID.
 	RemoteUnit(unitId string) (RelationUnit, error)
 
+	// AllRemoteUnits returns all the RelationUnits for the remote
+	// application units for a given application.
+	AllRemoteUnits(appName string) ([]RelationUnit, error)
+
 	// Endpoints returns the endpoints that constitute the relation.
 	Endpoints() []state.Endpoint
 

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -177,6 +177,18 @@ func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
 	return relationUnitShim{ru}, nil
 }
 
+func (r relationShim) AllRemoteUnits(appName string) ([]RelationUnit, error) {
+	all, err := r.Relation.AllRemoteUnits(appName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]RelationUnit, len(all))
+	for i, ru := range all {
+		result[i] = relationUnitShim{ru}
+	}
+	return result, nil
+}
+
 func (r relationShim) Unit(unitId string) (RelationUnit, error) {
 	unit, err := r.st.Unit(unitId)
 	if err != nil {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -88,7 +88,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	s.api = api
 }
 
-func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, life params.Life, suspendedReason string) {
+func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, life params.Life, suspendedReason string, forceCleanup bool) {
 	s.st.remoteApplications["db2"] = &mockRemoteApplication{}
 	s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
 	rel := newMockRelation(1)
@@ -116,6 +116,7 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, life p
 		Changes: []params.RemoteRelationChangeEvent{
 			{
 				Life:             life,
+				ForceCleanup:     &forceCleanup,
 				Suspended:        &suspended,
 				SuspendedReason:  suspendedReason,
 				ApplicationToken: "token-db2",
@@ -152,25 +153,35 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, life p
 		})
 	}
 	s.st.CheckCalls(c, expected)
-	ru1.CheckCalls(c, []testing.StubCall{
-		{"InScope", []interface{}{}},
-		{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
-	})
+	if forceCleanup {
+		ru1.CheckCalls(c, []testing.StubCall{
+			{"LeaveScope", []interface{}{}},
+		})
+	} else {
+		ru1.CheckCalls(c, []testing.StubCall{
+			{"InScope", []interface{}{}},
+			{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
+		})
+	}
 	ru2.CheckCalls(c, []testing.StubCall{
 		{"LeaveScope", []interface{}{}},
 	})
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChanges(c *gc.C) {
-	s.assertPublishRelationsChanges(c, params.Alive, "")
+	s.assertPublishRelationsChanges(c, params.Alive, "", false)
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChangesWithSuspendedReason(c *gc.C) {
-	s.assertPublishRelationsChanges(c, params.Alive, "reason")
+	s.assertPublishRelationsChanges(c, params.Alive, "reason", false)
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChangesDyingWhileSuspended(c *gc.C) {
-	s.assertPublishRelationsChanges(c, params.Dying, "")
+	s.assertPublishRelationsChanges(c, params.Dying, "", false)
+}
+
+func (s *crossmodelRelationsSuite) TestPublishRelationsChangesDyingForceCleanup(c *gc.C) {
+	s.assertPublishRelationsChanges(c, params.Dying, "", true)
 }
 
 func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/authentication"
-	common "github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelrelations"
@@ -373,6 +373,18 @@ func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit,
 		return nil, errors.NotFoundf("unit %q", unitId)
 	}
 	return u, nil
+}
+
+func (r *mockRelation) AllRemoteUnits(appName string) ([]commoncrossmodel.RelationUnit, error) {
+	r.MethodCall(r, "AllRemoteUnits", appName)
+	if err := r.NextErr(); err != nil {
+		return nil, err
+	}
+	var result []commoncrossmodel.RelationUnit
+	for _, ru := range r.units {
+		result = append(result, ru)
+	}
+	return result, nil
 }
 
 func (r *mockRelation) Unit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -358,6 +358,10 @@ type RemoteRelationChangeEvent struct {
 	// Life is the current lifecycle state of the relation.
 	Life Life `json:"life"`
 
+	// ForceCleanup is true if the offering side should forcibly
+	// ensure that all relation units have left scope.
+	ForceCleanup *bool `json:"force-cleanup,omitempty"`
+
 	// Suspended is the current suspended status of the relation.
 	Suspended *bool `json:"suspended,omitempty"`
 

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -101,6 +101,8 @@ func newNotifyWatcher(context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	resources := context.Resources()
 
+	// TODO(wallyworld) - enhance this watcher to support
+	// anonymous api calls with macaroons.
 	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, common.ErrPerm
 	}

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -192,6 +192,51 @@ func (s *RelationUnitSuite) TestRemoteUnitErrors(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `application "mysql1" is not a member of "wordpress:db mysql:server"`)
 }
 
+func (s *RelationUnitSuite) TestAllRemoteUnits(c *gc.C) {
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "server",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "another",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "server",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+
+	eps, err := s.State.InferEndpoints("mysql", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ru1 := addRemoteRU(c, rel, "mysql/0")
+	err = ru1.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	ru2 := addRemoteRU(c, rel, "mysql/1")
+	err = ru2.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = rel.AllRemoteUnits("wordpress")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = rel.AllRemoteUnits("another")
+	c.Assert(err, gc.ErrorMatches, `application "another" is not a member of "wordpress:db mysql:server"`)
+	all, err := rel.AllRemoteUnits("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, gc.HasLen, 2)
+	c.Assert(all, jc.SameContents, []*state.RelationUnit{ru1, ru2})
+}
+
 func (s *RelationUnitSuite) TestProReqSettings(c *gc.C) {
 	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeGlobal)
 	s.testProReqSettings(c, prr.pru0, prr.pru1, prr.rru0, prr.rru1)

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -101,6 +101,13 @@ func (w *remoteApplicationWorker) checkOfferPermissionDenied(err error, appToken
 }
 
 func (w *remoteApplicationWorker) loop() (err error) {
+	defer func() {
+		if err != nil && err.Error() != w.catacomb.ErrDying().Error() {
+			logger.Errorf("cross model worker for %v exited with an error: %v", w.applicationName, err)
+		}
+	}()
+
+	// Watch for changes to any remote relations to this application.
 	relationsWatcher, err := w.localModelFacade.WatchRemoteApplicationRelations(w.applicationName)
 	if errors.IsNotFound(err) {
 		return nil
@@ -191,24 +198,25 @@ func (w *remoteApplicationWorker) loop() (err error) {
 	}
 }
 
-func (w *remoteApplicationWorker) processRelationDying(key string, relations map[string]*relation) error {
-	logger.Debugf("relation %v dying", key)
-	relation, ok := relations[key]
-	if !ok {
-		return nil
-	}
+func (w *remoteApplicationWorker) processRelationDying(key string, r *relation, forceCleanup bool) error {
+	logger.Debugf("relation %v dying (%v)", key, forceCleanup)
 	// On the consuming side, inform the remote side the relation is dying
 	// (but only if we are killing the relation due to it dying, not because
 	// it is suspended).
 	if !w.isConsumerProxy {
 		change := params.RemoteRelationChangeEvent{
-			RelationToken:    relation.relationToken,
+			RelationToken:    r.relationToken,
 			Life:             params.Dying,
-			ApplicationToken: relation.applicationToken,
-			Macaroons:        macaroon.Slice{relation.macaroon},
+			ApplicationToken: r.applicationToken,
+			Macaroons:        macaroon.Slice{r.macaroon},
+		}
+		// forceCleanup will be true if the worker has restarted and because the relation had
+		// already been removed, we won't get any more unit departed events.
+		if forceCleanup {
+			change.ForceCleanup = &forceCleanup
 		}
 		if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
-			w.checkOfferPermissionDenied(err, relation.applicationToken, relation.relationToken)
+			w.checkOfferPermissionDenied(err, r.applicationToken, r.relationToken)
 			return errors.Annotatef(err, "publishing relation dying %+v to remote model %v", change, w.remoteModelUUID)
 		}
 	}
@@ -281,27 +289,20 @@ func (w *remoteApplicationWorker) relationChanged(
 	remoteRelation := result.Result
 
 	// If we have previously started the watcher and the
-	// relation is now dying, stop the watcher.
+	// relation is now suspended, stop the watcher.
 	if r := relations[key]; r != nil {
 		wasSuspended := r.suspended
 		r.suspended = remoteRelation.Suspended
 		relations[key] = r
-		if remoteRelation.Life == params.Dying {
-			return w.processRelationDying(key, relations)
-		}
 		if remoteRelation.Suspended {
 			return w.processRelationSuspended(key, relations)
 		}
-		if !wasSuspended {
+		if !wasSuspended && remoteRelation.Life == params.Alive {
 			// Nothing to do, we have previously started the watcher.
 			return nil
 		}
 	}
 
-	if remoteRelation.Life != params.Alive {
-		// We haven't started the relation unit watcher so just exit.
-		return nil
-	}
 	if w.isConsumerProxy {
 		// Nothing else to do on the offering side.
 		return nil
@@ -418,8 +419,8 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 	}
 
 	// Have we seen the relation before.
-	r, ok := relations[key]
-	if !ok {
+	r, relationKnown := relations[key]
+	if !relationKnown {
 		// Totally new so start the lifecycle watcher.
 		remoteRelationsWatcher, err := w.remoteModelFacade.WatchRelationSuspendedStatus(params.RemoteEntityArg{
 			Token:     relationToken,
@@ -453,9 +454,10 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 			applicationToken:   applicationToken,
 			relationToken:      relationToken,
 		}
+		relations[key] = r
 	}
 
-	if !remoteRelation.Suspended {
+	if r.localRuw == nil && !remoteRelation.Suspended {
 		// Also start the units watchers (local and remote).
 		localUnitsWorker, remoteUnitsWorker, err := w.startUnitsWorkers(
 			relationTag, applicationToken, relationToken, remoteAppToken, remoteRelation.ApplicationName, mac)
@@ -466,7 +468,11 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 		r.remoteRuw = remoteUnitsWorker
 	}
 
-	relations[key] = r
+	// If the relation is dying, stop the watcher.
+	if remoteRelation.Life != params.Alive {
+		return w.processRelationDying(key, r, !relationKnown)
+	}
+
 	return nil
 }
 
@@ -514,9 +520,6 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 	// remoteAppIds is a slice but there's only one item
 	// as we currently only register one remote application
 	if err := remoteRelation[0].Error; err != nil {
-		return fail(errors.Trace(err))
-	}
-	if err := results[0].Error; err != nil && !params.IsCodeAlreadyExists(err) {
 		return fail(errors.Annotatef(err, "registering relation %v", relationTag))
 	}
 	// Import the application id from the offering model.

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -337,16 +337,36 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 	// goes to Dying; they're only stopped when the relation is
 	// finally removed.
 	c.Assert(unitsWatcher.killed(), jc.IsFalse)
-	mac, err := macaroon.New(nil, "apimac", "")
+	apiMac, err := macaroon.New(nil, "apimac", "")
 	c.Assert(err, jc.ErrorIsNil)
+	mac, err := macaroon.New(nil, "test", "")
+	c.Assert(err, jc.ErrorIsNil)
+	relTag := names.NewRelationTag("db2:db django:db")
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"ExportEntities", []interface{}{
+			[]names.Tag{names.NewApplicationTag("django"), relTag}}},
+		{"RegisterRemoteRelations", []interface{}{[]params.RegisterRemoteRelationArg{{
+			ApplicationToken: "token-django",
+			SourceModelTag:   "model-local-model-uuid",
+			RelationToken:    "token-db2:db django:db",
+			RemoteEndpoint: params.RemoteEndpoint{
+				Name:      "db2",
+				Role:      "requires",
+				Interface: "db2",
+			},
+			OfferUUID:         "offer-db2-uuid",
+			LocalEndpointName: "data",
+			Macaroons:         macaroon.Slice{mac},
+		}}}},
+		{"SaveMacaroon", []interface{}{relTag, apiMac}},
+		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
 				Life:             params.Dying,
 				ApplicationToken: "token-django",
 				RelationToken:    "token-db2:db django:db",
-				Macaroons:        macaroon.Slice{mac},
+				Macaroons:        macaroon.Slice{apiMac},
 			},
 		}},
 	}
@@ -470,6 +490,14 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDyingConsumes(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
+	s.assertRemoteRelationsChangedError(c, false)
+}
+
+func (s *remoteRelationsSuite) TestRemoteDyingRelationsChangedError(c *gc.C) {
+	s.assertRemoteRelationsChangedError(c, true)
+}
+
+func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying bool) {
 	w := s.assertRemoteRelationsWorkers(c)
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
@@ -514,10 +542,9 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 		{"ControllerAPIInfoForModel", []interface{}{"remote-model-uuid"}},
 		{"WatchOfferStatus", []interface{}{"offer-db2-uuid", macaroon.Slice{mac}}},
 	}
-	// After the worker resumes, normal processing happens.
 	s.waitForWorkerStubCalls(c, expected)
-
 	s.stub.ResetCalls()
+
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 	relTag := names.NewRelationTag("db2:db django:db")
@@ -544,6 +571,25 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 		{"WatchRelationUnits", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 	}
+
+	// If a relation is dying and there's been an error, when processing resumes
+	// a cleanup is forced on the remote side.
+	if dying {
+		s.relationsFacade.updateRelationLife("db2:db django:db", params.Dying)
+		forceCleanup := true
+		expected = append(expected, jujutesting.StubCall{
+			"PublishRelationChange", []interface{}{
+				params.RemoteRelationChangeEvent{
+					ApplicationToken: "token-django",
+					RelationToken:    "token-db2:db django:db",
+					Life:             params.Dying,
+					Macaroons:        macaroon.Slice{apiMac},
+					ForceCleanup:     &forceCleanup,
+				},
+			}},
+		)
+	}
+	// After the worker resumes, normal processing happens.
 	s.waitForWorkerStubCalls(c, expected)
 }
 


### PR DESCRIPTION
## Description of change

Cross model relations required controller->controller connectivity. If a connection fails, the worker restarts but in the case of a dying relation, the units have already left scope on the consuming side and so the offering side is never informed.

Add logic to the worker which will send a forceCleanup=true along with the published relation dying event; this will be the case if a relation change arrives and the life is dying but there's no child worker running for that relation. The offering side will force any relation units to leave scope and thus the relation on the offering side can properly be removed instead of remaining in the dying state.

## QA steps

bootstrap 2 controllers and create a cmr
stop the agent on the offering side
remove the relation on the consuming side
check logs for connection errors
restart the agent
check that the relation is cleaned up on the offering side

## Bug reference

https://bugs.launchpad.net/juju/+bug/1795499
