### PR TITLE
Merge pull request #9296 from wallyworld/cmr-controller-connect-robust

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -104,6 +104,10 @@ type Relation interface {
 	// with the supplied ID.
 	RemoteUnit(unitId string) (RelationUnit, error)
 
+	// AllRemoteUnits returns all the RelationUnits for the remote
+	// application units for a given application.
+	AllRemoteUnits(appName string) ([]RelationUnit, error)
+
 	// Endpoints returns the endpoints that constitute the relation.
 	Endpoints() []state.Endpoint
 

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -177,6 +177,18 @@ func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
 	return relationUnitShim{ru}, nil
 }
 
+func (r relationShim) AllRemoteUnits(appName string) ([]RelationUnit, error) {
+	all, err := r.Relation.AllRemoteUnits(appName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]RelationUnit, len(all))
+	for i, ru := range all {
+		result[i] = relationUnitShim{ru}
+	}
+	return result, nil
+}
+
 func (r relationShim) Unit(unitId string) (RelationUnit, error) {
 	unit, err := r.st.Unit(unitId)
 	if err != nil {

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -16,7 +16,7 @@ import (
 
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/authentication"
-	common "github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelrelations"
@@ -374,6 +374,18 @@ func (r *mockRelation) RemoteUnit(unitId string) (commoncrossmodel.RelationUnit,
 		return nil, errors.NotFoundf("unit %q", unitId)
 	}
 	return u, nil
+}
+
+func (r *mockRelation) AllRemoteUnits(appName string) ([]commoncrossmodel.RelationUnit, error) {
+	r.MethodCall(r, "AllRemoteUnits", appName)
+	if err := r.NextErr(); err != nil {
+		return nil, err
+	}
+	var result []commoncrossmodel.RelationUnit
+	for _, ru := range r.units {
+		result = append(result, ru)
+	}
+	return result, nil
 }
 
 func (r *mockRelation) Unit(unitId string) (commoncrossmodel.RelationUnit, error) {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -358,6 +358,10 @@ type RemoteRelationChangeEvent struct {
 	// Life is the current lifecycle state of the relation.
 	Life Life `json:"life"`
 
+	// ForceCleanup is true if the offering side should forcibly
+	// ensure that all relation units have left scope.
+	ForceCleanup *bool `json:"force-cleanup,omitempty"`
+
 	// Suspended is the current suspended status of the relation.
 	Suspended *bool `json:"suspended,omitempty"`
 

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -101,6 +101,8 @@ func newNotifyWatcher(context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	resources := context.Resources()
 
+	// TODO(wallyworld) - enhance this watcher to support
+	// anonymous api calls with macaroons.
 	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, common.ErrPerm
 	}

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -338,16 +338,36 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 	// goes to Dying; they're only stopped when the relation is
 	// finally removed.
 	c.Assert(unitsWatcher.killed(), jc.IsFalse)
-	mac, err := apitesting.NewMacaroon("apimac")
+	apiMac, err := apitesting.NewMacaroon("apimac")
 	c.Assert(err, jc.ErrorIsNil)
+	mac, err := apitesting.NewMacaroon("test")
+	c.Assert(err, jc.ErrorIsNil)
+	relTag := names.NewRelationTag("db2:db django:db")
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"ExportEntities", []interface{}{
+			[]names.Tag{names.NewApplicationTag("django"), relTag}}},
+		{"RegisterRemoteRelations", []interface{}{[]params.RegisterRemoteRelationArg{{
+			ApplicationToken: "token-django",
+			SourceModelTag:   "model-local-model-uuid",
+			RelationToken:    "token-db2:db django:db",
+			RemoteEndpoint: params.RemoteEndpoint{
+				Name:      "db2",
+				Role:      "requires",
+				Interface: "db2",
+			},
+			OfferUUID:         "offer-db2-uuid",
+			LocalEndpointName: "data",
+			Macaroons:         macaroon.Slice{mac},
+		}}}},
+		{"SaveMacaroon", []interface{}{relTag, apiMac}},
+		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
 				Life:             params.Dying,
 				ApplicationToken: "token-django",
 				RelationToken:    "token-db2:db django:db",
-				Macaroons:        macaroon.Slice{mac},
+				Macaroons:        macaroon.Slice{apiMac},
 			},
 		}},
 	}
@@ -471,6 +491,14 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDyingConsumes(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
+	s.assertRemoteRelationsChangedError(c, false)
+}
+
+func (s *remoteRelationsSuite) TestRemoteDyingRelationsChangedError(c *gc.C) {
+	s.assertRemoteRelationsChangedError(c, true)
+}
+
+func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying bool) {
 	w := s.assertRemoteRelationsWorkers(c)
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
@@ -515,10 +543,9 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 		{"ControllerAPIInfoForModel", []interface{}{"remote-model-uuid"}},
 		{"WatchOfferStatus", []interface{}{"offer-db2-uuid", macaroon.Slice{mac}}},
 	}
-	// After the worker resumes, normal processing happens.
 	s.waitForWorkerStubCalls(c, expected)
-
 	s.stub.ResetCalls()
+
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 	relTag := names.NewRelationTag("db2:db django:db")
@@ -545,6 +572,25 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedError(c *gc.C) {
 		{"WatchLocalRelationUnits", []interface{}{"db2:db django:db"}},
 		{"WatchRelationUnits", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 	}
+
+	// If a relation is dying and there's been an error, when processing resumes
+	// a cleanup is forced on the remote side.
+	if dying {
+		s.relationsFacade.updateRelationLife("db2:db django:db", params.Dying)
+		forceCleanup := true
+		expected = append(expected, jujutesting.StubCall{
+			"PublishRelationChange", []interface{}{
+				params.RemoteRelationChangeEvent{
+					ApplicationToken: "token-django",
+					RelationToken:    "token-db2:db django:db",
+					Life:             params.Dying,
+					Macaroons:        macaroon.Slice{apiMac},
+					ForceCleanup:     &forceCleanup,
+				},
+			}},
+		)
+	}
+	// After the worker resumes, normal processing happens.
 	s.waitForWorkerStubCalls(c, expected)
 }
 


### PR DESCRIPTION
## Description of change

Forward port https://github.com/juju/juju/pull/9296

Cross model relations required controller->controller connectivity. If a connection fails, the worker restarts but in the case of a dying relation, the units have already left scope on the consuming side and so the offering side is never informed.

Add logic to the worker which will send a forceCleanup=true along with the published relation dying event; this will be the case if a relation change arrives and the life is dying but there's no child worker running for that relation. The offering side will force any relation units to leave scope and thus the relation on the offering side can properly be removed instead of remaining in the dying state.

## QA steps

bootstrap 2 controllers and create a cmr
stop the agent on the offering side
remove the relation on the consuming side
check logs for connection errors
restart the agent
check that the relation is cleaned up on the offering side

## Bug reference

https://bugs.launchpad.net/juju/+bug/1795499
