### PR TITLE
Console Output for Upgrade-Series - "Frozen" -> "Pinned"

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -282,7 +282,7 @@ func (c *upgradeSeriesCommand) pinLeaders(ctx *cmd.Context, units []string) erro
 		if err := c.leadershipClient.PinLeadership(app); err != nil {
 			return errors.Annotatef(err, "freezing leadership for %q", app)
 		}
-		ctx.Infof("leadership frozen for application %q", app)
+		ctx.Infof("leadership pinned for application %q", app)
 	}
 	return nil
 }
@@ -417,7 +417,7 @@ func (c *upgradeSeriesCommand) unpinLeaders(ctx *cmd.Context) error {
 		if err := c.leadershipClient.UnpinLeadership(app); err != nil {
 			return errors.Annotatef(err, "unfreezing leadership for %q", app)
 		}
-		ctx.Infof("leadership unfrozen for application %q", app)
+		ctx.Infof("leadership unpinned for application %q", app)
 	}
 	return nil
 }

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -163,7 +163,7 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeAndNotPrompt(c *
 
 	finishedMessage := ""
 	for _, unit := range units {
-		finishedMessage += fmt.Sprintf("leadership frozen for application %q\n", strings.Split(unit, "/")[0])
+		finishedMessage += fmt.Sprintf("leadership pinned for application %q\n", strings.Split(unit, "/")[0])
 	}
 	finishedMessage = fmt.Sprintf(finishedMessage+machine.UpgradeSeriesPrepareFinishedMessage, machineArg)
 	displayedMessage := strings.Join([]string{confirmationMessage, finishedMessage}, "") + "\n"


### PR DESCRIPTION
## Description of change

Changes console output to use "pinned" and "unpinned" instead of "frozen" and "unfrozen" for consistency with terminology used in code.

## QA steps

Bootstrap, deploy and run a series upgrade; verify the new verbiage.

## Documentation changes

None.

## Bug reference

N/A
