### PR TITLE
Pre-existing upgrade-series lock does not cause applications to be unpinned

### DIFF
--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -158,14 +158,17 @@ func (client *Client) UpgradeSeriesPrepare(machineName, series string, force boo
 		Force:  force,
 	}
 	result := params.ErrorResult{}
-	err := client.facade.FacadeCall("UpgradeSeriesPrepare", args, &result)
-	if err != nil {
+	if err := client.facade.FacadeCall("UpgradeSeriesPrepare", args, &result); err != nil {
 		return errors.Trace(err)
 	}
-	if result.Error != nil {
-		return result.Error
-	}
 
+	err := result.Error
+	if err != nil {
+		if params.IsCodeAlreadyExists(err) {
+			return errors.NewAlreadyExists(err, "")
+		}
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/api/machinemanager/machinemanagernew_test.go
+++ b/api/machinemanager/machinemanagernew_test.go
@@ -16,6 +16,7 @@ package machinemanager_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -101,6 +102,26 @@ func (s *NewMachineManagerSuite) TestApplicationsMultiResultError(c *gc.C) {
 
 	_, err := s.client.Applications(s.tag.Id())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
+}
+
+func (s *NewMachineManagerSuite) TestUpgradeSeriesPrepareAlreadyExists(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	arg := params.UpdateSeriesArg{
+		Entity: params.Entity{Tag: s.tag.String()},
+		Series: "xenial",
+		Force:  true,
+	}
+	resultSource := params.ErrorResult{
+		Error: &params.Error{
+			Message: "lock already exists",
+			Code:    params.CodeAlreadyExists,
+		},
+	}
+	s.facade.EXPECT().FacadeCall("UpgradeSeriesPrepare", arg, gomock.Any()).SetArg(2, resultSource)
+
+	err := s.client.UpgradeSeriesPrepare(s.tag.Id(), "xenial", true)
+	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
 }
 
 func (s *NewMachineManagerSuite) setup(c *gc.C) *gomock.Controller {


### PR DESCRIPTION
## Description of change

Changes API client to re-throw an `AlreadyExists` error when such a code is returned from the API server.

This condition is detected on upgrade-series _prepare_ and leadership unpinning does not occur in this case.

## QA steps

- Bootstrap, deploy an application (I use Redis).
- Run `juju upgradeseries prepare 0 xenial`.
- Run the command again and note that "unpinned" notification is not present in console output.

## Documentation changes

None.

## Bug reference

N/A
