### PR TITLE
Fix error on <TAB> autocomplete.

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -137,7 +137,7 @@ See also:
 func (c *upgradeSeriesCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upgrade-series",
-		Args:    "<action> [args]",
+		Args:    "<command> [args]",
 		Purpose: "Upgrade a machine's series.",
 		Doc:     upgradeSeriesDoc,
 	}

--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -60,6 +60,11 @@ print ("\n".join(j.get("applications", {}).keys()))
 '   < ${cache_fname}
 }
 
+# Print (return) upgradeseries commands
+_JUJU_2_upgrade_series_commands() {
+     echo -e "prepare\ncomplete"
+}
+
 # Print (return) all actions IDS from (cached) "juju show-action-status" output
 _JUJU_2_action_ids_from_action_status() {
     local model=$(_get_current_model)
@@ -203,6 +208,10 @@ _JUJU_2_completion_func_for_cmd() {
             echo true ;;  # help ok, existing command, no more expansion
         *juju?ssh*|*juju?scp*)
             echo _JUJU_2_units_and_machines_from_status;;
+        *upgrade-series*)
+            if [[ "preparecomplete" != *"${prev_word}"* ]]; then
+                        echo _JUJU_2_upgrade_series_commands
+            fi;;&
         *\<unit*)
             echo _JUJU_2_units_from_status;;
         *\<service*)


### PR DESCRIPTION
## Description of change

`upgrade-series` errors on auto-complete since the first line of its help text contains a keyword that `juju`'s bash auto-compete script interprets in the wrong way. There are several ways to handle this, the approach that is taken here is to tweak the bash auto-completion script. 

## QA steps

Reinstall the script from the juju-repo
```bash
make install-etc
```

Autocomplete an `upgrade-series` command
```bash
upgrade-series <TAB>
juju upgrade-series co<TAB>
```
You should get auto-completion instead of a juju "ERROR ...." style error.
