### PR TITLE
Caas surface operator status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -147,6 +147,12 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		if app.Exposed {
 			notes = "exposed"
 		}
+		// Expose any operator messages.
+		if fs.Model.Type == caasModelType {
+			if app.StatusInfo.Message != "" {
+				notes = app.StatusInfo.Message
+			}
+		}
 		w.Print(appName, version)
 		w.PrintStatus(app.StatusInfo.Current)
 		scale, warn := fs.applicationScale(appName)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4724,10 +4724,10 @@ func (s *StatusSuite) TestFormatTabularStatusNotes(c *gc.C) {
 						Address:     "10.0.0.1",
 						OpenedPorts: []string{"80/TCP"},
 						JujuStatusInfo: statusInfoContents{
-							Current: status.Running,
+							Current: status.Allocating,
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: status.Active,
+							Current: status.Waiting,
 						},
 					},
 				},
@@ -4742,14 +4742,15 @@ Model  Controller  Cloud/Region  Version
                                  
 
 App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Charm version  Notes
-foo                       1                  0      54.32.1.2                 Error: ImagePullBackOff
+foo                     0/1                  0      54.32.1.2                 Error: ImagePullBackOff
 
-Unit   Workload  Agent    Address   Ports   Message
-foo/0  active    running  10.0.0.1  80/TCP  
+Unit   Workload  Agent       Address   Ports   Message
+foo/0  waiting   allocating  10.0.0.1  80/TCP  
 `[1:])
+}
 
-	// Must not show the status message in notes for iaas.
-	fStatus = formattedStatus{
+func (s *StatusSuite) TestFormatTabularStatusNotesIAAS(c *gc.C) {
+	status := formattedStatus{
 		Applications: map[string]applicationStatus{
 			"foo": {
 				Address: "54.32.1.2",
@@ -4761,18 +4762,18 @@ foo/0  active    running  10.0.0.1  80/TCP
 						Address:     "10.0.0.1",
 						OpenedPorts: []string{"80/TCP"},
 						JujuStatusInfo: statusInfoContents{
-							Current: status.Running,
+							Current: status.Idle,
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: status.Active,
+							Current: status.Waiting,
 						},
 					},
 				},
 			},
 		},
 	}
-	out.Reset()
-	err = FormatTabular(out, false, fStatus)
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, false, status)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.String(), gc.Equals, `
 Model  Controller  Cloud/Region  Version
@@ -4781,8 +4782,8 @@ Model  Controller  Cloud/Region  Version
 App  Version  Status  Scale  Charm  Store  Rev  OS  Charm version  Notes
 foo                       1                  0                     
 
-Unit   Workload  Agent    Machine  Public address  Ports   Message
-foo/0  active    running                           80/TCP  
+Unit   Workload  Agent  Machine  Public address  Ports   Message
+foo/0  waiting   idle                            80/TCP  
 `[1:])
 }
 

--- a/state/application.go
+++ b/state/application.go
@@ -2242,20 +2242,52 @@ func (a *Application) SetStatus(statusInfo status.StatusInfo) error {
 	if !status.ValidWorkloadStatus(statusInfo.Status) {
 		return errors.Errorf("cannot set invalid status %q", statusInfo.Status)
 	}
+
+	var newHistory *statusDoc
+	model, err := a.st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if model.Type() == ModelTypeCAAS {
+		// Application status for a caas model needs to consider status
+		// info coming from the operator pod as well; It may need to
+		// override what is set here.
+		operatorStatus, err := getStatus(a.st.db(), applicationGlobalOperatorKey(a.Name()), "operator")
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return errors.Trace(err)
+			}
+		}
+
+		newHistory, err = caasHistoryRewriteDoc(statusInfo, operatorStatus, caasApplicationDisplayStatus, a.st.clock())
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	return setStatus(a.st.db(), setStatusParams{
-		badge:     "application",
-		globalKey: a.globalKey(),
-		status:    statusInfo.Status,
-		message:   statusInfo.Message,
-		rawData:   statusInfo.Data,
-		updated:   timeOrNow(statusInfo.Since, a.st.clock()),
+		badge:            "application",
+		globalKey:        a.globalKey(),
+		status:           statusInfo.Status,
+		message:          statusInfo.Message,
+		rawData:          statusInfo.Data,
+		updated:          timeOrNow(statusInfo.Since, a.st.clock()),
+		historyOverwrite: newHistory,
 	})
 }
 
 // SetOperatorStatus sets the operator status for an application.
 // This is used on CAAS models.
 func (a *Application) SetOperatorStatus(sInfo status.StatusInfo) error {
-	return setStatus(a.st.db(), setStatusParams{
+	model, err := a.st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if model.Type() != ModelTypeCAAS {
+		return errors.New("caas operation on non-caas model")
+	}
+
+	err = setStatus(a.st.db(), setStatusParams{
 		badge:     "operator",
 		globalKey: applicationGlobalOperatorKey(a.Name()),
 		status:    sInfo.Status,
@@ -2263,6 +2295,25 @@ func (a *Application) SetOperatorStatus(sInfo status.StatusInfo) error {
 		rawData:   sInfo.Data,
 		updated:   timeOrNow(sInfo.Since, a.st.clock()),
 	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	appStatus, err := a.Status()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	historyDoc, err := caasHistoryRewriteDoc(appStatus, sInfo, caasApplicationDisplayStatus, a.st.clock())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if historyDoc != nil {
+		// rewriting application status history
+		_, err = probablyUpdateStatusHistory(a.st.db(), a.globalKey(), *historyDoc)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }
 
 // StatusHistory returns a slice of at most filter.Size StatusInfo items
@@ -2591,7 +2642,7 @@ func (op *AddUnitOperation) Done(err error) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		newHistory, err := caasHistoryRewriteDoc(unitStatus, *op.props.CloudContainerStatus, op.application.st.clock())
+		newHistory, err := caasHistoryRewriteDoc(unitStatus, *op.props.CloudContainerStatus, caasUnitDisplayStatus, op.application.st.clock())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3722,18 +3722,6 @@ func (s *CAASApplicationSuite) TestRewriteStatusHistory(c *gc.C) {
 	c.Assert(history[0].Status, gc.Equals, status.Waiting)
 	c.Assert(history[0].Message, gc.Equals, "waiting for container")
 
-	// History will use operator status (and not written again.)
-	err = app.SetStatus(status.StatusInfo{
-		Status:  status.Maintenance,
-		Message: "app message",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	history, err = app.StatusHistory(status.StatusHistoryFilter{Size: 10})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(history, gc.HasLen, 1)
-	c.Assert(history[0].Status, gc.Equals, status.Waiting)
-	c.Assert(history[0].Message, gc.Equals, "waiting for container")
-
 	// Must overwrite the history
 	err = app.SetOperatorStatus(status.StatusInfo{
 		Status:  status.Allocating,

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3706,6 +3706,70 @@ func (s *CAASApplicationSuite) TestWatchScale(c *gc.C) {
 	wc.AssertNoChange()
 }
 
+func (s *CAASApplicationSuite) TestRewriteStatusHistory(c *gc.C) {
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "caas-model",
+		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+	})
+	defer st.Close()
+	f := factory.NewFactory(st, s.StatePool)
+	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
+	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: ch})
+
+	history, err := app.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 1)
+	c.Assert(history[0].Status, gc.Equals, status.Waiting)
+	c.Assert(history[0].Message, gc.Equals, "waiting for container")
+
+	// History will use operator status (and not written again.)
+	err = app.SetStatus(status.StatusInfo{
+		Status:  status.Maintenance,
+		Message: "app message",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	history, err = app.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 1)
+	c.Assert(history[0].Status, gc.Equals, status.Waiting)
+	c.Assert(history[0].Message, gc.Equals, "waiting for container")
+
+	// Must overwrite the history
+	err = app.SetOperatorStatus(status.StatusInfo{
+		Status:  status.Allocating,
+		Message: "operator message",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	history, err = app.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 2)
+	c.Assert(history[0].Status, gc.Equals, status.Allocating)
+	c.Assert(history[0].Message, gc.Equals, "operator message")
+	c.Assert(history[1].Status, gc.Equals, status.Waiting)
+	c.Assert(history[1].Message, gc.Equals, "waiting for container")
+
+	err = app.SetOperatorStatus(status.StatusInfo{
+		Status:  status.Running,
+		Message: "operator running",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = app.SetStatus(status.StatusInfo{
+		Status:  status.Active,
+		Message: "app active",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	history, err = app.StatusHistory(status.StatusHistoryFilter{Size: 10})
+	c.Log(history)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 3)
+	c.Assert(history[0].Status, gc.Equals, status.Active)
+	c.Assert(history[0].Message, gc.Equals, "app active")
+	c.Assert(history[1].Status, gc.Equals, status.Allocating)
+	c.Assert(history[1].Message, gc.Equals, "operator message")
+	c.Assert(history[2].Status, gc.Equals, status.Waiting)
+	c.Assert(history[2].Message, gc.Equals, "waiting for container")
+}
+
 func (s *ApplicationSuite) TestApplicationSetAgentPresence(c *gc.C) {
 	alive, err := s.mysql.AgentPresence()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -437,3 +437,39 @@ func setCloudContainerStatus(c *gc.C, unit *state.Unit, statusCode status.Status
 	err = app.UpdateUnits(&updateUnits)
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *CAASModelSuite) TestApplicationOperatorStatusOverwrite(c *gc.C) {
+	m, st := s.newCAASModel(c)
+	f := factory.NewFactory(st, s.StatePool)
+	f.MakeUnit(c, &factory.UnitParams{})
+	ch := f.MakeCharm(c, &factory.CharmParams{
+		Name:   "gitlab",
+		Series: "kubernetes",
+	})
+	app := f.MakeApplication(c, &factory.ApplicationParams{Charm: ch})
+	app.SetOperatorStatus(status.StatusInfo{
+		Status:  status.Error,
+		Message: "operator error",
+	})
+	app.SetStatus(status.StatusInfo{
+		Status:  status.Active,
+		Message: "app active",
+	})
+	ms, err := m.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	appStatus, err := ms.Application("gitlab", []string{"gitlab/0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(appStatus.Message, gc.Equals, "operator error")
+	c.Check(appStatus.Status, gc.Equals, status.Error)
+
+	app.SetOperatorStatus(status.StatusInfo{
+		Status:  status.Running,
+		Message: "operator running",
+	})
+	ms, err = m.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	appStatus, err = ms.Application("gitlab", []string{"gitlab/0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(appStatus.Message, gc.Equals, "app active")
+	c.Check(appStatus.Status, gc.Equals, status.Active)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -850,6 +850,10 @@ func CaasUnitDisplayStatus(unitStatus status.StatusInfo, cloudContainerStatus st
 	return caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
 }
 
+func CaasApplicationDisplayStatus(appStatus status.StatusInfo, operatorStatus status.StatusInfo) status.StatusInfo {
+	return caasApplicationDisplayStatus(appStatus, operatorStatus)
+}
+
 func ApplicationOperatorStatus(st *State, appName string) (status.StatusInfo, error) {
 	return getStatus(st.db(), applicationGlobalOperatorKey(appName), "operator")
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -429,9 +429,10 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 	c.Assert(err, jc.ErrorIsNil)
 	err = dbModel.SetAnnotations(application, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
-	s.primeStatusHistory(c, application, status.Active, addedHistoryCount)
 
 	if dbModel.Type() == state.ModelTypeCAAS {
+		application.SetOperatorStatus(status.StatusInfo{Status: status.Running})
+
 		caasModel, err := dbModel.CAASModel()
 		c.Assert(err, jc.ErrorIsNil)
 		err = caasModel.SetPodSpec(application.ApplicationTag(), "pod spec")
@@ -440,6 +441,8 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 		err = application.UpdateCloudService("provider-id", []network.Address{addr})
 		c.Assert(err, jc.ErrorIsNil)
 	}
+
+	s.primeStatusHistory(c, application, status.Active, addedHistoryCount)
 
 	model, err := st.Export()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -455,6 +455,9 @@ func (s *MigrationImportSuite) setupSourceApplications(
 	c.Assert(application.SetExposed(), jc.ErrorIsNil)
 	err = model.SetAnnotations(application, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
+	if model.Type() == state.ModelTypeCAAS {
+		application.SetOperatorStatus(status.StatusInfo{Status: status.Running})
+	}
 	s.primeStatusHistory(c, application, status.Active, 5)
 	return charm, application, pwd
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1225,8 +1225,8 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		Updated:    st.clock().Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour
 		// while we work out how to switch to an implementation that makes
-		// sense. It is only relevant for IAAS models.
-		NeverSet: model.Type() == ModelTypeIAAS,
+		// sense.
+		NeverSet: true,
 	}
 	if model.Type() == ModelTypeCAAS {
 		statusDoc.StatusInfo = status.MessageWaitForContainer

--- a/state/status.go
+++ b/state/status.go
@@ -140,7 +140,7 @@ func (m *ModelStatus) UnitWorkloadVersion(unitName string) (string, error) {
 	return info.Message, nil
 }
 
-// UnitAgent returns the status of the Units agent.
+// UnitAgent returns the status of the Unit's agent.
 func (m *ModelStatus) UnitAgent(unitName string) (status.StatusInfo, error) {
 	// We do horrible things with unit status.
 	// See notes in unitagent.go.
@@ -230,18 +230,17 @@ func caasUnitDisplayStatus(unitStatus status.StatusInfo, containerStatus status.
 	return unitStatus
 }
 
-// caasApplicationDisplayStatus determines which of the two statuses to use when displaying workload status in a CAAS model.
-func caasApplicationDisplayStatus(workloadStatus, operatorStatus status.StatusInfo) status.StatusInfo {
-	// Only interested in the operator status if it's not running
-	if workloadStatus.Status == status.Terminated {
-		return workloadStatus
+// caasApplicationDisplayStatus determines which of the two statuses to use when displaying application status in a CAAS model.
+func caasApplicationDisplayStatus(applicationStatus, operatorStatus status.StatusInfo) status.StatusInfo {
+	if applicationStatus.Status == status.Terminated {
+		return applicationStatus
 	}
-
+	// Only interested in the operator status if it's not running
 	if operatorStatus.Status != status.Running {
 		return operatorStatus
 	}
 
-	return workloadStatus
+	return applicationStatus
 }
 
 // caasHistoryRewriteDoc determines which status should be stored as history.

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -420,3 +420,84 @@ func (s *UnitCloudStatusSuite) TestContainerOrUnitStatusChoice(c *gc.C) {
 		c.Assert(state.CaasUnitDisplayStatus(check.unitStatus, check.cloudContainerStatus).Message, gc.Equals, check.messageCheck)
 	}
 }
+
+func (s *UnitCloudStatusSuite) TestApplicatoinOpeartorStatusChoice(c *gc.C) {
+
+	var checks = []struct {
+		operatorStatus status.StatusInfo
+		appStatus      status.StatusInfo
+		messageCheck   string
+	}{
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Terminated,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Active,
+				Message: "unit",
+			},
+			messageCheck: "operator",
+		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Error,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Active,
+				Message: "unit",
+			},
+			messageCheck: "operator",
+		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Allocating,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Active,
+				Message: "unit",
+			},
+			messageCheck: "operator",
+		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Unknown,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Active,
+				Message: "unit",
+			},
+			messageCheck: "operator",
+		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Running,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Active,
+				Message: "unit",
+			},
+			messageCheck: "unit",
+		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Terminated,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Terminated,
+				Message: "unit",
+			},
+			messageCheck: "unit",
+		},
+	}
+
+	for i, check := range checks {
+		c.Logf("Check %d", i)
+		c.Assert(state.CaasApplicationDisplayStatus(check.appStatus, check.operatorStatus).Message, gc.Equals, check.messageCheck)
+	}
+}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1196,7 +1196,7 @@ func (u *Unit) SetStatus(unitStatus status.StatusInfo) error {
 			}
 		}
 
-		newHistory, err = caasHistoryRewriteDoc(unitStatus, cloudContainerStatus, u.st.clock())
+		newHistory, err = caasHistoryRewriteDoc(unitStatus, cloudContainerStatus, caasUnitDisplayStatus, u.st.clock())
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

React and report on operator pod changes, funnel status changes from the operator back into theJuju data model.

This will allow Juju to surface error message encountered when spinning up an operator for a CAAS charm deploy.

The PR also includes a couple of drive-by fixes:

  - Various minor spelling and comment name fixes
  - Bug fix in ModelStatus Application
  - Bug fix where NeverSet status flag was only being set for IAAS models

## QA steps

Manually verify the status data is presented in ```juju status``` output
(Modified steps taken from 
  - Boostrap and setup a caas model as per [this post on discourse](https://discourse.jujucharms.com/t/storage-support/154).
  - BEFORE deploying the charm, poison the operator image config so that the operator pod will error (needs to be a valid docker url):
    - For instance I use: ```juju controller-config caas-operator-image-path=veebers/caap-operator@sha256:29498cb4c1f89e28b3f45df6c222e3b404586c56f1fe1c79978398e89b3e0309```
  - Run the command ```juju status``
    - Ensure under the 'mariabd' application *Notes* section the error message is shown
 - Run the command ```juju status --format yaml```
    - Ensure the operator error message is present under the application-status section.

## Documentation changes

None.

## Bug reference

N/A
