### PR TITLE
Replace model credential, facade call.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -74,7 +74,7 @@ var facadeVersions = map[string]int{
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,
 	"ModelConfig":                  2,
-	"ModelManager":                 4,
+	"ModelManager":                 5,
 	"ModelUpgrader":                1,
 	"NotifyWatcher":                1,
 	"OfferStatusWatcher":           1,

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -530,3 +530,30 @@ func (c *Client) UnsetModelDefaults(cloud, region string, keys ...string) error 
 	}
 	return result.OneError()
 }
+
+// ChangeModelCredential replaces cloud credential for a given model with the provided one.
+func (c *Client) ChangeModelCredential(model names.ModelTag, credential names.CloudCredentialTag) error {
+	if bestVer := c.BestAPIVersion(); bestVer < 5 {
+		return errors.NotImplementedf("ChangeModelCredential")
+	}
+
+	var out params.ErrorResults
+	in := params.ChangeModelCredentialsParams{
+		[]params.ChangeModelCredentialParams{
+			{ModelTag: model.String(), CloudCredentialTag: credential.String()},
+		},
+	}
+
+	err := c.facade.FacadeCall("ChangeModelCredential", in, &out)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if count := len(out.Results); count != 1 {
+		return errors.Errorf("unexpected result count: expected 1 but got %d", count)
+	}
+	result := out.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -548,12 +548,5 @@ func (c *Client) ChangeModelCredential(model names.ModelTag, credential names.Cl
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if count := len(out.Results); count != 1 {
-		return errors.Errorf("unexpected result count: expected 1 but got %d", count)
-	}
-	result := out.Results[0]
-	if result.Error != nil {
-		return errors.Trace(result.Error)
-	}
-	return nil
+	return out.OneError()
 }

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -579,7 +579,7 @@ func (s *modelmanagerSuite) TestChangeModelCredentialManyResults(c *gc.C) {
 
 	client := modelmanager.NewClient(apiCaller)
 	err := client.ChangeModelCredential(coretesting.ModelTag, credentialTag)
-	c.Assert(err, gc.ErrorMatches, `unexpected result count: expected 1 but got 2`)
+	c.Assert(err, gc.ErrorMatches, `expected 1 result, got 2`)
 	c.Assert(called, jc.IsTrue)
 }
 

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -232,6 +232,7 @@ func AllFacades() *facade.Registry {
 	reg("ModelManager", 2, modelmanager.NewFacadeV2)
 	reg("ModelManager", 3, modelmanager.NewFacadeV3)
 	reg("ModelManager", 4, modelmanager.NewFacadeV4)
+	reg("ModelManager", 5, modelmanager.NewFacadeV5) // adds ChangeModelCredential
 	reg("ModelUpgrader", 1, modelupgrader.NewStateFacade)
 
 	reg("Payloads", 1, payloads.NewFacade)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -102,6 +102,7 @@ type Model interface {
 	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
 	AutoConfigureContainerNetworking(environ environs.Environ) error
 	ModelConfigDefaultValues() (config.ModelDefaultAttributes, error)
+	SetCloudCredential(tag names.CloudCredentialTag) (bool, error)
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -71,8 +71,9 @@ func (s *ListModelsWithInfoSuite) createModel(c *gc.C, user names.UserTag) *mock
 	cfg, err := config.New(config.UseDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	return &mockModel{
-		owner: user,
-		cfg:   cfg,
+		owner:               user,
+		cfg:                 cfg,
+		setCloudCredentialF: func(tag names.CloudCredentialTag) (bool, error) { return false, nil },
 	}
 }
 

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -591,10 +591,12 @@ func (st *mockState) ControllerModelTag() names.ModelTag {
 }
 
 func (st *mockState) Export() (description.Model, error) {
+	st.MethodCall(st, "Export")
 	return &fakeModelDescription{UUID: st.model.UUID()}, nil
 }
 
-func (st *mockState) ExportPartial(state.ExportConfig) (description.Model, error) {
+func (st *mockState) ExportPartial(cfg state.ExportConfig) (description.Model, error) {
+	st.MethodCall(st, "ExportPartial", cfg)
 	return st.Export()
 }
 
@@ -923,15 +925,16 @@ func (m *mockMachine) Status() (status.StatusInfo, error) {
 
 type mockModel struct {
 	gitjujutesting.Stub
-	owner           names.UserTag
-	life            state.Life
-	tag             names.ModelTag
-	status          status.StatusInfo
-	cfg             *config.Config
-	users           []*mockModelUser
-	migrationStatus state.MigrationMode
-	controllerUUID  string
-	cfgDefaults     config.ModelDefaultAttributes
+	owner               names.UserTag
+	life                state.Life
+	tag                 names.ModelTag
+	status              status.StatusInfo
+	cfg                 *config.Config
+	users               []*mockModelUser
+	migrationStatus     state.MigrationMode
+	controllerUUID      string
+	cfgDefaults         config.ModelDefaultAttributes
+	setCloudCredentialF func(tag names.CloudCredentialTag) (bool, error)
 }
 
 func (m *mockModel) Config() (*config.Config, error) {
@@ -1067,6 +1070,11 @@ func (m *mockModel) getModelDetails() state.ModelSummary {
 		CloudRegion:        m.CloudRegion(),
 		CloudCredentialTag: cred.String(),
 	}
+}
+
+func (m *mockModel) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
+	m.MethodCall(m, "SetCloudCredential", tag)
+	return m.setCloudCredentialF(tag)
 }
 
 type mockModelUser struct {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1411,14 +1411,17 @@ func (m *ModelManagerAPI) ChangeModelCredential(args params.ChangeModelCredentia
 	}
 	// Only controller or model admin can change cloud credential on a model.
 	checkModelAccess := func(tag names.ModelTag) error {
+		if controllerAdmin {
+			return nil
+		}
 		modelAdmin, err := m.authorizer.HasPermission(permission.AdminAccess, tag)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if !controllerAdmin && !modelAdmin {
-			return common.ErrPerm
+		if modelAdmin {
+			return nil
 		}
-		return nil
+		return common.ErrPerm
 	}
 
 	replaceModelCredential := func(arg params.ChangeModelCredentialParams) error {
@@ -1444,7 +1447,7 @@ func (m *ModelManagerAPI) ChangeModelCredential(args params.ChangeModelCredentia
 			return errors.Trace(err)
 		}
 		if !updated {
-			return errors.Errorf("did not update credential on model %v to %v", modelTag.Id(), credentialTag.Id())
+			return errors.Errorf("model %v already uses credential %v", modelTag.Id(), credentialTag.Id())
 		}
 		return nil
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1749,7 +1749,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialNotUpdated(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
-	c.Assert(results.Results[0].Error, gc.ErrorMatches, `did not update credential on model deadbeef-0bad-400d-8000-4b1d0d06f00d to foo/bob/bar`)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `model deadbeef-0bad-400d-8000-4b1d0d06f00d already uses credential foo/bob/bar`)
 }
 
 type fakeProvider struct {

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -406,3 +406,19 @@ type ModelCredential struct {
 	// machines can be accessed with this credential.
 	Valid bool `json:"valid,omitempty"`
 }
+
+// ChangeModelCredentialParams holds the argument to replace cloud credential
+// used by a model.
+type ChangeModelCredentialParams struct {
+	// ModelTag is a tag for the model where cloud credential change takes place.
+	ModelTag string `json:"model-tag"`
+
+	// CloudCredentialTag is the tag for the new cloud credential.
+	CloudCredentialTag string `json:"credential-tag"`
+}
+
+// ChangeModelCredentialsParams holds the arguments for changing
+// cloud credentials on models.
+type ChangeModelCredentialsParams struct {
+	Models []ChangeModelCredentialParams `json:"models"`
+}

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -420,5 +420,5 @@ type ChangeModelCredentialParams struct {
 // ChangeModelCredentialsParams holds the arguments for changing
 // cloud credentials on models.
 type ChangeModelCredentialsParams struct {
-	Models []ChangeModelCredentialParams `json:"models"`
+	Models []ChangeModelCredentialParams `json:"model-credentials"`
 }


### PR DESCRIPTION
## Description of change

Model manager facade gets a new version with a new call to change models credentials.
Model credential can only be replaced by a model or a controller admin.
