### PR TITLE
Fixes lp#1796618:  Don't upload credential on add-model unless explicitly asked to.

### DIFF
--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -4,8 +4,6 @@
 package cloud
 
 import (
-	"sort"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -137,46 +135,7 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 	models, err := client.UpdateCredentialsCheckModels(credentialTag, *credToUpdate)
 
 	// We always want to display models information if there is any.
-	var valid []string
-	invalid := map[string][]error{}
-	for _, m := range models {
-		if len(m.Errors) == 0 {
-			valid = append(valid, m.ModelName)
-			continue
-		} else {
-			var mError []error
-			for _, anErr := range m.Errors {
-				mError = append(mError, errors.Trace(anErr.Error))
-			}
-			invalid[m.ModelName] = mError
-		}
-	}
-
-	if len(valid) > 0 {
-		ctx.Infof("Credential valid for:")
-		for _, v := range valid {
-			ctx.Infof("  %v", v)
-		}
-	}
-	if len(invalid) > 0 {
-		// ensure we sort the valid, invalid slices so that the output is consistent
-		i := 0
-		names := make([]string, len(invalid))
-		for k := range invalid {
-			names[i] = k
-			i++
-		}
-		sort.Strings(names)
-
-		ctx.Infof("Credential invalid for:")
-		for _, v := range names {
-			ctx.Infof("  %v:", v)
-			for _, e := range invalid[v] {
-				ctx.Infof("    %v", e)
-			}
-		}
-	}
-
+	common.OutputUpdateCredentialModelResult(ctx, models, true)
 	if err != nil {
 		ctx.Infof("Controller credential %q for user %q on cloud %q not updated: %v.", c.credential, accountDetails.User, c.cloud, err)
 		// TODO (anastasiamac 2018-09-21) When set-credential is done, also direct user to it.

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -16,7 +17,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
-	"sort"
 )
 
 // ErrMultipleDetectedCredentials is the error returned by

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -11,10 +11,12 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
+	"sort"
 )
 
 // ErrMultipleDetectedCredentials is the error returned by
@@ -132,6 +134,49 @@ func ResolveCloudCredentialTag(user names.UserTag, cloud names.CloudTag, credent
 		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential name %q", s)
 	}
 	return names.NewCloudCredentialTag(s), nil
+}
+
+// OutputUpdateCredentialModelResult prints detailed results of UpdateCredentialsCheckModels.
+func OutputUpdateCredentialModelResult(ctx *cmd.Context, models []params.UpdateCredentialModelResult, showValid bool) {
+	var valid []string
+	invalid := map[string][]error{}
+	for _, m := range models {
+		if len(m.Errors) == 0 {
+			valid = append(valid, m.ModelName)
+			continue
+		} else {
+			var mError []error
+			for _, anErr := range m.Errors {
+				mError = append(mError, errors.Trace(anErr.Error))
+			}
+			invalid[m.ModelName] = mError
+		}
+	}
+
+	if showValid && len(valid) > 0 {
+		ctx.Infof("Credential valid for:")
+		for _, v := range valid {
+			ctx.Infof("  %v", v)
+		}
+	}
+	if len(invalid) > 0 {
+		// ensure we sort the valid, invalid slices so that the output is consistent
+		i := 0
+		names := make([]string, len(invalid))
+		for k := range invalid {
+			names[i] = k
+			i++
+		}
+		sort.Strings(names)
+
+		ctx.Infof("Credential invalid for:")
+		for _, v := range names {
+			ctx.Infof("  %v:", v)
+			for _, e := range invalid[v] {
+				ctx.Infof("    %v", e)
+			}
+		}
+	}
 }
 
 //go:generate mockgen -package common -destination cloudprovider_mock_test.go github.com/juju/juju/cmd/juju/common TestCloudProvider

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -220,11 +220,13 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	// Upload the credential if it was found locally.
-	if credential != nil {
+	// Upload the credential if it was explicitly set and we have found it locally.
+	if c.CredentialName != "" && credential != nil {
 		ctx.Infof("Uploading credential '%s' to controller", credentialTag.Id())
-		if _, err := cloudClient.UpdateCredentialsCheckModels(credentialTag, *credential); err != nil {
-			return errors.Trace(err)
+		if all, err := cloudClient.UpdateCredentialsCheckModels(credentialTag, *credential); err != nil {
+			ctx.Infof("Failed to upload credential: %v", err)
+			common.OutputUpdateCredentialModelResult(ctx, all, false)
+			return cmd.ErrSilent
 		}
 	}
 

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -273,7 +273,7 @@ func (s *AddModelSuite) TestCredentialsOneCached(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-west-1")
 }
 
-func (s *AddModelSuite) TestCredentialsDetected(c *gc.C) {
+func (s *AddModelSuite) TestControllerCredentialsDetected(c *gc.C) {
 	// Disable empty auth and clear the local credentials,
 	// forcing a check for credentials in the controller.
 	// There are multiple credentials in the controller,
@@ -293,11 +293,10 @@ func (s *AddModelSuite) TestCredentialsDetected(c *gc.C) {
 	credential.Label = "finalized"
 
 	c.Assert(s.fakeAddModelAPI.cloudCredential, gc.Equals, credentialTag)
-	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials", "UpdateCredentialsCheckModels")
-	s.fakeCloudAPI.CheckCall(c, 3, "UpdateCredentialsCheckModels", credentialTag, credential)
+	s.fakeCloudAPI.CheckCallNames(c, "DefaultCloud", "Cloud", "UserCredentials")
 }
 
-func (s *AddModelSuite) TestCredentialsDetectedAmbiguous(c *gc.C) {
+func (s *AddModelSuite) TestControllerCredentialsDetectedAmbiguous(c *gc.C) {
 	// Disable empty auth and clear the local credentials,
 	// forcing a check for credentials in the controller.
 	// There are multiple credentials in the controller,


### PR DESCRIPTION
## Description of change

Juju will always upload a local credential when 'add-model' command is issued.

This is needed when a user explicitly asks to use a particular local credential via --credential option. In this case, before requesting to add a model, the command will try to upload a credential to the controller. If the credential is new on the controller, it will be uploaded without any further checks. If a credential with this name exists on the controller, this effectively becomes an update of an existing credential which entails check of all the models that use it. This update is not entirely appropriate here. There is a separate 'update-credential' command. Here we only need to cater for 'add' credential functionality (when using local credential is desired) and 'use a named credential that I know exists on controller' (when using controller credential is desired). This aspect will be dealt with in subsequent work when we tackle local vs remote clouds/credentials. At the moment, when specifying a credential explicitly while adding a model and if this credential is already on the controller, this command will try to update credential contents and, hence, run all the check necessary for update.

When a credential is not explicitly specified, Juju should not upload local credential. This PR fixes that.

## QA steps

Expected outcomes.
1: Adding a model without specifying a credential should not try to update credential content stored on controller.
2: Adding a model with a credential that does not exist on the controller will upload that credential.
3. Adding a model with a credential known to the controller will try to update credential content.

* bootstrap 
* add model
* add model by specifying new credential via --credential option
* add model by specifying the same credential used during bootstrap via --credential option [This will fail for k8s models for example]

Sample output for a detailed failure:
```
$ microk8s.config | juju add-k8s k8stest
$ juju add-model test k8stest
Added 'test' model on k8stest with credential 'admin' for user 'admin'
$ juju add-model trial k8stest
Added 'trial' model on k8stest with credential 'admin' for user 'admin'
$ juju add-model trial k8stest --credential=admin
Uploading credential 'k8stest/admin/admin' to controller
Failed to upload credential: some models are no longer visible
Credential invalid for:
  test:
    cloud environ provider provider.kubernetesEnvironProvider not valid
  trial:
    cloud environ provider provider.kubernetesEnvironProvider not valid
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1796618
