### PR TITLE
Changes bind flag to a space constraint for asses-container-networkin…

### DIFF
--- a/acceptancetests/assess_container_networking.py
+++ b/acceptancetests/assess_container_networking.py
@@ -58,8 +58,8 @@ def parse_args(argv=None):
         help='Which virtual machine/container type to test. Defaults to all.',
         choices=[KVM_MACHINE, LXC_MACHINE, LXD_MACHINE])
     parser.add_argument(
-        '--bind-space',
-        help='The network space to bind containers to. Default is no binding.',
+        '--space-constraint',
+        help='The network space to constrain containers to. Default is no space constraints.',
         default=None,
         dest='space')
     args = parser.parse_args(argv)
@@ -120,7 +120,7 @@ def make_machines(client, container_types, space):
     # Start any new containers we need
     sargs = []
     if space:
-        sargs = ['--bind', space]
+        sargs = ['--constraints', 'spaces=' + space]
          
     for host, containers in required.iteritems():
         for container in containers:


### PR DESCRIPTION
## Description of change

Prior patch for the same functional test introduced a new argument for space binding. This works for  "deploy", but container machine creation needs to use space constraints; "bind" is unrecognised.

This changes the script to use a space constraint instead of a binding.

## QA steps

Run the CI test and have it execute.

## Documentation changes

None.

## Bug reference

N/A
