### PR TITLE
upgrade-charm, updates the charm's lxd profile too

### DIFF
--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	provisioner "github.com/juju/juju/api/provisioner"
 	params "github.com/juju/juju/apiserver/params"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
@@ -49,6 +50,19 @@ func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
 // AvailabilityZone indicates an expected call of AvailabilityZone
 func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
+}
+
+// CharmProfileChangeInfo mocks base method
+func (m *MockMachineProvisioner) CharmProfileChangeInfo() (provisioner.CharmProfileChangeInfo, error) {
+	ret := m.ctrl.Call(m, "CharmProfileChangeInfo")
+	ret0, _ := ret[0].(provisioner.CharmProfileChangeInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CharmProfileChangeInfo indicates an expected call of CharmProfileChangeInfo
+func (mr *MockMachineProvisionerMockRecorder) CharmProfileChangeInfo() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfileChangeInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).CharmProfileChangeInfo))
 }
 
 // DistributionGroup mocks base method
@@ -227,6 +241,18 @@ func (mr *MockMachineProvisionerMockRecorder) Series() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockMachineProvisioner)(nil).Series))
 }
 
+// SetCharmProfiles mocks base method
+func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
+	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetCharmProfiles indicates an expected call of SetCharmProfiles
+func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
+}
+
 // SetInstanceInfo mocks base method
 func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1 string, arg2 *instance.HardwareCharacteristics, arg3 []params.NetworkConfig, arg4 []params.Volume, arg5 map[string]params.VolumeAttachmentInfo, arg6 []string) error {
 	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -289,6 +315,18 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 // SetSupportedContainers indicates an expected call of SetSupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
+}
+
+// SetUpgradeCharmProfileComplete mocks base method
+func (m *MockMachineProvisioner) SetUpgradeCharmProfileComplete(arg0 string) error {
+	ret := m.ctrl.Call(m, "SetUpgradeCharmProfileComplete", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetUpgradeCharmProfileComplete indicates an expected call of SetUpgradeCharmProfileComplete
+func (mr *MockMachineProvisionerMockRecorder) SetUpgradeCharmProfileComplete(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeCharmProfileComplete", reflect.TypeOf((*MockMachineProvisioner)(nil).SetUpgradeCharmProfileComplete), arg0)
 }
 
 // Status mocks base method

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -43,6 +43,14 @@ import (
 	"github.com/juju/juju/testing/factory"
 )
 
+// TODO (hml) lxd-profile 24-oct-2018
+// create mocks to write tests for:
+// WatchModelMachinesCharmProfiles
+// GetContainerProfileInfo
+// CharmProfileChangeInfo
+// SetCharmProfiles
+// SetUpgradeCharmProfileComplete
+
 func TestPackage(t *stdtesting.T) {
 	coretesting.MgoTestPackage(t)
 }
@@ -1807,10 +1815,6 @@ func (s *withControllerSuite) TestGetContainerProfileInfo(c *gc.C) {
 							"type":      "usb",
 							"vendorid":  "0fce",
 							"productid": "51da",
-						},
-						"bdisk": {
-							"source": "/dev/loop0",
-							"type":   "unix-block",
 						},
 					},
 				},

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -721,25 +721,8 @@ func (api *APIBase) SetCharmProfile(args params.ApplicationSetCharmProfile) erro
 	//	}
 	//}
 
-	curl, err := charm.ParseURL(args.CharmURL)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	ch, err := api.backend.Charm(curl)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	lxdCharm, ok := ch.(charm.LXDProfiler)
-	if !ok {
-		return nil
-	}
-	profile := lxdCharm.LXDProfile()
-	if profile == nil || profile.Empty() {
-		// TODO (hml) 3-oct-2018
-		// handle case of charm did have a profile and doesn't any longer.
-		return nil
-	}
+	// Don't verify the charm lxd profile, the watcher must be able to
+	// determine if a profile has been removed from the charm.
 
 	application, err := api.backend.Application(args.ApplicationName)
 	if err != nil {

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -165,7 +165,7 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 				},
 				Actions: &params.CharmActions{},
 				LXDProfile: &params.CharmLXDProfile{
-					Description: "lxd profile for testing, black list items grouped commented out",
+					Description: "lxd profile for testing, will pass validation",
 					Config: map[string]string{
 						"security.nesting":       "true",
 						"security.privileged":    "true",
@@ -183,8 +183,11 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 							"productid": "51da",
 						},
 						"bdisk": {
-							"type":   "unix-block",
 							"source": "/dev/loop0",
+							"type":   "unix-block",
+						},
+						"gpu": {
+							"type": "gpu",
 						},
 					},
 				},

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1383,3 +1383,32 @@ type UpgradeSeriesUnitsResult struct {
 	Error     *Error   `json:"error,omitempty"`
 	UnitNames []string `json:"unit-names"`
 }
+
+type ProfileChangeResult struct {
+	OldProfileName string           `json:"old-profile-name,omitempty"`
+	NewProfileName string           `json:"new-profile-name,omitempty"`
+	Profile        *CharmLXDProfile `json:"profile,omitempty"`
+	Error          *Error           `json:"error,omitempty"`
+}
+
+type ProfileChangeResults struct {
+	Results []ProfileChangeResult `json:"results"`
+}
+
+type SetProfileArgs struct {
+	Args []SetProfileArg `json:"args"`
+}
+
+type SetProfileArg struct {
+	Entity   Entity   `json:"entity"`
+	Profiles []string `json:"profiles"`
+}
+
+type SetProfileUpgradeCompleteArgs struct {
+	Args []SetProfileUpgradeCompleteArg `json:"args"`
+}
+
+type SetProfileUpgradeCompleteArg struct {
+	Entity  Entity `json:"entity"`
+	Message string `json:"message"`
+}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -275,11 +275,14 @@ var (
 					"security.nesting":       "true",
 					"security.privileged":    "true",
 				},
-				"description": "lxd profile for testing, black list items grouped commented out",
+				"description": "lxd profile for testing, will pass validation",
 				"devices": M{
 					"bdisk": M{
 						"source": "/dev/loop0",
 						"type":   "unix-block",
+					},
+					"gpu": M{
+						"type": "gpu",
 					},
 					"sony": M{
 						"productid": "51da",

--- a/container/interface.go
+++ b/container/interface.go
@@ -84,6 +84,13 @@ type LXDProfileManager interface {
 	// MaybeWriteLXDProfile, write given LXDProfile to machine if not already
 	// there.
 	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
+
+	// ReplaceOrAddInstanceProfile replaces, adds, a charm profile to
+	// the given instance and returns a slice of LXD profiles applied
+	// to the instance. Replace happens inplace in the current order of
+	// applied profiles. If the LXDProfile ptr is nil, replace becomes
+	// remove.
+	ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error)
 }
 
 // LXDProfileNameRetriever defines an interface for dealing with lxd profile

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -594,3 +594,56 @@ func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 	err := proMgr.MaybeWriteLXDProfile("juju-default-lxd-0", &put)
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServer(ctrl)
+	// Operation arrangements.
+	updateOp := lxdtesting.NewMockOperation(ctrl)
+	updateOp.EXPECT().Wait().Return(nil)
+	updateOp.EXPECT().Get().Return(lxdapi.Operation{Description: "Updating ontainer"})
+
+	instId := "testme"
+	old := "old-profile"
+	oldProfiles := []string{"default", "juju-default", old}
+	new := "new-profile"
+	newProfiles := []string{"default", "juju-default", new}
+	put := charm.LXDProfile{
+		Config: map[string]string{
+			"security.nesting": "true",
+		},
+		Description: "test profile",
+	}
+	post := lxdapi.ProfilesPost{
+		ProfilePut: lxdapi.ProfilePut(put),
+		Name:       new,
+	}
+	cExp := cSvr.EXPECT()
+	gomock.InOrder(
+		cExp.GetProfileNames().Return(oldProfiles, nil),
+		cExp.CreateProfile(post).Return(nil),
+		cExp.GetContainer(instId).Return(
+			&lxdapi.Container{
+				ContainerPut: lxdapi.ContainerPut{
+					Profiles: oldProfiles,
+				},
+			}, "", nil),
+		cExp.UpdateContainer(instId, gomock.Any(), gomock.Any()).Return(updateOp, nil),
+		cExp.DeleteProfile(old).Return(nil),
+		cExp.GetContainer(instId).Return(
+			&lxdapi.Container{
+				ContainerPut: lxdapi.ContainerPut{
+					Profiles: newProfiles,
+				},
+			}, "", nil),
+	)
+
+	mgr := s.makeManager(c, cSvr)
+	proMgr, ok := mgr.(container.LXDProfileManager)
+	c.Assert(ok, jc.IsTrue)
+
+	obtained, err := proMgr.ReplaceOrAddInstanceProfile(instId, old, new, &put)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.DeepEquals, newProfiles)
+}

--- a/container/testing/interface_mock.go
+++ b/container/testing/interface_mock.go
@@ -125,3 +125,16 @@ func (m *MockTestLXDManager) Namespace() instance.Namespace {
 func (mr *MockTestLXDManagerMockRecorder) Namespace() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockTestLXDManager)(nil).Namespace))
 }
+
+// ReplaceOrAddInstanceProfile mocks base method
+func (m *MockTestLXDManager) ReplaceOrAddInstanceProfile(arg0, arg1, arg2 string, arg3 *charm_v6.LXDProfile) ([]string, error) {
+	ret := m.ctrl.Call(m, "ReplaceOrAddInstanceProfile", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReplaceOrAddInstanceProfile indicates an expected call of ReplaceOrAddInstanceProfile
+func (mr *MockTestLXDManagerMockRecorder) ReplaceOrAddInstanceProfile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddInstanceProfile", reflect.TypeOf((*MockTestLXDManager)(nil).ReplaceOrAddInstanceProfile), arg0, arg1, arg2, arg3)
+}

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -1,9 +1,10 @@
-// Copyright 2016 Canonical Ltd.
+// Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package lxdprofile_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/lxdprofile"
@@ -71,7 +72,7 @@ func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
 		},
 	}
 	for k, tc := range testCases {
-		c.Logf("running test %d with input %s", k, tc.input)
+		c.Logf("running test %d with input %q", k, tc.input)
 		c.Assert(lxdprofile.LXDProfileNames(tc.input), gc.DeepEquals, tc.output)
 	}
 }
@@ -103,7 +104,151 @@ func (*LXDProfileNameSuite) TestIsValidName(c *gc.C) {
 		},
 	}
 	for k, tc := range testCases {
-		c.Logf("running test %d with input %s", k, tc.input)
+		c.Logf("running test %d with input %q", k, tc.input)
 		c.Assert(lxdprofile.IsValidName(tc.input), gc.Equals, tc.output)
+	}
+}
+
+func (*LXDProfileNameSuite) TestProfileRevision(c *gc.C) {
+	testCases := []struct {
+		input  string
+		output int
+		err    string
+	}{
+		{
+			input: "",
+			err:   "not a juju profile name: \"\"",
+		},
+		{
+			input: "default",
+			err:   "not a juju profile name: \"default\"",
+		},
+		{
+			input: "juju-model",
+			err:   "not a juju profile name: \"juju-model\"",
+		},
+		{
+			input:  lxdprofile.Name("foo", "bar", 1),
+			output: 1,
+		},
+		{
+			input:  lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 100),
+			output: 100,
+		},
+	}
+	for k, tc := range testCases {
+		c.Logf("running test %d of %d with input %q", k, len(testCases), tc.input)
+		obtained, err := lxdprofile.ProfileRevision(tc.input)
+		if tc.err != "" {
+			c.Assert(err, gc.ErrorMatches, tc.err)
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(obtained, gc.Equals, tc.output)
+	}
+}
+
+func (*LXDProfileNameSuite) TestProfileReplaceRevision(c *gc.C) {
+	testCases := []struct {
+		input    string
+		inputRev int
+		output   string
+		err      string
+	}{
+		{
+			input: "",
+			err:   "not a juju profile name: \"\"",
+		},
+		{
+			input: "default",
+			err:   "not a juju profile name: \"default\"",
+		},
+		{
+			input: "juju-model",
+			err:   "not a juju profile name: \"juju-model\"",
+		},
+		{
+			input:    lxdprofile.Name("foo", "bar", 1),
+			inputRev: 4,
+			output:   lxdprofile.Name("foo", "bar", 4),
+		},
+		{
+			input:    lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 123),
+			inputRev: 312,
+			output:   lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 312),
+		},
+	}
+	for k, tc := range testCases {
+		c.Logf("running test %d of %d with input %q", k, len(testCases), tc.input)
+		obtained, err := lxdprofile.ProfileReplaceRevision(tc.input, tc.inputRev)
+		if tc.err != "" {
+			c.Assert(err, gc.ErrorMatches, tc.err)
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(obtained, gc.Equals, tc.output)
+	}
+}
+
+func (*LXDProfileNameSuite) TestMatchProfileNameByAppName(c *gc.C) {
+	testCases := []struct {
+		input    []string
+		inputApp string
+		output   string
+		err      string
+	}{
+		{
+			input:    []string{},
+			inputApp: "",
+			err:      "no application name specified",
+		},
+		{
+			input:    []string{"default"},
+			inputApp: "one",
+			output:   "",
+		},
+		{
+			input:    []string{"default", "juju-model"},
+			inputApp: "one",
+			output:   "",
+		},
+		{
+			input: []string{
+				"default",
+				"juju-model",
+				lxdprofile.Name("foo", "bar", 2),
+			},
+			inputApp: "bar",
+			output:   lxdprofile.Name("foo", "bar", 2),
+		},
+		{
+			input: []string{
+				"default",
+				"juju-model",
+				lxdprofile.Name("foo", "nonebar", 2),
+				lxdprofile.Name("foo", "bar", 2),
+			},
+			inputApp: "bar",
+			output:   lxdprofile.Name("foo", "bar", 2),
+		},
+		{
+			input: []string{
+				"default",
+				"juju-model",
+				lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 123),
+			},
+			inputApp: "b312--?123!!bb-x__xx-012-y123yy",
+			output:   lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 123),
+		},
+	}
+	for k, tc := range testCases {
+		c.Logf("running test %d of %d with input %q", k, len(testCases), tc.input)
+		obtained, err := lxdprofile.MatchProfileNameByAppName(tc.input, tc.inputApp)
+		if tc.err != "" {
+			c.Assert(err, gc.ErrorMatches, tc.err)
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(obtained, gc.Equals, tc.output)
 	}
 }

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -170,4 +170,11 @@ type LXDProfiler interface {
 
 	// LXDProfileNames returns all the profiles associated to a container name
 	LXDProfileNames(containerName string) ([]string, error)
+
+	// ReplaceOrAddInstanceProfile replaces, adds, a charm profile to
+	// the given instance and returns a slice of LXD profiles applied
+	// to the instance. Replace happens inplace in the current order of
+	// applied profiles. If the LXDProfile ptr is nil, replace becomes
+	// remove.
+	ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error)
 }

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -54,6 +54,8 @@ type Server interface {
 	GetContainerProfiles(string) ([]string, error)
 	HasProfile(string) (bool, error)
 	CreateProfile(post lxdapi.ProfilesPost) (err error)
+	DeleteProfile(string) (err error)
+	ReplaceOrAddContainerProfile(string, string, string) error
 	VerifyNetworkDevice(*lxdapi.Profile, string) error
 	EnsureDefaultStorage(*lxdapi.Profile, string) error
 	StorageSupported() bool

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -160,6 +160,18 @@ func (mr *MockServerMockRecorder) DeleteCertificate(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCertificate", reflect.TypeOf((*MockServer)(nil).DeleteCertificate), arg0)
 }
 
+// DeleteProfile mocks base method
+func (m *MockServer) DeleteProfile(arg0 string) error {
+	ret := m.ctrl.Call(m, "DeleteProfile", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteProfile indicates an expected call of DeleteProfile
+func (mr *MockServerMockRecorder) DeleteProfile(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfile", reflect.TypeOf((*MockServer)(nil).DeleteProfile), arg0)
+}
+
 // DeleteStoragePoolVolume mocks base method
 func (m *MockServer) DeleteStoragePoolVolume(arg0, arg1, arg2 string) error {
 	ret := m.ctrl.Call(m, "DeleteStoragePoolVolume", arg0, arg1, arg2)
@@ -458,6 +470,18 @@ func (m *MockServer) RemoveContainers(arg0 []string) error {
 // RemoveContainers indicates an expected call of RemoveContainers
 func (mr *MockServerMockRecorder) RemoveContainers(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainers", reflect.TypeOf((*MockServer)(nil).RemoveContainers), arg0)
+}
+
+// ReplaceOrAddContainerProfile mocks base method
+func (m *MockServer) ReplaceOrAddContainerProfile(arg0, arg1, arg2 string) error {
+	ret := m.ctrl.Call(m, "ReplaceOrAddContainerProfile", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReplaceOrAddContainerProfile indicates an expected call of ReplaceOrAddContainerProfile
+func (mr *MockServerMockRecorder) ReplaceOrAddContainerProfile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddContainerProfile", reflect.TypeOf((*MockServer)(nil).ReplaceOrAddContainerProfile), arg0, arg1, arg2)
 }
 
 // ServerCertificate mocks base method

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -533,9 +533,19 @@ func (conn *StubClient) GetContainerProfiles(name string) ([]string, error) {
 	}, conn.NextErr()
 }
 
+func (conn *StubClient) DeleteProfile(name string) error {
+	conn.AddCall("DeleteProfile", name)
+	return conn.NextErr()
+}
+
 func (conn *StubClient) HasProfile(name string) (bool, error) {
 	conn.AddCall("HasProfile", name)
 	return false, conn.NextErr()
+}
+
+func (conn *StubClient) ReplaceOrAddContainerProfile(name, oldProfile, newProfile string) error {
+	conn.AddCall("ReplaceOrAddContainerProfile", name, oldProfile, newProfile)
+	return conn.NextErr()
 }
 
 func (conn *StubClient) VerifyNetworkDevice(profile *api.Profile, ETag string) error {

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -843,7 +843,7 @@ func (s *CharmTestHelperSuite) TestLXDProfileCharm(c *gc.C) {
 			"linux.kernel_modules":   "openvswitch,nbd,ip_tables,ip6_tables",
 			"environment.http_proxy": "",
 		},
-		Description: "lxd profile for testing, black list items grouped commented out",
+		Description: "lxd profile for testing, will pass validation",
 		Devices: map[string]map[string]string{
 			"tun": {
 				"path": "/dev/net/tun",
@@ -857,6 +857,9 @@ func (s *CharmTestHelperSuite) TestLXDProfileCharm(c *gc.C) {
 			"bdisk": {
 				"source": "/dev/loop0",
 				"type":   "unix-block",
+			},
+			"gpu": {
+				"type": "gpu",
 			},
 		},
 	})

--- a/state/machine.go
+++ b/state/machine.go
@@ -150,6 +150,10 @@ type machineDoc struct {
 	// upgrade event with a charm profile.  This is used before the application
 	// contains the new charm URL during a charm upgrade.
 	UpgradeCharmProfileCharmURL string `bson:",omitempty"`
+
+	// UpgradeCharmProfileComplete holds the outcome of charm upgrade event
+	// with a charm profile in play.  Success, Not Required or the Error.
+	UpgradeCharmProfileComplete string `bson:",omitempty"`
 }
 
 func newMachine(st *State, doc *machineDoc) *Machine {
@@ -182,6 +186,29 @@ func (m *Machine) Series() string {
 // ContainerType returns the type of container hosting this machine.
 func (m *Machine) ContainerType() instance.ContainerType {
 	return instance.ContainerType(m.doc.ContainerType)
+}
+
+// UpgradeCharmProfileApplication returns the replacement profile application name for the machine.
+func (m *Machine) UpgradeCharmProfileApplication() string {
+	return m.doc.UpgradeCharmProfileApplication
+}
+
+// UpgradeCharmProfileCharmURL returns the charm url for the replacement profile for the machine.
+func (m *Machine) UpgradeCharmProfileCharmURL() string {
+	return m.doc.UpgradeCharmProfileCharmURL
+}
+
+// UpgradeCharmProfileComplete returns the charm upgrade with profile completion message
+func (m *Machine) UpgradeCharmProfileComplete() string {
+	return m.doc.UpgradeCharmProfileComplete
+}
+
+func (m *Machine) ModelName() string {
+	name, err := m.st.modelName()
+	if err != nil {
+		logger.Errorf(err.Error())
+	}
+	return name
 }
 
 // machineGlobalKey returns the global database key for the identified machine.
@@ -2151,6 +2178,35 @@ func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
 	}
 	m.doc.UpgradeCharmProfileApplication = appName
 	m.doc.UpgradeCharmProfileCharmURL = chURL
+	return nil
+}
+
+func (m *Machine) SetUpgradeCharmProfileComplete(msg string) error {
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := m.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		life := m.Life()
+		if life == Dead || life == Dying {
+			return nil, ErrDead
+		}
+
+		ops := []txn.Op{{
+			C:      machinesC,
+			Id:     m.doc.DocID,
+			Assert: bson.D{{"life", Alive}},
+			Update: bson.D{{"$set", bson.D{{"upgradecharmprofilecomplete", msg}}}},
+		}}
+
+		return ops, nil
+	}
+	err := m.st.db().Run(buildTxn)
+	if err != nil {
+		return err
+	}
+	m.doc.UpgradeCharmProfileComplete = msg
 	return nil
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -144,6 +144,25 @@ func (s *MachineSuite) TestSetCharmProfile(c *gc.C) {
 	c.Assert(expectedProfiles, jc.SameContents, obtainedProfiles)
 }
 
+func (s *MachineSuite) TestSetUpgradeCharmProfile(c *gc.C) {
+	err := s.machine.SetUpgradeCharmProfile("app-name", "local:quantal/riak-7")
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Machine(s.machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.UpgradeCharmProfileApplication(), gc.Equals, "app-name")
+	c.Assert(m.UpgradeCharmProfileCharmURL(), gc.Equals, "local:quantal/riak-7")
+}
+
+func (s *MachineSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
+	err := s.machine.SetUpgradeCharmProfileComplete("success")
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Machine(s.machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, "success")
+}
+
 func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -316,10 +316,10 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 		// Ignored at this stage, could be an issue if mongo 3.0 isn't
 		// available.
 		"StopMongoUntilVersion",
-		// Ignore at this stage.  Depends on how we handle the machine charm
-		// profile watcher if this is a good idea.
+		// These items are transient data, so no need to save for model migrations.
 		"UpgradeCharmProfileApplication",
 		"UpgradeCharmProfileCharmURL",
+		"UpgradeCharmProfileComplete",
 	)
 	migrated := set.NewStrings(
 		"Addresses",

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -890,9 +890,10 @@ func (w *modelCharmProfileChangeWatcher) merge(machineIds set.Strings, change wa
 	if err := newMachines.FindId(change.Id).One(&doc); err != nil {
 		return err
 	}
-	profileApplication, _ := w.known[machineId]
+	charmProfileURL, isKnown := w.known[machineId]
 	w.known[machineId] = doc.UpgradeCharmProfileCharmURL
-	if doc.UpgradeCharmProfileCharmURL != profileApplication {
+	// only report changes, not new machines
+	if isKnown && doc.UpgradeCharmProfileCharmURL != charmProfileURL {
 		machineIds.Add(machineId)
 	}
 	return nil

--- a/testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml
@@ -1,23 +1,10 @@
-#name: juju-default
-description: lxd profile for testing, black list items grouped commented out
+description: lxd profile for testing, will pass validation
 config:
-#
-# allowed config
-#
   security.nesting: "true"
   security.privileged: "true"
   linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
   environment.http_proxy: ""
-#
-# blacklisted config
-#
-# boot.autostart: "true"
-# limits.... 
-# migration... 
 devices:
-#
-# allowed devices
-#
   tun:
     path: /dev/net/tun
     type: unix-char
@@ -28,19 +15,5 @@ devices:
   bdisk:
     type: unix-block
     source: /dev/loop0
-# gpu fails if not on a box where available.
-# gpu:
-#   type: gpu
-#
-# blacklisted devices
-#
-# eth0:
-#   mtu: "9000"
-#   name: eth0
-#   nictype: bridged
-#   parent: lxdbr0
-#   type: nic
-# root:
-#   path: /
-#   type: disk
-#   pool: default
+  gpu:
+    type: gpu


### PR DESCRIPTION
## Description of change

During charm upgrade steps: update the lxd profile from the charm for an lxd machine; add an lxd profile to an lxd machine if profile new to charm.

## QA steps
`export JUJU_DEV_FEATURE_FLAGS=lxd-profile`
1. `juju bootstrap localhost --build-agent`
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-profile-local`
3. `juju add-unit  lxd-profile-local --to lxd`
3. notice `lxc profile juju-default-lxd-profile-local-0` created and used
4. `juju upgrade-charm lxd-profile-local --path  ./testcharms/charm-repo/quantal/lxd-profile`
5. notice `lxc profile juju-default-lxd-profile-local-0` deleted; `juju-default-lxd-profile-local-0` created and now used.
6. `rm ./testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml`
7. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-local`
8. notice `lxc profile juju-default-lxd-local-0` does not exist
9. replace `./testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml`
10. `juju upgrade-charm lxd-local --path  ./testcharms/charm-repo/quantal/lxd-profile`
8. notice `lxc profile juju-default-lxd-local-1` exists and is used.