### PR TITLE
add-model error when passed nonexistent cloud

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -227,9 +227,6 @@ func (api *CloudAPI) Cloud(args params.Entities) (params.CloudResults, error) {
 	}
 	for i, arg := range args.Entities {
 		cloud, err := one(arg)
-		if errors.IsNotFound(err) {
-			continue
-		}
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 		} else {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -112,6 +112,17 @@ func (s *cloudSuite) TestCloud(c *gc.C) {
 	})
 }
 
+func (s *cloudSuite) TestCloudNotFound(c *gc.C) {
+	s.backend.SetErrors(errors.NotFoundf("cloud \"no-dice\""))
+	s.setTestAPIForUser(c, names.NewUserTag("admin"))
+	results, err := s.api.Cloud(params.Entities{
+		Entities: []params.Entity{{Tag: "cloud-no-dice"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, "cloud \"no-dice\" not found")
+}
+
 func (s *cloudSuite) TestClouds(c *gc.C) {
 	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
 	s.ctlrBackend.cloudAccess = permission.AddModelAccess


### PR DESCRIPTION
## Description of change

Fix the issue when passing the ```add-model``` command a cloud argument that doesn't exist resulting in a nil deference panic.

## QA steps

  - Bootstrap using juju built from develop (or use existing controller)
  - Run: ```juju add-model test this-doesnt-exist```
  - Observe panic

## Documentation changes

N/A

## Bug reference

N/A