### PR TITLE
LXD: Container instanceData missing lxd-profiles data

### DIFF
--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -136,6 +137,7 @@ type context struct {
 	pingers       map[string]*presence.Pinger
 	adminUserTag  string // A string repr of the tag.
 	expectIsoTime bool
+	skipTest      bool
 }
 
 func (ctx *context) reset(c *gc.C) {
@@ -147,6 +149,10 @@ func (ctx *context) reset(c *gc.C) {
 
 func (ctx *context) run(c *gc.C, steps []stepper) {
 	for i, s := range steps {
+		if ctx.skipTest {
+			c.Logf("skipping test %d", i)
+			return
+		}
 		c.Logf("step %d", i)
 		c.Logf("%#v", s)
 		s.step(c, ctx)
@@ -3388,7 +3394,8 @@ var statusTests = []testCase{
 		},
 	),
 	test( // 27
-		"application with local charm and lxd profiles",
+		"application with lxd profiles",
+		skipTestOnWindows{},
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
 		startAliveMachine{"0"},
@@ -3533,6 +3540,15 @@ func wordpressCharm(extras M) M {
 }
 
 // TODO(dfc) test failing components by destructively mutating the state under the hood
+
+// sometimes you just need to skip the tests for windows (environment variables etc)
+type skipTestOnWindows struct{}
+
+func (skipTestOnWindows) step(c *gc.C, ctx *context) {
+	if runtime.GOOS == "windows" {
+		ctx.skipTest = true
+	}
+}
 
 type setSLA struct {
 	level string

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -3395,6 +3395,8 @@ var statusTests = []testCase{
 	),
 	test( // 27
 		"application with lxd profiles",
+		// TODO (simon): remove skipTestOnWindows when we remove the feature
+		// flag for lxd profile - featureflag.LXDProfile
 		skipTestOnWindows{},
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},

--- a/container/interface.go
+++ b/container/interface.go
@@ -91,5 +91,5 @@ type LXDProfileManager interface {
 type LXDProfileNameRetriever interface {
 	// LXDProfileNames returns the list of available LXDProfile names from the
 	// manager.
-	LXDProfileNames() ([]string, error)
+	LXDProfileNames(string) ([]string, error)
 }

--- a/container/interface.go
+++ b/container/interface.go
@@ -81,6 +81,15 @@ func (m ManagerConfig) WarnAboutUnused() {
 // LXDProfileManager defines an interface for dealing with lxd profiles used to
 // deploy juju containers.
 type LXDProfileManager interface {
-	// MaybeWriteLXDProfile, write given LXDProfile to machine if not already there.
+	// MaybeWriteLXDProfile, write given LXDProfile to machine if not already
+	// there.
 	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
+}
+
+// LXDProfileNameRetriever defines an interface for dealing with lxd profile
+// names used to deploy juju containers.
+type LXDProfileNameRetriever interface {
+	// LXDProfileNames returns the list of available LXDProfile names from the
+	// manager.
+	LXDProfileNames() ([]string, error)
 }

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -309,6 +309,6 @@ func (m *containerManager) MaybeWriteLXDProfile(pName string, put *charm.LXDProf
 }
 
 // LXDProfileNames implements container.LXDProfileManager
-func (m *containerManager) LXDProfileNames() ([]string, error) {
-	return m.server.GetProfileNames()
+func (m *containerManager) LXDProfileNames(containerName string) ([]string, error) {
+	return m.server.GetContainerProfiles(containerName)
 }

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -307,3 +307,8 @@ func (m *containerManager) MaybeWriteLXDProfile(pName string, put *charm.LXDProf
 	logger.Debugf("wrote lxd profile %q", pName)
 	return nil
 }
+
+// LXDProfileNames implements container.LXDProfileManager
+func (m *containerManager) LXDProfileNames() ([]string, error) {
+	return m.server.GetProfileNames()
+}

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -158,6 +158,16 @@ func (s *Server) UpdateContainerConfig(name string, cfg map[string]string) error
 	return errors.Trace(resp.Wait())
 }
 
+// GetContainerProfiles returns the list of profiles that are assocated with a
+// container.
+func (s *Server) GetContainerProfiles(name string) ([]string, error) {
+	container, _, err := s.GetContainer(name)
+	if err != nil {
+		return []string{}, errors.Trace(err)
+	}
+	return container.Profiles, nil
+}
+
 // CreateClientCertificate adds the input certificate to the server,
 // indicating that is for use in client communication.
 func (s *Server) CreateClientCertificate(cert *Certificate) error {

--- a/container/test_interface.go
+++ b/container/test_interface.go
@@ -9,4 +9,5 @@ package container
 type TestLXDManager interface {
 	Manager
 	LXDProfileManager
+	LXDProfileNameRetriever
 }

--- a/container/testing/interface_mock.go
+++ b/container/testing/interface_mock.go
@@ -76,6 +76,19 @@ func (mr *MockTestLXDManagerMockRecorder) IsInitialized() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInitialized", reflect.TypeOf((*MockTestLXDManager)(nil).IsInitialized))
 }
 
+// LXDProfileNames mocks base method
+func (m *MockTestLXDManager) LXDProfileNames(arg0 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LXDProfileNames indicates an expected call of LXDProfileNames
+func (mr *MockTestLXDManagerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockTestLXDManager)(nil).LXDProfileNames), arg0)
+}
+
 // ListContainers mocks base method
 func (m *MockTestLXDManager) ListContainers() ([]instance.Instance, error) {
 	ret := m.ctrl.Call(m, "ListContainers")

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -6,6 +6,7 @@ package lxdprofile
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/juju/juju/juju/names"
@@ -29,7 +30,7 @@ func LXDProfileNames(names []string) []string {
 	// ensure that the ones we have are unique
 	unique := make(map[string]int)
 	for k, v := range names {
-		if !strings.HasPrefix(v, Prefix) {
+		if !IsValidName(v) {
 			continue
 		}
 		unique[v] = k
@@ -51,6 +52,24 @@ func LXDProfileNames(names []string) []string {
 		ordered[k] = v.Name
 	}
 	return ordered
+}
+
+// IsValidName returns if the name of the lxd profile looks valid.
+func IsValidName(name string) bool {
+	// doesn't contain the prefix
+	if !strings.HasPrefix(name, Prefix) {
+		return false
+	}
+	// it's required to have at least the following chars `x-x-0`
+	suffix := name[len(Prefix):]
+	if len(suffix) < 5 {
+		return false
+	}
+	// lastly check the last part is a number
+	lastHyphen := strings.LastIndex(suffix, "-")
+	revision := suffix[lastHyphen+1:]
+	_, err := strconv.Atoi(revision)
+	return err == nil
 }
 
 type nameIndex struct {

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -1,32 +1,35 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package lxdprofile
 
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/juju/juju/juju/names"
 )
 
+// Prefix is used to prefix all the lxd profile programmable profiles. If a
+// profile doesn't have the prefix, then it will be removed when ensuring the
+// the validity of the names (see LXDProfileNames)
+var Prefix = fmt.Sprintf("%s-", names.Juju)
+
 // Name returns a serialisable name that we can use to identify profiles
 // juju-<model>-<application>-<charm-revision>
 func Name(modelName, appName string, revision int) string {
-	return fmt.Sprintf("%s-%s-%s-%d", names.Juju, modelName, appName, revision)
+	return fmt.Sprintf("%s%s-%s-%d", Prefix, modelName, appName, revision)
 }
 
-var defaultLXDProfileNames = []string{
-	"default",
-}
-
-// LXDProfileNames ensures that the LXD profile names are unique and are sorted
-// correctly. It removes certain profile names from the list, for example
-// "default" profile name will be removed.
-//
-// The function aims to preserve the order from which it got the results from.
+// LXDProfileNames ensures that the LXD profile names are unique yet preserve
+// the same order as the input. It removes certain profile names from the list,
+// for example "default" profile name will be removed.
 func LXDProfileNames(names []string) []string {
 	// ensure that the ones we have are unique
 	unique := make(map[string]int)
 	for k, v := range names {
-		if contains(defaultLXDProfileNames, v) {
+		if !strings.HasPrefix(v, Prefix) {
 			continue
 		}
 		unique[v] = k

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -22,7 +22,7 @@ var defaultLXDProfileNames = []string{
 // "default" profile name will be removed.
 //
 // The function aims to preserve the order from which it got the results from.
-func LXDProfilesNames(names []string) []string {
+func LXDProfileNames(names []string) []string {
 	// ensure that the ones we have are unique
 	unique := make(map[string]int)
 	for k, v := range names {

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -2,6 +2,7 @@ package lxdprofile
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/juju/juju/juju/names"
 )
@@ -10,4 +11,55 @@ import (
 // juju-<model>-<application>-<charm-revision>
 func Name(modelName, appName string, revision int) string {
 	return fmt.Sprintf("%s-%s-%s-%d", names.Juju, modelName, appName, revision)
+}
+
+var defaultLXDProfileNames = []string{
+	"default",
+}
+
+// LXDProfileNames ensures that the LXD profile names are unique and are sorted
+// correctly. It removes certain profile names from the list, for example
+// "default" profile name will be removed.
+//
+// The function aims to preserve the order from which it got the results from.
+func LXDProfilesNames(names []string) []string {
+	// ensure that the ones we have are unique
+	unique := make(map[string]int)
+	for k, v := range names {
+		if contains(defaultLXDProfileNames, v) {
+			continue
+		}
+		unique[v] = k
+	}
+	i := 0
+	unordered := make([]nameIndex, len(unique))
+	for k, v := range unique {
+		unordered[i] = nameIndex{
+			Name:  k,
+			Index: v,
+		}
+		i++
+	}
+	sort.Slice(unordered, func(i, j int) bool {
+		return unordered[i].Index < unordered[j].Index
+	})
+	ordered := make([]string, len(unordered))
+	for k, v := range unordered {
+		ordered[k] = v.Name
+	}
+	return ordered
+}
+
+type nameIndex struct {
+	Name  string
+	Index int
+}
+
+func contains(a []string, b string) bool {
+	for _, v := range a {
+		if v == b {
+			return true
+		}
+	}
+	return false
 }

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -31,6 +31,13 @@ func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
 		},
 		{
 			input: []string{
+				"default",
+				"juju-model",
+			},
+			output: []string{},
+		},
+		{
+			input: []string{
 				lxdprofile.Name("foo", "bar", 1),
 			},
 			output: []string{
@@ -66,5 +73,37 @@ func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
 	for k, tc := range testCases {
 		c.Logf("running test %d with input %s", k, tc.input)
 		c.Assert(lxdprofile.LXDProfileNames(tc.input), gc.DeepEquals, tc.output)
+	}
+}
+
+func (*LXDProfileNameSuite) TestIsValidName(c *gc.C) {
+	testCases := []struct {
+		input  string
+		output bool
+	}{
+		{
+			input:  "",
+			output: false,
+		},
+		{
+			input:  "default",
+			output: false,
+		},
+		{
+			input:  "juju-model",
+			output: false,
+		},
+		{
+			input:  lxdprofile.Name("foo", "bar", 1),
+			output: true,
+		},
+		{
+			input:  lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 100),
+			output: true,
+		},
+	}
+	for k, tc := range testCases {
+		c.Logf("running test %d with input %s", k, tc.input)
+		c.Assert(lxdprofile.IsValidName(tc.input), gc.Equals, tc.output)
 	}
 }

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -1,9 +1,13 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package lxdprofile_test
 
 import (
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/testing"
-	gc "gopkg.in/check.v1"
 )
 
 type LXDProfileNameSuite struct {
@@ -35,6 +39,7 @@ func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
 		},
 		{
 			input: []string{
+				"default",
 				lxdprofile.Name("foo", "bar", 1),
 				lxdprofile.Name("foo", "bar", 1),
 				lxdprofile.Name("aaa", "bbb", 100),
@@ -44,8 +49,22 @@ func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
 				lxdprofile.Name("aaa", "bbb", 100),
 			},
 		},
+		{
+			input: []string{
+				"default",
+				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("foo", "bar", 1),
+				"some-other-profile",
+				lxdprofile.Name("aaa", "bbb", 100),
+			},
+			output: []string{
+				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("aaa", "bbb", 100),
+			},
+		},
 	}
-	for _, tc := range testCases {
+	for k, tc := range testCases {
+		c.Logf("running test %d with input %s", k, tc.input)
 		c.Assert(lxdprofile.LXDProfileNames(tc.input), gc.DeepEquals, tc.output)
 	}
 }

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -1,0 +1,51 @@
+package lxdprofile_test
+
+import (
+	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type LXDProfileNameSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&LXDProfileNameSuite{})
+
+func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
+	testCases := []struct {
+		input  []string
+		output []string
+	}{
+		{
+			input:  []string{},
+			output: []string{},
+		},
+		{
+			input:  []string{"default"},
+			output: []string{},
+		},
+		{
+			input: []string{
+				lxdprofile.Name("foo", "bar", 1),
+			},
+			output: []string{
+				lxdprofile.Name("foo", "bar", 1),
+			},
+		},
+		{
+			input: []string{
+				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("aaa", "bbb", 100),
+			},
+			output: []string{
+				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("aaa", "bbb", 100),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		c.Assert(lxdprofile.LXDProfileNames(tc.input), gc.DeepEquals, tc.output)
+	}
+}

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -167,4 +167,7 @@ type InstanceBroker interface {
 type LXDProfiler interface {
 	// MaybeWriteLXDProfile, write given LXDProfile to if not already there.
 	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
+
+	// LXDProfileNames returns all the profiles associated to a container name
+	LXDProfileNames(containerName string) ([]string, error)
 }

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -314,3 +314,8 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 	logger.Debugf("wrote lxd profile %q", pName)
 	return nil
 }
+
+// MaybeWriteLXDProfile implements environs.LXDProfiler.
+func (env *environ) LXDProfileNames() ([]string, error) {
+	return env.server.GetProfileNames()
+}

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -315,7 +315,7 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 	return nil
 }
 
-// MaybeWriteLXDProfile implements environs.LXDProfiler.
+// LXDProfileNames implements environs.LXDProfiler.
 func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
 	return env.server.GetContainerProfiles(containerName)
 }

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -316,6 +316,6 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 }
 
 // MaybeWriteLXDProfile implements environs.LXDProfiler.
-func (env *environ) LXDProfileNames() ([]string, error) {
-	return env.server.GetProfileNames()
+func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
+	return env.server.GetContainerProfiles(containerName)
 }

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -6,7 +6,6 @@ package lxd_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/juju/core/lxdprofile"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/lxc/lxd/shared/api"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -51,7 +51,7 @@ type Server interface {
 	WriteContainer(*lxd.Container) error
 	CreateProfileWithConfig(string, map[string]string) error
 	GetProfile(string) (*lxdapi.Profile, string, error)
-	GetProfileNames() ([]string, error)
+	GetContainerProfiles(string) ([]string, error)
 	HasProfile(string) (bool, error)
 	CreateProfile(post lxdapi.ProfilesPost) (err error)
 	VerifyNetworkDevice(*lxdapi.Profile, string) error

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -51,6 +51,7 @@ type Server interface {
 	WriteContainer(*lxd.Container) error
 	CreateProfileWithConfig(string, map[string]string) error
 	GetProfile(string) (*lxdapi.Profile, string, error)
+	GetProfileNames() ([]string, error)
 	HasProfile(string) (bool, error)
 	CreateProfile(post lxdapi.ProfilesPost) (err error)
 	VerifyNetworkDevice(*lxdapi.Profile, string) error

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -267,6 +267,19 @@ func (mr *MockServerMockRecorder) GetConnectionInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionInfo", reflect.TypeOf((*MockServer)(nil).GetConnectionInfo))
 }
 
+// GetContainerProfiles mocks base method
+func (m *MockServer) GetContainerProfiles(arg0 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "GetContainerProfiles", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContainerProfiles indicates an expected call of GetContainerProfiles
+func (mr *MockServerMockRecorder) GetContainerProfiles(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfiles", reflect.TypeOf((*MockServer)(nil).GetContainerProfiles), arg0)
+}
+
 // GetNICsFromProfile mocks base method
 func (m *MockServer) GetNICsFromProfile(arg0 string) (map[string]map[string]string, error) {
 	ret := m.ctrl.Call(m, "GetNICsFromProfile", arg0)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -529,6 +529,7 @@ func (conn *StubClient) GetContainerProfiles(name string) ([]string, error) {
 	conn.AddCall("GetContainerProfiles", name)
 	return []string{
 		"default",
+		"juju-model-name",
 	}, conn.NextErr()
 }
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -525,6 +525,13 @@ func (conn *StubClient) GetProfile(name string) (*api.Profile, string, error) {
 	return conn.Profile, "etag", conn.NextErr()
 }
 
+func (conn *StubClient) GetContainerProfiles(name string) ([]string, error) {
+	conn.AddCall("GetContainerProfiles", name)
+	return []string{
+		"default",
+	}, conn.NextErr()
+}
+
 func (conn *StubClient) HasProfile(name string) (bool, error) {
 	conn.AddCall("HasProfile", name)
 	return false, conn.NextErr()

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -205,6 +205,14 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 	return names, nil
 }
 
+func (broker *lxdBroker) LXDProfileNames() ([]string, error) {
+	nameRetriever, ok := broker.manager.(container.LXDProfileNameRetriever)
+	if !ok {
+		return nil, nil
+	}
+	return nameRetriever.LXDProfileNames()
+}
+
 func (broker *lxdBroker) maybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
 	profileMgr, ok := broker.manager.(container.LXDProfileManager)
 	if !ok {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -184,6 +184,16 @@ func (broker *lxdBroker) MaintainInstance(ctx context.ProviderCallContext, args 
 	return err
 }
 
+// LXDProfileNames returns all the profiles for a container that the broker
+// currently is aware of.
+func (broker *lxdBroker) LXDProfileNames(containerName string) ([]string, error) {
+	nameRetriever, ok := broker.manager.(container.LXDProfileNameRetriever)
+	if !ok {
+		return make([]string, 0), nil
+	}
+	return nameRetriever.LXDProfileNames(containerName)
+}
+
 func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 	containerTag := names.NewMachineTag(machineID)
 	profileInfo, err := broker.api.GetContainerProfileInfo(containerTag)
@@ -203,14 +213,6 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 		names[i] = profile.Name
 	}
 	return names, nil
-}
-
-func (broker *lxdBroker) LXDProfileNames(containerName string) ([]string, error) {
-	nameRetriever, ok := broker.manager.(container.LXDProfileNameRetriever)
-	if !ok {
-		return make([]string, 0), nil
-	}
-	return nameRetriever.LXDProfileNames(containerName)
 }
 
 func (broker *lxdBroker) maybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -205,12 +205,12 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 	return names, nil
 }
 
-func (broker *lxdBroker) LXDProfileNames() ([]string, error) {
+func (broker *lxdBroker) LXDProfileNames(containerName string) ([]string, error) {
 	nameRetriever, ok := broker.manager.(container.LXDProfileNameRetriever)
 	if !ok {
-		return nil, nil
+		return make([]string, 0), nil
 	}
-	return nameRetriever.LXDProfileNames()
+	return nameRetriever.LXDProfileNames(containerName)
 }
 
 func (broker *lxdBroker) maybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -6,6 +6,8 @@ package provisioner_test
 import (
 	"runtime"
 
+	"github.com/juju/juju/core/lxdprofile"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -20,6 +22,7 @@ import (
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
@@ -280,4 +283,29 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.startInstance(c, broker, machineId)
+}
+
+func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfileReturnsLXDProfileNames(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	containerTag := names.NewMachineTag("1-lxd-0")
+
+	mockApi := mocks.NewMockAPICalls(ctrl)
+	mockManager := testing.NewMockTestLXDManager(ctrl)
+	mockManager.EXPECT().LXDProfileNames(containerTag.Id()).Return([]string{
+		lxdprofile.Name("foo", "bar", 1),
+	}, nil)
+
+	broker, err := provisioner.NewLXDBroker(
+		func(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error { return nil },
+		mockApi, mockManager, s.agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nameRetriever := broker.(container.LXDProfileNameRetriever)
+	profileNames, err := nameRetriever.LXDProfileNames(containerTag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(profileNames, jc.DeepEquals, []string{
+		lxdprofile.Name("foo", "bar", 1),
+	})
 }

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -6,8 +6,6 @@ package provisioner_test
 import (
 	"runtime"
 
-	"github.com/juju/juju/core/lxdprofile"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -24,6 +22,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/testing"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -10,9 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/container"
-	"github.com/juju/juju/core/lxdprofile"
-
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
@@ -26,8 +23,10 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/container"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/controller/authentication"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"


### PR DESCRIPTION
## Description of change

Retrieve LXD profile names for containers  …
The following commit attempts to get profile names from the LXD
server API. At the moment the LXD profiles are filtered to remove
default names from the raw source. All the names that are returned
from the server are kept in the same order as returned from the LXD
API.

**Note** as this is retrieving information directly from the LXD API 
server, and _then_ getting the information from the container, this 
can take some time to show up in the show-machine / status output.

I'm unsure if this is an actual issue, as if you really wanted to get the 
profile information, you can use the charm, or query directly the lxc
containers?

```sh
juju ssh 0
sudo su
lxc profile list
```

(assumes you're on machine 0, sudo is used to talk to the socket,
without the need of adding lxd group to the ubuntu user).

## QA steps

```sh
export JUJU_DEV_FEATURE_FLAGS=lxd-profile
juju bootstrap aws
juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-profile --to=lxd
juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt lxd-profile-alt --to=lxd:0
```

You should see the following output:

```sh
$ juju show-machine
model: default
machines:
  "0":
    juju-status:
      current: started
      since: 15 Oct 2018 17:30:31+01:00
      version: 2.5-beta1.1
    dns-name: 18.203.67.172
    ip-addresses:
    - 18.203.67.172
    - 172.31.26.111
    - 252.26.111.1
    instance-id: i-02eda457d116ffd26
    machine-status:
      current: running
      message: running
      since: 15 Oct 2018 17:29:20+01:00
    series: bionic
    network-interfaces:
      ens5:
        ip-addresses:
        - 172.31.26.111
        mac-address: 02:6b:b6:30:db:9a
        gateway: 172.31.16.1
        is-up: true
      fan-252:
        ip-addresses:
        - 252.26.111.1
        mac-address: da:d1:0a:53:a7:e8
        is-up: true
      lxdbr0:
        ip-addresses:
        - 10.196.114.1
        mac-address: 16:f4:12:cf:03:80
        is-up: true
    containers:
      0/lxd/0:
        juju-status:
          current: started
          since: 15 Oct 2018 17:33:24+01:00
          version: 2.5-beta1.1
        dns-name: 252.26.111.42
        ip-addresses:
        - 252.26.111.42
        instance-id: juju-841a33-0-lxd-0
        machine-status:
          current: running
          message: Container started
          since: 15 Oct 2018 17:31:53+01:00
        series: bionic
        hardware: availability-zone=eu-west-1a
        lxd-profiles:
          juju-default-lxd-profile-0:
            config:
              environment.http_proxy: ""
              linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
              security.nesting: "true"
              security.privileged: "true"
            description: lxd profile for testing, black list items grouped commented
              out
            devices:
              bdisk:
                source: /dev/loop0
                type: unix-block
              sony:
                productid: 51da
                type: usb
                vendorid: 0fce
              tun:
                path: /dev/net/tun
                type: unix-char
      0/lxd/1:
        juju-status:
          current: started
          since: 15 Oct 2018 17:33:33+01:00
          version: 2.5-beta1.1
        dns-name: 252.26.111.7
        ip-addresses:
        - 252.26.111.7
        instance-id: juju-841a33-0-lxd-1
        machine-status:
          current: running
          message: Container started
          since: 15 Oct 2018 17:31:53+01:00
        series: bionic
        hardware: availability-zone=eu-west-1a
        lxd-profiles:
          juju-default-lxd-profile-alt-0:
            config:
              environment.http_proxy: ""
              linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
              security.nesting: "true"
              security.privileged: "true"
            description: lxd profile for testing, black list items grouped commented
              out
            devices:
              bdisk:
                source: /dev/loop0
                type: unix-block
              sony:
                productid: 51da
                type: usb
                vendorid: 0fce
              tun:
                path: /dev/net/tun
                type: unix-char
    hardware: arch=amd64 cores=2 cpu-power=200 mem=1024M root-disk=8192M availability-zone=eu-west-1a
```
