### PR TITLE
Fix incorrect machine agent logging path.

### DIFF
--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -28,10 +28,18 @@ const (
 	cloudInitCfgDir
 )
 
+const (
+	// NixDataDir is location for agent binaries on *nix operating systems.
+	NixDataDir = "/var/lib/juju"
+
+	// NixDataDir is location for Juju logs on *nix operating systems.
+	NixLogDir = "/var/log"
+)
+
 var nixVals = map[osVarType]string{
 	tmpDir:               "/tmp",
-	logDir:               "/var/log",
-	dataDir:              "/var/lib/juju",
+	logDir:               NixLogDir,
+	dataDir:              NixDataDir,
 	storageDir:           "/var/lib/juju/storage",
 	confDir:              "/etc/juju",
 	jujuRun:              "/usr/bin/juju-run",

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -207,7 +207,7 @@ func (s *systemdServiceManager) CreateAgentConf(agentName string, dataDir string
 		kind,
 		name,
 		dataDir,
-		paths.MustSucceed(srvPath, fmt.Errorf("path %s does not exist", srvPath)))
+		srvPath)
 	return AgentConf(info, renderer), nil
 }
 
@@ -315,7 +315,7 @@ func startAgent(name string, kind AgentKind, dataDir string, series string) (err
 		kind,
 		name,
 		dataDir,
-		paths.MustSucceed(srvPath, fmt.Errorf("path %s does not exist", srvPath)),
+		srvPath,
 	)
 	conf := AgentConf(info, renderer)
 	svcName := serviceName(name)

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -202,12 +202,12 @@ func (s *systemdServiceManager) CreateAgentConf(agentName string, dataDir string
 		return common.Conf{}, errors.NewNotValid(nil, fmt.Sprintf("agent %q is neither a machine nor a unit", agentName))
 	}
 
+	srvPath := path.Join(paths.NixLogDir, "juju")
 	info := NewAgentInfo(
 		kind,
 		name,
 		dataDir,
-		paths.MustSucceed(paths.LogDir(series)),
-	)
+		paths.MustSucceed(srvPath, fmt.Errorf("path %s does not exist", srvPath)))
 	return AgentConf(info, renderer), nil
 }
 
@@ -310,11 +310,12 @@ func startAgent(name string, kind AgentKind, dataDir string, series string) (err
 	if err != nil {
 		return err
 	}
+	srvPath := path.Join(paths.NixLogDir, "juju")
 	info := NewAgentInfo(
 		kind,
 		name,
 		dataDir,
-		paths.MustSucceed(paths.LogDir(series)),
+		paths.MustSucceed(srvPath, fmt.Errorf("path %s does not exist", srvPath)),
 	)
 	conf := AgentConf(info, renderer)
 	svcName := serviceName(name)

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -195,11 +195,17 @@ func (s *agentConfSuite) TestFindAgentsFail(c *gc.C) {
 	c.Assert(unitAgents, jc.SameContents, s.unitNames)
 }
 
-func (s *agentConfSuite) TestCreateAgentConf(c *gc.C) {
+func (s *agentConfSuite) TestCreateAgentConfDesc(c *gc.C) {
 	conf, err := s.manager.CreateAgentConf("machine-2", s.dataDir, "xenial")
 	c.Assert(err, jc.ErrorIsNil)
 	// Spot check Conf
 	c.Assert(conf.Desc, gc.Equals, "juju agent for machine-2")
+}
+
+func (s *agentConfSuite) TestCreateAgentConfLogPath(c *gc.C) {
+	conf, err := s.manager.CreateAgentConf("machine-2", s.dataDir, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(conf.Logfile, gc.Equals, "/var/log/juju/machine-2.log")
 }
 
 func (s *agentConfSuite) TestCreateAgentConfFailAgentKind(c *gc.C) {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -44,6 +44,7 @@ var upgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.0.0"), stepsFor20()},
 		upgradeToVersion{version.MustParse("2.2.0"), stepsFor22()},
 		upgradeToVersion{version.MustParse("2.4.0"), stepsFor24()},
+		upgradeToVersion{version.MustParse("2.4.5"), stepsFor245()},
 	}
 	return steps
 }

--- a/upgrades/steps_245.go
+++ b/upgrades/steps_245.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/utils/series"
+
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/service/systemd"
+)
+
+// stepsFor245 returns upgrade steps for Juju 2.4.5
+func stepsFor245() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "update exec.start.sh log path if incorrect",
+			targets:     []Target{AllMachines},
+			run:         correctServiceFileLogPath,
+		},
+	}
+}
+
+// install the service files in Standard location - '/lib/systemd/system path.
+func correctServiceFileLogPath(context Context) error {
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		logger.Errorf("getting host series: %e", err)
+	}
+	initName, err := service.VersionInitSystem(hostSeries)
+	if err != nil {
+		logger.Errorf("unsuccessful checking init script for correct log path: %e", err)
+		return err
+	}
+	if initName != service.InitSystemSystemd {
+		return nil
+	}
+	// rewrite files to correct errors in previous upgrade step
+	sysdManager := service.NewSystemdServiceManager(systemd.IsRunning)
+	err = sysdManager.WriteServiceFile()
+	if err != nil {
+		logger.Errorf("rewriting service file: %e", err)
+		return err
+	}
+	return nil
+}

--- a/upgrades/steps_245_test.go
+++ b/upgrades/steps_245_test.go
@@ -20,7 +20,7 @@ type steps245Suite struct {
 
 var _ = gc.Suite(&steps245Suite{})
 
-func (s *steps245Suite) TestCorrectServiceFileLogPath(c *gc.C) {
-	step := findStep(c, v245, "update exec.start.sh log path if not correct")
+func (s *steps245Suite) TestCorrectServiceLogFilePath(c *gc.C) {
+	step := findStep(c, v245, "update exec.start.sh log path if incorrect")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.AllMachines})
 }

--- a/upgrades/steps_245_test.go
+++ b/upgrades/steps_245_test.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v245 = version.MustParse("2.4.5")
+
+type steps245Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps245Suite{})
+
+func (s *steps245Suite) TestCorrectServiceFileLogPath(c *gc.C) {
+	step := findStep(c, v245, "update exec.start.sh log path if not correct")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.AllMachines})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -654,7 +654,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"2.0.0", "2.2.0", "2.4.0",
+		"2.0.0", "2.2.0", "2.4.0", "2.4.5",
 	})
 }
 


### PR DESCRIPTION
## Description of change

`Juju` moves the library directory of juju `systemd` init scripts to a the standard location in a `2.4` upgrade step. This upgrade step, however, was writing the services start script with an incorrect logging path. This PR fixes the issue by introducing a `2.4.5` upgrade step which rewrites the files with the correct log path.

## QA steps

This issue only happens on upgrade in `2.4`, due to the error being in an upgrade step, as such we must reproduce the case by upgrading juju from `2.3` to `2.4`:

1. Boostrap with `Juju 2.3`
```bash
snap install juju --channel 2.3 --classic  # Please ensure you are using the right version
juju bootstrap <cloud> test
juju deploy ubuntu # Not strictly necessary since we could check the controller machine
```

2. Upgrade to `Juju 2.4` 
```bash
snap refresh juju --channel 2.4 --classic
juju upgrade-juju -m controller
juju upgrade-juju
```

3. Inspect the `exec-start.sh` to see that the bug has in fact been reproduced
```bash
juju ssh 0 'cat /lib/systemd/system/jujud-machine-0/exec-start.sh'
```
4. Install this PR version of `Juju` (so you get the fix) and upgrade
```bash
snap remove juju
cd <path to juju repo>
go install -v ./...
juju upgrade-juju -m controller --build agent # assuming, of course, you have this PR branch checkout out
juju upgrade-juju
```
6. Wait a few seconds for the files to be rewritten
```bash
juju ssh 0 'cat /lib/systemd/system/jujud-machine-0/exec-start.sh'
```

The script should be corrected and the services should still work.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1793284
