### PR TITLE
Verify copyright

### DIFF
--- a/api/charms/export_test.go
+++ b/api/charms/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package charms
 
 import "github.com/juju/juju/api/base"

--- a/api/uniter/cloud_native_test.go
+++ b/api/uniter/cloud_native_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package uniter_test
 
 import (

--- a/apiserver/common/firewall/firewall.go
+++ b/apiserver/common/firewall/firewall.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package firewall
 
 import (

--- a/apiserver/facades/client/application/trust.go
+++ b/apiserver/facades/client/application/trust.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package application
 
 import (

--- a/apiserver/stateauthenticator/modeluser.go
+++ b/apiserver/stateauthenticator/modeluser.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package stateauthenticator
 
 import (

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing
 
 import (

--- a/apiserver/testing/fakeapi_test.go
+++ b/apiserver/testing/fakeapi_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing_test
 
 import (

--- a/apiserver/testing/package_test.go
+++ b/apiserver/testing/package_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing_test
 
 import (

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package clientconfig
 
 import (

--- a/caas/kubernetes/clientconfig/types.go
+++ b/caas/kubernetes/clientconfig/types.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package clientconfig
 
 import (

--- a/cmd/juju/interact/errwriter.go
+++ b/cmd/juju/interact/errwriter.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package interact
 
 import (

--- a/cmd/juju/romulus/api.go
+++ b/cmd/juju/romulus/api.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package romulus
 
 import (

--- a/cmd/juju/user/logincontroller_test.go
+++ b/cmd/juju/user/logincontroller_test.go
@@ -1,3 +1,4 @@
+// Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package user_test

--- a/cmd/jujud/updateseries/package_test.go
+++ b/cmd/jujud/updateseries/package_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package updateseries
 
 import (

--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package modelcmd_test
 
 import (

--- a/container/kvm/libvirt/doc.go
+++ b/container/kvm/libvirt/doc.go
@@ -1,6 +1,7 @@
-// libvirt provides types and functions for interacting with libvirt in kvm
-// containers.
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
+// libvirt provides types and functions for interacting with libvirt in kvm
+// containers.
 
 package libvirt

--- a/container/kvm/libvirt/ssh_test.go
+++ b/container/kvm/libvirt/ssh_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package libvirt
 
 import (

--- a/container/lxd/testing/suite.go
+++ b/container/lxd/testing/suite.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing
 
 import (

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Canonical Ltd.
+// Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package lxdprofile

--- a/environs/manual/package_test.go
+++ b/environs/manual/package_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package manual_test
 
 import (

--- a/environs/manual/winrmprovisioner/provisioner_test.go
+++ b/environs/manual/winrmprovisioner/provisioner_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package winrmprovisioner_test
 
 import (

--- a/environs/manual/winrmprovisioner/winrmprovisioner_test.go
+++ b/environs/manual/winrmprovisioner/winrmprovisioner_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package winrmprovisioner_test
 
 import (

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package juju
 
 var MoveToFront = moveToFront

--- a/juju/package_test.go
+++ b/juju/package_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package juju_test
 
 import (

--- a/network/fan.go
+++ b/network/fan.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package network
 
 import (

--- a/network/fan_test.go
+++ b/network/fan_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package network_test
 
 import (

--- a/network/gateway.go
+++ b/network/gateway.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package network
 
 import (

--- a/network/gateway_test.go
+++ b/network/gateway_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package network_test
 
 import (

--- a/network/netplan/activate.go
+++ b/network/netplan/activate.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package netplan
 
 import (

--- a/network/netplan/activate_test.go
+++ b/network/netplan/activate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package netplan_test
 
 import (

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package netplan
 
 import (

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package netplan_test
 
 import (

--- a/network/netplan/types.go
+++ b/network/netplan/types.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package netplan
 
 // DeviceToBridge gives the information about a particular device that

--- a/provider/azure/internal/armtemplates/template.go
+++ b/provider/azure/internal/armtemplates/template.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package armtemplates
 
 import "github.com/Azure/azure-sdk-for-go/arm/storage"

--- a/provider/gce/google/machine_type.go
+++ b/provider/gce/google/machine_type.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package google
 
 // MachineType represents a gce Machine Type.

--- a/provider/oci/common_test.go
+++ b/provider/oci/common_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/export_test.go
+++ b/provider/oci/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci
 
 import "github.com/juju/clock"

--- a/provider/oci/images_test.go
+++ b/provider/oci/images_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/instance_test.go
+++ b/provider/oci/instance_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/networking_test.go
+++ b/provider/oci/networking_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/provider_test.go
+++ b/provider/oci/provider_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/storage_test.go
+++ b/provider/oci/storage_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/storage_volumes_test.go
+++ b/provider/oci/storage_volumes_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package oci_test
 
 import (

--- a/provider/oci/testing/common.go
+++ b/provider/oci/testing/common.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing
 
 var PrivateKeyUnencrypted = `-----BEGIN RSA PRIVATE KEY-----

--- a/scripts/copyright.bash
+++ b/scripts/copyright.bash
@@ -1,11 +1,11 @@
-#!/bin/zsh
+#!/bin/bash
 
 # Copyright 2013 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
 exitstatus=0
-result=$(find -name '*.go' | xargs head -n 1 | grep -v -E "==> (./vendor|acceptancetests)" |  grep -v -E '// (Copyright|Code generated)' | grep -Pzo "==> (.*) <==\n.*\n\n" | grep -Pzo "==> (.*) <==\n" | sed 's/==> \(.*\) <==/\1/')
-missing=$(echo "$result" | wc -l)
-if [ missing != 0 ]; then
+result=$(find -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs head -n 1 | grep -v -E '// (Copyright|Code generated)' | xargs echo | sed 's/==>/\n==>/g' | sed 's/<==/<==\n/g' | grep -Pzo "==> (.*) <==\n.*\S+.*\n" | grep -Pzo "==> (.*) <==\n" | sed 's/==> \(.*\) <==/\1/')
+missing=$(echo "$result" | wc -w)
+if [ $missing != 0 ]; then
     echo "The following files are missing copyright headers"
     echo "$result"
     exitstatus=1

--- a/scripts/copyright.bash
+++ b/scripts/copyright.bash
@@ -1,0 +1,13 @@
+#!/bin/zsh
+
+# Copyright 2013 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+exitstatus=0
+result=$(find -name '*.go' | xargs head -n 1 | grep -v -E "==> (./vendor|acceptancetests)" |  grep -v -E '// (Copyright|Code generated)' | grep -Pzo "==> (.*) <==\n.*\n\n" | grep -Pzo "==> (.*) <==\n" | sed 's/==> \(.*\) <==/\1/')
+missing=$(echo "$result" | wc -l)
+if [ missing != 0 ]; then
+    echo "The following files are missing copyright headers"
+    echo "$result"
+    exitstatus=1
+fi
+exit $exitstatus

--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package main
 
 import (

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -77,3 +77,6 @@ go build $(go list github.com/juju/juju/... | grep -v /vendor/)
 
 echo "checking: tests are wired up ..."
 ./scripts/checktesting.bash
+
+echo "checking: copyright notices are in place ..."
+./scripts/copyright.bash

--- a/service/systemd/shims.go
+++ b/service/systemd/shims.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package systemd
 
 import (

--- a/state/logdb/buf_test.go
+++ b/state/logdb/buf_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package logdb_test
 
 import (

--- a/testing/time.go
+++ b/testing/time.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing
 
 import (

--- a/worker/lease/secretaries.go
+++ b/worker/lease/secretaries.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package lease
 
 import (

--- a/worker/pruner/config.go
+++ b/worker/pruner/config.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package pruner
 
 import (

--- a/worker/uniter/runner/jujuc/credential-get_test.go
+++ b/worker/uniter/runner/jujuc/credential-get_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package jujuc_test
 
 import (


### PR DESCRIPTION
## Description of change

The following ensures that the copyright notices are in place. I've
been caught out too many times and I need help to prevent someone
looking at a PR checking this simple step!

So the following validates that a copy right file for every file
exists.

## QA steps

Run the following:

```sh
./scripts/copyright.sh
```
