### PR TITLE
Pull the export-bundle command out from feature flag

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -368,10 +368,11 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewShowCommand())
 
 	r.Register(newMigrateCommand())
+    r.Register(model.NewExportBundleCommand())
+
 	if featureflag.Enabled(feature.DeveloperMode) {
 		r.Register(model.NewDumpCommand())
 		r.Register(model.NewDumpDBCommand())
-		r.Register(model.NewExportBundleCommand())
 	}
 
 	// Manage and control actions

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -368,7 +368,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewShowCommand())
 
 	r.Register(newMigrateCommand())
-    r.Register(model.NewExportBundleCommand())
+	r.Register(model.NewExportBundleCommand())
 
 	if featureflag.Enabled(feature.DeveloperMode) {
 		r.Register(model.NewDumpCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -440,6 +440,7 @@ var commandNames = []string{
 	"enable-destroy-controller",
 	"enable-ha",
 	"enable-user",
+	"export-bundle",
 	"expose",
 	"find-offers",
 	"firewall-rules",


### PR DESCRIPTION
Remove the feature flag from export-bundle command. 

QA: 
bootstrap
deploy the cs:kubernetes-core bundle
juju export-bundle > k8s.yaml
juju add-model test-bundle
juju deploy k8s.yaml

The bundle should export cleanly and redeploy matching the existing model. 