### PR TITLE
Change 'upgrade-series prepare' 'agree' flag to 'yes' with 'y' abbrev…

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -81,7 +81,7 @@ type upgradeSeriesCommand struct {
 	force         bool
 	machineNumber string
 	series        string
-	agree         bool
+	yes           bool
 
 	catacomb catacomb.Catacomb
 	plan     catacomb.Plan
@@ -146,9 +146,8 @@ func (c *upgradeSeriesCommand) Info() *cmd.Info {
 func (c *upgradeSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.force, "force", false, "Upgrade even if the series is not supported by the charm and/or related subordinate charms.")
-	// TODO (hml) 2018-06-28
-	// agree should be hidden, or available only during initial testing?
-	f.BoolVar(&c.agree, "agree", false, "Agree this operation cannot be reverted or canceled once started.")
+	f.BoolVar(&c.yes, "y", false, "Agree that the operation cannot be reverted or canceled once started without being prompted.")
+	f.BoolVar(&c.yes, "yes", false, "")
 }
 
 // Init implements cmd.Command.
@@ -263,7 +262,7 @@ func (c *upgradeSeriesCommand) UpgradeSeriesPrepare(ctx *cmd.Context) (err error
 
 func (c *upgradeSeriesCommand) promptConfirmation(ctx *cmd.Context, affectedUnits []string) error {
 	formattedUnitNames := strings.Join(affectedUnits, "\n")
-	if c.agree {
+	if c.yes {
 		return nil
 	}
 

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -141,8 +141,13 @@ func (s *UpgradeSeriesSuite) TestCompleteCommandDoesNotAcceptSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "wrong number of arguments")
 }
 
-func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgree(c *gc.C) {
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "--agree")
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYes(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "--yes")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesAbbreviation(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "-y")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -154,11 +159,11 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, confirmationMsg)
 }
 
-func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptAgreeAndNotPrompt(c *gc.C) {
-	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machine.PrepareCommand, machineArg, seriesArg, "--agree")
+func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesFlagAndNotPrompt(c *gc.C) {
+	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machine.PrepareCommand, machineArg, seriesArg, "-y")
 	c.Assert(err, jc.ErrorIsNil)
 
-	//There is no confirmation message since the `--agree` flag is being used to avoid the prompt.
+	//There is no confirmation message since the `-y/--yes` flag is being used to avoid the prompt.
 	confirmationMessage := ""
 
 	finishedMessage := ""


### PR DESCRIPTION
…iation.

## Description of change

Here we change the `upgrade-series` agree flag to `yes` with a `y` abbreviation.

## QA steps

```
upgrade-series --help
``` 

## Documentation changes

Ensure that documentation reflects this change. 



