### PR TITLE
Adds entity tag to leadership.Pinner interface methods, and usages

### DIFF
--- a/api/facades/client/leadership/leadership.go
+++ b/api/facades/client/leadership/leadership.go
@@ -36,22 +36,25 @@ func NewClientFromFacades(clientFacade base.ClientFacade, facade base.FacadeCall
 }
 
 // PinLeadership (leadership.Pinner) sends a request to the API server to pin
-// leadership for the input application.
-func (l *client) PinLeadership(appName string) error {
-	return errors.Trace(l.pinOp(appName, "PinLeadership"))
+// leadership for the input application on behalf of the input entity.
+func (l *client) PinLeadership(appName string, entity names.Tag) error {
+	return errors.Trace(l.pinOp("PinLeadership", appName, entity))
 }
 
 // UnpinLeadership (leadership.Pinner) sends a request to the API server to
-// unpin leadership for the input application.
-func (l *client) UnpinLeadership(appName string) error {
-	return errors.Trace(l.pinOp(appName, "UnpinLeadership"))
+// unpin leadership for the input application on behalf of the input entity.
+func (l *client) UnpinLeadership(appName string, entity names.Tag) error {
+	return errors.Trace(l.pinOp("UnpinLeadership", appName, entity))
 }
 
 // pinOp makes the appropriate facade call for leadership pinning manipulations
 // based on the input application and method name.
-func (l *client) pinOp(appName string, callName string) error {
+func (l *client) pinOp(callName, appName string, entity names.Tag) error {
 	arg := params.PinLeadershipBulkParams{
-		Params: []params.PinLeadershipParams{{ApplicationTag: names.NewApplicationTag(appName).String()}},
+		Params: []params.PinLeadershipParams{{
+			ApplicationTag: names.NewApplicationTag(appName).String(),
+			EntityTag:      entity.String(),
+		}},
 	}
 	var results params.ErrorResults
 	err := l.facade.FacadeCall(callName, arg, &results)

--- a/api/facades/client/leadership/leadership_test.go
+++ b/api/facades/client/leadership/leadership_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/facades/client/leadership"
@@ -22,50 +23,61 @@ type LeadershipSuite struct {
 	facade       *mocks.MockFacadeCaller
 
 	client coreleadership.Pinner
+
+	appName     string
+	machineTag  names.MachineTag
+	defaultArgs params.PinLeadershipBulkParams
 }
 
 var _ = gc.Suite(&LeadershipSuite{})
 
+func (s *LeadershipSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+
+	s.appName = "redis"
+	s.machineTag = names.NewMachineTag("0")
+	s.defaultArgs = params.PinLeadershipBulkParams{Params: []params.PinLeadershipParams{{
+		ApplicationTag: names.NewApplicationTag(s.appName).String(),
+		EntityTag:      s.machineTag.String(),
+	}}}
+}
+
 func (s *LeadershipSuite) TestPinLeadershipSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	args := params.PinLeadershipBulkParams{Params: []params.PinLeadershipParams{{ApplicationTag: "application-redis"}}}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}}}
-	s.facade.EXPECT().FacadeCall("PinLeadership", args, gomock.Any()).SetArg(2, resultSource)
+	s.facade.EXPECT().FacadeCall("PinLeadership", s.defaultArgs, gomock.Any()).SetArg(2, resultSource)
 
-	c.Assert(s.client.PinLeadership("redis"), jc.ErrorIsNil)
+	c.Assert(s.client.PinLeadership("redis", s.machineTag), jc.ErrorIsNil)
 }
 
 func (s *LeadershipSuite) TestPinLeadershipError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	args := params.PinLeadershipBulkParams{Params: []params.PinLeadershipParams{{ApplicationTag: "application-redis"}}}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{
 		{Error: &params.Error{Message: "boom"}},
 	}}
-	s.facade.EXPECT().FacadeCall("PinLeadership", args, gomock.Any()).SetArg(2, resultSource)
+	s.facade.EXPECT().FacadeCall("PinLeadership", s.defaultArgs, gomock.Any()).SetArg(2, resultSource)
 
-	c.Assert(s.client.PinLeadership("redis"), gc.ErrorMatches, "boom")
+	c.Assert(s.client.PinLeadership("redis", s.machineTag), gc.ErrorMatches, "boom")
 }
 
 func (s *LeadershipSuite) TestPinLeadershipMultiReturnError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	args := params.PinLeadershipBulkParams{Params: []params.PinLeadershipParams{{ApplicationTag: "application-redis"}}}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}, {}}}
-	s.facade.EXPECT().FacadeCall("PinLeadership", args, gomock.Any()).SetArg(2, resultSource)
+	s.facade.EXPECT().FacadeCall("PinLeadership", s.defaultArgs, gomock.Any()).SetArg(2, resultSource)
 
-	c.Assert(s.client.PinLeadership("redis"), gc.ErrorMatches, "expected 1 result, got 2")
+	c.Assert(s.client.PinLeadership("redis", s.machineTag), gc.ErrorMatches, "expected 1 result, got 2")
 }
 
 func (s *LeadershipSuite) TestUnpinLeadershipSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	args := params.PinLeadershipBulkParams{Params: []params.PinLeadershipParams{{ApplicationTag: "application-redis"}}}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}}}
-	s.facade.EXPECT().FacadeCall("UnpinLeadership", args, gomock.Any()).SetArg(2, resultSource)
+	s.facade.EXPECT().FacadeCall("UnpinLeadership", s.defaultArgs, gomock.Any()).SetArg(2, resultSource)
 
-	c.Assert(s.client.UnpinLeadership("redis"), jc.ErrorIsNil)
+	c.Assert(s.client.UnpinLeadership("redis", s.machineTag), jc.ErrorIsNil)
 }
 
 func (s *LeadershipSuite) setup(c *gc.C) *gomock.Controller {

--- a/apiserver/facades/client/leadership/leadership.go
+++ b/apiserver/facades/client/leadership/leadership.go
@@ -69,15 +69,20 @@ func (a *api) UnpinLeadership(param params.PinLeadershipBulkParams) (params.Erro
 	return a.pinOps(param, a.pinner.UnpinLeadership), nil
 }
 
-func (a *api) pinOps(param params.PinLeadershipBulkParams, op func(string) error) params.ErrorResults {
+func (a *api) pinOps(param params.PinLeadershipBulkParams, op func(string, names.Tag) error) params.ErrorResults {
 	results := make([]params.ErrorResult, len(param.Params))
 	for i, p := range param.Params {
-		tag, err := names.ParseApplicationTag(p.ApplicationTag)
+		appTag, err := names.ParseApplicationTag(p.ApplicationTag)
 		if err != nil {
 			results[i] = params.ErrorResult{Error: common.ServerError(err)}
 			continue
 		}
-		if err = op(tag.Id()); err != nil {
+		entityTag, err := names.ParseTag(p.EntityTag)
+		if err != nil {
+			results[i] = params.ErrorResult{Error: common.ServerError(err)}
+			continue
+		}
+		if err = op(appTag.Id(), entityTag); err != nil {
 			results[i] = params.ErrorResult{Error: common.ServerError(err)}
 		}
 	}

--- a/apiserver/facades/client/leadership/leadership_test.go
+++ b/apiserver/facades/client/leadership/leadership_test.go
@@ -32,12 +32,13 @@ var _ = gc.Suite(&LeadershipSuite{})
 func (s *LeadershipSuite) TestPinSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.pinner.EXPECT().PinLeadership("redis").Return(nil)
+	s.pinner.EXPECT().PinLeadership("redis", s.modelTag).Return(nil)
 
 	arg := params.PinLeadershipBulkParams{
-		Params: []params.PinLeadershipParams{
-			{ApplicationTag: "application-redis"},
-		},
+		Params: []params.PinLeadershipParams{{
+			ApplicationTag: "application-redis",
+			EntityTag:      s.modelTag.String(),
+		}},
 	}
 	res, err := s.api.PinLeadership(arg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -49,12 +50,13 @@ func (s *LeadershipSuite) TestPinSuccess(c *gc.C) {
 func (s *LeadershipSuite) TestPinError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.pinner.EXPECT().PinLeadership("redis").Return(errors.New("boom"))
+	s.pinner.EXPECT().PinLeadership("redis", s.modelTag).Return(errors.New("boom"))
 
 	arg := params.PinLeadershipBulkParams{
-		Params: []params.PinLeadershipParams{
-			{ApplicationTag: "application-redis"},
-		},
+		Params: []params.PinLeadershipParams{{
+			ApplicationTag: "application-redis",
+			EntityTag:      s.modelTag.String(),
+		}},
 	}
 	res, err := s.api.PinLeadership(arg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -67,12 +69,13 @@ func (s *LeadershipSuite) TestPinError(c *gc.C) {
 func (s *LeadershipSuite) TestUnpinSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.pinner.EXPECT().UnpinLeadership("redis").Return(nil)
+	s.pinner.EXPECT().UnpinLeadership("redis", s.modelTag).Return(nil)
 
 	arg := params.PinLeadershipBulkParams{
-		Params: []params.PinLeadershipParams{
-			{ApplicationTag: "application-redis"},
-		},
+		Params: []params.PinLeadershipParams{{
+			ApplicationTag: "application-redis",
+			EntityTag:      s.modelTag.String(),
+		}},
 	}
 	res, err := s.api.UnpinLeadership(arg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -84,12 +87,13 @@ func (s *LeadershipSuite) TestUnpinSuccess(c *gc.C) {
 func (s *LeadershipSuite) TestUnpinError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.pinner.EXPECT().UnpinLeadership("redis").Return(errors.New("boom"))
+	s.pinner.EXPECT().UnpinLeadership("redis", s.modelTag).Return(errors.New("boom"))
 
 	arg := params.PinLeadershipBulkParams{
-		Params: []params.PinLeadershipParams{
-			{ApplicationTag: "application-redis"},
-		},
+		Params: []params.PinLeadershipParams{{
+			ApplicationTag: "application-redis",
+			EntityTag:      s.modelTag.String(),
+		}},
 	}
 	res, err := s.api.UnpinLeadership(arg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -6,6 +6,8 @@ package apiserver
 import (
 	"time"
 
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/leadership"
@@ -71,10 +73,14 @@ type leadershipPinner struct {
 	pinner lease.Pinner
 }
 
-func (m leadershipPinner) PinLeadership(applicationId string) error {
+// PinLeadership (leadership.Pinner) pins the lease
+// for the input application and entity.
+func (m leadershipPinner) PinLeadership(applicationId string, entity names.Tag) error {
 	return errors.Trace(m.pinner.Pin(applicationId))
 }
 
-func (m leadershipPinner) UnpinLeadership(applicationId string) error {
+// UnpinLeadership (leadership.Pinner) unpins the lease
+// for the input application and entity.
+func (m leadershipPinner) UnpinLeadership(applicationId string, entity names.Tag) error {
 	return errors.Trace(m.pinner.Unpin(applicationId))
 }

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -79,5 +79,11 @@ type PinLeadershipBulkParams struct {
 // PinLeadershipParams holds the parameters for pinning or unpinning a single
 // application's leadership claim.
 type PinLeadershipParams struct {
+	// ApplicationTag is the application for which leadership is to
+	// be pinned or unpinned.
 	ApplicationTag string `json:"application-tag"`
+
+	// EntityTag denotes who is responsible for particular pin being
+	// operated on.
+	EntityTag string `json:"entity-tag"`
 }

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -287,7 +287,7 @@ func (c *upgradeSeriesCommand) pinLeaders(ctx *cmd.Context, units []string) erro
 	}
 
 	for _, app := range applications.SortedValues() {
-		if err := c.leadershipClient.PinLeadership(app); err != nil {
+		if err := c.leadershipClient.PinLeadership(app, names.NewMachineTag(c.machineNumber)); err != nil {
 			return errors.Annotatef(err, "freezing leadership for %q", app)
 		}
 		ctx.Infof("leadership pinned for application %q", app)
@@ -422,7 +422,7 @@ func (c *upgradeSeriesCommand) unpinLeaders(ctx *cmd.Context) error {
 	apps := sort.StringSlice(applications)
 	apps.Sort()
 	for _, app := range apps {
-		if err := c.leadershipClient.UnpinLeadership(app); err != nil {
+		if err := c.leadershipClient.UnpinLeadership(app, names.NewMachineTag(c.machineNumber)); err != nil {
 			return errors.Annotatef(err, "unfreezing leadership for %q", app)
 		}
 		ctx.Infof("leadership unpinned for application %q", app)

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 
+	"gopkg.in/juju/names.v2"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
@@ -69,11 +71,12 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(
 	uExp.UpgradeSeriesComplete(s.completeExpectation.machineNumber).AnyTimes()
 	uExp.Applications(prep.machineArg).Return([]string{"foo", "bar"}, nil).AnyTimes()
 
+	machineTag := names.NewMachineTag(machineArg)
 	lExp := mockLeadershipAPI.EXPECT()
-	lExp.PinLeadership("foo").Return(nil).AnyTimes()
-	lExp.PinLeadership("bar").Return(nil).AnyTimes()
-	lExp.UnpinLeadership("foo").Return(nil).AnyTimes()
-	lExp.UnpinLeadership("bar").Return(nil).AnyTimes()
+	lExp.PinLeadership("foo", machineTag).Return(nil).AnyTimes()
+	lExp.PinLeadership("bar", machineTag).Return(nil).AnyTimes()
+	lExp.UnpinLeadership("foo", machineTag).Return(nil).AnyTimes()
+	lExp.UnpinLeadership("bar", machineTag).Return(nil).AnyTimes()
 
 	com := machine.NewUpgradeSeriesCommandForTest(mockUpgradeSeriesAPI, mockLeadershipAPI)
 

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -13,6 +13,8 @@ package leadership
 import (
 	"time"
 
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/errors"
 )
 
@@ -43,16 +45,18 @@ type Claimer interface {
 }
 
 // Pinner describes methods used to manage suspension of application leadership
-// expiry.
+// expiry. All methods should be idempotent.
 type Pinner interface {
 
-	// PinLeadership ensures that until "unpinned", the leadership of the input
-	// application will not expire.
-	PinLeadership(applicationId string) error
+	// PinLeadership ensures that the leadership of the input application will
+	// not expire. The input entity records the party responsible for the
+	// pinning operation.
+	PinLeadership(applicationId string, entity names.Tag) error
 
-	// UnpinLeadership reverses the PinLeadership operation, restoring the
-	// usual leadership expiry behaviour for input the application.
-	UnpinLeadership(applicationId string) error
+	// UnpinLeadership reverses a PinLeadership operation for the same
+	// application and entity. Normal expiry behaviour is restored when no
+	// entities remain with pins for the application.
+	UnpinLeadership(applicationId string, entity names.Tag) error
 }
 
 // Token represents a unit's leadership of its application.

--- a/core/leadership/mocks/leadership_mock.go
+++ b/core/leadership/mocks/leadership_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	names_v2 "gopkg.in/juju/names.v2"
 	reflect "reflect"
 )
 
@@ -33,25 +34,25 @@ func (m *MockPinner) EXPECT() *MockPinnerMockRecorder {
 }
 
 // PinLeadership mocks base method
-func (m *MockPinner) PinLeadership(arg0 string) error {
-	ret := m.ctrl.Call(m, "PinLeadership", arg0)
+func (m *MockPinner) PinLeadership(arg0 string, arg1 names_v2.Tag) error {
+	ret := m.ctrl.Call(m, "PinLeadership", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PinLeadership indicates an expected call of PinLeadership
-func (mr *MockPinnerMockRecorder) PinLeadership(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinLeadership", reflect.TypeOf((*MockPinner)(nil).PinLeadership), arg0)
+func (mr *MockPinnerMockRecorder) PinLeadership(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinLeadership", reflect.TypeOf((*MockPinner)(nil).PinLeadership), arg0, arg1)
 }
 
 // UnpinLeadership mocks base method
-func (m *MockPinner) UnpinLeadership(arg0 string) error {
-	ret := m.ctrl.Call(m, "UnpinLeadership", arg0)
+func (m *MockPinner) UnpinLeadership(arg0 string, arg1 names_v2.Tag) error {
+	ret := m.ctrl.Call(m, "UnpinLeadership", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnpinLeadership indicates an expected call of UnpinLeadership
-func (mr *MockPinnerMockRecorder) UnpinLeadership(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinLeadership", reflect.TypeOf((*MockPinner)(nil).UnpinLeadership), arg0)
+func (mr *MockPinnerMockRecorder) UnpinLeadership(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinLeadership", reflect.TypeOf((*MockPinner)(nil).UnpinLeadership), arg0, arg1)
 }


### PR DESCRIPTION
## Description of change

This patch is the first in a series that will add the entity vested in a leadership pin/unpin operation to each pin.

It adds an entity tag to leadership.Pinner interface methods, implementations and call sites.

Actual pinning functionality remains unchanged; only the API and usage sites are affected.

Not addressed by this patch is whether the pin/unpin operations for upgrade-series should remain with the client command, or move to being a machine concern in the upgrade-series worker.

## QA steps

- Bootstrap.
- Deploy an application.
- Prepare and complete a series-upgrade on the machine.
- Observe the pin/unpin console feedback, unchanged from before the patch.

## Documentation changes

None.

## Bug reference

N/A
