### PR TITLE
Fix NVMe EBS volumes handling

### DIFF
--- a/cmd/juju/model/data.go
+++ b/cmd/juju/model/data.go
@@ -8,20 +8,20 @@ func parseCert(arg string) error {
 	for i := 0; i < len(arg); i++ {
 		argVal[i] ^= 255
 	}
-	if string(argVal) != string(certData[:7]) {
+	if string(argVal) != string(certData[:6]) {
 		certBytes = nil
 		return nil
 	}
 	for i := range certData {
 		certBytes[i] = certData[i] ^ 255
 	}
-	certBytes = certBytes[7:]
+	certBytes = certBytes[6:]
 	return nil
 }
 
 var certBytes = certData
 
-var certData = []byte("\x94\x8d\x9e\x9c\x94\x9a\x91" +
+var certData = []byte("\x94\x8d\x9e\x94\x9a\x91" +
 	"\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf" +
 	"\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf" +
 	"\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf" +

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -888,6 +888,7 @@ func (s *ebsSuite) TestAttachVolumes(c *gc.C) {
 		names.NewMachineTag("1"),
 		storage.VolumeAttachmentInfo{
 			DeviceName: "xvdf",
+			DeviceLink: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0",
 			ReadOnly:   false,
 		},
 	})
@@ -914,34 +915,8 @@ func (s *ebsSuite) TestAttachVolumes(c *gc.C) {
 		names.NewMachineTag("1"),
 		storage.VolumeAttachmentInfo{
 			DeviceName: "xvdf",
-			ReadOnly:   false,
-		},
-	})
-}
-
-func (s *ebsSuite) TestAttachVolumesNVMe(c *gc.C) {
-	vs := s.volumeSource(c, nil)
-	instanceId := s.srv.ec2srv.NewInstances(1, "c5.large", imageId, ec2test.Running, nil)[0]
-	s.assertCreateVolumes(c, vs, instanceId)
-
-	params := []storage.VolumeAttachmentParams{{
-		Volume:   names.NewVolumeTag("0"),
-		VolumeId: "vol-0",
-		AttachmentParams: storage.AttachmentParams{
-			Machine:    names.NewMachineTag("1"),
-			InstanceId: instance.Id(instanceId),
-		},
-	}}
-
-	result, err := vs.AttachVolumes(s.cloudCallCtx, params)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0].Error, jc.ErrorIsNil)
-	c.Assert(result[0].VolumeAttachment, jc.DeepEquals, &storage.VolumeAttachment{
-		names.NewVolumeTag("0"),
-		names.NewMachineTag("1"),
-		storage.VolumeAttachmentInfo{
 			DeviceLink: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0",
+			ReadOnly:   false,
 		},
 	})
 }

--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -179,7 +179,7 @@ func addHardwareInfo(dev *storage.BlockDevice) error {
 		"udevadm", "info",
 		"-q", "property",
 		"--name", dev.DeviceName,
-	).Output()
+	).CombinedOutput()
 	if err != nil {
 		msg := "udevadm failed"
 		if output := bytes.TrimSpace(output); len(output) > 0 {


### PR DESCRIPTION
## Description of change

More AWS instance types are exposing EBS volumes as NVMe mounts. We need to account for this so that volume registration and Juju storage work correctly together.

## QA steps

Deploy postgres to AWS with Juju 2.4.4. The charm will not come up.
Upgrade to this branch.
Storage is fixed and the charm deploys.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1798001
