### PR TITLE
Fix NVMe EBS volumes handling

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -706,11 +706,6 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 	results := make([]storage.AttachVolumesResult, len(attachParams))
 	for i, params := range attachParams {
 		instId := string(params.InstanceId)
-		inst, err := instances.get(instId)
-		if err != nil {
-			results[i].Error = err
-			continue
-		}
 
 		// By default we should allocate device names without the
 		// trailing number. Block devices with a trailing number are
@@ -729,26 +724,25 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 		}
 
 		var attachmentInfo storage.VolumeAttachmentInfo
-		if strings.HasPrefix(inst.InstanceType, "c5.") || strings.HasPrefix(inst.InstanceType, "m5.") {
-			// The newer hypervisor attaches EBS volumes
-			// as NVMe devices, and the block device names
-			// are unpredictable from here.
-			//
-			// Instead of using device name, we fill in
-			// the device link, based on the statically
-			// defined model name ("Amazon Elastic Block Store",
-			// and serial (vol123456abcdef...); the serial
-			// is the same as the volume ID without the "-".
-			//
-			// NOTE(axw) inst.Hypervisor still says "xen" for
-			// m5 and c5 instance types, which would seem to
-			// be a lie. This is why we check the prefix,
-			// rather than the hypervisor name.
-			sn := strings.Replace(params.VolumeId, "-", "", 1)
-			attachmentInfo.DeviceLink = nvmeDeviceLinkPrefix + sn
-		} else {
-			attachmentInfo.DeviceName = deviceName
-		}
+		// The newer hypervisor attaches EBS volumes
+		// as NVMe devices, and the block device names
+		// are unpredictable from here.
+		//
+		// Instead of using device name, we fill in
+		// the device link, based on the statically
+		// defined model name ("Amazon Elastic Block Store",
+		// and serial (vol123456abcdef...); the serial
+		// is the same as the volume ID without the "-".
+		//
+		// NOTE(axw) inst.Hypervisor still says "xen" for
+		// affected instance types, which would seem to
+		// be a lie. There's no way to tell how a volume will
+		// be exposed so we have to assume an nvme link - the
+		// subsequent matching code will correctly skip the link
+		// and match against device name for non-nvme volumes.
+		sn := strings.Replace(params.VolumeId, "-", "", 1)
+		attachmentInfo.DeviceLink = nvmeDeviceLinkPrefix + sn
+		attachmentInfo.DeviceName = deviceName
 
 		results[i].VolumeAttachment = &storage.VolumeAttachment{
 			params.Volume,

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -778,6 +778,7 @@ func (s *ebsSuite) TestAttachVolumes(c *gc.C) {
 		names.NewMachineTag("1"),
 		storage.VolumeAttachmentInfo{
 			DeviceName: "xvdf",
+			DeviceLink: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0",
 			ReadOnly:   false,
 		},
 	})
@@ -804,34 +805,8 @@ func (s *ebsSuite) TestAttachVolumes(c *gc.C) {
 		names.NewMachineTag("1"),
 		storage.VolumeAttachmentInfo{
 			DeviceName: "xvdf",
-			ReadOnly:   false,
-		},
-	})
-}
-
-func (s *ebsSuite) TestAttachVolumesNVMe(c *gc.C) {
-	vs := s.volumeSource(c, nil)
-	instanceId := s.srv.ec2srv.NewInstances(1, "c5.large", imageId, ec2test.Running, nil)[0]
-	s.assertCreateVolumes(c, vs, instanceId)
-
-	params := []storage.VolumeAttachmentParams{{
-		Volume:   names.NewVolumeTag("0"),
-		VolumeId: "vol-0",
-		AttachmentParams: storage.AttachmentParams{
-			Machine:    names.NewMachineTag("1"),
-			InstanceId: instance.Id(instanceId),
-		},
-	}}
-
-	result, err := vs.AttachVolumes(params)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0].Error, jc.ErrorIsNil)
-	c.Assert(result[0].VolumeAttachment, jc.DeepEquals, &storage.VolumeAttachment{
-		names.NewVolumeTag("0"),
-		names.NewMachineTag("1"),
-		storage.VolumeAttachmentInfo{
 			DeviceLink: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0",
+			ReadOnly:   false,
 		},
 	})
 }

--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -179,7 +179,7 @@ func addHardwareInfo(dev *storage.BlockDevice) error {
 		"udevadm", "info",
 		"-q", "property",
 		"--name", dev.DeviceName,
-	).Output()
+	).CombinedOutput()
 	if err != nil {
 		msg := "udevadm failed"
 		if output := bytes.TrimSpace(output); len(output) > 0 {


### PR DESCRIPTION
## Description of change

Backport https://github.com/juju/juju/pull/9331

More AWS instance types are exposing EBS volumes as NVMe mounts. We need to account for this so that volume registration and Juju storage work correctly together.

## QA steps

Deploy postgres to AWS with Juju 2.4.4. The charm will not come up.
Upgrade to this branch.
Storage is fixed and the charm deploys.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1798001
