### PR TITLE
New command to change model's cloud credential.

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -534,7 +534,7 @@ func (c *Client) UnsetModelDefaults(cloud, region string, keys ...string) error 
 // ChangeModelCredential replaces cloud credential for a given model with the provided one.
 func (c *Client) ChangeModelCredential(model names.ModelTag, credential names.CloudCredentialTag) error {
 	if bestVer := c.BestAPIVersion(); bestVer < 5 {
-		return errors.NotImplementedf("ChangeModelCredential")
+		return errors.NotImplementedf("ChangeModelCredential in version %v", bestVer)
 	}
 
 	var out params.ErrorResults

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -434,11 +434,11 @@ func (c *Client) modifyModelUser(action params.ModelAction, user, access string,
 	if err := permission.ValidateModelAccess(modelAccess); err != nil {
 		return errors.Trace(err)
 	}
-	for _, model := range modelUUIDs {
-		if !names.IsValidModel(model) {
-			return errors.Errorf("invalid model: %q", model)
+	for _, m := range modelUUIDs {
+		if !names.IsValidModel(m) {
+			return errors.Errorf("invalid model: %q", m)
 		}
-		modelTag := names.NewModelTag(model)
+		modelTag := names.NewModelTag(m)
 		args.Changes = append(args.Changes, params.ModifyModelAccess{
 			UserTag:  userTag.String(),
 			Action:   action,

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -632,7 +632,7 @@ func (s *modelmanagerSuite) TestChangeModelCredentialV4(c *gc.C) {
 
 	client := modelmanager.NewClient(apiCaller)
 	err := client.ChangeModelCredential(coretesting.ModelTag, credentialTag)
-	c.Assert(err, gc.ErrorMatches, `ChangeModelCredential not implemented`)
+	c.Assert(err, gc.ErrorMatches, `ChangeModelCredential in version 4 not implemented`)
 	c.Assert(called, jc.IsFalse)
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -368,6 +368,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewGrantCommand())
 	r.Register(model.NewRevokeCommand())
 	r.Register(model.NewShowCommand())
+	r.Register(model.NewModelCredentialCommand())
 
 	r.Register(newMigrateCommand())
 	if featureflag.Enabled(feature.DeveloperMode) {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -524,6 +524,7 @@ var commandNames = []string{
 	"run-action",
 	"scale-application",
 	"scp",
+	"set-credential",
 	"set-constraints",
 	"set-default-credential",
 	"set-default-region",

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -166,3 +166,18 @@ func NewModelGetConstraintsCommandForTest() cmd.Command {
 }
 
 var GetBudgetAPIClient = &getBudgetAPIClient
+
+// NewModelCredentialCommandForTest returns a ModelCredentialCommand with the api provided as specified.
+func NewModelCredentialCommandForTest(modelClient ModelCredentialAPI, cloudClient CloudAPI, rootFunc func() (base.APICallCloser, error), store jujuclient.ClientStore) cmd.Command {
+	cmd := &modelCredentialCommand{
+		newModelCredentialAPIFunc: func(root base.APICallCloser) ModelCredentialAPI {
+			return modelClient
+		},
+		newCloudAPIFunc: func(root base.APICallCloser) CloudAPI {
+			return cloudClient
+		},
+		newAPIRootFunc: rootFunc,
+	}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}

--- a/cmd/juju/model/setcredential.go
+++ b/cmd/juju/model/setcredential.go
@@ -6,7 +6,6 @@ package model
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/gnuflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
@@ -67,11 +66,6 @@ func (c *modelCredentialCommand) Info() *cmd.Info {
 	}
 }
 
-// SetFlags implements Command.SetFlags.
-func (c *modelCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
-}
-
 // Init implements Command.Init.
 func (c *modelCredentialCommand) Init(args []string) error {
 	if len(args) != 2 {
@@ -109,7 +103,7 @@ func (c *modelCredentialCommand) Run(ctx *cmd.Context) error {
 	cloudTag := names.NewCloudTag(c.cloud)
 	credentialTag, err := common.ResolveCloudCredentialTag(userTag, cloudTag, c.credential)
 	if err != nil {
-		return fail(errors.Annotate(err, "resolving credential tag"))
+		return fail(errors.Annotate(err, "resolving credential"))
 	}
 
 	cloudClient := c.newCloudAPIFunc(root)
@@ -144,7 +138,7 @@ func (c *modelCredentialCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	_, modelDetails, err := c.ModelDetails()
+	modelName, modelDetails, err := c.ModelDetails()
 	if err != nil {
 		return fail(errors.Trace(err))
 	}
@@ -157,7 +151,7 @@ func (c *modelCredentialCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return fail(errors.Trace(err))
 	}
-	ctx.Infof("Changed model credential.")
+	ctx.Infof("Changed cloud credential on model %q to %q.", modelName, c.credential)
 	return nil
 }
 
@@ -177,12 +171,12 @@ func (c *modelCredentialCommand) findCredentialLocally(ctx *cmd.Context) (*cloud
 	return credential, nil
 }
 
-const modelCredentialDoc = `This command changes a cloud credential used by a model.
+const modelCredentialDoc = `This command changes the cloud credential used by a model.
 
 When current user has specified credential for the given cloud remotely, i.e
 it exists on the controller, Juju will use it to replace model's credential.
 
-If specified credential does not exist remotely, but it exists locally on the client,
-Juju will upload it to the controller first and then use the remote copy to replace model's credential.
+If the specified credential does not exist remotely on the controller, but does exist locally on the client,
+Juju will upload it to the controller first and then replace the model's credential.
 
 `

--- a/cmd/juju/model/setcredential.go
+++ b/cmd/juju/model/setcredential.go
@@ -1,0 +1,188 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package model
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	cloudapi "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// ModelCredentialAPI defines methods used to replace model credential.
+type ModelCredentialAPI interface {
+	Close() error
+	ChangeModelCredential(model names.ModelTag, credential names.CloudCredentialTag) error
+}
+
+// CloudAPI defines methods used to detemine if cloud credential exists on the controller.
+type CloudAPI interface {
+	Close() error
+	UserCredentials(names.UserTag, names.CloudTag) ([]names.CloudCredentialTag, error)
+	AddCredential(tag string, credential cloud.Credential) error
+}
+
+// modelCredentialCommand allows to change, replace a cloud credential for a model.
+type modelCredentialCommand struct {
+	modelcmd.ModelCommandBase
+
+	cloud      string
+	credential string
+
+	newAPIRootFunc            func() (base.APICallCloser, error)
+	newModelCredentialAPIFunc func(base.APICallCloser) ModelCredentialAPI
+	newCloudAPIFunc           func(base.APICallCloser) CloudAPI
+}
+
+func NewModelCredentialCommand() cmd.Command {
+	command := &modelCredentialCommand{
+		newModelCredentialAPIFunc: func(root base.APICallCloser) ModelCredentialAPI {
+			return modelmanager.NewClient(root)
+		},
+		newCloudAPIFunc: func(root base.APICallCloser) CloudAPI {
+			return cloudapi.NewClient(root)
+		},
+	}
+	command.newAPIRootFunc = func() (base.APICallCloser, error) {
+		return command.NewControllerAPIRoot()
+	}
+	return modelcmd.Wrap(command)
+}
+
+// Info implements Command.Info.
+func (c *modelCredentialCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "set-credential",
+		Args:    "<cloud name> <credential name>",
+		Purpose: "Change cloud credential for the current or specified model.",
+		Doc:     modelCredentialDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *modelCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+}
+
+// Init implements Command.Init.
+func (c *modelCredentialCommand) Init(args []string) error {
+	if len(args) != 2 {
+		return errors.Errorf("Usage: juju set-credential [options] <cloud name> <credential name>")
+	}
+	if !names.IsValidCloud(args[0]) {
+		return errors.NotValidf("cloud name %q", args[0])
+	}
+	if !names.IsValidCloudCredentialName(args[1]) {
+		return errors.NotValidf("cloud credential name %q", args[1])
+	}
+	c.cloud = args[0]
+	c.credential = args[1]
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *modelCredentialCommand) Run(ctx *cmd.Context) error {
+	fail := func(e error) error {
+		ctx.Infof("Failed to change model credential: %v", e)
+		return e
+	}
+
+	root, err := c.newAPIRootFunc()
+	if err != nil {
+		return fail(errors.Annotate(err, "opening API connection"))
+	}
+	defer root.Close()
+
+	accountDetails, err := c.CurrentAccountDetails()
+	if err != nil {
+		return fail(errors.Annotate(err, "getting current account"))
+	}
+	userTag := names.NewUserTag(accountDetails.User)
+	cloudTag := names.NewCloudTag(c.cloud)
+	credentialTag, err := common.ResolveCloudCredentialTag(userTag, cloudTag, c.credential)
+	if err != nil {
+		return fail(errors.Annotate(err, "resolving credential tag"))
+	}
+
+	cloudClient := c.newCloudAPIFunc(root)
+	defer cloudClient.Close()
+
+	remote := false
+	remoteCredentials, err := cloudClient.UserCredentials(userTag, cloudTag)
+	if err != nil {
+		// This is ok - we can proceed with local ones anyway.
+		ctx.Infof("Could not determine if there are remote credentials for the user: %v", err)
+	} else {
+		for _, credTag := range remoteCredentials {
+			if credTag == credentialTag {
+				remote = true
+				ctx.Infof("Found credential remotely, on the controller. Not looking locally...")
+				break
+			}
+		}
+	}
+
+	// Credential does not exist remotely. Upload it.
+	if !remote {
+		ctx.Infof("Did not find credential remotely. Looking locally...")
+		credential, err := c.findCredentialLocally(ctx)
+		if err != nil {
+			return fail((err))
+		}
+		ctx.Infof("Uploading local credential to the controller.")
+		err = cloudClient.AddCredential(credentialTag.String(), *credential)
+		if err != nil {
+			return fail(err)
+		}
+	}
+
+	_, modelDetails, err := c.ModelDetails()
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	modelTag := names.NewModelTag(modelDetails.ModelUUID)
+
+	modelClient := c.newModelCredentialAPIFunc(root)
+	defer modelClient.Close()
+
+	err = modelClient.ChangeModelCredential(modelTag, credentialTag)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	ctx.Infof("Changed model credential.")
+	return nil
+}
+
+func (c *modelCredentialCommand) findCredentialLocally(ctx *cmd.Context) (*cloud.Credential, error) {
+	foundcloud, err := common.CloudByName(c.cloud)
+	if err != nil {
+		return nil, err
+	}
+	getCredentialsParams := modelcmd.GetCredentialsParams{
+		Cloud:          *foundcloud,
+		CredentialName: c.credential,
+	}
+	credential, _, _, err := modelcmd.GetCredentials(ctx, c.ClientStore(), getCredentialsParams)
+	if err != nil {
+		return nil, err
+	}
+	return credential, nil
+}
+
+const modelCredentialDoc = `This command changes a cloud credential used by a model.
+
+When current user has specified credential for the given cloud remotely, i.e
+it exists on the controller, Juju will use it to replace model's credential.
+
+If specified credential does not exist remotely, but it exists locally on the client,
+Juju will upload it to the controller first and then use the remote copy to replace model's credential.
+
+`

--- a/cmd/juju/model/setcredential_test.go
+++ b/cmd/juju/model/setcredential_test.go
@@ -4,11 +4,11 @@
 package model_test
 
 import (
-	"github.com/pkg/errors"
 	"regexp"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/cmd/juju/model/setcredential_test.go
+++ b/cmd/juju/model/setcredential_test.go
@@ -152,7 +152,7 @@ func (s *ModelCredentialCommandSuite) assertCredentialNotFound(c *gc.C, expected
 func (s *ModelCredentialCommandSuite) TestSetCredentialFoundRemote(c *gc.C) {
 	err := s.assertRemoteCredentialFound(c, `
 Found credential remotely, on the controller. Not looking locally...
-Changed model credential.
+Changed cloud credential on model "admin/mymodel" to "credential".
 `[1:])
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -197,7 +197,7 @@ func (s *ModelCredentialCommandSuite) TestSetCredentialLocal(c *gc.C) {
 	err := s.assertLocalCredentialUsed(c, `
 Did not find credential remotely. Looking locally...
 Uploading local credential to the controller.
-Changed model credential.
+Changed cloud credential on model "admin/mymodel" to "credential".
 `[1:])
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/model/setcredential_test.go
+++ b/cmd/juju/model/setcredential_test.go
@@ -1,0 +1,303 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package model_test
+
+import (
+	"github.com/pkg/errors"
+	"regexp"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/model"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
+	_ "github.com/juju/juju/provider/ec2" // needed when getting valid local credentials
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&ModelCredentialCommandSuite{})
+
+type ModelCredentialCommandSuite struct {
+	jujutesting.IsolationSuite
+
+	store *jujuclient.MemStore
+
+	modelClient fakeModelClient
+	cloudClient fakeCloudClient
+	rootFunc    func() (base.APICallCloser, error)
+}
+
+func (s *ModelCredentialCommandSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.store = jujuclient.NewMemStore()
+	s.store.CurrentControllerName = "testing"
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin",
+	}
+	err := s.store.UpdateModel("testing", "admin/mymodel", jujuclient.ModelDetails{
+		ModelUUID: testing.ModelTag.Id(),
+		ModelType: coremodel.IAAS,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.store.Models["testing"].CurrentModel = "admin/mymodel"
+
+	s.rootFunc = func() (base.APICallCloser, error) { return &fakeRoot{}, nil }
+	s.modelClient = fakeModelClient{}
+	s.cloudClient = fakeCloudClient{}
+}
+
+func (s *ModelCredentialCommandSuite) TestBadArguments(c *gc.C) {
+	badArgs := []struct {
+		about  string
+		args   []string
+		err    string
+		stderr string
+	}{{
+		about:  "no arguments",
+		args:   []string{},
+		err:    regexp.QuoteMeta("Usage: juju set-credential [options] <cloud name> <credential name>"),
+		stderr: "ERROR Usage: juju set-credential [options] <cloud name> <credential name>\n",
+	}, {
+		about:  "1 argument",
+		args:   []string{"cloud"},
+		err:    regexp.QuoteMeta("Usage: juju set-credential [options] <cloud name> <credential name>"),
+		stderr: "ERROR Usage: juju set-credential [options] <cloud name> <credential name>\n",
+	}, {
+		about:  "3 argument",
+		args:   []string{"cloud", "cred", "nothing"},
+		err:    regexp.QuoteMeta("Usage: juju set-credential [options] <cloud name> <credential name>"),
+		stderr: "ERROR Usage: juju set-credential [options] <cloud name> <credential name>\n",
+	}, {
+		about:  "not valid cloud name",
+		args:   []string{"#1foo", "cred"},
+		err:    "cloud name \"#1foo\" not valid",
+		stderr: "ERROR cloud name \"#1foo\" not valid\n",
+	}, {
+		about:  "not valid cloud credential name",
+		args:   []string{"cloud", "0foo"},
+		err:    "cloud credential name \"0foo\" not valid",
+		stderr: "ERROR cloud credential name \"0foo\" not valid\n",
+	}}
+
+	for i, bad := range badArgs {
+		c.Logf("%d: %v", i, bad.about)
+		ctx, err := cmdtesting.RunCommand(c, s.newSetCredentialCommand(), bad.args...)
+		c.Assert(err, gc.ErrorMatches, bad.err)
+
+		c.Assert(cmdtesting.Stderr(ctx), gc.Equals, bad.stderr)
+		c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+		s.modelClient.CheckNoCalls(c)
+		s.cloudClient.CheckNoCalls(c)
+	}
+}
+
+func (s *ModelCredentialCommandSuite) TestRootAPIError(c *gc.C) {
+	s.rootFunc = func() (base.APICallCloser, error) {
+		return nil, errors.New("kaboom")
+	}
+	ctx, err := cmdtesting.RunCommand(c, s.newSetCredentialCommand(), "cloud", "credential")
+	c.Assert(err, gc.ErrorMatches, "opening API connection: kaboom")
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Failed to change model credential: opening API connection: kaboom\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	s.modelClient.CheckNoCalls(c)
+	s.cloudClient.CheckNoCalls(c)
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialNotFoundAnywhere(c *gc.C) {
+	s.assertCredentialNotFound(c, `
+Did not find credential remotely. Looking locally...
+Failed to change model credential: loading credentials: credentials for cloud aws not found
+`[1:])
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialRemoteSearchErred(c *gc.C) {
+	s.cloudClient.SetErrors(errors.New("boom"))
+	s.assertCredentialNotFound(c, `
+Could not determine if there are remote credentials for the user: boom
+Did not find credential remotely. Looking locally...
+Failed to change model credential: loading credentials: credentials for cloud aws not found
+`[1:])
+}
+
+func (s *ModelCredentialCommandSuite) assertCredentialNotFound(c *gc.C, expectedStderr string) {
+	ctx, err := cmdtesting.RunCommand(c, s.newSetCredentialCommand(), "aws", "credential")
+	c.Assert(err, gc.ErrorMatches, "loading credentials: credentials for cloud aws not found")
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedStderr)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	s.modelClient.CheckNoCalls(c)
+	s.cloudClient.CheckCalls(c, []jujutesting.StubCall{
+		{"UserCredentials", []interface{}{
+			names.NewUserTag("admin"),
+			names.NewCloudTag("aws"),
+		}},
+		{"Close", nil},
+	})
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialFoundRemote(c *gc.C) {
+	err := s.assertRemoteCredentialFound(c, `
+Found credential remotely, on the controller. Not looking locally...
+Changed model credential.
+`[1:])
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialErred(c *gc.C) {
+	s.modelClient.SetErrors(errors.New("kaboom"))
+	err := s.assertRemoteCredentialFound(c, `
+Found credential remotely, on the controller. Not looking locally...
+Failed to change model credential: kaboom
+`[1:])
+	c.Assert(err, gc.ErrorMatches, "kaboom")
+}
+
+func (s *ModelCredentialCommandSuite) assertRemoteCredentialFound(c *gc.C, expectedStderr string) error {
+	credentialTag := names.NewCloudCredentialTag("aws/admin/credential")
+	s.cloudClient.userCredentials = []names.CloudCredentialTag{credentialTag}
+	ctx, err := cmdtesting.RunCommand(c, s.newSetCredentialCommand(), "aws", "credential")
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedStderr)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	s.modelClient.CheckCalls(c, []jujutesting.StubCall{
+		{"ChangeModelCredential", []interface{}{
+			testing.ModelTag,
+			credentialTag,
+		}},
+		{"Close", nil},
+	})
+	s.cloudClient.CheckCalls(c, []jujutesting.StubCall{
+		{"UserCredentials", []interface{}{
+			names.NewUserTag("admin"),
+			names.NewCloudTag("aws"),
+		}},
+		{"Close", nil},
+	})
+	// This the error from running the command.
+	// It's returned to allow individual test to assert their expectations.
+	return err
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialLocal(c *gc.C) {
+	err := s.assertLocalCredentialUsed(c, `
+Did not find credential remotely. Looking locally...
+Uploading local credential to the controller.
+Changed model credential.
+`[1:])
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.modelClient.CheckCalls(c, []jujutesting.StubCall{
+		{"ChangeModelCredential", []interface{}{
+			testing.ModelTag,
+			names.NewCloudCredentialTag("aws/admin/credential"),
+		}},
+		{"Close", nil},
+	})
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialLocalUploadFailed(c *gc.C) {
+	s.cloudClient.SetErrors(nil, errors.New("upload failed"))
+	err := s.assertLocalCredentialUsed(c, `
+Did not find credential remotely. Looking locally...
+Uploading local credential to the controller.
+Failed to change model credential: upload failed
+`[1:])
+	c.Assert(err, gc.ErrorMatches, "upload failed")
+	s.modelClient.CheckNoCalls(c)
+}
+
+func (s *ModelCredentialCommandSuite) assertLocalCredentialUsed(c *gc.C, expectedStderr string) error {
+	credential := cloud.NewCredential(cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "v",
+			"secret-key": "v",
+		},
+	)
+	cloudCredential := &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"credential": credential,
+		},
+	}
+	s.store.Credentials["aws"] = *cloudCredential
+	ctx, err := cmdtesting.RunCommand(c, s.newSetCredentialCommand(), "aws", "credential")
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedStderr)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	s.cloudClient.CheckCalls(c, []jujutesting.StubCall{
+		{"UserCredentials", []interface{}{
+			names.NewUserTag("admin"),
+			names.NewCloudTag("aws"),
+		}},
+		{"AddCredential", []interface{}{
+			names.NewCloudCredentialTag("aws/admin/credential").String(),
+			credential,
+		}},
+		{"Close", nil},
+	})
+	return err
+}
+
+func (s *ModelCredentialCommandSuite) newSetCredentialCommand() cmd.Command {
+	return model.NewModelCredentialCommandForTest(&s.modelClient, &s.cloudClient, s.rootFunc, s.store)
+}
+
+type fakeModelClient struct {
+	jujutesting.Stub
+}
+
+func (f *fakeModelClient) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeModelClient) ChangeModelCredential(model names.ModelTag, credential names.CloudCredentialTag) error {
+	f.MethodCall(f, "ChangeModelCredential", model, credential)
+	return f.NextErr()
+}
+
+type fakeCloudClient struct {
+	jujutesting.Stub
+
+	userCredentials []names.CloudCredentialTag
+}
+
+func (f *fakeCloudClient) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeCloudClient) UserCredentials(u names.UserTag, c names.CloudTag) ([]names.CloudCredentialTag, error) {
+	f.MethodCall(f, "UserCredentials", u, c)
+	return f.userCredentials, f.NextErr()
+}
+
+func (f *fakeCloudClient) AddCredential(tag string, credential cloud.Credential) error {
+	f.MethodCall(f, "AddCredential", tag, credential)
+	return f.NextErr()
+}
+
+type fakeRoot struct {
+	base.APICaller
+	jujutesting.Stub
+}
+
+func (f *fakeRoot) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -125,7 +125,7 @@ clouds:
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Did not find credential remotely. Looking locally...
 Uploading local credential to the controller.
-Changed model credential.
+Changed cloud credential on model "controller" to "newcred".
 `[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -15,23 +16,29 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type CmdCredentialSuite struct {
 	jujutesting.JujuConnSuite
 }
 
-func (s *CmdCredentialSuite) run(c *gc.C, args ...string) *cmd.Context {
-	context := cmdtesting.Context(c)
-	command := commands.NewJujuCommand(context)
-	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
-	command.Run(context)
-	//c.Assert(command.Run(context), jc.ErrorIsNil)
-	loggo.RemoveWriter("warning")
-	return context
+func (s *CmdCredentialSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	// JujuConnSuite sets up a cloud instance "localhost".
+	// When credential is updated, we check that we can still see
+	// all the instances on the provider using the new credential content.
+	// This check also verifies that all instances have corresponding machine records
+	// in our system and vice versa.
+	// This is why we need to add a machine that corresponds to a "localhost" instance,
+	// i.e. just making the suite model valid in credential's eyes.
+	s.Factory.MakeMachine(c, &factory.MachineParams{
+		InstanceId: instance.Id("localhost"),
+	})
 }
 
 func (s *CmdCredentialSuite) TestUpdateCredentialCommand(c *gc.C) {
@@ -53,7 +60,15 @@ clouds:
 			"cred": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "fred", "password": "secret", "identity-domain": "domain"}),
 		},
 	})
-	s.run(c, "update-credential", "dummy", "cred")
+	ctx, err := s.run(c, "update-credential", "dummy", "cred")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+Credential valid for:
+  controller
+Controller credential "cred" for user "admin" on cloud "dummy" updated.
+For more information, see ‘juju show-credential dummy cred’.
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
 	client := apicloud.NewClient(s.OpenControllerAPI(c))
 	defer client.Close()
@@ -63,22 +78,79 @@ clouds:
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []params.CloudCredentialResult{
 		{Result: &params.CloudCredential{
-			AuthType: "userpass",
-			// TODO (anastasiamac 2018-09-18) check this test once api and cmd is updated to cater for models check
-			// in followup PRs.
-			// At the moment, with models' check this test does not update credential as we are getting
-			// ...ERROR no machine with instance "localhost"...
-			// Ideally, if credential is updated successfully, we'd get:
-			// Attributes: map[string]string{"username": "fred", "identity-domain": "domain"},
-			Attributes: map[string]string{"username": "dummy"},
+			AuthType:   "userpass",
+			Attributes: map[string]string{"username": "fred", "identity-domain": "domain"},
 			Redacted:   []string{"password"},
 		}},
 	})
 }
 
-func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
-	ctx := s.run(c, "show-credential")
+func (s *CmdCredentialSuite) TestSetModelCredentialCommand(c *gc.C) {
+	//Add dummy cloud to cloud metadata
+	s.Home.AddFiles(c, testing.TestFile{
+		Name: ".local/share/clouds.yaml",
+		Data: `
+clouds:
+  dummy:
+    type: oracle
+    description: Dummy Test Cloud Metadata
+    auth-types: [ userpass ]
+`,
+	})
 
+	store := jujuclient.NewFileClientStore()
+	store.UpdateCredential("dummy", cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"newcred": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "fred", "password": "secret", "identity-domain": "domain"}),
+		},
+	})
+	newCredentialTag := names.NewCloudCredentialTag("dummy/admin@local/newcred")
+
+	client := apicloud.NewClient(s.OpenControllerAPI(c))
+	defer client.Close()
+
+	// Check new credential does not exist on the controller.
+	result, err := client.Credentials(newCredentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Assert(result[0].Error.Error(), gc.DeepEquals, "credential \"newcred\" not found")
+
+	// Check model references original credential.
+	originalCredentialTag, set := s.Model.CloudCredential()
+	c.Assert(set, jc.IsTrue)
+	c.Assert(originalCredentialTag.String(), jc.DeepEquals, "cloudcred-dummy_admin_cred")
+
+	ctx, err := s.run(c, "set-credential", "dummy", "newcred")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+Did not find credential remotely. Looking locally...
+Uploading local credential to the controller.
+Changed model credential.
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	// Check crdential was uploaded to the controller.
+	result2, err := client.Credentials(newCredentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result2, jc.DeepEquals, []params.CloudCredentialResult{
+		{Result: &params.CloudCredential{
+			AuthType:   "userpass",
+			Attributes: map[string]string{"username": "fred", "identity-domain": "domain"},
+			Redacted:   []string{"password"},
+		}},
+	})
+	// Check model reference was updated to a new credential.
+	err = s.Model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	updatedCredentialTag, set := s.Model.CloudCredential()
+	c.Assert(set, jc.IsTrue)
+	c.Assert(updatedCredentialTag.String(), jc.DeepEquals, "cloudcred-dummy_admin_newcred")
+
+}
+
+func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
+	ctx, err := s.run(c, "show-credential")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 controller-credentials:
@@ -93,8 +165,8 @@ controller-credentials:
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
-	ctx := s.run(c, "show-credential", "dummy", "cred", "--show-secrets")
-
+	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 controller-credentials:
@@ -107,4 +179,13 @@ controller-credentials:
       models:
         controller: admin
 `[1:])
+}
+
+func (s *CmdCredentialSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	context := cmdtesting.Context(c)
+	command := commands.NewJujuCommand(context)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
+	err := command.Run(context)
+	loggo.RemoveWriter("warning")
+	return context, err
 }


### PR DESCRIPTION
## Description of change

This PR describes a new command that allows to change the cloud credential that a model uses to communicate with its cloud.

If the credential with a given name is found on the controller for this user, Juju will link existing controller credential to the desired model.
If the credential cannot be found remotely, it will be first uploaded from the local client store to the controller. Then it will be linked to the model.
If the credential is not found remotely nor locally, the command will err.

As a drive-by, fixed a TODO on a featuretest that was updating a credential. 

## QA steps

1. bootstrap
2. add model
3. set model credential to a different credential, 'set-credential'
4. ensure model has the correct link, 'show-model'

## Documentation changes

New command alert \o/

