### PR TITLE
Fix repeate upgrade series message txns

### DIFF
--- a/state/machine_internal_test.go
+++ b/state/machine_internal_test.go
@@ -135,6 +135,42 @@ func (s *MachineInternalSuite) TestStartUpgradeSeriesUnitCompletionTxnOps(c *gc.
 	c.Assert(actualOpsSt, gc.Equals, expectedOpsSt)
 }
 
+func (s *MachineInternalSuite) TestSetUpgradeSeriesMessageTxnOps(c *gc.C) {
+	arbitraryMachineID := "id"
+	arbitraryTimestamp := bson.Now()
+	arbitraryMessages := []UpgradeSeriesMessage{
+		{
+			Message:   "arbitraryMessages0",
+			Timestamp: arbitraryTimestamp,
+			Seen:      false,
+		},
+		{
+			Message:   "arbitraryMessages1",
+			Timestamp: arbitraryTimestamp,
+			Seen:      false,
+		},
+	}
+	expectedOps := []txn.Op{
+		{
+			C:      machinesC,
+			Id:     arbitraryMachineID,
+			Assert: isAliveDoc,
+		},
+		{
+			C:  machineUpgradeSeriesLocksC,
+			Id: arbitraryMachineID,
+			Update: bson.D{{"$set", bson.D{
+				{"messages.0.seen", true},
+				{"messages.1.seen", true},
+			}}},
+		},
+	}
+	actualOps := setUpgradeSeriesMessageTxnOps(arbitraryMachineID, arbitraryMessages, true)
+	expectedOpsSt := fmt.Sprint(expectedOps)
+	actualOpsSt := fmt.Sprint(actualOps)
+	c.Assert(actualOpsSt, gc.Equals, expectedOpsSt)
+}
+
 func assertConstainsOP(c *gc.C, expectedOp txn.Op, actualOps []txn.Op) {
 	var found bool
 	for _, actualOp := range actualOps {

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -537,9 +537,7 @@ func (m *Machine) GetUpgradeSeriesMessages() ([]string, bool, error) {
 }
 
 // SetUpgradeSeriesMessagesAsSeen marks a given upgrade series messages as
-// having been seen by a client of the API. The method we use to determine have
-// that the message has actually been seen is that a client has made a call to
-// fetch the message.
+// having been seen by a client of the API.
 func (m *Machine) SetUpgradeSeriesMessagesAsSeen(messages []UpgradeSeriesMessage) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -571,14 +571,16 @@ func setUpgradeSeriesMessageTxnOps(machineDocID string, messages []UpgradeSeries
 			Assert: isAliveDoc,
 		},
 	}
+	fields := bson.D{}
 	for i := range messages {
 		field := fmt.Sprintf("messages.%d.seen", i)
-		ops = append(ops, txn.Op{
-			C:      machineUpgradeSeriesLocksC,
-			Id:     machineDocID,
-			Update: bson.D{{"$set", bson.D{{field, seen}}}},
-		})
+		fields = append(fields, bson.DocElem{field, seen})
 	}
+	ops = append(ops, txn.Op{
+		C:      machineUpgradeSeriesLocksC,
+		Id:     machineDocID,
+		Update: bson.D{{"$set", fields}},
+	})
 	return ops
 }
 


### PR DESCRIPTION
## Description of change

`upgrade-series` commands user messages where being marked as having been seen multiple times. This would cause unnecessary database activity during series upgrades. 

## QA steps

<TBA>

## Bug reference

<TBA>
