### PR TITLE
Fixes lp#1796148:  Only clear current model in client cache when user requests to change it.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -138,9 +138,11 @@ See also:
 const defaultHostedModelName = "default"
 
 func newBootstrapCommand() cmd.Command {
-	return modelcmd.Wrap(
-		&bootstrapCommand{},
-		modelcmd.WrapSkipModelFlags, modelcmd.WrapSkipDefaultModel,
+	command := &bootstrapCommand{}
+	command.CanClearCurrentModel = true
+	return modelcmd.Wrap(command,
+		modelcmd.WrapSkipModelFlags,
+		modelcmd.WrapSkipDefaultModel,
 	)
 }
 

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -16,11 +16,12 @@ import (
 )
 
 func newSwitchCommand() cmd.Command {
-	cmd := &switchCommand{
+	command := &switchCommand{
 		Store: jujuclient.NewFileClientStore(),
 	}
-	cmd.RefreshModels = cmd.CommandBase.RefreshModels
-	return modelcmd.WrapBase(cmd)
+	command.CanClearCurrentModel = true
+	command.RefreshModels = command.CommandBase.RefreshModels
+	return modelcmd.WrapBase(command)
 }
 
 type switchCommand struct {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -30,7 +30,7 @@ import (
 
 // NewAddModelCommand returns a command to add a model.
 func NewAddModelCommand() cmd.Command {
-	return modelcmd.WrapController(&addModelCommand{
+	command := &addModelCommand{
 		newAddModelAPI: func(caller base.APICallCloser) AddModelAPI {
 			return modelmanager.NewClient(caller)
 		},
@@ -38,7 +38,9 @@ func NewAddModelCommand() cmd.Command {
 			return cloudapi.NewClient(caller)
 		},
 		providerRegistry: environs.GlobalProviderRegistry(),
-	})
+	}
+	command.CanClearCurrentModel = true
+	return modelcmd.WrapController(command)
 }
 
 // addModelCommand calls the API to add a new model.

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -47,6 +47,7 @@ func NewRegisterCommand() cmd.Command {
 	c.apiOpen = c.APIOpen
 	c.listModelsFunc = c.listModels
 	c.store = jujuclient.NewFileClientStore()
+	c.CanClearCurrentModel = true
 	return modelcmd.WrapBase(c)
 }
 

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -36,6 +36,7 @@ var logger = loggo.GetLogger("juju.cmd.juju.model")
 // NewDestroyCommand returns a command used to destroy a model.
 func NewDestroyCommand() cmd.Command {
 	destroyCmd := &destroyCommand{}
+	destroyCmd.CanClearCurrentModel = true
 	destroyCmd.sleepFunc = time.Sleep
 	return modelcmd.Wrap(
 		destroyCmd,
@@ -294,11 +295,6 @@ upgrade the controller to version 2.3 or greater.
 		modelData = modelStatus(modelStatusPollWait)
 	}
 
-	err = store.RemoveModel(controllerName, modelName)
-	if err != nil && !errors.IsNotFound(err) {
-		return errors.Trace(err)
-	}
-
 	// Check if the model has an sla auth.
 	if slaIsSet {
 		err = c.removeModelBudget(modelDetails.ModelUUID)
@@ -307,6 +303,7 @@ upgrade the controller to version 2.3 or greater.
 		}
 	}
 
+	c.RemoveModelFromClientStore(store, controllerName, modelName)
 	return nil
 }
 

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -53,6 +53,10 @@ func (s *ExportBundleCommandSuite) TearDownTest(c *gc.C) {
 		if !os.IsNotExist(err) {
 			c.Check(err, jc.ErrorIsNil)
 		}
+		err = os.Remove(s.fake.filename)
+		if !os.IsNotExist(err) {
+			c.Check(err, jc.ErrorIsNil)
+		}
 	}
 
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -86,6 +86,7 @@ var (
 func NewLoginCommand() cmd.Command {
 	var c loginCommand
 	c.SetClientStore(loginClientStore)
+	c.CanClearCurrentModel = true
 	return modelcmd.WrapController(&c, modelcmd.WrapControllerSkipControllerFlags)
 }
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -157,13 +157,12 @@ func (c *CommandBase) NewAPIRoot(
 	return conn, err
 }
 
-func (c *CommandBase) missingModelError(store jujuclient.ClientStore, controllerName, modelName string) error {
+func (c *CommandBase) RemoveModelFromClientStore(store jujuclient.ClientStore, controllerName, modelName string) {
+	err := store.RemoveModel(controllerName, modelName)
+	if err != nil {
+		logger.Warningf("cannot remove unknown model from cache: %v", err)
+	}
 	if c.CanClearCurrentModel {
-		// First, we'll try and clean up the missing model from the local cache.
-		err := store.RemoveModel(controllerName, modelName)
-		if err != nil {
-			logger.Warningf("cannot remove unknown model from cache: %v", err)
-		}
 		currentModel, err := store.CurrentModel(controllerName)
 		if err != nil {
 			logger.Warningf("cannot read current model: %v", err)
@@ -173,6 +172,11 @@ func (c *CommandBase) missingModelError(store jujuclient.ClientStore, controller
 			}
 		}
 	}
+}
+
+func (c *CommandBase) missingModelError(store jujuclient.ClientStore, controllerName, modelName string) error {
+	// First, we'll try and clean up the missing model from the local cache.
+	c.RemoveModelFromClientStore(store, controllerName, modelName)
 	return errors.Errorf("model %q has been removed from the controller, run 'juju models' and switch to one of them.", modelName)
 }
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -58,13 +58,15 @@ type ModelAPI interface {
 // an API connection.
 type CommandBase struct {
 	cmd.CommandBase
-	cmdContext           *cmd.Context
-	apiContexts          map[string]*apiContext
-	modelAPI_            ModelAPI
-	apiOpenFunc          api.OpenFunc
-	authOpts             AuthOpts
-	runStarted           bool
-	refreshModels        func(jujuclient.ClientStore, string) error
+	cmdContext    *cmd.Context
+	apiContexts   map[string]*apiContext
+	modelAPI_     ModelAPI
+	apiOpenFunc   api.OpenFunc
+	authOpts      AuthOpts
+	runStarted    bool
+	refreshModels func(jujuclient.ClientStore, string) error
+
+	// CanClearCurrentModel indicates that this command can reset current model in local cache, aka client store.
 	CanClearCurrentModel bool
 }
 
@@ -157,6 +159,15 @@ func (c *CommandBase) NewAPIRoot(
 	return conn, err
 }
 
+// RemoveModelFromClientStore removes given model from client cache, store,
+// for a given controller.
+// If this model has also been cached as current, it will be reset if
+// the requesting command can modify current model.
+// For example, commands such as add/destroy-model, login/register, etc.
+// If the model was cached as currnet but the command is not expected to
+// change current model, this call will still remove model details from the client cache
+// but will keep current model name intact to allow subsequent calls to try to resolve
+// model details on the controller.
 func (c *CommandBase) RemoveModelFromClientStore(store jujuclient.ClientStore, controllerName, modelName string) {
 	err := store.RemoveModel(controllerName, modelName)
 	if err != nil {

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -58,13 +58,14 @@ type ModelAPI interface {
 // an API connection.
 type CommandBase struct {
 	cmd.CommandBase
-	cmdContext    *cmd.Context
-	apiContexts   map[string]*apiContext
-	modelAPI_     ModelAPI
-	apiOpenFunc   api.OpenFunc
-	authOpts      AuthOpts
-	runStarted    bool
-	refreshModels func(jujuclient.ClientStore, string) error
+	cmdContext           *cmd.Context
+	apiContexts          map[string]*apiContext
+	modelAPI_            ModelAPI
+	apiOpenFunc          api.OpenFunc
+	authOpts             AuthOpts
+	runStarted           bool
+	refreshModels        func(jujuclient.ClientStore, string) error
+	CanClearCurrentModel bool
 }
 
 func (c *CommandBase) assertRunStarted() {
@@ -157,17 +158,19 @@ func (c *CommandBase) NewAPIRoot(
 }
 
 func (c *CommandBase) missingModelError(store jujuclient.ClientStore, controllerName, modelName string) error {
-	// First, we'll try and clean up the missing model from the local cache.
-	err := store.RemoveModel(controllerName, modelName)
-	if err != nil {
-		logger.Warningf("cannot remove unknown model from cache: %v", err)
-	}
-	currentModel, err := store.CurrentModel(controllerName)
-	if err != nil {
-		logger.Warningf("cannot read current model: %v", err)
-	} else if currentModel == modelName {
-		if err := store.SetCurrentModel(controllerName, ""); err != nil {
-			logger.Warningf("cannot reset current model: %v", err)
+	if c.CanClearCurrentModel {
+		// First, we'll try and clean up the missing model from the local cache.
+		err := store.RemoveModel(controllerName, modelName)
+		if err != nil {
+			logger.Warningf("cannot remove unknown model from cache: %v", err)
+		}
+		currentModel, err := store.CurrentModel(controllerName)
+		if err != nil {
+			logger.Warningf("cannot read current model: %v", err)
+		} else if currentModel == modelName {
+			if err := store.SetCurrentModel(controllerName, ""); err != nil {
+				logger.Warningf("cannot reset current model: %v", err)
+			}
 		}
 	}
 	return errors.Errorf("model %q has been removed from the controller, run 'juju models' and switch to one of them.", modelName)

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -65,11 +65,7 @@ func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, baseCmd *modelcmd.ModelCo
 	c.Assert(conn, gc.IsNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Assert(msg, gc.Equals, `model "admin/badmodel" has been removed from the controller, run 'juju models' and switch to one of them.`)
-	if baseCmd.CanClearCurrentModel {
-		c.Assert(s.store.Models["foo"].Models, gc.HasLen, 1)
-	} else {
-		c.Assert(s.store.Models["foo"].Models, gc.HasLen, 2)
-	}
+	c.Assert(s.store.Models["foo"].Models, gc.HasLen, 1)
 	c.Assert(s.store.Models["foo"].Models["admin/goodmodel"], gc.DeepEquals,
 		jujuclient.ModelDetails{ModelUUID: "deadbeef2", ModelType: model.IAAS})
 	c.Assert(s.store.Models["foo"].CurrentModel, gc.Equals, expectedCurrent)
@@ -79,7 +75,7 @@ func (s *BaseCommandSuite) TestUnknownModel(c *gc.C) {
 	s.assertUnknownModel(c, new(modelcmd.ModelCommandBase), "admin/badmodel", "admin/badmodel")
 }
 
-func (s *BaseCommandSuite) TestUnknownModelCanRemoveCachedCurent(c *gc.C) {
+func (s *BaseCommandSuite) TestUnknownModelCanRemoveCachedCurrent(c *gc.C) {
 	baseCmd := new(modelcmd.ModelCommandBase)
 	baseCmd.CanClearCurrentModel = true
 	s.assertUnknownModel(c, baseCmd, "admin/badmodel", "")
@@ -89,7 +85,7 @@ func (s *BaseCommandSuite) TestUnknownModelNotCurrent(c *gc.C) {
 	s.assertUnknownModel(c, new(modelcmd.ModelCommandBase), "admin/goodmodel", "admin/goodmodel")
 }
 
-func (s *BaseCommandSuite) TestUnknownModelNotCurrentCanRemoveCachedCurent(c *gc.C) {
+func (s *BaseCommandSuite) TestUnknownModelNotCurrentCanRemoveCachedCurrent(c *gc.C) {
 	baseCmd := new(modelcmd.ModelCommandBase)
 	baseCmd.CanClearCurrentModel = true
 	s.assertUnknownModel(c, baseCmd, "admin/goodmodel", "admin/goodmodel")

--- a/cmd/modelcmd/clientstore.go
+++ b/cmd/modelcmd/clientstore.go
@@ -23,6 +23,9 @@ type QualifyingClientStore struct {
 // fully qualified name, it is returned untouched; otherwise it is
 // return qualified with the logged-in user name.
 func (s QualifyingClientStore) QualifiedModelName(controllerName, modelName string) (string, error) {
+	if modelName == "" {
+		return "", nil
+	}
 	if !jujuclient.IsQualifiedModelName(modelName) {
 		details, err := s.ClientStore.AccountDetails(controllerName)
 		if err != nil {

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -233,12 +233,18 @@ func (c *MemStore) SetCurrentModel(controllerName, modelName string) error {
 	if err := ValidateControllerName(controllerName); err != nil {
 		return errors.Trace(err)
 	}
-	if err := ValidateModelName(modelName); err != nil {
-		return errors.Trace(err)
-	}
 	controllerModels, ok := c.Models[controllerName]
 	if !ok {
 		return errors.NotFoundf("model %s:%s", controllerName, modelName)
+	}
+	if modelName == "" {
+		// We just want to reset
+		controllerModels.CurrentModel = ""
+		return nil
+	}
+
+	if err := ValidateModelName(modelName); err != nil {
+		return errors.Trace(err)
 	}
 	if _, ok := controllerModels.Models[modelName]; !ok {
 		return errors.NotFoundf("model %s:%s", controllerName, modelName)
@@ -266,9 +272,6 @@ func (c *MemStore) RemoveModel(controller, model string) error {
 		return errors.NotFoundf("model %s:%s", controller, model)
 	}
 	delete(controllerModels.Models, model)
-	if controllerModels.CurrentModel == model {
-		controllerModels.CurrentModel = ""
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

Juju caches current model information on the client. This cache gets updated every time we can deduce whether a model exists on the controller, i.e. every time we make an API call that sues current model reference.
We have recently encountered a few scenarios where the API response may think that the model is no longer there and cleared client's reference to the current model. However, the model still exists and all subsequent commands ran by the user surprising fail.

This PR ensures that we do not change current model reference for all the commands. Only some commands that are known to manipulate current model reference should update the cache to avoid surprising users.

Commands that affect current model are:
* bootstrap;
* login;
* register;
* switch;
* add-model; 
* destroy-model;
* login.

I have also verified that if we have only  a model name, say just current model name in a cache, we refresh on a subsequent command:

i. bootstrap 
```
$ juju status --debug --show-log
15:31:35 INFO  juju.cmd supercommand.go:56 running juju [2.4.5 gc go1.11.1]
15:31:35 DEBUG juju.cmd supercommand.go:57   args: []string{"juju", "status", "--debug", "--show-log"}
15:31:35 INFO  juju.juju api.go:67 connecting to API addresses: [34.207.203.58:17070 172.31.14.152:17070 252.14.152.1:17070]
15:31:38 DEBUG juju.api apiclient.go:877 successfully dialed "wss://34.207.203.58:17070/model/e7210adf-2a8c-4750-800b-4d16a2473931/api"
15:31:38 INFO  juju.api apiclient.go:599 connection established to "wss://34.207.203.58:17070/model/e7210adf-2a8c-4750-800b-4d16a2473931/api"
15:31:38 DEBUG juju.api monitor.go:35 RPC connection died
Model    Controller    Cloud/Region   Version  SLA          Timestamp
default  mycontroller  aws/us-east-1  2.4.5.1  unsupported  15:31:38+10:00

15:31:38 INFO  cmd status.go:252 Model "admin/default" is empty.
15:31:38 INFO  cmd supercommand.go:465 command finished

```
ii. Remove model details for current model from local cache @ models.yaml but keep the current model name 
```
$ juju status --debug --show-log
15:32:03 INFO  juju.cmd supercommand.go:56 running juju [2.4.5 gc go1.11.1]
15:32:03 DEBUG juju.cmd supercommand.go:57   args: []string{"juju", "status", "--debug", "--show-log"}
15:32:03 DEBUG juju.cmd.modelcmd modelcommand.go:287 model "admin/default" not found, refreshing
15:32:03 INFO  juju.juju api.go:67 connecting to API addresses: [34.207.203.58:17070 172.31.14.152:17070 252.14.152.1:17070]
15:32:04 DEBUG juju.api apiclient.go:877 successfully dialed "wss://34.207.203.58:17070/api"
15:32:04 INFO  juju.api apiclient.go:599 connection established to "wss://34.207.203.58:17070/api"
15:32:05 DEBUG juju.api monitor.go:35 RPC connection died
15:32:05 INFO  juju.juju api.go:67 connecting to API addresses: [34.207.203.58:17070 172.31.14.152:17070 252.14.152.1:17070]
15:32:06 DEBUG juju.api apiclient.go:877 successfully dialed "wss://34.207.203.58:17070/model/e7210adf-2a8c-4750-800b-4d16a2473931/api"
15:32:06 INFO  juju.api apiclient.go:599 connection established to "wss://34.207.203.58:17070/model/e7210adf-2a8c-4750-800b-4d16a2473931/api"
15:32:07 DEBUG juju.api monitor.go:35 RPC connection died
Model    Controller    Cloud/Region   Version  SLA          Timestamp
default  mycontroller  aws/us-east-1  2.4.5.1  unsupported  15:32:07+10:00

15:32:07 INFO  cmd status.go:252 Model "admin/default" is empty.
15:32:07 INFO  cmd supercommand.go:465 command finished

```
As you can see we have made an additional API call to refresh models list to obtain models' details before running status api call and displaying status correctly despite not having model uuid originally.

As a drive-by, export bundle command unit tests were leaving behind a test file. Added file removal code to ensure file system is the same as before tests run.



## Bug reference

https://bugs.launchpad.net/juju/+bug/1796148
