### PR TITLE
Removed restriction for collect-metrics on local charms

### DIFF
--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -131,27 +131,6 @@ var newApplicationClient = func(root api.Connection) applicationClient {
 	return application.NewClient(root)
 }
 
-func isLocalCharmURL(conn api.Connection, entity string) (bool, error) {
-	applicationName := entity
-	var err error
-	if names.IsValidUnit(entity) {
-		applicationName, err = names.UnitApplication(entity)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-	}
-
-	client := newApplicationClient(conn)
-	// TODO (mattyw, anastasiamac) The storage work might lead to an api
-	// allowing us to query charm url for a unit.
-	// When that api exists we should use that here.
-	url, err := client.GetCharmURL(applicationName)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	return url.Schema == "local", nil
-}
-
 var newAPIConn = func(cmd modelcmd.ModelCommandBase) (api.Connection, error) {
 	return cmd.NewAPIRoot()
 }
@@ -164,14 +143,6 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 	}
 	runnerClient := newRunClient(root)
 	defer runnerClient.Close()
-
-	islocal, err := isLocalCharmURL(root, c.entity)
-	if err != nil {
-		return errors.Annotate(err, "failed to find charmURL for entity")
-	}
-	if !islocal {
-		return errors.Errorf("%q is not a local charm", c.entity)
-	}
 
 	units := []string{}
 	applications := []string{}

--- a/cmd/juju/metricsdebug/collectmetrics_test.go
+++ b/cmd/juju/metricsdebug/collectmetrics_test.go
@@ -24,20 +24,13 @@ type collectMetricsSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 }
 
-var _ = gc.Suite(&collectMetricsSuite{})
+var (
+	_ = gc.Suite(&collectMetricsSuite{})
 
-func (s *collectMetricsSuite) TestCollectMetrics(c *gc.C) {
-	runClient := &testRunClient{}
-	applicationClient := &testApplicationClient{}
-	applicationClient.charmURL = "local:quantal/charm"
-	s.PatchValue(metricsdebug.NewAPIConn, noConn)
-	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
-	s.PatchValue(metricsdebug.NewApplicationClient, metricsdebug.NewApplicationClientFnc(applicationClient))
+	actionTag1 = names.NewActionTag("01234567-89ab-cdef-0123-456789abcdef")
+	actionTag2 = names.NewActionTag("11234567-89ab-cdef-0123-456789abcdef")
 
-	actionTag1 := names.NewActionTag("01234567-89ab-cdef-0123-456789abcdef")
-	actionTag2 := names.NewActionTag("11234567-89ab-cdef-0123-456789abcdef")
-
-	tests := []struct {
+	tests = []struct {
 		about     string
 		args      []string
 		stdout    string
@@ -302,6 +295,15 @@ func (s *collectMetricsSuite) TestCollectMetrics(c *gc.C) {
 		},
 		stdout: "failed to send metrics for unit uptime/0: kek\n",
 	}}
+)
+
+func (s *collectMetricsSuite) TestCollectMetricsLocal(c *gc.C) {
+	runClient := &testRunClient{}
+	applicationClient := &testApplicationClient{}
+	applicationClient.charmURL = "local:quantal/charm"
+	s.PatchValue(metricsdebug.NewAPIConn, noConn)
+	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
+	s.PatchValue(metricsdebug.NewApplicationClient, metricsdebug.NewApplicationClientFnc(applicationClient))
 
 	for i, test := range tests {
 		c.Logf("running test %d: %v", i, test.about)
@@ -320,16 +322,29 @@ func (s *collectMetricsSuite) TestCollectMetrics(c *gc.C) {
 	}
 }
 
-func (s *collectMetricsSuite) TestCollectMetricsFailsOnNonLocalCharm(c *gc.C) {
+func (s *collectMetricsSuite) TestCollectMetricsRemote(c *gc.C) {
 	runClient := &testRunClient{}
-	appClient := &testApplicationClient{}
-	appClient.charmURL = "cs:quantal/charm"
+	applicationClient := &testApplicationClient{}
+	applicationClient.charmURL = "quantal/charm"
 	s.PatchValue(metricsdebug.NewAPIConn, noConn)
 	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
-	s.PatchValue(metricsdebug.NewApplicationClient, metricsdebug.NewApplicationClientFnc(appClient))
-	_, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommandForTest(), "foobar")
-	c.Assert(err, gc.ErrorMatches, `"foobar" is not a local charm`)
-	runClient.CheckCallNames(c, "Close")
+	s.PatchValue(metricsdebug.NewApplicationClient, metricsdebug.NewApplicationClientFnc(applicationClient))
+
+	for i, test := range tests {
+		c.Logf("running test %d: %v", i, test.about)
+		runClient.reset()
+		if test.results != nil {
+			runClient.results = test.results
+		}
+		metricsdebug.PatchGetActionResult(s.PatchValue, test.actionMap)
+		ctx, err := cmdtesting.RunCommand(c, metricsdebug.NewCollectMetricsCommandForTest(), test.args...)
+		if test.err != "" {
+			c.Assert(err, gc.ErrorMatches, test.err)
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(cmdtesting.Stdout(ctx), gc.Matches, test.stdout)
+		}
+	}
 }
 
 type testRunClient struct {


### PR DESCRIPTION
## Description of change

This change removes the restriction that collect-metric only works on locally-deployed charms.

## QA steps

Run collect-metrics on any non-locally deployed charm.

