### PR TITLE
Don't show charm version in tabular status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -122,9 +122,9 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Charm version", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
 	} else {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Charm version", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
 	}
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
@@ -168,13 +168,6 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			app.OS)
 		if fs.Model.Type == caasModelType {
 			w.Print(app.Address)
-		}
-
-		charmVersion := fmt.Sprintf("%.15s", app.CharmVersion)
-		if len(app.CharmVersion) > len(charmVersion) {
-			w.Print(charmVersion + "...")
-		} else {
-			w.Print(charmVersion)
 		}
 
 		w.Println(notes)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4748,10 +4748,10 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
 
-App        Version          Status       Scale  Charm      Store       Rev  OS      Charm version  Notes
-logging    a bit too lo...  error            2  logging    jujucharms    1  ubuntu                 exposed
-mysql      5.7.13           maintenance      1  mysql      jujucharms    1  ubuntu                 exposed
-wordpress  4.5.3            active           1  wordpress  jujucharms    3  ubuntu                 exposed
+App        Version          Status       Scale  Charm      Store       Rev  OS      Notes
+logging    a bit too lo...  error            2  logging    jujucharms    1  ubuntu  exposed
+mysql      5.7.13           maintenance      1  mysql      jujucharms    1  ubuntu  exposed
+wordpress  4.5.3            active           1  wordpress  jujucharms    3  ubuntu  exposed
 
 Unit          Workload     Agent  Machine  Public address  Ports  Message
 mysql/0*      maintenance  idle   2        10.0.2.1               installing all the things
@@ -4816,8 +4816,8 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Charm version  Notes
-foo                       2                  0                     
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
+foo                       2                  0      
 
 Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
@@ -4863,8 +4863,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Charm version  Notes
-foo                     1/2                  0      54.32.1.2                 
+App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Notes
+foo                     1/2                  0      54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
@@ -4905,8 +4905,8 @@ func (s *StatusSuite) TestFormatTabularStatusNotes(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Charm version  Notes
-foo                     0/1                  0      54.32.1.2                 Error: ImagePullBackOff
+App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Notes
+foo                     0/1                  0      54.32.1.2  Error: ImagePullBackOff
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  waiting   allocating  10.0.0.1  80/TCP  
@@ -4943,8 +4943,8 @@ func (s *StatusSuite) TestFormatTabularStatusNotesIAAS(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Charm version  Notes
-foo                       1                  0                     
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
+foo                       1                  0      
 
 Unit   Workload  Agent  Machine  Public address  Ports   Message
 foo/0  waiting   idle                            80/TCP  
@@ -5007,8 +5007,8 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Charm version  Notes
-foo                     0/2                  0                     
+App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
+foo                     0/2                  0      
 
 Unit   Workload  Agent  Machine  Public address  Ports  Message
 foo/0                                                   

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -152,10 +152,10 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 
 	context := s.run(c, "status")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Charm version  Notes
-another             waiting    0/1  mysql      jujucharms    5  ubuntu                 
-mysql               waiting    0/1  mysql      jujucharms    1  ubuntu                 
-wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu                 
+App        Version  Status   Scale  Charm      Store       Rev  OS      Notes
+another             waiting    0/1  mysql      jujucharms    5  ubuntu  
+mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  
+wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 another/0    waiting   allocating  1                               waiting for machine
@@ -169,9 +169,9 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 	context = s.run(c, "status", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Charm version  Notes
-mysql               waiting    0/1  mysql      jujucharms    1  ubuntu                 
-wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu                 
+App        Version  Status   Scale  Charm      Store       Rev  OS      Notes
+mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  
+wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine


### PR DESCRIPTION
## Description of change

Only show charm version in yaml/json status output, not tabular.

## QA steps

juju status

