### PR TITLE
Ensure correct k8s unit status is displayed when blocked

### DIFF
--- a/state/status.go
+++ b/state/status.go
@@ -93,8 +93,7 @@ func (m *ModelStatus) Application(appName string, unitNames []string) (status.St
 		for _, name := range unitNames {
 			unitStatus, err := m.UnitWorkload(name)
 			if err != nil {
-				errors.Annotatef(err, "deriving application status from %q", name)
-				continue
+				return status.StatusInfo{}, errors.Annotatef(err, "deriving application status from %q", name)
 			}
 			unitStatuses = append(unitStatuses, unitStatus)
 		}
@@ -197,8 +196,13 @@ func caasUnitDisplayStatus(unitStatus status.StatusInfo, containerStatus status.
 		return containerStatus
 	}
 	if containerStatus.Status == "" {
-		// No container update received from k8s yet,
-		// so we have to assume it's still allocating.
+		// No container update received from k8s yet.
+		// Unit may have set status.
+		if unitStatus.Status != "" {
+			return unitStatus
+		}
+
+		// If no unit status set, assume still allocating.
 		return status.StatusInfo{
 			Status:  status.Waiting,
 			Message: status.MessageWaitForContainer,

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -408,10 +408,15 @@ func (s *UnitCloudStatusSuite) TestContainerOrUnitStatusChoice(c *gc.C) {
 		{
 			cloudContainerStatus: status.StatusInfo{},
 			unitStatus: status.StatusInfo{
-				Status:  status.Active,
+				Status:  status.Blocked,
 				Message: "unit",
 			},
-			messageCheck: status.MessageWaitForContainer,
+			messageCheck: "unit",
+		},
+		{
+			cloudContainerStatus: status.StatusInfo{},
+			unitStatus:           status.StatusInfo{},
+			messageCheck:         status.MessageWaitForContainer,
 		},
 	}
 


### PR DESCRIPTION
## Description of change

When reporting status of k8s units, if the unit is blocked, the status was incorrectly shown as waiting.

## QA steps

Deploy gitlab without a relation to a database.
Ensure the unit shows as blocked.
Relate to a database - status goes to active.

