### PR TITLE
2.4 LP:1723184 Log Instead of Error When Unit is Not Leader

### DIFF
--- a/worker/uniter/runner/context/leader.go
+++ b/worker/uniter/runner/context/leader.go
@@ -74,6 +74,10 @@ func (ctx *leadershipContext) WriteLeaderSettings(settings map[string]string) er
 	// `apiserver/leadership.LeadershipSettingsAccessor.Merge`, and as of
 	// 2015-02-19 it's better to stay eager.
 	err := ctx.ensureLeader()
+	if err == errIsMinion {
+		logger.Warningf("skipping write settings; not the leader")
+		return nil
+	}
 	if err == nil {
 		// Clear local settings; if we need them again we should use the values
 		// as merged by the server. But we don't need to get them again right now;

--- a/worker/uniter/runner/context/leader_test.go
+++ b/worker/uniter/runner/context/leader_test.go
@@ -201,16 +201,17 @@ func (s *LeaderSuite) TestWriteLeaderSettingsMinion(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeader",
 	}}, func() {
-		// The first call fails...
+		// We are not the leader.
 		s.tracker.results = []StubTicket{false}
 		err := s.context.WriteLeaderSettings(map[string]string{"blah": "blah"})
-		c.Check(err, gc.ErrorMatches, "cannot write settings: not the leader")
+		// No error, no call to Merge.
+		c.Check(err, jc.ErrorIsNil)
 	})
 
 	s.CheckCalls(c, nil, func() {
-		// The second doesn't even try.
+		// ctx.isMinion is now true. No call to claim leader.
 		err := s.context.WriteLeaderSettings(map[string]string{"blah": "blah"})
-		c.Check(err, gc.ErrorMatches, "cannot write settings: not the leader")
+		c.Check(err, jc.ErrorIsNil)
 	})
 }
 


### PR DESCRIPTION
## Description of change

If a _leader-elected_ hook is queued to run, and leadership changes before it executes, an error is returned due to the unit no longer being the leader.

This patch detects such a condition and skips the writing of leadership settings with a logged warning, instead of returning an error.

## QA steps

I tries for some time to replicate the error with the charm in question, _ubuntu-repository-cache_, but was not successful.

Modified unit test verifies the behaviour, and other error conditions still throw out as expected.

To check for regression:
1. Bootstrap to LXD.
2. `deploy ubuntu-repository-cache -n 5`
3. Once deployed and "starting", stop the leader's container with `lxc stop {container-id}`.
4. Check that a new leader is elected without error.
5. Repeat 3-4 several times.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/
