### PR TITLE
2.4 LP:1723184 Hook Error When Unit Not Leader

### DIFF
--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -153,7 +153,16 @@ func (rh *runHook) beforeHook(state State) error {
 			Status: string(status.Maintenance),
 			Info:   "cleaning up prior to charm deletion",
 		})
+	case hooks.LeaderElected:
+		// Check if leadership has changed between queueing of the hook and
+		// Actual execution. Set the error if we are no longer the leader.
+		isLeader := false
+		isLeader, err = rh.runner.Context().IsLeader()
+		if err == nil && !isLeader {
+			err = context.ErrIsNotLeader
+		}
 	}
+
 	if err != nil {
 		logger.Errorf("error updating workload status before %v hook: %v", rh.info.Kind, err)
 		return err

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -432,12 +432,17 @@ func NewRunCommandsRunnerFactory(runResponse *utilexec.ExecResponse, runErr erro
 	}
 }
 
-func NewRunHookRunnerFactory(runErr error) *MockRunnerFactory {
+func NewRunHookRunnerFactory(runErr error, contextOps ...func(*MockContext)) *MockRunnerFactory {
+	ctx := &MockContext{isLeader: true}
+	for _, op := range contextOps {
+		op(ctx)
+	}
+
 	return &MockRunnerFactory{
 		MockNewHookRunner: &MockNewHookRunner{
 			runner: &MockRunner{
 				MockRunHook: &MockRunHook{err: runErr},
-				context:     &MockContext{},
+				context:     ctx,
 			},
 		},
 	}

--- a/worker/uniter/runner/context/leader.go
+++ b/worker/uniter/runner/context/leader.go
@@ -74,6 +74,10 @@ func (ctx *leadershipContext) WriteLeaderSettings(settings map[string]string) er
 	// `apiserver/leadership.LeadershipSettingsAccessor.Merge`, and as of
 	// 2015-02-19 it's better to stay eager.
 	err := ctx.ensureLeader()
+	if err == errIsMinion {
+		logger.Warningf("skipping write settings; not the leader")
+		return nil
+	}
 	if err == nil {
 		// Clear local settings; if we need them again we should use the values
 		// as merged by the server. But we don't need to get them again right now;

--- a/worker/uniter/runner/context/leader_test.go
+++ b/worker/uniter/runner/context/leader_test.go
@@ -201,16 +201,17 @@ func (s *LeaderSuite) TestWriteLeaderSettingsMinion(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeader",
 	}}, func() {
-		// The first call fails...
+		// We are not the leader.
 		s.tracker.results = []StubTicket{false}
 		err := s.context.WriteLeaderSettings(map[string]string{"blah": "blah"})
-		c.Check(err, gc.ErrorMatches, "cannot write settings: not the leader")
+		// No error, no call to Merge.
+		c.Check(err, jc.ErrorIsNil)
 	})
 
 	s.CheckCalls(c, nil, func() {
-		// The second doesn't even try.
+		// ctx.isMinion is now true. No call to claim leader.
 		err := s.context.WriteLeaderSettings(map[string]string{"blah": "blah"})
-		c.Check(err, gc.ErrorMatches, "cannot write settings: not the leader")
+		c.Check(err, jc.ErrorIsNil)
 	})
 }
 


### PR DESCRIPTION
## Description of change

If the uniter queues a _leader-elected_ hook, but application leadership changes before it is run, the unit enters an error state.

This patch modifies the `runHook.Prepare` method to recheck for leadership when running a _leader-elected_ hook. If the unit is no longer the leader, `ErrSkipExecute` is returned.

It also skips the call to `Merge` leadership settings and logs a warning when the unit is not the leader, instead of returning an error.

## QA steps

I tried for some time without success to replicate the issue using the charm in the LP bug, _ubuntu-repository-cache_.

Modified test verifies new behaviour, and error returns for the other failure conditions remain.

To check for regression:
1. Bootstrap to LXD.
2. `juju deploy ubuntu-repository-cache -n 5`.
3. Stop the leader's container with `lxc stop {container-id}`.
4. Check that leadership changes without error and restart the container.
5. Repeat steps 3-4 several times.

## Documentation changes

None. 

## Bug reference

https://bugs.launchpad.net/juju-core/+bug/1723184
