### PR TITLE
add worker backoff as dependency engine config

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -8,7 +8,9 @@ package agent
 
 import (
 	"sync"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -16,6 +18,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1/dependency"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/util"
@@ -154,4 +157,17 @@ func GetJujuVersion(machineAgent string, dataDir string) (version.Number, error)
 		return version.Number{}, errors.Errorf("%s agent conf is not found", machineAgent)
 	}
 	return config.UpgradedToVersion(), nil
+}
+
+func dependencyEngineConfig() dependency.EngineConfig {
+	return dependency.EngineConfig{
+		IsFatal:       util.IsFatal,
+		WorstError:    util.MoreImportantError,
+		ErrorDelay:    3 * time.Second,
+		BounceDelay:   10 * time.Millisecond,
+		BackoffFactor: 1.5,
+		MaxDelay:      5 * time.Minute,
+		Clock:         clock.WallClock,
+		Logger:        loggo.GetLogger("juju.worker.dependency"),
+	}
 }

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -165,15 +165,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		MachineLock:          op.machineLock,
 	})
 
-	config := dependency.EngineConfig{
-		IsFatal:     cmdutil.IsFatal,
-		WorstError:  cmdutil.MoreImportantError,
-		ErrorDelay:  3 * time.Second,
-		BounceDelay: 10 * time.Millisecond,
-		Clock:       clock.WallClock,
-		Logger:      loggo.GetLogger("juju.worker.dependency"),
-	}
-	engine, err := dependency.NewEngine(config)
+	engine, err := dependency.NewEngine(dependencyEngineConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -499,12 +499,14 @@ func (a *MachineAgent) Run(*cmd.Context) (err error) {
 func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) func() (worker.Worker, error) {
 	return func() (worker.Worker, error) {
 		config := dependency.EngineConfig{
-			IsFatal:     cmdutil.IsFatal,
-			WorstError:  cmdutil.MoreImportantError,
-			ErrorDelay:  3 * time.Second,
-			BounceDelay: 10 * time.Millisecond,
-			Clock:       clock.WallClock,
-			Logger:      loggo.GetLogger("juju.worker.dependency"),
+			IsFatal:       cmdutil.IsFatal,
+			WorstError:    cmdutil.MoreImportantError,
+			ErrorDelay:    3 * time.Second,
+			BounceDelay:   10 * time.Millisecond,
+			BackoffFactor: 1.5,
+			MaxDelay:      5 * time.Minute,
+			Clock:         clock.WallClock,
+			Logger:        loggo.GetLogger("juju.worker.dependency"),
 		}
 		engine, err := dependency.NewEngine(config)
 		if err != nil {
@@ -996,13 +998,15 @@ func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.Model
 	}
 
 	engine, err := dependency.NewEngine(dependency.EngineConfig{
-		IsFatal:     model.IsFatal,
-		WorstError:  model.WorstError,
-		Filter:      model.IgnoreErrRemoved,
-		ErrorDelay:  3 * time.Second,
-		BounceDelay: 10 * time.Millisecond,
-		Clock:       clock.WallClock,
-		Logger:      loggo.GetLogger("juju.worker.dependency"),
+		IsFatal:       model.IsFatal,
+		WorstError:    model.WorstError,
+		Filter:        model.IgnoreErrRemoved,
+		ErrorDelay:    3 * time.Second,
+		BounceDelay:   10 * time.Millisecond,
+		BackoffFactor: 1.5,
+		MaxDelay:      5 * time.Minute,
+		Clock:         clock.WallClock,
+		Logger:        loggo.GetLogger("juju.worker.dependency"),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -498,17 +498,7 @@ func (a *MachineAgent) Run(*cmd.Context) (err error) {
 
 func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) func() (worker.Worker, error) {
 	return func() (worker.Worker, error) {
-		config := dependency.EngineConfig{
-			IsFatal:       cmdutil.IsFatal,
-			WorstError:    cmdutil.MoreImportantError,
-			ErrorDelay:    3 * time.Second,
-			BounceDelay:   10 * time.Millisecond,
-			BackoffFactor: 1.5,
-			MaxDelay:      5 * time.Minute,
-			Clock:         clock.WallClock,
-			Logger:        loggo.GetLogger("juju.worker.dependency"),
-		}
-		engine, err := dependency.NewEngine(config)
+		engine, err := dependency.NewEngine(dependencyEngineConfig())
 		if err != nil {
 			return nil, err
 		}
@@ -996,18 +986,11 @@ func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.Model
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	engine, err := dependency.NewEngine(dependency.EngineConfig{
-		IsFatal:       model.IsFatal,
-		WorstError:    model.WorstError,
-		Filter:        model.IgnoreErrRemoved,
-		ErrorDelay:    3 * time.Second,
-		BounceDelay:   10 * time.Millisecond,
-		BackoffFactor: 1.5,
-		MaxDelay:      5 * time.Minute,
-		Clock:         clock.WallClock,
-		Logger:        loggo.GetLogger("juju.worker.dependency"),
-	})
+	config := dependencyEngineConfig()
+	config.IsFatal = model.IsFatal
+	config.WorstError = model.WorstError
+	config.Filter = model.IgnoreErrRemoved
+	engine, err := dependency.NewEngine(config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -207,17 +207,7 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		MachineLock:          machineLock,
 	})
 
-	config := dependency.EngineConfig{
-		IsFatal:       cmdutil.IsFatal,
-		WorstError:    cmdutil.MoreImportantError,
-		ErrorDelay:    3 * time.Second,
-		BounceDelay:   10 * time.Millisecond,
-		BackoffFactor: 1.5,
-		MaxDelay:      5 * time.Minute,
-		Clock:         clock.WallClock,
-		Logger:        loggo.GetLogger("juju.worker.dependency"),
-	}
-	engine, err := dependency.NewEngine(config)
+	engine, err := dependency.NewEngine(dependencyEngineConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -208,12 +208,14 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 	})
 
 	config := dependency.EngineConfig{
-		IsFatal:     cmdutil.IsFatal,
-		WorstError:  cmdutil.MoreImportantError,
-		ErrorDelay:  3 * time.Second,
-		BounceDelay: 10 * time.Millisecond,
-		Clock:       clock.WallClock,
-		Logger:      loggo.GetLogger("juju.worker.dependency"),
+		IsFatal:       cmdutil.IsFatal,
+		WorstError:    cmdutil.MoreImportantError,
+		ErrorDelay:    3 * time.Second,
+		BounceDelay:   10 * time.Millisecond,
+		BackoffFactor: 1.5,
+		MaxDelay:      5 * time.Minute,
+		Clock:         clock.WallClock,
+		Logger:        loggo.GetLogger("juju.worker.dependency"),
 	}
 	engine, err := dependency.NewEngine(config)
 	if err != nil {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -119,7 +119,7 @@ gopkg.in/juju/charmstore.v5	git	13cd4113d314d1ddc44f678eea24835f25e2deac	2018-08
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v3	git	1ebf5c5481e815de683e57e0f46705ac567e4e58	2018-06-29T06:57:38Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
-gopkg.in/juju/worker.v1	git	e63ca51523be524b34f05ffa0c62eed10e231f8f	2018-08-07T05:06:55Z
+gopkg.in/juju/worker.v1	git	c8e59e2cf94d6dff665db2dde3ee722c9720414b	2018-10-23T03:27:20Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon-bakery.v2	git	ec9d2ad6796100720c154f614b6dea8798ec1181	2017-11-03T09:26:24Z
 gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf0	2016-06-23T14:27:47Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -119,7 +119,7 @@ gopkg.in/juju/charmstore.v5	git	13cd4113d314d1ddc44f678eea24835f25e2deac	2018-08
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v3	git	1ebf5c5481e815de683e57e0f46705ac567e4e58	2018-06-29T06:57:38Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
-gopkg.in/juju/worker.v1	git	c8e59e2cf94d6dff665db2dde3ee722c9720414b	2018-10-23T03:27:20Z
+gopkg.in/juju/worker.v1	git	9becf9b2c7057a1043a513b4a177fa33046f4535	2018-10-23T18:27:37Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon-bakery.v2	git	ec9d2ad6796100720c154f614b6dea8798ec1181	2017-11-03T09:26:24Z
 gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf0	2016-06-23T14:27:47Z


### PR DESCRIPTION
This branch brings in the new dependency engine code that adds exponential backoff to workers that fail to start a lot.

## QA steps

* bootstrap a controller
* deploy a charm, ubuntu is fine, in the default model
* ssh into the model and watch the unit log file
* ssh into the controller and stop the service
* watch the api-caller worker backoff its reconnections

## Documentation changes
None, internal only
## Bug reference

Partial fix for bug https://bugs.launchpad.net/juju/+bug/1793245
