### PR TITLE
Raft Logic for Querying Pinned Leases

### DIFF
--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -58,6 +58,11 @@ type Store interface {
 	// Normal expiry behaviour is restored when no entities remain with
 	// pins for the application.
 	UnpinLease(lease Key, tag names.Tag) error
+
+	// Pinned returns a snapshot of pinned leases.
+	// The return consists of each pinned lease and the collection of entities
+	// vested in its pinned behaviour.
+	Pinned() map[Key][]names.Tag
 }
 
 // Key fully identifies a lease, including the namespace and

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -183,6 +183,19 @@ func (f *FSM) Leases(localTime time.Time) map[lease.Key]lease.Info {
 	return results
 }
 
+// Pinned returns all of the currently known lease pins and vested entities.
+func (f *FSM) Pinned() map[lease.Key][]names.Tag {
+	f.mu.Lock()
+	pinned := make(map[lease.Key][]names.Tag)
+	for key, entities := range f.pinned {
+		if !entities.IsEmpty() {
+			pinned[key] = entities.SortedValues()
+		}
+	}
+	f.mu.Unlock()
+	return pinned
+}
+
 func (f *FSM) isPinned(key lease.Key) bool {
 	return !f.pinned[key].IsEmpty()
 }

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -43,6 +43,7 @@ type TrapdoorFunc func(lease.Key, string) lease.Trapdoor
 type ReadonlyFSM interface {
 	Leases(time.Time) map[lease.Key]lease.Info
 	GlobalTime() time.Time
+	Pinned() map[lease.Key][]names.Tag
 }
 
 // StoreConfig holds resources and settings needed to run the Store.
@@ -137,6 +138,11 @@ func (s *Store) PinLease(key lease.Key, entity names.Tag) error {
 // UnpinLease is part of lease.Store.
 func (s *Store) UnpinLease(key lease.Key, entity names.Tag) error {
 	return errors.Trace(s.pinOp(OperationUnpin, key, entity))
+}
+
+// Pinned is part of the Store interface.
+func (s *Store) Pinned() map[lease.Key][]names.Tag {
+	return s.fsm.Pinned()
 }
 
 func (s *Store) pinOp(operation string, key lease.Key, entity names.Tag) error {

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -281,6 +281,12 @@ func (s *storeSuite) TestUnpin(c *gc.C) {
 	)
 }
 
+func (s *storeSuite) TestPinned(c *gc.C) {
+	s.fsm.pinned = map[lease.Key][]names.Tag{}
+	c.Check(s.store.Pinned(), gc.DeepEquals, s.fsm.pinned)
+	s.fsm.CheckCallNames(c, "Pinned")
+}
+
 // handleHubRequest takes the action that triggers the request, the
 // expected command, and a function that will be run to make checks on
 // the request and send the response back.
@@ -456,11 +462,17 @@ type fakeFSM struct {
 	testing.Stub
 	leases     map[lease.Key]lease.Info
 	globalTime time.Time
+	pinned     map[lease.Key][]names.Tag
 }
 
 func (f *fakeFSM) Leases(t time.Time) map[lease.Key]lease.Info {
 	f.AddCall("Leases", t)
 	return f.leases
+}
+
+func (f *fakeFSM) Pinned() map[lease.Key][]names.Tag {
+	f.AddCall("Pinned")
+	return f.pinned
 }
 
 func (f *fakeFSM) GlobalTime() time.Time {

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -134,3 +134,8 @@ func (s *leaseStore) PinLease(key lease.Key, entity names.Tag) error {
 func (s *leaseStore) UnpinLease(key lease.Key, entity names.Tag) error {
 	return errors.NotImplementedf("lease unpinning")
 }
+
+// Pinned is part of the Store interface.
+func (s *leaseStore) Pinned() map[lease.Key][]names.Tag {
+	return nil
+}

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -199,6 +199,11 @@ func (store *store) UnpinLease(key lease.Key, entity names.Tag) error {
 	return errors.NotImplementedf("unpinning for legacy leases")
 }
 
+// Pinned is part of the Store interface.
+func (store *store) Pinned() map[lease.Key][]names.Tag {
+	return nil
+}
+
 // Refresh is part of the Store interface.
 func (store *store) Refresh() error {
 	store.mu.Lock()

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -182,6 +182,10 @@ func (store *Store) UnpinLease(key lease.Key, entity names.Tag) error {
 	return store.call("UnpinLease", []interface{}{key, entity})
 }
 
+func (Store *Store) Pinned() map[lease.Key][]names.Tag {
+	return nil
+}
+
 // call defines a expected method call on a Store; it encodes:
 type call struct {
 


### PR DESCRIPTION
## Description of change

This the first patch in a series that will enable pinned leaders to be queried, initially for the purpose of Juju status reporting.

These changes implement a `Pinned` method in the Raft store and FSM.

## QA steps

Behaviour is not recruited by APIs at present. Normal leadership claiming, pinning and expiry are unchanged.

## Documentation changes

None, though the eventual client command should be documented.

## Bug reference

N/A
