### PR TITLE
Ensure caas operator agent.conf is updated when controller addresses change

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -394,11 +394,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:835cd5922cfd2ed22a4540785e435c844699f96ca5c34b70dbf79ba2c45a3d4f"
+  digest = "1:ba62299b1d56575e42082da41af1f66fdefc4ba4615d08c04031374a679dfcf5"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "f78aa97b9713ee80ce5be42c50ca283357ba2c5e"
+  revision = "e4124cce3eacd96776497aa4868fb864bf309ef5"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "f78aa97b9713ee80ce5be42c50ca283357ba2c5e"
+  revision = "e4124cce3eacd96776497aa4868fb864bf309ef5"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -4,10 +4,12 @@
 package caasoperator_test
 
 import (
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
 	"github.com/juju/juju/testing"
 )
@@ -36,6 +38,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"agent",
 		"api-address-updater",
 		"api-caller",
+		"api-config-watcher",
 		"charm-dir",
 		"clock",
 		"hook-retry-strategy",
@@ -60,6 +63,135 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	c.Assert(expectedKeys, jc.SameContents, keys)
 }
 
+func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
+	exempt := set.NewStrings(
+		"agent",
+		"clock",
+		"machine-lock",
+		"api-config-watcher",
+		"api-caller",
+		"log-sender",
+		"upgrader",
+		"migration-fortress",
+		"migration-minion",
+		"migration-inactive-flag",
+		"upgrade-steps-gate",
+		"upgrade-check-flag",
+		"upgrade-steps-runner",
+		"upgrade-steps-flag",
+		"upgrade-check-gate",
+	)
+	config := caasoperator.ManifoldsConfig{}
+	manifolds := caasoperator.Manifolds(config)
+	for name, manifold := range manifolds {
+		c.Logf("%v [%v]", name, manifold.Inputs)
+		if !exempt.Contains(name) {
+			checkContains(c, manifold.Inputs, "migration-inactive-flag")
+			checkContains(c, manifold.Inputs, "migration-fortress")
+		}
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldsDependencies(c *gc.C) {
+	agenttest.AssertManifoldsDependencies(c,
+		caasoperator.Manifolds(caasoperator.ManifoldsConfig{
+			Agent: fakeAgent{},
+		}),
+		expectedOperatorManifoldsWithDependencies,
+	)
+}
+
+func checkContains(c *gc.C, names []string, seek string) {
+	for _, name := range names {
+		if name == seek {
+			return
+		}
+	}
+	c.Errorf("%q not present in %v", seek, names)
+}
+
 type fakeAgent struct {
 	agent.Agent
+}
+
+var expectedOperatorManifoldsWithDependencies = map[string][]string{
+
+	"agent": {},
+
+	"api-address-updater": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"api-caller": {"agent", "api-config-watcher"},
+
+	"api-config-watcher": {"agent"},
+
+	"charm-dir": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"hook-retry-strategy": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"log-sender": {"agent", "api-caller", "api-config-watcher"},
+
+	"logging-config-updater": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"migration-fortress": {
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"migration-inactive-flag": {
+		"agent",
+		"api-caller",
+		"api-config-watcher"},
+
+	"migration-minion": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"upgrade-steps-flag": {"upgrade-steps-gate"},
+
+	"upgrade-steps-gate": {},
+
+	"clock": {},
+
+	"operator": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"charm-dir",
+		"clock",
+		"hook-retry-strategy",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
 }

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -125,6 +125,7 @@ var (
 		"agent",
 		"api-address-updater",
 		"api-caller",
+		"api-config-watcher",
 		"clock",
 		"logging-config-updater",
 		"log-sender",


### PR DESCRIPTION
## Description of change

When controller api addresses change after a k8s model migration, ensure they are written to the agent.conf file.

## QA steps

Migrate a k8s model
Ensure the operator connects to the new controller.

