### PR TITLE
Rework the api-caller worker retry strategies.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -872,6 +872,7 @@ func (d dialer) dial1() (jsoncodec.JSONConn, *tls.Config, error) {
 	if d.opts.certPool == nil {
 		tlsConfig.ServerName = d.serverName
 	}
+	logger.Tracef("dialing: %q %v", d.urlStr, d.ipAddr)
 	conn, err := d.opts.DialWebsocket(d.ctx, d.urlStr, tlsConfig, d.ipAddr)
 	if err == nil {
 		logger.Debugf("successfully dialed %q", d.urlStr)

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -260,8 +260,8 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 	}()
 
-        place1 := "wss://place1.example:1234/api"
-        place2 := "wss://place2.example:1234/api"
+	place1 := "wss://place1.example:1234/api"
+	place2 := "wss://place2.example:1234/api"
 	// Wait for first connection, but don't
 	// reply immediately because we want
 	// to wait for the second connection before
@@ -272,16 +272,16 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for dial")
 	}
-        this := place1
-        other := place2
-        if info0.location != place1 {
-            // We now randomly order what we will connect to. So we check
-            // whether we first tried to connect to place1 or place2.
-            // However, we should still be able to interrupt a second dial by
-            // having the first one succeed.
-            this = place2
-            other = place1
-        }
+	this := place1
+	other := place2
+	if info0.location != place1 {
+		// We now randomly order what we will connect to. So we check
+		// whether we first tried to connect to place1 or place2.
+		// However, we should still be able to interrupt a second dial by
+		// having the first one succeed.
+		this = place2
+		other = place1
+	}
 
 	c.Assert(info0.location, gc.Equals, this)
 

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -260,6 +260,8 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 	}()
 
+        place1 := "wss://place1.example:1234/api"
+        place2 := "wss://place2.example:1234/api"
 	// Wait for first connection, but don't
 	// reply immediately because we want
 	// to wait for the second connection before
@@ -270,7 +272,18 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for dial")
 	}
-	c.Assert(info0.location, gc.Equals, "wss://place1.example:1234/api")
+        this := place1
+        other := place2
+        if info0.location != place1 {
+            // We now randomly order what we will connect to. So we check
+            // whether we first tried to connect to place1 or place2.
+            // However, we should still be able to interrupt a second dial by
+            // having the first one succeed.
+            this = place2
+            other = place1
+        }
+
+	c.Assert(info0.location, gc.Equals, this)
 
 	var info1 dialInfo
 	// Wait for the next dial to be made. Note that we wait for two
@@ -284,7 +297,7 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for dial")
 	}
-	c.Assert(info1.location, gc.Equals, "wss://place2.example:1234/api")
+	c.Assert(info1.location, gc.Equals, other)
 
 	// Allow the first dial to succeed.
 	info0.replyc <- dialResponse{

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -165,8 +165,8 @@ func dependencyEngineConfig() dependency.EngineConfig {
 		WorstError:    util.MoreImportantError,
 		ErrorDelay:    3 * time.Second,
 		BounceDelay:   10 * time.Millisecond,
-		BackoffFactor: 1.5,
-		MaxDelay:      5 * time.Minute,
+		BackoffFactor: 1.2,
+		MaxDelay:      2 * time.Minute,
 		Clock:         clock.WallClock,
 		Logger:        loggo.GetLogger("juju.worker.dependency"),
 	}

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -4,7 +4,6 @@
 package apicaller
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/juju/errors"
@@ -83,9 +82,6 @@ func connectFallback(
 ) (
 	conn api.Connection, didFallback bool, err error,
 ) {
-
-	// Encourage load balancing by defaulting to a different controller each time.
-	rand.Shuffle(len(info.Addrs), func(i, j int) { info.Addrs[i], info.Addrs[j] = info.Addrs[j], info.Addrs[i] })
 	// We expect to assign to `conn`, `err`, *and* `info` in
 	// the course of this operation: wrapping this repeated
 	// atom in a func currently seems to be less treacherous

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -4,6 +4,7 @@
 package apicaller
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/juju/errors"
@@ -83,6 +84,8 @@ func connectFallback(
 	conn api.Connection, didFallback bool, err error,
 ) {
 
+	// Encourage load balancing by defaulting to a different controller each time.
+	rand.Shuffle(len(info.Addrs), func(i, j int) { info.Addrs[i], info.Addrs[j] = info.Addrs[j], info.Addrs[i] })
 	// We expect to assign to `conn`, `err`, *and* `info` in
 	// the course of this operation: wrapping this repeated
 	// atom in a func currently seems to be less treacherous
@@ -95,7 +98,10 @@ func connectFallback(
 			// controller such that the round trip time could be as high
 			// as 500ms.
 			DialTimeout: 3 * time.Second,
-			RetryDelay:  200 * time.Millisecond,
+			// The delay between connecting to a different controller. Setting this to 0 means we try all controllers
+			// simultaneously. We set it to approximately how long the TLS handshake takes, to avoid doing TLS
+			// handshakes to a controller that we are going to end up ignoring.
+			DialAddressInterval: 200 * time.Millisecond,
 			// The timeout is for the complete login handshake.
 			// If the server is rate limiting, it will normally pause
 			// before responding to the login request, but the pause is

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -190,9 +190,9 @@ func openCalls(model names.ModelTag, entity names.Tag, passwords ...string) []te
 		calls[i] = testing.StubCall{
 			FuncName: "apiOpen",
 			Args: []interface{}{info, api.DialOpts{
-				DialTimeout: 3 * time.Second,
-				RetryDelay:  200 * time.Millisecond,
-				Timeout:     time.Minute,
+				DialAddressInterval: 200 * time.Millisecond,
+				DialTimeout:         3 * time.Second,
+				Timeout:             time.Minute,
 			}},
 		}
 	}


### PR DESCRIPTION
## Description of change

This changes how the workers try to connect to the controller, and how
they retry their connections.

Rather than trying all controllers every 200ms for 3s on, 3s off, this
relies on the exponential backoff of the dependency engine. And instead
we try 1 controller at a time, with a 200ms delay between controllers.

We also shuffle the order that we try controllers with each retry. This
should help balance the load on controllers, and avoid having them
hammered when starting up.

We max out the delay between retries to 2 minutes, and backoff by 20%
each time. This means it takes around 20 retries in 10 minutes before we
cap out at 2min per retry. (which is way below the original 1500 retries
in 10 minutes.)

## QA steps

```
$ juju bootstrap lxd
$ juju enable-ha
$ juju deploy simple-charm
```
Kill/stop various controllers and monitor the logs to see how the agents are trying to reconnect.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1799365
https://bugs.launchpad.net/juju/+bug/1793245
