### PR TITLE
OperatorProvisioningInfo should keep the version.build consistent 

### DIFF
--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -97,9 +97,9 @@ func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error
 	}
 
 	imagePath := cfg.CAASOperatorImagePath()
+	vers := version.Current
+	vers.Build = 0
 	if imagePath == "" {
-		vers := version.Current
-		vers.Build = 0
 		imagePath = fmt.Sprintf("%s/caas-jujud-operator:%s", "jujusolutions", vers.String())
 	}
 	charmStorageParams, err := charmStorageParams(a.storagePoolManager, a.storageProviderRegistry)
@@ -132,7 +132,7 @@ func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error
 
 	return params.OperatorProvisioningInfo{
 		ImagePath:    imagePath,
-		Version:      version.Current,
+		Version:      vers,
 		APIAddresses: apiAddresses.Result,
 		CharmStorage: charmStorageParams,
 		Tags:         resourceTags,

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -87,9 +87,9 @@ func (aw *applicationWorker) loop() error {
 		brokerUnitsWatcher watcher.NotifyWatcher
 		appOperatorWatcher watcher.NotifyWatcher
 	)
-	// The caas watcher can just die from underneath us hence it needs to be
+	// The caas watcher can just die from underneath hence it needs to be
 	// restarted all the time. So we don't abuse the catacomb by adding new
-	// workers unbounded, use use a defer to stop the running worker.
+	// workers unbounded, use a defer to stop the running worker.
 	defer func() {
 		if brokerUnitsWatcher != nil {
 			worker.Stop(brokerUnitsWatcher)
@@ -104,7 +104,7 @@ func (aw *applicationWorker) loop() error {
 	lastReportedStatus := make(map[string]status.StatusInfo)
 
 	for {
-		// The caas watcher can just die from underneath us so recreate if needed.
+		// The caas watcher can just die from underneath so recreate if needed.
 		if brokerUnitsWatcher == nil {
 			brokerUnitsWatcher, err = aw.containerBroker.WatchUnits(aw.application)
 			if err != nil {


### PR DESCRIPTION
## Description of change
fix caas operator pod re-created whenever juju controller upgraded.

OperatorProvisioningInfo should keep the version.build consistent because we will use it to label operator pod even it is not meaningful for caas oci image.

## QA steps

1. deploy a caas application;
2. upgrade controller: juju upgrade-juju --build-agent -m controller
3. monitor status of operator pod now, it's always `Running` without `Terminating` transition: kubectl get all -n <caas-model>

## Documentation changes

Bug fix, no document change.
