### PR TITLE
only show storage-pools of kubernetes provider for CAAS model

### DIFF
--- a/cmd/juju/storage/poollist.go
+++ b/cmd/juju/storage/poollist.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 )
 
 // PoolCommandBase is a helper base structure for pool commands.
@@ -99,6 +100,14 @@ func (c *poolListCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	defer api.Close()
+	modelType, err := c.ModelType()
+	if err != nil {
+		return err
+	}
+	if modelType == model.CAAS {
+		// always filter storage pools for CAAS model by kubernetes provider.
+		c.Providers = append(c.Providers, "kubernetes")
+	}
 	result, err := api.ListPools(c.Providers, c.Names)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description of change

only show storage-pools of kubernetes provider for CAAS model.

## QA steps

- create CAAS model;
- create storage pool like: juju create-storage-pool operator-storage kubernetes storage-class=microk8s-hostpath
- run: juju storage-pools

## Documentation changes

provider "kubernetes" filter is set for CAAS model by default.
