### PR TITLE
Updated relevant bugs and added lxd install instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,6 +259,8 @@ $ git checkout -b new_feature
 Testing
 -------
 
+Some of `juju` tests may require local lxd to be installed, see [installing lxd via snap](https://stgraber.org/2016/10/17/lxd-snap-available/).  
+
 `juju` uses the `gocheck` testing framework. `gocheck` is automatically
 installed as a dependency of `juju`. You can read more about `gocheck`
 at http://godoc.org/gopkg.in/check.v1. `gocheck` is integrated

--- a/README.md
+++ b/README.md
@@ -195,7 +195,5 @@ Needed for confinement
 To enable strict mode, the following bugs need to be resolved, and the snap updated accordingly.
 
  * Missing support for abstract unix sockets (https://bugs.launchpad.net/snappy/+bug/1604967)
- * Needs SSH interface (https://bugs.launchpad.net/snappy/+bug/1606574)
- * Bash completion doesn't work (https://launchpad.net/bugs/1612303)
  * Juju plugin support (https://bugs.launchpad.net/juju/+bug/1628538)
  


### PR DESCRIPTION
## Description of change

On a fresh machine, I followed our instructions to re-install juju locally.

I found that I cannot run tests without an lxd install - https://pastebin.ubuntu.com/p/KRt2d55vfd/

Also some bugs listed where no longer relevant.
