### PR TITLE
upgrade charm profile for subordinates

### DIFF
--- a/state/machine.go
+++ b/state/machine.go
@@ -2161,16 +2161,7 @@ func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
 		if life == Dead || life == Dying {
 			return nil, ErrDead
 		}
-
-		ops := []txn.Op{{
-			C:      machinesC,
-			Id:     m.doc.DocID,
-			Assert: bson.D{{"life", Alive}},
-			Update: bson.D{{"$set", bson.D{{"upgradecharmprofilecharmurl", chURL},
-				{"upgradecharmprofileapplication", appName}}}},
-		}}
-
-		return ops, nil
+		return []txn.Op{m.SetUpgradeCharmProfileOp(appName, chURL)}, nil
 	}
 	err := m.st.db().Run(buildTxn)
 	if err != nil {
@@ -2179,6 +2170,16 @@ func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
 	m.doc.UpgradeCharmProfileApplication = appName
 	m.doc.UpgradeCharmProfileCharmURL = chURL
 	return nil
+}
+
+func (m *Machine) SetUpgradeCharmProfileOp(appName, chURL string) txn.Op {
+	return txn.Op{
+		C:      machinesC,
+		Id:     m.doc.DocID,
+		Assert: bson.D{{"life", Alive}},
+		Update: bson.D{{"$set", bson.D{{"upgradecharmprofilecharmurl", chURL},
+			{"upgradecharmprofileapplication", appName}}}},
+	}
 }
 
 func (m *Machine) SetUpgradeCharmProfileComplete(msg string) error {

--- a/state/machine.go
+++ b/state/machine.go
@@ -2172,13 +2172,18 @@ func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
 	return nil
 }
 
+// SetUpgradeCharmProfileOp returns a transaction for the machine to
+// trigger a change to its LXD Profile(s).
 func (m *Machine) SetUpgradeCharmProfileOp(appName, chURL string) txn.Op {
 	return txn.Op{
 		C:      machinesC,
 		Id:     m.doc.DocID,
 		Assert: bson.D{{"life", Alive}},
-		Update: bson.D{{"$set", bson.D{{"upgradecharmprofilecharmurl", chURL},
-			{"upgradecharmprofileapplication", appName}}}},
+		Update: bson.D{{"$set", bson.D{
+			{"upgradecharmprofilecharmurl", chURL},
+			{"upgradecharmprofileapplication", appName},
+			{"upgradecharmprofilecomplete", ""},
+		}}},
 	}
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -145,20 +145,30 @@ func (s *MachineSuite) TestSetCharmProfile(c *gc.C) {
 }
 
 func (s *MachineSuite) TestSetUpgradeCharmProfile(c *gc.C) {
-	err := s.machine.SetUpgradeCharmProfile("app-name", "local:quantal/riak-7")
+	m := s.machine
+
+	// SetUpgradeCharmProfile should clear UpgradeCharmProfileComplete value
+	err := m.SetUpgradeCharmProfileComplete("success")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, "success")
+
+	err = m.SetUpgradeCharmProfile("app-name", "local:quantal/riak-7")
 	c.Assert(err, jc.ErrorIsNil)
 
-	m, err := s.State.Machine(s.machine.Id())
+	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.UpgradeCharmProfileApplication(), gc.Equals, "app-name")
 	c.Assert(m.UpgradeCharmProfileCharmURL(), gc.Equals, "local:quantal/riak-7")
+	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, "")
 }
 
 func (s *MachineSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
-	err := s.machine.SetUpgradeCharmProfileComplete("success")
+	m := s.machine
+
+	err := m.SetUpgradeCharmProfileComplete("success")
 	c.Assert(err, jc.ErrorIsNil)
 
-	m, err := s.State.Machine(s.machine.Id())
+	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, "success")
 }


### PR DESCRIPTION
## Description of change

When the subordinate unit is created, also write to the principal's machine so that notification of a profile add can be done.

## QA steps
`export JUJU_DEV_FEATURE_FLAGS=lxd-profile`
1. `juju bootstrap localhost --build-agent`
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-profile-local`
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate`
3. `juju add-relation lxd-profile-local lxd-profile-subordinate`
4. `juju upgrade-charm lxd-profile-local --path  ./testcharms/charm-repo/quantal/lxd-profile`
5. notice  the container has profiles for both the local charm and the subordinate.
10. `juju upgrade-charm lxd-profile-local --path  ./testcharms/charm-repo/quantal/lxd-profile`
5. notice  profile for the local charm on the machine has a new version.
10. `juju upgrade-charm lxd-profile-subordinate --path  ./testcharms/charm-repo/quantal/lxd-profile-subordinate`
5. notice  profile for the local subordinate charm on the machine has a new version.