### PR TITLE
diff-bundle: Compare bundle with model and report differences

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -57,6 +57,54 @@ type deploymentLogger interface {
 	Infof(string, ...interface{})
 }
 
+// composeBundle adds the overlays and bundle includes into the passed bundle
+// data struct.
+func composeBundle(data *charm.BundleData, ctx *cmd.Context, bundleDir string, overlayFileNames []string) error {
+	if err := processBundleOverlay(data, overlayFileNames...); err != nil {
+		return errors.Trace(err)
+	}
+	if bundleDir == "" {
+		bundleDir = ctx.Dir
+	}
+	if err := processBundleIncludes(bundleDir, data); err != nil {
+		return errors.Annotate(err, "unable to process includes")
+	}
+	return nil
+}
+
+func verifyBundle(data *charm.BundleData, bundleDir string) error {
+	verifyConstraints := func(s string) error {
+		_, err := constraints.Parse(s)
+		return err
+	}
+	verifyStorage := func(s string) error {
+		_, err := storage.ParseConstraints(s)
+		return err
+	}
+	verifyDevices := func(s string) error {
+		_, err := devices.ParseConstraints(s)
+		return err
+	}
+	var verifyError error
+	if bundleDir == "" {
+		verifyError = data.Verify(verifyConstraints, verifyStorage, verifyDevices)
+	} else {
+		verifyError = data.VerifyLocal(bundleDir, verifyConstraints, verifyStorage, verifyDevices)
+	}
+
+	if verr, ok := errors.Cause(verifyError).(*charm.VerificationError); ok {
+		errs := make([]string, len(verr.Errors))
+		for i, err := range verr.Errors {
+			errs[i] = err.Error()
+		}
+		return errors.New("the provided bundle has the following errors:\n" + strings.Join(errs, "\n"))
+	}
+	if verifyError != nil {
+		return errors.Trace(verifyError)
+	}
+	return nil
+}
+
 // deployBundle deploys the given bundle data using the given API client and
 // charm store client. The deployment is not transactional, and its progress is
 // notified using the given deployment logger.
@@ -75,44 +123,11 @@ func deployBundle(
 	bundleMachines map[string]string,
 ) (map[*charm.URL]*macaroon.Macaroon, error) {
 
-	if err := processBundleOverlay(data, bundleOverlayFile...); err != nil {
-		return nil, err
+	if err := composeBundle(data, ctx, bundleDir, bundleOverlayFile); err != nil {
+		return nil, errors.Trace(err)
 	}
-	verifyConstraints := func(s string) error {
-		_, err := constraints.Parse(s)
-		return err
-	}
-	verifyStorage := func(s string) error {
-		_, err := storage.ParseConstraints(s)
-		return err
-	}
-	verifyDevices := func(s string) error {
-		_, err := devices.ParseConstraints(s)
-		return err
-	}
-	var verifyError error
-	if bundleDir == "" {
-		// Process includes in the bundle data.
-		if err := processBundleIncludes(ctx.Dir, data); err != nil {
-			return nil, errors.Annotate(err, "unable to process includes")
-		}
-		verifyError = data.Verify(verifyConstraints, verifyStorage, verifyDevices)
-	} else {
-		// Process includes in the bundle data.
-		if err := processBundleIncludes(bundleDir, data); err != nil {
-			return nil, errors.Annotate(err, "unable to process includes")
-		}
-		verifyError = data.VerifyLocal(bundleDir, verifyConstraints, verifyStorage, verifyDevices)
-	}
-	if verifyError != nil {
-		if verr, ok := verifyError.(*charm.VerificationError); ok {
-			errs := make([]string, len(verr.Errors))
-			for i, err := range verr.Errors {
-				errs[i] = err.Error()
-			}
-			return nil, errors.New("the provided bundle has the following errors:\n" + strings.Join(errs, "\n"))
-		}
-		return nil, errors.Trace(verifyError)
+	if err := verifyBundle(data, bundleDir); err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	// TODO: move bundle parsing and checking into the handler.
@@ -249,13 +264,11 @@ func (h *bundleHandler) makeModel(
 	useExistingMachines bool,
 	bundleMachines map[string]string,
 ) error {
-
 	// Initialize the unit status.
 	status, err := h.api.Status(nil)
 	if err != nil {
 		return errors.Annotate(err, "cannot get model status")
 	}
-
 	h.model, err = buildModelRepresentation(status, h.api, useExistingMachines, bundleMachines)
 	if err != nil {
 		return errors.Trace(err)
@@ -319,7 +332,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		url, _, _, err := h.api.Resolve(h.modelConfig, ch)
+		url, _, _, err := resolveCharm(h.api.ResolveWithChannel, h.modelConfig, ch)
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
@@ -462,7 +475,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
-	url, channel, _, err := h.api.Resolve(h.modelConfig, ch)
+	url, channel, _, err := resolveCharm(h.api.ResolveWithChannel, h.modelConfig, ch)
 	if err != nil {
 		return errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}
@@ -1192,6 +1205,7 @@ func processBundleOverlay(data *charm.BundleData, bundleOverlayFiles ...string) 
 		}
 		// Make sure the filename is absolute.
 		if !filepath.IsAbs(bundleOverlayFile) {
+			// TODO(babbageclunk): pass in ctx.Dir rather than using os.Getwd.
 			cwd, err := os.Getwd()
 			if err != nil {
 				return errors.Trace(err)
@@ -1375,9 +1389,18 @@ func removeRelations(data [][]string, appName string) [][]string {
 	return result
 }
 
+// ModelExtractor provides everything we need to build a
+// bundlechanges.Model from a model API connection.
+type ModelExtractor interface {
+	GetAnnotations(tags []string) ([]params.AnnotationsGetResult, error)
+	GetConstraints(applications ...string) ([]constraints.Value, error)
+	GetConfig(applications ...string) ([]map[string]interface{}, error)
+	Sequences() (map[string]int, error)
+}
+
 func buildModelRepresentation(
 	status *params.FullStatus,
-	apiRoot DeployAPI,
+	apiRoot ModelExtractor,
 	useExistingMachines bool,
 	bundleMachines map[string]string,
 ) (*bundlechanges.Model, error) {
@@ -1388,8 +1411,11 @@ func buildModelRepresentation(
 	)
 	machineMap := make(map[string]string)
 	machines := make(map[string]*bundlechanges.Machine)
-	for id := range status.Machines {
-		machines[id] = &bundlechanges.Machine{ID: id}
+	for id, machineStatus := range status.Machines {
+		machines[id] = &bundlechanges.Machine{
+			ID:     id,
+			Series: machineStatus.Series,
+		}
 		tag := names.NewMachineTag(id)
 		annotationTags = append(annotationTags, tag.String())
 		if useExistingMachines && tag.ContainerType() == "" {
@@ -1403,9 +1429,11 @@ func buildModelRepresentation(
 	applications := make(map[string]*bundlechanges.Application)
 	for name, appStatus := range status.Applications {
 		application := &bundlechanges.Application{
-			Name:    name,
-			Charm:   appStatus.Charm,
-			Exposed: appStatus.Exposed,
+			Name:          name,
+			Charm:         appStatus.Charm,
+			Exposed:       appStatus.Exposed,
+			Series:        appStatus.Series,
+			SubordinateTo: appStatus.SubordinateTo,
 		}
 		for unitName, unit := range appStatus.Units {
 			application.Units = append(application.Units, bundlechanges.Unit{

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -61,7 +61,7 @@ type deploymentLogger interface {
 // data struct.
 func composeBundle(data *charm.BundleData, ctx *cmd.Context, bundleDir string, overlayFileNames []string) error {
 	if err := processBundleOverlay(data, overlayFileNames...); err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "unable to process overlays")
 	}
 	if bundleDir == "" {
 		bundleDir = ctx.Dir
@@ -99,10 +99,7 @@ func verifyBundle(data *charm.BundleData, bundleDir string) error {
 		}
 		return errors.New("the provided bundle has the following errors:\n" + strings.Join(errs, "\n"))
 	}
-	if verifyError != nil {
-		return errors.Trace(verifyError)
-	}
-	return nil
+	return errors.Trace(verifyError)
 }
 
 // deployBundle deploys the given bundle data using the given API client and

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -876,7 +876,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadConfig(c
             - ["wordpress:db", "mysql:server"]
     `, wordpressPath, mysqlPath),
 		"--overlay", "missing-file")
-	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: unable to read bundle overlay file .*")
+	c.Assert(err, gc.ErrorMatches, "cannot deploy bundle: unable to process overlays: unable to read bundle overlay file .*")
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(c *gc.C) {

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -1,0 +1,238 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/bundlechanges"
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/charmrepo.v3"
+	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/annotations"
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/constraints"
+)
+
+const bundleDiffDoc = `
+Bundle can be a local bundle file or the name of a bundle in
+the charm store. The bundle can also be combined with overlays (in the
+same way as the deploy command) before comparing with the model.
+
+The map-machines option works similarly as for the deploy command, but
+existing is always assumed, so it doesn't need to be specified.
+
+Examples:
+    juju diff-bundle localbundle.yaml
+    juju diff-bundle canonical-kubernetes
+    juju diff-bundle mongodb-cluster --channel beta
+    juju diff-bundle canonical-kubernetes --overlay local-config.yaml --overlay extra.yaml
+    juju diff-bundle localbundle.yaml --map-machines 3=4
+
+See also:
+    deploy
+`
+
+// NewBundleDiffCommand returns a command to compare a bundle against
+// the selected model.
+func NewBundleDiffCommand() cmd.Command {
+	return modelcmd.Wrap(&BundleDiffCommand{})
+}
+
+// BundleDiffCommand compares a bundle to a model.
+type BundleDiffCommand struct {
+	modelcmd.ModelCommandBase
+	Bundle         string
+	BundleOverlays []string
+	Channel        csparams.Channel
+
+	BundleMachines map[string]string
+	MachineMap     string
+}
+
+// IsSuperCommand is part of cmd.Command.
+func (c *BundleDiffCommand) IsSuperCommand() bool { return false }
+
+// AllowInterspersedFlags is part of cmd.Command.
+func (c *BundleDiffCommand) AllowInterspersedFlags() bool { return true }
+
+// Info is part of cmd.Command.
+func (c *BundleDiffCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "diff-bundle",
+		Args:    "<bundle file or name>",
+		Purpose: "Compare a bundle against a model and report any differences.",
+		Doc:     bundleDiffDoc,
+	}
+}
+
+// SetFlags is part of cmd.Command.
+func (c *BundleDiffCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	f.StringVar((*string)(&c.Channel), "channel", "", "Channel to use when getting the bundle from the charm store")
+	f.Var(cmd.NewAppendStringsValue(&c.BundleOverlays), "overlay", "Bundles to overlay on the primary bundle, applied in order")
+	f.StringVar(&c.MachineMap, "map-machines", "", "Indicates how existing machines correspond to bundle machines")
+}
+
+// Init is part of cmd.Command.
+func (c *BundleDiffCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("no bundle specified")
+	}
+	c.Bundle = args[0]
+	// UseExisting is assumed for diffing.
+	_, mapping, err := parseMachineMap(c.MachineMap)
+	if err != nil {
+		return errors.Annotate(err, "error in --map-machines")
+	}
+	c.BundleMachines = mapping
+
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run is part of cmd.Command.
+func (c *BundleDiffCommand) Run(ctx *cmd.Context) error {
+	apiRoot, err := c.NewAPIRoot()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer apiRoot.Close()
+
+	// Load up the bundle data, with includes and overlays.
+	bundle, bundleDir, err := c.readBundle(ctx, apiRoot)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := composeBundle(bundle, ctx, bundleDir, c.BundleOverlays); err != nil {
+		return errors.Trace(err)
+	}
+	if err := verifyBundle(bundle, bundleDir); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Extract the information from the current model.
+	model, err := c.readModel(apiRoot)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Get the differences between them.
+	diff, err := bundlechanges.BuildDiff(bundlechanges.DiffConfig{
+		Bundle: bundle,
+		Model:  model,
+		Logger: logger,
+	})
+
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	encoder := yaml.NewEncoder(ctx.Stdout)
+	defer encoder.Close()
+	err = encoder.Encode(diff)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *BundleDiffCommand) readBundle(ctx *cmd.Context, apiRoot api.Connection) (*charm.BundleData, string, error) {
+	bundleData, bundleDir, err := readLocalBundle(ctx, c.Bundle)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	if bundleData != nil {
+		return bundleData, bundleDir, nil
+	}
+
+	// Not a local bundle, so it must be from the charmstore.
+	charmStore, err := c.charmStore()
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	bundleURL, _, err := resolveBundleURL(
+		modelconfig.NewClient(apiRoot), charmStore, c.Bundle,
+	)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	if bundleURL == nil {
+		// This isn't a charmstore bundle either! Complain.
+		return nil, "", errors.Errorf("couldn't interpret %q as a local or charmstore bundle", c.Bundle)
+	}
+
+	bundle, err := charmStore.GetBundle(bundleURL)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	return bundle.Data(), "", nil
+}
+
+func (c *BundleDiffCommand) charmStore() (*charmrepo.CharmStore, error) {
+	controllerAPIRoot, err := c.NewControllerAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer controllerAPIRoot.Close()
+	csURL, err := getCharmStoreAPIURL(controllerAPIRoot)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	bakeryClient, err := c.BakeryClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cstoreClient := newCharmStoreClient(bakeryClient, csURL).WithChannel(c.Channel)
+	return charmrepo.NewCharmStoreFromClient(cstoreClient), nil
+}
+
+func (c *BundleDiffCommand) readModel(apiRoot api.Connection) (*bundlechanges.Model, error) {
+	status, err := apiRoot.Client().Status(nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting model status")
+	}
+	model, err := buildModelRepresentation(status, c.makeModelExtractor(apiRoot), true, c.BundleMachines)
+	return model, errors.Trace(err)
+}
+
+func (c *BundleDiffCommand) makeModelExtractor(apiRoot api.Connection) ModelExtractor {
+	return &extractorImpl{
+		application: application.NewClient(apiRoot),
+		annotations: annotations.NewClient(apiRoot),
+		modelConfig: modelconfig.NewClient(apiRoot),
+	}
+}
+
+type extractorImpl struct {
+	application *application.Client
+	annotations *annotations.Client
+	modelConfig *modelconfig.Client
+}
+
+// GetAnnotations is part of ModelExtractor.
+func (e *extractorImpl) GetAnnotations(tags []string) ([]params.AnnotationsGetResult, error) {
+	return e.annotations.Get(tags)
+}
+
+// GetConstraints is part of ModelExtractor.
+func (e *extractorImpl) GetConstraints(applications ...string) ([]constraints.Value, error) {
+	return e.application.GetConstraints(applications...)
+}
+
+// GetConfig is part of ModelExtractor.
+func (e *extractorImpl) GetConfig(applications ...string) ([]map[string]interface{}, error) {
+	return e.application.GetConfig(applications...)
+}
+
+// Sequences is part of ModelExtractor.
+func (e *extractorImpl) Sequences() (map[string]int, error) {
+	return e.modelConfig.Sequences()
+}

--- a/cmd/juju/application/bundlediff_test.go
+++ b/cmd/juju/application/bundlediff_test.go
@@ -1,0 +1,460 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/juju/loggo"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
+	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+var logger = loggo.GetLogger("xtian")
+
+type diffSuite struct {
+	jujutesting.IsolationSuite
+	apiRoot    *mockAPIRoot
+	charmStore *mockCharmStore
+	dir        string
+}
+
+var _ = gc.Suite(&diffSuite{})
+
+func (s *diffSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.apiRoot = &mockAPIRoot{responses: makeAPIResponses()}
+	s.charmStore = &mockCharmStore{}
+	s.dir = c.MkDir()
+}
+
+func (s *diffSuite) runDiffBundle(c *gc.C, args ...string) (*cmd.Context, error) {
+	store := jujuclienttesting.MinimalStore()
+	store.Models["enz"] = &jujuclient.ControllerModels{
+		CurrentModel: "golden/horse",
+		Models: map[string]jujuclient.ModelDetails{"golden/horse": {
+			ModelType: model.IAAS,
+		}},
+	}
+	command := application.NewBundleDiffCommandForTest(s.apiRoot, s.charmStore, store)
+	return cmdtesting.RunCommandInDir(c, command, args, s.dir)
+}
+
+func (s *diffSuite) TestNoArgs(c *gc.C) {
+	_, err := s.runDiffBundle(c)
+	c.Assert(err, gc.ErrorMatches, "no bundle specified")
+}
+
+func (s *diffSuite) TestTooManyArgs(c *gc.C) {
+	_, err := s.runDiffBundle(c, "bundle", "somethingelse")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["somethingelse"\]`)
+}
+
+func (s *diffSuite) TestVerifiesBundle(c *gc.C) {
+	_, err := s.runDiffBundle(c, s.writeLocalBundle(c, invalidBundle))
+	c.Assert(err, gc.ErrorMatches, "(?s)the provided bundle has the following errors:.*")
+}
+
+func (s *diffSuite) TestNotABundle(c *gc.C) {
+	s.charmStore.url = &charm.URL{
+		Schema:   "cs",
+		Name:     "prometheus",
+		Revision: 23,
+		Series:   "xenial",
+	}
+	s.apiRoot.responses["ModelConfig.ModelGet"] = params.ModelConfigResults{
+		Config: map[string]params.ConfigValue{
+			"uuid":           {Value: testing.ModelTag.Id()},
+			"type":           {Value: "iaas"},
+			"name":           {Value: "horse"},
+			"default-series": {Value: "xenial"},
+		},
+	}
+	_, err := s.runDiffBundle(c, "prometheus")
+	c.Logf(errors.ErrorStack(err))
+	// Fails because the series that comes back from the charm store
+	// is xenial rather than "bundle" (and there's no local bundle).
+	c.Assert(err, gc.ErrorMatches, `couldn't interpret "prometheus" as a local or charmstore bundle`)
+}
+
+func (s *diffSuite) TestLocalBundle(c *gc.C) {
+	ctx, err := s.runDiffBundle(c, s.writeLocalBundle(c, testBundle))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+applications:
+  grafana:
+    missing: bundle
+  prometheus:
+    options:
+      ontology:
+        bundle: anselm
+        model: kant
+    constraints:
+      bundle: cores=4
+      model: cores=3
+machines:
+  "1":
+    missing: bundle
+`[1:])
+}
+
+func (s *diffSuite) TestIncludeAnnotations(c *gc.C) {
+	ctx, err := s.runDiffBundle(c, "--annotations", s.writeLocalBundle(c, testBundle))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+applications:
+  grafana:
+    missing: bundle
+  prometheus:
+    options:
+      ontology:
+        bundle: anselm
+        model: kant
+    annotations:
+      aspect:
+        bundle: west
+        model: north
+    constraints:
+      bundle: cores=4
+      model: cores=3
+machines:
+  "1":
+    missing: bundle
+`[1:])
+}
+
+func (s *diffSuite) TestHandlesIncludes(c *gc.C) {
+	s.writeFile(c, "include.yaml", "hume")
+	ctx, err := s.runDiffBundle(c, s.writeLocalBundle(c, withInclude))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+applications:
+  grafana:
+    missing: bundle
+  prometheus:
+    options:
+      ontology:
+        bundle: hume
+        model: kant
+    constraints:
+      bundle: cores=4
+      model: cores=3
+machines:
+  "1":
+    missing: bundle
+`[1:])
+}
+
+func (s *diffSuite) TestHandlesOverlays(c *gc.C) {
+	path1 := s.writeFile(c, "overlay1.yaml", overlay1)
+	path2 := s.writeFile(c, "overlay2.yaml", overlay2)
+	ctx, err := s.runDiffBundle(c,
+		"--overlay", path1,
+		"--overlay", path2,
+		s.writeLocalBundle(c, testBundle))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+applications:
+  grafana:
+    missing: bundle
+  prometheus:
+    options:
+      admin-user:
+        bundle: lovecraft
+        model: null
+      ontology:
+        bundle: anselm
+        model: kant
+    constraints:
+      bundle: cores=4
+      model: cores=3
+  telegraf:
+    missing: model
+machines:
+  "1":
+    missing: bundle
+relations:
+  bundle-additions:
+  - - prometheus:juju-info
+    - telegraf:info
+`[1:])
+}
+
+func (s *diffSuite) TestCharmStoreBundle(c *gc.C) {
+	bundleData, err := charm.ReadBundleData(strings.NewReader(testBundle))
+	c.Assert(err, jc.ErrorIsNil)
+	s.charmStore.url = &charm.URL{
+		Schema: "cs",
+		Name:   "my-bundle",
+		Series: "bundle",
+	}
+	s.charmStore.bundle = &mockBundle{data: bundleData}
+
+	ctx, err := s.runDiffBundle(c, "my-bundle")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+applications:
+  grafana:
+    missing: bundle
+  prometheus:
+    options:
+      ontology:
+        bundle: anselm
+        model: kant
+    constraints:
+      bundle: cores=4
+      model: cores=3
+machines:
+  "1":
+    missing: bundle
+`[1:])
+}
+
+func (s *diffSuite) TestBundleNotFound(c *gc.C) {
+	s.charmStore.stub.SetErrors(errors.NotFoundf(`cannot resolve URL "cs:my-bundle": charm or bundle`))
+	_, err := s.runDiffBundle(c, "cs:my-bundle")
+	c.Assert(err, gc.ErrorMatches, `cannot resolve URL "cs:my-bundle": charm or bundle not found`)
+}
+
+func (s *diffSuite) TestMachineMap(c *gc.C) {
+	ctx, err := s.runDiffBundle(c,
+		"--map-machines", "0=1",
+		s.writeLocalBundle(c, testBundle))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+applications:
+  grafana:
+    missing: bundle
+  prometheus:
+    options:
+      ontology:
+        bundle: anselm
+        model: kant
+    constraints:
+      bundle: cores=4
+      model: cores=3
+machines:
+  "0":
+    missing: bundle
+  "1":
+    series:
+      bundle: xenial
+      model: bionic
+`[1:])
+}
+
+func (s *diffSuite) writeLocalBundle(c *gc.C, content string) string {
+	return s.writeFile(c, "bundle.yaml", content)
+}
+
+func (s *diffSuite) writeFile(c *gc.C, name, content string) string {
+	path := filepath.Join(s.dir, name)
+	err := ioutil.WriteFile(path, []byte(content), 0666)
+	c.Assert(err, jc.ErrorIsNil)
+	return path
+}
+
+func makeAPIResponses() map[string]interface{} {
+	var cores uint64 = 3
+	return map[string]interface{}{
+		"ModelConfig.ModelGet": params.ModelConfigResults{
+			Config: map[string]params.ConfigValue{
+				"uuid":           {Value: testing.ModelTag.Id()},
+				"type":           {Value: "iaas"},
+				"name":           {Value: "horse"},
+				"default-series": {Value: "xenial"},
+			},
+		},
+		"Client.FullStatus": params.FullStatus{
+			Applications: map[string]params.ApplicationStatus{
+				"prometheus": {
+					Charm:  "cs:prometheus2-7",
+					Series: "xenial",
+					Life:   "alive",
+					Units: map[string]params.UnitStatus{
+						"prometheus/0": {Machine: "0"},
+					},
+				},
+				"grafana": {
+					Charm:  "cs:grafana-19",
+					Series: "bionic",
+					Life:   "alive",
+					Units: map[string]params.UnitStatus{
+						"grafana/0": {Machine: "1"},
+					},
+				},
+			},
+			Machines: map[string]params.MachineStatus{
+				"0": {Series: "xenial"},
+				"1": {Series: "bionic"},
+			},
+		},
+		"Annotations.Get": params.AnnotationsGetResults{
+			Results: []params.AnnotationsGetResult{{
+				EntityTag: "application-prometheus",
+				Annotations: map[string]string{
+					"aspect": "north",
+				},
+			}},
+		},
+		"ModelConfig.Sequences": params.ModelSequencesResult{},
+		"Application.CharmConfig": params.ApplicationGetConfigResults{
+			// Included twice since we can't predict which app will be
+			// requested first.
+			Results: []params.ConfigResult{{
+				Config: map[string]interface{}{"ontology": map[string]interface{}{
+					"value":  "kant",
+					"source": "user",
+				}},
+			}, {
+				Config: map[string]interface{}{"ontology": map[string]interface{}{
+					"value":  "kant",
+					"source": "user",
+				}},
+			}},
+		},
+		"Application.GetConstraints": params.ApplicationGetConstraintsResults{
+			Results: []params.ApplicationConstraint{{
+				Constraints: constraints.Value{CpuCores: &cores},
+			}, {
+				Constraints: constraints.Value{CpuCores: &cores},
+			}},
+		},
+	}
+}
+
+type mockCharmStore struct {
+	stub    jujutesting.Stub
+	url     *charm.URL
+	channel csparams.Channel
+	series  []string
+	bundle  *mockBundle
+}
+
+func (s *mockCharmStore) ResolveWithChannel(url *charm.URL) (*charm.URL, csparams.Channel, []string, error) {
+	s.stub.AddCall("ResolveWithChannel", url)
+	return s.url, s.channel, s.series, s.stub.NextErr()
+}
+
+func (s *mockCharmStore) GetBundle(url *charm.URL) (charm.Bundle, error) {
+	s.stub.AddCall("GetBundle", url)
+	return s.bundle, s.stub.NextErr()
+}
+
+type mockBundle struct {
+	data *charm.BundleData
+}
+
+func (b *mockBundle) Data() *charm.BundleData { return b.data }
+func (b *mockBundle) ReadMe() string          { return "" }
+
+type mockAPIRoot struct {
+	base.APICallCloser
+
+	stub      jujutesting.Stub
+	responses map[string]interface{}
+}
+
+func (r *mockAPIRoot) BestFacadeVersion(name string) int {
+	r.stub.AddCall("BestFacadeVersion", name)
+	return 42
+}
+
+func (r *mockAPIRoot) APICall(objType string, version int, id, request string, params, response interface{}) error {
+	call := objType + "." + request
+	r.stub.AddCall(call, version, params)
+	value := r.responses[call]
+	rv := reflect.ValueOf(response)
+	if value == nil {
+		panic(fmt.Sprintf("nil response for %s call", call))
+	}
+	if reflect.TypeOf(value).AssignableTo(rv.Type().Elem()) {
+		rv.Elem().Set(reflect.ValueOf(value))
+	} else {
+		panic(fmt.Sprintf("%s: can't assign value %v to %T", call, value, response))
+	}
+	return r.stub.NextErr()
+}
+
+func (r *mockAPIRoot) Close() error {
+	r.stub.AddCall("Close")
+	return r.stub.NextErr()
+}
+
+const (
+	testBundle = `
+applications:
+  prometheus:
+    charm: 'cs:prometheus2-7'
+    num_units: 1
+    series: xenial
+    options:
+      ontology: anselm
+    annotations:
+      aspect: west
+    constraints: 'cores=4'
+    to:
+      - 0
+machines:
+  '0':
+    series: xenial
+`
+	withInclude = `
+applications:
+  prometheus:
+    charm: 'cs:prometheus2-7'
+    num_units: 1
+    series: xenial
+    options:
+      ontology: include-file://include.yaml
+    annotations:
+      aspect: west
+    constraints: 'cores=4'
+    to:
+      - 0
+machines:
+  '0':
+    series: xenial
+`
+	invalidBundle = `
+machines:
+  0:
+`
+	overlay1 = `
+applications:
+  prometheus:
+    options:
+      admin-user: lovecraft
+`
+
+	overlay2 = `
+applications:
+  telegraf:
+    charm: 'cs:telegraf-3'
+relations:
+- - telegraf:info
+  - prometheus:juju-info
+`
+)

--- a/cmd/juju/application/bundlediff_test.go
+++ b/cmd/juju/application/bundlediff_test.go
@@ -10,8 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/juju/loggo"
-
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -30,8 +28,6 @@ import (
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
-
-var logger = loggo.GetLogger("xtian")
 
 type diffSuite struct {
 	jujutesting.IsolationSuite

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
@@ -1201,10 +1200,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	fakeAPI.planURL = server.URL
 	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
-
-	cfg, err := config.New(config.NoDefaults, cfgAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, meteredURL, cfg)
+	withCharmRepoResolvable(fakeAPI, meteredURL)
 
 	// `"hello registration"\n` (quotes and newline from json
 	// encoding) is returned by the fake http server. This is binary64
@@ -1218,7 +1214,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 			return fakeAPI, nil
 		},
 	}
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(setMetricCredentialsCall(), gc.Equals, 1)
@@ -1252,10 +1248,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	fakeAPI.planURL = server.URL
 	withCharmDeployable(fakeAPI, meteredURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
-
-	cfg, err := config.New(config.NoDefaults, cfgAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, meteredURL, cfg)
+	withCharmRepoResolvable(fakeAPI, meteredURL)
 
 	creds := append([]byte(`"aGVsbG8gcmVnaXN0cmF0aW9u"`), 0xA)
 	setMetricCredentialsCall := fakeAPI.Call("SetMetricCredentials", meteredURL.Name, creds).Returns(error(nil))
@@ -1266,7 +1259,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 			return fakeAPI, nil
 		},
 	}
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(setMetricCredentialsCall(), gc.Equals, 1)
@@ -1295,9 +1288,7 @@ func (s *DeployCharmStoreSuite) TestSetMetricCredentialsNotCalledForUnmeteredCha
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 
 	charmURL := charm.MustParseURL("cs:quantal/dummy-1")
-	cfg, err := config.New(config.NoDefaults, cfgAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, charmURL, cfg)
+	withCharmRepoResolvable(fakeAPI, charmURL)
 	withCharmDeployable(fakeAPI, charmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	deploy := &DeployCommand{
@@ -1307,7 +1298,7 @@ func (s *DeployCharmStoreSuite) TestSetMetricCredentialsNotCalledForUnmeteredCha
 		},
 	}
 
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/dummy-1")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/dummy-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	for _, call := range fakeAPI.Calls() {
@@ -1339,10 +1330,7 @@ summary: summary
 		"type": "foo",
 	}
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
-
-	cfg, err := config.New(config.NoDefaults, cfgAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, url, cfg)
+	withCharmRepoResolvable(fakeAPI, url)
 	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, false, 1, nil, nil)
 
 	stub := &jujutesting.Stub{}
@@ -1356,7 +1344,7 @@ summary: summary
 		},
 	}
 
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), url.String())
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), url.String())
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckNoCalls(c)
 }
@@ -1389,10 +1377,7 @@ summary: summary
 	}
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	fakeAPI.planURL = server.URL
-
-	cfg, err := config.New(config.NoDefaults, cfgAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, url, cfg)
+	withCharmRepoResolvable(fakeAPI, url)
 	withCharmDeployable(fakeAPI, url, "quantal", ch.Meta(), ch.Metrics(), true, false, 1, nil, nil)
 
 	deploy := &DeployCommand{
@@ -1402,7 +1387,7 @@ summary: summary
 		},
 	}
 
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), url.String(), "--plan", "someplan")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), url.String(), "--plan", "someplan")
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{{
 		"Authorize", []interface{}{metricRegistrationPost{
@@ -1462,10 +1447,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 	}
 	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
 	fakeAPI.planURL = server.URL
-
-	cfg, err := config.New(config.NoDefaults, cfgAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, meteredCharmURL, cfg)
+	withCharmRepoResolvable(fakeAPI, meteredCharmURL)
 	withCharmDeployable(fakeAPI, meteredCharmURL, "quantal", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 
 	// `"hello registration"\n` (quotes and newline from json
@@ -1480,7 +1462,7 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 			return fakeAPI, nil
 		},
 	}
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:quantal/metered-1", "--plan", "someplan")
 
 	c.Check(err, gc.ErrorMatches, "IsMetered")
 }
@@ -1740,13 +1722,11 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 	withAllWatcher(fakeAPI)
 
 	fakeBundleURL := charm.MustParseURL("cs:bundle/wordpress-simple")
-	cfg, err := config.New(config.NoDefaults, s.cfgAttrs())
-	c.Assert(err, jc.ErrorIsNil)
-	withCharmRepoResolvable(fakeAPI, fakeBundleURL, cfg)
+	withCharmRepoResolvable(fakeAPI, fakeBundleURL)
 	fakeAPI.Call("GetBundle", fakeBundleURL).Returns(bundleDir, error(nil))
 
 	mysqlURL := charm.MustParseURL("cs:mysql")
-	withCharmRepoResolvable(fakeAPI, mysqlURL, cfg)
+	withCharmRepoResolvable(fakeAPI, mysqlURL)
 	withCharmDeployable(
 		fakeAPI,
 		mysqlURL,
@@ -1765,7 +1745,7 @@ func (s *DeployUnitTestSuite) TestDeployBundle_OutputsCorrectMessage(c *gc.C) {
 	}).Returns([]string{"mysql/0"}, error(nil))
 
 	wordpressURL := charm.MustParseURL("cs:wordpress")
-	withCharmRepoResolvable(fakeAPI, wordpressURL, cfg)
+	withCharmRepoResolvable(fakeAPI, wordpressURL)
 	withCharmDeployable(
 		fakeAPI,
 		wordpressURL,
@@ -1930,13 +1910,13 @@ func (f *fakeDeployAPI) ModelGet() (map[string]interface{}, error) {
 	return results[0].(map[string]interface{}), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) Resolve(cfg *config.Config, url *charm.URL) (
+func (f *fakeDeployAPI) ResolveWithChannel(url *charm.URL) (
 	*charm.URL,
 	csclientparams.Channel,
 	[]string,
 	error,
 ) {
-	results := f.MethodCall(f, "Resolve", cfg, url)
+	results := f.MethodCall(f, "ResolveWithChannel", url)
 
 	return results[0].(*charm.URL),
 		results[1].(csclientparams.Channel),
@@ -2141,9 +2121,8 @@ func withCharmDeployable(
 func withCharmRepoResolvable(
 	fakeAPI *fakeDeployAPI,
 	url *charm.URL,
-	cfg *config.Config,
 ) {
-	fakeAPI.Call("Resolve", cfg, url).Returns(
+	fakeAPI.Call("ResolveWithChannel", url).Returns(
 		url,
 		csclientparams.Channel(""),
 		[]string{"quantal"}, // Supported series

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/resource/resourceadapters"
@@ -18,11 +19,11 @@ func NewUpgradeCharmCommandForTest(
 	deployResources resourceadapters.DeployResourcesFunc,
 	resolveCharm ResolveCharmFunc,
 	newCharmAdder NewCharmAdderFunc,
-	newCharmClient func(api.Connection) CharmClient,
-	newCharmUpgradeClient func(api.Connection) CharmUpgradeClient,
-	newModelConfigGetter func(api.Connection) ModelConfigGetter,
-	newResourceLister func(api.Connection) (ResourceLister, error),
-	charmStoreURLGetter func(api.Connection) (string, error),
+	newCharmClient func(base.APICallCloser) CharmClient,
+	newCharmUpgradeClient func(base.APICallCloser) CharmUpgradeClient,
+	newModelConfigGetter func(base.APICallCloser) ModelConfigGetter,
+	newResourceLister func(base.APICallCloser) (ResourceLister, error),
+	charmStoreURLGetter func(base.APICallCloser) (string, error),
 ) cmd.Command {
 	cmd := &upgradeCharmCommand{
 		DeployResources:       deployResources,
@@ -136,6 +137,15 @@ func NewScaleCommandForTest(api scaleApplicationAPI, store jujuclient.ClientStor
 	cmd := &scaleApplicationCommand{newAPIFunc: func() (scaleApplicationAPI, error) {
 		return api, nil
 	}}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
+func NewBundleDiffCommandForTest(api base.APICallCloser, charmStore BundleResolver, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	cmd := &bundleDiffCommand{
+		_apiRoot:    api,
+		_charmStore: charmStore,
+	}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -41,16 +41,16 @@ func NewUpgradeCharmCommand() cmd.Command {
 		DeployResources: resourceadapters.DeployResources,
 		ResolveCharm:    resolveCharm,
 		NewCharmAdder:   newCharmAdder,
-		NewCharmClient: func(conn api.Connection) CharmClient {
+		NewCharmClient: func(conn base.APICallCloser) CharmClient {
 			return charms.NewClient(conn)
 		},
-		NewCharmUpgradeClient: func(conn api.Connection) CharmUpgradeClient {
+		NewCharmUpgradeClient: func(conn base.APICallCloser) CharmUpgradeClient {
 			return application.NewClient(conn)
 		},
-		NewModelConfigGetter: func(conn api.Connection) ModelConfigGetter {
+		NewModelConfigGetter: func(conn base.APICallCloser) ModelConfigGetter {
 			return modelconfig.NewClient(conn)
 		},
-		NewResourceLister: func(conn api.Connection) (ResourceLister, error) {
+		NewResourceLister: func(conn base.APICallCloser) (ResourceLister, error) {
 			resclient, err := resourceadapters.NewAPIClient(conn)
 			if err != nil {
 				return nil, err
@@ -99,11 +99,11 @@ type upgradeCharmCommand struct {
 	DeployResources       resourceadapters.DeployResourcesFunc
 	ResolveCharm          ResolveCharmFunc
 	NewCharmAdder         NewCharmAdderFunc
-	NewCharmClient        func(api.Connection) CharmClient
-	NewCharmUpgradeClient func(api.Connection) CharmUpgradeClient
-	NewModelConfigGetter  func(api.Connection) ModelConfigGetter
-	NewResourceLister     func(api.Connection) (ResourceLister, error)
-	CharmStoreURLGetter   func(api.Connection) (string, error)
+	NewCharmClient        func(base.APICallCloser) CharmClient
+	NewCharmUpgradeClient func(base.APICallCloser) CharmUpgradeClient
+	NewModelConfigGetter  func(base.APICallCloser) ModelConfigGetter
+	NewResourceLister     func(base.APICallCloser) (ResourceLister, error)
+	CharmStoreURLGetter   func(base.APICallCloser) (string, error)
 
 	ApplicationName string
 	// Force should be ubiquitous and we should eventually deprecate both
@@ -522,7 +522,7 @@ func (c *upgradeCharmCommand) getCharmStore(
 }
 
 // getCharmStoreAPIURL consults the controller config for the charmstore api url to use.
-var getCharmStoreAPIURL = func(conAPIRoot api.Connection) (string, error) {
+var getCharmStoreAPIURL = func(conAPIRoot base.APICallCloser) (string, error) {
 	controllerAPI := controller.NewClient(conAPIRoot)
 	controllerCfg, err := controllerAPI.ControllerConfig()
 	if err != nil {

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -146,25 +146,25 @@ func (s *UpgradeCharmSuite) SetUpTest(c *gc.C) {
 			s.PopNoErr()
 			return &s.charmAdder
 		},
-		func(conn api.Connection) CharmClient {
+		func(conn base.APICallCloser) CharmClient {
 			s.AddCall("NewCharmClient", conn)
 			s.PopNoErr()
 			return &s.charmClient
 		},
-		func(conn api.Connection) CharmUpgradeClient {
+		func(conn base.APICallCloser) CharmUpgradeClient {
 			s.AddCall("NewCharmUpgradeClient", conn)
 			s.PopNoErr()
 			return &s.charmUpgradeClient
 		},
-		func(conn api.Connection) ModelConfigGetter {
+		func(conn base.APICallCloser) ModelConfigGetter {
 			s.AddCall("NewModelConfigGetter", conn)
 			return &s.modelConfigGetter
 		},
-		func(conn api.Connection) (ResourceLister, error) {
+		func(conn base.APICallCloser) (ResourceLister, error) {
 			s.AddCall("NewResourceLister", conn)
 			return &s.resourceLister, s.NextErr()
 		},
-		func(conn api.Connection) (string, error) {
+		func(conn base.APICallCloser) (string, error) {
 			s.AddCall("CharmStoreURLGetter", conn)
 			return "testing.api.charmstore", s.NextErr()
 		},
@@ -272,7 +272,7 @@ func (s *UpgradeCharmErrorsStateSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.PatchValue(&charmrepo.CacheDir, c.MkDir())
-	s.PatchValue(&getCharmStoreAPIURL, func(api.Connection) (string, error) {
+	s.PatchValue(&getCharmStoreAPIURL, func(base.APICallCloser) (string, error) {
 		return s.srv.URL, nil
 	})
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -395,6 +395,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewUnexposeCommand())
 	r.Register(application.NewApplicationGetConstraintsCommand())
 	r.Register(application.NewApplicationSetConstraintsCommand())
+	r.Register(application.NewBundleDiffCommand())
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -432,6 +432,7 @@ var commandNames = []string{
 	"destroy-controller",
 	"destroy-model",
 	"detach-storage",
+	"diff-bundle",
 	"disable-command",
 	"disable-user",
 	"disabled-commands",


### PR DESCRIPTION
## Description of change

This adds a new command, `diff-bundle` that compares a local or charmstore bundle and reports differences between them. It supports includes and overlays in the same way as the deploy command, and uses the same code to extract model information to compare it to the bundle.

More information about the command including options and output is in the discourse post: https://discourse.jujucharms.com/t/new-diff-bundle-command/247

## QA steps

* Deploy a bundle to a model, and then compare the bundle to the model. Edit the bundle to change details like number of units or exposure and add machines, applications and relations, and make different changes to the model. See that they're reflected in the diff output.
* Remove units and machines deployed to the model from the bundle, and deploy it again (so those units get recreated with different IDs from the ones in the bundle). Run a diff and see that the different machines are reported. Use the --map-machines options to indicate which bundle machines correspond to the new machines and the differences should be removed.

## Documentation changes

Yes, this will need documentation. I'll do some more narrative/task-oriented documentation in discourse to help with this.

