### PR TITLE
K8s resource can be overwritten by file contents.

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 	"github.com/juju/juju/state"
@@ -158,11 +157,9 @@ func (h *ResourcesHandler) readResource(backend ResourcesBackend, req *http.Requ
 			return nil, errors.Errorf("incorrect extension on resource upload %q, expected %q", uReq.Filename, ext)
 		}
 	case charmresource.TypeContainerImage:
-		// Mapping the uploaded 'filename' which is actually the RegistryPath. There is no 'Path', it'll be written to file as content.yaml
-		err := resources.CheckDockerDetails(res.Name, uReq.Filename)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		// At this stage the docker 'filename' could be a reference to
+		// what the user has on their local filesystem that got parsed and
+		// is in the process of being uploaded so it makes no sense to validate uReq.Filename
 		// The uploaded finger print from the CLI will not match what comes in from the API request, do not store it.
 		uReq.Fingerprint = charmresource.Fingerprint{}
 	}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1178,12 +1178,16 @@ func (c *DeployCommand) validateResourcesNeededForLocalDeploy(charmMeta *charm.M
 	if modelType != model.CAAS {
 		return nil
 	}
+	var missingImages []string
 	for resName, resMeta := range charmMeta.Resources {
 		if resMeta.Type == resource.TypeContainerImage {
 			if _, ok := c.Resources[resName]; !ok {
-				return errors.NotValidf("must specify OCI images for local charm (%s)", resName)
+				missingImages = append(missingImages, resName)
 			}
 		}
+	}
+	if len(missingImages) > 0 {
+		return errors.NotValidf("local charm missing OCI images for: %v", strings.Join(missingImages, ", "))
 	}
 	return nil
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -542,9 +542,12 @@ func (s *CAASDeploySuite) TestLocalCharmNeedsResources(c *gc.C) {
 	repo := testcharms.RepoForSeries("kubernetes")
 	ch := repo.ClonedDirPath(s.CharmsPath, "mysql")
 	err = runDeploy(c, ch, "-m", m.Name())
-	c.Assert(err, gc.ErrorMatches, "must specify OCI images for local charm \\(mysql_image\\) not valid")
+	c.Assert(err, gc.ErrorMatches, "local charm missing OCI images for: [a-z]+_image, [a-z]+_image not valid")
 
 	err = runDeploy(c, ch, "-m", m.Name(), "--resource", "mysql_image=abc")
+	c.Assert(err, gc.ErrorMatches, "local charm missing OCI images for: another_image not valid")
+
+	err = runDeploy(c, ch, "-m", m.Name(), "--resource", "mysql_image=abc", "--resource", "another_image=zxc")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -84,7 +84,7 @@ func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 }
 
 func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
-	deps := uploadDeps{s.stub, rsc{&bytes.Buffer{}}}
+	deps := uploadDeps{s.stub, rsc{bytes.NewBufferString("file contents")}}
 	cURL := charm.MustParseURL("cs:~a-user/trusty/spam-5")
 	chID := charmstore.CharmID{
 		URL: cURL,
@@ -137,7 +137,7 @@ func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 		Meta:   du.resources["upload"],
 		Origin: charmresource.OriginUpload,
 	}
-	s.stub.CheckCall(c, 3, "UploadPendingResource", "mysql", expectedUpload, "foobar.txt", deps.ReadSeekCloser)
+	s.stub.CheckCall(c, 3, "UploadPendingResource", "mysql", expectedUpload, "foobar.txt", "file contents")
 }
 
 func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
@@ -193,7 +193,7 @@ func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
 }
 
 func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
-	deps := uploadDeps{s.stub, rsc{&bytes.Buffer{}}}
+	deps := uploadDeps{s.stub, rsc{bytes.NewBufferString("file contents")}}
 	cURL := charm.MustParseURL("cs:~a-user/trusty/spam-5")
 	chID := charmstore.CharmID{
 		URL: cURL,
@@ -248,7 +248,7 @@ func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
 		Meta:   du.resources["upload"],
 		Origin: charmresource.OriginUpload,
 	}
-	s.stub.CheckCall(c, 3, "UploadPendingResource", "mysql", expectedUpload, "foobar.txt", deps.ReadSeekCloser)
+	s.stub.CheckCall(c, 3, "UploadPendingResource", "mysql", expectedUpload, "foobar.txt", "file contents")
 }
 
 func (s DeploySuite) TestUploadUnexpectedResourceFile(c *gc.C) {
@@ -323,6 +323,153 @@ func (s DeploySuite) TestMissingResource(c *gc.C) {
 	_, err := du.upload(files, revisions)
 	c.Check(err, gc.ErrorMatches, `file for resource "res1".*`)
 	c.Check(errors.Cause(err), jc.Satisfies, os.IsNotExist)
+}
+
+func (s DeploySuite) TestDeployDockerResourceRegPathString(c *gc.C) {
+	deps := uploadDeps{s.stub, rsc{&bytes.Buffer{}}}
+	cURL := charm.MustParseURL("cs:~a-user/mysql-k8s-5")
+	chID := charmstore.CharmID{
+		URL: cURL,
+	}
+	csMac := &macaroon.Macaroon{}
+	resourceMeta := map[string]charmresource.Meta{
+		"mysql_image": {
+			Name: "mysql_image",
+			Type: charmresource.TypeContainerImage,
+		},
+	}
+
+	passedResourceValues := map[string]string{
+		"mysql_image": "mariadb:10.3.8",
+	}
+
+	du := deployUploader{
+		applicationID: "mysql",
+		chID:          chID,
+		csMac:         csMac,
+		client:        deps,
+		resources:     resourceMeta,
+		osOpen:        deps.Open,
+		osStat:        deps.Stat,
+	}
+	ids, err := du.upload(passedResourceValues, map[string]int{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(ids, gc.DeepEquals, map[string]string{
+		"mysql_image": "id-mysql_image",
+	})
+
+	expectedUpload := charmresource.Resource{
+		Meta:   resourceMeta["mysql_image"],
+		Origin: charmresource.OriginUpload,
+	}
+
+	expectedUploadData := "{\"ImageName\":\"mariadb:10.3.8\",\"Username\":\"\"}"
+	s.stub.CheckCallNames(c, "UploadPendingResource")
+	s.stub.CheckCall(c, 0, "UploadPendingResource", "mysql", expectedUpload, "mariadb:10.3.8", expectedUploadData)
+}
+
+func (s DeploySuite) TestDeployDockerResourceJSONFile(c *gc.C) {
+	fileContents := `
+{
+  "ImageName": "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
+  "Username": "docker-registry",
+  "Password": "hunter2"
+}
+`
+	dir := c.MkDir()
+	jsonFile := path.Join(dir, "details.json")
+	err := ioutil.WriteFile(jsonFile, []byte(fileContents), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+	deps := uploadDeps{s.stub, rsc{&bytes.Buffer{}}}
+	cURL := charm.MustParseURL("cs:~a-user/mysql-k8s-5")
+	chID := charmstore.CharmID{
+		URL: cURL,
+	}
+	csMac := &macaroon.Macaroon{}
+	resourceMeta := map[string]charmresource.Meta{
+		"mysql_image": {
+			Name: "mysql_image",
+			Type: charmresource.TypeContainerImage,
+		},
+	}
+
+	passedResourceValues := map[string]string{
+		"mysql_image": jsonFile,
+	}
+	du := deployUploader{
+		applicationID: "mysql",
+		chID:          chID,
+		csMac:         csMac,
+		client:        deps,
+		resources:     resourceMeta,
+		osOpen:        deps.Open,
+		osStat:        deps.Stat,
+	}
+	ids, err := du.upload(passedResourceValues, map[string]int{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(ids, gc.DeepEquals, map[string]string{
+		"mysql_image": "id-mysql_image",
+	})
+
+	expectedUpload := charmresource.Resource{
+		Meta:   resourceMeta["mysql_image"],
+		Origin: charmresource.OriginUpload,
+	}
+
+	expectedUploadData := "{\"ImageName\":\"registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image\",\"Username\":\"docker-registry\",\"Password\":\"hunter2\"}"
+	s.stub.CheckCallNames(c, "UploadPendingResource")
+	s.stub.CheckCall(c, 0, "UploadPendingResource", "mysql", expectedUpload, jsonFile, expectedUploadData)
+}
+
+func (s DeploySuite) TestDeployDockerResourceYAMLFile(c *gc.C) {
+	fileContents := `
+registrypath: registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image
+username: docker-registry
+password: hunter2
+`
+	dir := c.MkDir()
+	jsonFile := path.Join(dir, "details.yaml")
+	err := ioutil.WriteFile(jsonFile, []byte(fileContents), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+	deps := uploadDeps{s.stub, rsc{&bytes.Buffer{}}}
+	cURL := charm.MustParseURL("cs:~a-user/mysql-k8s-5")
+	chID := charmstore.CharmID{
+		URL: cURL,
+	}
+	csMac := &macaroon.Macaroon{}
+	resourceMeta := map[string]charmresource.Meta{
+		"mysql_image": {
+			Name: "mysql_image",
+			Type: charmresource.TypeContainerImage,
+		},
+	}
+
+	passedResourceValues := map[string]string{
+		"mysql_image": jsonFile,
+	}
+	du := deployUploader{
+		applicationID: "mysql",
+		chID:          chID,
+		csMac:         csMac,
+		client:        deps,
+		resources:     resourceMeta,
+		osOpen:        deps.Open,
+		osStat:        deps.Stat,
+	}
+	ids, err := du.upload(passedResourceValues, map[string]int{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(ids, gc.DeepEquals, map[string]string{
+		"mysql_image": "id-mysql_image",
+	})
+
+	expectedUpload := charmresource.Resource{
+		Meta:   resourceMeta["mysql_image"],
+		Origin: charmresource.OriginUpload,
+	}
+
+	expectedUploadData := "{\"ImageName\":\"registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image\",\"Username\":\"docker-registry\",\"Password\":\"hunter2\"}"
+	s.stub.CheckCallNames(c, "UploadPendingResource")
+	s.stub.CheckCall(c, 0, "UploadPendingResource", "mysql", expectedUpload, jsonFile, expectedUploadData)
 }
 
 func (s DeploySuite) TestUnMarshallingDockerDetails(c *gc.C) {
@@ -413,7 +560,14 @@ func (s uploadDeps) AddPendingResources(applicationID string, charmID charmstore
 }
 
 func (s uploadDeps) UploadPendingResource(applicationID string, resource charmresource.Resource, filename string, r io.ReadSeeker) (id string, err error) {
-	s.stub.AddCall("UploadPendingResource", applicationID, resource, filename, r)
+	data := new(bytes.Buffer)
+
+	// we care the right data has been passed, not the right io.ReaderSeeker pointer.
+	_, err = data.ReadFrom(r)
+	if err != nil {
+		return "", err
+	}
+	s.stub.AddCall("UploadPendingResource", applicationID, resource, filename, data.String())
 	if err := s.stub.NextErr(); err != nil {
 		return "", err
 	}

--- a/core/resources/resources.go
+++ b/core/resources/resources.go
@@ -34,7 +34,7 @@ func ValidateDockerRegistryPath(path string) error {
 }
 
 // CheckDockerDetails validates the provided resource is suitable for use.
-func CheckDockerDetails(name, registryPath string) error {
+func CheckDockerDetails(name string, details DockerImageDetails) error {
 	// TODO (veebers): Validate the URL actually works.
-	return ValidateDockerRegistryPath(registryPath)
+	return ValidateDockerRegistryPath(details.RegistryPath)
 }

--- a/testcharms/charm-repo/kubernetes/mysql/hooks/install
+++ b/testcharms/charm-repo/kubernetes/mysql/hooks/install
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Done!"

--- a/testcharms/charm-repo/kubernetes/mysql/metadata.yaml
+++ b/testcharms/charm-repo/kubernetes/mysql/metadata.yaml
@@ -10,5 +10,8 @@ resources:
   mysql_image:
     type: "oci-image"
     description: "Image used for gitlab pod."
+  another_image:
+    type: "oci-image"
+    description: "Image used for unit test results."
 series:
   - kubernetes

--- a/testcharms/charm-repo/kubernetes/mysql/metadata.yaml
+++ b/testcharms/charm-repo/kubernetes/mysql/metadata.yaml
@@ -6,5 +6,9 @@ provides:
     interface: mysql
   server-admin:
     interface: mysql-root
+resources:
+  mysql_image:
+    type: "oci-image"
+    description: "Image used for gitlab pod."
 series:
   - kubernetes


### PR DESCRIPTION
## Description of change

Extends the --resource argument to deploy to allow passing a filepath that
contains the OCI image details (incl. username/password).

Enforce the requirement that local k8s charms need any OCI-image resources to
be defined via --resource.

## QA steps

Bootstrap and add k8s cloud for example [this discourse post covers that](https://discourse.jujucharms.com/t/juju-kubernetes-and-microk8s/226) except deploy the charm with the --resource arg.

### Testing passing file to ```--resource```
  - Get private image details to use
    - go to ```https://api.staging.jujucharms.com/charmstore/v5/~wallyworld/mysql-k8s-12/resource/mysql_image/0```
    - save this as a file on disk
    - pass that file path as an argument to deploy

### Testing local charm requirements
  - grab k8s charms: ```github.com:wallyworld/caas.git```
  - build local charm: ```cd mariadb/ && /snap/bin/charm build -o /some/output/path```
  - Attempt to deploy without specifying resources: ```juju deploy /some/output/path/mariadb-k8s local --storage database=10M,mariadb-pv```
    - Note it should fail, complaining about needing oci image resources
  - Deploy with resource details supplied: ```juju deploy /some/output/path/mariadb-k8s local --storage database=10M,mariadb-pv --resource mysql_image=mariadb:10.3.8```

To ensure the application comes up
You can check the right image was used via logs: ```mkubectl -n test describe pods juju-mariadb-k8s-0```, look for ```pulling image: . . .```.

## Documentation changes

The help docs for deploy should be updated.

