### PR TITLE
[WIP] - check current unit public ip before firing relation-joined hook - caas;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requi
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
-	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
+	microk8s.docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -75,8 +75,21 @@ type Snapshot struct {
 
 	// UpgradeSeriesStatus is the preparation status of any currently running series upgrade
 	UpgradeSeriesStatus model.UpgradeSeriesStatus
+
+	// ModelType is the model type.
+	ModelType model.ModelType
+
+	// IpAddress
+	IPAddress string
 }
 
+// UnitIPAddressAVailable indicates if unit has a public ip address.
+func (ss *Snapshot) UnitIPAddressAVailable() bool {
+	// only check this for CAAS model.
+	return ss.ModelType == model.IAAS || ss.IPAddress != ""
+}
+
+// RelationSnapshot is a snapshot of the relation.
 type RelationSnapshot struct {
 	Life      params.Life
 	Suspended bool

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -50,6 +50,7 @@ type Unit interface {
 	// relevant for this unit change.
 	WatchRelations() (watcher.StringsWatcher, error)
 	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
+	PublicAddress() (string, error)
 }
 
 type Application interface {


### PR DESCRIPTION
## Description of change

check current unit public ip before firing relation-joined hook for caas model.

## QA steps

- prepare a caas model;
- juju deploy gitlab-k8s;
- juju deploy mariadb-k8s;
- juju relate mariadb gitlab-k8s
- network-get should run after relation-joined hook and get `real ip` returned;

## Documentation changes

No document change required because it's bug fix;
