### PR TITLE
Prevents controllers from being targeted for upgrade-series

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -194,6 +194,7 @@ func (s *MachineManagerSuite) setupUpdateMachineSeries(c *gc.C) {
 		"0": {series: "trusty", units: []string{"foo/0", "test/0"}},
 		"1": {series: "trusty", units: []string{"foo/1", "test/1"}},
 		"2": {series: "centos7", units: []string{"foo/1", "test/1"}},
+		"3": {series: "bionic", isManager: true},
 	}
 }
 
@@ -352,6 +353,21 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateOK(c *gc.C) {
 		expectedUnitNames = append(expectedUnitNames, unit)
 	}
 	c.Assert(result.UnitNames, gc.DeepEquals, expectedUnitNames)
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateIsControllerError(c *gc.C) {
+	s.setupUpdateMachineSeries(c)
+	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("3").String()},
+		}},
+	}
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results[0].Error, gc.ErrorMatches,
+		"machine-3 is a controller and cannot be targeted for series upgrade")
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateNoSeriesError(c *gc.C) {
@@ -792,6 +808,7 @@ type mockMachine struct {
 	units          []string
 	unitAgentState status.Status
 	unitState      status.Status
+	isManager      bool
 }
 
 func (m *mockMachine) Destroy() error {
@@ -856,6 +873,10 @@ func (m *mockMachine) RemoveUpgradeSeriesLock() error {
 func (m *mockMachine) CompleteUpgradeSeries() error {
 	m.MethodCall(m, "CompleteUpgradeSeries")
 	return m.NextErr()
+}
+
+func (m *mockMachine) IsManager() bool {
+	return m.isManager
 }
 
 type mockUnit struct {

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -52,6 +52,7 @@ type Machine interface {
 	Principals() []string
 	WatchUpgradeSeriesNotifications() (state.NotifyWatcher, error)
 	GetUpgradeSeriesMessages() ([]string, bool, error)
+	IsManager() bool
 }
 
 type stateShim struct {


### PR DESCRIPTION
## Description of change

This patch adds validation that returns an error if `upgrade-series` is attempted on a controller machine.

## QA steps

- Bootstrap
- `juju switch controller`
- `juju upgrade-series prepare 0 cosmic`
- Observe error message.

## Documentation changes

None.

## Bug reference

N/A
