### PR TITLE
fix - destroy model hangs for caas model with detached volumes

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -1084,7 +1084,7 @@ func (s *StorageProvisionerAPIv3) FilesystemAttachmentParams(
 	one := func(arg params.MachineStorageId) (params.FilesystemAttachmentParams, error) {
 		filesystemAttachment, err := s.oneFilesystemAttachment(arg, canAccess)
 		if err != nil {
-			return params.FilesystemAttachmentParams{}, err
+			return params.FilesystemAttachmentParams{}, errors.Trace(err)
 		}
 		hostTag := filesystemAttachment.Host()
 		// Filesystems can be attached to units (caas models) or machines.
@@ -1096,12 +1096,12 @@ func (s *StorageProvisionerAPIv3) FilesystemAttachmentParams(
 				// The worker must watch for machine provisioning events.
 				instanceId = ""
 			} else if err != nil {
-				return params.FilesystemAttachmentParams{}, err
+				return params.FilesystemAttachmentParams{}, errors.Trace(err)
 			}
 		}
 		filesystem, err := s.sb.Filesystem(filesystemAttachment.Filesystem())
 		if err != nil {
-			return params.FilesystemAttachmentParams{}, err
+			return params.FilesystemAttachmentParams{}, errors.Trace(err)
 		}
 		var filesystemId string
 		var pool string
@@ -1110,7 +1110,7 @@ func (s *StorageProvisionerAPIv3) FilesystemAttachmentParams(
 		} else {
 			filesystemInfo, err := filesystem.Info()
 			if err != nil {
-				return params.FilesystemAttachmentParams{}, err
+				return params.FilesystemAttachmentParams{}, errors.Trace(err)
 			}
 			filesystemId = filesystemInfo.FilesystemId
 			pool = filesystemInfo.Pool

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -82,7 +82,8 @@ func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
 // ProcessDyingModel checks if a dying model has any machines or applications.
 // If there are none, the model's life is changed from dying to dead.
 func (u *UndertakerAPI) ProcessDyingModel() error {
-	return u.st.ProcessDyingModel()
+	// if modelNotEmptyError, then err.Code = CodeModelNotEmpty
+	return common.ServerError(u.st.ProcessDyingModel())
 }
 
 // RemoveModel removes any records of this model from Juju.

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -82,8 +82,7 @@ func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
 // ProcessDyingModel checks if a dying model has any machines or applications.
 // If there are none, the model's life is changed from dying to dead.
 func (u *UndertakerAPI) ProcessDyingModel() error {
-	// if modelNotEmptyError, then err.Code = CodeModelNotEmpty
-	return common.ServerError(u.st.ProcessDyingModel())
+	return u.st.ProcessDyingModel()
 }
 
 // RemoveModel removes any records of this model from Juju.

--- a/apiserver/resources_unit.go
+++ b/apiserver/resources_unit.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// ResourcesHandler is the HTTP handler for unit agent downloads of
+// UnitResourcesHandler is the HTTP handler for unit agent downloads of
 // resources.
 type UnitResourcesHandler struct {
 	NewOpener func(*http.Request, ...string) (resource.Opener, state.PoolHelper, error)
@@ -37,7 +37,12 @@ func (h *UnitResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Req
 		name := req.URL.Query().Get(":resource")
 		opened, err := opener.OpenResource(name)
 		if err != nil {
-			logger.Errorf("cannot fetch resource reader: %v", err)
+			if errors.IsNotFound(err) {
+				// non internal errors is not real errors.
+				logger.Warningf("cannot fetch resource reader: %v", err)
+			} else {
+				logger.Errorf("cannot fetch resource reader: %v", err)
+			}
 			api.SendHTTPError(resp, err)
 			return
 		}

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -158,7 +158,7 @@ func (st *State) Cleanup() (err error) {
 			err = errors.Errorf("unknown cleanup kind %q", doc.Kind)
 		}
 		if err != nil {
-			logger.Errorf(
+			logger.Warningf(
 				"cleanup failed in model %v for %v(%q): %v",
 				modelUUID, doc.Kind, doc.Prefix, err,
 			)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -307,7 +307,6 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 	default:
 		return errors.Errorf("expected 0-1 arguments, got %d", n)
 	}
-
 	storage, err := sb.AllStorageInstances()
 	if err != nil {
 		return errors.Trace(err)

--- a/state/model.go
+++ b/state/model.go
@@ -1305,14 +1305,11 @@ func (m *Model) destroyOps(
 		// hosted model in the course of destroying the controller. In
 		// that case we'll get errors if we try to enqueue hosted-model
 		// cleanups, because the cleanups collection is non-global.
-		ops = append(ops,
-			newCleanupOp(cleanupApplicationsForDyingModel, modelUUID),
-		)
+		ops = append([]txn.Op{newCleanupOp(cleanupApplicationsForDyingModel, modelUUID)}, ops...)
 		if m.Type() == ModelTypeIAAS {
 			ops = append(ops, newCleanupOp(cleanupMachinesForDyingModel, modelUUID))
 		}
-
-		if args.DestroyStorage != nil {
+		if args.DestroyStorage != nil && *args.DestroyStorage {
 			// The user has specified that the storage should be destroyed
 			// or released, which we can do in a cleanup. If the user did
 			// not specify either, then we have already added prereq ops

--- a/state/model.go
+++ b/state/model.go
@@ -1305,11 +1305,13 @@ func (m *Model) destroyOps(
 		// hosted model in the course of destroying the controller. In
 		// that case we'll get errors if we try to enqueue hosted-model
 		// cleanups, because the cleanups collection is non-global.
-		ops = append([]txn.Op{newCleanupOp(cleanupApplicationsForDyingModel, modelUUID)}, ops...)
+		ops = append(ops,
+			newCleanupOp(cleanupApplicationsForDyingModel, modelUUID),
+		)
 		if m.Type() == ModelTypeIAAS {
 			ops = append(ops, newCleanupOp(cleanupMachinesForDyingModel, modelUUID))
 		}
-		if args.DestroyStorage != nil && *args.DestroyStorage {
+		if args.DestroyStorage != nil {
 			// The user has specified that the storage should be destroyed
 			// or released, which we can do in a cleanup. If the user did
 			// not specify either, then we have already added prereq ops

--- a/state/storage.go
+++ b/state/storage.go
@@ -541,7 +541,6 @@ func removeStorageInstanceOps(si *storageInstance, assert bson.D) ([]txn.Op, err
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
-
 	return ops, nil
 }
 
@@ -930,7 +929,7 @@ func (sb *storageBackend) storageAttachments(query bson.D) ([]StorageAttachment,
 	return storageAttachments, nil
 }
 
-// StorageAttachment returns the StorageAttachment wit hthe specified tags.
+// StorageAttachment returns the StorageAttachment with the specified tags.
 func (sb *storageBackend) StorageAttachment(storage names.StorageTag, unit names.UnitTag) (StorageAttachment, error) {
 	att, err := sb.storageAttachment(storage, unit)
 	if err != nil {

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -105,7 +105,8 @@ func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
 		return errors.Annotate(err, "removing attachments")
 	}
 	for i, result := range errorResults {
-		if result.Error != nil {
+		if result.Error != nil && !params.IsCodeNotFound(result.Error) {
+			// ignore not found error.
 			return errors.Annotatef(
 				result.Error, "removing attachment of %s to %s from state",
 				ids[i].AttachmentTag, ids[i].MachineTag,

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -53,7 +53,7 @@ func attachmentLife(ctx *context, ids []params.MachineStorageId) (
 	for i, result := range lifeResults {
 		life := result.Life
 		if result.Error != nil {
-			if !params.IsCodeNotFound(err) {
+			if !params.IsCodeNotFound(result.Error) {
 				return nil, nil, nil, errors.Annotatef(
 					result.Error, "getting life of %s attached to %s",
 					ids[i].AttachmentTag, ids[i].MachineTag,

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -23,13 +23,17 @@ func storageEntityLife(ctx *context, tags []names.Tag) (alive, dying, dead []nam
 		return nil, nil, nil, errors.Annotate(err, "getting storage entity life")
 	}
 	for i, result := range lifeResults {
+		life := result.Life
 		if result.Error != nil {
-			return nil, nil, nil, errors.Annotatef(
-				result.Error, "getting life of %s",
-				names.ReadableString(tags[i]),
-			)
+			if !params.IsCodeNotFound(result.Error) {
+				return nil, nil, nil, errors.Annotatef(
+					result.Error, "getting life of %s",
+					names.ReadableString(tags[i]),
+				)
+			}
+			life = params.Dead
 		}
-		switch result.Life {
+		switch life {
 		case params.Alive:
 			alive = append(alive, tags[i])
 		case params.Dying:

--- a/worker/storageprovisioner/filesystem_events.go
+++ b/worker/storageprovisioner/filesystem_events.go
@@ -77,7 +77,7 @@ func filesystemAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStor
 	if len(dead) != 0 {
 		// We should not see dead filesystem attachments;
 		// attachments go directly from Dying to removed.
-		logger.Warningf("dead filesystem attachments: %v", dead)
+		logger.Warningf("unexpected dead filesystem attachments: %v", dead)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil
@@ -292,7 +292,7 @@ func processAliveFilesystems(ctx *context, tags []names.FilesystemTag, filesyste
 				return errors.Annotate(err, "getting filesystem info")
 			}
 			updateFilesystem(ctx, filesystem)
-			if ctx.config.Scope.Kind() != names.ApplicationTagKind {
+			if !ctx.isApplicationKind() {
 				if filesystem.Volume != (names.VolumeTag{}) {
 					// Ensure that volume-backed filesystems' block
 					// devices are present even after creating the
@@ -319,7 +319,7 @@ func processAliveFilesystems(ctx *context, tags []names.FilesystemTag, filesyste
 		return errors.Annotate(err, "getting filesystem params")
 	}
 	for _, params := range params {
-		if ctx.config.Scope.Kind() == names.ApplicationTagKind {
+		if ctx.isApplicationKind() {
 			logger.Debugf("not queuing filesystem for %v unit", ctx.config.Scope.Id())
 			continue
 		}

--- a/worker/storageprovisioner/filesystem_events.go
+++ b/worker/storageprovisioner/filesystem_events.go
@@ -77,7 +77,7 @@ func filesystemAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStor
 	if len(dead) != 0 {
 		// We should not see dead filesystem attachments;
 		// attachments go directly from Dying to removed.
-		logger.Warningf("unexpected dead filesystem attachments: %v", dead)
+		logger.Warningf("dead filesystem attachments: %v", dead)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -312,7 +312,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 	for sourceName, filesystemAttachmentParams := range paramsBySource {
 		logger.Debugf("detaching filesystems: %+v", filesystemAttachmentParams)
 		filesystemSource, ok := filesystemSources[sourceName]
-		if !ok && ctx.IsApplicationKind() {
+		if !ok && ctx.isApplicationKind() {
 			continue
 		}
 		errs, err := filesystemSource.DetachFilesystems(ctx.config.CloudCallContext, filesystemAttachmentParams)

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -312,8 +312,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 	for sourceName, filesystemAttachmentParams := range paramsBySource {
 		logger.Debugf("detaching filesystems: %+v", filesystemAttachmentParams)
 		filesystemSource, ok := filesystemSources[sourceName]
-		if !ok && ctx.IsCAASModel() {
-			logger.Criticalf("sfsdfsdfsdfdsfds filesystemSource -> %+v", filesystemSource)
+		if !ok && ctx.IsApplicationKind() {
 			continue
 		}
 		errs, err := filesystemSource.DetachFilesystems(ctx.config.CloudCallContext, filesystemAttachmentParams)

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -531,6 +531,6 @@ type context struct {
 	managedFilesystemSource storage.FilesystemSource
 }
 
-func (c *context) IsCAASModel() bool {
+func (c *context) IsApplicationKind() bool {
 	return c.config.Scope.Kind() == names.ApplicationTagKind
 }

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -277,7 +277,6 @@ func (w *storageProvisioner) loop() error {
 	if err := w.catacomb.Add(volumeAttachmentsWatcher); err != nil {
 		return errors.Trace(err)
 	}
-
 	volumeAttachmentsChanges = volumeAttachmentsWatcher.Changes()
 
 	filesystemAttachmentsWatcher, err := w.config.Filesystems.WatchFilesystemAttachments(w.config.Scope)
@@ -530,4 +529,8 @@ type context struct {
 	// manages filesystems backed by volumes attached to the host
 	// machine.
 	managedFilesystemSource storage.FilesystemSource
+}
+
+func (c *context) IsCAASModel() bool {
+	return c.config.Scope.Kind() == names.ApplicationTagKind
 }

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -182,7 +182,7 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 	if len(dead) != 0 {
 		// We should not see dead volume attachments;
 		// attachments go directly from Dying to removed.
-		logger.Warningf("dead volume attachments: %v", dead)
+		logger.Warningf("unexpected dead volume attachments: %v", dead)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil
@@ -214,7 +214,8 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 // processDyingVolumes processes the VolumeResults for Dying volumes,
 // removing them from provisioning-pending as necessary.
 func processDyingVolumes(ctx *context, tags []names.Tag) error {
-	if ctx.IsApplicationKind() {
+	if ctx.isApplicationKind() {
+		// only care dead for application.
 		return nil
 	}
 	for _, tag := range tags {
@@ -379,7 +380,8 @@ func processDyingVolumeAttachments(
 // processAliveVolumes processes the VolumeResults for Alive volumes,
 // provisioning volumes and setting the info in state as necessary.
 func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.VolumeResult) error {
-	if ctx.IsApplicationKind() {
+	if ctx.isApplicationKind() {
+		// only care dead for application kind.
 		return nil
 	}
 

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -214,6 +214,9 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 // processDyingVolumes processes the VolumeResults for Dying volumes,
 // removing them from provisioning-pending as necessary.
 func processDyingVolumes(ctx *context, tags []names.Tag) error {
+	if ctx.IsApplicationKind() {
+		return nil
+	}
 	for _, tag := range tags {
 		removePendingVolume(ctx, tag.(names.VolumeTag))
 	}
@@ -376,6 +379,10 @@ func processDyingVolumeAttachments(
 // processAliveVolumes processes the VolumeResults for Alive volumes,
 // provisioning volumes and setting the info in state as necessary.
 func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.VolumeResult) error {
+	if ctx.IsApplicationKind() {
+		return nil
+	}
+
 	// Filter out the already-provisioned volumes.
 	pending := make([]names.VolumeTag, 0, len(tags))
 	for i, result := range volumeResults {

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -182,7 +182,7 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 	if len(dead) != 0 {
 		// We should not see dead volume attachments;
 		// attachments go directly from Dying to removed.
-		logger.Warningf("unexpected dead volume attachments: %v", dead)
+		logger.Warningf("dead volume attachments: %v", dead)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -310,14 +310,10 @@ func removeVolumes(ctx *context, ops map[names.VolumeTag]*removeVolumeOp) error 
 		}
 		destroyTags, destroyIds, releaseTags, releaseIds := partitionRemoveVolumeParams(removeTags, removeParams)
 		if err := removeVolumes(destroyTags, destroyIds, volumeSource.DestroyVolumes); err != nil {
-			if err != nil {
-				return errors.Trace(err)
-			}
+			return errors.Trace(err)
 		}
 		if err := removeVolumes(releaseTags, releaseIds, volumeSource.ReleaseVolumes); err != nil {
-			if err != nil {
-				return errors.Trace(err)
-			}
+			return errors.Trace(err)
 		}
 	}
 	scheduleOperations(ctx, reschedule...)


### PR DESCRIPTION
## Description of change

fix destroy model hangs if there are volumes in the model.

## QA steps

1. prepare a caas model;
2. deploy stateful caas charm(mariadb-k8s for example);
3. remove application without removing storage: `juju remove-application mariadb-k8s`
4. check the storage are detached after application was removed: `juju storage [--filesystem]`
5. destroy model with `--destroy-storage` enabled: `juju destroy-model t1 --debug -y --destroy-storage`

## Documentation changes

No doc change because it's a bug fix.