### PR TITLE
Model credential changes adjustment for validity watcher.

### DIFF
--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -86,3 +86,22 @@ func (c *Facade) InvalidateModelCredential(reason string) error {
 	}
 	return nil
 }
+
+// WatchModelCredential provides a notify watcher that is responsive to changes
+// to a given cloud credential.
+func (c *Facade) WatchModelCredential() (watcher.NotifyWatcher, error) {
+	if v := c.facade.BestAPIVersion(); v < 2 {
+		return nil, errors.NotSupportedf("WatchModelCredential on CredentialValidator v%v", v)
+	}
+	var result params.NotifyWatchResult
+	err := c.facade.FacadeCall("WatchModelCredential", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err := result.Error; err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -150,3 +150,33 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	err := client.InvalidateModelCredential("")
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
+
+func (s *CredentialValidatorSuite) TestWatchModelCredentialError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{Error: &params.Error{Message: "foo"}}
+		return nil
+	})
+	client := credentialvalidator.NewFacade(apitesting.BestVersionCaller{apiCaller, 2})
+	_, err := client.WatchModelCredential()
+	c.Assert(err, gc.ErrorMatches, "foo")
+}
+
+func (s *CredentialValidatorSuite) TestWatchModelCredentialCallError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("foo")
+	})
+
+	client := credentialvalidator.NewFacade(apitesting.BestVersionCaller{apiCaller, 2})
+	_, err := client.WatchModelCredential()
+	c.Assert(err, gc.ErrorMatches, "foo")
+}
+
+func (s *CredentialValidatorSuite) TestWatchModelCredentialCallV1(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("foo")
+	})
+
+	client := credentialvalidator.NewFacade(apitesting.BestVersionCaller{apiCaller, 1})
+	_, err := client.WatchModelCredential()
+	c.Assert(err, gc.ErrorMatches, "WatchModelCredential on CredentialValidator v1 not supported")
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -36,7 +36,7 @@ var facadeVersions = map[string]int{
 	"Cloud":                        3,
 	"Controller":                   5,
 	"CredentialManager":            1,
-	"CredentialValidator":          1,
+	"CredentialValidator":          2,
 	"CrossController":              1,
 	"CrossModelRelations":          1,
 	"Deployer":                     1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -176,7 +176,8 @@ func AllFacades() *facade.Registry {
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
 	reg("CredentialManager", 1, credentialmanager.NewCredentialManagerAPI)
-	reg("CredentialValidator", 1, credentialvalidator.NewCredentialValidatorAPI)
+	reg("CredentialValidator", 1, credentialvalidator.NewCredentialValidatorAPIv1)
+	reg("CredentialValidator", 2, credentialvalidator.NewCredentialValidatorAPI) // adds WatchModelCredential
 	reg("ExternalControllerUpdater", 1, externalcontrollerupdater.NewStateAPI)
 
 	reg("Deployer", 1, deployer.NewDeployerAPI)

--- a/apiserver/facades/agent/credentialvalidator/backend.go
+++ b/apiserver/facades/agent/credentialvalidator/backend.go
@@ -13,7 +13,6 @@ import (
 
 // Backend defines behavior that credential validator needs.
 type Backend interface {
-
 	// ModelUsesCredential determines if the model uses given cloud credential.
 	ModelUsesCredential(tag names.CloudCredentialTag) (bool, error)
 
@@ -27,6 +26,9 @@ type Backend interface {
 	// InvalidateModelCredential marks the cloud credential that a current model
 	// uses as invalid.
 	InvalidateModelCredential(reason string) error
+
+	// WatchModelCredential returns a watcher that is keeping an eye on what cloud credential a model uses.
+	WatchModelCredential() (state.NotifyWatcher, error)
 }
 
 func NewBackend(st StateAccessor) Backend {
@@ -72,6 +74,16 @@ func (b *backend) ModelCredential() (*ModelCredential, error) {
 	}
 	result.Valid = credential.IsValid()
 	return result, nil
+}
+
+// WatchModelCredential implements Backend.WatchModelCredential.
+func (b *backend) WatchModelCredential() (state.NotifyWatcher, error) {
+	m, err := b.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return m.WatchModelCredential(), nil
 }
 
 func (b *backend) cloudSupportsNoAuth(cloudName string) (bool, error) {

--- a/apiserver/facades/agent/credentialvalidator/backend.go
+++ b/apiserver/facades/agent/credentialvalidator/backend.go
@@ -82,7 +82,6 @@ func (b *backend) WatchModelCredential() (state.NotifyWatcher, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	return m.WatchModelCredential(), nil
 }
 

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -4,9 +4,9 @@
 package credentialvalidator_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -105,6 +105,20 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	})
 }
 
+func (s *CredentialValidatorSuite) TestWatchModelCredential(c *gc.C) {
+	result, err := s.api.WatchModelCredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+}
+
+func (s *CredentialValidatorSuite) TestWatchModelCredentialError(c *gc.C) {
+	s.backend.SetErrors(errors.New("no nope niet"))
+	_, err := s.api.WatchModelCredential()
+	c.Assert(err, gc.ErrorMatches, "no nope niet")
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+}
+
 // modelUUID is the model tag we're using in the tests.
 var modelUUID = "01234567-89ab-cdef-0123-456789abcdef"
 
@@ -157,4 +171,12 @@ func (b *testBackend) WatchCredential(t names.CloudCredentialTag) state.NotifyWa
 func (b *testBackend) InvalidateModelCredential(reason string) error {
 	b.AddCall("InvalidateModelCredential", reason)
 	return b.NextErr()
+}
+
+func (b *testBackend) WatchModelCredential() (state.NotifyWatcher, error) {
+	b.AddCall("WatchModelCredential")
+	if err := b.NextErr(); err != nil {
+		return nil, err
+	}
+	return apiservertesting.NewFakeNotifyWatcher(), nil
 }

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -15,6 +15,7 @@ type ModelAccessor interface {
 	CloudCredential() (names.CloudCredentialTag, bool)
 	ModelTag() names.ModelTag
 	Cloud() string
+	WatchModelCredential() state.NotifyWatcher
 }
 
 // StateAccessor exposes State methods needed by credential validator.

--- a/worker/credentialvalidator/manifold.go
+++ b/worker/credentialvalidator/manifold.go
@@ -70,7 +70,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 func filterErrors(err error) error {
 	cause := errors.Cause(err)
 	if cause == ErrValidityChanged ||
-		cause == ErrModelMissingCredentialRequired {
+		cause == ErrModelMissingCredentialRequired ||
+		cause == ErrModelCredentialChanged {
 		return dependency.ErrBounce
 	}
 	return err

--- a/worker/credentialvalidator/manifold_test.go
+++ b/worker/credentialvalidator/manifold_test.go
@@ -54,6 +54,12 @@ func (*ManifoldSuite) TestFilterErrModelDoesNotNeedCredential(c *gc.C) {
 	c.Check(err, gc.Equals, dependency.ErrBounce)
 }
 
+func (*ManifoldSuite) TestFilterErrModelCredentialChanged(c *gc.C) {
+	manifold := credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{})
+	err := manifold.Filter(credentialvalidator.ErrModelCredentialChanged)
+	c.Check(err, gc.Equals, dependency.ErrBounce)
+}
+
 func (*ManifoldSuite) TestFilterOther(c *gc.C) {
 	manifold := credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{})
 	expect := errors.New("whatever")

--- a/worker/credentialvalidator/util_test.go
+++ b/worker/credentialvalidator/util_test.go
@@ -24,7 +24,8 @@ type mockFacade struct {
 	credential *base.StoredCredential
 	exists     bool
 
-	watcher *watchertest.MockNotifyWatcher
+	watcher      *watchertest.MockNotifyWatcher
+	modelWatcher *watchertest.MockNotifyWatcher
 }
 
 func (m *mockFacade) setupModelHasNoCredential() {
@@ -49,6 +50,15 @@ func (mock *mockFacade) WatchCredential(id string) (watcher.NotifyWatcher, error
 		return nil, err
 	}
 	return mock.watcher, nil
+}
+
+// WatchModelCredential is part of the credentialvalidator.Facade interface.
+func (mock *mockFacade) WatchModelCredential() (watcher.NotifyWatcher, error) {
+	mock.AddCall("WatchModelCredential")
+	if err := mock.NextErr(); err != nil {
+		return nil, err
+	}
+	return mock.modelWatcher, nil
 }
 
 // credentialTag is the credential tag we're using in the tests.

--- a/worker/credentialvalidator/worker_test.go
+++ b/worker/credentialvalidator/worker_test.go
@@ -4,13 +4,13 @@
 package credentialvalidator_test
 
 import (
-	"gopkg.in/juju/names.v2"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/api/base"


### PR DESCRIPTION
## Description of change

Since model's cloud credential can now change, this PR adjusts credential validity worker that gates cloud communications between a cloud provider and a model.
Previously the worker only watched the changes to cloud credential content for this model.
With this PR, the worker also gains a watcher that notifies it of changes to what cloud credential a model uses. 

## QA steps

1. bootstrap
2. change model credential for a default model
3. observe credential validity worker restart
 
