### PR TITLE
Modifies detail of upgrade-series prepare console messages.

### DIFF
--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -145,9 +145,7 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesAbbreviation(c *gc
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c *gc.C) {
 	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machine.PrepareCommand, machineArg, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
-	confirmationMsg := fmt.Sprintf(machine.UpgradeSeriesConfirmationMsg,
-		machineArg, seriesArg, machineArg, strings.Join(units, "\n"))
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, confirmationMsg)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), jc.HasSuffix, "Continue [y/N]?")
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesFlagAndNotPrompt(c *gc.C) {

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -137,7 +137,7 @@ func (m *Machine) prepareUpgradeSeriesLock(unitNames []string, toSeries string) 
 		unitStatuses[name] = UpgradeSeriesUnitStatus{Status: model.UpgradeSeriesPrepareStarted, Timestamp: bson.Now()}
 	}
 	timestamp := bson.Now()
-	message := fmt.Sprintf("started upgrade series from series %s to series %s", m.Series(), toSeries)
+	message := fmt.Sprintf("started upgrade series from %q to %q", m.Series(), toSeries)
 	updateMessage := newUpgradeSeriesMessage(m.Tag().String(), message, timestamp)
 	return &upgradeSeriesLockDoc{
 		Id:            m.Id(),


### PR DESCRIPTION
## Description of change

This patch changes the messages written to the console for upgrade-series _prepare_:
- Applications to be pinned are included in confirmation prompt.
- The start message omits "series" prefixes with the from/to notification.
- Units and applications are not shown when the machine is empty.

## QA steps

- Bootstrap.
- Deploy 2 units to a new machine (0).
- Add a new machine with no units (1).
- `juju upgrade-series prepare 0 bionic` and check that units and apps are listed.
- `juju upgrade-series prepare 1 bionic` and check that no unit/app message is displayed.
- Check that the first message is of the form `machine-1 started upgrade series from "xenial" to "bionic"`.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1797396
