### PR TITLE
fix migration of charm profiles instance data

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -413,7 +413,6 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 			return nil, errors.NotValidf("missing instance data for machine %s", machine.Id())
 		}
 		exMachine.SetInstance(e.newCloudInstanceArgs(instData))
-
 		instance := exMachine.Instance()
 		instanceKey := machine.globalInstanceKey()
 		statusArgs, err := e.statusArgs(instanceKey)
@@ -542,6 +541,9 @@ func (e *exporter) newCloudInstanceArgs(data instanceData) description.CloudInst
 	}
 	if data.AvailZone != nil {
 		inst.AvailabilityZone = *data.AvailZone
+	}
+	if len(data.CharmProfiles) > 0 {
+		inst.CharmProfiles = data.CharmProfiles
 	}
 	return inst
 }


### PR DESCRIPTION
## Description of change

exporter newCloudInstanceArgs should include CharmProfiles for successful migration

## QA steps

1. `juju bootstrap` 2 controllers
2. `juju add-model` move
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile`
3. `juju migrate` move to other-controller
3. juju switch other-controller:move
4. check the other-controller db:
`db.instanceData.find({},{"instanceid":1, "charm-profiles":1})`
4. verify the profiles listed are applied to the lxc machines via `lxc info`


