### PR TITLE
Refactor common error parsing for auth failures.

### DIFF
--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -86,7 +86,7 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 // MaybeHandleCredentialError determines if a given error relates to an invalid credential.
 //  If it is, the credential is invalidated and the return bool is true.
 // Original error is returned untouched.
-func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) (error, bool) {
+func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) bool {
 	denied := isAuthError(errors.Cause(err))
 	if ctx != nil && denied {
 		invalidateErr := ctx.InvalidateCredential("cloud denied access")
@@ -94,12 +94,11 @@ func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx con
 			logger.Warningf("could not invalidate stored cloud credential on the controller: %v", invalidateErr)
 		}
 	}
-	return err, denied
+	return denied
 }
 
 // HandleCredentialError determines if a given error relates to an invalid credential.
 // If it is, the credential is invalidated. Original error is returned untouched.
-func HandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) error {
+func HandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) {
 	MaybeHandleCredentialError(isAuthError, err, ctx)
-	return err
 }

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -70,8 +70,7 @@ func (s *ErrorsSuite) TestNilContext(c *gc.C) {
 	isAuthF := func(e error) bool {
 		return true
 	}
-	err, denied := common.MaybeHandleCredentialError(isAuthF, authFailureError, nil)
-	c.Assert(err, gc.DeepEquals, authFailureError)
+	denied := common.MaybeHandleCredentialError(isAuthF, authFailureError, nil)
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -84,7 +83,7 @@ func (s *ErrorsSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
-	_, denied := common.MaybeHandleCredentialError(isAuthF, authFailureError, ctx)
+	denied := common.MaybeHandleCredentialError(isAuthF, authFailureError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -119,7 +118,7 @@ func (s *ErrorsSuite) checkPermissionHandling(c *gc.C, e error, handled bool) {
 		return nil
 	}
 
-	_, denied := common.MaybeHandleCredentialError(isAuthF, e, ctx)
+	denied := common.MaybeHandleCredentialError(isAuthF, e, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
 }

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -5,12 +5,12 @@ package common_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/common"
 )
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -5,7 +5,6 @@ package maas
 
 import (
 	"fmt"
-	"github.com/juju/juju/provider/common"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
 )
 
 var cloudSchema = &jsonschema.Schema{

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -5,6 +5,7 @@ package maas
 
 import (
 	"fmt"
+	"github.com/juju/juju/provider/common"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -134,7 +135,7 @@ func verifyCredentials(env *maasEnviron, ctx context.ProviderCallContext) error 
 		return nil
 	}
 	_, err := env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)
-	if _, denied := MaybeHandleCredentialError(err, ctx); denied {
+	if _, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 		logger.Debugf("authentication failed: %v", err)
 		return errors.New(`authentication failed.
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -135,7 +135,7 @@ func verifyCredentials(env *maasEnviron, ctx context.ProviderCallContext) error 
 		return nil
 	}
 	_, err := env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)
-	if _, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+	if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 		logger.Debugf("authentication failed: %v", err)
 		return errors.New(`authentication failed.
 

--- a/provider/maas/errors.go
+++ b/provider/maas/errors.go
@@ -4,33 +4,10 @@
 package maas
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/common"
 )
-
-// MaybeHandleCredentialError determines if a given error relates to an invalid credential.
-//  If it is, the credential is invalidated and the return bool is true.
-// Original error is returned untouched.
-func MaybeHandleCredentialError(err error, ctx context.ProviderCallContext) (error, bool) {
-	denied := IsAuthorisationFailure(errors.Cause(err))
-	if ctx != nil && denied {
-		invalidateErr := ctx.InvalidateCredential("maas cloud denied access")
-		if invalidateErr != nil {
-			logger.Warningf("could not invalidate stored maas cloud credential on the controller: %v", invalidateErr)
-		}
-	}
-	return err, denied
-}
-
-// HandleCredentialError determines if a given error relates to an invalid credential.
-// If it is, the credential is invalidated. Original error is returned untouched.
-func HandleCredentialError(err error, ctx context.ProviderCallContext) error {
-	MaybeHandleCredentialError(err, ctx)
-	return err
-}
 
 // IsAuthorisationFailure determines if the given error has an authorisation failure.
 func IsAuthorisationFailure(err error) bool {

--- a/provider/maas/errors_test.go
+++ b/provider/maas/errors_test.go
@@ -30,8 +30,7 @@ func (s *ErrorSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestNilContext(c *gc.C) {
-	err, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, nil)
-	c.Assert(err, gc.DeepEquals, s.maasError)
+	denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, nil)
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -41,7 +40,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
-	_, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -86,7 +85,7 @@ func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
 		return nil
 	}
 
-	_, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
 }

--- a/provider/maas/errors_test.go
+++ b/provider/maas/errors_test.go
@@ -30,7 +30,7 @@ func (s *ErrorSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestNilContext(c *gc.C) {
-	err, denied := MaybeHandleCredentialError(s.maasError, nil)
+	err, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, nil)
 	c.Assert(err, gc.DeepEquals, s.maasError)
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
@@ -41,8 +41,8 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
-	_, denied := MaybeHandleCredentialError(s.maasError, ctx)
-	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored maas cloud credential on the controller")
+	_, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
 
@@ -81,13 +81,12 @@ func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "maas cloud denied access")
+		c.Assert(msg, gc.DeepEquals, "cloud denied access")
 		called = true
 		return nil
 	}
 
-	_, denied := MaybeHandleCredentialError(s.maasError, ctx)
+	_, denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
-
 }

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -5,6 +5,7 @@ package maas
 
 import (
 	"fmt"
+	"github.com/juju/juju/provider/common"
 	"strings"
 
 	"github.com/juju/errors"
@@ -115,7 +116,7 @@ func (mi *maas1Instance) interfaceAddresses(ctx context.ProviderCallContext) ([]
 	// Fetch a fresh copy of the instance JSON first.
 	obj, err := refreshMAASObject(mi.maasObject)
 	if err != nil {
-		return nil, HandleCredentialError(errors.Annotate(err, "getting instance details"), ctx)
+		return nil, common.HandleCredentialError(IsAuthorisationFailure, errors.Annotate(err, "getting instance details"), ctx)
 	}
 
 	subnetsMap, err := mi.environ.subnetToSpaceIds(ctx)

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -116,7 +116,8 @@ func (mi *maas1Instance) interfaceAddresses(ctx context.ProviderCallContext) ([]
 	// Fetch a fresh copy of the instance JSON first.
 	obj, err := refreshMAASObject(mi.maasObject)
 	if err != nil {
-		return nil, common.HandleCredentialError(IsAuthorisationFailure, errors.Annotate(err, "getting instance details"), ctx)
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return nil, errors.Annotate(err, "getting instance details")
 	}
 
 	subnetsMap, err := mi.environ.subnetToSpaceIds(ctx)

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -5,7 +5,6 @@ package maas
 
 import (
 	"fmt"
-	"github.com/juju/juju/provider/common"
 	"strings"
 
 	"github.com/juju/errors"
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 )
 


### PR DESCRIPTION
## Description of change

Some Juju providers already react to an invalid cloud credential.
This code is refactored for ease of use by other providers. For example, the next-in-line provider to benefit from this code is openstack. It will only need to define a function that determines if a given error is related to auth and call a common method.

The most interesting logic has been moved to provider/common/errors.go and maas provider logic changed to call these refactored methods when processing errors from the cloud. 
