### PR TITLE
API Methods for Querying Pinned Leadership

### DIFF
--- a/api/common/leadership.go
+++ b/api/common/leadership.go
@@ -36,8 +36,9 @@ func NewLeadershipPinningAPIFromFacade(facade base.FacadeCaller) *LeadershipPinn
 	}
 }
 
-// PinnedLeadership returns a collection of application tags and corresponding
-// vested entity tags for which leadership is currently pinned.
+// PinnedLeadership returns a collection of application tags for which
+// leadership is currently pinned, with the applications requiring each
+// application's pinned behaviour.
 func (a *LeadershipPinningAPI) PinnedLeadership() (map[names.ApplicationTag][]names.Tag, error) {
 	var callResult params.PinnedLeadershipResult
 	err := a.facade.FacadeCall("PinnedLeadership", nil, &callResult)

--- a/api/common/leadership_test.go
+++ b/api/common/leadership_test.go
@@ -33,6 +33,21 @@ func (s *LeadershipSuite) SetUpSuite(c *gc.C) {
 	s.machineApps = []string{"mysql", "redis", "wordpress"}
 }
 
+func (s *LeadershipSuite) TestPinnedLeadership(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	resultSource := params.PinnedLeadershipResult{Result: map[string][]string{
+		"application-redis": {"machine-0", "machine-1"},
+	}}
+	s.facade.EXPECT().FacadeCall("PinnedLeadership", nil, gomock.Any()).SetArg(2, resultSource)
+
+	res, err := s.client.PinnedLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.DeepEquals, map[names.ApplicationTag][]names.Tag{
+		names.NewApplicationTag("redis"): {names.NewMachineTag("0"), names.NewMachineTag("1")},
+	})
+}
+
 func (s *LeadershipSuite) TestPinMachineApplicationsSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 

--- a/apiserver/common/leadership.go
+++ b/apiserver/common/leadership.go
@@ -86,8 +86,8 @@ type leadershipPinningAPI struct {
 	authorizer facade.Authorizer
 }
 
-// PinnedLeadership returns all applications and their vested entities that
-// currently have their leadership pinned in the current model.
+// PinnedLeadership returns all pinned applications and the entities that
+// require their pinned behaviour, for leadership in the current model.
 func (a *leadershipPinningAPI) PinnedLeadership() (params.PinnedLeadershipResult, error) {
 	result := params.PinnedLeadershipResult{}
 

--- a/apiserver/common/leadership.go
+++ b/apiserver/common/leadership.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
 
@@ -47,6 +48,7 @@ func (s leadershipPinningBackend) Machine(name string) (LeadershipMachine, error
 type LeadershipPinningAPI interface {
 	PinMachineApplications() (params.PinApplicationsResults, error)
 	UnpinMachineApplications() (params.PinApplicationsResults, error)
+	PinnedLeadership() (params.PinnedLeadershipResult, error)
 }
 
 // NewLeadershipPinningFacade creates and returns a new leadership API.
@@ -83,6 +85,36 @@ type leadershipPinningAPI struct {
 	pinner     leadership.Pinner
 	authorizer facade.Authorizer
 }
+
+// PinnedLeadership returns all applications and their vested entities that
+// currently have their leadership pinned in the current model.
+func (a *leadershipPinningAPI) PinnedLeadership() (params.PinnedLeadershipResult, error) {
+	result := params.PinnedLeadershipResult{}
+
+	canAccess, err := a.authorizer.HasPermission(permission.ReadAccess, a.modelTag)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	if !canAccess {
+		return result, ErrPerm
+	}
+
+	pinTags := a.pinner.PinnedLeadership()
+	pinned := make(map[string][]string, len(pinTags))
+	for app, tags := range pinTags {
+		entities := make([]string, len(tags))
+		for i, tag := range tags {
+			entities[i] = tag.String()
+		}
+		pinned[names.NewApplicationTag(app).String()] = entities
+	}
+	result.Result = pinned
+	return result, nil
+}
+
+// TODO (manadart 2018-10-29): Rename the two methods below (and on the client
+// side) to be [Un]PinApplicationLeaders, and derive the list of applications
+// based on the authenticating entity.
 
 // PinMachineApplications pins leadership for applications represented by units
 // running on the auth'd machine.

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -84,3 +84,9 @@ func (m leadershipPinner) PinLeadership(applicationId string, entity names.Tag) 
 func (m leadershipPinner) UnpinLeadership(applicationId string, entity names.Tag) error {
 	return errors.Trace(m.pinner.Unpin(applicationId, entity))
 }
+
+// PinnedLeadership (leadership.Pinner) returns applications and vested
+// entities for which leadership is pinned.
+func (m leadershipPinner) PinnedLeadership() map[string][]names.Tag {
+	return m.pinner.Pinned()
+}

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -85,8 +85,9 @@ func (m leadershipPinner) UnpinLeadership(applicationId string, entity names.Tag
 	return errors.Trace(m.pinner.Unpin(applicationId, entity))
 }
 
-// PinnedLeadership (leadership.Pinner) returns applications and vested
-// entities for which leadership is pinned.
+// PinnedLeadership (leadership.Pinner) returns applications for which
+// leadership is pinned, along with the entities requiring the
+// pinned behaviour.
 func (m leadershipPinner) PinnedLeadership() map[string][]names.Tag {
 	return m.pinner.Pinned()
 }

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -90,7 +90,7 @@ type PinApplicationResult struct {
 type PinnedLeadershipResult struct {
 	// Result has:
 	// - Application tag keys representing the application pinned.
-	// - Tag slice values representing the entities vested in the pinned
+	// - Tag slice values representing the entities requiring pinned
 	//   behaviour for each application.
-	Result map[string][]string `json:"pinned,omitempty"`
+	Result map[string][]string `json:"result,omitempty"`
 }

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -84,3 +84,13 @@ type PinApplicationResult struct {
 	// if one occurred.
 	Error *Error `json:"error,omitempty"`
 }
+
+// PinnedLeadershipResults holds data representing the current applications for
+// which leadership is pinned
+type PinnedLeadershipResult struct {
+	// Result has:
+	// - Application tag keys representing the application pinned.
+	// - Tag slice values representing the entities vested in the pinned
+	//   behaviour for each application.
+	Result map[string][]string `json:"pinned,omitempty"`
+}

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -56,6 +56,10 @@ type Pinner interface {
 	// application and entity. Normal expiry behaviour is restored when no
 	// entities remain with pins for the application.
 	UnpinLeadership(applicationId string, entity names.Tag) error
+
+	// PinnedLeadership returns a map keyed on pinned application names,
+	// with their corresponding vested entities.
+	PinnedLeadership() map[string][]names.Tag
 }
 
 // Token represents a unit's leadership of its application.

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -58,7 +58,7 @@ type Pinner interface {
 	UnpinLeadership(applicationId string, entity names.Tag) error
 
 	// PinnedLeadership returns a map keyed on pinned application names,
-	// with their corresponding vested entities.
+	// with entities that require the application's pinned behaviour.
 	PinnedLeadership() map[string][]names.Tag
 }
 

--- a/core/leadership/mocks/leadership_mock.go
+++ b/core/leadership/mocks/leadership_mock.go
@@ -45,6 +45,18 @@ func (mr *MockPinnerMockRecorder) PinLeadership(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinLeadership", reflect.TypeOf((*MockPinner)(nil).PinLeadership), arg0, arg1)
 }
 
+// PinnedLeadership mocks base method
+func (m *MockPinner) PinnedLeadership() map[string][]names_v2.Tag {
+	ret := m.ctrl.Call(m, "PinnedLeadership")
+	ret0, _ := ret[0].(map[string][]names_v2.Tag)
+	return ret0
+}
+
+// PinnedLeadership indicates an expected call of PinnedLeadership
+func (mr *MockPinnerMockRecorder) PinnedLeadership() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinnedLeadership", reflect.TypeOf((*MockPinner)(nil).PinnedLeadership))
+}
+
 // UnpinLeadership mocks base method
 func (m *MockPinner) UnpinLeadership(arg0 string, arg1 names_v2.Tag) error {
 	ret := m.ctrl.Call(m, "UnpinLeadership", arg0, arg1)

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -63,7 +63,8 @@ type Pinner interface {
 	// pins for the application.
 	Unpin(leaseName string, entity names.Tag) error
 
-	// Pinned returns all applications and vested entities for pinned leases.
+	// Pinned returns all names for pinned leases, with the entities requiring
+	// their pinned behaviour
 	Pinned() map[string][]names.Tag
 }
 

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -61,7 +61,10 @@ type Pinner interface {
 	// Unpin reverses a Pin operation for the same application and entity.
 	// Normal expiry behaviour is restored when no entities remain with
 	// pins for the application.
-	Unpin(leaseName string, tag names.Tag) error
+	Unpin(leaseName string, entity names.Tag) error
+
+	// Pinned returns all applications and vested entities for pinned leases.
+	Pinned() map[string][]names.Tag
 }
 
 // Checker exposes facts about lease ownership.

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -61,7 +61,7 @@ type Store interface {
 
 	// Pinned returns a snapshot of pinned leases.
 	// The return consists of each pinned lease and the collection of entities
-	// vested in its pinned behaviour.
+	// requiring its pinned behaviour.
 	Pinned() map[Key][]names.Tag
 }
 

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -75,7 +75,8 @@ type FSM struct {
 	entries    map[lease.Key]*entry
 
 	// Pinned leases are denoted by having a non-empty collection of tags
-	// representing vested "pinners" against their key.
+	// representing the applications requiring pinned behaviour,
+	// against their key.
 	// This allows different Juju concerns to pin leases, but remove only
 	// their own pins. It is done to avoid restoring normal expiration
 	// to a lease pinned by another concern operating under under the
@@ -183,7 +184,8 @@ func (f *FSM) Leases(localTime time.Time) map[lease.Key]lease.Info {
 	return results
 }
 
-// Pinned returns all of the currently known lease pins and vested entities.
+// Pinned returns all of the currently known lease pins and applications
+// requiring the pinned behaviour.
 func (f *FSM) Pinned() map[lease.Key][]names.Tag {
 	f.mu.Lock()
 	pinned := make(map[lease.Key][]names.Tag)

--- a/worker/lease/bound.go
+++ b/worker/lease/bound.go
@@ -76,6 +76,12 @@ func (b *boundManager) Token(leaseName, holderName string) lease.Token {
 	}
 }
 
+// Pinned (lease.Pinner) returns applications and vested entities for
+// pinned leases in the bound namespace/model.
+func (b *boundManager) Pinned() map[string][]names.Tag {
+	return b.manager.pinned(b.namespace, b.modelUUID)
+}
+
 // Pin (lease.Pinner) sends a pin message to the worker loop.
 func (b *boundManager) Pin(leaseName string, entity names.Tag) error {
 	return errors.Trace(b.pinOp(leaseName, entity, b.manager.pins))

--- a/worker/lease/bound.go
+++ b/worker/lease/bound.go
@@ -76,8 +76,8 @@ func (b *boundManager) Token(leaseName, holderName string) lease.Token {
 	}
 }
 
-// Pinned (lease.Pinner) returns applications and vested entities for
-// pinned leases in the bound namespace/model.
+// Pinned (lease.Pinner) returns applications and the entities requiring their
+// pinned behaviour, for pinned leases in the bound namespace/model.
 func (b *boundManager) Pinned() map[string][]names.Tag {
 	return b.manager.pinned(b.namespace, b.modelUUID)
 }

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1/catacomb"
@@ -454,6 +456,18 @@ func (manager *Manager) handlePin(p pin) {
 
 func (manager *Manager) handleUnpin(p pin) {
 	p.respond(errors.Trace(manager.config.Store.UnpinLease(p.leaseKey, p.entity)))
+}
+
+// pinned returns lease names and their vested entities from the input
+// namespace/model for which leases are pinned.
+func (manager *Manager) pinned(namespace, modelUUID string) map[string][]names.Tag {
+	pinned := make(map[string][]names.Tag)
+	for key, entities := range manager.config.Store.Pinned() {
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			pinned[key.Lease] = entities
+		}
+	}
+	return pinned
 }
 
 func keysLess(a, b lease.Key) bool {

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -458,8 +458,8 @@ func (manager *Manager) handleUnpin(p pin) {
 	p.respond(errors.Trace(manager.config.Store.UnpinLease(p.leaseKey, p.entity)))
 }
 
-// pinned returns lease names and their vested entities from the input
-// namespace/model for which leases are pinned.
+// pinned returns lease names and the entities requiring their pinned
+// behaviour, from the input namespace/model for which leases are pinned.
 func (manager *Manager) pinned(namespace, modelUUID string) map[string][]names.Tag {
 	pinned := make(map[string][]names.Tag)
 	for key, entities := range manager.config.Store.Pinned() {

--- a/worker/lease/manager_pin_test.go
+++ b/worker/lease/manager_pin_test.go
@@ -94,6 +94,18 @@ func (s *PinSuite) TestUnpinLease_Error(c *gc.C) {
 	})
 }
 
+func (s *PinSuite) TestPinned(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Pinned",
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
+		pinned := getPinner(c, manager).Pinned()
+		c.Check(pinned, gc.DeepEquals, map[string][]names.Tag{"redis": {s.machineTag}})
+	})
+}
+
 func getPinner(c *gc.C, manager *lease.Manager) corelease.Pinner {
 	pinner, err := manager.Pinner("namespace", "modelUUID")
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -185,12 +185,12 @@ func (store *Store) UnpinLease(key lease.Key, entity names.Tag) error {
 func (store *Store) Pinned() map[lease.Key][]names.Tag {
 	store.call("Pinned", nil)
 	return map[lease.Key][]names.Tag{
-		lease.Key{
+		{
 			Namespace: "namespace",
 			ModelUUID: "modelUUID",
 			Lease:     "redis",
 		}: {names.NewMachineTag("0")},
-		lease.Key{
+		{
 			Namespace: "ignored-namespace",
 			ModelUUID: "ignored modelUUID",
 			Lease:     "lolwut",

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -182,8 +182,20 @@ func (store *Store) UnpinLease(key lease.Key, entity names.Tag) error {
 	return store.call("UnpinLease", []interface{}{key, entity})
 }
 
-func (Store *Store) Pinned() map[lease.Key][]names.Tag {
-	return nil
+func (store *Store) Pinned() map[lease.Key][]names.Tag {
+	store.call("Pinned", nil)
+	return map[lease.Key][]names.Tag{
+		lease.Key{
+			Namespace: "namespace",
+			ModelUUID: "modelUUID",
+			Lease:     "redis",
+		}: {names.NewMachineTag("0")},
+		lease.Key{
+			Namespace: "ignored-namespace",
+			ModelUUID: "ignored modelUUID",
+			Lease:     "lolwut",
+		}: {names.NewMachineTag("666")},
+	}
 }
 
 // call defines a expected method call on a Store; it encodes:


### PR DESCRIPTION
## Description of change

This patch threads the pinned lease query facility previously added to Raft, through the lease-worker and exposes it for the leadership name-space via the common leadership API.

## QA steps

New unit tests.

Leadership and lease functionality remains unchanged and there are not yet any consumers of the new API.

## Documentation changes

None, though forthcoming client reporting of pinned leadership will require docs. 

## Bug reference

N/A
