### PR TITLE
Merge pull request #9323 from ExternalReality/fix_logging_path

### DIFF
--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -372,7 +372,8 @@ func (s *systemdServiceManager) startAgent(name string, kind AgentKind, dataDir 
 		return errors.Trace(err)
 	}
 
-	info := NewAgentInfo(kind, name, dataDir, paths.NixLogDir)
+	srvPath := path.Join(paths.NixLogDir, "juju")
+	info := NewAgentInfo(kind, name, dataDir, srvPath)
 	conf := AgentConf(info, renderer)
 
 	svc, err := s.newService(serviceName(name), conf)

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -195,7 +195,7 @@ func (s *agentConfSuite) TestFindAgentsUnexpectedTagType(c *gc.C) {
 	c.Assert(unexpectedAgents, gc.DeepEquals, []string{unexpectedAgent})
 }
 
-func (s *agentConfSuite) TestCreateAgentConf(c *gc.C) {
+func (s *agentConfSuite) TestCreateAgentConfDesc(c *gc.C) {
 	conf, err := s.manager.CreateAgentConf("machine-2", s.dataDir)
 	c.Assert(err, jc.ErrorIsNil)
 	// Spot check Conf


### PR DESCRIPTION
https://github.com/juju/juju/pull/9323

`Juju` moves the library directory of juju `systemd` init scripts to a the standard location in a `2.4` upgrade step. This upgrade step, however, was writing the services start script with an incorrect logging path. This PR fixes the issue by introducing a `2.4.5` upgrade step which rewrites the files with the correct log path.

This issue only happens on upgrade in `2.4`, due to the error being in an upgrade step, as such we must reproduce the case by upgrading juju from `2.3` to `2.4`:

1. Boostrap with `Juju 2.3`
```bash
snap install juju --channel 2.3 --classic # Please ensure you are using the right version
juju bootstrap <cloud> test
juju deploy ubuntu # Not strictly necessary since we could check the controller machine
```

2. Upgrade to `Juju 2.4`
```bash
snap refresh juju --channel 2.4 --classic
juju upgrade-juju -m controller
juju upgrade-juju
```

3. Inspect the `exec-start.sh` to see that the bug has in fact been reproduced
```bash
juju ssh 0 'cat /lib/systemd/system/jujud-machine-0/exec-start.sh'
```
4. Install this PR version of `Juju` (so you get the fix) and upgrade
```bash
snap remove juju
cd <path to juju repo>
go install -v ./...
juju upgrade-juju -m controller --build agent # assuming, of course, you have this PR branch checkout out
juju upgrade-juju
```
6. Wait a few seconds for the files to be rewritten
```bash
juju ssh 0 'cat /lib/systemd/system/jujud-machine-0/exec-start.sh'
```

The script should be corrected and the services should still work.

https://bugs.launchpad.net/juju/+bug/1793284

## Please provide the following details to expedite Pull Request review:

----

## Description of change

*Please replace with a description about why this change is needed?*

## QA steps

*Please replace with how we can verify that the change works?*

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?* 

## Bug reference

*Please add a link to any bugs that this change is related to.*
