### PR TITLE
httpserver: enable using a different port for controller connections

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -304,6 +304,9 @@ type configSetterOnly interface {
 	// to run a controller
 	SetStateServingInfo(info params.StateServingInfo)
 
+	// SetControllerAPIPort sets the controller API port in the config.
+	SetControllerAPIPort(port int)
+
 	// SetMongoVersion sets the passed version as currently in use.
 	SetMongoVersion(mongo.Version)
 
@@ -684,6 +687,12 @@ func (c *configInternal) SetStateServingInfo(info params.StateServingInfo) {
 	}
 }
 
+func (c *configInternal) SetControllerAPIPort(port int) {
+	if c.servingInfo != nil {
+		c.servingInfo.ControllerAPIPort = port
+	}
+}
+
 func (c *configInternal) APIAddresses() ([]string, error) {
 	if c.apiDetails == nil {
 		return []string{}, errors.New("No apidetails in config")
@@ -800,6 +809,11 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 	// to other controllers if we can talk locally.
 	if isController {
 		port := servingInfo.APIPort
+		// If the controller has been configured with a controller api port,
+		// we return that instead of the normal api port.
+		if servingInfo.ControllerAPIPort != 0 {
+			port = servingInfo.ControllerAPIPort
+		}
 		// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4
 		// loopback, and when/if this changes localhost should resolve
 		// to IPv6 loopback in any case (lp:1644009). Review.

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -53,6 +53,7 @@ type format_2_0Serialization struct {
 	ControllerKey      string `yaml:"controllerkey,omitempty"`
 	CAPrivateKey       string `yaml:"caprivatekey,omitempty"`
 	APIPort            int    `yaml:"apiport,omitempty"`
+	ControllerAPIPort  int    `yaml:"controller-apiport,omitempty"`
 	StatePort          int    `yaml:"stateport,omitempty"`
 	SharedSecret       string `yaml:"sharedsecret,omitempty"`
 	SystemIdentity     string `yaml:"systemidentity,omitempty"`
@@ -113,13 +114,14 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 	}
 	if len(format.ControllerKey) != 0 {
 		config.servingInfo = &params.StateServingInfo{
-			Cert:           format.ControllerCert,
-			PrivateKey:     format.ControllerKey,
-			CAPrivateKey:   format.CAPrivateKey,
-			APIPort:        format.APIPort,
-			StatePort:      format.StatePort,
-			SharedSecret:   format.SharedSecret,
-			SystemIdentity: format.SystemIdentity,
+			Cert:              format.ControllerCert,
+			PrivateKey:        format.ControllerKey,
+			CAPrivateKey:      format.CAPrivateKey,
+			APIPort:           format.APIPort,
+			ControllerAPIPort: format.ControllerAPIPort,
+			StatePort:         format.StatePort,
+			SharedSecret:      format.SharedSecret,
+			SystemIdentity:    format.SystemIdentity,
 		}
 		// If private key is not present, infer it from the ports in the state addresses.
 		if config.servingInfo.StatePort == 0 {
@@ -178,6 +180,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		format.ControllerKey = config.servingInfo.PrivateKey
 		format.CAPrivateKey = config.servingInfo.CAPrivateKey
 		format.APIPort = config.servingInfo.APIPort
+		format.ControllerAPIPort = config.servingInfo.ControllerAPIPort
 		format.StatePort = config.servingInfo.StatePort
 		format.SharedSecret = config.servingInfo.SharedSecret
 		format.SystemIdentity = config.servingInfo.SystemIdentity

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -53,7 +53,7 @@ type format_2_0Serialization struct {
 	ControllerKey      string `yaml:"controllerkey,omitempty"`
 	CAPrivateKey       string `yaml:"caprivatekey,omitempty"`
 	APIPort            int    `yaml:"apiport,omitempty"`
-	ControllerAPIPort  int    `yaml:"controller-apiport,omitempty"`
+	ControllerAPIPort  int    `yaml:"controllerapiport,omitempty"`
 	StatePort          int    `yaml:"stateport,omitempty"`
 	SharedSecret       string `yaml:"sharedsecret,omitempty"`
 	SystemIdentity     string `yaml:"systemidentity,omitempty"`

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -111,7 +111,7 @@ stateaddresses:
 - localhost:37017
 statepassword: NB5imrDaWCCRW/4akSSvUxhX
 apiaddresses:
-- localhost:17070
+- localhost:17071
 apipassword: NB5imrDaWCCRW/4akSSvUxhX
 oldpassword: oBlMbFUGvCb2PMFgYVzjS6GD
 values:
@@ -213,6 +213,7 @@ caprivatekey: '-----BEGIN RSA PRIVATE KEY-----
 
 '
 apiport: 17070
+controllerapiport: 17071
 `[1:]
 
 var agentConfig2_0NotStateMachine = `

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -114,14 +114,21 @@ func (api *AgentAPIV2) StateServingInfo() (result params.StateServingInfo, err e
 	if err != nil {
 		return params.StateServingInfo{}, errors.Trace(err)
 	}
+	// ControllerAPIPort comes from the controller config.
+	config, err := api.st.ControllerConfig()
+	if err != nil {
+		return params.StateServingInfo{}, errors.Trace(err)
+	}
+
 	result = params.StateServingInfo{
-		APIPort:        info.APIPort,
-		StatePort:      info.StatePort,
-		Cert:           info.Cert,
-		PrivateKey:     info.PrivateKey,
-		CAPrivateKey:   info.CAPrivateKey,
-		SharedSecret:   info.SharedSecret,
-		SystemIdentity: info.SystemIdentity,
+		APIPort:           info.APIPort,
+		ControllerAPIPort: config.ControllerAPIPort(),
+		StatePort:         info.StatePort,
+		Cert:              info.Cert,
+		PrivateKey:        info.PrivateKey,
+		CAPrivateKey:      info.CAPrivateKey,
+		SharedSecret:      info.SharedSecret,
+		SystemIdentity:    info.SystemIdentity,
 	}
 
 	return result, nil

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -731,8 +731,9 @@ type ModifyUserSSHKeys struct {
 // StateServingInfo holds information needed by a state
 // server.
 type StateServingInfo struct {
-	APIPort   int `json:"api-port"`
-	StatePort int `json:"state-port"`
+	APIPort           int `json:"api-port"`
+	ControllerAPIPort int `json:"controller-api-port,omitempty"`
+	StatePort         int `json:"state-port"`
 	// The controller cert and corresponding private key.
 	Cert       string `json:"cert"`
 	PrivateKey string `json:"private-key"`

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -510,6 +510,12 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 				return nil
 			})
 		}
+		updateControllerAPIPort := func(port int) error {
+			return a.AgentConfigWriter.ChangeConfig(func(setter agent.ConfigSetter) error {
+				setter.SetControllerAPIPort(port)
+				return nil
+			})
+		}
 
 		// statePoolReporter is an introspection.IntrospectionReporter,
 		// which is set to the current StatePool managed by the state
@@ -542,26 +548,27 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 		}
 
 		manifolds := machineManifolds(machine.ManifoldsConfig{
-			PreviousAgentVersion: previousAgentVersion,
-			Agent:                agent.APIHostPortsSetter{Agent: a},
-			RootDir:              a.rootDir,
-			AgentConfigChanged:   a.configChangedVal,
-			UpgradeStepsLock:     a.upgradeComplete,
-			UpgradeCheckLock:     a.initialUpgradeCheckComplete,
-			OpenController:       a.initController,
-			OpenState:            a.initState,
-			OpenStateForUpgrade:  a.openStateForUpgrade,
-			StartAPIWorkers:      a.startAPIWorkers,
-			PreUpgradeSteps:      a.preUpgradeSteps,
-			LogSource:            a.bufferedLogger.Logs(),
-			NewDeployContext:     newDeployContext,
-			Clock:                clock.WallClock,
-			ValidateMigration:    a.validateMigration,
-			PrometheusRegisterer: a.prometheusRegistry,
-			CentralHub:           a.centralHub,
-			PubSubReporter:       pubsubReporter,
-			PresenceRecorder:     presenceRecorder,
-			UpdateLoggerConfig:   updateAgentConfLogging,
+			PreviousAgentVersion:    previousAgentVersion,
+			Agent:                   agent.APIHostPortsSetter{Agent: a},
+			RootDir:                 a.rootDir,
+			AgentConfigChanged:      a.configChangedVal,
+			UpgradeStepsLock:        a.upgradeComplete,
+			UpgradeCheckLock:        a.initialUpgradeCheckComplete,
+			OpenController:          a.initController,
+			OpenState:               a.initState,
+			OpenStateForUpgrade:     a.openStateForUpgrade,
+			StartAPIWorkers:         a.startAPIWorkers,
+			PreUpgradeSteps:         a.preUpgradeSteps,
+			LogSource:               a.bufferedLogger.Logs(),
+			NewDeployContext:        newDeployContext,
+			Clock:                   clock.WallClock,
+			ValidateMigration:       a.validateMigration,
+			PrometheusRegisterer:    a.prometheusRegistry,
+			CentralHub:              a.centralHub,
+			PubSubReporter:          pubsubReporter,
+			PresenceRecorder:        presenceRecorder,
+			UpdateLoggerConfig:      updateAgentConfLogging,
+			UpdateControllerAPIPort: updateControllerAPIPort,
 			NewAgentStatusSetter: func(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
 				return a.machine(apiConn)
 			},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -700,6 +700,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			StateName:               stateName,
 			Logger:                  loggo.GetLogger("juju.worker.controllerport"),
 			UpdateControllerAPIPort: config.UpdateControllerAPIPort,
+			GetControllerConfig:     controllerport.GetControllerConfig,
 			NewWorker:               controllerport.NewWorker,
 		}),
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -685,6 +685,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		httpServerArgsName: httpserverargs.Manifold(httpserverargs.ManifoldConfig{
 			ClockName:             clockName,
+			ControllerPortName:    controllerPortName,
 			StateName:             stateName,
 			NewStateAuthenticator: httpserverargs.NewStateAuthenticator,
 		}),
@@ -705,15 +706,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		httpServerName: httpserver.Manifold(httpserver.ManifoldConfig{
 			AgentName:            agentName,
 			CertWatcherName:      certificateWatcherName,
-			ClockName:            clockName,
-			ControllerPortName:   controllerPortName,
+			HubName:              centralHubName,
 			StateName:            stateName,
 			MuxName:              httpServerArgsName,
 			APIServerName:        apiServerName,
 			RaftTransportName:    raftTransportName,
 			RaftEnabledName:      raftEnabledName,
 			PrometheusRegisterer: config.PrometheusRegisterer,
-			Hub:                  config.CentralHub,
+			Clock:                config.Clock,
 			NewTLSConfig:         httpserver.NewTLSConfig,
 			NewWorker:            httpserver.NewWorkerShim,
 		}),

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -704,7 +704,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		httpServerName: httpserver.Manifold(httpserver.ManifoldConfig{
-			AgentName:            agentName,
 			CertWatcherName:      certificateWatcherName,
 			HubName:              centralHubName,
 			StateName:            stateName,
@@ -714,6 +713,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			RaftEnabledName:      raftEnabledName,
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			Clock:                config.Clock,
+			GetControllerConfig:  httpserver.GetControllerConfig,
 			NewTLSConfig:         httpserver.NewTLSConfig,
 			NewWorker:            httpserver.NewWorkerShim,
 		}),

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -54,6 +54,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"certificate-updater",
 		"certificate-watcher",
 		"clock",
+		"controller-port",
 		"disk-manager",
 		"external-controller-updater",
 		"fan-configurer",
@@ -128,6 +129,7 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"certificate-watcher",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"global-clock-updater",
 		"http-server",
 		"http-server-args",
@@ -286,7 +288,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 	"api-server": {
 		"agent",
 		"audit-config-updater",
+		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"restore-watcher",
@@ -318,6 +322,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"state-config-watcher"},
 
 	"clock": {},
+
+	"controller-port": {
+		"agent",
+		"central-hub",
+		"state",
+		"state-config-watcher"},
 
 	"disk-manager": {
 		"agent",
@@ -381,6 +391,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"central-hub",
 		"certificate-watcher",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft-enabled-flag",
@@ -393,7 +404,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 
 	"http-server-args": {
 		"agent",
+		"central-hub",
 		"clock",
+		"controller-port",
 		"state",
 		"state-config-watcher"},
 
@@ -512,7 +525,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 
 	"peer-grouper": {
 		"agent",
+		"central-hub",
 		"clock",
+		"controller-port",
 		"state",
 		"state-config-watcher",
 		"upgrade-check-flag",
@@ -542,6 +557,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft-enabled-flag",
@@ -558,6 +574,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -575,6 +592,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -599,6 +617,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -616,6 +635,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft-enabled-flag",

--- a/controller/config.go
+++ b/controller/config.go
@@ -371,6 +371,8 @@ func (c Config) ControllerAPIPort() int {
 	if value, ok := c[ControllerAPIPort].(float64); ok {
 		return int(value)
 	}
+	// If the value isn't an int, this conversion will fail and value
+	// will be 0, which is what we want here.
 	value, _ := c[ControllerAPIPort].(int)
 	return value
 }

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -232,13 +232,6 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 	c.Assert(err, gc.ErrorMatches, "current upgrade info not found")
 }
 
-func (s *upgradeSuite) logAPIPort(c *gc.C, tag string) {
-	agentConf := agentcmd.NewAgentConf(s.DataDir())
-	agentConf.ReadConfig(tag)
-	info, ok := agentConf.CurrentConfig().StateServingInfo()
-	c.Logf("\n\nok=%v, API port is %d\n\n", ok, info.APIPort)
-}
-
 // TODO(mjs) - the following should maybe be part of AgentSuite
 func (s *upgradeSuite) newAgent(c *gc.C, m *state.Machine) *agentcmd.MachineAgent {
 	agentConf := agentcmd.NewAgentConf(s.DataDir())

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -40,13 +40,15 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxPruneTxnPasses,
 		controller.CAASOperatorImagePath,
 		controller.Features,
+		controller.APIPortOpenDelay,
+		controller.ControllerAPIPort,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)
 		c.Logf(controllerAttr)
 		if !optional.Contains(controllerAttr) {
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(v, gc.Not(gc.Equals), "")
+			c.Check(ok, jc.IsTrue)
+			c.Check(v, gc.Not(gc.Equals), "")
 		}
 	}
 }

--- a/worker/controllerport/manifold.go
+++ b/worker/controllerport/manifold.go
@@ -1,0 +1,117 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+
+	"github.com/juju/juju/agent"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// Logger defines the methods needed for the worker to log messages.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// ManifoldConfig holds the information necessary to determine the controller
+// api port and keep it up to date.
+type ManifoldConfig struct {
+	AgentName string
+	HubName   string
+	StateName string
+
+	Logger                  Logger
+	UpdateControllerAPIPort func(int) error
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.HubName == "" {
+		return errors.NotValidf("empty HubName")
+	}
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.UpdateControllerAPIPort == nil {
+		return errors.NotValidf("nil UpdateControllerAPIPort")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run an HTTP server
+// worker. The manifold outputs an *apiserverhttp.Mux, for other workers
+// to register handlers against.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.HubName,
+			config.StateName,
+		},
+		Start: config.start,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var hub *pubsub.StructuredHub
+	if err := context.Get(config.HubName, &hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer stTracker.Done()
+
+	systemState := statePool.SystemState()
+	controllerConfig, err := systemState.ControllerConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get controller config")
+	}
+	controllerAPIPort := controllerConfig.ControllerAPIPort()
+
+	w, err := config.NewWorker(Config{
+		AgentConfig:             agent.CurrentConfig(),
+		Hub:                     hub,
+		Logger:                  config.Logger,
+		ControllerAPIPort:       controllerAPIPort,
+		UpdateControllerAPIPort: config.UpdateControllerAPIPort,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}

--- a/worker/controllerport/manifold_test.go
+++ b/worker/controllerport/manifold_test.go
@@ -1,0 +1,214 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/controllerport"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	config           controllerport.ManifoldConfig
+	manifold         dependency.Manifold
+	context          dependency.Context
+	agent            *mockAgent
+	hub              *pubsub.StructuredHub
+	state            stubStateTracker
+	logger           loggo.Logger
+	controllerConfig controller.Config
+	worker           worker.Worker
+
+	stub testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.agent = &mockAgent{}
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.state = stubStateTracker{}
+	s.logger = loggo.GetLogger("controllerport_manifold")
+	s.controllerConfig = controller.Config(map[string]interface{}{
+		"controller-api-port": 2048,
+	})
+	s.worker = &struct{ worker.Worker }{}
+	s.stub.ResetCalls()
+
+	s.context = s.newContext(nil)
+	s.config = controllerport.ManifoldConfig{
+		AgentName:               "agent",
+		HubName:                 "hub",
+		StateName:               "state",
+		Logger:                  s.logger,
+		UpdateControllerAPIPort: s.updatePort,
+		GetControllerConfig:     s.getControllerConfig,
+		NewWorker:               s.newWorker,
+	}
+	s.manifold = controllerport.Manifold(s.config)
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"agent": s.agent,
+		"hub":   s.hub,
+		"state": &s.state,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) getControllerConfig(st *state.State) (controller.Config, error) {
+	s.stub.MethodCall(s, "GetControllerConfig", st)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.controllerConfig, nil
+}
+
+func (s *ManifoldSuite) updatePort(port int) error {
+	return errors.Errorf("braincake")
+}
+
+func (s *ManifoldSuite) newWorker(config controllerport.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{"state", "agent", "hub"}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestValidate(c *gc.C) {
+	type test struct {
+		f      func(*controllerport.ManifoldConfig)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *controllerport.ManifoldConfig) { cfg.StateName = "" },
+		"empty StateName not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.HubName = "" },
+		"empty HubName not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.AgentName = "" },
+		"empty AgentName not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.UpdateControllerAPIPort = nil },
+		"nil UpdateControllerAPIPort not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.GetControllerConfig = nil },
+		"nil GetControllerConfig not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.NewWorker = nil },
+		"nil NewWorker not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		config := s.config
+		test.f(&config)
+		manifold := controllerport.Manifold(config)
+		w, err := manifold.Start(s.context)
+		workertest.CheckNilOrKill(c, w)
+		c.Check(err, gc.ErrorMatches, test.expect)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "GetControllerConfig", "NewWorker")
+	args := s.stub.Calls()[1].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, controllerport.Config{})
+	config := args[0].(controllerport.Config)
+
+	// Can't directly compare functions, so blank it out.
+	c.Assert(config.UpdateControllerAPIPort(3), gc.ErrorMatches, "braincake")
+	config.UpdateControllerAPIPort = nil
+
+	c.Assert(config, jc.DeepEquals, controllerport.Config{
+		AgentConfig:       &s.agent.conf,
+		Hub:               s.hub,
+		Logger:            s.logger,
+		ControllerAPIPort: 2048,
+	})
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.Equals, s.worker)
+	return w
+}
+
+type stubStateTracker struct {
+	testing.Stub
+	pool state.StatePool
+}
+
+func (s *stubStateTracker) Use() (*state.StatePool, error) {
+	s.MethodCall(s, "Use")
+	return &s.pool, s.NextErr()
+}
+
+func (s *stubStateTracker) Done() error {
+	s.MethodCall(s, "Done")
+	return s.NextErr()
+}
+
+type mockAgent struct {
+	agent.Agent
+	conf mockAgentConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+type mockAgentConfig struct {
+	agent.Config
+	port int
+}
+
+func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
+	return params.StateServingInfo{ControllerAPIPort: c.port}, true
+}

--- a/worker/controllerport/package_test.go
+++ b/worker/controllerport/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/controllerport/worker.go
+++ b/worker/controllerport/worker.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/pubsub/controller"
+)
+
+// Config is the configuration required for running an API server worker.
+type Config struct {
+	AgentConfig             agent.Config
+	Hub                     *pubsub.StructuredHub
+	Logger                  Logger
+	ControllerAPIPort       int
+	UpdateControllerAPIPort func(int) error
+}
+
+// Validate validates the API server configuration.
+func (config Config) Validate() error {
+	if config.AgentConfig == nil {
+		return errors.NotValidf("nil AgentConfig")
+	}
+	if config.Hub == nil {
+		return errors.NotValidf("nil Hub")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.UpdateControllerAPIPort == nil {
+		return errors.NotValidf("nil UpdateControllerAPIPort")
+	}
+	return nil
+}
+
+// NewWorker returns a new API server worker, with the given configuration.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Worker{
+		logger: config.Logger,
+		update: config.UpdateControllerAPIPort,
+	}
+
+	servingInfo, ok := config.AgentConfig.StateServingInfo()
+	if !ok {
+		return nil, errors.New("missing state serving info")
+	}
+	w.controllerAPIPort = servingInfo.ControllerAPIPort
+	// We need to make sure that update the agent config with
+	// the potentially new controller api port from the database
+	// before we start any other workers that need to connect
+	// to the controller over the controller port.
+	w.updateControllerPort(config.ControllerAPIPort)
+
+	unsub, err := config.Hub.Subscribe(controller.ConfigChanged,
+		func(topic string, data controller.ConfigChangedMessage, err error) {
+			w.updateControllerPort(data.Config.ControllerAPIPort())
+			w.tomb.Kill(dependency.ErrBounce)
+		})
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to subscribe to details topic")
+	}
+
+	w.tomb.Go(func() error {
+		defer unsub()
+		<-w.tomb.Dying()
+		return nil
+	})
+	return w, nil
+}
+
+// Worker is responsible for updating the agent config when the controller api
+// port value changes, and then bouncing the worker to notify the other
+// dependent workers, which should be the peer-grouper and http-server.
+type Worker struct {
+	tomb   tomb.Tomb
+	logger Logger
+	update func(int) error
+
+	controllerAPIPort int
+}
+
+// Kill implements Worker.Kill.
+func (w *Worker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements Worker.Wait.
+func (w *Worker) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *Worker) updateControllerPort(port int) {
+	if w.controllerAPIPort != port {
+		// The local cache is out of date, update it.
+		w.logger.Infof("updating controller API port to %v", port)
+		err := w.update(port)
+		if err != nil {
+			w.logger.Errorf("unable to update agent.conf with new controller API port: %v", err)
+		}
+		w.controllerAPIPort = port
+	}
+}

--- a/worker/controllerport/worker_test.go
+++ b/worker/controllerport/worker_test.go
@@ -1,0 +1,135 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/controller"
+	pscontroller "github.com/juju/juju/pubsub/controller"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/controllerport"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+	agentConfig *mockAgentConfig
+	hub         *pubsub.StructuredHub
+	logger      loggo.Logger
+	config      controllerport.Config
+	stub        testing.Stub
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.agentConfig = &mockAgentConfig{port: 232323}
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.logger = loggo.GetLogger("controllerport_worker_test")
+	s.stub.ResetCalls()
+
+	s.logger.SetLogLevel(loggo.TRACE)
+
+	s.config = controllerport.Config{
+		AgentConfig: s.agentConfig,
+		Hub:         s.hub,
+		Logger:      s.logger,
+
+		ControllerAPIPort:       232323,
+		UpdateControllerAPIPort: s.updatePort,
+	}
+}
+
+func (s *WorkerSuite) updatePort(port int) error {
+	s.stub.MethodCall(s, "UpdatePort", port)
+	return s.stub.NextErr()
+}
+
+func (s *WorkerSuite) newWorker(c *gc.C, config controllerport.Config) worker.Worker {
+	w, err := controllerport.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
+	return w
+}
+
+func (s *WorkerSuite) TestImmediateUpdate(c *gc.C) {
+	// Change the agent config so the ports are out of sync.
+	s.agentConfig.port = 23456
+	w := s.newWorker(c, s.config)
+	workertest.CheckAlive(c, w)
+	s.stub.CheckCall(c, 0, "UpdatePort", 232323)
+}
+
+func (s *WorkerSuite) TestNoChange(c *gc.C) {
+	w := s.newWorker(c, s.config)
+	processed, err := s.hub.Publish(pscontroller.ConfigChanged, pscontroller.ConfigChangedMessage{
+		Config: controller.Config{
+			"controller-api-port": 232323,
+			"some-other-field":    "new value!",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-processed:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for processed")
+	}
+	workertest.CheckAlive(c, w)
+	s.stub.CheckCallNames(c)
+}
+
+func (s *WorkerSuite) TestChange(c *gc.C) {
+	w := s.newWorker(c, s.config)
+	processed, err := s.hub.Publish(pscontroller.ConfigChanged, pscontroller.ConfigChangedMessage{
+		Config: controller.Config{"controller-api-port": 444444},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-processed:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for processed")
+	}
+	s.stub.CheckCall(c, 0, "UpdatePort", 444444)
+	err = workertest.CheckKilled(c, w)
+	c.Assert(errors.Cause(err), gc.Equals, dependency.ErrBounce)
+}
+
+func (s *WorkerSuite) TestValidate(c *gc.C) {
+	type test struct {
+		f      func(*controllerport.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *controllerport.Config) { cfg.AgentConfig = nil },
+		"nil AgentConfig not valid",
+	}, {
+		func(cfg *controllerport.Config) { cfg.Hub = nil },
+		"nil Hub not valid",
+	}, {
+		func(cfg *controllerport.Config) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *controllerport.Config) { cfg.UpdateControllerAPIPort = nil },
+		"nil UpdateControllerAPIPort not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		config := s.config
+		test.f(&config)
+		w, err := controllerport.NewWorker(config)
+		workertest.CheckNilOrKill(c, w)
+		c.Check(err, gc.ErrorMatches, test.expect)
+	}
+}

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -7,8 +7,10 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/pubsub"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -18,6 +20,7 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/httpserver"
 )
@@ -28,13 +31,15 @@ type ManifoldSuite struct {
 	config               httpserver.ManifoldConfig
 	manifold             dependency.Manifold
 	context              dependency.Context
-	agent                *mockAgent
 	state                stubStateTracker
+	hub                  *pubsub.StructuredHub
 	mux                  *apiserverhttp.Mux
 	raftEnabled          *mockFlag
+	clock                *testing.Clock
 	prometheusRegisterer stubPrometheusRegisterer
 	certWatcher          stubCertWatcher
 	tlsConfig            *tls.Config
+	controllerConfig     controller.Config
 
 	stub testing.Stub
 }
@@ -44,25 +49,33 @@ var _ = gc.Suite(&ManifoldSuite{})
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
-	s.agent = &mockAgent{}
 	s.state = stubStateTracker{}
 	s.mux = &apiserverhttp.Mux{}
+	s.hub = pubsub.NewStructuredHub(nil)
 	s.raftEnabled = &mockFlag{set: true}
+	s.clock = testing.NewClock(time.Now())
 	s.prometheusRegisterer = stubPrometheusRegisterer{}
 	s.certWatcher = stubCertWatcher{}
 	s.tlsConfig = &tls.Config{}
+	s.controllerConfig = controller.Config(map[string]interface{}{
+		"api-port":            1024,
+		"controller-api-port": 2048,
+		"api-port-open-delay": "5s",
+	})
 	s.stub.ResetCalls()
 
 	s.context = s.newContext(nil)
 	s.config = httpserver.ManifoldConfig{
-		AgentName:            "agent",
 		CertWatcherName:      "cert-watcher",
+		HubName:              "hub",
 		StateName:            "state",
 		MuxName:              "mux",
 		APIServerName:        "api-server",
 		RaftTransportName:    "raft-transport",
 		RaftEnabledName:      "raft-enabled",
+		Clock:                s.clock,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		GetControllerConfig:  s.getControllerConfig,
 		NewTLSConfig:         s.newTLSConfig,
 		NewWorker:            s.newWorker,
 	}
@@ -71,9 +84,9 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
 	resources := map[string]interface{}{
-		"agent":          s.agent,
 		"cert-watcher":   s.certWatcher.get,
 		"state":          &s.state,
+		"hub":            s.hub,
 		"mux":            s.mux,
 		"raft-enabled":   s.raftEnabled,
 		"raft-transport": nil,
@@ -83,6 +96,14 @@ func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Co
 		resources[k] = v
 	}
 	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) getControllerConfig(st *state.State) (controller.Config, error) {
+	s.stub.MethodCall(s, "GetControllerConfig", st)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.controllerConfig, nil
 }
 
 func (s *ManifoldSuite) newTLSConfig(
@@ -116,10 +137,10 @@ func (s *ManifoldSuite) newWorker(config httpserver.Config) (worker.Worker, erro
 }
 
 var expectedInputs = []string{
-	"agent",
 	"cert-watcher",
 	"state",
 	"mux",
+	"hub",
 	"raft-enabled",
 	"raft-transport",
 	"api-server",
@@ -143,8 +164,8 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	w := s.startWorkerClean(c)
 	workertest.CleanKill(c, w)
 
-	s.stub.CheckCallNames(c, "NewTLSConfig", "NewWorker")
-	newWorkerArgs := s.stub.Calls()[1].Args
+	s.stub.CheckCallNames(c, "NewTLSConfig", "GetControllerConfig", "NewWorker")
+	newWorkerArgs := s.stub.Calls()[2].Args
 	c.Assert(newWorkerArgs, gc.HasLen, 1)
 	c.Assert(newWorkerArgs[0], gc.FitsTypeOf, httpserver.Config{})
 	config := newWorkerArgs[0].(httpserver.Config)
@@ -161,11 +182,15 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.AutocertListener = nil
 
 	c.Assert(config, jc.DeepEquals, httpserver.Config{
-		AgentConfig:          &s.agent.conf,
+		Clock:                s.clock,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		Hub:                  s.hub,
 		TLSConfig:            s.tlsConfig,
 		AutocertHandler:      autocertHandler,
 		Mux:                  s.mux,
+		APIPort:              1024,
+		APIPortOpenDelay:     5 * time.Second,
+		ControllerAPIPort:    2048,
 	})
 }
 
@@ -175,9 +200,6 @@ func (s *ManifoldSuite) TestValidate(c *gc.C) {
 		expect string
 	}
 	tests := []test{{
-		func(cfg *httpserver.ManifoldConfig) { cfg.AgentName = "" },
-		"empty AgentName not valid",
-	}, {
 		func(cfg *httpserver.ManifoldConfig) { cfg.CertWatcherName = "" },
 		"empty CertWatcherName not valid",
 	}, {
@@ -198,6 +220,9 @@ func (s *ManifoldSuite) TestValidate(c *gc.C) {
 	}, {
 		func(cfg *httpserver.ManifoldConfig) { cfg.PrometheusRegisterer = nil },
 		"nil PrometheusRegisterer not valid",
+	}, {
+		func(cfg *httpserver.ManifoldConfig) { cfg.GetControllerConfig = nil },
+		"nil GetControllerConfig not valid",
 	}, {
 		func(cfg *httpserver.ManifoldConfig) { cfg.NewTLSConfig = nil },
 		"nil NewTLSConfig not valid",
@@ -229,21 +254,23 @@ func (s *ManifoldSuite) TestStartWithRaftDisabled(c *gc.C) {
 
 func (s *ManifoldSuite) TestStartNoAutocert(c *gc.C) {
 	s.manifold = httpserver.Manifold(httpserver.ManifoldConfig{
-		AgentName:            "agent",
 		CertWatcherName:      "cert-watcher",
 		StateName:            "state",
 		MuxName:              "mux",
+		HubName:              "hub",
 		APIServerName:        "api-server",
 		RaftTransportName:    "raft-transport",
 		RaftEnabledName:      "raft-enabled",
+		Clock:                s.clock,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		GetControllerConfig:  s.getControllerConfig,
 		NewTLSConfig:         s.newTLSConfigNoHandler,
 		NewWorker:            s.newWorker,
 	})
 	w := s.startWorkerClean(c)
 	defer workertest.CleanKill(c, w)
-	s.stub.CheckCallNames(c, "NewTLSConfig", "NewWorker")
-	newWorkerArgs := s.stub.Calls()[1].Args
+	s.stub.CheckCallNames(c, "NewTLSConfig", "GetControllerConfig", "NewWorker")
+	newWorkerArgs := s.stub.Calls()[2].Args
 	c.Assert(newWorkerArgs, gc.HasLen, 1)
 	c.Assert(newWorkerArgs[0], gc.FitsTypeOf, httpserver.Config{})
 	config := newWorkerArgs[0].(httpserver.Config)

--- a/worker/httpserver/mock_test.go
+++ b/worker/httpserver/mock_test.go
@@ -9,32 +9,9 @@ import (
 	"github.com/juju/testing"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/httpcontext"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
-
-type mockAgent struct {
-	agent.Agent
-	conf mockAgentConfig
-}
-
-func (ma *mockAgent) CurrentConfig() agent.Config {
-	return &ma.conf
-}
-
-type mockAgentConfig struct {
-	agent.Config
-	info *params.StateServingInfo
-}
-
-func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
-	if c.info != nil {
-		return *c.info, true
-	}
-	return params.StateServingInfo{}, false
-}
 
 type stubStateTracker struct {
 	testing.Stub

--- a/worker/httpserver/shim.go
+++ b/worker/httpserver/shim.go
@@ -3,10 +3,21 @@
 
 package httpserver
 
-import "gopkg.in/juju/worker.v1"
+import (
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+)
 
 // NewWorkerShim calls through to NewWorker, and exists only
 // to adapt to the signature of ManifoldConfig.NewWorker.
 func NewWorkerShim(config Config) (worker.Worker, error) {
 	return NewWorker(config)
+}
+
+// GetControllerConfig gets the controller config from a *State - it
+// exists so we can test the manifold without a StateSuite.
+func GetControllerConfig(st *state.State) (controller.Config, error) {
+	return st.ControllerConfig()
 }

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -11,14 +11,19 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/utils/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1/catacomb"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/pubsub/apiserver"
 )
 
 var logger = loggo.GetLogger("juju.worker.httpserver")
@@ -26,11 +31,16 @@ var logger = loggo.GetLogger("juju.worker.httpserver")
 // Config is the configuration required for running an API server worker.
 type Config struct {
 	AgentConfig          agent.Config
+	Clock                clock.Clock
 	TLSConfig            *tls.Config
 	AutocertHandler      http.Handler
 	AutocertListener     net.Listener
 	Mux                  *apiserverhttp.Mux
 	PrometheusRegisterer prometheus.Registerer
+	Hub                  *pubsub.StructuredHub
+	APIPort              int
+	APIPortOpenDelay     time.Duration
+	ControllerAPIPort    int
 }
 
 // Validate validates the API server configuration.
@@ -58,10 +68,12 @@ func NewWorker(config Config) (*Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	w := &Worker{
 		config: config,
 		url:    make(chan string),
 	}
+
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
 		Work: w.loop,
@@ -75,6 +87,8 @@ type Worker struct {
 	catacomb catacomb.Catacomb
 	config   Config
 	url      chan string
+
+	unsub func()
 }
 
 func (w *Worker) Kill() {
@@ -97,33 +111,34 @@ func (w *Worker) URL() string {
 }
 
 func (w *Worker) loop() error {
-	servingInfo, ok := w.config.AgentConfig.StateServingInfo()
-	if !ok {
-		return errors.New("missing state serving info")
+	var err error
+	var listener listener
+	if w.config.ControllerAPIPort == 0 {
+		listener, err = w.newSimpleListener()
+	} else {
+		listener, err = w.newDualPortListener()
 	}
-	listenAddr := net.JoinHostPort("", strconv.Itoa(servingInfo.APIPort))
-	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	listener = tls.NewListener(listener, w.config.TLSConfig)
-	// TODO(axw) rate-limit connections by wrapping listener
+	holdable := newHeldListener(listener, w.config.Clock)
 
 	serverLog := log.New(&loggoWrapper{
 		level:  loggo.WARNING,
 		logger: logger,
 	}, "", 0) // no prefix and no flags so log.Logger doesn't add extra prefixes
-	logger.Infof("listening on %q", listener.Addr())
 	server := &http.Server{
 		Handler:   w.config.Mux,
 		TLSConfig: w.config.TLSConfig,
 		ErrorLog:  serverLog,
 	}
-	go server.Serve(listener)
+	go server.Serve(tls.NewListener(holdable, w.config.TLSConfig))
 	defer func() {
 		logger.Infof("shutting down HTTP server")
 		// Shutting down the server will also close listener.
 		err := server.Shutdown(context.Background())
+		// Release the holdable listener to unblock any pending accepts.
+		holdable.release()
 		w.catacomb.Kill(err)
 	}()
 
@@ -141,15 +156,233 @@ func (w *Worker) loop() error {
 		}()
 	}
 
-	url := fmt.Sprintf("https://%s", listener.Addr())
 	for {
 		select {
 		case <-w.catacomb.Dying():
+			// Stop accepting new connections. This allows the mux
+			// to process all pending requests without having to deal with
+			// new ones.
+			holdable.hold()
 			// Asked to shutdown - make sure we wait until all clients
 			// have finished up.
 			w.config.Mux.Wait()
 			return w.catacomb.ErrDying()
-		case w.url <- url:
+		case w.url <- listener.URL():
 		}
 	}
+}
+
+type heldListener struct {
+	net.Listener
+	clock clock.Clock
+	mu    sync.Mutex
+	held  bool
+}
+
+func newHeldListener(l net.Listener, c clock.Clock) *heldListener {
+	return &heldListener{
+		Listener: l,
+		clock:    c,
+	}
+}
+
+func (h *heldListener) hold() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.held = true
+}
+
+func (h *heldListener) release() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.held = false
+}
+
+func (h *heldListener) Accept() (net.Conn, error) {
+	// Normally we'd use a channel to signal between goroutines,
+	// but in this case where we want accept to be fast in almost all cases,
+	// but wait when held, we can't have it selecting on a channel outside
+	// of the mutex lock without a race condition. So the safe and slightly
+	// icky method is to wait in a for loop.
+	h.mu.Lock()
+	for h.held {
+		h.mu.Unlock()
+		<-h.clock.After(100 * time.Millisecond)
+		h.mu.Lock()
+	}
+	h.mu.Unlock()
+	return h.Listener.Accept()
+}
+
+type listener interface {
+	net.Listener
+	URL() string
+}
+
+func (w *Worker) newSimpleListener() (listener, error) {
+	listenAddr := net.JoinHostPort("", strconv.Itoa(w.config.APIPort))
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Infof("listening on %q", listener.Addr())
+	return &simpleListener{listener}, nil
+}
+
+type simpleListener struct {
+	net.Listener
+}
+
+func (s *simpleListener) URL() string {
+	return fmt.Sprintf("https://%s", s.Addr())
+}
+
+func (w *Worker) newDualPortListener() (listener, error) {
+	// Only open the controller port until we have been told that
+	// the controller is ready. This is currently done by the event
+	// from the peergrouper.
+	// TODO (thumper): make the raft worker publish an event when
+	// it knows who the raft master is. This means that this controller
+	// is part of the consensus set, and when it is, is is OK to accept
+	// agent connections. Until that time, accepting an agent connection
+	// would be a bit of a waste of time.
+	listenAddr := net.JoinHostPort("", strconv.Itoa(w.config.ControllerAPIPort))
+	listener, err := net.Listen("tcp", listenAddr)
+	logger.Infof("listening for controller connections on %q", listener.Addr())
+	dual := &dualListener{
+		clock:              w.config.Clock,
+		delay:              w.config.APIPortOpenDelay,
+		apiPort:            w.config.APIPort,
+		controllerListener: listener,
+		done:               make(chan struct{}),
+		errors:             make(chan error),
+		connections:        make(chan net.Conn),
+	}
+	go dual.accept(listener)
+
+	dual.unsub, err = w.config.Hub.Subscribe(apiserver.DetailsTopic, dual.openAPIPort)
+	if err != nil {
+		dual.Close()
+		return nil, errors.Annotate(err, "unable to subscribe to details topic")
+	}
+
+	return dual, err
+}
+
+type dualListener struct {
+	clock   clock.Clock
+	delay   time.Duration
+	apiPort int
+
+	controllerListener net.Listener
+	apiListener        net.Listener
+
+	mu     sync.Mutex
+	closer sync.Once
+
+	done        chan struct{}
+	errors      chan error
+	connections chan net.Conn
+
+	unsub func()
+}
+
+func (d *dualListener) accept(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case d.errors <- err:
+			case <-d.done:
+				logger.Infof("no longer accepting connections on %s", listener.Addr())
+				return
+			}
+		} else {
+			select {
+			case d.connections <- conn:
+			case <-d.done:
+				conn.Close()
+				logger.Infof("no longer accepting connections on %s", listener.Addr())
+				return
+			}
+		}
+	}
+}
+
+// Accept implements net.Listener.
+func (d *dualListener) Accept() (net.Conn, error) {
+	select {
+	case <-d.done:
+		return nil, errors.New("listener has been closed")
+	case err := <-d.errors:
+		return nil, errors.Trace(err)
+	case conn := <-d.connections:
+		return conn, nil
+	}
+}
+
+// Close implements net.Listener. Closes all the open listeners.
+func (d *dualListener) Close() error {
+	// Only close the channel once.
+	d.closer.Do(func() { close(d.done) })
+	err := d.controllerListener.Close()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.apiListener != nil {
+		err2 := d.apiListener.Close()
+		if err == nil {
+			err = err2
+		}
+		// If we already have a close error, we don't really care
+		// about this one.
+	}
+	return errors.Trace(err)
+}
+
+// Addr implements net.Listener. If the api port has been opened, we
+// return that, otherwise we return the controller port address.
+func (d *dualListener) Addr() net.Addr {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.apiListener != nil {
+		return d.apiListener.Addr()
+	}
+	return d.controllerListener.Addr()
+}
+
+// URL implements the listener method.
+func (d *dualListener) URL() string {
+	return fmt.Sprintf("https://%s", d.Addr())
+}
+
+// openAPIPort opens the api port and starts accepting connections.
+func (d *dualListener) openAPIPort(_ string, _ map[string]interface{}) {
+	logger.Infof("waiting for %s before allowing api connections", d.delay)
+	<-d.clock.After(d.delay)
+
+	defer d.unsub()
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Make sure we haven't been closed already.
+	select {
+	case <-d.done:
+		return
+	default:
+		// We are all good.
+	}
+
+	listenAddr := net.JoinHostPort("", strconv.Itoa(d.apiPort))
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		select {
+		case d.errors <- err:
+		case <-d.done:
+			logger.Errorf("can't open api port: %v, but worker exiting already", err)
+		}
+		return
+	}
+
+	logger.Infof("listening for api connections on %q", listener.Addr())
+	go d.accept(listener)
 }

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1/catacomb"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/pubsub/apiserver"
 )
@@ -30,7 +29,6 @@ var logger = loggo.GetLogger("juju.worker.httpserver")
 
 // Config is the configuration required for running an API server worker.
 type Config struct {
-	AgentConfig          agent.Config
 	Clock                clock.Clock
 	TLSConfig            *tls.Config
 	AutocertHandler      http.Handler
@@ -45,9 +43,6 @@ type Config struct {
 
 // Validate validates the API server configuration.
 func (config Config) Validate() error {
-	if config.AgentConfig == nil {
-		return errors.NotValidf("nil AgentConfig")
-	}
 	if config.TLSConfig == nil {
 		return errors.NotValidf("nil TLSConfig")
 	}

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/pubsub/apiserver"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/httpserver"
 )
@@ -205,6 +206,156 @@ func (s *WorkerSuite) TestMinTLSVersion(c *gc.C) {
 	conn, err := tls.Dial("tcp", parsed.Host, tlsConfig)
 	c.Assert(err, gc.ErrorMatches, ".*protocol version not supported")
 	c.Assert(conn, gc.IsNil)
+}
+
+func (s *WorkerSuite) TestHeldListener(c *gc.C) {
+	// Worker url comes back as "" when the worker is dying.
+	url := s.worker.URL()
+
+	// Simulate having a slow request being handled.
+	s.mux.AddClient()
+
+	err := s.mux.AddHandler("GET", "/quick", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	quickErr := make(chan error)
+	request := func() {
+		// Make a new client each request so we don't reuse
+		// connections.
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: s.config.TLSConfig,
+			},
+		}
+		_, err := client.Get(url + "/quick")
+		quickErr <- err
+	}
+
+	// Sanity check - the quick one should be quick normally.
+	go request()
+
+	select {
+	case err := <-quickErr:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("timed out waiting for quick request")
+	}
+
+	// Stop the server.
+	s.worker.Kill()
+
+	// Eventually quick requests get blocked by the held listener.
+	var quickBlocked bool
+attempts:
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		go request()
+		select {
+		case <-quickErr:
+		case <-time.After(coretesting.ShortWait):
+			quickBlocked = true
+			break attempts
+		}
+	}
+	c.Assert(quickBlocked, gc.Equals, true)
+
+	// The server doesn't die yet - it's kept alive by the slow
+	// request.
+	workertest.CheckAlive(c, s.worker)
+
+	// Let the slow request complete.  See that the server
+	// stops, and the 2nd request completes.
+	s.mux.ClientDone()
+
+	select {
+	case err := <-quickErr:
+		// It doesn't really matter what the error is.
+		c.Assert(err, gc.NotNil)
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("timed out waiting for 2nd quick request")
+	}
+	workertest.CheckKilled(c, s.worker)
+}
+
+type WorkerControllerPortSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&WorkerControllerPortSuite{})
+
+func (s *WorkerControllerPortSuite) newWorker(c *gc.C) *httpserver.Worker {
+	worker, err := httpserver.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	return worker
+}
+
+func (s *WorkerControllerPortSuite) TestDualPortListenerWithDelay(c *gc.C) {
+	err := s.mux.AddHandler("GET", "/quick", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	request := func(url string) error {
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: s.config.TLSConfig,
+			},
+		}
+		_, err := client.Get(url + "/quick")
+		return err
+	}
+
+	// Make a worker with a controller API port.
+	port := testing.FindTCPPort()
+	controllerPort := testing.FindTCPPort()
+	s.config.APIPort = port
+	s.config.ControllerAPIPort = controllerPort
+	s.config.APIPortOpenDelay = 10 * time.Second
+
+	worker := s.newWorker(c)
+
+	// The worker reports its URL as the controller port.
+	controllerURL := worker.URL()
+	parsed, err := url.Parse(controllerURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(parsed.Port(), gc.Equals, fmt.Sprint(controllerPort))
+
+	// Requests on that port work.
+	c.Assert(request(controllerURL), jc.ErrorIsNil)
+
+	// Requests on the regular API port fail to connect.
+	parsed.Host = net.JoinHostPort(parsed.Hostname(), fmt.Sprint(port))
+	normalURL := parsed.String()
+	c.Assert(request(normalURL), gc.ErrorMatches, `.*: connection refused$`)
+
+	// Send API details on the hub - still no luck connecting on the
+	// non-controller port.
+	_, err = s.hub.Publish(apiserver.DetailsTopic, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.clock.WaitAdvance(5*time.Second, coretesting.LongWait, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(request(controllerURL), jc.ErrorIsNil)
+	c.Assert(request(normalURL), gc.ErrorMatches, `.*: connection refused$`)
+
+	// After the required delay the port eventually opens.
+	err = s.clock.WaitAdvance(5*time.Second, coretesting.LongWait, 1)
+
+	// The reported url changes to the regular port.
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		if worker.URL() == normalURL {
+			break
+		}
+	}
+	c.Assert(worker.URL(), gc.Equals, normalURL)
+
+	// Requests on both ports work.
+	c.Assert(request(controllerURL), jc.ErrorIsNil)
+	c.Assert(request(normalURL), jc.ErrorIsNil)
 }
 
 type WorkerAutocertSuite struct {

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -25,8 +25,9 @@ type desiredPeerGroupSuite struct {
 var _ = gc.Suite(&desiredPeerGroupSuite{})
 
 const (
-	mongoPort = 1234
-	apiPort   = 5678
+	mongoPort         = 1234
+	apiPort           = 5678
+	controllerAPIPort = 9876
 )
 
 type desiredPeerGroupTest struct {

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -53,11 +53,12 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.context = s.newContext(nil)
 	s.manifold = peergrouper.Manifold(peergrouper.ManifoldConfig{
-		AgentName: "agent",
-		ClockName: "clock",
-		StateName: "state",
-		Hub:       s.hub,
-		NewWorker: s.newWorker,
+		AgentName:          "agent",
+		ClockName:          "clock",
+		ControllerPortName: "controller-port",
+		StateName:          "state",
+		Hub:                s.hub,
+		NewWorker:          s.newWorker,
 		ControllerSupportsSpaces: func(st *state.State) (bool, error) {
 			if st != s.State {
 				return false, errors.New("invalid state")
@@ -69,9 +70,10 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
 	resources := map[string]interface{}{
-		"agent": s.agent,
-		"clock": s.clock,
-		"state": &s.stateTracker,
+		"agent":           s.agent,
+		"clock":           s.clock,
+		"controller-port": nil,
+		"state":           &s.stateTracker,
 	}
 	for k, v := range overlay {
 		resources[k] = v
@@ -89,7 +91,7 @@ func (s *ManifoldSuite) newWorker(config peergrouper.Config) (worker.Worker, err
 	return w, nil
 }
 
-var expectedInputs = []string{"agent", "clock", "state"}
+var expectedInputs = []string{"agent", "clock", "controller-port", "state"}
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
 	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -22,8 +22,6 @@ import (
 	"github.com/juju/juju/pubsub/apiserver"
 )
 
-//var logger = loggo.GetLogger("juju.worker.pubsub")
-
 // WorkerConfig defines the configuration values that the pubsub worker needs
 // to operate.
 type WorkerConfig struct {
@@ -168,14 +166,20 @@ func (s *subscriber) apiServerChanges(topic string, details apiserver.Details, e
 			continue
 		}
 
+		// TODO: always use the internal address?
+		addresses := apiServer.Addresses
+		if apiServer.InternalAddress != "" {
+			addresses = []string{apiServer.InternalAddress}
+		}
+
 		server, found := s.servers[target]
 		if found {
-			s.config.Logger.Tracef("update addresses for %s to %v", target, apiServer.Addresses)
-			server.UpdateAddresses(apiServer.Addresses)
+			s.config.Logger.Tracef("update addresses for %s to %v", target, addresses)
+			server.UpdateAddresses(addresses)
 		} else {
 			s.config.Logger.Debugf("new forwarder for %s", target)
 			newInfo := *s.config.APIInfo
-			newInfo.Addrs = apiServer.Addresses
+			newInfo.Addrs = addresses
 			server, err := s.config.NewRemote(RemoteServerConfig{
 				Hub:       s.config.Hub,
 				Origin:    s.config.Origin,

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -182,15 +182,15 @@ func (s *SubscriberSuite) TestNoInitialRemotes(c *gc.C) {
 func (s *SubscriberSuite) enableHA(c *gc.C) {
 	done, err := s.hub.Publish(apiserver.DetailsTopic, apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
-			"3": apiserver.APIServer{
+			"3": {
 				ID:        "3",
 				Addresses: []string{"10.1.2.3"},
 			},
-			"5": apiserver.APIServer{
+			"5": {
 				ID:        "5",
 				Addresses: []string{"10.1.2.5"},
 			},
-			"42": apiserver.APIServer{
+			"42": {
 				ID:        "42",
 				Addresses: []string{"10.1.2.42"},
 			},
@@ -222,7 +222,44 @@ func (s *SubscriberSuite) TestEnableHA(c *gc.C) {
 	c.Assert(remote3.config.APIInfo.Addrs, jc.DeepEquals, []string{"10.1.2.3"})
 	remote5 := s.remotes.remotes["machine-5"]
 	c.Assert(remote5.config.APIInfo.Addrs, jc.DeepEquals, []string{"10.1.2.5"})
+}
 
+func (s *SubscriberSuite) TestEnableHAInternalAddress(c *gc.C) {
+	w, err := psworker.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, w) })
+	done, err := s.hub.Publish(apiserver.DetailsTopic, apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"3": {
+				ID:              "3",
+				Addresses:       []string{"10.1.2.3"},
+				InternalAddress: "10.5.4.3",
+			},
+			"5": {
+				ID:              "5",
+				Addresses:       []string{"10.1.2.5"},
+				InternalAddress: "10.5.4.4",
+			},
+			"42": {
+				ID:              "42",
+				Addresses:       []string{"10.1.2.42"},
+				InternalAddress: "10.5.4.5",
+			},
+		},
+		LocalOnly: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("message handling not completed")
+	}
+	c.Assert(s.remotes.remotes, gc.HasLen, 2)
+	remote3 := s.remotes.remotes["machine-3"]
+	c.Assert(remote3.config.APIInfo.Addrs, jc.DeepEquals, []string{"10.5.4.3"})
+	remote5 := s.remotes.remotes["machine-5"]
+	c.Assert(remote5.config.APIInfo.Addrs, jc.DeepEquals, []string{"10.5.4.4"})
 }
 
 func (s *SubscriberSuite) TestSameMessagesForwarded(c *gc.C) {


### PR DESCRIPTION
## Description of change

For controllers with a lot of agents we see problems at controller agent start time (for example after upgrades) - as soon as the controller opens its API port it's hammered by connections from the agents and doesn't manage to get up and stable properly. To fix this, we enable setting a controller API port (`controller-api-port` in controller config) that will be used by the controller agents to connect to themselves and the other controllers, and the regular API port won't accept requests until the controllers are connected. There's also another option `api-port-open-delay` (set as a duration, eg `20s`) - if this is set the API port won't accept connections for that long after the controllers are ready.

The new options can be changed in a running controller (otherwise big existing controllers wouldn't be able to use them). To support this there's a new `controller-port` worker which bounces when the `controller-api-port` option is changed - the http-server and peer-grouper depend on this so that they'll respond to the changed value.

The firewaller will need to be changed to open the controller API port if it's set, and some providers that don't use the firewaller but still need to manage ports will also need updating. These will happen in follow-up PRs.

## QA steps

* Bootstrap a controller, enable-ha, deploy some applications.
* Once everything is up, set `controller-api-port` to 17071 and `api-open-port-delay` to 20s.
* Everything should settle again.
* Check in debug-log that the http-servers on each controller machine report that they open the controller ports first and then the normal API port after a 20s delay. 
* The api-callers in each agent should be using the right port (based on whether they're a controller agent or not). The connection delay should also be reflected in the agent logs.

## Documentation changes

Yes - the new controller config options `controller-api-port` and `api-port-open-delay` will need documentation.

