### PR TITLE
Prevent Deployment via Placement to Machines Locked for Series Upgrade

### DIFF
--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -97,6 +97,7 @@ type Charm interface {
 // details on the methods, see the methods on state.Machine with
 // the same names.
 type Machine interface {
+	IsLocked() (bool, error)
 }
 
 // Relation defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -194,7 +194,7 @@ func addUnits(
 			continue
 		}
 		if err := unit.AssignWithPlacement(placement[i]); err != nil {
-			return nil, errors.Annotatef(err, "adding new machine to host unit %q", unit.UnitTag().Id())
+			return nil, errors.Annotatef(err, "acquiring machine to host unit %q", unit.UnitTag().Id())
 		}
 	}
 	return units, nil

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -756,7 +756,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidSeries(c *gc.C) {
             1:
                 series: xenial
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for application "django": adding new machine to host unit "django/0": cannot assign unit "django/0" to machine 0: series does not match`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for application "django": acquiring machine to host unit "django/0": cannot assign unit "django/0" to machine 0: series does not match`)
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidBinding(c *gc.C) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -2385,6 +2385,9 @@ var hasNoContainersTerm = bson.DocElem{
 // findCleanMachineQuery returns a Mongo query to find clean (and possibly empty) machines with
 // characteristics matching the specified constraints.
 func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value) (bson.D, error) {
+	// TODO (manadart 2018-10-25): Modify the generated query here to omit
+	// machines with upgrade-series locks.
+
 	db, closer := u.st.newDB()
 	defer closer()
 	containerRefsCollection, closer := db.GetCollection(containerRefsC)


### PR DESCRIPTION
## Description of change

This is the first of 2 patches for preventing deployment to machines that are in the upgrade-series workflow. This patch prevents deployment via placement directives; the next will deal with policy-based deployment.

- For `juju deploy`, the up-front check in the application API is modified. This is for the same reason that the initial up-front check for machine existence was done in the same place - we need to return an error early, before the application is added, in order not to leave the application and unit(s) in an unrecoverable error state.
- For `juju add-unit`, the check is done where placement is parsed in state.

## QA steps

- Bootstrap and add a trusty machine.
- `juju upgrade-series prepare 0 xenial`.
- `juju deploy redis --to 0` and check that the lock error is returned.
- `juju deploy redis --to lxd:0` and check that the lock error is returned.
- Deploy redis to another machine.
- `juju add-unit redis --to 0` and check that the lock error is returned.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1798097
