### PR TITLE
Update unsuported series error to inlcude charm name.

### DIFF
--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1083,7 +1083,7 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesOfSubordinate(c *gc.C) {
 
 func (s *ApplicationSuite) TestApplicationUpdateSeriesIncompatibleSeries(c *gc.C) {
 	app := s.backend.applications["postgresql"]
-	app.SetErrors(nil, nil, &state.ErrIncompatibleSeries{[]string{"yakkety", "zesty"}, "xenial"})
+	app.SetErrors(nil, nil, &state.ErrIncompatibleSeries{[]string{"yakkety", "zesty"}, "xenial", "testCharm"})
 	results, err := s.api.UpdateApplicationSeries(
 		params.UpdateSeriesArgs{
 			Args: []params.UpdateSeriesArg{{
@@ -1096,7 +1096,7 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesIncompatibleSeries(c *gc.C
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm, supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"testCharm\", supported series are: yakkety,zesty",
 		},
 	})
 }

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -273,6 +273,7 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesIncompatibleSeries(c *gc.C)
 	s.st.machines["0"].SetErrors(&state.ErrIncompatibleSeries{
 		SeriesList: []string{"yakkety", "zesty"},
 		Series:     "xenial",
+		CharmName:  "TestCharm",
 	})
 	apiV4 := s.machineManagerAPIV4()
 	results, err := apiV4.UpdateMachineSeries(
@@ -288,7 +289,7 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesIncompatibleSeries(c *gc.C)
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm, supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety,zesty",
 		},
 	})
 }
@@ -585,6 +586,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	s.st.machines["0"].SetErrors(&state.ErrIncompatibleSeries{
 		SeriesList: []string{"yakkety", "zesty"},
 		Series:     "xenial",
+		CharmName:  "TestCharm",
 	})
 	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
 	result, err := apiV5.UpgradeSeriesPrepare(
@@ -598,7 +600,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	c.Assert(result, jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm, supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety,zesty",
 		},
 	})
 }

--- a/state/application.go
+++ b/state/application.go
@@ -1291,6 +1291,7 @@ func (a *Application) VerifySupportedSeries(series string, force bool) error {
 		return &ErrIncompatibleSeries{
 			SeriesList: ch.Meta().Series,
 			Series:     series,
+			CharmName:  ch.String(),
 		}
 	}
 	return nil

--- a/state/errors.go
+++ b/state/errors.go
@@ -165,11 +165,12 @@ func IsParentDeviceHasChildrenError(err interface{}) bool {
 type ErrIncompatibleSeries struct {
 	SeriesList []string
 	Series     string
+	CharmName  string
 }
 
 func (e *ErrIncompatibleSeries) Error() string {
-	return fmt.Sprintf("series %q not supported by charm, supported series are: %s",
-		e.Series, strings.Join(e.SeriesList, ","))
+	return fmt.Sprintf("series %q not supported by charm '%s', supported series are: %s",
+		e.Series, e.CharmName, strings.Join(e.SeriesList, ","))
 }
 
 // IsIncompatibleSeriesError returns if the given error or its cause is


### PR DESCRIPTION
## Description of change

Unsupported series error messages did not include the offended charm's name in the message.

## QA steps

deploy a charm with limited series support
`juju deploy mysql`

Upgrade one of the charm's hosts
`juju upgrade series-prepare <machine> bionic`

You should see that the error message specifically indicates which charm does not support a particular series.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1797593
