### PR TITLE
charm profiles: add/remove from existing machines.

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1442,9 +1442,17 @@ func (p *ProvisionerAPI) machineChangeProfileChangeInfo(machineTag string, canAc
 	}
 
 	url := machine.UpgradeCharmProfileCharmURL()
-	if url == "" {
-		return nothing, errors.Trace(errors.New("no url for profile charm upgrade"))
+	switch {
+	case url == "" && oldProfileName != "":
+		// Remove the old profile from the machine,
+		// the unit is being removed.
+		return params.ProfileChangeResult{
+			OldProfileName: oldProfileName,
+		}, nil
+	case url == "":
+		return nothing, errors.Trace(errors.New("no url for profile charm upgrade, no profile to remove"))
 	}
+
 	chURL, err := charm.ParseURL(url)
 	if err != nil {
 		return nothing, errors.Trace(err)

--- a/state/application.go
+++ b/state/application.go
@@ -878,14 +878,13 @@ func (a *Application) SetCharmProfile(charmURL string) error {
 		return errors.Trace(err)
 	}
 	for _, u := range units {
-		principal, ok := u.PrincipalName()
-		if ok {
-			u, err = a.st.Unit(principal)
-			if err != nil {
-				return errors.Trace(err)
-			}
+		// AssignedMachineId returns the correct machine whether
+		// principal or subordinate
+		id, err := u.AssignedMachineId()
+		if err != nil {
+			return errors.Trace(err)
 		}
-		m, err := u.machine()
+		m, err := a.st.Machine(id)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1816,6 +1816,29 @@ func (s *StateSuite) TestAddApplicationWithInvalidBindings(c *gc.C) {
 	}
 }
 
+func (s *StateSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C) {
+	machine, err := s.State.AddMachine("xenial", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	name := "lxd-profile"
+	charm := state.AddTestingCharmForSeries(c, s.State, "xenial", name)
+	application := s.AddTestingApplication(c, name, charm)
+	c.Assert(err, jc.ErrorIsNil)
+	unit, err := application.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AssignUnitWithPlacement(unit,
+		&instance.Placement{
+			instance.MachineScope, machine.Id(),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.UpgradeCharmProfileApplication(), gc.Equals, name)
+	c.Assert(machine.UpgradeCharmProfileCharmURL(), gc.Equals, charm.URL().String())
+}
+
 func (s *StateSuite) TestAddApplicationMachinePlacementInvalidSeries(c *gc.C) {
 	m, err := s.State.AddMachine("trusty", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -697,6 +697,8 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 			{{"jobs", bson.D{{"$in", []MachineJob{JobManageModel}}}}},
 			{{"hasvote", true}},
 		}}}
+		// Remove the charm profile.
+		ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), ""))
 	}
 
 	// If removal conditions satisfied by machine & container docs, we can


### PR DESCRIPTION
## Description of change

    Add lxd profile where deploy/add-unit to existing machine.  Remove lxd
    profile from machine when remove-unit/remove-application does not
    destroy the machine.  Add related tests.

## QA steps

1. `juju bootstrap localhost --build-agent`
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-profile-local`
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate`
3. `juju add-relation lxd-profile-local lxd-profile-subordinate`
4.  `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt`
5. `juju add-unit lxd-profile-local --to 1`
4.  `juju remove-unit lxd-profile-alt/0`

Both lxd machines should have the same profiles applied at the end.  juju-default-lxd-profile-alt-0 was added and removed from machine 1 during this process.
