### PR TITLE
Fixes lp#1800724: switching to non-existing model succeeds.

### DIFF
--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -388,9 +388,6 @@ func (s *store) SetCurrentModel(controllerName, modelName string) error {
 				return true, nil
 
 			}
-			if models.CurrentModel == modelName {
-				return false, nil
-			}
 			if _, ok := models.Models[modelName]; !ok {
 				return false, errors.NotFoundf(
 					"model %s:%s",
@@ -592,9 +589,6 @@ func (s *store) SetModels(controllerName string, models map[string]ModelDetails)
 		for modelName, _ := range storedModels.Models {
 			if _, ok := models[modelName]; !ok {
 				delete(storedModels.Models, modelName)
-				if storedModels.CurrentModel == modelName {
-					storedModels.CurrentModel = ""
-				}
 			}
 		}
 		return changed, nil

--- a/jujuclient/setmodels_test.go
+++ b/jujuclient/setmodels_test.go
@@ -126,7 +126,7 @@ func (s *SetModelsSuite) TestSetModelsAddUpdateDeleteCombination(c *gc.C) {
 	s.assertSetModels(c, after)
 }
 
-func (s *SetModelsSuite) TestSetModelsUpdatesCurrentModel(c *gc.C) {
+func (s *SetModelsSuite) TestSetModelsDoesNotUpdateCurrentModel(c *gc.C) {
 	before := map[string]jujuclient.ModelDetails{
 		"admin/delete-model": s.assertUpdateModel(c, "admin/delete-model", "test.model.uuid"),
 	}
@@ -136,8 +136,9 @@ func (s *SetModelsSuite) TestSetModelsUpdatesCurrentModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storedModels, gc.DeepEquals, before)
 	s.assertSetModels(c, nil)
-	_, err = s.store.CurrentModel(s.controllerName)
-	c.Assert(err, gc.ErrorMatches, "current model for controller test.controller not found")
+	currentModel, err := s.store.CurrentModel(s.controllerName)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currentModel, gc.DeepEquals, "admin/delete-model")
 }
 
 func (s *SetModelsSuite) TestSetModelsControllerIsolated(c *gc.C) {


### PR DESCRIPTION
## Description of change

As per linked bug, it was possible to successfully switch to an already-destroyed model if:
* that model was considered as 'current' on this client;
* it was destroyed;
* there were no other model switches performed since this model's destruction.

In other words, if a previous current model was the same as the model the operator decided to switch to, and this model was destroyed, Juju will consider it as a no-op and will not let the operator know that the model no longer exists.

This was happening because we have short circuited the logic that sets current model - if the model name is the same, we would not perform certain checks.

This PR removes the short cut ensuring that the model name is always checks against known models.   

## QA steps

1. bootstrap;
2. add-model [this will also make it *current* on this client];
3. destroy-model form 2;
4. switch t model form 2. 

We should get an error. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1800724
