### PR TITLE
More informative k8s add-unit error

### DIFF
--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -155,6 +155,20 @@ func (c *addUnitCommand) Info() *cmd.Info {
 	}
 }
 
+// IncompatibleModel returns an error if the command is being run against
+// a model with which it is not compatible.
+func (c *addUnitCommand) IncompatibleModel(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := `
+add-unit is not allowed on Kubernetes models.
+Instead, use juju scale-application.
+See juju help scale-application.
+`[1:]
+	return errors.New(msg)
+}
+
 func (c *addUnitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.UnitCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "Number of units to add")

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/resource/resourceadapters"
 )
 
+type RemoveApplicationAPI removeApplicationAPI
+
 func NewUpgradeCharmCommandForTest(
 	store jujuclient.ClientStore,
 	apiOpen api.OpenFunc,
@@ -50,6 +52,13 @@ func NewResolvedCommandForTest(applicationResolveAPI applicationResolveAPI, clie
 // NewAddUnitCommandForTest returns an AddUnitCommand with the api provided as specified.
 func NewAddUnitCommandForTest(api applicationAddUnitAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &addUnitCommand{api: api}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
+// NewRemoveUnitCommandForTest returns a RemoveUnitCommand with the api provided as specified.
+func NewRemoveUnitCommandForTest(api removeApplicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	cmd := &removeUnitCommand{api: api}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -81,6 +81,7 @@ type removeApplicationAPI interface {
 	DestroyUnitsDeprecated(unitNames ...string) error
 	GetCharmURL(appName string) (*charm.URL, error)
 	ModelUUID() string
+	BestAPIVersion() int
 }
 
 type storageAPI interface {

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -1,111 +1,160 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package application
+package application_test
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6"
 
-	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/state"
-	"github.com/juju/juju/testcharms"
+	apiapplication "github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type RemoveUnitSuite struct {
-	jujutesting.RepoSuite
-	testing.CmdBlockHelper
-}
+	testing.FakeJujuXDGDataHomeSuite
+	fake *fakeApplicationRemoveUnitAPI
 
-func (s *RemoveUnitSuite) SetUpTest(c *gc.C) {
-	s.RepoSuite.SetUpTest(c)
-	s.CmdBlockHelper = testing.NewCmdBlockHelper(s.APIState)
-	c.Assert(s.CmdBlockHelper, gc.NotNil)
-	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&RemoveUnitSuite{})
 
-func runRemoveUnit(c *gc.C, args ...string) (*cmd.Context, error) {
-	return cmdtesting.RunCommand(c, NewRemoveUnitCommand(), args...)
+type fakeApplicationRemoveUnitAPI struct {
+	application.RemoveApplicationAPI
+
+	units          []string
+	destroyStorage bool
+	bestAPIVersion int
+	err            error
 }
 
-func (s *RemoveUnitSuite) setupUnitForRemove(c *gc.C) *state.Application {
-	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "multi-series")
-	err := runDeploy(c, "-n", "2", ch, "multi-series", "--series", "precise")
-	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:precise/multi-series-1")
-	svc, _ := s.AssertApplication(c, "multi-series", curl, 2, 0)
-	return svc
+func (f *fakeApplicationRemoveUnitAPI) BestAPIVersion() int {
+	return f.bestAPIVersion
+}
+
+func (f *fakeApplicationRemoveUnitAPI) Close() error {
+	return nil
+}
+
+func (f *fakeApplicationRemoveUnitAPI) ModelUUID() string {
+	return "fake-uuid"
+}
+
+func (f *fakeApplicationRemoveUnitAPI) DestroyUnits(args apiapplication.DestroyUnitsParams) ([]params.DestroyUnitResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.units = args.Units
+	f.destroyStorage = args.DestroyStorage
+	var result []params.DestroyUnitResult
+	for _, u := range args.Units {
+		var info *params.DestroyUnitInfo
+		var err *params.Error
+		switch u {
+		case "unit/0":
+			st := []params.Entity{{Tag: "storage-data-0"}}
+			info = &params.DestroyUnitInfo{}
+			if f.destroyStorage {
+				info.DestroyedStorage = st
+			} else {
+				info.DetachedStorage = st
+			}
+		case "unit/1":
+			st := []params.Entity{{Tag: "storage-data-1"}}
+			info = &params.DestroyUnitInfo{}
+			if f.destroyStorage {
+				info.DestroyedStorage = st
+			} else {
+				info.DetachedStorage = st
+			}
+		case "unit/2":
+			err = &params.Error{Code: params.CodeNotFound, Message: `unit "unit/2" does not exist`}
+		}
+		result = append(result, params.DestroyUnitResult{
+			Info:  info,
+			Error: err,
+		})
+	}
+	return result, nil
+}
+
+func (s *RemoveUnitSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.fake = &fakeApplicationRemoveUnitAPI{
+		bestAPIVersion: 5,
+	}
+	s.store = jujuclienttesting.MinimalStore()
+}
+
+func (s *RemoveUnitSuite) runRemoveUnit(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, application.NewRemoveUnitCommandForTest(s.fake, s.store), args...)
 }
 
 func (s *RemoveUnitSuite) TestRemoveUnit(c *gc.C) {
-	app := s.setupUnitForRemove(c)
-
-	ctx, err := runRemoveUnit(c, "multi-series/0", "multi-series/1", "multi-series/2", "sillybilly/17")
+	ctx, err := s.runRemoveUnit(c, "unit/0", "unit/1", "unit/2")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(s.fake.units, jc.DeepEquals, []string{"unit/0", "unit/1", "unit/2"})
+	c.Assert(s.fake.destroyStorage, jc.IsFalse)
+
 	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-removing unit multi-series/0
-removing unit multi-series/1
-removing unit multi-series/2 failed: unit "multi-series/2" does not exist
-removing unit sillybilly/17 failed: unit "sillybilly/17" does not exist
+removing unit unit/0
+- will detach storage data/0
+removing unit unit/1
+- will detach storage data/1
+removing unit unit/2 failed: unit "unit/2" does not exist
 `[1:])
-
-	units, err := app.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	for _, u := range units {
-		c.Assert(u.Life(), gc.Equals, state.Dying)
-	}
-}
-
-func (s *RemoveUnitSuite) TestRemoveUnitDetachesStorage(c *gc.C) {
-	s.testRemoveUnitRemoveStorage(c, false)
 }
 
 func (s *RemoveUnitSuite) TestRemoveUnitDestroyStorage(c *gc.C) {
-	s.testRemoveUnitRemoveStorage(c, true)
-}
+	ctx, err := s.runRemoveUnit(c, "unit/0", "unit/1", "unit/2", "--destroy-storage")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(s.fake.units, jc.DeepEquals, []string{"unit/0", "unit/1", "unit/2"})
+	c.Assert(s.fake.destroyStorage, jc.IsTrue)
 
-func (s *RemoveUnitSuite) testRemoveUnitRemoveStorage(c *gc.C, destroy bool) {
-	ch := testcharms.Repo.CharmArchivePath(s.CharmsPath, "storage-filesystem-multi-series")
-	err := runDeploy(c, ch, "storage-filesystem", "--storage", "data=modelscoped,2")
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Materialise the storage by assigning the unit to a machine.
-	u, err := s.State.Unit("storage-filesystem/0")
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.AssignUnit(u, state.AssignCleanEmpty)
-	c.Assert(err, jc.ErrorIsNil)
-
-	args := []string{"storage-filesystem/0"}
-	action := "detach"
-	if destroy {
-		args = append(args, "--destroy-storage")
-		action = "remove"
-	}
-	ctx, err := runRemoveUnit(c, args...)
-	c.Assert(err, jc.ErrorIsNil)
 	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, fmt.Sprintf(`
-removing unit storage-filesystem/0
-- will %[1]s storage data/0
-- will %[1]s storage data/1
-`[1:], action))
+	c.Assert(stderr, gc.Equals, `
+removing unit unit/0
+- will remove storage data/0
+removing unit unit/1
+- will remove storage data/1
+removing unit unit/2 failed: unit "unit/2" does not exist
+`[1:])
 }
 
 func (s *RemoveUnitSuite) TestBlockRemoveUnit(c *gc.C) {
-	app := s.setupUnitForRemove(c)
+	// Block operation
+	s.fake.err = common.OperationBlockedError("TestBlockRemoveUnit")
+	s.runRemoveUnit(c, "some-unit-name/0")
 
-	// block operation
-	s.BlockRemoveObject(c, "TestBlockRemoveUnit")
-	_, err := runRemoveUnit(c, "dummy/0", "dummy/1")
-	s.AssertBlocked(c, err, ".*TestBlockRemoveUnit.*")
-	c.Assert(app.Life(), gc.Equals, state.Alive)
+	// msg is logged
+	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
+	c.Check(stripped, gc.Matches, ".*TestBlockRemoveUnit.*")
+}
+
+func (s *RemoveUnitSuite) TestCAASDisallowed(c *gc.C) {
+	m := s.store.Models["arthur"].Models["king/sword"]
+	m.ModelType = model.CAAS
+	s.store.Models["arthur"].Models["king/sword"] = m
+	_, err := s.runRemoveUnit(c, "unit/0")
+	c.Assert(err, gc.NotNil)
+	expected := `
+remove-unit is not allowed on Kubernetes models.
+Instead, use juju scale-application.
+See juju help scale-application.
+`
+	expected = strings.Replace(expected, "\n", "", -1)
+	msg := strings.Replace(err.Error(), "\n", "", -1)
+	c.Assert(msg, gc.Equals, expected)
 }

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -48,8 +48,8 @@ func createUnitWithStorage(c *gc.C, s *jujutesting.JujuConnSuite, poolName strin
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(poolName, 1024, 1),
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-block", ch, storage)
-	unit, err := service.AddUnit(state.AddUnitParams{})
+	app := s.AddTestingApplicationWithStorage(c, "storage-block", ch, storage)
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
@@ -628,8 +628,8 @@ func createUnitWithFileSystemStorage(c *gc.C, s *jujutesting.JujuConnSuite, pool
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(poolName, 1024, 1),
 	}
-	service := s.AddTestingApplicationWithStorage(c, "storage-filesystem", ch, storage)
-	unit, err := service.AddUnit(state.AddUnitParams{})
+	app := s.AddTestingApplicationWithStorage(c, "storage-filesystem", ch, storage)
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

When running add/remove unit on a k8s model, print a better error message telling the user to use scale-application instead.

As a drive by, convert the remove-unit tests to proper unit tests instead of JujuConnSuite tests.

## QA steps

add/remove unit works on IAAS model
check errors on CAAS model

