### PR TITLE
Leadership and Lease Pinning - Use Strings Instead of Tags

### DIFF
--- a/api/common/leadership_test.go
+++ b/api/common/leadership_test.go
@@ -36,16 +36,13 @@ func (s *LeadershipSuite) SetUpSuite(c *gc.C) {
 func (s *LeadershipSuite) TestPinnedLeadership(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	resultSource := params.PinnedLeadershipResult{Result: map[string][]string{
-		"application-redis": {"machine-0", "machine-1"},
-	}}
+	pinned := map[string][]string{"redis": {"machine-0", "machine-1"}}
+	resultSource := params.PinnedLeadershipResult{Result: pinned}
 	s.facade.EXPECT().FacadeCall("PinnedLeadership", nil, gomock.Any()).SetArg(2, resultSource)
 
 	res, err := s.client.PinnedLeadership()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(res, gc.DeepEquals, map[names.ApplicationTag][]names.Tag{
-		names.NewApplicationTag("redis"): {names.NewMachineTag("0"), names.NewMachineTag("1")},
-	})
+	c.Check(res, gc.DeepEquals, map[string][]names.Tag{"redis": {names.NewMachineTag("0"), names.NewMachineTag("1")}})
 }
 
 func (s *LeadershipSuite) TestPinMachineApplicationsSuccess(c *gc.C) {
@@ -72,7 +69,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsPartialError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := s.pinApplicationsClientSuccessResults()
-	exp[names.NewApplicationTag("wordpress")] = errorRes
+	exp["wordpress"] = errorRes
 	c.Check(res, gc.DeepEquals, exp)
 }
 
@@ -109,22 +106,22 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsPartialError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := s.pinApplicationsClientSuccessResults()
-	exp[names.NewApplicationTag("redis")] = errorRes
+	exp["redis"] = errorRes
 	c.Check(res, gc.DeepEquals, exp)
 }
 
 func (s *LeadershipSuite) pinApplicationsServerSuccessResults() []params.PinApplicationResult {
 	results := make([]params.PinApplicationResult, len(s.machineApps))
 	for i, app := range s.machineApps {
-		results[i] = params.PinApplicationResult{ApplicationTag: names.NewApplicationTag(app).String()}
+		results[i] = params.PinApplicationResult{ApplicationName: app}
 	}
 	return results
 }
 
-func (s *LeadershipSuite) pinApplicationsClientSuccessResults() map[names.ApplicationTag]error {
-	results := make(map[names.ApplicationTag]error, len(s.machineApps))
+func (s *LeadershipSuite) pinApplicationsClientSuccessResults() map[string]error {
+	results := make(map[string]error, len(s.machineApps))
 	for _, app := range s.machineApps {
-		results[names.NewApplicationTag(app)] = nil
+		results[app] = nil
 	}
 	return results
 }

--- a/apiserver/common/leadership_test.go
+++ b/apiserver/common/leadership_test.go
@@ -50,13 +50,12 @@ func (s *LeadershipSuite) TestPinnedLeadershipSuccess(c *gc.C) {
 	s.authTag = names.NewUserTag("admin")
 	defer s.setup(c).Finish()
 
-	s.pinner.EXPECT().PinnedLeadership().Return(map[string][]names.Tag{
-		"redis": {names.NewMachineTag("0"), names.NewMachineTag("1")},
-	})
+	pinned := map[string][]string{"redis": {"machine-0", "machine-1"}}
+	s.pinner.EXPECT().PinnedLeadership().Return(pinned)
 
 	res, err := s.api.PinnedLeadership()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(res.Result, gc.DeepEquals, map[string][]string{"application-redis": {"machine-0", "machine-1"}})
+	c.Check(res.Result, gc.DeepEquals, pinned)
 }
 
 func (s *LeadershipSuite) TestPinnedLeadershipPermissionDenied(c *gc.C) {
@@ -70,7 +69,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	for _, app := range s.machineApps {
-		s.pinner.EXPECT().PinLeadership(app, s.authTag).Return(nil)
+		s.pinner.EXPECT().PinLeadership(app, s.authTag.String()).Return(nil)
 	}
 
 	res, err := s.api.PinMachineApplications()
@@ -82,9 +81,9 @@ func (s *LeadershipSuite) TestPinMachineApplicationsPartialError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	errorRes := errors.New("boom")
-	s.pinner.EXPECT().PinLeadership("mysql", s.authTag).Return(nil)
-	s.pinner.EXPECT().PinLeadership("redis", s.authTag).Return(nil)
-	s.pinner.EXPECT().PinLeadership("wordpress", s.authTag).Return(errorRes)
+	s.pinner.EXPECT().PinLeadership("mysql", s.authTag.String()).Return(nil)
+	s.pinner.EXPECT().PinLeadership("redis", s.authTag.String()).Return(nil)
+	s.pinner.EXPECT().PinLeadership("wordpress", s.authTag.String()).Return(errorRes)
 
 	res, err := s.api.PinMachineApplications()
 	c.Assert(err, jc.ErrorIsNil)
@@ -98,7 +97,7 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	for _, app := range s.machineApps {
-		s.pinner.EXPECT().UnpinLeadership(app, s.authTag).Return(nil)
+		s.pinner.EXPECT().UnpinLeadership(app, s.authTag.String()).Return(nil)
 	}
 
 	res, err := s.api.UnpinMachineApplications()
@@ -110,9 +109,9 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsPartialError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	errorRes := errors.New("boom")
-	s.pinner.EXPECT().UnpinLeadership("mysql", s.authTag).Return(nil)
-	s.pinner.EXPECT().UnpinLeadership("redis", s.authTag).Return(errorRes)
-	s.pinner.EXPECT().UnpinLeadership("wordpress", s.authTag).Return(nil)
+	s.pinner.EXPECT().UnpinLeadership("mysql", s.authTag.String()).Return(nil)
+	s.pinner.EXPECT().UnpinLeadership("redis", s.authTag.String()).Return(errorRes)
+	s.pinner.EXPECT().UnpinLeadership("wordpress", s.authTag.String()).Return(nil)
 
 	res, err := s.api.UnpinMachineApplications()
 	c.Assert(err, jc.ErrorIsNil)
@@ -162,7 +161,7 @@ func (s *LeadershipSuite) setup(c *gc.C) *gomock.Controller {
 func (s *LeadershipSuite) pinApplicationsSuccessResults() []params.PinApplicationResult {
 	results := make([]params.PinApplicationResult, len(s.machineApps))
 	for i, app := range s.machineApps {
-		results[i] = params.PinApplicationResult{ApplicationTag: names.NewApplicationTag(app).String()}
+		results[i] = params.PinApplicationResult{ApplicationName: app}
 	}
 	return results
 }

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -6,8 +6,6 @@ package apiserver
 import (
 	"time"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/leadership"
@@ -75,19 +73,19 @@ type leadershipPinner struct {
 
 // PinLeadership (leadership.Pinner) pins the lease
 // for the input application and entity.
-func (m leadershipPinner) PinLeadership(applicationId string, entity names.Tag) error {
-	return errors.Trace(m.pinner.Pin(applicationId, entity))
+func (m leadershipPinner) PinLeadership(applicationName string, entity string) error {
+	return errors.Trace(m.pinner.Pin(applicationName, entity))
 }
 
 // UnpinLeadership (leadership.Pinner) unpins the lease
 // for the input application and entity.
-func (m leadershipPinner) UnpinLeadership(applicationId string, entity names.Tag) error {
-	return errors.Trace(m.pinner.Unpin(applicationId, entity))
+func (m leadershipPinner) UnpinLeadership(applicationName string, entity string) error {
+	return errors.Trace(m.pinner.Unpin(applicationName, entity))
 }
 
 // PinnedLeadership (leadership.Pinner) returns applications for which
 // leadership is pinned, along with the entities requiring the
 // pinned behaviour.
-func (m leadershipPinner) PinnedLeadership() map[string][]names.Tag {
+func (m leadershipPinner) PinnedLeadership() map[string][]string {
 	return m.pinner.Pinned()
 }

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -77,9 +77,9 @@ type PinApplicationsResults struct {
 // PinApplicationResult represents the result of a single application
 // leadership pin/unpin operation
 type PinApplicationResult struct {
-	// ApplicationTag is the application for which a leadership pin/unpin
+	// ApplicationName is the application for which a leadership pin/unpin
 	// operation was attempted.
-	ApplicationTag string `json:"application-tag"`
+	ApplicationName string `json:"application-name"`
 	// Error will container a reference to an error resulting from pin/unpin
 	// if one occurred.
 	Error *Error `json:"error,omitempty"`
@@ -89,7 +89,7 @@ type PinApplicationResult struct {
 // which leadership is pinned
 type PinnedLeadershipResult struct {
 	// Result has:
-	// - Application tag keys representing the application pinned.
+	// - Application name keys representing the application pinned.
 	// - Tag slice values representing the entities requiring pinned
 	//   behaviour for each application.
 	Result map[string][]string `json:"result,omitempty"`

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 )
 
 // TODO (manadart 2010-10-05) Add interfaces to the end of this line,
@@ -50,16 +49,16 @@ type Pinner interface {
 	// PinLeadership ensures that the leadership of the input application will
 	// not expire. The input entity records the party responsible for the
 	// pinning operation.
-	PinLeadership(applicationId string, entity names.Tag) error
+	PinLeadership(applicationId string, entity string) error
 
 	// UnpinLeadership reverses a PinLeadership operation for the same
 	// application and entity. Normal expiry behaviour is restored when no
 	// entities remain with pins for the application.
-	UnpinLeadership(applicationId string, entity names.Tag) error
+	UnpinLeadership(applicationId string, entity string) error
 
 	// PinnedLeadership returns a map keyed on pinned application names,
 	// with entities that require the application's pinned behaviour.
-	PinnedLeadership() map[string][]names.Tag
+	PinnedLeadership() map[string][]string
 }
 
 // Token represents a unit's leadership of its application.

--- a/core/leadership/mocks/leadership_mock.go
+++ b/core/leadership/mocks/leadership_mock.go
@@ -6,7 +6,6 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	names_v2 "gopkg.in/juju/names.v2"
 	reflect "reflect"
 )
 
@@ -34,7 +33,7 @@ func (m *MockPinner) EXPECT() *MockPinnerMockRecorder {
 }
 
 // PinLeadership mocks base method
-func (m *MockPinner) PinLeadership(arg0 string, arg1 names_v2.Tag) error {
+func (m *MockPinner) PinLeadership(arg0, arg1 string) error {
 	ret := m.ctrl.Call(m, "PinLeadership", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -46,9 +45,9 @@ func (mr *MockPinnerMockRecorder) PinLeadership(arg0, arg1 interface{}) *gomock.
 }
 
 // PinnedLeadership mocks base method
-func (m *MockPinner) PinnedLeadership() map[string][]names_v2.Tag {
+func (m *MockPinner) PinnedLeadership() map[string][]string {
 	ret := m.ctrl.Call(m, "PinnedLeadership")
-	ret0, _ := ret[0].(map[string][]names_v2.Tag)
+	ret0, _ := ret[0].(map[string][]string)
 	return ret0
 }
 
@@ -58,7 +57,7 @@ func (mr *MockPinnerMockRecorder) PinnedLeadership() *gomock.Call {
 }
 
 // UnpinLeadership mocks base method
-func (m *MockPinner) UnpinLeadership(arg0 string, arg1 names_v2.Tag) error {
+func (m *MockPinner) UnpinLeadership(arg0, arg1 string) error {
 	ret := m.ctrl.Call(m, "UnpinLeadership", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 )
 
 const (
@@ -56,16 +55,16 @@ type Pinner interface {
 	// the recipient of the pin behaviour.
 	// The input entity denotes the party responsible for the
 	// pinning operation.
-	Pin(leaseName string, entity names.Tag) error
+	Pin(leaseName string, entity string) error
 
 	// Unpin reverses a Pin operation for the same application and entity.
 	// Normal expiry behaviour is restored when no entities remain with
 	// pins for the application.
-	Unpin(leaseName string, entity names.Tag) error
+	Unpin(leaseName string, entity string) error
 
 	// Pinned returns all names for pinned leases, with the entities requiring
-	// their pinned behaviour
-	Pinned() map[string][]names.Tag
+	// their pinned behaviour.
+	Pinned() map[string][]string
 }
 
 // Checker exposes facts about lease ownership.

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 )
 
 // Store manipulates leases directly, and is most likely to be seen set on a
@@ -52,17 +51,17 @@ type Store interface {
 	// the recipient of the pin behaviour.
 	// The input entity denotes the party responsible for the
 	// pinning operation.
-	PinLease(lease Key, entity names.Tag) error
+	PinLease(lease Key, entity string) error
 
 	// Unpin reverses a Pin operation for the same key and entity.
 	// Normal expiry behaviour is restored when no entities remain with
 	// pins for the application.
-	UnpinLease(lease Key, tag names.Tag) error
+	UnpinLease(lease Key, entity string) error
 
 	// Pinned returns a snapshot of pinned leases.
 	// The return consists of each pinned lease and the collection of entities
 	// requiring its pinned behaviour.
-	Pinned() map[Key][]names.Tag
+	Pinned() map[Key][]string
 }
 
 // Key fully identifies a lease, including the namespace and

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -254,14 +254,14 @@ func (s *fsmSuite) TestPinUnpin(c *gc.C) {
 		Duration:  time.Second,
 	}).Error(), jc.ErrorIsNil)
 
-	machineTag := names.NewMachineTag("0")
+	machine := names.NewMachineTag("0").String()
 	c.Assert(s.apply(c, raftlease.Command{
 		Version:   1,
 		Operation: raftlease.OperationPin,
 		Namespace: "ns",
 		ModelUUID: "model",
 		Lease:     "lease",
-		PinEntity: machineTag.String(),
+		PinEntity: machine,
 	}).Error(), jc.ErrorIsNil)
 
 	// Pinned lease does not expire.
@@ -274,7 +274,7 @@ func (s *fsmSuite) TestPinUnpin(c *gc.C) {
 	c.Assert(resp.Error(), jc.ErrorIsNil)
 	assertExpired(c, resp)
 
-	exp := map[lease.Key][]names.Tag{{Namespace: "ns", ModelUUID: "model", Lease: "lease"}: {machineTag}}
+	exp := map[lease.Key][]string{{Namespace: "ns", ModelUUID: "model", Lease: "lease"}: {machine}}
 	c.Assert(s.fsm.Pinned(), gc.DeepEquals, exp)
 
 	c.Assert(s.apply(c, raftlease.Command{
@@ -283,7 +283,7 @@ func (s *fsmSuite) TestPinUnpin(c *gc.C) {
 		Namespace: "ns",
 		ModelUUID: "model",
 		Lease:     "lease",
-		PinEntity: machineTag.String(),
+		PinEntity: machine,
 	}).Error(), jc.ErrorIsNil)
 
 	// Unpinned lease expires when time advances.
@@ -296,7 +296,7 @@ func (s *fsmSuite) TestPinUnpin(c *gc.C) {
 	c.Assert(resp.Error(), jc.ErrorIsNil)
 	assertExpired(c, resp, lease.Key{"ns", "model", "lease"})
 
-	c.Assert(s.fsm.Pinned(), gc.DeepEquals, map[lease.Key][]names.Tag{})
+	c.Assert(s.fsm.Pinned(), gc.DeepEquals, map[lease.Key][]string{})
 }
 
 func (s *fsmSuite) TestPinUnpinMultipleHoldersNoExpiry(c *gc.C) {
@@ -317,27 +317,27 @@ func (s *fsmSuite) TestPinUnpinMultipleHoldersNoExpiry(c *gc.C) {
 	}).Error(), jc.ErrorIsNil)
 
 	// Two different entities pin the same lease.
-	m0Tag := names.NewMachineTag("0")
+	m0 := names.NewMachineTag("0").String()
 	c.Assert(s.apply(c, raftlease.Command{
 		Version:   1,
 		Operation: raftlease.OperationPin,
 		Namespace: "ns",
 		ModelUUID: "model",
 		Lease:     "lease",
-		PinEntity: m0Tag.String(),
+		PinEntity: m0,
 	}).Error(), jc.ErrorIsNil)
 
-	m1Tag := names.NewMachineTag("1")
+	m1 := names.NewMachineTag("1").String()
 	c.Assert(s.apply(c, raftlease.Command{
 		Version:   1,
 		Operation: raftlease.OperationPin,
 		Namespace: "ns",
 		ModelUUID: "model",
 		Lease:     "lease",
-		PinEntity: m1Tag.String(),
+		PinEntity: m1,
 	}).Error(), jc.ErrorIsNil)
 
-	exp := map[lease.Key][]names.Tag{{Namespace: "ns", ModelUUID: "model", Lease: "lease"}: {m0Tag, m1Tag}}
+	exp := map[lease.Key][]string{{Namespace: "ns", ModelUUID: "model", Lease: "lease"}: {m0, m1}}
 	c.Assert(s.fsm.Pinned(), gc.DeepEquals, exp)
 
 	// One entity releases.
@@ -347,10 +347,10 @@ func (s *fsmSuite) TestPinUnpinMultipleHoldersNoExpiry(c *gc.C) {
 		Namespace: "ns",
 		ModelUUID: "model",
 		Lease:     "lease",
-		PinEntity: m0Tag.String(),
+		PinEntity: m0,
 	}).Error(), jc.ErrorIsNil)
 
-	exp = map[lease.Key][]names.Tag{{Namespace: "ns", ModelUUID: "model", Lease: "lease"}: {m1Tag}}
+	exp = map[lease.Key][]string{{Namespace: "ns", ModelUUID: "model", Lease: "lease"}: {m1}}
 	c.Assert(s.fsm.Pinned(), gc.DeepEquals, exp)
 
 	// Lease does not expire, as there is still one pin.

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/pubsub"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/core/globalclock"
 	"github.com/juju/juju/core/lease"
@@ -43,7 +42,7 @@ type TrapdoorFunc func(lease.Key, string) lease.Trapdoor
 type ReadonlyFSM interface {
 	Leases(time.Time) map[lease.Key]lease.Info
 	GlobalTime() time.Time
-	Pinned() map[lease.Key][]names.Tag
+	Pinned() map[lease.Key][]string
 }
 
 // StoreConfig holds resources and settings needed to run the Store.
@@ -131,28 +130,28 @@ func (s *Store) Refresh() error {
 }
 
 // PinLease is part of lease.Store.
-func (s *Store) PinLease(key lease.Key, entity names.Tag) error {
+func (s *Store) PinLease(key lease.Key, entity string) error {
 	return errors.Trace(s.pinOp(OperationPin, key, entity))
 }
 
 // UnpinLease is part of lease.Store.
-func (s *Store) UnpinLease(key lease.Key, entity names.Tag) error {
+func (s *Store) UnpinLease(key lease.Key, entity string) error {
 	return errors.Trace(s.pinOp(OperationUnpin, key, entity))
 }
 
 // Pinned is part of the Store interface.
-func (s *Store) Pinned() map[lease.Key][]names.Tag {
+func (s *Store) Pinned() map[lease.Key][]string {
 	return s.fsm.Pinned()
 }
 
-func (s *Store) pinOp(operation string, key lease.Key, entity names.Tag) error {
+func (s *Store) pinOp(operation string, key lease.Key, entity string) error {
 	return errors.Trace(s.runOnLeader(&Command{
 		Version:   CommandVersion,
 		Operation: operation,
 		Namespace: key.Namespace,
 		ModelUUID: key.ModelUUID,
 		Lease:     key.Lease,
-		PinEntity: entity.String(),
+		PinEntity: entity,
 	}))
 }
 

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -226,12 +226,12 @@ func (s *storeSuite) TestLeases(c *gc.C) {
 }
 
 func (s *storeSuite) TestPin(c *gc.C) {
-	machineTag := names.NewMachineTag("0")
+	machine := names.NewMachineTag("0").String()
 	s.handleHubRequest(c,
 		func() {
 			err := s.store.PinLease(
 				lease.Key{"warframe", "frost", "prime"},
-				machineTag,
+				machine,
 			)
 			c.Assert(err, jc.ErrorIsNil)
 		},
@@ -241,7 +241,7 @@ func (s *storeSuite) TestPin(c *gc.C) {
 			Namespace: "warframe",
 			ModelUUID: "frost",
 			Lease:     "prime",
-			PinEntity: machineTag.String(),
+			PinEntity: machine,
 		},
 		func(req raftlease.ForwardRequest) {
 			_, err := s.hub.Publish(
@@ -254,12 +254,12 @@ func (s *storeSuite) TestPin(c *gc.C) {
 }
 
 func (s *storeSuite) TestUnpin(c *gc.C) {
-	machineTag := names.NewMachineTag("0")
+	machine := names.NewMachineTag("0").String()
 	s.handleHubRequest(c,
 		func() {
 			err := s.store.UnpinLease(
 				lease.Key{"warframe", "frost", "prime"},
-				machineTag,
+				machine,
 			)
 			c.Assert(err, jc.ErrorIsNil)
 		},
@@ -269,7 +269,7 @@ func (s *storeSuite) TestUnpin(c *gc.C) {
 			Namespace: "warframe",
 			ModelUUID: "frost",
 			Lease:     "prime",
-			PinEntity: machineTag.String(),
+			PinEntity: machine,
 		},
 		func(req raftlease.ForwardRequest) {
 			_, err := s.hub.Publish(
@@ -282,7 +282,7 @@ func (s *storeSuite) TestUnpin(c *gc.C) {
 }
 
 func (s *storeSuite) TestPinned(c *gc.C) {
-	s.fsm.pinned = map[lease.Key][]names.Tag{}
+	s.fsm.pinned = map[lease.Key][]string{}
 	c.Check(s.store.Pinned(), gc.DeepEquals, s.fsm.pinned)
 	s.fsm.CheckCallNames(c, "Pinned")
 }
@@ -462,7 +462,7 @@ type fakeFSM struct {
 	testing.Stub
 	leases     map[lease.Key]lease.Info
 	globalTime time.Time
-	pinned     map[lease.Key][]names.Tag
+	pinned     map[lease.Key][]string
 }
 
 func (f *fakeFSM) Leases(t time.Time) map[lease.Key]lease.Info {
@@ -470,7 +470,7 @@ func (f *fakeFSM) Leases(t time.Time) map[lease.Key]lease.Info {
 	return f.leases
 }
 
-func (f *fakeFSM) Pinned() map[lease.Key][]names.Tag {
+func (f *fakeFSM) Pinned() map[lease.Key][]string {
 	f.AddCall("Pinned")
 	return f.pinned
 }

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/raftlease"
@@ -126,16 +125,16 @@ func (s *leaseStore) Refresh() error {
 }
 
 // PinLease is part of lease.Store.
-func (s *leaseStore) PinLease(key lease.Key, entity names.Tag) error {
+func (s *leaseStore) PinLease(key lease.Key, entity string) error {
 	return errors.NotImplementedf("lease pinning")
 }
 
 // UnpinLease is part of lease.Store.
-func (s *leaseStore) UnpinLease(key lease.Key, entity names.Tag) error {
+func (s *leaseStore) UnpinLease(key lease.Key, entity string) error {
 	return errors.NotImplementedf("lease unpinning")
 }
 
 // Pinned is part of the Store interface.
-func (s *leaseStore) Pinned() map[lease.Key][]names.Tag {
+func (s *leaseStore) Pinned() map[lease.Key][]string {
 	return nil
 }

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujutxn "github.com/juju/txn"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -190,17 +189,17 @@ func (store *store) ExpireLease(key lease.Key) error {
 }
 
 // PinLease is part of the Store interface.
-func (store *store) PinLease(key lease.Key, entity names.Tag) error {
+func (store *store) PinLease(key lease.Key, entity string) error {
 	return errors.NotImplementedf("pinning for legacy leases")
 }
 
 // UnpinLease is part of the Store interface.
-func (store *store) UnpinLease(key lease.Key, entity names.Tag) error {
+func (store *store) UnpinLease(key lease.Key, entity string) error {
 	return errors.NotImplementedf("unpinning for legacy leases")
 }
 
 // Pinned is part of the Store interface.
-func (store *store) Pinned() map[lease.Key][]names.Tag {
+func (store *store) Pinned() map[lease.Key][]string {
 	return nil
 }
 

--- a/worker/lease/bound.go
+++ b/worker/lease/bound.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/core/lease"
 )
@@ -78,23 +77,23 @@ func (b *boundManager) Token(leaseName, holderName string) lease.Token {
 
 // Pinned (lease.Pinner) returns applications and the entities requiring their
 // pinned behaviour, for pinned leases in the bound namespace/model.
-func (b *boundManager) Pinned() map[string][]names.Tag {
+func (b *boundManager) Pinned() map[string][]string {
 	return b.manager.pinned(b.namespace, b.modelUUID)
 }
 
 // Pin (lease.Pinner) sends a pin message to the worker loop.
-func (b *boundManager) Pin(leaseName string, entity names.Tag) error {
+func (b *boundManager) Pin(leaseName string, entity string) error {
 	return errors.Trace(b.pinOp(leaseName, entity, b.manager.pins))
 }
 
 // Unpin (lease.Pinner) sends an unpin message to the worker loop.
-func (b *boundManager) Unpin(leaseName string, entity names.Tag) error {
+func (b *boundManager) Unpin(leaseName string, entity string) error {
 	return errors.Trace(b.pinOp(leaseName, entity, b.manager.unpins))
 }
 
 // pinOp creates a pin instance from the input lease name,
 // then sends it on the input channel.
-func (b *boundManager) pinOp(leaseName string, entity names.Tag, ch chan pin) error {
+func (b *boundManager) pinOp(leaseName string, entity string, ch chan pin) error {
 	return errors.Trace(pin{
 		leaseKey: b.leaseKey(leaseName),
 		entity:   entity,

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1/catacomb"
@@ -460,8 +458,8 @@ func (manager *Manager) handleUnpin(p pin) {
 
 // pinned returns lease names and the entities requiring their pinned
 // behaviour, from the input namespace/model for which leases are pinned.
-func (manager *Manager) pinned(namespace, modelUUID string) map[string][]names.Tag {
-	pinned := make(map[string][]names.Tag)
+func (manager *Manager) pinned(namespace, modelUUID string) map[string][]string {
+	pinned := make(map[string][]string)
 	for key, entities := range manager.config.Store.Pinned() {
 		if key.Namespace == namespace && key.ModelUUID == modelUUID {
 			pinned[key.Lease] = entities

--- a/worker/lease/manager_pin_test.go
+++ b/worker/lease/manager_pin_test.go
@@ -18,23 +18,23 @@ import (
 type PinSuite struct {
 	testing.IsolationSuite
 
-	appName    string
-	machineTag names.MachineTag
-	pinArgs    []interface{}
+	appName string
+	machine string
+	pinArgs []interface{}
 }
 
 func (s *PinSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
 	s.appName = "redis"
-	s.machineTag = names.NewMachineTag("0")
+	s.machine = names.NewMachineTag("0").String()
 	s.pinArgs = []interface{}{
 		corelease.Key{
 			Namespace: "namespace",
 			ModelUUID: "modelUUID",
 			Lease:     s.appName,
 		},
-		s.machineTag,
+		s.machine,
 	}
 }
 
@@ -48,7 +48,7 @@ func (s *PinSuite) TestPinLease_Success(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		err := getPinner(c, manager).Pin(s.appName, s.machineTag)
+		err := getPinner(c, manager).Pin(s.appName, s.machine)
 		c.Assert(err, jc.ErrorIsNil)
 	})
 }
@@ -62,7 +62,7 @@ func (s *PinSuite) TestPinLease_Error(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		err := getPinner(c, manager).Pin(s.appName, s.machineTag)
+		err := getPinner(c, manager).Pin(s.appName, s.machine)
 		c.Check(err, gc.ErrorMatches, "boom")
 	})
 }
@@ -75,7 +75,7 @@ func (s *PinSuite) TestUnpinLease_Success(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		err := getPinner(c, manager).Unpin(s.appName, s.machineTag)
+		err := getPinner(c, manager).Unpin(s.appName, s.machine)
 		c.Assert(err, jc.ErrorIsNil)
 	})
 }
@@ -89,7 +89,7 @@ func (s *PinSuite) TestUnpinLease_Error(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		err := getPinner(c, manager).Unpin(s.appName, s.machineTag)
+		err := getPinner(c, manager).Unpin(s.appName, s.machine)
 		c.Check(err, gc.ErrorMatches, "boom")
 	})
 }
@@ -102,7 +102,7 @@ func (s *PinSuite) TestPinned(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		pinned := getPinner(c, manager).Pinned()
-		c.Check(pinned, gc.DeepEquals, map[string][]names.Tag{"redis": {s.machineTag}})
+		c.Check(pinned, gc.DeepEquals, map[string][]string{"redis": {s.machine}})
 	})
 }
 

--- a/worker/lease/pin.go
+++ b/worker/lease/pin.go
@@ -4,8 +4,6 @@
 package lease
 
 import (
-	"gopkg.in/juju/names.v2"
-
 	"github.com/juju/juju/core/lease"
 )
 
@@ -13,7 +11,7 @@ import (
 // worker loop on behalf of PinLeadership and UnpinLeadership.
 type pin struct {
 	leaseKey lease.Key
-	entity   names.Tag
+	entity   string
 	response chan error
 	stop     <-chan struct{}
 }

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -173,28 +173,28 @@ func (store *Store) Refresh() error {
 }
 
 // PinLease is part of the corelease.Store interface.
-func (store *Store) PinLease(key lease.Key, entity names.Tag) error {
+func (store *Store) PinLease(key lease.Key, entity string) error {
 	return store.call("PinLease", []interface{}{key, entity})
 }
 
 // UnpinLease is part of the corelease.Store interface.
-func (store *Store) UnpinLease(key lease.Key, entity names.Tag) error {
+func (store *Store) UnpinLease(key lease.Key, entity string) error {
 	return store.call("UnpinLease", []interface{}{key, entity})
 }
 
-func (store *Store) Pinned() map[lease.Key][]names.Tag {
+func (store *Store) Pinned() map[lease.Key][]string {
 	store.call("Pinned", nil)
-	return map[lease.Key][]names.Tag{
+	return map[lease.Key][]string{
 		{
 			Namespace: "namespace",
 			ModelUUID: "modelUUID",
 			Lease:     "redis",
-		}: {names.NewMachineTag("0")},
+		}: {names.NewMachineTag("0").String()},
 		{
 			Namespace: "ignored-namespace",
 			ModelUUID: "ignored modelUUID",
 			Lease:     "lolwut",
-		}: {names.NewMachineTag("666")},
+		}: {names.NewMachineTag("666").String()},
 	}
 }
 

--- a/worker/upgradeseries/mocks/package_mock.go
+++ b/worker/upgradeseries/mocks/package_mock.go
@@ -62,9 +62,9 @@ func (mr *MockFacadeMockRecorder) MachineStatus() *gomock.Call {
 }
 
 // PinMachineApplications mocks base method
-func (m *MockFacade) PinMachineApplications() (map[names_v2.ApplicationTag]error, error) {
+func (m *MockFacade) PinMachineApplications() (map[string]error, error) {
 	ret := m.ctrl.Call(m, "PinMachineApplications")
-	ret0, _ := ret[0].(map[names_v2.ApplicationTag]error)
+	ret0, _ := ret[0].(map[string]error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -138,9 +138,9 @@ func (mr *MockFacadeMockRecorder) UnitsPrepared() *gomock.Call {
 }
 
 // UnpinMachineApplications mocks base method
-func (m *MockFacade) UnpinMachineApplications() (map[names_v2.ApplicationTag]error, error) {
+func (m *MockFacade) UnpinMachineApplications() (map[string]error, error) {
 	ret := m.ctrl.Call(m, "UnpinMachineApplications")
-	ret0, _ := ret[0].(map[names_v2.ApplicationTag]error)
+	ret0, _ := ret[0].(map[string]error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -25,8 +25,8 @@ type Facade interface {
 	StartUnitCompletion(reason string) error
 	SetMachineStatus(status model.UpgradeSeriesStatus, reason string) error
 	FinishUpgradeSeries(string) error
-	PinMachineApplications() (map[names.ApplicationTag]error, error)
-	UnpinMachineApplications() (map[names.ApplicationTag]error, error)
+	PinMachineApplications() (map[string]error, error)
+	UnpinMachineApplications() (map[string]error, error)
 }
 
 // NewFacade creates a *upgradeseries.Client and returns it as a Facade.

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -356,12 +356,12 @@ func (w *upgradeSeriesWorker) pinLeaders() (err error) {
 	}
 
 	var lastErr error
-	for appTag, err := range results {
+	for app, err := range results {
 		if err == nil {
-			w.logger.Infof("unpin leader for application %q", appTag.Id())
+			w.logger.Infof("unpin leader for application %q", app)
 			continue
 		}
-		w.logger.Errorf("failed to pin leader for application %q: %s", appTag.Id(), err.Error())
+		w.logger.Errorf("failed to pin leader for application %q: %s", app, err.Error())
 		lastErr = err
 	}
 
@@ -381,12 +381,12 @@ func (w *upgradeSeriesWorker) unpinLeaders() error {
 	}
 
 	var lastErr error
-	for appTag, err := range results {
+	for app, err := range results {
 		if err == nil {
-			w.logger.Infof("unpinned leader for application %q", appTag.Id())
+			w.logger.Infof("unpinned leader for application %q", app)
 			continue
 		}
-		w.logger.Errorf("failed to unpin leader for application %q: %s", appTag.Id(), err.Error())
+		w.logger.Errorf("failed to unpin leader for application %q: %s", app, err.Error())
 		lastErr = err
 	}
 

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -275,9 +275,9 @@ func (s *workerSuite) expectMachineCompletedFinishUpgradeSeries() {
 	exp := s.facade.EXPECT()
 	exp.MachineStatus().Return(model.UpgradeSeriesCompleted, nil)
 	exp.FinishUpgradeSeries("xenial").Return(nil)
-	exp.UnpinMachineApplications().Return(map[names.ApplicationTag]error{
-		names.NewApplicationTag("mysql"):     nil,
-		names.NewApplicationTag("wordpress"): nil,
+	exp.UnpinMachineApplications().Return(map[string]error{
+		"mysql":     nil,
+		"wordpress": nil,
 	}, nil)
 }
 
@@ -332,9 +332,9 @@ func (s *workerSuite) expectUnitsPrepared(units ...string) {
 // often be in the Test... method instead of its partner expectation
 // method.
 func (s *workerSuite) expectPinLeadership() {
-	s.facade.EXPECT().PinMachineApplications().Return(map[names.ApplicationTag]error{
-		names.NewApplicationTag("mysql"):     nil,
-		names.NewApplicationTag("wordpress"): nil,
+	s.facade.EXPECT().PinMachineApplications().Return(map[string]error{
+		"mysql":     nil,
+		"wordpress": nil,
 	}, nil)
 }
 


### PR DESCRIPTION
## Description of change

Entities responsible for pin and unpin requests are passed as strings behind the API boundary. At the API client, they are still passed as tags.

For all pin/unpin usages, the pinned applications are represented as application names instead of application tags.

## QA steps

Ensure leadership pinning, unpinning and expiry work as before:

- Bootstrap to LXD.
- `juju deploy redis`.
- `juju add-unit redis`.
- `juju upgrade-series prepare 0` and confirm.
- `juju upgrade-series prepare 1` and confirm.
- The leader should be redis/0. Run `upgrade-series complete 0`
- Stop the container for machine 0 with `lxc stop {container ID}`.
- Watch `juju status` for a while to ensure that leadership does not change from redis/0, even though the machine is down.
- `juju upgrade-series complete 1`
- After a moment, leadership should change to redis/1.

## Documentation changes

None

## Bug reference

N/A
