### PR TITLE
Swaps machine and sub-command arguments for upgrade-series command.

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -78,7 +78,7 @@ type upgradeSeriesCommand struct {
 
 	upgradeMachineSeriesClient UpgradeMachineSeriesAPI
 
-	prepCommand   string
+	subCommand    string
 	force         bool
 	machineNumber string
 	series        string
@@ -116,17 +116,17 @@ Examples:
 
 Prepare <machine> for upgrade to series <series>:
 
-	juju upgrade-series prepare <machine> <series>
+	juju upgrade-series <machine> prepare <series>
 
 Prepare <machine> for upgrade to series <series> even if there are applications
 running units that do not support the target series:
 
-	juju upgrade-series prepare <machine> <series> --force
+	juju upgrade-series <machine> prepare <series> --force
 
 Complete upgrade of <machine> to <series> indicating that all automatic and any
 necessary manual upgrade steps have completed successfully:
 
-	juju upgrade-series complete <machine>
+	juju upgrade-series <machine> complete
 
 See also:
     machines
@@ -138,8 +138,8 @@ See also:
 func (c *upgradeSeriesCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upgrade-series",
-		Args:    "<command> [args]",
-		Purpose: "Upgrade a machine's series.",
+		Args:    "<machine number> <command> [args]",
+		Purpose: "Upgrade the Ubuntu series of a machine.",
 		Doc:     upgradeSeriesDoc,
 	}
 }
@@ -155,34 +155,31 @@ func (c *upgradeSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init implements cmd.Command.
 func (c *upgradeSeriesCommand) Init(args []string) error {
-	numArguments := 3
-
 	if len(args) < 1 {
 		return errors.Errorf("wrong number of arguments")
 	}
 
-	prepCommandStrings := []string{PrepareCommand, CompleteCommand}
-	prepCommand, err := checkPrepCommands(prepCommandStrings, args[0])
+	subCommand, err := checkSubCommands([]string{PrepareCommand, CompleteCommand}, args[1])
 	if err != nil {
 		return errors.Annotate(err, "invalid argument")
 	}
-	c.prepCommand = prepCommand
+	c.subCommand = subCommand
 
-	if c.prepCommand == CompleteCommand {
+	numArguments := 3
+	if c.subCommand == CompleteCommand {
 		numArguments = 2
 	}
-
 	if len(args) != numArguments {
 		return errors.Errorf("wrong number of arguments")
 	}
 
-	if names.IsValidMachine(args[1]) {
-		c.machineNumber = args[1]
+	if names.IsValidMachine(args[0]) {
+		c.machineNumber = args[0]
 	} else {
-		return errors.Errorf("%q is an invalid machine name", args[1])
+		return errors.Errorf("%q is an invalid machine name", args[0])
 	}
 
-	if c.prepCommand == PrepareCommand {
+	if c.subCommand == PrepareCommand {
 		s, err := checkSeries(series.SupportedSeries(), args[2])
 		if err != nil {
 			return err
@@ -195,13 +192,13 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 
 // Run implements cmd.Run.
 func (c *upgradeSeriesCommand) Run(ctx *cmd.Context) error {
-	if c.prepCommand == PrepareCommand {
+	if c.subCommand == PrepareCommand {
 		err := c.UpgradeSeriesPrepare(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	}
-	if c.prepCommand == CompleteCommand {
+	if c.subCommand == CompleteCommand {
 		err := c.UpgradeSeriesComplete(ctx)
 		if err != nil {
 			return errors.Trace(err)
@@ -377,15 +374,15 @@ func (c *upgradeSeriesCommand) ensureAPIClient() (api.Connection, error) {
 	return apiRoot, nil
 }
 
-func checkPrepCommands(prepCommands []string, argCommand string) (string, error) {
-	for _, prepCommand := range prepCommands {
-		if prepCommand == argCommand {
-			return prepCommand, nil
+func checkSubCommands(validCommands []string, argCommand string) (string, error) {
+	for _, subCommand := range validCommands {
+		if subCommand == argCommand {
+			return subCommand, nil
 		}
 	}
 
 	return "", errors.Errorf("%q is an invalid upgrade-series command; valid commands are: %s.",
-		argCommand, strings.Join(prepCommands, ", "))
+		argCommand, strings.Join(validCommands, ", "))
 }
 
 func checkSeries(supportedSeries []string, seriesArgument string) (string, error) {

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -114,19 +114,19 @@ run beforehand.
 
 Examples:
 
-Prepare <machine> for upgrade to series <series>:
+Prepare machine 3 for upgrade to series "bionic"":
 
-	juju upgrade-series <machine> prepare <series>
+	juju upgrade-series 3 prepare bionic
 
-Prepare <machine> for upgrade to series <series> even if there are applications
+Prepare machine 4 for upgrade to series "cosmic" even if there are applications
 running units that do not support the target series:
 
-	juju upgrade-series <machine> prepare <series> --force
+	juju upgrade-series 4 prepare cosmic --force
 
-Complete upgrade of <machine> to <series> indicating that all automatic and any
+Complete upgrade of machine 5, indicating that all automatic and any
 necessary manual upgrade steps have completed successfully:
 
-	juju upgrade-series <machine> complete
+	juju upgrade-series 5 complete
 
 See also:
     machines

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -138,7 +138,7 @@ See also:
 func (c *upgradeSeriesCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upgrade-series",
-		Args:    "<machine number> <command> [args]",
+		Args:    "<machine> <command> [args]",
 		Purpose: "Upgrade the Ubuntu series of a machine.",
 		Doc:     upgradeSeriesDoc,
 	}

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -81,75 +81,75 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(
 
 func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
 	s.prepareExpectation = &upgradeSeriesPrepareExpectation{machineArg, seriesArg, gomock.Eq(false)}
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg)
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptForceOption(c *gc.C) {
 	s.prepareExpectation = &upgradeSeriesPrepareExpectation{machineArg, seriesArg, gomock.Eq(true)}
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "--force")
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, seriesArg, "--force")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAbortOnFailedConfirmation(c *gc.C) {
-	_, err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machine.PrepareCommand, machineArg, seriesArg)
+	_, err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, gc.ErrorMatches, "upgrade series: aborted")
 }
 
 func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidPrepCommands(c *gc.C) {
 	invalidPrepCommand := "actuate"
-	err := s.runUpgradeSeriesCommand(c, invalidPrepCommand, machineArg, seriesArg)
+	err := s.runUpgradeSeriesCommand(c, machineArg, invalidPrepCommand, seriesArg)
 	c.Assert(err, gc.ErrorMatches,
 		".* \"actuate\" is an invalid upgrade-series command; valid commands are: prepare, complete.")
 }
 
 func (s *UpgradeSeriesSuite) TestUpgradeCommandShouldNotAcceptInvalidMachineArgs(c *gc.C) {
 	invalidMachineArg := "machine5"
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, invalidMachineArg, seriesArg)
+	err := s.runUpgradeSeriesCommand(c, invalidMachineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, gc.ErrorMatches, "\"machine5\" is an invalid machine name")
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldOnlyAcceptSupportedSeries(c *gc.C) {
 	BadSeries := "Combative Caribou"
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, BadSeries)
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, BadSeries)
 	c.Assert(err, gc.ErrorMatches, ".* is an unsupported series")
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldSupportSeriesRegardlessOfCase(c *gc.C) {
 	capitalizedCaseXenial := "Xenial"
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, capitalizedCaseXenial)
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, capitalizedCaseXenial)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestCompleteCommand(c *gc.C) {
 	s.completeExpectation.machineNumber = machineArg
-	err := s.runUpgradeSeriesCommand(c, machine.CompleteCommand, machineArg)
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.CompleteCommand)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestCompleteCommandDoesNotAcceptSeries(c *gc.C) {
-	err := s.runUpgradeSeriesCommand(c, machine.CompleteCommand, machineArg, seriesArg)
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.CompleteCommand, seriesArg)
 	c.Assert(err, gc.ErrorMatches, "wrong number of arguments")
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYes(c *gc.C) {
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "--yes")
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, seriesArg, "--yes")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesAbbreviation(c *gc.C) {
-	err := s.runUpgradeSeriesCommand(c, machine.PrepareCommand, machineArg, seriesArg, "-y")
+	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, seriesArg, "-y")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c *gc.C) {
-	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machine.PrepareCommand, machineArg, seriesArg)
+	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), jc.HasSuffix, "Continue [y/N]?")
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesFlagAndNotPrompt(c *gc.C) {
-	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machine.PrepareCommand, machineArg, seriesArg, "-y")
+	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "n", machineArg, machine.PrepareCommand, seriesArg, "-y")
 	c.Assert(err, jc.ErrorIsNil)
 
 	//There is no confirmation message since the `-y/--yes` flag is being used to avoid the prompt.


### PR DESCRIPTION
## Description of change

This patch changes the upgrade-series syntax so that the machine comes before the sub-command instead of after.

## QA steps

- Bootstrap and add a machine.
- `juju upgrade-series 0 prepare cosmic`.
- `juju upgrade-series 0 complete`.
- Check that command tab-completion works.

## Documentation changes

Yes.

## Bug reference

None.
