### PR TITLE
Fix caas application status after migration.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -394,11 +394,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:ba62299b1d56575e42082da41af1f66fdefc4ba4615d08c04031374a679dfcf5"
+  digest = "1:3f92a18fd624b90c1984b09a665775f2ff437b48c30d2ee40e0e6197670489d9"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "e4124cce3eacd96776497aa4868fb864bf309ef5"
+  revision = "16527177881d2374d8bf776106fb20672bd03872"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "e4124cce3eacd96776497aa4868fb864bf309ef5"
+  revision = "16527177881d2374d8bf776106fb20672bd03872"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/application.go
+++ b/state/application.go
@@ -2451,6 +2451,7 @@ type addApplicationOpsArgs struct {
 	// These are nil when adding a new application, and most likely
 	// non-nil when migrating.
 	leadershipSettings map[string]interface{}
+	operatorStatus     *statusDoc
 }
 
 // addApplicationOps returns the operations required to add an application to the
@@ -2485,7 +2486,11 @@ func addApplicationOps(mb modelBackend, app *Application, args addApplicationOps
 		return nil, errors.Trace(err)
 	}
 	if model.Type() == ModelTypeCAAS {
-		ops = append(ops, createStatusOp(mb, applicationGlobalOperatorKey(app.Name()), args.statusDoc))
+		operatorStatusDoc := args.statusDoc
+		if args.operatorStatus != nil {
+			operatorStatusDoc = *args.operatorStatus
+		}
+		ops = append(ops, createStatusOp(mb, applicationGlobalOperatorKey(app.Name()), operatorStatusDoc))
 	}
 
 	ops = append(ops, charmRefOps...)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -743,15 +743,14 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	exApplication.SetStatusHistory(e.statusHistoryArgs(globalKey))
 	exApplication.SetAnnotations(e.getAnnotations(globalKey))
 
-	// TODO(caas) - Actually use the exported application operator details and status history.
-	// Currently these are only grabbed to make the MigrationExportSuite tests happy.
 	globalAppWorkloadKey := applicationGlobalOperatorKey(appName)
-	_, err = e.statusArgs(globalAppWorkloadKey)
+	operatorStatusArgs, err := e.statusArgs(globalAppWorkloadKey)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return errors.Annotatef(err, "application operator status for applucation %s", appName)
+			return errors.Annotatef(err, "application operator status for application %s", appName)
 		}
 	}
+	exApplication.SetOperatorStatus(operatorStatusArgs)
 	e.statusHistoryArgs(globalAppWorkloadKey)
 
 	constraintsArgs, err := e.constraintsArgs(globalKey)
@@ -1557,11 +1556,16 @@ func (e *exporter) statusArgs(globalKey string) (description.StatusArgs, error) 
 	if !ok {
 		return result, errors.Errorf("expected int64 for updated, got %T", statusDoc["updated"])
 	}
+	neverset, ok := statusDoc["neverset"].(bool)
+	if !ok {
+		return result, errors.Errorf("expected neverset for updated, got %T", statusDoc["neverset"])
+	}
 
 	result.Value = status
 	result.Message = info
 	result.Data = dataMap
 	result.Updated = time.Unix(0, updated)
+	result.NeverSet = neverset
 	return result, nil
 }
 


### PR DESCRIPTION
## Description of change

This branch fixes the application status shown after a migration.
It also ensures that the operator status is migrated (for caas applications)
as well as the neverset field of Status.

## QA steps

  - Bootstrap 2x controllers
  - Deploy some caas applications
  - Check status of application is active
  - Migrate the model to the other controller 
  - Once complete check the status of the application is active.

