### PR TITLE
Replace oracle cloud with new oci provider

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -253,17 +253,15 @@ clouds:
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
   oracle:
-    type: oracle
-    description: Oracle Cloud
-    auth-types: [ userpass ]
+    type: oci
+    description: Oracle Cloud Infrastructure
+    auth-types: [ httpsig ]
     regions:
-      uscom-central-1:
-        endpoint: https://compute.uscom-central-1.oraclecloud.com
-      us2:
-        endpoint: https://compute.uscom-central-1.oraclecloud.com
-      us6:
-        endpoint: https://compute.us6.oraclecloud.com
-      em2:
-        endpoint: https://compute.em2.oraclecloud.com
-      em3:
-        endpoint: https://compute.em3.oraclecloud.com
+      us-phoenix-1:
+        endpoint: https://iaas.us-phoenix-1.oraclecloud.com
+      us-ashburn-1:
+        endpoint: https://iaas.us-ashburn-1.oraclecloud.com
+      eu-frankfurt-1:
+        endpoint: https://iaas.eu-frankfurt-1.oraclecloud.com
+      uk-london-1:
+        endpoint: https://iaas.uk-london-1.oraclecloud.com

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -260,18 +260,16 @@ clouds:
       zrh:
         endpoint: https://zrh.cloudsigma.com/api/2.0/
   oracle:
-    type: oracle
-    description: Oracle Cloud
-    auth-types: [ userpass ]
+    type: oci
+    description: Oracle Cloud Infrastructure
+    auth-types: [ httpsig ]
     regions:
-      uscom-central-1:
-        endpoint: https://compute.uscom-central-1.oraclecloud.com
-      us2:
-        endpoint: https://compute.uscom-central-1.oraclecloud.com
-      us6:
-        endpoint: https://compute.us6.oraclecloud.com
-      em2:
-        endpoint: https://compute.em2.oraclecloud.com
-      em3:
-        endpoint: https://compute.em3.oraclecloud.com
+      us-phoenix-1:
+        endpoint: https://iaas.us-phoenix-1.oraclecloud.com
+      us-ashburn-1:
+        endpoint: https://iaas.us-ashburn-1.oraclecloud.com
+      eu-frankfurt-1:
+        endpoint: https://iaas.eu-frankfurt-1.oraclecloud.com
+      uk-london-1:
+        endpoint: https://iaas.uk-london-1.oraclecloud.com
 `

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -56,7 +56,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london           openstack   Openstack Cloud`)
+	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london         openstack   Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {


### PR DESCRIPTION
## Description of change

The new Oracle OCI provider should be what Juju now uses for the "oracle" cloud.

## QA steps

run juju clouds

## Documentation changes

The doc referencing our supported clouds needs updating.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1800892
