### PR TITLE
Openstack provider learns to react to an invalid cloud credential.

### DIFF
--- a/provider/openstack/errors.go
+++ b/provider/openstack/errors.go
@@ -1,0 +1,18 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"github.com/juju/errors"
+	gooseerrors "gopkg.in/goose.v2/errors"
+)
+
+// IsAuthorisationFailure determines if the given error has an authorisation failure.
+func IsAuthorisationFailure(err error) bool {
+	// This should cover most cases.
+	if gooseerrors.IsUnauthorised(errors.Cause(err)) {
+		return true
+	}
+	return false
+}

--- a/provider/openstack/errors_test.go
+++ b/provider/openstack/errors_test.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	gooseerrors "gopkg.in/goose.v2/errors"
+
+	"github.com/juju/juju/testing"
+)
+
+type ErrorSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ErrorSuite{})
+
+func (s *ErrorSuite) TestIsUnauthorisedError(c *gc.C) {
+	e := gooseerrors.NewUnauthorisedf(nil, "", "not on")
+	c.Assert(IsAuthorisationFailure(e), jc.IsTrue)
+	c.Assert(IsAuthorisationFailure(errors.Cause(e)), jc.IsTrue)
+
+	traced := errors.Trace(e)
+	c.Assert(IsAuthorisationFailure(traced), jc.IsTrue)
+
+	annotated := errors.Annotatef(e, "more and more")
+	c.Assert(IsAuthorisationFailure(annotated), jc.IsTrue)
+}
+
+func (s *ErrorSuite) TestIsNotUnauthorisedErro(c *gc.C) {
+	e := errors.New("fluffy")
+	c.Assert(IsAuthorisationFailure(e), jc.IsFalse)
+
+	c.Assert(IsAuthorisationFailure(nil), jc.IsFalse)
+}

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/goose.v2/swift"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	envstorage "github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
@@ -60,17 +61,17 @@ func (fakeNamespace) Value(s string) string {
 	return "juju-" + s
 }
 
-func SetUpGlobalGroup(e environs.Environ, name string, apiPort int) (neutron.SecurityGroupV2, error) {
+func SetUpGlobalGroup(e environs.Environ, ctx context.ProviderCallContext, name string, apiPort int) (neutron.SecurityGroupV2, error) {
 	switching := e.(*Environ).firewaller.(*switchingFirewaller)
-	if err := switching.initFirewaller(); err != nil {
+	if err := switching.initFirewaller(ctx); err != nil {
 		return neutron.SecurityGroupV2{}, err
 	}
 	return switching.fw.(*neutronFirewaller).setUpGlobalGroup(name, apiPort)
 }
 
-func EnsureGroup(e environs.Environ, name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
+func EnsureGroup(e environs.Environ, ctx context.ProviderCallContext, name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
 	switching := e.(*Environ).firewaller.(*switchingFirewaller)
-	if err := switching.initFirewaller(); err != nil {
+	if err := switching.initFirewaller(ctx); err != nil {
 		return neutron.SecurityGroupV2{}, err
 	}
 	return switching.fw.(*neutronFirewaller).ensureGroup(name, rules)
@@ -86,12 +87,12 @@ func MachineGroupName(e environs.Environ, controllerUUID, machineId string) stri
 	return switching.fw.(*neutronFirewaller).machineGroupName(controllerUUID, machineId)
 }
 
-func MatchingGroup(e environs.Environ, nameRegExp string) (neutron.SecurityGroupV2, error) {
+func MatchingGroup(e environs.Environ, ctx context.ProviderCallContext, nameRegExp string) (neutron.SecurityGroupV2, error) {
 	switching := e.(*Environ).firewaller.(*switchingFirewaller)
-	if err := switching.initFirewaller(); err != nil {
+	if err := switching.initFirewaller(ctx); err != nil {
 		return neutron.SecurityGroupV2{}, err
 	}
-	return switching.fw.(*neutronFirewaller).matchingGroup(nameRegExp)
+	return switching.fw.(*neutronFirewaller).matchingGroup(ctx, nameRegExp)
 }
 
 // ImageMetadataStorage returns a Storage object pointing where the goose

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
 )
 
 const (
@@ -99,7 +100,7 @@ type switchingFirewaller struct {
 	fw Firewaller
 }
 
-func (f *switchingFirewaller) initFirewaller() error {
+func (f *switchingFirewaller) initFirewaller(ctx context.ProviderCallContext) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.fw != nil {
@@ -109,6 +110,7 @@ func (f *switchingFirewaller) initFirewaller() error {
 	client := f.env.client()
 	if !client.IsAuthenticated() {
 		if err := authenticateClient(client); err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return errors.Trace(err)
 		}
 	}
@@ -122,84 +124,84 @@ func (f *switchingFirewaller) initFirewaller() error {
 }
 
 func (f *switchingFirewaller) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.OpenPorts(ctx, rules)
 }
 
 func (f *switchingFirewaller) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.ClosePorts(ctx, rules)
 }
 
 func (f *switchingFirewaller) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return f.fw.IngressRules(ctx)
 }
 
 func (f *switchingFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.DeleteAllModelGroups(ctx)
 }
 
 func (f *switchingFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallContext, controllerUUID string) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.DeleteAllControllerGroups(ctx, controllerUUID)
 }
 
 func (f *switchingFirewaller) DeleteGroups(ctx context.ProviderCallContext, names ...string) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.DeleteGroups(ctx, names...)
 }
 
 func (f *switchingFirewaller) UpdateGroupController(ctx context.ProviderCallContext, controllerUUID string) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.UpdateGroupController(ctx, controllerUUID)
 }
 
 func (f *switchingFirewaller) GetSecurityGroups(ctx context.ProviderCallContext, ids ...instance.Id) ([]string, error) {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return f.fw.GetSecurityGroups(ctx, ids...)
 }
 
 func (f *switchingFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error) {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return f.fw.SetUpGroups(ctx, controllerUUID, machineId, apiPort)
 }
 
 func (f *switchingFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instance.Instance, machineId string, rules []network.IngressRule) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.OpenInstancePorts(ctx, inst, machineId, rules)
 }
 
 func (f *switchingFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instance.Instance, machineId string, rules []network.IngressRule) error {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return f.fw.CloseInstancePorts(ctx, inst, machineId, rules)
 }
 
 func (f *switchingFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instance.Instance, machineId string) ([]network.IngressRule, error) {
-	if err := f.initFirewaller(); err != nil {
+	if err := f.initFirewaller(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return f.fw.InstanceIngressRules(ctx, inst, machineId)
@@ -230,6 +232,7 @@ func (c *firewallerBase) GetSecurityGroups(ctx context.ProviderCallContext, ids 
 			}
 			groups, err := novaClient.GetServerSecurityGroups(string(inst.Id()))
 			if err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 				return nil, errors.Trace(err)
 			}
 			for _, group := range groups {
@@ -256,18 +259,20 @@ func instServerId(inst instance.Instance) (string, error) {
 }
 
 func deleteSecurityGroupsMatchingName(
-	deleteSecurityGroups func(match func(name string) bool) error,
+	ctx context.ProviderCallContext,
+	deleteSecurityGroups func(ctx context.ProviderCallContext, match func(name string) bool) error,
 	prefix string,
 ) error {
 	re, err := regexp.Compile("^" + prefix)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return deleteSecurityGroups(re.MatchString)
+	return deleteSecurityGroups(ctx, re.MatchString)
 }
 
 func deleteSecurityGroupsOneOfNames(
-	deleteSecurityGroups func(match func(name string) bool) error,
+	ctx context.ProviderCallContext,
+	deleteSecurityGroups func(ctx context.ProviderCallContext, match func(name string) bool) error,
 	names ...string,
 ) error {
 	match := func(check string) bool {
@@ -278,7 +283,7 @@ func deleteSecurityGroupsOneOfNames(
 		}
 		return false
 	}
-	return deleteSecurityGroups(match)
+	return deleteSecurityGroups(ctx, match)
 }
 
 // deleteSecurityGroup attempts to delete the security group. Should it fail,
@@ -291,6 +296,7 @@ func deleteSecurityGroupsOneOfNames(
 // has it around internally. To attempt to catch this timing issue, deletion
 // of the groups is tried multiple times.
 func deleteSecurityGroup(
+	ctx context.ProviderCallContext,
 	deleteSecurityGroupById func(string) error,
 	name, id string,
 	clock clock.Clock,
@@ -298,7 +304,11 @@ func deleteSecurityGroup(
 	logger.Debugf("deleting security group %q", name)
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
-			return deleteSecurityGroupById(id)
+			if err := deleteSecurityGroupById(id); err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				return errors.Trace(err)
+			}
+			return nil
 		},
 		NotifyFunc: func(err error, attempt int) {
 			if attempt%4 == 0 {
@@ -319,14 +329,15 @@ func deleteSecurityGroup(
 }
 
 func (c *firewallerBase) openPorts(
-	openPortsInGroup func(string, []network.IngressRule) error,
+	ctx context.ProviderCallContext,
+	openPortsInGroup func(context.ProviderCallContext, string, []network.IngressRule) error,
 	rules []network.IngressRule,
 ) error {
 	if c.environ.Config().FirewallMode() != config.FwGlobal {
 		return errors.Errorf("invalid firewall mode %q for opening ports on model",
 			c.environ.Config().FirewallMode())
 	}
-	if err := openPortsInGroup(c.globalGroupRegexp(), rules); err != nil {
+	if err := openPortsInGroup(ctx, c.globalGroupRegexp(), rules); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Infof("opened ports in global group: %v", rules)
@@ -334,14 +345,15 @@ func (c *firewallerBase) openPorts(
 }
 
 func (c *firewallerBase) closePorts(
-	closePortsInGroup func(string, []network.IngressRule) error,
+	ctx context.ProviderCallContext,
+	closePortsInGroup func(context.ProviderCallContext, string, []network.IngressRule) error,
 	rules []network.IngressRule,
 ) error {
 	if c.environ.Config().FirewallMode() != config.FwGlobal {
 		return errors.Errorf("invalid firewall mode %q for closing ports on model",
 			c.environ.Config().FirewallMode())
 	}
-	if err := closePortsInGroup(c.globalGroupRegexp(), rules); err != nil {
+	if err := closePortsInGroup(ctx, c.globalGroupRegexp(), rules); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Infof("closed ports in global group: %v", rules)
@@ -349,22 +361,24 @@ func (c *firewallerBase) closePorts(
 }
 
 func (c *firewallerBase) ingressRules(
-	ingressRulesInGroup func(string) ([]network.IngressRule, error),
+	ctx context.ProviderCallContext,
+	ingressRulesInGroup func(context.ProviderCallContext, string) ([]network.IngressRule, error),
 ) ([]network.IngressRule, error) {
 	if c.environ.Config().FirewallMode() != config.FwGlobal {
 		return nil, errors.Errorf("invalid firewall mode %q for retrieving ingress rules from model",
 			c.environ.Config().FirewallMode())
 	}
-	return ingressRulesInGroup(c.globalGroupRegexp())
+	return ingressRulesInGroup(ctx, c.globalGroupRegexp())
 }
 
 func (c *firewallerBase) openInstancePorts(
-	openPortsInGroup func(string, []network.IngressRule) error,
+	ctx context.ProviderCallContext,
+	openPortsInGroup func(context.ProviderCallContext, string, []network.IngressRule) error,
 	machineId string,
 	rules []network.IngressRule,
 ) error {
 	nameRegexp := c.machineGroupRegexp(machineId)
-	if err := openPortsInGroup(nameRegexp, rules); err != nil {
+	if err := openPortsInGroup(ctx, nameRegexp, rules); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Infof("opened ports in security group %s-%s: %v", c.environ.Config().UUID(), machineId, rules)
@@ -372,12 +386,13 @@ func (c *firewallerBase) openInstancePorts(
 }
 
 func (c *firewallerBase) closeInstancePorts(
-	closePortsInGroup func(string, []network.IngressRule) error,
+	ctx context.ProviderCallContext,
+	closePortsInGroup func(context.ProviderCallContext, string, []network.IngressRule) error,
 	machineId string,
 	rules []network.IngressRule,
 ) error {
 	nameRegexp := c.machineGroupRegexp(machineId)
-	if err := closePortsInGroup(nameRegexp, rules); err != nil {
+	if err := closePortsInGroup(ctx, nameRegexp, rules); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Infof("closed ports in security group %s-%s: %v", c.environ.Config().UUID(), machineId, rules)
@@ -385,11 +400,12 @@ func (c *firewallerBase) closeInstancePorts(
 }
 
 func (c *firewallerBase) instanceIngressRules(
-	ingressRulesInGroup func(string) ([]network.IngressRule, error),
+	ctx context.ProviderCallContext,
+	ingressRulesInGroup func(context.ProviderCallContext, string) ([]network.IngressRule, error),
 	machineId string,
 ) ([]network.IngressRule, error) {
 	nameRegexp := c.machineGroupRegexp(machineId)
-	portRanges, err := ingressRulesInGroup(nameRegexp)
+	portRanges, err := ingressRulesInGroup(ctx, nameRegexp)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -455,6 +471,7 @@ func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, control
 		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), nil)
 	}
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	groups := []string{jujuGroup.Name, machineGroup.Name}
@@ -673,15 +690,17 @@ func newRuleInfoSetFromRuleInfo(rules []neutron.RuleInfoV2) ruleInfoSet {
 	return m
 }
 
-func (c *neutronFirewaller) deleteSecurityGroups(match func(name string) bool) error {
+func (c *neutronFirewaller) deleteSecurityGroups(ctx context.ProviderCallContext, match func(name string) bool) error {
 	neutronClient := c.environ.neutron()
 	securityGroups, err := neutronClient.ListSecurityGroupsV2()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "cannot list security groups")
 	}
 	for _, group := range securityGroups {
 		if match(group.Name) {
 			deleteSecurityGroup(
+				ctx,
 				neutronClient.DeleteSecurityGroupV2,
 				group.Name,
 				group.Id,
@@ -694,17 +713,17 @@ func (c *neutronFirewaller) deleteSecurityGroups(match func(name string) bool) e
 
 // DeleteGroups implements Firewaller interface.
 func (c *neutronFirewaller) DeleteGroups(ctx context.ProviderCallContext, names ...string) error {
-	return deleteSecurityGroupsOneOfNames(c.deleteSecurityGroups, names...)
+	return deleteSecurityGroupsOneOfNames(ctx, c.deleteSecurityGroups, names...)
 }
 
 // DeleteAllControllerGroups implements Firewaller interface.
 func (c *neutronFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallContext, controllerUUID string) error {
-	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuControllerGroupPrefix(controllerUUID))
+	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuControllerGroupPrefix(controllerUUID))
 }
 
 // DeleteAllModelGroups implements Firewaller interface.
 func (c *neutronFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
-	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuGroupRegexp())
+	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuGroupRegexp())
 }
 
 // UpdateGroupController implements Firewaller interface.
@@ -712,10 +731,12 @@ func (c *neutronFirewaller) UpdateGroupController(ctx context.ProviderCallContex
 	neutronClient := c.environ.neutron()
 	groups, err := neutronClient.ListSecurityGroupsV2()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
 	}
 	re, err := regexp.Compile(c.jujuGroupRegexp())
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
 	}
 
@@ -728,6 +749,11 @@ func (c *neutronFirewaller) UpdateGroupController(ctx context.ProviderCallContex
 		if err != nil {
 			logger.Errorf("error updating controller for security group %s: %v", group.Id, err)
 			failed = append(failed, group.Id)
+			if common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx) {
+				// No need to continue here since we will 100% fail with an invalid credential.
+				break
+			}
+
 		}
 	}
 	if len(failed) != 0 {
@@ -748,17 +774,32 @@ func (c *neutronFirewaller) updateGroupControllerUUID(group *neutron.SecurityGro
 
 // OpenPorts implements Firewaller interface.
 func (c *neutronFirewaller) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
-	return c.openPorts(c.openPortsInGroup, rules)
+	err := c.openPorts(ctx, c.openPortsInGroup, rules)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // ClosePorts implements Firewaller interface.
 func (c *neutronFirewaller) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
-	return c.closePorts(c.closePortsInGroup, rules)
+	err := c.closePorts(ctx, c.closePortsInGroup, rules)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // IngressRules implements Firewaller interface.
 func (c *neutronFirewaller) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
-	return c.ingressRules(c.ingressRulesInGroup)
+	rules, err := c.ingressRules(ctx, c.ingressRulesInGroup)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return rules, errors.Trace(err)
+	}
+	return rules, nil
 }
 
 // OpenInstancePorts implements Firewaller interface.
@@ -774,7 +815,12 @@ func (c *neutronFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, i
 	if securityGroups := inst.(*openstackInstance).getServerDetail().Groups; securityGroups == nil {
 		return nil
 	}
-	return c.openInstancePorts(c.openPortsInGroup, machineId, ports)
+	err := c.openInstancePorts(ctx, c.openPortsInGroup, machineId, ports)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // CloseInstancePorts implements Firewaller interface.
@@ -790,7 +836,12 @@ func (c *neutronFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, 
 	if securityGroups := inst.(*openstackInstance).getServerDetail().Groups; securityGroups == nil {
 		return nil
 	}
-	return c.closeInstancePorts(c.closePortsInGroup, machineId, ports)
+	err := c.closeInstancePorts(ctx, c.closePortsInGroup, machineId, ports)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // InstanceIngressRules implements Firewaller interface.
@@ -806,13 +857,18 @@ func (c *neutronFirewaller) InstanceIngressRules(ctx context.ProviderCallContext
 	if securityGroups := inst.(*openstackInstance).getServerDetail().Groups; securityGroups == nil {
 		return []network.IngressRule{}, nil
 	}
-	return c.instanceIngressRules(c.ingressRulesInGroup, machineId)
+	rules, err := c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineId)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return rules, errors.Trace(err)
+	}
+	return rules, err
 }
 
 // Matching a security group by name only works if each name is unqiue.  Neutron
 // security groups are not required to have unique names.  Juju constructs unique
 // names, but there are frequently multiple matches to 'default'
-func (c *neutronFirewaller) matchingGroup(nameRegExp string) (neutron.SecurityGroupV2, error) {
+func (c *neutronFirewaller) matchingGroup(ctx context.ProviderCallContext, nameRegExp string) (neutron.SecurityGroupV2, error) {
 	re, err := regexp.Compile(nameRegExp)
 	if err != nil {
 		return neutron.SecurityGroupV2{}, err
@@ -820,6 +876,7 @@ func (c *neutronFirewaller) matchingGroup(nameRegExp string) (neutron.SecurityGr
 	neutronClient := c.environ.neutron()
 	allGroups, err := neutronClient.ListSecurityGroupsV2()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return neutron.SecurityGroupV2{}, err
 	}
 	var matchingGroups []neutron.SecurityGroupV2
@@ -837,8 +894,8 @@ func (c *neutronFirewaller) matchingGroup(nameRegExp string) (neutron.SecurityGr
 	return matchingGroups[0], nil
 }
 
-func (c *neutronFirewaller) openPortsInGroup(nameRegExp string, rules []network.IngressRule) error {
-	group, err := c.matchingGroup(nameRegExp)
+func (c *neutronFirewaller) openPortsInGroup(ctx context.ProviderCallContext, nameRegExp string, rules []network.IngressRule) error {
+	group, err := c.matchingGroup(ctx, nameRegExp)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -847,6 +904,7 @@ func (c *neutronFirewaller) openPortsInGroup(nameRegExp string, rules []network.
 	for _, rule := range ruleInfo {
 		_, err := neutronClient.CreateSecurityGroupRuleV2(rule)
 		if err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			// TODO: if err is not rule already exists, raise?
 			logger.Debugf("error creating security group rule: %v", err.Error())
 		}
@@ -880,11 +938,11 @@ func secGroupMatchesIngressRule(secGroupRule neutron.SecurityGroupRuleV2, rule n
 	return false
 }
 
-func (c *neutronFirewaller) closePortsInGroup(nameRegExp string, rules []network.IngressRule) error {
+func (c *neutronFirewaller) closePortsInGroup(ctx context.ProviderCallContext, nameRegExp string, rules []network.IngressRule) error {
 	if len(rules) == 0 {
 		return nil
 	}
-	group, err := c.matchingGroup(nameRegExp)
+	group, err := c.matchingGroup(ctx, nameRegExp)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -897,6 +955,7 @@ func (c *neutronFirewaller) closePortsInGroup(nameRegExp string, rules []network
 			}
 			err := neutronClient.DeleteSecurityGroupRuleV2(p.Id)
 			if err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 				return errors.Trace(err)
 			}
 			break
@@ -905,8 +964,8 @@ func (c *neutronFirewaller) closePortsInGroup(nameRegExp string, rules []network
 	return nil
 }
 
-func (c *neutronFirewaller) ingressRulesInGroup(nameRegexp string) (rules []network.IngressRule, err error) {
-	group, err := c.matchingGroup(nameRegexp)
+func (c *neutronFirewaller) ingressRulesInGroup(ctx context.ProviderCallContext, nameRegexp string) (rules []network.IngressRule, err error) {
+	group, err := c.matchingGroup(ctx, nameRegexp)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
 )
 
 type legacyNovaFirewaller struct {
@@ -31,16 +32,16 @@ type legacyNovaFirewaller struct {
 // In addition, a specific machine security group is created for each
 // machine, so that its firewall rules can be configured per machine.
 func (c *legacyNovaFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error) {
-	jujuGroup, err := c.setUpGlobalGroup(c.jujuGroupName(controllerUUID), apiPort)
+	jujuGroup, err := c.setUpGlobalGroup(ctx, c.jujuGroupName(controllerUUID), apiPort)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	var machineGroup nova.SecurityGroup
 	switch c.environ.Config().FirewallMode() {
 	case config.FwInstance:
-		machineGroup, err = c.ensureGroup(c.machineGroupName(controllerUUID, machineId), nil)
+		machineGroup, err = c.ensureGroup(ctx, c.machineGroupName(controllerUUID, machineId), nil)
 	case config.FwGlobal:
-		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), nil)
+		machineGroup, err = c.ensureGroup(ctx, c.globalGroupName(controllerUUID), nil)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -52,8 +53,8 @@ func (c *legacyNovaFirewaller) SetUpGroups(ctx context.ProviderCallContext, cont
 	return groupNames, nil
 }
 
-func (c *legacyNovaFirewaller) setUpGlobalGroup(groupName string, apiPort int) (nova.SecurityGroup, error) {
-	return c.ensureGroup(groupName,
+func (c *legacyNovaFirewaller) setUpGlobalGroup(ctx context.ProviderCallContext, groupName string, apiPort int) (nova.SecurityGroup, error) {
+	return c.ensureGroup(ctx, groupName,
 		[]nova.RuleInfo{
 			{
 				IPProtocol: "tcp",
@@ -91,11 +92,12 @@ var legacyZeroGroup nova.SecurityGroup
 // ensureGroup returns the security group with name and perms.
 // If a group with name does not exist, one will be created.
 // If it exists, its permissions are set to perms.
-func (c *legacyNovaFirewaller) ensureGroup(name string, rules []nova.RuleInfo) (nova.SecurityGroup, error) {
+func (c *legacyNovaFirewaller) ensureGroup(ctx context.ProviderCallContext, name string, rules []nova.RuleInfo) (nova.SecurityGroup, error) {
 	novaClient := c.environ.nova()
 	// First attempt to look up an existing group by name.
 	group, err := novaClient.SecurityGroupByName(name)
 	if err == nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		// Group exists, so assume it is correctly set up and return it.
 		// TODO(jam): 2013-09-18 http://pad.lv/121795
 		// We really should verify the group is set up correctly,
@@ -112,6 +114,7 @@ func (c *legacyNovaFirewaller) ensureGroup(name string, rules []nova.RuleInfo) (
 			// We just tried to create a duplicate group, so load the existing group.
 			group, err = novaClient.SecurityGroupByName(name)
 			if err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 				return legacyZeroGroup, err
 			}
 			return *group, nil
@@ -130,6 +133,7 @@ func (c *legacyNovaFirewaller) ensureGroup(name string, rules []nova.RuleInfo) (
 		}
 		groupRule, err := novaClient.CreateSecurityGroupRule(rule)
 		if err != nil && !gooseerrors.IsDuplicateValue(err) {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return legacyZeroGroup, err
 		}
 		group.Rules[i] = *groupRule
@@ -137,15 +141,16 @@ func (c *legacyNovaFirewaller) ensureGroup(name string, rules []nova.RuleInfo) (
 	return *group, nil
 }
 
-func (c *legacyNovaFirewaller) deleteSecurityGroups(match func(name string) bool) error {
+func (c *legacyNovaFirewaller) deleteSecurityGroups(ctx context.ProviderCallContext, match func(name string) bool) error {
 	novaclient := c.environ.nova()
 	securityGroups, err := novaclient.ListSecurityGroups()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "cannot list security groups")
 	}
 	for _, group := range securityGroups {
 		if match(group.Name) {
-			deleteSecurityGroup(
+			deleteSecurityGroup(ctx,
 				novaclient.DeleteSecurityGroup,
 				group.Name,
 				group.Id,
@@ -158,17 +163,17 @@ func (c *legacyNovaFirewaller) deleteSecurityGroups(match func(name string) bool
 
 // DeleteAllControllerGroups implements Firewaller interface.
 func (c *legacyNovaFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallContext, controllerUUID string) error {
-	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuControllerGroupPrefix(controllerUUID))
+	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuControllerGroupPrefix(controllerUUID))
 }
 
 // DeleteAllModelGroups implements Firewaller interface.
 func (c *legacyNovaFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
-	return deleteSecurityGroupsMatchingName(c.deleteSecurityGroups, c.jujuGroupRegexp())
+	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuGroupRegexp())
 }
 
 // DeleteGroups implements Firewaller interface.
 func (c *legacyNovaFirewaller) DeleteGroups(ctx context.ProviderCallContext, names ...string) error {
-	return deleteSecurityGroupsOneOfNames(c.deleteSecurityGroups, names...)
+	return deleteSecurityGroupsOneOfNames(ctx, c.deleteSecurityGroups, names...)
 }
 
 // UpdateGroupController implements Firewaller interface.
@@ -176,6 +181,7 @@ func (c *legacyNovaFirewaller) UpdateGroupController(ctx context.ProviderCallCon
 	novaClient := c.environ.nova()
 	groups, err := novaClient.ListSecurityGroups()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
 	}
 	re, err := regexp.Compile(c.jujuGroupRegexp())
@@ -188,10 +194,14 @@ func (c *legacyNovaFirewaller) UpdateGroupController(ctx context.ProviderCallCon
 		if !re.MatchString(group.Name) {
 			continue
 		}
-		err := c.updateGroupControllerUUID(&group, controllerUUID)
+		err := c.updateGroupControllerUUID(ctx, &group, controllerUUID)
 		if err != nil {
 			logger.Errorf("error updating controller for security group %s: %v", group.Id, err)
 			failed = append(failed, group.Id)
+			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+				// We will keep failing 100% once the credential is deemed invalid - no point in persisting.
+				break
+			}
 		}
 	}
 	if len(failed) != 0 {
@@ -200,47 +210,48 @@ func (c *legacyNovaFirewaller) UpdateGroupController(ctx context.ProviderCallCon
 	return nil
 }
 
-func (c *legacyNovaFirewaller) updateGroupControllerUUID(group *nova.SecurityGroup, controllerUUID string) error {
+func (c *legacyNovaFirewaller) updateGroupControllerUUID(ctx context.ProviderCallContext, group *nova.SecurityGroup, controllerUUID string) error {
 	newName, err := replaceControllerUUID(group.Name, controllerUUID)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	client := c.environ.nova()
 	_, err = client.UpdateSecurityGroup(group.Id, newName, group.Description)
+	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 	return errors.Trace(err)
 }
 
 // OpenPorts implements Firewaller interface.
 func (c *legacyNovaFirewaller) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
-	return c.openPorts(c.openPortsInGroup, rules)
+	return c.openPorts(ctx, c.openPortsInGroup, rules)
 }
 
 // ClosePorts implements Firewaller interface.
 func (c *legacyNovaFirewaller) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
-	return c.closePorts(c.closePortsInGroup, rules)
+	return c.closePorts(ctx, c.closePortsInGroup, rules)
 }
 
 // IngressRules implements Firewaller interface.
 func (c *legacyNovaFirewaller) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
-	return c.ingressRules(c.ingressRulesInGroup)
+	return c.ingressRules(ctx, c.ingressRulesInGroup)
 }
 
 // OpenInstancePorts implements Firewaller interface.
 func (c *legacyNovaFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instance.Instance, machineId string, rules []network.IngressRule) error {
-	return c.openInstancePorts(c.openPortsInGroup, machineId, rules)
+	return c.openInstancePorts(ctx, c.openPortsInGroup, machineId, rules)
 }
 
 // CloseInstancePorts implements Firewaller interface.
 func (c *legacyNovaFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instance.Instance, machineId string, rules []network.IngressRule) error {
-	return c.closeInstancePorts(c.closePortsInGroup, machineId, rules)
+	return c.closeInstancePorts(ctx, c.closePortsInGroup, machineId, rules)
 }
 
 // InstanceIngressRules implements Firewaller interface.
 func (c *legacyNovaFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instance.Instance, machineId string) ([]network.IngressRule, error) {
-	return c.instanceIngressRules(c.ingressRulesInGroup, machineId)
+	return c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineId)
 }
 
-func (c *legacyNovaFirewaller) matchingGroup(nameRegExp string) (nova.SecurityGroup, error) {
+func (c *legacyNovaFirewaller) matchingGroup(ctx context.ProviderCallContext, nameRegExp string) (nova.SecurityGroup, error) {
 	re, err := regexp.Compile(nameRegExp)
 	if err != nil {
 		return nova.SecurityGroup{}, err
@@ -248,6 +259,7 @@ func (c *legacyNovaFirewaller) matchingGroup(nameRegExp string) (nova.SecurityGr
 	novaclient := c.environ.nova()
 	allGroups, err := novaclient.ListSecurityGroups()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nova.SecurityGroup{}, err
 	}
 	var matchingGroups []nova.SecurityGroup
@@ -265,8 +277,8 @@ func (c *legacyNovaFirewaller) matchingGroup(nameRegExp string) (nova.SecurityGr
 	return matchingGroups[0], nil
 }
 
-func (c *legacyNovaFirewaller) openPortsInGroup(nameRegExp string, rules []network.IngressRule) error {
-	group, err := c.matchingGroup(nameRegExp)
+func (c *legacyNovaFirewaller) openPortsInGroup(ctx context.ProviderCallContext, nameRegExp string, rules []network.IngressRule) error {
+	group, err := c.matchingGroup(ctx, nameRegExp)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -275,6 +287,7 @@ func (c *legacyNovaFirewaller) openPortsInGroup(nameRegExp string, rules []netwo
 	for _, rule := range ruleInfo {
 		_, err := novaclient.CreateSecurityGroupRule(legacyRuleInfo(rule))
 		if err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			// TODO: if err is not rule already exists, raise?
 			logger.Debugf("error creating security group rule: %v", err.Error())
 		}
@@ -302,11 +315,11 @@ func legacyRuleMatchesPortRange(rule nova.SecurityGroupRule, portRange network.I
 		*rule.ToPort == portRange.ToPort
 }
 
-func (c *legacyNovaFirewaller) closePortsInGroup(nameRegExp string, rules []network.IngressRule) error {
+func (c *legacyNovaFirewaller) closePortsInGroup(ctx context.ProviderCallContext, nameRegExp string, rules []network.IngressRule) error {
 	if len(rules) == 0 {
 		return nil
 	}
-	group, err := c.matchingGroup(nameRegExp)
+	group, err := c.matchingGroup(ctx, nameRegExp)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -318,6 +331,7 @@ func (c *legacyNovaFirewaller) closePortsInGroup(nameRegExp string, rules []netw
 			}
 			err := novaclient.DeleteSecurityGroupRule(p.Id)
 			if err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 				return errors.Trace(err)
 			}
 			break
@@ -326,8 +340,8 @@ func (c *legacyNovaFirewaller) closePortsInGroup(nameRegExp string, rules []netw
 	return nil
 }
 
-func (c *legacyNovaFirewaller) ingressRulesInGroup(nameRegexp string) (rules []network.IngressRule, err error) {
-	group, err := c.matchingGroup(nameRegexp)
+func (c *legacyNovaFirewaller) ingressRulesInGroup(ctx context.ProviderCallContext, nameRegexp string) (rules []network.IngressRule, err error) {
+	group, err := c.matchingGroup(ctx, nameRegexp)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -355,6 +369,7 @@ func (c *legacyNovaFirewaller) ingressRulesInGroup(nameRegexp string) (rules []n
 			portRange.ToPort,
 			*sourceCIDRs...)
 		if err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return nil, errors.Trace(err)
 		}
 		rules = append(rules, rule)

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -137,7 +137,7 @@ func (t *LiveTests) TestSetupGlobalGroupExposesCorrectPorts(c *gc.C) {
 	cleanup()
 	defer cleanup()
 	apiPort := 34567 // Default 17070
-	group, err := openstack.SetUpGlobalGroup(t.Env, groupName, apiPort)
+	group, err := openstack.SetUpGlobalGroup(t.Env, t.ProviderCallContext, groupName, apiPort)
 	c.Assert(err, jc.ErrorIsNil)
 	// We default to exporting 22, apiPort, and icmp/udp/tcp on
 	// all ports to other machines inside the same group

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1706,7 +1706,7 @@ func (s *localServerSuite) TestEnsureGroup(c *gc.C) {
 		},
 	}
 
-	group, err := openstack.EnsureGroup(s.env, "test group", rule)
+	group, err := openstack.EnsureGroup(s.env, s.callCtx, "test group", rule)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(group.Name, gc.Equals, "test group")
 
@@ -1742,7 +1742,7 @@ func (s *localServerSuite) TestEnsureGroup(c *gc.C) {
 			EthernetType: "IPv6",
 		},
 	}
-	group, err = openstack.EnsureGroup(s.env, "test group", rules)
+	group, err = openstack.EnsureGroup(s.env, s.callCtx, "test group", rules)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(group.Id, gc.Equals, id)
 	c.Assert(group.Name, gc.Equals, "test group")
@@ -1752,7 +1752,7 @@ func (s *localServerSuite) TestEnsureGroup(c *gc.C) {
 	c.Check(obtainedRulesSecondTime, jc.SameContents, expectedRules)
 
 	// 3rd time with same name, should be back to the original now
-	group, err = openstack.EnsureGroup(s.env, "test group", rule)
+	group, err = openstack.EnsureGroup(s.env, s.callCtx, "test group", rule)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(group.Id, gc.Equals, id)
 	c.Assert(group.Name, gc.Equals, "test group")
@@ -1776,24 +1776,24 @@ func (s *localServerSuite) TestMatchingGroup(c *gc.C) {
 	}
 
 	err := bootstrapEnv(c, s.env)
-	group1, err := openstack.EnsureGroup(s.env,
+	group1, err := openstack.EnsureGroup(s.env, s.callCtx,
 		openstack.MachineGroupName(s.env, s.ControllerUUID, "1"), rule)
 	c.Assert(err, jc.ErrorIsNil)
-	group2, err := openstack.EnsureGroup(s.env,
+	group2, err := openstack.EnsureGroup(s.env, s.callCtx,
 		openstack.MachineGroupName(s.env, s.ControllerUUID, "2"), rule)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = openstack.EnsureGroup(s.env, openstack.MachineGroupName(s.env, s.ControllerUUID, "11"), rule)
+	_, err = openstack.EnsureGroup(s.env, s.callCtx, openstack.MachineGroupName(s.env, s.ControllerUUID, "11"), rule)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = openstack.EnsureGroup(s.env, openstack.MachineGroupName(s.env, s.ControllerUUID, "12"), rule)
+	_, err = openstack.EnsureGroup(s.env, s.callCtx, openstack.MachineGroupName(s.env, s.ControllerUUID, "12"), rule)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineNameRegexp := openstack.MachineGroupRegexp(s.env, "1")
-	groupMatched, err := openstack.MatchingGroup(s.env, machineNameRegexp)
+	groupMatched, err := openstack.MatchingGroup(s.env, s.callCtx, machineNameRegexp)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(group1.Id, gc.Equals, groupMatched.Id)
 
 	machineNameRegexp = openstack.MachineGroupRegexp(s.env, "2")
-	groupMatched, err = openstack.MatchingGroup(s.env, machineNameRegexp)
+	groupMatched, err = openstack.MatchingGroup(s.env, s.callCtx, machineNameRegexp)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(group2.Id, gc.Equals, groupMatched.Id)
 }


### PR DESCRIPTION
## Description of change

Juju uses cloud credentials stored on the controller against a model to communicate with the underlying cloud.
However, this credential may become invalid, for eg. expire. When this happens, Juju needs to stop trying to communicate with the cloud and wait for a user to provide either a new credential for the model or update the old one.

This PR ensures that openstack provider behaves as described.
The most interesting bit is the definition of what constitutes auth failure by the cloud, see errors.go. The rest is mechanical - ensure that errors from cloud calls are examined and when needed mark a cloud credential as invalid. 

