### PR TITLE
New Uniter Resolver for Upgrade-Series

### DIFF
--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
 	"github.com/juju/juju/worker/uniter/storage"
+	"github.com/juju/juju/worker/uniter/upgradeseries"
 )
 
 type resolverSuite struct {
@@ -87,6 +88,7 @@ func (s *resolverSuite) SetUpTest(c *gc.C) {
 		StartRetryHookTimer: func() { s.stub.AddCall("StartRetryHookTimer") },
 		StopRetryHookTimer:  func() { s.stub.AddCall("StopRetryHookTimer") },
 		ShouldRetryHooks:    true,
+		UpgradeSeries:       upgradeseries.NewResolver(),
 		Leadership:          leadership.NewResolver(),
 		Actions:             uniteractions.NewResolver(),
 		Relations:           relation.NewRelationsResolver(&dummyRelations{}),

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -192,11 +192,12 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 
 func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c *gc.C) {
 	localState := resolver.LocalState{
-		CharmModifiedVersion: s.charmModifiedVersion,
-		CharmURL:             s.charmURL,
-		Series:               s.charmURL.Series,
-		UpgradeSeriesStatus:  model.UpgradeSeriesNotStarted,
-		ConfigVersion:        1,
+		CharmModifiedVersion:  s.charmModifiedVersion,
+		CharmURL:              s.charmURL,
+		Series:                s.charmURL.Series,
+		UpgradeSeriesStatus:   model.UpgradeSeriesNotStarted,
+		ConfigVersion:         1,
+		LeaderSettingsVersion: 1,
 		State: operation.State{
 			Kind:      operation.Continue,
 			Installed: true,
@@ -206,9 +207,10 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 	s.remoteState.Series = s.charmURL.Series
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesCompleteStarted
 
-	// Bumping the remote state config version checks that the upgrade-series
+	// Bumping the remote state versions verifies that the upgrade-series
 	// completion hook takes precedence.
 	s.remoteState.ConfigVersion = 2
+	s.remoteState.LeaderSettingsVersion = 2
 
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	"github.com/juju/juju/worker/uniter/storage"
+	"github.com/juju/juju/worker/uniter/upgradeseries"
 )
 
 var logger = loggo.GetLogger("juju.worker.uniter")
@@ -321,6 +322,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			StartRetryHookTimer: retryHookTimer.Start,
 			StopRetryHookTimer:  retryHookTimer.Reset,
 			Actions:             actions.NewResolver(),
+			UpgradeSeries:       upgradeseries.NewResolver(),
 			Leadership:          uniterleadership.NewResolver(),
 			Relations:           relation.NewRelationsResolver(u.relations),
 			Storage:             storage.NewResolver(u.storage, u.modelType),

--- a/worker/uniter/upgradeseries/resolver.go
+++ b/worker/uniter/upgradeseries/resolver.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgradeseries
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6/hooks"
+
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/remotestate"
+	"github.com/juju/juju/worker/uniter/resolver"
+)
+
+// ErrDoNotProceed is used to distinguish behaviour from
+// resolver.ErrNoOperation. I.e do not run any operations versus
+// this resolver has no operations to run.
+var ErrDoNotProceed = errors.New("do not proceed")
+
+type upgradeSeriesResolver struct{}
+
+// NewResolver returns a new upgrade-series resolver.
+func NewResolver() resolver.Resolver {
+	return &upgradeSeriesResolver{}
+}
+
+// NextOp is defined on the Resolver interface.
+func (l *upgradeSeriesResolver) NextOp(
+	localState resolver.LocalState, remoteState remotestate.Snapshot, opFactory operation.Factory,
+) (operation.Operation, error) {
+	// If the unit has completed a pre-series-upgrade hook
+	// (as noted by its state) then the uniter should idle in the face of all
+	// remote state changes.
+	if remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareCompleted {
+		return nil, ErrDoNotProceed
+	}
+
+	if localState.Kind == operation.Continue {
+		if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
+			remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareStarted {
+			return opFactory.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
+		}
+
+		// The uniter's local state will be in the "not started" state if the
+		// uniter was stopped for any reason, while performing a series upgrade.
+		// If the uniter was not stopped then it will be in the "prepare completed"
+		// state and likewise run the post upgrade hook.
+		if (localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted ||
+			localState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareCompleted) &&
+			remoteState.UpgradeSeriesStatus == model.UpgradeSeriesCompleteStarted {
+			return opFactory.NewRunHook(hook.Info{Kind: hooks.PostSeriesUpgrade})
+		}
+
+		// If the local state is completed but the remote state is not started,
+		// then this means that the lock has been removed and the local uniter
+		// state should be reset.
+		if localState.UpgradeSeriesStatus == model.UpgradeSeriesCompleted &&
+			remoteState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted {
+			return opFactory.NewNoOpFinishUpgradeSeries()
+		}
+	}
+
+	return nil, resolver.ErrNoOperation
+}


### PR DESCRIPTION
## Description of change

This patch adds a new resolver to the uniter, for dealing with series-upgrade operations.
- The previous resolution conditions and steps are all co-located here.
- This resolver is the first called by the main uniter resolver, so that other hooks cannot run before essential transitions are made in response to upgrade-series steps.

## QA steps

These steps produced an error due to a _leader-settings-changed_ hook firing before the _upgrade-series-complete_ hook, and the unit had not done the required preparation after OS upgrade.

- Bootstrap.
- `juju deploy cs:~thedac/cinder-2 cinder --series=xenial -n 2`.
- `juju deploy telegraf --series=xenial`.
- `juju relate telegraf cinder`.
- Wait a bit, then `juju upgrade-series prepare 0 bionic`.
- `juju ssh 0` and run `sudo do-release-upgrade`, accepting defaults.
- `juju upgrade-series complete 0`.
- `juju upgrade-series prepare 1 bionic`.
- `juju ssh 0` and run `sudo do-release-upgrade`, accepting defaults.
- Wait some time (an hour?), then run `juju upgrade-series complete 1`.
- No errors should occur.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1801059
