### PR TITLE
Bug 1800654 - don't try to add a profile not provided, or without a name

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -1086,25 +1086,27 @@ func (s *provisionerContainerSuite) TestGetContainerProfileInfo(c *gc.C) {
 	results := params.ContainerProfileResults{
 		Results: []params.ContainerProfileResult{
 			{
-				LXDProfiles: []params.ContainerLXDProfile{{
-					Profile: params.CharmLXDProfile{
-						Config: map[string]string{
-							"security.nesting":    "true",
-							"security.privileged": "true",
-						},
-					},
-					Name: "one",
-				}, {
-					Profile: params.CharmLXDProfile{
-						Devices: map[string]map[string]string{
-							"bdisk": {
-								"source": "/dev/loop0",
-								"type":   "unix-block",
+				LXDProfiles: []*params.ContainerLXDProfile{
+					{
+						Profile: params.CharmLXDProfile{
+							Config: map[string]string{
+								"security.nesting":    "true",
+								"security.privileged": "true",
 							},
 						},
+						Name: "one",
 					},
-					Name: "two",
-				}},
+					{
+						Profile: params.CharmLXDProfile{
+							Devices: map[string]map[string]string{
+								"bdisk": {
+									"source": "/dev/loop0",
+									"type":   "unix-block",
+								},
+							},
+						},
+						Name: "two",
+					}},
 				Error: nil,
 			}},
 	}
@@ -1117,20 +1119,22 @@ func (s *provisionerContainerSuite) TestGetContainerProfileInfo(c *gc.C) {
 
 	obtainedResults, err := provisionerApi.GetContainerProfileInfo(s.containerTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedResults, gc.DeepEquals, []provisioner.LXDProfileResult{{
-		Config: map[string]string{
-			"security.nesting":    "true",
-			"security.privileged": "true",
-		},
-		Name: "one",
-	}, {
-		Devices: map[string]map[string]string{
-			"bdisk": {
-				"source": "/dev/loop0",
-				"type":   "unix-block",
+	c.Assert(obtainedResults, gc.DeepEquals, []*provisioner.LXDProfileResult{
+		{
+			Config: map[string]string{
+				"security.nesting":    "true",
+				"security.privileged": "true",
 			},
+			Name: "one",
 		},
-		Name: "two",
-	}})
+		{
+			Devices: map[string]map[string]string{
+				"bdisk": {
+					"source": "/dev/loop0",
+					"type":   "unix-block",
+				},
+			},
+			Name: "two",
+		}})
 
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1223,7 +1223,7 @@ func (p *ProvisionerAPI) GetContainerProfileInfo(args params.Entities) (params.C
 			continue
 		}
 
-		profiles, err := p.containerProfiles(container)
+		profiles, err := p.containerLXDProfilesInfo(container)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -1233,14 +1233,17 @@ func (p *ProvisionerAPI) GetContainerProfileInfo(args params.Entities) (params.C
 	return result, nil
 }
 
-func (p *ProvisionerAPI) containerProfiles(m *state.Machine) (params.ContainerProfileResult, error) {
+// containerLXDProfilesInfo returns the info necessary to write lxd profiles
+// via the lxd broker. Unlike machineLXDProfileNames which has the environ
+// write the lxd profiles and returns the names of profiles already written.
+func (p *ProvisionerAPI) containerLXDProfilesInfo(m *state.Machine) (params.ContainerProfileResult, error) {
 	var result params.ContainerProfileResult
 	units, err := m.Units()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	result.LXDProfiles = make([]params.ContainerLXDProfile, len(units))
-	for i, unit := range units {
+	var resPro []*params.ContainerLXDProfile
+	for _, unit := range units {
 		app, err := unit.Application()
 		if err != nil {
 			return result, errors.Trace(err)
@@ -1251,18 +1254,19 @@ func (p *ProvisionerAPI) containerProfiles(m *state.Machine) (params.ContainerPr
 		}
 		profile := ch.LXDProfile()
 		if profile == nil || (profile != nil && profile.Empty()) {
+			logger.Tracef("no profile to return for %q", unit.Name())
 			continue
 		}
-		paramProfile := params.ContainerLXDProfile{
+		resPro = append(resPro, &params.ContainerLXDProfile{
 			Profile: params.CharmLXDProfile{
 				Config:      profile.Config,
 				Description: profile.Description,
 				Devices:     profile.Devices,
 			},
 			Name: lxdprofile.Name(p.m.Name(), app.Name(), ch.Revision()),
-		}
-		result.LXDProfiles[i] = paramProfile
+		})
 	}
+	result.LXDProfiles = resPro
 	return result, nil
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1790,29 +1790,30 @@ func (s *withControllerSuite) TestGetContainerProfileInfo(c *gc.C) {
 	pName := fmt.Sprintf("juju-%s-lxd-profile-0", coretesting.ModelConfig(c).Name())
 	expected := params.ContainerProfileResults{
 		Results: []params.ContainerProfileResult{{
-			LXDProfiles: []params.ContainerLXDProfile{{
-				Profile: params.CharmLXDProfile{
-					Config: map[string]string{
-						"security.nesting":       "true",
-						"security.privileged":    "true",
-						"linux.kernel_modules":   "openvswitch,nbd,ip_tables,ip6_tables",
-						"environment.http_proxy": "",
-					},
-					Description: "lxd profile for testing, black list items grouped commented out",
-					Devices: map[string]map[string]string{
-						"tun": {
-							"path": "/dev/net/tun",
-							"type": "unix-char",
+			LXDProfiles: []*params.ContainerLXDProfile{
+				{
+					Profile: params.CharmLXDProfile{
+						Config: map[string]string{
+							"security.nesting":       "true",
+							"security.privileged":    "true",
+							"linux.kernel_modules":   "openvswitch,nbd,ip_tables,ip6_tables",
+							"environment.http_proxy": "",
 						},
-						"sony": {
-							"type":      "usb",
-							"vendorid":  "0fce",
-							"productid": "51da",
+						Description: "lxd profile for testing, black list items grouped commented out",
+						Devices: map[string]map[string]string{
+							"tun": {
+								"path": "/dev/net/tun",
+								"type": "unix-char",
+							},
+							"sony": {
+								"type":      "usb",
+								"vendorid":  "0fce",
+								"productid": "51da",
+							},
 						},
 					},
-				},
-				Name: pName,
-			}},
+					Name: pName,
+				}},
 		}},
 	}
 

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -85,7 +85,7 @@ func (p *ProvisionerAPI) getProvisioningInfo(m *state.Machine, env environs.Envi
 	// TODO: lxd-profile 2018-09-18
 	// Add withoutControllerSuite.TestProvisioningInfoWithLXDProfile when
 	// lxd profiles added to ProvisioningInfo.
-	pNames, err := p.machineLXDProfiles(m, env)
+	pNames, err := p.machineLXDProfileNames(m, env)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot write lxd profiles")
 	}
@@ -312,7 +312,11 @@ func (p *ProvisionerAPI) machineSubnetsAndZones(m *state.Machine) (map[string][]
 	return subnetsToZones, nil
 }
 
-func (p *ProvisionerAPI) machineLXDProfiles(m *state.Machine, env environs.Environ) ([]string, error) {
+// machineLXDProfileNames give the environ info to write lxd profiles needed for
+// the given machine and returns the names of profiles. Unlike
+// containerLXDProfilesInfo which returns the info necessary to write lxd profiles
+// via the lxd broker.
+func (p *ProvisionerAPI) machineLXDProfileNames(m *state.Machine, env environs.Environ) ([]string, error) {
 	profileEnv, ok := env.(environs.LXDProfiler)
 	if !ok {
 		return nil, nil

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -915,7 +915,7 @@ func (c *statusContext) makeMachineStatus(machine *state.Machine, appStatusInfo 
 			}
 		}
 	} else {
-		logger.Debugf("error fetching lxd profiles for %s: %q", machine.String(), err.Error())
+		logger.Tracef("error fetching lxd profiles for %s: %q", machine.String(), err.Error())
 	}
 	status.LXDProfiles = lxdProfiles
 

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -185,8 +185,8 @@ type ContainerLXDProfile struct {
 // ContainerProfileResult returns the result of finding the CharmLXDProfile and name of
 // the lxd profile to be used for 1 unit on the container
 type ContainerProfileResult struct {
-	Error       *Error                `json:"error,omitempty"`
-	LXDProfiles []ContainerLXDProfile `json:"lxd-profiles,omitempty"`
+	Error       *Error                 `json:"error,omitempty"`
+	LXDProfiles []*ContainerLXDProfile `json:"lxd-profiles,omitempty"`
 }
 
 // ContainerProfileResults returns the ContainerProfileResult for each unit to be placed

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -24,7 +24,7 @@ type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
-	GetContainerProfileInfo(names.MachineTag) ([]apiprovisioner.LXDProfileResult, error)
+	GetContainerProfileInfo(names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error)
 	ReleaseContainerAddresses(names.MachineTag) error
 	SetHostMachineNetworkConfig(names.MachineTag, []params.NetworkConfig) error
 	HostChangesForContainer(containerTag names.MachineTag) ([]network.DeviceToBridge, int, error)

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -223,12 +223,12 @@ func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log loggo.Logger, a
 	return nil
 }
 
-func (f *fakeAPI) GetContainerProfileInfo(containerTag names.MachineTag) ([]apiprovisioner.LXDProfileResult, error) {
+func (f *fakeAPI) GetContainerProfileInfo(containerTag names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error) {
 	f.MethodCall(f, "GetContainerProfileInfo", containerTag)
 	if err := f.NextErr(); err != nil {
 		return nil, err
 	}
-	return []apiprovisioner.LXDProfileResult{}, nil
+	return []*apiprovisioner.LXDProfileResult{}, nil
 }
 
 type fakeContainerManager struct {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -205,8 +205,14 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, len(profileInfo))
-	for i, profile := range profileInfo {
+	var names []string
+	for _, profile := range profileInfo {
+		if profile == nil {
+			continue
+		}
+		if profile.Name == "" {
+			return nil, errors.Errorf("request to write LXD profile for machine %s with no profile name", machineID)
+		}
 		err := broker.MaybeWriteLXDProfile(profile.Name, &charm.LXDProfile{
 			Config:      profile.Config,
 			Description: profile.Description,
@@ -215,7 +221,7 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		names[i] = profile.Name
+		names = append(names, profile.Name)
 	}
 	return names, nil
 }

--- a/worker/provisioner/mocks/apicalls_mock.go
+++ b/worker/provisioner/mocks/apicalls_mock.go
@@ -63,9 +63,9 @@ func (mr *MockAPICallsMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) 
 }
 
 // GetContainerProfileInfo mocks base method
-func (m *MockAPICalls) GetContainerProfileInfo(arg0 names_v2.MachineTag) ([]provisioner.LXDProfileResult, error) {
+func (m *MockAPICalls) GetContainerProfileInfo(arg0 names_v2.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
-	ret0, _ := ret[0].([]provisioner.LXDProfileResult)
+	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -377,20 +377,16 @@ func (task *provisionerTask) processOneMachineProfileChange(
 	logger.Debugf("processOneMachineProfileChange(%s)", m.Id())
 	info, err := m.CharmProfileChangeInfo()
 	if err != nil {
-		logger.Debugf("processOneMachineProfileChange(%s) CharmProfileChangeInfo failed with %v", m.Id(), err)
 		return err
 	}
-	logger.Debugf("processOneMachineProfileChange(%s) CharmProfileChangeInfo results(%#v)", m.Id(), info)
 	instId, err := m.InstanceId()
 	if err != nil {
 		return err
 	}
 	newProfiles, err := profileBroker.ReplaceOrAddInstanceProfile(string(instId), info.OldProfileName, info.NewProfileName, info.LXDProfile)
 	if err != nil {
-		logger.Debugf("processOneMachineProfileChange(%s) profileBroker.ReplaceOrAddInstanceProfile failed with %v", m.Id(), err)
 		return err
 	}
-	logger.Debugf("processOneMachineProfileChange(%s) profileBroker.ReplaceOrAddInstanceProfile results(%#v)", m.Id(), newProfiles)
 	// newProfiles:
 	//   default
 	//   juju-<model>      <-- not included on containers


### PR DESCRIPTION
## Description of change

Use slice of ptrs for GetContainerProfileInfo and ensure no attempt to write profile with empty name.

## QA steps

1. vim ./testcharms/charm-repo/quantal/lxd-profile-alt/lxd-profile.yaml, remove the Devices section.
2. juju bootstrap localhost
2.  juju deploy ubuntu --to lxd  -n 2
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd -n 2

All 4 units should succeed, the lxd-profile-alt ones should have charm profiles attached.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1800654