### PR TITLE
Fixes lp#1793303: deploy fails if model missing from local cache.

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -386,7 +386,7 @@ type DeployCommand struct {
 	machineMap string
 	flagSet    *gnuflag.FlagSet
 
-	notLocalModel bool
+	unknownModel bool
 }
 
 const deployDoc = `
@@ -723,7 +723,7 @@ func (c *DeployCommand) Init(args []string) error {
 		// at Init() we do not yet have an API connection.
 		// So we do not want to fail here if we encountered NotFoundErr, we want to
 		// do a late validation at Run().
-		c.notLocalModel = true
+		c.unknownModel = true
 	}
 	switch len(args) {
 	case 2:
@@ -764,7 +764,7 @@ func (c *DeployCommand) Init(args []string) error {
 		// at Init() we do not yet have an API connection.
 		// So we do not want to fail here if we encountered NotFoundErr, we want to
 		// do a late validation at Run().
-		c.notLocalModel = true
+		c.unknownModel = true
 	}
 	return nil
 }
@@ -1144,7 +1144,7 @@ func (c *DeployCommand) parseBind() error {
 }
 
 func (c *DeployCommand) Run(ctx *cmd.Context) error {
-	if c.notLocalModel {
+	if c.unknownModel {
 		if err := c.validateStorageByModelType(); err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -385,6 +385,8 @@ type DeployCommand struct {
 
 	machineMap string
 	flagSet    *gnuflag.FlagSet
+
+	notLocalModel bool
 }
 
 const deployDoc = `
@@ -627,7 +629,6 @@ type DeployStepAPI interface {
 
 // DeployStep is an action that needs to be taken during charm deployment.
 type DeployStep interface {
-
 	// SetFlags sets flags necessary for the deploy step.
 	SetFlags(*gnuflag.FlagSet)
 
@@ -712,14 +713,17 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *DeployCommand) Init(args []string) error {
-	modelType, err := c.ModelType()
-	if err != nil {
-		return err
-	}
-	if len(c.AttachStorage) > 0 {
-		if modelType == model.CAAS && len(c.AttachStorage) > 0 {
-			return errors.New("--attach-storage cannot be used on kubernetes models")
+	if err := c.validateStorageByModelType(); err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.Trace(err)
 		}
+		// It is possible that we will not be able to get model type to validate with.
+		// For example, if current client does not know about a model, we
+		// would have queried the controller about the model. However,
+		// at Init() we do not yet have an API connection.
+		// So we do not want to fail here if we encountered NotFoundErr, we want to
+		// do a late validation at Run().
+		c.notLocalModel = true
 	}
 	switch len(args) {
 	case 2:
@@ -748,6 +752,40 @@ func (c *DeployCommand) Init(args []string) error {
 	c.BundleMachines = mapping
 
 	if err := c.UnitCommandBase.Init(args); err != nil {
+		return err
+	}
+	if err := c.validatePlacementByModelType(); err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+		// It is possible that we will not be able to get model type to validate with.
+		// For example, if current client does not know about a model, we
+		// would have queried the controller about the model. However,
+		// at Init() we do not yet have an API connection.
+		// So we do not want to fail here if we encountered NotFoundErr, we want to
+		// do a late validation at Run().
+		c.notLocalModel = true
+	}
+	return nil
+}
+
+func (c *DeployCommand) validateStorageByModelType() error {
+	modelType, err := c.ModelType()
+	if err != nil {
+		return err
+	}
+	if modelType == model.IAAS {
+		return nil
+	}
+	if len(c.AttachStorage) > 0 {
+		return errors.New("--attach-storage cannot be used on kubernetes models")
+	}
+	return nil
+}
+
+func (c *DeployCommand) validatePlacementByModelType() error {
+	modelType, err := c.ModelType()
+	if err != nil {
 		return err
 	}
 	if modelType == model.IAAS {
@@ -1106,6 +1144,14 @@ func (c *DeployCommand) parseBind() error {
 }
 
 func (c *DeployCommand) Run(ctx *cmd.Context) error {
+	if c.notLocalModel {
+		if err := c.validateStorageByModelType(); err != nil {
+			return errors.Trace(err)
+		}
+		if err := c.validatePlacementByModelType(); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	var err error
 	c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr)
 	if err != nil {


### PR DESCRIPTION
## Description of change

Juju commands are able to query the controller if a user specifies a model that their client does not know about.

However, deploy command has been recently changed to support CAAS models. The change meant that Juju needed to know model type to validate fully at command.Init() stage. 

There is a scenario, see linked bug, where Juju will not be able to determine model type from local cache (the model is not there) and has to go to the controller. However, at Init() stage, the API connection has not been established yet. So, in cases where specified model is not known locally, we need to postpone some model-type based checks until command.Run() stage which can get API connection and refresh local models knowledge.

This PR does just that. Note that for all other scenarios, we still perform the validation as soon as possible, in command.Init().

## QA steps

1. bootstrap
2. remove default model details from client's local cache
3. 'juju deploy ubuntu -m default'

[SUCCESS] 'ubuntu' application gets deployed without errors and your local models' cache gains 'default' model details back.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1793303
