### PR TITLE
Unit Series Change Does Not Fire Config-Changed Hook

### DIFF
--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -46,7 +46,6 @@ func CreateUnit(st *State, tag names.UnitTag) *Unit {
 		tag:          tag,
 		life:         params.Alive,
 		resolvedMode: params.ResolvedNone,
-		series:       "trusty",
 	}
 }
 

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -22,7 +22,6 @@ type Unit struct {
 	tag          names.UnitTag
 	life         params.Life
 	resolvedMode params.ResolvedMode
-	series       string
 }
 
 // Tag returns the unit's tag.
@@ -43,11 +42,6 @@ func (u *Unit) String() string {
 // Life returns the unit's lifecycle value.
 func (u *Unit) Life() params.Life {
 	return u.life
-}
-
-// Series returns the unit's series value.
-func (u *Unit) Series() string {
-	return u.series
 }
 
 // Resolved returns the unit's resolved mode value.
@@ -77,7 +71,6 @@ func (u *Unit) Refresh() error {
 
 	u.life = result.Life
 	u.resolvedMode = result.Resolved
-	u.series = result.Series
 	return nil
 }
 
@@ -785,7 +778,11 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 	all := make([]params.StorageAddParams, 0, len(constraints))
 	for storage, cons := range constraints {
 		for _, one := range cons {
-			all = append(all, params.StorageAddParams{u.Tag().String(), storage, one})
+			all = append(all, params.StorageAddParams{
+				UnitTag:     u.Tag().String(),
+				StorageName: storage,
+				Constraints: one,
+			})
 		}
 	}
 

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -467,7 +467,7 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 		called++
 		if called == 1 {
 			*(result.(*params.UnitRefreshResults)) = params.UnitRefreshResults{
-				Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}
+				Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}
 			return nil
 		}
 		c.Check(objType, gc.Equals, "Uniter")

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -241,17 +241,6 @@ func (s *unitSuite) TestRefreshResolve(c *gc.C) {
 	c.Assert(mode, gc.Equals, params.ResolvedNone)
 }
 
-func (s *unitSuite) TestRefreshSeries(c *gc.C) {
-	c.Assert(s.apiUnit.Series(), gc.Equals, "quantal")
-	err := s.wordpressMachine.UpdateMachineSeries("xenial", true)
-	c.Assert(err, gc.IsNil)
-	c.Assert(s.apiUnit.Series(), gc.Equals, "quantal")
-
-	err = s.apiUnit.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiUnit.Series(), gc.Equals, "xenial")
-}
-
 func (s *unitSuite) TestWatch(c *gc.C) {
 	c.Assert(s.apiUnit.Life(), gc.Equals, params.Alive)
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1260,7 +1260,6 @@ func (u *UniterAPI) Refresh(args params.Entities) (params.UnitRefreshResults, er
 		if canRead(tag) {
 			var unit *state.Unit
 			if unit, err = u.getUnit(tag); err == nil {
-				result.Results[i].Series = unit.Series()
 				result.Results[i].Life = params.Life(unit.Life().String())
 				result.Results[i].Resolved = params.ResolvedMode(unit.Resolved())
 			}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3063,7 +3063,7 @@ func (s *uniterSuite) TestRefresh(c *gc.C) {
 	}
 	expect := params.UnitRefreshResults{
 		Results: []params.UnitRefreshResult{
-			{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"},
+			{Life: params.Alive, Resolved: params.ResolvedNone},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -816,7 +816,6 @@ type ResourceUploadResult struct {
 type UnitRefreshResult struct {
 	Life     Life
 	Resolved ResolvedMode
-	Series   string
 	Error    *Error
 }
 

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -138,7 +138,7 @@ func (s *relationsSuite) setupRelations(c *gc.C) relation.Relations {
 	var numCalls int32
 	unitEntity := params.Entities{Entities: []params.Entity{{Tag: "unit-wordpress-0"}}}
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 	)
@@ -194,7 +194,7 @@ func (s *relationsSuite) assertNewRelationsWithExistingRelations(c *gc.C, isLead
 	}}}
 
 	apiCalls := []apiCall{
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{
 			{RelationResults: []params.RelationUnitStatus{{RelationTag: "relation-wordpress:db mysql:db", InScope: true}}}}}, nil),
@@ -247,7 +247,7 @@ func (s *relationsSuite) TestNextOpNothing(c *gc.C) {
 	var numCalls int32
 	unitEntity := params.Entities{Entities: []params.Entity{{Tag: "unit-wordpress-0"}}}
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 	)
@@ -298,7 +298,7 @@ func relationJoinedAPICalls() []apiCall {
 		Status:     params.Joined,
 	}}}
 	apiCalls := []apiCall{
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
@@ -659,7 +659,7 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 		Status:     params.Joined,
 	}}}
 	apiCalls := []apiCall{
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
@@ -772,7 +772,7 @@ func subSubRelationAPICalls() []apiCall {
 	}}}
 
 	return []apiCall{
-		uniterAPICall("Refresh", nrpeUnitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone, Series: "quantal"}}}, nil),
+		uniterAPICall("Refresh", nrpeUnitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", nrpeUnitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "unit-wordpress-0", Ok: true}}}, nil),
 		uniterAPICall("RelationsStatus", nrpeUnitEntity, relationStatusResults, nil),
 		uniterAPICall("Relation", relationUnits1, relationResults1, nil),

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -198,7 +198,6 @@ type mockUnit struct {
 	tag                              names.UnitTag
 	life                             params.Life
 	resolved                         params.ResolvedMode
-	series                           string
 	application                      mockApplication
 	unitWatcher                      *mockNotifyWatcher
 	addressesWatcher                 *mockNotifyWatcher
@@ -224,10 +223,6 @@ func (u *mockUnit) Resolved() params.ResolvedMode {
 
 func (u *mockUnit) Application() (remotestate.Application, error) {
 	return &u.application, nil
-}
-
-func (u *mockUnit) Series() string {
-	return u.series
 }
 
 func (u *mockUnit) Tag() names.UnitTag {

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -70,9 +70,6 @@ type Snapshot struct {
 	// executed by this unit.
 	Commands []string
 
-	// Series is the current series running on the unit
-	Series string
-
 	// UpgradeSeriesStatus is the preparation status of any currently running
 	// series upgrade
 	UpgradeSeriesStatus model.UpgradeSeriesStatus

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -37,7 +37,6 @@ type Unit interface {
 	Refresh() error
 	Resolved() params.ResolvedMode
 	Application() (Application, error)
-	Series() string
 	Tag() names.UnitTag
 	Watch() (watcher.NotifyWatcher, error)
 	WatchAddresses() (watcher.NotifyWatcher, error)

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -622,7 +622,6 @@ func (w *RemoteStateWatcher) unitChanged() error {
 	defer w.mu.Unlock()
 	w.current.Life = w.unit.Life()
 	w.current.ResolvedMode = w.unit.Resolved()
-	w.current.Series = w.unit.Series()
 	return nil
 }
 

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -203,7 +203,6 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 		ConfigVersion:         expectedVersion,
 		LeaderSettingsVersion: 1,
 		Leader:                true,
-		Series:                "",
 		UpgradeSeriesStatus:   model.UpgradeSeriesPrepareStarted,
 	})
 }
@@ -227,7 +226,6 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 		ConfigVersion:         expectedVersion,
 		LeaderSettingsVersion: 1,
 		Leader:                true,
-		Series:                "",
 		UpgradeSeriesStatus:   "",
 	})
 }
@@ -246,11 +244,6 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	s.st.unit.unitWatcher.changes <- struct{}{}
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().Life, gc.Equals, params.Dying)
-
-	s.st.unit.series = "trusty"
-	s.st.unit.unitWatcher.changes <- struct{}{}
-	assertOneChange()
-	c.Assert(s.watcher.Snapshot().Series, gc.Equals, "trusty")
 
 	s.st.unit.resolved = params.ResolvedRetryHooks
 	s.st.unit.unitWatcher.changes <- struct{}{}

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -285,8 +285,7 @@ func (s *uniterResolver) nextOp(
 		}
 	}
 
-	if localState.ConfigVersion != remoteState.ConfigVersion ||
-		localState.Series != remoteState.Series {
+	if localState.ConfigVersion != remoteState.ConfigVersion {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -96,10 +96,6 @@ type LocalState struct {
 	// controller.
 	CompletedActions map[string]struct{}
 
-	// Series is the current series running on the unit from remotestate.Snapshot
-	// for which a config-changed hook has been committed.
-	Series string
-
 	// UpgradeSeriesStatus is the current state of any currently running
 	// upgrade series.
 	UpgradeSeriesStatus model.UpgradeSeriesStatus

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -152,10 +152,8 @@ func (s *resolverOpFactory) wrapHookOp(op operation.Operation, info hook.Info) o
 		}}
 	case hooks.ConfigChanged:
 		v := s.RemoteState.ConfigVersion
-		series := s.RemoteState.Series
 		op = onCommitWrapper{op, func() {
 			s.LocalState.ConfigVersion = v
-			s.LocalState.Series = series
 		}}
 	case hooks.LeaderSettingsChanged:
 		v := s.RemoteState.LeaderSettingsVersion

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -69,9 +69,9 @@ func (s *ResolverOpFactorySuite) TestConfigChanged(c *gc.C) {
 func (s *ResolverOpFactorySuite) TestUpgradeSeriesStatusChanged(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
 
-	// The initial state
-	f.LocalState.UpgradeSeriesStatus = model.UpgradeSeriesNotStarted      // Local state is not started
-	f.RemoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareStarted // Remote state is in the prepare started state
+	// The initial state.
+	f.LocalState.UpgradeSeriesStatus = model.UpgradeSeriesNotStarted
+	f.RemoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareStarted
 
 	op, err := f.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
 	c.Assert(err, jc.ErrorIsNil)
@@ -106,13 +106,11 @@ func (s *ResolverOpFactorySuite) testConfigChanged(
 	f := resolver.NewResolverOpFactory(s.opFactory)
 	f.RemoteState.ConfigVersion = 1
 	f.RemoteState.UpdateStatusVersion = 3
-	f.RemoteState.Series = "trusty"
 
 	op, err := f.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 	f.RemoteState.ConfigVersion = 2
 	f.RemoteState.UpdateStatusVersion = 4
-	f.RemoteState.Series = "xenial"
 
 	_, err = op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -122,7 +120,6 @@ func (s *ResolverOpFactorySuite) testConfigChanged(
 	// was constructed.
 	c.Assert(f.LocalState.ConfigVersion, gc.Equals, 1)
 	c.Assert(f.LocalState.UpdateStatusVersion, gc.Equals, 3)
-	c.Assert(f.LocalState.Series, gc.Equals, "trusty")
 }
 
 func (s *ResolverOpFactorySuite) TestLeaderSettingsChanged(c *gc.C) {
@@ -193,12 +190,12 @@ func (s *ResolverOpFactorySuite) TestCommitError(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
 	curl := charm.MustParseURL("cs:trusty/mysql")
 	s.opFactory.op.commit = func(operation.State) (*operation.State, error) {
-		return nil, errors.New("Commit fails")
+		return nil, errors.New("commit fails")
 	}
 	op, err := f.NewUpgrade(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = op.Commit(operation.State{})
-	c.Assert(err, gc.ErrorMatches, "Commit fails")
+	c.Assert(err, gc.ErrorMatches, "commit fails")
 	// Local state should not have been updated. We use the same code
 	// internally for all operations, so it suffices to test just the
 	// upgrade case.

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -134,35 +134,16 @@ func (s *resolverSuite) TestNotStartedNotInstalled(c *gc.C) {
 	c.Assert(op.String(), gc.Equals, "run install hook")
 }
 
-func (s *resolverSuite) TestSeriesChanged(c *gc.C) {
-	localState := resolver.LocalState{
-		CharmModifiedVersion: s.charmModifiedVersion,
-		CharmURL:             s.charmURL,
-		Series:               s.charmURL.Series,
-		State: operation.State{
-			Kind:      operation.Continue,
-			Installed: true,
-			Started:   true,
-		},
-	}
-	s.remoteState.Series = "trusty"
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(op.String(), gc.Equals, "run config-changed hook")
-}
-
 func (s *iaasResolverSuite) TestCharmModifiedTakesPrecedenceOverRelationsChanges(c *gc.C) {
 	localState := resolver.LocalState{
 		CharmModifiedVersion: s.charmModifiedVersion,
 		CharmURL:             s.charmURL,
-		Series:               s.charmURL.Series,
 		State: operation.State{
 			Kind:      operation.Continue,
 			Installed: true,
 			Started:   true,
 		},
 	}
-	s.remoteState.Series = "trusty"
 	s.remoteState.CharmModifiedVersion = s.charmModifiedVersion + 1
 	// Change relation state (to simulate simultaneous change remote state update)
 	s.remoteState.Relations = map[int]remotestate.RelationSnapshot{0: {}}
@@ -175,7 +156,6 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 	localState := resolver.LocalState{
 		CharmModifiedVersion: s.charmModifiedVersion,
 		CharmURL:             s.charmURL,
-		Series:               s.charmURL.Series,
 		UpgradeSeriesStatus:  model.UpgradeSeriesNotStarted,
 		State: operation.State{
 			Kind:      operation.Continue,
@@ -183,7 +163,6 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 			Started:   true,
 		},
 	}
-	s.remoteState.Series = s.charmURL.Series
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareStarted
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
@@ -194,7 +173,6 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 	localState := resolver.LocalState{
 		CharmModifiedVersion:  s.charmModifiedVersion,
 		CharmURL:              s.charmURL,
-		Series:                s.charmURL.Series,
 		UpgradeSeriesStatus:   model.UpgradeSeriesNotStarted,
 		ConfigVersion:         1,
 		LeaderSettingsVersion: 1,
@@ -204,7 +182,6 @@ func (s *iaasResolverSuite) TestPostSeriesUpgradeHookRunsWhenConditionsAreMet(c 
 			Started:   true,
 		},
 	}
-	s.remoteState.Series = s.charmURL.Series
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesCompleteStarted
 
 	// Bumping the remote state versions verifies that the upgrade-series
@@ -221,7 +198,6 @@ func (s *iaasResolverSuite) TestRunsOperationToResetLocalUpgradeSeriesStateWhenC
 	localState := resolver.LocalState{
 		CharmModifiedVersion: s.charmModifiedVersion,
 		CharmURL:             s.charmURL,
-		Series:               s.charmURL.Series,
 		UpgradeSeriesStatus:  model.UpgradeSeriesCompleted,
 		State: operation.State{
 			Kind:      operation.Continue,
@@ -229,7 +205,6 @@ func (s *iaasResolverSuite) TestRunsOperationToResetLocalUpgradeSeriesStateWhenC
 			Started:   true,
 		},
 	}
-	s.remoteState.Series = s.charmURL.Series
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesNotStarted
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
@@ -248,22 +223,6 @@ func (s *iaasResolverSuite) TestUniterIdlesWhenRemoteStateIsUpgradeSeriesComplet
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareCompleted
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-}
-
-func (s *resolverSuite) TestSeriesChangedBlank(c *gc.C) {
-	localState := resolver.LocalState{
-		CharmModifiedVersion: s.charmModifiedVersion,
-		CharmURL:             s.charmURL,
-		State: operation.State{
-			Kind:      operation.Continue,
-			Installed: true,
-			Started:   true,
-		},
-	}
-	s.remoteState.Series = "trusty"
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(op.String(), gc.Equals, "run config-changed hook")
 }
 
 func (s *resolverSuite) TestHookErrorDoesNotStartRetryTimerIfShouldRetryFalse(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch reverts early work intended as part of the upgrade-series functionality.
- Series is no longer passed in a uniter API call to `Refresh`.
- Series is not tracked in uniter local or remote state.
- Series being now absent is obviously not used to determine firing a config-changed hook.

The PR landing the changes was https://github.com/juju/juju/pull/7794. Some of those changes remain, such as the `Refresh` method itself, and the fact that it delivers both `Life` and `Resolved` members.

## QA steps

Bootstrap, deploy and execute a series-upgrade workflow. No errors are reported at the CLI or in the log.

## Documentation changes

None.

## Bug reference

N/A
