### PR TITLE
Cloud Facade 3 gains call to validate credentials.

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -112,7 +112,7 @@ func (c *Client) UserCredentials(user names.UserTag, cloud names.CloudTag) ([]na
 // stored on the controller. This call validates that the new content works
 // for all models that are using this credential.
 func (c *Client) UpdateCredentialsCheckModels(tag names.CloudCredentialTag, credential jujucloud.Credential) ([]params.UpdateCredentialModelResult, error) {
-	in := params.TaggedCredentials{
+	in := params.UpdateCredentialArgs{
 		Credentials: []params.TaggedCredential{{
 			Tag: tag.String(),
 			Credential: params.CloudCredential{

--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -177,7 +177,7 @@ func (s *cloudSuite) TestUpdateCredentialV2(c *gc.C) {
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "UpdateCredentials")
 				c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-				c.Assert(a, jc.DeepEquals, params.TaggedCredentials{
+				c.Assert(a, jc.DeepEquals, params.UpdateCredentialArgs{
 					Credentials: []params.TaggedCredential{{
 						Tag: "cloudcred-foo_bob_bar",
 						Credential: params.CloudCredential{
@@ -217,7 +217,7 @@ func (s *cloudSuite) TestUpdateCredential(c *gc.C) {
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
 				c.Assert(result, gc.FitsTypeOf, &params.UpdateCredentialResults{})
-				c.Assert(a, jc.DeepEquals, params.TaggedCredentials{
+				c.Assert(a, jc.DeepEquals, params.UpdateCredentialArgs{
 					Credentials: []params.TaggedCredential{{
 						Tag: "cloudcred-foo_bob_bar",
 						Credential: params.CloudCredential{

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -330,7 +330,7 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 
 func (s *cloudSuite) TestCheckCredentialsModels(c *gc.C) {
 	// Most of the actual validation functionality is tested by other tests in the suite.
-	// All we need to know is that this call does not actually update exisitng controller credential content.
+	// All we need to know is that this call does not actually update existing controller credential content.
 	s.backend.SetErrors(nil, errors.NotFoundf("cloud"))
 	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
 	results, err := s.api.CheckCredentialsModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -278,23 +278,25 @@ func (s *cloudSuite) TestUserCredentialsAdminAccess(c *gc.C) {
 func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 	s.backend.SetErrors(nil, errors.NotFoundf("cloud"))
 	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag: "machine-0",
-	}, {
-		Tag: "cloudcred-meep_admin_whatever",
-	}, {
-		Tag: "cloudcred-meep_bruce_three",
-		Credential: params.CloudCredential{
-			AuthType:   "oauth1",
-			Attributes: map[string]string{"token": "foo:bar:baz"},
-		},
-	}, {
-		Tag: "cloudcred-badcloud_bruce_three",
-		Credential: params.CloudCredential{
-			AuthType:   "oauth1",
-			Attributes: map[string]string{"token": "foo:bar:baz"},
-		},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag: "machine-0",
+		}, {
+			Tag: "cloudcred-meep_admin_whatever",
+		}, {
+			Tag: "cloudcred-meep_bruce_three",
+			Credential: params.CloudCredential{
+				AuthType:   "oauth1",
+				Attributes: map[string]string{"token": "foo:bar:baz"},
+			},
+		}, {
+			Tag: "cloudcred-badcloud_bruce_three",
+			Credential: params.CloudCredential{
+				AuthType:   "oauth1",
+				Attributes: map[string]string{"token": "foo:bar:baz"},
+			},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential", "CredentialModels", "UpdateCloudCredential")
 
@@ -326,11 +328,35 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 	)
 }
 
-func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
+func (s *cloudSuite) TestCheckCredentialsModels(c *gc.C) {
+	// Most of the actual validation functionality is tested by other tests in the suite.
+	// All we need to know is that this call does not actually update exisitng controller credential content.
+	s.backend.SetErrors(nil, errors.NotFoundf("cloud"))
+	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
+	results, err := s.api.CheckCredentialsModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+		Tag: "cloudcred-meep_bruce_three",
+		Credential: params.CloudCredential{
+			AuthType:   "oauth1",
+			Attributes: map[string]string{"token": "foo:bar:baz"},
+		},
 	}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{
+			{CredentialTag: "cloudcred-meep_bruce_three"},
+		},
+	})
+}
+
+func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
@@ -341,10 +367,12 @@ func (s *cloudSuite) TestUpdateCredentialsNoModelsFound(c *gc.C) {
 	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
 		return nil, errors.NotFoundf("how about it")
 	}
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
@@ -355,12 +383,35 @@ func (s *cloudSuite) TestUpdateCredentialsModelsError(c *gc.C) {
 	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
 		return nil, errors.New("cannot get models")
 	}
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{
+			{
+				CredentialTag: "cloudcred-meep_julia_three",
+				Error:         &params.Error{Message: "cannot get models"},
+			},
+		}})
+}
+
+func (s *cloudSuite) TestUpdateCredentialsModelsErrorForce(c *gc.C) {
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return nil, errors.New("cannot get models")
+	}
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: true,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{
 			{
@@ -381,10 +432,12 @@ func (s *cloudSuite) TestUpdateCredentialsOneModelSuccess(c *gc.C) {
 		return params.ErrorResults{}, nil
 	})
 
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
@@ -410,12 +463,47 @@ func (s *cloudSuite) TestUpdateCredentialsModelGetError(c *gc.C) {
 		return nil, errors.New("cannot get a model")
 	}
 
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
+			Error:         &params.Error{Message: "some models are no longer visible"},
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "cannot get a model", Code: ""}}},
+				},
+			},
+		}},
+	})
+}
+
+func (s *cloudSuite) TestUpdateCredentialsModelGetErrorForce(c *gc.C) {
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return map[string]string{
+			coretesting.ModelTag.Id(): "testModel1",
+		}, nil
+	}
+	s.statePool.getF = func(modelUUID string) (cloudfacade.PooledModelBackend, error) {
+		return nil, errors.New("cannot get a model")
+	}
+
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: true,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
@@ -442,12 +530,48 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidation(c *gc.C) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
+			Error:         &params.Error{Message: "some models are no longer visible"},
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: coretesting.ModelTag.Id(),
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model", Code: ""}}},
+				},
+			},
+		}},
+	})
+}
+
+func (s *cloudSuite) TestUpdateCredentialsModelFailedValidationForce(c *gc.C) {
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return map[string]string{
+			coretesting.ModelTag.Id(): "testModel1",
+		}, nil
+	}
+
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
+	})
+
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: true,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
@@ -480,12 +604,60 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) {
 		return params.ErrorResults{[]params.ErrorResult{}}, nil
 	})
 
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{
+			{
+				CredentialTag: "cloudcred-meep_julia_three",
+				Error:         &params.Error{Message: "some models are no longer visible"},
+				Models: []params.UpdateCredentialModelResult{
+					{
+						ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+						ModelName: "testModel1",
+						Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model", Code: ""}}},
+					},
+					{
+						ModelUUID: "deadbeef-2f18-4fd2-967d-db9663db7bea",
+						ModelName: "testModel2",
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *gc.C) {
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return map[string]string{
+			coretesting.ModelTag.Id():              "testModel1",
+			"deadbeef-2f18-4fd2-967d-db9663db7bea": "testModel2",
+		}, nil
+	}
+
+	calls := 0
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+		calls++
+		if calls == 1 {
+			return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
+		}
+		return params.ErrorResults{[]params.ErrorResult{}}, nil
+	})
+
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: true,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{
 			{
@@ -519,12 +691,54 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidation(c *gc.C) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
-	results, err := s.api.UpdateCredentialsCheckModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
-		Tag:        "cloudcred-meep_julia_three",
-		Credential: params.CloudCredential{},
-	}}})
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
+			Error:         &params.Error{Message: "some models are no longer visible"},
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: coretesting.ModelTag.Id(),
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}},
+				},
+				{
+					ModelUUID: "deadbeef-2f18-4fd2-967d-db9663db7bea",
+					ModelName: "testModel2",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}},
+				},
+			},
+		}}},
+	)
+}
+
+func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidationForce(c *gc.C) {
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return map[string]string{
+			coretesting.ModelTag.Id():              "testModel1",
+			"deadbeef-2f18-4fd2-967d-db9663db7bea": "testModel2",
+		}, nil
+	}
+
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
+	})
+
+	results, err := s.api.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: true,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "UpdateCloudCredential")
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -280,7 +280,6 @@ type ValidateCredentialArgs struct {
 // UpdateCredentialModelResult contains results for a model credential validation check
 // from a cloud credential update.
 type UpdateCredentialModelResult struct {
-
 	// ModelUUID contains model's UUID.
 	ModelUUID string `json:"uuid"`
 
@@ -306,4 +305,13 @@ type UpdateCredentialResult struct {
 // UpdateCredentialResult contains a set of UpdateCredentialResult.
 type UpdateCredentialResults struct {
 	Results []UpdateCredentialResult `json:"results,omitempty"`
+}
+
+// UpdateCredentialArgs contains a TaggedCredential set and is used in the call to update credentials.
+type UpdateCredentialArgs struct {
+	// Credentials holds credentials to update.
+	Credentials []TaggedCredential `json:"credentials"`
+
+	// Force indicates whether the update should be forced.
+	Force bool `json:"force"`
 }


### PR DESCRIPTION
## Description of change

There is a need to be able to verify that a credential is valid for the models that use it without updating it. This PR introduces this validation as a separate method.

There is also a need for controller admins to be able to force an update of a credential content irrespective of whether the credential is valid for the models that use it or not.

These changes are only needed at Facade level. 

No user-facing functionality change.
