### PR TITLE
Fix invalidate credential to take in params structure.

### DIFF
--- a/api/credentialmanager/client.go
+++ b/api/credentialmanager/client.go
@@ -27,8 +27,9 @@ func NewClient(st base.APICallCloser) *Client {
 
 // InvalidateModelCredential invalidates cloud credential for the model that made a connection.
 func (c *Client) InvalidateModelCredential(reason string) error {
+	in := params.InvalidateCredentialArg{reason}
 	var result params.ErrorResult
-	err := c.facade.FacadeCall("InvalidateModelCredential", reason, &result)
+	err := c.facade.FacadeCall("InvalidateModelCredential", in, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/credentialmanager/client_test.go
+++ b/api/credentialmanager/client_test.go
@@ -25,7 +25,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialManager")
 		c.Check(request, gc.Equals, "InvalidateModelCredential")
-		c.Assert(arg, gc.Equals, "")
+		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: ""})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
 		*(result.(*params.ErrorResult)) = params.ErrorResult{}
 		return nil

--- a/api/credentialmanager/client_test.go
+++ b/api/credentialmanager/client_test.go
@@ -25,14 +25,14 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialManager")
 		c.Check(request, gc.Equals, "InvalidateModelCredential")
-		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: ""})
+		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: "auth fail"})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
 		*(result.(*params.ErrorResult)) = params.ErrorResult{}
 		return nil
 	})
 
 	client := credentialmanager.NewClient(apiCaller)
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential("auth fail")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -75,8 +75,9 @@ func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, er
 
 // InvalidateModelCredential invalidates cloud credential for the model that made a connection.
 func (c *Facade) InvalidateModelCredential(reason string) error {
+	in := params.InvalidateCredentialArg{reason}
 	var result params.ErrorResult
-	err := c.facade.FacadeCall("InvalidateModelCredential", reason, &result)
+	err := c.facade.FacadeCall("InvalidateModelCredential", in, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -119,14 +119,14 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
 		c.Check(request, gc.Equals, "InvalidateModelCredential")
-		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: ""})
+		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: "auth fail"})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
 		*(result.(*params.ErrorResult)) = params.ErrorResult{}
 		return nil
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential("auth fail")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -119,7 +119,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
 		c.Check(request, gc.Equals, "InvalidateModelCredential")
-		c.Assert(arg, gc.Equals, "")
+		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: ""})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
 		*(result.(*params.ErrorResult)) = params.ErrorResult{}
 		return nil

--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -23,8 +23,8 @@ func NewCredentialManagerAPI(backend StateBackend) *CredentialManagerAPI {
 }
 
 // InvalidateModelCredential marks the cloud credential for this model as invalid.
-func (api *CredentialManagerAPI) InvalidateModelCredential(reason string) (params.ErrorResult, error) {
-	err := api.backend.InvalidateModelCredential(reason)
+func (api *CredentialManagerAPI) InvalidateModelCredential(args params.InvalidateCredentialArg) (params.ErrorResult, error) {
+	err := api.backend.InvalidateModelCredential(args.Reason)
 	if err != nil {
 		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}

--- a/apiserver/common/credentialcommon/cloudcredential_test.go
+++ b/apiserver/common/credentialcommon/cloudcredential_test.go
@@ -31,7 +31,7 @@ func (s *CredentialSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -42,7 +42,7 @@ func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: common.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -19,7 +19,7 @@ var logger = loggo.GetLogger("juju.api.credentialvalidator")
 // CredentialValidatorV2 defines the methods on version 2 facade for the
 // credentialvalidator API endpoint.
 type CredentialValidatorV2 interface {
-	InvalidateModelCredential(reason string) (params.ErrorResult, error)
+	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
 	ModelCredential() (params.ModelCredential, error)
 	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
 	WatchModelCredential() (params.NotifyWatchResult, error)
@@ -28,7 +28,7 @@ type CredentialValidatorV2 interface {
 // CredentialValidatorV1 defines the methods on version 1 facade
 // for the credentialvalidator API endpoint.
 type CredentialValidatorV1 interface {
-	InvalidateModelCredential(reason string) (params.ErrorResult, error)
+	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
 	ModelCredential() (params.ModelCredential, error)
 	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
 }

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -86,7 +86,7 @@ func (s *CredentialValidatorSuite) TestWatchCredentialInvalidTag(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -97,7 +97,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: common.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{

--- a/apiserver/facades/client/credentialmanager/client.go
+++ b/apiserver/facades/client/credentialmanager/client.go
@@ -16,7 +16,7 @@ var logger = loggo.GetLogger("juju.apiserver.credentialmanager")
 
 // CredentialManager defines the methods on credentialmanager API endpoint.
 type CredentialManager interface {
-	InvalidateModelCredential(reason string) (params.ErrorResult, error)
+	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
 }
 
 type CredentialManagerAPI struct {

--- a/apiserver/facades/client/credentialmanager/client_test.go
+++ b/apiserver/facades/client/credentialmanager/client_test.go
@@ -54,7 +54,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredentialUnauthorized(c *gc
 }
 
 func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -65,7 +65,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialManagerSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: common.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -280,7 +280,6 @@ type ValidateCredentialArgs struct {
 // UpdateCredentialModelResult contains results for a model credential validation check
 // from a cloud credential update.
 type UpdateCredentialModelResult struct {
-
 	// ModelUUID contains model's UUID.
 	ModelUUID string `json:"uuid"`
 
@@ -306,4 +305,10 @@ type UpdateCredentialResult struct {
 // UpdateCredentialResult contains a set of UpdateCredentialResult.
 type UpdateCredentialResults struct {
 	Results []UpdateCredentialResult `json:"results,omitempty"`
+}
+
+// InvalidateCredentialArg is used to invalidate a controller credential.
+type InvalidateCredentialArg struct {
+	// Reason is the desription of why we are invalidating credential.
+	Reason string `json:"reason,omitempty"`
 }

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -321,4 +321,3 @@ type InvalidateCredentialArg struct {
 	// Reason is the desription of why we are invalidating credential.
 	Reason string `json:"reason,omitempty"`
 }
-

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -307,6 +307,15 @@ type UpdateCredentialResults struct {
 	Results []UpdateCredentialResult `json:"results,omitempty"`
 }
 
+// UpdateCredentialArgs contains a TaggedCredential set and is used in the call to update credentials.
+type UpdateCredentialArgs struct {
+	// Credentials holds credentials to update.
+	Credentials []TaggedCredential `json:"credentials"`
+
+	// Force indicates whether the update should be forced.
+	Force bool `json:"force"`
+}
+
 // InvalidateCredentialArg is used to invalidate a controller credential.
 type InvalidateCredentialArg struct {
 	// Reason is the desription of why we are invalidating credential.

--- a/featuretests/api_credentialmanager_test.go
+++ b/featuretests/api_credentialmanager_test.go
@@ -36,6 +36,15 @@ func (s *CredentialManagerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
-	err := s.client.InvalidateModelCredential("no reason really")
+	tag, set := s.Model.CloudCredential()
+	c.Assert(set, jc.IsTrue)
+	credential, err := s.State.CloudCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credential.IsValid(), jc.IsTrue)
+
+	c.Assert(s.client.InvalidateModelCredential("no reason really"), jc.ErrorIsNil)
+
+	credential, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credential.IsValid(), jc.IsFalse)
 }

--- a/featuretests/api_credentialmanager_test.go
+++ b/featuretests/api_credentialmanager_test.go
@@ -1,0 +1,41 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/credentialmanager"
+	"github.com/juju/juju/juju/testing"
+)
+
+// This suite only exists because no user facing calls exercise
+// invalidate credential calls enough to expose serialisation bugs.
+// If/when we have commands that would expose this,
+// we should drop this suite and write a new command-based one.
+
+type CredentialManagerSuite struct {
+	testing.JujuConnSuite
+	client *credentialmanager.Client
+}
+
+func (s *CredentialManagerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	info := s.APIInfo(c)
+	userConn := s.OpenAPIAs(c, info.Tag, info.Password)
+
+	s.client = credentialmanager.NewClient(userConn)
+}
+
+func (s *CredentialManagerSuite) TearDownTest(c *gc.C) {
+	s.client.Close()
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
+	err := s.client.InvalidateModelCredential("no reason really")
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -73,6 +73,7 @@ func init() {
 	gc.Suite(&cmdSetSeriesSuite{})
 	gc.Suite(&CmdExportBundleSuite{})
 	gc.Suite(&cmdDeploySuite{})
+	gc.Suite(&CredentialManagerSuite{})
 
 	// TODO (anastasiamac 2016-07-19) Bug#1603585
 	// These tests cannot run on windows - they require a bootstrapped controller.


### PR DESCRIPTION
## Description of change

API server calls fail when non structures are passed in.

Change the call to invalidate credential to take in params structure instead of a string.

## QA

Before the change to the code, the newly added feature test was failing with:

[LOG] 0:00.790 ERROR juju.apiserver error serving RPCs: codec.handleRequest rpc.Header{RequestId:0x2, Request:rpc.Request{Type:"CredentialManager", Version:1, Id:"", Action:"InvalidateModelCredential"}, Error:"", ErrorCode:"", Version:1} ***error: json: cannot unmarshal string into Go value of type struct {}***
[LOG] 0:00.790 DEBUG juju.apiserver [2] user-admin API connection terminated after 16.453462ms
[LOG] 0:00.790 DEBUG juju.api RPC connection died
api_credentialmanager_test.go:40:
    c.Assert(err, jc.ErrorIsNil)
... value *errors.Err = &errors.unformatter{message:"", cause:(*errors.Err)(0xc000109d60), previous:(*errors.Err)(0xc000d12af0), file:"github.com/juju/juju/api/credentialmanager/client.go", line:33} ()
... error stack:
        github.com/juju/juju/rpc/client.go:12: connection is shut down
        github.com/juju/juju/rpc/client.go:149: 
        github.com/juju/juju/api/apiclient.go:972: 
        github.com/juju/juju/api/credentialmanager/client.go:33: 

[LOG] 0:00.791 DEBUG juju.rpc error closing codec: write tcp 127.0.0.1:54104->127.0.0.1:36421: write: broken pipe
[LOG] 0:00.791 DEBUG juju.api RPC connection died

After the change, the test succeeded.
