### PR TITLE
Include Charm in Messages for Unsupported Series

### DIFF
--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1096,7 +1096,7 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesIncompatibleSeries(c *gc.C
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm \"testCharm\", supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"testCharm\", supported series are: yakkety, zesty",
 		},
 	})
 }

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1083,7 +1083,7 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesOfSubordinate(c *gc.C) {
 
 func (s *ApplicationSuite) TestApplicationUpdateSeriesIncompatibleSeries(c *gc.C) {
 	app := s.backend.applications["postgresql"]
-	app.SetErrors(nil, nil, &state.ErrIncompatibleSeries{[]string{"yakkety", "zesty"}, "xenial"})
+	app.SetErrors(nil, nil, &state.ErrIncompatibleSeries{[]string{"yakkety", "zesty"}, "xenial", "testCharm"})
 	results, err := s.api.UpdateApplicationSeries(
 		params.UpdateSeriesArgs{
 			Args: []params.UpdateSeriesArg{{
@@ -1096,7 +1096,7 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesIncompatibleSeries(c *gc.C
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm, supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"testCharm\", supported series are: yakkety,zesty",
 		},
 	})
 }

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -289,7 +289,7 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesIncompatibleSeries(c *gc.C)
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety, zesty",
 		},
 	})
 }
@@ -600,7 +600,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	c.Assert(result, jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety, zesty",
 		},
 	})
 }

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -273,6 +273,7 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesIncompatibleSeries(c *gc.C)
 	s.st.machines["0"].SetErrors(&state.ErrIncompatibleSeries{
 		SeriesList: []string{"yakkety", "zesty"},
 		Series:     "xenial",
+		CharmName:  "TestCharm",
 	})
 	apiV4 := s.machineManagerAPIV4()
 	results, err := apiV4.UpdateMachineSeries(
@@ -288,7 +289,7 @@ func (s *MachineManagerSuite) TestUpdateMachineSeriesIncompatibleSeries(c *gc.C)
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm, supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety,zesty",
 		},
 	})
 }
@@ -585,6 +586,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	s.st.machines["0"].SetErrors(&state.ErrIncompatibleSeries{
 		SeriesList: []string{"yakkety", "zesty"},
 		Series:     "xenial",
+		CharmName:  "TestCharm",
 	})
 	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
 	result, err := apiV5.UpgradeSeriesPrepare(
@@ -598,7 +600,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	c.Assert(result, jc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
 			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm, supported series are: yakkety,zesty",
+			Message: "series \"xenial\" not supported by charm \"TestCharm\", supported series are: yakkety,zesty",
 		},
 	})
 }

--- a/state/application.go
+++ b/state/application.go
@@ -1276,7 +1276,7 @@ func (a *Application) UpdateApplicationSeries(series string, force bool) (err er
 	}
 
 	err = a.st.db().Run(buildTxn)
-	return errors.Annotatef(err, "cannot update series for %q to %s", a, series)
+	return errors.Annotatef(err, "updating application series")
 }
 
 // VerifySupportedSeries verifies if the given series is supported by the

--- a/state/application.go
+++ b/state/application.go
@@ -1291,6 +1291,7 @@ func (a *Application) VerifySupportedSeries(series string, force bool) error {
 		return &ErrIncompatibleSeries{
 			SeriesList: ch.Meta().Series,
 			Series:     series,
+			CharmName:  ch.String(),
 		}
 	}
 	return nil

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1029,7 +1029,9 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesCharmURLChangedSeriesFail(
 
 	// Trusty is listed in only version 1 of the charm.
 	err := app.UpdateApplicationSeries("trusty", false)
-	c.Assert(err, gc.ErrorMatches, "cannot update series for \"multi-series\" to trusty: series \"trusty\" not supported by charm, supported series are: precise,xenial")
+	c.Assert(err, gc.ErrorMatches,
+		"updating application series: series \"trusty\" not supported by charm \"cs:multi-series-2\", "+
+			"supported series are: precise, xenial")
 }
 
 func (s *ApplicationSuite) TestUpdateApplicationSeriesCharmURLChangedSeriesPass(c *gc.C) {

--- a/state/errors.go
+++ b/state/errors.go
@@ -165,11 +165,12 @@ func IsParentDeviceHasChildrenError(err interface{}) bool {
 type ErrIncompatibleSeries struct {
 	SeriesList []string
 	Series     string
+	CharmName  string
 }
 
 func (e *ErrIncompatibleSeries) Error() string {
-	return fmt.Sprintf("series %q not supported by charm, supported series are: %s",
-		e.Series, strings.Join(e.SeriesList, ","))
+	return fmt.Sprintf("series %q not supported by charm '%s', supported series are: %s",
+		e.Series, e.CharmName, strings.Join(e.SeriesList, ","))
 }
 
 // IsIncompatibleSeriesError returns if the given error or its cause is

--- a/state/errors.go
+++ b/state/errors.go
@@ -169,8 +169,8 @@ type ErrIncompatibleSeries struct {
 }
 
 func (e *ErrIncompatibleSeries) Error() string {
-	return fmt.Sprintf("series %q not supported by charm '%s', supported series are: %s",
-		e.Series, e.CharmName, strings.Join(e.SeriesList, ","))
+	return fmt.Sprintf("series %q not supported by charm %q, supported series are: %s",
+		e.Series, e.CharmName, strings.Join(e.SeriesList, ", "))
 }
 
 // IsIncompatibleSeriesError returns if the given error or its cause is

--- a/state/machine.go
+++ b/state/machine.go
@@ -2128,7 +2128,7 @@ func (m *Machine) UpdateMachineSeries(series string, force bool) error {
 		return ops, nil
 	}
 	err := m.st.db().Run(buildTxn)
-	return errors.Annotatef(err, "cannot update series for %q to %s", m, series)
+	return errors.Annotatef(err, "updating series for machine %q", m)
 }
 
 // VerifyUnitsSeries iterates over the units with the input names, and checks

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2610,7 +2610,9 @@ func (s *MachineSuite) TestUpdateMachineSeriesCharmURLChangedSeriesFail(c *gc.C)
 
 	// Trusty is listed in only version 1 of the charm.
 	err := mach.UpdateMachineSeries("trusty", false)
-	c.Assert(err, gc.ErrorMatches, "cannot update series for \"2\" to trusty: series \"trusty\" not supported by charm, supported series are: precise,xenial")
+	c.Assert(err, gc.ErrorMatches,
+		"updating series for machine \"2\": series \"trusty\" not supported by charm \"cs:multi-series-2\", "+
+			"supported series are: precise, xenial")
 }
 
 func (s *MachineSuite) TestUpdateMachineSeriesPrincipalsListChange(c *gc.C) {


### PR DESCRIPTION
## Description of change

Unsupported series error messages did not include the offended charm's name in the message.
This PR supersedes https://github.com/juju/juju/pull/9389.

## QA steps

deploy a charm with limited series support
`juju deploy mysql`

Upgrade one of the charm's hosts
`juju upgrade series-prepare <machine> bionic`

You should see that the error message specifically indicates which charm does not support a particular series.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1797593