### PR TITLE
2.4 hubwatcher report

### DIFF
--- a/state/pool.go
+++ b/state/pool.go
@@ -347,5 +347,14 @@ func (p *StatePool) IntrospectionReport() string {
 }
 
 func (p *StatePool) Report() map[string]interface{} {
-	return nil
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	report := make(map[string]interface{})
+	for uuid, item := range p.pool {
+		modelReport := make(map[string]interface{})
+		modelReport["ref-count"] = item.refCount()
+		modelReport["to-remove"] = item.remove
+		report[uuid] = modelReport
+	}
+	return report
 }

--- a/state/pool.go
+++ b/state/pool.go
@@ -350,8 +350,11 @@ func (p *StatePool) Report() map[string]interface{} {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	report := make(map[string]interface{})
+	report["txn-watcher"] = p.watcherRunner.Report()
+	report["system"] = p.systemState.Report()
+	report["pool-size"] = len(p.pool)
 	for uuid, item := range p.pool {
-		modelReport := make(map[string]interface{})
+		modelReport := item.state.Report()
 		modelReport["ref-count"] = item.refCount()
 		modelReport["to-remove"] = item.remove
 		report[uuid] = modelReport

--- a/state/pool.go
+++ b/state/pool.go
@@ -345,3 +345,7 @@ func (p *StatePool) IntrospectionReport() string {
 		"Marked for removal: %d models\n"+
 		"\n%s", len(p.pool), removeCount, buff)
 }
+
+func (p *StatePool) Report() map[string]interface{} {
+	return nil
+}

--- a/state/pool.go
+++ b/state/pool.go
@@ -337,6 +337,7 @@ func (p *StatePool) IntrospectionReport() string {
 			index++
 			fmt.Fprintf(buff, "    [%d]\n%s\n", index, ref)
 		}
+		item.state.workers.Runner.Report()
 	}
 
 	return fmt.Sprintf(""+

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -195,3 +195,8 @@ func (s *statePoolSuite) TestGetRemovedNotAllowed(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("model %v has been removed", s.ModelUUID1))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
+
+func (s *statePoolSuite) TestReport(c *gc.C) {
+	report := s.StatePool.Report()
+	c.Check(report, gc.HasLen, 5)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1980,6 +1980,10 @@ func (st *State) AllRelations() (relations []*Relation, err error) {
 	return
 }
 
+func (st *State) Report() map[string]interface{} {
+	return st.workers.Report()
+}
+
 type relationDocSlice []relationDoc
 
 func (rdc relationDocSlice) Len() int      { return len(rdc) }

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -175,6 +175,7 @@ func (w *TxnWatcher) Err() error {
 
 // Report is part of the watcher/runner Reporting interface, to expose runtime details of the watcher.
 func (w *TxnWatcher) Report() map[string]interface{} {
+	// TODO: (jam) do we need to synchronize with the loop?
 	return map[string]interface{}{
 		"sync-events-len":     len(w.syncEvents),
 		"sync-events-cap":     cap(w.syncEvents),

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -167,6 +167,13 @@ func (w *TxnWatcher) Err() error {
 	return w.tomb.Err()
 }
 
+// Report is part of the watcher/runner Reporting interface, to expose runtime details of the watcher.
+func (w *TxnWatcher) Report() map[string]interface{} {
+	return map[string]interface{}{
+		"sync-events": len(w.syncEvents),
+	}
+}
+
 // loop implements the main watcher loop.
 // period is the delay between each sync.
 func (w *TxnWatcher) loop() error {

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -206,19 +206,6 @@ type reqUnwatch struct {
 
 type reqSync struct{}
 
-type HubWatcherStats struct {
-	WatchCount      int
-	RevnoMapSize    int
-	SyncQueueCap    int
-	SyncQueueLen    int
-	RequestQueueCap int
-	RequestQueueLen int
-}
-
-type reqStats struct {
-	ch chan<- HubWatcherStats
-}
-
 func (w *Watcher) sendReq(req interface{}) {
 	select {
 	case w.request <- req:

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -206,6 +206,19 @@ type reqUnwatch struct {
 
 type reqSync struct{}
 
+type HubWatcherStats struct {
+	WatchCount      int
+	RevnoMapSize    int
+	SyncQueueCap    int
+	SyncQueueLen    int
+	RequestQueueCap int
+	RequestQueueLen int
+}
+
+type reqStats struct {
+	ch chan<- HubWatcherStats
+}
+
 func (w *Watcher) sendReq(req interface{}) {
 	select {
 	case w.request <- req:

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -184,6 +184,10 @@ func (w *stateWorker) loop() error {
 	}
 }
 
+func (w *stateWorker) Report() map[string]interface{} {
+	return w.stTracker.Report()
+}
+
 func (w *stateWorker) processModelLifeChange(
 	modelUUID string,
 	modelStateWorkers map[string]worker.Worker,

--- a/worker/state/statetracker.go
+++ b/worker/state/statetracker.go
@@ -26,6 +26,7 @@ type StateTracker interface {
 	// called too many times).
 	Done() error
 
+	// Report is used to give details about what is going on with this state tracker.
 	Report() map[string]interface{}
 }
 
@@ -83,5 +84,7 @@ func (c *stateTracker) Done() error {
 }
 
 func (c *stateTracker) Report() map[string]interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.pool.Report()
 }

--- a/worker/state/statetracker.go
+++ b/worker/state/statetracker.go
@@ -25,6 +25,8 @@ type StateTracker interface {
 	// if the StatePool has already been closed (indicating that Done has
 	// called too many times).
 	Done() error
+
+	Report() map[string]interface{}
 }
 
 // stateTracker wraps a *state.State, keeping a reference count and
@@ -78,4 +80,8 @@ func (c *stateTracker) Done() error {
 		}
 	}
 	return nil
+}
+
+func (c *stateTracker) Report() map[string]interface{} {
+	return c.pool.Report()
 }

--- a/worker/state/statetracker_test.go
+++ b/worker/state/statetracker_test.go
@@ -124,3 +124,14 @@ func assertStateNotClosed(c *gc.C, st *state.State) {
 func assertStateClosed(c *gc.C, st *state.State) {
 	c.Assert(st.Ping, gc.PanicMatches, "Session already closed")
 }
+
+func (s *StateTrackerSuite) TestReport(c *gc.C) {
+	pool, err := s.stateTracker.Use()
+	c.Assert(err, jc.ErrorIsNil)
+	report := pool.Report()
+	c.Check(report, gc.NotNil)
+	// We don't have any State models in the pool, but we do have the txn-watcher report.
+	c.Check(report, gc.HasLen, 2)
+	c.Check(report["pool-size"], gc.Equals, 2)
+	c.Check(s.stateTracker.Report(), gc.DeepEquals, report)
+}


### PR DESCRIPTION
## Description of change

This adds some introspection to the hub watcher in the "juju_engine_report". This might allow us to understand more what is going on in the controller models when we are seeing that they are consuming significant amounts of memory over time.

## QA steps

```
$ juju bootstrap
$ juju ssh -m controller 0
$$ juju_engine_report | grep -A15 txnlog
```

Should show items like:
```
          txnlog:
            report:
              change-count: 1163751
              request-count: 5443
              request-event-count: 0
              request-queue-cap: 0
              request-queue-len: 0
              revno-map-bytes: 544149
              revno-map-size: 4058
              sync-avg-len: 0
              sync-event-coll-count: 0
              sync-event-doc-count: 0
              sync-last-len: 0
              sync-max-len: 0
              sync-queue-cap: 0
              sync-queue-len: 0
```
## Documentation changes

None.

## Bug reference

None.

