### PR TITLE
Changes upgrade-series command order in completion instructions.

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -49,7 +49,7 @@ Juju is now ready for the series to be updated.
 Perform any manual steps required along with "do-release-upgrade".
 When ready, run the following to complete the upgrade series process:
 
-juju upgrade-series complete %s`
+juju upgrade-series %s complete`
 
 const UpgradeSeriesCompleteFinishedMessage = `
 Upgrade series for machine %q has successfully completed`

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -157,7 +157,9 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesFlagAndNotPrompt(c
 
 	finishedMessage := fmt.Sprintf(machine.UpgradeSeriesPrepareFinishedMessage, machineArg)
 	displayedMessage := strings.Join([]string{confirmationMessage, finishedMessage}, "") + "\n"
-	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, displayedMessage)
+	out := ctx.Stderr.(*bytes.Buffer).String()
+	c.Assert(out, gc.Equals, displayedMessage)
+	c.Assert(out, jc.Contains, fmt.Sprintf("juju upgrade-series %s complete", machineArg))
 }
 
 type upgradeSeriesPrepareExpectation struct {


### PR DESCRIPTION
## Description of change

This changes the completion instructions that are written to the CLI after an upgrade-series _prepare_ command is run.

## QA steps

Bootstrap, add a Xenial machine and run `juju upgrade-series 0 prepare bionic`.
The last line after prepare has finished should be:
> juju upgrade-series 0 complete

## Documentation changes

None

## Bug reference

N/A
