### PR TITLE
Fix invalidate credential to take in params structure.

### DIFF
--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -75,8 +75,9 @@ func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, er
 
 // InvalidateModelCredential invalidates cloud credential for the model that made a connection.
 func (c *Facade) InvalidateModelCredential(reason string) error {
+	in := params.InvalidateCredentialArg{reason}
 	var result params.ErrorResult
-	err := c.facade.FacadeCall("InvalidateModelCredential", reason, &result)
+	err := c.facade.FacadeCall("InvalidateModelCredential", in, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/credentialvalidator/credentialvalidator_test.go
+++ b/api/credentialvalidator/credentialvalidator_test.go
@@ -119,14 +119,14 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CredentialValidator")
 		c.Check(request, gc.Equals, "InvalidateModelCredential")
-		c.Assert(arg, gc.Equals, "")
+		c.Assert(arg, gc.Equals, params.InvalidateCredentialArg{Reason: "auth fail"})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
 		*(result.(*params.ErrorResult)) = params.ErrorResult{}
 		return nil
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential("auth fail")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -17,7 +17,7 @@ var logger = loggo.GetLogger("juju.api.credentialvalidator")
 
 // CredentialValidator defines the methods on credentialvalidator API endpoint.
 type CredentialValidator interface {
-	InvalidateModelCredential(reason string) (params.ErrorResult, error)
+	InvalidateModelCredential(args params.InvalidateCredentialArg) (params.ErrorResult, error)
 	ModelCredential() (params.ModelCredential, error)
 	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
 }
@@ -96,8 +96,8 @@ func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, er
 }
 
 // InvalidateModelCredential marks the cloud credential for this model as invalid.
-func (api *CredentialValidatorAPI) InvalidateModelCredential(reason string) (params.ErrorResult, error) {
-	err := api.backend.InvalidateModelCredential(reason)
+func (api *CredentialValidatorAPI) InvalidateModelCredential(args params.InvalidateCredentialArg) (params.ErrorResult, error) {
+	err := api.backend.InvalidateModelCredential(args.Reason)
 	if err != nil {
 		return params.ErrorResult{Error: common.ServerError(err)}, nil
 	}

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -86,7 +86,7 @@ func (s *CredentialValidatorSuite) TestWatchCredentialInvalidTag(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -97,7 +97,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential("not again")
+	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: common.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -189,3 +189,9 @@ type ValidateCredentialArg struct {
 type ValidateCredentialArgs struct {
 	All []ValidateCredentialArg `json:"credentials,omitempty"`
 }
+
+// InvalidateCredentialArg is used to invalidate a controller credential.
+type InvalidateCredentialArg struct {
+	// Reason is the description of why we are invalidating credential.
+	Reason string `json:"reason,omitempty"`
+}


### PR DESCRIPTION
## Description of change

Backport of https://github.com/juju/juju/pull/9407/.

Differences are:
1. Invalidate credential has not been refactored yet into a common area to share. Hence, here, for 2.4, all the changes are on the only facade that uses it.
2. Featuretest is not backported as it was written on a facade that does not yet exist in 2.4.
3. params/cloud.go might cause issues when 2.4 is forward ported as new struct is placed differently in 2.4 and develop. It is the last one in both cases but, in develop, there is another new struct before it.
