### PR TITLE
Rackspace provider reacting to invalid credential.

### DIFF
--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -27,7 +27,7 @@ var bootstrap = common.Bootstrap
 
 // Bootstrap implements environs.Environ.
 func (e environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	// can't redirect to openstack provider as ussually, because correct environ should be passed for common.Bootstrap
+	// can't redirect to openstack provider as usually, because correct environ should be passed for common.Bootstrap
 	return bootstrap(ctx, e, callCtx, params)
 }
 
@@ -75,6 +75,7 @@ func (e environ) StartInstance(ctx context.ProviderCallContext, args environs.St
 		}
 		err = client.DropAllPorts([]int{apiPort, 22}, addr)
 		if err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return nil, errors.Trace(err)
 		}
 	}

--- a/provider/rackspace/errors.go
+++ b/provider/rackspace/errors.go
@@ -1,0 +1,18 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rackspace
+
+import (
+	"github.com/juju/errors"
+	gooseerrors "gopkg.in/goose.v2/errors"
+)
+
+// IsAuthorisationFailure determines if the given error has an authorisation failure.
+func IsAuthorisationFailure(err error) bool {
+	// This should cover most cases.
+	if gooseerrors.IsUnauthorised(errors.Cause(err)) {
+		return true
+	}
+	return false
+}

--- a/provider/rackspace/firewaller.go
+++ b/provider/rackspace/firewaller.go
@@ -90,7 +90,11 @@ func (c *rackspaceFirewaller) InstanceIngressRules(ctx context.ProviderCallConte
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return configurator.FindIngressRules()
+	rules, err := configurator.FindIngressRules()
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	}
+	return rules, err
 }
 
 func (c *rackspaceFirewaller) changeIngressRules(ctx context.ProviderCallContext, inst instance.Instance, insert bool, rules []network.IngressRule) error {
@@ -103,6 +107,7 @@ func (c *rackspaceFirewaller) changeIngressRules(ctx context.ProviderCallContext
 		if addr.Scope == network.ScopePublic {
 			err = sshClient.ChangeIngressRules(addr.Value, insert, rules)
 			if err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 				return errors.Trace(err)
 			}
 		}
@@ -113,6 +118,7 @@ func (c *rackspaceFirewaller) changeIngressRules(ctx context.ProviderCallContext
 func (c *rackspaceFirewaller) getInstanceConfigurator(ctx context.ProviderCallContext, inst instance.Instance) ([]network.Address, common.InstanceConfigurator, error) {
 	addresses, err := inst.Addresses(ctx)
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, nil, errors.Trace(err)
 	}
 	if len(addresses) == 0 {


### PR DESCRIPTION
## Description of change

Rackspace provider is built on top of the openstack provider and, thus, is already capable of reacting to a cloud credential becoming invalid.

This PR closes the gap for the rackspace-only implementation.

