### PR TITLE
vsphere: Invalidate credential on auth error

### DIFF
--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -29,7 +29,7 @@ func (z *vmwareAvailZone) Available() bool {
 
 // AvailabilityZones is part of the common.ZonedEnviron interface.
 func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (zones []common.AvailabilityZone, err error) {
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		zones, err = env.AvailabilityZones(ctx)
 		return err
 	})
@@ -41,6 +41,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([
 	if env.zones == nil {
 		computeResources, err := env.client.ComputeResources(env.ctx)
 		if err != nil {
+			HandleCredentialError(err, ctx)
 			return nil, errors.Trace(err)
 		}
 		zones := make([]common.AvailabilityZone, len(computeResources))
@@ -54,7 +55,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([
 
 // InstanceAvailabilityZoneNames is part of the common.ZonedEnviron interface.
 func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (names []string, err error) {
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		names, err = env.InstanceAvailabilityZoneNames(ctx, ids)
 		return err
 	})
@@ -96,7 +97,7 @@ func (env *sessionEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCal
 
 // DeriveAvailabilityZones is part of the common.ZonedEnviron interface.
 func (env *environ) DeriveAvailabilityZones(ctx context.ProviderCallContext, args environs.StartInstanceParams) (names []string, err error) {
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		names, err = env.DeriveAvailabilityZones(ctx, args)
 		return err
 	})

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 )
@@ -95,4 +96,12 @@ func (s *environAvailzonesSuite) TestDeriveAvailabilityZonesInvalidPlacement(c *
 		})
 	c.Assert(err, gc.ErrorMatches, `unknown placement directive: invalid-placement`)
 	c.Assert(zones, gc.HasLen, 0)
+}
+
+func (s *environAvailzonesSuite) TestAvailabilityZonesPermissionError(c *gc.C) {
+	AssertInvalidatesCredential(c, s.client, func(ctx context.ProviderCallContext) error {
+		zonedEnv := s.env.(common.ZonedEnviron)
+		_, err := zonedEnv.AvailabilityZones(ctx)
+		return err
+	})
 }

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -67,7 +67,7 @@ func (*environ) MaintainInstance(ctx context.ProviderCallContext, args environs.
 
 // StartInstance implements environs.InstanceBroker.
 func (env *environ) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (result *environs.StartInstanceResult, err error) {
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		result, err = env.StartInstance(ctx, args)
 		return err
 	})
@@ -239,6 +239,7 @@ func (env *sessionEnviron) newRawInstance(
 
 	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
 	if err != nil {
+		HandleCredentialError(err, ctx)
 		return nil, nil, errors.Trace(err)
 	}
 
@@ -254,7 +255,7 @@ func (env *sessionEnviron) newRawInstance(
 
 // AllInstances implements environs.InstanceBroker.
 func (env *environ) AllInstances(ctx context.ProviderCallContext) (instances []instance.Instance, err error) {
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		instances, err = env.AllInstances(ctx)
 		return err
 	})
@@ -269,6 +270,7 @@ func (env *sessionEnviron) AllInstances(ctx context.ProviderCallContext) ([]inst
 	)
 	vms, err := env.client.VirtualMachines(env.ctx, modelFolderPath+"/*")
 	if err != nil {
+		HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -283,7 +285,7 @@ func (env *sessionEnviron) AllInstances(ctx context.ProviderCallContext) ([]inst
 
 // StopInstances implements environs.InstanceBroker.
 func (env *environ) StopInstances(ctx context.ProviderCallContext, ids ...instance.Id) error {
-	return env.withSession(func(env *sessionEnviron) error {
+	return env.withSession(ctx, func(env *sessionEnviron) error {
 		return env.StopInstances(ctx, ids...)
 	})
 }
@@ -304,6 +306,7 @@ func (env *sessionEnviron) StopInstances(ctx context.ProviderCallContext, ids ..
 				env.ctx,
 				path.Join(modelFolderPath, string(id)),
 			)
+			HandleCredentialError(results[i], ctx)
 		}(i, id)
 	}
 	wg.Wait()

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -19,7 +19,7 @@ func (env *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id
 	if len(ids) == 0 {
 		return nil, environs.ErrNoInstances
 	}
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		instances, err = env.Instances(ctx, ids)
 		return err
 	})
@@ -63,7 +63,7 @@ func (env *sessionEnviron) Instances(ctx context.ProviderCallContext, ids []inst
 
 // ControllerInstances is part of the environs.Environ interface.
 func (env *environ) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) (ids []instance.Id, err error) {
-	err = env.withSession(func(env *sessionEnviron) error {
+	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		ids, err = env.ControllerInstances(ctx, controllerUUID)
 		return err
 	})

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -16,7 +16,7 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 	if args.Placement == "" {
 		return nil
 	}
-	return env.withSession(func(env *sessionEnviron) error {
+	return env.withSession(ctx, func(env *sessionEnviron) error {
 		return env.PrecheckInstance(ctx, args)
 	})
 }

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -157,3 +157,30 @@ func (s *environSuite) TestSupportsNetworking(c *gc.C) {
 	_, ok := environs.SupportsNetworking(s.env)
 	c.Assert(ok, jc.IsFalse)
 }
+
+func (s *environSuite) TestAdoptResourcesPermissionError(c *gc.C) {
+	AssertInvalidatesCredential(c, s.client, func(ctx environscontext.ProviderCallContext) error {
+		return s.env.AdoptResources(ctx, "foo", version.Number{})
+	})
+}
+
+func (s *environSuite) TestBootstrapPermissionError(c *gc.C) {
+	AssertInvalidatesCredential(c, s.client, func(ctx environscontext.ProviderCallContext) error {
+		_, err := s.env.Bootstrap(nil, ctx, environs.BootstrapParams{
+			ControllerConfig: testing.FakeControllerConfig(),
+		})
+		return err
+	})
+}
+
+func (s *environSuite) TestDestroyPermissionError(c *gc.C) {
+	AssertInvalidatesCredential(c, s.client, func(ctx environscontext.ProviderCallContext) error {
+		return s.env.Destroy(ctx)
+	})
+}
+
+func (s *environSuite) TestDestroyControllerPermissionError(c *gc.C) {
+	AssertInvalidatesCredential(c, s.client, func(ctx environscontext.ProviderCallContext) error {
+		return s.env.DestroyController(ctx, "foo")
+	})
+}

--- a/provider/vsphere/errors.go
+++ b/provider/vsphere/errors.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
+)
+
+const (
+	// serverFaultCode is the code on the SOAP fault for an
+	// authentication error.
+	serverFaultCode = "ServerFaultCode"
+
+	// loginErrorFragment is what we look for in the message string to
+	// determine whether this is a login failure. (Using a fragment
+	// instead of the exact string to try to avoid breaking if a
+	// 'cosmetic' is made to the message.)
+	loginErrorFragment = "incorrect user name or password"
+)
+
+// IsAuthorisationFailure determines whether the given error indicates
+// that the vsphere credential used is bad.
+func IsAuthorisationFailure(err error) bool {
+	baseErr := errors.Cause(err)
+	if !soap.IsSoapFault(baseErr) {
+		return false
+	}
+	fault := soap.ToSoapFault(baseErr)
+	if fault.Code != serverFaultCode {
+		return false
+	}
+	_, isPermissionError := fault.Detail.Fault.(types.NoPermission)
+	if isPermissionError {
+		return true
+	}
+	// Otherwise it could be a login error.
+	return strings.Contains(fault.String, loginErrorFragment)
+}
+
+// HandleCredentialError marks the current credential as invalid if
+// the passed vsphere error indicates it should be.
+func HandleCredentialError(err error, ctx context.ProviderCallContext) {
+	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+}

--- a/provider/vsphere/session.go
+++ b/provider/vsphere/session.go
@@ -6,6 +6,7 @@ package vsphere
 import (
 	"golang.org/x/net/context"
 
+	callcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/common"
 )
 
@@ -32,9 +33,9 @@ type sessionEnviron struct {
 	zones []common.AvailabilityZone
 }
 
-func (env *environ) withSession(f func(*sessionEnviron) error) error {
+func (env *environ) withSession(callCtx callcontext.ProviderCallContext, f func(*sessionEnviron) error) error {
 	ctx := context.Background()
-	return env.withClient(ctx, func(client Client) error {
+	return env.withClient(ctx, callCtx, func(client Client) error {
 		return f(&sessionEnviron{
 			environ: env,
 			ctx:     ctx,

--- a/provider/vsphere/upgrades_test.go
+++ b/provider/vsphere/upgrades_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 )
 
 type environUpgradeSuite struct {
@@ -90,4 +91,25 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationModelFolders(c *gc.C) {
 	c.Assert(moveVMsIntoCall.Args[2], jc.DeepEquals,
 		[]types.ManagedObjectReference{vm1.Reference(), vm2.Reference(), vm3.Reference()},
 	)
+}
+
+func (s *environUpgradeSuite) TestExtraConfigPermissionError(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	step := upgrader.UpgradeOperations(s.callCtx,
+		environs.UpgradeOperationsParams{
+			ControllerUUID: "foo",
+		})[0].Steps[0]
+	AssertInvalidatesCredential(c, s.client, func(ctx context.ProviderCallContext) error {
+		return step.Run(ctx)
+	})
+}
+func (s *environUpgradeSuite) TestModelFoldersPermissionError(c *gc.C) {
+	upgrader := s.env.(environs.Upgrader)
+	step := upgrader.UpgradeOperations(s.callCtx,
+		environs.UpgradeOperationsParams{
+			ControllerUUID: "foo",
+		})[0].Steps[1]
+	AssertInvalidatesCredential(c, s.client, func(ctx context.ProviderCallContext) error {
+		return step.Run(ctx)
+	})
 }


### PR DESCRIPTION
## Description of change
When we get a login or permission error from the vsphere client, invalidate the credential.

## QA steps
* In vsphere, create a new user and give them permission to the datacenter you'll create a controller in.
* Add the vsphere cloud and a credential for the new user.
* Bootstrap a controller in that datacenter using the new credential, and deploy some applications.
* Disable the user in the vsphere UI and then add a unit to one of the applications.
* The controller debug-log should show the login error and report that the credential is marked as invalid.
* Re-enable the user  in vsphere and update the credential in juju (to the same one).
* The unit should be added successfully.

* Do the same thing again but instead of disabling/enabling the user, remove the permission to manage the datacenter instead.
