### PR TITLE
apiserver: Skip unprovisioned machines when checking cloud creds

### DIFF
--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -119,7 +119,11 @@ func checkMachineInstances(backend PersistentBackend, provider CloudProvider, ca
 			continue
 		}
 		instanceId, err := machine.InstanceId()
-		if err != nil {
+		if errors.IsNotProvisioned(err) {
+			// Skip over this machine; we wouldn't expect the cloud
+			// to know about it.
+			continue
+		} else if err != nil {
 			results = append(results, serverError(errors.Annotatef(err, "getting instance id for machine %s", machine.Id())))
 			continue
 		}

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -177,6 +177,20 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 	})
 }
 
+func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
+	machine2 := createTestMachine("2", "")
+	machine2.instanceIdFunc = func() (instance.Id, error) { return "", errors.NotProvisionedf("machine 2") }
+	s.backend.allMachinesFunc = func() ([]credentialcommon.Machine, error) {
+		return []credentialcommon.Machine{s.machine, machine2}, nil
+	}
+
+	// We should ignore the unprovisioned machine - we wouldn't expect
+	// the cloud to know about it.
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
+}
+
 type ModelCredentialSuite struct {
 	testing.IsolationSuite
 


### PR DESCRIPTION
## Description of change

If I do an add-unit with a bad cloud credential, a new machine gets created in the model but when the provisioner tries to start a corresponding instance the credential will get invalidated. If I try to use update-credential to mark the credential as valid again, it fails because of the NotProvisioned error from getting the machine's instance id. Change the check to skip unprovisioned machines - we don't expect the cloud to know about these anyway.

## QA steps

* Bootstrap a controller with a credential that you can disable in the cloud provider (and deploy an application).
* Disable the credential.
* Add a unit to the application. This will create a machine for the unit, but when we try to provision it the cred will be invalidated.
* Reenable the cred in the cloud.
* Use update-credential to reactivate the credential - it succeeds.
* The machine and unit get added successfully.
