### PR TITLE
Prevent Adding Machine to, and Deploying to Extant Containers on Upgrading Machines

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -464,7 +464,7 @@ func deployApplication(
 			return errors.Annotatef(err, errTemplate, args.ApplicationName, p.Directive)
 		}
 
-		locked, err := m.IsLocked()
+		locked, err := m.IsLockedForSeriesUpgrade()
 		if locked {
 			err = errors.New("machine is locked for series upgrade")
 		}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -445,32 +445,10 @@ func deployApplication(
 		}
 	}
 
-	// Do a quick, incomplete validation check before going any further.
-	// If the placement scope is for a machine, ensure that the machine exists.
-	// If the placement is for a machine or a container on an existing machine,
-	// check that the machine is not locked for series upgrade.
-	errTemplate := "cannot deploy %q to machine %s"
-	for _, p := range args.Placement {
-		machineMustExist := p.Scope == instance.MachineScope
-		if !machineMustExist && p.Directive == "" {
-			continue
-		}
-
-		m, err := backend.Machine(p.Directive)
-		if err != nil {
-			if errors.IsNotFound(err) && !machineMustExist {
-				continue
-			}
-			return errors.Annotatef(err, errTemplate, args.ApplicationName, p.Directive)
-		}
-
-		locked, err := m.IsLockedForSeriesUpgrade()
-		if locked {
-			err = errors.New("machine is locked for series upgrade")
-		}
-		if err != nil {
-			return errors.Annotatef(err, errTemplate, args.ApplicationName, p.Directive)
-		}
+	// This check is done early so that errors deeper in the call-stack do not
+	// leave an application deployment in an unrecoverable error state.
+	if err := checkMachinePlacement(backend, args); err != nil {
+		return errors.Trace(err)
 	}
 
 	// Try to find the charm URL in state first.
@@ -547,6 +525,51 @@ func deployApplication(
 		Resources:         args.Resources,
 	})
 	return errors.Trace(err)
+}
+
+// checkMachinePlacement does a non-exhaustive validation of any supplied
+// placement directives.
+// If the placement scope is for a machine, ensure that the machine exists.
+// If the placement is for a machine or a container on an existing machine,
+// check that the machine is not locked for series upgrade.
+func checkMachinePlacement(backend Backend, args params.ApplicationDeploy) error {
+	errTemplate := "cannot deploy %q to machine %s"
+	app := args.ApplicationName
+
+	for _, p := range args.Placement {
+		dir := p.Directive
+
+		toExtantMachine := p.Scope == instance.MachineScope
+		if !toExtantMachine && dir == "" {
+			continue
+		}
+
+		m, err := backend.Machine(dir)
+		if err != nil {
+			if errors.IsNotFound(err) && !toExtantMachine {
+				continue
+			}
+			return errors.Annotatef(err, errTemplate, app, dir)
+		}
+
+		locked, err := m.IsLockedForSeriesUpgrade()
+		if locked {
+			err = errors.New("machine is locked for series upgrade")
+		}
+		if err != nil {
+			return errors.Annotatef(err, errTemplate, app, dir)
+		}
+
+		locked, err = m.IsParentLockedForSeriesUpgrade()
+		if locked {
+			err = errors.New("parent machine is locked for series upgrade")
+		}
+		if err != nil {
+			return errors.Annotatef(err, errTemplate, app, dir)
+		}
+	}
+
+	return nil
 }
 
 // ApplicationSetSettingsStrings updates the settings for the given application,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -668,10 +668,10 @@ func (s *applicationSuite) testClientApplicationsDeployWithBindings(c *gc.C, end
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	application, err := s.State.Application(args.ApplicationName)
+	app, err := s.State.Application(args.ApplicationName)
 	c.Assert(err, jc.ErrorIsNil)
 
-	retrievedBindings, err := application.EndpointBindings()
+	retrievedBindings, err := app.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(retrievedBindings, jc.DeepEquals, expected)
 }
@@ -913,9 +913,9 @@ func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure that the charm is not marked as forced.
-	application, err := s.State.Application("application")
+	app, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
-	charm, force, err := application.Charm()
+	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charm.URL().String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsFalse)
@@ -951,9 +951,9 @@ func (s *applicationSuite) assertApplicationSetCharm(c *gc.C, forceUnits bool) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure that the charm is not marked as forced.
-	application, err := s.State.Application("application")
+	app, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
-	charm, _, err := application.Charm()
+	charm, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charm.URL().String(), gc.Equals, "cs:~who/precise/wordpress-3")
 }
@@ -1012,9 +1012,9 @@ func (s *applicationSuite) TestApplicationSetCharmForceUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure that the charm is marked as forced.
-	application, err := s.State.Application("application")
+	app, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
-	charm, force, err := application.Charm()
+	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charm.URL().String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsTrue)
@@ -1313,16 +1313,16 @@ func (s *applicationSuite) TestApplicationDeploySubordinate(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	application, err := s.State.Application("application-name")
+	app, err := s.State.Application("application-name")
 	c.Assert(err, jc.ErrorIsNil)
-	charm, force, err := application.Charm()
+	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, jc.IsFalse)
 	c.Assert(charm.URL(), gc.DeepEquals, curl)
 	c.Assert(charm.Meta(), gc.DeepEquals, ch.Meta())
 	c.Assert(charm.Config(), gc.DeepEquals, ch.Config())
 
-	units, err := application.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 0)
 }
@@ -1352,11 +1352,11 @@ func (s *applicationSuite) TestApplicationDeployConfig(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	application, err := s.State.Application("application-name")
+	app, err := s.State.Application("application-name")
 	c.Assert(err, jc.ErrorIsNil)
-	settings, err := application.CharmConfig()
+	settings, err := app.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	ch, _, err := application.Charm()
+	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, s.combinedSettings(ch, charm.Settings{"username": "fred"}))
 }
@@ -1403,9 +1403,9 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	application, err := s.State.Application("application-name")
+	app, err := s.State.Application("application-name")
 	c.Assert(err, jc.ErrorIsNil)
-	charm, force, err := application.Charm()
+	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, jc.IsFalse)
 	c.Assert(charm.URL(), gc.DeepEquals, curl)
@@ -1416,7 +1416,7 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	c.Assert(errs, gc.DeepEquals, []error{nil})
 	c.Assert(err, jc.ErrorIsNil)
 
-	units, err := application.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
 
@@ -1495,9 +1495,9 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	application, err := s.State.Application("application-name")
+	app, err := s.State.Application("application-name")
 	c.Assert(err, jc.ErrorIsNil)
-	expected, force, err := application.Charm()
+	expected, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, jc.IsFalse)
 	c.Assert(expected.URL(), gc.DeepEquals, curl)
@@ -1509,7 +1509,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	c.Assert(errs, gc.DeepEquals, []error{nil})
 	c.Assert(err, jc.ErrorIsNil)
 
-	units, err := application.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
 
@@ -1569,9 +1569,9 @@ func (s *applicationSuite) checkClientApplicationUpdateSetCharm(c *gc.C, forceCh
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the charm has been updated and and the force flag correctly set.
-	application, err := s.State.Application("application")
+	app, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
-	ch, force, err := application.Charm()
+	ch, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL().String(), gc.Equals, curl.String())
 	c.Assert(force, gc.Equals, forceCharmURL)
@@ -1636,9 +1636,9 @@ func (s *applicationSuite) TestBlockApplicationUpdateForced(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the charm has been updated and and the force flag correctly set.
-	application, err := s.State.Application("application")
+	app, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
-	ch, force, err := application.Charm()
+	ch, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL().String(), gc.Equals, curl)
 	c.Assert(force, jc.IsTrue)
@@ -1655,7 +1655,7 @@ func (s *applicationSuite) TestApplicationUpdateSetCharmNotFound(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetMinUnits(c *gc.C) {
-	application := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
+	app := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Set minimum units for the application.
 	minUnits := 2
@@ -1667,12 +1667,12 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the minimum number of units has been set.
-	c.Assert(application.Refresh(), gc.IsNil)
-	c.Assert(application.MinUnits(), gc.Equals, minUnits)
+	c.Assert(app.Refresh(), gc.IsNil)
+	c.Assert(app.MinUnits(), gc.Equals, minUnits)
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetMinUnitsWithLXDProfile(c *gc.C) {
-	application := s.AddTestingApplication(c, "lxd-profile", s.AddTestingCharm(c, "lxd-profile"))
+	app := s.AddTestingApplication(c, "lxd-profile", s.AddTestingCharm(c, "lxd-profile"))
 
 	// Set minimum units for the application.
 	minUnits := 2
@@ -1684,8 +1684,8 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnitsWithLXDProfile(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the minimum number of units has been set.
-	c.Assert(application.Refresh(), gc.IsNil)
-	c.Assert(application.MinUnits(), gc.Equals, minUnits)
+	c.Assert(app.Refresh(), gc.IsNil)
+	c.Assert(app.MinUnits(), gc.Equals, minUnits)
 }
 
 func (s *applicationSuite) TestApplicationUpdateDoesNotSetMinUnitsWithLXDProfile(c *gc.C) {
@@ -1704,7 +1704,7 @@ func (s *applicationSuite) TestApplicationUpdateDoesNotSetMinUnitsWithLXDProfile
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetMinUnitsError(c *gc.C) {
-	application := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
+	app := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Set a negative minimum number of units for the application.
 	minUnits := -1
@@ -1717,13 +1717,13 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnitsError(c *gc.C) {
 		`cannot set minimum units for application "dummy": cannot set a negative minimum number of units`)
 
 	// Ensure the minimum number of units has not been set.
-	c.Assert(application.Refresh(), gc.IsNil)
-	c.Assert(application.MinUnits(), gc.Equals, 0)
+	c.Assert(app.Refresh(), gc.IsNil)
+	c.Assert(app.MinUnits(), gc.Equals, 0)
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetSettingsStrings(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
-	application := s.AddTestingApplication(c, "dummy", ch)
+	app := s.AddTestingApplication(c, "dummy", ch)
 
 	// Update settings for the application.
 	args := params.ApplicationUpdate{
@@ -1735,14 +1735,14 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsStrings(c *gc.C) {
 
 	// Ensure the settings have been correctly updated.
 	expected := charm.Settings{"title": "s-title", "username": "s-user"}
-	obtained, err := application.CharmConfig()
+	obtained, err := app.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
-	application := s.AddTestingApplication(c, "dummy", ch)
+	app := s.AddTestingApplication(c, "dummy", ch)
 
 	// Update settings for the application.
 	args := params.ApplicationUpdate{
@@ -1754,14 +1754,14 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 
 	// Ensure the settings have been correctly updated.
 	expected := charm.Settings{"title": "y-title", "username": "y-user"}
-	obtained, err := application.CharmConfig()
+	obtained, err := app.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
 }
 
 func (s *applicationSuite) TestClientApplicationUpdateSetSettingsGetYAML(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
-	application := s.AddTestingApplication(c, "dummy", ch)
+	app := s.AddTestingApplication(c, "dummy", ch)
 
 	// Update settings for the application.
 	args := params.ApplicationUpdate{
@@ -1773,13 +1773,13 @@ func (s *applicationSuite) TestClientApplicationUpdateSetSettingsGetYAML(c *gc.C
 
 	// Ensure the settings have been correctly updated.
 	expected := charm.Settings{"title": "y-title", "username": "y-user"}
-	obtained, err := application.CharmConfig()
+	obtained, err := app.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetConstraints(c *gc.C) {
-	application := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
+	app := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update constraints for the application.
 	cons, err := constraints.Parse("mem=4096", "cores=2")
@@ -1792,7 +1792,7 @@ func (s *applicationSuite) TestApplicationUpdateSetConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
-	obtained, err := application.Constraints()
+	obtained, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
@@ -1822,27 +1822,27 @@ func (s *applicationSuite) TestApplicationUpdateAllParams(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the application has been correctly updated.
-	application, err := s.State.Application("application")
+	app, err := s.State.Application("application")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the charm.
-	ch, force, err := application.Charm()
+	ch, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL().String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsTrue)
 
 	// Check the minimum number of units.
-	c.Assert(application.MinUnits(), gc.Equals, minUnits)
+	c.Assert(app.MinUnits(), gc.Equals, minUnits)
 
 	// Check the settings: also ensure the YAML settings take precedence
 	// over strings ones.
 	expectedSettings := charm.Settings{"blog-title": "yaml-title"}
-	obtainedSettings, err := application.CharmConfig()
+	obtainedSettings, err := app.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedSettings, gc.DeepEquals, expectedSettings)
 
 	// Check the constraints.
-	obtainedConstraints, err := application.Constraints()
+	obtainedConstraints, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedConstraints, gc.DeepEquals, cons)
 }
@@ -2261,9 +2261,9 @@ func (s *applicationSuite) TestApplicationExpose(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
-			application, err := s.State.Application(t.application)
+			app, err := s.State.Application(t.application)
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(application.IsExposed(), gc.Equals, t.exposed)
+			c.Assert(app.IsExposed(), gc.Equals, t.exposed)
 		}
 	}
 }
@@ -2481,11 +2481,11 @@ func (s *applicationSuite) TestApplicationDestroy(c *gc.C) {
 	// document.
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	applicationName := "wordpress"
-	application, err := s.State.Application(applicationName)
+	app, err := s.State.Application(applicationName)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.applicationAPI.Destroy(params.ApplicationDestroy{applicationName})
 	c.Assert(err, jc.ErrorIsNil)
-	err = application.Refresh()
+	err = app.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -2503,10 +2503,10 @@ func (s *applicationSuite) TestBlockApplicationDestroy(c *gc.C) {
 	err := s.applicationAPI.Destroy(params.ApplicationDestroy{"dummy-application"})
 	s.AssertBlocked(c, err, "TestBlockApplicationDestroy")
 	// Tests may have invalid application names.
-	application, err := s.State.Application("dummy-application")
+	app, err := s.State.Application("dummy-application")
 	if err == nil {
 		// For valid application names, check that application is alive :-)
-		assertLife(c, application, state.Alive)
+		assertLife(c, app, state.Alive)
 	}
 }
 
@@ -2771,7 +2771,7 @@ func (s *applicationSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 }
 
 func (s *applicationSuite) TestClientSetApplicationConstraints(c *gc.C) {
-	application := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
+	app := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
 	// Update constraints for the application.
 	cons, err := constraints.Parse("mem=4096", "cores=2")
@@ -2780,17 +2780,17 @@ func (s *applicationSuite) TestClientSetApplicationConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
-	obtained, err := application.Constraints()
+	obtained, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
 
 func (s *applicationSuite) setupSetApplicationConstraints(c *gc.C) (*state.Application, constraints.Value) {
-	application := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
+	app := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
 	// Update constraints for the application.
 	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
-	return application, cons
+	return app, cons
 }
 
 func (s *applicationSuite) assertSetApplicationConstraints(c *gc.C, application *state.Application, cons constraints.Value) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -99,6 +99,7 @@ type Charm interface {
 // the same names.
 type Machine interface {
 	IsLockedForSeriesUpgrade() (bool, error)
+	IsParentLockedForSeriesUpgrade() (bool, error)
 	UpgradeCharmProfileComplete() string
 	SetUpgradeCharmProfileComplete(string) error
 }

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -98,7 +98,7 @@ type Charm interface {
 // details on the methods, see the methods on state.Machine with
 // the same names.
 type Machine interface {
-	IsLocked() (bool, error)
+	IsLockedForSeriesUpgrade() (bool, error)
 	UpgradeCharmProfileComplete() string
 	SetUpgradeCharmProfileComplete(string) error
 }

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -352,7 +352,7 @@ type mockMachine struct {
 }
 
 func (m *mockMachine) IsLocked() (bool, error) {
-	m.MethodCall(m, "IsLocked")
+	m.MethodCall(m, "IsLockedForSeriesUpgrade")
 	return false, m.NextErr()
 }
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -351,8 +351,13 @@ type mockMachine struct {
 	upgradeCharmProfileComplete string
 }
 
-func (m *mockMachine) IsLocked() (bool, error) {
+func (m *mockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.MethodCall(m, "IsLockedForSeriesUpgrade")
+	return false, m.NextErr()
+}
+
+func (m *mockMachine) IsParentLockedForSeriesUpgrade() (bool, error) {
+	m.MethodCall(m, "IsParentLockedForSeriesUpgrade")
 	return false, m.NextErr()
 }
 

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -356,7 +356,7 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 	}
 
 	// Ensure that the machine is not locked for series-upgrade.
-	locked, err := parent.IsLocked()
+	locked, err := parent.IsLockedForSeriesUpgrade()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -355,6 +355,15 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 		return nil, nil, errors.Errorf("machine %s cannot host %s containers", parentId, containerType)
 	}
 
+	// Ensure that the machine is not locked for series-upgrade.
+	locked, err := parent.IsLocked()
+	if err != nil {
+		return nil, nil, err
+	}
+	if locked {
+		return nil, nil, errors.Errorf("machine %s is locked for series upgrade", parentId)
+	}
+
 	newId, err := st.newContainerId(parentId, containerType)
 	if err != nil {
 		return nil, nil, err

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -64,7 +64,7 @@ func (m *Machine) CreateUpgradeSeriesLock(unitNames []string, toSeries string) e
 				return nil, errors.Trace(err)
 			}
 		}
-		locked, err := m.IsLocked()
+		locked, err := m.IsLockedForSeriesUpgrade()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -100,8 +100,8 @@ func (m *Machine) CreateUpgradeSeriesLock(unitNames []string, toSeries string) e
 	return nil
 }
 
-// IsLocked determines if a machine is locked for upgrade series.
-func (m *Machine) IsLocked() (bool, error) {
+// IsLockedForSeriesUpgrade determines if a machine is locked for upgrade series.
+func (m *Machine) IsLockedForSeriesUpgrade() (bool, error) {
 	_, err := m.getUpgradeSeriesLock()
 	if err == nil {
 		return true, nil
@@ -308,7 +308,7 @@ func (m *Machine) RemoveUpgradeSeriesLock() error {
 				return nil, errors.Trace(err)
 			}
 		}
-		locked, err := m.IsLocked()
+		locked, err := m.IsLockedForSeriesUpgrade()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -100,6 +100,23 @@ func (m *Machine) CreateUpgradeSeriesLock(unitNames []string, toSeries string) e
 	return nil
 }
 
+// IsParentLockedForSeriesUpgrade determines if a machine is a container who's
+// parent is locked for series upgrade.
+func (m *Machine) IsParentLockedForSeriesUpgrade() (bool, error) {
+	parentId, isContainer := m.ParentId()
+	if !isContainer {
+		return false, nil
+	}
+
+	parent, err := m.st.Machine(parentId)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	locked, err := parent.IsLockedForSeriesUpgrade()
+	return locked, errors.Trace(err)
+}
+
 // IsLockedForSeriesUpgrade determines if a machine is locked for upgrade series.
 func (m *Machine) IsLockedForSeriesUpgrade() (bool, error) {
 	_, err := m.getUpgradeSeriesLock()

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -13,7 +13,7 @@ import (
 
 func (s *MachineSuite) TestCreateUpgradeSeriesLock(c *gc.C) {
 	mach := s.setupTestUpdateMachineSeries(c)
-	locked, err := mach.IsLocked()
+	locked, err := mach.IsLockedForSeriesUpgrade()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsFalse)
 
@@ -21,7 +21,7 @@ func (s *MachineSuite) TestCreateUpgradeSeriesLock(c *gc.C) {
 	err = mach.CreateUpgradeSeriesLock(unitIds, "xenial")
 	c.Assert(err, jc.ErrorIsNil)
 
-	locked, err = mach.IsLocked()
+	locked, err = mach.IsLockedForSeriesUpgrade()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsTrue)
 
@@ -218,19 +218,19 @@ func (s *MachineSuite) TestGetUpgradeSeriesMessagesMissingLockMeansFinished(c *g
 }
 
 func (s *MachineSuite) TestIsLockedIndicatesUnlockedWhenNoLockDocIsFound(c *gc.C) {
-	locked, err := s.machine.IsLocked()
+	locked, err := s.machine.IsLockedForSeriesUpgrade()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsFalse)
 }
 
 func AssertMachineLockedForPrepare(c *gc.C, mach *state.Machine) {
-	locked, err := mach.IsLocked()
+	locked, err := mach.IsLockedForSeriesUpgrade()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsTrue)
 }
 
 func AssertMachineIsNOTLockedForPrepare(c *gc.C, mach *state.Machine) {
-	locked, err := mach.IsLocked()
+	locked, err := mach.IsLockedForSeriesUpgrade()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(locked, jc.IsFalse)
 }

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -37,6 +37,24 @@ func (s *MachineSuite) TestCreateUpgradeSeriesLock(c *gc.C) {
 	c.Assert(lockedUnitsIds, jc.SameContents, unitIds)
 }
 
+func (s *MachineSuite) TestIsParentLockedForSeriesUpgrade(c *gc.C) {
+	parent, err := s.State.AddMachine("xenial", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	template := state.MachineTemplate{
+		Series: "xenial",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	}
+	child, err := s.State.AddMachineInsideMachine(template, parent.Id(), "lxd")
+
+	err = parent.CreateUpgradeSeriesLock([]string{}, "bionic")
+	c.Assert(err, jc.ErrorIsNil)
+
+	locked, err := child.IsParentLockedForSeriesUpgrade()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(locked, jc.IsTrue)
+}
+
 func (s *MachineSuite) TestCreateUpgradeSeriesLockErrorsIfLockExists(c *gc.C) {
 	mach := s.setupTestUpdateMachineSeries(c)
 	err := mach.CreateUpgradeSeriesLock([]string{"wordpress/0", "multi-series/0", "multi-series-subordinate/0"}, "xenial")

--- a/state/state.go
+++ b/state/state.go
@@ -1685,7 +1685,7 @@ func (st *State) addMachineWithPlacement(unit *Unit, placement *instance.Placeme
 
 		// Check if an upgrade-series lock is present for the requested
 		// machine. If one exists, return an error to prevent deployment.
-		locked, err := machine.IsLocked()
+		locked, err := machine.IsLockedForSeriesUpgrade()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

This patch builds on https://github.com/juju/juju/pull/9387.

It prevents:
- Creation of containers on machines locked for series upgrade and;
- Deployment via placement to extant containers on machines locked for series upgrade.

Note that this change does not prevent deployment via policy to an empty container on an upgrading machine. That will be addressed in a forthcoming patch.

## QA steps

- Bootstrap and add a xenial machine.
- `juju add-machine lxd:0 --series trusty`
- `juju upgrade-series prepare 0 bionic`.
- `juju add-machine lxd:0` and check that the lock error is returned.
- `juju deploy redis --to 0/lxd/0` and check that the lock error is returned.
- Deploy redis to another machine.
- `juju add-unit redis --to 0/lxd/0` and check that the lock error is returned.

## Documentation changes

None.

## Bug reference

N/A
