### PR TITLE
fix apiserver provisioner TestProvisioningInfoWithLXDProfile test

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -282,10 +282,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithUnsuitableSpacesConstra
 }
 
 func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
-	// TODO (hml) lxd-profile
-	// enable this test once charmrepo test accepts charms with an lxdprofile
-	c.Skip("will fail until charm.v6 lxdprofile functionality added to charmrepo testing")
-
 	profileMachine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -310,7 +306,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 	apiPort := dummy.APIPort(s.Environ.Provider())
 	controllerCfg["api-port"] = apiPort
 
-	pName := fmt.Sprintf("juju-%s-lxd-profile-0", coretesting.ModelConfig(c).Name())
+	pName := fmt.Sprintf("juju-%s-lxd-profile-0", profileMachine.ModelName())
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1850,6 +1850,16 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 	return nil
 }
 
+// LXDProfileNames implements environs.LXDProfiler.
+func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
+	return nil, nil
+}
+
+// ReplaceOrAddInstanceProfile implements environs.LXDProfiler.
+func (env *environ) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
+	return []string{newProfile}, nil
+}
+
 // SSHAddresses implements environs.SSHAddresses.
 // For testing we cut "100.100.100.100" out of this list.
 func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses []network.Address) ([]network.Address, error) {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -235,7 +235,7 @@ func (broker *lxdBroker) MaybeWriteLXDProfile(pName string, put *charm.LXDProfil
 	return profileMgr.MaybeWriteLXDProfile(pName, put)
 }
 
-// MaybeWriteLXDProfile implements environs.LXDProfiler.
+// ReplaceOrAddInstanceProfile implements environs.LXDProfiler.
 func (broker *lxdBroker) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
 	profileMgr, ok := broker.manager.(container.LXDProfileManager)
 	if !ok {


### PR DESCRIPTION
## Description of change

fix apiserver provisioner TestProvisioningInfoWithLXDProfile test, dummy provider needed to implement environs.LXDProfiler.