### PR TITLE
Prevents deployment via policy to existing containers on locked machines

### DIFF
--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -104,7 +104,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementMakesContainerInNewMach
 }
 
 func (s *UnitAssignmentSuite) TestAssignUnitCleanMachineUpgradeSeriesLockError(c *gc.C) {
-	s.addLockedMachine(c, false)
+	s.addLockedMachine(c, true)
 
 	charm := s.AddTestingCharm(c, "dummy")
 	app, err := s.State.AddApplication(state.AddApplicationArgs{


### PR DESCRIPTION
## Description of change

This patch prevents an empty container from being recruited for deployment when it is on a machine that is locked for series upgrade.

## QA steps

- Bootstrap and add a Xenial machine.
- `juju add-machine lxd:0 --series trusty`
- `juju upgrade-series prepare 0 bionic`.
- `juju deploy redis`
- Check that redis was not deployed to machine 0/lxd/0.

## Documentation changes

None.

## Bug reference

N/A
