### PR TITLE
Independent charm instance information

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -713,9 +713,6 @@ func (s *provisionerSuite) TestWatchContainersCharmProfiles(c *gc.C) {
 	wc := watchertest.NewStringsWatcherC(c, w, s.BackingState.StartSync)
 	defer wc.AssertStops()
 
-	// Initial event.
-	wc.AssertChange(container.Id())
-
 	// Update the upgrade-charm charm profile to trigger watcher.
 	container.SetUpgradeCharmProfile("app-name", "local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -429,14 +429,24 @@ func (s *provisionerSuite) TestSetCharmProfiles(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
+	application := s.AddTestingApplication(c, "lxd-profile", s.AddTestingCharm(c, "lxd-profile"))
+	curl, _ := application.CharmURL()
+	s.machine.SetUpgradeCharmProfile(application.Name(), curl.String())
+
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	err := apiMachine.SetUpgradeCharmProfileComplete("testme")
+	profiles := []string{"juju-default-profile-0", "juju-default-lxd-2"}
+	err := apiMachine.SetCharmProfiles(profiles)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = apiMachine.SetUpgradeCharmProfileComplete("testme")
 	c.Assert(err, jc.ErrorIsNil)
 
 	mach, err := s.State.Machine(apiMachine.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mach.UpgradeCharmProfileComplete(), gc.Equals, "testme")
+	status, err := mach.UpgradeCharmProfileComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, "testme")
 }
 
 func (s *provisionerSuite) TestCharmProfileChangeInfo(c *gc.C) {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -976,9 +976,6 @@ func (s *provisionerSuite) TestWatchModelMachinesCharmProfiles(c *gc.C) {
 	wc := watchertest.NewStringsWatcherC(c, w, s.BackingState.StartSync)
 	defer wc.AssertStops()
 
-	// Initial event.
-	wc.AssertChange(s.machine.Id())
-
 	// Update the upgrade-charm charm profile to trigger watcher.
 	s.machine.SetUpgradeCharmProfile("app-name", "local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1441,7 +1441,10 @@ func (p *ProvisionerAPI) machineChangeProfileChangeInfo(machineTag string, canAc
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}
-	appName := machine.UpgradeCharmProfileApplication()
+	appName, err := machine.UpgradeCharmProfileApplication()
+	if err != nil {
+		return nothing, errors.Trace(err)
+	}
 	if appName == "" {
 		return nothing, errors.Trace(errors.New("no appname for profile charm upgrade"))
 	}
@@ -1456,7 +1459,10 @@ func (p *ProvisionerAPI) machineChangeProfileChangeInfo(machineTag string, canAc
 		return nothing, errors.Trace(err)
 	}
 
-	url := machine.UpgradeCharmProfileCharmURL()
+	url, err := machine.UpgradeCharmProfileCharmURL()
+	if err != nil {
+		return nothing, errors.Trace(err)
+	}
 	switch {
 	case url == "" && oldProfileName != "":
 		// Remove the old profile from the machine,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -898,7 +898,7 @@ func (api *APIBase) GetLXDProfileUpgradeMessages(arg params.LXDProfileUpgradeMes
 		}
 		// reset the upgrade charm profile complete status so that it's in a
 		// known consistent state.
-		if resErr := api.setUpgradeCharmProfileCompleteStatus(units, lxdprofile.EmptyStatus); resErr != nil {
+		if resErr := api.removeUpgradeCharmProfileData(units); resErr != nil {
 			// we maybe in a incomplete status and performing upgrades may not work
 			// correctly. It requires operator intervention.
 			return results, resErr
@@ -907,7 +907,7 @@ func (api *APIBase) GetLXDProfileUpgradeMessages(arg params.LXDProfileUpgradeMes
 	return results, nil
 }
 
-func (api *APIBase) setUpgradeCharmProfileCompleteStatus(units []Unit, status string) error {
+func (api *APIBase) removeUpgradeCharmProfileData(units []Unit) error {
 	var errs []error
 	for _, unit := range units {
 		machineId, err := unit.AssignedMachineId()
@@ -925,8 +925,8 @@ func (api *APIBase) setUpgradeCharmProfileCompleteStatus(units []Unit, status st
 			errs = append(errs, err)
 			continue
 		}
-		if err := machine.SetUpgradeCharmProfileComplete(status); err != nil {
-			logger.Debugf("unable to set the upgrade charm profile complete status for %q :%v", unit.UnitTag(), err)
+		if err := machine.RemoveUpgradeCharmProfileData(); err != nil {
+			logger.Debugf("unable to remove the upgrade charm profile data for %q :%v", unit.UnitTag(), err)
 			errs = append(errs, err)
 		}
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -875,7 +875,11 @@ func (api *APIBase) GetLXDProfileUpgradeMessages(arg params.LXDProfileUpgradeMes
 			results.Results[k].Error = common.ServerError(errors.Annotatef(err, "machine %q failure", machineId))
 			continue
 		}
-		status := machine.UpgradeCharmProfileComplete()
+		status, err := machine.UpgradeCharmProfileComplete()
+		if err != nil {
+			results.Results[k].Error = common.ServerError(errors.Annotatef(err, "machine instance %q failure", machineId))
+			continue
+		}
 		if !lxdprofile.UpgradeStatusTerminal(status) {
 			finished = false
 		}

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -101,7 +101,7 @@ type Machine interface {
 	IsLockedForSeriesUpgrade() (bool, error)
 	IsParentLockedForSeriesUpgrade() (bool, error)
 	UpgradeCharmProfileComplete() (string, error)
-	SetUpgradeCharmProfileComplete(string) error
+	RemoveUpgradeCharmProfileData() error
 }
 
 // Relation defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -100,7 +100,7 @@ type Charm interface {
 type Machine interface {
 	IsLockedForSeriesUpgrade() (bool, error)
 	IsParentLockedForSeriesUpgrade() (bool, error)
-	UpgradeCharmProfileComplete() string
+	UpgradeCharmProfileComplete() (string, error)
 	SetUpgradeCharmProfileComplete(string) error
 }
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -366,14 +366,13 @@ func (m *mockMachine) Id() string {
 	return m.id
 }
 
-func (m *mockMachine) UpgradeCharmProfileComplete() string {
+func (m *mockMachine) UpgradeCharmProfileComplete() (string, error) {
 	m.MethodCall(m, "UpgradeCharmProfileComplete")
-	return m.upgradeCharmProfileComplete
+	return m.upgradeCharmProfileComplete, m.NextErr()
 }
 
-func (m *mockMachine) SetUpgradeCharmProfileComplete(s string) error {
-	m.MethodCall(m, "SetUpgradeCharmProfileComplete", s)
-	m.upgradeCharmProfileComplete = s
+func (m *mockMachine) RemoveUpgradeCharmProfileData() error {
+	m.MethodCall(m, "RemoveUpgradeCharmProfileData")
 	return m.NextErr()
 }
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -313,8 +313,9 @@ func allCollections() collectionSchema {
 		// -----
 
 		// These collections hold information associated with machines.
-		containerRefsC: {},
-		instanceDataC:  {},
+		containerRefsC:            {},
+		instanceDataC:             {},
+		instanceCharmProfileDataC: {},
 		machinesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machineid"},
@@ -546,6 +547,7 @@ const (
 	guimetadataC               = "guimetadata"
 	guisettingsC               = "guisettings"
 	instanceDataC              = "instanceData"
+	instanceCharmProfileDataC  = "instanceCharmProfileData"
 	leasesC                    = "leases"
 	leaseHoldersC              = "leaseholders"
 	machinesC                  = "machines"

--- a/state/application.go
+++ b/state/application.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	mgoutils "github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/network"
@@ -1597,7 +1598,7 @@ func (a *Application) addUnitSubordinateCharmProfileOp(principalName string) (tx
 	if err != nil {
 		return txn.Op{}, false, err
 	}
-	return machine.SetUpgradeCharmProfileOp(a.doc.Name, a.doc.CharmURL.String()), true, nil
+	return machine.SetUpgradeCharmProfileOp(a.doc.Name, a.doc.CharmURL.String(), lxdprofile.EmptyStatus), true, nil
 }
 
 func (a *Application) addUnitStorageOps(

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2098,8 +2098,13 @@ func (s *ApplicationSuite) assertCharmProfileSubordinate(c *gc.C) (*state.Machin
 func assertUpgradeCharmProfile(c *gc.C, m *state.Machine, appName, charmURL string) {
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.UpgradeCharmProfileApplication(), gc.Equals, appName)
-	c.Assert(m.UpgradeCharmProfileCharmURL(), gc.Equals, charmURL)
+
+	chAppName, err := m.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chAppName, gc.Equals, appName)
+	chCharmURL, err := m.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chCharmURL, gc.Equals, charmURL)
 }
 
 func (s *ApplicationSuite) TestAgentTools(c *gc.C) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2059,13 +2059,8 @@ func (s *ApplicationSuite) TestSetCharmProfile(c *gc.C) {
 
 	err := profileApp.SetCharmProfile("local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO (stickupkid): work out why this has changed
-	// assertUpgradeCharmProfile(c, m, profileApp.Name(), "local:quantal/lxd-profile-0")
-
 	err = subApp.SetCharmProfile("local:quantal/lxd-profile-subordinate-0")
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO (stickupkid): work out why this has changed
-	// assertUpgradeCharmProfile(c, m, subApp.Name(), "local:quantal/lxd-profile-subordinate-0")
 }
 
 func (s *ApplicationSuite) assertCharmProfileSubordinate(c *gc.C) (*state.Machine, *state.Application, *state.Application) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -301,8 +301,11 @@ func getInstanceCharmProfileData(st *State, id string) (instanceCharmProfileData
 
 // UpgradeCharmProfileApplication returns the replacement profile application name for the machine.
 func (m *Machine) UpgradeCharmProfileApplication() (string, error) {
-	instData, err := getInstanceCharmProfileData(m.st, m.doc.DocID)
+	instData, err := getInstanceCharmProfileData(m.st, m.Id())
 	if err != nil {
+		if errors.Cause(err) == mgo.ErrNotFound {
+			return "", nil
+		}
 		return "", err
 	}
 	return instData.UpgradeCharmProfileApplication, nil
@@ -310,8 +313,11 @@ func (m *Machine) UpgradeCharmProfileApplication() (string, error) {
 
 // UpgradeCharmProfileCharmURL returns the charm url for the replacement profile for the machine.
 func (m *Machine) UpgradeCharmProfileCharmURL() (string, error) {
-	instData, err := getInstanceCharmProfileData(m.st, m.doc.DocID)
+	instData, err := getInstanceCharmProfileData(m.st, m.Id())
 	if err != nil {
+		if errors.Cause(err) == mgo.ErrNotFound {
+			return "", nil
+		}
 		return "", err
 	}
 	return instData.UpgradeCharmProfileCharmURL, nil
@@ -319,8 +325,11 @@ func (m *Machine) UpgradeCharmProfileCharmURL() (string, error) {
 
 // UpgradeCharmProfileComplete returns the charm upgrade with profile completion message
 func (m *Machine) UpgradeCharmProfileComplete() (string, error) {
-	instData, err := getInstanceCharmProfileData(m.st, m.doc.DocID)
+	instData, err := getInstanceCharmProfileData(m.st, m.Id())
 	if err != nil {
+		if errors.Cause(err) == mgo.ErrNotFound {
+			return "", nil
+		}
 		return "", err
 	}
 	return instData.UpgradeCharmProfileComplete, nil

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -148,12 +148,18 @@ func (s *MachineSuite) TestSetCharmProfile(c *gc.C) {
 func (s *MachineSuite) TestSetUpgradeCharmProfileWithoutLXDProfile(c *gc.C) {
 	m := s.machine
 
+	app := s.AddTestingApplication(c, "lxd-profile", s.AddTestingCharm(c, "lxd-profile"))
+	unit, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(m)
+	c.Assert(err, jc.ErrorIsNil)
+
 	// SetUpgradeCharmProfile should clear UpgradeCharmProfileComplete value
-	err := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
+	err = m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
 	c.Assert(err, jc.ErrorIsNil)
 	status, err := m.UpgradeCharmProfileComplete()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, lxdprofile.SuccessStatus)
+	c.Assert(status, gc.Equals, "")
 
 	err = m.SetUpgradeCharmProfile("app-name", "local:quantal/riak-7")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -151,16 +151,25 @@ func (s *MachineSuite) TestSetUpgradeCharmProfileWithoutLXDProfile(c *gc.C) {
 	// SetUpgradeCharmProfile should clear UpgradeCharmProfileComplete value
 	err := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, lxdprofile.SuccessStatus)
+	status, err := m.UpgradeCharmProfileComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, lxdprofile.SuccessStatus)
 
 	err = m.SetUpgradeCharmProfile("app-name", "local:quantal/riak-7")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.UpgradeCharmProfileApplication(), gc.Equals, "")
-	c.Assert(m.UpgradeCharmProfileCharmURL(), gc.Equals, "")
-	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, "Not Required")
+
+	appName, err := m.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(appName, gc.Equals, "")
+	charmURL, err := m.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(charmURL, gc.Equals, "")
+	status, err = m.UpgradeCharmProfileComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, "Not Required")
 }
 
 func (s *MachineSuite) TestSetUpgradeCharmProfileWithLXDProfile(c *gc.C) {
@@ -177,20 +186,39 @@ func (s *MachineSuite) TestSetUpgradeCharmProfileWithLXDProfile(c *gc.C) {
 
 	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.UpgradeCharmProfileApplication(), gc.Equals, "app-name")
-	c.Assert(m.UpgradeCharmProfileCharmURL(), gc.Equals, "local:quantal/quantal-lxd-profile-0")
-	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, "")
+
+	appName, err := m.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(appName, gc.Equals, "app-name")
+	charmURL, err := m.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(charmURL, gc.Equals, "local:quantal/quantal-lxd-profile-0")
+	status, err := m.UpgradeCharmProfileComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, "")
 }
 
 func (s *MachineSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
 	m := s.machine
 
-	err := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
+	app := s.AddTestingApplication(c, "lxd-profile", s.AddTestingCharm(c, "lxd-profile"))
+	unit, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(m)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = m.SetUpgradeCharmProfile("app-name", "local:quantal/quantal-lxd-profile-0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.UpgradeCharmProfileComplete(), gc.Equals, lxdprofile.SuccessStatus)
+
+	status, err := m.UpgradeCharmProfileComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, lxdprofile.SuccessStatus)
 }
 
 func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -33,6 +33,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// machine
 		instanceDataC,
+		instanceCharmProfileDataC,
 		machineUpgradeSeriesLocksC,
 		machinesC,
 		openedPortsC,
@@ -368,6 +369,19 @@ func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
 		"CharmProfiles",
 	)
 	s.AssertExportedFields(c, instanceData{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestInstanceCharmProfileDataFields(c *gc.C) {
+	ignored := set.NewStrings(
+		// DocID is the model + machine id
+		"DocID",
+		"MachineId",
+		"UpgradeCharmProfileApplication",
+		"UpgradeCharmProfileCharmURL",
+		"UpgradeCharmProfileComplete",
+	)
+	migrated := set.NewStrings()
+	s.AssertExportedFields(c, instanceCharmProfileData{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -317,10 +317,6 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 		// Ignored at this stage, could be an issue if mongo 3.0 isn't
 		// available.
 		"StopMongoUntilVersion",
-		// These items are transient data, so no need to save for model migrations.
-		"UpgradeCharmProfileApplication",
-		"UpgradeCharmProfileCharmURL",
-		"UpgradeCharmProfileComplete",
 	)
 	migrated := set.NewStrings(
 		"Addresses",

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1850,8 +1850,13 @@ func (s *StateSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.UpgradeCharmProfileApplication(), gc.Equals, name)
-	c.Assert(machine.UpgradeCharmProfileCharmURL(), gc.Equals, charm.URL().String())
+
+	chAppName, err := machine.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chAppName, gc.Equals, name)
+	chCharmURL, err := machine.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chCharmURL, gc.Equals, charm.URL().String())
 }
 
 func (s *StateSuite) TestAddApplicationMachinePlacementInvalidSeries(c *gc.C) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/actions"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -698,7 +699,7 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 			{{"hasvote", true}},
 		}}}
 		// Remove the charm profile.
-		ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), ""))
+		ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
 	}
 
 	// If removal conditions satisfied by machine & container docs, we can

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -460,8 +460,14 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 
 	c.Assert(colocated.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Alive)
-	c.Assert(host.UpgradeCharmProfileApplication(), gc.Equals, "lxd-profile")
-	c.Assert(host.UpgradeCharmProfileCharmURL(), gc.Equals, "")
+
+	chAppName, err := host.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chAppName, gc.Equals, "lxd-profile")
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chCharmURL, gc.Equals, "")
+
 	c.Assert(host.Destroy(), gc.NotNil)
 }
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -909,19 +909,11 @@ func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.C
 		return nil
 	}
 
-	machinesCol, machinesCloser := w.db.GetCollection(machinesC)
-	defer machinesCloser()
-
-	var doc machineDoc
-	if err := machinesCol.FindId(change.Id).One(&doc); err != nil {
-		return err
-	}
-
-	instanceDataCol, instanceCloser := w.db.GetCollection(instanceCharmProfileDataC)
-	defer instanceCloser()
+	collection, closer := w.db.GetCollection(instanceCharmProfileDataC)
+	defer closer()
 
 	var instanceData instanceCharmProfileData
-	if err := instanceDataCol.FindId(change.Id).One(&instanceData); err != nil {
+	if err := collection.FindId(change.Id).One(&instanceData); err != nil {
 		return err
 	}
 
@@ -930,7 +922,7 @@ func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.C
 	// check the field before adding to the machineId
 	field, isKnown := w.known[machineId]
 	w.known[machineId] = docField
-	if isKnown && docField != field {
+	if !isKnown || docField != field {
 		machineIds.Add(machineId)
 	}
 	return nil


### PR DESCRIPTION
## Description of change

The following changes move the charm data information into a
independent collection. This should improve the number of watchers
that become alive when something changes on a machine. Although
an optimisation without measurement, it seem reasonable because of
how many watchers watch for change on the machine and become awake
might large deployments.

## QA steps

Success scenario:
```sh
export JUJU_DEV_FEATURE_FLAGS=lxd-profile
juju bootstrap localhost lxd-profile-test
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
```

Output:
```   
Added charm "local:bionic/lxd-profile-3" to the model.
LXD profile upgrade for "unit-lxd-profile-local-0" is Success
```

Error scenario:
Deploy the lxd profile, then add `limits.memory: 256mb` to the `lxd-profile.yaml`
```sh
export JUJU_DEV_FEATURE_FLAGS=lxd-profile
juju bootstrap localhost lxd-profile-test
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
# edit the `lxd-profile.yaml`
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile --force
```
Output:
```
Added charm "local:bionic/lxd-profile-3" to the model.
LXD profile upgrade for "unit-lxd-profile-local-0" is Invalid value: 256mb
```

Units Success scenario:
```sh
export JUJU_DEV_FEATURE_FLAGS=lxd-profile
juju bootstrap localhost lxd-profile-test
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
add-unit lxd-profile-local -n 2
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
```

Output:
```   
Added charm "local:bionic/lxd-profile-3" to the model.
LXD profile upgrade for "unit-lxd-profile-local-0" is Success
LXD profile upgrade for "unit-lxd-profile-local-1" is Success
LXD profile upgrade for "unit-lxd-profile-local-2" is Success
```