### PR TITLE
export bundle contains options and bindings

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -172,7 +172,7 @@ func (b *BundleAPI) ExportBundle() (params.StringResult, error) {
 		return fail(err)
 	}
 
-	// Fill it in charm.BundleData datastructure.
+	// Fill it in charm.BundleData data structure.
 	bundleData, err := b.fillBundleData(model)
 	if err != nil {
 		return fail(err)
@@ -227,12 +227,20 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 		var newApplication *charm.ApplicationSpec
 		appSeries := application.Series()
 		usedSeries.Add(appSeries)
+		// Only care about endpoints with non-empty bindings.
+		bindings := make(map[string]string)
+		for ep, space := range application.EndpointBindings() {
+			if space != "" {
+				bindings[ep] = space
+			}
+		}
 		if application.Subordinate() {
 			newApplication = &charm.ApplicationSpec{
-				Charm:       application.CharmURL(),
-				Expose:      application.Exposed(),
-				Options:     application.CharmConfig(),
-				Annotations: application.Annotations(),
+				Charm:            application.CharmURL(),
+				Expose:           application.Exposed(),
+				Options:          application.CharmConfig(),
+				Annotations:      application.Annotations(),
+				EndpointBindings: bindings,
 			}
 			if appSeries != defaultSeries {
 				newApplication.Series = appSeries
@@ -256,12 +264,13 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 			}
 
 			newApplication = &charm.ApplicationSpec{
-				Charm:       application.CharmURL(),
-				NumUnits:    len(application.Units()),
-				To:          ut,
-				Expose:      application.Exposed(),
-				Options:     application.CharmConfig(),
-				Annotations: application.Annotations(),
+				Charm:            application.CharmURL(),
+				NumUnits:         len(application.Units()),
+				To:               ut,
+				Expose:           application.Exposed(),
+				Options:          application.CharmConfig(),
+				Annotations:      application.Annotations(),
+				EndpointBindings: bindings,
 			}
 			if appSeries != defaultSeries {
 				newApplication.Series = appSeries

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -250,6 +250,7 @@ func (s *bundleSuite) minimalApplicationArgs(modelType string) description.Appli
 			"leader": true,
 		},
 		MetricsCredentials: []byte("sekrit"),
+		EndpointBindings:   map[string]string{"juju-info": "vlan2", "another": ""},
 	}
 	if modelType == description.CAAS {
 		result.PasswordHash = "some-hash"
@@ -316,6 +317,8 @@ applications:
     - "0"
     options:
       key: value
+    bindings:
+      juju-info: vlan2
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)
@@ -543,6 +546,8 @@ applications:
     expose: true
     options:
       key: value
+    bindings:
+      rel-name: some-space
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)

--- a/apiserver/facades/client/bundle/state.go
+++ b/apiserver/facades/client/bundle/state.go
@@ -28,11 +28,10 @@ func (m *stateShim) GetExportConfig() state.ExportConfig {
 	cfg.SkipSSHHostKeys = true
 	cfg.SkipStatusHistory = true
 	cfg.SkipLinkLayerDevices = true
-	cfg.SkipRelationScope = true
+	cfg.SkipRelationData = true
 	cfg.SkipMachineAgentBinaries = true
 	cfg.SkipUnitAgentBinaries = true
 	cfg.SkipInstanceData = true
-	cfg.SkipSettings = true
 
 	return cfg
 }

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -19,6 +19,7 @@ type CmdExportBundleSuite struct {
 }
 
 func (s *CmdExportBundleSuite) setupApplications(c *gc.C) {
+	s.Factory.MakeSpace(c, &factory.SpaceParams{Name: "vlan2"})
 	// make an application with 2 endpoints
 	application1 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
@@ -37,6 +38,8 @@ func (s *CmdExportBundleSuite) setupApplications(c *gc.C) {
 			Name:     "logging",
 			Revision: "43",
 		}),
+		CharmConfig:      map[string]interface{}{"foo": "bar"},
+		EndpointBindings: map[string]string{"info": "vlan2"},
 	})
 	endpoint3, err := application2.Endpoint("info")
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,6 +72,10 @@ series: quantal
 applications:
   logging:
     charm: cs:quantal/logging-43
+    options:
+      foo: bar
+    bindings:
+      info: vlan2
   wordpress:
     charm: cs:quantal/wordpress-23
 relations:

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -39,7 +39,7 @@ type ExportConfig struct {
 	SkipLinkLayerDevices     bool
 	SkipUnitAgentBinaries    bool
 	SkipMachineAgentBinaries bool
-	SkipRelationScope        bool
+	SkipRelationData         bool
 	SkipInstanceData         bool
 }
 
@@ -953,7 +953,7 @@ func (e *exporter) relations() error {
 	e.logger.Debugf("read %d relations", len(rels))
 
 	relationScopes := set.NewStrings()
-	if !e.cfg.SkipRelationScope {
+	if !e.cfg.SkipRelationData {
 		relationScopes, err = e.readAllRelationScopes()
 		if err != nil {
 			return errors.Trace(err)
@@ -1018,11 +1018,11 @@ func (e *exporter) relations() error {
 					continue
 				}
 				key := ru.key()
-				if !e.cfg.SkipRelationScope && !relationScopes.Contains(key) {
+				if !e.cfg.SkipRelationData && !relationScopes.Contains(key) {
 					return errors.Errorf("missing relation scope for %s and %s", relation, unit.Name())
 				}
 				settingsDoc, found := e.modelSettings[key]
-				if !found && !e.cfg.SkipSettings {
+				if !found && !e.cfg.SkipSettings && !e.cfg.SkipRelationData {
 					return errors.Errorf("missing relation settings for %s and %s", relation, unit.Name())
 				}
 				delete(e.modelSettings, key)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -918,8 +918,7 @@ func (s *MigrationBaseSuite) TestRelationScopeSkipped(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
 
 	model, err := s.State.ExportPartial(state.ExportConfig{
-		SkipRelationScope: true,
-		SkipSettings:      true,
+		SkipRelationData: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

juju export-bundle was not including charm config (options) or endpoint bindings.

## QA steps

deploy a charm with --config options and --bind bindings
check export-bundle output
do the above in one line as a chained command to check for incomplete data errors

## Bug reference

https://bugs.launchpad.net/bugs/1802033
