### PR TITLE
Enable invalid credential handling for LXD

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -155,10 +155,12 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Pro
 // known environment.
 func (env *environ) Destroy(ctx context.ProviderCallContext) error {
 	if err := env.base.DestroyEnv(ctx); err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
 	}
 	if env.storageSupported() {
 		if err := destroyModelFilesystems(env); err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return errors.Annotate(err, "destroying LXD filesystems for model")
 		}
 	}
@@ -171,10 +173,12 @@ func (env *environ) DestroyController(ctx context.ProviderCallContext, controlle
 		return errors.Trace(err)
 	}
 	if err := env.destroyHostedModelResources(controllerUUID); err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
 	}
 	if env.storageSupported() {
 		if err := destroyControllerFilesystems(env, controllerUUID); err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return errors.Annotate(err, "destroying LXD filesystems for controller")
 		}
 	}
@@ -239,6 +243,7 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common
 
 	nodes, err := env.server.GetClusterMembers()
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, errors.Annotate(err, "listing cluster members")
 	}
 	aZones := make([]common.AvailabilityZone, len(nodes))

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -42,6 +42,7 @@ func (env *environ) StartInstance(
 
 	container, err := env.newContainer(ctx, args, arch)
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		if args.StatusCallback != nil {
 			args.StatusCallback(status.ProvisioningError, err.Error(), nil)
 		}
@@ -335,5 +336,9 @@ func (env *environ) StopInstances(ctx context.ProviderCallContext, instances ...
 		}
 	}
 
-	return errors.Trace(env.server.RemoveContainers(names))
+	err := env.server.RemoveContainers(names)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	}
+	return errors.Trace(err)
 }

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -382,7 +382,6 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
-	c.Assert(s.invalidCredential, jc.IsFalse)
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -395,6 +394,7 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestStopInstancesInvalidCredentials(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/provider/common"
 )
 
 // Instances returns the available instances in the environment that
@@ -31,6 +32,7 @@ func (env *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id
 		// will return either ErrPartialInstances or ErrNoInstances.
 		// TODO(ericsnow) Skip returning here only for certain errors?
 		logger.Errorf("failed to get instances from LXD: %v", err)
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		err = errors.Trace(err)
 	}
 
@@ -95,6 +97,7 @@ func (env *environ) prefixedInstances(prefix string) ([]*environInstance, error)
 func (env *environ) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
 	containers, err := env.server.AliveContainers("juju-")
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -118,6 +121,7 @@ func (env *environ) ControllerInstances(ctx context.ProviderCallContext, control
 func (env *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	instances, err := env.AllInstances(ctx)
 	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "all instances")
 	}
 

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -6,6 +6,7 @@ package lxd_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/lxc/lxd/shared/api"
@@ -18,21 +19,35 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/lxd"
 	coretesting "github.com/juju/juju/testing"
 )
 
+var errTestUnAuth = errors.New("not authorized")
+
 type environSuite struct {
 	lxd.BaseSuite
 
-	callCtx context.ProviderCallContext
+	callCtx           context.ProviderCallContext
+	invalidCredential bool
 }
 
 var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = &context.CloudCallContext{
+		InvalidateCredentialFunc: func(string) error {
+			s.invalidCredential = true
+			return nil
+		},
+	}
+}
+
+func (s *environSuite) TearDownTest(c *gc.C) {
+	s.invalidCredential = false
+	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *environSuite) TestName(c *gc.C) {
@@ -139,6 +154,41 @@ func (s *environSuite) TestDestroy(c *gc.C) {
 	})
 }
 
+func (s *environSuite) TestDestroyInvalidCredentials(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	s.Client.Stub.SetErrors(errTestUnAuth)
+	err := s.Env.Destroy(s.callCtx)
+	c.Assert(err, gc.ErrorMatches, "not authorized")
+	c.Assert(s.invalidCredential, jc.IsTrue)
+}
+
+func (s *environSuite) TestDestroyInvalidCredentialsDestroyingFileSystems(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	// DeleteStoragePoolVolume will error w/ un-auth.
+	s.Client.Stub.SetErrors(nil, nil, nil, errTestUnAuth)
+
+	s.Client.Volumes = map[string][]api.StorageVolume{
+		"juju": {{
+			Name: "ours",
+			StorageVolumePut: api.StorageVolumePut{
+				Config: map[string]string{
+					"user.juju-model-uuid": s.Config.UUID(),
+				},
+			},
+		}},
+	}
+	err := s.Env.Destroy(s.callCtx)
+	c.Assert(err, gc.ErrorMatches, ".* not authorized")
+	c.Assert(s.invalidCredential, jc.IsTrue)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Destroy", []interface{}{s.callCtx}},
+		{"StorageSupported", nil},
+		{"GetStoragePools", nil},
+		{"GetStoragePoolVolumes", []interface{}{"juju"}},
+		{"DeleteStoragePoolVolume", []interface{}{"juju", "custom", "ours"}},
+	})
+}
+
 func (s *environSuite) TestDestroyController(c *gc.C) {
 	s.UpdateConfig(c, map[string]interface{}{
 		"controller-uuid": s.Config.UUID(),
@@ -197,6 +247,121 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 		{"GetStoragePoolVolumes", []interface{}{"juju"}},
 		{"DeleteStoragePoolVolume", []interface{}{"juju", "custom", "ours"}},
 		{"GetStoragePoolVolumes", []interface{}{"juju-zfs"}},
+	})
+}
+
+func (s *environSuite) TestDestroyControllerInvalidCredentialsHostedModels(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	s.UpdateConfig(c, map[string]interface{}{
+		"controller-uuid": s.Config.UUID(),
+	})
+	s.Stub.ResetCalls()
+
+	s.Client.Volumes = map[string][]api.StorageVolume{
+		"juju": {{
+			Name: "ours",
+			StorageVolumePut: api.StorageVolumePut{
+				Config: map[string]string{
+					"user.juju-controller-uuid": s.Config.UUID(),
+				},
+			},
+		}},
+	}
+
+	// machine0 is in the controller model.
+	machine0 := s.NewContainer(c, "juju-controller-machine-0")
+	machine0.Config["user.juju-model-uuid"] = s.Config.UUID()
+	machine0.Config["user.juju-controller-uuid"] = s.Config.UUID()
+
+	s.Client.Containers = append(s.Client.Containers, *machine0)
+
+	// RemoveContainers will error not-auth.
+	s.Client.Stub.SetErrors(nil, nil, nil, nil, nil, errTestUnAuth)
+
+	err := s.Env.DestroyController(s.callCtx, s.Config.UUID())
+	c.Assert(err, gc.ErrorMatches, "not authorized")
+	c.Assert(s.invalidCredential, jc.IsTrue)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Destroy", []interface{}{s.callCtx}},
+		{"StorageSupported", nil},
+		{"GetStoragePools", nil},
+		{"GetStoragePoolVolumes", []interface{}{"juju"}},
+		{"GetStoragePoolVolumes", []interface{}{"juju-zfs"}},
+		{"AliveContainers", []interface{}{"juju-"}},
+		{"RemoveContainers", []interface{}{[]string{}}},
+	})
+}
+
+func (s *environSuite) TestDestroyControllerInvalidCredentialsDestroyFilesystem(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	s.UpdateConfig(c, map[string]interface{}{
+		"controller-uuid": s.Config.UUID(),
+	})
+	s.Stub.ResetCalls()
+
+	s.Client.Volumes = map[string][]api.StorageVolume{
+		"juju": {{
+			Name: "ours",
+			StorageVolumePut: api.StorageVolumePut{
+				Config: map[string]string{
+					"user.juju-controller-uuid": s.Config.UUID(),
+				},
+			},
+		}},
+	}
+
+	// machine0 is in the controller model.
+	machine0 := s.NewContainer(c, "juju-controller-machine-0")
+	machine0.Config["user.juju-model-uuid"] = s.Config.UUID()
+	machine0.Config["user.juju-controller-uuid"] = s.Config.UUID()
+
+	s.Client.Containers = append(s.Client.Containers, *machine0)
+
+	// RemoveContainers will error not-auth.
+	s.Client.Stub.SetErrors(nil, nil, nil, nil, nil, nil, nil, nil, errTestUnAuth)
+
+	err := s.Env.DestroyController(s.callCtx, s.Config.UUID())
+	c.Assert(err, gc.ErrorMatches, ".*not authorized")
+	c.Assert(s.invalidCredential, jc.IsTrue)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Destroy", []interface{}{s.callCtx}},
+		{"StorageSupported", nil},
+		{"GetStoragePools", nil},
+		{"GetStoragePoolVolumes", []interface{}{"juju"}},
+		{"GetStoragePoolVolumes", []interface{}{"juju-zfs"}},
+		{"AliveContainers", []interface{}{"juju-"}},
+		{"RemoveContainers", []interface{}{[]string{}}},
+		{"StorageSupported", nil},
+		{"GetStoragePools", nil},
+		{"GetStoragePoolVolumes", []interface{}{"juju"}},
+		{"DeleteStoragePoolVolume", []interface{}{"juju", "custom", "ours"}},
+	})
+}
+
+func (s *environSuite) TestAvailabilityZonesInvalidCredentials(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	// GetClusterMembers will return un-auth error
+	s.Client.Stub.SetErrors(errTestUnAuth)
+	_, err := s.Env.AvailabilityZones(s.callCtx)
+	c.Assert(err, gc.ErrorMatches, ".*not authorized")
+	c.Assert(s.invalidCredential, jc.IsTrue)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"IsClustered", nil},
+		{"GetClusterMembers", nil},
+	})
+}
+
+func (s *environSuite) TestInstanceAvailabilityZoneNamesInvalidCredentials(c *gc.C) {
+	c.Assert(s.invalidCredential, jc.IsFalse)
+	// AliveContainers will return un-auth error
+	s.Client.Stub.SetErrors(errTestUnAuth)
+
+	// the call to Instances takes care of updating invalid credential details
+	_, err := s.Env.InstanceAvailabilityZoneNames(s.callCtx, []instance.Id{"not-valid"})
+	c.Assert(err, gc.ErrorMatches, ".*not authorized")
+	c.Assert(s.invalidCredential, jc.IsTrue)
+	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+		{"AliveContainers", []interface{}{s.Prefix()}},
 	})
 }
 

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -290,6 +290,14 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsHostedModels(c *gc
 		{"AliveContainers", []interface{}{"juju-"}},
 		{"RemoveContainers", []interface{}{[]string{}}},
 	})
+	s.Stub.CheckCallNames(c,
+		"Destroy",
+		"StorageSupported",
+		"GetStoragePools",
+		"GetStoragePoolVolumes",
+		"GetStoragePoolVolumes",
+		"AliveContainers",
+		"RemoveContainers")
 }
 
 func (s *environSuite) TestDestroyControllerInvalidCredentialsDestroyFilesystem(c *gc.C) {

--- a/provider/lxd/errors.go
+++ b/provider/lxd/errors.go
@@ -4,6 +4,8 @@
 package lxd
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 )
 
@@ -11,7 +13,7 @@ import (
 func IsAuthorisationFailure(err error) bool {
 	if err == nil {
 		return false
-	} else if errors.Cause(err).Error() == "not authorized" {
+	} else if strings.Contains(errors.Cause(err).Error(), "not authorized") {
 		return true
 	}
 	return false

--- a/provider/lxd/errors.go
+++ b/provider/lxd/errors.go
@@ -1,0 +1,18 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"github.com/juju/errors"
+)
+
+// IsAuthorisationFailure determines if the given error has an authorisation failure.
+func IsAuthorisationFailure(err error) bool {
+	if err == nil {
+		return false
+	} else if errors.Cause(err).Error() == "not authorized" {
+		return true
+	}
+	return false
+}

--- a/provider/lxd/errors_test.go
+++ b/provider/lxd/errors_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+type ErrorSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ErrorSuite{})
+
+func (s *ErrorSuite) TestIsUnauthorisedError(c *gc.C) {
+	err := errors.New("not authorized")
+	c.Assert(IsAuthorisationFailure(err), jc.IsTrue)
+	c.Assert(IsAuthorisationFailure(errors.Cause(err)), jc.IsTrue)
+
+	traced := errors.Trace(err)
+	c.Assert(IsAuthorisationFailure(traced), jc.IsTrue)
+
+	annotated := errors.Annotate(err, "testing is great")
+	c.Assert(IsAuthorisationFailure(annotated), jc.IsTrue)
+}
+
+func (s *ErrorSuite) TestNotUnauthorisedError(c *gc.C) {
+	err := errors.New("everything is fine")
+	c.Assert(IsAuthorisationFailure(err), jc.IsFalse)
+
+	c.Assert(IsAuthorisationFailure(nil), jc.IsFalse)
+}


### PR DESCRIPTION
## Description of change

Invalidate the credential whenever we get an authorisation error back from any provider action.
