### PR TITLE
Match muti-series suborinate charms

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -357,11 +357,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:fe244e1841c7ca5e9d23558d9994521e740496e424ed2a7fe5c70a505b18c907"
+  digest = "1:16c440010c52d4051e1c9116946759834d55cf98d43fed3c1ddcc47567064c54"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "a87de0e48b53995bf50f6db7730cd4ab71340950"
+  revision = "b8d279cc30ffcc57dab7a51c4bc39be08fb2b569"
 
 [[projects]]
   digest = "1:3d4df54c1d5e1be4d7aab3e6e3a3807b4ddbeebd0bf7a87ea363fe41e6aec0ac"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "a87de0e48b53995bf50f6db7730cd4ab71340950"
+  revision = "b8d279cc30ffcc57dab7a51c4bc39be08fb2b569"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -207,6 +207,46 @@ func (s *RelationSuite) TestAddContainerRelationSeriesMustMatch(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": principal and subordinate applications' series must match`)
 }
 
+func (s *RelationSuite) TestAddContainerRelationMultiSeriesMatch(c *gc.C) {
+	principal := s.AddTestingApplication(c, "multi-series", s.AddSeriesCharm(c, "multi-series", "precise"))
+	principalEP, err := principal.Endpoint("multi-directory")
+	c.Assert(err, jc.ErrorIsNil)
+	subord := s.AddTestingApplication(c, "multi-series-subordinate", s.AddSeriesCharm(c, "multi-series-subordinate", "trusty"))
+	subordEP, err := subord.Endpoint("multi-directory")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.AddRelation(principalEP, subordEP)
+	principalEP.Scope = charm.ScopeContainer
+	c.Assert(err, jc.ErrorIsNil)
+	assertOneRelation(c, subord, 0, subordEP, principalEP)
+	assertOneRelation(c, principal, 0, principalEP, subordEP)
+}
+
+func (s *RelationSuite) TestAddContainerRelationMultiSeriesNoMatch(c *gc.C) {
+	principal := s.AddTestingApplication(c, "multi-series", s.AddTestingCharm(c, "multi-series"))
+	principalEP, err := principal.Endpoint("multi-directory")
+	c.Assert(err, jc.ErrorIsNil)
+	meta := `
+name: multi-series-subordinate
+summary: a test charm
+description: a test
+subordinate: true
+series:
+    - bionic
+requires:
+    multi-directory:
+       interface: logging
+       scope: container
+`[1:]
+	subord := s.AddTestingApplication(c, "multi-series-subordinate", s.AddMetaCharm(c, "multi-series-subordinate", meta, 1))
+	subordEP, err := subord.Endpoint("multi-directory")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.AddRelation(principalEP, subordEP)
+	principalEP.Scope = charm.ScopeContainer
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "multi-series-subordinate:multi-directory multi-series:multi-directory": principal and subordinate applications' series must match`)
+}
+
 func (s *RelationSuite) TestAddContainerRelationWithNoSubordinate(c *gc.C) {
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	wordpressSubEP, err := wordpress.Endpoint("db")


### PR DESCRIPTION
## Description of change

Allow relation between principal and subordinate charms so long as they declare a common supported series, even if their nominal application series doesn't match.

As driveby, pick up new dependency for latest bundlechanges to fix https://pad.lv/1796378

## QA steps

As per bug, deploy ubuntu and ntp charms with matching supported series.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1776995
