### PR TITLE
Include all machine constraints in bundle export

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -296,12 +296,8 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 			newMachine.Series = macSeries
 		}
 
-		if result := b.hardwareConstraints(machine.Instance()); len(result) != 0 {
+		if result := b.constraints(machine.Constraints()); len(result) != 0 {
 			newMachine.Constraints = strings.Join(result, " ")
-		} else {
-			if result = b.constraints(machine.Constraints()); len(result) != 0 {
-				newMachine.Constraints = strings.Join(result, " ")
-			}
 		}
 
 		data.Machines[machine.Id()] = newMachine
@@ -344,30 +340,6 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 	return data, nil
 }
 
-func (b *BundleAPI) hardwareConstraints(instance description.CloudInstance) []string {
-	if instance == nil {
-		return []string{}
-	}
-
-	var constraints []string
-	if arch := instance.Architecture(); arch != "" {
-		constraints = append(constraints, "arch="+(arch))
-	}
-	if cores := instance.CpuCores(); cores != 0 {
-		constraints = append(constraints, "cpu-cores="+strconv.Itoa(int(cores)))
-	}
-	if power := instance.CpuPower(); power != 0 {
-		constraints = append(constraints, "cpu-power="+strconv.Itoa(int(power)))
-	}
-	if mem := instance.Memory(); mem != 0 {
-		constraints = append(constraints, "mem="+strconv.Itoa(int(mem)))
-	}
-	if disk := instance.RootDisk(); disk != 0 {
-		constraints = append(constraints, "root-disk="+strconv.Itoa(int(disk)))
-	}
-	return constraints
-}
-
 func (b *BundleAPI) constraints(cons description.Constraints) []string {
 	if cons == nil {
 		return []string{}
@@ -388,6 +360,21 @@ func (b *BundleAPI) constraints(cons description.Constraints) []string {
 	}
 	if disk := cons.RootDisk(); disk != 0 {
 		constraints = append(constraints, "root-disk="+strconv.Itoa(int(disk)))
+	}
+	if instType := cons.InstanceType(); instType != "" {
+		constraints = append(constraints, "instance-type="+instType)
+	}
+	if container := cons.Container(); container != "" {
+		constraints = append(constraints, "container="+container)
+	}
+	if virtType := cons.VirtType(); virtType != "" {
+		constraints = append(constraints, "virt-type="+virtType)
+	}
+	if tags := cons.Tags(); len(tags) != 0 {
+		constraints = append(constraints, "tags="+strings.Join(tags, ","))
+	}
+	if spaces := cons.Spaces(); len(spaces) != 0 {
+		constraints = append(constraints, "spaces="+strings.Join(spaces, ","))
 	}
 	return constraints
 }

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -606,6 +606,13 @@ func (s *bundleSuite) addMinimalMachineWithConstraints(model description.Model, 
 		Architecture: "amd64",
 		Memory:       8 * 1024,
 		RootDisk:     40 * 1024,
+		CpuCores:     2,
+		CpuPower:     100,
+		InstanceType: "big-inst",
+		Tags:         []string{"foo", "bar"},
+		VirtType:     "pv",
+		Container:    "kvm",
+		Spaces:       []string{"internal"},
 	}
 	m.SetConstraints(args)
 	m.SetStatus(minimalStatusArgs())
@@ -637,71 +644,11 @@ applications:
     - "0"
 machines:
   "0":
-    constraints: arch=amd64 mem=8192 root-disk=40960
+    constraints: arch=amd64 cpu-cores=2 cpu-power=100 mem=8192 root-disk=40960 instance-type=big-inst
+      container=kvm virt-type=pv tags=foo,bar spaces=internal
   "1":
-    constraints: arch=amd64 mem=8192 root-disk=40960
-relations:
-- - mediawiki:db
-  - mysql:mysql
-`[1:]}
-
-	c.Assert(result, gc.Equals, expectedResult)
-
-	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
-}
-
-func (s *bundleSuite) addMinimalMachinewithHardwareConstraints(model description.Model, id string) {
-	m := model.AddMachine(description.MachineArgs{
-		Id:           names.NewMachineTag(id),
-		Nonce:        "a-nonce",
-		PasswordHash: "some-hash",
-		Series:       "xenial",
-		Jobs:         []string{"host-units"},
-	})
-	args := description.ConstraintsArgs{
-		Architecture: "amd64",
-		Memory:       8 * 1024,
-		RootDisk:     40 * 1024,
-	}
-	m.SetConstraints(args)
-	instanceArgs := description.CloudInstanceArgs{
-		Architecture: "amd64",
-		Memory:       4 * 1024,
-		RootDisk:     16 * 1024,
-	}
-	m.SetInstance(instanceArgs)
-	m.SetStatus(minimalStatusArgs())
-}
-
-func (s *bundleSuite) TestExportBundleModelWithHardwareConstraints(c *gc.C) {
-	model := s.newModel("mediawiki", "mysql")
-
-	s.addMinimalMachinewithHardwareConstraints(model, "0")
-	s.addMinimalMachinewithHardwareConstraints(model, "1")
-
-	model.SetStatus(description.StatusArgs{Value: "available"})
-
-	result, err := s.facade.ExportBundle()
-	c.Assert(err, jc.ErrorIsNil)
-	expectedResult := params.StringResult{nil, `
-series: xenial
-applications:
-  mediawiki:
-    charm: cs:mediawiki
-    num_units: 2
-    to:
-    - "0"
-    - "1"
-  mysql:
-    charm: cs:mysql
-    num_units: 1
-    to:
-    - "0"
-machines:
-  "0":
-    constraints: arch=amd64 mem=4096 root-disk=16384
-  "1":
-    constraints: arch=amd64 mem=4096 root-disk=16384
+    constraints: arch=amd64 cpu-cores=2 cpu-power=100 mem=8192 root-disk=40960 instance-type=big-inst
+      container=kvm virt-type=pv tags=foo,bar spaces=internal
 relations:
 - - mediawiki:db
   - mysql:mysql


### PR DESCRIPTION
## Description of change

When exporting a bundle, there were 2 issues with getting the machine constraints to add to the export data:
1. tags, spaces and others attributes were being ignored
2. machine hardware info (as provisioned) was being preferred to the actual constraints

The as-provisioned hardware info is irrelevant - to export what matches the bundle is to use the actual constraints specified.

## QA steps

deploy a bundle with machine constraints and check output of export-bundle

## Bug reference

https://bugs.launchpad.net/juju/+bug/1802599

