### PR TITLE
Add remove-unit support for kubernetes models.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -596,8 +596,11 @@ type ScaleApplicationParams struct {
 	// ApplicationName is the application to scale.
 	ApplicationName string
 
-	// Scale is the number of units which should be running.
+	// Scale is the target number of units which should exist
 	Scale int
+
+	// ScaleChange is the amount of change to the target amount of existing units
+	ScaleChange int
 }
 
 // ScaleApplication sets the desired unit count for one or more applications.
@@ -609,6 +612,7 @@ func (c *Client) ScaleApplication(in ScaleApplicationParams) (params.ScaleApplic
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: names.NewApplicationTag(in.ApplicationName).String(),
 			Scale:          in.Scale,
+			ScaleChange:    in.ScaleChange,
 		}},
 	}
 	var results params.ScaleApplicationResults

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1154,6 +1154,36 @@ func (s *applicationSuite) TestScaleApplication(c *gc.C) {
 	})
 }
 
+func (s *applicationSuite) TestChangeScaleApplication(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			c.Assert(request, gc.Equals, "ScaleApplications")
+			args, ok := a.(params.ScaleApplicationsParams)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(args, jc.DeepEquals, params.ScaleApplicationsParams{
+				Applications: []params.ScaleApplicationParams{
+					{ApplicationTag: "application-foo", ScaleChange: 5},
+				}})
+
+			result, ok := response.(*params.ScaleApplicationResults)
+			c.Assert(ok, jc.IsTrue)
+			result.Results = []params.ScaleApplicationResult{
+				{Info: &params.ScaleApplicationInfo{Scale: 7}},
+			}
+			return nil
+		},
+	)
+	client := application.NewClient(apiCaller)
+	results, err := client.ScaleApplication(application.ScaleApplicationParams{
+		ApplicationName: "foo",
+		ScaleChange:     5,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ScaleApplicationResult{
+		Info: &params.ScaleApplicationInfo{Scale: 7},
+	})
+}
+
 func (s *applicationSuite) TestScaleApplicationArity(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(
 		func(objType string, version int, id, request string, a, response interface{}) error {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -83,7 +83,7 @@ type Application interface {
 	ApplicationConfig() (application.ConfigAttributes, error)
 	UpdateApplicationConfig(application.ConfigAttributes, []string, environschema.Fields, schema.Defaults) error
 	Scale(int) error
-	GetScale() int
+	ChangeScale(int) (int, error)
 }
 
 // Charm defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -83,6 +83,7 @@ type Application interface {
 	ApplicationConfig() (application.ConfigAttributes, error)
 	UpdateApplicationConfig(application.ConfigAttributes, []string, environschema.Fields, schema.Defaults) error
 	Scale(int) error
+	GetScale() int
 }
 
 // Charm defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -76,6 +76,7 @@ type mockApplication struct {
 	curl                     *charm.URL
 	endpoints                []state.Endpoint
 	name                     string
+	scale                    int
 	subordinate              bool
 	series                   string
 	units                    []*mockUnit
@@ -132,6 +133,11 @@ func (a *mockApplication) AddUnit(args state.AddUnitParams) (application.Unit, e
 		return nil, err
 	}
 	return &a.addedUnit, nil
+}
+
+func (a *mockApplication) GetScale() int {
+	a.MethodCall(a, "GetScale")
+	return a.scale
 }
 
 func (a *mockApplication) Scale(scale int) error {

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -140,6 +140,14 @@ func (a *mockApplication) GetScale() int {
 	return a.scale
 }
 
+func (a *mockApplication) ChangeScale(scaleChange int) (int, error) {
+	a.MethodCall(a, "ChangeScale", scaleChange)
+	if err := a.NextErr(); err != nil {
+		return a.scale, err
+	}
+	return a.scale + scaleChange, nil
+}
+
 func (a *mockApplication) Scale(scale int) error {
 	a.MethodCall(a, "Scale", scale)
 	if err := a.NextErr(); err != nil {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1324,6 +1324,9 @@ type ScaleApplicationParams struct {
 
 	// Scale is the number of units which should be running.
 	Scale int `json:"scale"`
+
+	// Scale is the number of units which should be added/removed from the existing count.
+	ScaleChange int `json:"scale-change,omitempty"`
 }
 
 // ScaleApplicationResults contains the results of a ScaleApplication

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -27,18 +27,27 @@ var usageAddUnitDetails = `
 The add-unit is used to scale out an application for improved performance or
 availability.
 
+The usage of this command differs depending on whether it is being used on a
+Kubernetes or cloud model.
+
 Many charms will seamlessly support horizontal scaling while others may need
 an additional application support (e.g. a separate load balancer). See the
 documentation for specific charms to check how scale-out is supported.
 
-By default, units are deployed to newly provisioned machines in accordance
-with any application or model constraints. This command also supports the
-placement directive ("--to") for targeting specific machines or containers,
-which will bypass application and model constraints.
-
-Note:
 For Kubernetes models the only valid argument is -n, --num-units.
 Anything additional will result in an error.
+
+Example:
+
+Add five units of mysql:
+    juju add-unit mysql --num-units 5
+
+
+For cloud models, by default, units are deployed to newly provisioned machines
+in accordance with any application or model constraints.
+This command also supports the placement directive ("--to") for targeting
+specific machines or containers, which will bypass application and model
+constraints.
 
 Examples:
 
@@ -190,7 +199,7 @@ func (c *addUnitCommand) Init(args []string) error {
 	if err := cmd.CheckEmpty(args[1:]); err != nil {
 		return err
 	}
-	if err := c.validateArgs(); err != nil {
+	if err := c.validateArgsByModelType(); err != nil {
 		if !errors.IsNotFound(err) {
 			return errors.Trace(err)
 		}
@@ -200,7 +209,7 @@ func (c *addUnitCommand) Init(args []string) error {
 	return c.UnitCommandBase.Init(args)
 }
 
-func (c *addUnitCommand) validateArgs() error {
+func (c *addUnitCommand) validateArgsByModelType() error {
 	modelType, err := c.ModelType()
 	if err != nil {
 		return err
@@ -244,7 +253,7 @@ func (c *addUnitCommand) Run(ctx *cmd.Context) error {
 	defer apiclient.Close()
 
 	if c.unknownModel {
-		if err := c.validateArgs(); err != nil {
+		if err := c.validateArgsByModelType(); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -66,6 +66,17 @@ func (f *fakeApplicationAddUnitAPI) AddUnits(args apiapplication.AddUnitsParams)
 	return nil, nil
 }
 
+func (f *fakeApplicationAddUnitAPI) ScaleApplication(args apiapplication.ScaleApplicationParams) (params.ScaleApplicationResult, error) {
+	if f.err != nil {
+		return params.ScaleApplicationResult{}, f.err
+	}
+	if args.ApplicationName != f.application {
+		return params.ScaleApplicationResult{}, errors.NotFoundf("application %q", args.ApplicationName)
+	}
+	f.numUnits += args.ScaleChange
+	return params.ScaleApplicationResult{}, nil
+}
+
 func (f *fakeApplicationAddUnitAPI) ModelGet() (map[string]interface{}, error) {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"type": f.envType,
@@ -116,6 +127,15 @@ func (s *AddUnitSuite) TestInitErrors(c *gc.C) {
 		err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, s.store), t.args)
 		c.Check(err, gc.ErrorMatches, t.err)
 	}
+}
+
+// Must error at init when the model type is known (and args are invalid)
+func (s *AddUnitSuite) TestInitErrorsForCAAS(c *gc.C) {
+	m := s.store.Models["arthur"].Models["king/sword"]
+	m.ModelType = model.CAAS
+	s.store.Models["arthur"].Models["king/sword"] = m
+	err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, s.store), []string{"some-application-name", "--to", "lxd:1"})
+	c.Check(err, gc.ErrorMatches, "Kubernetes models only support --num-units")
 }
 
 func (s *AddUnitSuite) runAddUnit(c *gc.C, args ...string) error {
@@ -231,7 +251,7 @@ func (s *AddUnitSuite) TestNameChecks(c *gc.C) {
 }
 
 func (s *AddUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
-	expectedError := "Kubernetes models only supports num-units flag"
+	expectedError := "Kubernetes models only support --num-units"
 	m := s.store.Models["arthur"].Models["king/sword"]
 	m.ModelType = model.CAAS
 	s.store.Models["arthur"].Models["king/sword"] = m

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -274,3 +274,15 @@ func (s *AddUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	err = s.runAddUnit(c, "some-application-name", "--num-units", "2")
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *AddUnitSuite) TestUnknownModelCallsRefresh(c *gc.C) {
+	called := false
+	refresh := func(jujuclient.ClientStore, string) error {
+		called = true
+		return nil
+	}
+	cmd := application.NewAddUnitCommandForTestWithRefresh(s.fake, s.store, refresh)
+	_, err := cmdtesting.RunCommand(c, cmd, "-m", "nope", "no-app")
+	c.Check(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "model arthur:king/nope not found")
+}

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -56,6 +56,14 @@ func NewAddUnitCommandForTest(api applicationAddUnitAPI, store jujuclient.Client
 	return modelcmd.Wrap(cmd)
 }
 
+// NewAddUnitCommandForTest returns an AddUnitCommand with the api provided as specified as well as overrides the refresh function.
+func NewAddUnitCommandForTestWithRefresh(api applicationAddUnitAPI, store jujuclient.ClientStore, refreshFunc func(jujuclient.ClientStore, string) error) modelcmd.ModelCommand {
+	cmd := &addUnitCommand{api: api}
+	cmd.SetClientStore(store)
+	cmd.SetModelRefresh(refreshFunc)
+	return modelcmd.Wrap(cmd)
+}
+
 // NewRemoveUnitCommandForTest returns a RemoveUnitCommand with the api provided as specified.
 func NewRemoveUnitCommandForTest(api removeApplicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &removeUnitCommand{api: api}

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -75,6 +75,7 @@ func (c *removeApplicationCommand) Init(args []string) error {
 
 type removeApplicationAPI interface {
 	Close() error
+	ScaleApplication(application.ScaleApplicationParams) (params.ScaleApplicationResult, error)
 	DestroyApplications(application.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error)
 	DestroyDeprecated(appName string) error
 	DestroyUnits(application.DestroyUnitsParams) ([]params.DestroyUnitResult, error)

--- a/state/application.go
+++ b/state/application.go
@@ -1337,6 +1337,46 @@ func (a *Application) GetScale() int {
 	return a.doc.DesiredScale
 }
 
+// ChangeScale alters the existing scale by the provided change amount, returning the new amount.
+// This is used on CAAS models.
+func (a *Application) ChangeScale(scaleChange int) (int, error) {
+	newScale := a.doc.DesiredScale + scaleChange
+	if newScale < 0 {
+		return a.doc.DesiredScale, errors.NotValidf("cannot remove more units than currently exist")
+	}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			alive, err := isAlive(a.st, applicationsC, a.doc.DocID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			} else if !alive {
+				return nil, applicationNotAliveErr
+			}
+			if err := a.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			newScale = a.doc.DesiredScale + scaleChange
+			if newScale < 0 {
+				return nil, errors.NotValidf("cannot remove more units than currently exist")
+			}
+		}
+		return []txn.Op{{
+			C:  applicationsC,
+			Id: a.doc.DocID,
+			Assert: bson.D{{"life", Alive},
+				{"charmurl", a.doc.CharmURL},
+				{"unitcount", a.doc.UnitCount},
+				{"scale", a.doc.DesiredScale}},
+			Update: bson.D{{"$set", bson.D{{"scale", newScale}}}},
+		}}, nil
+	}
+	if err := a.st.db().Run(buildTxn); err != nil {
+		return a.doc.DesiredScale, errors.Errorf("cannot set scale for application %q to %v: %v", a, newScale, onAbort(err, applicationNotAliveErr))
+	}
+	a.doc.DesiredScale = newScale
+	return newScale, nil
+}
+
 // Scale sets the application's desired scale value.
 // This is used on CAAS models.
 func (a *Application) Scale(scale int) error {

--- a/state/application.go
+++ b/state/application.go
@@ -1391,6 +1391,9 @@ func (a *Application) Scale(scale int) error {
 			} else if !alive {
 				return nil, applicationNotAliveErr
 			}
+			if err := a.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 		return []txn.Op{{
 			C:  applicationsC,

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3847,6 +3847,28 @@ func (s *CAASApplicationSuite) TestScale(c *gc.C) {
 	c.Assert(s.app.GetScale(), gc.Equals, 5)
 }
 
+func (s *CAASApplicationSuite) TestInvalidChangeScale(c *gc.C) {
+	newScale, err := s.app.ChangeScale(-1)
+	c.Assert(err, gc.ErrorMatches, "cannot remove more units than currently exist not valid")
+	c.Assert(newScale, gc.Equals, 0)
+}
+
+func (s *CAASApplicationSuite) TestChangeScale(c *gc.C) {
+	newScale, err := s.app.ChangeScale(5)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newScale, gc.Equals, 5)
+	err = s.app.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.app.GetScale(), gc.Equals, 5)
+
+	newScale, err = s.app.ChangeScale(-4)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newScale, gc.Equals, 1)
+	err = s.app.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.app.GetScale(), gc.Equals, 1)
+}
+
 func (s *CAASApplicationSuite) TestWatchScale(c *gc.C) {
 	// Empty initial event.
 	w := s.app.WatchScale()


### PR DESCRIPTION
## Description of change

Put a veneer over the ```scale-application``` command and allow ```remove-unit``` to work with K8s models albeit supporting only the ```num-units``` argument.

## Documentation changes

Added a 'note' in the commands help text although this might need to be expanded.
