### PR TITLE
Allow log pruning settings to be configured after bootstrap

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -249,6 +249,8 @@ var (
 		ControllerAPIPort,
 		MaxPruneTxnBatchSize,
 		MaxPruneTxnPasses,
+		MaxLogsSize,
+		MaxLogsAge,
 		JujuHASpace,
 		JujuManagementSpace,
 		CAASOperatorImagePath,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -287,6 +287,9 @@ func (s *ConfigSuite) TestLogConfigDefaults(c *gc.C) {
 }
 
 func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
+	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.MaxLogsAge), jc.IsTrue)
+	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.MaxLogsSize), jc.IsTrue)
+
 	cfg, err := controller.NewConfig(
 		testing.ControllerTag.Id(),
 		testing.CACert,

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -38,6 +38,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AuditLogExcludeMethods,
 		controller.MaxPruneTxnBatchSize,
 		controller.MaxPruneTxnPasses,
+		controller.MaxLogsSize,
+		controller.MaxLogsAge,
 		controller.CAASOperatorImagePath,
 		controller.Features,
 		controller.APIPortOpenDelay,


### PR DESCRIPTION
## Description of change

Allow the log pruning controller config to be changed after bootstrap.

## QA steps

bootstrap
change max-logs-age and max-logs-size
observe that log pruner is called with new values

## Bug reference

https://bugs.launchpad.net/bugs/1682627
