### PR TITLE
http-server: Merge controller API port changes into develop branch

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -304,6 +304,9 @@ type configSetterOnly interface {
 	// to run a controller
 	SetStateServingInfo(info params.StateServingInfo)
 
+	// SetControllerAPIPort sets the controller API port in the config.
+	SetControllerAPIPort(port int)
+
 	// SetMongoVersion sets the passed version as currently in use.
 	SetMongoVersion(mongo.Version)
 
@@ -684,6 +687,12 @@ func (c *configInternal) SetStateServingInfo(info params.StateServingInfo) {
 	}
 }
 
+func (c *configInternal) SetControllerAPIPort(port int) {
+	if c.servingInfo != nil {
+		c.servingInfo.ControllerAPIPort = port
+	}
+}
+
 func (c *configInternal) APIAddresses() ([]string, error) {
 	if c.apiDetails == nil {
 		return []string{}, errors.New("No apidetails in config")
@@ -800,6 +809,11 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 	// to other controllers if we can talk locally.
 	if isController {
 		port := servingInfo.APIPort
+		// If the controller has been configured with a controller api port,
+		// we return that instead of the normal api port.
+		if servingInfo.ControllerAPIPort != 0 {
+			port = servingInfo.ControllerAPIPort
+		}
 		// TODO(macgreagoir) IPv6. Ubuntu still always provides IPv4
 		// loopback, and when/if this changes localhost should resolve
 		// to IPv6 loopback in any case (lp:1644009). Review.

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -53,6 +53,7 @@ type format_2_0Serialization struct {
 	ControllerKey      string `yaml:"controllerkey,omitempty"`
 	CAPrivateKey       string `yaml:"caprivatekey,omitempty"`
 	APIPort            int    `yaml:"apiport,omitempty"`
+	ControllerAPIPort  int    `yaml:"controllerapiport,omitempty"`
 	StatePort          int    `yaml:"stateport,omitempty"`
 	SharedSecret       string `yaml:"sharedsecret,omitempty"`
 	SystemIdentity     string `yaml:"systemidentity,omitempty"`
@@ -113,13 +114,14 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 	}
 	if len(format.ControllerKey) != 0 {
 		config.servingInfo = &params.StateServingInfo{
-			Cert:           format.ControllerCert,
-			PrivateKey:     format.ControllerKey,
-			CAPrivateKey:   format.CAPrivateKey,
-			APIPort:        format.APIPort,
-			StatePort:      format.StatePort,
-			SharedSecret:   format.SharedSecret,
-			SystemIdentity: format.SystemIdentity,
+			Cert:              format.ControllerCert,
+			PrivateKey:        format.ControllerKey,
+			CAPrivateKey:      format.CAPrivateKey,
+			APIPort:           format.APIPort,
+			ControllerAPIPort: format.ControllerAPIPort,
+			StatePort:         format.StatePort,
+			SharedSecret:      format.SharedSecret,
+			SystemIdentity:    format.SystemIdentity,
 		}
 		// If private key is not present, infer it from the ports in the state addresses.
 		if config.servingInfo.StatePort == 0 {
@@ -178,6 +180,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		format.ControllerKey = config.servingInfo.PrivateKey
 		format.CAPrivateKey = config.servingInfo.CAPrivateKey
 		format.APIPort = config.servingInfo.APIPort
+		format.ControllerAPIPort = config.servingInfo.ControllerAPIPort
 		format.StatePort = config.servingInfo.StatePort
 		format.SharedSecret = config.servingInfo.SharedSecret
 		format.SystemIdentity = config.servingInfo.SystemIdentity

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -111,7 +111,7 @@ stateaddresses:
 - localhost:37017
 statepassword: NB5imrDaWCCRW/4akSSvUxhX
 apiaddresses:
-- localhost:17070
+- localhost:17071
 apipassword: NB5imrDaWCCRW/4akSSvUxhX
 oldpassword: oBlMbFUGvCb2PMFgYVzjS6GD
 values:
@@ -213,6 +213,7 @@ caprivatekey: '-----BEGIN RSA PRIVATE KEY-----
 
 '
 apiport: 17070
+controllerapiport: 17071
 `[1:]
 
 var agentConfig2_0NotStateMachine = `

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -592,7 +593,10 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 		defer cancel()
 		ctx = ctx1
 	}
-	dialInfo, err := dialWebsocketMulti(ctx, info.Addrs, path, opts)
+	// Encourage load balancing by shuffling controller addresses.
+	addrs := info.Addrs[:]
+	rand.Shuffle(len(addrs), func(i, j int) { addrs[i], addrs[j] = addrs[j], addrs[i] })
+	dialInfo, err := dialWebsocketMulti(ctx, addrs, path, opts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -698,6 +702,7 @@ func dialWebsocketMulti(ctx context.Context, addrs []string, path string, opts d
 			cacheUsed = nil
 			opts.DNSCache = emptyDNSCache{opts.DNSCache}
 		}
+
 		if len(addrs) == 0 {
 			break
 		}
@@ -872,6 +877,7 @@ func (d dialer) dial1() (jsoncodec.JSONConn, *tls.Config, error) {
 	if d.opts.certPool == nil {
 		tlsConfig.ServerName = d.serverName
 	}
+	logger.Tracef("dialing: %q %v", d.urlStr, d.ipAddr)
 	conn, err := d.opts.DialWebsocket(d.ctx, d.urlStr, tlsConfig, d.ipAddr)
 	if err == nil {
 		logger.Debugf("successfully dialed %q", d.urlStr)

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -261,6 +261,8 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 	}()
 
+	place1 := "wss://place1.example:1234/api"
+	place2 := "wss://place2.example:1234/api"
 	// Wait for first connection, but don't
 	// reply immediately because we want
 	// to wait for the second connection before
@@ -271,7 +273,18 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for dial")
 	}
-	c.Assert(info0.location, gc.Equals, "wss://place1.example:1234/api")
+	this := place1
+	other := place2
+	if info0.location != place1 {
+		// We now randomly order what we will connect to. So we check
+		// whether we first tried to connect to place1 or place2.
+		// However, we should still be able to interrupt a second dial by
+		// having the first one succeed.
+		this = place2
+		other = place1
+	}
+
+	c.Assert(info0.location, gc.Equals, this)
 
 	var info1 dialInfo
 	// Wait for the next dial to be made. Note that we wait for two
@@ -285,7 +298,7 @@ func (s *apiclientSuite) TestDialWebsocketStopsOtherDialAttempts(c *gc.C) {
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for dial")
 	}
-	c.Assert(info1.location, gc.Equals, "wss://place2.example:1234/api")
+	c.Assert(info1.location, gc.Equals, other)
 
 	// Allow the first dial to succeed.
 	info0.replyc <- dialResponse{

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -114,14 +114,21 @@ func (api *AgentAPIV2) StateServingInfo() (result params.StateServingInfo, err e
 	if err != nil {
 		return params.StateServingInfo{}, errors.Trace(err)
 	}
+	// ControllerAPIPort comes from the controller config.
+	config, err := api.st.ControllerConfig()
+	if err != nil {
+		return params.StateServingInfo{}, errors.Trace(err)
+	}
+
 	result = params.StateServingInfo{
-		APIPort:        info.APIPort,
-		StatePort:      info.StatePort,
-		Cert:           info.Cert,
-		PrivateKey:     info.PrivateKey,
-		CAPrivateKey:   info.CAPrivateKey,
-		SharedSecret:   info.SharedSecret,
-		SystemIdentity: info.SystemIdentity,
+		APIPort:           info.APIPort,
+		ControllerAPIPort: config.ControllerAPIPort(),
+		StatePort:         info.StatePort,
+		Cert:              info.Cert,
+		PrivateKey:        info.PrivateKey,
+		CAPrivateKey:      info.CAPrivateKey,
+		SharedSecret:      info.SharedSecret,
+		SystemIdentity:    info.SystemIdentity,
 	}
 
 	return result, nil

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -799,8 +799,9 @@ type ModifyUserSSHKeys struct {
 // StateServingInfo holds information needed by a state
 // server.
 type StateServingInfo struct {
-	APIPort   int `json:"api-port"`
-	StatePort int `json:"state-port"`
+	APIPort           int `json:"api-port"`
+	ControllerAPIPort int `json:"controller-api-port,omitempty"`
+	StatePort         int `json:"state-port"`
 	// The controller cert and corresponding private key.
 	Cert       string `json:"cert"`
 	PrivateKey string `json:"private-key"`

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -165,8 +165,8 @@ func dependencyEngineConfig() dependency.EngineConfig {
 		WorstError:    util.MoreImportantError,
 		ErrorDelay:    3 * time.Second,
 		BounceDelay:   10 * time.Millisecond,
-		BackoffFactor: 1.5,
-		MaxDelay:      5 * time.Minute,
+		BackoffFactor: 1.2,
+		MaxDelay:      2 * time.Minute,
 		Clock:         clock.WallClock,
 		Logger:        loggo.GetLogger("juju.worker.dependency"),
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -510,6 +510,12 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 				return nil
 			})
 		}
+		updateControllerAPIPort := func(port int) error {
+			return a.AgentConfigWriter.ChangeConfig(func(setter agent.ConfigSetter) error {
+				setter.SetControllerAPIPort(port)
+				return nil
+			})
+		}
 
 		// statePoolReporter is an introspection.IntrospectionReporter,
 		// which is set to the current StatePool managed by the state
@@ -542,26 +548,27 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 		}
 
 		manifolds := machineManifolds(machine.ManifoldsConfig{
-			PreviousAgentVersion: previousAgentVersion,
-			Agent:                agent.APIHostPortsSetter{Agent: a},
-			RootDir:              a.rootDir,
-			AgentConfigChanged:   a.configChangedVal,
-			UpgradeStepsLock:     a.upgradeComplete,
-			UpgradeCheckLock:     a.initialUpgradeCheckComplete,
-			OpenController:       a.initController,
-			OpenStatePool:        a.initState,
-			OpenStateForUpgrade:  a.openStateForUpgrade,
-			StartAPIWorkers:      a.startAPIWorkers,
-			PreUpgradeSteps:      a.preUpgradeSteps,
-			LogSource:            a.bufferedLogger.Logs(),
-			NewDeployContext:     newDeployContext,
-			Clock:                clock.WallClock,
-			ValidateMigration:    a.validateMigration,
-			PrometheusRegisterer: a.prometheusRegistry,
-			CentralHub:           a.centralHub,
-			PubSubReporter:       pubsubReporter,
-			PresenceRecorder:     presenceRecorder,
-			UpdateLoggerConfig:   updateAgentConfLogging,
+			PreviousAgentVersion:    previousAgentVersion,
+			Agent:                   agent.APIHostPortsSetter{Agent: a},
+			RootDir:                 a.rootDir,
+			AgentConfigChanged:      a.configChangedVal,
+			UpgradeStepsLock:        a.upgradeComplete,
+			UpgradeCheckLock:        a.initialUpgradeCheckComplete,
+			OpenController:          a.initController,
+			OpenStatePool:           a.initState,
+			OpenStateForUpgrade:     a.openStateForUpgrade,
+			StartAPIWorkers:         a.startAPIWorkers,
+			PreUpgradeSteps:         a.preUpgradeSteps,
+			LogSource:               a.bufferedLogger.Logs(),
+			NewDeployContext:        newDeployContext,
+			Clock:                   clock.WallClock,
+			ValidateMigration:       a.validateMigration,
+			PrometheusRegisterer:    a.prometheusRegistry,
+			CentralHub:              a.centralHub,
+			PubSubReporter:          pubsubReporter,
+			PresenceRecorder:        presenceRecorder,
+			UpdateLoggerConfig:      updateAgentConfLogging,
+			UpdateControllerAPIPort: updateControllerAPIPort,
 			NewAgentStatusSetter: func(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
 				return a.machine(apiConn)
 			},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -44,6 +44,7 @@ import (
 	"github.com/juju/juju/worker/centralhub"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/common"
+	"github.com/juju/juju/worker/controllerport"
 	"github.com/juju/juju/worker/credentialvalidator"
 	"github.com/juju/juju/worker/dblogpruner"
 	"github.com/juju/juju/worker/deployer"
@@ -192,6 +193,10 @@ type ManifoldsConfig struct {
 	// UpdateLoggerConfig is a function that will save the specified
 	// config value as the logging config in the agent.conf file.
 	UpdateLoggerConfig func(string) error
+
+	// UpdateControllerAPIPort is a function that will save the updated
+	// controller api port in the agent.conf file.
+	UpdateControllerAPIPort func(int) error
 
 	// NewAgentStatusSetter provides upgradesteps.StatusSetter.
 	NewAgentStatusSetter func(apiConn api.Connection) (upgradesteps.StatusSetter, error)
@@ -703,18 +708,35 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		httpServerArgsName: httpserverargs.Manifold(httpserverargs.ManifoldConfig{
 			ClockName:             clockName,
+			ControllerPortName:    controllerPortName,
 			StateName:             stateName,
 			NewStateAuthenticator: httpserverargs.NewStateAuthenticator,
 		}),
 
+		// TODO Juju 3.0: the controller port worker is only needed while
+		// the controller port is a mutable controller config value.
+		// When we hit 3.0 we should make controller-port a required
+		// and unmutable value.
+		controllerPortName: controllerport.Manifold(controllerport.ManifoldConfig{
+			AgentName:               agentName,
+			HubName:                 centralHubName,
+			StateName:               stateName,
+			Logger:                  loggo.GetLogger("juju.worker.controllerport"),
+			UpdateControllerAPIPort: config.UpdateControllerAPIPort,
+			GetControllerConfig:     controllerport.GetControllerConfig,
+			NewWorker:               controllerport.NewWorker,
+		}),
+
 		httpServerName: httpserver.Manifold(httpserver.ManifoldConfig{
-			AgentName:            agentName,
 			CertWatcherName:      certificateWatcherName,
+			HubName:              centralHubName,
 			StateName:            stateName,
 			MuxName:              httpServerArgsName,
 			APIServerName:        apiServerName,
 			RaftTransportName:    raftTransportName,
 			PrometheusRegisterer: config.PrometheusRegisterer,
+			Clock:                config.Clock,
+			GetControllerConfig:  httpserver.GetControllerConfig,
 			NewTLSConfig:         httpserver.NewTLSConfig,
 			NewWorker:            httpserver.NewWorkerShim,
 		}),
@@ -745,6 +767,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{
 			AgentName:                agentName,
 			ClockName:                clockName,
+			ControllerPortName:       controllerPortName,
 			StateName:                stateName,
 			Hub:                      config.CentralHub,
 			NewWorker:                peergrouper.New,
@@ -907,6 +930,7 @@ const (
 	terminationName        = "termination-signal-handler"
 	stateConfigWatcherName = "state-config-watcher"
 	controllerName         = "controller"
+	controllerPortName     = "controller-port"
 	stateName              = "state"
 	apiCallerName          = "api-caller"
 	apiConfigWatcherName   = "api-config-watcher"

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -58,6 +58,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"certificate-updater",
 		"certificate-watcher",
 		"clock",
+		"controller-port",
 		"disk-manager",
 		"external-controller-updater",
 		"fan-configurer",
@@ -136,6 +137,7 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"certificate-watcher",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"global-clock-updater",
 		"http-server",
 		"http-server-args",
@@ -302,6 +304,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"audit-config-updater",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"lease-manager",
@@ -334,6 +337,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"state-config-watcher"},
 
 	"clock": {},
+
+	"controller-port": {
+		"agent",
+		"central-hub",
+		"state",
+		"state-config-watcher"},
 
 	"disk-manager": {
 		"agent",
@@ -397,6 +406,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"central-hub",
 		"certificate-watcher",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"lease-manager",
@@ -409,7 +419,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 
 	"http-server-args": {
 		"agent",
+		"central-hub",
 		"clock",
+		"controller-port",
 		"state",
 		"state-config-watcher"},
 
@@ -428,6 +440,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"lease-manager",
@@ -556,7 +569,9 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 
 	"peer-grouper": {
 		"agent",
+		"central-hub",
 		"clock",
+		"controller-port",
 		"state",
 		"state-config-watcher",
 		"upgrade-check-flag",
@@ -586,6 +601,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft-transport",
@@ -601,6 +617,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -617,6 +634,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -634,6 +652,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -651,6 +670,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"raft",
@@ -667,6 +687,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"controller-port",
 		"http-server-args",
 		"is-controller-flag",
 		"state",

--- a/controller/config.go
+++ b/controller/config.go
@@ -34,6 +34,20 @@ const (
 	// APIPort is the port used for api connections.
 	APIPort = "api-port"
 
+	// ControllerAPIPort is an optional port that may be set for controllers
+	// that have a very heavy load. If this port is set, this port is used by
+	// the controllers to talk to each other - used for the local API connection
+	// as well as the pubsub forwarders, and the raft workers. If this value is
+	// set, the api-port isn't opened until the controllers have started
+	// properly.
+	ControllerAPIPort = "controller-api-port"
+
+	// APIPortOpenDelay is a duration that the controller will wait
+	// between when the controller has been deemed to be ready to open
+	// the api-port and when the api-port is actually opened. This value
+	// is only used when a controller-api-port value is set.
+	APIPortOpenDelay = "api-port-open-delay"
+
 	// AuditingEnabled determines whether the controller will record
 	// auditing information.
 	AuditingEnabled = "auditing-enabled"
@@ -156,6 +170,10 @@ const (
 	// DefaultAPIPort is the default port the API server is listening on.
 	DefaultAPIPort int = 17070
 
+	// DefaultAPIPortOpenDelay is the default value for api-port-open-delay.
+	// It is a string representation of a time.Duration.
+	DefaultAPIPortOpenDelay = "2s"
+
 	// DefaultMongoMemoryProfile is the default profile used by mongo.
 	DefaultMongoMemoryProfile = MongoProfLow
 
@@ -200,10 +218,12 @@ var (
 	ControllerOnlyConfigAttributes = []string{
 		AllowModelAccessKey,
 		APIPort,
+		APIPortOpenDelay,
 		AutocertDNSNameKey,
 		AutocertURLKey,
 		CACertKey,
 		CharmStoreURL,
+		ControllerAPIPort,
 		ControllerUUIDKey,
 		IdentityPublicKey,
 		IdentityURL,
@@ -231,9 +251,13 @@ var (
 	// config attributes that are allowed to be updated after the
 	// controller has been created.
 	AllowedUpdateConfigAttributes = set.NewStrings(
+		APIPortOpenDelay,
 		AuditingEnabled,
 		AuditLogCaptureArgs,
 		AuditLogExcludeMethods,
+		// TODO Juju 3.0: ControllerAPIPort should be required and treated
+		// more like api-port.
+		ControllerAPIPort,
 		MaxPruneTxnBatchSize,
 		MaxPruneTxnPasses,
 		JujuHASpace,
@@ -338,6 +362,30 @@ func (c Config) StatePort() int {
 // APIPort returns the API server port for the environment.
 func (c Config) APIPort() int {
 	return c.mustInt(APIPort)
+}
+
+// APIPortOpenDelay returns the duration to wait before opening
+// the APIPort once the controller has started up. Only used when
+// the ControllerAPIPort is non-zero.
+func (c Config) APIPortOpenDelay() time.Duration {
+	v := c.asString(APIPortOpenDelay)
+	// We know that v must be a parseable time.Duration for the config
+	// to be valid.
+	d, _ := time.ParseDuration(v)
+	return d
+}
+
+// ControllerAPIPort returns the optional API port to be used for
+// the controllers to talk to each other. A zero value means that
+// it is not set.
+func (c Config) ControllerAPIPort() int {
+	if value, ok := c[ControllerAPIPort].(float64); ok {
+		return int(value)
+	}
+	// If the value isn't an int, this conversion will fail and value
+	// will be 0, which is what we want here.
+	value, _ := c[ControllerAPIPort].(int)
+	return value
 }
 
 // AuditingEnabled returns whether or not auditing has been enabled
@@ -649,6 +697,26 @@ func Validate(c Config) error {
 		}
 	}
 
+	if v, ok := c[ControllerAPIPort].(int); ok {
+		// TODO: change the validation so 0 is invalide and --reset is used.
+		// However that doesn't exist yet.
+		if v < 0 {
+			return errors.NotValidf("non-positive integer for controller-api-port")
+		}
+		if v == c.APIPort() {
+			return errors.NotValidf("controller-api-port matching api-port")
+		}
+		if v == c.StatePort() {
+			return errors.NotValidf("controller-api-port matching state-port")
+		}
+	}
+	if v, ok := c[APIPortOpenDelay].(string); ok {
+		_, err := time.ParseDuration(v)
+		if err != nil {
+			return errors.Errorf("%s value %q must be a valid duration", APIPortOpenDelay, v)
+		}
+	}
+
 	return nil
 }
 
@@ -710,6 +778,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AuditLogMaxBackups:      schema.ForceInt(),
 	AuditLogExcludeMethods:  schema.List(schema.String()),
 	APIPort:                 schema.ForceInt(),
+	APIPortOpenDelay:        schema.String(),
+	ControllerAPIPort:       schema.ForceInt(),
 	StatePort:               schema.ForceInt(),
 	IdentityURL:             schema.String(),
 	IdentityPublicKey:       schema.String(),
@@ -731,6 +801,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MeteringURL:             schema.String(),
 }, schema.Defaults{
 	APIPort:                 DefaultAPIPort,
+	APIPortOpenDelay:        DefaultAPIPortOpenDelay,
+	ControllerAPIPort:       schema.Omit,
 	AuditingEnabled:         DefaultAuditingEnabled,
 	AuditLogCaptureArgs:     DefaultAuditLogCaptureArgs,
 	AuditLogMaxSize:         fmt.Sprintf("%vM", DefaultAuditLogMaxSizeMB),

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -230,6 +230,37 @@ var validateTests = []struct {
 		controller.CAASOperatorImagePath: "foo//bar",
 	},
 	expectError: `docker image path "foo//bar" not valid`,
+}, {
+	about: "negative controller-api-port",
+	config: controller.Config{
+		controller.CACertKey:         testing.CACert,
+		controller.ControllerAPIPort: -5,
+	},
+	expectError: `non-positive integer for controller-api-port not valid`,
+}, {
+	about: "controller-api-port matching api-port",
+	config: controller.Config{
+		controller.APIPort:           12345,
+		controller.CACertKey:         testing.CACert,
+		controller.ControllerAPIPort: 12345,
+	},
+	expectError: `controller-api-port matching api-port not valid`,
+}, {
+	about: "controller-api-port matching state-port",
+	config: controller.Config{
+		controller.APIPort:           12345,
+		controller.StatePort:         54321,
+		controller.CACertKey:         testing.CACert,
+		controller.ControllerAPIPort: 54321,
+	},
+	expectError: `controller-api-port matching state-port not valid`,
+}, {
+	about: "api-port-open-delay not a duration",
+	config: controller.Config{
+		controller.CACertKey:        testing.CACert,
+		controller.APIPortOpenDelay: "15",
+	},
+	expectError: `api-port-open-delay value "15" must be a valid duration`,
 }}
 
 func (s *ConfigSuite) TestValidate(c *gc.C) {
@@ -237,11 +268,17 @@ func (s *ConfigSuite) TestValidate(c *gc.C) {
 		c.Logf("test %d: %v", i, test.about)
 		err := test.config.Validate()
 		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Check(err, gc.ErrorMatches, test.expectError)
 		} else {
-			c.Assert(err, jc.ErrorIsNil)
+			c.Check(err, jc.ErrorIsNil)
 		}
 	}
+}
+
+func (s *ConfigSuite) TestAPIPortDefaults(c *gc.C) {
+	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.APIPortOpenDelay(), gc.Equals, 2*time.Second)
 }
 
 func (s *ConfigSuite) TestLogConfigDefaults(c *gc.C) {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -177,11 +177,18 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 
 	// Create 3 controllers
 	machineA, _ := s.makeStateAgentVersion(c, s.oldVersion)
+	// We're not going to start the agents for machines A or B - we
+	// need to make sure the API port is still set to the one picked
+	// for this machine after we create the other machines.
+	apiPort := s.ControllerConfig.APIPort()
+
 	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(changes.Added), gc.Equals, 2)
 	machineB, _, _ := s.configureMachine(c, changes.Added[0], s.oldVersion)
 	s.configureMachine(c, changes.Added[1], s.oldVersion)
+
+	s.SetControllerConfigAPIPort(c, apiPort)
 
 	// One of the other controllers is ready for upgrade (but machine C isn't).
 	info, err := s.State.EnsureUpgradeInfo(machineB.Id(), s.oldVersion.Number, jujuversion.Current)

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -42,13 +42,15 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.CharmStoreURL,
 		controller.Features,
 		controller.MeteringURL,
+		controller.APIPortOpenDelay,
+		controller.ControllerAPIPort,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)
 		c.Logf(controllerAttr)
 		if !optional.Contains(controllerAttr) {
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(v, gc.Not(gc.Equals), "")
+			c.Check(ok, jc.IsTrue)
+			c.Check(v, gc.Not(gc.Equals), "")
 		}
 	}
 }

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -82,7 +82,6 @@ func connectFallback(
 ) (
 	conn api.Connection, didFallback bool, err error,
 ) {
-
 	// We expect to assign to `conn`, `err`, *and* `info` in
 	// the course of this operation: wrapping this repeated
 	// atom in a func currently seems to be less treacherous
@@ -95,7 +94,10 @@ func connectFallback(
 			// controller such that the round trip time could be as high
 			// as 500ms.
 			DialTimeout: 3 * time.Second,
-			RetryDelay:  200 * time.Millisecond,
+			// The delay between connecting to a different controller. Setting this to 0 means we try all controllers
+			// simultaneously. We set it to approximately how long the TLS handshake takes, to avoid doing TLS
+			// handshakes to a controller that we are going to end up ignoring.
+			DialAddressInterval: 200 * time.Millisecond,
 			// The timeout is for the complete login handshake.
 			// If the server is rate limiting, it will normally pause
 			// before responding to the login request, but the pause is

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -190,9 +190,9 @@ func openCalls(model names.ModelTag, entity names.Tag, passwords ...string) []te
 		calls[i] = testing.StubCall{
 			FuncName: "apiOpen",
 			Args: []interface{}{info, api.DialOpts{
-				DialTimeout: 3 * time.Second,
-				RetryDelay:  200 * time.Millisecond,
-				Timeout:     time.Minute,
+				DialAddressInterval: 200 * time.Millisecond,
+				DialTimeout:         3 * time.Second,
+				Timeout:             time.Minute,
 			}},
 		}
 	}

--- a/worker/controllerport/manifold.go
+++ b/worker/controllerport/manifold.go
@@ -1,0 +1,129 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// Logger defines the methods needed for the worker to log messages.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// ManifoldConfig holds the information necessary to determine the controller
+// api port and keep it up to date.
+type ManifoldConfig struct {
+	AgentName string
+	HubName   string
+	StateName string
+
+	Logger                  Logger
+	UpdateControllerAPIPort func(int) error
+
+	GetControllerConfig func(*state.State) (controller.Config, error)
+	NewWorker           func(Config) (worker.Worker, error)
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.HubName == "" {
+		return errors.NotValidf("empty HubName")
+	}
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.UpdateControllerAPIPort == nil {
+		return errors.NotValidf("nil UpdateControllerAPIPort")
+	}
+	if config.GetControllerConfig == nil {
+		return errors.NotValidf("nil GetControllerConfig")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run an HTTP server
+// worker. The manifold outputs an *apiserverhttp.Mux, for other workers
+// to register handlers against.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.HubName,
+			config.StateName,
+		},
+		Start: config.start,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var hub *pubsub.StructuredHub
+	if err := context.Get(config.HubName, &hub); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer stTracker.Done()
+
+	systemState := statePool.SystemState()
+	controllerConfig, err := config.GetControllerConfig(systemState)
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get controller config")
+	}
+	controllerAPIPort := controllerConfig.ControllerAPIPort()
+
+	w, err := config.NewWorker(Config{
+		AgentConfig:             agent.CurrentConfig(),
+		Hub:                     hub,
+		Logger:                  config.Logger,
+		ControllerAPIPort:       controllerAPIPort,
+		UpdateControllerAPIPort: config.UpdateControllerAPIPort,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// GetControllerConfig gets the controller config from the given state
+// - it's a shim so we can test the manifold without a state suite.
+func GetControllerConfig(st *state.State) (controller.Config, error) {
+	return st.ControllerConfig()
+}

--- a/worker/controllerport/manifold_test.go
+++ b/worker/controllerport/manifold_test.go
@@ -1,0 +1,214 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/controllerport"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	config           controllerport.ManifoldConfig
+	manifold         dependency.Manifold
+	context          dependency.Context
+	agent            *mockAgent
+	hub              *pubsub.StructuredHub
+	state            stubStateTracker
+	logger           loggo.Logger
+	controllerConfig controller.Config
+	worker           worker.Worker
+
+	stub testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.agent = &mockAgent{}
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.state = stubStateTracker{}
+	s.logger = loggo.GetLogger("controllerport_manifold")
+	s.controllerConfig = controller.Config(map[string]interface{}{
+		"controller-api-port": 2048,
+	})
+	s.worker = &struct{ worker.Worker }{}
+	s.stub.ResetCalls()
+
+	s.context = s.newContext(nil)
+	s.config = controllerport.ManifoldConfig{
+		AgentName:               "agent",
+		HubName:                 "hub",
+		StateName:               "state",
+		Logger:                  s.logger,
+		UpdateControllerAPIPort: s.updatePort,
+		GetControllerConfig:     s.getControllerConfig,
+		NewWorker:               s.newWorker,
+	}
+	s.manifold = controllerport.Manifold(s.config)
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"agent": s.agent,
+		"hub":   s.hub,
+		"state": &s.state,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) getControllerConfig(st *state.State) (controller.Config, error) {
+	s.stub.MethodCall(s, "GetControllerConfig", st)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.controllerConfig, nil
+}
+
+func (s *ManifoldSuite) updatePort(port int) error {
+	return errors.Errorf("braincake")
+}
+
+func (s *ManifoldSuite) newWorker(config controllerport.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+var expectedInputs = []string{"state", "agent", "hub"}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestValidate(c *gc.C) {
+	type test struct {
+		f      func(*controllerport.ManifoldConfig)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *controllerport.ManifoldConfig) { cfg.StateName = "" },
+		"empty StateName not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.HubName = "" },
+		"empty HubName not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.AgentName = "" },
+		"empty AgentName not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.UpdateControllerAPIPort = nil },
+		"nil UpdateControllerAPIPort not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.GetControllerConfig = nil },
+		"nil GetControllerConfig not valid",
+	}, {
+		func(cfg *controllerport.ManifoldConfig) { cfg.NewWorker = nil },
+		"nil NewWorker not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		config := s.config
+		test.f(&config)
+		manifold := controllerport.Manifold(config)
+		w, err := manifold.Start(s.context)
+		workertest.CheckNilOrKill(c, w)
+		c.Check(err, gc.ErrorMatches, test.expect)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	s.startWorkerClean(c)
+
+	s.stub.CheckCallNames(c, "GetControllerConfig", "NewWorker")
+	args := s.stub.Calls()[1].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, controllerport.Config{})
+	config := args[0].(controllerport.Config)
+
+	// Can't directly compare functions, so blank it out.
+	c.Assert(config.UpdateControllerAPIPort(3), gc.ErrorMatches, "braincake")
+	config.UpdateControllerAPIPort = nil
+
+	c.Assert(config, jc.DeepEquals, controllerport.Config{
+		AgentConfig:       &s.agent.conf,
+		Hub:               s.hub,
+		Logger:            s.logger,
+		ControllerAPIPort: 2048,
+	})
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.Equals, s.worker)
+	return w
+}
+
+type stubStateTracker struct {
+	testing.Stub
+	pool state.StatePool
+}
+
+func (s *stubStateTracker) Use() (*state.StatePool, error) {
+	s.MethodCall(s, "Use")
+	return &s.pool, s.NextErr()
+}
+
+func (s *stubStateTracker) Done() error {
+	s.MethodCall(s, "Done")
+	return s.NextErr()
+}
+
+type mockAgent struct {
+	agent.Agent
+	conf mockAgentConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+type mockAgentConfig struct {
+	agent.Config
+	port int
+}
+
+func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
+	return params.StateServingInfo{ControllerAPIPort: c.port}, true
+}

--- a/worker/controllerport/package_test.go
+++ b/worker/controllerport/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/controllerport/worker.go
+++ b/worker/controllerport/worker.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/pubsub"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/pubsub/controller"
+)
+
+// Config is the configuration required for running an API server worker.
+type Config struct {
+	AgentConfig             agent.Config
+	Hub                     *pubsub.StructuredHub
+	Logger                  Logger
+	ControllerAPIPort       int
+	UpdateControllerAPIPort func(int) error
+}
+
+// Validate validates the API server configuration.
+func (config Config) Validate() error {
+	if config.AgentConfig == nil {
+		return errors.NotValidf("nil AgentConfig")
+	}
+	if config.Hub == nil {
+		return errors.NotValidf("nil Hub")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.UpdateControllerAPIPort == nil {
+		return errors.NotValidf("nil UpdateControllerAPIPort")
+	}
+	return nil
+}
+
+// NewWorker returns a new API server worker, with the given configuration.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Worker{
+		logger: config.Logger,
+		update: config.UpdateControllerAPIPort,
+	}
+
+	servingInfo, ok := config.AgentConfig.StateServingInfo()
+	if !ok {
+		return nil, errors.New("missing state serving info")
+	}
+	w.controllerAPIPort = servingInfo.ControllerAPIPort
+	// We need to make sure that update the agent config with
+	// the potentially new controller api port from the database
+	// before we start any other workers that need to connect
+	// to the controller over the controller port.
+	w.updateControllerPort(config.ControllerAPIPort)
+
+	unsub, err := config.Hub.Subscribe(controller.ConfigChanged,
+		func(topic string, data controller.ConfigChangedMessage, err error) {
+			if w.updateControllerPort(data.Config.ControllerAPIPort()) {
+				w.tomb.Kill(dependency.ErrBounce)
+			}
+		})
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to subscribe to details topic")
+	}
+
+	w.tomb.Go(func() error {
+		defer unsub()
+		<-w.tomb.Dying()
+		return nil
+	})
+	return w, nil
+}
+
+// Worker is responsible for updating the agent config when the controller api
+// port value changes, and then bouncing the worker to notify the other
+// dependent workers, which should be the peer-grouper and http-server.
+type Worker struct {
+	tomb   tomb.Tomb
+	logger Logger
+	update func(int) error
+
+	controllerAPIPort int
+}
+
+// Kill implements Worker.Kill.
+func (w *Worker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements Worker.Wait.
+func (w *Worker) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *Worker) updateControllerPort(port int) bool {
+	if w.controllerAPIPort == port {
+		return false
+	}
+	// The local cache is out of date, update it.
+	w.logger.Infof("updating controller API port to %v", port)
+	err := w.update(port)
+	if err != nil {
+		w.logger.Errorf("unable to update agent.conf with new controller API port: %v", err)
+	}
+	w.controllerAPIPort = port
+	return true
+}

--- a/worker/controllerport/worker_test.go
+++ b/worker/controllerport/worker_test.go
@@ -1,0 +1,135 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerport_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/controller"
+	pscontroller "github.com/juju/juju/pubsub/controller"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/controllerport"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+	agentConfig *mockAgentConfig
+	hub         *pubsub.StructuredHub
+	logger      loggo.Logger
+	config      controllerport.Config
+	stub        testing.Stub
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.agentConfig = &mockAgentConfig{port: 232323}
+	s.hub = pubsub.NewStructuredHub(nil)
+	s.logger = loggo.GetLogger("controllerport_worker_test")
+	s.stub.ResetCalls()
+
+	s.logger.SetLogLevel(loggo.TRACE)
+
+	s.config = controllerport.Config{
+		AgentConfig: s.agentConfig,
+		Hub:         s.hub,
+		Logger:      s.logger,
+
+		ControllerAPIPort:       232323,
+		UpdateControllerAPIPort: s.updatePort,
+	}
+}
+
+func (s *WorkerSuite) updatePort(port int) error {
+	s.stub.MethodCall(s, "UpdatePort", port)
+	return s.stub.NextErr()
+}
+
+func (s *WorkerSuite) newWorker(c *gc.C, config controllerport.Config) worker.Worker {
+	w, err := controllerport.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
+	return w
+}
+
+func (s *WorkerSuite) TestImmediateUpdate(c *gc.C) {
+	// Change the agent config so the ports are out of sync.
+	s.agentConfig.port = 23456
+	w := s.newWorker(c, s.config)
+	workertest.CheckAlive(c, w)
+	s.stub.CheckCall(c, 0, "UpdatePort", 232323)
+}
+
+func (s *WorkerSuite) TestNoChange(c *gc.C) {
+	w := s.newWorker(c, s.config)
+	processed, err := s.hub.Publish(pscontroller.ConfigChanged, pscontroller.ConfigChangedMessage{
+		Config: controller.Config{
+			"controller-api-port": 232323,
+			"some-other-field":    "new value!",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-processed:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for processed")
+	}
+	workertest.CheckAlive(c, w)
+	s.stub.CheckCallNames(c)
+}
+
+func (s *WorkerSuite) TestChange(c *gc.C) {
+	w := s.newWorker(c, s.config)
+	processed, err := s.hub.Publish(pscontroller.ConfigChanged, pscontroller.ConfigChangedMessage{
+		Config: controller.Config{"controller-api-port": 444444},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-processed:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for processed")
+	}
+	s.stub.CheckCall(c, 0, "UpdatePort", 444444)
+	err = workertest.CheckKilled(c, w)
+	c.Assert(errors.Cause(err), gc.Equals, dependency.ErrBounce)
+}
+
+func (s *WorkerSuite) TestValidate(c *gc.C) {
+	type test struct {
+		f      func(*controllerport.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *controllerport.Config) { cfg.AgentConfig = nil },
+		"nil AgentConfig not valid",
+	}, {
+		func(cfg *controllerport.Config) { cfg.Hub = nil },
+		"nil Hub not valid",
+	}, {
+		func(cfg *controllerport.Config) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *controllerport.Config) { cfg.UpdateControllerAPIPort = nil },
+		"nil UpdateControllerAPIPort not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		config := s.config
+		test.f(&config)
+		w, err := controllerport.NewWorker(config)
+		workertest.CheckNilOrKill(c, w)
+		c.Check(err, gc.ErrorMatches, test.expect)
+	}
+}

--- a/worker/httpserver/manifold.go
+++ b/worker/httpserver/manifold.go
@@ -6,13 +6,15 @@ package httpserver
 import (
 	"crypto/tls"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/pubsub"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/dependency"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common"
 	workerstate "github.com/juju/juju/worker/state"
@@ -21,10 +23,10 @@ import (
 // ManifoldConfig holds the information necessary to run an HTTP server
 // in a dependency.Engine.
 type ManifoldConfig struct {
-	AgentName       string
 	CertWatcherName string
-	StateName       string
+	HubName         string
 	MuxName         string
+	StateName       string
 
 	// We don't use these in the worker, but we want to prevent the
 	// httpserver from starting until they're running so that all of
@@ -32,19 +34,21 @@ type ManifoldConfig struct {
 	RaftTransportName string
 	APIServerName     string
 
+	Clock                clock.Clock
 	PrometheusRegisterer prometheus.Registerer
 
-	NewTLSConfig func(*state.State, func() *tls.Certificate) (*tls.Config, error)
-	NewWorker    func(Config) (worker.Worker, error)
+	GetControllerConfig func(*state.State) (controller.Config, error)
+	NewTLSConfig        func(*state.State, func() *tls.Certificate) (*tls.Config, error)
+	NewWorker           func(Config) (worker.Worker, error)
 }
 
 // Validate validates the manifold configuration.
 func (config ManifoldConfig) Validate() error {
-	if config.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
-	}
 	if config.CertWatcherName == "" {
 		return errors.NotValidf("empty CertWatcherName")
+	}
+	if config.HubName == "" {
+		return errors.NotValidf("empty HubName")
 	}
 	if config.StateName == "" {
 		return errors.NotValidf("empty StateName")
@@ -58,8 +62,14 @@ func (config ManifoldConfig) Validate() error {
 	if config.APIServerName == "" {
 		return errors.NotValidf("empty APIServerName")
 	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
 	if config.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
+	}
+	if config.GetControllerConfig == nil {
+		return errors.NotValidf("nil GetControllerConfig")
 	}
 	if config.NewTLSConfig == nil {
 		return errors.NotValidf("nil NewTLSConfig")
@@ -76,8 +86,8 @@ func (config ManifoldConfig) Validate() error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.CertWatcherName,
+			config.HubName,
 			config.StateName,
 			config.MuxName,
 			config.RaftTransportName,
@@ -93,8 +103,8 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 		return nil, errors.Trace(err)
 	}
 
-	var agent agent.Agent
-	if err := context.Get(config.AgentName, &agent); err != nil {
+	var hub *pubsub.StructuredHub
+	if err := context.Get(config.HubName, &hub); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -136,12 +146,20 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	controllerConfig, err := config.GetControllerConfig(systemState)
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get controller config")
+	}
 
 	w, err := config.NewWorker(Config{
-		AgentConfig:          agent.CurrentConfig(),
+		Clock:                config.Clock,
 		PrometheusRegisterer: config.PrometheusRegisterer,
+		Hub:                  hub,
 		TLSConfig:            tlsConfig,
 		Mux:                  mux,
+		APIPort:              controllerConfig.APIPort(),
+		APIPortOpenDelay:     controllerConfig.APIPortOpenDelay(),
+		ControllerAPIPort:    controllerConfig.ControllerAPIPort(),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/httpserver/mock_test.go
+++ b/worker/httpserver/mock_test.go
@@ -9,32 +9,9 @@ import (
 	"github.com/juju/testing"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/httpcontext"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
-
-type mockAgent struct {
-	agent.Agent
-	conf mockAgentConfig
-}
-
-func (ma *mockAgent) CurrentConfig() agent.Config {
-	return &ma.conf
-}
-
-type mockAgentConfig struct {
-	agent.Config
-	info *params.StateServingInfo
-}
-
-func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
-	if c.info != nil {
-		return *c.info, true
-	}
-	return params.StateServingInfo{}, false
-}
 
 type stubStateTracker struct {
 	testing.Stub

--- a/worker/httpserver/shim.go
+++ b/worker/httpserver/shim.go
@@ -3,10 +3,21 @@
 
 package httpserver
 
-import "gopkg.in/juju/worker.v1"
+import (
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/state"
+)
 
 // NewWorkerShim calls through to NewWorker, and exists only
 // to adapt to the signature of ManifoldConfig.NewWorker.
 func NewWorkerShim(config Config) (worker.Worker, error) {
 	return NewWorker(config)
+}
+
+// GetControllerConfig gets the controller config from a *State - it
+// exists so we can test the manifold without a StateSuite.
+func GetControllerConfig(st *state.State) (controller.Config, error) {
+	return st.ControllerConfig()
 }

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -11,31 +11,36 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1/catacomb"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/pubsub/apiserver"
 )
 
 var logger = loggo.GetLogger("juju.worker.httpserver")
 
 // Config is the configuration required for running an API server worker.
 type Config struct {
-	AgentConfig          agent.Config
+	Clock                clock.Clock
 	TLSConfig            *tls.Config
 	Mux                  *apiserverhttp.Mux
 	PrometheusRegisterer prometheus.Registerer
+	Hub                  *pubsub.StructuredHub
+	APIPort              int
+	APIPortOpenDelay     time.Duration
+	ControllerAPIPort    int
 }
 
 // Validate validates the API server configuration.
 func (config Config) Validate() error {
-	if config.AgentConfig == nil {
-		return errors.NotValidf("nil AgentConfig")
-	}
 	if config.TLSConfig == nil {
 		return errors.NotValidf("nil TLSConfig")
 	}
@@ -53,10 +58,12 @@ func NewWorker(config Config) (*Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	w := &Worker{
 		config: config,
 		url:    make(chan string),
 	}
+
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
 		Work: w.loop,
@@ -70,6 +77,8 @@ type Worker struct {
 	catacomb catacomb.Catacomb
 	config   Config
 	url      chan string
+
+	unsub func()
 }
 
 func (w *Worker) Kill() {
@@ -92,45 +101,268 @@ func (w *Worker) URL() string {
 }
 
 func (w *Worker) loop() error {
-	servingInfo, ok := w.config.AgentConfig.StateServingInfo()
-	if !ok {
-		return errors.New("missing state serving info")
+	var err error
+	var listener listener
+	if w.config.ControllerAPIPort == 0 {
+		listener, err = w.newSimpleListener()
+	} else {
+		listener, err = w.newDualPortListener()
 	}
-	listenAddr := net.JoinHostPort("", strconv.Itoa(servingInfo.APIPort))
-	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	listener = tls.NewListener(listener, w.config.TLSConfig)
-	// TODO(axw) rate-limit connections by wrapping listener
+	holdable := newHeldListener(listener, w.config.Clock)
 
 	serverLog := log.New(&loggoWrapper{
 		level:  loggo.WARNING,
 		logger: logger,
 	}, "", 0) // no prefix and no flags so log.Logger doesn't add extra prefixes
-	logger.Infof("listening on %q", listener.Addr())
 	server := &http.Server{
 		Handler:   w.config.Mux,
 		TLSConfig: w.config.TLSConfig,
 		ErrorLog:  serverLog,
 	}
-	go server.Serve(listener)
+	go server.Serve(tls.NewListener(holdable, w.config.TLSConfig))
 	defer func() {
 		logger.Infof("shutting down HTTP server")
 		// Shutting down the server will also close listener.
 		err := server.Shutdown(context.Background())
+		// Release the holdable listener to unblock any pending accepts.
+		holdable.release()
 		w.catacomb.Kill(err)
 	}()
 
-	url := fmt.Sprintf("https://%s", listener.Addr())
 	for {
 		select {
 		case <-w.catacomb.Dying():
+			// Stop accepting new connections. This allows the mux
+			// to process all pending requests without having to deal with
+			// new ones.
+			holdable.hold()
 			// Asked to shutdown - make sure we wait until all clients
 			// have finished up.
 			w.config.Mux.Wait()
 			return w.catacomb.ErrDying()
-		case w.url <- url:
+		case w.url <- listener.URL():
 		}
 	}
+}
+
+type heldListener struct {
+	net.Listener
+	clock clock.Clock
+	cond  *sync.Cond
+	held  bool
+}
+
+func newHeldListener(l net.Listener, c clock.Clock) *heldListener {
+	var mu sync.Mutex
+	return &heldListener{
+		Listener: l,
+		clock:    c,
+		cond:     sync.NewCond(&mu),
+	}
+}
+
+func (h *heldListener) hold() {
+	h.cond.L.Lock()
+	defer h.cond.L.Unlock()
+	h.held = true
+	// No need to signal the cond here, since nothing that's waiting
+	// for the listener to be unheld can run.
+}
+
+func (h *heldListener) release() {
+	h.cond.L.Lock()
+	defer h.cond.L.Unlock()
+	h.held = false
+	// Wake up any goroutines waiting for held to be false.
+	h.cond.Broadcast()
+}
+
+func (h *heldListener) Accept() (net.Conn, error) {
+	h.cond.L.Lock()
+	for h.held {
+		h.cond.Wait()
+	}
+	h.cond.L.Unlock()
+	return h.Listener.Accept()
+}
+
+type listener interface {
+	net.Listener
+	URL() string
+}
+
+func (w *Worker) newSimpleListener() (listener, error) {
+	listenAddr := net.JoinHostPort("", strconv.Itoa(w.config.APIPort))
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Infof("listening on %q", listener.Addr())
+	return &simpleListener{listener}, nil
+}
+
+type simpleListener struct {
+	net.Listener
+}
+
+func (s *simpleListener) URL() string {
+	return fmt.Sprintf("https://%s", s.Addr())
+}
+
+func (w *Worker) newDualPortListener() (listener, error) {
+	// Only open the controller port until we have been told that
+	// the controller is ready. This is currently done by the event
+	// from the peergrouper.
+	// TODO (thumper): make the raft worker publish an event when
+	// it knows who the raft master is. This means that this controller
+	// is part of the consensus set, and when it is, is is OK to accept
+	// agent connections. Until that time, accepting an agent connection
+	// would be a bit of a waste of time.
+	listenAddr := net.JoinHostPort("", strconv.Itoa(w.config.ControllerAPIPort))
+	listener, err := net.Listen("tcp", listenAddr)
+	logger.Infof("listening for controller connections on %q", listener.Addr())
+	dual := &dualListener{
+		clock:              w.config.Clock,
+		delay:              w.config.APIPortOpenDelay,
+		apiPort:            w.config.APIPort,
+		controllerListener: listener,
+		done:               make(chan struct{}),
+		errors:             make(chan error),
+		connections:        make(chan net.Conn),
+	}
+	go dual.accept(listener)
+
+	dual.unsub, err = w.config.Hub.Subscribe(apiserver.DetailsTopic, dual.openAPIPort)
+	if err != nil {
+		dual.Close()
+		return nil, errors.Annotate(err, "unable to subscribe to details topic")
+	}
+
+	return dual, err
+}
+
+type dualListener struct {
+	clock   clock.Clock
+	delay   time.Duration
+	apiPort int
+
+	controllerListener net.Listener
+	apiListener        net.Listener
+
+	mu     sync.Mutex
+	closer sync.Once
+
+	done        chan struct{}
+	errors      chan error
+	connections chan net.Conn
+
+	unsub func()
+}
+
+func (d *dualListener) accept(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case d.errors <- err:
+			case <-d.done:
+				logger.Infof("no longer accepting connections on %s", listener.Addr())
+				return
+			}
+		} else {
+			select {
+			case d.connections <- conn:
+			case <-d.done:
+				conn.Close()
+				logger.Infof("no longer accepting connections on %s", listener.Addr())
+				return
+			}
+		}
+	}
+}
+
+// Accept implements net.Listener.
+func (d *dualListener) Accept() (net.Conn, error) {
+	select {
+	case <-d.done:
+		return nil, errors.New("listener has been closed")
+	case err := <-d.errors:
+		// Don't wrap this error with errors.Trace - the stdlib http
+		// server code has handling for various net error types (like
+		// temporary failures) that we don't want to interfere with.
+		return nil, err
+	case conn := <-d.connections:
+		return conn, nil
+	}
+}
+
+// Close implements net.Listener. Closes all the open listeners.
+func (d *dualListener) Close() error {
+	// Only close the channel once.
+	d.closer.Do(func() { close(d.done) })
+	err := d.controllerListener.Close()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.apiListener != nil {
+		err2 := d.apiListener.Close()
+		if err == nil {
+			err = err2
+		}
+		// If we already have a close error, we don't really care
+		// about this one.
+	}
+	return errors.Trace(err)
+}
+
+// Addr implements net.Listener. If the api port has been opened, we
+// return that, otherwise we return the controller port address.
+func (d *dualListener) Addr() net.Addr {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.apiListener != nil {
+		return d.apiListener.Addr()
+	}
+	return d.controllerListener.Addr()
+}
+
+// URL implements the listener method.
+func (d *dualListener) URL() string {
+	return fmt.Sprintf("https://%s", d.Addr())
+}
+
+// openAPIPort opens the api port and starts accepting connections.
+func (d *dualListener) openAPIPort(_ string, _ map[string]interface{}) {
+	d.unsub()
+	if d.delay > 0 {
+		logger.Infof("waiting for %s before allowing api connections", d.delay)
+		<-d.clock.After(d.delay)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Make sure we haven't been closed already.
+	select {
+	case <-d.done:
+		return
+	default:
+		// We are all good.
+	}
+
+	listenAddr := net.JoinHostPort("", strconv.Itoa(d.apiPort))
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		select {
+		case d.errors <- err:
+		case <-d.done:
+			logger.Errorf("can't open api port: %v, but worker exiting already", err)
+		}
+		return
+	}
+
+	logger.Infof("listening for api connections on %q", listener.Addr())
+	d.apiListener = listener
+	go d.accept(listener)
 }

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -5,12 +5,16 @@ package httpserver_test
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/juju/clock/testclock"
+	"github.com/juju/pubsub"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -18,28 +22,23 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/apiserverhttp"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/pubsub/apiserver"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/httpserver"
 )
 
 type workerFixture struct {
 	testing.IsolationSuite
-	agentConfig          mockAgentConfig
 	prometheusRegisterer stubPrometheusRegisterer
 	mux                  *apiserverhttp.Mux
+	clock                *testclock.Clock
+	hub                  *pubsub.StructuredHub
 	config               httpserver.Config
 	stub                 testing.Stub
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-
-	s.agentConfig = mockAgentConfig{
-		info: &params.StateServingInfo{
-			APIPort: 0, // listen on any port
-		},
-	}
 	certPool, err := api.CreateCertPool(coretesting.CACert)
 	c.Assert(err, jc.ErrorIsNil)
 	tlsConfig := api.NewTLSConfig(certPool)
@@ -47,12 +46,18 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	tlsConfig.Certificates = []tls.Certificate{*coretesting.ServerTLSCert}
 	s.prometheusRegisterer = stubPrometheusRegisterer{}
 	s.mux = apiserverhttp.NewMux()
+	s.clock = testclock.NewClock(time.Now())
+	s.hub = pubsub.NewStructuredHub(nil)
 
 	s.config = httpserver.Config{
-		AgentConfig:          &s.agentConfig,
+		Clock:                s.clock,
 		TLSConfig:            tlsConfig,
 		Mux:                  s.mux,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		Hub:                  s.hub,
+		APIPort:              0,
+		APIPortOpenDelay:     0,
+		ControllerAPIPort:    0,
 	}
 }
 
@@ -68,9 +73,6 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		expect string
 	}
 	tests := []test{{
-		func(cfg *httpserver.Config) { cfg.AgentConfig = nil },
-		"nil AgentConfig not valid",
-	}, {
 		func(cfg *httpserver.Config) { cfg.TLSConfig = nil },
 		"nil TLSConfig not valid",
 	}, {
@@ -200,4 +202,154 @@ func (s *WorkerSuite) TestMinTLSVersion(c *gc.C) {
 	conn, err := tls.Dial("tcp", parsed.Host, tlsConfig)
 	c.Assert(err, gc.ErrorMatches, ".*protocol version not supported")
 	c.Assert(conn, gc.IsNil)
+}
+
+func (s *WorkerSuite) TestHeldListener(c *gc.C) {
+	// Worker url comes back as "" when the worker is dying.
+	url := s.worker.URL()
+
+	// Simulate having a slow request being handled.
+	s.mux.AddClient()
+
+	err := s.mux.AddHandler("GET", "/quick", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	quickErr := make(chan error)
+	request := func() {
+		// Make a new client each request so we don't reuse
+		// connections.
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: s.config.TLSConfig,
+			},
+		}
+		_, err := client.Get(url + "/quick")
+		quickErr <- err
+	}
+
+	// Sanity check - the quick one should be quick normally.
+	go request()
+
+	select {
+	case err := <-quickErr:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("timed out waiting for quick request")
+	}
+
+	// Stop the server.
+	s.worker.Kill()
+
+	// Eventually quick requests get blocked by the held listener.
+	var quickBlocked bool
+attempts:
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		go request()
+		select {
+		case <-quickErr:
+		case <-time.After(coretesting.ShortWait):
+			quickBlocked = true
+			break attempts
+		}
+	}
+	c.Assert(quickBlocked, gc.Equals, true)
+
+	// The server doesn't die yet - it's kept alive by the slow
+	// request.
+	workertest.CheckAlive(c, s.worker)
+
+	// Let the slow request complete.  See that the server
+	// stops, and the 2nd request completes.
+	s.mux.ClientDone()
+
+	select {
+	case err := <-quickErr:
+		// It doesn't really matter what the error is.
+		c.Assert(err, gc.NotNil)
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("timed out waiting for 2nd quick request")
+	}
+	workertest.CheckKilled(c, s.worker)
+}
+
+type WorkerControllerPortSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&WorkerControllerPortSuite{})
+
+func (s *WorkerControllerPortSuite) newWorker(c *gc.C) *httpserver.Worker {
+	worker, err := httpserver.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	return worker
+}
+
+func (s *WorkerControllerPortSuite) TestDualPortListenerWithDelay(c *gc.C) {
+	err := s.mux.AddHandler("GET", "/quick", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	request := func(url string) error {
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: s.config.TLSConfig,
+			},
+		}
+		_, err := client.Get(url + "/quick")
+		return err
+	}
+
+	// Make a worker with a controller API port.
+	port := testing.FindTCPPort()
+	controllerPort := testing.FindTCPPort()
+	s.config.APIPort = port
+	s.config.ControllerAPIPort = controllerPort
+	s.config.APIPortOpenDelay = 10 * time.Second
+
+	worker := s.newWorker(c)
+
+	// The worker reports its URL as the controller port.
+	controllerURL := worker.URL()
+	parsed, err := url.Parse(controllerURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(parsed.Port(), gc.Equals, fmt.Sprint(controllerPort))
+
+	// Requests on that port work.
+	c.Assert(request(controllerURL), jc.ErrorIsNil)
+
+	// Requests on the regular API port fail to connect.
+	parsed.Host = net.JoinHostPort(parsed.Hostname(), fmt.Sprint(port))
+	normalURL := parsed.String()
+	c.Assert(request(normalURL), gc.ErrorMatches, `.*: connection refused$`)
+
+	// Send API details on the hub - still no luck connecting on the
+	// non-controller port.
+	_, err = s.hub.Publish(apiserver.DetailsTopic, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.clock.WaitAdvance(5*time.Second, coretesting.LongWait, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(request(controllerURL), jc.ErrorIsNil)
+	c.Assert(request(normalURL), gc.ErrorMatches, `.*: connection refused$`)
+
+	// After the required delay the port eventually opens.
+	err = s.clock.WaitAdvance(5*time.Second, coretesting.LongWait, 1)
+
+	// The reported url changes to the regular port.
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		if worker.URL() == normalURL {
+			break
+		}
+	}
+	c.Assert(worker.URL(), gc.Equals, normalURL)
+
+	// Requests on both ports work.
+	c.Assert(request(controllerURL), jc.ErrorIsNil)
+	c.Assert(request(normalURL), jc.ErrorIsNil)
 }

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -25,8 +25,9 @@ type desiredPeerGroupSuite struct {
 var _ = gc.Suite(&desiredPeerGroupSuite{})
 
 const (
-	mongoPort = 1234
-	apiPort   = 5678
+	mongoPort         = 1234
+	apiPort           = 5678
+	controllerAPIPort = 9876
 )
 
 type desiredPeerGroupTest struct {

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -54,11 +54,12 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.context = s.newContext(nil)
 	s.manifold = peergrouper.Manifold(peergrouper.ManifoldConfig{
-		AgentName: "agent",
-		ClockName: "clock",
-		StateName: "state",
-		Hub:       s.hub,
-		NewWorker: s.newWorker,
+		AgentName:          "agent",
+		ClockName:          "clock",
+		ControllerPortName: "controller-port",
+		StateName:          "state",
+		Hub:                s.hub,
+		NewWorker:          s.newWorker,
 		ControllerSupportsSpaces: func(st *state.State) (bool, error) {
 			if st != s.State {
 				return false, errors.New("invalid state")
@@ -70,9 +71,10 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
 	resources := map[string]interface{}{
-		"agent": s.agent,
-		"clock": s.clock,
-		"state": &s.stateTracker,
+		"agent":           s.agent,
+		"clock":           s.clock,
+		"controller-port": nil,
+		"state":           &s.stateTracker,
 	}
 	for k, v := range overlay {
 		resources[k] = v
@@ -90,7 +92,7 @@ func (s *ManifoldSuite) newWorker(config peergrouper.Config) (worker.Worker, err
 	return w, nil
 }
 
-var expectedInputs = []string{"agent", "clock", "state"}
+var expectedInputs = []string{"agent", "clock", "controller-port", "state"}
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
 	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -503,6 +503,48 @@ func (s *workerSuite) TestControllersArePublishedOverHub(c *gc.C) {
 	}
 }
 
+func (s *workerSuite) TestControllersPublishedWithControllerAPIPort(c *gc.C) {
+	st := NewFakeState()
+	InitState(c, st, 3, testIPv4)
+
+	hub := pubsub.NewStructuredHub(nil)
+	event := make(chan apiserver.Details)
+	_, err := hub.Subscribe(apiserver.DetailsTopic, func(topic string, data apiserver.Details, err error) {
+		c.Check(err, jc.ErrorIsNil)
+		event <- data
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.hub = hub
+
+	w := s.newWorkerWithConfig(c, Config{
+		Clock:              s.clock,
+		State:              st,
+		MongoSession:       st.session,
+		APIHostPortsSetter: nopAPIHostPortsSetter{},
+		MongoPort:          mongoPort,
+		APIPort:            apiPort,
+		ControllerAPIPort:  controllerAPIPort,
+		Hub:                s.hub,
+	})
+	defer workertest.CleanKill(c, w)
+
+	expected := apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"10": {ID: "10", Addresses: []string{"0.1.2.10:5678"}, InternalAddress: "0.1.2.10:9876"},
+			"11": {ID: "11", Addresses: []string{"0.1.2.11:5678"}, InternalAddress: "0.1.2.11:9876"},
+			"12": {ID: "12", Addresses: []string{"0.1.2.12:5678"}, InternalAddress: "0.1.2.12:9876"},
+		},
+		LocalOnly: true,
+	}
+
+	select {
+	case obtained := <-event:
+		c.Assert(obtained, jc.DeepEquals, expected)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for event")
+	}
+}
+
 func (s *workerSuite) TestControllersArePublishedOverHubWithNewVoters(c *gc.C) {
 	st := NewFakeState()
 	var ids []string
@@ -1034,17 +1076,27 @@ func (nopHub) Subscribe(topic string, handler interface{}) (func(), error) {
 	return func() {}, nil
 }
 
+func (s *workerSuite) newWorkerWithConfig(
+	c *gc.C,
+	config Config,
+) worker.Worker {
+	// We create a new clock for the worker so we can wait on alarms even when
+	// a single test tests both ipv4 and 6 so is creating two workers.
+	s.clock = testclock.NewClock(time.Now())
+	config.Clock = s.clock
+	w, err := New(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
+	return w
+}
+
 func (s *workerSuite) newWorker(
 	c *gc.C,
 	st State,
 	session MongoSession,
 	apiHostPortsSetter APIHostPortsSetter,
 ) worker.Worker {
-	// We create a new clock for the worker so we can wait on alarms even when
-	// a single test tests both ipv4 and 6 so is creating two workers.
-	s.clock = testclock.NewClock(time.Now())
-	w, err := New(Config{
-		Clock:              s.clock,
+	return s.newWorkerWithConfig(c, Config{
 		State:              st,
 		MongoSession:       session,
 		APIHostPortsSetter: apiHostPortsSetter,
@@ -1052,7 +1104,4 @@ func (s *workerSuite) newWorker(
 		APIPort:            apiPort,
 		Hub:                s.hub,
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
-	return w
 }

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -22,8 +22,6 @@ import (
 	"github.com/juju/juju/pubsub/apiserver"
 )
 
-//var logger = loggo.GetLogger("juju.worker.pubsub")
-
 // WorkerConfig defines the configuration values that the pubsub worker needs
 // to operate.
 type WorkerConfig struct {
@@ -168,14 +166,20 @@ func (s *subscriber) apiServerChanges(topic string, details apiserver.Details, e
 			continue
 		}
 
+		// TODO: always use the internal address?
+		addresses := apiServer.Addresses
+		if apiServer.InternalAddress != "" {
+			addresses = []string{apiServer.InternalAddress}
+		}
+
 		server, found := s.servers[target]
 		if found {
-			s.config.Logger.Tracef("update addresses for %s to %v", target, apiServer.Addresses)
-			server.UpdateAddresses(apiServer.Addresses)
+			s.config.Logger.Tracef("update addresses for %s to %v", target, addresses)
+			server.UpdateAddresses(addresses)
 		} else {
 			s.config.Logger.Debugf("new forwarder for %s", target)
 			newInfo := *s.config.APIInfo
-			newInfo.Addrs = apiServer.Addresses
+			newInfo.Addrs = addresses
 			server, err := s.config.NewRemote(RemoteServerConfig{
 				Hub:       s.config.Hub,
 				Origin:    s.config.Origin,

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -60,6 +60,21 @@ func (rh *runHook) Prepare(state State) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if hooks.Kind(name) == hooks.LeaderElected {
+		// Check if leadership has changed between queueing of the hook and
+		// Actual execution. Skip execution if we are no longer the leader.
+		isLeader := false
+		isLeader, err = rnr.Context().IsLeader()
+		if err == nil && !isLeader {
+			logger.Infof("unit is no longer the leader; skipping %q execution", name)
+			return nil, ErrSkipExecute
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	err = rnr.Context().Prepare()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -161,6 +176,7 @@ func (rh *runHook) beforeHook(state State) error {
 	case hooks.PostSeriesUpgrade:
 		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleteRunning, "post-series-upgrade hook running")
 	}
+
 	if err != nil {
 		logger.Errorf("error updating workload status before %v hook: %v", rh.info.Kind, err)
 		return err

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -437,12 +437,17 @@ func NewRunCommandsRunnerFactory(runResponse *utilexec.ExecResponse, runErr erro
 	}
 }
 
-func NewRunHookRunnerFactory(runErr error) *MockRunnerFactory {
+func NewRunHookRunnerFactory(runErr error, contextOps ...func(*MockContext)) *MockRunnerFactory {
+	ctx := &MockContext{isLeader: true}
+	for _, op := range contextOps {
+		op(ctx)
+	}
+
 	return &MockRunnerFactory{
 		MockNewHookRunner: &MockNewHookRunner{
 			runner: &MockRunner{
 				MockRunHook: &MockRunHook{err: runErr},
-				context:     &MockContext{},
+				context:     ctx,
 			},
 		},
 	}

--- a/worker/uniter/runner/context/leader.go
+++ b/worker/uniter/runner/context/leader.go
@@ -74,6 +74,10 @@ func (ctx *leadershipContext) WriteLeaderSettings(settings map[string]string) er
 	// `apiserver/leadership.LeadershipSettingsAccessor.Merge`, and as of
 	// 2015-02-19 it's better to stay eager.
 	err := ctx.ensureLeader()
+	if err == errIsMinion {
+		logger.Warningf("skipping write settings; not the leader")
+		return nil
+	}
 	if err == nil {
 		// Clear local settings; if we need them again we should use the values
 		// as merged by the server. But we don't need to get them again right now;

--- a/worker/uniter/runner/context/leader_test.go
+++ b/worker/uniter/runner/context/leader_test.go
@@ -201,16 +201,17 @@ func (s *LeaderSuite) TestWriteLeaderSettingsMinion(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "ClaimLeader",
 	}}, func() {
-		// The first call fails...
+		// We are not the leader.
 		s.tracker.results = []StubTicket{false}
 		err := s.context.WriteLeaderSettings(map[string]string{"blah": "blah"})
-		c.Check(err, gc.ErrorMatches, "cannot write settings: not the leader")
+		// No error, no call to Merge.
+		c.Check(err, jc.ErrorIsNil)
 	})
 
 	s.CheckCalls(c, nil, func() {
-		// The second doesn't even try.
+		// ctx.isMinion is now true. No call to claim leader.
 		err := s.context.WriteLeaderSettings(map[string]string{"blah": "blah"})
-		c.Check(err, gc.ErrorMatches, "cannot write settings: not the leader")
+		c.Check(err, jc.ErrorIsNil)
 	})
 }
 


### PR DESCRIPTION
## Description of change

This is a forward-merge of the controller API port changes from #9386 to the develop/2.5 branch. The main source of conflicts was that the autocert handling was removed from the httpserver worker in #9030, but it's still present in the 2.4 branch.

## QA steps

Tests run, and a basic smoke-test deployment works, including changing the controller API port.

