### PR TITLE
Run action on leader

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -118,18 +118,3 @@ func (c *Client) ApplicationCharmActions(arg params.Entity) (map[string]params.A
 	}
 	return result.Actions, nil
 }
-
-// Leaders returns applications and their current leader units.
-func (c *Client) Leaders() (map[string]string, error) {
-	var result params.LeadersResult
-	if err := c.facade.FacadeCall("Leaders", nil, &result); err != nil {
-		if params.IsCodeNotImplemented(err) {
-			return nil, errors.NewNotImplemented(err, "")
-		}
-		return nil, err
-	}
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	return result.Result, nil
-}

--- a/api/action/client.go
+++ b/api/action/client.go
@@ -118,3 +118,18 @@ func (c *Client) ApplicationCharmActions(arg params.Entity) (map[string]params.A
 	}
 	return result.Actions, nil
 }
+
+// Leaders returns applications and their current leader units.
+func (c *Client) Leaders() (map[string]string, error) {
+	var result params.LeadersResult
+	if err := c.facade.FacadeCall("Leaders", nil, &result); err != nil {
+		if params.IsCodeNotImplemented(err) {
+			return nil, errors.NewNotImplemented(err, "")
+		}
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return result.Result, nil
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -11,7 +11,7 @@ package api
 // New facades should start at 1.
 // Facades that existed before versioning start at 0.
 var facadeVersions = map[string]int{
-	"Action":                       2,
+       "Action":                       3,
 	"ActionPruner":                 1,
 	"Agent":                        2,
 	"AgentTools":                   1,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -11,7 +11,7 @@ package api
 // New facades should start at 1.
 // Facades that existed before versioning start at 0.
 var facadeVersions = map[string]int{
-       "Action":                       3,
+	"Action":                       3,
 	"ActionPruner":                 1,
 	"Agent":                        2,
 	"AgentTools":                   1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -126,7 +126,8 @@ func AllFacades() *facade.Registry {
 		}
 	}
 
-	reg("Action", 2, action.NewActionAPI)
+       reg("Action", 2, action.NewActionAPIV2)
+       reg("Action", 3, action.NewActionAPIV3)
 	reg("ActionPruner", 1, actionpruner.NewAPI)
 	reg("Agent", 2, agent.NewAgentAPIV2)
 	reg("AgentTools", 1, agenttools.NewFacade)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -126,8 +126,8 @@ func AllFacades() *facade.Registry {
 		}
 	}
 
-       reg("Action", 2, action.NewActionAPIV2)
-       reg("Action", 3, action.NewActionAPIV3)
+	reg("Action", 2, action.NewActionAPIV2)
+	reg("Action", 3, action.NewActionAPIV3)
 	reg("ActionPruner", 1, actionpruner.NewAPI)
 	reg("Agent", 2, agent.NewAgentAPIV2)
 	reg("AgentTools", 1, agenttools.NewFacade)

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+       "strings"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -23,8 +25,35 @@ type ActionAPI struct {
 	check      *common.BlockChecker
 }
 
-// NewActionAPI returns an initialized ActionAPI
-func NewActionAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ActionAPI, error) {
+// APIv2 provides the Action API facade for version 2.
+type APIv2 struct {
+       *APIv3
+}
+
+// APIv3 provides the Action API facade for version 3.
+type APIv3 struct {
+       *ActionAPI
+}
+
+// NewActionAPIV2 returns an initialized ActionAPI for version 2.
+func NewActionAPIV2(ctx facade.Context) (*APIv2, error) {
+       api, err := NewActionAPIV3(ctx)
+       if err != nil {
+               return nil, errors.Trace(err)
+       }
+       return &APIv2{api}, nil
+}
+
+// NewActionAPIV3 returns an initialized ActionAPI for version 3.
+func NewActionAPIV3(ctx facade.Context) (*APIv3, error) {
+       api, err := newActionAPI(ctx.State(), ctx.Resources(), ctx.Auth())
+       if err != nil {
+               return nil, errors.Trace(err)
+       }
+       return &APIv3{api}, nil
+}
+
+func newActionAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ActionAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
@@ -184,11 +213,36 @@ func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 		return params.ActionResults{}, errors.Trace(err)
 	}
 
+       var leaders map[string]string
+       getLeader := func(appName string) (string, error) {
+               if leaders == nil {
+                       var err error
+                       leaders, err = a.state.ApplicationLeaders()
+                       if err != nil {
+                               return "", err
+                       }
+               }
+               if leader, ok := leaders[appName]; ok {
+                       return leader, nil
+               }
+               return "", errors.Errorf("could not determine leader for %q", appName)
+       }
+
 	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
 	for i, action := range arg.Actions {
 		currentResult := &response.Results[i]
-		receiver, err := tagToActionReceiver(action.Receiver)
+               actionReceiver := action.Receiver
+               if strings.HasSuffix(actionReceiver, "leader") {
+                       app := strings.Split(actionReceiver, "/")[0]
+                       receiverName, err := getLeader(app)
+                       if err != nil {
+                               currentResult.Error = common.ServerError(err)
+                               continue
+                       }
+                       actionReceiver = names.NewUnitTag(receiverName).String()
+               }
+               receiver, err := tagToActionReceiver(actionReceiver)
 		if err != nil {
 			currentResult.Error = common.ServerError(err)
 			continue
@@ -202,19 +256,6 @@ func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued)
 	}
 	return response, nil
-}
-
-// Leaders returns currently known applications and their leader units.
-func (a *ActionAPI) Leaders() (params.LeadersResult, error) {
-	if err := a.checkCanRead(); err != nil {
-		return params.LeadersResult{}, errors.Trace(err)
-	}
-
-	leaders, err := a.state.ApplicationLeaders()
-	if err != nil {
-		return params.LeadersResult{Error: common.ServerError(err)}, nil
-	}
-	return params.LeadersResult{Result: leaders}, nil
 }
 
 // ListAll takes a list of Entities representing ActionReceivers and

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -204,6 +204,19 @@ func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 	return response, nil
 }
 
+// Leaders returns currently known applications and their leader units.
+func (a *ActionAPI) Leaders() (params.LeadersResult, error) {
+	if err := a.checkCanRead(); err != nil {
+		return params.LeadersResult{}, errors.Trace(err)
+	}
+
+	leaders, err := a.state.ApplicationLeaders()
+	if err != nil {
+		return params.LeadersResult{Error: common.ServerError(err)}, nil
+	}
+	return params.LeadersResult{Result: leaders}, nil
+}
+
 // ListAll takes a list of Entities representing ActionReceivers and
 // returns all of the Actions that have been enqueued or run by each of
 // those Entities.

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -4,7 +4,7 @@
 package action
 
 import (
-       "strings"
+	"strings"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
@@ -27,30 +27,30 @@ type ActionAPI struct {
 
 // APIv2 provides the Action API facade for version 2.
 type APIv2 struct {
-       *APIv3
+	*APIv3
 }
 
 // APIv3 provides the Action API facade for version 3.
 type APIv3 struct {
-       *ActionAPI
+	*ActionAPI
 }
 
 // NewActionAPIV2 returns an initialized ActionAPI for version 2.
 func NewActionAPIV2(ctx facade.Context) (*APIv2, error) {
-       api, err := NewActionAPIV3(ctx)
-       if err != nil {
-               return nil, errors.Trace(err)
-       }
-       return &APIv2{api}, nil
+	api, err := NewActionAPIV3(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv2{api}, nil
 }
 
 // NewActionAPIV3 returns an initialized ActionAPI for version 3.
 func NewActionAPIV3(ctx facade.Context) (*APIv3, error) {
-       api, err := newActionAPI(ctx.State(), ctx.Resources(), ctx.Auth())
-       if err != nil {
-               return nil, errors.Trace(err)
-       }
-       return &APIv3{api}, nil
+	api, err := newActionAPI(ctx.State(), ctx.Resources(), ctx.Auth())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv3{api}, nil
 }
 
 func newActionAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ActionAPI, error) {
@@ -213,36 +213,36 @@ func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 		return params.ActionResults{}, errors.Trace(err)
 	}
 
-       var leaders map[string]string
-       getLeader := func(appName string) (string, error) {
-               if leaders == nil {
-                       var err error
-                       leaders, err = a.state.ApplicationLeaders()
-                       if err != nil {
-                               return "", err
-                       }
-               }
-               if leader, ok := leaders[appName]; ok {
-                       return leader, nil
-               }
-               return "", errors.Errorf("could not determine leader for %q", appName)
-       }
+	var leaders map[string]string
+	getLeader := func(appName string) (string, error) {
+		if leaders == nil {
+			var err error
+			leaders, err = a.state.ApplicationLeaders()
+			if err != nil {
+				return "", err
+			}
+		}
+		if leader, ok := leaders[appName]; ok {
+			return leader, nil
+		}
+		return "", errors.Errorf("could not determine leader for %q", appName)
+	}
 
 	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
 	for i, action := range arg.Actions {
 		currentResult := &response.Results[i]
-               actionReceiver := action.Receiver
-               if strings.HasSuffix(actionReceiver, "leader") {
-                       app := strings.Split(actionReceiver, "/")[0]
-                       receiverName, err := getLeader(app)
-                       if err != nil {
-                               currentResult.Error = common.ServerError(err)
-                               continue
-                       }
-                       actionReceiver = names.NewUnitTag(receiverName).String()
-               }
-               receiver, err := tagToActionReceiver(actionReceiver)
+		actionReceiver := action.Receiver
+		if strings.HasSuffix(actionReceiver, "leader") {
+			app := strings.Split(actionReceiver, "/")[0]
+			receiverName, err := getLeader(app)
+			if err != nil {
+				currentResult.Error = common.ServerError(err)
+				continue
+			}
+			actionReceiver = names.NewUnitTag(receiverName).String()
+		}
+		receiver, err := tagToActionReceiver(actionReceiver)
 		if err != nil {
 			currentResult.Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -6,7 +6,6 @@ package action_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -270,18 +269,6 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	actions, err = s.mysqlUnit.Actions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actions, gc.HasLen, 0)
-}
-
-func (s *actionSuite) TestLeaders(c *gc.C) {
-	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-	err = claimer.Claim("mysql", "mysql/0", time.Minute)
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := s.action.Leaders()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.IsNil)
-	c.Check(result.Result, gc.DeepEquals, map[string]string{"mysql": "mysql/0"})
 }
 
 type testCaseAction struct {

--- a/apiserver/facades/client/action/export_test.go
+++ b/apiserver/facades/client/action/export_test.go
@@ -6,4 +6,5 @@ package action
 var (
 	GetAllUnitNames = getAllUnitNames
 	QueueActions    = &queueActions
+       NewActionAPI    = newActionAPI
 )

--- a/apiserver/facades/client/action/export_test.go
+++ b/apiserver/facades/client/action/export_test.go
@@ -6,5 +6,5 @@ package action
 var (
 	GetAllUnitNames = getAllUnitNames
 	QueueActions    = &queueActions
-       NewActionAPI    = newActionAPI
+	NewActionAPI    = newActionAPI
 )

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -94,11 +94,3 @@ type PinnedLeadershipResult struct {
 	//   behaviour for each application.
 	Result map[string][]string `json:"result,omitempty"`
 }
-
-// LeadersResult transports data for applications and their current leaders.
-type LeadersResult struct {
-	// Result is collection of current leading units keyed by application.
-	Result map[string]string `json:"result,omitempty"`
-	// Error is a reference to an error from querying current leaders.
-	Error *Error `json:"error,omitempty"`
-}

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -80,7 +80,7 @@ type PinApplicationResult struct {
 	// ApplicationName is the application for which a leadership pin/unpin
 	// operation was attempted.
 	ApplicationName string `json:"application-name"`
-	// Error will container a reference to an error resulting from pin/unpin
+	// Error will contain a reference to an error resulting from pin/unpin
 	// if one occurred.
 	Error *Error `json:"error,omitempty"`
 }
@@ -93,4 +93,12 @@ type PinnedLeadershipResult struct {
 	// - Tag slice values representing the entities requiring pinned
 	//   behaviour for each application.
 	Result map[string][]string `json:"result,omitempty"`
+}
+
+// LeadersResult transports data for applications and their current leaders.
+type LeadersResult struct {
+	// Result is collection of current leading units keyed by application.
+	Result map[string]string `json:"result,omitempty"`
+	// Error is a reference to an error from querying current leaders.
+	Error *Error `json:"error,omitempty"`
 }

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -56,6 +56,9 @@ type APIClient interface {
 	// FindActionsByNames takes a list of names and finds a corresponding list of
 	// Actions for every name.
 	FindActionsByNames(params.FindActionsByNames) (params.ActionsByNames, error)
+
+	// Leaders returns applications and their current leader units.
+	Leaders() (map[string]string, error)
 }
 
 // ActionCommandBase is the base type for action sub-commands.

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -17,6 +17,10 @@ import (
 type APIClient interface {
 	io.Closer
 
+       // BestAPIVersion returns the API version that we were able to
+       // determine is supported by both the client and the API Server
+       BestAPIVersion() int
+
 	// Enqueue takes a list of Actions and queues them up to be executed by
 	// the designated ActionReceiver, returning the params.Action for each
 	// queued Action, or an error if there was a problem queueing up the
@@ -56,9 +60,6 @@ type APIClient interface {
 	// FindActionsByNames takes a list of names and finds a corresponding list of
 	// Actions for every name.
 	FindActionsByNames(params.FindActionsByNames) (params.ActionsByNames, error)
-
-	// Leaders returns applications and their current leader units.
-	Leaders() (map[string]string, error)
 }
 
 // ActionCommandBase is the base type for action sub-commands.

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -17,9 +17,9 @@ import (
 type APIClient interface {
 	io.Closer
 
-       // BestAPIVersion returns the API version that we were able to
-       // determine is supported by both the client and the API Server
-       BestAPIVersion() int
+	// BestAPIVersion returns the API version that we were able to
+	// determine is supported by both the client and the API Server
+	BestAPIVersion() int
 
 	// Enqueue takes a list of Actions and queues them up to be executed by
 	// the designated ActionReceiver, returning the params.Action for each

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -34,7 +34,7 @@ type RunCommand struct {
 }
 
 func (c *RunCommand) UnitNames() []string {
-	return c.unitNames
+       return c.unitReceivers
 }
 
 func (c *RunCommand) ActionName() string {

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -34,7 +34,7 @@ type RunCommand struct {
 }
 
 func (c *RunCommand) UnitNames() []string {
-       return c.unitReceivers
+	return c.unitReceivers
 }
 
 func (c *RunCommand) ActionName() string {

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -33,8 +33,8 @@ type RunCommand struct {
 	*runCommand
 }
 
-func (c *RunCommand) UnitTags() []names.UnitTag {
-	return c.unitTags
+func (c *RunCommand) UnitNames() []string {
+	return c.unitNames
 }
 
 func (c *RunCommand) ActionName() string {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -130,7 +130,7 @@ type fakeAPIClient struct {
 	actionTagMatches   params.FindTagsResults
 	actionsByNames     params.ActionsByNames
 	charmActions       map[string]params.ActionSpec
-	leaders            map[string]string
+	apiVersion         int
 	apiErr             error
 }
 
@@ -144,6 +144,10 @@ func (c *fakeAPIClient) EnqueuedActions() params.Actions {
 
 func (c *fakeAPIClient) Close() error {
 	return nil
+}
+
+func (c *fakeAPIClient) BestAPIVersion() int {
+	return c.apiVersion
 }
 
 func (c *fakeAPIClient) Enqueue(args params.Actions) (params.ActionResults, error) {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -25,7 +25,6 @@ const (
 	validActionTagString   = "action-f47ac10b-58cc-4372-a567-0e02b2c3d479"
 	invalidActionTagString = "action-f47ac10b-58cc-4372-a567-0e02b2c3d47"
 	validActionId          = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-	invalidActionId        = "f47ac10b-58cc-4372-a567-0e02b2c3d47"
 	validUnitId            = "mysql/0"
 	validUnitId2           = "mysql/1"
 	invalidUnitId          = "something-strange-"
@@ -131,6 +130,7 @@ type fakeAPIClient struct {
 	actionTagMatches   params.FindTagsResults
 	actionsByNames     params.ActionsByNames
 	charmActions       map[string]params.ActionSpec
+	leaders            map[string]string
 	apiErr             error
 }
 
@@ -212,4 +212,8 @@ func (c *fakeAPIClient) FindActionTagsByPrefix(arg params.FindTags) (params.Find
 
 func (c *fakeAPIClient) FindActionsByNames(args params.FindActionsByNames) (params.ActionsByNames, error) {
 	return c.actionsByNames, c.apiErr
+}
+
+func (c *fakeAPIClient) Leaders() (map[string]string, error) {
+	return c.leaders, c.apiErr
 }

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -213,7 +213,3 @@ func (c *fakeAPIClient) FindActionTagsByPrefix(arg params.FindTags) (params.Find
 func (c *fakeAPIClient) FindActionsByNames(args params.FindActionsByNames) (params.ActionsByNames, error) {
 	return c.actionsByNames, c.apiErr
 }
-
-func (c *fakeAPIClient) Leaders() (map[string]string, error) {
-	return c.leaders, c.apiErr
-}

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -159,12 +159,6 @@ func (c *runCommand) Info() *cmd.Info {
 
 // Init gets the unit tag(s), action name and action arguments.
 func (c *runCommand) Init(args []string) (err error) {
-	defer func() {
-		if err != nil && c.api != nil {
-			c.api.Close()
-		}
-	}()
-
 	for _, arg := range args {
 		if names.IsValidUnit(arg) || validLeader.MatchString(arg) {
 			c.unitReceivers = append(c.unitReceivers, arg)

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -259,12 +259,10 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	for i, unitReceiver := range c.unitReceivers {
 		if strings.HasSuffix(unitReceiver, "leader") {
 			if c.api.BestAPIVersion() < 3 {
-				var leaderErrMsg = "unable to determine leader for application %q"
 				app := strings.Split(unitReceiver, "/")[0]
-				err := errors.Errorf(leaderErrMsg+
+				return errors.Errorf("unable to determine leader for application %q"+
 					"\nleader determination is unsupported by this API"+
 					"\neither upgrade your controller, or explicitly specify a unit", app)
-				return err
 			}
 			actions[i].Receiver = unitReceiver
 		} else {

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -54,6 +54,13 @@ Queue an Action for execution on a given unit, with a given set of params.
 The Action ID is returned for use with 'juju show-action-output <ID>' or
 'juju show-action-status <ID>'.
 
+Valid unit identifiers are: 
+  a standard unit ID, such as mysql/0 or;
+  leader syntax of the form <application>/leader, such as mysql/leader.
+
+If the leader syntax is used, the leader unit for the application will be
+resolved before the action is enqueued.
+
 Params are validated according to the charm for the unit's application.  The
 valid params can be seen using "juju actions <application> --schema".
 Params may be in a yaml file which is passed with the --params flag, or they
@@ -79,6 +86,10 @@ result:
 
 
 $ juju run-action mysql/3 backup
+action: <ID>
+
+$ juju run-action mysql/leader backup
+resolved leader: mysql/0
 action: <ID>
 
 $ juju show-action-output <ID>

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -5,11 +5,11 @@ package action_test
 
 import (
 	"bytes"
-	"errors"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -59,7 +59,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	tests := []struct {
 		should               string
 		args                 []string
-		expectUnits          []names.UnitTag
+		expectUnits          []string
 		expectAction         string
 		expectParamsYamlPath string
 		expectParseStrings   bool
@@ -75,21 +75,21 @@ func (s *RunSuite) TestInit(c *gc.C) {
 		args:        []string{validUnitId},
 		expectError: "no action specified",
 	}, {
-		should:      "fail with invalid unit tag",
+		should:      "fail with invalid unit ID",
 		args:        []string{invalidUnitId, "valid-action-name"},
 		expectError: "invalid unit or action name \"something-strange-\"",
 	}, {
-		should:      "fail with invalid unit tag first",
+		should:      "fail with invalid unit ID first",
 		args:        []string{validUnitId, invalidUnitId, "valid-action-name"},
 		expectError: "invalid unit or action name \"something-strange-\"",
 	}, {
-		should:      "fail with invalid unit tag second",
+		should:      "fail with invalid unit ID second",
 		args:        []string{invalidUnitId, validUnitId, "valid-action-name"},
 		expectError: "invalid unit or action name \"something-strange-\"",
 	}, {
 		should:       "work with multiple valid units",
 		args:         []string{validUnitId, validUnitId2, "valid-action-name"},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId), names.NewUnitTag(validUnitId2)},
+		expectUnits:  []string{validUnitId, validUnitId2},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{},
 	}, {}, {
@@ -115,46 +115,46 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	}, {
 		should:       "work with action name ending in numeric values",
 		args:         []string{validUnitId, "action-01"},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "action-01",
 	}, {
 		should:       "work with numeric values within action name",
 		args:         []string{validUnitId, "action-00-foo"},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "action-00-foo",
 	}, {
 		should:       "work with action name starting with numeric values",
 		args:         []string{validUnitId, "00-action"},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "00-action",
 	}, {
 		should:       "work with empty values",
 		args:         []string{validUnitId, "valid-action-name", "ok="},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{{"ok", ""}},
 	}, {
 		should:             "handle --parse-strings",
 		args:               []string{validUnitId, "valid-action-name", "--string-args"},
-		expectUnits:        []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:        []string{validUnitId},
 		expectAction:       "valid-action-name",
 		expectParseStrings: true,
 	}, {
 		// cf. worker/uniter/runner/jujuc/action-set_test.go per @fwereade
 		should:       "work with multiple '=' signs",
 		args:         []string{validUnitId, "valid-action-name", "ok=this=is=weird="},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{{"ok", "this=is=weird="}},
 	}, {
 		should:       "init properly with no params",
 		args:         []string{validUnitId, "valid-action-name"},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "valid-action-name",
 	}, {
 		should:               "handle --params properly",
 		args:                 []string{validUnitId, "valid-action-name", "--params=foo.yml"},
-		expectUnits:          []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:          []string{validUnitId},
 		expectAction:         "valid-action-name",
 		expectParamsYamlPath: "foo.yml",
 	}, {
@@ -167,7 +167,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			"foo.baz.bo=3",
 			"bar.foo=hello",
 		},
-		expectUnits:          []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:          []string{validUnitId},
 		expectAction:         "valid-action-name",
 		expectParamsYamlPath: "foo.yml",
 		expectKVArgs: [][]string{
@@ -184,13 +184,19 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			"foo.baz.bo=y",
 			"bar.foo=hello",
 		},
-		expectUnits:  []names.UnitTag{names.NewUnitTag(validUnitId)},
+		expectUnits:  []string{validUnitId},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{
 			{"foo", "bar", "2"},
 			{"foo", "baz", "bo", "y"},
 			{"bar", "foo", "hello"},
 		},
+	}, {
+		should:       "work with leader identifier",
+		args:         []string{"mysql/leader", "valid-action-name"},
+		expectUnits:  []string{"mysql/leader"},
+		expectAction: "valid-action-name",
+		expectKVArgs: [][]string{},
 	}}
 
 	for i, t := range tests {
@@ -201,7 +207,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 			args := append([]string{modelFlag, "admin"}, t.args...)
 			err := cmdtesting.InitCommand(wrappedCommand, args)
 			if t.expectError == "" {
-				c.Check(command.UnitTags(), gc.DeepEquals, t.expectUnits)
+				c.Check(command.UnitNames(), gc.DeepEquals, t.expectUnits)
 				c.Check(command.ActionName(), gc.Equals, t.expectAction)
 				c.Check(command.ParamsYAML().Path, gc.Equals, t.expectParamsYamlPath)
 				c.Check(command.Args(), jc.DeepEquals, t.expectKVArgs)
@@ -217,7 +223,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 	tests := []struct {
 		should                 string
 		withArgs               []string
-		withAPIErr             string
+		withAPIErr             error
 		withActionResults      []params.ActionResult
 		expectedActionEnqueued params.Action
 		expectedErr            string
@@ -235,7 +241,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 		withActionResults: []params.ActionResult{{
 			Action: &params.Action{Tag: validActionTagString}},
 		},
-		withAPIErr:  "something wrong in API",
+		withAPIErr:  errors.New("something wrong in API"),
 		expectedErr: "something wrong in API",
 	}, {
 		should:   "fail with error in result",
@@ -382,6 +388,27 @@ func (s *RunSuite) TestRun(c *gc.C) {
 				},
 			},
 		},
+	}, {
+		should:   "fail with not implemented Leaders method",
+		withArgs: []string{"mysql/leader", "some-action"},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString}},
+		},
+		withAPIErr: errors.NotImplementedf("Not implemented"),
+		expectedErr: "unable to determine leader for application \"mysql\"" +
+			"\nleader determination is unsupported by this API" +
+			"\neither upgrade your controller, or explicitly specify a unit",
+	}, {
+		should:   "enqueue a basic action on leader unit",
+		withArgs: []string{"mysql/leader", "some-action"},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString},
+		}},
+		expectedActionEnqueued: params.Action{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		},
 	}}
 
 	for i, t := range tests {
@@ -391,10 +418,9 @@ func (s *RunSuite) TestRun(c *gc.C) {
 					t.should, strings.Join(t.withArgs, " "))
 				fakeClient := &fakeAPIClient{
 					actionResults: t.withActionResults,
+					leaders:       map[string]string{"mysql": validUnitId},
 				}
-				if t.withAPIErr != "" {
-					fakeClient.apiErr = errors.New(t.withAPIErr)
-				}
+				fakeClient.apiErr = t.withAPIErr
 				restore := s.patchAPIClient(fakeClient)
 				defer restore()
 
@@ -402,7 +428,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 				args := append([]string{modelFlag, "admin"}, t.withArgs...)
 				ctx, err := cmdtesting.RunCommand(c, wrappedCommand, args...)
 
-				if t.expectedErr != "" || t.withAPIErr != "" {
+				if t.expectedErr != "" || t.withAPIErr != nil {
 					c.Check(err, gc.ErrorMatches, t.expectedErr)
 				} else {
 					c.Assert(err, gc.IsNil)
@@ -414,14 +440,14 @@ func (s *RunSuite) TestRun(c *gc.C) {
 					c.Assert(t.withActionResults[0].Action, gc.NotNil)
 					expectedTag, err := names.ParseActionTag(t.withActionResults[0].Action.Tag)
 					c.Assert(err, gc.IsNil)
+
 					// Make sure the CLI responded with the expected tag
-					keyToCheck := "Action queued with id"
-					expectedMap := map[string]string{keyToCheck: expectedTag.Id()}
 					outputResult := ctx.Stdout.(*bytes.Buffer).Bytes()
 					resultMap := make(map[string]string)
 					err = yaml.Unmarshal(outputResult, &resultMap)
 					c.Assert(err, gc.IsNil)
-					c.Check(resultMap, jc.DeepEquals, expectedMap)
+					c.Check(resultMap["Action queued with id"], jc.DeepEquals, expectedTag.Id())
+
 					// Make sure the Action sent to the API to be
 					// enqueued was indeed the expected map
 					enqueued := fakeClient.EnqueuedActions()


### PR DESCRIPTION
## Description of change

This patch allows actions to be run on the current leader by using surrogate unit IDs of the form `<application>/leader`.

Leader resolution is done server-side, but there could conceivably be a leadership change between leader unit identification and execution of the queued action. This limitation is deemed acceptable for the initial implementation.

## QA steps

### On a model not created with this version of Juju:
- `juju run-action <some-app-in-your-model>/leader`.
- Check that the three-line message is displayed regarding unavailable leadership resolution.

Then using this version:
- Bootstrap a new controller.
- `juju deploy postgresql pg`
- `juju add-unit pg`
- Wait for deployments to complete and for pg/1 to clone pg/0.
- `juju run-action pg/leader switchover --string-args master=pg/1`
- First line of feeback should show the resolved unit, followed by the action ID.

Note: for me, the result of the action ultimately had a Python error trace, but it ran on the correct unit.

## Documentation changes

Yes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1787986
