### PR TITLE
Seed random number generator during agents init()

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -4,13 +4,16 @@
 package main
 
 import (
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/cmd/juju/commands"
 	components "github.com/juju/juju/component/all"
+
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
 )
@@ -18,6 +21,7 @@ import (
 var log = loggo.GetLogger("juju.cmd.juju")
 
 func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
 	if err := components.RegisterForClient(); err != nil {
 		log.Criticalf("unable to register client components: %v", err)
 		os.Exit(1)

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -102,6 +103,7 @@ func (op *CaasOperatorAgent) Init(args []string) error {
 	if err := op.AgentConf.CheckArgs(args); err != nil {
 		return err
 	}
+	rand.Seed(time.Now().UTC().UnixNano())
 	op.runner = worker.NewRunner(worker.RunnerParams{
 		IsFatal:       cmdutil.IsFatal,
 		MoreImportant: cmdutil.MoreImportant,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -108,6 +109,8 @@ var (
 var ProductionMongoWriteConcern = true
 
 func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	stateWorkerDialOpts = mongo.DefaultDialOpts()
 	stateWorkerDialOpts.PostDial = func(session *mgo.Session) error {
 		safe := mgo.Safe{}

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/juju/clock"
@@ -104,6 +105,7 @@ func (a *UnitAgent) Init(args []string) error {
 	if err := a.AgentConf.CheckArgs(args); err != nil {
 		return err
 	}
+	rand.Seed(time.Now().UTC().UnixNano())
 	a.runner = worker.NewRunner(worker.RunnerParams{
 		IsFatal:       cmdutil.IsFatal,
 		MoreImportant: cmdutil.MoreImportant,


### PR DESCRIPTION
This commit calls `rand.Seed()` with the current UTC time as a UNIX timestamp. Code changes affect the  machine, unit, caasoperaor agents as wells as the CLI.

I'm currently unsure what the best strategy for testing and documenting this change should be, so tagging the PR as WIP. 

----

## Description of change

From the [original bug report](https://bugs.launchpad.net/juju/+bug/1802824):

> Juju recently gained the ability to randomise which controller address it connected to. Except that it's not so random because Go requires that the random number generator be seeded first and this is not currently done.

## QA steps

Using the CLI multiple times should result in the addresses that controller selects being different each time.

## Documentation changes

Currently undocumented

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1802824
