### PR TITLE
Merge 2.4 changes into develop

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -387,12 +387,8 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 			newMachine.Series = macSeries
 		}
 
-		if result := b.hardwareConstraints(machine.Instance()); len(result) != 0 {
+		if result := b.constraints(machine.Constraints()); len(result) != 0 {
 			newMachine.Constraints = strings.Join(result, " ")
-		} else {
-			if result = b.constraints(machine.Constraints()); len(result) != 0 {
-				newMachine.Constraints = strings.Join(result, " ")
-			}
 		}
 
 		data.Machines[machine.Id()] = newMachine
@@ -440,30 +436,6 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 	return data, nil
 }
 
-func (b *BundleAPI) hardwareConstraints(instance description.CloudInstance) []string {
-	if instance == nil {
-		return []string{}
-	}
-
-	var constraints []string
-	if arch := instance.Architecture(); arch != "" {
-		constraints = append(constraints, "arch="+(arch))
-	}
-	if cores := instance.CpuCores(); cores != 0 {
-		constraints = append(constraints, "cpu-cores="+strconv.Itoa(int(cores)))
-	}
-	if power := instance.CpuPower(); power != 0 {
-		constraints = append(constraints, "cpu-power="+strconv.Itoa(int(power)))
-	}
-	if mem := instance.Memory(); mem != 0 {
-		constraints = append(constraints, "mem="+strconv.Itoa(int(mem)))
-	}
-	if disk := instance.RootDisk(); disk != 0 {
-		constraints = append(constraints, "root-disk="+strconv.Itoa(int(disk)))
-	}
-	return constraints
-}
-
 func (b *BundleAPI) constraints(cons description.Constraints) []string {
 	if cons == nil {
 		return []string{}
@@ -484,6 +456,21 @@ func (b *BundleAPI) constraints(cons description.Constraints) []string {
 	}
 	if disk := cons.RootDisk(); disk != 0 {
 		constraints = append(constraints, "root-disk="+strconv.Itoa(int(disk)))
+	}
+	if instType := cons.InstanceType(); instType != "" {
+		constraints = append(constraints, "instance-type="+instType)
+	}
+	if container := cons.Container(); container != "" {
+		constraints = append(constraints, "container="+container)
+	}
+	if virtType := cons.VirtType(); virtType != "" {
+		constraints = append(constraints, "virt-type="+virtType)
+	}
+	if tags := cons.Tags(); len(tags) != 0 {
+		constraints = append(constraints, "tags="+strings.Join(tags, ","))
+	}
+	if spaces := cons.Spaces(); len(spaces) != 0 {
+		constraints = append(constraints, "spaces="+strings.Join(spaces, ","))
 	}
 	return constraints
 }

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -796,6 +796,13 @@ func (s *bundleSuite) addMinimalMachineWithConstraints(model description.Model, 
 		Architecture: "amd64",
 		Memory:       8 * 1024,
 		RootDisk:     40 * 1024,
+		CpuCores:     2,
+		CpuPower:     100,
+		InstanceType: "big-inst",
+		Tags:         []string{"foo", "bar"},
+		VirtType:     "pv",
+		Container:    "kvm",
+		Spaces:       []string{"internal"},
 	}
 	m.SetConstraints(args)
 	m.SetStatus(minimalStatusArgs())
@@ -827,9 +834,11 @@ applications:
     - "0"
 machines:
   "0":
-    constraints: arch=amd64 mem=8192 root-disk=40960
+    constraints: arch=amd64 cpu-cores=2 cpu-power=100 mem=8192 root-disk=40960 instance-type=big-inst
+      container=kvm virt-type=pv tags=foo,bar spaces=internal
   "1":
-    constraints: arch=amd64 mem=8192 root-disk=40960
+    constraints: arch=amd64 cpu-cores=2 cpu-power=100 mem=8192 root-disk=40960 instance-type=big-inst
+      container=kvm virt-type=pv tags=foo,bar spaces=internal
 relations:
 - - mediawiki:db
   - mysql:mysql
@@ -889,9 +898,9 @@ applications:
     - "0"
 machines:
   "0":
-    constraints: arch=amd64 mem=4096 root-disk=16384
+    constraints: arch=amd64 mem=8192 root-disk=40960
   "1":
-    constraints: arch=amd64 mem=4096 root-disk=16384
+    constraints: arch=amd64 mem=8192 root-disk=40960
 relations:
 - - mediawiki:db
   - mysql:mysql

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -849,68 +849,6 @@ relations:
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
 }
 
-func (s *bundleSuite) addMinimalMachinewithHardwareConstraints(model description.Model, id string) {
-	m := model.AddMachine(description.MachineArgs{
-		Id:           names.NewMachineTag(id),
-		Nonce:        "a-nonce",
-		PasswordHash: "some-hash",
-		Series:       "xenial",
-		Jobs:         []string{"host-units"},
-	})
-	args := description.ConstraintsArgs{
-		Architecture: "amd64",
-		Memory:       8 * 1024,
-		RootDisk:     40 * 1024,
-	}
-	m.SetConstraints(args)
-	instanceArgs := description.CloudInstanceArgs{
-		Architecture: "amd64",
-		Memory:       4 * 1024,
-		RootDisk:     16 * 1024,
-	}
-	m.SetInstance(instanceArgs)
-	m.SetStatus(minimalStatusArgs())
-}
-
-func (s *bundleSuite) TestExportBundleModelWithHardwareConstraints(c *gc.C) {
-	model := s.newModel("iaas", "mediawiki", "mysql")
-
-	s.addMinimalMachinewithHardwareConstraints(model, "0")
-	s.addMinimalMachinewithHardwareConstraints(model, "1")
-
-	model.SetStatus(description.StatusArgs{Value: "available"})
-
-	result, err := s.facade.ExportBundle()
-	c.Assert(err, jc.ErrorIsNil)
-	expectedResult := params.StringResult{nil, `
-series: xenial
-applications:
-  mediawiki:
-    charm: cs:mediawiki
-    num_units: 2
-    to:
-    - "0"
-    - "1"
-  mysql:
-    charm: cs:mysql
-    num_units: 1
-    to:
-    - "0"
-machines:
-  "0":
-    constraints: arch=amd64 mem=8192 root-disk=40960
-  "1":
-    constraints: arch=amd64 mem=8192 root-disk=40960
-relations:
-- - mediawiki:db
-  - mysql:mysql
-`[1:]}
-
-	c.Assert(result, gc.Equals, expectedResult)
-
-	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
-}
-
 func (s *bundleSuite) addMinimalMachineWithAnnotations(model description.Model, id string) {
 	m := model.AddMachine(description.MachineArgs{
 		Id:           names.NewMachineTag(id),

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -221,7 +221,7 @@ type CloudCredentialArgs struct {
 	IncludeSecrets bool                 `json:"include-secrets"`
 }
 
-// CloudCredential contains a cloud credential content.
+// CredentialContent contains a cloud credential content.
 type CredentialContent struct {
 	// Name is the short name of the credential.
 	Name string `json:"name"`
@@ -302,7 +302,7 @@ type UpdateCredentialResult struct {
 	Models []UpdateCredentialModelResult `json:"models,omitempty"`
 }
 
-// UpdateCredentialResult contains a set of UpdateCredentialResult.
+// UpdateCredentialResults contains a set of UpdateCredentialResult.
 type UpdateCredentialResults struct {
 	Results []UpdateCredentialResult `json:"results,omitempty"`
 }
@@ -318,6 +318,6 @@ type UpdateCredentialArgs struct {
 
 // InvalidateCredentialArg is used to invalidate a controller credential.
 type InvalidateCredentialArg struct {
-	// Reason is the desription of why we are invalidating credential.
+	// Reason is the description of why we are invalidating credential.
 	Reason string `json:"reason,omitempty"`
 }

--- a/controller/config.go
+++ b/controller/config.go
@@ -260,6 +260,8 @@ var (
 		ControllerAPIPort,
 		MaxPruneTxnBatchSize,
 		MaxPruneTxnPasses,
+		MaxLogsSize,
+		MaxLogsAge,
 		JujuHASpace,
 		JujuManagementSpace,
 		CAASOperatorImagePath,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -289,6 +289,9 @@ func (s *ConfigSuite) TestLogConfigDefaults(c *gc.C) {
 }
 
 func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
+	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.MaxLogsAge), jc.IsTrue)
+	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.MaxLogsSize), jc.IsTrue)
+
 	cfg, err := controller.NewConfig(
 		testing.ControllerTag.Id(),
 		testing.CACert,

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -38,6 +38,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AuditLogExcludeMethods,
 		controller.MaxPruneTxnBatchSize,
 		controller.MaxPruneTxnPasses,
+		controller.MaxLogsSize,
+		controller.MaxLogsAge,
 		controller.CAASOperatorImagePath,
 		controller.CharmStoreURL,
 		controller.Features,

--- a/state/pool_test.go
+++ b/state/pool_test.go
@@ -198,3 +198,8 @@ func (s *statePoolSuite) TestGetRemovedNotAllowed(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("model %v has been removed", s.ModelUUID1))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
+
+func (s *statePoolSuite) TestReport(c *gc.C) {
+	report := s.StatePool.Report()
+	c.Check(report, gc.HasLen, 3)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -2158,6 +2158,12 @@ func (st *State) AllRelations() (relations []*Relation, err error) {
 	return
 }
 
+// Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
+// what is going on at runtime.
+func (st *State) Report() map[string]interface{} {
+	return st.workers.Report()
+}
+
 type relationDocSlice []relationDoc
 
 func (rdc relationDocSlice) Len() int      { return len(rdc) }

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -231,7 +231,6 @@ func (w *TxnWatcher) loop() error {
 	next := w.clock.After(d)
 	w.hub.Publish(txnWatcherStarting, nil)
 	for {
-		var d time.Duration
 		select {
 		case <-w.tomb.Dying():
 			return errors.Trace(tomb.ErrDying)
@@ -276,13 +275,11 @@ func (w *TxnWatcher) loop() error {
 		if added {
 			// Something's happened, so reset the exponential backoff
 			// so we'll retry again quickly.
-			now = w.clock.Now()
-			backoff = PollStrategy.NewTimer(now)
-			d, _ = backoff.NextSleep(now)
+			backoff = PollStrategy.NewTimer(w.clock.Now())
+			next = w.clock.After(txnWatcherShortWait)
 		} else if w.notifySync != nil {
 			w.notifySync()
 		}
-		next = w.clock.After(d)
 	}
 }
 

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -66,11 +66,11 @@ func (s *TxnWatcherSuite) TearDownTest(c *gc.C) {
 	s.MgoSuite.TearDownTest(c)
 }
 
-func (s *TxnWatcherSuite) advanceTime(c *gc.C, d time.Duration) {
+func (s *TxnWatcherSuite) advanceTime(c *gc.C, d time.Duration, waiters int) {
 	// Here we are assuming that there is one and only one thing
 	// using the After function on the testing clock, that being our
 	// watcher.
-	s.clock.WaitAdvance(d, testing.ShortWait, 1)
+	c.Assert(s.clock.WaitAdvance(d, testing.ShortWait, waiters), jc.ErrorIsNil)
 }
 
 func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, *fakeHub) {
@@ -167,7 +167,7 @@ func (s *TxnWatcherSuite) TestInsert(c *gc.C) {
 
 	revno := s.insert(c, "test", "a")
 
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	hub.waitForExpected(c)
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
@@ -181,7 +181,7 @@ func (s *TxnWatcherSuite) TestUpdate(c *gc.C) {
 	_, hub := s.newWatcher(c, 1)
 	revno := s.update(c, "test", "a")
 
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	hub.waitForExpected(c)
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
@@ -195,7 +195,7 @@ func (s *TxnWatcherSuite) TestRemove(c *gc.C) {
 	_, hub := s.newWatcher(c, 1)
 	revno := s.remove(c, "test", "a")
 
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	hub.waitForExpected(c)
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
@@ -210,7 +210,7 @@ func (s *TxnWatcherSuite) TestWatchOrder(c *gc.C) {
 	revno2 := s.insert(c, "test", "b")
 	revno3 := s.insert(c, "test", "c")
 
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	hub.waitForExpected(c)
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
@@ -225,7 +225,7 @@ func (s *TxnWatcherSuite) TestTransactionWithMultiple(c *gc.C) {
 
 	revnos := s.insertAll(c, "test", "a", "b", "c")
 
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	hub.waitForExpected(c)
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
@@ -257,7 +257,7 @@ func (s *TxnWatcherSuite) TestScale(c *gc.C) {
 	c.Logf("Got %d documents in the collection...", count)
 	c.Assert(count, gc.Equals, N)
 
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	hub.waitForExpected(c)
 
 	for i := 0; i < N; i++ {
@@ -269,9 +269,9 @@ func (s *TxnWatcherSuite) TestInsertThenRemove(c *gc.C) {
 	_, hub := s.newWatcher(c, 2)
 
 	revno1 := s.insert(c, "test", "a")
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	revno2 := s.remove(c, "test", "a")
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 2)
 
 	hub.waitForExpected(c)
 
@@ -285,10 +285,10 @@ func (s *TxnWatcherSuite) TestDoubleUpdate(c *gc.C) {
 	_, hub := s.newWatcher(c, 2)
 
 	revno1 := s.insert(c, "test", "a")
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
 	s.update(c, "test", "a")
 	revno3 := s.update(c, "test", "a")
-	s.advanceTime(c, watcher.TxnWatcherShortWait)
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 2)
 
 	hub.waitForExpected(c)
 

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -283,6 +283,11 @@ func (s *stubStateTracker) Done() error {
 	return s.NextErr()
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}
+
 type stubPrometheusRegisterer struct {
 	testing.Stub
 }

--- a/worker/auditconfigupdater/manifold_test.go
+++ b/worker/auditconfigupdater/manifold_test.go
@@ -223,6 +223,11 @@ func (s *stubStateTracker) Done() error {
 	return s.NextErr()
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}
+
 type fakeWorker struct {
 	config auditlog.Config
 }

--- a/worker/certupdater/manifold_test.go
+++ b/worker/certupdater/manifold_test.go
@@ -190,6 +190,11 @@ func (s *stubStateTracker) Done() error {
 	return s.NextErr()
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}
+
 type fakeAddressWatcher struct {
 	certupdater.AddressWatcher
 }

--- a/worker/controllerport/manifold_test.go
+++ b/worker/controllerport/manifold_test.go
@@ -195,6 +195,11 @@ func (s *stubStateTracker) Done() error {
 	return s.NextErr()
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}
+
 type mockAgent struct {
 	agent.Agent
 	conf mockAgentConfig

--- a/worker/featureflag/manifold_test.go
+++ b/worker/featureflag/manifold_test.go
@@ -200,3 +200,8 @@ func (s *stubStateTracker) Done() error {
 	s.MethodCall(s, "Done")
 	return s.NextErr()
 }
+
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -320,3 +320,8 @@ func (s *stubStateTracker) waitDone(c *gc.C) {
 		c.Fatal("timed out waiting for state to be released")
 	}
 }
+
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}

--- a/worker/httpserver/mock_test.go
+++ b/worker/httpserver/mock_test.go
@@ -28,6 +28,11 @@ func (s *stubStateTracker) Done() error {
 	return s.NextErr()
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}
+
 type stubPrometheusRegisterer struct {
 	testing.Stub
 }

--- a/worker/httpserverargs/manifold_test.go
+++ b/worker/httpserverargs/manifold_test.go
@@ -206,3 +206,8 @@ func (s *stubStateTracker) Done() error {
 	s.MethodCall(s, "Done")
 	return s.NextErr()
 }
+
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}

--- a/worker/modelworkermanager/manifold_test.go
+++ b/worker/modelworkermanager/manifold_test.go
@@ -141,3 +141,8 @@ func (s *stubStateTracker) Done() error {
 	s.MethodCall(s, "Done")
 	return s.NextErr()
 }
+
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -164,6 +164,11 @@ func (s *stubStateTracker) Done() error {
 	return s.NextErr()
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}
+
 type mockAgent struct {
 	agent.Agent
 	conf mockAgentConfig

--- a/worker/raft/raftforwarder/manifold_test.go
+++ b/worker/raft/raftforwarder/manifold_test.go
@@ -263,6 +263,10 @@ func (s *stubStateTracker) Done() error {
 	return err
 }
 
+func (s *stubStateTracker) Report() map[string]interface{} {
+	return map[string]interface{}{"hey": "mum"}
+}
+
 func (s *stubStateTracker) waitDone(c *gc.C) {
 	select {
 	case <-s.done:

--- a/worker/restorewatcher/manifold_test.go
+++ b/worker/restorewatcher/manifold_test.go
@@ -131,3 +131,8 @@ func (s *stubStateTracker) Done() error {
 	s.MethodCall(s, "Done")
 	return s.NextErr()
 }
+
+func (s *stubStateTracker) Report() map[string]interface{} {
+	s.MethodCall(s, "Report")
+	return nil
+}

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -184,6 +184,12 @@ func (w *stateWorker) loop() error {
 	}
 }
 
+// Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
+// what is going on at runtime.
+func (w *stateWorker) Report() map[string]interface{} {
+	return w.stTracker.Report()
+}
+
 func (w *stateWorker) processModelLifeChange(
 	modelUUID string,
 	modelStateWorkers map[string]worker.Worker,

--- a/worker/state/statetracker.go
+++ b/worker/state/statetracker.go
@@ -25,6 +25,9 @@ type StateTracker interface {
 	// if the StatePool has already been closed (indicating that Done has
 	// called too many times).
 	Done() error
+
+	// Report is used to give details about what is going on with this state tracker.
+	Report() map[string]interface{}
 }
 
 // stateTracker wraps a *state.State, keeping a reference count and
@@ -73,4 +76,10 @@ func (c *stateTracker) Done() error {
 		}
 	}
 	return nil
+}
+
+func (c *stateTracker) Report() map[string]interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pool.Report()
 }


### PR DESCRIPTION
## Description of change

There were two areas with non-trivial conflicts.  In apiserver/facades/client/bundle, the changes for k8s bundles in 2.5 overlapped a bit with 2.4 changes to use machine constraints rather than instance details.

The other was in the engine reports added to state/watcher/hubwatcher.go and txnwatcher.go - these caused some changes in the timer usage so WaitAdvance calls needed tweaking. The new reports required some changes in the worker/state tests as well (since the report now contains a request count which changes with each report request).

## QA steps

* Ran unit tests, bootstrapped a new controller for a basic smoke test.
