### PR TITLE
Add a report for the log pruner.

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/deque"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
-// TODO(wallyworld) - lp:1602508 - collections need to be defined in collections.go
 const (
 	logsDB      = "logs"
 	logsCPrefix = "logs."
@@ -50,6 +50,8 @@ type ControllerSessioner interface {
 
 	// IsController indicates if current state is controller.
 	IsController() bool
+	// clock returns the clock used by the state instance.
+	clock() clock.Clock
 }
 
 // ModelSessioner supports creating new mongo sessions for a model.
@@ -751,20 +753,27 @@ func logDocToRecord(modelUUID string, doc *logDoc) (*LogRecord, error) {
 	return rec, nil
 }
 
+// DebugLogger is a logger that implements Debugf.
+type DebugLogger interface {
+	Debugf(string, ...interface{})
+}
+
 // PruneLogs removes old log documents in order to control the size of
 // logs collection. All logs older than minLogTime are
 // removed. Further removal is also performed if the logs collection
 // size is greater than maxLogsMB.
-func PruneLogs(st ControllerSessioner, minLogTime time.Time, maxLogsMB int) error {
+func PruneLogs(st ControllerSessioner, minLogTime time.Time, maxLogsMB int, logger DebugLogger) (string, error) {
 	if !st.IsController() {
-		return errors.Errorf("pruning logs requires a controller state")
+		return "", errors.Errorf("pruning logs requires a controller state")
 	}
 	session, logsDB := initLogsSessionDB(st)
 	defer session.Close()
 
+	startTime := st.clock().Now()
+
 	logColls, err := getLogCollections(logsDB)
 	if err != nil {
-		return errors.Annotate(err, "failed to get log counts")
+		return "", errors.Annotate(err, "failed to get log counts")
 	}
 
 	pruneCounts := make(map[string]int)
@@ -775,25 +784,27 @@ func PruneLogs(st ControllerSessioner, minLogTime time.Time, maxLogsMB int) erro
 			"t": bson.M{"$lt": minLogTime.UnixNano()},
 		})
 		if err != nil {
-			return errors.Annotate(err, "failed to prune logs by time")
+			return "", errors.Annotate(err, "failed to prune logs by time")
 		}
 		pruneCounts[modelUUID] = removeInfo.Removed
 	}
 
 	// Do further pruning if the total size of the log collections is
 	// over the maximum size.
+	var endSize string
 	for {
 		collMB, err := getCollectionTotalMB(logColls)
 		if err != nil {
-			return errors.Annotate(err, "failed to retrieve log counts")
+			return "", errors.Annotate(err, "failed to retrieve log counts")
 		}
 		if collMB <= maxLogsMB {
+			endSize = fmt.Sprintf("logs db now %d MB", collMB)
 			break
 		}
 
 		modelUUID, count, err := findModelWithMostLogs(logColls)
 		if err != nil {
-			return errors.Annotate(err, "log count query failed")
+			return "", errors.Annotate(err, "log count query failed")
 		}
 		if count < 5000 {
 			break // Pruning is not worthwhile
@@ -813,7 +824,7 @@ func PruneLogs(st ControllerSessioner, minLogTime time.Time, maxLogsMB int) erro
 		var doc bson.M
 		err = tsQuery.One(&doc)
 		if err != nil {
-			return errors.Annotate(err, "log pruning timestamp query failed")
+			return "", errors.Annotate(err, "log pruning timestamp query failed")
 		}
 		thresholdTs := doc["t"]
 
@@ -822,17 +833,35 @@ func PruneLogs(st ControllerSessioner, minLogTime time.Time, maxLogsMB int) erro
 			"t": bson.M{"$lt": thresholdTs},
 		})
 		if err != nil {
-			return errors.Annotate(err, "log pruning failed")
+			return "", errors.Annotate(err, "log pruning failed")
 		}
 		pruneCounts[modelUUID] += removeInfo.Removed
 	}
 
+	totalRemoved := 0
+	modelCount := 0
 	for modelUUID, count := range pruneCounts {
 		if count > 0 {
+			totalRemoved += count
+			modelCount++
 			logger.Debugf("pruned %d logs for model %s", count, modelUUID)
 		}
 	}
-	return nil
+
+	var removed string
+	if totalRemoved == 0 {
+		removed = "no pruning necessary"
+	} else {
+		s := "s"
+		if modelCount == 1 {
+			s = ""
+		}
+		removed = fmt.Sprintf("pruned %d entries from %d model%s", totalRemoved, modelCount, s)
+	}
+	elapsed := st.clock().Now().Sub(startTime).Round(time.Millisecond)
+
+	message := fmt.Sprintf("pruning complete after %s, %s, %s", elapsed, removed, endSize)
+	return message, nil
 }
 
 func initLogsSessionDB(st MongoSessioner) (*mgo.Session, *mgo.Database) {

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -90,6 +90,25 @@ func (s *suite) startWorker(c *gc.C) {
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, s.pruner) })
 }
 
+func (s *suite) TestWorkerHasReport(c *gc.C) {
+	s.setupState(c, "24h", "1024M")
+	s.startWorker(c)
+
+	type reporter interface {
+		Report() map[string]interface{}
+	}
+
+	r, ok := s.pruner.(reporter)
+	c.Assert(ok, jc.IsTrue)
+	report := r.Report()
+	// We can't generally check on particular values except that there are keys for
+	// prune-age and prune-size.
+	_, ok = report["prune-age"]
+	c.Assert(ok, jc.IsTrue)
+	_, ok = report["prune-size"]
+	c.Assert(ok, jc.IsTrue)
+}
+
 func (s *suite) TestPrunesOldLogs(c *gc.C) {
 	maxLogAge := 24 * time.Hour
 	s.setupState(c, "24h", "1000P")


### PR DESCRIPTION
Based on the lack of feedback when trying to debug the process of the log pruner, this branch does two things:
* It passes a logger into the PruneLogs function so the worker logging module is used for the log messages
* Adds a Report method to the dblogpruner worker so results are shown in the the engine report.

## QA steps

juju run -m controller --all juju_engine_report
