### PR TITLE
rand.Seed() agents via init()

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/cmd/juju/commands"
 	components "github.com/juju/juju/component/all"
-
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
 )

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
-
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/upgrades"


### PR DESCRIPTION
Call `rand.Seed()` with the current UTC time as a UNIX timestamp. Code changes affect the machine, unit, caasoperator agents as well as the CLI.

Note: Uses a separate `init()` function where one already exists within each file to maintain separation of concerns. Let me know if this was the wrong approach.

----

## Description of change

From the [original bug report](https://bugs.launchpad.net/juju/+bug/1802824):

> Juju recently gained the ability to randomise which controller address it connected to. Except that it's not so random because Go requires that the random number generator be seeded first and this is not currently done.

## QA steps

Using the CLI multiple times should result in the addresses that controller selects being different each time.

## Documentation changes

Currently undocumented

## Bug reference

https://bugs.launchpad.net/juju/+bug/1802824
