### PR TITLE
Cloud facade, revoke credentials signature change.

### DIFF
--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -461,7 +461,43 @@ var (
 
 func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 	var called bool
-	apiCaller := basetesting.APICallerFunc(
+	apiCallerF := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Cloud")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "RevokeCredentialsCheckModels")
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			c.Assert(a, jc.DeepEquals, params.RevokeCredentialArgs{
+				Credentials: []params.RevokeCredentialArg{
+					{Tag: "cloudcred-foo_bob_bar"},
+				},
+			})
+			*result.(*params.ErrorResults) = params.ErrorResults{
+				Results: []params.ErrorResult{{}},
+			}
+			called = true
+			return nil
+		},
+	)
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: apiCallerF,
+		BestVersion:   3,
+	}
+
+	client := cloudapi.NewClient(apiCaller)
+	tag := names.NewCloudCredentialTag("foo/bob/bar")
+	err := client.RevokeCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestRevokeCredentialV2(c *gc.C) {
+	var called bool
+	apiCallerF := basetesting.APICallerFunc(
 		func(objType string,
 			version int,
 			id, request string,
@@ -481,6 +517,10 @@ func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 			return nil
 		},
 	)
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: apiCallerF,
+		BestVersion:   2,
+	}
 
 	client := cloudapi.NewClient(apiCaller)
 	tag := names.NewCloudCredentialTag("foo/bob/bar")

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -761,13 +761,13 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidationForce(c *gc.C
 
 func (s *cloudSuite) TestRevokeCredentials(c *gc.C) {
 	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
-	results, err := s.api.RevokeCredentials(params.Entities{Entities: []params.Entity{{
-		Tag: "machine-0",
-	}, {
-		Tag: "cloudcred-meep_admin_whatever",
-	}, {
-		Tag: "cloudcred-meep_bruce_three",
-	}}})
+	results, err := s.api.RevokeCredentialsCheckModels(params.RevokeCredentialArgs{
+		Credentials: []params.RevokeCredentialArg{
+			{Tag: "machine-0"},
+			{Tag: "cloudcred-meep_admin_whatever"},
+			{Tag: "cloudcred-meep_bruce_three"},
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "RemoveCloudCredential")
 	c.Assert(results.Results, gc.HasLen, 3)
@@ -786,9 +786,11 @@ func (s *cloudSuite) TestRevokeCredentials(c *gc.C) {
 }
 
 func (s *cloudSuite) TestRevokeCredentialsAdminAccess(c *gc.C) {
-	results, err := s.api.RevokeCredentials(params.Entities{Entities: []params.Entity{{
-		Tag: "cloudcred-meep_julia_three",
-	}}})
+	results, err := s.api.RevokeCredentialsCheckModels(params.RevokeCredentialArgs{
+		Credentials: []params.RevokeCredentialArg{
+			{Tag: "cloudcred-meep_julia_three"},
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "ControllerTag", "RemoveCloudCredential")
 	c.Assert(results.Results, gc.HasLen, 1)

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -324,7 +324,7 @@ type InvalidateCredentialArg struct {
 
 // RevokeCredentialArg contains data needed to revoke credential.
 type RevokeCredentialArg struct {
-	// Tag holds credential tag to update.
+	// Tag holds credential tag to revoke.
 	Tag string `json:"tag"`
 
 	// Force indicates whether the credential can be revoked forcefully.

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -321,3 +321,18 @@ type InvalidateCredentialArg struct {
 	// Reason is the description of why we are invalidating credential.
 	Reason string `json:"reason,omitempty"`
 }
+
+// RevokeCredentialArg contains data needed to revoke credential.
+type RevokeCredentialArg struct {
+	// Tag holds credential tag to update.
+	Tag string `json:"tag"`
+
+	// Force indicates whether the credential can be revoked forcefully.
+	Force bool `json:"force"`
+}
+
+// RevokeCredentialArgs contains credentials to revoke.
+type RevokeCredentialArgs struct {
+	// Credentials holds credentials to revoke.
+	Credentials []RevokeCredentialArg `json:"credentials"`
+}


### PR DESCRIPTION
## Description of change

When deleting credentials on the controller, we need to check if their being used by any of the models and warn the user. We also want to provide the option to force deletion either way.

This is a simple PR to change signature on the cloud facade in time for 2.5-b1. The actual behavior change will come during beta time.

## Bug reference

related to https://bugs.launchpad.net/juju/+bug/1802875
