### PR TITLE
Merge pull request #9445 from timClicks/2.4-add-rng-seed

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
@@ -16,6 +18,10 @@ import (
 )
 
 var log = loggo.GetLogger("juju.cmd.juju")
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
 
 func init() {
 	if err := components.RegisterForClient(); err != nil {

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -45,6 +46,10 @@ func init() {
 		log.Criticalf("unabled to register server components: %v", err)
 		os.Exit(1)
 	}
+}
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
 }
 
 var jujudDoc = `


### PR DESCRIPTION
https://github.com/juju/juju/pull/9445

Call `rand.Seed()` with the current UTC time as a UNIX timestamp. Code changes affect the machine, unit, caasoperator agents as well as the CLI.

Note: Uses a separate `init()` function where one already exists within each file to maintain separation of concerns. Let me know if this was the wrong approach.

