### PR TITLE
Upgrade-Series Instance Status

### DIFF
--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
 
@@ -35,6 +36,11 @@ func (s *MachineSuite) TestCreateUpgradeSeriesLock(c *gc.C) {
 		i++
 	}
 	c.Assert(lockedUnitsIds, jc.SameContents, unitIds)
+
+	sts, err := mach.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sts.Status, gc.Equals, status.Running)
+	c.Check(sts.Message, gc.Equals, "Series upgrade: prepare started")
 }
 
 func (s *MachineSuite) TestIsParentLockedForSeriesUpgrade(c *gc.C) {
@@ -180,8 +186,24 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSetCompleteStatusOfMachine
 
 	sts, err := s.machine.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-
 	c.Assert(sts, gc.Equals, model.UpgradeSeriesCompleteStarted)
+
+	iStatus, err := s.machine.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(iStatus.Status, gc.Equals, status.Running)
+	c.Check(iStatus.Message, gc.Equals, "Series upgrade: complete started")
+}
+
+func (s *MachineSuite) TestUpgradeSeriesCompletedResetsInstanceStatus(c *gc.C) {
+	err := s.machine.CreateUpgradeSeriesLock([]string{}, "cosmic")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, "")
+
+	iStatus, err := s.machine.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(iStatus.Status, gc.Equals, status.Running)
+	c.Check(iStatus.Message, gc.Equals, "Running")
 }
 
 func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailIfAlreadyInCompleteState(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch sets machine instance status (as shown in `juju status`) in accordance with progression through the upgrade-series workflow.

## QA steps

- Bootstrap and add a Xenial machine.
- `watch -c juju status --color`. The machine message will be "Running" at rest.
- `juju upgrade-series 0 prepare xenial -y`
- Watch the status messages transition through to "Series upgrade: prepare complete".
- `juju upgrade-series 0 complete`
- Watch the status messages track the workflow and go back to "Running".

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1798094
