### PR TITLE
Add engine report entries for pubsub-forwarder and presence.

### DIFF
--- a/worker/presence/presence_test.go
+++ b/worker/presence/presence_test.go
@@ -96,6 +96,26 @@ func (s *PresenceSuite) TestWorkerDies(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
+func (s *PresenceSuite) TestReport(c *gc.C) {
+	w := s.worker(c)
+	defer workertest.CleanKill(c, w)
+
+	s.recorder.Connect("machine-0", "model-uuid", "agent", 1, false, "")
+	s.recorder.Connect("machine-0", "model-uuid", "agent", 2, false, "")
+	s.recorder.Connect("machine-0", "model-uuid", "agent", 3, false, "")
+	s.recorder.Connect("machine-1", "model-uuid", "agent", 4, false, "")
+	s.recorder.Connect("machine-1", "model-uuid", "agent", 5, false, "")
+	s.recorder.Connect("machine-2", "model-uuid", "agent", 6, false, "")
+
+	reporter, ok := w.(worker.Reporter)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(reporter.Report(), jc.DeepEquals, map[string]interface{}{
+		"machine-0": 3,
+		"machine-1": 2,
+		"machine-2": 1,
+	})
+}
+
 func (s *PresenceSuite) TestForwarderConnectToOther(c *gc.C) {
 	w := s.worker(c)
 	defer workertest.CleanKill(c, w)

--- a/worker/pubsub/remoteserver.go
+++ b/worker/pubsub/remoteserver.go
@@ -95,6 +95,26 @@ func NewRemoteServer(config RemoteServerConfig) (RemoteServer, error) {
 	return remote, nil
 }
 
+// Report provides information to the engine report.
+// It should be fast and minimally blocking.
+func (r *remoteServer) Report() map[string]interface{} {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	var status string
+	if r.connection == nil {
+		status = "disconnected"
+	} else {
+		status = "connected"
+	}
+	return map[string]interface{}{
+		"status":    status,
+		"addresses": r.info.Addrs,
+		"queue-len": r.pending.Len(),
+		"sent":      r.sent,
+	}
+}
+
 // IntrospectionReport is the method called by the subscriber to get
 // information about this server.
 func (r *remoteServer) IntrospectionReport() string {

--- a/worker/pubsub/remoteserver_test.go
+++ b/worker/pubsub/remoteserver_test.go
@@ -95,6 +95,12 @@ func (s *RemoteServerSuite) TestConnectPublished(c *gc.C) {
 		"  Addresses: [localhost]\n"+
 		"  Queue length: 0\n"+
 		"  Sent count: 0\n")
+	c.Check(r.Report(), jc.DeepEquals, map[string]interface{}{
+		"status":    "connected",
+		"addresses": []string{"localhost"},
+		"queue-len": 0,
+		"sent":      uint64(0),
+	})
 }
 
 func (s *RemoteServerSuite) TestDisconnectPublishedOnWriteError(c *gc.C) {

--- a/worker/pubsub/reporter.go
+++ b/worker/pubsub/reporter.go
@@ -10,8 +10,10 @@ import (
 )
 
 // Reporter gives visibility for the introspection worker into the
-// internals of the pubsub forwarding worker.
+// internals of the pubsub forwarding worker. Also defines the
+// Report method used by the engine report.
 type Reporter interface {
+	Report() map[string]interface{}
 	IntrospectionReport() string
 }
 
@@ -34,6 +36,16 @@ func (r *reporter) IntrospectionReport() string {
 		return "pubsub worker not started"
 	}
 	return r.worker.IntrospectionReport()
+}
+
+// Report hooks in to the worker's report mechanism.
+func (r *reporter) Report() map[string]interface{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.worker == nil {
+		return nil
+	}
+	return r.worker.Report()
 }
 
 func (r *reporter) setWorker(w worker.Worker) {

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -118,6 +118,25 @@ func newSubscriber(config WorkerConfig) (*subscriber, error) {
 	return sub, nil
 }
 
+// Report returns the same information as the introspection report
+// but in the map for for the dependency engine report.
+func (s *subscriber) Report() map[string]interface{} {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	result := map[string]interface{}{
+		"source": s.config.Origin,
+	}
+	targets := make(map[string]interface{})
+	for target, remote := range s.servers {
+		targets[target] = remote.Report()
+	}
+	if len(targets) > 0 {
+		result["targets"] = targets
+	}
+	return result
+
+}
+
 // IntrospectionReport is the method called by the introspection
 // worker to get what to show to the user.
 func (s *subscriber) IntrospectionReport() string {


### PR DESCRIPTION
The juju_engine_report is a great mechanism for getting a view into the current working state of the juju agent.

The summary of the presence worker is just a connection count to each of the servers.
The pubsub-forwarder provides the same infomration as the introspection report, the target, address, connection status, queue length, and messges sent.

## QA steps

bootstrap, enable-ha, ssh into the controller and run juju_engine_report.
