### PR TITLE
httpserver: fix intermittent failure in TestHeldListener

### DIFF
--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -269,9 +269,9 @@ attempts:
 	s.mux.ClientDone()
 
 	select {
-	case err := <-quickErr:
-		// It doesn't really matter what the error is.
-		c.Assert(err, gc.NotNil)
+	case <-quickErr:
+		// It doesn't really matter what the error is, and
+		// occasionally we don't get any error.
 	case <-time.After(coretesting.ShortWait):
 		c.Fatalf("timed out waiting for 2nd quick request")
 	}


### PR DESCRIPTION
## Description of change

Occasionally we'd see an intermittent failure in WorkerSuite.TestHeldListener because there's no error from the final blocked http request - this is ok. What we care about is that the request finishes and the worker stops.

## QA steps
Ran under stress-race for a long time with no failure.
