### PR TITLE
make upgrade charm profile failure a machine error

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1341,7 +1341,8 @@ func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg par
 		logger.Debugf("failed to SetInstanceStatus for %q: %v", mTag, err)
 		return err
 	}
-	if status.Status(arg.Status) == status.ProvisioningError {
+	if status.Status(arg.Status) == status.ProvisioningError ||
+		status.Status(arg.Status) == status.Error {
 		s.Status = status.Error
 		logger.Debugf("SetInstanceStatus triggering SetStatus for %#v", s)
 		if err = machine.SetStatus(s); err != nil {

--- a/core/status/status.go
+++ b/core/status/status.go
@@ -236,6 +236,7 @@ func (status Status) KnownInstanceStatus() bool {
 		ProvisioningError,
 		Allocating,
 		Running,
+		Error,
 		Unknown:
 		return true
 	}


### PR DESCRIPTION
## Description of change

make upgrade charm profile failure a machine error

## QA steps

1. `juju bootstrap localhost`
2. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt  --to lxd -n 2`
3. `cp ./testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml ./testcharms/charm-repo/quantal/lxd-profile-alt`
3. `juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt`
    verify that container unit is in an error state, with charm upgrade failure message
3. `git checkout ./testcharms/charm-repo/quantal/lxd-profile-alt/lxd-profile.yaml`
4. `juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt`
    verify that the container unit is no longer in an error state, though the machine unit is.
4.  `juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt`
    the machine unit may come out of the error state, or stay in due to new profile error. not sure what the issue is with the profile.

