### PR TITLE
Fixes lp#1802875: Check models when deleting credential.

### DIFF
--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -406,7 +406,7 @@ func (s *cloudSuiteV2) TestRevokeCredentialsCantGetModels(c *gc.C) {
 		func(tag names.CloudCredentialTag) (map[string]string, error) {
 			return nil, errors.New("no niet nope")
 		},
-		"[LOG] 0:00.000 WARNING juju.apiserver.cloud could not get models that use credential cloudcred-meep_julia_three: no niet nope\n",
+		" WARNING juju.apiserver.cloud could not get models that use credential cloudcred-meep_julia_three: no niet nope",
 	)
 }
 
@@ -417,7 +417,7 @@ func (s *cloudSuiteV2) TestRevokeCredentialsLogModels(c *gc.C) {
 				coretesting.ModelTag.Id(): "modelName",
 			}, nil
 		},
-		"[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is still used by model deadbeef-0bad-400d-8000-4b1d0d06f00d\n",
+		" WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is still used by model deadbeef-0bad-400d-8000-4b1d0d06f00d",
 	)
 }
 
@@ -432,7 +432,7 @@ func (s *cloudSuiteV2) assertCredentialRemoved(c *gc.C, f credentialModelFunctio
 	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "RemoveCloudCredential")
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(c.GetTestLog(), gc.DeepEquals, expectedLog)
+	c.Assert(c.GetTestLog(), jc.Contains, expectedLog)
 }
 
 var cloudTypes = map[string]string{

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -417,7 +417,7 @@ func (s *cloudSuiteV2) TestRevokeCredentialsLogModels(c *gc.C) {
 				coretesting.ModelTag.Id(): "modelName",
 			}, nil
 		},
-		"[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but model deadbeef-0bad-400d-8000-4b1d0d06f00d still uses it\n",
+		"[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is still used by model deadbeef-0bad-400d-8000-4b1d0d06f00d\n",
 	)
 }
 

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -867,10 +867,10 @@ func (s *cloudSuite) TestRevokeCredentialsHasModel(c *gc.C) {
 		callsMade: []string{"ControllerTag", "CredentialModels"},
 		results: params.ErrorResults{
 			Results: []params.ErrorResult{
-				{common.ServerError(errors.New("cannot delete credential cloudcred-meep_julia_three: still in use by 1 model"))},
+				{common.ServerError(errors.New("cannot delete credential cloudcred-meep_julia_three: it is still used by 1 model"))},
 			},
 		},
-		expectedLog: "[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three cannot be deleted as model deadbeef-0bad-400d-8000-4b1d0d06f00d still uses it\n",
+		expectedLog: "[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three cannot be deleted as it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d\n",
 	}
 	s.assertRevokeCredentials(c, t)
 }
@@ -889,12 +889,13 @@ func (s *cloudSuite) TestRevokeCredentialsHasModels(c *gc.C) {
 		callsMade: []string{"ControllerTag", "CredentialModels"},
 		results: params.ErrorResults{
 			Results: []params.ErrorResult{
-				{common.ServerError(errors.New("cannot delete credential cloudcred-meep_julia_three: still in use by 2 models"))},
+				{common.ServerError(errors.New("cannot delete credential cloudcred-meep_julia_three: it is still used by 2 models"))},
 			},
 		},
 		expectedLog: `
-[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three cannot be deleted as model deadbeef-0bad-400d-8000-4b1d0d06f00d still uses it
-[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three cannot be deleted as model deadbeef-1bad-511d-8000-4b1d0d06f00d still uses it
+[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three cannot be deleted as it is used by models:
+- deadbeef-0bad-400d-8000-4b1d0d06f00d
+- deadbeef-1bad-511d-8000-4b1d0d06f00d
 `[1:],
 	}
 	s.assertRevokeCredentials(c, t)
@@ -918,7 +919,7 @@ func (s *cloudSuite) TestRevokeCredentialsForceHasModel(c *gc.C) {
 			},
 		},
 		expectedLog: `
-[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but model deadbeef-0bad-400d-8000-4b1d0d06f00d still uses it
+[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d
 `[1:],
 	}
 	s.assertRevokeCredentials(c, t)
@@ -939,12 +940,12 @@ func (s *cloudSuite) TestRevokeCredentialsForceMany(c *gc.C) {
 		results: params.ErrorResults{
 			Results: []params.ErrorResult{
 				{},
-				{common.ServerError(errors.New("cannot delete credential cloudcred-meep_bruce_three: still in use by 1 model"))},
+				{common.ServerError(errors.New("cannot delete credential cloudcred-meep_bruce_three: it is still used by 1 model"))},
 			},
 		},
 		expectedLog: `
-[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but model deadbeef-0bad-400d-8000-4b1d0d06f00d still uses it
-[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_bruce_three cannot be deleted as model deadbeef-0bad-400d-8000-4b1d0d06f00d still uses it
+[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d
+[LOG] 0:00.000 WARNING juju.apiserver.cloud credential cloudcred-meep_bruce_three cannot be deleted as it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d
 `[1:],
 	}
 	s.assertRevokeCredentials(c, t)


### PR DESCRIPTION
## Description of change

As per linked bug, Juju was previously allowing to delete a credential from the system even if there were models using it. 

This PR will not allow deletion of a used credential unless it is forced.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1802875
