### PR TITLE
Register the alternative name for lxd

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -876,7 +876,9 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 
 	// When looking for credentials, we should attempt to see if there are any
 	// credentials that should be registered, before we get or detect them
-	err = common.RegisterCredentials(ctx, store, provider)
+	err = common.RegisterCredentials(ctx, store, provider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud,
+	})
 	if err != nil {
 		logger.Errorf("registering credentials errored %s", err)
 	}

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -32,8 +32,9 @@ func RegisterCredentials(
 	ctx *cmd.Context,
 	store jujuclient.CredentialStore,
 	provider environs.EnvironProvider,
+	args modelcmd.RegisterCredentialsParams,
 ) error {
-	credentials, err := modelcmd.RegisterCredentials(provider)
+	credentials, err := modelcmd.RegisterCredentials(provider, args)
 	switch {
 	case errors.IsNotFound(err):
 		return nil

--- a/cmd/juju/common/cloudcredential_test.go
+++ b/cmd/juju/common/cloudcredential_test.go
@@ -68,7 +68,9 @@ func (*cloudCredentialSuite) TestRegisterCredentials(c *gc.C) {
 	}
 
 	mockProvider := common.NewMockTestCloudProvider(ctrl)
-	mockProvider.EXPECT().RegisterCredentials("fake").Return(map[string]*cloud.CloudCredential{
+	mockProvider.EXPECT().RegisterCredentials(cloud.Cloud{
+		Name: "fake",
+	}).Return(map[string]*cloud.CloudCredential{
 		"fake": credential,
 	}, nil)
 	mockStore := common.NewMockCredentialStore(ctrl)
@@ -92,7 +94,9 @@ func (*cloudCredentialSuite) TestRegisterCredentialsWithNoCredentials(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockProvider := common.NewMockTestCloudProvider(ctrl)
-	mockProvider.EXPECT().RegisterCredentials("fake").Return(map[string]*cloud.CloudCredential{}, nil)
+	mockProvider.EXPECT().RegisterCredentials(cloud.Cloud{
+		Name: "fake",
+	}).Return(map[string]*cloud.CloudCredential{}, nil)
 	mockStore := common.NewMockCredentialStore(ctrl)
 
 	stderr := new(bytes.Buffer)
@@ -112,7 +116,9 @@ func (*cloudCredentialSuite) TestRegisterCredentialsWithCallFailure(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockProvider := common.NewMockTestCloudProvider(ctrl)
-	mockProvider.EXPECT().RegisterCredentials("fake").Return(nil, errors.New("bad"))
+	mockProvider.EXPECT().RegisterCredentials(cloud.Cloud{
+		Name: "fake",
+	}).Return(nil, errors.New("bad"))
 	mockStore := common.NewMockCredentialStore(ctrl)
 
 	stderr := new(bytes.Buffer)

--- a/cmd/juju/common/cloudcredential_test.go
+++ b/cmd/juju/common/cloudcredential_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 var _ = gc.Suite(&cloudCredentialSuite{})
@@ -67,7 +68,7 @@ func (*cloudCredentialSuite) TestRegisterCredentials(c *gc.C) {
 	}
 
 	mockProvider := common.NewMockTestCloudProvider(ctrl)
-	mockProvider.EXPECT().RegisterCredentials().Return(map[string]*cloud.CloudCredential{
+	mockProvider.EXPECT().RegisterCredentials("fake").Return(map[string]*cloud.CloudCredential{
 		"fake": credential,
 	}, nil)
 	mockStore := common.NewMockCredentialStore(ctrl)
@@ -77,7 +78,11 @@ func (*cloudCredentialSuite) TestRegisterCredentials(c *gc.C) {
 
 	err := common.RegisterCredentials(&cmd.Context{
 		Stderr: stderr,
-	}, mockStore, mockProvider)
+	}, mockStore, mockProvider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud.Cloud{
+			Name: "fake",
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stderr.String(), gc.Equals, "")
 }
@@ -87,14 +92,18 @@ func (*cloudCredentialSuite) TestRegisterCredentialsWithNoCredentials(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockProvider := common.NewMockTestCloudProvider(ctrl)
-	mockProvider.EXPECT().RegisterCredentials().Return(map[string]*cloud.CloudCredential{}, nil)
+	mockProvider.EXPECT().RegisterCredentials("fake").Return(map[string]*cloud.CloudCredential{}, nil)
 	mockStore := common.NewMockCredentialStore(ctrl)
 
 	stderr := new(bytes.Buffer)
 
 	err := common.RegisterCredentials(&cmd.Context{
 		Stderr: stderr,
-	}, mockStore, mockProvider)
+	}, mockStore, mockProvider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud.Cloud{
+			Name: "fake",
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -103,13 +112,17 @@ func (*cloudCredentialSuite) TestRegisterCredentialsWithCallFailure(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockProvider := common.NewMockTestCloudProvider(ctrl)
-	mockProvider.EXPECT().RegisterCredentials().Return(nil, errors.New("bad"))
+	mockProvider.EXPECT().RegisterCredentials("fake").Return(nil, errors.New("bad"))
 	mockStore := common.NewMockCredentialStore(ctrl)
 
 	stderr := new(bytes.Buffer)
 
 	err := common.RegisterCredentials(&cmd.Context{
 		Stderr: stderr,
-	}, mockStore, mockProvider)
+	}, mockStore, mockProvider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud.Cloud{
+			Name: "fake",
+		},
+	})
 	c.Assert(errors.Cause(err).Error(), gc.Matches, "bad")
 }

--- a/cmd/juju/common/cloudprovider_mock_test.go
+++ b/cmd/juju/common/cloudprovider_mock_test.go
@@ -113,7 +113,7 @@ func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0 interface{}) *go
 }
 
 // RegisterCredentials mocks base method
-func (m *MockTestCloudProvider) RegisterCredentials(arg0 string) (map[string]*cloud.CloudCredential, error) {
+func (m *MockTestCloudProvider) RegisterCredentials(arg0 cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	ret := m.ctrl.Call(m, "RegisterCredentials", arg0)
 	ret0, _ := ret[0].(map[string]*cloud.CloudCredential)
 	ret1, _ := ret[1].(error)

--- a/cmd/juju/common/cloudprovider_mock_test.go
+++ b/cmd/juju/common/cloudprovider_mock_test.go
@@ -113,16 +113,16 @@ func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0 interface{}) *go
 }
 
 // RegisterCredentials mocks base method
-func (m *MockTestCloudProvider) RegisterCredentials() (map[string]*cloud.CloudCredential, error) {
-	ret := m.ctrl.Call(m, "RegisterCredentials")
+func (m *MockTestCloudProvider) RegisterCredentials(arg0 string) (map[string]*cloud.CloudCredential, error) {
+	ret := m.ctrl.Call(m, "RegisterCredentials", arg0)
 	ret0, _ := ret[0].(map[string]*cloud.CloudCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RegisterCredentials indicates an expected call of RegisterCredentials
-func (mr *MockTestCloudProviderMockRecorder) RegisterCredentials() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCredentials", reflect.TypeOf((*MockTestCloudProvider)(nil).RegisterCredentials))
+func (mr *MockTestCloudProviderMockRecorder) RegisterCredentials(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCredentials", reflect.TypeOf((*MockTestCloudProvider)(nil).RegisterCredentials), arg0)
 }
 
 // Validate mocks base method

--- a/cmd/modelcmd/cloudprovider_mock_test.go
+++ b/cmd/modelcmd/cloudprovider_mock_test.go
@@ -113,7 +113,7 @@ func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0 interface{}) *go
 }
 
 // RegisterCredentials mocks base method
-func (m *MockTestCloudProvider) RegisterCredentials(arg0 string) (map[string]*cloud.CloudCredential, error) {
+func (m *MockTestCloudProvider) RegisterCredentials(arg0 cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	ret := m.ctrl.Call(m, "RegisterCredentials", arg0)
 	ret0, _ := ret[0].(map[string]*cloud.CloudCredential)
 	ret1, _ := ret[1].(error)

--- a/cmd/modelcmd/cloudprovider_mock_test.go
+++ b/cmd/modelcmd/cloudprovider_mock_test.go
@@ -113,16 +113,16 @@ func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0 interface{}) *go
 }
 
 // RegisterCredentials mocks base method
-func (m *MockTestCloudProvider) RegisterCredentials() (map[string]*cloud.CloudCredential, error) {
-	ret := m.ctrl.Call(m, "RegisterCredentials")
+func (m *MockTestCloudProvider) RegisterCredentials(arg0 string) (map[string]*cloud.CloudCredential, error) {
+	ret := m.ctrl.Call(m, "RegisterCredentials", arg0)
 	ret0, _ := ret[0].(map[string]*cloud.CloudCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RegisterCredentials indicates an expected call of RegisterCredentials
-func (mr *MockTestCloudProviderMockRecorder) RegisterCredentials() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCredentials", reflect.TypeOf((*MockTestCloudProvider)(nil).RegisterCredentials))
+func (mr *MockTestCloudProviderMockRecorder) RegisterCredentials(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCredentials", reflect.TypeOf((*MockTestCloudProvider)(nil).RegisterCredentials), arg0)
 }
 
 // Validate mocks base method

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -186,11 +186,17 @@ func DetectCredential(cloudName string, provider environs.EnvironProvider) (*clo
 	return detected, nil
 }
 
+// RegisterCredentialsParams contains parameters for the RegisterCredentials function.
+type RegisterCredentialsParams struct {
+	// Cloud is the cloud definition.
+	Cloud cloud.Cloud
+}
+
 // RegisterCredentials returns any credentials that need to be registered for
 // a provider.
-func RegisterCredentials(provider environs.EnvironProvider) (map[string]*cloud.CloudCredential, error) {
+func RegisterCredentials(provider environs.EnvironProvider, args RegisterCredentialsParams) (map[string]*cloud.CloudCredential, error) {
 	if register, ok := provider.(environs.ProviderCredentialsRegister); ok {
-		found, err := register.RegisterCredentials()
+		found, err := register.RegisterCredentials(args.Cloud.Name)
 		if err != nil {
 			return nil, errors.Annotatef(
 				err, "registering credentials for provider",

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -196,7 +196,7 @@ type RegisterCredentialsParams struct {
 // a provider.
 func RegisterCredentials(provider environs.EnvironProvider, args RegisterCredentialsParams) (map[string]*cloud.CloudCredential, error) {
 	if register, ok := provider.(environs.ProviderCredentialsRegister); ok {
-		found, err := register.RegisterCredentials(args.Cloud.Name)
+		found, err := register.RegisterCredentials(args.Cloud)
 		if err != nil {
 			return nil, errors.Annotatef(
 				err, "registering credentials for provider",

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -178,7 +178,9 @@ func (s *credentialsSuite) TestRegisterCredentials(c *gc.C) {
 	}
 
 	exp := mockProvider.EXPECT()
-	exp.RegisterCredentials("fake").Return(credential, nil)
+	exp.RegisterCredentials(cloud.Cloud{
+		Name: "fake",
+	}).Return(credential, nil)
 
 	credentials, err := modelcmd.RegisterCredentials(mockProvider, modelcmd.RegisterCredentialsParams{
 		Cloud: cloud.Cloud{
@@ -198,7 +200,9 @@ func (s *credentialsSuite) TestRegisterCredentialsWithNoCredentials(c *gc.C) {
 	credential := map[string]*cloud.CloudCredential{}
 
 	exp := mockProvider.EXPECT()
-	exp.RegisterCredentials("fake").Return(credential, nil)
+	exp.RegisterCredentials(cloud.Cloud{
+		Name: "fake",
+	}).Return(credential, nil)
 
 	credentials, err := modelcmd.RegisterCredentials(mockProvider, modelcmd.RegisterCredentialsParams{
 		Cloud: cloud.Cloud{
@@ -216,7 +220,9 @@ func (s *credentialsSuite) TestRegisterCredentialsWithCallFailure(c *gc.C) {
 	mockProvider := modelcmd.NewMockTestCloudProvider(ctrl)
 
 	exp := mockProvider.EXPECT()
-	exp.RegisterCredentials("fake").Return(nil, errors.New("bad"))
+	exp.RegisterCredentials(cloud.Cloud{
+		Name: "fake",
+	}).Return(nil, errors.New("bad"))
 
 	credentials, err := modelcmd.RegisterCredentials(mockProvider, modelcmd.RegisterCredentialsParams{
 		Cloud: cloud.Cloud{

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -178,9 +178,13 @@ func (s *credentialsSuite) TestRegisterCredentials(c *gc.C) {
 	}
 
 	exp := mockProvider.EXPECT()
-	exp.RegisterCredentials().Return(credential, nil)
+	exp.RegisterCredentials("fake").Return(credential, nil)
 
-	credentials, err := modelcmd.RegisterCredentials(mockProvider)
+	credentials, err := modelcmd.RegisterCredentials(mockProvider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud.Cloud{
+			Name: "fake",
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.DeepEquals, credential)
 }
@@ -194,9 +198,13 @@ func (s *credentialsSuite) TestRegisterCredentialsWithNoCredentials(c *gc.C) {
 	credential := map[string]*cloud.CloudCredential{}
 
 	exp := mockProvider.EXPECT()
-	exp.RegisterCredentials().Return(credential, nil)
+	exp.RegisterCredentials("fake").Return(credential, nil)
 
-	credentials, err := modelcmd.RegisterCredentials(mockProvider)
+	credentials, err := modelcmd.RegisterCredentials(mockProvider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud.Cloud{
+			Name: "fake",
+		},
+	})
 	c.Assert(errors.Cause(err).Error(), gc.Matches, `credentials for provider not found`)
 	c.Assert(credentials, gc.IsNil)
 }
@@ -208,9 +216,13 @@ func (s *credentialsSuite) TestRegisterCredentialsWithCallFailure(c *gc.C) {
 	mockProvider := modelcmd.NewMockTestCloudProvider(ctrl)
 
 	exp := mockProvider.EXPECT()
-	exp.RegisterCredentials().Return(nil, errors.New("bad"))
+	exp.RegisterCredentials("fake").Return(nil, errors.New("bad"))
 
-	credentials, err := modelcmd.RegisterCredentials(mockProvider)
+	credentials, err := modelcmd.RegisterCredentials(mockProvider, modelcmd.RegisterCredentialsParams{
+		Cloud: cloud.Cloud{
+			Name: "fake",
+		},
+	})
 	c.Assert(err.Error(), gc.Matches, `registering credentials for provider: bad`)
 	c.Assert(credentials, gc.IsNil)
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -137,7 +137,7 @@ type ProviderCredentialsRegister interface {
 	//
 	// If no credentials can be found, RegisterCredentials should return
 	// an error satisfying errors.IsNotFound.
-	RegisterCredentials() (map[string]*cloud.CloudCredential, error)
+	RegisterCredentials(string) (map[string]*cloud.CloudCredential, error)
 }
 
 // RequestFinalizeCredential is an interface that an EnvironProvider implements

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -137,7 +137,7 @@ type ProviderCredentialsRegister interface {
 	//
 	// If no credentials can be found, RegisterCredentials should return
 	// an error satisfying errors.IsNotFound.
-	RegisterCredentials(string) (map[string]*cloud.CloudCredential, error)
+	RegisterCredentials(cloud.Cloud) (map[string]*cloud.CloudCredential, error)
 }
 
 // RequestFinalizeCredential is an interface that an EnvironProvider implements

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -1262,16 +1262,16 @@ func (m *MockProviderCredentialsRegister) EXPECT() *MockProviderCredentialsRegis
 }
 
 // RegisterCredentials mocks base method
-func (m *MockProviderCredentialsRegister) RegisterCredentials() (map[string]*cloud.CloudCredential, error) {
-	ret := m.ctrl.Call(m, "RegisterCredentials")
+func (m *MockProviderCredentialsRegister) RegisterCredentials(arg0 string) (map[string]*cloud.CloudCredential, error) {
+	ret := m.ctrl.Call(m, "RegisterCredentials", arg0)
 	ret0, _ := ret[0].(map[string]*cloud.CloudCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RegisterCredentials indicates an expected call of RegisterCredentials
-func (mr *MockProviderCredentialsRegisterMockRecorder) RegisterCredentials() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCredentials", reflect.TypeOf((*MockProviderCredentialsRegister)(nil).RegisterCredentials))
+func (mr *MockProviderCredentialsRegisterMockRecorder) RegisterCredentials(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCredentials", reflect.TypeOf((*MockProviderCredentialsRegister)(nil).RegisterCredentials), arg0)
 }
 
 // MockRequestFinalizeCredential is a mock of RequestFinalizeCredential interface

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -1262,7 +1262,7 @@ func (m *MockProviderCredentialsRegister) EXPECT() *MockProviderCredentialsRegis
 }
 
 // RegisterCredentials mocks base method
-func (m *MockProviderCredentialsRegister) RegisterCredentials(arg0 string) (map[string]*cloud.CloudCredential, error) {
+func (m *MockProviderCredentialsRegister) RegisterCredentials(arg0 cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	ret := m.ctrl.Call(m, "RegisterCredentials", arg0)
 	ret0, _ := ret[0].(map[string]*cloud.CloudCredential)
 	ret1, _ := ret[1].(error)

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -111,16 +111,14 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // RegisterCredentials is part of the environs.ProviderCredentialsRegister interface.
-func (p environProviderCredentials) RegisterCredentials(credentialName string) (map[string]*cloud.CloudCredential, error) {
+func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	// only register credentials if the operator is attempting to access "lxd"
 	// or "localhost"
-	if credentialName != lxdnames.DefaultCloud && credentialName != lxdnames.DefaultCloudAltName {
+	cloudName := cld.Name
+	if cloudName != lxdnames.DefaultCloud && cloudName != lxdnames.DefaultCloudAltName {
 		return make(map[string]*cloud.CloudCredential), nil
 	}
 
-	// register the local lxd credentials, not we register both "localhost" and
-	// "lxd" credentials at the same type, as they can be used interchangeably
-	// through out the use of the commands.
 	nopLogf := func(msg string, args ...interface{}) {}
 	certPEM, keyPEM, err := p.readOrGenerateCert(nopLogf)
 	if err != nil {
@@ -133,16 +131,10 @@ func (p environProviderCredentials) RegisterCredentials(credentialName string) (
 	}
 
 	return map[string]*cloud.CloudCredential{
-		lxdnames.DefaultCloud: {
-			DefaultCredential: lxdnames.DefaultCloud,
+		cloudName: {
+			DefaultCredential: cloudName,
 			AuthCredentials: map[string]cloud.Credential{
-				lxdnames.DefaultCloud: *localCertCredential,
-			},
-		},
-		lxdnames.DefaultCloudAltName: {
-			DefaultCredential: lxdnames.DefaultCloudAltName,
-			AuthCredentials: map[string]cloud.Credential{
-				lxdnames.DefaultCloudAltName: *localCertCredential,
+				cloudName: *localCertCredential,
 			},
 		},
 	}, nil

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -130,6 +130,12 @@ func (p environProviderCredentials) RegisterCredentials() (map[string]*cloud.Clo
 				lxdnames.DefaultCloud: *localCertCredential,
 			},
 		},
+		lxdnames.DefaultCloudAltName: {
+			DefaultCredential: lxdnames.DefaultCloudAltName,
+			AuthCredentials: map[string]cloud.Credential{
+				lxdnames.DefaultCloudAltName: *localCertCredential,
+			},
+		},
 	}, nil
 }
 

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -111,7 +111,16 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // RegisterCredentials is part of the environs.ProviderCredentialsRegister interface.
-func (p environProviderCredentials) RegisterCredentials() (map[string]*cloud.CloudCredential, error) {
+func (p environProviderCredentials) RegisterCredentials(credentialName string) (map[string]*cloud.CloudCredential, error) {
+	// only register credentials if the operator is attempting to access "lxd"
+	// or "localhost"
+	if credentialName != lxdnames.DefaultCloud && credentialName != lxdnames.DefaultCloudAltName {
+		return make(map[string]*cloud.CloudCredential), nil
+	}
+
+	// register the local lxd credentials, not we register both "localhost" and
+	// "lxd" credentials at the same type, as they can be used interchangeably
+	// through out the use of the commands.
 	nopLogf := func(msg string, args ...interface{}) {}
 	certPEM, keyPEM, err := p.readOrGenerateCert(nopLogf)
 	if err != nil {

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -267,13 +267,19 @@ func (s *credentialsSuite) TestRegisterCredentials(c *gc.C) {
 	expected.Label = `LXD credential "localhost"`
 
 	provider := deps.provider.(environs.ProviderCredentialsRegister)
-	credentials, err := provider.RegisterCredentials()
+	credentials, err := provider.RegisterCredentials("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, jc.DeepEquals, map[string]*cloud.CloudCredential{
 		"localhost": {
 			DefaultCredential: "localhost",
 			AuthCredentials: map[string]cloud.Credential{
 				"localhost": expected,
+			},
+		},
+		"lxd": {
+			DefaultCredential: "lxd",
+			AuthCredentials: map[string]cloud.Credential{
+				"lxd": expected,
 			},
 		},
 	})
@@ -292,7 +298,7 @@ func (s *credentialsSuite) TestRegisterCredentialsUsesJujuCert(c *gc.C) {
 	deps.certReadWriter.EXPECT().Read(path).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
 
 	provider := deps.provider.(environs.ProviderCredentialsRegister)
-	credentials, err := provider.RegisterCredentials()
+	credentials, err := provider.RegisterCredentials("localhost")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := cloud.NewCredential(
@@ -310,6 +316,12 @@ func (s *credentialsSuite) TestRegisterCredentialsUsesJujuCert(c *gc.C) {
 			DefaultCredential: "localhost",
 			AuthCredentials: map[string]cloud.Credential{
 				"localhost": expected,
+			},
+		},
+		"lxd": {
+			DefaultCredential: "lxd",
+			AuthCredentials: map[string]cloud.Credential{
+				"lxd": expected,
 			},
 		},
 	})
@@ -331,7 +343,7 @@ func (s *credentialsSuite) TestRegisterCredentialsUsesLXCCert(c *gc.C) {
 	deps.certReadWriter.EXPECT().Read(path).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
 
 	provider := deps.provider.(environs.ProviderCredentialsRegister)
-	credentials, err := provider.RegisterCredentials()
+	credentials, err := provider.RegisterCredentials("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := cloud.NewCredential(
@@ -349,6 +361,12 @@ func (s *credentialsSuite) TestRegisterCredentialsUsesLXCCert(c *gc.C) {
 			DefaultCredential: "localhost",
 			AuthCredentials: map[string]cloud.Credential{
 				"localhost": expected,
+			},
+		},
+		"lxd": {
+			DefaultCredential: "lxd",
+			AuthCredentials: map[string]cloud.Credential{
+				"lxd": expected,
 			},
 		},
 	})

--- a/provider/lxd/lxdnames/names.go
+++ b/provider/lxd/lxdnames/names.go
@@ -11,6 +11,10 @@ package lxdnames
 // the local lxd daemon.
 const DefaultCloud = "localhost"
 
+// DefaultCloudAltName is the alternative name of the default lxd cloud,
+// which corresponds to the local lxd daemon.
+const DefaultCloudAltName = "lxd"
+
 // DefaultLocalRegion is the name of the "region" we support in a local lxd,
 // which corresponds to the local lxd daemon.
 const DefaultLocalRegion = "localhost"


### PR DESCRIPTION
## Description of change

The following registers the alternative name for the localhost
lxd provider. This way we can bootstrap juju just using the
alternative name "lxd" rather than the perceived more popular one
"localhost".

The question of if this is correct or not is a bit of a concern.
Why we don't reconcile both localhost and lxd names and normalise
them to mean the same one when bootstrapping seems a mystery.

Anyway, I'll supply a good deal of Cunningham's Law to this and
see what the fallout to that is.

## QA steps

```sh
juju bootstrap lxd
```

## Documentation changes

This is a regression from 2.4, where you could bootstrap using
"lxd" correctly.

## Bug reference

N/A
