### PR TITLE
Ensure that we handle the case of non-LXD

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/instance"
 	mgoutils "github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/presence"
@@ -1640,6 +1641,10 @@ func (a *Application) addUnitSubordinateCharmProfileOp(principalName string) (tx
 	machine, err := unit.machine()
 	if err != nil {
 		return txn.Op{}, false, err
+	}
+	// If we're not a LXD container type don't register the document.
+	if machine.ContainerType() != instance.LXD {
+		return txn.Op{}, false, nil
 	}
 	return machine.SetUpgradeCharmProfileOp(a.doc.Name, a.doc.CharmURL.String(), lxdprofile.EmptyStatus), true, nil
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -2217,6 +2217,11 @@ func (m *Machine) VerifyUnitsSeries(unitNames []string, series string, force boo
 // SetUpgradeCharmProfile sets a application name and a charm url for
 // machine's needing a charm profile change.  For a container only.
 func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
+	// If we're not a LXD container type, don't attempt to set any information
+	if m.ContainerType() != instance.LXD {
+		return nil
+	}
+
 	charmURL, err := charm.ParseURL(chURL)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/unit.go
+++ b/state/unit.go
@@ -699,7 +699,9 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 			{{"hasvote", true}},
 		}}}
 		// Remove the charm profile.
-		ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
+		if m.ContainerType() == instance.LXD {
+			ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
+		}
 	}
 
 	// If removal conditions satisfied by machine & container docs, we can

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -152,7 +152,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		return nil, err
 	}
 	profileWatcher, err := p.getProfileWatcher()
-	if err != nil {
+	if err != nil && !errors.IsNotImplemented(err) {
 		return nil, err
 	}
 	tag := p.agentConfig.Tag()
@@ -406,8 +406,7 @@ func (p *containerProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) 
 
 func (p *containerProvisioner) getProfileWatcher() (watcher.StringsWatcher, error) {
 	if p.containerType != instance.LXD {
-		// TODO (hml) lxd-profile 17-oct-2018
-		// what is the correct way to handle this, only start for LXD containers
+		return nil, errors.NotImplementedf("getProfileWatcher")
 	}
 	machine, err := p.getMachine()
 	if err != nil {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -97,6 +97,7 @@ func NewProvisionerTask(
 	var profileChanges watcher.StringsChannel
 	if profileWatcher != nil {
 		profileChanges = profileWatcher.Changes()
+		workers = append(workers, profileWatcher)
 	}
 	task := &provisionerTask{
 		controllerUUID:             controllerUUID,

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -94,7 +94,10 @@ func NewProvisionerTask(
 		retryChanges = retryWatcher.Changes()
 		workers = append(workers, retryWatcher)
 	}
-	profileChanges := profileWatcher.Changes()
+	var profileChanges watcher.StringsChannel
+	if profileWatcher != nil {
+		profileChanges = profileWatcher.Changes()
+	}
 	task := &provisionerTask{
 		controllerUUID:             controllerUUID,
 		machineTag:                 machineTag,


### PR DESCRIPTION
## Description of change

The following ensures that we handle what happens if we're not
running on LXD containers.

## QA steps

```
juju bootstrap localhost lxd-profile-test
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
watch juju status
```

## Documentation changes

The following change ensures that we don't have any issues with running
on KVM containers et al.

## Bug reference

N/A
