### PR TITLE
Update public cloud data

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -42,6 +42,8 @@ clouds:
     regions:
       cn-north-1:
         endpoint: https://ec2.cn-north-1.amazonaws.com.cn
+      cn-northwest-1:
+        endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn
   aws-gov:
     type: ec2
     description: Amazon (USA Government)
@@ -62,21 +64,31 @@ clouds:
         endpoint: https://www.googleapis.com
       us-west1:
         endpoint: https://www.googleapis.com
+      us-west2:
+        endpoint: https://www.googleapis.com
+      asia-east1:
+        endpoint: https://www.googleapis.com
+      asia-east2:
+        endpoint: https://www.googleapis.com
+      asia-northeast1:
+        endpoint: https://www.googleapis.com
+      asia-south1:
+        endpoint: https://www.googleapis.com
+      asia-southeast1:
+        endpoint: https://www.googleapis.com
+      australia-southeast1:
+        endpoint: https://www.googleapis.com
+      europe-north1:
+        endpoint: https://www.googleapis.com
       europe-west1:
         endpoint: https://www.googleapis.com
       europe-west2:
         endpoint: https://www.googleapis.com
       europe-west3:
         endpoint: https://www.googleapis.com
-      asia-east1:
+      europe-west4:
         endpoint: https://www.googleapis.com
-      asia-northeast1:
-        endpoint: https://www.googleapis.com
-      asia-southeast1:
-        endpoint: https://www.googleapis.com
-      asia-south1:
-        endpoint: https://www.googleapis.com
-      australia-southeast1:
+      northamerica-northeast1:
         endpoint: https://www.googleapis.com
       southamerica-east1:
         endpoint: https://www.googleapis.com
@@ -188,6 +200,10 @@ clouds:
       koreasouth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
+      francecentral:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net        
   azure-china:
     type: azure
@@ -225,10 +241,6 @@ clouds:
     description: Joyent Cloud
     auth-types: [ userpass ]
     regions:
-      eu-ams-1:
-        endpoint: https://eu-ams-1.api.joyentcloud.com
-      us-sw-1:
-        endpoint: https://us-sw-1.api.joyentcloud.com
       us-east-1:
         endpoint: https://us-east-1.api.joyentcloud.com
       us-east-2:
@@ -237,17 +249,35 @@ clouds:
         endpoint: https://us-east-3.api.joyentcloud.com
       us-west-1:
         endpoint: https://us-west-1.api.joyentcloud.com
+      us-sw-1:
+        endpoint: https://us-sw-1.api.joyentcloud.com
+      eu-ams-1:
+        endpoint: https://eu-ams-1.api.joyentcloud.com
   cloudsigma:
     type: cloudsigma
     description: CloudSigma Cloud
     auth-types: [ userpass ]
     regions:
+      dub:
+        endpoint: https://dub.cloudsigma.com/api/2.0/
+      fra:
+        endpoint: https://fra.cloudsigma.com/api/2.0/
       hnl:
         endpoint: https://hnl.cloudsigma.com/api/2.0/
+      mel:
+        endpoint: https://mel.cloudsigma.com/api/2.0/
       mia:
         endpoint: https://mia.cloudsigma.com/api/2.0/
+      mnl:
+        endpoint: https://mnl.cloudsigma.com/api/2.0/
+      per:
+        endpoint: https://per.cloudsigma.com/api/2.0/
+      ruh:
+        endpoint: https://ruh.cloudsigma.com/api/2.0/
       sjc:
         endpoint: https://sjc.cloudsigma.com/api/2.0/
+      waw:
+        endpoint: https://waw.cloudsigma.com/api/2.0/
       wdc:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -49,6 +49,8 @@ clouds:
     regions:
       cn-north-1:
         endpoint: https://ec2.cn-north-1.amazonaws.com.cn
+      cn-northwest-1:
+        endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn
   aws-gov:
     type: ec2
     description: Amazon (USA Government)
@@ -69,21 +71,31 @@ clouds:
         endpoint: https://www.googleapis.com
       us-west1:
         endpoint: https://www.googleapis.com
+      us-west2:
+        endpoint: https://www.googleapis.com
+      asia-east1:
+        endpoint: https://www.googleapis.com
+      asia-east2:
+        endpoint: https://www.googleapis.com
+      asia-northeast1:
+        endpoint: https://www.googleapis.com
+      asia-south1:
+        endpoint: https://www.googleapis.com
+      asia-southeast1:
+        endpoint: https://www.googleapis.com
+      australia-southeast1:
+        endpoint: https://www.googleapis.com
+      europe-north1:
+        endpoint: https://www.googleapis.com
       europe-west1:
         endpoint: https://www.googleapis.com
       europe-west2:
         endpoint: https://www.googleapis.com
       europe-west3:
         endpoint: https://www.googleapis.com
-      asia-east1:
+      europe-west4:
         endpoint: https://www.googleapis.com
-      asia-northeast1:
-        endpoint: https://www.googleapis.com
-      asia-southeast1:
-        endpoint: https://www.googleapis.com
-      asia-south1:
-        endpoint: https://www.googleapis.com
-      australia-southeast1:
+      northamerica-northeast1:
         endpoint: https://www.googleapis.com
       southamerica-east1:
         endpoint: https://www.googleapis.com
@@ -195,7 +207,11 @@ clouds:
       koreasouth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://graph.windows.net        
+        identity-endpoint: https://graph.windows.net
+      francecentral:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net       
   azure-china:
     type: azure
     description: Microsoft Azure China
@@ -232,10 +248,6 @@ clouds:
     description: Joyent Cloud
     auth-types: [ userpass ]
     regions:
-      eu-ams-1:
-        endpoint: https://eu-ams-1.api.joyentcloud.com
-      us-sw-1:
-        endpoint: https://us-sw-1.api.joyentcloud.com
       us-east-1:
         endpoint: https://us-east-1.api.joyentcloud.com
       us-east-2:
@@ -244,17 +256,35 @@ clouds:
         endpoint: https://us-east-3.api.joyentcloud.com
       us-west-1:
         endpoint: https://us-west-1.api.joyentcloud.com
+      us-sw-1:
+        endpoint: https://us-sw-1.api.joyentcloud.com
+      eu-ams-1:
+        endpoint: https://eu-ams-1.api.joyentcloud.com
   cloudsigma:
     type: cloudsigma
     description: CloudSigma Cloud
     auth-types: [ userpass ]
     regions:
+      dub:
+        endpoint: https://dub.cloudsigma.com/api/2.0/
+      fra:
+        endpoint: https://fra.cloudsigma.com/api/2.0/
       hnl:
         endpoint: https://hnl.cloudsigma.com/api/2.0/
+      mel:
+        endpoint: https://mel.cloudsigma.com/api/2.0/
       mia:
         endpoint: https://mia.cloudsigma.com/api/2.0/
+      mnl:
+        endpoint: https://mnl.cloudsigma.com/api/2.0/
+      per:
+        endpoint: https://per.cloudsigma.com/api/2.0/
+      ruh:
+        endpoint: https://ruh.cloudsigma.com/api/2.0/
       sjc:
         endpoint: https://sjc.cloudsigma.com/api/2.0/
+      waw:
+        endpoint: https://waw.cloudsigma.com/api/2.0/
       wdc:
         endpoint: https://wdc.cloudsigma.com/api/2.0/
       zrh:
@@ -272,4 +302,5 @@ clouds:
         endpoint: https://iaas.eu-frankfurt-1.oraclecloud.com
       uk-london-1:
         endpoint: https://iaas.uk-london-1.oraclecloud.com
+
 `

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -29,8 +29,11 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-	// Just check couple of snippets of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws-china[ ]*1[ ]*cn-north-1[ ]*ec2.*`)
+	// Check that we are producing the expected fields
+	c.Assert(out, gc.Matches, `Cloud        Regions  Default        Type        Description.*`)
+	// // Just check couple of snippets of the output to make sure it looks ok.
+	c.Assert(out, gc.Matches, `.*aws               [0-9]+  [a-z0-9-]+      ec2         Amazon Web Services.*`)
+	c.Assert(out, gc.Matches, `.*azure             [0-9]+  [a-z0-9-]+      azure       Microsoft Azure.*`)
 	// LXD should be there too.
 	c.Assert(out, gc.Matches, `.*localhost[ ]*1[ ]*localhost[ ]*lxd.*`)
 }

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -109,14 +109,19 @@ us-east1
 us-east4
 us-central1
 us-west1
+us-west2
+asia-east1
+asia-east2
+asia-northeast1
+asia-south1
+asia-southeast1
+australia-southeast1
+europe-north1
 europe-west1
 europe-west2
 europe-west3
-asia-east1
-asia-northeast1
-asia-southeast1
-asia-south1
-australia-southeast1
+europe-west4
+northamerica-northeast1
 southamerica-east1
 
 `[1:])
@@ -135,21 +140,31 @@ us-central1:
   endpoint: https://www.googleapis.com
 us-west1:
   endpoint: https://www.googleapis.com
+us-west2:
+  endpoint: https://www.googleapis.com
+asia-east1:
+  endpoint: https://www.googleapis.com
+asia-east2:
+  endpoint: https://www.googleapis.com
+asia-northeast1:
+  endpoint: https://www.googleapis.com
+asia-south1:
+  endpoint: https://www.googleapis.com
+asia-southeast1:
+  endpoint: https://www.googleapis.com
+australia-southeast1:
+  endpoint: https://www.googleapis.com
+europe-north1:
+  endpoint: https://www.googleapis.com
 europe-west1:
   endpoint: https://www.googleapis.com
 europe-west2:
   endpoint: https://www.googleapis.com
 europe-west3:
   endpoint: https://www.googleapis.com
-asia-east1:
+europe-west4:
   endpoint: https://www.googleapis.com
-asia-northeast1:
-  endpoint: https://www.googleapis.com
-asia-southeast1:
-  endpoint: https://www.googleapis.com
-asia-south1:
-  endpoint: https://www.googleapis.com
-australia-southeast1:
+northamerica-northeast1:
   endpoint: https://www.googleapis.com
 southamerica-east1:
   endpoint: https://www.googleapis.com
@@ -170,31 +185,32 @@ func (s *regionsSuite) TestListRegionsJson(c *gc.C) {
 	err = json.Unmarshal([]byte(out), &data)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, jc.DeepEquals, map[string]regionDetails{
-		"northeurope":        {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"eastasia":           {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"japanwest":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"westcentralus":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"centralus":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"westus2":            {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"eastus":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"eastus2":            {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"japaneast":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"northcentralus":     {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"southcentralus":     {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"australiaeast":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westcentralus":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westus":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westus2":            {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"northeurope":        {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"westeurope":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"eastasia":           {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"southeastasia":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"japaneast":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"japanwest":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"brazilsouth":        {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"australiaeast":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"australiasoutheast": {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"centralindia":       {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"southindia":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"westeurope":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"westindia":          {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"westus":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"australiasoutheast": {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"eastus":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"southeastasia":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"canadacentral":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"canadaeast":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"uksouth":            {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"ukwest":             {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
-		"koreasouth":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"koreacentral":       {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"koreasouth":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"francecentral":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 	})
 }

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -40,6 +40,8 @@ auth-types: [access-key]
 regions:
   cn-north-1:
     endpoint: https://ec2.cn-north-1.amazonaws.com.cn
+  cn-northwest-1:
+    endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn
 `[1:])
 }
 
@@ -157,10 +159,6 @@ type: joyent
 description: Joyent Cloud
 auth-types: [userpass]
 regions:
-  eu-ams-1:
-    endpoint: https://eu-ams-1.api.joyentcloud.com
-  us-sw-1:
-    endpoint: https://us-sw-1.api.joyentcloud.com
   us-east-1:
     endpoint: https://us-east-1.api.joyentcloud.com
   us-east-2:
@@ -169,6 +167,10 @@ regions:
     endpoint: https://us-east-3.api.joyentcloud.com
   us-west-1:
     endpoint: https://us-west-1.api.joyentcloud.com
+  us-sw-1:
+    endpoint: https://us-sw-1.api.joyentcloud.com
+  eu-ams-1:
+    endpoint: https://eu-ams-1.api.joyentcloud.com
 `[1:])
 }
 


### PR DESCRIPTION
Updates regions of public clouds supported by Juju. 

(Sorry that the PR includes some deletes; I started to sort the YAML files by alphabetical order. Can revert.)

----

## Description of change

The current listing of public clouds is outdated. Several providers have added new regions.

## QA steps
 
`$ juju regions google` should include europe-north1
`$ juju regions aws-china` should include cn-northwest1

## Documentation changes

It's possible that re-ordering the YAML files will change the default regions for aws and azure from what users have been used to. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1787753
