### PR TITLE
More robust controller-api port handling.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -100,6 +100,12 @@ const (
 // ManifoldsConfig allows specialisation of the result of Manifolds.
 type ManifoldsConfig struct {
 
+	// AgentName is the name of the machine agent, like "machine-12".
+	// This will never change during the execution of an agent, and
+	// is used to provide this as config into a worker rather than
+	// making the worker get it from the agent worker itself.
+	AgentName string
+
 	// Agent contains the agent that will be wrapped and made available to
 	// its dependencies via a dependency.Engine.
 	Agent coreagent.Agent
@@ -713,6 +719,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			RaftTransportName:    raftTransportName,
 			RaftEnabledName:      raftEnabledName,
 			PrometheusRegisterer: config.PrometheusRegisterer,
+			AgentName:            config.AgentName,
 			Clock:                config.Clock,
 			GetControllerConfig:  httpserver.GetControllerConfig,
 			NewTLSConfig:         httpserver.NewTLSConfig,

--- a/worker/agent/manifold.go
+++ b/worker/agent/manifold.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/version"
 )
 
 // Manifold returns a manifold that starts a worker proxying the supplied Agent
@@ -66,7 +67,8 @@ func (w *agentWorker) Wait() error {
 func (w *agentWorker) Report() map[string]interface{} {
 	cfg := w.agent.CurrentConfig()
 	return map[string]interface{}{
-		"model-uuid": cfg.Model().Id(),
 		"agent":      cfg.Tag().String(),
+		"model-uuid": cfg.Model().Id(),
+		"version":    version.Current.String(),
 	}
 }

--- a/worker/agent/manifold_test.go
+++ b/worker/agent/manifold_test.go
@@ -6,11 +6,13 @@ package agent_test
 import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
 	coreagent "github.com/juju/juju/agent"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/agent"
 )
 
@@ -81,6 +83,8 @@ func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
 }
 
 func (s *ManifoldSuite) TestReport(c *gc.C) {
+	s.PatchValue(&jujuversion.Current, version.MustParse("3.2.1"))
+
 	inputAgent := &dummyAgent{}
 	manifold := agent.Manifold(inputAgent)
 
@@ -91,8 +95,9 @@ func (s *ManifoldSuite) TestReport(c *gc.C) {
 	reporter, ok := agentWorker.(worker.Reporter)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(reporter.Report(), jc.DeepEquals, map[string]interface{}{
-		"model-uuid": "model-uuid",
 		"agent":      "machine-42",
+		"model-uuid": "model-uuid",
+		"version":    "3.2.1",
 	})
 }
 

--- a/worker/httpserver/manifold.go
+++ b/worker/httpserver/manifold.go
@@ -38,6 +38,7 @@ type ManifoldConfig struct {
 	APIServerName     string
 	RaftEnabledName   string
 
+	AgentName            string
 	Clock                clock.Clock
 	PrometheusRegisterer prometheus.Registerer
 
@@ -68,6 +69,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.APIServerName == "" {
 		return errors.NotValidf("empty APIServerName")
+	}
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")
@@ -186,6 +190,7 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 	}
 
 	w, err := config.NewWorker(Config{
+		AgentName:            config.AgentName,
 		Clock:                config.Clock,
 		PrometheusRegisterer: config.PrometheusRegisterer,
 		Hub:                  hub,

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -66,6 +66,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.context = s.newContext(nil)
 	s.config = httpserver.ManifoldConfig{
+		AgentName:            "machine-42",
 		CertWatcherName:      "cert-watcher",
 		HubName:              "hub",
 		StateName:            "state",
@@ -182,6 +183,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.AutocertListener = nil
 
 	c.Assert(config, jc.DeepEquals, httpserver.Config{
+		AgentName:            "machine-42",
 		Clock:                s.clock,
 		PrometheusRegisterer: &s.prometheusRegisterer,
 		Hub:                  s.hub,
@@ -200,6 +202,9 @@ func (s *ManifoldSuite) TestValidate(c *gc.C) {
 		expect string
 	}
 	tests := []test{{
+		func(cfg *httpserver.ManifoldConfig) { cfg.AgentName = "" },
+		"empty AgentName not valid",
+	}, {
 		func(cfg *httpserver.ManifoldConfig) { cfg.CertWatcherName = "" },
 		"empty CertWatcherName not valid",
 	}, {
@@ -254,6 +259,7 @@ func (s *ManifoldSuite) TestStartWithRaftDisabled(c *gc.C) {
 
 func (s *ManifoldSuite) TestStartNoAutocert(c *gc.C) {
 	s.manifold = httpserver.Manifold(httpserver.ManifoldConfig{
+		AgentName:            "machine-42",
 		CertWatcherName:      "cert-watcher",
 		StateName:            "state",
 		MuxName:              "mux",


### PR DESCRIPTION
This work does two things:
 * it changes the trigger to open the api-port if the controller-api-port is set
 * adds a report for better observability in the juju_engine_report

Instead of waiting from an event from the peer grouper, the trigger is now an api connection from itself. All api connections are already published, and we know that whenever the httpserver is restarted, the api-caller will have to reconnect as its connection would have been dropped. When we get a published api connection event from ourselves, we initiate the opening of the api-port, after the configured delay of course.

To facilitate this, the agent name is now part of the manifold config. There is no need to get this immutable piece of information out of the agent worker itself.

As a drive by, the current version is added to the agent worker report, as I found myself wanting this information regularly.

## QA steps

* bootstrap lxd
* enable-ha
* `juju controller-config controller-api-port=17071`
* run the juju_engine_report on the controller machines

## Bug reference

https://bugs.launchpad.net/juju/+bug/1803484