### PR TITLE
Fix some state panics (hopefully)

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -26,7 +26,6 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
@@ -39,20 +38,9 @@ import (
 	"github.com/juju/juju/storage"
 )
 
-var watchAll = func(c *api.Client) (allWatcher, error) {
-	return c.WatchAll()
-}
-
 type allWatcher interface {
 	Next() ([]multiwatcher.Delta, error)
 	Stop() error
-}
-
-// deploymentLogger is used to notify clients about the bundle deployment
-// progress.
-type deploymentLogger interface {
-	// Infof formats and logs the given message.
-	Infof(string, ...interface{})
 }
 
 // deployBundle deploys the given bundle data using the given API client and
@@ -948,7 +936,7 @@ mainloop:
 var updateUnitStatusPeriod = watcher.Period + 5*time.Second
 
 // updateUnitStatus uses the mega-watcher to update units and machines info
-// (h.unitStatus) so that it reflects the current environment status.
+// (h.unitStatus) so that it reflects the current model status.
 // This function must be called assuming new delta changes are available or
 // will be available within the watcher time period. Otherwise, the function
 // unblocks and an error is returned.

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -26,11 +26,9 @@ import (
 	"gopkg.in/juju/charmrepo.v3"
 	"gopkg.in/juju/charmrepo.v3/csclient"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -731,16 +729,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWatcherTimeout(c *gc.C) {
 	// Inject an "AllWatcher" that never delivers a result.
 	ch := make(chan struct{})
 	defer close(ch)
-	watcher := mockAllWatcher{
-		next: func() []multiwatcher.Delta {
-			<-ch
-			return nil
-		},
-	}
-	s.PatchValue(&watchAll, func(*api.Client) (allWatcher, error) {
-		return watcher, nil
-	})
-
 	testcharms.UploadCharm(c, s.client, "xenial/django-0", "dummy")
 	testcharms.UploadCharm(c, s.client, "xenial/wordpress-0", "wordpress")
 	s.PatchValue(&updateUnitStatusPeriod, 0*time.Second)
@@ -1689,18 +1677,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleExistingMachines(c *gc.C) 
 		"django/1": "1",
 		"django/2": "3",
 	})
-}
-
-type mockAllWatcher struct {
-	next func() []multiwatcher.Delta
-}
-
-func (w mockAllWatcher) Next() ([]multiwatcher.Delta, error) {
-	return w.next(), nil
-}
-
-func (mockAllWatcher) Stop() error {
-	return nil
 }
 
 type ProcessIncludesSuite struct {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1248,6 +1248,10 @@ type backingEntityDoc interface {
 	mongoId() string
 }
 
+// newAllWatcherStateBacking returns a backing implementation
+// to service an all watcher.
+// Note: the st passed in is managed by the backing instance.
+// It must use its own session (copy) as when the backing is relased, the st is closed.
 func newAllWatcherStateBacking(st *State, params WatchParams) Backing {
 	collectionNames := []string{
 		machinesC,
@@ -1333,6 +1337,10 @@ func (b *allWatcherStateBacking) Release() error {
 	return b.st.Close()
 }
 
+// NewAllModelWatcherStateBacking returns a backing implementation
+// to service a model all watcher.
+// Note: the st passed in is managed by the backing instance.
+// It must use its own session (copy) as when the backing is relased, the st is closed.
 func NewAllModelWatcherStateBacking(st *State, pool *StatePool) Backing {
 	collections := makeAllWatcherCollectionInfo(
 		modelsC,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1334,14 +1334,18 @@ func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBacking(c *gc.C) Back
 func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBackingForState(c *gc.C, st *State) Backing {
 	pool := NewStatePool(st)
 	s.AddCleanup(func(*gc.C) { pool.Close() })
-	stCopy, err := Open(OpenParams{
-		Clock:                  st.stateClock,
-		ControllerTag:          st.controllerTag,
-		ControllerModelTag:     st.modelTag,
-		MongoSession:           st.session,
-		NewPolicy:              st.newPolicy,
-		RunTransactionObserver: st.runTransactionObserver,
-	})
+	session := st.session.Copy()
+	stCopy, err := newState(
+		st.modelTag,
+		st.controllerModelTag,
+		session,
+		st.newPolicy,
+		st.stateClock,
+		st.runTransactionObserver,
+	)
+	if err != nil {
+		session.Close()
+	}
 	c.Assert(err, jc.ErrorIsNil)
 	return NewAllModelWatcherStateBacking(stCopy, pool)
 }

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -219,7 +219,10 @@ func newStoreManager(backing Backing) *storeManager {
 func (sm *storeManager) loop() error {
 	in := make(chan watcher.Change)
 	sm.backing.Watch(in)
-	defer sm.backing.Unwatch(in)
+	defer func() {
+		sm.backing.Unwatch(in)
+		sm.backing.Release()
+	}()
 	// We have no idea what changes the watcher might be trying to
 	// send us while getAll proceeds, but we don't mind, because
 	// storeManager.changed is idempotent with respect to both updates

--- a/state/statemetrics/statemetrics.go
+++ b/state/statemetrics/statemetrics.go
@@ -4,6 +4,8 @@
 package statemetrics
 
 import (
+	"runtime/debug"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/prometheus/client_golang/prometheus"
@@ -133,6 +135,12 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *Collector) updateMetrics() {
+	defer func() {
+		if panicResult := recover(); panicResult != nil {
+			logger.Errorf("state metrics could not be updated, state probably closed:\n%v", string(debug.Stack()))
+		}
+	}()
+
 	logger.Tracef("updating state metrics")
 	defer logger.Tracef("updated state metrics")
 

--- a/state/workers.go
+++ b/state/workers.go
@@ -176,14 +176,15 @@ func (ws *workers) allManager(params WatchParams) *storeManager {
 		// from the state pool, so create a copy here and use that to guard against
 		// the possibility that the system state may be closed elsewhere.
 		// The state copy is closed then the store manager is released.
-		stCopy, err := Open(OpenParams{
-			Clock:                  ws.state.stateClock,
-			ControllerTag:          ws.state.controllerTag,
-			ControllerModelTag:     ws.state.modelTag,
-			MongoSession:           ws.state.session,
-			NewPolicy:              ws.state.newPolicy,
-			RunTransactionObserver: ws.state.runTransactionObserver,
-		})
+		session := ws.state.session.Copy()
+		stCopy, err := newState(
+			ws.state.modelTag,
+			ws.state.controllerModelTag,
+			session,
+			ws.state.newPolicy,
+			ws.state.stateClock,
+			ws.state.runTransactionObserver,
+		)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -210,14 +211,15 @@ func (ws *workers) allModelManager(pool *StatePool) *storeManager {
 		// from the state pool, so create a copy here and use that to guard against
 		// the possibility that the system state may be closed elsewhere.
 		// The state copy is closed then the store manager is released.
-		stCopy, err := Open(OpenParams{
-			Clock:                  ws.state.stateClock,
-			ControllerTag:          ws.state.controllerTag,
-			ControllerModelTag:     ws.state.modelTag,
-			MongoSession:           ws.state.session,
-			NewPolicy:              ws.state.newPolicy,
-			RunTransactionObserver: ws.state.runTransactionObserver,
-		})
+		session := ws.state.session.Copy()
+		stCopy, err := newState(
+			ws.state.modelTag,
+			ws.state.controllerModelTag,
+			session,
+			ws.state.newPolicy,
+			ws.state.stateClock,
+			ws.state.runTransactionObserver,
+		)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

Some panics were observed on a heavily loaded system. Examining the code appeared to show a couple of places where the underlying database connection could be closed before the code that was using it. These holes have been optimistically plugged as it's hard to reproduce the issue.

As a driveby, remove some unused code. And ensure errors are checked when starting state workers.

## QA steps

bootstrap, start the gui, deploy some charms, observed the logs, ensure gui works
destroy a model, ensure that completes

## Bug reference

https://bugs.launchpad.net/bugs/1803629
