### PR TITLE
vsphere: add enable-disk-uuid model config setting

### DIFF
--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -15,6 +15,7 @@ const (
 	cfgPrimaryNetwork  = "primary-network"
 	cfgExternalNetwork = "external-network"
 	cfgDatastore       = "datastore"
+	cfgEnableDiskUUID  = "enable-disk-uuid"
 )
 
 // configFields is the spec for each vmware config value's type.
@@ -23,12 +24,14 @@ var (
 		cfgExternalNetwork: schema.String(),
 		cfgDatastore:       schema.String(),
 		cfgPrimaryNetwork:  schema.String(),
+		cfgEnableDiskUUID:  schema.Bool(),
 	}
 
 	configDefaults = schema.Defaults{
 		cfgExternalNetwork: "",
 		cfgDatastore:       schema.Omit,
 		cfgPrimaryNetwork:  schema.Omit,
+		cfgEnableDiskUUID:  true,
 	}
 
 	configRequiredFields  = []string{}
@@ -90,6 +93,10 @@ func (c *environConfig) datastore() string {
 func (c *environConfig) primaryNetwork() string {
 	network, _ := c.attrs[cfgPrimaryNetwork].(string)
 	return network
+}
+
+func (c *environConfig) enableDiskUUID() bool {
+	return c.attrs[cfgEnableDiskUUID].(bool)
 }
 
 // validate checks vmware-specific config values.

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -25,6 +25,7 @@ func fakeConfigAttrs(attrs ...testing.Attrs) testing.Attrs {
 		"type":             "vsphere",
 		"uuid":             "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
 		"external-network": "",
+		"enable-disk-uuid": true,
 	})
 	for _, attrs := range attrs {
 		merged = merged.Merge(attrs)

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -227,6 +227,7 @@ func (env *sessionEnviron) newRawInstance(
 		UpdateProgress:         updateProgress,
 		UpdateProgressInterval: updateProgressInterval,
 		Clock:                  clock.WallClock,
+		EnableDiskUUID:         env.ecfg.enableDiskUUID(),
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -133,6 +133,7 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 		Metadata:               startInstArgs.InstanceConfig.Tags,
 		ComputeResource:        s.client.computeResources[0],
 		UpdateProgressInterval: 5 * time.Second,
+		EnableDiskUUID:         true,
 	})
 
 	ovaLocation, ovaReadCloser, err := readOVA()
@@ -189,6 +190,25 @@ func (s *environBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
 	c.Assert(createVMArgs.Folder, gc.Equals,
 		`Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/Model "supercalifragilisticexpialidociou" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
 	)
+}
+
+func (s *environBrokerSuite) TestStartInstanceDiskUUIDDisabled(c *gc.C) {
+	env, err := s.provider.Open(environs.OpenParams{
+		Cloud: fakeCloudSpec(),
+		Config: fakeConfig(c, coretesting.Attrs{
+			"enable-disk-uuid":   false,
+			"image-metadata-url": s.imageServer.URL,
+		}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.NotNil)
+
+	call := s.client.Calls()[1]
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
+	c.Assert(createVMArgs.EnableDiskUUID, gc.Equals, false)
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithUnsupportedConstraints(c *gc.C) {

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -100,6 +100,10 @@ type CreateVirtualMachineParams struct {
 
 	// Clock is used for controlling the timing of progress updates.
 	Clock clock.Clock
+
+	// EnableDiskUUID controls whether the VMware disk should expose a
+	// consistent UUID to the guest OS.
+	EnableDiskUUID bool
 }
 
 // CreateVirtualMachine creates and powers on a new VM.
@@ -324,6 +328,10 @@ func (c *Client) createImportSpec(
 			Reservation: &cpuPower,
 		}
 	}
+	if s.Flags == nil {
+		s.Flags = &types.VirtualMachineFlagInfo{}
+	}
+	s.Flags.DiskUuidEnabled = &args.EnableDiskUUID
 	if err := c.addRootDisk(s, args, datastore, vmdkDatastorePath); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -133,6 +133,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 				ExtraConfig: []types.BaseOptionValue{
 					&types.OptionValue{Key: "k", Value: "v"},
 				},
+				Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
 			},
 		}}},
 		{"CreatePropertyCollector", nil},
@@ -164,6 +165,24 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		{"CreatePropertyCollector", nil},
 		{"CreateFilter", nil},
 		{"WaitForUpdatesEx", nil},
+	})
+}
+
+func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.EnableDiskUUID = false
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCall(c, 26, "ImportVApp", &types.VirtualMachineImportSpec{
+		ConfigSpec: types.VirtualMachineConfigSpec{
+			Name: "vm-name.tmp",
+			ExtraConfig: []types.BaseOptionValue{
+				&types.OptionValue{Key: "k", Value: "v"},
+			},
+			Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(false)},
+		},
 	})
 }
 
@@ -298,6 +317,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 					Device:    &networkDevice2,
 				},
 			},
+			Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
 		},
 	})
 }
@@ -344,6 +364,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 					Device:    &networkDevice,
 				},
 			},
+			Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
 		},
 	})
 }
@@ -452,6 +473,7 @@ func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 		UpdateProgress:         func(status string) {},
 		UpdateProgressInterval: time.Second,
 		Clock:                  testclock.NewClock(time.Time{}),
+		EnableDiskUUID:         true,
 	}
 }
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -57,6 +57,7 @@ type StateBackend interface {
 	MigrateStorageMachineIdFields() error
 	MigrateAddModelPermissions() error
 	LegacyLeases(time.Time) (map[lease.Key]lease.Info, error)
+	SetEnableDiskUUIDOnVsphere() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -213,4 +214,8 @@ func (s stateBackend) LeaseNotifyTarget(w io.Writer, logger raftleasestore.Logge
 
 func (s stateBackend) LegacyLeases(localTime time.Time) (map[lease.Key]lease.Info, error) {
 	return state.LegacyLeases(s.pool, localTime)
+}
+
+func (s stateBackend) SetEnableDiskUUIDOnVsphere() error {
+	return state.SetEnableDiskUUIDOnVsphere(s.pool)
 }

--- a/upgrades/steps_25.go
+++ b/upgrades/steps_25.go
@@ -25,5 +25,12 @@ func stateStepsFor25() []Step {
 				return context.State().MigrateAddModelPermissions()
 			},
 		},
+		&upgradeStep{
+			description: "set enable-disk-uuid (if on vsphere)",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().SetEnableDiskUUIDOnVsphere()
+			},
+		},
 	}
 }

--- a/upgrades/steps_25_test.go
+++ b/upgrades/steps_25_test.go
@@ -37,3 +37,9 @@ func (s *steps25Suite) TestMigrateAddModelPermissions(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps25Suite) TestSetEnableDiskUUIDOnVsphere(c *gc.C) {
+	step := findStateStep(c, v25, `set enable-disk-uuid (if on vsphere)`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
## Description of change
By default VMs created in vsphere don't expose consistent disk UUIDs to the guest OS - this means that k8s (for example) deployed into a vsphere model can't use the vsphere storage features. This can be changed by setting disk.EnableUUID=true on the VM, but we don't want to force that in all situations since in some cases operators might need it to be off: https://kb.vmware.com/s/article/2146204

This PR adds model config option enable-disk-uuid to the vsphere provider - it defaults to true, but can still be set to false if the operator needs to use vsphere features that require it to be off.

Since machines in existing models will have the underlying VM config option set to false (by default), an upgrade step sets enable-disk-uuid=false when upgrading to 2.5 to be consistent.

## QA steps

* Bootstrap a vsphere controller and add an application. The machines created in the controller model and default model should have `disk.EnableUUID=true` in the VM config options in the vsphere console. `enable-disk-uuid` should default to false in the model-config output.
* Bootstrap another controller with `--config="enable-disk-uuid=false" - the machines in that controller should have `disk.EnableUUID=false`.
* Bootstrap a 2.4.x controller in vsphere and upgrade it to a version with this change. The model-config option should be set to false, and new machines created in the model should get `disk.EnableUUID` set to false.

## Documentation changes

* Yes - this new option will need to be documented. A key point to make is that the setting will be applied to new machines in the model, but changing the value won't go and change the VM setting on existing machines - doing this would require stopping and starting the VM, so it needs to be done by the operator.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1751858
