### PR TITLE
fixed unreleased pooledState when getting model failed

### DIFF
--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -31,7 +31,8 @@ func (p *statePoolShim) Get(modelUUID string) (Backend, func(), error) {
 	}
 	model, err := st.Model()
 	if err != nil {
-		return stateShim{}, closer, err
+		closer()
+		return nil, nil, err
 	}
 	return stateShim{st.State, model}, closer, err
 }

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -151,6 +151,7 @@ func (st modelManagerStateShim) GetBackend(modelUUID string) (ModelManagerBacken
 	}
 	otherModel, err := otherState.Model()
 	if err != nil {
+		otherState.Release()
 		return nil, nil, err
 	}
 	return modelManagerStateShim{otherState.State, otherModel, st.pool}, otherState.Release, nil

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -52,12 +52,10 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 	st := c.backend
 	if modelTag != c.backend.ModelTag() {
 		otherSt, releaser, err := c.backend.GetBackend(modelTag.Id())
-		if releaser != nil {
-			defer releaser()
-		}
 		if err != nil {
 			return status, errors.Trace(err)
 		}
+		defer releaser()
 		st = otherSt
 	}
 

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -52,10 +52,12 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 	st := c.backend
 	if modelTag != c.backend.ModelTag() {
 		otherSt, releaser, err := c.backend.GetBackend(modelTag.Id())
+		if releaser != nil {
+			defer releaser()
+		}
 		if err != nil {
 			return status, errors.Trace(err)
 		}
-		defer releaser()
 		st = otherSt
 	}
 

--- a/state/pool.go
+++ b/state/pool.go
@@ -256,13 +256,13 @@ func (p *StatePool) openState(modelUUID string) (*State, error) {
 func (p *StatePool) GetModel(modelUUID string) (*Model, PoolHelper, error) {
 	ps, err := p.Get(modelUUID)
 	if err != nil {
-		return nil, ps, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
 	model, err := ps.Model()
 	if err != nil {
 		ps.Release()
-		return nil, ps, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
 	return model, ps, nil

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -273,8 +273,7 @@ func (w *modelStateWorker) loop() error {
 	st, err := w.pool.Get(w.modelUUID)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// poolItem is marked as removed, try to remove it from pool.
-			w.pool.Remove(w.modelUUID)
+			// ignore not found error here, because the pooledState has already been removed.
 			return nil
 		}
 		return errors.Trace(err)

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -272,6 +272,11 @@ func newModelStateWorker(
 func (w *modelStateWorker) loop() error {
 	st, err := w.pool.Get(w.modelUUID)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// poolItem is marked as removed, try to remove it from pool.
+			w.pool.Remove(w.modelUUID)
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	defer func() {


### PR DESCRIPTION
## Description of change

fixed `unreleased` pooledState when getting model failed which is causing uncleared cached state in statepool even the model has been destroyed.

## QA steps

1. prepare a model and deploy some workload;
2. run `juju destroy-model <model-name> --debug --release-storage`;
3. jump into the controller: `juju ssh -m <controller-name>:controller 0`;
4. run `juju_statepool_report` to see if the removed model still have been removed from the state pool and does not have any goroutine refererence.

* Before this fix: 
```
ubuntu@juju-bc7b54-0:~$ juju_statepool_report
Querying @jujud-machine-0 introspection socket: /statepool
State Pool Report:

Model count: 1 models
Marked for removal: 1 models


Model: 2187cbe4-73c4-48d7-8836-f3012f41e288
  Marked for removal: true
  Reference count: 1
    [1]
goroutine 10098 [running]:
runtime/debug.Stack(0x2eb40a0, 0xc0005ff980, 0xc002927656)
	/snap/go/3039/src/runtime/debug/stack.go:24 +0xa7
github.com/juju/juju/state.(*StatePool).Get(0xc0005ff9b0, 0xc002927656, 0x24, 0x0, 0x0, 0x0)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/state/pool.go:212 +0x12f
github.com/juju/juju/apiserver/common.modelManagerStateShim.GetBackend(0xc00041c210, 0xc003570000, 0xc0005ff9b0, 0xc002927656, 0x24, 0xc00041c210, 0xc003570000, 0xc0005ff9b0, 0xc00050b086, 0x24)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/apiserver/common/modelmanagerinterface.go:148 +0x49
github.com/juju/juju/apiserver/common.(*ModelStatusAPI).modelStatus(0xc0019c3440, 0xc002927650, 0x2a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/apiserver/common/modelstatus.go:54 +0xab5
github.com/juju/juju/apiserver/common.(*ModelStatusAPI).ModelStatus(0xc0019c3440, 0xc001f842c0, 0x1, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/apiserver/common/modelstatus.go:36 +0xfb
reflect.Value.call(0x347b160, 0xc00323f400, 0x2613, 0x35c46a5, 0x4, 0xc00399c680, 0x1, 0x1, 0x9f80e1, 0x2df67e0, ...)
	/snap/go/3039/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x347b160, 0xc00323f400, 0x2613, 0xc00399c680, 0x1, 0x1, 0x1, 0x1, 0xc000496000)
	/snap/go/3039/src/reflect/value.go:308 +0xa4
github.com/juju/juju/rpc/rpcreflect.newMethod.func8(0x3b54d20, 0xc003c9d580, 0x347b160, 0xc00323f400, 0x16, 0x300dfc0, 0xc003c72500, 0x199, 0x42d7e2, 0xc000000000, ...)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/rpc/rpcreflect/type.go:344 +0x109
github.com/juju/juju/apiserver.(*srvCaller).Call(0xc001f84280, 0x3b54d20, 0xc003c9d580, 0x0, 0x0, 0x300dfc0, 0xc003c72500, 0x199, 0xc003c724e0, 0x1a332f9f, ...)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/apiserver/root.go:158 +0xd6
github.com/juju/juju/rpc.(*Conn).runRequest(0xc00323ed20, 0x3b416a0, 0xc001f84280, 0x3719c90, 0x1e, 0xc003ffe940, 0xc, 0x5, 0x0, 0x0, ...)
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/rpc/server.go:560 +0x1ab
created by github.com/juju/juju/rpc.(*Conn).handleRequest
	/home/kelvinliu/Code/Golang/src/github.com/juju/juju/rpc/server.go:467 +0x8f9
```

* Now:
```
ubuntu@juju-bc7b54-0:~$ juju_statepool_report
Querying @jujud-machine-0 introspection socket: /statepool
State Pool Report:

Model count: 0 models
Marked for removal: 0 models
```

## Documentation changes

Bug fix, no document change is required.
