### PR TITLE
Replace '.' with '-' when creating bridge name to avoid confict with VLANs

### DIFF
--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -180,14 +180,16 @@ var skippedDeviceNames = set.NewStrings(
 // 2. Add b- to device name, if it doesn't fit in 15 characters then:
 // 3a. For devices starting in 'en' remove 'en' and add 'b-'
 // 3b. For all other devices 'b-' + 6-char hash of name + '-' + last 6 chars of name
+// 4. If using the device name directly always replace '.' with '-', to make sure that bridges from VLANs won't break
 func BridgeNameForDevice(device string) string {
+	device = strings.Replace(device, ".", "-", -1)
 	switch {
 	case len(device) < 13:
-		return fmt.Sprintf("br-%s", device)
+		return fmt.Sprintf("br-%s", strings.Replace(device, ".", "-", -1))
 	case len(device) == 13:
-		return fmt.Sprintf("b-%s", device)
+		return fmt.Sprintf("b-%s", strings.Replace(device, ".", "-", -1))
 	case device[:2] == "en":
-		return fmt.Sprintf("b-%s", device[2:])
+		return fmt.Sprintf("b-%s", strings.Replace(device[2:], ".", "-", -1))
 	default:
 		hash := crc32.Checksum([]byte(device), crc32.IEEETable) & 0xffffff
 		return fmt.Sprintf("b-%0.6x-%s", hash, device[len(device)-6:])

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -1145,6 +1145,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNetworkingMet
 
 var bridgeNames = map[string]string{
 	"eno0":            "br-eno0",
+	"enovlan.123":     "br-enovlan-123",
 	"twelvechars0":    "br-twelvechars0",
 	"thirteenchars":   "b-thirteenchars",
 	"enfourteenchar":  "b-fourteenchar",


### PR DESCRIPTION
## Description of change
Creating bridge br-device.123 for VLANed device.123 can confuse network scripts, avoid it by replacing '.' with '-' in generated bridge name.

## QA steps
Described in bug report

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1804018