### PR TITLE
Remove "oracle" and "oci" clouds from juju add-cloud's interactive prompt

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -33,26 +33,63 @@ type CloudMetadataStore interface {
 }
 
 var usageAddCloudSummary = `
-Adds a user-defined cloud to Juju from among known cloud types.`[1:]
+Adds a cloud definition to Juju.
+`[1:]
 
 var usageAddCloudDetails = `
+Juju needs to know how to connect to clouds. A cloud definition 
+describes a cloud's endpoints and authentication requirements. Each
+definition is stored and accessed later as <cloud name>.
+
+If you are accessing a public cloud, running add-cloud unlikely to be 
+necessary.  Juju already contains definitions for the public cloud 
+providers it supports.
+
+add-cloud operates in two modes:
+
+    juju add-cloud
+    juju add-cloud <cloud name> <cloud definition file>
+
+When invoked without arguments, add-cloud begins an interactive session
+designed for working with private clouds.  The session will enable you 
+to instruct Juju how to connect to your private cloud.
+
+When <cloud definition file> is provided with <cloud name>, 
+Juju stores that definition its internal cache directly after 
+validating the contents.
+
+If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
+flag is required.
+
 A cloud definition file has the following YAML format:
 
-clouds:
-  mycloud:
-    type: openstack
+clouds:                           # mandatory
+  mycloud:                        # <cloud name> argument
+    type: openstack               # <cloud type>, see below
     auth-types: [ userpass ]
     regions:
       london:
         endpoint: https://london.mycloud.com:35574/v3.0/
 
-If the named cloud already exists, the `[1:] + "`--replace`" + ` option is required to 
-overwrite its configuration.
-Known cloud types: azure, cloudsigma, ec2, gce, joyent, lxd, maas, manual,
-openstack, rackspace
+<cloud types> for private clouds: 
+ - lxd
+ - maas
+ - manual
+ - openstack
+ - vsphere
+
+<cloud types> for public clouds:
+ - azure
+ - cloudsigma
+ - ec2
+ - gce
+ - joyent
+ - oci
 
 Examples:
+    juju add-cloud
     juju add-cloud mycloud ~/mycloud.yaml
+    juju add-cloud --replace mycloud ~/mycloud2.yaml
 
 See also: 
     clouds`
@@ -108,7 +145,7 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 // SetFlags initializes the flags supported by the command.
 func (c *AddCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.Replace, "replace", false, "Overwrite any existing cloud information")
+	f.BoolVar(&c.Replace, "replace", false, "Overwrite any existing cloud information for <cloud name>")
 	f.StringVar(&c.CloudFile, "f", "", "The path to a cloud definition file")
 }
 

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -323,9 +323,7 @@ func (*addSuite) TestInteractive(c *gc.C) {
 		"  lxd\n"+
 		"  maas\n"+
 		"  manual\n"+
-		"  oci\n"+
 		"  openstack\n"+
-		"  oracle\n"+
 		"  vsphere\n"+
 		"\n"+
 		"Select cloud type: \n",

--- a/provider/oci/provider.go
+++ b/provider/oci/provider.go
@@ -41,26 +41,26 @@ type environConfig struct {
 var _ config.ConfigSchemaSource = (*EnvironProvider)(nil)
 var _ environs.ProviderSchema = (*EnvironProvider)(nil)
 
-var cloudSchema = &jsonschema.Schema{
-	Type:     []jsonschema.Type{jsonschema.ObjectType},
-	Required: []string{cloud.RegionsKey, cloud.AuthTypesKey},
-	Order:    []string{cloud.RegionsKey, cloud.AuthTypesKey},
-	Properties: map[string]*jsonschema.Schema{
-		cloud.RegionsKey: {
-			Type:     []jsonschema.Type{jsonschema.ObjectType},
-			Singular: "region",
-			Plural:   "regions",
-			AdditionalProperties: &jsonschema.Schema{
-				Type: []jsonschema.Type{jsonschema.ObjectType},
-			},
-		},
-		cloud.AuthTypesKey: {
-			// don't need a prompt, since there's only one choice.
-			Type: []jsonschema.Type{jsonschema.ArrayType},
-			Enum: []interface{}{[]string{string(cloud.HTTPSigAuthType)}},
-		},
-	},
-}
+// var cloudSchema = &jsonschema.Schema{
+// 	Type:     []jsonschema.Type{jsonschema.ObjectType},
+// 	Required: []string{cloud.RegionsKey, cloud.AuthTypesKey},
+// 	Order:    []string{cloud.RegionsKey, cloud.AuthTypesKey},
+// 	Properties: map[string]*jsonschema.Schema{
+// 		cloud.RegionsKey: {
+// 			Type:     []jsonschema.Type{jsonschema.ObjectType},
+// 			Singular: "region",
+// 			Plural:   "regions",
+// 			AdditionalProperties: &jsonschema.Schema{
+// 				Type: []jsonschema.Type{jsonschema.ObjectType},
+// 			},
+// 		},
+// 		cloud.AuthTypesKey: {
+// 			// don't need a prompt, since there's only one choice.
+// 			Type: []jsonschema.Type{jsonschema.ArrayType},
+// 			Enum: []interface{}{[]string{string(cloud.HTTPSigAuthType)}},
+// 		},
+// 	},
+// }
 
 var configSchema = environschema.Fields{
 	"compartment-id": {
@@ -188,7 +188,7 @@ func (e EnvironProvider) Version() int {
 
 // CloudSchema implements environs.EnvironProvider.
 func (e EnvironProvider) CloudSchema() *jsonschema.Schema {
-	return cloudSchema
+	return nil
 }
 
 // Ping implements environs.EnvironProvider.

--- a/provider/oracle/export_test.go
+++ b/provider/oracle/export_test.go
@@ -12,7 +12,6 @@ var (
 	DefaultStorageProviderType = oracleStorageProviderType
 	OracleVolumeType           = oracleVolumeType
 	OracleLatencyPool          = latencyPool
-	OracleCloudSchema          = cloudSchema
 	OracleCredentials          = credentials
 	NewOracleVolumeSource      = newOracleVolumeSource
 	NewOracleInstance          = newInstance

--- a/provider/oracle/provider.go
+++ b/provider/oracle/provider.go
@@ -28,27 +28,9 @@ type EnvironProvider struct{}
 
 var _ environs.CloudEnvironProvider = (*EnvironProvider)(nil)
 
-var cloudSchema = &jsonschema.Schema{
-	Type:     []jsonschema.Type{jsonschema.ObjectType},
-	Required: []string{cloud.EndpointKey, cloud.AuthTypesKey},
-	Order:    []string{cloud.EndpointKey, cloud.AuthTypesKey},
-	Properties: map[string]*jsonschema.Schema{
-		cloud.EndpointKey: {
-			Singular: "the API endpoint url for the cloud",
-			Type:     []jsonschema.Type{jsonschema.StringType},
-			Format:   jsonschema.FormatURI,
-		},
-		cloud.AuthTypesKey: {
-			// don't need a prompt, since there's only one choice.
-			Type: []jsonschema.Type{jsonschema.ArrayType},
-			Enum: []interface{}{[]string{string(cloud.UserPassAuthType)}},
-		},
-	},
-}
-
 // CloudSchema is defined on the environs.EnvironProvider interface.
 func (e EnvironProvider) CloudSchema() *jsonschema.Schema {
-	return cloudSchema
+	return nil
 }
 
 // Ping implements environs.EnvironProvider.

--- a/provider/oracle/provider_test.go
+++ b/provider/oracle/provider_test.go
@@ -32,8 +32,7 @@ func (e *environProviderSuite) NewProvider(c *gc.C) environs.EnvironProvider {
 func (e *environProviderSuite) TestCloudSchma(c *gc.C) {
 	provider := e.NewProvider(c)
 	schema := provider.CloudSchema()
-	c.Assert(schema, gc.NotNil)
-	c.Assert(schema, jc.DeepEquals, oracle.OracleCloudSchema)
+	c.Assert(schema, gc.IsNil)
 }
 
 func (e *environProviderSuite) TestPing(c *gc.C) {


### PR DESCRIPTION
This commit removes the "oracle" cloud from `juju add-cloud`'s list of clouds supported by the interactive setup.

----

## QA steps

Run `juju add-cloud`

Expect to see:

```
Cloud Types
 lxd
 maas
 manual
 openstack
 vsphere

Select cloud type:
````

## Documentation changes

Change to Juju CLI: Running `juju add-cloud` no longer presents `oracle` as an option.

Rationale: Oracle Cloud Infrastructure (OCI) is now the favored cloud for Juju developers. Oracle's public cloud offering has been renamed "Oracle Classic" in their documentation. Accordingly, within Juju, the "oracle" cloud has been deprecated in favor of the "oci" cloud provider. 



## Bug reference

https://bugs.launchpad.net/juju/+bug/1802540