### PR TITLE
Include an mgo patch to filter txn-queue during Insert and Remove

### DIFF
--- a/patches/mgo_6_insert_remove_pr4.diff
+++ b/patches/mgo_6_insert_remove_pr4.diff
@@ -1,0 +1,131 @@
+--- a/gopkg.in/mgo.v2/txn/flusher.go	2018-11-20 09:30:38.194598846 +0000
++++ b/gopkg.in/mgo.v2/txn/flusher.go	2018-11-20 09:34:29.163063296 +0000
+@@ -831,12 +831,13 @@
+ 					updated := false
+ 					if !hasToken(stash.Queue, tt) {
+ 						var set, unset bson.D
++						cleanedQueue := filterQueue(info.Queue, pull, tt)
+ 						if revno == 0 {
+ 							// Missing revno in stash means -1.
+-							set = bson.D{{"txn-queue", info.Queue}}
++							set = bson.D{{"txn-queue", cleanedQueue}}
+ 							unset = bson.D{{"n", 1}, {"txn-revno", 1}}
+ 						} else {
+-							set = bson.D{{"txn-queue", info.Queue}, {"txn-revno", newRevno}}
++							set = bson.D{{"txn-queue", cleanedQueue}, {"txn-revno", newRevno}}
+ 							unset = bson.D{{"n", 1}}
+ 						}
+ 						qdoc := bson.D{{"_id", dkey}, {"n", nonce}}
+@@ -872,7 +873,12 @@
+ 				var info txnInfo
+ 				if _, err = f.sc.Find(qdoc).Apply(change, &info); err == nil {
+ 					f.debugf("Stash for document %v has revno %d and queue: %v", dkey, info.Revno, info.Queue)
+-					d = setInDoc(d, bson.D{{"_id", op.Id}, {"txn-revno", newRevno}, {"txn-queue", info.Queue}})
++					cleanedQueue := filterQueue(info.Queue, pull, tt)
++					d = setInDoc(d, bson.D{
++						{"_id", op.Id},
++						{"txn-revno", newRevno},
++						{"txn-queue", cleanedQueue},
++					})
+ 					// Unlikely yet unfortunate race in here if this gets seriously
+ 					// delayed. If someone inserts+removes meanwhile, this will
+ 					// reinsert, and there's no way to avoid that while keeping the
+@@ -894,7 +900,7 @@
+ 				}
+ 			}
+ 		case op.Assert != nil:
+-			// Pure assertion. No changes to apply.
++			// Pure assertion. No updates to apply, but check if we should clear out the txn-queue.
+ 			if f.opts.AssertionCleanupLength > 0 && len(pullAll) >= f.opts.AssertionCleanupLength {
+ 				chaos("")
+ 				err = c.Update(qdoc, bson.D{{"$pullAll", bson.D{{"txn-queue", pullAll}}}})
+@@ -970,6 +976,24 @@
+ 	return result
+ }
+ 
++// filterQueue takes an existing queue and removes all the items in pull from it. The returned slice will only contain
++// items that aren't in 'pull'.
++func filterQueue(queue []token, pull map[bson.ObjectId]*transaction, dontPull token) []token {
++	cleaned := make([]token, 0, len(queue))
++	for _, tt := range queue {
++		if tt == dontPull {
++			cleaned = append(cleaned, tt)
++			continue
++		}
++		txnId := tt.id()
++		if _, ok := pull[txnId]; !ok {
++			// shouldn't be pulled, so add it to the cleaned queue
++			cleaned = append(cleaned, tt)
++		}
++	}
++	return cleaned
++}
++
+ func objToDoc(obj interface{}) (d bson.D, err error) {
+ 	data, err := bson.Marshal(obj)
+ 	if err != nil {
+--- a/gopkg.in/mgo.v2/txn/txn_test.go	2018-11-20 09:30:38.198598923 +0000
++++ b/gopkg.in/mgo.v2/txn/txn_test.go	2018-11-20 09:35:18.256015277 +0000
+@@ -18,6 +18,8 @@
+ 	TestingT(t)
+ }
+ 
++var fast = flag.Bool("fast", false, "Skip slow tests")
++
+ type S struct {
+ 	server   dbtest.DBServer
+ 	session  *mgo.Session
+@@ -578,6 +580,9 @@
+ }
+ 
+ func (s *S) TestTxnQueueStashStressTest(c *C) {
++	if *fast {
++		c.Skip("-fast was supplied and this test is slow")
++	}
+ 	txn.SetChaos(txn.Chaos{
+ 		SlowdownChance: 0.3,
+ 		Slowdown:       50 * time.Millisecond,
+@@ -1032,6 +1037,11 @@
+ 
+ func (s *S) TestTxnQueueAssertionGrowth(c *C) {
+ 	txn.SetDebug(false) // too much spam
++	opts := txn.DefaultRunnerOptions()
++	// Disable automatic cleanup of queue, so that we can see the queue
++	// properly cleared on update.
++	opts.AssertionCleanupLength = 0
++	s.runner.SetOptions(opts)
+ 	err := s.accounts.Insert(M{"_id": 0, "balance": 0})
+ 	c.Assert(err, IsNil)
+ 	// Create many assertion only transactions.
+@@ -1139,3 +1149,31 @@
+ 	c.Check(len(qdoc.Queue), Equals, expectedCount)
+ }
+ 
++func (s *S) TestTxnQueueAddAndRemove(c *C) {
++	opts := txn.DefaultRunnerOptions()
++	opts.MaxTxnQueueLength = 10
++	s.runner.SetOptions(opts)
++	opInsert := []txn.Op{{
++		C:      "accounts",
++		Id:     0,
++		Insert: M{"balance": 0},
++	}}
++	opRemove := []txn.Op{{
++		C:      "accounts",
++		Id:     0,
++		Remove: true,
++	}}
++	err := s.runner.Run(opInsert, "", nil)
++	c.Assert(err, IsNil)
++	for n := 0; n < 10; n++ {
++		err = s.runner.Run(opRemove, "", nil)
++		c.Assert(err, IsNil)
++		err = s.runner.Run(opInsert, "", nil)
++		c.Assert(err, IsNil)
++	}
++	var qdoc txnQueue
++	err = s.accounts.FindId(0).One(&qdoc)
++	c.Assert(err, IsNil)
++	// Both Remove and Insert should prune all the completed transactions
++	c.Check(len(qdoc.Queue), Equals, 1)
++}


### PR DESCRIPTION
## Description of change

This is the patch from
  https://github.com/juju/mgo/pull/4
  https://github.com/globalsign/mgo/pull/301

It filters the txn-queue when copying a document from or to the stash,
just like we would do during a normal Update operation. This prevents a
sequence of Insert + Remove pairs from filling up the txn-queue.

## QA steps

The associated test shows the basic change. To trigger this manually you can:

```
$ juju bootstrap lxd
$ while true; do juju deploy cs:~jameinel/ubuntu-lite; sleep 90; juju remove-application ubuntu-lite; sleep 30 done
```

While doing that, you should be able to go into the juju controller and either
```
> db.constraints.find()
> db.txns.stash.find({"_id.c": "constraints"})
```
And see that there is a document whose txn-queue is growing quite large. With this patch, the txn-queue should stay around 1 or 2 entries.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804197
