### PR TITLE
Remove dead URLs from source code comments and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ juju
 
 juju is devops distilled.
 
-Juju enables you to use [Charms](https://jujucharms.com/docs/stable/charms) to deploy your
+Juju enables you to use [Charms](https://docs.jujucharms.com/stable/en/charms) to deploy your
 application architectures to EC2, OpenStack, Azure, GCE, your data center, and
 even your own Ubuntu based laptop.  Moving between models is simple giving you
 the flexibility to switch hosts whenever you want — for free.
 
-For more information, see the [docs](https://jujucharms.com/docs/stable/getting-started).
+For more information, see the [docs](https://docs.jujucharms.com/stable/en/getting-started).
 
 Getting started
 ===============

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/hook.template
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/hook.template
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-broken
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-broken
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-changed
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-changed
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-departed
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-departed
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-joined
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/mysql-relation-joined
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-broken
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-broken
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-changed
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-changed
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-departed
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-departed
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-joined
+++ b/acceptancetests/repository/charms/caas-gitlab/hooks/pgsql-relation-joined
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-mysql/hooks/hook.template
+++ b/acceptancetests/repository/charms/caas-mysql/hooks/hook.template
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-broken
+++ b/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-broken
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-changed
+++ b/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-changed
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-departed
+++ b/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-departed
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-joined
+++ b/acceptancetests/repository/charms/caas-mysql/hooks/server-relation-joined
@@ -11,8 +11,5 @@ basic.init_config_states()
 # This will load and run the appropriate @hook and other decorated
 # handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
 # and $JUJU_CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/authors-charm-building
-# for more information on this pattern.
 from charms.reactive import main
 main()

--- a/acceptancetests/repository/charms/lxd-profile/metadata.yaml
+++ b/acceptancetests/repository/charms/lxd-profile/metadata.yaml
@@ -9,7 +9,6 @@ provides:
 extra-bindings:
   another:
 tags:
-  # https://jujucharms.com/docs/stable/authors-charm-metadata
   - misc
   - application_development
 subordinate: false

--- a/doc/logging.txt
+++ b/doc/logging.txt
@@ -9,7 +9,7 @@ Accessing logs as a user
 Please consult the available user documentation for details of how to
 access Juju's logs. Specifically:
 
-  * https://jujucharms.com/docs/devel/troubleshooting-logs
+  * https://docs.jujucharms.com/stable/en/troubleshooting-logs
   * juju help logging
   * juju help debug-log
   * juju-dumplogs --help

--- a/scripts/jujuman.py
+++ b/scripts/jujuman.py
@@ -175,7 +175,7 @@ Records the UUIDs of all models known to Juju.
 .I "~/.local/share/juju/ssh/"
 A directory containing the SSH credentials for the Juju client.
 .SH "SEE ALSO"
-.UR https://jujucharms.com/docs
-.BR https://jujucharms.com/docs
+.UR https://docs.jujucharms.com/
+.BR https://docs.jujucharms.com/
 """
 

--- a/scripts/win-installer/README.txt
+++ b/scripts/win-installer/README.txt
@@ -13,8 +13,8 @@ Amazon EC2, Google Compute Engine, or an OpenStack installation.
 in a directory called '.ssh' in your home directory. There are instructions on
 how to generate these keys at:
 
-    https://jujucharms.com/docs/stable/getting-started-keygen-win
+    https://docs.jujucharms.com/stable/en/getting-started-keygen-win
 
 To continue, please follow the online documentation at:
 
-    https://jujucharms.com/docs/stable/getting-started-other
+    https://docs.jujucharms.com/stable/en/getting-started

--- a/testcharms/charm-repo/quantal/lxd-profile-alt/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-alt/metadata.yaml
@@ -9,7 +9,6 @@ provides:
 extra-bindings:
   another:
 tags:
-  # https://jujucharms.com/docs/stable/authors-charm-metadata
   - misc
   - application_development
 subordinate: false

--- a/testcharms/charm-repo/quantal/lxd-profile-fail/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-fail/metadata.yaml
@@ -10,7 +10,6 @@ provides:
 extra-bindings:
   another:
 tags:
-  # https://jujucharms.com/docs/stable/authors-charm-metadata
   - misc
   - application_development
 subordinate: false

--- a/testcharms/charm-repo/quantal/lxd-profile-subordinate-fail/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-subordinate-fail/metadata.yaml
@@ -4,7 +4,6 @@ maintainer: Juju QA
 description: |
   Run an Ubuntu system, with the given subordinate lxd-profile
 tags:
-  # https://jujucharms.com/docs/stable/authors-charm-metadata
   - misc
   - application_development
 subordinate: true

--- a/testcharms/charm-repo/quantal/lxd-profile-subordinate/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-subordinate/metadata.yaml
@@ -4,7 +4,6 @@ maintainer: Juju QA
 description: |
   Run an Ubuntu system, with the given subordinate lxd-profile
 tags:
-  # https://jujucharms.com/docs/stable/authors-charm-metadata
   - misc
   - application_development
 subordinate: true

--- a/testcharms/charm-repo/quantal/lxd-profile/metadata.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile/metadata.yaml
@@ -9,7 +9,6 @@ provides:
 extra-bindings:
   another:
 tags:
-  # https://jujucharms.com/docs/stable/authors-charm-metadata
   - misc
   - application_development
 subordinate: false

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -176,7 +176,7 @@ tmux kill-session -t $JUJU_UNIT_NAME # or, equivalently, CTRL+a d
 4. CTRL+a is tmux prefix.
 
 More help and info is available in the online documentation:
-https://jujucharms.com/docs/authors-hook-debug.html
+https://docs.jujucharms.com/stable/en/developer-debugging#the-'debug-hooks'-command
 
 `
 


### PR DESCRIPTION
This commit removes references to jujucharms.com/docs, replacing them with
their counterpart in docs.jujucharms.com or deleting them.

----

## Description of change

There are a few dozen references to pages within jujucharms.com/docs. They no longer exist, and users face an HTTP 404 when attempting to visit them.

## QA steps

n/a

## Bug reference

fixes https://bugs.launchpad.net/juju/+bug/1792202
fixes https://bugs.launchpad.net/juju/+bug/1784701