### PR TITLE
Feature/add storage data to juju status

### DIFF
--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -28,40 +28,12 @@ type FullStatus struct {
 	RemoteApplications  map[string]RemoteApplicationStatus `json:"remote-applications"`
 	Offers              map[string]ApplicationOfferStatus  `json:"offers"`
 	Relations           []RelationStatus                   `json:"relations"`
-	Storage             []CombinedStorageInfo              `json:"combined-storage-info"`
 	ControllerTimestamp *time.Time                         `json:"controller-timestamp"`
 }
-
-// TODO
-type CombinedStorageInfo struct{}
 
 // IsEmpty checks all collections on FullStatus to determine if the status is empty.
 // Note that only the collections are checked here as Model information will always be populated.
 func (fs *FullStatus) IsEmpty() bool {
-	return len(fs.Applications) == 0 &&
-		len(fs.Machines) == 0 &&
-		len(fs.Offers) == 0 &&
-		len(fs.RemoteApplications) == 0 &&
-		len(fs.Relations) == 0 &&
-		len(fs.Storage) == 0
-}
-
-// FullStatusV1 holds information about the status of a juju model.
-// V1 is missing Storage.
-type FullStatusV1 struct {
-	Model               ModelStatusInfo                    `json:"model"`
-	Machines            map[string]MachineStatus           `json:"machines"`
-	Applications        map[string]ApplicationStatus       `json:"applications"`
-	RemoteApplications  map[string]RemoteApplicationStatus `json:"remote-applications"`
-	Offers              map[string]ApplicationOfferStatus  `json:"offers"`
-	Relations           []RelationStatus                   `json:"relations"`
-	ControllerTimestamp *time.Time                         `json:"controller-timestamp"`
-}
-
-// IsEmpty checks all collections on FullStatusV1 to determine if the status is empty.
-// Note that only the collections are checked here as Model information will always be populated.
-// V1 does not check Storage.
-func (fs *FullStatusV1) IsEmpty() bool {
 	return len(fs.Applications) == 0 &&
 		len(fs.Machines) == 0 &&
 		len(fs.Offers) == 0 &&

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -28,12 +28,40 @@ type FullStatus struct {
 	RemoteApplications  map[string]RemoteApplicationStatus `json:"remote-applications"`
 	Offers              map[string]ApplicationOfferStatus  `json:"offers"`
 	Relations           []RelationStatus                   `json:"relations"`
+	Storage             []CombinedStorageInfo              `json:"combined-storage-info"`
 	ControllerTimestamp *time.Time                         `json:"controller-timestamp"`
 }
+
+// TODO
+type CombinedStorageInfo struct{}
 
 // IsEmpty checks all collections on FullStatus to determine if the status is empty.
 // Note that only the collections are checked here as Model information will always be populated.
 func (fs *FullStatus) IsEmpty() bool {
+	return len(fs.Applications) == 0 &&
+		len(fs.Machines) == 0 &&
+		len(fs.Offers) == 0 &&
+		len(fs.RemoteApplications) == 0 &&
+		len(fs.Relations) == 0 &&
+		len(fs.Storage) == 0
+}
+
+// FullStatusV1 holds information about the status of a juju model.
+// V1 is missing Storage.
+type FullStatusV1 struct {
+	Model               ModelStatusInfo                    `json:"model"`
+	Machines            map[string]MachineStatus           `json:"machines"`
+	Applications        map[string]ApplicationStatus       `json:"applications"`
+	RemoteApplications  map[string]RemoteApplicationStatus `json:"remote-applications"`
+	Offers              map[string]ApplicationOfferStatus  `json:"offers"`
+	Relations           []RelationStatus                   `json:"relations"`
+	ControllerTimestamp *time.Time                         `json:"controller-timestamp"`
+}
+
+// IsEmpty checks all collections on FullStatusV1 to determine if the status is empty.
+// Note that only the collections are checked here as Model information will always be populated.
+// V1 does not check Storage.
+func (fs *FullStatusV1) IsEmpty() bool {
 	return len(fs.Applications) == 0 &&
 		len(fs.Machines) == 0 &&
 		len(fs.Offers) == 0 &&

--- a/apiserver/restrict_migrations.go
+++ b/apiserver/restrict_migrations.go
@@ -30,6 +30,12 @@ var allowedMethodsDuringMigration = map[string]set.Strings{
 	"Client": set.NewStrings(
 		"FullStatus", // for "juju status"
 	),
+	"Storage": set.NewStrings(
+		// for "juju status --storage"
+		"ListFilesystems",
+		"ListVolumes",
+		"ListStorageDetails",
+	),
 	"SSHClient": set.NewStrings( // allow all SSH client related calls
 		"PublicAddress",
 		"PrivateAddress",

--- a/cmd/juju/status/export_test.go
+++ b/cmd/juju/status/export_test.go
@@ -6,6 +6,7 @@ package status
 import (
 	"github.com/juju/cmd"
 
+	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -13,7 +14,7 @@ func NewTestStatusHistoryCommand(api HistoryAPI) cmd.Command {
 	return &statusHistoryCommand{api: api}
 }
 
-func NewTestStatusCommand(api statusAPI, clock Clock) cmd.Command {
+func NewTestStatusCommand(statusapi statusAPI, storageapi storage.StorageListAPI, clock Clock) cmd.Command {
 	return modelcmd.Wrap(
-		&statusCommand{api: api, clock: clock})
+		&statusCommand{statusAPI: statusapi, storageAPI: storageapi, clock: clock})
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/instance"
 )
@@ -20,6 +21,7 @@ type formattedStatus struct {
 	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
 	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
 	Relations          []relationStatus                   `json:"-" yaml:"-"`
+	Storage            *storage.CombinedStorage           `json:"storage,omitempty" yaml:"storage,omitempty"`
 	Controller         *controllerStatus                  `json:"controller,omitempty" yaml:"controller,omitempty"`
 }
 
@@ -226,10 +228,10 @@ func (s *formattedStatus) applicationScale(name string) (string, bool) {
 
 	app := s.Applications[name]
 	match := func(u unitStatus) {
-		desiredUnitCount += 1
+		desiredUnitCount++
 		switch u.JujuStatusInfo.Current {
 		case status.Executing, status.Idle, status.Running:
-			currentUnitCount += 1
+			currentUnitCount++
 		}
 	}
 	// If the app is subordinate to other units, then this is a subordinate charm.

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -20,11 +20,11 @@ import (
 )
 
 type statusFormatter struct {
-	status                              *params.FullStatus
-	controllerName                      string
-	relations                           map[int]params.RelationStatus
-	storage                             *storage.CombinedStorage
-	isoTime, showRelations, showStorage bool
+	status                 *params.FullStatus
+	controllerName         string
+	relations              map[int]params.RelationStatus
+	storage                *storage.CombinedStorage
+	isoTime, showRelations bool
 }
 
 // NewStatusFormatter takes stored model information (params.FullStatus) and populates
@@ -39,10 +39,10 @@ func NewStatusFormatter(status *params.FullStatus, isoTime bool) *statusFormatte
 }
 
 type newStatusFormatterParams struct {
-	storage                             *storage.CombinedStorage
-	status                              *params.FullStatus
-	controllerName                      string
-	isoTime, showRelations, showStorage bool
+	storage                *storage.CombinedStorage
+	status                 *params.FullStatus
+	controllerName         string
+	isoTime, showRelations bool
 }
 
 func newStatusFormatter(p newStatusFormatterParams) *statusFormatter {
@@ -53,7 +53,6 @@ func newStatusFormatter(p newStatusFormatterParams) *statusFormatter {
 		relations:      make(map[int]params.RelationStatus),
 		isoTime:        p.isoTime,
 		showRelations:  p.showRelations,
-		showStorage:    p.showStorage,
 	}
 	if p.showRelations {
 		for _, relation := range p.status.Relations {
@@ -117,7 +116,7 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 		out.Relations[i] = sf.formatRelation(rel)
 		i++
 	}
-	if sf.showStorage {
+	if sf.storage != nil {
 		out.Storage = sf.storage
 	}
 	return out, nil

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -30,7 +30,6 @@ type statusFormatter struct {
 // NewStatusFormatter takes stored model information (params.FullStatus) and populates
 // the statusFormatter struct used in various status formatting methods
 func NewStatusFormatter(status *params.FullStatus, isoTime bool) *statusFormatter {
-	// return newStatusFormatter(status, "", isoTime, true, false)
 	return newStatusFormatter(
 		newStatusFormatterParams{
 			status:        status,
@@ -47,7 +46,6 @@ type newStatusFormatterParams struct {
 }
 
 func newStatusFormatter(p newStatusFormatterParams) *statusFormatter {
-	logger.Criticalf("newStatusFormatter.newStatusFormatterParams -> %+v", p)
 	sf := statusFormatter{
 		storage:        p.storage,
 		status:         p.status,

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -29,10 +29,11 @@ type statusFormatter struct {
 // NewStatusFormatter takes stored model information (params.FullStatus) and populates
 // the statusFormatter struct used in various status formatting methods
 func NewStatusFormatter(status *params.FullStatus, isoTime bool) *statusFormatter {
-	return newStatusFormatter(status, "", isoTime, true)
+	return newStatusFormatter(status, "", isoTime, true, false)
 }
 
-func newStatusFormatter(status *params.FullStatus, controllerName string, isoTime, showRelations bool) *statusFormatter {
+func newStatusFormatter(status *params.FullStatus, controllerName string, isoTime, showRelations, showStorage bool) *statusFormatter {
+	logger.Criticalf("newStatusFormatter.showStorage -> %t", showStorage)
 	sf := statusFormatter{
 		status:         status,
 		controllerName: controllerName,

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -20,10 +20,10 @@ import (
 )
 
 type statusFormatter struct {
-	storage                             *storage.CombinedStorage
 	status                              *params.FullStatus
 	controllerName                      string
 	relations                           map[int]params.RelationStatus
+	storage                             *storage.CombinedStorage
 	isoTime, showRelations, showStorage bool
 }
 

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/juju/charm.v6/hooks"
 
 	cmdcrossmodel "github.com/juju/juju/cmd/juju/crossmodel"
+	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/relation"
@@ -92,6 +93,11 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 
 	if len(fs.Relations) > 0 {
 		printRelations(tw, fs.Relations)
+	}
+
+	if fs.Storage != nil {
+		fmt.Fprintln(tw)
+		storage.FormatListTabularAll(tw, *fs.Storage)
 	}
 
 	endSection(tw)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -96,8 +96,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	if fs.Storage != nil {
-		fmt.Fprintln(tw)
-		storage.FormatListTabularAll(tw, *fs.Storage)
+		storage.FormatStorageListForStatusTabular(tw, *fs.Storage)
 	}
 
 	endSection(tw)

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -8,15 +8,19 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 
+	storageapi "github.com/juju/juju/api/storage"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju/osenv"
 )
@@ -32,7 +36,7 @@ type statusAPI interface {
 // runtime state of various system entities.
 func NewStatusCommand() cmd.Command {
 	return modelcmd.Wrap(&statusCommand{
-		relationsFlagProvidedF: func() bool { return false },
+		checkProvidedIgnoredFlagF: func() set.Strings { return set.NewStrings() },
 	})
 }
 
@@ -43,11 +47,12 @@ type Clock interface {
 
 type statusCommand struct {
 	modelcmd.ModelCommandBase
-	out      cmd.Output
-	patterns []string
-	isoTime  bool
-	api      statusAPI
-	clock    Clock
+	out        cmd.Output
+	patterns   []string
+	isoTime    bool
+	statusAPI  statusAPI
+	storageAPI storage.StorageListAPI
+	clock      Clock
 
 	retryCount int
 	retryDelay time.Duration
@@ -57,8 +62,11 @@ type statusCommand struct {
 	// relations indicates if 'relations' section is displayed
 	relations bool
 
-	// relationsFlagProvidedF indicates whether 'relations' option was provided by the user.
-	relationsFlagProvidedF func() bool
+	// checkProvidedIgnoredFlagF indicates whether ignored options were provided by the user.
+	checkProvidedIgnoredFlagF func() set.Strings
+
+	// storage indicates if 'storage' section is displayed
+	storage bool
 }
 
 var usageSummary = `
@@ -81,7 +89,8 @@ section will only contain the applications that have units on these machines, et
 The available output formats are:
 
 - tabular (default): Displays status in a tabular format with a separate table
-      for the model, machines, applications, relations (if any) and units.
+	  for the model, machines, applications, relations (if any), storage (if any) 
+	  and units.
       Note: in this format, the AZ column refers to the cloud region's
       availability zone.
 - {short|line|oneline}: List units and their subordinates. For each unit, the IP
@@ -104,7 +113,8 @@ Examples:
     juju show-status
     juju show-status mysql
     juju show-status nova-*
-    juju show-status --relations
+	juju show-status --relations
+	juju show-status --storage
 
 See also:
     machines
@@ -129,16 +139,22 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.color, "color", false, "Force use of ANSI color codes")
 
 	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section")
+	f.BoolVar(&c.storage, "storage", false, "Show 'storage' section")
 
 	f.IntVar(&c.retryCount, "retry-count", 3, "Number of times to retry API failures")
 	f.DurationVar(&c.retryDelay, "retry-delay", 100*time.Millisecond, "Time to wait between retry attempts")
 
-	c.relationsFlagProvidedF = func() bool {
-		provided := false
+	c.checkProvidedIgnoredFlagF = func() set.Strings {
+		ignoredFlagForNonTabularFormat := set.NewStrings(
+			"relations",
+			"storage",
+		)
+		provided := set.NewStrings()
 		f.Visit(func(flag *gnuflag.Flag) {
-			if flag.Name == "relations" {
-				provided = true
+			if ignoredFlagForNonTabularFormat.Contains(flag.Name) {
+				provided.Add(flag.Name)
 			}
+
 		})
 		return provided
 	}
@@ -176,10 +192,25 @@ func (c *statusCommand) Init(args []string) error {
 }
 
 var newAPIClientForStatus = func(c *statusCommand) (statusAPI, error) {
-	if c.api != nil {
-		return c.api, nil
+	if c.statusAPI == nil {
+		api, err := c.NewAPIClient()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		c.statusAPI = api
 	}
-	return c.NewAPIClient()
+	return c.statusAPI, nil
+}
+
+var newAPIClientForStorage = func(c *statusCommand) (storage.StorageListAPI, error) {
+	if c.storageAPI == nil {
+		root, err := c.NewAPIRoot()
+		if err != nil {
+			return nil, err
+		}
+		c.storageAPI = storageapi.NewClient(root)
+	}
+	return c.storageAPI, nil
 }
 
 func (c *statusCommand) getStatus() (*params.FullStatus, error) {
@@ -190,6 +221,24 @@ func (c *statusCommand) getStatus() (*params.FullStatus, error) {
 	defer apiclient.Close()
 
 	return apiclient.Status(c.patterns)
+}
+
+func (c *statusCommand) getStorageInfo(ctx *cmd.Context) (*storage.CombinedStorage, error) {
+	apiclient, err := newAPIClientForStorage(c)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer apiclient.Close()
+
+	return storage.GetCombinedStorageInfo(
+		storage.GetCombinedStorageInfoParams{
+			Context:         ctx,
+			APIClient:       apiclient,
+			Ids:             []string{},
+			WantStorage:     true,
+			WantVolumes:     true,
+			WantFilesystems: true,
+		})
 }
 
 func (c *statusCommand) Run(ctx *cmd.Context) error {
@@ -222,16 +271,30 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	showRelations := true
+	showRelations := c.relations
+	showStorage := c.storage
 	if c.out.Name() != "tabular" {
-		if c.relationsFlagProvidedF() {
+		showRelations = true
+		showStorage = true
+		providedIgnoredFlags := c.checkProvidedIgnoredFlagF()
+		if !providedIgnoredFlags.IsEmpty() {
 			// For non-tabular formats this is redundant and needs to be mentioned to the user.
-			ctx.Infof("provided --relations option is ignored")
+			joinedMsg := strings.Join(providedIgnoredFlags.Values(), ", ")
+			if providedIgnoredFlags.Size() > 1 {
+				joinedMsg += " options are"
+			} else {
+				joinedMsg += " option is"
+			}
+			ctx.Infof("provided %s always enabled in non tabular formats.", joinedMsg)
 		}
-	} else {
-		showRelations = c.relations
 	}
-	formatter := newStatusFormatter(status, controllerName, c.isoTime, showRelations)
+	storageInfo, err := c.getStorageInfo(ctx)
+	if err != nil {
+		return err
+	}
+	logger.Criticalf("storageInfo -> \n%+v", storageInfo)
+
+	formatter := newStatusFormatter(status, controllerName, c.isoTime, showRelations, showStorage)
 	formatted, err := formatter.format()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -301,7 +301,7 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 			} else {
 				joinedMsg += " option is"
 			}
-			ctx.Infof("provided %s always enabled in non tabular formats.", joinedMsg)
+			ctx.Infof("provided %s always enabled in non tabular formats", joinedMsg)
 		}
 	}
 	formatterParams := newStatusFormatterParams{

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -113,8 +113,8 @@ Examples:
     juju show-status
     juju show-status mysql
     juju show-status nova-*
-	juju show-status --relations
-	juju show-status --storage
+    juju show-status --relations
+    juju show-status --storage
 
 See also:
     machines
@@ -254,7 +254,7 @@ func (c *statusCommand) getStorageInfo(ctx *cmd.Context) (*storage.CombinedStora
 func (c *statusCommand) Run(ctx *cmd.Context) error {
 	defer func() {
 		if err := c.close(); err != nil {
-			logger.Warningf("closing api sessions %v", err)
+			logger.Warningf("closing api sessions failed %v", err)
 		}
 	}()
 

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -295,7 +295,7 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		providedIgnoredFlags := c.checkProvidedIgnoredFlagF()
 		if !providedIgnoredFlags.IsEmpty() {
 			// For non-tabular formats this is redundant and needs to be mentioned to the user.
-			joinedMsg := strings.Join(providedIgnoredFlags.Values(), ", ")
+			joinedMsg := strings.Join(providedIgnoredFlags.SortedValues(), ", ")
 			if providedIgnoredFlags.Size() > 1 {
 				joinedMsg += " options are"
 			} else {
@@ -309,7 +309,6 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		controllerName: controllerName,
 		isoTime:        c.isoTime,
 		showRelations:  showRelations,
-		showStorage:    showStorage,
 	}
 	if showStorage {
 		storageInfo, err := c.getStorageInfo(ctx)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -519,6 +519,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -565,6 +566,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -607,6 +609,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -650,6 +653,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -701,6 +705,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -734,6 +739,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -763,6 +769,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -792,6 +799,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -819,6 +827,7 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedApplication,
 					"exposed-application": unexposedApplication,
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -838,6 +847,7 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedApplication,
 					"exposed-application": exposedApplication,
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -866,6 +876,7 @@ var statusTests = []testCase{
 					"dummy-application":   unexposedApplication,
 					"exposed-application": exposedApplication,
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -945,6 +956,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1080,6 +1092,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1117,6 +1130,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1158,6 +1172,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1193,6 +1208,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1234,6 +1250,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1296,6 +1313,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1403,6 +1421,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1510,6 +1529,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1566,6 +1586,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1625,6 +1646,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1832,6 +1854,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -1945,6 +1968,7 @@ var statusTests = []testCase{
 						},
 					},
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2109,6 +2133,7 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2223,6 +2248,7 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2290,6 +2316,7 @@ var statusTests = []testCase{
 					}),
 					"logging": loggingCharm,
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2380,6 +2407,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2469,6 +2497,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2530,6 +2559,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2593,6 +2623,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2658,6 +2689,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2722,6 +2754,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2874,6 +2907,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2902,6 +2936,7 @@ var statusTests = []testCase{
 				},
 				"machines":     M{},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -2964,6 +2999,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3046,6 +3082,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3073,6 +3110,7 @@ var statusTests = []testCase{
 					"0": machine0,
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3122,6 +3160,7 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3210,6 +3249,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3242,6 +3282,7 @@ var statusTests = []testCase{
 				},
 				"machines":     M{},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3270,6 +3311,7 @@ var statusTests = []testCase{
 				},
 				"machines":     M{},
 				"applications": M{},
+				"storage":      M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3397,6 +3439,7 @@ var statusTests = []testCase{
 						},
 					},
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -3460,6 +3503,7 @@ var statusTests = []testCase{
 						},
 					}),
 				},
+				"storage": M{},
 				"controller": M{
 					"timestamp": "15:04:05+07:00",
 				},
@@ -4416,6 +4460,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 		},
 		"machines":     M{},
 		"applications": M{},
+		"storage":      M{},
 		"controller": M{
 			"timestamp": "15:04:05+07:00",
 		},
@@ -5215,6 +5260,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 		"    hardware: arch=amd64 cores=1 mem=1024M root-disk=8192M\n" +
 		"    controller-member-status: adding-vote\n" +
 		"applications: {}\n" +
+		"storage: {}\n" +
 		"controller:\n" +
 		"  timestamp: 15:04:05+07:00\n"
 
@@ -5523,6 +5569,7 @@ var statusTimeTest = test(
 					},
 				}),
 			},
+			"storage": M{},
 			"controller": M{
 				"timestamp": "15:04:05",
 			},
@@ -5708,8 +5755,30 @@ func (s *StatusSuite) TestNonTabularDisplayRelations(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	_, stdout, stderr := runStatus(c, "--format=yaml", "--relations")
-	c.Assert(string(stderr), gc.Equals, "provided --relations option is ignored\n")
+	c.Assert(string(stderr), gc.Equals, "provided relations option is always enabled in non tabular formats\n")
+	logger.Criticalf("stdout -> \n%q", stdout)
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
+}
+
+func (s *StatusSuite) TestNonTabularDisplayStorage(c *gc.C) {
+	ctx := s.FilteringTestSetup(c)
+	defer s.resetContext(c, ctx)
+
+	_, stdout, stderr := runStatus(c, "--format=yaml", "--storage")
+	c.Assert(string(stderr), gc.Equals, "provided storage option is always enabled in non tabular formats\n")
+	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
+}
+
+func (s *StatusSuite) TestNonTabularDisplayRelationsAndStorage(c *gc.C) {
+	ctx := s.FilteringTestSetup(c)
+	defer s.resetContext(c, ctx)
+
+	_, stdout, stderr := runStatus(c, "--format=yaml", "--relations", "--storage")
+	c.Assert(string(stderr), gc.Equals, "provided relations, storage options are always enabled in non tabular formats\n")
+	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
 }
 
 func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
@@ -5719,6 +5788,7 @@ func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
 	_, stdout, stderr := runStatus(c, "--format=yaml")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
 }
 
 func (s *StatusSuite) TestStatusFormatTabularEmptyModel(c *gc.C) {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -64,7 +64,7 @@ func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
 test   test        foo           
 
-Unit          Storage id    Type        Pool      Mountpoint  Size    Status    Message
+Storage Unit  Storage id    Type        Pool      Mountpoint  Size    Status    Message
               persistent/1  filesystem                                detached  
 postgresql/0  db-dir/1100   block                             3.0MiB  attached  
 transcode/0   db-dir/1000   block                                     pending   creating volume

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -64,7 +64,7 @@ func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
 test   test        foo           
 
-Unit          Storage Id    Type        Pool      Mountpoint  Size    Status    Message
+Unit          Storage id    Type        Pool      Mountpoint  Size    Status    Message
               persistent/1  filesystem                                detached  
 postgresql/0  db-dir/1100   block                             3.0MiB  attached  
 transcode/0   db-dir/1000   block                                     pending   creating volume

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -14,21 +14,23 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/status"
+	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
 )
 
 type MinimalStatusSuite struct {
 	testing.BaseSuite
 
-	api   *fakeStatusAPI
-	clock *timeRecorder
+	statusapi  *fakeStatusAPI
+	storageapi *mockListStorageAPI
+	clock      *timeRecorder
 }
 
 var _ = gc.Suite(&MinimalStatusSuite{})
 
 func (s *MinimalStatusSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.api = &fakeStatusAPI{
+	s.statusapi = &fakeStatusAPI{
 		result: &params.FullStatus{
 			Model: params.ModelStatusInfo{
 				Name:     "test",
@@ -36,12 +38,13 @@ func (s *MinimalStatusSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
+	s.storageapi = &mockListStorageAPI{}
 	s.clock = &timeRecorder{}
 	s.SetModelAndController(c, "test", "admin/test")
 }
 
 func (s *MinimalStatusSuite) runStatus(c *gc.C, args ...string) (*cmd.Context, error) {
-	statusCmd := status.NewTestStatusCommand(s.api, s.clock)
+	statusCmd := status.NewTestStatusCommand(s.statusapi, s.storageapi, s.clock)
 	return cmdtesting.RunCommand(c, statusCmd, args...)
 }
 
@@ -51,8 +54,28 @@ func (s *MinimalStatusSuite) TestGoodCall(c *gc.C) {
 	c.Assert(s.clock.waits, gc.HasLen, 0)
 }
 
+func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
+	context, err := s.runStatus(c, "--storage")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.clock.waits, gc.HasLen, 0)
+
+	obtainedValid := cmdtesting.Stdout(context)
+	c.Assert(obtainedValid, gc.Equals, `
+Model  Controller  Cloud/Region  Version
+test   test        foo           
+
+Unit          Storage Id    Type        Pool      Mountpoint  Size    Status    Message
+              persistent/1  filesystem                                detached  
+postgresql/0  db-dir/1100   block                             3.0MiB  attached  
+transcode/0   db-dir/1000   block                                     pending   creating volume
+transcode/0   shared-fs/0   filesystem  radiance              1.0GiB  attached  
+transcode/1   shared-fs/0   filesystem  radiance              1.0GiB  attached  
+
+`[1:])
+}
+
 func (s *MinimalStatusSuite) TestRetryOnError(c *gc.C) {
-	s.api.errors = []error{
+	s.statusapi.errors = []error{
 		errors.New("boom"),
 		errors.New("splat"),
 	}
@@ -65,7 +88,7 @@ func (s *MinimalStatusSuite) TestRetryOnError(c *gc.C) {
 }
 
 func (s *MinimalStatusSuite) TestRetryDelays(c *gc.C) {
-	s.api.errors = []error{
+	s.statusapi.errors = []error{
 		errors.New("boom"),
 		errors.New("splat"),
 	}
@@ -77,7 +100,7 @@ func (s *MinimalStatusSuite) TestRetryDelays(c *gc.C) {
 }
 
 func (s *MinimalStatusSuite) TestRetryCount(c *gc.C) {
-	s.api.errors = []error{
+	s.statusapi.errors = []error{
 		errors.New("error 1"),
 		errors.New("error 2"),
 		errors.New("error 3"),
@@ -95,7 +118,7 @@ func (s *MinimalStatusSuite) TestRetryCount(c *gc.C) {
 }
 
 func (s *MinimalStatusSuite) TestRetryCountOfZero(c *gc.C) {
-	s.api.errors = []error{
+	s.statusapi.errors = []error{
 		errors.New("error 1"),
 		errors.New("error 2"),
 		errors.New("error 3"),
@@ -139,4 +162,392 @@ func (r *timeRecorder) After(d time.Duration) <-chan time.Time {
 		close(r.result)
 	}
 	return r.result
+}
+
+type mockListStorageAPI struct {
+	listErrors      bool
+	listFilesystems func([]string) ([]params.FilesystemDetailsListResult, error)
+	listVolumes     func([]string) ([]params.VolumeDetailsListResult, error)
+	omitPool        bool
+	time            time.Time
+}
+
+func (s *mockListStorageAPI) Close() error {
+	return nil
+}
+
+func (s *mockListStorageAPI) ListStorageDetails() ([]params.StorageDetails, error) {
+	if s.listErrors {
+		return nil, errors.New("list fails")
+	}
+	results := []params.StorageDetails{{
+		StorageTag: "storage-db-dir-1000",
+		OwnerTag:   "unit-transcode-0",
+		Kind:       params.StorageKindBlock,
+		Status: params.EntityStatus{
+			Status: corestatus.Pending,
+			Since:  &s.time,
+			Info:   "creating volume",
+		},
+		Attachments: map[string]params.StorageAttachmentDetails{
+			"unit-transcode-0": {
+				Location: "thither",
+			},
+		},
+	}, {
+		StorageTag: "storage-db-dir-1100",
+		OwnerTag:   "unit-postgresql-0",
+		Kind:       params.StorageKindBlock,
+		Life:       "dying",
+		Status: params.EntityStatus{
+			Status: corestatus.Attached,
+			Since:  &s.time,
+		},
+		Persistent: true,
+		Attachments: map[string]params.StorageAttachmentDetails{
+			"unit-postgresql-0": {
+				Location: "hither",
+				Life:     "dying",
+			},
+		},
+	}, {
+		StorageTag: "storage-shared-fs-0",
+		OwnerTag:   "application-transcode",
+		Kind:       params.StorageKindFilesystem,
+		Status: params.EntityStatus{
+			Status: corestatus.Attached,
+			Since:  &s.time,
+		},
+		Persistent: true,
+		Attachments: map[string]params.StorageAttachmentDetails{
+			"unit-transcode-0": {
+				Location: "there",
+			},
+			"unit-transcode-1": {
+				Location: "here",
+			},
+		},
+	}, {
+		StorageTag: "storage-persistent-1",
+		Kind:       params.StorageKindFilesystem,
+		Status: params.EntityStatus{
+			Status: corestatus.Detached,
+			Since:  &s.time,
+		},
+		Persistent: true,
+	}}
+	return results, nil
+}
+
+func (s *mockListStorageAPI) ListFilesystems(machines []string) ([]params.FilesystemDetailsListResult, error) {
+	if s.listFilesystems != nil {
+		return s.listFilesystems(machines)
+	}
+	results := []params.FilesystemDetailsListResult{{Result: []params.FilesystemDetails{
+		// filesystem 0/0 is attached to machine 0, assigned to
+		// storage db-dir/1001, which is attached to unit
+		// abc/0.
+		{
+			FilesystemTag: "filesystem-0-0",
+			VolumeTag:     "volume-0-1",
+			Info: params.FilesystemInfo{
+				FilesystemId: "provider-supplied-filesystem-0-0",
+				Size:         512,
+			},
+			Life:   "alive",
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+				"machine-0": {
+					Life: "alive",
+					FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+						MountPoint: "/mnt/fuji",
+					},
+				},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-db-dir-1001",
+				OwnerTag:   "unit-abc-0",
+				Kind:       params.StorageKindBlock,
+				Life:       "alive",
+				Status:     createTestStatus(corestatus.Attached, "", s.time),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-abc-0": {
+						StorageTag: "storage-db-dir-1001",
+						UnitTag:    "unit-abc-0",
+						MachineTag: "machine-0",
+						Location:   "/mnt/fuji",
+					},
+				},
+			},
+		},
+		// filesystem 1 is attaching to machine 0, but is not assigned
+		// to any storage.
+		{
+			FilesystemTag: "filesystem-1",
+			Info: params.FilesystemInfo{
+				FilesystemId: "provider-supplied-filesystem-1",
+				Size:         2048,
+			},
+			Status: createTestStatus(corestatus.Attaching, "failed to attach, will retry", s.time),
+			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+				"machine-0": {},
+			},
+		},
+		// filesystem 3 is due to be attached to machine 1, but is not
+		// assigned to any storage and has not yet been provisioned.
+		{
+			FilesystemTag: "filesystem-3",
+			Info: params.FilesystemInfo{
+				Size: 42,
+			},
+			Status: createTestStatus(corestatus.Pending, "", s.time),
+			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+				"machine-1": {},
+			},
+		},
+		// filesystem 2 is due to be attached to machine 1, but is not
+		// assigned to any storage.
+		{
+			FilesystemTag: "filesystem-2",
+			Info: params.FilesystemInfo{
+				FilesystemId: "provider-supplied-filesystem-2",
+				Size:         3,
+			},
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+				"machine-1": {
+					FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+						MountPoint: "/mnt/zion",
+					},
+				},
+			},
+		},
+		// filesystem 4 is attached to machines 0 and 1, and is assigned
+		// to shared storage.
+		{
+			FilesystemTag: "filesystem-4",
+			Info: params.FilesystemInfo{
+				FilesystemId: "provider-supplied-filesystem-4",
+				Pool:         "radiance",
+				Size:         1024,
+			},
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			MachineAttachments: map[string]params.FilesystemAttachmentDetails{
+				"machine-0": {
+					FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+						MountPoint: "/mnt/doom",
+						ReadOnly:   true,
+					},
+				},
+				"machine-1": {
+					FilesystemAttachmentInfo: params.FilesystemAttachmentInfo{
+						MountPoint: "/mnt/huang",
+						ReadOnly:   true,
+					},
+				},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-shared-fs-0",
+				OwnerTag:   "application-transcode",
+				Kind:       params.StorageKindBlock,
+				Status:     createTestStatus(corestatus.Attached, "", s.time),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-transcode-0": {
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-0",
+						MachineTag: "machine-0",
+						Location:   "/mnt/bits",
+					},
+					"unit-transcode-1": {
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-1",
+						MachineTag: "machine-1",
+						Location:   "/mnt/pieces",
+					},
+				},
+			},
+		}, {
+			// filesystem 5 is assigned to db-dir/1100, but is not yet
+			// attached to any machines.
+			FilesystemTag: "filesystem-5",
+			Info: params.FilesystemInfo{
+				FilesystemId: "provider-supplied-filesystem-5",
+				Size:         3,
+			},
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-db-dir-1100",
+				OwnerTag:   "unit-abc-0",
+				Kind:       params.StorageKindBlock,
+				Life:       "alive",
+				Status:     createTestStatus(corestatus.Attached, "", s.time),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-abc-0": {
+						StorageTag: "storage-db-dir-1100",
+						UnitTag:    "unit-abc-0",
+						Location:   "/mnt/fuji",
+					},
+				},
+			},
+		},
+	}}}
+	if s.omitPool {
+		for _, result := range results {
+			for i, details := range result.Result {
+				details.Info.Pool = ""
+				result.Result[i] = details
+			}
+		}
+	}
+	return results, nil
+}
+
+func (s *mockListStorageAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListResult, error) {
+	if s.listVolumes != nil {
+		return s.listVolumes(machines)
+	}
+	results := []params.VolumeDetailsListResult{{Result: []params.VolumeDetails{
+		// volume 0/0 is attached to machine 0, assigned to
+		// storage db-dir/1001, which is attached to unit
+		// abc/0.
+		{
+			VolumeTag: "volume-0-0",
+			Info: params.VolumeInfo{
+				VolumeId: "provider-supplied-volume-0-0",
+				Pool:     "radiance",
+				Size:     512,
+			},
+			Life:   "alive",
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {
+					Life: "alive",
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "loop0",
+					},
+				},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-db-dir-1001",
+				OwnerTag:   "unit-abc-0",
+				Kind:       params.StorageKindBlock,
+				Life:       "alive",
+				Status:     createTestStatus(corestatus.Attached, "", s.time),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-abc-0": {
+						StorageTag: "storage-db-dir-1001",
+						UnitTag:    "unit-abc-0",
+						MachineTag: "machine-0",
+						Location:   "/dev/loop0",
+					},
+				},
+			},
+		},
+		// volume 1 is attaching to machine 0, but is not assigned
+		// to any storage.
+		{
+			VolumeTag: "volume-1",
+			Info: params.VolumeInfo{
+				VolumeId:   "provider-supplied-volume-1",
+				HardwareId: "serial blah blah",
+				Persistent: true,
+				Size:       2048,
+			},
+			Status: createTestStatus(corestatus.Attaching, "failed to attach, will retry", s.time),
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {},
+			},
+		},
+		// volume 3 is due to be attached to machine 1, but is not
+		// assigned to any storage and has not yet been provisioned.
+		{
+			VolumeTag: "volume-3",
+			Info: params.VolumeInfo{
+				Size: 42,
+			},
+			Status: createTestStatus(corestatus.Pending, "", s.time),
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-1": {},
+			},
+		},
+		// volume 2 is due to be attached to machine 1, but is not
+		// assigned to any storage and has not yet been provisioned.
+		{
+			VolumeTag: "volume-2",
+			Info: params.VolumeInfo{
+				VolumeId: "provider-supplied-volume-2",
+				Size:     3,
+			},
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-1": {
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "xvdf1",
+					},
+				},
+			},
+		},
+		// volume 4 is attached to machines 0 and 1, and is assigned
+		// to shared storage.
+		{
+			VolumeTag: "volume-4",
+			Info: params.VolumeInfo{
+				VolumeId:   "provider-supplied-volume-4",
+				Persistent: true,
+				Size:       1024,
+			},
+			Status: createTestStatus(corestatus.Attached, "", s.time),
+			MachineAttachments: map[string]params.VolumeAttachmentDetails{
+				"machine-0": {
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "xvdf2",
+						ReadOnly:   true,
+					},
+				},
+				"machine-1": {
+					VolumeAttachmentInfo: params.VolumeAttachmentInfo{
+						DeviceName: "xvdf3",
+						ReadOnly:   true,
+					},
+				},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-shared-fs-0",
+				OwnerTag:   "application-transcode",
+				Kind:       params.StorageKindBlock,
+				Status:     createTestStatus(corestatus.Attached, "", s.time),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-transcode-0": {
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-0",
+						MachineTag: "machine-0",
+						Location:   "/mnt/bits",
+					},
+					"unit-transcode-1": {
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-1",
+						MachineTag: "machine-1",
+						Location:   "/mnt/pieces",
+					},
+				},
+			},
+		},
+	}}}
+	if s.omitPool {
+		for _, result := range results {
+			for i, details := range result.Result {
+				details.Info.Pool = ""
+				result.Result[i] = details
+			}
+		}
+	}
+	return results, nil
+}
+
+func createTestStatus(testStatus corestatus.Status, message string, since time.Time) params.EntityStatus {
+	return params.EntityStatus{
+		Status: testStatus,
+		Info:   message,
+		Since:  &since,
+	}
 }

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -64,7 +64,7 @@ func generateListFilesystemsOutput(ctx *cmd.Context, api StorageListAPI, ids []s
 
 	results, err := api.ListFilesystems(ids)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	// filter out valid output, if any

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -89,7 +89,7 @@ func (s *ListSuite) TestFilesystemListWithErrorResults(c *gc.C) {
 }
 
 var expectedFilesystemListTabular = `
-Machine  Unit         Storage Id   Id   Volume  Provider id                       Mountpoint  Size    State      Message
+Machine  Unit         Storage id   Id   Volume  Provider id                       Mountpoint  Size    State      Message
 0        abc/0        db-dir/1001  0/0  0/1     provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached   
 0        transcode/0  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/doom   1.0GiB  attached   
 0                                  1            provider-supplied-filesystem-1                2.0GiB  attaching  failed to attach, will retry
@@ -116,7 +116,7 @@ func (s *ListSuite) TestFilesystemListTabular(c *gc.C) {
 }
 
 var expectedCAASFilesystemListTabular = `
-Unit     Storage Id   Id   Provider id                       Mountpoint  Size    State     Message
+Unit     Storage id   Id   Provider id                       Mountpoint  Size    State     Message
 mysql/0  db-dir/1001  0/0  provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached  
 
 `[1:]

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -89,8 +89,7 @@ func (s *ListSuite) TestFilesystemListWithErrorResults(c *gc.C) {
 }
 
 var expectedFilesystemListTabular = `
-[Filesystems]
-Machine  Unit         Storage      Id   Volume  Provider id                       Mountpoint  Size    State      Message
+Machine  Unit         Storage Id   Id   Volume  Provider id                       Mountpoint  Size    State      Message
 0        abc/0        db-dir/1001  0/0  0/1     provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached   
 0        transcode/0  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/doom   1.0GiB  attached   
 0                                  1            provider-supplied-filesystem-1                2.0GiB  attaching  failed to attach, will retry
@@ -117,8 +116,7 @@ func (s *ListSuite) TestFilesystemListTabular(c *gc.C) {
 }
 
 var expectedCAASFilesystemListTabular = `
-[Filesystems]
-Unit     Storage      Id   Provider id                       Mountpoint  Size    State     Message
+Unit     Storage Id   Id   Provider id                       Mountpoint  Size    State     Message
 mysql/0  db-dir/1001  0/0  provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached  
 
 `[1:]

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -21,7 +21,7 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("[Filesystems]")
+	// print("[Filesystems]")
 
 	haveMachines := false
 	filesystemAttachmentInfos := make(filesystemAttachmentInfos, 0, len(infos))
@@ -70,9 +70,9 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	sort.Sort(filesystemAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage Id", "Filesystem Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage", "Id", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Unit", "Storage Id", "Filesystem Id", "Provider id", "Mountpoint", "Size", "State", "Message")
 	}
 
 	for _, info := range filesystemAttachmentInfos {

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -69,9 +69,9 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	sort.Sort(filesystemAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage Id", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage id", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage Id", "Id", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Unit", "Storage id", "Id", "Provider id", "Mountpoint", "Size", "State", "Message")
 	}
 
 	for _, info := range filesystemAttachmentInfos {

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -21,7 +21,6 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	// print("[Filesystems]")
 
 	haveMachines := false
 	filesystemAttachmentInfos := make(filesystemAttachmentInfos, 0, len(infos))

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -69,9 +69,9 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	sort.Sort(filesystemAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage Id", "Filesystem Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage Id", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage Id", "Filesystem Id", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Unit", "Storage Id", "Id", "Provider id", "Mountpoint", "Size", "State", "Message")
 	}
 
 	for _, info := range filesystemAttachmentInfos {

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -187,12 +187,7 @@ func formatListTabular(writer io.Writer, value interface{}, all bool) error {
 	if len(combined.StorageInstances) > 0 {
 		// If we're listing storage in tabular format, we combine all
 		// of the information into a list of "storage".
-		if err := formatStorageInstancesListTabular(
-			writer,
-			combined.StorageInstances,
-			combined.Filesystems,
-			combined.Volumes,
-		); err != nil {
+		if err := formatStorageInstancesListTabular(writer, combined); err != nil {
 			return errors.Trace(err)
 		}
 		if !all {

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -157,7 +157,7 @@ type StorageListAPI interface {
 func generateListStorageOutput(ctx *cmd.Context, api StorageListAPI) (map[string]StorageInfo, error) {
 	results, err := api.ListStorageDetails()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if len(results) == 0 {
 		return nil, nil

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -43,7 +43,7 @@ func (s *ListSuite) TestList(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-Unit          Storage Id    Type        Pool      Size    Status    Message
+Unit          Storage id    Type        Pool      Size    Status    Message
               persistent/1  filesystem                    detached  
 postgresql/0  db-dir/1100   block                 3.0MiB  attached  
 transcode/0   db-dir/1000   block                         pending   creating volume
@@ -60,7 +60,7 @@ func (s *ListSuite) TestListNoPool(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-Unit          Storage Id    Type        Size    Status    Message
+Unit          Storage id    Type        Size    Status    Message
               persistent/1  filesystem          detached  
 postgresql/0  db-dir/1100   block       3.0MiB  attached  
 transcode/0   db-dir/1000   block               pending   creating volume

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -43,13 +43,12 @@ func (s *ListSuite) TestList(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-[Storage]
-Unit          Id            Type        Pool      Provider id                     Size    Status    Message
-              persistent/1  filesystem                                                    detached  
-postgresql/0  db-dir/1100   block                 provider-supplied-filesystem-5  3.0MiB  attached  
-transcode/0   db-dir/1000   block                                                         pending   creating volume
-transcode/0   shared-fs/0   filesystem  radiance  provider-supplied-volume-4      1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  radiance  provider-supplied-volume-4      1.0GiB  attached  
+Unit          Storage Id    Type        Pool      Size    Status    Message
+              persistent/1  filesystem                    detached  
+postgresql/0  db-dir/1100   block                 3.0MiB  attached  
+transcode/0   db-dir/1000   block                         pending   creating volume
+transcode/0   shared-fs/0   filesystem  radiance  1.0GiB  attached  
+transcode/1   shared-fs/0   filesystem  radiance  1.0GiB  attached  
 
 `[1:])
 }
@@ -61,13 +60,12 @@ func (s *ListSuite) TestListNoPool(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-[Storage]
-Unit          Id            Type        Provider id                     Size    Status    Message
-              persistent/1  filesystem                                          detached  
-postgresql/0  db-dir/1100   block       provider-supplied-filesystem-5  3.0MiB  attached  
-transcode/0   db-dir/1000   block                                               pending   creating volume
-transcode/0   shared-fs/0   filesystem  provider-supplied-volume-4      1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  provider-supplied-volume-4      1.0GiB  attached  
+Unit          Storage Id    Type        Size    Status    Message
+              persistent/1  filesystem          detached  
+postgresql/0  db-dir/1100   block       3.0MiB  attached  
+transcode/0   db-dir/1000   block               pending   creating volume
+transcode/0   shared-fs/0   filesystem  1.0GiB  attached  
+transcode/1   shared-fs/0   filesystem  1.0GiB  attached  
 
 `[1:])
 }

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -123,9 +123,9 @@ func getStoragePoolAndSize(s CombinedStorage) (map[string]string, map[string]uin
 	return storagePool, storageSize
 }
 
-func getFilesystemAttachments(combined CombinedStorage, attachmentInfo storageAttachmentInfo) FilesystemAttachment {
+func getFilesystemAttachment(combined CombinedStorage, attachmentInfo storageAttachmentInfo) FilesystemAttachment {
 	for _, f := range combined.Filesystems {
-		getAllAttachments := func() map[string]FilesystemAttachment {
+		combineAllAttachments := func() map[string]FilesystemAttachment {
 			all := map[string]FilesystemAttachment{}
 			for k, v := range f.Attachments.Machines {
 				all[k] = v
@@ -137,7 +137,7 @@ func getFilesystemAttachments(combined CombinedStorage, attachmentInfo storageAt
 		}
 
 		if f.Storage == attachmentInfo.storageId {
-			if attachment, ok := getAllAttachments()[attachmentInfo.unitId]; ok {
+			if attachment, ok := combineAllAttachments()[attachmentInfo.unitId]; ok {
 				return attachment
 			}
 		}
@@ -176,7 +176,7 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 			if len(storagePool) > 0 {
 				w.Print(storagePool[info.storageId])
 			}
-			w.Print(getFilesystemAttachments(s, info).MountPoint)
+			w.Print(getFilesystemAttachment(s, info).MountPoint)
 			w.Print(humanizeStorageSize(storageSize[storageId]))
 			w.PrintStatus(info.status.Current)
 			w.Println(info.status.Message)
@@ -201,7 +201,7 @@ type storageAttachmentInfo struct {
 	status    EntityStatus
 }
 
-// slashSeparatedIds represents a list of slash seperated ids.
+// slashSeparatedIds represents a list of slash separated ids.
 type slashSeparatedIds []string
 
 func (s slashSeparatedIds) Len() int {

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -127,10 +127,15 @@ func getFilesystemAttachment(combined CombinedStorage, attachmentInfo storageAtt
 	for _, f := range combined.Filesystems {
 		combineAllAttachments := func() map[string]FilesystemAttachment {
 			all := map[string]FilesystemAttachment{}
-			for k, v := range f.Attachments.Machines {
+			attachment := f.Attachments
+
+			if attachment == nil {
+				return all
+			}
+			for k, v := range attachment.Machines {
 				all[k] = v
 			}
-			for k, v := range f.Attachments.Containers {
+			for k, v := range attachment.Containers {
 				all[k] = v
 			}
 			return all
@@ -153,7 +158,7 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 	units, byUnit := sortStorageInstancesByUnitId(s)
 
 	w.Println()
-	w.Print("Unit", "Storage id", "Type")
+	w.Print("Storage Unit", "Storage id", "Type")
 	if len(storagePool) > 0 {
 		w.Print("Pool")
 	}

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -23,16 +23,16 @@ func formatStorageInstancesListTabular(
 ) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.Println("[Storage]")
+	// w.Println("[Storage]")
 
-	storageProviderId := make(map[string]string)
+	// storageProviderId := make(map[string]string)
 	storageSize := make(map[string]uint64)
 	storagePool := make(map[string]string)
 	for _, f := range filesystems {
 		if f.Pool != "" {
 			storagePool[f.Storage] = f.Pool
 		}
-		storageProviderId[f.Storage] = f.ProviderFilesystemId
+		// storageProviderId[f.Storage] = f.ProviderFilesystemId
 		storageSize[f.Storage] = f.Size
 	}
 	for _, v := range volumes {
@@ -41,22 +41,22 @@ func formatStorageInstancesListTabular(
 		if v.Pool != "" {
 			storagePool[v.Storage] = v.Pool
 		}
-		storageProviderId[v.Storage] = v.ProviderVolumeId
-		// For size, we want to use the size of the fileystem
+		// storageProviderId[v.Storage] = v.ProviderVolumeId
+		// For size, we want to use the size of the filesystem
 		// rather than the volume.
 		if _, ok := storageSize[v.Storage]; !ok {
 			storageSize[v.Storage] = v.Size
 		}
 	}
 
-	w.Print("Unit", "Id", "Type")
+	w.Print("Unit", "Storage Id", "Type")
 	if len(storagePool) > 0 {
 		// Older versions of Juju do not include
 		// the pool name in the storage details.
 		// We omit the column in that case.
 		w.Print("Pool")
 	}
-	w.Println("Provider id", "Size", "Status", "Message")
+	w.Println("Size", "Status", "Message")
 
 	byUnit := make(map[string]map[string]storageAttachmentInfo)
 	for storageId, storageInfo := range storageInfo {
@@ -117,7 +117,7 @@ func formatStorageInstancesListTabular(
 				w.Print(storagePool[info.storageId])
 			}
 			w.Print(
-				storageProviderId[info.storageId],
+				// storageProviderId[info.storageId],
 				sizeStr,
 			)
 			w.PrintStatus(info.status.Current)

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/juju/cmd/output"
 )
 
-// formatListTabular writes a tabular summary of storage instances.
-func formatStorageListTabular(
+// formatStorageInstancesListTabular writes a tabular summary of storage instances.
+func formatStorageInstancesListTabular(
 	writer io.Writer,
 	storageInfo map[string]StorageInfo,
 	filesystems map[string]FilesystemInfo,

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -23,7 +23,7 @@ func formatStorageInstancesListTabular(writer io.Writer, s CombinedStorage) erro
 	storagePool, storageSize := getStoragePoolAndSize(s)
 	units, byUnit := sortStorageInstancesByUnitId(s)
 
-	w.Print("Unit", "Storage Id", "Type")
+	w.Print("Unit", "Storage id", "Type")
 	if len(storagePool) > 0 {
 		// Older versions of Juju do not include
 		// the pool name in the storage details.
@@ -153,7 +153,7 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 	units, byUnit := sortStorageInstancesByUnitId(s)
 
 	w.Println()
-	w.Print("Unit", "Storage Id", "Type")
+	w.Print("Unit", "Storage id", "Type")
 	if len(storagePool) > 0 {
 		w.Print("Pool")
 	}

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -75,7 +75,7 @@ func generateListVolumeOutput(ctx *cmd.Context, api StorageListAPI, ids []string
 
 	results, err := api.ListVolumes(ids)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	// filter out valid output, if any
 	var valid []params.VolumeDetails

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -90,14 +90,13 @@ func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 }
 
 var expectedVolumeListTabular = `
-[Volumes]
-Machine  Unit         Storage      Id   Provider Id                   Device  Size    State      Message
-0        abc/0        db-dir/1001  0/0  provider-supplied-volume-0-0  loop0   512MiB  attached   
-0        transcode/0  shared-fs/0  4    provider-supplied-volume-4    xvdf2   1.0GiB  attached   
-0                                  1    provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
-1        transcode/1  shared-fs/0  4    provider-supplied-volume-4    xvdf3   1.0GiB  attached   
-1                                  2    provider-supplied-volume-2    xvdf1   3.0MiB  attached   
-1                                  3                                          42MiB   pending    
+Machine  Unit         Storage Id   Volumes Id  Provider Id                   Device  Size    State      Message
+0        abc/0        db-dir/1001  0/0         provider-supplied-volume-0-0  loop0   512MiB  attached   
+0        transcode/0  shared-fs/0  4           provider-supplied-volume-4    xvdf2   1.0GiB  attached   
+0                                  1           provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
+1        transcode/1  shared-fs/0  4           provider-supplied-volume-4    xvdf3   1.0GiB  attached   
+1                                  2           provider-supplied-volume-2    xvdf1   3.0MiB  attached   
+1                                  3                                                 42MiB   pending    
 
 `[1:]
 
@@ -119,9 +118,8 @@ func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
 }
 
 var expectedCAASVolumeListTabular = `
-[Volumes]
-Unit     Storage      Id  Provider Id                 Size    State     Message
-mysql/0  db-dir/1001  0   provider-supplied-volume-0  512MiB  attached  
+Unit     Storage Id   Volumes Id  Provider Id                 Size    State     Message
+mysql/0  db-dir/1001  0           provider-supplied-volume-0  512MiB  attached  
 
 `[1:]
 

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -90,7 +90,7 @@ func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 }
 
 var expectedVolumeListTabular = `
-Machine  Unit         Storage Id   Volumes Id  Provider Id                   Device  Size    State      Message
+Machine  Unit         Storage id   Volume id  Provider Id                   Device  Size    State      Message
 0        abc/0        db-dir/1001  0/0         provider-supplied-volume-0-0  loop0   512MiB  attached   
 0        transcode/0  shared-fs/0  4           provider-supplied-volume-4    xvdf2   1.0GiB  attached   
 0                                  1           provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
@@ -118,7 +118,7 @@ func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
 }
 
 var expectedCAASVolumeListTabular = `
-Unit     Storage Id   Volumes Id  Provider Id                 Size    State     Message
+Unit     Storage id   Volume id  Provider Id                 Size    State     Message
 mysql/0  db-dir/1001  0           provider-supplied-volume-0  512MiB  attached  
 
 `[1:]

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -91,12 +91,12 @@ func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 
 var expectedVolumeListTabular = `
 Machine  Unit         Storage id   Volume id  Provider Id                   Device  Size    State      Message
-0        abc/0        db-dir/1001  0/0         provider-supplied-volume-0-0  loop0   512MiB  attached   
-0        transcode/0  shared-fs/0  4           provider-supplied-volume-4    xvdf2   1.0GiB  attached   
-0                                  1           provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
-1        transcode/1  shared-fs/0  4           provider-supplied-volume-4    xvdf3   1.0GiB  attached   
-1                                  2           provider-supplied-volume-2    xvdf1   3.0MiB  attached   
-1                                  3                                                 42MiB   pending    
+0        abc/0        db-dir/1001  0/0        provider-supplied-volume-0-0  loop0   512MiB  attached   
+0        transcode/0  shared-fs/0  4          provider-supplied-volume-4    xvdf2   1.0GiB  attached   
+0                                  1          provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
+1        transcode/1  shared-fs/0  4          provider-supplied-volume-4    xvdf3   1.0GiB  attached   
+1                                  2          provider-supplied-volume-2    xvdf1   3.0MiB  attached   
+1                                  3                                                42MiB   pending    
 
 `[1:]
 
@@ -119,7 +119,7 @@ func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
 
 var expectedCAASVolumeListTabular = `
 Unit     Storage id   Volume id  Provider Id                 Size    State     Message
-mysql/0  db-dir/1001  0           provider-supplied-volume-0  512MiB  attached  
+mysql/0  db-dir/1001  0          provider-supplied-volume-0  512MiB  attached  
 
 `[1:]
 

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -21,7 +21,7 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("[Volumes]")
+	// print("[Volumes]")
 
 	haveMachines := false
 	volumeAttachmentInfos := make(volumeAttachmentInfos, 0, len(infos))
@@ -70,9 +70,9 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	sort.Sort(volumeAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage", "Id", "Provider Id", "Device", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage Id", "Volumes Id", "Provider Id", "Device", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage", "Id", "Provider Id", "Size", "State", "Message")
+		print("Unit", "Storage Id", "Volumes Id", "Provider Id", "Size", "State", "Message")
 	}
 
 	for _, info := range volumeAttachmentInfos {

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -69,9 +69,9 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	sort.Sort(volumeAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage Id", "Volumes Id", "Provider Id", "Device", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage id", "Volume id", "Provider Id", "Device", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage Id", "Volumes Id", "Provider Id", "Size", "State", "Message")
+		print("Unit", "Storage id", "Volume id", "Provider Id", "Size", "State", "Message")
 	}
 
 	for _, info := range volumeAttachmentInfos {

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -21,7 +21,6 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	// print("[Volumes]")
 
 	haveMachines := false
 	volumeAttachmentInfos := make(volumeAttachmentInfos, 0, len(infos))

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -133,9 +133,8 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
 	expected := `
-[Storage]
-Unit             Id      Type   Provider id  Size  Status   Message
-storage-block/0  data/0  block                     pending  
+Unit             Storage id  Type   Size  Status   Message
+storage-block/0  data/0      block        pending  
 
 `[1:]
 	runList(c, expected)
@@ -147,9 +146,8 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	// There are currently no guarantees about whether storage
 	// will be persistent until it has been provisioned.
 	expected := `
-[Storage]
-Unit             Id      Type   Provider id  Size  Status   Message
-storage-block/0  data/0  block                     pending  
+Unit             Storage id  Type   Size  Status   Message
+storage-block/0  data/0      block        pending  
 
 `[1:]
 	runList(c, expected)
@@ -471,9 +469,8 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	stdout, _, err := runVolumeList(c, "0")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-[Volumes]
-Machine  Unit             Storage  Id   Provider Id  Device  Size  State    Message
-0        storage-block/0  data/0   0/0                             pending  
+Machine  Unit             Storage id  Volume id  Provider Id  Device  Size  State    Message
+0        storage-block/0  data/0      0/0                                    pending  
 
 `[1:]
 	c.Assert(stdout, gc.Equals, expected)
@@ -592,9 +589,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	context, err := runJujuCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
-[Storage]
-Unit                  Id      Type        Provider id  Size  Status   Message
-storage-filesystem/0  data/0  filesystem                     pending  
+Unit                  Storage id  Type        Size  Status   Message
+storage-filesystem/0  data/0      filesystem        pending  
 
 `[1:])
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
@@ -614,10 +610,9 @@ storage-filesystem/0  data/0  filesystem                     pending
 	context, err = runJujuCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
-[Storage]
-Unit                  Id      Type        Provider id  Size  Status   Message
-storage-filesystem/0  data/0  filesystem                     pending  
-storage-filesystem/0  data/1  filesystem                     pending  
+Unit                  Storage id  Type        Size  Status   Message
+storage-filesystem/0  data/0      filesystem        pending  
+storage-filesystem/0  data/1      filesystem        pending  
 
 `[1:])
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
@@ -667,11 +662,10 @@ func (s *cmdStorageSuite) TestStorageDetachAttach(c *gc.C) {
 	ctx, err := runJujuCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-[Storage]
-Unit             Id         Type   Pool         Provider id  Size    Status     Message
-                 allecto/2  block  modelscoped  vol-ume      1.0GiB  detaching  
-storage-block/0  data/0     block                                    pending    
-storage-block/1  data/1     block                                    pending    
+Unit             Storage id  Type   Pool         Size    Status     Message
+                 allecto/2   block  modelscoped  1.0GiB  detaching  
+storage-block/0  data/0      block                       pending    
+storage-block/1  data/1      block                       pending    
 
 `[1:])
 
@@ -696,11 +690,10 @@ storage-block/1  data/1     block                                    pending
 	ctx, err = runJujuCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-[Storage]
-Unit             Id         Type   Pool         Provider id  Size    Status     Message
-storage-block/0  data/0     block                                    pending    
-storage-block/1  allecto/2  block  modelscoped  vol-ume      1.0GiB  attaching  
-storage-block/1  data/1     block                                    pending    
+Unit             Storage id  Type   Pool         Size    Status     Message
+storage-block/0  data/0      block                       pending    
+storage-block/1  allecto/2   block  modelscoped  1.0GiB  attaching  
+storage-block/1  data/1      block                       pending    
 
 `[1:])
 }

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -470,7 +470,7 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 Machine  Unit             Storage id  Volume id  Provider Id  Device  Size  State    Message
-0        storage-block/0  data/0      0/0                                    pending  
+0        storage-block/0  data/0      0/0                                   pending  
 
 `[1:]
 	c.Assert(stdout, gc.Equals, expected)


### PR DESCRIPTION
## Description of change

introduce storage information to status cmd;

## QA steps

1. deploy some workloads with storage;
2. `juju status --storage  -m <model-name>`;
3. `juju status --format json -m <model-name> | python -m json.tool`;
4. `juju status --format yaml -m <model-name> `;
5. `juju status --format yaml -m <model-name> --storage`;
6. `juju status --format yaml -m <model-name> --relations --storage`;

### current status example
```
Model    Controller  Cloud/Region         Version      SLA          Timestamp
default  ctrl1       localhost/localhost  2.5-beta2.1  unsupported  13:21:45+11:00

App         Version  Status   Scale  Charm       Store       Rev  OS      Notes
postgresql           waiting    0/1  postgresql  jujucharms  187  ubuntu  

Unit           Workload  Agent       Machine  Public address  Ports  Message
postgresql/1*  waiting   allocating  1        10.10.145.50           agent initializing

Machine  State    DNS           Inst id        Series  AZ  Message
1        started  10.10.145.50  juju-052c15-1  bionic      Running

Relation provider       Requirer                Interface    Type  Message
postgresql:coordinator  postgresql:coordinator  coordinator  peer  joining  
postgresql:replication  postgresql:replication  pgpeer       peer  joining  

Storage Unit  Storage id  Type        Pool  Mountpoint  Size    Status     Message
postgresql/1  pgdata/1    filesystem  lxd               100GiB  attaching  attaching filesystem 1 to machine 1: Missing device type for device 'filesystem-1'

```

## Documentation changes

Yes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1653753