### PR TITLE
2.4 Fix Cloud-Init Stanza for Disabling Network Config

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -432,6 +432,5 @@ if __name__ == "__main__":
     main()
 `
 
-const CloudInitNetworkConfigDisabled = `network:
-  config: "disabled"
+const CloudInitNetworkConfigDisabled = `config: "disabled"
 `


### PR DESCRIPTION
## Description of change

For Bionic containers (Netplan) _/var/log/cloud-init.log_ contains:
```
2018-11-21 16:26:31,173 - stages.py[DEBUG]: applying net config names for {'network': {'config': 'disabled'}}
2018-11-21 16:26:31,173 - stages.py[WARNING]: Failed to rename devices: Failed to apply network config names. Found bad network config version: None
2018-11-21 16:26:31,173 - stages.py[INFO]: Applying network configuration from ds bringup=False: {'network': {'config': 'disabled'}}
2018-11-21 16:26:31,174 - __init__.py[DEBUG]: Selected renderer 'netplan' from priority list: None
2018-11-21 16:26:31,174 - util.py[WARNING]: failed stage init-local
2018-11-21 16:26:31,174 - util.py[DEBUG]: failed stage init-local
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 658, in status_wrapper
    ret = functor(name, args)
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 362, in main_init
    init.apply_network_config(bring_up=bool(mode != sources.DSMODE_LOCAL))
  File "/usr/lib/python3/dist-packages/cloudinit/stages.py", line 671, in apply_network_config
    return self.distro.apply_network_config(netcfg, bring_up=bring_up)
  File "/usr/lib/python3/dist-packages/cloudinit/distros/__init__.py", line 178, in apply_network_config
    dev_names = self._write_network_config(netconfig)
  File "/usr/lib/python3/dist-packages/cloudinit/distros/debian.py", line 114, in _write_network_config
    return self._supported_write_network_config(netconfig)
  File "/usr/lib/python3/dist-packages/cloudinit/distros/__init__.py", line 93, in _supported_write_network_config
    renderer.render_network_config(network_config)
  File "/usr/lib/python3/dist-packages/cloudinit/net/renderer.py", line 56, in render_network_config
    templates=templates, target=target)
  File "/usr/lib/python3/dist-packages/cloudinit/net/netplan.py", line 202, in render_network_state
    content = self._render_content(network_state)
  File "/usr/lib/python3/dist-packages/cloudinit/net/netplan.py", line 236, in _render_content
    if network_state.version == 2:
AttributeError: 'NoneType' object has no attribute 'version'
```
This patch changes the value of `CloudInitNetworkConfigDisabled` to a simple key/value.

## QA steps

- Bootstrap
- `juju add-machine`
- `juju add-machine lxd:0`
- `juju add-machine kvm:0`
- `juju add-machine lxd:0 --series trusty`

Check that for all the containers, _/var/log/cloud-init.log_ contains:

```
2018-11-21 16:47:38,561 - stages.py[DEBUG]: network config disabled by ds
2018-11-21 16:47:38,561 - stages.py[INFO]: network config is disabled by ds
2018-11-21 16:47:38,561 - main.py[DEBUG]: [local] Exiting. datasource DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net] not in local mode.
2018-11-21 16:47:38,562 - util.py[DEBUG]: Reading from /proc/uptime (quiet=False)
2018-11-21 16:47:38,563 - util.py[DEBUG]: Read 10 bytes from /proc/uptime
2018-11-21 16:47:38,563 - util.py[DEBUG]: cloud-init mode 'init' took 0.163 seconds (0.00)
2018-11-21 16:47:38,563 - handlers.py[DEBUG]: finish: init-local: SUCCESS: searching for local datasources
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804493
