### PR TITLE
Truncate Oracle OCIDs in juju status --format=tabular

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -387,7 +387,14 @@ func printMachine(w output.Wrapper, m machineStatus) {
 	}
 	w.Print(m.Id)
 	w.PrintStatus(m.JujuStatus.Current)
-	w.Println(m.DNSName, m.InstanceId, m.Series, az, m.MachineStatus.Message)
+
+	instanceId := string(m.InstanceId)
+	// Truncate Oracle's OCID strings
+	if strings.HasPrefix(instanceId, "ocid") {
+		instanceId = ellipsis + instanceId[len(instanceId)-6:]
+	}
+
+	w.Println(m.DNSName, instanceId, m.Series, az, m.MachineStatus.Message)
 	for _, name := range naturalsort.Sort(stringKeysFromMap(m.Containers)) {
 		printMachine(w, m.Containers[name])
 	}


### PR DESCRIPTION
This commit changes the formatting for OCIDs. The new behaviour avoids spilling far
into the right of the screen. The truncation pattern (3 dots, last 6 characters) is
consistent with how OCIDs are displayed on Oracle's own web interface.

Before (2.4.6):

```plain
$ /snap/bin/juju show-status
Model    Controller  Cloud/Region                Version      SLA          Timestamp
default  oci-1       oci-canonical/us-phoenix-1  2.5-beta2.1  unsupported  10:38:16+13:00

App    Version  Status   Scale  Charm      Store       Rev  OS      Notes
mysql           unknown      1  mysql      jujucharms   55  ubuntu
wiki            error        1  mediawiki  jujucharms    5  ubuntu

Unit      Workload  Agent  Machine  Public address   Ports     Message
mysql/0*  unknown   idle   0        129.146.84.62    3306/tcp
wiki/0*   error     idle   1        129.146.131.194            hook failed: "db-relation-changed"

Machine  State    DNS              Inst id                                                                              Series  AZ  Message
0        started  129.146.84.62    ocid1.instance.oc1.phx.abyhqljts7czgvq7hb5uhsly7j3hjp5a6zbbh3ghndypjpikdxbhyisivpgq  trusty      running
1        started  129.146.131.194  ocid1.instance.oc1.phx.abyhqljto2gm6nbn75a6uionit5actskpqz5ukqfcapalhniavvtm6ttu6uq  trusty      running
```

After (present commit)

```plain
$ juju show-status
Model    Controller  Cloud/Region                Version      SLA          Timestamp
default  oci-1       oci-canonical/us-phoenix-1  2.5-beta2.1  unsupported  10:38:30+13:00

App    Version  Status   Scale  Charm      Store       Rev  OS      Notes
mysql           unknown      1  mysql      jujucharms   55  ubuntu
wiki            error        1  mediawiki  jujucharms    5  ubuntu

Unit      Workload  Agent  Machine  Public address   Ports     Message
mysql/0*  unknown   idle   0        129.146.84.62    3306/tcp
wiki/0*   error     idle   1        129.146.131.194            hook failed: "db-relation-changed"

Machine  State    DNS              Inst id    Series  AZ  Message
0        started  129.146.84.62    ...sivpgq  trusty      running
1        started  129.146.131.194  ...ttu6uq  trusty      running
```

----

## QA steps

*Steps*

* bootstrap into into oci, deploy a bundle
* run `juju status`

*Desired output*

The `Inst id` column should look like "After" example rather than the "Before" one

## Documentation changes

n/a

## Bug reference

[to be added to lp]