### PR TITLE
Use extended wwn if available for block devices

### DIFF
--- a/apiserver/common/storagecommon/blockdevices.go
+++ b/apiserver/common/storagecommon/blockdevices.go
@@ -4,9 +4,13 @@
 package storagecommon
 
 import (
+	"github.com/juju/loggo"
+
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.storagecommon")
 
 // BlockDeviceFromState translates a state.BlockDeviceInfo to a
 // storage.BlockDevice.
@@ -33,23 +37,27 @@ func MatchingBlockDevice(
 	volumeInfo state.VolumeInfo,
 	attachmentInfo state.VolumeAttachmentInfo,
 ) (*state.BlockDeviceInfo, bool) {
+	logger.Tracef("looking for block device for volume %#v", volumeInfo)
 	for _, dev := range blockDevices {
 		if volumeInfo.WWN != "" {
 			if volumeInfo.WWN == dev.WWN {
 				return &dev, true
 			}
+			logger.Tracef("no match for block device WWN: %v", dev.WWN)
 			continue
 		}
 		if volumeInfo.HardwareId != "" {
 			if volumeInfo.HardwareId == dev.HardwareId {
 				return &dev, true
 			}
+			logger.Tracef("no match for block device hardware id: %v", dev.HardwareId)
 			continue
 		}
 		if attachmentInfo.BusAddress != "" {
 			if attachmentInfo.BusAddress == dev.BusAddress {
 				return &dev, true
 			}
+			logger.Tracef("no match for block device bus address: %v", dev.BusAddress)
 			continue
 		}
 		if attachmentInfo.DeviceLink != "" {
@@ -58,11 +66,13 @@ func MatchingBlockDevice(
 					return &dev, true
 				}
 			}
+			logger.Tracef("no match for block device dev links: %v", dev.DeviceLinks)
 			continue
 		}
 		if attachmentInfo.DeviceName == dev.DeviceName {
 			return &dev, true
 		}
+		logger.Tracef("no match for block device name: %v", dev.DeviceName)
 	}
 	return nil, false
 }

--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -83,6 +83,15 @@ ID_WWN=foo
 `, storage.BlockDevice{WWN: "foo"})
 }
 
+func (s *ListBlockDevicesSuite) TestListBlockDevicesExtendedWWN(c *gc.C) {
+	// If ID_WWN_WITH_EXTENSION is found, then we should use that
+	// in preference to the ID_WWN value.
+	s.testListBlockDevicesExtended(c, `
+ID_WWN_WITH_EXTENSION=foobar
+ID_WWN=foo
+`, storage.BlockDevice{WWN: "foobar"})
+}
+
 func (s *ListBlockDevicesSuite) TestListBlockDevicesBusAddress(c *gc.C) {
 	// If ID_BUS is scsi, then we should get a
 	// BusAddress value.


### PR DESCRIPTION
## Description of change

For logical block devices, it's possible they are identified by an extended wwn; the "normal" wwn itself identifies the controller. Add support for recording the extended wwn if present as that's how the volumes will appear under /dev/disk/by-id and is expected to be what is reported by the provider, eg MAAS.

Also add trace level debugging for troubleshooting.

## QA steps

Will be tested on site.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1778033
