### PR TITLE
TLSStateAutocertSuite.TestAutocert - Fix Long Test Duration

### DIFF
--- a/worker/httpserver/tls_state_test.go
+++ b/worker/httpserver/tls_state_test.go
@@ -64,7 +64,7 @@ var _ = gc.Suite(&TLSStateAutocertSuite{})
 func (s *TLSStateAutocertSuite) SetUpSuite(c *gc.C) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.autocertQueried = true
-		http.Error(w, "burp", http.StatusInternalServerError)
+		http.Error(w, "burp", http.StatusUnavailableForLegalReasons)
 	}))
 	s.ControllerConfig = map[string]interface{}{
 		"autocert-dns-name": "public.invalid",


### PR DESCRIPTION
## Description of change

The version of _golang.org/x/crypto_ that we are using for autocert has been updated since 2.4. This version changes the behaviour of its raw _GET_ when acquiring a certificate, such that it considers a HTTP 500 status as a suitable for retry, which it does for the duration of its 5 minute timeout period.

#### Summary

We call:
https://github.com/golang/crypto/blob/74cb1d3d52f4c01cbfb44c1b50d204462f3124c7/acme/autocert/autocert.go#L234

5 minute time-out is internal to the method:
https://github.com/golang/crypto/blob/74cb1d3d52f4c01cbfb44c1b50d204462f3124c7/acme/autocert/autocert.go#L252

Call stack ends up here:
https://github.com/golang/crypto/blob/a49355c7e3f8fe157a85be2f77e6e269a0f89602/acme/http.go#L142

Which is defined as:
https://github.com/golang/crypto/blob/a49355c7e3f8fe157a85be2f77e6e269a0f89602/acme/http.go#L261

Using a different status for our test server, in this case 451, brings us back to sub-second duration for the test.

## QA steps

Test passed in less than a second instead of 5 minutes.

## Documentation changes

None.

## Bug reference

N/A
