### PR TITLE
uniter: Be smarter about when we run config-changed (part 1)

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -100,7 +100,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       8,
+	"Uniter":                       9,
 	"Upgrader":                     1,
 	"UpgradeSeries":                1,
 	"UserManager":                  2,

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -21,7 +21,7 @@ type storageSuite struct {
 	coretesting.BaseSuite
 }
 
-const expectedVersion = 8
+const expectedVersion = 9
 
 func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	storageAttachmentIds := []params.StorageAttachmentId{{

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -574,13 +574,13 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	defer wc.AssertStops()
 
 	// Initial event - this is the sha-256 hash of an empty bson.D.
-	wc.AssertChange("49e8e3297545c15ab6a79471a7a34d43e24a8f1cb25ea3d8417c61f699267a3f")
+	wc.AssertChange("e8d7e8dfff0eed1e77b15638581672f7b25ecc1163cc5fd5a52d29d51d096c00")
 
 	err = s.wordpressApplication.UpdateCharmConfig(charm.Settings{
 		"blog-title": "sauceror central",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange("22090c06037bbaffecd736b45a466671762656c7d4c2e057a1873c2a606b89ed")
+	wc.AssertChange("7ed6151e9c3d5144faf0946d20c283c466b4885dded6a6122ff3fdac7ee2334f")
 
 	// Non-change is not reported.
 	err = s.wordpressApplication.UpdateCharmConfig(charm.Settings{

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -74,12 +74,12 @@ func newStateForVersionFn(version int) func(base.APICaller, names.UnitTag) *Stat
 	}
 }
 
-// newStateV8 creates a new client-side Uniter facade, version 8
-var newStateV8 = newStateForVersionFn(8)
+// newStateV9 creates a new client-side Uniter facade, version 9
+var newStateV9 = newStateForVersionFn(9)
 
 // NewState creates a new client-side Uniter facade.
 // Defined like this to allow patching during tests.
-var NewState = newStateV8
+var NewState = newStateV9
 
 // BestAPIVersion returns the API version that we were able to
 // determine is supported by both the client and the API Server.

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -21,7 +21,7 @@ type unitStorageSuite struct {
 
 var _ = gc.Suite(&unitStorageSuite{})
 
-const expectedAPIVersion = 8
+const expectedAPIVersion = 9
 
 func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesting.APICallerFunc) *uniter.Unit {
 	tag := names.NewUnitTag(t)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -280,7 +280,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 5, uniter.NewUniterAPIV5)
 	reg("Uniter", 6, uniter.NewUniterAPIV6)
 	reg("Uniter", 7, uniter.NewUniterAPIV7)
-	reg("Uniter", 8, uniter.NewUniterAPI)
+	reg("Uniter", 8, uniter.NewUniterAPIV8)
+	reg("Uniter", 9, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UpgradeSeries", 1, upgradeseries.NewAPI)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1044,7 +1044,7 @@ func (s *uniterSuite) TestWatchConfigSettingsHash(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 			{
 				StringsWatcherId: "1",
-				Changes:          []string{"22090c06037bbaffecd736b45a466671762656c7d4c2e057a1873c2a606b89ed"},
+				Changes:          []string{"af35e298300150f2c357b4a1c40c1109bde305841c6343113b634b9dada22d00"},
 			},
 			{Error: apiservertesting.ErrUnauthorized},
 		},

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -530,6 +530,11 @@ options:
     description: Something late in the alphabet.
 `
 
+var wordpressConfig = `
+options:
+  blog-title: {default: My Title, description: A descriptive title used for the blog., type: string}
+`
+
 var setCharmConfigTests = []struct {
 	summary     string
 	startconfig string

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -519,6 +519,17 @@ options:
   other: {default: None, description: My Other, type: string}
 `
 
+var sortableConfig = `
+options:
+  blog-title: {default: My Title, description: A descriptive title used for the blog., type: string}
+  alphabetic:
+    type: int
+    description: Something early in the alphabet.
+  zygomatic:
+    type: int
+    description: Something late in the alphabet.
+`
+
 var setCharmConfigTests = []struct {
 	summary     string
 	startconfig string

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -216,6 +216,14 @@ func (s *UnitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("9ca0a511647f09db8fab07be3c70f49cc93f38f300ca82d6e26ec7d4a8b1b4c2")
 
+	// Setting a value to int64 instead of int has no effect on the
+	// hash.
+	err = s.application.UpdateCharmConfig(charm.Settings{
+		"alphabetic": int64(1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+
 	// Change application's charm; nothing detected.
 	newCharm = s.AddConfigCharm(c, "wordpress", floatConfig, 125)
 	cfg = state.SetCharmConfig{Charm: newCharm}

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -234,6 +234,10 @@ func (s *UnitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	// another event, because the originally-watched document will become
 	// unreferenced and be removed. But I'm not testing that behaviour
 	// because it's not very helpful and subject to change.
+
+	err = s.unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange("")
 }
 
 func (s *UnitSuite) addSubordinateUnit(c *gc.C) *state.Unit {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -3704,6 +3704,7 @@ func newSettingsHashWatcher(st *State, localID string) StringsWatcher {
 		commonWatcher: newCommonWatcher(st),
 		out:           make(chan []string),
 		id:            st.docID(localID),
+		name:          localID,
 	}
 	w.tomb.Go(func() error {
 		defer close(w.out)
@@ -3714,8 +3715,9 @@ func newSettingsHashWatcher(st *State, localID string) StringsWatcher {
 
 type settingsHashWatcher struct {
 	commonWatcher
-	id  string
-	out chan []string
+	id   string
+	name string
+	out  chan []string
 }
 
 func (w *settingsHashWatcher) Changes() <-chan []string {
@@ -3786,6 +3788,7 @@ func (w *settingsHashWatcher) hash() (string, error) {
 		return "", errors.Trace(err)
 	}
 	hash := sha256.New()
+	hash.Write([]byte(w.name))
 	hash.Write(data)
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -4,9 +4,11 @@
 package state
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1871,6 +1873,18 @@ func (u *Unit) WatchApplicationConfigSettings() (NotifyWatcher, error) {
 	return newEntityWatcher(u.st, settingsC, u.st.docID(applicationConfigKey)), nil
 }
 
+// WatchConfigSettingsHash returns a watcher that yields a hash of the
+// unit's charm config settings whenever they are changed. The
+// returned watcher will be valid only while the application's charm
+// URL is not changed.
+func (u *Unit) WatchConfigSettingsHash() (StringsWatcher, error) {
+	if u.doc.CharmURL == nil {
+		return nil, fmt.Errorf("unit charm not set")
+	}
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+	return newSettingsHashWatcher(u.st, charmConfigKey), nil
+}
+
 // WatchMeterStatus returns a watcher observing changes that affect the meter status
 // of a unit.
 func (u *Unit) WatchMeterStatus() NotifyWatcher {
@@ -3683,4 +3697,95 @@ func (w *containerAddressesWatcher) loop() error {
 			out = nil
 		}
 	}
+}
+
+func newSettingsHashWatcher(st *State, localID string) StringsWatcher {
+	w := &settingsHashWatcher{
+		commonWatcher: newCommonWatcher(st),
+		out:           make(chan []string),
+		id:            st.docID(localID),
+	}
+	w.tomb.Go(func() error {
+		defer close(w.out)
+		return w.loop()
+	})
+	return w
+}
+
+type settingsHashWatcher struct {
+	commonWatcher
+	id  string
+	out chan []string
+}
+
+func (w *settingsHashWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+func (w *settingsHashWatcher) loop() error {
+	settings, closer := w.db.GetCollection(settingsC)
+	revno, err := getTxnRevno(settings, w.id)
+	closer()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	settingsCh := make(chan watcher.Change)
+	w.watcher.Watch(settingsC, w.id, revno, settingsCh)
+	defer w.watcher.Unwatch(settingsC, w.id, settingsCh)
+
+	lastHash, err := w.hash()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	out := w.out
+	for {
+		select {
+		case <-w.watcher.Dead():
+			return stateWatcherDeadError(w.watcher.Err())
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case change := <-settingsCh:
+			if _, ok := collect(change, settingsCh, w.tomb.Dying()); !ok {
+				return tomb.ErrDying
+			}
+			newHash, err := w.hash()
+			// TODO(babbageclunk): how should we handle notfound? Stop
+			// the watcher, or return ""? Something else?
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if lastHash != newHash {
+				lastHash = newHash
+				out = w.out
+			}
+		case out <- []string{lastHash}:
+			out = nil
+		}
+	}
+}
+
+func (w *settingsHashWatcher) hash() (string, error) {
+	settings, closer := w.db.GetCollection(settingsC)
+	defer closer()
+	var doc settingsDoc
+	if err := settings.FindId(w.id).One(&doc); err != nil {
+		return "", errors.Trace(err)
+	}
+	// Ensure elements are in a consistent order.
+	var items bson.D
+	for name, value := range doc.Settings {
+		items = append(items, bson.DocElem{Name: name, Value: value})
+	}
+	// We know that there aren't any equal names because the source is
+	// a map.
+	sort.Slice(items, func(i int, j int) bool {
+		return items[i].Name < items[j].Name
+	})
+	data, err := bson.Marshal(items)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	hash := sha256.New()
+	hash.Write(data)
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -249,7 +249,7 @@ func (rh *runHook) Commit(state State) (*State, error) {
 		Step: Pending,
 	}
 
-	var hi *hook.Info = &hook.Info{Kind: hooks.ConfigChanged}
+	hi := &hook.Info{Kind: hooks.ConfigChanged}
 	switch rh.info.Kind {
 	case hooks.ConfigChanged:
 		if state.Started {
@@ -269,6 +269,9 @@ func (rh *runHook) Commit(state State) (*State, error) {
 	case hooks.PostSeriesUpgrade:
 		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
 		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, message)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	newState := change.apply(state)

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -93,6 +93,21 @@ type State struct {
 	// Charm describes the charm being deployed by an Install or Upgrade
 	// operation, and is otherwise blank.
 	CharmURL *charm.URL `yaml:"charm,omitempty"`
+
+	// ConfigHash stores a hash of the latest known charm
+	// configuration settings - it's used to determine whether we need
+	// to run config-changed.
+	ConfigHash string `yaml:"config-hash,omitempty"`
+
+	// TrustHash stores a hash of the latest known charm trust
+	// configuration settings - it's used to determine whether we need
+	// to run config-changed.
+	TrustHash string `yaml:"trust-hash,omitempty"`
+
+	// AddressesHash stores a hash of the latest known
+	// machine/container addresses - it's used to determine whether we
+	// need to run config-changed.
+	AddressesHash string `yaml:"addresses-hash,omitempty"`
 }
 
 // validate returns an error if the state violates expectations.

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -81,7 +81,7 @@ func mockAPICaller(c *gc.C, callNumber *int32, apiCalls ...apiCall) apitesting.A
 			c.Check(index < len(apiCalls), jc.IsTrue)
 			call := apiCalls[index]
 			c.Logf("request %d, %s", index, request)
-			c.Check(version, gc.Equals, 8)
+			c.Check(version, gc.Equals, 9)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, call.request)
 			c.Check(arg, jc.DeepEquals, call.args)

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -201,7 +201,7 @@ type mockUnit struct {
 	application                      mockApplication
 	unitWatcher                      *mockNotifyWatcher
 	addressesWatcher                 *mockNotifyWatcher
-	configSettingsWatcher            *mockNotifyWatcher
+	configSettingsWatcher            *mockStringsWatcher
 	applicationConfigSettingsWatcher *mockNotifyWatcher
 	upgradeSeriesWatcher             *mockNotifyWatcher
 	storageWatcher                   *mockStringsWatcher
@@ -237,7 +237,7 @@ func (u *mockUnit) WatchAddresses() (watcher.NotifyWatcher, error) {
 	return u.addressesWatcher, nil
 }
 
-func (u *mockUnit) WatchConfigSettings() (watcher.NotifyWatcher, error) {
+func (u *mockUnit) WatchConfigSettingsHash() (watcher.StringsWatcher, error) {
 	return u.configSettingsWatcher, nil
 }
 

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -50,6 +50,18 @@ type Snapshot struct {
 	// the unit's config settings.
 	ConfigVersion int
 
+	// ConfigHash is a hash of the last published version of the
+	// unit's config settings.
+	ConfigHash string
+
+	// TrustHash is a hash of the last published version of the unit's
+	// trust settings.
+	TrustHash string
+
+	// AddressesHash is a hash of the last published addresses for the
+	// unit's machine/container.
+	AddressesHash string
+
 	// Leader indicates whether or not the unit is the
 	// elected leader.
 	Leader bool

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -40,7 +40,7 @@ type Unit interface {
 	Tag() names.UnitTag
 	Watch() (watcher.NotifyWatcher, error)
 	WatchAddresses() (watcher.NotifyWatcher, error)
-	WatchConfigSettings() (watcher.NotifyWatcher, error)
+	WatchConfigSettingsHash() (watcher.StringsWatcher, error)
 	WatchTrustConfigSettings() (watcher.NotifyWatcher, error)
 	WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -188,9 +188,9 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	// Note that the configuration change is updated on both application and
-	// charm config which increments it twice.
-	expectedVersion := 3
+	// Note that the configuration change is updated on both application config and
+	// addresses which increments it twice.
+	expectedVersion := 2
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
 		Life:                  s.st.unit.life,
@@ -212,9 +212,9 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	// Note that the configuration change is updated on both application and
-	// charm config which increments it twice.
-	expectedVersion := 3
+	// Note that the configuration change is updated on both application config and
+	// addresses which increments it twice.
+	expectedVersion := 2
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
 		Life:                  s.st.unit.life,
@@ -254,14 +254,14 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 
 	s.st.unit.addressesWatcher.changes <- struct{}{}
 	assertOneChange()
-	c.Assert(s.watcher.Snapshot().ConfigVersion, gc.Equals, initial.ConfigVersion+1)
+	expectVersion := initial.ConfigVersion + 1
+	c.Assert(s.watcher.Snapshot().ConfigVersion, gc.Equals, expectVersion)
 
 	s.st.unit.storageWatcher.changes <- []string{}
 	assertOneChange()
 
 	s.st.unit.configSettingsWatcher.changes <- []string{"confighash"}
 	assertOneChange()
-	expectVersion := initial.ConfigVersion + 2
 	c.Assert(s.watcher.Snapshot().ConfigVersion, gc.Equals, expectVersion)
 
 	s.st.unit.application.leaderSettingsWatcher.changes <- struct{}{}

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -58,7 +58,7 @@ func (s *WatcherSuite) SetUpTest(c *gc.C) {
 			},
 			unitWatcher:                      newMockNotifyWatcher(),
 			addressesWatcher:                 newMockNotifyWatcher(),
-			configSettingsWatcher:            newMockNotifyWatcher(),
+			configSettingsWatcher:            newMockStringsWatcher(),
 			applicationConfigSettingsWatcher: newMockNotifyWatcher(),
 			storageWatcher:                   newMockStringsWatcher(),
 			actionWatcher:                    newMockStringsWatcher(),
@@ -150,7 +150,7 @@ func (s *WatcherSuite) TestInitialSignal(c *gc.C) {
 	s.st.unit.unitWatcher.changes <- struct{}{}
 	assertNoNotifyEvent(c, s.watcher.RemoteStateChanged(), "remote state change")
 	s.st.unit.addressesWatcher.changes <- struct{}{}
-	s.st.unit.configSettingsWatcher.changes <- struct{}{}
+	s.st.unit.configSettingsWatcher.changes <- []string{"confighash"}
 	s.st.unit.applicationConfigSettingsWatcher.changes <- struct{}{}
 	if s.st.unit.upgradeSeriesWatcher != nil {
 		s.st.unit.upgradeSeriesWatcher.changes <- struct{}{}
@@ -169,7 +169,7 @@ func (s *WatcherSuite) TestInitialSignal(c *gc.C) {
 
 func (s *WatcherSuite) signalAll() {
 	s.st.unit.unitWatcher.changes <- struct{}{}
-	s.st.unit.configSettingsWatcher.changes <- struct{}{}
+	s.st.unit.configSettingsWatcher.changes <- []string{"confighash"}
 	s.st.unit.applicationConfigSettingsWatcher.changes <- struct{}{}
 	s.st.unit.actionWatcher.changes <- []string{}
 	s.st.unit.application.leaderSettingsWatcher.changes <- struct{}{}
@@ -201,6 +201,7 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 		ForceCharmUpgrade:     s.st.unit.application.forceUpgrade,
 		ResolvedMode:          s.st.unit.resolved,
 		ConfigVersion:         expectedVersion,
+		ConfigHash:            "confighash",
 		LeaderSettingsVersion: 1,
 		Leader:                true,
 		UpgradeSeriesStatus:   model.UpgradeSeriesPrepareStarted,
@@ -224,6 +225,7 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 		ForceCharmUpgrade:     s.st.unit.application.forceUpgrade,
 		ResolvedMode:          s.st.unit.resolved,
 		ConfigVersion:         expectedVersion,
+		ConfigHash:            "confighash",
 		LeaderSettingsVersion: 1,
 		Leader:                true,
 		UpgradeSeriesStatus:   "",
@@ -257,7 +259,7 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	s.st.unit.storageWatcher.changes <- []string{}
 	assertOneChange()
 
-	s.st.unit.configSettingsWatcher.changes <- struct{}{}
+	s.st.unit.configSettingsWatcher.changes <- []string{"confighash"}
 	assertOneChange()
 	expectVersion := initial.ConfigVersion + 2
 	c.Assert(s.watcher.Snapshot().ConfigVersion, gc.Equals, expectVersion)

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -188,8 +188,8 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	// Note that the configuration change is updated on both application config and
-	// addresses which increments it twice.
+	// Note that the configuration version is updated on both trust
+	// and address changes which increments it twice.
 	expectedVersion := 2
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
@@ -212,8 +212,8 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	// Note that the configuration change is updated on both application config and
-	// addresses which increments it twice.
+	// Note that the configuration version is updated on both trust
+	// and address changes which increments it twice.
 	expectedVersion := 2
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -285,7 +285,11 @@ func (s *uniterResolver) nextOp(
 		}
 	}
 
-	if localState.ConfigVersion != remoteState.ConfigVersion {
+	versionChanged := localState.ConfigVersion != remoteState.ConfigVersion
+	configHashChanged := localState.ConfigHash != remoteState.ConfigHash
+	trustHashChanged := localState.TrustHash != remoteState.TrustHash
+	addressesHashChanged := localState.AddressesHash != remoteState.AddressesHash
+	if versionChanged || configHashChanged || trustHashChanged || addressesHashChanged {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -422,3 +422,24 @@ func (s *resolverSuite) TestRunsConfigChangedIfAddressesHashChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run config-changed hook")
 }
+
+func (s *resolverSuite) TestNoOperationIfHashesAllMatch(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmModifiedVersion: s.charmModifiedVersion,
+		CharmURL:             s.charmURL,
+		State: operation.State{
+			Kind:          operation.Continue,
+			Installed:     true,
+			Started:       true,
+			ConfigHash:    "config",
+			TrustHash:     "trust",
+			AddressesHash: "addresses",
+		},
+	}
+	s.remoteState.ConfigHash = "config"
+	s.remoteState.TrustHash = "trust"
+	s.remoteState.AddressesHash = "addresses"
+
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+}

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -368,3 +368,57 @@ func (s *resolverSuite) TestRunHookStopRetryTimer(c *gc.C) {
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 	s.stub.CheckCallNames(c, "StartRetryHookTimer", "StopRetryHookTimer")
 }
+
+func (s *resolverSuite) TestRunsConfigChangedIfConfigHashChanges(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmModifiedVersion: s.charmModifiedVersion,
+		CharmURL:             s.charmURL,
+		State: operation.State{
+			Kind:       operation.Continue,
+			Installed:  true,
+			Started:    true,
+			ConfigHash: "somehash",
+		},
+	}
+	s.remoteState.ConfigHash = "differenthash"
+
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+}
+
+func (s *resolverSuite) TestRunsConfigChangedIfTrustHashChanges(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmModifiedVersion: s.charmModifiedVersion,
+		CharmURL:             s.charmURL,
+		State: operation.State{
+			Kind:      operation.Continue,
+			Installed: true,
+			Started:   true,
+			TrustHash: "somehash",
+		},
+	}
+	s.remoteState.TrustHash = "differenthash"
+
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+}
+
+func (s *resolverSuite) TestRunsConfigChangedIfAddressesHashChanges(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmModifiedVersion: s.charmModifiedVersion,
+		CharmURL:             s.charmURL,
+		State: operation.State{
+			Kind:          operation.Continue,
+			Installed:     true,
+			Started:       true,
+			AddressesHash: "somehash",
+		},
+	}
+	s.remoteState.AddressesHash = "differenthash"
+
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+}


### PR DESCRIPTION
## Description of change
At the moment, when a controller agent restarts all of the unit agents that were connected to it reconnect and then immediately fire config-changed, even if no configuration has actually changed. On controllers with thousands of units, this can overload the controller agent while all the units get all their config and run any other hook commands in response.

The uniter always runs config-changed when it first starts because it doesn't track any local state that would enable it to see that the config is the same and avoid running the hook.

Change the API to expose Uniter.WatchConfigSettingsHash - this works like .WatchConfigSettings, except it sends a hash of the current config when it signals. The uniter stores that value in the local uniter state file, so that it persists across agent restarts, and checks it before firing config-changed.

This bumps the uniter API to version 9.

This PR plumbs the config hash through the API and uniter, but the uniter also watches trust config and addresses, so the behaviour won't change until those other parts are done in followups.

## QA steps

* Bootstrap a controller and model, deploy some applications and relate them. 
* See that the uniter state files for various units includes the config-hash.
* Change a config value for one of the applications.
* See that the config-hash changes when the config-changed hook fires.

## Documentation changes

None
