### PR TITLE
uniter: Smarter config-changed part 2: trust config

### DIFF
--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -202,7 +202,7 @@ type mockUnit struct {
 	unitWatcher                      *mockNotifyWatcher
 	addressesWatcher                 *mockNotifyWatcher
 	configSettingsWatcher            *mockStringsWatcher
-	applicationConfigSettingsWatcher *mockNotifyWatcher
+	applicationConfigSettingsWatcher *mockStringsWatcher
 	upgradeSeriesWatcher             *mockNotifyWatcher
 	storageWatcher                   *mockStringsWatcher
 	actionWatcher                    *mockStringsWatcher
@@ -241,7 +241,7 @@ func (u *mockUnit) WatchConfigSettingsHash() (watcher.StringsWatcher, error) {
 	return u.configSettingsWatcher, nil
 }
 
-func (u *mockUnit) WatchTrustConfigSettings() (watcher.NotifyWatcher, error) {
+func (u *mockUnit) WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error) {
 	return u.applicationConfigSettingsWatcher, nil
 }
 

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -41,7 +41,7 @@ type Unit interface {
 	Watch() (watcher.NotifyWatcher, error)
 	WatchAddresses() (watcher.NotifyWatcher, error)
 	WatchConfigSettingsHash() (watcher.StringsWatcher, error)
-	WatchTrustConfigSettings() (watcher.NotifyWatcher, error)
+	WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error)
 	WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)
 	WatchActionNotifications() (watcher.StringsWatcher, error)

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -59,7 +59,7 @@ func (s *WatcherSuite) SetUpTest(c *gc.C) {
 			unitWatcher:                      newMockNotifyWatcher(),
 			addressesWatcher:                 newMockNotifyWatcher(),
 			configSettingsWatcher:            newMockStringsWatcher(),
-			applicationConfigSettingsWatcher: newMockNotifyWatcher(),
+			applicationConfigSettingsWatcher: newMockStringsWatcher(),
 			storageWatcher:                   newMockStringsWatcher(),
 			actionWatcher:                    newMockStringsWatcher(),
 			relationsWatcher:                 newMockStringsWatcher(),
@@ -151,7 +151,7 @@ func (s *WatcherSuite) TestInitialSignal(c *gc.C) {
 	assertNoNotifyEvent(c, s.watcher.RemoteStateChanged(), "remote state change")
 	s.st.unit.addressesWatcher.changes <- struct{}{}
 	s.st.unit.configSettingsWatcher.changes <- []string{"confighash"}
-	s.st.unit.applicationConfigSettingsWatcher.changes <- struct{}{}
+	s.st.unit.applicationConfigSettingsWatcher.changes <- []string{"trusthash"}
 	if s.st.unit.upgradeSeriesWatcher != nil {
 		s.st.unit.upgradeSeriesWatcher.changes <- struct{}{}
 	}
@@ -170,7 +170,7 @@ func (s *WatcherSuite) TestInitialSignal(c *gc.C) {
 func (s *WatcherSuite) signalAll() {
 	s.st.unit.unitWatcher.changes <- struct{}{}
 	s.st.unit.configSettingsWatcher.changes <- []string{"confighash"}
-	s.st.unit.applicationConfigSettingsWatcher.changes <- struct{}{}
+	s.st.unit.applicationConfigSettingsWatcher.changes <- []string{"trusthash"}
 	s.st.unit.actionWatcher.changes <- []string{}
 	s.st.unit.application.leaderSettingsWatcher.changes <- struct{}{}
 	s.st.unit.relationsWatcher.changes <- []string{}
@@ -188,9 +188,8 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	// Note that the configuration version is updated on both trust
-	// and address changes which increments it twice.
-	expectedVersion := 2
+	// Note that the configuration version is updated on address changes (for now).
+	expectedVersion := 1
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
 		Life:                  s.st.unit.life,
@@ -202,6 +201,7 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 		ResolvedMode:          s.st.unit.resolved,
 		ConfigVersion:         expectedVersion,
 		ConfigHash:            "confighash",
+		TrustHash:             "trusthash",
 		LeaderSettingsVersion: 1,
 		Leader:                true,
 		UpgradeSeriesStatus:   model.UpgradeSeriesPrepareStarted,
@@ -212,9 +212,8 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 	s.signalAll()
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
-	// Note that the configuration version is updated on both trust
-	// and address changes which increments it twice.
-	expectedVersion := 2
+	// Note that the configuration version is updated on address changes (for now).
+	expectedVersion := 1
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
 		Life:                  s.st.unit.life,
@@ -226,6 +225,7 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 		ResolvedMode:          s.st.unit.resolved,
 		ConfigVersion:         expectedVersion,
 		ConfigHash:            "confighash",
+		TrustHash:             "trusthash",
 		LeaderSettingsVersion: 1,
 		Leader:                true,
 		UpgradeSeriesStatus:   "",


### PR DESCRIPTION
## Description of change

This follows on from #9498 - it adds a hash watcher for application trust config settings and stores the current hash in the uniter state file. The final watcher for addresses will be in a subsequent PR.

## QA steps

* Bootstrap a controller and model, deploy some applications and relate them. 
* See that the uniter state files for various units includes the trust-hash.
* Change the trust config for one of the applications using `juju trust <application>`.
* See that the trust-hash changes when the config-changed hook fires.

## Documentation changes

None
