### PR TITLE
LXD Initialiser - Use Host Series

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -71,12 +71,6 @@ type MachineProvisioner interface {
 	// provider-level resources cleaned up and be removed.
 	MarkForRemoval() error
 
-	// Series returns the operating system series running on the machine.
-	//
-	// NOTE: Unlike state.Machine.Series(), this method returns an error
-	// as well, because it needs to do an API call.
-	Series() (string, error)
-
 	// AvailabilityZone returns an underlying provider's availability zone
 	// for a machine.
 	AvailabilityZone() (string, error)
@@ -322,26 +316,6 @@ func (m *Machine) MarkForRemoval() error {
 		return err
 	}
 	return result.OneError()
-}
-
-// Series implements MachineProvisioner.Series.
-func (m *Machine) Series() (string, error) {
-	var results params.StringResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: m.tag.String()}},
-	}
-	err := m.st.facade.FacadeCall("Series", args, &results)
-	if err != nil {
-		return "", err
-	}
-	if len(results.Results) != 1 {
-		return "", fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return "", result.Error
-	}
-	return result.Result, nil
 }
 
 // AvailabilityZone implements MachineProvisioner.AvailabilityZone.

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -240,19 +240,6 @@ func (mr *MockMachineProvisionerMockRecorder) RemoveUpgradeCharmProfileData() *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockMachineProvisioner)(nil).RemoveUpgradeCharmProfileData))
 }
 
-// Series mocks base method
-func (m *MockMachineProvisioner) Series() (string, error) {
-	ret := m.ctrl.Call(m, "Series")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Series indicates an expected call of Series
-func (mr *MockMachineProvisionerMockRecorder) Series() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockMachineProvisioner)(nil).Series))
-}
-
 // SetCharmProfiles mocks base method
 func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
 	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -337,23 +337,6 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	})
 }
 
-func (s *provisionerSuite) TestSeries(c *gc.C) {
-	// Create a fresh machine with different series.
-	foobarMachine, err := s.State.AddMachine("foobar", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-
-	apiMachine := s.assertGetOneMachine(c, foobarMachine.MachineTag())
-	series, err := apiMachine.Series()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(series, gc.Equals, "foobar")
-
-	// Now try machine 0.
-	apiMachine = s.assertGetOneMachine(c, s.machine.MachineTag())
-	series, err = apiMachine.Series()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(series, gc.Equals, "quantal")
-}
-
 func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 	// Create a fresh machine, since machine 0 is already provisioned.
 	template := state.MachineTemplate{

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -44,6 +44,10 @@ func PatchLXDViaSnap(patcher patcher, isSnap bool) {
 	patcher.PatchValue(&lxdViaSnap, func() bool { return isSnap })
 }
 
+func PatchHostSeries(patcher patcher, series string) {
+	patcher.PatchValue(&hostSeries, func() (string, error) { return series, nil })
+}
+
 func GetImageSources(mgr container.Manager) ([]ServerSpec, error) {
 	return mgr.(*containerManager).getImageSources()
 }

--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -19,7 +19,7 @@ type containerInitialiser struct {
 var _ container.Initialiser = (*containerInitialiser)(nil)
 
 // NewContainerInitialiser  - on anything but Linux this is a NOP
-func NewContainerInitialiser(series string) container.Initialiser {
+func NewContainerInitialiser() container.Initialiser {
 	return &containerInitialiser{}
 }
 

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -211,11 +211,7 @@ func (cs *ContainerSetup) getManagerConfig(containerType instance.ContainerType)
 // initContainerDependencies ensures that the host machine is set-up to manage
 // containers of the input type.
 func (cs *ContainerSetup) initContainerDependencies(abort <-chan struct{}, containerType instance.ContainerType) error {
-	series, err := cs.machine.Series()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	initialiser := getContainerInitialiser(containerType, series)
+	initialiser := getContainerInitialiser(containerType)
 
 	releaser, err := cs.acquireLock(fmt.Sprintf("%s container initialisation", containerType), abort)
 	if err != nil {
@@ -310,9 +306,9 @@ func (cs *ContainerSetup) TearDown() error {
 }
 
 // getContainerInitialiser exists to patch out in tests.
-var getContainerInitialiser = func(ct instance.ContainerType, series string) container.Initialiser {
+var getContainerInitialiser = func(ct instance.ContainerType) container.Initialiser {
 	if ct == instance.LXD {
-		return lxd.NewContainerInitialiser(series)
+		return lxd.NewContainerInitialiser()
 	}
 	return kvm.NewContainerInitialiser()
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -169,7 +169,7 @@ func (s *containerSetupSuite) setUpContainerWorker(c *gc.C) (watcher.StringsHand
 			return nil, nil
 		})
 
-	runner.StartWorker(watcherName, func() (worker.Worker, error) {
+	_ = runner.StartWorker(watcherName, func() (worker.Worker, error) {
 		return watcher.NewStringsWorker(watcher.StringsConfig{
 			Handler: handler,
 		})
@@ -192,7 +192,7 @@ func (s *containerSetupSuite) patch(c *gc.C) *gomock.Controller {
 	s.machine.EXPECT().Id().Return("0").AnyTimes()
 	s.machine.EXPECT().MachineTag().Return(names.NewMachineTag("0")).AnyTimes()
 
-	s.PatchValue(provisioner.GetContainerInitialiser, func(instance.ContainerType, string) container.Initialiser {
+	s.PatchValue(provisioner.GetContainerInitialiser, func(instance.ContainerType) container.Initialiser {
 		return s.initialiser
 	})
 
@@ -298,7 +298,6 @@ func (s *containerSetupSuite) expectContainerManagerConfig(cType instance.Contai
 	).SetArg(2, resultSource).MinTimes(1)
 
 	s.machine.EXPECT().AvailabilityZone().Return("az1", nil)
-	s.machine.EXPECT().Series().Return("bionic", nil)
 }
 
 // cleanKill waits for notifications to be processed, then waits for the input


### PR DESCRIPTION
## Description of change

This patch fixes an issue whereby:
- A Trusty host exists with container machines.
- A series upgrade is run for transition to Xenial.
- Upon coming up after `do-release-upgrade`, the container provisioner starts a container initialiser for Trusty (which it gets via the API) *before* the upgrade-series worker has changed the series.
- The container initialiser tries to install LXD from Trusty backports, throwing an error now that we are on Xenial.

The LXD container initialiser now gets the host series directly, and the now-unused `Series` method is removed from the provisioner API client.

## QA steps

- Bootstrap, add a Trusty machine, then add a LXD container to that machine.
- `juju upgrade-series 0 prepare xenial`
- Once prepared, SSH to the machine and run `do-release-upgrade`
- Check that after a restart, there are no container initialiser errors in the machine log.

## Documentation changes

None.

## Bug reference

Fixes one of 2 errors reported under:
https://bugs.launchpad.net/juju/+bug/1804701/
