### PR TITLE
Make upgrade-series auto-complete work like other commands.

### DIFF
--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -60,11 +60,6 @@ print ("\n".join(j.get("applications", {}).keys()))
 '   < ${cache_fname}
 }
 
-# Print (return) upgradeseries commands
-_JUJU_2_upgrade_series_commands() {
-     echo -e "prepare\ncomplete"
-}
-
 # Print (return) all actions IDS from (cached) "juju show-action-status" output
 _JUJU_2_action_ids_from_action_status() {
     local model=$(_get_current_model)
@@ -208,10 +203,6 @@ _JUJU_2_completion_func_for_cmd() {
             echo true ;;  # help ok, existing command, no more expansion
         *juju?ssh*|*juju?scp*)
             echo _JUJU_2_units_and_machines_from_status;;
-        *upgrade-series*)
-            if [[ "preparecomplete" != *"${prev_word}"* ]]; then
-                        echo _JUJU_2_upgrade_series_commands
-            fi;;&
         *\<unit*)
             echo _JUJU_2_units_from_status;;
         *\<service*)


### PR DESCRIPTION
## Description of change

Remove auto-completion tweak that is deprecated by the commands restructuring.

## QA steps

Compare the auto-completion of the `upgrade-series` command with that of the `juju remove-application` command. You will see that in both cases the options are completed indefinitely. Thus `upgrade-series` auto-completion is now consistent with other commands in that if it hits options it will indefinitely complete the options tag not making it to subsequent things like \<machine\> or \<application\> in the command usage string.
