### PR TITLE
docs: Update comment to match function signature

### DIFF
--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -85,7 +85,6 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 
 // MaybeHandleCredentialError determines if a given error relates to an invalid credential.
 //  If it is, the credential is invalidated and the return bool is true.
-// Original error is returned untouched.
 func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) bool {
 	denied := isAuthError(errors.Cause(err))
 	if ctx != nil && denied {
@@ -98,7 +97,7 @@ func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx con
 }
 
 // HandleCredentialError determines if a given error relates to an invalid credential.
-// If it is, the credential is invalidated. Original error is returned untouched.
+// If it is, the credential is invalidated.
 func HandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) {
 	MaybeHandleCredentialError(isAuthError, err, ctx)
 }


### PR DESCRIPTION
## Description of change

The comments within the provider/common credential invalidation handling code the are misleading.

## QA steps

n/a

## Documentation changes

n/a

## Bug reference

n/a
