### PR TITLE
feature/juju status surface storage deletion better

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -46,6 +46,7 @@ type Machine struct {
 	HasVote    bool
 	WantsVote  bool
 	Status     string
+	Message    string
 	Hardware   *instance.HardwareCharacteristics
 }
 
@@ -89,6 +90,7 @@ type Volume struct {
 	Id         string
 	ProviderId string
 	Status     string
+	Message    string
 	Detachable bool
 }
 
@@ -97,6 +99,7 @@ type Filesystem struct {
 	Id         string
 	ProviderId string
 	Status     string
+	Message    string
 	Detachable bool
 }
 

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -70,6 +70,7 @@ func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.Mo
 			Id:         in.Id,
 			ProviderId: in.ProviderId,
 			Status:     in.Status,
+			Message:    in.Message,
 			Detachable: in.Detachable,
 		}
 	}
@@ -80,6 +81,7 @@ func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.Mo
 			Id:         in.Id,
 			ProviderId: in.ProviderId,
 			Status:     in.Status,
+			Message:    in.Message,
 			Detachable: in.Detachable,
 		}
 	}
@@ -105,6 +107,7 @@ func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.Mo
 			HasVote:    mm.HasVote,
 			WantsVote:  mm.WantsVote,
 			Status:     mm.Status,
+			Message:    mm.Message,
 		}
 	}
 	return result

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -120,6 +120,7 @@ func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachine
 			HasVote:   m.HasVote(),
 			WantsVote: m.WantsVote(),
 			Status:    status,
+			Message:   statusInfo.Message,
 		}
 		instId, err := m.InstanceId()
 		switch {

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -135,6 +135,7 @@ func ModelFilesystemInfo(in []state.Filesystem) []params.ModelFilesystemInfo {
 			Id:         in.Tag().Id(),
 			ProviderId: providerId,
 			Status:     statusString,
+			Message:    status.Message,
 			Detachable: in.Detachable(),
 		}
 	}
@@ -160,6 +161,7 @@ func ModelVolumeInfo(in []state.Volume) []params.ModelVolumeInfo {
 			Id:         in.Tag().Id(),
 			ProviderId: providerId,
 			Status:     statusString,
+			Message:    status.Message,
 			Detachable: in.Detachable(),
 		}
 	}

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -285,6 +285,7 @@ type ModelMachineInfo struct {
 	Hardware   *MachineHardware `json:"hardware,omitempty"`
 	InstanceId string           `json:"instance-id,omitempty"`
 	Status     string           `json:"status,omitempty"`
+	Message    string           `json:"message,omitempty"`
 	HasVote    bool             `json:"has-vote,omitempty"`
 	WantsVote  bool             `json:"wants-vote,omitempty"`
 }
@@ -305,6 +306,7 @@ type ModelVolumeInfo struct {
 	Id         string `json:"id"`
 	ProviderId string `json:"provider-id,omitempty"`
 	Status     string `json:"status,omitempty"`
+	Message    string `json:"message,omitempty"`
 	Detachable bool   `json:"detachable,omitempty"`
 }
 
@@ -313,6 +315,7 @@ type ModelFilesystemInfo struct {
 	Id         string `json:"id"`
 	ProviderId string `json:"provider-id,omitempty"`
 	Status     string `json:"status,omitempty"`
+	Message    string `json:"message,omitempty"`
 	Detachable bool   `json:"detachable,omitempty"`
 }
 

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -6,7 +6,6 @@ package model
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/juju/cmd"
@@ -27,6 +26,7 @@ import (
 	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
+	corestatus "github.com/juju/juju/core/status"
 )
 
 const (
@@ -360,24 +360,24 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 			}
 			return nil
 		}
-		isErrorMessage := func(s string) bool {
-			return strings.Contains(s, "error")
+		isError := func(s string) bool {
+			return corestatus.Error.Matches(corestatus.Status(s))
 		}
 		for _, s := range status {
 			for _, v := range s.Machines {
-				if isErrorMessage(v.Status) {
+				if isError(v.Status) {
 					ctx.Infof("unable to destroy machine: %q, \ngot error: %q\ntry `juju status` for more details.", v.Id, v.Message)
 					return nil
 				}
 			}
 			for _, v := range s.Filesystems {
-				if isErrorMessage(v.Status) {
+				if isError(v.Status) {
 					ctx.Infof("unable to destroy filesystem: %q, \ngot error: %q\ntry `juju status --storage --format yaml` for more details.", v.Id, v.Message)
 					return nil
 				}
 			}
 			for _, v := range s.Volumes {
-				if isErrorMessage(v.Status) {
+				if isError(v.Status) {
 					ctx.Infof("unable to destroy volume: %q, \ngot error: %q\ntry `juju status --storage --format yaml` for more details.", v.Id, v.Message)
 					return nil
 				}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -6,8 +6,11 @@ package model
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"time"
 
+	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -25,6 +28,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	rcmd "github.com/juju/juju/cmd/juju/romulus"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/core/model"
 	corestatus "github.com/juju/juju/core/status"
 )
@@ -37,8 +41,9 @@ var logger = loggo.GetLogger("juju.cmd.juju.model")
 
 // NewDestroyCommand returns a command used to destroy a model.
 func NewDestroyCommand() cmd.Command {
-	destroyCmd := &destroyCommand{}
-	destroyCmd.sleepFunc = time.Sleep
+	destroyCmd := &destroyCommand{
+		clock: jujuclock.WallClock,
+	}
 	destroyCmd.CanClearCurrentModel = true
 	return modelcmd.Wrap(
 		destroyCmd,
@@ -51,10 +56,10 @@ func NewDestroyCommand() cmd.Command {
 type destroyCommand struct {
 	modelcmd.ModelCommandBase
 
-	// sleepFunc is used when calling the timed function to get model status updates.
-	sleepFunc func(time.Duration)
+	clock jujuclock.Clock
 
 	assumeYes      bool
+	timeout        time.Duration
 	destroyStorage bool
 	releaseStorage bool
 	api            DestroyModelAPI
@@ -126,6 +131,8 @@ func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
+	f.DurationVar(&c.timeout, "t", 30*time.Minute, "Timeout to exit")
+	f.DurationVar(&c.timeout, "timeout", 30*time.Minute, "Timeout to exit")
 	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage instances in the model")
 	f.BoolVar(&c.releaseStorage, "release-storage", false, "Release all storage instances from the model, and management of the controller, without destroying them")
 }
@@ -289,18 +296,13 @@ upgrade the controller to version 2.3 or greater.
 	}
 
 	// Wait for model to be destroyed.
-	const modelStatusPollWait = 2 * time.Second
-	modelStatus := newTimedModelStatus(ctx, api, names.NewModelTag(modelDetails.ModelUUID), c.sleepFunc)
-	modelData, err := modelStatus(0)
-	if err != nil {
+	if err := waitForModelDestroyed(
+		ctx, api,
+		names.NewModelTag(modelDetails.ModelUUID),
+		c.timeout,
+		c.clock,
+	); err != nil {
 		return err
-	}
-	for modelData != nil {
-		ctx.Infof(formatDestroyModelInfo(modelData) + "...")
-		modelData, err = modelStatus(modelStatusPollWait)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Check if the model has an sla auth.
@@ -345,73 +347,153 @@ type modelData struct {
 	applicationCount int
 	volumeCount      int
 	filesystemCount  int
+	errorCount       int
 }
 
-// newTimedModelStatus returns a function which waits a given period of time
-// before querying the API server for the status of a model.
-func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelTag, sleepFunc func(time.Duration)) func(time.Duration) (*modelData, error) {
-	return func(wait time.Duration) (*modelData, error) {
-		sleepFunc(wait)
-		status, err := api.ModelStatus(tag)
-		if err == nil && len(status) == 1 && status[0].Error != nil {
-			// In 2.2 an error of one model generate an error for the entire request,
-			// in 2.3 this was corrected to just be an error for the requested model.
-			err = status[0].Error
-		}
-		if err != nil {
-			if params.IsCodeNotFound(err) {
-				ctx.Infof("Model destroyed.")
-			} else {
-				ctx.Infof("Unable to get the model status from the API: %v.", err)
-			}
-			return nil, nil
-		}
-		isError := func(s string) bool {
-			return corestatus.Error.Matches(corestatus.Status(s))
-		}
-		getErrMsg := func(s string) string {
-			var errMsg string
-			if s != "" {
-				errMsg = fmt.Sprintf("\ngot error: %q", s)
-			}
-			return errMsg
-		}
-		for _, s := range status {
-			for _, v := range s.Machines {
-				if isError(v.Status) {
-					ctx.Infof("unable to destroy machine: %q, %s\ntry `juju status` for more details.", v.Id, getErrMsg(v.Message))
-					return nil, cmd.ErrSilent
-				}
-			}
-			for _, v := range s.Filesystems {
-				if isError(v.Status) {
-					ctx.Infof("unable to destroy filesystem: %q, %s\ntry `juju status --storage --format yaml` for more details.", v.Id, getErrMsg(v.Message))
-					return nil, cmd.ErrSilent
-				}
-			}
-			for _, v := range s.Volumes {
-				if isError(v.Status) {
-					ctx.Infof("unable to destroy volume: %q, %s\ntry `juju status --storage --format yaml` for more details.", v.Id, getErrMsg(v.Message))
-					return nil, cmd.ErrSilent
-				}
-			}
-		}
+func waitForModelDestroyed(
+	ctx *cmd.Context,
+	api DestroyModelAPI,
+	tag names.ModelTag,
+	timeout time.Duration,
+	clock jujuclock.Clock,
+) error {
 
-		if l := len(status); l != 1 {
-			ctx.Infof("error finding model status: expected one result, got %d", l)
-			return nil, nil
-		}
-		return &modelData{
-			machineCount:     status[0].HostedMachineCount,
-			applicationCount: status[0].ApplicationCount,
-			volumeCount:      len(status[0].Volumes),
-			filesystemCount:  len(status[0].Filesystems),
-		}, nil
+	interrupted := make(chan os.Signal, 1)
+	defer close(interrupted)
+	ctx.InterruptNotify(interrupted)
+	defer ctx.StopInterruptNotify(interrupted)
+
+	var data *modelData
+	var erroredStatuses modelResourceErrorStatusSummary
+
+	printErrors := func() {
+		erroredStatuses.PrettyPrint(ctx.Stdout)
 	}
+
+	// no wait for 1st time.
+	intervalSeconds := 0 * time.Second
+	timeoutAfter := clock.After(timeout)
+	for {
+		select {
+		case <-interrupted:
+			ctx.Infof("ctrl+c detected, abort...")
+			printErrors()
+			return cmd.ErrSilent
+		case <-timeoutAfter:
+			printErrors()
+			return errors.Timeoutf("timeout after %v", timeout)
+		case <-clock.After(intervalSeconds):
+			data, erroredStatuses = getModelStatus(ctx, api, tag)
+			if data == nil {
+				// model has been destroyed successfully.
+				return nil
+			}
+			ctx.Infof(formatDestroyModelInfo(data) + "...")
+			intervalSeconds = 2 * time.Second
+		}
+	}
+}
+
+type modelResourceErrorStatus struct {
+	ID, Message string
+}
+
+type modelResourceErrorStatusSummary struct {
+	Machines    []modelResourceErrorStatus
+	Filesystems []modelResourceErrorStatus
+	Volumes     []modelResourceErrorStatus
+}
+
+func (s modelResourceErrorStatusSummary) Count() int {
+	return len(s.Machines) + len(s.Filesystems) + len(s.Volumes)
+}
+
+func (s modelResourceErrorStatusSummary) PrettyPrint(writer io.Writer) error {
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{tw}
+	w.Println()
+	w.Println("Resource", "Id", "Message")
+	for k, resources := range map[string][]modelResourceErrorStatus{
+		"Machine":    s.Machines,
+		"Filesystem": s.Filesystems,
+		"Volume":     s.Volumes,
+	} {
+		resourceType := k
+		for _, r := range resources {
+			w.Println(resourceType, r.ID, r.Message)
+			resourceType = ""
+		}
+	}
+	tw.Flush()
+	return nil
+}
+
+func getModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelTag) (*modelData, modelResourceErrorStatusSummary) {
+	var erroredStatuses modelResourceErrorStatusSummary
+
+	status, err := api.ModelStatus(tag)
+	if err == nil && len(status) == 1 && status[0].Error != nil {
+		// In 2.2 an error of one model generate an error for the entire request,
+		// in 2.3 this was corrected to just be an error for the requested model.
+		err = status[0].Error
+	}
+	if err != nil {
+		if params.IsCodeNotFound(err) {
+			ctx.Infof("Model destroyed.")
+		} else {
+			ctx.Infof("Unable to get the model status from the API: %v.", err)
+		}
+		return nil, erroredStatuses
+	}
+	isError := func(s string) bool {
+		return corestatus.Error.Matches(corestatus.Status(s))
+	}
+	for _, s := range status {
+		for _, v := range s.Machines {
+			if isError(v.Status) {
+				erroredStatuses.Machines = append(erroredStatuses.Machines, modelResourceErrorStatus{
+					ID:      v.Id,
+					Message: v.Message,
+				})
+			}
+		}
+		for _, v := range s.Filesystems {
+			if isError(v.Status) {
+				erroredStatuses.Filesystems = append(erroredStatuses.Filesystems, modelResourceErrorStatus{
+					ID:      v.Id,
+					Message: v.Message,
+				})
+			}
+		}
+		for _, v := range s.Volumes {
+			if isError(v.Status) {
+				erroredStatuses.Volumes = append(erroredStatuses.Volumes, modelResourceErrorStatus{
+					ID:      v.Id,
+					Message: v.Message,
+				})
+			}
+		}
+	}
+
+	if l := len(status); l != 1 {
+		ctx.Infof("error finding model status: expected one result, got %d", l)
+		return nil, erroredStatuses
+	}
+	return &modelData{
+		machineCount:     status[0].HostedMachineCount,
+		applicationCount: status[0].ApplicationCount,
+		volumeCount:      len(status[0].Volumes),
+		filesystemCount:  len(status[0].Filesystems),
+		errorCount:       erroredStatuses.Count(),
+	}, erroredStatuses
 }
 
 func formatDestroyModelInfo(data *modelData) string {
 	out := "Waiting on model to be removed"
+	if data.errorCount > 0 {
+		// always shows errorCount even if no machines and applications left.
+		out += fmt.Sprintf(", %d error(s)", data.errorCount)
+	}
 	if data.machineCount == 0 && data.applicationCount == 0 {
 		return out
 	}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -363,23 +363,22 @@ func newTimedModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelT
 		isErrorMessage := func(s string) bool {
 			return strings.Contains(s, "error")
 		}
-		logger.Criticalf("status -> \n%+v", status)
 		for _, s := range status {
 			for _, v := range s.Machines {
 				if isErrorMessage(v.Status) {
-					ctx.Infof("unable to destroy machine: %+v, \nerror: %q\ntry `juju status` for more details.", v, v.Status)
+					ctx.Infof("unable to destroy machine: %q, \ngot error: %q\ntry `juju status` for more details.", v.Id, v.Message)
 					return nil
 				}
 			}
 			for _, v := range s.Filesystems {
 				if isErrorMessage(v.Status) {
-					ctx.Infof("unable to destroy filesystem: %+v, \nerror: %q\ntry `juju status --storage` for more details.", v, v.Status)
+					ctx.Infof("unable to destroy filesystem: %q, \ngot error: %q\ntry `juju status --storage --format yaml` for more details.", v.Id, v.Message)
 					return nil
 				}
 			}
 			for _, v := range s.Volumes {
 				if isErrorMessage(v.Status) {
-					ctx.Infof("unable to destroy volume: %+v, \nerror: %q\ntry `juju status --storage` for more details.", v, v.Status)
+					ctx.Infof("unable to destroy volume: %q, \ngot error: %q\ntry `juju status --storage --format yaml` for more details.", v.Id, v.Message)
 					return nil
 				}
 			}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"time"
 
+	testclock "github.com/juju/clock/testclock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -37,7 +38,8 @@ type DestroySuite struct {
 	stub            *jutesting.Stub
 	budgetAPIClient *mockBudgetAPIClient
 	store           *jujuclient.MemStore
-	sleep           func(time.Duration)
+
+	clock *testclock.Clock
 }
 
 var _ = gc.Suite(&DestroySuite{})
@@ -45,11 +47,12 @@ var _ = gc.Suite(&DestroySuite{})
 // fakeDestroyAPI mocks out the client API
 type fakeAPI struct {
 	*jutesting.Stub
-	err             error
-	env             map[string]interface{}
-	statusCallCount int
-	bestAPIVersion  int
-	modelInfoErr    []*params.Error
+	err                error
+	env                map[string]interface{}
+	statusCallCount    int
+	bestAPIVersion     int
+	modelInfoErr       []*params.Error
+	modelStatusPayload []base.ModelStatus
 }
 
 func (f *fakeAPI) Close() error { return nil }
@@ -74,13 +77,17 @@ func (f *fakeAPI) ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, err
 		err = &params.Error{Code: params.CodeNotFound}
 	}
 	f.statusCallCount++
-	return []base.ModelStatus{{
-		Volumes: []base.Volume{
-			{Detachable: true},
-			{Detachable: true},
-		},
-		Filesystems: []base.Filesystem{{Detachable: true}},
-	}}, err
+
+	if f.modelStatusPayload == nil {
+		f.modelStatusPayload = []base.ModelStatus{{
+			Volumes: []base.Volume{
+				{Detachable: true},
+				{Detachable: true},
+			},
+			Filesystems: []base.Filesystem{{Detachable: true}},
+		}}
+	}
+	return f.modelStatusPayload, err
 }
 
 // fakeConfigAPI mocks out the ModelConfigAPI.
@@ -104,6 +111,7 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	}
 	s.configAPI = &fakeConfigAPI{}
 	s.storageAPI = &mockStorageAPI{Stub: s.stub}
+	s.clock = testclock.NewClock(time.Now())
 
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "test1"
@@ -117,7 +125,6 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.store.Accounts["test1"] = jujuclient.AccountDetails{
 		User: "admin",
 	}
-	s.sleep = func(time.Duration) {}
 
 	s.budgetAPIClient = &mockBudgetAPIClient{Stub: s.stub}
 	s.PatchValue(model.GetBudgetAPIClient,
@@ -127,12 +134,12 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	cmd := model.NewDestroyCommandForTest(s.api, s.configAPI, s.storageAPI, noOpRefresh, s.store, s.sleep)
+	cmd := model.NewDestroyCommandForTest(s.api, s.configAPI, s.storageAPI, s.clock, noOpRefresh, s.store)
 	return cmdtesting.RunCommand(c, cmd, args...)
 }
 
 func (s *DestroySuite) NewDestroyCommand() cmd.Command {
-	return model.NewDestroyCommandForTest(s.api, s.configAPI, s.storageAPI, noOpRefresh, s.store, s.sleep)
+	return model.NewDestroyCommandForTest(s.api, s.configAPI, s.storageAPI, s.clock, noOpRefresh, s.store)
 }
 
 func checkModelExistsInStore(c *gc.C, name string, store jujuclient.ClientStore) {
@@ -169,7 +176,7 @@ func (s *DestroySuite) TestDestroyUnknownModelCallsRefresh(c *gc.C) {
 		return nil
 	}
 
-	cmd := model.NewDestroyCommandForTest(s.api, s.configAPI, s.storageAPI, refresh, s.store, s.sleep)
+	cmd := model.NewDestroyCommandForTest(s.api, s.configAPI, s.storageAPI, s.clock, refresh, s.store)
 	_, err := cmdtesting.RunCommand(c, cmd, "foo")
 	c.Check(called, jc.IsTrue)
 	c.Check(err, gc.ErrorMatches, `model test1:admin/foo not found`)
@@ -370,6 +377,67 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 
 		// Add the test2 model back into the store for the next test
 		s.resetModel(c)
+	}
+}
+
+func (s *DestroySuite) TestDestroyCommandWait(c *gc.C) {
+	checkModelExistsInStore(c, "test1:admin/test2", s.store)
+
+	s.api.modelInfoErr = []*params.Error{nil, nil}
+	s.api.modelStatusPayload = []base.ModelStatus{{
+		ApplicationCount:   2,
+		HostedMachineCount: 1,
+		Volumes: []base.Volume{
+			{Detachable: true, Status: "error", Message: "failed to destroy volume 0", Id: "0"},
+			{Detachable: true, Status: "error", Message: "failed to destroy volume 1", Id: "1"},
+			{Detachable: true, Status: "error", Message: "failed to destroy volume 2", Id: "2"},
+		},
+		Filesystems: []base.Filesystem{
+			{Detachable: true, Status: "error", Message: "failed to destroy filesystem 0", Id: "0"},
+			{Detachable: true, Status: "error", Message: "failed to destroy filesystem 1", Id: "1"},
+		},
+	}}
+
+	done := make(chan struct{}, 1)
+	outErr := make(chan error, 1)
+	outStdOut := make(chan string, 1)
+	outStdErr := make(chan string, 1)
+
+	go func() {
+		// run destroy model cmd, and timeout in 3s.
+		ctx, err := s.runDestroyCommand(c, "test2", "-y", "-t", "3s")
+		outStdOut <- cmdtesting.Stdout(ctx)
+		outStdErr <- cmdtesting.Stderr(ctx)
+		outErr <- err
+		done <- struct{}{}
+	}()
+
+	c.Assert(s.clock.WaitAdvance(5*time.Second, testing.LongWait, 2), jc.ErrorIsNil)
+
+	select {
+	case <-done:
+		c.Assert(<-outStdErr, gc.Equals, `
+Destroying model
+Waiting on model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
+Waiting on model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
+`[1:])
+		c.Assert(<-outStdOut, gc.Equals, `
+
+The following errors were encountered during destroying the model.
+You can fix the problem causing the errors and run destroy-model again.
+
+Resource    Id  Message
+Filesystem  0   failed to destroy filesystem 0
+            1   failed to destroy filesystem 1
+Volume      0   failed to destroy volume 0
+            1   failed to destroy volume 1
+            2   failed to destroy volume 2
+`[1:])
+		// timeout after 3s.
+		c.Assert(<-outErr, jc.Satisfies, errors.IsTimeout)
+		checkModelExistsInStore(c, "test1:admin/test2", s.store)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for destroy cmd.")
 	}
 }
 

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -83,7 +83,7 @@ func (f *fakeAPI) ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, err
 	}}, err
 }
 
-// faceConfiAPI mocks out the ModelConfigAPI.
+// fakeConfigAPI mocks out the ModelConfigAPI.
 type fakeConfigAPI struct {
 	err      error
 	slaLevel string

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"time"
 
+	testclock "github.com/juju/clock/testclock"
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/api"
@@ -86,9 +87,9 @@ func NewDestroyCommandForTest(
 ) cmd.Command {
 	cmd := &destroyCommand{
 		api:        api,
+		clock:      testclock.NewClock(time.Time{}),
 		configAPI:  configAPI,
 		storageAPI: storageAPI,
-		sleepFunc:  sleepFunc,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetModelRefresh(refreshFunc)

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -4,9 +4,7 @@
 package model
 
 import (
-	"time"
-
-	testclock "github.com/juju/clock/testclock"
+	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/api"
@@ -82,12 +80,12 @@ func NewDestroyCommandForTest(
 	api DestroyModelAPI,
 	configAPI ModelConfigAPI,
 	storageAPI StorageAPI,
+	clk jujuclock.Clock,
 	refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore,
-	sleepFunc func(time.Duration),
 ) cmd.Command {
 	cmd := &destroyCommand{
 		api:        api,
-		clock:      testclock.NewClock(time.Time{}),
+		clock:      clk,
 		configAPI:  configAPI,
 		storageAPI: storageAPI,
 	}

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -352,8 +352,9 @@ func destroyFilesystems(env *environ, match func(api.StorageVolume) bool) error 
 // DestroyFilesystems is specified on the storage.FilesystemSource interface.
 func (s *lxdFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	results := make([]error, len(filesystemIds))
-	for i, filesystemId := range filesystemIds {
-		results[i] = s.destroyFilesystem(filesystemId)
+	for i, _ := range filesystemIds {
+		// results[i] = s.destroyFilesystem(filesystemId)
+		results[i] = errors.NewNotValid(nil, "testing invalid errors!!!!!")
 		common.HandleCredentialError(IsAuthorisationFailure, results[i], ctx)
 	}
 	return results, nil

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -352,9 +352,8 @@ func destroyFilesystems(env *environ, match func(api.StorageVolume) bool) error 
 // DestroyFilesystems is specified on the storage.FilesystemSource interface.
 func (s *lxdFilesystemSource) DestroyFilesystems(ctx context.ProviderCallContext, filesystemIds []string) ([]error, error) {
 	results := make([]error, len(filesystemIds))
-	for i, _ := range filesystemIds {
-		// results[i] = s.destroyFilesystem(filesystemId)
-		results[i] = errors.NewNotValid(nil, "testing invalid errors!!!!!")
+	for i, filesystemId := range filesystemIds {
+		results[i] = s.destroyFilesystem(filesystemId)
 		common.HandleCredentialError(IsAuthorisationFailure, results[i], ctx)
 	}
 	return results, nil

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -193,7 +193,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 		}
 		err = errors.Annotatef(err, "%s failed to set machine to dead", mr.config.Tag)
 		if e := mr.machine.SetStatus(status.Error, err.Error(), nil); e != nil {
-			err = errors.Annotatef(err, "failed to set status")
+			logger.Errorf("failed to set status for error %v ", err)
 		}
 		return errors.Trace(err)
 	}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -192,7 +192,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 			return nil
 		}
 		err = errors.Annotatef(err, "%s failed to set machine to dead", mr.config.Tag)
-		if e := mr.machine.SetStatus(status.Error, err.Error(), nil); e != nil {
+		if e := mr.machine.SetStatus(status.Error, errors.Annotate(err, "destroying machine").Error(), nil); e != nil {
 			logger.Errorf("failed to set status for error %v ", err)
 		}
 		return errors.Trace(err)

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -191,7 +191,11 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 			logger.Tracef("machine still has storage attached")
 			return nil
 		}
-		return errors.Annotatef(err, "%s failed to set machine to dead", mr.config.Tag)
+		err = errors.Annotatef(err, "%s failed to set machine to dead", mr.config.Tag)
+		if e := mr.machine.SetStatus(status.Error, err.Error(), nil); e != nil {
+			err = errors.Annotatef(err, "failed to set status")
+		}
+		return errors.Trace(err)
 	}
 	// Report on the machine's death. It is important that we do this after
 	// the machine is Dead, because this is the mechanism we use to clean up

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -183,6 +183,12 @@ func (s *MachinerSuite) TestMachinerMachineEnsureDeadError(c *gc.C) {
 		err, gc.ErrorMatches,
 		"machine-123 failed to set machine to dead: cannot ensure machine is dead",
 	)
+	s.accessor.machine.CheckCall(
+		c, 7, "SetStatus",
+		status.Error,
+		"destroying machine: machine-123 failed to set machine to dead: cannot ensure machine is dead",
+		map[string]interface{}(nil),
+	)
 }
 
 func (s *MachinerSuite) TestMachinerMachineAssignedUnits(c *gc.C) {

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -234,7 +234,7 @@ func removeFilesystems(ctx *context, ops map[names.FilesystemTag]*removeFilesyst
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: status.Destroying.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
 		}

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -224,25 +224,18 @@ func removeFilesystems(ctx *context, ops map[names.FilesystemTag]*removeFilesyst
 		if err != nil {
 			return errors.Trace(err)
 		}
-		errCount := 0
 		for i, err := range errs {
 			tag := tags[i]
 			if err == nil {
 				remove = append(remove, tag)
 				continue
 			}
-			errCount++
-			statusToSet := status.Destroying
-			if errCount > len(errs)/2 {
-				// if more than half of the filesystem removal failed, set status to Error to let juju cli exits.
-				statusToSet = status.Error
-			}
 			// Failed to destroy or release filesystem; reschedule and update status.
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: statusToSet.String(),
-				Info:   err.Error(),
+				Status: status.Error.String(),
+				Info:   errors.Annotate(err, "destroying filesystem").Error(),
 			})
 		}
 		return nil

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -235,7 +235,7 @@ func removeFilesystems(ctx *context, ops map[names.FilesystemTag]*removeFilesyst
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
 				Status: status.Error.String(),
-				Info:   errors.Annotate(err, "destroying filesystem").Error(),
+				Info:   errors.Annotate(err, "removing filesystem").Error(),
 			})
 		}
 		return nil

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -1678,15 +1678,15 @@ func (s *storageProvisionerSuite) TestDestroyVolumesRetry(c *gc.C) {
 	})
 
 	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
-		{Tag: "volume-1", Status: "destroying", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "badness"},
 	})
 }
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -1678,15 +1678,15 @@ func (s *storageProvisionerSuite) TestDestroyVolumesRetry(c *gc.C) {
 	})
 
 	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
-		{Tag: "volume-1", Status: "error", Info: "badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
+		{Tag: "volume-1", Status: "error", Info: "destroying volume: badness"},
 	})
 }
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -1767,6 +1767,86 @@ func (s *storageProvisionerSuite) TestDestroyFilesystems(c *gc.C) {
 	assertNoEvent(c, removedChan, "filesystems removed")
 }
 
+func (s *storageProvisionerSuite) TestDestroyFilesystemsRetry(c *gc.C) {
+	provisionedDestroyFilesystem := names.NewFilesystemTag("0")
+
+	filesystemAccessor := newMockFilesystemAccessor()
+	filesystemAccessor.provisionFilesystem(provisionedDestroyFilesystem)
+
+	life := func(tags []names.Tag) ([]params.LifeResult, error) {
+		return []params.LifeResult{{Life: params.Dead}}, nil
+	}
+
+	// mockFunc's After will progress the current time by the specified
+	// duration and signal the channel immediately.
+	clock := &mockClock{}
+	var destroyFilesystemTimes []time.Time
+	s.provider.destroyFilesystemsFunc = func(filesystemIds []string) ([]error, error) {
+		destroyFilesystemTimes = append(destroyFilesystemTimes, clock.Now())
+		if len(destroyFilesystemTimes) < 10 {
+			return []error{errors.New("destroyFilesystems failed, please retry later")}, nil
+		}
+		return []error{nil}, nil
+	}
+
+	removedChan := make(chan interface{}, 1)
+	remove := func(tags []names.Tag) ([]params.ErrorResult, error) {
+		removedChan <- tags
+		return make([]params.ErrorResult, len(tags)), nil
+	}
+
+	args := &workerArgs{
+		filesystems: filesystemAccessor,
+		clock:       clock,
+		life: &mockLifecycleManager{
+			life:   life,
+			remove: remove,
+		},
+		registry: s.registry,
+	}
+	worker := newStorageProvisioner(c, args)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	filesystemAccessor.filesystemsWatcher.changes <- []string{
+		provisionedDestroyFilesystem.Id(),
+	}
+
+	waitChannel(c, removedChan, "waiting for filesystem to be removed")
+	c.Assert(destroyFilesystemTimes, gc.HasLen, 10)
+
+	// The first attempt should have been immediate: T0.
+	c.Assert(destroyFilesystemTimes[0], gc.Equals, time.Time{})
+
+	delays := make([]time.Duration, len(destroyFilesystemTimes)-1)
+	for i := range destroyFilesystemTimes[1:] {
+		delays[i] = destroyFilesystemTimes[i+1].Sub(destroyFilesystemTimes[i])
+	}
+	c.Assert(delays, jc.DeepEquals, []time.Duration{
+		30 * time.Second,
+		1 * time.Minute,
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		16 * time.Minute,
+		30 * time.Minute, // ceiling reached
+		30 * time.Minute,
+		30 * time.Minute,
+	})
+
+	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+		{Tag: "filesystem-0", Status: "error", Info: "removing filesystem: destroyFilesystems failed, please retry later"},
+	})
+}
+
 type caasStorageProvisionerSuite struct {
 	coretesting.BaseSuite
 	provider *dummyProvider

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -294,7 +294,7 @@ func removeVolumes(ctx *context, ops map[names.VolumeTag]*removeVolumeOp) error 
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
 				Status: status.Error.String(),
-				Info:   err.Error(),
+				Info:   errors.Annotate(err, "destroying volume").Error(),
 			})
 		}
 		return nil

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -293,7 +293,7 @@ func removeVolumes(ctx *context, ops map[names.VolumeTag]*removeVolumeOp) error 
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: status.Destroying.String(),
+				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
 		}


### PR DESCRIPTION
## Description of change

`juju destroy-model` cmd now exits and prints debug cmd rather than hanging there forever if there is an error in destroying machine/filesystem/volume.

## QA steps
1. prepare an IAAS model on aws(could be any cloud, here make assumption for step 3);
2. deploy an application with storage;
3. set the ebs volume to DeleteOnTermination=False;
4. run `juju destroy-model <model-name> --destroy-storage -t 10s` (prints error report after timeout);
4. run `juju destroy-model <model-name> --destroy-storage`, then ctrl +C (prints error report when it exits);
sample output: 
```
⇒  juju destroy-model t1 --destroy-storage -y -t 15s
Destroying model
Waiting on model to be removed, 1 machine(s), 1 application(s), 1 filesystems(s)...
Waiting on model to be removed, 1 machine(s), 1 application(s), 1 filesystems(s)...
Waiting on model to be removed, 1 machine(s), 1 application(s), 1 filesystems(s)...
Waiting on model to be removed, 1 machine(s), 1 application(s), 1 filesystems(s)...
Waiting on model to be removed, 1 machine(s), 1 filesystems(s)...
Waiting on model to be removed, 1 error(s), 1 machine(s), 1 filesystems(s)...
Waiting on model to be removed, 1 error(s), 1 machine(s), 1 filesystems(s)...
^Cctrl+c detected, aborting...

The following errors were encountered during destroying the model.
You can fix the problem causing the errors and run destroy-model again.

Resource    Id  Message
Filesystem  0   removing filesystem: testing invalid errors!!!!!
```


## Documentation changes

slightly changed error handling, probably no doc change required? 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1734287