### PR TITLE
Fix anon auth in notify watcher

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -107,7 +107,7 @@ func newNotifyWatcher(context facade.Context) (facade.Facade, error) {
 
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
-	if !isAgentOrUser(auth) {
+	if auth.GetAuthTag() != nil && !isAgentOrUser(auth) {
 		return nil, common.ErrPerm
 	}
 


### PR DESCRIPTION
One line fix due to an omission from an earlier forward port.
Properly allow anon invocations of Stop() on notify watcher.