### PR TITLE
Merge pull request #9509 from wallyworld/cmr-offer-terminated

### DIFF
--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -168,3 +168,9 @@ func (s *precheckRelationShim) Unit(pu PrecheckUnit) (PrecheckRelationUnit, erro
 	}
 	return ru, nil
 }
+
+// IsCrossModel implements PreCheckRelation.
+func (s *precheckRelationShim) IsCrossModel() (bool, error) {
+	_, result, err := s.Relation.RemoteApplication()
+	return result, err
+}

--- a/state/interface.go
+++ b/state/interface.go
@@ -225,6 +225,8 @@ type Action interface {
 
 // ApplicationEntity represents a local or remote application.
 type ApplicationEntity interface {
+	status.StatusGetter
+
 	// Life returns the life status of the application.
 	Life() Life
 

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -294,6 +294,80 @@ func (s *RelationSuite) TestDestroyPeerRelation(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *RelationSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {
+	ok, err := relUnit.InScope()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, gc.Equals, inScope)
+}
+
+func (s *RelationSuite) assertDestroyCrossModelRelation(c *gc.C, appStatus *status.Status) {
+	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "remote-wordpress",
+		SourceModel: names.NewModelTag("source-model"),
+		OfferUUID:   "offer-uuid",
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Limit:     1,
+			Name:      "db",
+			Role:      charm.RoleRequirer,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wordpressEP, err := rwordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+
+	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	mysqlUnit, err := mysql.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	mysqlEP, err := mysql.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+
+	rel, err := s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+	mysqlru, err := rel.Unit(mysqlUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mysqlru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, mysqlru, true)
+
+	wpru, err := rel.RemoteUnit("remote-wordpress/0")
+	c.Assert(err, jc.ErrorIsNil)
+	err = wpru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, wpru, true)
+
+	if appStatus != nil {
+		err = rwordpress.SetStatus(status.StatusInfo{Status: *appStatus})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	err = rel.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rel.Life(), gc.Equals, state.Dying)
+
+	// If the remote app for the relation is terminated, any remote units are
+	// forcibly removed from scope, but not local ones.
+	s.assertInScope(c, wpru, appStatus == nil || *appStatus != status.Terminated)
+	s.assertInScope(c, mysqlru, true)
+}
+
+func (s *RelationSuite) TestDestroyCrossModelRelationNoAppStatus(c *gc.C) {
+	s.assertDestroyCrossModelRelation(c, nil)
+}
+
+func (s *RelationSuite) TestDestroyCrossModelRelationAppNotTerminated(c *gc.C) {
+	st := status.Active
+	s.assertDestroyCrossModelRelation(c, &st)
+}
+
+func (s *RelationSuite) TestDestroyCrossModelRelationAppTerminated(c *gc.C) {
+	st := status.Terminated
+	s.assertDestroyCrossModelRelation(c, &st)
+}
+
 func (s *RelationSuite) TestIsCrossModelYup(c *gc.C) {
 	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:            "remote-wordpress",
@@ -317,9 +391,37 @@ func (s *RelationSuite) TestIsCrossModelYup(c *gc.C) {
 	relation, err := s.State.AddRelation(wordpressEP, mysqlEP)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := relation.IsCrossModel()
+	app, result, err := relation.RemoteApplication()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.IsTrue)
+	c.Assert(app.Name(), gc.Equals, "remote-wordpress")
+}
+
+func (s *RelationSuite) TestAddCrossModelNotAllowed(c *gc.C) {
+	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "remote-wordpress",
+		SourceModel: names.NewModelTag("source-model"),
+		OfferUUID:   "offer-uuid",
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Limit:     1,
+			Name:      "db",
+			Role:      charm.RoleRequirer,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wordpressEP, err := rwordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	mysqlEP, err := mysql.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = rwordpress.SetStatus(status.StatusInfo{Status: status.Terminated})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "remote-wordpress:db mysql:server": remote offer remote-wordpress is terminated`)
+
 }
 
 func (s *RelationSuite) TestIsCrossModelNope(c *gc.C) {
@@ -332,13 +434,14 @@ func (s *RelationSuite) TestIsCrossModelNope(c *gc.C) {
 	relation, err := s.State.AddRelation(wordpressEP, mysqlEP)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := relation.IsCrossModel()
+	app, result, err := relation.RemoteApplication()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.IsFalse)
+	c.Assert(app, gc.IsNil)
 }
 
-func assertNoRelations(c *gc.C, srv *state.Application) {
-	rels, err := srv.Relations()
+func assertNoRelations(c *gc.C, app state.ApplicationEntity) {
+	rels, err := app.Relations()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rels, gc.HasLen, 0)
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -518,7 +518,7 @@ func NetworksForRelation(
 	// is bound to the default space, we need to look up the ingress
 	// address info which is aware of cross model relations.
 	if boundSpace == environs.DefaultSpaceName || err != nil {
-		crossmodel, err := rel.IsCrossModel()
+		_, crossmodel, err := rel.RemoteApplication()
 		if err != nil {
 			return "", nil, nil, errors.Trace(err)
 		}

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -291,7 +291,7 @@ func (s *RemoteApplication) destroyOps() ([]txn.Op, error) {
 	}
 	rels, err := s.Relations()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if len(rels) != s.doc.RelationCount {
 		// This is just an early bail out. The relations obtained may still
@@ -299,9 +299,32 @@ func (s *RemoteApplication) destroyOps() ([]txn.Op, error) {
 		// asserts on relationcount and on each known relation, below.
 		return nil, errRefresh
 	}
+
+	// We'll need status below when processing relations.
+	statusInfo, statusErr := s.Status()
+	if statusErr != nil && !errors.IsNotFound(statusErr) {
+		return nil, errors.Trace(statusErr)
+	}
+
 	var ops []txn.Op
 	removeCount := 0
 	for _, rel := range rels {
+		// If the remote app has been terminated, we may have been offline
+		// and not noticed so need to clean up any exiting relation units.
+		if statusErr == nil && statusInfo.Status == status.Terminated {
+			logger.Debugf("forcing cleanup of units for %v", s.Name())
+			remoteUnits, err := rel.AllRemoteUnits(s.Name())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			logger.Debugf("got %v relation units to clean", len(remoteUnits))
+			for _, ru := range remoteUnits {
+				if err := ru.LeaveScope(); err != nil {
+					return nil, errors.Trace(err)
+				}
+			}
+		}
+
 		relOps, isRemove, err := rel.destroyOps(s.doc.Name)
 		if err == errAlreadyDying {
 			relOps = []txn.Op{{
@@ -310,7 +333,7 @@ func (s *RemoteApplication) destroyOps() ([]txn.Op, error) {
 				Assert: bson.D{{"life", Dying}},
 			}}
 		} else if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 		if isRemove {
 			removeCount++
@@ -323,7 +346,7 @@ func (s *RemoteApplication) destroyOps() ([]txn.Op, error) {
 		hasLastRefs := bson.D{{"life", Alive}, {"relationcount", removeCount}}
 		removeOps, err := s.removeOps(hasLastRefs)
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 		return append(ops, removeOps...), nil
 	}

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -8,10 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6"
-
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
@@ -19,6 +15,9 @@ import (
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 )
 
 type remoteApplicationSuite struct {
@@ -850,6 +849,67 @@ func (s *remoteApplicationSuite) assertDestroyWithReferencedRelation(c *gc.C, re
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	err = rel0.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *remoteApplicationSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {
+	ok, err := relUnit.InScope()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, gc.Equals, inScope)
+}
+
+func (s *remoteApplicationSuite) assertDestroyAppWithStatus(c *gc.C, appStatus *status.Status) {
+	mysqlEP, err := s.application.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+
+	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	wpUnit, err := wordpress.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	wpEP, err := wordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+
+	rel, err := s.State.AddRelation(wpEP, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+	wpru, err := rel.Unit(wpUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = wpru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, wpru, true)
+
+	mysqlru, err := rel.RemoteUnit("mysql/0")
+	c.Assert(err, jc.ErrorIsNil)
+	err = mysqlru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, mysqlru, true)
+
+	if appStatus != nil {
+		err = s.application.SetStatus(status.StatusInfo{Status: *appStatus})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	err = s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.application.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.application.Life(), gc.Equals, state.Dying)
+
+	// If the remote app is terminated, any remote units are
+	// forcibly removed from scope, but not local ones.
+	s.assertInScope(c, mysqlru, appStatus == nil || *appStatus != status.Terminated)
+	s.assertInScope(c, wpru, true)
+}
+
+func (s *remoteApplicationSuite) TestDestroyNoStatus(c *gc.C) {
+	s.assertDestroyAppWithStatus(c, nil)
+}
+
+func (s *remoteApplicationSuite) TestDestroyNotTerminated(c *gc.C) {
+	appStatus := status.Active
+	s.assertDestroyAppWithStatus(c, &appStatus)
+}
+
+func (s *remoteApplicationSuite) TestDestroyTerminated(c *gc.C) {
+	appStatus := status.Terminated
+	s.assertDestroyAppWithStatus(c, &appStatus)
 }
 
 func (s *remoteApplicationSuite) TestAllRemoteApplicationsNone(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1843,6 +1843,15 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 				return nil, err
 			}
 			if app.IsRemote() {
+				// If the remote application is known to be terminated, we don't
+				// allow a relation to it.
+				statusInfo, err := app.Status()
+				if err != nil && !errors.IsNotFound(err) {
+					return nil, errors.Trace(err)
+				}
+				if err == nil && statusInfo.Status == status.Terminated {
+					return nil, errors.Errorf("remote offer %s is terminated", ep.ApplicationName)
+				}
 				ops = append(ops, txn.Op{
 					C:      remoteApplicationsC,
 					Id:     st.docID(ep.ApplicationName),


### PR DESCRIPTION
Backport https://github.com/juju/juju/pull/9509

## Description of change

When controllers in a cmr scenario lost contact, it's possible that relations get in a stuck state. We're now more aggressive about removing remote units from scope, and also on the consuming side set the remote app to terminated if the offer has been removed. Removing a terminated remote application also triggers extra cleanup of the units to allow any relations to also be deleted.

## QA steps

Run a multi-controller cmr scenario.
firewall the offering side so outbound traffic to the consuming controller is blocked
forcibly remove the offer
open the firewall
consuming side shows saas application in status as terminated
remove-saas will remove the application plus the relations and run the departed/broken hooks

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804362
