### PR TITLE
Handle D-Bus Method Not Found When Systemd is Not the Current Init System

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -135,6 +135,7 @@
   packages = [
     "dbus",
     "unit",
+    "util",
   ]
   pruneopts = ""
   revision = "7b2428fec40033549c68f54e26e89e7ca9a9ce31"
@@ -1775,6 +1776,7 @@
     "github.com/bmizerany/pat",
     "github.com/coreos/go-systemd/dbus",
     "github.com/coreos/go-systemd/unit",
+    "github.com/coreos/go-systemd/util",
     "github.com/docker/distribution/reference",
     "github.com/dustin/go-humanize",
     "github.com/golang/mock/gomock",

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -193,7 +193,7 @@ func (s *systemdServiceManager) WriteSystemdAgents(
 			return nil, nil, nil, errors.Errorf("%s service not of type UpgradableService", svcName)
 		}
 
-		dbusMethodNotFound := false
+		dbusMethodFound := true
 		if err = uSvc.WriteService(); err != nil {
 			// Note that this error is already logged by the systemd package.
 
@@ -204,7 +204,7 @@ func (s *systemdServiceManager) WriteSystemdAgents(
 			// We need to detect this condition and fall through to linking the
 			// service files manually.
 			if strings.Contains(err.Error(), "No such method 'LinkUnitFiles'") {
-				dbusMethodNotFound = true
+				dbusMethodFound = false
 				logger.Infof("attempting to manually link service file for %s", agentName)
 			} else {
 				errAgentNames = append(errAgentNames, agentName)
@@ -219,7 +219,7 @@ func (s *systemdServiceManager) WriteSystemdAgents(
 		// call to DBusAPI.LinkUnitFiles in WriteService above returned no
 		// error, it will have resulted in updated sym-links for the file.
 		// We are done.
-		if s.isRunning() && !dbusMethodNotFound {
+		if s.isRunning() && dbusMethodFound {
 			startedSysServiceNames = append(startedSysServiceNames, svcName)
 			logger.Infof("wrote %s agent, enabled and linked by systemd", svcName)
 			continue

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -203,7 +203,7 @@ func (s *systemdServiceManager) WriteSystemdAgents(
 			// If this happens, then D-Bus will error with the message below.
 			// We need to detect this condition and fall through to linking the
 			// service files manually.
-			if strings.Contains(err.Error(), "No such method 'LinkUnitFiles'") {
+			if strings.Contains(strings.ToLower(err.Error()), "no such method") {
 				dbusMethodFound = false
 				logger.Infof("attempting to manually link service file for %s", agentName)
 			} else {

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-//The unit testcases in this file do not pertain to an specific command.
+// The test cases in this file do not pertain to a specific command.
 
 package service_test
 
@@ -38,8 +38,8 @@ type agentConfSuite struct {
 	dataDir             string
 	machineName         string
 	unitNames           []string
-	systemdDir          string // updateseries.systemDir
-	systemdMultiUserDir string // updateseries.systemMultiUserDir
+	systemdDir          string
+	systemdMultiUserDir string
 	systemdDataDir      string // service.SystemdDataDir
 	manager             service.SystemdServiceManager
 
@@ -57,14 +57,14 @@ func (s *agentConfSuite) SetUpTest(c *gc.C) {
 	s.dataDir = c.MkDir()
 	s.systemdDir = path.Join(s.dataDir, "etc", "systemd", "system")
 	s.systemdMultiUserDir = path.Join(s.systemdDir, "multi-user.target.wants")
-	os.MkdirAll(s.systemdMultiUserDir, os.ModeDir|os.ModePerm)
+	c.Assert(os.MkdirAll(s.systemdMultiUserDir, os.ModeDir|os.ModePerm), jc.ErrorIsNil)
 	s.systemdDataDir = path.Join(s.dataDir, "lib", "systemd", "system")
 
 	s.machineName = "machine-0"
 	s.unitNames = []string{"unit-ubuntu-0", "unit-mysql-0"}
 
 	s.manager = service.NewServiceManager(
-		func() (bool, error) { return true, nil },
+		func() bool { return true },
 		s.newService,
 	)
 
@@ -108,15 +108,16 @@ func (s *agentConfSuite) setUpAgentConf(c *gc.C) {
 
 func (s *agentConfSuite) setUpServices(c *gc.C) {
 	for _, fake := range append(s.unitNames, s.machineName) {
-		s.addService("jujud-" + fake)
+		s.addService(c, "jujud-"+fake)
 	}
 	s.PatchValue(&service.ListServices, s.listServices)
 }
 
-func (s *agentConfSuite) addService(name string) {
-	svc, _ := s.newService(name, common.Conf{})
-	svc.Install()
-	svc.Start()
+func (s *agentConfSuite) addService(c *gc.C, name string) {
+	svc, err := s.newService(name, common.Conf{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(svc.Install(), jc.ErrorIsNil)
+	c.Assert(svc.Start(), jc.ErrorIsNil)
 }
 
 func (s *agentConfSuite) listServices() ([]string, error) {
@@ -258,7 +259,7 @@ func (s *agentConfSuite) TestStartAllAgentsFailMachine(c *gc.C) {
 
 func (s *agentConfSuite) TestStartAllAgentsSystemdNotRunning(c *gc.C) {
 	s.manager = service.NewServiceManager(
-		func() (bool, error) { return false, nil },
+		func() bool { return false },
 		s.newService,
 	)
 
@@ -289,8 +290,6 @@ func (s *agentConfSuite) TestCopyAgentBinaryOriginalAgentBinariesNotFound(c *gc.
 }
 
 func (s *agentConfSuite) TestWriteSystemdAgents(c *gc.C) {
-	s.PatchValue(&systemd.SystemPath, s.dataDir)
-
 	startedSymLinkAgents, startedSysServiceNames, errAgents, err := s.manager.WriteSystemdAgents(
 		s.machineName, s.unitNames, s.systemdDataDir, s.systemdDir, s.systemdMultiUserDir)
 
@@ -303,7 +302,7 @@ func (s *agentConfSuite) TestWriteSystemdAgents(c *gc.C) {
 
 func (s *agentConfSuite) TestWriteSystemdAgentsSystemdNotRunning(c *gc.C) {
 	s.manager = service.NewServiceManager(
-		func() (bool, error) { return false, nil },
+		func() bool { return false },
 		s.newService,
 	)
 
@@ -319,7 +318,6 @@ func (s *agentConfSuite) TestWriteSystemdAgentsSystemdNotRunning(c *gc.C) {
 }
 
 func (s *agentConfSuite) TestWriteSystemdAgentsWriteServiceFail(c *gc.C) {
-	s.PatchValue(&systemd.SystemPath, s.dataDir)
 	s.services[0].SetErrors(
 		nil,
 		nil,

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -100,7 +100,7 @@ type discoveryCheck struct {
 
 var discoveryFuncs = []discoveryCheck{
 	{InitSystemUpstart, upstart.IsRunning},
-	{InitSystemSystemd, systemd.IsRunning},
+	{InitSystemSystemd, func() (bool, error) { return systemd.IsRunning(), nil }},
 	{InitSystemWindows, windows.IsRunning},
 }
 

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/dbus"
+	"github.com/coreos/go-systemd/util"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/shell"
@@ -30,19 +31,12 @@ var (
 
 	renderer = shell.BashRenderer{}
 	cmds     = commands{renderer, executable}
-
-	SystemPath = "/run/systemd/system"
 )
 
 // IsRunning returns whether or not systemd is the local init system.
-func IsRunning() (bool, error) {
-	if _, err := os.Stat(SystemPath); err == nil {
-		return true, nil
-	} else if os.IsNotExist(err) {
-		return false, nil
-	} else {
-		return false, errors.Trace(err)
-	}
+// It has a signature consistent with similar methods in other service modules.
+func IsRunning() bool {
+	return util.IsRunningSystemd()
 }
 
 // ListServices returns the list of installed service names.
@@ -584,9 +578,9 @@ func (s *Service) WriteService() error {
 		return errors.Trace(err)
 	}
 
-	if running, err := IsRunning(); err != nil {
-		return errors.Trace(err)
-	} else if !running {
+	// If systemd is not the running init system,
+	// then do not attempt to use it for linking unit files.
+	if !IsRunning() {
 		return nil
 	}
 

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -34,7 +34,6 @@ var (
 )
 
 // IsRunning returns whether or not systemd is the local init system.
-// It has a signature consistent with similar methods in other service modules.
 func IsRunning() bool {
 	return util.IsRunningSystemd()
 }


### PR DESCRIPTION
## Description of change

A bug was raised whereby:
- A series upgrade was attempted on a KVM container running Trusty.
- That system had a directory _/run/systemd/system_, which is used to detect systemd as the current init system.
- Calls to D-Bus method _LinkUnitFiles_ threw errors due to the method not being present.

This patch has 2 main commits.

The first simplifies the detection of systemd, using the upstream library's method instead of duplicating its logic.

The second has the logic change that handles the specific error and falls back to manually sym-linking service unit files. 

## QA steps

- Bootstrap and deploy a Trusty machine.
- SSH to the machine and create the directory _/run/systemd/system_.
- `juju upgrade-series 0 prepare Xenial`.
- Check the machine log and ensure that despite the systemd error messages, manually linking the agent service files follows and succeeds.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804701/
