### PR TITLE
Fixes minimum length check for upgrade-series command args.

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -155,7 +155,7 @@ func (c *upgradeSeriesCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init implements cmd.Command.
 func (c *upgradeSeriesCommand) Init(args []string) error {
-	if len(args) < 1 {
+	if len(args) < 2 {
 		return errors.Errorf("wrong number of arguments")
 	}
 

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -85,6 +85,11 @@ func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *UpgradeSeriesSuite) TestTooFewArgs(c *gc.C) {
+	err := s.runUpgradeSeriesCommand(c, machineArg)
+	c.Assert(err, gc.ErrorMatches, "wrong number of arguments")
+}
+
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptForceOption(c *gc.C) {
 	s.prepareExpectation = &upgradeSeriesPrepareExpectation{machineArg, seriesArg, gomock.Eq(true)}
 	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, seriesArg, "--force")


### PR DESCRIPTION
## Description of change

This patch fixes the validation for the number of argument supplied to the _upgrade-series_ command.  

## QA steps

- `juju upgrade-series 0`
- An error should be shown, instead of panicking.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1805577
