### PR TITLE
Do not use model's default-series when locating charm.

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -329,7 +329,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		url, _, _, err := resolveCharm(h.api.ResolveWithChannel, h.modelConfig, ch)
+		url, _, _, err := resolveCharm(h.api.ResolveWithChannel, ch)
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
@@ -474,7 +474,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
-	url, channel, _, err := resolveCharm(h.api.ResolveWithChannel, h.modelConfig, ch)
+	url, channel, _, err := resolveCharm(h.api.ResolveWithChannel, ch)
 	if err != nil {
 		return errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -115,7 +115,7 @@ func (c *bundleDiffCommand) Run(ctx *cmd.Context) error {
 	defer apiRoot.Close()
 
 	// Load up the bundle data, with includes and overlays.
-	bundle, bundleDir, err := c.readBundle(ctx, apiRoot)
+	bundle, bundleDir, err := c.readBundle(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -159,7 +159,7 @@ func (c *bundleDiffCommand) newAPIRoot() (base.APICallCloser, error) {
 	return c.NewAPIRoot()
 }
 
-func (c *bundleDiffCommand) readBundle(ctx *cmd.Context, apiRoot base.APICallCloser) (*charm.BundleData, string, error) {
+func (c *bundleDiffCommand) readBundle(ctx *cmd.Context) (*charm.BundleData, string, error) {
 	bundleData, bundleDir, err := readLocalBundle(ctx, c.bundle)
 	// NotValid means we should try interpreting it as a charm store
 	// bundle URL.
@@ -176,7 +176,7 @@ func (c *bundleDiffCommand) readBundle(ctx *cmd.Context, apiRoot base.APICallClo
 		return nil, "", errors.Trace(err)
 	}
 	bundleURL, _, err := resolveBundleURL(
-		modelconfig.NewClient(apiRoot), charmStore, c.bundle,
+		charmStore, c.bundle,
 	)
 	if err != nil && !errors.IsNotValid(err) {
 		return nil, "", errors.Trace(err)

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -43,28 +43,7 @@ func resolveCharm(
 	if url.Schema != "cs" {
 		return nil, csparams.NoChannel, nil, errors.Errorf("unknown schema for charm URL %q", url)
 	}
-	// If the user hasn't explicitly asked for a particular series,
-	// query for the charm that matches the model's default series.
-	// If this fails, we'll fall back to asking for whatever charm is available.
-	defaultedSeries := false
-	if url.Series == "" {
-		if s, ok := conf.DefaultSeries(); ok {
-			defaultedSeries = true
-			// TODO(katco): Don't update the value passed in. Not only
-			// is there no indication that this method will do so, we
-			// return a charm.URL which signals to the developer that
-			// we don't modify the original.
-			url.Series = s
-		}
-	}
-
 	resultURL, channel, supportedSeries, err := resolveWithChannel(url)
-	if defaultedSeries && errors.Cause(err) == csparams.ErrNotFound {
-		// we tried to use the model's default the series, but the store said it doesn't exist.
-		// retry without the defaulted series, to take what we can get.
-		url.Series = ""
-		resultURL, channel, supportedSeries, err = resolveWithChannel(url)
-	}
 	if err != nil {
 		return nil, csparams.NoChannel, nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -31,13 +31,11 @@ type SeriesConfig interface {
 // ResolveCharmFunc is the type of a function that resolves a charm URL.
 type ResolveCharmFunc func(
 	resolveWithChannel func(*charm.URL) (*charm.URL, csparams.Channel, []string, error),
-	conf SeriesConfig,
 	url *charm.URL,
 ) (*charm.URL, csparams.Channel, []string, error)
 
 func resolveCharm(
 	resolveWithChannel func(*charm.URL) (*charm.URL, csparams.Channel, []string, error),
-	conf SeriesConfig,
 	url *charm.URL,
 ) (*charm.URL, csparams.Channel, []string, error) {
 	if url.Schema != "cs" {

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -682,7 +682,7 @@ func (c *upgradeCharmCommand) addCharm(
 	}
 
 	// Charm has been supplied as a URL so we resolve and deploy using the store.
-	newURL, channel, supportedSeries, err := c.ResolveCharm(charmRepo.ResolveWithChannel, config, refURL)
+	newURL, channel, supportedSeries, err := c.ResolveCharm(charmRepo.ResolveWithChannel, refURL)
 	if err != nil {
 		return id, nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -88,10 +88,9 @@ func (s *UpgradeCharmSuite) SetUpTest(c *gc.C) {
 
 	s.resolveCharm = func(
 		resolveWithChannel func(*charm.URL) (*charm.URL, csclientparams.Channel, []string, error),
-		conf SeriesConfig,
 		url *charm.URL,
 	) (*charm.URL, csclientparams.Channel, []string, error) {
-		s.AddCall("ResolveCharm", resolveWithChannel, conf, url)
+		s.AddCall("ResolveCharm", resolveWithChannel, url)
 		if err := s.NextErr(); err != nil {
 			return nil, csclientparams.NoChannel, nil, err
 		}


### PR DESCRIPTION
## Description of change

When issuing a `juju deploy` command without specifying a series juju would use the model's default series. This behavior was undesirable since the model's default series can cause a charm revision other than the latest to be deployed by default. To fix this we no longer take into account the model's default series when no series is specified by a `juju deploy` command.

## QA steps
Get a charm whose latest revision does not have support for the model's default:

`juju mode-config default-series=xenial`
`juju deploy cs:~ecjones/ubuntu-series-upgrade`

There are two revisions of the deployed charm. Before this change set, revision 0 would be deployed by the above command. After applying this change set revision 1 should be deployed. Different revision are deployed since juju no longer takes into account the `default-series` when deciding what revision of the charm to deploy by default, that is, when no revision or series is specified. So if a model's `default-series` is `xenial` and the latest charm revision supports only bionic, then by default, the latest charm revision will be deployed not being excluded by the model's default. 


## Documentation changes

Changes what cham revision gets deployed in certain cases. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1788604
