### PR TITLE
Fixes lp#1804140: misleading unhelpful message when running status for non-existing model.

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -197,6 +197,8 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	status, err := c.getStatus()
 	if err != nil {
 		for i := 0; i < c.retryCount; i++ {
+			// fun bit - make sure a new api connection is used for each new call
+			c.SetModelAPI(nil)
 			// Wait for a bit before retries.
 			<-c.clock.After(c.retryDelay)
 			status, err = c.getStatus()

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -113,9 +113,6 @@ func (c *CommandBase) SetModelRefresh(refresh func(jujuclient.ClientStore, strin
 
 func (c *CommandBase) modelAPI(store jujuclient.ClientStore, controllerName string) (ModelAPI, error) {
 	c.assertRunStarted()
-	if c.modelAPI_ != nil {
-		return c.modelAPI_, nil
-	}
 	conn, err := c.NewAPIRoot(store, controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -113,6 +113,9 @@ func (c *CommandBase) SetModelRefresh(refresh func(jujuclient.ClientStore, strin
 
 func (c *CommandBase) modelAPI(store jujuclient.ClientStore, controllerName string) (ModelAPI, error) {
 	c.assertRunStarted()
+	if c.modelAPI_ != nil {
+		return c.modelAPI_, nil
+	}
 	conn, err := c.NewAPIRoot(store, controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

Juju model commands cache an api connection made by the backing model. This is a pretty unhelpful caching, especially for commands that may re-try making calls. For example, newer implementation of 'status' command re-tries to get model status at least 3 times. Closing model api connection after 1st call means that the subsequent calls will/can only return call-made-on-a-closed-connection error rather then the actual original error that caused the retries in the first place.

For more details, see linked bug.   

## QA steps
BEFORE CHANGE
https://pastebin.ubuntu.com/p/RbS7dQG2pb/

AFTER CHANGE
https://pastebin.ubuntu.com/p/5hGdTgvqQG/

## Bug reference
https://bugs.launchpad.net/juju/+bug/1804140 
