### PR TITLE
Fixes lp#1804140: misleading unhelpful message when running status for non-existing model.

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -262,6 +262,8 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	status, err := c.getStatus()
 	if err != nil {
 		for i := 0; i < c.retryCount; i++ {
+			// fun bit - make sure a new api connection is used for each new call
+			c.SetModelAPI(nil)
 			// Wait for a bit before retries.
 			<-c.clock.After(c.retryDelay)
 			status, err = c.getStatus()


### PR DESCRIPTION
## Description of change

Straight forward port of https://github.com/juju/juju/pull/9520 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804140
