### PR TITLE
Fixes lp#1804630: panic when logging failures.

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1148,7 +1148,8 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 				break
 			}
 			if server == nil {
-				continue
+				logger.Warningf("may have lost contact with nova api while creating instances, some stray instances may be around and need to be deleted")
+				break
 			}
 			var serverDetail *nova.ServerDetail
 			serverDetail, err = waitForActiveServerDetails(client, server.Id, 5*time.Minute)
@@ -1164,7 +1165,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 				if serverDetail.Fault != nil {
 					faultMsg = fmt.Sprintf(" with fault %q", serverDetail.Fault.Message)
 				} else {
-					logger.Debugf("getting activer server details from nova failed without fault details")
+					logger.Debugf("getting active server details from nova failed without fault details")
 				}
 				logger.Infof("Deleting instance %q in ERROR state%v", server.Id, faultMsg)
 				if err = e.terminateInstances([]instance.Id{instance.Id(server.Id)}); err != nil {


### PR DESCRIPTION
## Description of change

There are some details that are not available when failures occur. Re-arrane log messages to only access available information.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804630
