### PR TITLE
Fix command output for docs gen

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -33,8 +33,7 @@ type CloudMetadataStore interface {
 }
 
 var usageAddCloudSummary = `
-Adds a cloud definition to Juju.
-`[1:]
+Adds a cloud definition to Juju.`[1:]
 
 var usageAddCloudDetails = `
 Juju needs to know how to connect to clouds. A cloud definition 

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.5-rc1"
+#define MyAppVersion "2.5-beta2"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.5-beta2"
+#define MyAppVersion "2.5-beta3"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.5-beta2
+version: 2.5-beta3
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.5-rc1
+version: 2.5-beta2
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.5-rc1"
+const version = "2.5-beta2"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.5-beta2"
+const version = "2.5-beta3"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")


### PR DESCRIPTION
## Description of change

Remove an unexpected newline in the 'juju help commands' output that the man page generation script chokes on.

## QA steps

Before this fix:
  - Build Juju
  - Make sure built juju is in $PATH
  - Run: scripts/generate-docs.py man -o /tmp/juju-1
  - It will fail

Apply this branch, build and try again, it will succeed.
