### PR TITLE
Fixes lp#1805251: warning removing not found model.

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -170,7 +170,7 @@ func (c *CommandBase) NewAPIRoot(
 // model details on the controller.
 func (c *CommandBase) RemoveModelFromClientStore(store jujuclient.ClientStore, controllerName, modelName string) {
 	err := store.RemoveModel(controllerName, modelName)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		logger.Warningf("cannot remove unknown model from cache: %v", err)
 	}
 	if c.CanClearCurrentModel {

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -75,6 +75,14 @@ func (s *BaseCommandSuite) TestUnknownModel(c *gc.C) {
 	s.assertUnknownModel(c, new(modelcmd.ModelCommandBase), "admin/badmodel", "admin/badmodel")
 }
 
+func (s *BaseCommandSuite) TestUnknownUncachedModel(c *gc.C) {
+	baseCmd := new(modelcmd.ModelCommandBase)
+	baseCmd.CanClearCurrentModel = false
+	baseCmd.RemoveModelFromClientStore(s.store, "foo", "admin/nonexistent")
+	// expecting silence in the logs since this model has never been cached.
+	c.Assert(c.GetTestLog(), gc.DeepEquals, "")
+}
+
 func (s *BaseCommandSuite) TestUnknownModelCanRemoveCachedCurrent(c *gc.C) {
 	baseCmd := new(modelcmd.ModelCommandBase)
 	baseCmd.CanClearCurrentModel = true


### PR DESCRIPTION
## Description of change

When removing a model from cache that was not in the cache in the first place, treat it as a no-op not as error.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1805251
