### PR TITLE
introduce cached models for api server

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/api/controller"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -137,10 +136,6 @@ func (s *legacySuite) TestRemoveBlocks(c *gc.C) {
 func (s *legacySuite) TestWatchAllModels(c *gc.C) {
 	// The WatchAllModels infrastructure is comprehensively tested
 	// else. This test just ensure that the API calls work end-to-end.
-	cons := constraints.MustParse("mem=4G")
-	err := s.State.SetModelConstraints(cons)
-	c.Assert(err, jc.ErrorIsNil)
-
 	sysManager := s.OpenAPI(c)
 	defer sysManager.Close()
 
@@ -201,7 +196,6 @@ func (s *legacySuite) TestWatchAllModels(c *gc.C) {
 		c.Assert(modelInfo.ControllerUUID, gc.Equals, model.ControllerUUID())
 		c.Assert(modelInfo.Config, jc.DeepEquals, cfg.AllAttrs())
 		c.Assert(modelInfo.Status, jc.DeepEquals, expectedStatus)
-		c.Assert(modelInfo.Constraints, jc.DeepEquals, cons)
 	case <-time.After(testing.LongWait):
 		c.Fatal("timed out")
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -63,6 +63,7 @@ func (s *baseLoginSuite) newServer(c *gc.C) (*api.Info, *apiserver.Server) {
 }
 
 func (s *baseLoginSuite) newServerWithConfig(c *gc.C, cfg apiserver.ServerConfig) (*api.Info, *apiserver.Server) {
+	cfg.Controller = s.JujuConnSuite.Controller
 	server := testserver.NewServerWithConfig(c, s.StatePool, cfg)
 	s.AddCleanup(func(c *gc.C) { assertStop(c, server) })
 	return server.Info, server.APIServer
@@ -376,6 +377,7 @@ func (s *loginSuite) setupDelayServer(c *gc.C) (*api.Info, *apiserver.Server, ch
 	cfg := testserver.DefaultServerConfig(c)
 	delayChan := make(chan struct{}, 10)
 	cfg.Authenticator = &mockDelayAuthenticator{delay: delayChan}
+	cfg.Controller = s.JujuConnSuite.Controller
 	info, srv := s.newServerWithConfig(c, cfg)
 	info.Tag = machine.Tag()
 	info.Password = password
@@ -642,6 +644,7 @@ func (s *loginSuite) TestMachineLoginDuringMaintenance(c *gc.C) {
 		// upgrade is in progress
 		return false
 	}
+	cfg.Controller = s.JujuConnSuite.Controller
 	info, srv := s.newServerWithConfig(c, cfg)
 	defer assertStop(c, srv)
 
@@ -660,6 +663,7 @@ func (s *loginSuite) TestControllerMachineLoginDuringMaintenance(c *gc.C) {
 		// upgrade is in progress
 		return false
 	}
+	cfg.Controller = s.JujuConnSuite.Controller
 	info, srv := s.newServerWithConfig(c, cfg)
 	defer assertStop(c, srv)
 
@@ -1214,7 +1218,7 @@ func (s *macaroonLoginSuite) TestPublicKeyLocatorErrorIsNotPersistent(c *gc.C) {
 	s.DischargerLogin = func() string {
 		return "test@somewhere"
 	}
-	srv := testserver.NewServer(c, s.StatePool)
+	srv := testserver.NewServer(c, s.StatePool, s.Controller)
 	defer assertStop(c, srv)
 	workingTransport := http.DefaultTransport
 	failingTransport := errorTransport{
@@ -1377,7 +1381,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToModelWithExplicitAccessAndAllo
 func (s *macaroonLoginSuite) testRemoteUserLoginToModelWithExplicitAccess(c *gc.C, allowModelAccess bool) {
 	cfg := testserver.DefaultServerConfig(c)
 	cfg.AllowModelAccess = allowModelAccess
-
+	cfg.Controller = s.Controller
 	srv := testserver.NewServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, srv)
 	srv.Info.ModelTag = s.Model.ModelTag()

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -5,6 +5,7 @@ package facadetest
 
 import (
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/state"
@@ -12,13 +13,14 @@ import (
 
 // Context implements facade.Context in the simplest possible way.
 type Context struct {
-	Auth_      facade.Authorizer
-	Dispose_   func()
-	Hub_       facade.Hub
-	Resources_ facade.Resources
-	State_     *state.State
-	StatePool_ *state.StatePool
-	ID_        string
+	Auth_       facade.Authorizer
+	Dispose_    func()
+	Hub_        facade.Hub
+	Resources_  facade.Resources
+	State_      *state.State
+	StatePool_  *state.StatePool
+	Controller_ *cache.Controller
+	ID_         string
 
 	LeadershipClaimer_ leadership.Claimer
 	LeadershipChecker_ leadership.Checker
@@ -42,6 +44,11 @@ func (context Context) Dispose() {
 // Hub is part of the facade.Context interface.
 func (context Context) Hub() facade.Hub {
 	return context.Hub_
+}
+
+// Controller is part of the facade.Context interface.
+func (context Context) Controller() *cache.Controller {
+	return context.Controller_
 }
 
 // Resources is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -6,6 +6,7 @@ package facade
 import (
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
@@ -63,6 +64,10 @@ type Context interface {
 	// StatePool returns the state pool used by the apiserver to minimise the
 	// creation of the expensive *State instances.
 	StatePool() *state.StatePool
+
+	// Controller returns the in-memory representation of the models
+	// in the database.
+	Controller() *cache.Controller
 
 	// Presence returns an instance that is able to be asked for
 	// the current model presence.

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -4,21 +4,28 @@
 package logger_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/agent/logger"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/cache/cachetest"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
 )
 
 type loggerSuite struct {
-	jujutesting.JujuConnSuite
+	statetesting.StateSuite
 
 	// These are raw State objects. Use them for setup and assertions, but
 	// should never be touched by the API calls themselves
@@ -26,12 +33,18 @@ type loggerSuite struct {
 	logger     *logger.LoggerAPI
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
+
+	change     cache.ModelChange
+	changes    chan interface{}
+	controller *cache.Controller
+	events     chan interface{}
+	capture    func(change interface{})
 }
 
 var _ = gc.Suite(&loggerSuite{})
 
 func (s *loggerSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
+	s.StateSuite.SetUpTest(c)
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
@@ -44,15 +57,64 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.rawMachine.Tag(),
 	}
-	s.logger, err = logger.NewLoggerAPI(s.State, s.resources, s.authorizer)
+
+	s.events = make(chan interface{})
+	notify := func(change interface{}) {
+		send := false
+		switch change.(type) {
+		case cache.ModelChange:
+			send = true
+		case cache.RemoveModel:
+			send = true
+		default:
+			// no-op
+		}
+		if send {
+			c.Logf("sending %#v", change)
+			select {
+			case s.events <- change:
+			case <-time.After(testing.LongWait):
+				c.Fatalf("change not processed by test")
+			}
+		}
+	}
+
+	s.changes = make(chan interface{})
+	controller, err := cache.NewController(cache.ControllerConfig{
+		Changes: s.changes,
+		Notify:  notify,
+	})
 	c.Assert(err, jc.ErrorIsNil)
+	s.controller = controller
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, s.controller) })
+	// Add the current model to the controller.
+	s.change = cachetest.ModelChangeFromState(c, s.State)
+	s.changes <- s.change
+	// Ensure it is processed before we create the logger api.
+	select {
+	case <-s.events:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("change not processed by test")
+	}
+	s.logger, err = s.makeLoggerAPI(s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *loggerSuite) makeLoggerAPI(auth facade.Authorizer) (*logger.LoggerAPI, error) {
+	ctx := facadetest.Context{
+		Auth_:       auth,
+		Controller_: s.controller,
+		Resources_:  s.resources,
+		State_:      s.State,
+	}
+	return logger.NewLoggerAPI(ctx)
 }
 
 func (s *loggerSuite) TestNewLoggerAPIRefusesNonAgent(c *gc.C) {
 	// We aren't even a machine agent
 	anAuthorizer := s.authorizer
-	anAuthorizer.Tag = s.AdminUserTag(c)
-	endPoint, err := logger.NewLoggerAPI(s.State, s.resources, anAuthorizer)
+	anAuthorizer.Tag = names.NewUserTag("some-user")
+	endPoint, err := s.makeLoggerAPI(anAuthorizer)
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -61,7 +123,7 @@ func (s *loggerSuite) TestNewLoggerAPIAcceptsUnitAgent(c *gc.C) {
 	// We aren't even a machine agent
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewUnitTag("germany/7")
-	endPoint, err := logger.NewLoggerAPI(s.State, s.resources, anAuthorizer)
+	endPoint, err := s.makeLoggerAPI(anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(endPoint, gc.NotNil)
 }
@@ -69,7 +131,7 @@ func (s *loggerSuite) TestNewLoggerAPIAcceptsUnitAgent(c *gc.C) {
 func (s *loggerSuite) TestNewLoggerAPIAcceptsApplicationAgent(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewApplicationTag("germany")
-	endPoint, err := logger.NewLoggerAPI(s.State, s.resources, anAuthorizer)
+	endPoint, err := s.makeLoggerAPI(anAuthorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(endPoint, gc.NotNil)
 }
@@ -81,11 +143,13 @@ func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 }
 
 func (s *loggerSuite) setLoggingConfig(c *gc.C, loggingConfig string) {
-	err := s.Model.UpdateModelConfig(map[string]interface{}{"logging-config": loggingConfig}, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	modelConfig, err := s.Model.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelConfig.LoggingConfig(), gc.Equals, loggingConfig)
+	s.change.Config["logging-config"] = loggingConfig
+	s.changes <- s.change
+	select {
+	case <-s.events:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("change not processed by test")
+	}
 }
 
 func (s *loggerSuite) TestWatchLoggingConfig(c *gc.C) {
@@ -99,16 +163,9 @@ func (s *loggerSuite) TestWatchLoggingConfig(c *gc.C) {
 	resource := s.resources.Get(results.Results[0].NotifyWatcherId)
 	c.Assert(resource, gc.NotNil)
 
-	w := resource.(state.NotifyWatcher)
-	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
-	wc.AssertNoChange()
-
-	newLoggingConfig := "<root>=WARN;juju.log.test=DEBUG;unit=INFO"
-	s.setLoggingConfig(c, newLoggingConfig)
-
-	wc.AssertOneChange()
-	statetesting.AssertStop(c, w)
-	wc.AssertClosed()
+	_, ok := resource.(cache.NotifyWatcher)
+	c.Assert(ok, jc.IsTrue)
+	// The watcher implementation is tested in the cache package.
 }
 
 func (s *loggerSuite) TestWatchLoggingConfigRefusesWrongAgent(c *gc.C) {

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/charms"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -31,15 +32,16 @@ var _ = gc.Suite(&charmsSuite{})
 // charmsSuiteContext implements the facade.Context interface.
 type charmsSuiteContext struct{ cs *charmsSuite }
 
-func (ctx *charmsSuiteContext) Abort() <-chan struct{}      { return nil }
-func (ctx *charmsSuiteContext) Auth() facade.Authorizer     { return ctx.cs.auth }
-func (ctx *charmsSuiteContext) Dispose()                    {}
-func (ctx *charmsSuiteContext) Resources() facade.Resources { return common.NewResources() }
-func (ctx *charmsSuiteContext) State() *state.State         { return ctx.cs.State }
-func (ctx *charmsSuiteContext) StatePool() *state.StatePool { return nil }
-func (ctx *charmsSuiteContext) ID() string                  { return "" }
-func (ctx *charmsSuiteContext) Presence() facade.Presence   { return nil }
-func (ctx *charmsSuiteContext) Hub() facade.Hub             { return nil }
+func (ctx *charmsSuiteContext) Abort() <-chan struct{}        { return nil }
+func (ctx *charmsSuiteContext) Auth() facade.Authorizer       { return ctx.cs.auth }
+func (ctx *charmsSuiteContext) Dispose()                      {}
+func (ctx *charmsSuiteContext) Resources() facade.Resources   { return common.NewResources() }
+func (ctx *charmsSuiteContext) State() *state.State           { return ctx.cs.State }
+func (ctx *charmsSuiteContext) StatePool() *state.StatePool   { return nil }
+func (ctx *charmsSuiteContext) ID() string                    { return "" }
+func (ctx *charmsSuiteContext) Presence() facade.Presence     { return nil }
+func (ctx *charmsSuiteContext) Hub() facade.Hub               { return nil }
+func (ctx *charmsSuiteContext) Controller() *cache.Controller { return nil }
 
 func (ctx *charmsSuiteContext) LeadershipClaimer(string) (leadership.Claimer, error) { return nil, nil }
 func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error)       { return nil, nil }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/feature"
@@ -418,6 +419,11 @@ func (ctx *facadeContext) ModelPresence(modelUUID string) facade.ModelPresence {
 // Hub implements facade.Context.
 func (ctx *facadeContext) Hub() facade.Hub {
 	return ctx.r.shared.centralHub
+}
+
+// Controller implements facade.Context.
+func (ctx *facadeContext) Controller() *cache.Controller {
+	return ctx.r.shared.controller
 }
 
 // State is part of of the facade.Context interface.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -54,7 +54,7 @@ func (s *serverSuite) SetUpTest(c *gc.C) {
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
-	srv := testserver.NewServer(c, s.StatePool)
+	srv := testserver.NewServer(c, s.StatePool, s.Controller)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -94,7 +94,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 
 	// Start our own instance of the server listening on
 	// both IPv4 and IPv6 localhost addresses and an ephemeral port.
-	srv := testserver.NewServer(c, s.StatePool)
+	srv := testserver.NewServer(c, s.StatePool, s.Controller)
 	defer assertStop(c, srv)
 
 	machine, password := s.Factory.MakeMachineReturningPassword(
@@ -249,7 +249,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	// We expose the API at '/api', '/' (controller-only), and at '/ModelUUID/api'
 	// for the correct location, but other paths should fail.
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	srv := testserver.NewServer(c, s.StatePool)
+	srv := testserver.NewServer(c, s.StatePool, s.Controller)
 	defer assertStop(c, srv)
 
 	// We have to use 'localhost' because that is what the TLS cert says.
@@ -346,6 +346,7 @@ func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 
 func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 	cfg := testserver.DefaultServerConfig(c)
+	cfg.Controller = s.Controller
 	server := testserver.NewServerWithConfig(c, s.StatePool, cfg)
 	defer assertStop(c, server)
 

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/feature"
@@ -35,6 +36,7 @@ type SharedHub interface {
 // presence, or protected and only accessed through methods on this context object.
 type sharedServerContext struct {
 	statePool    *state.StatePool
+	controller   *cache.Controller
 	centralHub   SharedHub
 	presence     presence.Recorder
 	leaseManager lease.Manager
@@ -48,6 +50,7 @@ type sharedServerContext struct {
 
 type sharedServerConfig struct {
 	statePool    *state.StatePool
+	controller   *cache.Controller
 	centralHub   SharedHub
 	presence     presence.Recorder
 	leaseManager lease.Manager
@@ -57,6 +60,9 @@ type sharedServerConfig struct {
 func (c *sharedServerConfig) validate() error {
 	if c.statePool == nil {
 		return errors.NotValidf("nil statePool")
+	}
+	if c.controller == nil {
+		return errors.NotValidf("nil controller")
 	}
 	if c.centralHub == nil {
 		return errors.NotValidf("nil centralHub")
@@ -76,6 +82,7 @@ func newSharedServerContex(config sharedServerConfig) (*sharedServerContext, err
 	}
 	ctx := &sharedServerContext{
 		statePool:    config.statePool,
+		controller:   config.controller,
 		centralHub:   config.centralHub,
 		presence:     config.presence,
 		leaseManager: config.leaseManager,

--- a/apiserver/testserver/server.go
+++ b/apiserver/testserver/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/stateauthenticator"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
@@ -38,6 +39,7 @@ func DefaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		Tag:             names.NewMachineTag("0"),
 		LogDir:          c.MkDir(),
 		Hub:             hub,
+		Controller:      &cache.Controller{}, // Not useful for anything except providing a default.
 		Presence:        presence.New(clock.WallClock),
 		LeaseManager:    &lease.Manager{},
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
@@ -57,8 +59,10 @@ func DefaultServerConfig(c *gc.C) apiserver.ServerConfig {
 // It returns information suitable for connecting to the state
 // without any authentication information or model tag, and the server
 // that's been started.
-func NewServer(c *gc.C, statePool *state.StatePool) *Server {
-	return NewServerWithConfig(c, statePool, DefaultServerConfig(c))
+func NewServer(c *gc.C, statePool *state.StatePool, controller *cache.Controller) *Server {
+	config := DefaultServerConfig(c)
+	config.Controller = controller
+	return NewServerWithConfig(c, statePool, config)
 }
 
 // NewServerWithConfig is like NewServer except that the entire

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -65,6 +65,7 @@ import (
 	"github.com/juju/juju/worker/machiner"
 	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationminion"
+	"github.com/juju/juju/worker/modelcache"
 	"github.com/juju/juju/worker/modelworkermanager"
 	"github.com/juju/juju/worker/peergrouper"
 	prworker "github.com/juju/juju/worker/presence"
@@ -384,6 +385,16 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			OpenStatePool:          config.OpenStatePool,
 			PrometheusRegisterer:   config.PrometheusRegisterer,
 			SetStatePool:           config.SetStatePool,
+		}),
+
+		// The modelcache manifold creates a cache.Controller and keeps
+		// it up to date using an all model watcher. The controller is then
+		// used by the apiserver.
+		modelCacheName: modelcache.Manifold(modelcache.ManifoldConfig{
+			StateName:            stateName,
+			Logger:               loggo.GetLogger("juju.worker.modelcache"),
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewWorker:            modelcache.NewWorker,
 		}),
 
 		// The api-config-watcher manifold monitors the API server
@@ -753,6 +764,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AuthenticatorName:                 httpServerArgsName,
 			ClockName:                         clockName,
 			StateName:                         stateName,
+			ModelCacheName:                    modelCacheName,
 			MuxName:                           httpServerArgsName,
 			LeaseManagerName:                  leaseManagerName,
 			UpgradeGateName:                   upgradeStepsGateName,
@@ -985,6 +997,7 @@ const (
 	logPrunerName                 = "log-pruner"
 	txnPrunerName                 = "transaction-pruner"
 	certificateWatcherName        = "certificate-watcher"
+	modelCacheName                = "model-cache"
 	modelWorkerManagerName        = "model-worker-manager"
 	peergrouperName               = "peer-grouper"
 	restoreWatcherName            = "restore-watcher"

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -79,6 +79,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"migration-fortress",
 		"migration-minion",
 		"migration-inactive-flag",
+		"model-cache",
 		"model-worker-manager",
 		"peer-grouper",
 		"presence",
@@ -146,6 +147,7 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"lease-clock-updater",
 		"lease-manager",
 		"log-forwarder",
+		"model-cache",
 		"model-worker-manager",
 		"peer-grouper",
 		"presence",
@@ -308,6 +310,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"http-server-args",
 		"is-controller-flag",
 		"lease-manager",
+		"model-cache",
 		"restore-watcher",
 		"state",
 		"state-config-watcher",
@@ -410,6 +413,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"http-server-args",
 		"is-controller-flag",
 		"lease-manager",
+		"model-cache",
 		"raft-transport",
 		"restore-watcher",
 		"state",
@@ -557,6 +561,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-check-gate",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
+
+	"model-cache": {
+		"agent",
+		"state",
+		"state-config-watcher",
+	},
 
 	"model-worker-manager": {
 		"agent",

--- a/featuretests/api_logger_test.go
+++ b/featuretests/api_logger_test.go
@@ -1,0 +1,51 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/logger"
+	"github.com/juju/juju/core/watcher/watchertest"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+)
+
+type apiLoggerSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *apiLoggerSuite) TestLoggingConfig(c *gc.C) {
+	root, machine := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	logging := logger.NewState(root)
+
+	obtained, err := logging.LoggingConfig(machine.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.Equals, "<root>=DEBUG;unit=DEBUG")
+}
+
+func (s *apiLoggerSuite) TestWatchLoggingConfig(c *gc.C) {
+	root, machine := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	logging := logger.NewState(root)
+
+	watcher, err := logging.WatchLoggingConfig(machine.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	_ = watcher
+
+	wc := watchertest.NewNotifyWatcherC(c, watcher, nil)
+	// Initial event.
+	wc.AssertOneChange()
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.UpdateModelConfig(
+		map[string]interface{}{
+			"logging-config": "juju=INFO;test=TRACE",
+		}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wc.AssertOneChange()
+	wc.AssertStops()
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -36,6 +36,7 @@ func init() {
 	gc.Suite(&annotationsSuite{})
 	gc.Suite(&CloudAPISuite{})
 	gc.Suite(&apiEnvironmentSuite{})
+	gc.Suite(&apiLoggerSuite{})
 	gc.Suite(&BakeryStorageSuite{})
 	gc.Suite(&blockSuite{})
 	gc.Suite(&cmdControllerSuite{})

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/presence"
@@ -106,9 +107,10 @@ type JujuConnSuite struct {
 	APIState            api.Connection
 	apiStates           []api.Connection // additional api.Connections to close on teardown
 	ControllerStore     jujuclient.ClientStore
-	BackingState        *state.State          // The State being used by the API server
-	BackingStatePool    *state.StatePool      // The StatePool being used by the API server
+	BackingState        *state.State          // The State being used by the API server.
+	BackingStatePool    *state.StatePool      // The StatePool being used by the API server.
 	Hub                 *pubsub.StructuredHub // The central hub being used by the API server.
+	Controller          *cache.Controller     // The cache.Controller used by the API server.
 	LeaseManager        lease.Manager         // The lease manager being used by the API server.
 	RootDir             string                // The faked-up root directory.
 	LogDir              string
@@ -493,6 +495,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.BackingStatePool = getStater.GetStatePoolInAPIServer()
 	s.Hub = getStater.GetHubInAPIServer()
 	s.LeaseManager = getStater.GetLeaseManagerInAPIServer()
+	s.Controller = getStater.GetController()
 
 	s.StatePool, err = newState(s.ControllerConfig.ControllerUUID(), environ, s.MongoInfo(c))
 	c.Assert(err, jc.ErrorIsNil)
@@ -723,6 +726,7 @@ type GetStater interface {
 	GetStatePoolInAPIServer() *state.StatePool
 	GetHubInAPIServer() *pubsub.StructuredHub
 	GetLeaseManagerInAPIServer() lease.Manager
+	GetController() *cache.Controller
 }
 
 func (s *JujuConnSuite) tearDownConn(c *gc.C) {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -436,11 +436,11 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 func getUnitAddresses(u *Unit) (string, string, error) {
 	publicAddress, err := u.PublicAddress()
 	if err != nil {
-		logger.Errorf("getting a public address for unit %q failed: %q", u.Name(), err)
+		logger.Infof("getting a public address for unit %q failed: %q", u.Name(), err)
 	}
 	privateAddress, err := u.PrivateAddress()
 	if err != nil {
-		logger.Errorf("getting a private address for unit %q failed: %q", u.Name(), err)
+		logger.Infof("getting a private address for unit %q failed: %q", u.Name(), err)
 	}
 	return publicAddress.Value, privateAddress.Value, nil
 }

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
@@ -34,6 +35,7 @@ type Config struct {
 	Mux                               *apiserverhttp.Mux
 	Authenticator                     httpcontext.LocalMacaroonAuthenticator
 	StatePool                         *state.StatePool
+	Controller                        *cache.Controller
 	LeaseManager                      lease.Manager
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
@@ -63,6 +65,9 @@ func (config Config) Validate() error {
 	}
 	if config.StatePool == nil {
 		return errors.NotValidf("nil StatePool")
+	}
+	if config.Controller == nil {
+		return errors.NotValidf("nil Controller")
 	}
 	if config.Mux == nil {
 		return errors.NotValidf("nil Mux")
@@ -125,6 +130,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 	serverConfig := apiserver.ServerConfig{
 		StatePool:                     config.StatePool,
+		Controller:                    config.Controller,
 		Clock:                         config.Clock,
 		Tag:                           config.AgentConfig.Tag(),
 		DataDir:                       config.AgentConfig.DataDir(),

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -110,6 +110,7 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		Authenticator:        s.authenticator,
 		Mux:                  s.mux,
 		Clock:                s.clock,
+		Controller:           s.controller,
 		Tag:                  s.agentConfig.Tag(),
 		DataDir:              s.agentConfig.DataDir(),
 		LogDir:               s.agentConfig.LogDir(),

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -124,7 +124,11 @@ func (c *cacheWorker) loop() error {
 	wg.Add(1)
 	defer func() {
 		c.mu.Lock()
-		c.watcher.Stop()
+		// If we have been stopped before we have properly been started
+		// there may not be a watcher yet.
+		if c.watcher != nil {
+			c.watcher.Stop()
+		}
 		c.mu.Unlock()
 		wg.Wait()
 	}()


### PR DESCRIPTION
This work hooks up the previously landed modelcache worker (#9580) and the core cache (#9556).

Adds the modelcache to the machine agent's manifold setup and is a dependency for the apiserver.

To illustrate the new model config watcher, the logging config facade is updated to use both get the model config from the cache, and uses the new config watcher to only watch the 'logging-config' value from the model configuration.

## QA
- bootstrap a new lxd controller
- deploy an ubuntu-lite unit in the default model
- update the model-config a few times to update the logging-config and observe in the logs that they are changed.
