### PR TITLE
Add New Telemetry Values

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -4,6 +4,8 @@
 package charmrevisionupdater
 
 import (
+	"strconv"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -139,6 +141,7 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		"controller_uuid": st.ControllerUUID(),
 		"cloud":           model.Cloud(),
 		"cloud_region":    model.CloudRegion(),
+		"is_controller":   strconv.FormatBool(model.IsControllerModel()),
 	}
 	cloud, err := st.Cloud(model.Cloud())
 	if err != nil {

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -5,9 +5,11 @@ package charmrevisionupdater
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
@@ -129,11 +131,18 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		if curl.Schema == "local" {
 			continue
 		}
+
+		archs, err := deployedArchs(application)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
 		cid := charmstore.CharmID{
 			URL:     curl,
 			Channel: application.Channel(),
 			Metadata: map[string]string{
 				"series": application.Series(),
+				"arch":   strings.Join(archs, ","),
 			},
 		}
 		charms = append(charms, cid)
@@ -173,4 +182,27 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		})
 	}
 	return latest, nil
+}
+
+func deployedArchs(app *state.Application) ([]string, error) {
+	machines, err := app.DeployedMachines()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	archs := set.NewStrings()
+	for _, m := range machines {
+		hw, err := m.HardwareCharacteristics()
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return nil, errors.Trace(err)
+		}
+		arch := hw.Arch
+		if arch != nil && *arch != "" {
+			archs.Add(*arch)
+		}
+	}
+	return archs.SortedValues(), nil
 }

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.charmrevisionupdater")
@@ -131,17 +132,22 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		cid := charmstore.CharmID{
 			URL:     curl,
 			Channel: application.Channel(),
+			Metadata: map[string]string{
+				"series": application.Series(),
+			},
 		}
 		charms = append(charms, cid)
 		resultsIndexedApps = append(resultsIndexedApps, application)
 	}
 
 	metadata := map[string]string{
-		"model_uuid":      model.UUID(),
-		"controller_uuid": st.ControllerUUID(),
-		"cloud":           model.Cloud(),
-		"cloud_region":    model.CloudRegion(),
-		"is_controller":   strconv.FormatBool(model.IsControllerModel()),
+		"environment_uuid":   model.UUID(),
+		"model_uuid":         model.UUID(),
+		"controller_uuid":    st.ControllerUUID(),
+		"controller_version": version.Current.String(),
+		"cloud":              model.Cloud(),
+		"cloud_region":       model.CloudRegion(),
+		"is_controller":      strconv.FormatBool(model.IsControllerModel()),
 	}
 	cloud, err := st.Cloud(model.Cloud())
 	if err != nil {

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -186,14 +186,15 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 	cloud, err := s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedHeader := []string{
-		"environment_uuid=" + model.UUID(),
-		"model_uuid=" + model.UUID(),
-		"controller_uuid=" + s.State.ControllerUUID(),
 		"cloud=" + model.Cloud(),
 		"cloud_region=" + model.CloudRegion(),
-		"provider=" + cloud.Type,
+		"controller_uuid=" + s.State.ControllerUUID(),
 		"controller_version=" + version.Current.String(),
+		"environment_uuid=" + model.UUID(),
 		"is_controller=true",
+		"model_uuid=" + model.UUID(),
+		"provider=" + cloud.Type,
+		"series=quantal",
 	}
 	for i, expected := range expectedHeader {
 		c.Assert(header[charmrepo.JujuMetadataHTTPHeader][i], gc.Equals, expected)

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/juju/utils/arch"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -130,7 +132,7 @@ func (s *charmVersionSuite) TestUpdateRevisions(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *charmVersionSuite) TestWordpressCharmNoReadAccessIsntVisible(c *gc.C) {
+func (s *charmVersionSuite) TestWordpressCharmNoReadAccessIsNotVisible(c *gc.C) {
 	s.AddMachine(c, "0", state.JobManageModel)
 	s.SetupScenario(c)
 
@@ -186,6 +188,7 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 	cloud, err := s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedHeader := []string{
+		"arch=" + arch.HostArch(),
 		"cloud=" + model.Cloud(),
 		"cloud_region=" + model.CloudRegion(),
 		"controller_uuid=" + s.State.ControllerUUID(),

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -185,7 +185,7 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cloud, err := s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
-	expected_header := []string{
+	expectedHeader := []string{
 		"environment_uuid=" + model.UUID(),
 		"model_uuid=" + model.UUID(),
 		"controller_uuid=" + s.State.ControllerUUID(),
@@ -193,8 +193,9 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 		"cloud_region=" + model.CloudRegion(),
 		"provider=" + cloud.Type,
 		"controller_version=" + version.Current.String(),
+		"is_controller=true",
 	}
-	for i, expected := range expected_header {
+	for i, expected := range expectedHeader {
 		c.Assert(header[charmrepo.JujuMetadataHTTPHeader][i], gc.Equals, expected)
 	}
 }

--- a/charmstore/charmid.go
+++ b/charmstore/charmid.go
@@ -8,12 +8,16 @@ import (
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 )
 
-// CharmID is a type that encapsulates all the data required to interact with a
-// unique charm from the charmstore.
+// CharmID encapsulates data for identifying a
+// unique charm from the charm store.
 type CharmID struct {
 	// URL is the url of the charm.
 	URL *charm.URL
 
 	// Channel is the channel in which the charm was published.
 	Channel csparams.Channel
+
+	// Metadata is optional extra information about a particular model's
+	// "in-theatre" use use of the charm.
+	Metadata map[string]string
 }

--- a/charmstore/client.go
+++ b/charmstore/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -27,7 +28,7 @@ var logger = loggo.GetLogger("juju.charmstore")
 // more available to tools outside juju-core).
 
 // MacaroonCache represents a value that can store and retrieve macaroons for
-// charms.  It is used when we are requesting data from the charmstore for
+// charms. It is used when we are requesting data from the charmstore for
 // private charms.
 type MacaroonCache interface {
 	Set(*charm.URL, macaroon.Slice) error
@@ -107,7 +108,7 @@ type Client struct {
 }
 
 // CharmRevision holds the data returned from the charmstore about the latest
-// revision of a charm.  Note that this may be different per channel.
+// revision of a charm. Note that this may be different per channel.
 type CharmRevision struct {
 	// Revision is newest revision for the charm.
 	Revision int
@@ -144,6 +145,17 @@ func makeMetadataHeader(modelMetadata, charmMetadata map[string]string) map[stri
 	}
 
 	headers := make([]string, 0, len(modelMetadata)+len(charmMetadata))
+
+	// We expect the deployed architecture for a charm to be singular,
+	// but it is possible for deployment across multiple architectures.
+	// We need to handle this, which violates the general case following.
+	if arch, ok := charmMetadata["arch"]; ok {
+		for _, a := range strings.Split(arch, ",") {
+			headers = append(headers, fmt.Sprintf("arch=%s", a))
+		}
+		delete(charmMetadata, "arch")
+	}
+
 	addHeaders := func(metadata map[string]string) {
 		for k, v := range metadata {
 			headers = append(headers, fmt.Sprintf("%s=%s", k, v))
@@ -292,7 +304,7 @@ func (c csclientImpl) ListResources(channel csparams.Channel, id *charm.URL) ([]
 	return client.ListResources(id)
 }
 
-// Getresource downloads the bytes and some metadata about the bytes for the revisioned resource.
+// GetResource downloads the bytes and some metadata about the bytes for the revisioned resource.
 func (c csclientImpl) GetResource(channel csparams.Channel, id *charm.URL, name string, revision int) (csclient.ResourceData, error) {
 	client := c.WithChannel(channel)
 	return client.GetResource(id, name, revision)

--- a/charmstore/latest.go
+++ b/charmstore/latest.go
@@ -34,6 +34,7 @@ func LatestCharmInfo(client Client, charms []CharmID, metadata map[string]string
 			"cloud_region=" + metadata["cloud_region"],
 			"provider=" + metadata["provider"],
 			"controller_version=" + version.Current.String(),
+			"is_controller=" + metadata["is_controller"],
 		},
 	})
 	if err != nil {

--- a/charmstore/latest.go
+++ b/charmstore/latest.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/version"
 )
 
 const jujuMetadataHTTPHeader = "Juju-Metadata"
@@ -24,19 +22,7 @@ func LatestCharmInfo(client Client, charms []CharmID, metadata map[string]string
 	now := time.Now().UTC()
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(charms))
-	revResults, err := client.LatestRevisions(charms, map[string][]string{
-		jujuMetadataHTTPHeader: {
-			// environment_uuid is deprecated.
-			"environment_uuid=" + metadata["model_uuid"],
-			"model_uuid=" + metadata["model_uuid"],
-			"controller_uuid=" + metadata["controller_uuid"],
-			"cloud=" + metadata["cloud"],
-			"cloud_region=" + metadata["cloud_region"],
-			"provider=" + metadata["provider"],
-			"controller_version=" + version.Current.String(),
-			"is_controller=" + metadata["is_controller"],
-		},
-	})
+	revResults, err := client.LatestRevisions(charms, metadata)
 	if err != nil {
 		err = errors.Annotate(err, "while getting latest charm revision info")
 		logger.Infof(err.Error())

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -76,6 +76,7 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 		"cloud":            "foocloud",
 		"cloud_region":     "fooregion",
 		"provider":         "fooprovider",
+		"is_controller":    "false",
 	}
 	results, err := LatestCharmInfo(client, charms, metadata)
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,6 +89,7 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 		"cloud_region=fooregion",
 		"provider=fooprovider",
 		"controller_version=" + version.Current.String(),
+		"is_controller=false",
 	}
 	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, []*charm.URL{spam}, map[string][]string{"Juju-Metadata": header})
 	s.lowLevel.stableStub.CheckCall(c, 1, "Latest", params.StableChannel, []*charm.URL{eggs}, map[string][]string{"Juju-Metadata": header})

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -45,9 +45,9 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	eggs := charm.MustParseURL("cs:quantal/eggs-2")
 	ham := charm.MustParseURL("cs:quantal/ham-1")
 	charms := []CharmID{
-		{URL: spam, Channel: "stable", Metadata: map[string]string{"series": "quantal"}},
-		{URL: eggs, Channel: "stable", Metadata: map[string]string{"series": "quantal"}},
-		{URL: ham, Channel: "stable", Metadata: map[string]string{"series": "quantal"}},
+		{URL: spam, Channel: "stable", Metadata: map[string]string{"series": "quantal", "arch": "amd64,arm64"}},
+		{URL: eggs, Channel: "stable", Metadata: map[string]string{"series": "quantal", "arch": "amd64,arm64"}},
+		{URL: ham, Channel: "stable", Metadata: map[string]string{"series": "quantal", "arch": "amd64,arm64"}},
 	}
 	notFound := errors.New("not found")
 	s.lowLevel.ReturnLatestStable = [][]params.CharmRevision{{{
@@ -83,6 +83,8 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	header := []string{
+		"arch=amd64",
+		"arch=arm64",
 		"cloud=foocloud",
 		"cloud_region=fooregion",
 		"controller_uuid=controlleruuid",

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -45,9 +45,9 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	eggs := charm.MustParseURL("cs:quantal/eggs-2")
 	ham := charm.MustParseURL("cs:quantal/ham-1")
 	charms := []CharmID{
-		{URL: spam, Channel: "stable"},
-		{URL: eggs, Channel: "stable"},
-		{URL: ham, Channel: "stable"},
+		{URL: spam, Channel: "stable", Metadata: map[string]string{"series": "quantal"}},
+		{URL: eggs, Channel: "stable", Metadata: map[string]string{"series": "quantal"}},
+		{URL: ham, Channel: "stable", Metadata: map[string]string{"series": "quantal"}},
 	}
 	notFound := errors.New("not found")
 	s.lowLevel.ReturnLatestStable = [][]params.CharmRevision{{{
@@ -70,26 +70,28 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	metadata := map[string]string{
-		"environment_uuid": "foouuid",
-		"model_uuid":       "foouuid",
-		"controller_uuid":  "controlleruuid",
-		"cloud":            "foocloud",
-		"cloud_region":     "fooregion",
-		"provider":         "fooprovider",
-		"is_controller":    "false",
+		"environment_uuid":   "foouuid",
+		"model_uuid":         "foouuid",
+		"controller_uuid":    "controlleruuid",
+		"cloud":              "foocloud",
+		"cloud_region":       "fooregion",
+		"provider":           "fooprovider",
+		"controller_version": version.Current.String(),
+		"is_controller":      "false",
 	}
 	results, err := LatestCharmInfo(client, charms, metadata)
 	c.Assert(err, jc.ErrorIsNil)
 
 	header := []string{
-		"environment_uuid=foouuid",
-		"model_uuid=foouuid",
-		"controller_uuid=controlleruuid",
 		"cloud=foocloud",
 		"cloud_region=fooregion",
-		"provider=fooprovider",
+		"controller_uuid=controlleruuid",
 		"controller_version=" + version.Current.String(),
+		"environment_uuid=foouuid",
 		"is_controller=false",
+		"model_uuid=foouuid",
+		"provider=fooprovider",
+		"series=quantal",
 	}
 	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, []*charm.URL{spam}, map[string][]string{"Juju-Metadata": header})
 	s.lowLevel.stableStub.CheckCall(c, 1, "Latest", params.StableChannel, []*charm.URL{eggs}, map[string][]string{"Juju-Metadata": header})

--- a/state/model.go
+++ b/state/model.go
@@ -946,7 +946,9 @@ func (m *Model) Users() ([]permission.UserAccess, error) {
 	return modelUsers, nil
 }
 
-func (m *Model) isControllerModel() bool {
+// IsControllerModel returns a boolean indicating whether
+// this model is responsible for running a controller.
+func (m *Model) IsControllerModel() bool {
 	return m.st.controllerModelTag.Id() == m.doc.UUID
 }
 
@@ -1160,7 +1162,7 @@ func (m *Model) destroyOps(
 		}
 	}
 
-	if m.isControllerModel() && (!args.DestroyHostedModels || args.DestroyStorage == nil || !*args.DestroyStorage) {
+	if m.IsControllerModel() && (!args.DestroyHostedModels || args.DestroyStorage == nil || !*args.DestroyStorage) {
 		// This is the controller model, and we've not been instructed
 		// to destroy hosted models, or we've not been instructed to
 		// destroy storage.
@@ -1274,7 +1276,7 @@ func (m *Model) destroyOps(
 	// arbitrarily long delays, we need to make sure every op
 	// causes a state change that's still consistent; so we make
 	// sure the cleanup ops are the last thing that will execute.
-	if m.isControllerModel() {
+	if m.IsControllerModel() {
 		ops = append(ops, newCleanupOp(
 			cleanupModelsForDyingController, modelUUID,
 			// pass through the DestroyModelArgs to the cleanup,

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -35,6 +35,7 @@ var _ = gc.Suite(&ModelSuite{})
 func (s *ModelSuite) TestModel(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Check(model.IsControllerModel(), jc.IsTrue)
 
 	expectedTag := names.NewModelTag(model.UUID())
 	c.Assert(model.Tag(), gc.Equals, expectedTag)
@@ -227,6 +228,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Check(model.IsControllerModel(), jc.IsFalse)
 	defer st.Close()
 
 	modelTag := names.NewModelTag(uuid)


### PR DESCRIPTION
## Description of change

This path adds the following values to the metadata header when requesting latest charm info from the store:
- `series`
- `arch`
- `is_controller`

## QA steps

Edit the value of `CharmRevisionUpdateInterval` in _/home/joseph/go/src/github.com/juju/juju/cmd/jujud/agent/machine.go_ so that we don't have to wait a day for metrics to be sent - a few minutes should be sufficient.

Build this patch.

Run these steps for providers LXD and another that supports "hardware characteristics" such as MAAS. This tests for both the absence and presence of metadata for architecture.

- Bootstrap and add a unit.
- `juju debug-log -m controller`.
- Check that the calls to `CharmRevisionUpdater` calls succeed without error.

Note that appearance of the actual metrics in _juju-kpi_ lags by a couple of days, so we will have to wait to check actual handling by the charm-store (unless there is another way I am not aware of).

## Documentation changes

None.

## Bug reference

N/A
