### PR TITLE
machineFieldChangeWatcher shouldn't watch machines matching complete criteria from start.

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -332,6 +332,12 @@ func (task *provisionerTask) processMachines(ids []string) error {
 
 func (task *provisionerTask) processProfileChanges(ids []string) error {
 	logger.Tracef("processProfileChanges(%v)", ids)
+	if len(ids) == 0 {
+		// TODO: (hml) 2018-11-29
+		// This shouldn't be triggered, until that's fixed
+		// short circuit here when there's nothing to process.
+		return nil
+	}
 
 	machineTags := make([]names.MachineTag, len(ids))
 	for i, id := range ids {


### PR DESCRIPTION
## Description of change

Don't starting watching instanceCharmProfileData docs if they are added with completed of not required.

## QA steps

suggest using a maas config, can't always reproduce with a localhost config.
1. `bootstrap with juju 2.4.7 and --config logging-config="<root>=DEBUG;unit=DEBUG;juju.state=TRACE"`
2. `juju deploy cs:openstack-dashboard-268 --to lxd,lxd -n 2`
3. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd`
3. with juju under test: `juju upgrade-juju --build-agent -m controller`
3. with juju under test: `juju upgrade-juju `
4. `juju upgrade-charm openstack-dashboard`
    no no appname errors should occur, NOTE: sometimes there watcher errors, these can be ignore, the watcher in question is in the process of being removed from the upgrade-charm command.
4. `juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt`
    profile should be applied 
5. check the controller logs for "field" messages, only the lxd-profile-alt machine should be watched.

Try other upgrade and non upgrade scenarios with this change please.

## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804704