### PR TITLE
Shortcutting add-cloud UX

### DIFF
--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -119,6 +119,13 @@ func (p *Pollster) MultiSelect(l MultiList) ([]string, error) {
 		return nil, err
 	}
 
+	// If there is only ever one option and that option also equals the default
+	// option, then just echo out what that option is (above), then return that
+	// option back.
+	if len(l.Default) == 1 && len(l.Options) == 1 && l.Options[0] == l.Default[0] {
+		return l.Default, nil
+	}
+
 	question, err := sprint(multiSelectTmpl, l)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/interact/pollster_test.go
+++ b/cmd/juju/interact/pollster_test.go
@@ -66,6 +66,21 @@ func (PollsterSuite) TestSelectDefault(c *gc.C) {
 	c.Assert(w.String(), jc.Contains, `Select apple [macintosh]: `)
 }
 
+func (PollsterSuite) TestSelectDefaultIfOnlyOption(c *gc.C) {
+	r := strings.NewReader("\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	s, err := p.Select(List{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh"},
+		Default:  "macintosh",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s, gc.Equals, "macintosh")
+	c.Assert(w.String(), jc.Contains, `Select apple [macintosh]: `)
+}
+
 func (PollsterSuite) TestSelectIncorrect(c *gc.C) {
 	r := strings.NewReader("mac\nmacintosh")
 	w := &bytes.Buffer{}
@@ -140,6 +155,36 @@ func (PollsterSuite) TestMultiSelectDefault(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vals, jc.SameContents, []string{"gala", "granny smith"})
+}
+
+func (PollsterSuite) TestMultiSelectDefaultIfOnlyOne(c *gc.C) {
+	r := strings.NewReader("\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh"},
+		Default:  []string{"macintosh"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"macintosh"})
+	c.Assert(w.String(), gc.Equals, "Apples\n  macintosh\n\n")
+}
+
+func (PollsterSuite) TestMultiSelectWithMultipleDefaults(c *gc.C) {
+	r := strings.NewReader("\n")
+	w := &bytes.Buffer{}
+	p := New(r, w, w)
+	vals, err := p.MultiSelect(MultiList{
+		Singular: "apple",
+		Plural:   "apples",
+		Options:  []string{"macintosh", "gala"},
+		Default:  []string{"macintosh", "gala"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vals, jc.SameContents, []string{"macintosh", "gala"})
+	c.Assert(w.String(), jc.Contains, "Select one or more apples separated by commas [macintosh, gala]: \n")
 }
 
 func (PollsterSuite) TestMultiSelectOneError(c *gc.C) {


### PR DESCRIPTION
## Description of change

The following commit makes it easier for the operator when adding
a cloud, by not asking redundant questions if we already know the
answer.

## QA steps

```
juju add-cloud lxd
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: lxd

Enter the API endpoint url for the remote LXD server: https://192.168.1.201:8443

Auth Types
  certificate

Enter region [default]: 
```

## Documentation changes

If we already know all possible answers, don't ask redundant questions
to the operator.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1794342
