### PR TITLE
fixes to assess_bundle_export (nw-export-bundle-lxd)

### DIFF
--- a/acceptancetests/README.md
+++ b/acceptancetests/README.md
@@ -24,7 +24,7 @@ $ make install-deps
 
 
 ### Quick run using LXD
-To run a test locally with lxd:
+To run a test locally with lxd and locally complied juju:
 
   * ```$ mkdir /tmp/test-run```
   * ```$ export JUJU_HOME=/tmp/test-run```
@@ -37,6 +37,11 @@ To run a test locally with lxd:
             default-series: bionic
     ```
   * ```export JUJU_REPOSITORY=./path/to/acceptancetests/repository```
+  * ```mkdir /tmp/artifacts```
+  * Now you can run the test with:
+     * ```$ ./assess_model_migration.py lxd $GOPATH/bin/juju /tmp/artifacts```
+
+  Old method, stopped working before 1-DEC-2018:
   * Now you can run the test with:
      * ```$ ./assess_model_migration.py lxd . . .```
 
@@ -44,7 +49,7 @@ To run a test locally with lxd:
 
 See [(Use of environments.yaml below)](#envs) and [(Use of credentials.yaml below)](#envs-creds) for a full explanation of the files used here.
 
-To run a test using AWS:
+To run a test using AWS and locally complied juju:
 
   * ```$ mkdir /tmp/test-run```
   * ```$ export JUJU_HOME=/tmp/test-run```
@@ -67,10 +72,28 @@ To run a test using AWS:
           secret-key: <secret key>
     ```
   * ```export JUJU_REPOSITORY=/path/to/acceptancetests/repository```
+  * ```mkdir /tmp/artifacts```
+  * Now you can run the test with:
+       * ```$ ./assess_model_migration.py aws $GOPATH/bin/juju /tmp/artifacts```
+
+  Old method, stopped working before 1-DEC-2018:
   * Now you can run the test with:
      * ```$ ./assess_model_migration.py myaws . . .```
 
+### Typical command line required options for tests
+
+<test> <cloud> <path-to-juju> <path-to-artifacts-dir> <controller-name>
+    * <cloud> specified in your $JUJU_HOME/environments.yaml
+    * <path-to-juju> specify full path to juju you wish to test.
+    * <path-to-artifacts-dir>, test will complain if the directory has contents, but still run.
+    * <controller-name> will be used to bootstrap if the controller does not currently exist, if not specified a controller name is generated.
+
+example:
+```./assess_bundle_export.py lxd /snap/bin/juju /tmp/artifacts nw-export-bundle-lxd```
+
 ### Which juju binary is used?
+
+NOTE: As of 3-dec-2018, juju is not found in your path, please specify directly
 
 If no *juju_bin* argument is passed to an *assess* script it will default to using the juju in your **$PATH**.
 
@@ -88,6 +111,8 @@ Adding this feature to a new test is as easy as passing ```existing=True``` to `
 
 ### Running a test on an existing controller
 
+TODO 3-DEC-2018, this section needs to be updated for current working methods
+
 To iterate quickly on a test it can be useful to bootstrap a controller and run the test against that multiple times.
 This example isolates the juju interactions so your system configuration is not touched.
 
@@ -100,7 +125,7 @@ export JUJU_DATA=/tmp/testing-controller
 export JUJU_HOME=~/tmp/test-run
 mkdir -p $JUJU_DATA
 
-juju bootstrap lxd/localhost testing-feature-x
+juju bootstrap lxd testing-feature-x
 
 ./assess_feature-x.py lxd --existing testing-feature-x
 ```


### PR DESCRIPTION
## Description of change

Update the assess_bundle_export test to not assume that juju adds .yaml to the export filename provided.

## QA steps
1. setup per github.com/juju/juju/acceptancetests/README.md
1. ./assess_bundle_export.py lxd /snap/bin/juju /tmp/artifacts nw-export-bundle-lxd