### PR TITLE
Revert deletion of the Oracle Classic provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,6 +450,17 @@
   revision = "2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65"
 
 [[projects]]
+  digest = "1:88472cd128b0e341f80d682a5ac7059a67992b53dea26c59185d26445a36284a"
+  name = "github.com/juju/go-oracle-cloud"
+  packages = [
+    "api",
+    "common",
+    "response",
+  ]
+  pruneopts = ""
+  revision = "932a8cea00a1cd5cba3829a672c823955db674ae"
+
+[[projects]]
   branch = "master"
   digest = "1:499860665660bef418a86e824c23d98c56cc05c2e2f50d5c77164f58a934def7"
   name = "github.com/juju/go4"
@@ -1802,6 +1813,9 @@
     "github.com/juju/description",
     "github.com/juju/errors",
     "github.com/juju/gnuflag",
+    "github.com/juju/go-oracle-cloud/api",
+    "github.com/juju/go-oracle-cloud/common",
+    "github.com/juju/go-oracle-cloud/response",
     "github.com/juju/gojsonschema",
     "github.com/juju/gomaasapi",
     "github.com/juju/httprequest",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -298,6 +298,10 @@
   revision = "22422dad46e14561a0854ad42497a75af9b61909"
 
 [[constraint]]
+  name = "github.com/juju/go-oracle-cloud"
+  revision = "932a8cea00a1cd5cba3829a672c823955db674ae"
+
+[[constraint]]
   name = "github.com/juju/httprequest"
   revision = "266fd1e9debf09c037a63f074d099a2da4559ece"
 

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -21,7 +21,7 @@ type cloudSuite struct {
 var _ = gc.Suite(&cloudSuite{})
 
 var publicCloudNames = []string{
-	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle",
+	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma", "oracle", "oracle-classic",
 }
 
 func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -295,3 +295,18 @@ clouds:
         endpoint: https://iaas.eu-frankfurt-1.oraclecloud.com
       uk-london-1:
         endpoint: https://iaas.uk-london-1.oraclecloud.com
+  oracle-classic:
+    type: oracle
+    description: Oracle Cloud Infrastructure Classic
+    auth-types: [ userpass ]
+    regions:
+      uscom-central-1:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us2:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us6:
+        endpoint: https://compute.us6.oraclecloud.com
+      em2:
+        endpoint: https://compute.em2.oraclecloud.com
+      em3:
+        endpoint: https://compute.em3.oraclecloud.com

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -302,5 +302,20 @@ clouds:
         endpoint: https://iaas.eu-frankfurt-1.oraclecloud.com
       uk-london-1:
         endpoint: https://iaas.uk-london-1.oraclecloud.com
+  oracle-classic:
+    type: oracle
+    description: Oracle Cloud Infrastructure Classic
+    auth-types: [ userpass ]
+    regions:
+      uscom-central-1:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us2:
+        endpoint: https://compute.uscom-central-1.oraclecloud.com
+      us6:
+        endpoint: https://compute.us6.oraclecloud.com
+      em2:
+        endpoint: https://compute.em2.oraclecloud.com
+      em3:
+        endpoint: https://compute.em3.oraclecloud.com
 
 `

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -31,10 +31,10 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	out = strings.Replace(out, "\n", "", -1)
 
 	// Check that we are producing the expected fields
-	c.Assert(out, gc.Matches, `Cloud        Regions  Default        Type        Description.*`)
+	c.Assert(out, gc.Matches, `Cloud +Regions +Default +Type +Description.*`)
 	// // Just check couple of snippets of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws               [0-9]+  [a-z0-9-]+      ec2         Amazon Web Services.*`)
-	c.Assert(out, gc.Matches, `.*azure             [0-9]+  [a-z0-9-]+      azure       Microsoft Azure.*`)
+	c.Assert(out, gc.Matches, `.*aws +[0-9]+ +[a-z0-9-]+ +ec2 +Amazon Web Services.*`)
+	c.Assert(out, gc.Matches, `.*azure +[0-9]+ +[a-z0-9-]+ +azure +Microsoft Azure.*`)
 	// LXD should be there too.
 	c.Assert(out, gc.Matches, `.*localhost[ ]*1[ ]*localhost[ ]*lxd.*`)
 }
@@ -60,7 +60,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `Hypervisorhomestack          1  london         openstack   Openstack Cloud`)
+	c.Assert(out, jc.Contains, `Hypervisorhomestack             1  london           openstack   Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1817,6 +1817,7 @@ cloudsigma
 google                                        
 joyent                                        
 oracle                                        
+oracle-classic                                
 rackspace                                     
 localhost                                     
 dummy-cloud                      joe          home

--- a/provider/all/all.go
+++ b/provider/all/all.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/juju/juju/provider/manual"
 	_ "github.com/juju/juju/provider/oci"
 	_ "github.com/juju/juju/provider/openstack"
+	_ "github.com/juju/juju/provider/oracle"
 	_ "github.com/juju/juju/provider/rackspace"
 	_ "github.com/juju/juju/provider/vsphere"
 )

--- a/provider/oracle/common/interfaces.go
+++ b/provider/oracle/common/interfaces.go
@@ -1,0 +1,260 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+)
+
+type OracleInstancer interface {
+	environs.Environ
+
+	Details(id instance.Id) (response.Instance, error)
+}
+
+// Instancer used to retrieve details from a given instance
+// in the oracle cloud infrastructure
+type Instancer interface {
+	// InstanceDetails retrieves information from the provider
+	// about one instance
+	InstanceDetails(string) (response.Instance, error)
+}
+
+// Composer has the simple task of composing an oracle compatible
+// resource name
+type Composer interface {
+	// ComposeName composes the name for a provider resource. The name
+	// for an oracle API resource typically has the following form:
+	//
+	// /Compute-<Identity Domain>/<username>/<resource name>
+	//
+	// The Identity Domain in this case equates to what some other providers
+	// like OpenStack refer to as tenants or projects.
+	// This information is supplied by the user in the cloud configuration
+	// information.
+	// This function is generally needed
+	ComposeName(string) string
+}
+
+// InstanceAPI uses to retrieve all instances, delete and create
+// in the oracle cloud infrastructure
+type InstanceAPI interface {
+	CreateInstance(api.InstanceParams) (response.LaunchPlan, error)
+	AllInstances([]api.Filter) (response.AllInstances, error)
+	DeleteInstance(string) error
+}
+
+// Authenticater authenticates the oracle client in the
+// oracle IAAS api
+type Authenticater interface {
+	Authenticate() error
+}
+
+// Shaper used to retrieve all shapes from the oracle cloud
+// environ
+type Shaper interface {
+	AllShapes([]api.Filter) (response.AllShapes, error)
+}
+
+// Imager used to retrieve all images iso meta data format from the
+// oracle cloud environment
+type Imager interface {
+	AllImageLists([]api.Filter) (response.AllImageLists, error)
+	CreateImageList(def int, description string, name string) (resp response.ImageList, err error)
+	CreateImageListEntry(name string, attributes map[string]interface{}, version int, machineImages []string) (resp response.ImageListEntryAdd, err error)
+	DeleteImageList(name string) (err error)
+}
+
+// IpReservationAPI provider methods for retrieving, updating, creating
+// and deleting ip reservations inside the oracle cloud infrastructure
+type IpReservationAPI interface {
+	AllIpReservations([]api.Filter) (response.AllIpReservations, error)
+	UpdateIpReservation(string, string,
+		common.IPPool, bool, []string) (response.IpReservation, error)
+	CreateIpReservation(string, common.IPPool,
+		bool, []string) (response.IpReservation, error)
+	DeleteIpReservation(string) error
+}
+
+// IpAssociationAPI provides methods for creating deleting and listing all
+// ip associations inside the oracle cloud environment
+type IpAssociationAPI interface {
+	CreateIpAssociation(common.IPPool, common.VcableID) (response.IpAssociation, error)
+	DeleteIpAssociation(string) error
+	AllIpAssociations([]api.Filter) (response.AllIpAssociations, error)
+}
+
+// IpNetworkExchanger provides a simple interface for retrieving all
+// ip network exchanges inside the oracle cloud environment
+type IpNetworkExchanger interface {
+	AllIpNetworkExchanges([]api.Filter) (response.AllIpNetworkExchanges, error)
+}
+
+// IpNetowrker provides a simple interface for retrieving all
+// ip networks inside the oracle cloud environment
+type IpNetworker interface {
+	AllIpNetworks([]api.Filter) (response.AllIpNetworks, error)
+}
+
+// VnicSetAPI provides methods for deleting, retrieving details and creating
+// virtual nics for providing access for instances to different subnets inside
+// the oracle cloud environment
+type VnicSetAPI interface {
+	DeleteVnicSet(string) error
+	VnicSetDetails(string) (response.VnicSet, error)
+	CreateVnicSet(api.VnicSetParams) (response.VnicSet, error)
+}
+
+// RulesAPI defines methods for retrieving, creating and deleting
+// Sec rules under the oracle cloud endpoint
+// For more information on sec rules, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-SecRules.html
+type RulesAPI interface {
+	// AllSecRules returns all sec rules matching a filter. A nil valued
+	// filter will return all entries in the API.
+	AllSecRules([]api.Filter) (response.AllSecRules, error)
+	// DeleteSecRule deletes the security rule with the given name
+	DeleteSecRule(string) error
+	// CreateSecRule creates the security rule inside oracle cloud
+	// given the sec rule parameters
+	CreateSecRule(api.SecRuleParams) (response.SecRule, error)
+}
+
+// AclAPI defines methods for retrieving, creating and deleting
+// access control lists under the oracle cloud endpoint
+type AclAPI interface {
+	// AclDetails retrieves the access control list details for one list
+	AclDetails(string) (response.Acl, error)
+	// CreateAcl creates the access control list
+	CreateAcl(string, string, bool, []string) (response.Acl, error)
+	// DeleteAcl deletes one access control list
+	DeleteAcl(string) error
+	// AllAcls fetches a list of all ACLs matching the given filter.
+	AllAcls([]api.Filter) (response.AllAcls, error)
+}
+
+// SecIpAPI defines methods for retrieving creating sec IP lists
+// in the oracle cloud
+// For more information about sec ip lists, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-SecIPLists.html
+type SecIpAPI interface {
+	// AllSecIpLists returns all sec IP lists that match a filter. A nil valued
+	// filter will return all entries in the API.
+	AllSecIpLists([]api.Filter) (response.AllSecIpLists, error)
+	// CreateSecIpList creates the sec IP list under the oracle cloud endpoint
+	CreateSecIpList(string, string, []string) (response.SecIpList, error)
+	// AllDefaultSecIpLists retrieves all default sec IP lists from the
+	// oracle cloud account. Default lists are defined by the cloud and cannot
+	// be changed in any way.
+	AllDefaultSecIpLists([]api.Filter) (response.AllSecIpLists, error)
+}
+
+// IpAddressPrefixSetAPI defines methods for creating and listing
+// IP address prefix sets under the oracle cloud endpoint
+// For information about IP address prefix sets, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-IPAddressPrefixSets.html
+type IpAddressPrefixSetAPI interface {
+	// CreateIpAddressPrefixSet creates a new IP address prefix set inside the oracle
+	// cloud, for the current user
+	CreateIpAddressPrefixSet(
+		api.IpAddressPrefixSetParams) (response.IpAddressPrefixSet, error)
+
+	// AllIpAddressPrefixSets returns all IP address prefix sets that match the given filter.
+	// A nil valued filter will return all entries in the API.
+	AllIpAddressPrefixSets([]api.Filter) (response.AllIpAddressPrefixSets, error)
+}
+
+// SecListAPI defines methods for retrieving, creating and deleting
+// sec lists under the oracle cloud endpoint
+// For more information about sec lists, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-SecLists.html
+type SecListAPI interface {
+	// SecListDetails retrieves sec list details for the given list
+	SecListDetails(string) (response.SecList, error)
+	// DeleteSecList deletes one sec list
+	DeleteSecList(string) error
+	// CreateSecList creates a sec list
+	CreateSecList(string, string,
+		common.SecRuleAction, common.SecRuleAction) (response.SecList, error)
+}
+
+// SecRulesAPI defines methods for retrieving, deleting and creating
+// security rules under the oracle cloud endpoint
+// For more details on sec rules, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-SecRules.html
+type SecRulesAPI interface {
+	// AllSecurityRules returns all security rules matching a filter. A nil valued
+	// filter will return all entries in the API.
+	AllSecurityRules([]api.Filter) (response.AllSecurityRules, error)
+	// DeleteSecurityRule deletes the security rule with the given name
+	DeleteSecurityRule(string) error
+	// CreateSecurityRule creates a security rule based on the security rule
+	// parameters under the oracle cloud endpoint
+	CreateSecurityRule(api.SecurityRuleParams) (response.SecurityRule, error)
+}
+
+// ApplicationsAPI also named protocols in the oracle cloud defines methods
+// for retriving and creating applications rules/protocol rules
+// under the oracle cloud endpoint
+// For more information about sec applications, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-SecApplications.html
+type ApplicationsAPI interface {
+	// AllSecApplications returns all sec applications matching a filter. A nil valued
+	// filter will return all entries in the API.
+	AllSecApplications([]api.Filter) (response.AllSecApplications, error)
+	// DefaultSecApplications returns all default security applications matching a filter.
+	// A nil valued filter will return all entries in the API.
+	DefaultSecApplications([]api.Filter) (response.AllSecApplications, error)
+	// CreateSecApplications creates a security applications
+	CreateSecApplication(api.SecApplicationParams) (response.SecApplication, error)
+}
+
+// AssociationAPI defines a rule for listing, retrieving all security
+// associations under the oracle cloud API
+// For more details about sec associations, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-SecAssociations.html
+type AssociationAPI interface {
+	// AllSecAssociations returns all security associations matching a filter. A nil valued
+	// filter will return all entries in the API.
+	AllSecAssociations([]api.Filter) (response.AllSecAssociations, error)
+}
+
+// StorageVolumeAPI defines methods for retrieving, creating, deleting and
+// updating storage volumes under the oracle cloud endpoint
+// For more details about storage volumes, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-StorageVolumes.html
+type StorageVolumeAPI interface {
+	// CreateStorageVolume creates a storage volume
+	CreateStorageVolume(p api.StorageVolumeParams) (resp response.StorageVolume, err error)
+	// DeleteStorageVolume deletes the storage volume
+	DeleteStorageVolume(name string) (err error)
+	// StorageVolumeDetails retrieves storage volume details
+	StorageVolumeDetails(name string) (resp response.StorageVolume, err error)
+	// AllStoragevolumes retrieves all storage volumes matching a filter. A nil valued
+	// filter will return all entries in the API.
+	AllStorageVolumes(filter []api.Filter) (resp response.AllStorageVolumes, err error)
+	// UpdateStorageVolume updates the state of the storage volume
+	UpdateStorageVolume(p api.StorageVolumeParams, currentName string) (resp response.StorageVolume, err error)
+}
+
+// StorageAttachmentAPI defines methods for attaching, detaching storages to
+// instances under the oracle cloud endpoint
+// For more information on storage attachments, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-StorageAttachments.html
+type StorageAttachmentAPI interface {
+	// CreateStorageAttachment creates a storage attachment
+	CreateStorageAttachment(p api.StorageAttachmentParams) (response.StorageAttachment, error)
+	// DeleteStorageAttachment deletes the storage attachment
+	DeleteStorageAttachment(name string) error
+	// StorageAttachmentDetails retrieves details of the storage attachment
+	StorageAttachmentDetails(name string) (response.StorageAttachment, error)
+	// AllStorageAttachments retrieves all storage attachments matching a filter. A nil valued
+	// filter will return all entries in the API.
+	AllStorageAttachments(filter []api.Filter) (response.AllStorageAttachments, error)
+}

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -1,0 +1,798 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	oci "github.com/juju/go-oracle-cloud/api"
+	ociCommon "github.com/juju/go-oracle-cloud/common"
+	ociResponse "github.com/juju/go-oracle-cloud/response"
+	"github.com/juju/os"
+	jujuseries "github.com/juju/os/series"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/cloudconfig/providerinit"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	envinstance "github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/environs/tags"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
+	commonProvider "github.com/juju/juju/provider/oracle/common"
+	oraclenet "github.com/juju/juju/provider/oracle/network"
+	"github.com/juju/juju/tools"
+)
+
+// OracleEnviron implements the environs.Environ interface
+type OracleEnviron struct {
+	environs.Networking
+	oraclenet.Firewaller
+
+	mutex     *sync.Mutex
+	p         *EnvironProvider
+	spec      environs.CloudSpec
+	cfg       *config.Config
+	client    EnvironAPI
+	namespace instance.Namespace
+	clock     clock.Clock
+	rand      *rand.Rand
+}
+
+// EnvironAPI provides interface to access and make operation
+// inside a oracle environ
+type EnvironAPI interface {
+	commonProvider.Instancer
+	commonProvider.InstanceAPI
+	commonProvider.Authenticater
+	commonProvider.Shaper
+	commonProvider.Imager
+	commonProvider.IpReservationAPI
+	commonProvider.IpAssociationAPI
+	commonProvider.IpNetworkExchanger
+	commonProvider.IpNetworker
+	commonProvider.VnicSetAPI
+
+	commonProvider.RulesAPI
+	commonProvider.AclAPI
+	commonProvider.SecIpAPI
+	commonProvider.IpAddressPrefixSetAPI
+	commonProvider.SecListAPI
+	commonProvider.ApplicationsAPI
+	commonProvider.SecRulesAPI
+	commonProvider.AssociationAPI
+
+	StorageAPI
+}
+
+// AvailabilityZones is defined in the common.ZonedEnviron interface
+func (o *OracleEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+	return []common.AvailabilityZone{
+		oraclenet.NewAvailabilityZone("default"),
+	}, nil
+}
+
+// InstanceAvailabilityzoneNames is defined in the common.ZonedEnviron interface
+func (o *OracleEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	instances, err := o.Instances(ctx, ids)
+	if err != nil && err != environs.ErrPartialInstances {
+		return nil, err
+	}
+	zones := make([]string, len(instances))
+	for idx := range instances {
+		zones[idx] = "default"
+	}
+	return zones, nil
+}
+
+// NewOracleEnviron returns a new OracleEnviron
+func NewOracleEnviron(p *EnvironProvider, args environs.OpenParams, client EnvironAPI, c clock.Clock) (env *OracleEnviron, err error) {
+	if client == nil {
+		return nil, errors.NotFoundf("oracle client")
+	}
+	if p == nil {
+		return nil, errors.NotFoundf("environ proivder")
+	}
+	env = &OracleEnviron{
+		p:      p,
+		spec:   args.Cloud,
+		cfg:    args.Config,
+		mutex:  &sync.Mutex{},
+		client: client,
+		clock:  c,
+	}
+	env.namespace, err = instance.NewNamespace(env.cfg.UUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env.Firewaller = oraclenet.NewFirewall(env, client, c)
+	env.Networking = oraclenet.NewEnviron(client, env)
+
+	source := rand.NewSource(env.clock.Now().UTC().UnixNano())
+	r := rand.New(source)
+	env.rand = r
+
+	return env, nil
+}
+
+// PrepareForBootstrap is part of the Environ interface.
+func (o *OracleEnviron) PrepareForBootstrap(ctx environs.BootstrapContext) error {
+	if ctx.ShouldVerifyCredentials() {
+		logger.Infof("Logging into the oracle cloud infrastructure")
+		if err := o.client.Authenticate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}
+
+// Bootstrap is part of the Environ interface.
+func (o *OracleEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	return common.Bootstrap(ctx, o, callCtx, args)
+}
+
+// Create is part of the Environ interface.
+func (o *OracleEnviron) Create(ctx context.ProviderCallContext, params environs.CreateParams) error {
+	if err := o.client.Authenticate(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// AdoptResources is part of the Environ interface.
+func (e *OracleEnviron) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
+	//TODO (gsamfira): Implement AdoptResources. Controller tag for all resources needs to
+	// be changed
+	return nil
+}
+
+// getCloudInitConfig returns a CloudConfig instance. this function only exists because of a
+// limitation that currently exists in cloud-init see bug report:
+// https://bugs.launchpad.net/cloud-init/+bug/1675370
+func (e *OracleEnviron) getCloudInitConfig(series string, networks map[string]oci.Networker) (cloudinit.CloudConfig, error) {
+	// TODO (gsamfira): remove this function when the above mention bug is fixed
+	cloudcfg, err := cloudinit.New(series)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot create cloudinit template")
+	}
+	operatingSystem, err := jujuseries.GetOSFromSeries(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	renderer := cloudcfg.ShellRenderer()
+	// by default windows has all NICs set on DHCP, so no need to configure
+	// anything.
+	// gsamfira: I could not find a CentOS image in the oracle compute
+	// marketplace, so not doing anything CentOS specific here.
+	var scripts []string
+	switch operatingSystem {
+	case os.Ubuntu:
+		for key := range networks {
+			if key == defaultNicName {
+				continue
+			}
+			fileBaseName := fmt.Sprintf("%s.cfg", key)
+			fileContents := fmt.Sprintf(ubuntuInterfaceTemplate, key, key)
+			fileName := renderer.Join(
+				renderer.FromSlash(interfacesConfigDir), fileBaseName)
+			scripts = append(scripts,
+				renderer.WriteFile(fileName, []byte(fileContents))...)
+			scripts = append(scripts, fmt.Sprintf("/sbin/ifup %s", key))
+			scripts = append(scripts, "")
+
+		}
+		if len(scripts) > 0 {
+			cloudcfg.AddScripts(strings.Join(scripts, "\n"))
+		}
+	}
+	return cloudcfg, nil
+}
+
+// buildSpacesMap builds a map with juju converted names from provider space names
+//
+// shamelessly copied from the MAAS provider
+func (e *OracleEnviron) buildSpacesMap(ctx context.ProviderCallContext) (map[string]network.SpaceInfo, map[string]string, error) {
+	empty := set.Strings{}
+	providerIdMap := map[string]string{}
+	// NOTE (gsamfira): This seems brittle to me, and I would much rather get this
+	// from state, as that information should already be there from the discovered spaces
+	// and that is the information that gets presented to the user when running:
+	// juju spaces
+	// However I have not found a clean way to access that info from the provider,
+	// without creating a facade. Someone with more knowledge on this might be able to chip in.
+	spaces, err := e.Spaces(ctx)
+	if err != nil {
+		return nil, providerIdMap, errors.Trace(err)
+	}
+	spaceMap := make(map[string]network.SpaceInfo)
+	for _, space := range spaces {
+		jujuName := network.ConvertSpaceName(space.Name, empty)
+		spaceMap[jujuName] = space
+		empty.Add(jujuName)
+		providerIdMap[string(space.ProviderId)] = space.Name
+	}
+	return spaceMap, providerIdMap, nil
+
+}
+
+func (e *OracleEnviron) getInstanceNetworks(
+	ctx context.ProviderCallContext,
+	args environs.StartInstanceParams,
+	secLists, vnicSets []string,
+) (map[string]oci.Networker, error) {
+
+	// gsamfira: We add a default NIC attached o the shared network provided
+	// by the oracle cloud. This NIC is used for outbound traffic.
+	// While you can attach just a VNIC to the instance, and assign a
+	// public IP to it, I have not been able to get any outbound traffic
+	// through the thing.
+	// NOTE (gsamfira): The NIC ordering inside the instance is determined
+	// by the order in which the API returns the network interfaces. It seems
+	// the API orders the NICs alphanumerically. When adding new network
+	// interfaces, make sure they are ordered to come after eth0
+	networking := map[string]oci.Networker{
+		defaultNicName: oci.SharedNetwork{
+			Seclists: secLists,
+		},
+	}
+	spaces := set.Strings{}
+	if s := args.Constraints.IncludeSpaces(); len(s) != 0 {
+		for _, val := range s {
+			logger.Debugf("Adding space from constraints %s", val)
+			spaces.Add(val)
+		}
+	}
+
+	// NOTE (gsamfira): The way spaces works seems really iffy to me. We currently
+	// rely on two sources of truth to determine the spaces to which we should attach
+	// an instance. This becomes evident then we try to use --constraints and --bind
+	// to specify the space.
+	// In both cases, the user specifies the space name that comes up in juju spaces
+	// When fetching the space using constraints inside the provider, we get the actual
+	// space name passed in by the user. However, when we go through args.EndpointBindings
+	// we get a mapping between the endpoint binding name (not the space name) and the ProviderID
+	// of the space (unlike constraints where you get the name). All this without being able to access
+	// the source of truth the user used when selecting the space, which is juju state. So we need to:
+	// 1) fetch spaces from the provider
+	// 2) parse the name and mutate it to match what the discover spaces worker does (and hope
+	// that the API returns the spaces in the same order every time)
+	// 3) create a map of those spaces both name-->space and providerID-->name to be able to match
+	// both cases. This all seems really brittle to me.
+	providerSpaces, providerIds, err := e.buildSpacesMap(ctx)
+	if err != nil {
+		return map[string]oci.Networker{}, err
+	}
+
+	if len(args.EndpointBindings) != 0 {
+		for _, providerID := range args.EndpointBindings {
+			if name, ok := providerIds[string(providerID)]; ok {
+				logger.Debugf("Adding space from bindings %s", name)
+				spaces.Add(name)
+			}
+		}
+	}
+
+	//start from 1. eth0 is the default nic that gets attached by default.
+	idx := 1
+	for _, space := range spaces.Values() {
+		providerSpace, ok := providerSpaces[space]
+		if !ok {
+			return map[string]oci.Networker{},
+				errors.Errorf("Could not find space %q", space)
+		}
+		if len(providerSpace.Subnets) == 0 {
+			return map[string]oci.Networker{},
+				errors.Errorf("No usable subnets found in space %q", space)
+		}
+
+		ipNet := providerSpace.Subnets[e.rand.Intn(len(providerSpace.Subnets))]
+		vnic := oci.IPNetwork{
+			Ipnetwork: string(ipNet.ProviderId),
+			Vnicsets:  vnicSets,
+		}
+		nicName := fmt.Sprintf("%s%s", nicPrefix, strconv.Itoa(idx))
+		networking[nicName] = vnic
+		idx++
+	}
+	logger.Debugf("returning networking interfaces: %v", networking)
+	return networking, nil
+}
+
+// StartInstance is part of the InstanceBroker interface.
+func (o *OracleEnviron) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	if args.ControllerUUID == "" {
+		return nil, errors.NotFoundf("Controller UUID")
+	}
+
+	series := args.Tools.OneSeries()
+	arches := args.Tools.Arches()
+
+	// take all instance types from the oracle cloud provider
+	types, err := instanceTypes(o.client)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// check if we find an image that is compliant with the
+	// constraints provided in the oracle cloud account
+	if args.ImageMetadata, err = checkImageList(o.client); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// find the best suitable instance based on
+	// the oracle cloud instance types,
+	// the images that already matched the juju constrains
+	spec, imagelist, err := findInstanceSpec(
+		o.client,
+		args.ImageMetadata,
+		types,
+		&envinstance.InstanceConstraint{
+			Region:      o.spec.Region,
+			Series:      series,
+			Arches:      arches,
+			Constraints: args.Constraints,
+		},
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	tools, err := args.Tools.Match(tools.Filter{Arch: spec.Image.Arch})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Tracef("agent binaries: %v", tools)
+	if err = args.InstanceConfig.SetTools(tools); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err = instancecfg.FinishInstanceConfig(
+		args.InstanceConfig,
+		o.Config(),
+	); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	hostname, err := o.namespace.Hostname(args.InstanceConfig.MachineId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	machineName := o.client.ComposeName(hostname)
+	imageName := o.client.ComposeName(imagelist)
+
+	tags := make([]string, 0, len(args.InstanceConfig.Tags)+1)
+	for k, v := range args.InstanceConfig.Tags {
+		if k == "" || v == "" {
+			continue
+		}
+		t := tagValue{k, v}
+		tags = append(tags, t.String())
+	}
+	tags = append(tags, machineName)
+
+	var apiPort int
+	var desiredStatus ociCommon.InstanceState
+	if args.InstanceConfig.Controller != nil {
+		apiPort = args.InstanceConfig.Controller.Config.APIPort()
+		desiredStatus = ociCommon.StateRunning
+	} else {
+		// All ports are the same so pick the first.
+		apiPort = args.InstanceConfig.APIInfo.Ports()[0]
+		desiredStatus = ociCommon.StateStarting
+	}
+
+	// create a new seclists
+	secLists, err := o.CreateMachineSecLists(
+		args.InstanceConfig.MachineId, apiPort)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("Creating vnic sets")
+	vnicSets, err := o.ensureVnicSet(ctx, args.InstanceConfig.MachineId, tags)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// fetch instance network card configuration
+	logger.Debugf("Getting instance networks")
+	networking, err := o.getInstanceNetworks(ctx, args, secLists, []string{vnicSets.Name})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	logger.Debugf("Getting cloud config")
+	cloudcfg, err := o.getCloudInitConfig(args.InstanceConfig.Series, networking)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot create cloudinit template")
+	}
+
+	// compose userdata with the cloud config template
+	logger.Debugf("Composing userdata")
+	userData, err := providerinit.ComposeUserData(
+		args.InstanceConfig,
+		cloudcfg,
+		OracleRenderer{},
+	)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot make user data")
+	}
+
+	logger.Debugf("oracle user data: %d bytes", len(userData))
+
+	attributes := map[string]interface{}{
+		"userdata": string(userData),
+	}
+
+	// create the instance based on the instance params
+	instance, err := o.createInstance(oci.InstanceParams{
+		Instances: []oci.Instances{
+			{
+				Shape:       spec.InstanceType.Name,
+				Imagelist:   imageName,
+				Name:        machineName,
+				Label:       args.InstanceConfig.MachineAgentServiceName,
+				Hostname:    hostname,
+				Tags:        tags,
+				Attributes:  attributes,
+				Reverse_dns: true,
+				Networking:  networking,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	instance.arch = &spec.Image.Arch
+	instance.instType = &spec.InstanceType
+
+	machineId := instance.machine.Name
+	timeout := 10 * time.Minute
+	if err := instance.waitForMachineStatus(desiredStatus, timeout); err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Infof("started instance %q", machineId)
+
+	//TODO: add config option for public IP allocation
+	logger.Debugf("Associating public IP to instance %q", machineId)
+	if err := instance.associatePublicIP(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := &environs.StartInstanceResult{
+		Instance: instance,
+		Hardware: instance.hardwareCharacteristics(),
+	}
+
+	return result, nil
+}
+
+// StopInstances is part of the InstanceBroker interface.
+func (o *OracleEnviron) StopInstances(ctx context.ProviderCallContext, ids ...instance.Id) error {
+	oracleInstances, err := o.getOracleInstances(ids...)
+	if err == environs.ErrNoInstances {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Debugf("terminating instances %v", ids)
+	if err := o.terminateInstances(oracleInstances...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *OracleEnviron) terminateInstances(instances ...*oracleInstance) error {
+	wg := sync.WaitGroup{}
+	wg.Add(len(instances))
+	errs := []error{}
+	instIds := []instance.Id{}
+	for _, oInst := range instances {
+		inst := oInst
+		go func() {
+			defer wg.Done()
+			if err := inst.deleteInstanceAndResources(true); err != nil {
+				if !oci.IsNotFound(err) {
+					instIds = append(instIds, instance.Id(inst.name))
+					errs = append(errs, err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errors.Annotatef(errs[0], "failed to stop instance %s", instIds[0])
+	default:
+		return errors.Errorf(
+			"failed to stop instances %s: %s",
+			instIds, errs,
+		)
+	}
+}
+
+type tagValue struct {
+	tag, value string
+}
+
+func (t *tagValue) String() string {
+	return fmt.Sprintf("%s=%s", t.tag, t.value)
+}
+
+// allControllerManagedInstances returns all instances managed by this
+// environment's controller, matching the optionally specified filter.
+func (o *OracleEnviron) allControllerManagedInstances(controllerUUID string) ([]*oracleInstance, error) {
+	return o.allInstances(tagValue{
+		tag:   tags.JujuController,
+		value: controllerUUID,
+	})
+}
+
+// getOracleInstances attempts to fetch information from the oracle API for the
+// specified IDs.
+func (o *OracleEnviron) getOracleInstances(ids ...instance.Id) ([]*oracleInstance, error) {
+	ret := make([]*oracleInstance, 0, len(ids))
+	resp, err := o.client.AllInstances(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if len(resp.Result) == 0 {
+		return nil, environs.ErrNoInstances
+	}
+
+	for _, val := range resp.Result {
+		for _, id := range ids {
+			oInst, err := newInstance(val, o)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if oInst.Id() == id {
+				ret = append(ret, oInst)
+				break
+			}
+		}
+	}
+	if len(ret) < len(ids) {
+		return ret, environs.ErrPartialInstances
+	}
+	return ret, nil
+}
+
+func (o *OracleEnviron) getOracleInstancesAsMap(ids ...instance.Id) (map[string]*oracleInstance, error) {
+	instances, err := o.getOracleInstances(ids...)
+	if err != nil {
+		return map[string]*oracleInstance{}, errors.Trace(err)
+	}
+	ret := map[string]*oracleInstance{}
+	for _, val := range instances {
+		ret[string(val.Id())] = val
+	}
+	return ret, nil
+}
+
+// AllInstances is part of the InstanceBroker interface.
+func (o *OracleEnviron) AllInstances(ctx context.ProviderCallContext) ([]instance.Instance, error) {
+	tagFilter := tagValue{tags.JujuModel, o.Config().UUID()}
+	instances, err := o.allInstances(tagFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]instance.Instance, len(instances))
+	for i, val := range instances {
+		ret[i] = val
+	}
+	return ret, nil
+}
+
+func (o *OracleEnviron) allInstances(tagFilter tagValue) ([]*oracleInstance, error) {
+	filter := []oci.Filter{
+		{
+			Arg:   "tags",
+			Value: tagFilter.String(),
+		},
+	}
+	logger.Infof("Looking for instances with tags: %v", filter)
+	resp, err := o.client.AllInstances(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	n := len(resp.Result)
+	instances := make([]*oracleInstance, 0, n)
+	for _, val := range resp.Result {
+		oracleInstance, err := newInstance(val, o)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		instances = append(instances, oracleInstance)
+	}
+
+	return instances, nil
+}
+
+// MaintainInstance is part of the InstanceBroker interface.
+func (o *OracleEnviron) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {
+	return nil
+}
+
+// Config is part of the Environ interface.
+func (o *OracleEnviron) Config() *config.Config {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	return o.cfg
+}
+
+// ConstraintsValidator is part of the environs.Environ interface.
+func (o *OracleEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+	// list of unsupported oracle provider constraints
+	unsupportedConstraints := []string{
+		constraints.Container,
+		constraints.CpuPower,
+		constraints.RootDisk,
+		constraints.VirtType,
+	}
+
+	// we choose to use the default validator implementation
+	validator := constraints.NewValidator()
+	// we must feed the validator that the oracle cloud
+	// provider does not support these constraints
+	validator.RegisterUnsupported(unsupportedConstraints)
+	validator.RegisterVocabulary(constraints.Arch, []string{arch.I386, arch.AMD64})
+	logger.Infof("Returning constraints validator: %v", validator)
+	return validator, nil
+}
+
+// SetConfig is part of the environs.Environ interface.
+func (o *OracleEnviron) SetConfig(cfg *config.Config) error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	var old *config.Config
+	if o.cfg != nil {
+		old = o.cfg
+	}
+	if err := config.Validate(cfg, old); err != nil {
+		return errors.Trace(err)
+	}
+	o.cfg = cfg
+	return nil
+}
+
+func (o *OracleEnviron) Details(id instance.Id) (ociResponse.Instance, error) {
+	inst, err := o.getOracleInstances(id)
+	if err != nil {
+		return ociResponse.Instance{}, err
+	}
+
+	return inst[0].machine, nil
+}
+
+// Instances is part of the environs.Environ interface.
+func (o *OracleEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instance.Instance, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	instances, err := o.getOracleInstances(ids...)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []instance.Instance{}
+	for _, val := range instances {
+		ret = append(ret, val)
+	}
+	return ret, nil
+}
+
+// ControllerInstances is part of the environs.Environ interface.
+func (o *OracleEnviron) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
+	instances, err := o.allControllerManagedInstances(controllerUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	filter := tagValue{tags.JujuIsController, "true"}
+	ids := make([]instance.Id, 0, 1)
+	for _, val := range instances {
+		found := false
+		for _, tag := range val.machine.Tags {
+			if tag == filter.String() {
+				found = true
+				break
+			}
+		}
+		if found == false {
+			continue
+		}
+		ids = append(ids, val.Id())
+	}
+
+	if len(ids) == 0 {
+		return nil, environs.ErrNoInstances
+	}
+
+	return ids, nil
+}
+
+// Destroy is part of the environs.Environ interface.
+func (o *OracleEnviron) Destroy(ctx context.ProviderCallContext) error {
+	return common.Destroy(o, ctx)
+}
+
+// DestroyController is part of the environs.Environ interface.
+func (o *OracleEnviron) DestroyController(ctx context.ProviderCallContext, controllerUUID string) error {
+	err := o.Destroy(ctx)
+	if err != nil {
+		logger.Errorf("Failed to destroy environment through controller: %s", errors.Trace(err))
+	}
+	instances, err := o.allControllerManagedInstances(controllerUUID)
+	if err != nil {
+		if err == environs.ErrNoInstances {
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	ids := make([]instance.Id, len(instances))
+	for i, val := range instances {
+		ids[i] = val.Id()
+	}
+	return o.StopInstances(ctx, ids...)
+}
+
+// Provider is part of the environs.Environ interface.
+func (o *OracleEnviron) Provider() environs.EnvironProvider {
+	return o.p
+}
+
+// PrecheckInstance is part of the environs.Environ interface.
+func (o *OracleEnviron) PrecheckInstance(context.ProviderCallContext, environs.PrecheckInstanceParams) error {
+	return nil
+}
+
+// InstanceTypes is part of the environs.InstanceTypesFetcher interface.
+func (o *OracleEnviron) InstanceTypes(context.ProviderCallContext, constraints.Value) (envinstance.InstanceTypesWithCostMetadata, error) {
+	var i envinstance.InstanceTypesWithCostMetadata
+	return i, nil
+}
+
+// createInstance creates a new instance inside the oracle infrastructure
+func (e *OracleEnviron) createInstance(params oci.InstanceParams) (*oracleInstance, error) {
+	if len(params.Instances) > 1 {
+		return nil, errors.NotSupportedf("launching multiple instances")
+	}
+
+	logger.Debugf("running createInstance")
+	resp, err := e.client.CreateInstance(params)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	instance, err := newInstance(resp.Instances[0], e)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return instance, nil
+}

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -1,0 +1,289 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/juju/clock/testclock"
+	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+)
+
+type environSuite struct {
+	gitjujutesting.IsolationSuite
+	env *oracle.OracleEnviron
+
+	callCtx context.ProviderCallContext
+}
+
+func (e *environSuite) SetUpTest(c *gc.C) {
+	var err error
+	testEnvironAPI := oracletesting.DefaultEnvironAPI
+	e.env, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		testEnvironAPI,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(e.env, gc.NotNil)
+
+	// Setup the FakeInstance Name to match with the new
+	// OracleEnviron.  Note, we are actually changing the
+	// value in oracletesting.DefaultEnvironAPI.
+	hostname, err := oracle.CreateHostname(e.env, "0")
+	c.Assert(err, gc.IsNil)
+	testEnvironAPI.FakeInstance.All.Result[0].Name = fmt.Sprintf("/Compute-a432100/sgiulitti@cloudbase.com/%s/ebc4ce91-56bb-4120-ba78-13762597f837", hostname)
+	oracle.SetEnvironAPI(e.env, testEnvironAPI)
+	e.callCtx = context.NewCloudCallContext()
+}
+
+var _ = gc.Suite(&environSuite{})
+
+// shamelessly copied from one of the OpenStack tests
+var clk = testclock.NewClock(time.Time{})
+var advancingClock = testclock.AutoAdvancingClock{clk, clk.Advance}
+
+func (e *environSuite) TestAvailabilityZone(c *gc.C) {
+	zones, err := e.env.AvailabilityZones(e.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(zones, gc.NotNil)
+}
+
+func (e *environSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
+	zones, err := e.env.InstanceAvailabilityZoneNames(e.callCtx, []instance.Id{
+		instance.Id("0"),
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(zones, gc.NotNil)
+}
+
+func (e *environSuite) TestInstanceAvailabilityZoneNamesWithErrors(c *gc.C) {
+	environ, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		&oracletesting.FakeEnvironAPI{
+			FakeInstancer: oracletesting.FakeInstancer{
+				InstanceErr: errors.New("FakeInstanceErr"),
+			},
+		},
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+
+	_, err = environ.InstanceAvailabilityZoneNames(e.callCtx, []instance.Id{instance.Id("0")})
+	c.Assert(err, gc.NotNil)
+
+	environ, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		&oracletesting.FakeEnvironAPI{
+			FakeInstance: oracletesting.FakeInstance{
+				AllErr: errors.New("FakeInstanceErr"),
+			},
+		},
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+
+	_, err = environ.InstanceAvailabilityZoneNames(e.callCtx, []instance.Id{
+		instance.Id("0"),
+		instance.Id("1"),
+	})
+	c.Assert(err, gc.NotNil)
+}
+
+func (e *environSuite) TestPrepareForBootstrap(c *gc.C) {
+	ctx := envtesting.BootstrapContext(c)
+	err := e.env.PrepareForBootstrap(ctx)
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestPrepareForBootstrapWithErrors(c *gc.C) {
+	environ, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		&oracletesting.FakeEnvironAPI{
+			FakeAuthenticater: oracletesting.FakeAuthenticater{
+				AuthenticateErr: errors.New("FakeAuthenticateErr"),
+			},
+		},
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+
+	ctx := envtesting.BootstrapContext(c)
+	err = environ.PrepareForBootstrap(ctx)
+	c.Assert(err, gc.NotNil)
+}
+
+func makeToolsList(series string) tools.List {
+	var toolsVersion version.Binary
+	toolsVersion.Number = version.MustParse("1.26.0")
+	toolsVersion.Arch = arch.AMD64
+	toolsVersion.Series = series
+	return tools.List{{
+		Version: toolsVersion,
+		URL:     fmt.Sprintf("http://example.com/tools/juju-%s.tgz", toolsVersion),
+		SHA256:  "1234567890abcdef",
+		Size:    1024,
+	}}
+}
+
+func (e *environSuite) TestBootstrap(c *gc.C) {
+	environ, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+
+	ctx := envtesting.BootstrapContext(c)
+	_, err = environ.Bootstrap(ctx, e.callCtx,
+		environs.BootstrapParams{
+			ControllerConfig:     testing.FakeControllerConfig(),
+			AvailableTools:       makeToolsList("xenial"),
+			BootstrapSeries:      "xenial",
+			BootstrapConstraints: constraints.MustParse("mem=3.5G"),
+		})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestCreate(c *gc.C) {
+	err := e.env.Create(e.callCtx, environs.CreateParams{
+		ControllerUUID: "dsauhdiuashd",
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestCreateWithErrors(c *gc.C) {
+	environ, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		&oracletesting.FakeEnvironAPI{
+			FakeAuthenticater: oracletesting.FakeAuthenticater{
+				AuthenticateErr: errors.New("FakeAuthenticateErr"),
+			},
+		},
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+
+	err = environ.Create(e.callCtx, environs.CreateParams{
+		ControllerUUID: "daushdasd",
+	})
+	c.Assert(err, gc.NotNil)
+}
+
+func (e *environSuite) TestAdoptResources(c *gc.C) {
+	err := e.env.AdoptResources(e.callCtx, "", version.Number{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestStopInstances(c *gc.C) {
+	hostname, err := oracle.CreateHostname(e.env, "0")
+	c.Assert(err, gc.IsNil)
+	ids := []instance.Id{instance.Id(hostname)}
+	err = e.env.StopInstances(e.callCtx, ids...)
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestAllInstances(c *gc.C) {
+	_, err := e.env.AllInstances(e.callCtx)
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestMaintainInstance(c *gc.C) {
+	err := e.env.MaintainInstance(e.callCtx, environs.StartInstanceParams{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestConfig(c *gc.C) {
+	cfg := e.env.Config()
+	c.Assert(cfg, gc.NotNil)
+}
+
+func (e *environSuite) TestConstraintsValidator(c *gc.C) {
+	validator, err := e.env.ConstraintsValidator(e.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(validator, gc.NotNil)
+}
+
+func (e *environSuite) TestSetConfig(c *gc.C) {
+	err := e.env.SetConfig(testing.ModelConfig(c))
+	c.Assert(err, gc.NotNil)
+}
+
+func (e *environSuite) TestInstances(c *gc.C) {
+	hostname, err := oracle.CreateHostname(e.env, "0")
+	c.Assert(err, gc.IsNil)
+	instances, err := e.env.Instances(e.callCtx, []instance.Id{instance.Id(hostname)})
+	c.Assert(err, gc.IsNil)
+	c.Assert(instances, gc.NotNil)
+}
+
+func (e *environSuite) TestConstrollerInstances(c *gc.C) {
+	instances, err := e.env.ControllerInstances(e.callCtx, "23123-3123-12312")
+	c.Assert(err, gc.Equals, environs.ErrNoInstances)
+	c.Assert(instances, gc.IsNil)
+}
+
+func (e *environSuite) TestDestroy(c *gc.C) {
+	err := e.env.Destroy(e.callCtx)
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestDestroyController(c *gc.C) {
+	err := e.env.DestroyController(e.callCtx, "231233-312-321-3312")
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestProvider(c *gc.C) {
+	p := e.env.Provider()
+	c.Assert(p, gc.NotNil)
+}
+
+func (e *environSuite) TestPrecheckInstance(c *gc.C) {
+	err := e.env.PrecheckInstance(e.callCtx, environs.PrecheckInstanceParams{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestInstanceTypes(c *gc.C) {
+	types, err := e.env.InstanceTypes(e.callCtx, constraints.Value{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(types, gc.NotNil)
+}

--- a/provider/oracle/export_test.go
+++ b/provider/oracle/export_test.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"github.com/juju/juju/storage"
+)
+
+var (
+	DefaultTypes               = []storage.ProviderType{DefaultStorageProviderType}
+	DefaultStorageProviderType = oracleStorageProviderType
+	OracleVolumeType           = oracleVolumeType
+	OracleLatencyPool          = latencyPool
+	OracleCredentials          = credentials
+	NewOracleVolumeSource      = newOracleVolumeSource
+	NewOracleInstance          = newInstance
+	GetImageName               = getImageName
+	InstanceTypes              = instanceTypes
+	FindInstanceSpec           = findInstanceSpec
+	ParseImageName             = parseImageName
+	CheckImageList             = checkImageList
+)
+
+func SetEnvironAPI(o *OracleEnviron, client EnvironAPI) {
+	if o == nil {
+		return
+	}
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.client = client
+}
+
+func CreateHostname(o *OracleEnviron, id string) (string, error) {
+	return o.namespace.Hostname(id)
+}

--- a/provider/oracle/images.go
+++ b/provider/oracle/images.go
@@ -1,0 +1,197 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/os/series"
+
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/instances"
+)
+
+var windowsServerMap = map[string]string{
+	"Microsoft_Windows_Server_2012_R2": "win2012r2",
+	"Microsoft_Windows_Server_2008_R2": "win2018r2",
+}
+
+// instanceTypes returns all oracle cloud shapes and wraps them into instance.InstanceType
+// For more information about oracle cloud shapes, please see:
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/api-Shapes.html
+// https://docs.oracle.com/cloud/latest/stcomputecs/STCSG/GUID-1DD0FA71-AC7B-461C-B8C1-14892725AA69.htm#OCSUG210
+func instanceTypes(c EnvironAPI) ([]instances.InstanceType, error) {
+	if c == nil {
+		return nil, errors.Errorf("cannot use nil client")
+	}
+
+	// fetch all shapes from the provider
+	shapes, err := c.AllShapes(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// convert shapes to InstanceType
+	onlyArch := []string{"amd64"}
+	types := make([]instances.InstanceType, len(shapes.Result), len(shapes.Result))
+	for key, val := range shapes.Result {
+		types[key].Name = val.Name
+		types[key].Arches = onlyArch
+		types[key].Mem = val.Ram
+		types[key].CpuCores = uint64(val.Cpus)
+		types[key].RootDisk = val.Root_disk_size
+	}
+
+	return types, nil
+}
+
+// findInstanceSpec returns an *InstanceSpec, imagelist name
+// satisfying the supplied instanceConstraint
+func findInstanceSpec(
+	c EnvironAPI,
+	allImageMetadata []*imagemetadata.ImageMetadata,
+	instanceType []instances.InstanceType,
+	ic *instances.InstanceConstraint,
+) (*instances.InstanceSpec, string, error) {
+
+	logger.Debugf("received %d image(s): %v", len(allImageMetadata), allImageMetadata)
+	version, err := series.SeriesVersion(ic.Series)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	filtered := []*imagemetadata.ImageMetadata{}
+	for _, val := range allImageMetadata {
+		if val.Version != version {
+			continue
+		}
+		filtered = append(filtered, val)
+	}
+
+	images := instances.ImageMetadataToImages(filtered)
+	spec, err := instances.FindInstanceSpec(images, ic, instanceType)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	imagelist, err := getImageName(c, spec.Image.Id)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	return spec, imagelist, nil
+}
+
+func parseImageName(name string, uri *url.URL) (*imagemetadata.ImageMetadata, error) {
+	var id, arch, version string
+	if strings.HasPrefix(name, "Ubuntu") {
+		meta := strings.Split(name, ".")
+		if len(meta) < 4 {
+			return nil, errors.Errorf("invalid ubuntu image name: %s", name)
+		}
+		id = meta[len(meta)-1]
+		arch = meta[3]
+		version = meta[1] + "." + strings.TrimSuffix(meta[2], "-LTS")
+	} else if strings.HasPrefix(name, "Microsoft") {
+		if ver, ok := windowsServerMap[name]; ok {
+			version = ver
+			id = ver
+			arch = "amd64"
+		} else {
+			return nil, errors.Errorf("unknown windows version: %q", name)
+		}
+	} else {
+		return nil, errors.Errorf("could not determine OS from image name: %q", name)
+	}
+
+	tmp := strings.Split(uri.Host, ".")
+	region := tmp[0]
+	if len(tmp) > 1 {
+		region = tmp[1]
+	}
+	return &imagemetadata.ImageMetadata{
+		Id:         id,
+		Arch:       arch,
+		Endpoint:   fmt.Sprintf("%s://%s", uri.Scheme, uri.Host),
+		RegionName: region,
+		Version:    version,
+	}, nil
+}
+
+// checkImageList creates image metadata from the oracle image list
+func checkImageList(c EnvironAPI) ([]*imagemetadata.ImageMetadata, error) {
+	if c == nil {
+		return nil, errors.NotFoundf("oracle client")
+	}
+
+	// take a list of all images that are in the oracle cloud account
+	resp, err := c.AllImageLists(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// if we don't have any images that are in
+	// the oracle cloud account under your username namespace
+	// we should let the user know this
+	n := len(resp.Result)
+	if n == 0 {
+		return nil, errors.NotFoundf(
+			"images under the current client username are",
+		)
+	}
+
+	images := make([]*imagemetadata.ImageMetadata, 0, n)
+	for _, val := range resp.Result {
+		uri, err := url.Parse(val.Uri)
+		if err != nil {
+			logger.Warningf("image with ID %q had invalid resource URI %q", val.Name, val.Uri)
+			continue
+		}
+		requestUri := strings.Split(uri.RequestURI(), "/")
+		if len(requestUri) == 0 {
+			continue
+		}
+		name := requestUri[len(requestUri)-1]
+		metadata, err := parseImageName(name, uri)
+		if err != nil {
+			logger.Warningf("failed to parse image name %s. Error was: %q", name, err)
+			continue
+		}
+		logger.Infof("adding image %v to metadata", metadata.String())
+		images = append(images, metadata)
+	}
+	return images, nil
+}
+
+// getImageName gets the name of the image represented by the supplied ID
+func getImageName(c EnvironAPI, id string) (string, error) {
+	if id == "" {
+		return "", errors.NotFoundf("empty id")
+	}
+
+	resp, err := c.AllImageLists(nil)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// if we don't have any images that are in
+	// the oracle cloud account under your username namespace
+	// we should let the user know this
+	if resp.Result == nil {
+		return "", errors.NotFoundf(
+			"no usable images found in your account. Please add images from the oracle market",
+		)
+	}
+
+	for _, val := range resp.Result {
+		if strings.Contains(val.Name, id) {
+			s := strings.Split(val.Name, "/")
+			return s[len(s)-1], nil
+		}
+	}
+
+	return "", errors.NotFoundf("image not found: %q", id)
+}

--- a/provider/oracle/images_test.go
+++ b/provider/oracle/images_test.go
@@ -1,0 +1,200 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"errors"
+
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+)
+
+type imageSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&imageSuite{})
+
+func (i imageSuite) TestGetImageName(c *gc.C) {
+	name, err := oracle.GetImageName(oracletesting.DefaultEnvironAPI, "0")
+	c.Assert(err, gc.IsNil)
+	ok := len(name) > 0
+	c.Assert(ok, gc.Equals, true)
+}
+
+func (i imageSuite) TestGetImageNameWithErrors(c *gc.C) {
+	_, err := oracle.GetImageName(oracletesting.DefaultEnvironAPI, "")
+	c.Assert(err, gc.NotNil)
+
+	_, err = oracle.GetImageName(&oracletesting.FakeEnvironAPI{
+		FakeImager: oracletesting.FakeImager{
+			AllErr: errors.New("FakeImageListErr"),
+		}}, "0")
+	c.Assert(err, gc.NotNil)
+}
+
+func (i imageSuite) TestCheckImageList(c *gc.C) {
+	images, err := oracle.CheckImageList(oracletesting.DefaultEnvironAPI)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(images, gc.NotNil)
+}
+
+func (i imageSuite) TestCheckImageListWithErrors(c *gc.C) {
+	_, err := oracle.CheckImageList(&oracletesting.FakeEnvironAPI{
+		FakeImager: oracletesting.FakeImager{
+			AllErr: errors.New("FakeImageListErr"),
+		},
+	})
+	c.Assert(err, gc.NotNil)
+
+	_, err = oracle.CheckImageList(nil)
+	c.Assert(err, gc.NotNil)
+}
+
+func (i imageSuite) TestFindInstanceSpec(c *gc.C) {
+	spec, imagelist, err := oracle.FindInstanceSpec(
+		oracletesting.DefaultEnvironAPI,
+		TestImageMetadata,
+		[]instances.InstanceType{
+			{
+				Id:     "win2018r2",
+				Name:   "",
+				Arches: []string{"amd64"},
+			},
+		},
+
+		&instances.InstanceConstraint{
+			Region: "uscom-central-1",
+			Series: "xenial",
+		},
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(spec, gc.NotNil)
+	c.Assert((len(imagelist) > 0), gc.Equals, true)
+}
+
+func (i imageSuite) TestFindInstanceSpecWithSeriesError(c *gc.C) {
+	_, _, err := oracle.FindInstanceSpec(
+		oracletesting.DefaultEnvironAPI,
+		TestImageMetadata,
+		[]instances.InstanceType{
+			{
+				Id:     "win2018r2",
+				Name:   "",
+				Arches: []string{"amd64"},
+			},
+		},
+
+		&instances.InstanceConstraint{
+			Region: "uscom-central-1",
+			Series: "non-supported-series",
+		},
+	)
+
+	c.Assert(err, gc.NotNil)
+}
+
+func (i imageSuite) TestFindInstanceSpecWithError(c *gc.C) {
+	_, _, err := oracle.FindInstanceSpec(
+		oracletesting.DefaultEnvironAPI,
+		[]*imagemetadata.ImageMetadata{},
+		[]instances.InstanceType{
+			{
+				Id:     "win2018r2",
+				Name:   "",
+				Arches: []string{"amd64"},
+			},
+		},
+
+		&instances.InstanceConstraint{
+			Region: "uscom-central-1",
+			Series: "xenial",
+		},
+	)
+	c.Assert(err, gc.NotNil)
+}
+
+func (i imageSuite) TestInstanceTypes(c *gc.C) {
+	types, err := oracle.InstanceTypes(oracletesting.DefaultEnvironAPI)
+	c.Assert(err, gc.IsNil)
+	c.Assert(types, gc.NotNil)
+}
+
+func (i imageSuite) TestInstanceTypesWithErrrors(c *gc.C) {
+	for _, fake := range []*oracletesting.FakeEnvironAPI{
+		{
+			FakeShaper: oracletesting.FakeShaper{
+				AllErr: errors.New("FakeShaperErr"),
+			},
+		},
+	} {
+		_, err := oracle.InstanceTypes(fake)
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+var TestImageMetadata = []*imagemetadata.ImageMetadata{
+	{
+		Id:          "win2012r2",
+		Storage:     "",
+		VirtType:    "",
+		Arch:        "amd64",
+		Version:     "win2012r2",
+		RegionAlias: "",
+		RegionName:  "uscom-central-1",
+		Endpoint:    "https://compute.uscom-central-1.oraclecloud.com",
+		Stream:      "",
+	},
+	{
+		Id:          "20170307",
+		Storage:     "",
+		VirtType:    "",
+		Arch:        "amd64",
+		Version:     "16.04",
+		RegionAlias: "",
+		RegionName:  "uscom-central-1",
+		Endpoint:    "https://compute.uscom-central-1.oraclecloud.com",
+		Stream:      "",
+	},
+	{
+		Id:          "20170307",
+		Storage:     "",
+		VirtType:    "",
+		Arch:        "amd64",
+		Version:     "14.04",
+		RegionAlias: "",
+		RegionName:  "uscom-central-1",
+		Endpoint:    "https://compute.uscom-central-1.oraclecloud.com",
+		Stream:      "",
+	},
+	{
+		Id:          "20170307",
+		Storage:     "",
+		VirtType:    "",
+		Arch:        "amd64",
+		Version:     "12.04",
+		RegionAlias: "",
+		RegionName:  "uscom-central-1",
+		Endpoint:    "https://compute.uscom-central-1.oraclecloud.com",
+		Stream:      "",
+	},
+	{
+		Id:          "win2018r2",
+		Storage:     "",
+		VirtType:    "",
+		Arch:        "amd64",
+		Version:     "win2018r2",
+		RegionAlias: "",
+		RegionName:  "uscom-central-1",
+		Endpoint:    "https://compute.uscom-central-1.oraclecloud.com",
+		Stream:      "",
+	},
+}

--- a/provider/oracle/init.go
+++ b/provider/oracle/init.go
@@ -1,0 +1,10 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import "github.com/juju/juju/environs"
+
+func init() {
+	environs.RegisterProvider(providerType, &EnvironProvider{})
+}

--- a/provider/oracle/instance.go
+++ b/provider/oracle/instance.go
@@ -1,0 +1,424 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	oci "github.com/juju/go-oracle-cloud/api"
+	ociCommon "github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	oraclenetwork "github.com/juju/juju/provider/oracle/network"
+)
+
+// oracleInstance implements the instance.Instance interface
+type oracleInstance struct {
+	// name of the instance, generated after the vm creation
+	name string
+	// status holds the status of the instance
+	status instance.InstanceStatus
+	// machine will hold the raw instance details obtained from
+	// the provider
+	machine response.Instance
+	// arch will hold the architecture information of the instance
+	arch     *string
+	instType *instances.InstanceType
+	mutex    *sync.Mutex
+	env      *OracleEnviron
+}
+
+// hardwareCharacteristics returns the hardware characteristics of the current
+// instance
+func (o *oracleInstance) hardwareCharacteristics() *instance.HardwareCharacteristics {
+	if o.arch == nil {
+		return nil
+	}
+
+	hc := &instance.HardwareCharacteristics{Arch: o.arch}
+	if o.instType != nil {
+		hc.Mem = &o.instType.Mem
+		hc.RootDisk = &o.instType.RootDisk
+		hc.CpuCores = &o.instType.CpuCores
+	}
+
+	return hc
+}
+
+// extractInstanceIDFromMachineName will return the hostname of the machine
+// identified by the provider ID. In the Oracle compute cloud the provider
+// IDs of the instances has the following format:
+// /Compute-tenant_domain/tenant_username/instance_hostname/instance_UUID
+func extractInstanceIDFromMachineName(id string) (instance.Id, error) {
+	var instId instance.Id
+	name := strings.Split(id, "/")
+	if len(name) < 4 {
+		return instId, errors.Errorf("invalid instance name: %s", id)
+	}
+	instId = instance.Id(name[3])
+	return instId, nil
+}
+
+// newInstance returns a new oracleInstance
+func newInstance(params response.Instance, env *OracleEnviron) (*oracleInstance, error) {
+	if params.Name == "" {
+		return nil, errors.New(
+			"Instance response does not contain a name",
+		)
+	}
+	name, err := extractInstanceIDFromMachineName(params.Name)
+	if err != nil {
+		return nil, err
+	}
+	mutex := &sync.Mutex{}
+	instance := &oracleInstance{
+		name: string(name),
+		status: instance.InstanceStatus{
+			Status:  status.Status(params.State),
+			Message: "",
+		},
+		machine: params,
+		mutex:   mutex,
+		env:     env,
+	}
+
+	return instance, nil
+}
+
+// Id is defined on the instance.Instance interface.
+func (o *oracleInstance) Id() instance.Id {
+	if o.machine.Name != "" {
+		name, err := extractInstanceIDFromMachineName(o.machine.Name)
+		if err != nil {
+			return instance.Id(o.machine.Name)
+		}
+		return name
+	}
+
+	return instance.Id(o.name)
+}
+
+// Status is defined on the instance.Instance interface.
+func (o *oracleInstance) Status(ctx context.ProviderCallContext) instance.InstanceStatus {
+	return o.status
+}
+
+// StorageAttachments returns the storage that was attached in the moment
+// of instance creation. This storage cannot be detached dynamically.
+// this is also needed if you wish to determine the free disk index
+// you can use when attaching a new disk
+func (o *oracleInstance) StorageAttachments() []response.Storage {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	return o.machine.Storage_attachments
+}
+
+// refresh refreshes the instance raw details from the oracle api
+// this method is mutex protected
+func (o *oracleInstance) refresh() error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	machine, err := o.env.client.InstanceDetails(o.machine.Name)
+	// if the request failed for any reason
+	// we should not update the information and
+	// let the old one persist
+	if err != nil {
+		return err
+	}
+
+	o.machine = machine
+	return nil
+}
+
+// waitForMachineStatus will ping the machine status until the timeout
+// duration is reached or an error appeared
+func (o *oracleInstance) waitForMachineStatus(state ociCommon.InstanceState, timeout time.Duration) error {
+	timer := o.env.clock.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.Chan():
+			return errors.Errorf(
+				"Timed out waiting for instance to transition from %v to %v",
+				o.machine.State, state,
+			)
+		case <-o.env.clock.After(10 * time.Second):
+			err := o.refresh()
+			if err != nil {
+				return err
+			}
+			if o.machine.State == state {
+				return nil
+			}
+		}
+	}
+}
+
+// delete will delete the instance and attempt to cleanup any instance related
+// resources
+func (o *oracleInstance) deleteInstanceAndResources(cleanup bool) error {
+	if cleanup {
+		err := o.disassociatePublicIps(true)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := o.env.client.DeleteInstance(o.machine.Name); err != nil {
+		return errors.Trace(err)
+	}
+
+	if cleanup {
+		// Wait for instance to be deleted. The oracle API does not allow us to
+		// delete a security list if there is still a VM associated with it.
+		iteration := 0
+		for {
+			if instance, err := o.env.client.InstanceDetails(o.machine.Name); !oci.IsNotFound(err) {
+				if instance.State == ociCommon.StateError {
+					logger.Warningf("Instance %s entered error state", o.machine.Name)
+					break
+				}
+				if iteration >= 30 && instance.State == ociCommon.StateRunning {
+					logger.Warningf("Instance still in running state after %v checks. breaking loop", iteration)
+					break
+				}
+				if oci.IsInternalApi(err) {
+					logger.Errorf("got internal server error from API: %q", err)
+				}
+				<-o.env.clock.After(1 * time.Second)
+				iteration++
+				continue
+			}
+			logger.Debugf("Machine %v successfully deleted", o.machine.Name)
+			break
+		}
+
+		//
+		// seclist, vnicset, secrules, and acl created with
+		// StartInstanceParams.InstanceConfig.MachineId,
+		// convert o.Id() to machineId for deletion.
+		// o.Id() returns a string in hostname form.
+		tag, err := o.env.namespace.MachineTag(string(o.Id()))
+		if err != nil {
+			return errors.Annotatef(err, "failed to get a machine tag to complete cleanup of instance")
+		}
+		machineId := tag.Id()
+
+		// the VM association is now gone, now we can delete the
+		// machine sec list
+		logger.Debugf("deleting seclist for instance: %s", machineId)
+		if err := o.env.DeleteMachineSecList(machineId); err != nil {
+			logger.Errorf("failed to delete seclist: %s", err)
+			if !oci.IsMethodNotAllowed(err) {
+				return errors.Trace(err)
+			}
+		}
+		logger.Debugf("deleting vnic set for instance: %s", machineId)
+		if err := o.env.DeleteMachineVnicSet(machineId); err != nil {
+			logger.Errorf("failed to delete vnic set: %s", err)
+			if !oci.IsMethodNotAllowed(err) {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return nil
+}
+
+// unusedPublicIps returns a slice of IpReservation that are currently not used
+func (o *oracleInstance) unusedPublicIps() ([]response.IpReservation, error) {
+	filter := []oci.Filter{
+		{
+			Arg:   "permanent",
+			Value: "true",
+		},
+		{
+			Arg:   "used",
+			Value: "false",
+		},
+	}
+
+	res, err := o.env.client.AllIpReservations(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Result, nil
+}
+
+// associatePublicIP associates a public IP with the current instance
+func (o *oracleInstance) associatePublicIP() error {
+	// return all unused public IPs
+	unusedIps, err := o.unusedPublicIps()
+	if err != nil {
+		return err
+	}
+
+	for _, val := range unusedIps {
+		assocPoolName := ociCommon.NewIPPool(
+			ociCommon.IPPool(val.Name),
+			ociCommon.IPReservationType,
+		)
+		// create the association for it
+		if _, err := o.env.client.CreateIpAssociation(
+			assocPoolName,
+			o.machine.Vcable_id,
+		); err != nil {
+			if oci.IsBadRequest(err) {
+				// the IP probably got allocated after we fetched it
+				// from the API. Move on to the next one.
+				continue
+			}
+
+			return err
+		} else {
+			if _, err = o.env.client.UpdateIpReservation(val.Name, "", val.Parentpool, val.Permanent, o.machine.Tags); err != nil {
+				// we don't really want to terminate execution if we fail to update
+				// tags
+				logger.Errorf("failed to update IP reservation tags: %q", err)
+			}
+			return nil
+		}
+	}
+
+	// no unused IP reservations found. Allocate a new one.
+	reservation, err := o.env.client.CreateIpReservation(
+		o.machine.Name, ociCommon.PublicIPPool, true, o.machine.Tags)
+	if err != nil {
+		return err
+	}
+
+	// compose IP pool name
+	assocPoolName := ociCommon.NewIPPool(
+		ociCommon.IPPool(reservation.Name),
+		ociCommon.IPReservationType,
+	)
+	if _, err := o.env.client.CreateIpAssociation(
+		assocPoolName,
+		o.machine.Vcable_id,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// dissasociatePublicIps disassociates the public IP address from the current instance.
+// Optionally, the remove flag will also remove the IP reservation after the IP was disassociated
+func (o *oracleInstance) disassociatePublicIps(remove bool) error {
+	associations, err := o.publicAddressesAssociations()
+	if err != nil {
+		return err
+	}
+
+	for _, ipAssoc := range associations {
+		reservation := ipAssoc.Reservation
+		name := ipAssoc.Name
+		if err := o.env.client.DeleteIpAssociation(name); err != nil {
+			if oci.IsNotFound(err) {
+				continue
+			}
+
+			return err
+		}
+
+		if remove {
+			if err := o.env.client.DeleteIpReservation(reservation); err != nil {
+				if oci.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// publicAddressesAssociations returns a slice of all IP associations for the current instance
+func (o *oracleInstance) publicAddressesAssociations() ([]response.IpAssociation, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	filter := []oci.Filter{
+		{
+			Arg:   "vcable",
+			Value: string(o.machine.Vcable_id),
+		},
+	}
+
+	assoc, err := o.env.client.AllIpAssociations(filter)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return assoc.Result, nil
+}
+
+// Addresses is defined on the instance.Instance interface.
+func (o *oracleInstance) Addresses(ctx context.ProviderCallContext) ([]network.Address, error) {
+	addresses := []network.Address{}
+
+	ips, err := o.publicAddressesAssociations()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if len(o.machine.Attributes.Network) > 0 {
+		for name, val := range o.machine.Attributes.Network {
+			if _, ip, err := oraclenetwork.GetMacAndIP(val.Address); err == nil {
+				address := network.NewScopedAddress(ip, network.ScopeCloudLocal)
+				addresses = append(addresses, address)
+			} else {
+				logger.Errorf("failed to get IP address for NIC %q: %q", name, err)
+			}
+		}
+	}
+
+	for _, val := range ips {
+		address := network.NewScopedAddress(val.Ip, network.ScopePublic)
+		addresses = append(addresses, address)
+	}
+
+	return addresses, nil
+}
+
+// OpenPorts is defined on the instance.Instance interface.
+func (o *oracleInstance) OpenPorts(ctx context.ProviderCallContext, machineId string, rules []network.IngressRule) error {
+	if o.env.Config().FirewallMode() != config.FwInstance {
+		return errors.Errorf(
+			"invalid firewall mode %q for opening ports on instance",
+			o.env.Config().FirewallMode(),
+		)
+	}
+
+	return o.env.OpenPortsOnInstance(ctx, machineId, rules)
+}
+
+// ClosePorts is defined on the instance.Instance interface.
+func (o *oracleInstance) ClosePorts(ctx context.ProviderCallContext, machineId string, rules []network.IngressRule) error {
+	if o.env.Config().FirewallMode() != config.FwInstance {
+		return errors.Errorf(
+			"invalid firewall mode %q for closing ports on instance",
+			o.env.Config().FirewallMode(),
+		)
+	}
+
+	return o.env.ClosePortsOnInstance(ctx, machineId, rules)
+}
+
+// IngressRules is defined on the instance.Instance interface.
+func (o *oracleInstance) IngressRules(ctx context.ProviderCallContext, machineId string) ([]network.IngressRule, error) {
+	return o.env.MachineIngressRules(ctx, machineId)
+}

--- a/provider/oracle/instance_test.go
+++ b/provider/oracle/instance_test.go
@@ -1,0 +1,193 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/juju/go-oracle-cloud/response"
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/instance"
+	jujunetwork "github.com/juju/juju/network"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/testing"
+)
+
+type instanceSuite struct {
+	gitjujutesting.IsolationSuite
+	env   *oracle.OracleEnviron
+	mutex *sync.Mutex
+
+	callCtx context.ProviderCallContext
+}
+
+func (i *instanceSuite) SetUpTest(c *gc.C) {
+	var err error
+	i.env, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(i.env, gc.NotNil)
+	i.mutex = &sync.Mutex{}
+	i.callCtx = context.NewCloudCallContext()
+}
+
+func (i *instanceSuite) setEnvironAPI(client oracle.EnvironAPI) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	oracle.SetEnvironAPI(i.env, client)
+}
+
+var _ = gc.Suite(&instanceSuite{})
+
+func (i instanceSuite) TestNewOracleInstanceEmpty(c *gc.C) {
+	instance, err := oracle.NewOracleInstance(response.Instance{}, i.env)
+	c.Assert(err, gc.NotNil)
+	c.Assert(instance, gc.IsNil)
+}
+
+func (i instanceSuite) TestNewOracleInstance(c *gc.C) {
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+}
+
+func (i instanceSuite) TestId(c *gc.C) {
+	inst, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(inst, gc.NotNil)
+	id := inst.Id()
+	c.Assert(id, gc.Equals, instance.Id("0"))
+}
+
+func (i instanceSuite) TestStatus(c *gc.C) {
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	status := instance.Status(i.callCtx)
+	ok := (len(status.Status) > 0)
+	c.Assert(ok, gc.Equals, true)
+	ok = (len(status.Message) > 0)
+	c.Assert(ok, gc.Equals, false)
+}
+
+func (i instanceSuite) TestStorageAttachments(c *gc.C) {
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	attachs := instance.StorageAttachments()
+	c.Assert(attachs, gc.NotNil)
+}
+
+func (i instanceSuite) TestAddresses(c *gc.C) {
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	addrs, err := instance.Addresses(i.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(addrs, gc.NotNil)
+}
+
+func (i instanceSuite) TestAddressesWithErrors(c *gc.C) {
+	fakeEnv := &oracletesting.FakeEnvironAPI{
+		FakeIpAssociation: oracletesting.FakeIpAssociation{
+			AllErr: errors.New("FakeEnvironAPI"),
+		},
+	}
+	i.setEnvironAPI(fakeEnv)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	_, err = instance.Addresses(i.callCtx)
+	c.Assert(err, gc.ErrorMatches, "FakeEnvironAPI")
+}
+
+func (i instanceSuite) TestOpenPorts(c *gc.C) {
+	fakeConfig := map[string]interface{}{
+		"firewall-mode": config.FwInstance,
+	}
+	config, err := i.env.Config().Apply(fakeConfig)
+	c.Assert(err, gc.IsNil)
+
+	err = i.env.SetConfig(config)
+	c.Assert(err, gc.IsNil)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	err = instance.OpenPorts(i.callCtx, "0", []jujunetwork.IngressRule{
+		{
+			PortRange: jujunetwork.PortRange{
+				FromPort: 0,
+				ToPort:   0,
+			},
+			SourceCIDRs: nil,
+		},
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (i instanceSuite) TestClosePorts(c *gc.C) {
+	fakeConfig := map[string]interface{}{
+		"firewall-mode": config.FwInstance,
+	}
+	config, err := i.env.Config().Apply(fakeConfig)
+	c.Assert(err, gc.IsNil)
+
+	err = i.env.SetConfig(config)
+	c.Assert(err, gc.IsNil)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	err = instance.ClosePorts(i.callCtx, "0", []jujunetwork.IngressRule{
+		{
+			PortRange: jujunetwork.PortRange{
+				FromPort: 0,
+				ToPort:   0,
+			},
+			SourceCIDRs: nil,
+		},
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (i instanceSuite) TestIngressRules(c *gc.C) {
+	fakeConfig := map[string]interface{}{
+		"firewall-mode": config.FwInstance,
+	}
+
+	config, err := i.env.Config().Apply(fakeConfig)
+	c.Assert(err, gc.IsNil)
+
+	err = i.env.SetConfig(config)
+	c.Assert(err, gc.IsNil)
+
+	instance, err := oracle.NewOracleInstance(oracletesting.DefaultFakeInstancer.Instance, i.env)
+	c.Assert(err, gc.IsNil)
+	c.Assert(instance, gc.NotNil)
+
+	rules, err := instance.IngressRules(i.callCtx, "0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(rules, gc.NotNil)
+}

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -1,0 +1,373 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+	"github.com/juju/loggo"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	commonProvider "github.com/juju/juju/provider/oracle/common"
+)
+
+var logger = loggo.GetLogger("juju.provider.oracle.network")
+
+// NetworkingAPI defines methods needed to interact with the networking features
+// of the Oracle API
+type NetworkingAPI interface {
+	commonProvider.Instancer
+	commonProvider.Composer
+
+	// AllIpNetworks fetches all IP networks matching a filter. A nil valued filter
+	// will return all IP networks
+	AllIpNetworks([]api.Filter) (response.AllIpNetworks, error)
+
+	// AllAcls fetches all ACLs that match a given filter.
+	AllAcls([]api.Filter) (response.AllAcls, error)
+}
+
+// Environ implements the environs.Networking interface
+type Environ struct {
+	client NetworkingAPI
+
+	env commonProvider.OracleInstancer
+}
+
+var _ environs.Networking = (*Environ)(nil)
+
+// NewEnviron returns a new instance of Environ
+func NewEnviron(api NetworkingAPI, env commonProvider.OracleInstancer) *Environ {
+	return &Environ{
+		client: api,
+		env:    env,
+	}
+}
+
+// Subnets is defined on the environs.Networking interface.
+func (e Environ) Subnets(ctx context.ProviderCallContext, id instance.Id, subnets []network.Id) ([]network.SubnetInfo, error) {
+	ret := []network.SubnetInfo{}
+	found := make(map[string]bool)
+	if id != instance.UnknownId {
+		instanceNets, err := e.NetworkInterfaces(ctx, id)
+		if err != nil {
+			return ret, errors.Trace(err)
+		}
+		if len(subnets) == 0 {
+			for _, val := range instanceNets {
+				found[string(val.ProviderSubnetId)] = false
+			}
+		}
+		for _, val := range instanceNets {
+			if _, ok := found[string(val.ProviderSubnetId)]; !ok {
+				continue
+			} else {
+				found[string(val.ProviderSubnetId)] = true
+				subnetInfo := network.SubnetInfo{
+					CIDR:            val.CIDR,
+					ProviderId:      val.ProviderSubnetId,
+					SpaceProviderId: val.ProviderSpaceId,
+				}
+				ret = append(ret, subnetInfo)
+			}
+		}
+	} else {
+		subnets, err := e.getSubnetInfoAsMap()
+		if err != nil {
+			return ret, errors.Trace(err)
+		}
+		if len(subnets) == 0 {
+			for key := range subnets {
+				found[key] = false
+			}
+		}
+		for key, val := range subnets {
+			if _, ok := found[key]; !ok {
+				continue
+			}
+			found[key] = true
+			ret = append(ret, val)
+		}
+	}
+	missing := []string{}
+	for key, ok := range found {
+		if !ok {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, errors.Errorf(
+			"missing subnets: %s", strings.Join(missing, ","))
+	}
+	return ret, nil
+}
+
+// getSubnetInfoAsMap will return the subnet information
+// for the getSubnetInfo as a map rather than a slice
+func (e Environ) getSubnetInfoAsMap() (map[string]network.SubnetInfo, error) {
+	subnets, err := e.getSubnetInfo()
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]network.SubnetInfo, len(subnets))
+	for _, val := range subnets {
+		ret[string(val.ProviderId)] = val
+	}
+	return ret, nil
+}
+
+// getSubnetInfo returns subnet information for all subnets known to
+// the oracle provider
+func (e Environ) getSubnetInfo() ([]network.SubnetInfo, error) {
+	networks, err := e.client.AllIpNetworks(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	subnets := make([]network.SubnetInfo, len(networks.Result))
+	idx := 0
+	for _, val := range networks.Result {
+		var spaceId network.Id
+		if val.IpNetworkExchange != nil {
+			spaceId = network.Id(*val.IpNetworkExchange)
+		}
+		subnets[idx] = network.SubnetInfo{
+			ProviderId:      network.Id(val.Name),
+			CIDR:            val.IpAddressPrefix,
+			SpaceProviderId: spaceId,
+			AvailabilityZones: []string{
+				"default",
+			},
+		}
+		idx++
+	}
+	return subnets, nil
+}
+
+// NetworkInterfaces is defined on the environs.Networking interface.
+func (e Environ) NetworkInterfaces(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
+	instance, err := e.env.Details(instId)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(instance.Networking) == 0 {
+		return []network.InterfaceInfo{}, nil
+	}
+	subnetInfo, err := e.getSubnetInfoAsMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	nicAttributes := e.getNicAttributes(instance)
+
+	interfaces := make([]network.InterfaceInfo, 0, len(instance.Networking))
+	idx := 0
+	for nicName, nicObj := range instance.Networking {
+		// gsamfira: While the API may hold any alphanumeric NIC name
+		// of up to 4 characters, inside an ubuntu instance,
+		// the NIC will always be named eth0 (where 0 is the index of the NIC).
+		// NICs inside the instance will be ordered in the same way the API
+		// returns them; i.e. first element returned by the API will be eth0,
+		// second element will be eth1 and so on. Sorting is done
+		// alphanumerically it makes sense to use the name that will be
+		// seen by the juju agent instead of the name that shows up
+		// in the provider.
+		// TODO (gsamfira): Check NIC naming in CentOS and Windows.
+		name := fmt.Sprintf("eth%s", strconv.Itoa(idx))
+		deviceIndex := idx
+
+		idx += 1
+
+		deviceAttributes, ok := nicAttributes[nicName]
+		if !ok {
+			return nil, errors.Errorf(
+				"failed to get NIC attributes for %q", nicName)
+		}
+		mac, ip, err := GetMacAndIP(deviceAttributes.Address)
+		if err != nil {
+			return nil, err
+		}
+		addr := network.NewScopedAddress(ip, network.ScopeCloudLocal)
+		nic := network.InterfaceInfo{
+			InterfaceName: name,
+			DeviceIndex:   deviceIndex,
+			ProviderId:    network.Id(deviceAttributes.Id),
+			MACAddress:    mac,
+			Address:       addr,
+			InterfaceType: network.EthernetInterface,
+		}
+
+		// gsamfira: VEthernet NICs are connected to shared networks
+		// I have not found a way to interrogate details about the shared
+		// networks available inside the oracle cloud. There is some
+		// documentation on the matter here:
+		//
+		// https://docs.oracle.com/cloud-machine/latest/stcomputecs/ELUAP/GUID-8CBE0F4E-E376-4C93-BB56-884836273168.htm
+		//
+		// but I have not been able to get any information about the
+		// shared networks using the resources described there.
+		// We only populate Space information for NICs attached to
+		// IPNetworks (user defined)
+		if nicObj.GetType() == common.VNic {
+			nicSubnetDetails := subnetInfo[deviceAttributes.Ipnetwork]
+			nic.ProviderSpaceId = nicSubnetDetails.SpaceProviderId
+			nic.ProviderSubnetId = nicSubnetDetails.ProviderId
+			nic.CIDR = nicSubnetDetails.CIDR
+		}
+		interfaces = append(interfaces, nic)
+	}
+
+	return interfaces, nil
+}
+
+// getNicAttributes returns all network cards attributes from a oracle instance
+func (e Environ) getNicAttributes(instance response.Instance) map[string]response.Network {
+	if instance.Attributes.Network == nil {
+		return map[string]response.Network{}
+	}
+	n := len(instance.Attributes.Network)
+	ret := make(map[string]response.Network, n)
+	for name, obj := range instance.Attributes.Network {
+		tmp := strings.TrimPrefix(name, `nimbula_vcable-`)
+		ret[tmp] = obj
+	}
+	return ret
+}
+
+// canAccessNetworkAPI checks whether or not we have access to the necessary
+// API endpoints needed for spaces support
+func (e *Environ) canAccessNetworkAPI() (bool, error) {
+	_, err := e.client.AllAcls(nil)
+	if err != nil {
+		if api.IsMethodNotAllowed(err) {
+			return false, nil
+		}
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+// SupportsSpaces is defined on the environs.Networking interface.
+func (e Environ) SupportsSpaces(ctx context.ProviderCallContext) (bool, error) {
+	logger.Infof("checking for spaces support")
+	access, err := e.canAccessNetworkAPI()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if access {
+		return true, nil
+	}
+	return false, nil
+}
+
+// SupportsSpaceDiscovery is defined on the environs.Networking interface.
+func (e Environ) SupportsSpaceDiscovery(ctx context.ProviderCallContext) (bool, error) {
+	access, err := e.canAccessNetworkAPI()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if access {
+		return true, nil
+	}
+	return false, nil
+}
+
+// SupportsContainerAddresses is defined on the environs.Networking interface.
+func (e Environ) SupportsContainerAddresses(ctx context.ProviderCallContext) (bool, error) {
+	return false, errors.NotSupportedf("container address allocation")
+}
+
+// AllocateContainerAddresses is defined on the environs.Networking interface.
+func (e Environ) AllocateContainerAddresses(
+	ctx context.ProviderCallContext,
+	hostInstanceID instance.Id,
+	containerTag names.MachineTag,
+	preparedInfo []network.InterfaceInfo,
+) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotSupportedf("containers")
+}
+
+// ReleaseContainerAddresses is defined on the environs.Networking interface.
+func (e Environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
+	return errors.NotSupportedf("container")
+}
+
+// Spaces is defined on the environs.Networking interface.
+func (e Environ) Spaces(ctx context.ProviderCallContext) ([]network.SpaceInfo, error) {
+	networks, err := e.getSubnetInfo()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	exchanges := map[string]network.SpaceInfo{}
+	for _, val := range networks {
+		if val.SpaceProviderId == "" {
+			continue
+		}
+		logger.Infof("found network %s with space %s",
+			string(val.ProviderId), string(val.SpaceProviderId))
+		providerID := string(val.SpaceProviderId)
+		tmp := strings.Split(providerID, `/`)
+		name := tmp[len(tmp)-1]
+		// Oracle allows us to attach an IP network to a space belonging to
+		// another user using the web portal. We recompose the provider ID
+		// (which is unique) and compare to the provider ID of the space.
+		// If they match, the space belongs to us
+		tmpProviderId := e.client.ComposeName(name)
+		if tmpProviderId != providerID {
+			continue
+		}
+		if space, ok := exchanges[name]; !ok {
+			logger.Infof("creating new space obj for %s and adding %s",
+				name, string(val.ProviderId))
+			exchanges[name] = network.SpaceInfo{
+				Name:       name,
+				ProviderId: val.SpaceProviderId,
+				Subnets: []network.SubnetInfo{
+					val,
+				},
+			}
+		} else {
+			logger.Infof("appending subnet %s to %s", string(val.ProviderId), space.Name)
+			space.Subnets = append(space.Subnets, val)
+			exchanges[name] = space
+		}
+
+	}
+	var ret []network.SpaceInfo
+	for _, val := range exchanges {
+		ret = append(ret, val)
+	}
+
+	logger.Infof("returning spaces: %v", ret)
+	return ret, nil
+}
+
+// ProviderSpaceInfo is defined on the environs.NetworkingEnviron interface.
+func (Environ) ProviderSpaceInfo(ctx context.ProviderCallContext, space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+	return nil, errors.NotSupportedf("provider space info")
+}
+
+// AreSpacesRoutable is defined on the environs.NetworkingEnviron interface.
+func (Environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
+	return false, nil
+}
+
+// SSHAddresses is defined on the environs.SSHAddresses interface.
+func (*Environ) SSHAddresses(ctx context.ProviderCallContext, addresses []network.Address) ([]network.Address, error) {
+	return addresses, nil
+}
+
+// SuperSubnets implements environs.SuperSubnets
+func (*Environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
+}

--- a/provider/oracle/network/environ_test.go
+++ b/provider/oracle/network/environ_test.go
@@ -1,0 +1,179 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	names "gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/instance"
+	networkenv "github.com/juju/juju/network"
+	"github.com/juju/juju/provider/oracle"
+	"github.com/juju/juju/provider/oracle/network"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/testing"
+)
+
+type environSuite struct {
+	env    *oracle.OracleEnviron
+	netEnv *network.Environ
+
+	callCtx context.ProviderCallContext
+}
+
+var _ = gc.Suite(&environSuite{})
+
+type fakeNetworkingAPI struct{}
+
+func (f *environSuite) SetUpTest(c *gc.C) {
+	var err error
+	f.env, err = oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(f.env, gc.NotNil)
+
+	f.netEnv = network.NewEnviron(&fakeNetworkingAPI{}, f.env)
+	c.Assert(f.netEnv, gc.NotNil)
+	f.callCtx = context.NewCloudCallContext()
+}
+
+func (f fakeNetworkingAPI) AllIpNetworks(
+	filter []api.Filter,
+) (response.AllIpNetworks, error) {
+	return response.AllIpNetworks{
+		Result: []response.IpNetwork{{
+			Name:                  "/Compute-acme/jack.jones@example.com/ipnet1",
+			Uri:                   "https://api-z999.compute.us0.oraclecloud.com:443/network/v1/ipnetwork/Compute-acme/jack.jones@example.com/ipnet1",
+			Description:           nil,
+			Tags:                  nil,
+			IpAddressPrefix:       "192.168.0.0/24",
+			IpNetworkExchange:     nil,
+			PublicNaptEnabledFlag: false,
+		}},
+	}, nil
+}
+
+func (f fakeNetworkingAPI) InstanceDetails(
+	name string,
+) (response.Instance, error) {
+	return response.Instance{
+		Shape:     "oc3",
+		Imagelist: "/oracle/public/oel_6.4_2GB_v1",
+		Name:      "/Compute-acme/jack.jones@example.com/0/88e5710d-ccce-4da6-97f8-36ab7999b705",
+		Label:     "0",
+		SSHKeys: []string{
+			"/Compute-acme/jack.jones@example.com/dev-key1",
+		},
+	}, nil
+}
+
+func (f fakeNetworkingAPI) AllAcls(filter []api.Filter) (response.AllAcls, error) {
+	return response.AllAcls{}, nil
+}
+
+func (f fakeNetworkingAPI) ComposeName(name string) string {
+	return fmt.Sprintf("https://some-url.us6.com/%s", name)
+}
+
+func (e *environSuite) TestSupportSpaces(c *gc.C) {
+	ok, err := e.netEnv.SupportsSpaces(e.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (e *environSuite) TestSupportsSpaceDiscovery(c *gc.C) {
+	ok, err := e.netEnv.SupportsSpaceDiscovery(e.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (e *environSuite) TestSupportsContainerAddress(c *gc.C) {
+	ok, err := e.netEnv.SupportsContainerAddresses(e.callCtx)
+	c.Assert(err, gc.NotNil)
+	c.Assert(ok, jc.IsFalse)
+	is := errors.IsNotSupported(err)
+	c.Assert(is, jc.IsTrue)
+}
+
+func (e *environSuite) TestAllocateContainerAddress(c *gc.C) {
+	var (
+		id   instance.Id
+		tag  names.MachineTag
+		info []networkenv.InterfaceInfo
+	)
+
+	addr, err := e.netEnv.AllocateContainerAddresses(e.callCtx, id, tag, info)
+	c.Assert(err, gc.NotNil)
+	c.Assert(addr, gc.IsNil)
+	is := errors.IsNotSupported(err)
+	c.Assert(is, jc.IsTrue)
+}
+
+func (e *environSuite) TestReleaseContainerAddresses(c *gc.C) {
+	var i []networkenv.ProviderInterfaceInfo
+	err := e.netEnv.ReleaseContainerAddresses(e.callCtx, i)
+	c.Assert(err, gc.NotNil)
+	is := errors.IsNotSupported(err)
+	c.Assert(is, jc.IsTrue)
+}
+
+func (e *environSuite) TestSubnetsWithEmptyParams(c *gc.C) {
+	info, err := e.netEnv.Subnets(e.callCtx, "", nil)
+	c.Assert(info, jc.DeepEquals, []networkenv.SubnetInfo{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestSubnets(c *gc.C) {
+	ids := []networkenv.Id{networkenv.Id("0")}
+	info, err := e.netEnv.Subnets(e.callCtx, instance.Id("0"), ids)
+	c.Assert(info, jc.DeepEquals, []networkenv.SubnetInfo{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestNetworkInterfacesWithEmptyParams(c *gc.C) {
+	envAPI := oracletesting.DefaultEnvironAPI
+	envAPI.FakeInstance.All.Result[0].Networking = common.Networking{}
+	envAPI.FakeInstance.All.Result[0].Attributes.Network = map[string]response.Network{}
+
+	env, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		envAPI,
+		&advancingClock,
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(env, gc.NotNil)
+
+	netEnv := network.NewEnviron(&fakeNetworkingAPI{}, env)
+	c.Assert(netEnv, gc.NotNil)
+
+	info, err := netEnv.NetworkInterfaces(e.callCtx, instance.Id("0"))
+	c.Assert(info, jc.DeepEquals, []networkenv.InterfaceInfo{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environSuite) TestSpaces(c *gc.C) {
+	info, err := e.netEnv.Spaces(e.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(info, jc.DeepEquals, []networkenv.SpaceInfo{})
+}

--- a/provider/oracle/network/firewall.go
+++ b/provider/oracle/network/firewall.go
@@ -1,0 +1,975 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/network"
+	commonProvider "github.com/juju/juju/provider/oracle/common"
+)
+
+// Firewaller exposes methods for managing network ports.
+type Firewaller interface {
+	environs.Firewaller
+
+	// Return all machine ingress rules for a given machine id
+	MachineIngressRules(ctx context.ProviderCallContext, id string) ([]network.IngressRule, error)
+
+	// OpenPortsOnInstance will open ports corresponding to the supplied rules
+	// on the given instance
+	OpenPortsOnInstance(ctx context.ProviderCallContext, machineId string, rules []network.IngressRule) error
+
+	// ClosePortsOnInstnace will close ports corresponding to the supplied rules
+	// for a given instance.
+	ClosePortsOnInstance(ctx context.ProviderCallContext, machineId string, rules []network.IngressRule) error
+
+	// CreateMachineSecLists creates a security list for the given instance.
+	// It's worth noting that this function also ensures that the default environment
+	// sec list is also present, and has the appropriate default rules.
+	// The port parameter is the API port for the state machine, for which we need
+	// to create rules.
+	CreateMachineSecLists(id string, port int) ([]string, error)
+
+	// DeleteMachineSecList will delete the security list on the given machine
+	// id
+	DeleteMachineSecList(id string) error
+
+	// CreateDefaultACLAndRules will create a default ACL and associated rules, for
+	// a given machine. This ACL applies to user defined IP networks, which are attached
+	// to the instance.
+	CreateDefaultACLAndRules(id string) (response.Acl, error)
+
+	// RemoveACLAndRules will remove the ACL and any associated rules.
+	RemoveACLAndRules(id string) error
+}
+
+var _ Firewaller = (*Firewall)(nil)
+
+// FirewallerAPI defines methods necessary for interacting with the firewall
+// feature of Oracle compute cloud
+type FirewallerAPI interface {
+	commonProvider.Composer
+	commonProvider.RulesAPI
+	commonProvider.AclAPI
+	commonProvider.SecIpAPI
+	commonProvider.IpAddressPrefixSetAPI
+	commonProvider.SecListAPI
+	commonProvider.ApplicationsAPI
+	commonProvider.SecRulesAPI
+	commonProvider.AssociationAPI
+}
+
+// Firewall implements environ.Firewaller
+type Firewall struct {
+	// environ is the current oracle cloud environment
+	// this will use to access the underlying config
+	environ environs.ConfigGetter
+	// client is used to make operations on the oracle provider
+	client FirewallerAPI
+	clock  clock.Clock
+}
+
+// NewFirewall returns a new Firewall
+func NewFirewall(cfg environs.ConfigGetter, client FirewallerAPI, c clock.Clock) *Firewall {
+	return &Firewall{
+		environ: cfg,
+		client:  client,
+		clock:   c,
+	}
+}
+
+// OpenPorts is specified on the environ.Firewaller interface.
+func (f Firewall) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
+	mode := f.environ.Config().FirewallMode()
+	if mode != config.FwGlobal {
+		return fmt.Errorf(
+			"invalid firewall mode %q for opening ports on model",
+			mode,
+		)
+	}
+
+	globalGroupName := f.globalGroupName()
+	seclist, err := f.ensureSecList(f.client.ComposeName(globalGroupName))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = f.ensureSecRules(seclist, rules)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// ClosePorts is specified on the environ.Firewaller interface.
+func (f Firewall) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
+	groupName := f.globalGroupName()
+	return f.closePortsOnList(ctx, f.client.ComposeName(groupName), rules)
+}
+
+// IngressRules is specified on the environ.Firewaller interface.
+func (f Firewall) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
+	return f.GlobalIngressRules(ctx)
+}
+
+// MachineIngressRules returns all ingress rules from the machine specific sec list
+func (f Firewall) MachineIngressRules(ctx context.ProviderCallContext, machineId string) ([]network.IngressRule, error) {
+	seclist := f.machineGroupName(machineId)
+	return f.getIngressRules(ctx, f.client.ComposeName(seclist))
+}
+
+// OpenPortsOnInstance will open ports corresponding to the supplied rules
+// on the given instance
+func (f Firewall) OpenPortsOnInstance(ctx context.ProviderCallContext, machineId string, rules []network.IngressRule) error {
+	machineGroup := f.machineGroupName(machineId)
+	seclist, err := f.ensureSecList(f.client.ComposeName(machineGroup))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = f.ensureSecRules(seclist, rules)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// ClosePortsOnInstnace will close ports corresponding to the supplied rules
+// for a given instance.
+func (f Firewall) ClosePortsOnInstance(ctx context.ProviderCallContext, machineId string, rules []network.IngressRule) error {
+	// fetch the group name based on the machine id provided
+	groupName := f.machineGroupName(machineId)
+	return f.closePortsOnList(ctx, f.client.ComposeName(groupName), rules)
+}
+
+// CreateMachineSecLists creates a security list for the given instance.
+// It's worth noting that this function also ensures that the default environment
+// sec list is also present, and has the appropriate default rules.
+// The port parameter is the API port for the state machine, for which we need
+// to create rules.
+func (f Firewall) CreateMachineSecLists(machineId string, apiPort int) ([]string, error) {
+	defaultSecList, err := f.createDefaultGroupAndRules(apiPort)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	name := f.machineGroupName(machineId)
+	resourceName := f.client.ComposeName(name)
+	secList, err := f.ensureSecList(resourceName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return []string{
+		defaultSecList.Name,
+		secList.Name,
+	}, nil
+}
+
+// DeleteMachineSecList will delete the security list on the given machine
+func (f Firewall) DeleteMachineSecList(machineId string) error {
+	listName := f.machineGroupName(machineId)
+	globalListName := f.globalGroupName()
+	err := f.maybeDeleteList(f.client.ComposeName(listName))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// check if we can delete the global list as well
+	err = f.maybeDeleteList(f.client.ComposeName(globalListName))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// CreateDefaultACLAndRules creates default ACL and rules for IP networks attached to
+// units.
+// NOTE (gsamfira): For now we apply an allow all on these ACLs. Traffic will be cloud-only
+// between instances connected to the same ip network exchange (the equivalent of a space)
+// There will be no public IP associated to interfaces connected to IP networks, so only
+// instances connected to the same network, or a network managed by the same space will
+// be able to connect. This will ensure that peers and units entering a relationship can connect
+// to services deployed by a particular unit, without having to expose the application.
+func (f Firewall) CreateDefaultACLAndRules(machineId string) (response.Acl, error) {
+	var details response.Acl
+	var err error
+	description := fmt.Sprintf("ACL for machine %s", machineId)
+	groupName := f.machineGroupName(machineId)
+	resourceName := f.client.ComposeName(groupName)
+	if err != nil {
+		return response.Acl{}, err
+	}
+	rules := []api.SecurityRuleParams{
+		{
+			Name:                   fmt.Sprintf("%s-allow-ingress", resourceName),
+			Description:            "Allow all ingress",
+			FlowDirection:          common.Ingress,
+			EnabledFlag:            true,
+			DstIpAddressPrefixSets: []string{},
+			SecProtocols:           []string{},
+			SrcIpAddressPrefixSets: []string{},
+		},
+		{
+			Name:                   fmt.Sprintf("%s-allow-egress", resourceName),
+			Description:            "Allow all egress",
+			FlowDirection:          common.Egress,
+			EnabledFlag:            true,
+			DstIpAddressPrefixSets: []string{},
+			SecProtocols:           []string{},
+			SrcIpAddressPrefixSets: []string{},
+		},
+	}
+	details, err = f.client.AclDetails(resourceName)
+	if err != nil {
+		if api.IsNotFound(err) {
+			details, err = f.client.CreateAcl(resourceName, description, true, nil)
+			if err != nil {
+				return response.Acl{}, errors.Trace(err)
+			}
+		} else {
+			return response.Acl{}, errors.Trace(err)
+		}
+	}
+	aclRules, err := f.getAllSecurityRules(details.Name)
+	if err != nil {
+		return response.Acl{}, errors.Trace(err)
+	}
+
+	var toAdd []api.SecurityRuleParams
+
+	for _, val := range rules {
+		found := false
+		val.Acl = details.Name
+		newRuleAsStub := f.convertSecurityRuleParamsToStub(val)
+		for _, existing := range aclRules {
+			existingRulesAsStub := f.convertSecurityRuleToStub(existing)
+			if reflect.DeepEqual(existingRulesAsStub, newRuleAsStub) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, val)
+		}
+	}
+	for _, val := range toAdd {
+		_, err := f.client.CreateSecurityRule(val)
+		if err != nil {
+			return response.Acl{}, errors.Trace(err)
+		}
+	}
+	return details, nil
+}
+
+// RemoveACLAndRules will remove the ACL and any associated rules.
+func (f Firewall) RemoveACLAndRules(machineId string) error {
+	groupName := f.machineGroupName(machineId)
+	resourceName := f.client.ComposeName(groupName)
+	secRules, err := f.getAllSecurityRules(resourceName)
+	if err != nil {
+		return err
+	}
+	for _, val := range secRules {
+		err := f.client.DeleteSecurityRule(val.Name)
+		if err != nil {
+			if !api.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	err = f.client.DeleteAcl(resourceName)
+	if err != nil {
+		if !api.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// GlobalIngressRules returns the ingress rules applied to the whole environment.
+func (f Firewall) GlobalIngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
+	seclist := f.globalGroupName()
+	return f.getIngressRules(ctx, f.client.ComposeName(seclist))
+}
+
+// getDefaultIngressRules will create the default ingressRules given an api port
+func (f Firewall) getDefaultIngressRules(apiPort int) []network.IngressRule {
+	return []network.IngressRule{
+		{
+			PortRange: network.PortRange{
+				FromPort: 22,
+				ToPort:   22,
+				Protocol: "tcp",
+			},
+			SourceCIDRs: []string{
+				"0.0.0.0/0",
+			},
+		},
+		{
+			PortRange: network.PortRange{
+				FromPort: 3389,
+				ToPort:   3389,
+				Protocol: "tcp",
+			},
+			SourceCIDRs: []string{
+				"0.0.0.0/0",
+			},
+		},
+		{
+			PortRange: network.PortRange{
+				FromPort: apiPort,
+				ToPort:   apiPort,
+				Protocol: "tcp",
+			},
+			SourceCIDRs: []string{
+				"0.0.0.0/0",
+			},
+		},
+		{
+			PortRange: network.PortRange{
+				FromPort: controller.DefaultStatePort,
+				ToPort:   controller.DefaultStatePort,
+				Protocol: "tcp",
+			},
+			SourceCIDRs: []string{
+				"0.0.0.0/0",
+			},
+		},
+	}
+}
+
+type stubSecurityRule struct {
+	Acl                    string
+	FlowDirection          common.FlowDirection
+	DstIpAddressPrefixSets []string
+	SecProtocols           []string
+	SrcIpAddressPrefixSets []string
+}
+
+func (f Firewall) createDefaultGroupAndRules(apiPort int) (response.SecList, error) {
+	rules := f.getDefaultIngressRules(apiPort)
+	var details response.SecList
+	var err error
+	globalGroupName := f.globalGroupName()
+	resourceName := f.client.ComposeName(globalGroupName)
+	details, err = f.client.SecListDetails(resourceName)
+	if err != nil {
+		if api.IsNotFound(err) {
+			details, err = f.ensureSecList(resourceName)
+			if err != nil {
+				return response.SecList{}, errors.Trace(err)
+			}
+		} else {
+			return response.SecList{}, errors.Trace(err)
+		}
+	}
+
+	err = f.ensureSecRules(details, rules)
+	if err != nil {
+		return response.SecList{}, errors.Trace(err)
+	}
+	return details, nil
+}
+
+// closePortsOnList on list will close all ports corresponding to the supplied ingress rules
+// on a particular list
+func (f Firewall) closePortsOnList(ctx context.ProviderCallContext, list string, rules []network.IngressRule) error {
+	// get all security rules based on the dst_list=list
+	secrules, err := f.getSecRules(list)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// converts all security rules into a map of ingress rules
+	mapping, err := f.secRuleToIngresRule(secrules...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	//TODO (gsamfira): optimize this
+	for name, rule := range mapping {
+		sort.Strings(rule.SourceCIDRs)
+		for _, ingressRule := range rules {
+			sort.Strings(ingressRule.SourceCIDRs)
+			if reflect.DeepEqual(rule, ingressRule) {
+				err := f.client.DeleteSecRule(name)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// deleteAllSecRulesOnList will delete all security rules from a give
+// security list
+func (f Firewall) deleteAllSecRulesOnList(list string) error {
+	// get all security rules associated with this list
+	secrules, err := f.getSecRules(list)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// delete everything
+	for _, rule := range secrules {
+		err := f.client.DeleteSecRule(rule.Name)
+		if err != nil {
+			if api.IsNotFound(err) {
+				continue
+			}
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// maybeDeleteList tries to delete a security list. Lists that are still in use
+// may not be deleted. When deleting an environment, we want to also cleanup the
+// environment level sec list. This function attempts to delete a sec list. If the
+// sec list still has some associations to any instance, we simply return and assume
+// the last VM to get killed as part of the tear-down, will also remove the global
+// list as well
+func (f *Firewall) maybeDeleteList(list string) error {
+	filter := []api.Filter{
+		{
+			Arg:   "seclist",
+			Value: list,
+		},
+	}
+	iter := 0
+	found := true
+	var assoc response.AllSecAssociations
+	for {
+		if iter >= 10 {
+			break
+		}
+		assoc, err := f.client.AllSecAssociations(filter)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(assoc.Result) > 0 {
+			<-f.clock.After(1 * time.Second)
+			iter++
+			continue
+		}
+		found = false
+		break
+	}
+	if found {
+		logger.Warningf(
+			"seclist %s is still has some associations to instance(s): %v. Will not delete",
+			list, assoc.Result,
+		)
+		return nil
+	}
+	err := f.deleteAllSecRulesOnList(list)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Tracef("deleting seclist %v", list)
+	err = f.client.DeleteSecList(list)
+	if err != nil {
+		if api.IsNotFound(err) {
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// getIngressRules returns all rules associated with the given sec list
+// values are converted and returned as []network.IngressRule
+func (f Firewall) getIngressRules(ctx context.ProviderCallContext, seclist string) ([]network.IngressRule, error) {
+	// get all security rules associated with the seclist
+	secrules, err := f.getSecRules(seclist)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// convert all security rules into a map of ingress rules
+	ingressRules, err := f.convertFromSecRules(secrules...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if rules, ok := ingressRules[seclist]; ok {
+		return rules, nil
+	}
+	return []network.IngressRule{}, nil
+}
+
+// getAllApplications returns all security applications known to the
+// oracle compute cloud. These are used as part of security rules
+func (f Firewall) getAllApplications() ([]response.SecApplication, error) {
+	// get all user defined sec applications
+	applications, err := f.client.AllSecApplications(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// get also default ones defined in the provider
+	defaultApps, err := f.client.DefaultSecApplications(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	allApps := []response.SecApplication{}
+	for _, val := range applications.Result {
+		if val.PortProtocolPair() == "" {
+			// (gsamfira):this should not really happen,
+			// but I get paranoid when I run out of coffee
+			continue
+		}
+		allApps = append(allApps, val)
+	}
+	for _, val := range defaultApps.Result {
+		if val.PortProtocolPair() == "" {
+			continue
+		}
+		allApps = append(allApps, val)
+	}
+	return allApps, nil
+}
+
+// getAllApplicationsAsMap returns all sec applications as a map
+func (f Firewall) getAllApplicationsAsMap() (map[string]response.SecApplication, error) {
+	// get all defined protocols
+	// from the current identity and default ones
+	apps, err := f.getAllApplications()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// copy all of them into this map
+	allApps := map[string]response.SecApplication{}
+	for _, val := range apps {
+		if val.String() == "" {
+			continue
+		}
+		if _, ok := allApps[val.String()]; !ok {
+			allApps[val.String()] = val
+		}
+	}
+	return allApps, nil
+}
+
+func (f Firewall) ensureApplication(portRange network.PortRange, cache *[]response.SecApplication) (string, error) {
+	// check if the security application is already created
+	for _, val := range *cache {
+		if val.PortProtocolPair() == portRange.String() {
+			return val.Name, nil
+		}
+	}
+	// We need to create a new application
+	// There is always the chance of a race condition
+	// when it comes to creating new resources.
+	// ie: someone may have already created a matching
+	// application between the time we fetched all of them
+	// and the moment we actually got to create one
+	// Worst thing that can happen is that we have a few duplicate
+	// rules, that we cleanup anyway when we destroy the environment
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	// create new name for sec application
+	secAppName := f.newResourceName(uuid.String())
+	var dport string
+
+	if portRange.FromPort == portRange.ToPort {
+		dport = strconv.Itoa(portRange.FromPort)
+	} else {
+		dport = fmt.Sprintf("%s-%s",
+			strconv.Itoa(portRange.FromPort), strconv.Itoa(portRange.ToPort))
+	}
+	// compose the provider resource name for the new application
+	name := f.client.ComposeName(secAppName)
+	secAppParams := api.SecApplicationParams{
+		Description: "Juju created security application",
+		Dport:       dport,
+		Protocol:    common.Protocol(portRange.Protocol),
+		Name:        name,
+	}
+	application, err := f.client.CreateSecApplication(secAppParams)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	*cache = append(*cache, application)
+	return application.Name, nil
+}
+
+// convertToSecRules converts network.IngressRules to api.SecRuleParams
+func (f Firewall) convertToSecRules(seclist response.SecList, rules []network.IngressRule) ([]api.SecRuleParams, error) {
+	applications, err := f.getAllApplications()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	iplists, err := f.getAllIPLists()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ret := make([]api.SecRuleParams, 0, len(rules))
+	// for every rule we need to ensure that the there is a relationship
+	// between security applications and security IP lists
+	// and from every one of them create a slice of security rule parameters
+	for _, val := range rules {
+		app, err := f.ensureApplication(val.PortRange, &applications)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ipList, err := f.ensureSecIpList(val.SourceCIDRs, &iplists)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		name := f.newResourceName(uuid.String())
+		resourceName := f.client.ComposeName(name)
+		dstList := fmt.Sprintf("seclist:%s", seclist.Name)
+		srcList := fmt.Sprintf("seciplist:%s", ipList)
+		// create the new security rule parameters
+		rule := api.SecRuleParams{
+			Action:      common.SecRulePermit,
+			Application: app,
+			Description: "Juju created security rule",
+			Disabled:    false,
+			Dst_list:    dstList,
+			Name:        resourceName,
+			Src_list:    srcList,
+		}
+		// append the new parameters rule
+		ret = append(ret, rule)
+	}
+	return ret, nil
+}
+
+// convertApplicationToPortRange takes a SecApplication and
+// converts it to a network.PortRange type
+func (f Firewall) convertApplicationToPortRange(app response.SecApplication) network.PortRange {
+	appCopy := app
+	if appCopy.Value2 == -1 {
+		appCopy.Value2 = appCopy.Value1
+	}
+	return network.PortRange{
+		FromPort: appCopy.Value1,
+		ToPort:   appCopy.Value2,
+		Protocol: string(appCopy.Protocol),
+	}
+}
+
+// convertFromSecRules takes a slice of security rules and creates a map of them
+func (f Firewall) convertFromSecRules(rules ...response.SecRule) (map[string][]network.IngressRule, error) {
+	applications, err := f.getAllApplicationsAsMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	iplists, err := f.getAllIPListsAsMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ret := map[string][]network.IngressRule{}
+	for _, val := range rules {
+		app := val.Application
+		srcList := strings.TrimPrefix(val.Src_list, "seciplist:")
+		dstList := strings.TrimPrefix(val.Dst_list, "seclist:")
+		portRange := f.convertApplicationToPortRange(applications[app])
+		if _, ok := ret[dstList]; !ok {
+			ret[dstList] = []network.IngressRule{
+				{
+					PortRange:   portRange,
+					SourceCIDRs: iplists[srcList].Secipentries,
+				},
+			}
+		} else {
+			toAdd := network.IngressRule{
+				PortRange:   portRange,
+				SourceCIDRs: iplists[srcList].Secipentries,
+			}
+			ret[dstList] = append(ret[dstList], toAdd)
+		}
+	}
+	return ret, nil
+}
+
+// secRuleToIngressRule convert all security rules into a map of ingress rules
+func (f Firewall) secRuleToIngresRule(rules ...response.SecRule) (map[string]network.IngressRule, error) {
+
+	applications, err := f.getAllApplicationsAsMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	iplists, err := f.getAllIPListsAsMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ret := map[string]network.IngressRule{}
+	for _, val := range rules {
+		app := val.Application
+		srcList := strings.TrimPrefix(val.Src_list, "seciplist:")
+		portRange := f.convertApplicationToPortRange(applications[app])
+		if _, ok := ret[val.Name]; !ok {
+			ret[val.Name] = network.IngressRule{
+				PortRange:   portRange,
+				SourceCIDRs: iplists[srcList].Secipentries,
+			}
+		}
+	}
+	return ret, nil
+}
+
+func (f Firewall) convertSecurityRuleToStub(rules response.SecurityRule) stubSecurityRule {
+	sort.Strings(rules.DstIpAddressPrefixSets)
+	sort.Strings(rules.SecProtocols)
+	sort.Strings(rules.SrcIpAddressPrefixSets)
+	return stubSecurityRule{
+		Acl:                    rules.Acl,
+		FlowDirection:          rules.FlowDirection,
+		DstIpAddressPrefixSets: rules.DstIpAddressPrefixSets,
+		SecProtocols:           rules.SecProtocols,
+		SrcIpAddressPrefixSets: rules.SrcIpAddressPrefixSets,
+	}
+}
+
+func (f Firewall) convertSecurityRuleParamsToStub(params api.SecurityRuleParams) stubSecurityRule {
+	sort.Strings(params.DstIpAddressPrefixSets)
+	sort.Strings(params.SecProtocols)
+	sort.Strings(params.SrcIpAddressPrefixSets)
+	return stubSecurityRule{
+		Acl:                    params.Acl,
+		FlowDirection:          params.FlowDirection,
+		DstIpAddressPrefixSets: params.DstIpAddressPrefixSets,
+		SecProtocols:           params.SecProtocols,
+		SrcIpAddressPrefixSets: params.SrcIpAddressPrefixSets,
+	}
+}
+
+// globalGroupName returns the global group name
+// derived from the model UUID
+func (f Firewall) globalGroupName() string {
+	return fmt.Sprintf("juju-%s-global", f.environ.Config().UUID())
+}
+
+// machineGroupName returns the machine group name
+// derived from the model UUID and the machine ID
+func (f Firewall) machineGroupName(machineId string) string {
+	return fmt.Sprintf("juju-%s-%s", f.environ.Config().UUID(), machineId)
+}
+
+// resourceName returns the resource name
+// derived from the model UUID and the name of the resource
+func (f Firewall) newResourceName(appName string) string {
+	return fmt.Sprintf("juju-%s-%s", f.environ.Config().UUID(), appName)
+}
+
+// get all security rules associated with an ACL
+func (f Firewall) getAllSecurityRules(aclName string) ([]response.SecurityRule, error) {
+	rules, err := f.client.AllSecurityRules(nil)
+	if err != nil {
+		return nil, err
+	}
+	if aclName == "" {
+		return rules.Result, nil
+	}
+	var ret []response.SecurityRule
+	for _, val := range rules.Result {
+		if val.Acl == aclName {
+			ret = append(ret, val)
+		}
+	}
+	return ret, nil
+}
+
+// getSecRules retrieves the security rules associated with a particular security list
+func (f Firewall) getSecRules(seclist string) ([]response.SecRule, error) {
+	// we only care about ingress rules
+	name := fmt.Sprintf("seclist:%s", seclist)
+	rulesFilter := []api.Filter{
+		{
+			Arg:   "dst_list",
+			Value: name,
+		},
+	}
+	rules, err := f.client.AllSecRules(rulesFilter)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// gsamfira: the oracle compute API does not allow filtering by action
+	ret := []response.SecRule{}
+	for _, val := range rules.Result {
+		// gsamfira: We set a default policy of DENY. No use in worrying about
+		// DENY rules (if by any chance someone add one manually for some reason)
+		if val.Action != common.SecRulePermit {
+			continue
+		}
+		// We only care about rules that have a destination set
+		// to a security list. Those lists get attached to VMs
+		// NOTE: someone decided, when writing the oracle API
+		// that some fields should be bool, some should be string.
+		// never mind they both are boolean values...but hey.
+		// I swear...some people like to watch the world burn
+		if val.Dst_is_ip == "true" {
+			continue
+		}
+		// We only care about rules that have an IP list as source
+		if val.Src_is_ip == "false" {
+			continue
+		}
+		ret = append(ret, val)
+	}
+	return ret, nil
+}
+
+// ensureSecRules ensures that the list passed has all the rules
+// that it needs, if one is missing it will create it inside the oracle
+// cloud environment and it will return nil
+// if none rule is missing then it will return nil
+func (f Firewall) ensureSecRules(seclist response.SecList, rules []network.IngressRule) error {
+	// get all security rules associated with the seclist
+	secRules, err := f.getSecRules(seclist.Name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Tracef("list %v has sec rules: %v", seclist.Name, secRules)
+
+	converted, err := f.convertFromSecRules(secRules...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Tracef("converted rules are: %v", converted)
+	asIngressRules := converted[seclist.Name]
+	missing := []network.IngressRule{}
+
+	// search through all rules and find the missing ones
+	for _, toAdd := range rules {
+		found := false
+		for _, exists := range asIngressRules {
+			sort.Strings(toAdd.SourceCIDRs)
+			sort.Strings(exists.SourceCIDRs)
+			logger.Tracef("comparing %v to %v", toAdd.SourceCIDRs, exists.SourceCIDRs)
+			if reflect.DeepEqual(toAdd, exists) {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		missing = append(missing, toAdd)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	logger.Tracef("Found missing rules: %v", missing)
+	// convert the missing rules back to sec rules
+	asSecRule, err := f.convertToSecRules(seclist, missing)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, val := range asSecRule {
+		_, err = f.client.CreateSecRule(val)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// ensureSecList creates a new seclist if one does not already exist.
+// this function is idempotent
+func (f Firewall) ensureSecList(name string) (response.SecList, error) {
+	logger.Infof("Fetching details for list: %s", name)
+	// check if the security list is already there
+	details, err := f.client.SecListDetails(name)
+	if err != nil {
+		logger.Infof("Got error fetching details for %s: %v", name, err)
+		if api.IsNotFound(err) {
+			logger.Infof("Creating new seclist: %s", name)
+			details, err := f.client.CreateSecList(
+				"Juju created security list",
+				name,
+				common.SecRulePermit,
+				common.SecRuleDeny)
+			if err != nil {
+				return response.SecList{}, err
+			}
+			return details, nil
+		}
+		return response.SecList{}, err
+	}
+	return details, nil
+}
+
+// getAllIPLists returns all IP lists known to the provider (both the user defined ones,
+// and the default ones)
+func (f Firewall) getAllIPLists() ([]response.SecIpList, error) {
+	// get all security ip lists from the current identity endpoint
+	secIpLists, err := f.client.AllSecIpLists(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// get all security ip lists from the default oracle cloud definitions
+	defaultSecIpLists, err := f.client.AllDefaultSecIpLists(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	allIpLists := []response.SecIpList{}
+	allIpLists = append(allIpLists, secIpLists.Result...)
+	allIpLists = append(allIpLists, defaultSecIpLists.Result...)
+	return allIpLists, nil
+}
+
+// getAllIPListsAsMap returns all IP lists as a map, with the key being
+// the resource name
+func (f Firewall) getAllIPListsAsMap() (map[string]response.SecIpList, error) {
+	allIps, err := f.getAllIPLists()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	allIpLists := map[string]response.SecIpList{}
+	for _, val := range allIps {
+		allIpLists[val.Name] = val
+	}
+	return allIpLists, nil
+}
+
+// ensureSecIpList ensures that a sec ip list with the provided cidr list
+// exists. If one does not, it gets created. This function is idempotent.
+func (f Firewall) ensureSecIpList(cidr []string, cache *[]response.SecIpList) (string, error) {
+	sort.Strings(cidr)
+	for _, val := range *cache {
+		sort.Strings(val.Secipentries)
+		if reflect.DeepEqual(val.Secipentries, cidr) {
+			return val.Name, nil
+		}
+	}
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	name := f.newResourceName(uuid.String())
+	resource := f.client.ComposeName(name)
+	secList, err := f.client.CreateSecIpList(
+		"Juju created security IP list",
+		resource, cidr)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	*cache = append(*cache, secList)
+	return secList.Name, nil
+}

--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -1,0 +1,1028 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	jujunetwork "github.com/juju/juju/network"
+	"github.com/juju/juju/provider/oracle/network"
+	providertest "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/testing"
+)
+
+type firewallSuite struct {
+	gitjujutesting.IsolationSuite
+
+	callCtx context.ProviderCallContext
+}
+
+var _ = gc.Suite(&firewallSuite{})
+
+func (f *firewallSuite) SetUpTest(c *gc.C) {
+	f.IsolationSuite.SetUpTest(c)
+	f.callCtx = context.NewCloudCallContext()
+}
+
+var clk = testclock.NewClock(time.Time{})
+var advancingClock = testclock.AutoAdvancingClock{clk, clk.Advance}
+
+type fakeEnvironConfig struct {
+	cfg *config.Config
+}
+
+func (f *fakeEnvironConfig) Config() *config.Config {
+	return f.cfg
+}
+
+func (f *firewallSuite) TestNewFirewall(c *gc.C) {
+	firewall := network.NewFirewall(nil, nil, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	cli := &api.Client{}
+	firewall = network.NewFirewall(cfg, cli, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+}
+
+func (f *firewallSuite) TestGlobalIngressRules(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	rule, err := firewall.GlobalIngressRules(f.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(rule, gc.NotNil)
+}
+
+func (f *firewallSuite) TestIngressRules(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	rule, err := firewall.IngressRules(f.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(rule, gc.NotNil)
+}
+
+func (f *firewallSuite) TestIngressRulesWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{
+				AllErr: errors.New("FakeRulesError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{AllErr: errors.New("FakeSecIpError")},
+		},
+	} {
+
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		rule, err := firewall.IngressRules(f.callCtx)
+		c.Assert(err, gc.NotNil)
+		c.Assert(rule, gc.IsNil)
+	}
+
+}
+func (f *firewallSuite) TestGlobalIngressRulesWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{AllErr: errors.New("FakeRulesError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{AllErr: errors.New("FakeSecIpError")},
+		},
+	} {
+
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		rule, err := firewall.GlobalIngressRules(f.callCtx)
+		c.Assert(err, gc.NotNil)
+		c.Assert(rule, gc.IsNil)
+	}
+
+}
+
+func (f *firewallSuite) TestOpenPorts(c *gc.C) {
+	fakeConfig := testing.CustomModelConfig(c, testing.Attrs{
+		"firewall-mode": config.FwGlobal,
+	})
+	cfg := &fakeEnvironConfig{cfg: fakeConfig}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	err := firewall.OpenPorts(f.callCtx, []jujunetwork.IngressRule{})
+	c.Assert(err, gc.IsNil)
+
+}
+
+func (f *firewallSuite) TestOpenPortsWithErrors(c *gc.C) {
+	fakeConfig := testing.CustomModelConfig(c, testing.Attrs{
+		"firewall-mode": config.FwGlobal,
+	})
+	cfg := &fakeEnvironConfig{cfg: fakeConfig}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{AllErr: errors.New("FakeRulesError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{AllErr: errors.New("FakeSecIpError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				SecListErr: errors.New("FakeSecListErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				SecListErr: api.ErrNotFound{},
+				CreateErr:  errors.New("FakeSecListErr"),
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		err := firewall.OpenPorts(f.callCtx, []jujunetwork.IngressRule{})
+		c.Assert(err, gc.NotNil)
+	}
+
+	// test with error in firewall config
+	cfg = &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	err := firewall.OpenPorts(f.callCtx, []jujunetwork.IngressRule{})
+	c.Assert(err, gc.NotNil)
+}
+
+func (f *firewallSuite) TestClosePorts(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	err := firewall.ClosePorts(f.callCtx, []jujunetwork.IngressRule{})
+	c.Assert(err, gc.IsNil)
+}
+
+func (f *firewallSuite) TestClosePortsWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{
+				AllErr: errors.New("FakeRulesErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{
+				AllErr: errors.New("FakeSecIpErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{
+				AllDefaultErr: errors.New("FakeSecIpErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{
+				All: response.AllSecRules{
+					Result: []response.SecRule{
+						{
+							Action:      common.SecRulePermit,
+							Application: "/Compute-acme/jack.jones@example.com/video_streaming_udp",
+							Name:        "/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+							Dst_list:    "seclist:/Compute-acme/jack.jones@example.com/allowed_video_servers",
+							Src_list:    "seciplist:/Compute-acme/jack.jones@example.com/es_iplist",
+							Uri:         "https://api-z999.compute.us0.oraclecloud.com/secrule/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+							Src_is_ip:   "true",
+							Dst_is_ip:   "false",
+						},
+					},
+				},
+				AllErr:    nil,
+				DeleteErr: errors.New("FakeSecRules"),
+			},
+			FakeApplication: providertest.FakeApplication{
+				All: response.AllSecApplications{
+					Result: []response.SecApplication{
+						{
+							Description: "Juju created security application",
+							Dport:       "17070",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/Compute-a432100/sgiulitti@cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-7993630e-d13b-43a3-850e-a1778c7e394e",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/Compute-a432100/sgiulitti%40cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-7993630e-d13b-43a3-850e-a1778c7e394e",
+							Value1:      17070,
+							Value2:      -1,
+							Id:          "1869cb17-5b12-49c5-a09a-046da8899bc9",
+						},
+						{
+							Description: "Juju created security application",
+							Dport:       "37017",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/Compute-a432100/sgiulitti@cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-ef8a7955-4315-47a2-83c1-8d2978ab77c7",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/Compute-a432100/sgiulitti%40cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-ef8a7955-4315-47a2-83c1-8d2978ab77c7",
+							Value1:      37017,
+							Value2:      -1,
+							Id:          "cbefdac0-7684-4f81-a575-825c175aa7b4",
+						},
+					},
+				},
+				AllErr: nil,
+				Default: response.AllSecApplications{
+					Result: []response.SecApplication{
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/all",
+							Protocol:    "all",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/all",
+							Value1:      0,
+							Value2:      0,
+							Id:          "381c2267-1b38-4bbd-b53d-5149deddb094",
+						},
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "echo",
+							Name:        "/oracle/public/pings",
+							Protocol:    "icmp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/pings",
+							Value1:      8,
+							Value2:      0,
+							Id:          "57b0350b-2f02-4a2d-b5ec-cf731de36027",
+						},
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/icmp",
+							Protocol:    "icmp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/icmp",
+							Value1:      255,
+							Value2:      255,
+							Id:          "abb27ccd-1872-48f9-86ef-38c72d6f8a38",
+						},
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "reply",
+							Name:        "/oracle/public/ping-reply",
+							Protocol:    "icmp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/ping-reply",
+							Value1:      0,
+							Value2:      0,
+							Id:          "3ad808d4-b740-42c1-805c-57feb7c96d40",
+						},
+						{
+							Description: "",
+							Dport:       "3306",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/mysql",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/mysql",
+							Value1:      3306,
+							Value2:      -1,
+							Id:          "2fb5eaff-3127-4334-8b03-367a44bb83bd",
+						},
+						{
+							Description: "",
+							Dport:       "22",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/ssh",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/ssh",
+							Value1:      22, Value2: -1,
+							Id: "5f027043-f6b3-4e1a-b9fa-a10d075744de",
+						},
+					},
+				},
+				DefaultErr: nil,
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		err := firewall.ClosePorts(f.callCtx, []jujunetwork.IngressRule{
+			{
+				PortRange: jujunetwork.PortRange{
+					FromPort: 0,
+					ToPort:   0,
+				},
+				SourceCIDRs: nil,
+			},
+		})
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestClosePortsOnInstance(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{
+				AllErr: errors.New("FakeRulesErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{
+				AllErr: errors.New("FakeSecIpErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{
+				AllDefaultErr: errors.New("FakeSecIpErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{
+				All: response.AllSecRules{
+					Result: []response.SecRule{
+						{
+							Action:      common.SecRulePermit,
+							Application: "/Compute-acme/jack.jones@example.com/video_streaming_udp",
+							Name:        "/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+							Dst_list:    "seclist:/Compute-acme/jack.jones@example.com/allowed_video_servers",
+							Src_list:    "seciplist:/Compute-acme/jack.jones@example.com/es_iplist",
+							Uri:         "https://api-z999.compute.us0.oraclecloud.com/secrule/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+							Src_is_ip:   "true",
+							Dst_is_ip:   "false",
+						},
+					},
+				},
+				AllErr:    nil,
+				DeleteErr: errors.New("FakeSecRules"),
+			},
+			FakeApplication: providertest.FakeApplication{
+				All: response.AllSecApplications{
+					Result: []response.SecApplication{
+						{
+							Description: "Juju created security application",
+							Dport:       "17070",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/Compute-a432100/sgiulitti@cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-7993630e-d13b-43a3-850e-a1778c7e394e",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/Compute-a432100/sgiulitti%40cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-7993630e-d13b-43a3-850e-a1778c7e394e",
+							Value1:      17070,
+							Value2:      -1,
+							Id:          "1869cb17-5b12-49c5-a09a-046da8899bc9",
+						},
+						{
+							Description: "Juju created security application",
+							Dport:       "37017",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/Compute-a432100/sgiulitti@cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-ef8a7955-4315-47a2-83c1-8d2978ab77c7",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/Compute-a432100/sgiulitti%40cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-ef8a7955-4315-47a2-83c1-8d2978ab77c7",
+							Value1:      37017,
+							Value2:      -1,
+							Id:          "cbefdac0-7684-4f81-a575-825c175aa7b4",
+						},
+					},
+				},
+				AllErr: nil,
+				Default: response.AllSecApplications{
+					Result: []response.SecApplication{
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/all",
+							Protocol:    "all",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/all",
+							Value1:      0,
+							Value2:      0,
+							Id:          "381c2267-1b38-4bbd-b53d-5149deddb094",
+						},
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "echo",
+							Name:        "/oracle/public/pings",
+							Protocol:    "icmp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/pings",
+							Value1:      8,
+							Value2:      0,
+							Id:          "57b0350b-2f02-4a2d-b5ec-cf731de36027",
+						},
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/icmp",
+							Protocol:    "icmp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/icmp",
+							Value1:      255,
+							Value2:      255,
+							Id:          "abb27ccd-1872-48f9-86ef-38c72d6f8a38",
+						},
+						{
+							Description: "",
+							Dport:       "",
+							Icmpcode:    "",
+							Icmptype:    "reply",
+							Name:        "/oracle/public/ping-reply",
+							Protocol:    "icmp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/ping-reply",
+							Value1:      0,
+							Value2:      0,
+							Id:          "3ad808d4-b740-42c1-805c-57feb7c96d40",
+						},
+						{
+							Description: "",
+							Dport:       "3306",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/mysql",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/mysql",
+							Value1:      3306,
+							Value2:      -1,
+							Id:          "2fb5eaff-3127-4334-8b03-367a44bb83bd",
+						},
+						{
+							Description: "",
+							Dport:       "22",
+							Icmpcode:    "",
+							Icmptype:    "",
+							Name:        "/oracle/public/ssh",
+							Protocol:    "tcp",
+							Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/ssh",
+							Value1:      22, Value2: -1,
+							Id: "5f027043-f6b3-4e1a-b9fa-a10d075744de",
+						},
+					},
+				},
+				DefaultErr: nil,
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		err := firewall.ClosePortsOnInstance(f.callCtx, "0,", []jujunetwork.IngressRule{
+			{
+				PortRange: jujunetwork.PortRange{
+					FromPort: 0,
+					ToPort:   0,
+				},
+				SourceCIDRs: nil,
+			},
+		})
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestMachineIngressRules(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	rules, err := firewall.MachineIngressRules(f.callCtx, "0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(rules, gc.NotNil)
+}
+
+func (f *firewallSuite) TestMachineIngressRulesWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{AllErr: errors.New("FakeRulesError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{AllErr: errors.New("FakeSecIpError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{
+				AllDefaultErr: errors.New("FakeSecIpError"),
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		_, err := firewall.MachineIngressRules(f.callCtx, "0")
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestOpenPortsOnInstance(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	err := firewall.OpenPortsOnInstance(f.callCtx, "0", []jujunetwork.IngressRule{})
+	c.Assert(err, gc.IsNil)
+
+}
+
+func (f *firewallSuite) TestOpenPortsOnInstanceWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{AllErr: errors.New("FakeRulesError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{AllErr: errors.New("FakeSecIpError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				SecListErr: errors.New("FakeSecListErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				SecListErr: api.ErrNotFound{},
+				CreateErr:  errors.New("FakeSecListErr"),
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		err := firewall.OpenPortsOnInstance(f.callCtx, "0", []jujunetwork.IngressRule{})
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestCreateMachineSecLists(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	lists, err := firewall.CreateMachineSecLists("0", 7070)
+	c.Assert(err, gc.IsNil)
+	c.Assert(lists, gc.NotNil)
+}
+
+func (f *firewallSuite) TestCreateMachineSecListsWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				SecListErr: errors.New("FakeSecListErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				SecListErr: api.ErrNotFound{},
+				CreateErr:  errors.New("FakeSecListErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{AllErr: errors.New("FakeRulesError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				AllErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeApplication: providertest.FakeApplication{
+				DefaultErr: errors.New("FakeApplicationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecIp: providertest.FakeSecIp{AllErr: errors.New("FakeSecIpError")},
+		},
+	} {
+
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		_, err := firewall.CreateMachineSecLists("0", 7070)
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestDeleteMachineSecList(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	err := firewall.DeleteMachineSecList("0")
+	c.Assert(err, gc.IsNil)
+}
+
+func (f *firewallSuite) TestDeleteMachineSecListWithErrors(c *gc.C) {
+
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeAssociation: providertest.FakeAssociation{
+				AllErr: errors.New("FakeAssociationError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{AllErr: errors.New("FakeRulesError")},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeRules: providertest.FakeRules{
+				All: response.AllSecRules{
+					Result: []response.SecRule{
+						{
+							Action:      common.SecRulePermit,
+							Application: "/Compute-acme/jack.jones@example.com/video_streaming_udp",
+							Name:        "/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+							Dst_list:    "seclist:/Compute-acme/jack.jones@example.com/allowed_video_servers",
+							Src_list:    "seciplist:/Compute-acme/jack.jones@example.com/es_iplist",
+							Uri:         "https://api-z999.compute.us0.oraclecloud.com/secrule/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+							Src_is_ip:   "true",
+							Dst_is_ip:   "false",
+						},
+					},
+				},
+
+				DeleteErr: errors.New("FakeRulesError"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecList: providertest.FakeSecList{
+				DeleteErr: errors.New("FakeSecListErr"),
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		err := firewall.DeleteMachineSecList("0")
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestCreateDefaultACLAndRules(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+
+	acls, err := firewall.CreateDefaultACLAndRules("0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(acls, gc.NotNil)
+}
+
+func (f *firewallSuite) TestCreateDefaultACLAndRulesWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeAcl: providertest.FakeAcl{
+				AclErr: errors.New("FakeAclErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeAcl: providertest.FakeAcl{
+				AclErr:    api.ErrNotFound{},
+				CreateErr: errors.New("FakeAclErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecRules: providertest.FakeSecRules{
+				AllErr: errors.New("FakeAclErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecRules: providertest.FakeSecRules{
+				CreateErr: errors.New("FakeAclErr"),
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		_, err := firewall.CreateDefaultACLAndRules("0")
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (f *firewallSuite) TestRemoveACLAndRules(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+
+	firewall := network.NewFirewall(cfg, providertest.DefaultFakeFirewallAPI, &advancingClock)
+	c.Assert(firewall, gc.NotNil)
+	err := firewall.RemoveACLAndRules("0")
+	c.Assert(err, gc.IsNil)
+}
+
+func (f *firewallSuite) TestRemoveACLAndRulesWithErrors(c *gc.C) {
+	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
+	for _, fake := range []*providertest.FakeFirewallAPI{
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecRules: providertest.FakeSecRules{
+				AllErr: errors.New("FakeSecRulesErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeSecRules: providertest.FakeSecRules{
+				All: response.AllSecurityRules{
+					Result: []response.SecurityRule{
+						{
+							Name:                   "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+							Uri:                    "https://api-z999.compute.us0.oraclecloud.com:443/network/v1/secrule/Compute-acme/jack.jones@example.com/secrule1",
+							Description:            "Sample security rule",
+							Tags:                   nil,
+							Acl:                    "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+							FlowDirection:          common.Egress,
+							SrcVnicSet:             "/Compute-acme/jack.jones@example.com/vnicset1",
+							DstVnicSet:             "/Compute-acme/jack.jones@example.com/vnicset2",
+							SrcIpAddressPrefixSets: []string{"/Compute-acme/jack.jones@example.com/ipaddressprefixset1"},
+							DstIpAddressPrefixSets: nil,
+							SecProtocols:           []string{"/Compute-acme/jack.jones@example.com/secprotocol1"},
+							EnabledFlag:            true,
+						},
+					},
+				},
+				AllErr:    nil,
+				DeleteErr: errors.New("FakeSecRulesErr"),
+			},
+		},
+		{
+			FakeComposer: providertest.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeAcl: providertest.FakeAcl{
+				DeleteErr: errors.New("FakeAclErr"),
+			},
+		},
+	} {
+		firewall := network.NewFirewall(cfg, fake, &advancingClock)
+		c.Assert(firewall, gc.NotNil)
+
+		err := firewall.RemoveACLAndRules("0")
+		c.Assert(err, gc.NotNil)
+	}
+}

--- a/provider/oracle/network/package_test.go
+++ b/provider/oracle/network/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/oracle/network/util.go
+++ b/provider/oracle/network/util.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"net"
+
+	"github.com/juju/errors"
+)
+
+// GetMacAndIp is a helper function that returns a mac and an IP,
+// given a list of strings containing both. This type of array
+// is returned by the oracle API as part of instance details.
+func GetMacAndIP(address []string) (mac string, ip string, err error) {
+	if address == nil {
+		err = errors.New("Empty address slice given")
+		return
+	}
+	for _, val := range address {
+		valIp := net.ParseIP(val)
+		if valIp != nil {
+			ip = val
+			continue
+		}
+		if _, err = net.ParseMAC(val); err != nil {
+			err = errors.Errorf("The address is not an mac neither an ip %s", val)
+			break
+		}
+		mac = val
+	}
+	return
+}

--- a/provider/oracle/network/util_test.go
+++ b/provider/oracle/network/util_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/oracle/network"
+)
+
+type utilSuite struct{}
+
+var _ = gc.Suite(&utilSuite{})
+
+func (u *utilSuite) TestGetMacAndIP(c *gc.C) {
+	macAddress := "29-E7-9F-D9-83-C8"
+	ipAddress := "120.120.120.0"
+	address := []string{
+		macAddress,
+		ipAddress,
+	}
+
+	mac, ip, err := network.GetMacAndIP(address)
+	c.Assert(err, gc.IsNil)
+	c.Assert(mac, jc.DeepEquals, macAddress)
+	c.Assert(ip, jc.DeepEquals, ipAddress)
+}
+
+func (u *utilSuite) TestGetMacAndIPWithError(c *gc.C) {
+	macAddress1 := "29-E7-9F-D9-83-C8"
+	macAddress2 := "UDIUSHIDUSIDHSIUDh"
+	ipAddress1 := "idaijds.daisdia.daishd"
+	ipAddress2 := "127.0.0.1"
+
+	address := []string{
+		macAddress1,
+		ipAddress1,
+		macAddress2,
+		ipAddress2,
+	}
+
+	mac, ip, err := network.GetMacAndIP(address)
+	c.Assert(err, gc.NotNil)
+	c.Assert(mac, jc.DeepEquals, macAddress1)
+	c.Assert(ip, jc.DeepEquals, "")
+
+	mac, ip, err = network.GetMacAndIP(nil)
+	c.Assert(err, gc.NotNil)
+	c.Assert(mac, jc.DeepEquals, "")
+	c.Assert(ip, jc.DeepEquals, "")
+
+	address = []string{
+		ipAddress2,
+		ipAddress1,
+	}
+
+	mac, ip, err = network.GetMacAndIP(address)
+	c.Assert(err, gc.NotNil)
+	c.Assert(mac, jc.DeepEquals, "")
+	c.Assert(ip, jc.DeepEquals, ipAddress2)
+}

--- a/provider/oracle/network/zone_test.go
+++ b/provider/oracle/network/zone_test.go
@@ -1,0 +1,23 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/oracle/network"
+)
+
+type zoneSuite struct{}
+
+var _ = gc.Suite(&zoneSuite{})
+
+func (z *zoneSuite) TestNewAvailabilityZone(c *gc.C) {
+	name := "us6"
+	zone := network.NewAvailabilityZone(name)
+	c.Assert(zone, gc.NotNil)
+	c.Assert(zone.Available(), jc.IsTrue)
+	c.Assert(zone.Name(), jc.DeepEquals, name)
+}

--- a/provider/oracle/network/zones.go
+++ b/provider/oracle/network/zones.go
@@ -1,0 +1,32 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+// AvailabilityZone implements common.AvailabilityZone
+type AvailabilityZone struct {
+	// name is the nam of the zone
+	name string
+}
+
+// NewAvailabilityZone returns a new availability zone
+func NewAvailabilityZone(name string) AvailabilityZone {
+	return AvailabilityZone{
+		name: name,
+	}
+}
+
+// Name is specified on the common.AvailabilityZone interface
+func (a AvailabilityZone) Name() string {
+	return a.name
+}
+
+// Available is specified on the common.AvailabilityZone interface
+func (a AvailabilityZone) Available() bool {
+	// we don't really have availability zones in oracle cloud. We only
+	// have regions
+	// TODO (gsamfira): Remove AvailabilityZone when bug
+	// https://bugs.launchpad.net/juju/+bug/1680652
+	// is resolved
+	return true
+}

--- a/provider/oracle/networking.go
+++ b/provider/oracle/networking.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"github.com/juju/errors"
+	oci "github.com/juju/go-oracle-cloud/api"
+	ociResponse "github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+)
+
+var _ environs.NetworkingEnviron = (*OracleEnviron)(nil)
+
+// Only Ubuntu for now. There is no CentOS image in the oracle
+// compute marketplace
+var ubuntuInterfaceTemplate = `
+auto %s
+iface %s inet dhcp
+`
+
+const (
+	// defaultNicName is the default network card name attached by default
+	// to every instance. This NIC is used for outbound internet access
+	defaultNicName = "eth0"
+	// nicPrefix si the default NIC prefix name for any extra NICs attached
+	// to instances spawned by juju
+	nicPrefix = "eth"
+	// interfacesConfigDir default path of interfaces.d directory on Ubuntu machines
+	// currently CentOS is not available in the oracle market, and windows needs
+	// no extra configuration to bring up additional NICs
+	interfacesConfigDir = `/etc/network/interfaces.d`
+)
+
+// DeleteMachineVnicSet will delete the machine vNIC set and any ACLs bound to it.
+func (o *OracleEnviron) DeleteMachineVnicSet(machineId string) error {
+	if err := o.RemoveACLAndRules(machineId); err != nil {
+		// A method not allowed error denotes that this feature
+		// is not enabled. Probably a trial account, so not really an error
+		if !oci.IsMethodNotAllowed(err) {
+			return errors.Trace(err)
+		}
+	}
+	name := o.client.ComposeName(o.namespace.Value(machineId))
+	if err := o.client.DeleteVnicSet(name); err != nil {
+		if !oci.IsNotFound(err) && !oci.IsMethodNotAllowed(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *OracleEnviron) ensureVnicSet(ctx context.ProviderCallContext, machineId string, tags []string) (ociResponse.VnicSet, error) {
+	if access, err := o.SupportsSpaces(ctx); err != nil || access == false {
+		logger.Debugf("Spaces is not supported on this API endpoint.")
+		return ociResponse.VnicSet{}, nil
+	}
+
+	acl, err := o.CreateDefaultACLAndRules(machineId)
+	if err != nil {
+		return ociResponse.VnicSet{}, errors.Trace(err)
+	}
+	name := o.client.ComposeName(o.namespace.Value(machineId))
+	details, err := o.client.VnicSetDetails(name)
+	if err != nil {
+		if !oci.IsNotFound(err) {
+			return ociResponse.VnicSet{}, errors.Trace(err)
+		}
+		logger.Debugf("Creating vnic set %q", name)
+		vnicSetParams := oci.VnicSetParams{
+			AppliedAcls: []string{
+				acl.Name,
+			},
+			Description: "Juju created vnic set",
+			Name:        name,
+			Tags:        tags,
+		}
+		details, err := o.client.CreateVnicSet(vnicSetParams)
+		if err != nil {
+			return ociResponse.VnicSet{}, errors.Trace(err)
+		}
+		return details, nil
+	}
+	return details, nil
+}

--- a/provider/oracle/networking_test.go
+++ b/provider/oracle/networking_test.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/testing"
+)
+
+type networkingSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&networkingSuite{})
+
+func (n networkingSuite) TestDeleteMachineVnicSet(c *gc.C) {
+	environ, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+
+	err = environ.DeleteMachineVnicSet("0")
+	c.Assert(err, gc.IsNil)
+}

--- a/provider/oracle/package_test.go
+++ b/provider/oracle/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/provider/oracle/provider.go
+++ b/provider/oracle/provider.go
@@ -1,0 +1,156 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	oci "github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/jsonschema"
+	"github.com/juju/loggo"
+	"github.com/juju/schema"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+)
+
+var logger = loggo.GetLogger("juju.provider.oracle")
+
+const (
+	providerType = "oracle"
+)
+
+// EnvironProvider type implements environs.EnvironProvider interface
+type EnvironProvider struct{}
+
+var _ environs.CloudEnvironProvider = (*EnvironProvider)(nil)
+
+// CloudSchema is defined on the environs.EnvironProvider interface.
+func (e EnvironProvider) CloudSchema() *jsonschema.Schema {
+	return nil
+}
+
+// Ping implements environs.EnvironProvider.
+func (e *EnvironProvider) Ping(ctx context.ProviderCallContext, endpoint string) error {
+	return nil
+}
+
+// PrepareConfig is defined on the environs.EnvironProvider interface.
+func (e EnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+	if err := e.validateCloudSpec(args.Cloud); err != nil {
+		return nil, errors.Annotatef(err, "validating cloud spec")
+	}
+	// Set the default block-storage source.
+	attrs := make(map[string]interface{})
+	if _, ok := args.Config.StorageDefaultBlockSource(); !ok {
+		attrs[config.StorageDefaultBlockSourceKey] = oracleStorageProviderType
+	}
+	if len(attrs) == 0 {
+		return args.Config, nil
+	}
+	return args.Config.Apply(attrs)
+}
+
+// validateCloudSpec validates the given configuration against the oracle cloud spec
+func (e EnvironProvider) validateCloudSpec(spec environs.CloudSpec) error {
+	if err := spec.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	if spec.Credential == nil {
+		return errors.NotValidf("missing credentials")
+	}
+
+	// validate the authentication type
+	if authType := spec.Credential.AuthType(); authType != cloud.UserPassAuthType {
+		return errors.NotSupportedf("%q auth-type ", authType)
+	}
+
+	if _, ok := spec.Credential.Attributes()["identity-domain"]; !ok {
+		return errors.NotFoundf("identity-domain in the credentials")
+	}
+
+	return nil
+}
+
+// Version is part of the EnvironProvider interface.
+func (EnvironProvider) Version() int {
+	return 0
+}
+
+// Open is defined on the environs.EnvironProvider interface.
+func (e *EnvironProvider) Open(params environs.OpenParams) (environs.Environ, error) {
+	logger.Debugf("opening model %q", params.Config.Name())
+	if err := e.validateCloudSpec(params.Cloud); err != nil {
+		return nil, errors.Annotatef(err, "validating cloud spec")
+	}
+
+	cli, err := oci.NewClient(oci.Config{
+		Username: params.Cloud.Credential.Attributes()["username"],
+		Password: params.Cloud.Credential.Attributes()["password"],
+		Endpoint: params.Cloud.Endpoint,
+		Identify: params.Cloud.Credential.Attributes()["identity-domain"],
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err = cli.Authenticate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return NewOracleEnviron(e, params, cli, clock.WallClock)
+}
+
+// Validate is defined on the config.Validator interface.
+func (e EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+	if err := config.Validate(cfg, old); err != nil {
+		return nil, err
+	}
+	newAttrs, err := cfg.ValidateUnknownAttrs(
+		schema.Fields{}, schema.Defaults{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.Apply(newAttrs)
+}
+
+var credentials = map[cloud.AuthType]cloud.CredentialSchema{
+	cloud.UserPassAuthType: {{
+		"username", cloud.CredentialAttr{
+			Description: "account username",
+		},
+	}, {
+		"password", cloud.CredentialAttr{
+			Description: "account password",
+			Hidden:      true,
+		},
+	}, {
+		"identity-domain", cloud.CredentialAttr{
+			Description: "indetity domain of the oracle account",
+		},
+	}},
+}
+
+// CredentialSchemas is defined on the environs.ProviderCredentials interface.
+func (e EnvironProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
+	return credentials
+}
+
+// DetectCredentials is defined on the environs.ProviderCredentials interface.
+func (e EnvironProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+	return nil, errors.NotFoundf("credentials")
+}
+
+// FinalizeCredential is defined on the environs.ProviderCredentials interface.
+func (e EnvironProvider) FinalizeCredential(
+	cfx environs.FinalizeCredentialContext,
+	params environs.FinalizeCredentialParams,
+) (*cloud.Credential, error) {
+
+	return &params.Credential, nil
+}

--- a/provider/oracle/provider_test.go
+++ b/provider/oracle/provider_test.go
@@ -1,0 +1,147 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/oracle"
+	"github.com/juju/juju/testing"
+)
+
+type environProviderSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&environProviderSuite{})
+
+func (e *environProviderSuite) NewProvider(c *gc.C) environs.EnvironProvider {
+	provider, err := environs.Provider("oracle")
+	c.Assert(err, gc.IsNil)
+	c.Assert(provider, gc.NotNil)
+	return provider
+}
+
+func (e *environProviderSuite) TestCloudSchma(c *gc.C) {
+	provider := e.NewProvider(c)
+	schema := provider.CloudSchema()
+	c.Assert(schema, gc.IsNil)
+}
+
+func (e *environProviderSuite) TestPing(c *gc.C) {
+	provider := e.NewProvider(c)
+	err := provider.Ping(context.NewCloudCallContext(), "")
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environProviderSuite) TestPrepareConfigWithErrors(c *gc.C) {
+	provider := e.NewProvider(c)
+	_, err := provider.PrepareConfig(environs.PrepareConfigParams{})
+	c.Assert(err, gc.NotNil)
+
+	_, err = provider.PrepareConfig(environs.PrepareConfigParams{
+		Config: testing.ModelConfig(c),
+	})
+	c.Assert(err, gc.NotNil)
+}
+
+func (e *environProviderSuite) TestPrepareConfig(c *gc.C) {
+	provider := e.NewProvider(c)
+	credentials := jujucloud.NewCredential(
+		jujucloud.UserPassAuthType,
+		map[string]string{
+			"identity-domain": "bretdd",
+		},
+	)
+	_, err := provider.PrepareConfig(environs.PrepareConfigParams{
+		Cloud: environs.CloudSpec{
+			Type:       "oracle",
+			Name:       "oracle",
+			Credential: &credentials,
+		},
+		Config: testing.ModelConfig(c),
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environProviderSuite) TestOpen(c *gc.C) {
+	provider := e.NewProvider(c)
+	credentials := jujucloud.NewCredential(
+		jujucloud.UserPassAuthType,
+		map[string]string{
+			"identity-domain": "bretdd",
+			"username":        "some-friendly-username",
+			"password":        "some-friendly-password",
+		},
+	)
+	_, err := environs.Open(provider, environs.OpenParams{
+		Cloud: environs.CloudSpec{
+			Type:       "oracle",
+			Name:       "oracle",
+			Credential: &credentials,
+			Endpoint:   "https://127.0.0.1/",
+		},
+		Config: testing.ModelConfig(c),
+	})
+	c.Assert(err, gc.NotNil)
+}
+
+func (e *environProviderSuite) TestValidateWithErrors(c *gc.C) {
+	provider := e.NewProvider(c)
+	_, err := provider.Validate(
+		testing.ModelConfig(c),
+		testing.ModelConfig(c),
+	)
+	c.Assert(err, gc.NotNil)
+}
+
+func (e *environProviderSuite) TestValidate(c *gc.C) {
+	provider := e.NewProvider(c)
+	_, err := provider.Validate(testing.ModelConfig(c), nil)
+	c.Assert(err, gc.IsNil)
+}
+
+func (e *environProviderSuite) TestCredentialSchema(c *gc.C) {
+	provider := e.NewProvider(c)
+	credentials := provider.CredentialSchemas()
+	c.Assert(credentials,
+		jc.DeepEquals,
+		oracle.OracleCredentials,
+	)
+}
+
+func (e *environProviderSuite) TestDetectCredentials(c *gc.C) {
+	provider := e.NewProvider(c)
+	_, err := provider.DetectCredentials()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (e *environProviderSuite) TestFinalizeCredential(c *gc.C) {
+	provider := e.NewProvider(c)
+	cloudcred := jujucloud.NewCredential(
+		jujucloud.UserPassAuthType,
+		map[string]string{
+			"identity-domain": "bretdd",
+			"username":        "some-friendly-username",
+			"password":        "some-friendly-password",
+		},
+	)
+
+	credentials, err := provider.FinalizeCredential(
+		nil,
+		environs.FinalizeCredentialParams{
+			Credential: cloudcred,
+		},
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(credentials, gc.NotNil)
+	c.Assert(*credentials, jc.DeepEquals, cloudcred)
+
+}

--- a/provider/oracle/storage.go
+++ b/provider/oracle/storage.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"github.com/juju/errors"
+	oci "github.com/juju/go-oracle-cloud/api"
+
+	"github.com/juju/juju/provider/oracle/common"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	oracleStorageProviderType = storage.ProviderType("oracle")
+
+	// maxVolumeSizeInGB represents the maximum size in GiB for
+	// a single volume. For more information please see:
+	// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-storage-volume--post.html#request
+	maxVolumeSizeInGB = 2000
+	// minVolumeSizeInGB represents the minimum size in GiB for
+	// a single volume. For more information please see:
+	// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-storage-volume--post.html#request
+	minVolumeSizeInGB = 1
+	// maxDevices is the maximum number of volumes that can be attached to a single instance
+	// for more information, please see:
+	// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-storage-attachment--post.html#request
+	maxDevices = 10
+	// blockDevicePrefix is the default block storage prefix for an oracle
+	// cloud storage volume, as seen by GNU/Linux guests. For more information, please see:
+	// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-storage-attachment--post.html#request
+	blockDevicePrefix = "xvd"
+
+	// blockDeviceStartIndex is the base from which we start incrementing block device names
+	// start from 'a'. xvda will always be the root disk.
+	blockDeviceStartIndex = 'a'
+)
+
+// storageProvider implements the storage.Provider interface
+type storageProvider struct {
+	env *OracleEnviron
+	api StorageAPI
+}
+
+var _ storage.Provider = (*storageProvider)(nil)
+
+// StorageAPI defines the storage API in the oracle cloud provider
+// this enables the provider to talk with the storage API and make
+// storage specific operations
+type StorageAPI interface {
+	common.StorageVolumeAPI
+	common.StorageAttachmentAPI
+	common.Composer
+}
+
+func mibToGib(m uint64) uint64 {
+	return (m + 1023) / 1024
+}
+
+func (o *OracleEnviron) canAccessStorageAPI() (bool, error) {
+	// Check if we actually have access to the storage APIs.
+	_, err := o.client.AllStorageVolumes(nil)
+	if err != nil {
+		// The API usually returns a 405 error if we don't have access to that bit of the cloud
+		// this is something that happens for trial accounts.
+		if oci.IsMethodNotAllowed(err) {
+			return false, nil
+		}
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
+// StorageProviderTypes implements storage.ProviderRegistry.
+func (o *OracleEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	if access, err := o.canAccessStorageAPI(); access {
+		return []storage.ProviderType{oracleStorageProviderType}, nil
+	} else {
+		return nil, errors.Trace(err)
+	}
+}
+
+// StorageProvider implements storage.ProviderRegistry.
+func (o *OracleEnviron) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
+	access, err := o.canAccessStorageAPI()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if access && t == oracleStorageProviderType {
+		return &storageProvider{
+			env: o,
+			api: o.client,
+		}, nil
+	}
+
+	return nil, errors.NotFoundf("storage provider %q", t)
+}

--- a/provider/oracle/storage_provider.go
+++ b/provider/oracle/storage_provider.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	ociCommon "github.com/juju/go-oracle-cloud/common"
+
+	"github.com/juju/juju/storage"
+)
+
+type poolType string
+
+const (
+	// for details please see:
+	// https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-storage-volume--post.html#request-definitions-StorageVolume-post-request-properties-properties
+	latencyPool      poolType = "latency"
+	defaultPool      poolType = "default"
+	oracleVolumeType string   = "volume-type"
+)
+
+var poolTypeMap map[poolType]ociCommon.StoragePool = map[poolType]ociCommon.StoragePool{
+	latencyPool: ociCommon.LatencyPool,
+	defaultPool: ociCommon.DefaultPool,
+}
+
+// VolumeSource is defined on the storage.Provider interface.
+func (s *storageProvider) VolumeSource(cfg *storage.Config) (storage.VolumeSource, error) {
+	environConfig := s.env.Config()
+	name := environConfig.Name()
+	uuid := environConfig.UUID()
+	return newOracleVolumeSource(s.env, name, uuid, s.env.client, clock.WallClock)
+}
+
+// FilesystemSource is defined on the storage.Provider interface.
+func (s storageProvider) FilesystemSource(cfg *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystemsource")
+}
+
+// Supports  is defined on the storage.Provider interface.
+func (s storageProvider) Supports(kind storage.StorageKind) bool {
+	return kind == storage.StorageKindBlock
+}
+
+// Scope  is defined on the storage.Provider interface.
+func (s storageProvider) Scope() storage.Scope {
+	return storage.ScopeEnviron
+}
+
+// Dynamic  is defined on the storage.Provider interface.
+func (s storageProvider) Dynamic() bool {
+	return true
+}
+
+// Releasable is defined on the Provider interface.
+func (s storageProvider) Releasable() bool {
+	// TODO(axw) support releasing Oracle storage volumes.
+	return false
+}
+
+// DefaultPools  is defined on the storage.Provider interface.
+func (s storageProvider) DefaultPools() []*storage.Config {
+	latencyPool, _ := storage.NewConfig("oracle-latency", oracleStorageProviderType, map[string]interface{}{
+		oracleVolumeType: latencyPool,
+	})
+	return []*storage.Config{latencyPool}
+}
+
+// ValidateConfig  is defined on the storage.Provider interface.
+func (s storageProvider) ValidateConfig(cfg *storage.Config) error {
+	attrs := cfg.Attrs()
+	if volType, ok := attrs[oracleVolumeType]; ok {
+		switch kind := volType.(type) {
+		case string:
+			pool := volType.(string)
+			if _, ok := poolTypeMap[poolType(pool)]; !ok {
+				return errors.Errorf("invalid volume-type %q", volType)
+			}
+			return nil
+		case poolType:
+			if _, ok := poolTypeMap[volType.(poolType)]; !ok {
+				return errors.Errorf("invalid volume-type %q", volType)
+			}
+			return nil
+		default:
+			return errors.Errorf("invalid volume-type %T", kind)
+		}
+	}
+	return nil
+}

--- a/provider/oracle/storage_provider_test.go
+++ b/provider/oracle/storage_provider_test.go
@@ -1,0 +1,146 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+type storageProviderSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&storageProviderSuite{})
+
+func NewStorageProviderTest(c *gc.C) storage.Provider {
+	env, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(env, gc.NotNil)
+
+	provider, err := env.StorageProvider(
+		oracle.DefaultStorageProviderType,
+	)
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(provider, gc.NotNil)
+
+	return provider
+}
+
+func (s *storageProviderSuite) NewStorageProvider(c *gc.C) storage.Provider {
+	return NewStorageProviderTest(c)
+}
+
+func (s *storageProviderSuite) TestVolumeSource(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+	source, err := provider.VolumeSource(nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(source, gc.NotNil)
+	cfg, err := storage.NewConfig("oracle-latency", oracle.DefaultTypes[0],
+		map[string]interface{}{
+			oracle.OracleVolumeType: oracle.OracleLatencyPool,
+		})
+	c.Assert(err, gc.IsNil)
+	c.Assert(cfg, gc.NotNil)
+
+	source, err = provider.VolumeSource(cfg)
+	c.Assert(err, gc.IsNil)
+	c.Assert(source, gc.NotNil)
+}
+
+func (s *storageProviderSuite) TestFileSystemSource(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+
+	_, err := provider.FilesystemSource(nil)
+	c.Assert(err, gc.NotNil)
+	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
+}
+
+func (s *storageProviderSuite) TestSupports(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+
+	ok := provider.Supports(storage.StorageKindBlock)
+	c.Assert(ok, jc.IsTrue)
+
+	ok = provider.Supports(storage.StorageKindFilesystem)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *storageProviderSuite) TestScope(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+
+	scope := provider.Scope()
+	c.Assert(scope, jc.DeepEquals, storage.ScopeEnviron)
+}
+
+func (s *storageProviderSuite) TestDynamic(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+
+	ok := provider.Dynamic()
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *storageProviderSuite) TestDefaultPools(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+	cfg := provider.DefaultPools()
+	c.Assert(cfg, gc.NotNil)
+}
+
+func (s *storageProviderSuite) TestValidateConfig(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+	cfg, err := storage.NewConfig("oracle-latency", oracle.DefaultTypes[0],
+		map[string]interface{}{
+			oracle.OracleVolumeType: oracle.OracleLatencyPool,
+		})
+	c.Assert(err, gc.IsNil)
+	err = provider.ValidateConfig(cfg)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *storageProviderSuite) TestValidateConfigWithError(c *gc.C) {
+	provider := s.NewStorageProvider(c)
+	cfg, err := storage.NewConfig("some-test-name", oracle.DefaultTypes[0],
+		map[string]interface{}{
+			"some-werid-type": 321,
+		})
+	c.Assert(err, gc.IsNil)
+
+	err = provider.ValidateConfig(cfg)
+	c.Assert(err, gc.IsNil)
+
+	cfg, err = storage.NewConfig("some-test-name", oracle.DefaultTypes[0],
+		map[string]interface{}{
+			oracle.OracleVolumeType: 321,
+		})
+	c.Assert(err, gc.IsNil)
+
+	err = provider.ValidateConfig(cfg)
+	c.Assert(err, gc.NotNil)
+
+	cfg, err = storage.NewConfig("some-test-name", oracle.DefaultTypes[0],
+		map[string]interface{}{
+			oracle.OracleVolumeType: "some-string",
+		})
+	c.Assert(err, gc.IsNil)
+
+	err = provider.ValidateConfig(cfg)
+	c.Assert(err, gc.NotNil)
+}

--- a/provider/oracle/storage_test.go
+++ b/provider/oracle/storage_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+type storageSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&storageSuite{})
+
+func (s *storageSuite) NewStorageProvider(c *gc.C) storage.ProviderRegistry {
+	env, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		oracletesting.DefaultEnvironAPI,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(env, gc.NotNil)
+	return env
+}
+
+func (s *storageSuite) TestStorageProviderTypes(c *gc.C) {
+	environ := s.NewStorageProvider(c)
+
+	types, err := environ.StorageProviderTypes()
+	c.Assert(err, gc.IsNil)
+	c.Assert(types, gc.DeepEquals, oracle.DefaultTypes)
+}
+
+func (s *storageSuite) TestStorageProvider(c *gc.C) {
+	environ := s.NewStorageProvider(c)
+	provider, err := environ.StorageProvider(
+		oracle.DefaultStorageProviderType)
+	c.Assert(err, gc.IsNil)
+	c.Assert(provider, gc.NotNil)
+}
+
+func (s *storageSuite) TestStorageProviderWithError(c *gc.C) {
+	environ := s.NewStorageProvider(c)
+	someType := storage.ProviderType("someType")
+	provider, err := environ.StorageProvider(someType)
+	c.Assert(err, gc.NotNil)
+	c.Assert(provider, gc.IsNil)
+
+}

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -1,0 +1,626 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	oci "github.com/juju/go-oracle-cloud/api"
+	ociCommon "github.com/juju/go-oracle-cloud/common"
+	ociResponse "github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/tags"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+)
+
+// oracleVolumeSource implements the storage.VolumeSource interface
+type oracleVolumeSource struct {
+	env       *OracleEnviron
+	envName   string // non-unique, informational only
+	modelUUID string
+	api       StorageAPI
+	clock     clock.Clock
+}
+
+// newOracleVolumeSource returns a new volume source to provide an interface
+// for creating, destroying, describing attaching and detaching volumes in the
+// oracle cloud environment
+func newOracleVolumeSource(env *OracleEnviron, name, uuid string, api StorageAPI, clock clock.Clock) (*oracleVolumeSource, error) {
+	if env == nil {
+		return nil, errors.NotFoundf("environ")
+	}
+
+	if api == nil {
+		return nil, errors.NotFoundf("storage client")
+	}
+
+	return &oracleVolumeSource{
+		env:       env,
+		envName:   name,
+		modelUUID: uuid,
+		api:       api,
+		clock:     clock,
+	}, nil
+}
+
+var _ storage.VolumeSource = (*oracleVolumeSource)(nil)
+
+// resourceName returns an oracle compatible resource name.
+func (s *oracleVolumeSource) resourceName(tag string) string {
+	return s.api.ComposeName(s.env.namespace.Value(s.envName + "-" + tag))
+}
+
+func (s *oracleVolumeSource) getStoragePool(attr map[string]interface{}) (ociCommon.StoragePool, error) {
+	volumeType, ok := attr[oracleVolumeType]
+	if !ok {
+		return poolTypeMap[defaultPool], nil
+	}
+	switch volumeType.(type) {
+	case poolType:
+		if t, ok := poolTypeMap[volumeType.(poolType)]; ok {
+			return t, nil
+		}
+		return poolTypeMap[defaultPool], errors.NotFoundf("storage pool %q not found", volumeType.(poolType))
+	}
+	return poolTypeMap[defaultPool], nil
+}
+
+// createVolume will create a storage volume given the storage volume parameters
+// under the oracle cloud endpoint
+func (s *oracleVolumeSource) createVolume(p storage.VolumeParams) (_ *storage.Volume, err error) {
+	var details ociResponse.StorageVolume
+	defer func() {
+		// gsamfira: not really sure if this is needed. The only relevant error
+		// on which we act is the one returned by the oracle API when creating
+		// the volume. If the API returned an error, there is little chance, that
+		// a volume was created. But for the sake of thoroughness, let's leave this
+		// here
+		if err != nil && details.Name != "" {
+			_ = s.api.DeleteStorageVolume(details.Name)
+		}
+	}()
+
+	// validate the parameters
+	if err := s.ValidateVolumeParams(p); err != nil {
+		return nil, errors.Trace(err)
+	}
+	name := s.resourceName(p.Tag.String())
+	size := mibToGib(p.Size)
+	if size > maxVolumeSizeInGB || size < minVolumeSizeInGB {
+		return nil, errors.Errorf("invalid size for volume: %d", size)
+	}
+
+	poolType, err := s.getStoragePool(p.Attributes)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	volumeTags := []string{p.Tag.String()}
+	for k, v := range p.ResourceTags {
+		volumeTags = append(volumeTags, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	params := oci.StorageVolumeParams{
+		Bootable:    false,
+		Description: fmt.Sprintf("Juju created volume for %q", p.Tag.String()),
+		Name:        name,
+		Properties: []ociCommon.StoragePool{
+			poolType,
+		},
+		Size: ociCommon.NewStorageSize(size, ociCommon.G),
+		Tags: volumeTags,
+	}
+	logger.Infof("creating volume: %v", params)
+	details, err = s.api.CreateStorageVolume(params)
+	if oci.IsStatusConflict(err) {
+		// Volume already exists, so return its details.
+		conflictErr := err
+		details, err = s.api.StorageVolumeDetails(name)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var modelTagValue string
+		for _, tag := range details.Tags {
+			prefix := tags.JujuModel + "="
+			if !strings.HasPrefix(tag, prefix) {
+				continue
+			}
+			modelTagValue = tag[len(prefix):]
+		}
+		if modelTagValue != s.modelUUID {
+			return nil, errors.Trace(conflictErr)
+		}
+		return &storage.Volume{p.Tag, makeVolumeInfo(details)}, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// wait for the newly created volume to reach "Online" status
+	logger.Debugf("waiting for resource %v", details.Name)
+	if err := s.waitForResourceStatus(
+		s.fetchVolumeStatus,
+		details.Name,
+		string(ociCommon.VolumeOnline), 5*time.Minute); err != nil {
+		return nil, errors.Trace(err)
+	}
+	volume := &storage.Volume{p.Tag, makeVolumeInfo(details)}
+	logger.Debugf("volume details: %v", volume)
+	return volume, nil
+}
+
+// CreateVolumes is specified on the storage.VolumeSource interface
+func (s *oracleVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+	if params == nil {
+		return []storage.CreateVolumesResult{}, nil
+	}
+	results := make([]storage.CreateVolumesResult, len(params))
+	for i, volume := range params {
+		vol, err := s.createVolume(volume)
+		if err != nil {
+			results[i].Error = errors.Trace(err)
+			continue
+		}
+		results[i].Volume = vol
+	}
+	return results, nil
+}
+
+// fetchVolumeStatus polls the status of a volume and returns true if the current status
+// coincides with the desired status
+func (s *oracleVolumeSource) fetchVolumeStatus(name, desiredStatus string) (complete bool, err error) {
+	details, err := s.api.StorageVolumeDetails(name)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	if details.Status == ociCommon.VolumeError {
+		return false, errors.Errorf("volume entered error state: %q", details.Status_detail)
+	}
+	return string(details.Status) == desiredStatus, nil
+}
+
+// fetchVolumeAttachmentStatus polls the status of a volume attachment and returns true if the current status
+// coincides with the desired status
+func (s *oracleVolumeSource) fetchVolumeAttachmentStatus(name, desiredStatus string) (bool, error) {
+	details, err := s.api.StorageAttachmentDetails(name)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return string(details.State) == desiredStatus, nil
+}
+
+// waitForResourceStatus will ping the resource until the fetch function returns true,
+// the timeout is reached, or an error occurs.
+func (o *oracleVolumeSource) waitForResourceStatus(
+	fetch func(name string, desiredStatus string) (complete bool, err error),
+	name, state string,
+	timeout time.Duration,
+) error {
+
+	timeoutTimer := o.clock.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	retryTimer := o.clock.NewTimer(0)
+	defer retryTimer.Stop()
+
+	for {
+		select {
+		case <-retryTimer.Chan():
+			done, err := fetch(name, state)
+			if err != nil {
+				return err
+			}
+			if done {
+				return nil
+			}
+			retryTimer.Reset(2 * time.Second)
+		case <-timeoutTimer.Chan():
+			return errors.Errorf(
+				"timed out waiting for resource %q to transition to %v",
+				name, state,
+			)
+		}
+	}
+}
+
+// ListVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) ListVolumes(ctx context.ProviderCallContext) ([]string, error) {
+	tag := fmt.Sprintf("%s=%s", tags.JujuModel, s.modelUUID)
+	filter := []oci.Filter{{
+		Arg:   "tags",
+		Value: tag,
+	}}
+	volumes, err := s.api.AllStorageVolumes(filter)
+	if err != nil {
+		return nil, errors.Annotate(err, "listing volumes")
+	}
+
+	ids := make([]string, len(volumes.Result))
+	for i, volume := range volumes.Result {
+		ids[i] = volume.Name
+	}
+
+	return ids, nil
+}
+
+// DescribeVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) DescribeVolumes(ctx context.ProviderCallContext, volIds []string) ([]storage.DescribeVolumesResult, error) {
+	if volIds == nil || len(volIds) == 0 {
+		return []storage.DescribeVolumesResult{}, nil
+	}
+
+	tag := fmt.Sprintf("%s=%s", tags.JujuModel, s.modelUUID)
+	filter := []oci.Filter{{
+		Arg:   "tags",
+		Value: tag,
+	}}
+
+	result := make([]storage.DescribeVolumesResult, len(volIds), len(volIds))
+	volumes, err := s.api.AllStorageVolumes(filter)
+	if err != nil {
+		return nil, errors.Annotatef(err, "describe volumes")
+	}
+	asMap := map[string]ociResponse.StorageVolume{}
+	for _, val := range volumes.Result {
+		asMap[val.Name] = val
+	}
+	for i, volume := range volIds {
+		if vol, ok := asMap[volume]; ok {
+			volumeInfo := makeVolumeInfo(vol)
+			result[i].VolumeInfo = &volumeInfo
+		} else {
+			result[i].Error = errors.NotFoundf("%s", volume)
+		}
+	}
+	return result, nil
+}
+
+func makeVolumeInfo(vol ociResponse.StorageVolume) storage.VolumeInfo {
+	return storage.VolumeInfo{
+		VolumeId: vol.Name,
+		// Oracle returns the size of the volume
+		// in bytes, VolumeInfo expects MiB.
+		Size:       uint64(vol.Size) / (1024 * 1024),
+		Persistent: true,
+	}
+}
+
+// DestroyVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) DestroyVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
+	return foreachVolume(volIds, s.api.DeleteStorageVolume), nil
+}
+
+// ReleaseVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) ReleaseVolumes(ctx context.ProviderCallContext, volIds []string) ([]error, error) {
+	releaseStorageVolume := func(volumeId string) error {
+		details, err := s.api.StorageVolumeDetails(volumeId)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		var newTags []string
+		for _, tag := range details.Tags {
+			fields := strings.Split(tag, "=")
+			if len(fields) != 2 {
+				newTags = append(newTags, tag)
+				continue
+			}
+			switch fields[0] {
+			case tags.JujuController, tags.JujuModel:
+			default:
+				newTags = append(newTags, tag)
+			}
+		}
+		if len(newTags) == len(details.Tags) {
+			return nil
+		}
+		details.Tags = newTags
+		return errors.Trace(s.updateVolume(volumeId, details))
+	}
+	return foreachVolume(volIds, releaseStorageVolume), nil
+}
+
+func foreachVolume(volIds []string, f func(string) error) []error {
+	results := make([]error, len(volIds))
+	wg := sync.WaitGroup{}
+	wg.Add(len(volIds))
+	for i, val := range volIds {
+		go func(volId string, idx int) {
+			defer wg.Done()
+			results[idx] = f(volId)
+		}(val, i)
+	}
+	wg.Wait()
+	return results
+}
+
+// ImportVolume is specified on the storage.VolumeImporter interface.
+func (s *oracleVolumeSource) ImportVolume(ctx context.ProviderCallContext, volumeId string, tags map[string]string) (storage.VolumeInfo, error) {
+	details, err := s.api.StorageVolumeDetails(volumeId)
+	if err != nil {
+		return storage.VolumeInfo{}, errors.Trace(err)
+	}
+	var newTags []string
+	for _, tag := range details.Tags {
+		fields := strings.Split(tag, "=")
+		if len(fields) != 2 {
+			newTags = append(newTags, tag)
+			continue
+		}
+		key, value := fields[0], fields[1]
+		if newValue, ok := tags[key]; !ok || newValue == value {
+			delete(tags, key)
+			newTags = append(newTags, tag)
+			continue
+		}
+		// The tag has changed; we'll add it in the loop below.
+	}
+	if len(tags) != 0 {
+		for key, value := range tags {
+			newTags = append(newTags, fmt.Sprintf("%s=%s", key, value))
+		}
+		details.Tags = newTags
+		if err := s.updateVolume(volumeId, details); err != nil {
+			return storage.VolumeInfo{}, errors.Trace(err)
+		}
+	}
+	return makeVolumeInfo(details), nil
+}
+
+func (s *oracleVolumeSource) updateVolume(volumeId string, details ociResponse.StorageVolume) error {
+	derefString := func(s *string) string {
+		if s != nil {
+			return *s
+		}
+		return ""
+	}
+	_, err := s.api.UpdateStorageVolume(
+		oci.StorageVolumeParams{
+			Bootable:         details.Bootable,
+			Description:      derefString(details.Description),
+			Imagelist:        details.Imagelist,
+			Imagelist_entry:  details.Imagelist_entry,
+			Name:             details.Name,
+			Properties:       details.Properties,
+			Size:             ociCommon.StorageSize(details.Size),
+			Snapshot:         derefString(details.Snapshot),
+			Snapshot_account: details.Snapshot_account,
+			Snapshot_id:      details.Snapshot_id,
+			Tags:             details.Tags,
+		},
+		volumeId,
+	)
+	return errors.Annotatef(err, "updating volume %q", volumeId)
+}
+
+// ValidateVolumeParams is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+	size := mibToGib(params.Size)
+	if size > maxVolumeSizeInGB || size < minVolumeSizeInGB {
+		return errors.Errorf("invalid size for volume in GiB %d", size)
+	}
+	return nil
+}
+
+func (s *oracleVolumeSource) getStorageAttachments() (map[string][]ociResponse.StorageAttachment, error) {
+	allAttachments, err := s.api.AllStorageAttachments(nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	asMap := map[string][]ociResponse.StorageAttachment{}
+	for _, val := range allAttachments.Result {
+		hostname, err := extractInstanceIDFromMachineName(val.Instance_name)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := asMap[string(hostname)]; !ok {
+			asMap[string(hostname)] = []ociResponse.StorageAttachment{
+				val,
+			}
+		} else {
+			asMap[string(hostname)] = append(asMap[string(hostname)], val)
+		}
+	}
+	return asMap, nil
+}
+
+// AttachVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) AttachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+	instanceIds := []instance.Id{}
+	for _, val := range params {
+		instanceIds = append(instanceIds, val.InstanceId)
+	}
+	if len(instanceIds) == 0 {
+		return []storage.AttachVolumesResult{}, nil
+	}
+	instancesAsMap, err := s.env.getOracleInstancesAsMap(instanceIds...)
+	if err != nil {
+		return []storage.AttachVolumesResult{}, errors.Trace(err)
+	}
+	attachmentsAsMap, err := s.getStorageAttachments()
+	if err != nil {
+		return []storage.AttachVolumesResult{}, errors.Trace(err)
+	}
+
+	ret := make([]storage.AttachVolumesResult, len(params))
+
+	for i, val := range params {
+		instance, ok := instancesAsMap[string(val.InstanceId)]
+		if !ok {
+			ret[i].Error = errors.NotFoundf("instance %q was not found", string(val.InstanceId))
+			continue
+		}
+
+		result, err := s.attachVolume(instance, attachmentsAsMap, val)
+		if err != nil {
+			ret[i].Error = errors.Trace(err)
+			continue
+		}
+		ret[i] = result
+
+	}
+	logger.Infof("returning attachments: %v", ret)
+	return ret, nil
+}
+
+// getFreeIndexNumber returns the first unused consecutive value in a sorted array of ints
+// this is used to find an available index number for attaching a volume to an instance
+func (s *oracleVolumeSource) getFreeIndexNumber(existing []int, max int) (int, error) {
+	if len(existing) == 0 {
+		return 1, nil
+	}
+	sort.Ints(existing)
+	for i := 0; i <= len(existing)-1; i++ {
+		if i+1 >= max {
+			break
+		}
+		if i+1 == len(existing) {
+			return existing[i] + 1, nil
+		}
+		if existing[0] > 1 {
+			return existing[0] - 1, nil
+		}
+		diff := existing[i+1] - existing[i]
+		if diff > 1 {
+			return existing[i] + 1, nil
+		}
+	}
+	return 0, errors.Errorf("no free index")
+}
+
+func (s *oracleVolumeSource) getDeviceNameForIndex(idx int) string {
+	// We use an ephemeral disk when booting instances, so we get
+	// the full range of 10 disks we can attach to an instance.
+	// Alternatively, we can create a volume from an image and attach
+	// it to the launchplan, and set it as a boot device.
+	// NOTE(gsamfira): if we ever decide to boot from volume, this
+	// needs to be addressed to return the proper device name
+	return fmt.Sprintf("%s%s", blockDevicePrefix, string([]byte{blockDeviceStartIndex + byte(idx)}))
+}
+
+func (s *oracleVolumeSource) attachVolume(
+	instance *oracleInstance,
+	currentAttachments map[string][]ociResponse.StorageAttachment,
+	params storage.VolumeAttachmentParams) (storage.AttachVolumesResult, error) {
+
+	// keep track of all indexes of volumes attached to the instance
+	existingIndexes := []int{}
+	instanceStorage := instance.StorageAttachments()
+	// append index numbers of volumes that were attached when creating the
+	// launchpan. Not the case in the current implementation of the provider
+	// but should this change in the future, this function will still work as
+	// expected.
+	// For information about attaching volumes at instance creation time, please
+	// see: https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-launchplan--post.html
+	for _, val := range instanceStorage {
+		existingIndexes = append(existingIndexes, int(val.Index))
+	}
+
+	for _, val := range currentAttachments[string(instance.Id())] {
+		// index numbers range from 1 to 10. Ignore 0 valued indexes
+		// see: https://docs.oracle.com/cloud/latest/stcomputecs/STCSA/op-storage-attachment--post.html
+		if val.Index == 0 {
+			continue
+		}
+		if val.Storage_volume_name == params.VolumeId && val.Instance_name == string(params.InstanceId) {
+			// volume is already attached to this instance. Simply return it.
+			return storage.AttachVolumesResult{
+				VolumeAttachment: &storage.VolumeAttachment{
+					params.Volume,
+					params.Machine,
+					storage.VolumeAttachmentInfo{
+						DeviceName: s.getDeviceNameForIndex(int(val.Index)),
+					},
+				},
+			}, nil
+		}
+		// append any indexes for volumes that were attached dynamically (after instance creation)
+		existingIndexes = append(existingIndexes, int(val.Index))
+	}
+
+	logger.Infof("fetching free index. Existing: %v, Max: %v", existingIndexes, maxDevices)
+	// gsamfira: fetch a free index number for this disk. There is a limit of 10 disks that can be attached to any
+	// instance. The index number dictates the order in which the operating system will see the disks
+	// Essentially an index for an attachment can be equated to the bus number that the disk will be made
+	// available on inside the guest. This way, an index number of 1 will be (on a linux host) xvda, index 2
+	// will be xvdb, and so on. One exception to this rule; if you boot an instance using an ephemeral disk
+	// (which we currently do), then inside the guest, that disk will be xvda. Index 1 will be xvdb, index 2
+	// will be xvdc and so on. Booting from ephemeral disks also has the added advantage that you get one
+	// extra disk attachment on the instance, and it saves us the trouble of running another operation to
+	// create the root disk from an image.
+	idx, err := s.getFreeIndexNumber(existingIndexes, maxDevices)
+	if err != nil {
+		return storage.AttachVolumesResult{Error: errors.Trace(err)}, nil
+	}
+
+	p := oci.StorageAttachmentParams{
+		Index:               ociCommon.Index(idx),
+		Instance_name:       instance.machine.Name,
+		Storage_volume_name: params.VolumeId,
+	}
+	details, err := s.api.CreateStorageAttachment(p)
+	if err != nil {
+		return storage.AttachVolumesResult{Error: errors.Trace(err)}, nil
+	}
+	if err := s.waitForResourceStatus(
+		s.fetchVolumeAttachmentStatus,
+		details.Name,
+		string(ociCommon.StateAttached), 5*time.Minute); err != nil {
+
+		currentAttachments[string(instance.Id())] = append(currentAttachments[string(instance.Id())], details)
+		return storage.AttachVolumesResult{Error: errors.Trace(err)}, nil
+	}
+	currentAttachments[string(instance.Id())] = append(currentAttachments[string(instance.Id())], details)
+
+	// TODO (gsamfira): make this more OS agnostic. In Windows you get disk indexes
+	// instead of device names; however storage is not supported on windows instances (yet).
+	result := storage.AttachVolumesResult{
+		VolumeAttachment: &storage.VolumeAttachment{
+			params.Volume,
+			params.Machine,
+			storage.VolumeAttachmentInfo{
+				DeviceName: s.getDeviceNameForIndex(idx),
+			},
+		},
+	}
+	return result, nil
+}
+
+// DetachVolumes is specified on the storage.VolumeSource interface.
+func (s *oracleVolumeSource) DetachVolumes(ctx context.ProviderCallContext, params []storage.VolumeAttachmentParams) ([]error, error) {
+	attachAsMap, err := s.getStorageAttachments()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	toDelete := make([]string, len(params))
+	ret := make([]error, len(params))
+	for i, val := range params {
+		found := false
+		for _, attach := range attachAsMap[string(val.InstanceId)] {
+			if val.VolumeId == attach.Storage_volume_name {
+				toDelete[i] = attach.Name
+				found = true
+			}
+		}
+		if !found {
+			toDelete[i] = ""
+			ret[i] = errors.NotFoundf(
+				"volume attachment for instance %v and volumeID %v not found",
+				val.InstanceId, val.VolumeId)
+		}
+	}
+	for i, val := range toDelete {
+		if val == "" {
+			continue
+		}
+		ret[i] = s.api.DeleteStorageAttachment(val)
+	}
+	return ret, nil
+}

--- a/provider/oracle/storage_volumes_test.go
+++ b/provider/oracle/storage_volumes_test.go
@@ -1,0 +1,400 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	"errors"
+
+	"github.com/juju/clock"
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/response"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/oracle"
+	oracletesting "github.com/juju/juju/provider/oracle/testing"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+type oracleVolumeSource struct {
+	testing.BaseSuite
+
+	callCtx context.ProviderCallContext
+}
+
+var _ = gc.Suite(&oracleVolumeSource{})
+
+func (s *oracleVolumeSource) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	oracletesting.DefaultFakeStorageAPI.ResetCalls()
+	// Reset name from changes in environ_test SetUpTest()
+	// not required here.
+	oracletesting.DefaultEnvironAPI.FakeInstance.All.Result[0].Name = "/Compute-a432100/sgiulitti@cloudbase.com/0/ebc4ce91-56bb-4120-ba78-13762597f837"
+	s.callCtx = context.NewCloudCallContext()
+}
+
+func (o *oracleVolumeSource) NewVolumeSource(
+	c *gc.C,
+	fakestorage *oracletesting.FakeStorageAPI,
+	fakeenv *oracletesting.FakeEnvironAPI,
+) storage.VolumeSource {
+
+	var client oracle.EnvironAPI
+	if fakeenv == nil {
+		client = &api.Client{}
+	} else {
+		client = fakeenv
+	}
+
+	environ, err := oracle.NewOracleEnviron(
+		&oracle.EnvironProvider{},
+		environs.OpenParams{
+			Config: testing.ModelConfig(c),
+		},
+		client,
+		&advancingClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(environ, gc.NotNil)
+	source, err := oracle.NewOracleVolumeSource(environ,
+		"controller-uuid",
+		"some-uuid-things-with-magic",
+		fakestorage,
+		clock.WallClock,
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(source, gc.NotNil)
+	return source
+}
+
+func (o *oracleVolumeSource) TestCreateVolumesWithEmptyParams(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	result, err := source.CreateVolumes(o.callCtx, nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.NotNil)
+}
+
+func (o *oracleVolumeSource) TestCreateVolumes(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	results, err := source.CreateVolumes(o.callCtx, []storage.VolumeParams{
+		{
+			Size:     uint64(10000),
+			Provider: oracle.DefaultTypes[0],
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, jc.ErrorIsNil)
+}
+
+func (o *oracleVolumeSource) TestCreateVolumesAlreadyExists(c *gc.C) {
+	source := o.NewVolumeSource(c, &oracletesting.FakeStorageAPI{
+		FakeComposer: oracletesting.FakeComposer{
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+		},
+		FakeStorageVolume: oracletesting.FakeStorageVolume{
+			StorageVolume: response.StorageVolume{
+				Name: "foo",
+				Size: 123 * 1024 * 1024,
+				Tags: []string{
+					"juju-model-uuid=some-uuid-things-with-magic",
+				},
+			},
+			CreateErr: &api.ErrStatusConflict{},
+		},
+	}, nil)
+	volumeTag := names.NewVolumeTag("666")
+	results, err := source.CreateVolumes(o.callCtx, []storage.VolumeParams{{
+		Tag:      volumeTag,
+		Size:     uint64(10000),
+		Provider: oracle.DefaultTypes[0],
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, jc.ErrorIsNil)
+	c.Assert(results[0].Volume, jc.DeepEquals, &storage.Volume{
+		volumeTag,
+		storage.VolumeInfo{
+			VolumeId:   "foo",
+			Size:       123,
+			Persistent: true,
+		},
+	})
+}
+
+func (o *oracleVolumeSource) TestCreateVolumeError(c *gc.C) {
+	fake := &oracletesting.FakeStorageAPI{
+		FakeComposer: oracletesting.FakeComposer{
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+		},
+		FakeStorageVolume: oracletesting.FakeStorageVolume{
+			CreateErr: errors.New("FakeStorageVolumeErr"),
+		},
+	}
+	source := o.NewVolumeSource(c, fake, nil)
+	results, err := source.CreateVolumes(o.callCtx, []storage.VolumeParams{
+		{
+			Size:     uint64(10000),
+			Provider: oracle.DefaultTypes[0],
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, gc.NotNil)
+	c.Assert(results[0].Error, gc.ErrorMatches, "FakeStorageVolumeErr")
+}
+
+func (o *oracleVolumeSource) TestListVolumes(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	volumes, err := source.ListVolumes(o.callCtx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(volumes, gc.NotNil)
+}
+
+func (o *oracleVolumeSource) TestListVolumesWithErrors(c *gc.C) {
+	for _, fake := range []*oracletesting.FakeStorageAPI{
+		{
+			FakeComposer: oracletesting.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeStorageVolume: oracletesting.FakeStorageVolume{
+				AllErr: errors.New("FakeStorageVolumeErr"),
+			},
+		},
+	} {
+		source := o.NewVolumeSource(c, fake, nil)
+		_, err := source.ListVolumes(o.callCtx)
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (o *oracleVolumeSource) TestDescribeVolumes(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	volumes, err := source.DescribeVolumes(o.callCtx, []string{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(volumes, gc.NotNil)
+
+	volumes, err = source.DescribeVolumes(o.callCtx, []string{"JujuTools_storage"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(volumes, gc.NotNil)
+}
+
+func (o *oracleVolumeSource) TestDescribeVolumesWithErrors(c *gc.C) {
+	for _, fake := range []*oracletesting.FakeStorageAPI{
+		{
+			FakeComposer: oracletesting.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeStorageVolume: oracletesting.FakeStorageVolume{
+				AllErr: errors.New("FakeStorageVolumeErr"),
+			},
+		},
+	} {
+		source := o.NewVolumeSource(c, fake, nil)
+		_, err := source.DescribeVolumes(o.callCtx, []string{"JujuTools_storage"})
+		c.Assert(err, gc.NotNil)
+	}
+}
+
+func (o *oracleVolumeSource) TestDestroyVolumes(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	errs, err := source.DestroyVolumes(o.callCtx, []string{"foo"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+}
+
+func (o *oracleVolumeSource) TestDestroyVolumesWithErrors(c *gc.C) {
+	for _, fake := range []*oracletesting.FakeStorageAPI{
+		{
+			FakeComposer: oracletesting.FakeComposer{
+				Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			},
+			FakeStorageVolume: oracletesting.FakeStorageVolume{
+				DeleteErr: errors.New("FakeStorageVolumeErr"),
+			},
+		},
+	} {
+		source := o.NewVolumeSource(c, fake, nil)
+		errs, err := source.DestroyVolumes(o.callCtx, []string{"JujuTools_storage"})
+		c.Assert(err, gc.IsNil)
+		for _, val := range errs {
+			c.Assert(val, gc.NotNil)
+		}
+	}
+}
+
+func (o *oracleVolumeSource) TestReleaseVolumes(c *gc.C) {
+	o.PatchValue(
+		&oracletesting.DefaultFakeStorageAPI.StorageVolume.Tags,
+		[]string{"abc", "juju-model-uuid=foo", "bar=baz"},
+	)
+
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	errs, err := source.ReleaseVolumes(o.callCtx, []string{"foo"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+
+	oracletesting.DefaultFakeStorageAPI.FakeStorageVolume.CheckCallNames(
+		c, "StorageVolumeDetails", "UpdateStorageVolume",
+	)
+	updateCall := oracletesting.DefaultFakeStorageAPI.FakeStorageVolume.Calls()[1]
+	arg0 := updateCall.Args[0].(api.StorageVolumeParams)
+	c.Assert(arg0.Tags, jc.DeepEquals, []string{"abc", "bar=baz"})
+}
+
+func (o *oracleVolumeSource) TestReleaseVolumesUnchanged(c *gc.C) {
+	// Volume has no tags, which means there's no update required.
+	o.PatchValue(
+		&oracletesting.DefaultFakeStorageAPI.StorageVolume.Tags,
+		[]string{},
+	)
+
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	errs, err := source.ReleaseVolumes(o.callCtx, []string{"foo"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+
+	oracletesting.DefaultFakeStorageAPI.FakeStorageVolume.CheckCallNames(
+		c, "StorageVolumeDetails",
+	)
+}
+
+func (o *oracleVolumeSource) TestImportVolume(c *gc.C) {
+	// Volume has no tags, which means there's no update required.
+	o.PatchValue(
+		&oracletesting.DefaultFakeStorageAPI.StorageVolume.Tags,
+		[]string{"abc"},
+	)
+
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	c.Assert(source, gc.Implements, new(storage.VolumeImporter))
+
+	info, err := source.(storage.VolumeImporter).ImportVolume(o.callCtx, "foo", map[string]string{"bar": "baz"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(info, jc.DeepEquals, storage.VolumeInfo{
+		VolumeId:   "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+		Size:       10,
+		Persistent: true,
+	})
+
+	oracletesting.DefaultFakeStorageAPI.FakeStorageVolume.CheckCallNames(
+		c, "StorageVolumeDetails", "UpdateStorageVolume",
+	)
+	updateCall := oracletesting.DefaultFakeStorageAPI.FakeStorageVolume.Calls()[1]
+	arg0 := updateCall.Args[0].(api.StorageVolumeParams)
+	c.Assert(arg0.Tags, jc.DeepEquals, []string{"abc", "bar=baz"})
+}
+
+func (o *oracleVolumeSource) TestValidateVolumeParamsWithError(c *gc.C) {
+	source := o.NewVolumeSource(c, nil, nil)
+	err := source.ValidateVolumeParams(
+		storage.VolumeParams{
+			Size: uint64(3921739812739812739),
+		},
+	)
+	c.Assert(err, gc.NotNil)
+}
+
+func (o *oracleVolumeSource) TestValidateVolumeParams(c *gc.C) {
+	source := o.NewVolumeSource(c, nil, nil)
+	err := source.ValidateVolumeParams(
+		storage.VolumeParams{
+			Size: uint64(9999),
+		},
+	)
+	c.Assert(err, gc.IsNil)
+}
+
+func (o *oracleVolumeSource) TestAttachVolumes(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, oracletesting.DefaultEnvironAPI)
+	_, err := source.AttachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
+		{
+			AttachmentParams: storage.AttachmentParams{
+				Provider:   oracle.DefaultTypes[0],
+				InstanceId: "0",
+				ReadOnly:   false,
+			},
+			VolumeId: "1",
+		},
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (o *oracleVolumeSource) TestDetachVolumes(c *gc.C) {
+	source := o.NewVolumeSource(c, oracletesting.DefaultFakeStorageAPI, nil)
+	errs, err := source.DetachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
+		{
+			AttachmentParams: storage.AttachmentParams{
+				Provider:   oracle.DefaultTypes[0],
+				InstanceId: "JujuTools_storage",
+				ReadOnly:   false,
+			},
+			VolumeId: "1",
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(errs, gc.NotNil)
+}
+
+func (o *oracleVolumeSource) TestDetachVolumesWithErrors(c *gc.C) {
+	source := o.NewVolumeSource(c, &oracletesting.FakeStorageAPI{
+		FakeComposer: oracletesting.FakeComposer{
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+		},
+		FakeStorageAttachment: oracletesting.FakeStorageAttachment{
+			AllErr: errors.New("FakeStorageAttachmentErr"),
+		}}, oracletesting.DefaultEnvironAPI)
+	_, err := source.DetachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
+		{
+			AttachmentParams: storage.AttachmentParams{
+				Provider:   oracle.DefaultTypes[0],
+				InstanceId: "JujuTools_storage",
+				ReadOnly:   false,
+			},
+			VolumeId: "1",
+		},
+	})
+	c.Assert(err, gc.NotNil)
+
+	source = o.NewVolumeSource(c, &oracletesting.FakeStorageAPI{
+		FakeComposer: oracletesting.FakeComposer{
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+		},
+		FakeStorageAttachment: oracletesting.FakeStorageAttachment{
+			All: response.AllStorageAttachments{
+				Result: []response.StorageAttachment{
+					{
+						Account:             nil,
+						Hypervisor:          nil,
+						Index:               1,
+						Instance_name:       "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837",
+						Storage_volume_name: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+						Name:                "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+						Readonly:            false,
+						State:               "attached",
+						Uri:                 "https://compute.uscom-central-1.oraclecloud.com/storage/attachment/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+					},
+				},
+			},
+			DeleteErr: errors.New("FakeStorageAttachmentErr")}}, oracletesting.DefaultEnvironAPI)
+	results, err := source.DetachVolumes(o.callCtx, []storage.VolumeAttachmentParams{
+		{
+			AttachmentParams: storage.AttachmentParams{
+				Provider:   oracle.DefaultTypes[0],
+				InstanceId: "JujuTools_storage",
+				ReadOnly:   false,
+			},
+			VolumeId: "1",
+		},
+	})
+
+	c.Assert(err, gc.IsNil)
+	for _, val := range results {
+		c.Assert(val, gc.NotNil)
+	}
+}

--- a/provider/oracle/testing/fakeenvironapi.go
+++ b/provider/oracle/testing/fakeenvironapi.go
@@ -1,0 +1,824 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/provider/oracle"
+)
+
+type FakeInstancer struct {
+	Instance    response.Instance
+	InstanceErr error
+}
+
+func (f FakeInstancer) InstanceDetails(string) (response.Instance, error) {
+	return f.Instance, f.InstanceErr
+}
+
+type FakeInstance struct {
+	Create    response.LaunchPlan
+	CreateErr error
+	All       response.AllInstances
+	AllErr    error
+	DeleteErr error
+}
+
+func (f FakeInstance) CreateInstance(api.InstanceParams) (response.LaunchPlan, error) {
+	return f.Create, f.CreateErr
+}
+
+func (f FakeInstance) AllInstances([]api.Filter) (response.AllInstances, error) {
+	return f.All, f.AllErr
+}
+
+func (f FakeInstance) DeleteInstance(string) error {
+	return f.DeleteErr
+}
+
+type FakeAuthenticater struct {
+	AuthenticateErr error
+}
+
+func (f FakeAuthenticater) Authenticate() error {
+	return f.AuthenticateErr
+}
+
+type FakeShaper struct {
+	All    response.AllShapes
+	AllErr error
+}
+
+func (f FakeShaper) AllShapes([]api.Filter) (response.AllShapes, error) {
+	return f.All, f.AllErr
+}
+
+type FakeImager struct {
+	All    response.AllImageLists
+	AllErr error
+}
+
+func (f FakeImager) AllImageLists([]api.Filter) (response.AllImageLists, error) {
+	return f.All, f.AllErr
+}
+
+func (f FakeImager) CreateImageList(def int, description string, name string) (resp response.ImageList, err error) {
+	return response.ImageList{}, nil
+}
+
+func (f FakeImager) CreateImageListEntry(
+	name string,
+	attributes map[string]interface{},
+	version int,
+	machineImages []string,
+) (resp response.ImageListEntryAdd, err error) {
+
+	return response.ImageListEntryAdd{}, nil
+}
+
+func (f FakeImager) DeleteImageList(name string) (err error) {
+	return nil
+}
+
+type FakeIpReservation struct {
+	All       response.AllIpReservations
+	AllErr    error
+	Update    response.IpReservation
+	UpdateErr error
+	Create    response.IpReservation
+	CreateErr error
+	DeleteErr error
+}
+
+func (f FakeIpReservation) AllIpReservations([]api.Filter) (response.AllIpReservations, error) {
+	return f.All, f.AllErr
+}
+
+func (f FakeIpReservation) UpdateIpReservation(string, string, common.IPPool, bool, []string) (response.IpReservation, error) {
+	return f.Update, f.UpdateErr
+}
+
+func (f FakeIpReservation) CreateIpReservation(string, common.IPPool, bool, []string) (response.IpReservation, error) {
+	return f.Create, f.CreateErr
+}
+
+func (f FakeIpReservation) DeleteIpReservation(string) error {
+	return f.DeleteErr
+}
+
+type FakeIpAssociation struct {
+	Create    response.IpAssociation
+	CreateErr error
+	DeleteErr error
+	All       response.AllIpAssociations
+	AllErr    error
+}
+
+func (f FakeIpAssociation) CreateIpAssociation(common.IPPool,
+	common.VcableID) (response.IpAssociation, error) {
+	return f.Create, f.CreateErr
+}
+
+func (f FakeIpAssociation) DeleteIpAssociation(string) error {
+	return f.DeleteErr
+}
+
+func (f FakeIpAssociation) AllIpAssociations([]api.Filter) (response.AllIpAssociations, error) {
+	return f.All, f.AllErr
+}
+
+type FakeIpNetworkExchanger struct {
+	All    response.AllIpNetworkExchanges
+	AllErr error
+}
+
+func (f FakeIpNetworkExchanger) AllIpNetworkExchanges([]api.Filter) (response.AllIpNetworkExchanges, error) {
+	return f.All, f.AllErr
+}
+
+type FakeIpNetworker struct {
+	All    response.AllIpNetworks
+	AllErr error
+}
+
+func (f FakeIpNetworker) AllIpNetworks([]api.Filter) (response.AllIpNetworks, error) {
+	return f.All, f.AllErr
+}
+
+type FakeVnicSet struct {
+	Create     response.VnicSet
+	CreateErr  error
+	VnicSet    response.VnicSet
+	VnicSetErr error
+	DeleteErr  error
+}
+
+func (f FakeVnicSet) DeleteVnicSet(string) error {
+	return f.DeleteErr
+}
+
+func (f FakeVnicSet) CreateVnicSet(api.VnicSetParams) (response.VnicSet, error) {
+	return f.Create, f.CreateErr
+}
+
+func (f FakeVnicSet) VnicSetDetails(string) (response.VnicSet, error) {
+	return f.VnicSet, f.VnicSetErr
+}
+
+type FakeEnvironAPI struct {
+	FakeInstancer
+	FakeInstance
+	FakeAuthenticater
+	FakeImager
+	FakeIpReservation
+	FakeIpAssociation
+	FakeIpNetworkExchanger
+	FakeIpNetworker
+	FakeVnicSet
+	FakeShaper
+
+	*FakeStorageAPI
+
+	FakeRules
+	FakeAcl
+	FakeSecIp
+	FakeIpAddressprefixSet
+	FakeSecList
+	FakeSecRules
+	FakeApplication
+	FakeAssociation
+}
+
+var _ oracle.EnvironAPI = (*FakeEnvironAPI)(nil)
+
+var (
+	DefaultFakeInstancer = FakeInstancer{
+		Instance: response.Instance{
+			Domain: "compute-a432100.oraclecloud.internal.",
+			Placement_requirements: []string{
+				"/system/compute/placement/default",
+				"/system/compute/allow_instances",
+			},
+			Ip:                     "10.31.5.106",
+			Fingerprint:            "",
+			Site:                   "",
+			Last_state_change_time: interface{}(nil),
+			Error_exception:        interface{}(nil),
+			Cluster:                interface{}(nil),
+			Shape:                  "oc5",
+			Start_requested:        false,
+			Vethernets:             interface{}(nil),
+			Imagelist:              "",
+			Image_format:           "raw",
+			Cluster_uri:            interface{}(nil),
+			Relationships:          []string{},
+			Target_node:            interface{}(nil),
+			Availability_domain:    "/uscom-central-1a",
+			Networking: common.Networking{
+				"eth0": common.Nic{
+					Dns: []string{
+						"ea63b8.compute-a432100.oraclecloud.internal.",
+					},
+					Model: "",
+					Nat:   "ippool:/oracle/public/ippool",
+					Seclists: []string{
+						"/Compute-a432100/default/default",
+					},
+					Vethernet: "/oracle/public/default",
+					Vnic:      "",
+					Ipnetwork: "",
+				},
+			},
+			Seclist_associations: interface{}(nil),
+			Hostname:             "ea63b8.compute-a432100.oraclecloud.internal.",
+			State:                "running",
+			Disk_attach:          "",
+			Label:                "tools",
+			Priority:             "/oracle/public/default",
+			Platform:             "linux",
+			Quota_reservation:    interface{}(nil),
+			Suspend_file:         interface{}(nil),
+			Node:                 interface{}(nil),
+			Resource_requirements: response.ResourceRequirments{
+				Compressed_size:   0x0,
+				Is_root_ssd:       false,
+				Ram:               0x0,
+				Cpus:              0,
+				Root_disk_size:    0x0,
+				Io:                0x0,
+				Decompressed_size: 0x0,
+				Gpus:              0x0,
+				Ssd_data_size:     0x0,
+			},
+			Virtio:        interface{}(nil),
+			Vnc:           "10.31.5.105:5900",
+			Desired_state: "running",
+			Storage_attachments: []response.Storage{
+				{
+					Index:               0x1,
+					Storage_volume_name: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+					Name:                "/Compute-a432100/sgiulitti@cloudbase.com/0/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+				},
+			},
+			Start_time: "2017-03-11T11:07:14Z", Storage_attachment_associations: []interface{}(nil),
+			Quota: "/Compute-a432100", Vnc_key: interface{}(nil),
+			Numerical_priority: 0x0,
+			Suspend_requested:  false,
+			Entry:              0,
+			Error_reason:       "",
+			Nat_associations:   interface{}(nil),
+			SSHKeys: []string{
+				"/Compute-a432100/sgiulitti@cloudbase.com/sgiulitti",
+			},
+			Tags: []string{
+				"vm-dev",
+				"juju-tools",
+				"toolsdir",
+				"/Compute-a432100/sgiulitti@cloudbase.com/0",
+				"16a4e037dd2068fe691aed9ed0c40460",
+			},
+			Resolvers: interface{}(nil),
+			Metrics:   interface{}(nil),
+			Account:   "/Compute-a432100/default",
+			Node_uuid: interface{}(nil),
+			Name:      "/Compute-a432100/sgiulitti@cloudbase.com/0/ebc4ce91-56bb-4120-ba78-13762597f837",
+			Vcable_id: "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6",
+			Higgs:     interface{}(nil),
+			Hypervisor: response.Hypervisor{
+				Mode: "hvm",
+			},
+			Uri:              "https://compute.uscom-central-1.oraclecloud.com/instance/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837",
+			Console:          interface{}(nil),
+			Reverse_dns:      true,
+			Launch_context:   "",
+			Delete_requested: interface{}(nil),
+			Tracking_id:      interface{}(nil),
+			Hypervisor_type:  interface{}(nil),
+			Attributes: response.Attributes{
+				Dns: map[string]string{
+					"domain":              "compute-a432100.oraclecloud.internal.",
+					"hostname":            "ea63b8.compute-a432100.oraclecloud.internal.",
+					"nimbula_vcable-eth0": "ea63b8.compute-a432100.oraclecloud.internal.",
+				},
+				Network: map[string]response.Network{
+					"nimbula_vcable-eth0": {
+						Address: []string{
+							"c6:b0:fd:f1:ef:ac",
+							"10.31.5.106",
+						},
+						Dhcp_options:   []string{},
+						Id:             "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6",
+						Model:          "",
+						Vethernet:      "/oracle/public/default",
+						Vethernet_id:   "0",
+						Vethernet_type: "vlan",
+						Instance:       "",
+						Ipassociations: []string(nil),
+						Ipattachment:   "",
+						Ipnetwork:      "",
+						Vnic:           "",
+						Vnicsets:       []string(nil),
+					},
+				},
+				Nimbula_orchestration: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_instance",
+				Sshkeys: []string{
+					"ssh-rsa AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+				},
+				Userdata: map[string]interface{}{}},
+			Boot_order: []int{1},
+			Last_seen:  interface{}(nil),
+		},
+	}
+
+	DefaultEnvironAPI = &FakeEnvironAPI{
+		FakeInstancer: DefaultFakeInstancer,
+		FakeInstance: FakeInstance{
+			Create: response.LaunchPlan{
+				Relationships: nil,
+				Instances: []response.Instance{
+					DefaultFakeInstancer.Instance,
+				},
+			},
+			CreateErr: nil,
+			All: response.AllInstances{
+				Result: []response.Instance{
+					DefaultFakeInstancer.Instance,
+				},
+			},
+			AllErr:    nil,
+			DeleteErr: nil,
+		},
+		FakeAuthenticater: FakeAuthenticater{
+			AuthenticateErr: nil,
+		},
+		FakeShaper: FakeShaper{
+			All: response.AllShapes{
+				Result: []response.Shape{
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0xf000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x174876e8000,
+						Gpus:           0x0,
+						Cpus:           8,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/ocio3m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "ocio3m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x7800,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           4,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc2m",
+						Root_disk_size: 0x0,
+						Io:             0x190,
+						Name:           "oc2m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0xf000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           8,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc3m",
+						Root_disk_size: 0x0,
+						Io:             0x258,
+						Name:           "oc3m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x3c00,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           4,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc4",
+						Root_disk_size: 0x0,
+						Io:             0x190,
+						Name:           "oc4",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0xf000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           16,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc6",
+						Root_disk_size: 0x0,
+						Io:             0x320,
+						Name:           "oc6",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x3c000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x5d21dba0000,
+						Gpus:           0x0,
+						Cpus:           32,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/ocio5m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "ocio5m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x7800,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0xba43b74000,
+						Gpus:           0x0,
+						Cpus:           4,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/ocio2m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "ocio2m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x1e00,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           2,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc3",
+						Root_disk_size: 0x0,
+						Io:             0xc8,
+						Name:           "oc3",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x7800,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           8,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc5",
+						Root_disk_size: 0x0,
+						Io:             0x258,
+						Name:           "oc5",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x1e000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           32,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc7",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "oc7",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x2d000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           48,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc8",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "oc8",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x1e000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           16,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc4m",
+						Root_disk_size: 0x0,
+						Io:             0x320,
+						Name:           "oc4m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x3c000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           32,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc5m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "oc5m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x3c00,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           2,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc1m",
+						Root_disk_size: 0x0,
+						Io:             0xc8,
+						Name:           "oc1m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x78000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           64,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc9m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "oc9m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x5a000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           48,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc8m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "oc8m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x3c000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x0,
+						Gpus:           0x0,
+						Cpus:           64,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/oc9",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "oc9",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x3c00,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x5d21dba000,
+						Gpus:           0x0,
+						Cpus:           2,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/ocio1m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "ocio1m",
+					},
+					{
+						Nds_iops_limit: 0x0,
+						Ram:            0x1e000,
+						Is_root_ssd:    false,
+						Ssd_data_size:  0x2e90edd0000,
+						Gpus:           0x0,
+						Cpus:           16,
+						Uri:            "https://compute.uscom-central-1.oraclecloud.com/shape/ocio4m",
+						Root_disk_size: 0x0,
+						Io:             0x3e8,
+						Name:           "ocio4m",
+					},
+				},
+			},
+			AllErr: nil,
+		},
+		FakeImager: FakeImager{
+			All: response.AllImageLists{
+				Result: []response.ImageList{
+					{
+						Default:     1,
+						Description: nil,
+						Entries: []response.ImageListEntry{
+							{
+								Attributes: response.AttributesEntry{
+									Userdata:        map[string]interface{}{"enable_rdp": "true"},
+									MinimumDiskSize: "27",
+									DefaultShape:    "oc4",
+									SupportedShapes: "oc1m,oc2m,oc3,oc3m,oc4,oc4m,oc5,oc5m,oc6,oc7,ocio1m,ocio2m,ocio3m,ocio4m,ocio5m,ociog1k80,ociog2k80,ociog3k80"},
+								Imagelist:     "",
+								Version:       1,
+								Machineimages: []string{"/Compute-a432100/sgiulitti@cloudbase.com/Microsoft_Windows_Server_2012_R2"},
+								Uri:           "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Microsoft_Windows_Server_2012_R2/entry/1",
+							},
+						},
+						Uri:  "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Microsoft_Windows_Server_2012_R2",
+						Name: "/Compute-a432100/sgiulitti@cloudbase.com/Microsoft_Windows_Server_2012_R2",
+					},
+					{
+						Default:     1,
+						Description: nil,
+						Entries: []response.ImageListEntry{
+							{
+								Attributes: response.AttributesEntry{
+									Userdata:        map[string]interface{}{},
+									MinimumDiskSize: "10",
+									DefaultShape:    "oc2m",
+									SupportedShapes: "oc3,oc4,oc5,oc6,oc7,oc1m,oc2m,oc3m,oc4m,oc5m",
+								},
+								Imagelist:     "",
+								Version:       1,
+								Machineimages: []string{"/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307"},
+								Uri:           "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307/entry/1",
+							},
+						},
+						Uri:  "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+						Name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+					},
+					{
+						Default:     1,
+						Description: nil,
+						Entries: []response.ImageListEntry{
+							{
+								Attributes: response.AttributesEntry{
+									Userdata:        map[string]interface{}{},
+									MinimumDiskSize: "10",
+									DefaultShape:    "oc2m",
+									SupportedShapes: "oc3,oc4,oc5,oc6,oc7,oc1m,oc2m,oc3m,oc4m,oc5m",
+								},
+								Imagelist: "",
+								Version:   1,
+								Machineimages: []string{
+									"/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.14.04-LTS.amd64.20170307",
+								},
+								Uri: "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Ubuntu.14.04-LTS.amd64.20170307/entry/1",
+							},
+						},
+						Uri:  "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Ubuntu.14.04-LTS.amd64.20170307",
+						Name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.14.04-LTS.amd64.20170307",
+					},
+					{
+						Default:     1,
+						Description: nil,
+						Entries: []response.ImageListEntry{
+							{
+								Attributes: response.AttributesEntry{
+									Userdata:        map[string]interface{}{},
+									MinimumDiskSize: "10",
+									DefaultShape:    "oc2m",
+									SupportedShapes: "oc3,oc4,oc5,oc6,oc7,oc1m,oc2m,oc3m,oc4m,oc5m",
+								},
+								Imagelist: "",
+								Version:   1,
+								Machineimages: []string{
+									"/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.12.04-LTS.amd64.20170307",
+								},
+								Uri: "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Ubuntu.12.04-LTS.amd64.20170307/entry/1",
+							},
+						},
+						Uri:  "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Ubuntu.12.04-LTS.amd64.20170307",
+						Name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.12.04-LTS.amd64.20170307",
+					},
+					{
+						Default:     1,
+						Description: nil,
+						Entries: []response.ImageListEntry{
+							{
+								Attributes: response.AttributesEntry{
+									Userdata:        map[string]interface{}{"enable_rdp": "true"},
+									MinimumDiskSize: "27",
+									DefaultShape:    "oc4",
+									SupportedShapes: "oc1m,oc2m,oc3,oc3m,oc4,oc4m,oc5,oc5m,oc6,oc7,ocio1m,ocio2m,ocio3m,ocio4m,ocio5m,ociog1k80,ociog2k80,ociog3k80",
+								},
+								Imagelist: "",
+								Version:   1,
+								Machineimages: []string{
+									"/Compute-a432100/sgiulitti@cloudbase.com/Microsoft_Windows_Server_2008_R2",
+								},
+								Uri: "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Microsoft_Windows_Server_2008_R2/entry/1",
+							},
+						},
+						Uri:  "https://compute.uscom-central-1.oraclecloud.com/imagelist/Compute-a432100/sgiulitti%40cloudbase.com/Microsoft_Windows_Server_2008_R2",
+						Name: "/Compute-a432100/sgiulitti@cloudbase.com/Microsoft_Windows_Server_2008_R2",
+					},
+				},
+			},
+			AllErr: nil,
+		},
+		FakeIpReservation: FakeIpReservation{
+			All: response.AllIpReservations{
+				Result: []response.IpReservation{
+					{
+						Account:    "/Compute-a432100/default",
+						Ip:         "129.150.66.1",
+						Name:       "/Compute-a432100/sgiulitti@cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+						Parentpool: "/oracle/public/ippool",
+						Permanent:  false,
+						Quota:      nil,
+						Tags:       []string{},
+						Uri:        "https://compute.uscom-central-1.oraclecloud.com/ip/reservation/Compute-a432100/sgiulitti%40cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+						Used:       true,
+					},
+				},
+			},
+			Update: response.IpReservation{
+				Account:    "/Compute-a432100/default",
+				Ip:         "129.150.66.1",
+				Name:       "/Compute-a432100/sgiulitti@cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+				Parentpool: "/oracle/public/ippool",
+				Permanent:  false,
+				Quota:      nil,
+				Tags:       []string{},
+				Uri:        "https://compute.uscom-central-1.oraclecloud.com/ip/reservation/Compute-a432100/sgiulitti%40cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+				Used:       true,
+			},
+			Create: response.IpReservation{
+				Account:    "/Compute-a432100/default",
+				Ip:         "129.150.66.1",
+				Name:       "/Compute-a432100/sgiulitti@cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+				Parentpool: "/oracle/public/ippool",
+				Permanent:  false,
+				Quota:      nil,
+				Tags:       []string{},
+				Uri:        "https://compute.uscom-central-1.oraclecloud.com/ip/reservation/Compute-a432100/sgiulitti%40cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+				Used:       true,
+			},
+			UpdateErr: nil,
+			CreateErr: nil,
+			AllErr:    nil,
+			DeleteErr: nil,
+		},
+		FakeIpAssociation: FakeIpAssociation{
+			All: response.AllIpAssociations{
+				Result: []response.IpAssociation{
+					{
+						Account:     "/Compute-a432100/default",
+						Ip:          "129.150.66.1",
+						Name:        "/Compute-a432100/sgiulitti@cloudbase.com/f490e701-c68f-415d-a166-b75f1e1116d4",
+						Parentpool:  "ippool:/oracle/public/ippool",
+						Reservation: "/Compute-a432100/sgiulitti@cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+						Uri:         "https://compute.uscom-central-1.oraclecloud.com/ip/association/Compute-a432100/sgiulitti%40cloudbase.com/f490e701-c68f-415d-a166-b75f1e1116d4",
+						Vcable:      "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6",
+					},
+				},
+			},
+			AllErr: nil,
+			Create: response.IpAssociation{
+				Account:     "/Compute-a432100/default",
+				Ip:          "129.150.66.1",
+				Name:        "/Compute-a432100/sgiulitti@cloudbase.com/f490e701-c68f-415d-a166-b75f1e1116d4",
+				Parentpool:  "ippool:/oracle/public/ippool",
+				Reservation: "/Compute-a432100/sgiulitti@cloudbase.com/29286b89-8d91-45b7-8a3a-78fffa2109b9",
+				Uri:         "https://compute.uscom-central-1.oraclecloud.com/ip/association/Compute-a432100/sgiulitti%40cloudbase.com/f490e701-c68f-415d-a166-b75f1e1116d4",
+				Vcable:      "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6",
+			},
+			CreateErr: nil,
+			DeleteErr: nil,
+		},
+		FakeIpNetworkExchanger: FakeIpNetworkExchanger{
+			All: response.AllIpNetworkExchanges{
+				Result: []response.IpNetworkExchange{
+					{
+						Description: nil,
+						Name:        "/Compute-a432100/sgiulitti@cloudbase.com/dbsql",
+						Tags:        []string{},
+						Uri:         "https://compute.uscom-central-1.oraclecloud.com:443/network/v1/ipnetworkexchange/Compute-a432100/sgiulitti@cloudbase.com/dbsql",
+					},
+					{
+						Description: nil,
+						Name:        "/Compute-a432100/sgiulitti@cloudbase.com/test",
+						Tags:        []string{},
+						Uri:         "https://compute.uscom-central-1.oraclecloud.com:443/network/v1/ipnetworkexchange/Compute-a432100/sgiulitti@cloudbase.com/test",
+					},
+				},
+			},
+			AllErr: nil,
+		},
+		FakeIpNetworker: FakeIpNetworker{
+			All: response.AllIpNetworks{
+				Result: []response.IpNetwork{
+					{
+						Description:           nil,
+						IpAddressPrefix:       "120.120.120.0/24",
+						IpNetworkExchange:     nil,
+						Name:                  "/Compute-a432100/sgiulitti@cloudbase.com/juju-charm-db",
+						PublicNaptEnabledFlag: false,
+						Tags:                  []string{},
+						Uri:                   "https://compute.uscom-central-1.oraclecloud.com:443/network/v1/ipnetwork/Compute-a432100/sgiulitti@cloudbase.com/juju-charm-db",
+					},
+				},
+			},
+			AllErr: nil,
+		},
+		FakeVnicSet: FakeVnicSet{
+			VnicSetErr: nil,
+			CreateErr:  nil,
+			DeleteErr:  nil,
+		},
+		FakeStorageAPI:  DefaultFakeStorageAPI,
+		FakeRules:       DefaultFakeRules,
+		FakeApplication: DefaultSecApplications,
+		FakeSecIp:       DefaultSecIp,
+		FakeSecList:     DefaultFakeSecList,
+		FakeAssociation: DefaultFakeAssociation,
+		FakeAcl:         DefaultFakeAcl,
+		FakeSecRules:    DefaultFakeSecrules,
+	}
+)

--- a/provider/oracle/testing/fakefirewall.go
+++ b/provider/oracle/testing/fakefirewall.go
@@ -1,0 +1,459 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+
+	"github.com/juju/juju/provider/oracle/network"
+)
+
+// FakeRules implement common.RuleAPI interface
+type FakeRules struct {
+	All       response.AllSecRules
+	AllErr    error
+	Create    response.SecRule
+	CreateErr error
+	DeleteErr error
+}
+
+var _ network.FirewallerAPI = (*FakeFirewallAPI)(nil)
+
+func (f FakeRules) AllSecRules([]api.Filter) (response.AllSecRules, error) {
+	return f.All, f.AllErr
+}
+func (f FakeRules) CreateSecRule(api.SecRuleParams) (response.SecRule, error) {
+	return f.Create, f.CreateErr
+}
+func (f FakeRules) DeleteSecRule(name string) error {
+	return f.DeleteErr
+}
+
+// FakeAcl implements the common.AclAPI interface
+type FakeAcl struct {
+	Acls      response.AllAcls
+	Acl       response.Acl
+	AclErr    error
+	Create    response.Acl
+	CreateErr error
+	DeleteErr error
+}
+
+func (f FakeAcl) AclDetails(string) (response.Acl, error) {
+	return f.Acl, f.AclErr
+}
+
+func (f FakeAcl) CreateAcl(string, string, bool, []string) (response.Acl, error) {
+	return f.Create, f.CreateErr
+}
+
+func (f FakeAcl) DeleteAcl(string) error {
+	return f.DeleteErr
+}
+
+func (f FakeAcl) AllAcls([]api.Filter) (response.AllAcls, error) {
+	return f.Acls, nil
+}
+
+// FakeSecIp implements common.SecIpAPI interface
+type FakeSecIp struct {
+	All           response.AllSecIpLists
+	AllErr        error
+	Create        response.SecIpList
+	CreateErr     error
+	AllDefault    response.AllSecIpLists
+	AllDefaultErr error
+}
+
+func (f FakeSecIp) AllSecIpLists([]api.Filter) (response.AllSecIpLists, error) {
+	return f.All, f.AllErr
+}
+
+func (f FakeSecIp) CreateSecIpList(string, string, []string) (response.SecIpList, error) {
+	return f.Create, f.CreateErr
+}
+func (f FakeSecIp) AllDefaultSecIpLists([]api.Filter) (response.AllSecIpLists, error) {
+	return f.AllDefault, f.AllDefaultErr
+}
+
+// FakeIpAddressPrefixSet type implements the common.IpAddressPrefixSetAPI interface
+type FakeIpAddressprefixSet struct {
+	Create    response.IpAddressPrefixSet
+	CreateErr error
+	All       response.AllIpAddressPrefixSets
+	AllErr    error
+}
+
+func (f FakeIpAddressprefixSet) CreateIpAddressPrefixSet(
+	api.IpAddressPrefixSetParams) (response.IpAddressPrefixSet, error) {
+	return f.Create, f.CreateErr
+}
+
+func (f FakeIpAddressprefixSet) AllIpAddressPrefixSets(
+	[]api.Filter,
+) (response.AllIpAddressPrefixSets, error) {
+	return f.All, f.AllErr
+}
+
+// FakeSecList implement the common.SecListAPI interface
+type FakeSecList struct {
+	SecList    response.SecList
+	SecListErr error
+	DeleteErr  error
+	Create     response.SecList
+	CreateErr  error
+}
+
+func (f FakeSecList) SecListDetails(string) (response.SecList, error) {
+	return f.SecList, f.SecListErr
+}
+func (f FakeSecList) DeleteSecList(string) error {
+	return f.DeleteErr
+}
+func (f FakeSecList) CreateSecList(string, string, common.SecRuleAction, common.SecRuleAction) (response.SecList, error) {
+	return f.Create, f.CreateErr
+}
+
+// type FakeSecRules imeplements the common.SecRulesAPI interface
+type FakeSecRules struct {
+	All       response.AllSecurityRules
+	AllErr    error
+	DeleteErr error
+	Create    response.SecurityRule
+	CreateErr error
+}
+
+func (f FakeSecRules) AllSecurityRules([]api.Filter) (response.AllSecurityRules, error) {
+	return f.All, f.AllErr
+}
+func (f FakeSecRules) DeleteSecurityRule(string) error {
+	return f.DeleteErr
+}
+func (f FakeSecRules) CreateSecurityRule(
+	api.SecurityRuleParams,
+) (response.SecurityRule, error) {
+	return f.Create, f.CreateErr
+}
+
+// FakeApplications type implements the common.ApplicationsAPI
+type FakeApplication struct {
+	All        response.AllSecApplications
+	AllErr     error
+	Default    response.AllSecApplications
+	DefaultErr error
+	Create     response.SecApplication
+	CreateErr  error
+}
+
+func (f FakeApplication) AllSecApplications([]api.Filter) (response.AllSecApplications, error) {
+	return f.All, f.AllErr
+}
+
+func (f FakeApplication) DefaultSecApplications([]api.Filter) (response.AllSecApplications, error) {
+	return f.Default, f.DefaultErr
+}
+
+func (f FakeApplication) CreateSecApplication(api.SecApplicationParams) (response.SecApplication, error) {
+	return f.Create, f.CreateErr
+}
+
+type FakeAssociation struct {
+	All    response.AllSecAssociations
+	AllErr error
+}
+
+func (f FakeAssociation) AllSecAssociations([]api.Filter) (response.AllSecAssociations, error) {
+	return f.All, f.AllErr
+}
+
+// FakeFirewallAPI used to mock the internal Firewaller implementation
+// This type implements the network.FirewallerAPI interface
+type FakeFirewallAPI struct {
+	FakeComposer
+	FakeRules
+	FakeAcl
+	FakeSecIp
+	FakeIpAddressprefixSet
+	FakeSecList
+	FakeSecRules
+	FakeApplication
+	FakeAssociation
+}
+
+var (
+	DefaultFakeRules = FakeRules{
+		All: response.AllSecRules{
+			Result: []response.SecRule{
+				{
+					Action:      common.SecRulePermit,
+					Application: "/Compute-acme/jack.jones@example.com/video_streaming_udp",
+					Name:        "/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+					Dst_list:    "seclist:/Compute-acme/jack.jones@example.com/allowed_video_servers",
+					Src_list:    "seciplist:/Compute-acme/jack.jones@example.com/es_iplist",
+					Uri:         "https://api-z999.compute.us0.oraclecloud.com/secrule/Compute-acme/jack.jones@example.com/es_to_videoservers_stream",
+					Src_is_ip:   "true",
+					Dst_is_ip:   "false",
+				},
+			},
+		},
+		AllErr: nil,
+	}
+
+	DefaultSecApplications = FakeApplication{
+		All: response.AllSecApplications{
+			Result: []response.SecApplication{
+				{
+					Description: "Juju created security application",
+					Dport:       "17070",
+					Icmpcode:    "",
+					Icmptype:    "",
+					Name:        "/Compute-a432100/sgiulitti@cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-7993630e-d13b-43a3-850e-a1778c7e394e",
+					Protocol:    "tcp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/Compute-a432100/sgiulitti%40cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-7993630e-d13b-43a3-850e-a1778c7e394e",
+					Value1:      17070,
+					Value2:      -1,
+					Id:          "1869cb17-5b12-49c5-a09a-046da8899bc9",
+				},
+				{
+					Description: "Juju created security application",
+					Dport:       "37017",
+					Icmpcode:    "",
+					Icmptype:    "",
+					Name:        "/Compute-a432100/sgiulitti@cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-ef8a7955-4315-47a2-83c1-8d2978ab77c7",
+					Protocol:    "tcp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/Compute-a432100/sgiulitti%40cloudbase.com/juju-72324bcb-e837-4542-8867-844282af22e3-ef8a7955-4315-47a2-83c1-8d2978ab77c7",
+					Value1:      37017,
+					Value2:      -1,
+					Id:          "cbefdac0-7684-4f81-a575-825c175aa7b4",
+				},
+			},
+		},
+		AllErr: nil,
+		Default: response.AllSecApplications{
+			Result: []response.SecApplication{
+				{
+					Description: "",
+					Dport:       "",
+					Icmpcode:    "",
+					Icmptype:    "",
+					Name:        "/oracle/public/all",
+					Protocol:    "all",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/all",
+					Value1:      0,
+					Value2:      0,
+					Id:          "381c2267-1b38-4bbd-b53d-5149deddb094",
+				},
+				{
+					Description: "",
+					Dport:       "",
+					Icmpcode:    "",
+					Icmptype:    "echo",
+					Name:        "/oracle/public/pings",
+					Protocol:    "icmp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/pings",
+					Value1:      8,
+					Value2:      0,
+					Id:          "57b0350b-2f02-4a2d-b5ec-cf731de36027",
+				},
+				{
+					Description: "",
+					Dport:       "",
+					Icmpcode:    "",
+					Icmptype:    "",
+					Name:        "/oracle/public/icmp",
+					Protocol:    "icmp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/icmp",
+					Value1:      255,
+					Value2:      255,
+					Id:          "abb27ccd-1872-48f9-86ef-38c72d6f8a38",
+				},
+				{
+					Description: "",
+					Dport:       "",
+					Icmpcode:    "",
+					Icmptype:    "reply",
+					Name:        "/oracle/public/ping-reply",
+					Protocol:    "icmp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/ping-reply",
+					Value1:      0,
+					Value2:      0,
+					Id:          "3ad808d4-b740-42c1-805c-57feb7c96d40",
+				},
+				{
+					Description: "",
+					Dport:       "3306",
+					Icmpcode:    "",
+					Icmptype:    "",
+					Name:        "/oracle/public/mysql",
+					Protocol:    "tcp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/mysql",
+					Value1:      3306,
+					Value2:      -1,
+					Id:          "2fb5eaff-3127-4334-8b03-367a44bb83bd",
+				},
+				{
+					Description: "",
+					Dport:       "22",
+					Icmpcode:    "",
+					Icmptype:    "",
+					Name:        "/oracle/public/ssh",
+					Protocol:    "tcp",
+					Uri:         "https://compute.uscom-central-1.oraclecloud.com/secapplication/oracle/public/ssh",
+					Value1:      22, Value2: -1,
+					Id: "5f027043-f6b3-4e1a-b9fa-a10d075744de",
+				},
+			},
+		},
+		DefaultErr: nil,
+	}
+
+	DefaultSecIp = FakeSecIp{
+		All: response.AllSecIpLists{
+			Result: []response.SecIpList{
+				{
+					Description: nil,
+					Name:        "/oracle/public/site",
+					Secipentries: []string{
+						"10.60.32.128/26",
+						"10.60.32.0/26",
+						"10.60.37.0/26",
+						"10.60.33.0/26",
+						"10.60.36.128/26",
+						"10.60.36.0/26",
+					},
+					Uri:      "https://compute.uscom-central-1.oraclecloud.com/seciplist/oracle/public/site",
+					Group_id: "1003",
+					Id:       "492ad26e-4c86-44bb-a439-535614d25f56",
+				},
+				{
+					Description: nil,
+					Name:        "/oracle/public/paas-infra",
+					Secipentries: []string{
+						"10.199.34.192/26",
+						"160.34.15.48/29",
+						"100.64.0.0/24",
+					},
+					Uri:      "https://compute.uscom-central-1.oraclecloud.com/seciplist/oracle/public/paas-infra",
+					Group_id: "1006",
+					Id:       "a671b8b6-2422-45ef-84fc-c65010f0c1a5",
+				},
+				{
+					Description: nil,
+					Name:        "/oracle/public/instance",
+					Secipentries: []string{
+						"10.31.0.0/19",
+						"10.2.0.0/26",
+						"10.16.0.0/19",
+						"10.31.32.0/19",
+						"10.16.64.0/19",
+						"10.16.32.0/19",
+						"10.16.128.0/19",
+						"10.16.160.0/19",
+						"10.16.192.0/19",
+						"10.16.224.0/19",
+						"10.28.192.0/19",
+						"10.28.224.0/19",
+					},
+					Uri:      "https://compute.uscom-central-1.oraclecloud.com/seciplist/oracle/public/instance",
+					Group_id: "1004",
+					Id:       "5c3a5100-ced7-43f8-a5cd-10dce263db33",
+				},
+				{
+					Description:  nil,
+					Name:         "/oracle/public/public-internet",
+					Secipentries: []string{"0.0.0.0/0"},
+					Uri:          "https://compute.uscom-central-1.oraclecloud.com/seciplist/oracle/public/public-internet",
+					Group_id:     "1002",
+					Id:           "26fc6f14-4c3c-4059-a813-8a76ff141a0b",
+				},
+			},
+		},
+		AllErr: nil,
+	}
+
+	DefaultFakeSecList = FakeSecList{
+		SecList: response.SecList{
+			Account:              "/Compute-acme/default",
+			Name:                 "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			Uri:                  "https://api-z999.compute.us0.oraclecloud.com/seclist/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			Outbound_cidr_policy: "PERMIT",
+			Policy:               common.SecRulePermit,
+		},
+		SecListErr: nil,
+		Create: response.SecList{
+			Account:              "/Compute-acme/default",
+			Name:                 "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			Uri:                  "https://api-z999.compute.us0.oraclecloud.com/seclist/Compute-acme/jack.jones@example.com/allowed_video_servers",
+			Outbound_cidr_policy: "PERMIT",
+			Policy:               common.SecRuleDeny,
+		},
+		CreateErr: nil,
+	}
+
+	DefaultFakeAssociation = FakeAssociation{
+		All: response.AllSecAssociations{
+			Result: []response.SecAssociation{
+				{
+					Name:    "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6/9e5c3f31-1769-46b6-bdc3-b8f3db0f0479",
+					Seclist: "/Compute-a432100/default/default",
+					Vcable:  "/Compute-a432100/sgiulitti@cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6",
+					Uri:     "https://compute.uscom-central-1.oraclecloud.com/secassociation/Compute-a432100/sgiulitti%40cloudbase.com/faa46f2e-28c9-4500-b060-0997717540a6/9e5c3f31-1769-46b6-bdc3-b8f3db0f0479",
+				},
+			},
+		},
+		AllErr: nil,
+	}
+
+	DefaultFakeAcl = FakeAcl{
+		Acl: response.Acl{
+			Name:        "/Compute-a432100/gsamfira@cloudbase.com/juju-b3329a64-58f5-416c-85f7-e24de0beb979-0",
+			Description: "ACL for machine 0",
+			EnableFlag:  false,
+			Tags:        []string{},
+			Uri:         "https://compute.uscom-central-1.oraclecloud.com:443/network/v1/acl/Compute-a432100/gsamfira@cloudbase.com/juju-b3329a64-58f5-416c-85f7-e24de0beb979-0",
+		},
+		AclErr: nil,
+		Create: response.Acl{
+			Name:        "/Compute-a432100/gsamfira@cloudbase.com/juju-b3329a64-58f5-416c-85f7-e24de0beb979-0",
+			Description: "ACL for machine 0",
+			EnableFlag:  false,
+			Tags:        []string{},
+			Uri:         "https://compute.uscom-central-1.oraclecloud.com:443/network/v1/acl/Compute-a432100/gsamfira@cloudbase.com/juju-b3329a64-58f5-416c-85f7-e24de0beb979-0",
+		},
+	}
+
+	DefaultFakeSecrules = FakeSecRules{
+		All:    response.AllSecurityRules{},
+		AllErr: nil,
+		Create: response.SecurityRule{
+			Name:                   "/Compute-acme/jack.jones@example.com/secrule1",
+			Uri:                    "https://api-z999.compute.us0.oraclecloud.com:443/network/v1/secrule/Compute-acme/jack.jones@example.com/secrule1",
+			Description:            "Sample security rule",
+			Tags:                   nil,
+			Acl:                    "/Compute-acme/jack.jones@example.com/acl1",
+			FlowDirection:          common.Egress,
+			SrcVnicSet:             "/Compute-acme/jack.jones@example.com/vnicset1",
+			DstVnicSet:             "/Compute-acme/jack.jones@example.com/vnicset2",
+			SrcIpAddressPrefixSets: []string{"/Compute-acme/jack.jones@example.com/ipaddressprefixset1"},
+			DstIpAddressPrefixSets: nil,
+			SecProtocols:           []string{"/Compute-acme/jack.jones@example.com/secprotocol1"},
+			EnabledFlag:            true,
+		},
+	}
+
+	DefaultFakeFirewallAPI = &FakeFirewallAPI{
+		FakeComposer: FakeComposer{
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+		},
+		FakeRules:       DefaultFakeRules,
+		FakeApplication: DefaultSecApplications,
+		FakeSecIp:       DefaultSecIp,
+		FakeSecList:     DefaultFakeSecList,
+		FakeAssociation: DefaultFakeAssociation,
+		FakeAcl:         DefaultFakeAcl,
+		FakeSecRules:    DefaultFakeSecrules,
+	}
+)

--- a/provider/oracle/testing/fakestorageapi.go
+++ b/provider/oracle/testing/fakestorageapi.go
@@ -1,0 +1,277 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/go-oracle-cloud/api"
+	"github.com/juju/go-oracle-cloud/common"
+	"github.com/juju/go-oracle-cloud/response"
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/provider/oracle"
+)
+
+// FakeComposer implements common.Composer interface
+type FakeComposer struct {
+	Compose string
+}
+
+func (f FakeComposer) ComposeName(name string) string {
+	return f.Compose
+}
+
+// FakeStorageVolume implements the common.StorageVolumeAPI
+type FakeStorageVolume struct {
+	testing.Stub
+
+	StorageVolume    response.StorageVolume
+	StorageVolumeErr error
+	Create           response.StorageVolume
+	CreateErr        error
+	All              response.AllStorageVolumes
+	AllErr           error
+	DeleteErr        error
+	Update           response.StorageVolume
+	UpdateErr        error
+}
+
+var _ oracle.StorageAPI = (*FakeStorageAPI)(nil)
+
+func (f *FakeStorageVolume) AllStorageVolumes(filter []api.Filter) (response.AllStorageVolumes, error) {
+	f.MethodCall(f, "AllStorageVolumes", filter)
+	return f.All, f.AllErr
+}
+
+func (f *FakeStorageVolume) StorageVolumeDetails(name string) (response.StorageVolume, error) {
+	f.MethodCall(f, "StorageVolumeDetails", name)
+	return f.StorageVolume, f.StorageVolumeErr
+}
+
+func (f *FakeStorageVolume) CreateStorageVolume(params api.StorageVolumeParams) (response.StorageVolume, error) {
+	f.MethodCall(f, "CreateStorageVolume", params)
+	return f.Create, f.CreateErr
+}
+
+func (f *FakeStorageVolume) DeleteStorageVolume(name string) error {
+	f.MethodCall(f, "DeleteStorageVolume", name)
+	return f.DeleteErr
+}
+
+func (f *FakeStorageVolume) UpdateStorageVolume(params api.StorageVolumeParams, name string) (response.StorageVolume, error) {
+	f.MethodCall(f, "UpdateStorageVolume", params, name)
+	return f.Update, f.UpdateErr
+}
+
+// FakeStorageAttachment implements the common.FakeStorageAttachmentAPI
+type FakeStorageAttachment struct {
+	Create               response.StorageAttachment
+	CreateErr            error
+	DeleteErr            error
+	All                  response.AllStorageAttachments
+	AllErr               error
+	StorageAttachment    response.StorageAttachment
+	StorageAttachmentErr error
+}
+
+func (f FakeStorageAttachment) CreateStorageAttachment(api.StorageAttachmentParams) (response.StorageAttachment, error) {
+	return f.Create, f.CreateErr
+}
+func (f FakeStorageAttachment) DeleteStorageAttachment(string) error {
+	return f.DeleteErr
+}
+func (f FakeStorageAttachment) StorageAttachmentDetails(string) (response.StorageAttachment, error) {
+	return f.StorageAttachment, f.StorageAttachmentErr
+}
+func (f FakeStorageAttachment) AllStorageAttachments([]api.Filter) (response.AllStorageAttachments, error) {
+	return f.All, f.AllErr
+}
+
+// FakeStorageAPi used to mock the internal StorageAPI imeplementation
+// This type implements the StorageAPI interface
+type FakeStorageAPI struct {
+	FakeComposer
+	FakeStorageVolume
+	FakeStorageAttachment
+}
+
+var (
+	DefaultAllStorageVolumes = response.AllStorageVolumes{
+		Result: []response.StorageVolume{
+			{
+				Account:           "/Compute-a432100/default",
+				Bootable:          true,
+				Description:       nil,
+				Hypervisor:        nil,
+				Imagelist:         "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Imagelist_entry:   1,
+				Machineimage_name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Managed:           true,
+				Name:              "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+				Platform:          "linux",
+				Properties: []common.StoragePool{
+					"/oracle/public/storage/default",
+				},
+				Quota:            nil,
+				Readonly:         false,
+				Shared:           false,
+				Size:             10,
+				Snapshot:         nil,
+				Snapshot_account: "",
+				Snapshot_id:      "",
+				Status:           "Online",
+				Status_detail:    "",
+				Status_timestamp: "2017-04-06T14:23:54Z",
+				Storage_pool:     "/uscom-central-1/chi1-opc-c10r310-zfs-1-v1/storagepool/iscsi",
+				Tags:             []string{},
+				Uri:              "https://compute.uscom-central-1.oraclecloud.com/storage/volume/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools_storage",
+				Writecache:       false,
+			},
+		},
+	}
+
+	DefaultFakeStorageAPI = &FakeStorageAPI{
+		FakeComposer: FakeComposer{
+			Compose: "/Compute-acme/jack.jones@example.com/allowed_video_servers",
+		},
+		FakeStorageVolume: FakeStorageVolume{
+			All:    DefaultAllStorageVolumes,
+			AllErr: nil,
+			StorageVolume: response.StorageVolume{
+				Account:           "/Compute-a432100/default",
+				Bootable:          true,
+				Description:       nil,
+				Hypervisor:        nil,
+				Imagelist:         "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Imagelist_entry:   1,
+				Machineimage_name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Managed:           true,
+				Name:              "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+				Platform:          "linux",
+				Properties: []common.StoragePool{
+					"/oracle/public/storage/default",
+				},
+				Quota:            nil,
+				Readonly:         false,
+				Shared:           false,
+				Size:             10485760,
+				Snapshot:         nil,
+				Snapshot_account: "",
+				Snapshot_id:      "",
+				Status:           "Online",
+				Status_detail:    "",
+				Status_timestamp: "2017-04-06T14:23:54Z",
+				Storage_pool:     "/uscom-central-1/chi1-opc-c10r310-zfs-1-v1/storagepool/iscsi",
+				Tags:             []string{},
+				Uri:              "https://compute.uscom-central-1.oraclecloud.com/storage/volume/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools_storage",
+				Writecache:       false,
+			},
+			StorageVolumeErr: nil,
+			DeleteErr:        nil,
+			Create: response.StorageVolume{
+				Account:           "/Compute-a432100/default",
+				Bootable:          true,
+				Description:       nil,
+				Hypervisor:        nil,
+				Imagelist:         "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Imagelist_entry:   1,
+				Machineimage_name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Managed:           true,
+				Name:              "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+				Platform:          "linux",
+				Properties: []common.StoragePool{
+					"/oracle/public/storage/default",
+				},
+				Quota:            nil,
+				Readonly:         false,
+				Shared:           false,
+				Size:             10,
+				Snapshot:         nil,
+				Snapshot_account: "",
+				Snapshot_id:      "",
+				Status:           "Online",
+				Status_detail:    "",
+				Status_timestamp: "2017-04-06T14:23:54Z",
+				Storage_pool:     "/uscom-central-1/chi1-opc-c10r310-zfs-1-v1/storagepool/iscsi",
+				Tags:             []string{},
+				Uri:              "https://compute.uscom-central-1.oraclecloud.com/storage/volume/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools_storage",
+				Writecache:       false,
+			},
+			CreateErr: nil,
+			Update: response.StorageVolume{
+				Account:           "/Compute-a432100/default",
+				Bootable:          true,
+				Description:       nil,
+				Hypervisor:        nil,
+				Imagelist:         "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Imagelist_entry:   1,
+				Machineimage_name: "/Compute-a432100/sgiulitti@cloudbase.com/Ubuntu.16.04-LTS.amd64.20170307",
+				Managed:           true,
+				Name:              "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+				Platform:          "linux",
+				Properties: []common.StoragePool{
+					"/oracle/public/storage/default",
+				},
+				Quota:            nil,
+				Readonly:         false,
+				Shared:           false,
+				Size:             10,
+				Snapshot:         nil,
+				Snapshot_account: "",
+				Snapshot_id:      "",
+				Status:           "Online",
+				Status_detail:    "",
+				Status_timestamp: "2017-04-06T14:23:54Z",
+				Storage_pool:     "/uscom-central-1/chi1-opc-c10r310-zfs-1-v1/storagepool/iscsi",
+				Tags:             []string{},
+				Uri:              "https://compute.uscom-central-1.oraclecloud.com/storage/volume/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools_storage",
+				Writecache:       false,
+			},
+
+			UpdateErr: nil,
+		},
+		FakeStorageAttachment: FakeStorageAttachment{
+			All: response.AllStorageAttachments{
+				Result: []response.StorageAttachment{
+					{
+						Account:             nil,
+						Hypervisor:          nil,
+						Index:               1,
+						Instance_name:       "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837",
+						Storage_volume_name: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+						Name:                "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+						Readonly:            false,
+						State:               "attached",
+						Uri:                 "https://compute.uscom-central-1.oraclecloud.com/storage/attachment/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+					},
+				},
+			},
+			AllErr: nil,
+			StorageAttachment: response.StorageAttachment{
+				Account:             nil,
+				Hypervisor:          nil,
+				Index:               1,
+				Instance_name:       "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837",
+				Storage_volume_name: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+				Name:                "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+				Readonly:            false,
+				State:               "attached",
+				Uri:                 "https://compute.uscom-central-1.oraclecloud.com/storage/attachment/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+			},
+			StorageAttachmentErr: nil,
+			Create: response.StorageAttachment{
+				Account:             nil,
+				Hypervisor:          nil,
+				Index:               1,
+				Instance_name:       "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837",
+				Storage_volume_name: "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools_storage",
+				Name:                "/Compute-a432100/sgiulitti@cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+				Readonly:            false,
+				State:               "attached",
+				Uri:                 "https://compute.uscom-central-1.oraclecloud.com/storage/attachment/Compute-a432100/sgiulitti%40cloudbase.com/JujuTools/ebc4ce91-56bb-4120-ba78-13762597f837/1f90e657-f852-45ad-afbf-9a94f640a7ae",
+			},
+			CreateErr: nil,
+			DeleteErr: nil,
+		},
+	}
+)

--- a/provider/oracle/userdata.go
+++ b/provider/oracle/userdata.go
@@ -1,0 +1,25 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle
+
+import (
+	"github.com/juju/errors"
+	jujuos "github.com/juju/os"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/cloudconfig/providerinit/renderers"
+)
+
+// OracleRenderer implements the renderers.ProviderRenderer interface
+type OracleRenderer struct{}
+
+// Renderer is defined in the renderers.ProviderRenderer interface
+func (OracleRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
+	switch os {
+	case jujuos.Ubuntu:
+		return renderers.RenderYAML(cfg)
+	default:
+		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
+	}
+}

--- a/provider/oracle/userdata_test.go
+++ b/provider/oracle/userdata_test.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oracle_test
+
+import (
+	jujuos "github.com/juju/os"
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/provider/oracle"
+)
+
+type userdataSuite struct {
+	gitjujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&userdataSuite{})
+
+func (s *userdataSuite) TestRedner(c *gc.C) {
+	renderer := oracle.OracleRenderer{}
+	cfg, err := cloudinit.New("trusty")
+	c.Assert(err, gc.IsNil)
+	c.Assert(cfg, gc.NotNil)
+
+	_, err = renderer.Render(cfg, jujuos.Ubuntu)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *userdataSuite) TestRenderWithErrors(c *gc.C) {
+	renderer := oracle.OracleRenderer{}
+	cfg, err := cloudinit.New("trusty")
+	c.Assert(err, gc.IsNil)
+	c.Assert(cfg, gc.NotNil)
+
+	for _, val := range []jujuos.OSType{
+		jujuos.Windows,
+		jujuos.CentOS,
+		jujuos.Unknown,
+		jujuos.OSX,
+	} {
+		_, err := renderer.Render(cfg, val)
+		c.Assert(err, gc.NotNil)
+	}
+}


### PR DESCRIPTION
This commit reverts the deletion of the Oracle Classic provider, while keeping the changes to the feature tests made to enable its removal in-place. 

Note: OCI is the only provider available via `juju list-clouds`, but the "oracle" cloud type is available for any pre-existing cloud definitions. In essence, this retains backwards compatibility without advertising oracle classic's availability.  

## QA steps

Ensure that Oracle Classic clouds can still be operated on via Juju.

Here is the current output from `juju list-clouds`:

```plain
$ juju list-clouds
Cloud           Regions  Default          Type        Description
aws                  15  us-east-1        ec2         Amazon Web Services
aws-china             2  cn-north-1       ec2         Amazon China
aws-gov               1  us-gov-west-1    ec2         Amazon (USA Government)
azure                27  centralus        azure       Microsoft Azure
azure-china           2  chinaeast        azure       Microsoft Azure China
cloudsigma           12  dub              cloudsigma  CloudSigma Cloud
google               18  us-east1         gce         Google Cloud Platform
joyent                6  us-east-1        joyent      Joyent Cloud
oracle                4  us-phoenix-1     oci         Oracle Cloud Infrastructure
oracle-classic        5  uscom-central-1  oracle      Oracle Cloud Infrastructure Classic
rackspace             6  dfw              rackspace   Rackspace Cloud
localhost             1  localhost        lxd         LXD Container Hypervisor
```

## Documentation changes

n/a

## Bug reference

n/a