### PR TITLE
Ensure that we handle the case of non-LXD

### DIFF
--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -405,6 +405,10 @@ func (p *containerProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) 
 }
 
 func (p *containerProvisioner) getProfileWatcher() (watcher.StringsWatcher, error) {
+	// Note: we don't care what type the container is when watching. The
+	// provisioner task will make this become a no-op.
+	// Also we'll always clean up any documents once the uniter has finished
+	// deploying/upgrading a charm.
 	machine, err := p.getMachine()
 	if err != nil {
 		return nil, err

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -405,10 +405,6 @@ func (p *containerProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) 
 }
 
 func (p *containerProvisioner) getProfileWatcher() (watcher.StringsWatcher, error) {
-	if p.containerType != instance.LXD {
-		// TODO (hml) lxd-profile 17-oct-2018
-		// what is the correct way to handle this, only start for LXD containers
-	}
 	machine, err := p.getMachine()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Supersedes https://github.com/juju/juju/pull/9470

## Description of change

We actually don't care about this TODO, as we handle it in other
ways, which include:

 - Only provisioning the correct machine/container with the correct
   provisioner task. If the provisioner task doesn't support the
   lxd profile, then this becomes a no-op.
 - In the #9513 PR we always clean up after a lxd profile, so that
   any documents created in this process are never left in an
   orphan state.

## QA steps

N/A

## Documentation changes

All providers are treated equally, as long as we always clean
up after ourselves.
