### PR TITLE
Ensure we handle situations where profile is empty

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -97,7 +97,7 @@ func (a *API) CharmInfo(args params.CharmURL) (params.CharmInfo, error) {
 
 	// we don't need to check that this is a charm.LXDProfiler, as we can
 	// state that the function exists.
-	if profile := aCharm.LXDProfile(); !profile.Empty() {
+	if profile := aCharm.LXDProfile(); profile != nil && !profile.Empty() {
 		info.LXDProfile = convertCharmLXDProfile(profile)
 	}
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -646,7 +646,9 @@ func fetchAllApplicationsAndUnits(
 			continue
 		}
 		chName := lxdprofile.Name(model.Name(), app.Name(), ch.Revision())
-		lxdProfiles[chName] = ch.LXDProfile()
+		if profile := ch.LXDProfile(); profile != nil {
+			lxdProfiles[chName] = profile
+		}
 	}
 
 	for baseURL := range latestCharms {


### PR DESCRIPTION
## Description of change

The following checks to see if the profile might be empty when
getting the information about the charm. As charm profiles can
sometimes be nil, that check is encoded into the codebase
throughout, except here.

A drive by is also added to the status output to ensure that we
also don't print nil if the upgrade happens and there is no lxd
profile, yet there is a placeholder for it.

## QA steps

```
git checkout 2.4
JUJU_MAKE_GODEPS=true make godeps
make go-install
juju bootstrap localhost xxx --build-agent=true
juju deploy $APP app1
juju upgrade-juju -m controller --agent-version 2.5-beta3
juju deploy $APP app2
```

## Documentation changes

Ensure that we can upgrade the controller to the latest version
of the 2.5 release, from a 2.x release.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1806331
