### PR TITLE
WIP: Old-style, non-multiseries charms should not support all series.

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -1313,10 +1313,14 @@ func (a *Application) VerifySupportedSeries(series string, force bool) error {
 	if err != nil {
 		return err
 	}
-	_, seriesSupportedErr := charm.SeriesForCharm(series, ch.Meta().Series)
+	supportedSeries := ch.Meta().Series
+	if len(supportedSeries) == 0 {
+		supportedSeries = append(supportedSeries, ch.URL().Series)
+	}
+	_, seriesSupportedErr := charm.SeriesForCharm(series, supportedSeries)
 	if seriesSupportedErr != nil && !force {
 		return &ErrIncompatibleSeries{
-			SeriesList: ch.Meta().Series,
+			SeriesList: supportedSeries,
 			Series:     series,
 			CharmName:  ch.String(),
 		}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -4057,3 +4057,12 @@ func (s *ApplicationSuite) TestSetOperatorStatus(c *gc.C) {
 	c.Assert(appStatus.Status, gc.DeepEquals, status.Error)
 	c.Assert(appStatus.Message, gc.DeepEquals, "broken")
 }
+
+func (s *ApplicationSuite) TestCharmLegacyOnlySupportsOneSeries(c *gc.C) {
+	ch := state.AddTestingCharmForSeries(c, s.State, "precise", "mysql")
+	app := s.AddTestingApplication(c, "legacy-charm", ch)
+	err := app.VerifySupportedSeries("precise", false)
+	c.Assert(err, jc.ErrorIsNil)
+	err = app.VerifySupportedSeries("xenial", false)
+	c.Assert(err, gc.ErrorMatches, "series \"xenial\" not supported by charm \"local:precise/precise-mysql-1\", supported series are: precise")
+}


### PR DESCRIPTION
## Description of change

Charms that don't list any series in their metadata (i.e legacy non-multiseries charms), in some cases validated against all valid series. This change corrects that behavior. For example `juju` allows a deployed Wordpress charm to be set to any series even though the documentation for `set-series` indicates that only series supported by the charm should be allowed.

## QA steps

`juju deploy wordpress`
`juju set-series wordpress cosmic`

The above now errors whereas before it would work fine.