### PR TITLE
raft leases: Forward commands concurrently

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,11 +81,14 @@
   source = "github.com/juju/gosigma"
 
 [[projects]]
-  digest = "1:8e384478a0e2aa016605896748d186832db7b7350a975bb26aa53ca702d19573"
+  digest = "1:0a776e52fa4deb432e3c382436ed79c2e20fb6fd02061782c11e3e3a58b86d78"
   name = "github.com/armon/go-metrics"
-  packages = ["."]
+  packages = [
+    ".",
+    "prometheus",
+  ]
   pruneopts = ""
-  revision = "93f237eba9b0602f3e73710416558854a81d9337"
+  revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[projects]]
   digest = "1:de184b64adb3054bea074db0b1be1327c7dc3aaa04e3fd6cb01f62f339caecd5"
@@ -313,11 +316,27 @@
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
+  digest = "1:c5466dfad4c14bf8e52a34b0eb98f1301acc1e304e0f0ff2c51c356ca1b86747"
+  name = "github.com/hashicorp/go-immutable-radix"
+  packages = ["."]
+  pruneopts = ""
+  revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:6396690228a7560bf9247cb90e5ae9c797bd630b01e7d2acab430bbca9a1ecb3"
   name = "github.com/hashicorp/go-msgpack"
   packages = ["codec"]
   pruneopts = ""
   revision = "fa3f63826f7c23912c15263591e65d54d080b458"
+
+[[projects]]
+  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
+  name = "github.com/hashicorp/golang-lru"
+  packages = ["simplelru"]
+  pruneopts = ""
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
   digest = "1:3dea8a64498e503e13eaa87133ab0c5423988a67f739e52273631230cf15a428"
@@ -1770,6 +1789,8 @@
     "github.com/altoros/gosigma",
     "github.com/altoros/gosigma/data",
     "github.com/altoros/gosigma/mock",
+    "github.com/armon/go-metrics",
+    "github.com/armon/go-metrics/prometheus",
     "github.com/bmizerany/pat",
     "github.com/coreos/go-systemd/dbus",
     "github.com/coreos/go-systemd/unit",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -203,7 +203,7 @@
 
 [[override]]
   name = "github.com/armon/go-metrics"
-  revision = "93f237eba9b0602f3e73710416558854a81d9337"
+  revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[override]]
   name = "github.com/beorn7/perks"

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -857,14 +857,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The global lease manager tracks lease information in the raft
 		// cluster rather than in mongo.
 		leaseManagerName: ifController(leasemanager.Manifold(leasemanager.ManifoldConfig{
-			AgentName:      agentName,
-			ClockName:      clockName,
-			CentralHubName: centralHubName,
-			FSM:            leaseFSM,
-			RequestTopic:   leaseRequestTopic,
-			Logger:         loggo.GetLogger("juju.worker.lease.raft"),
-			NewWorker:      leasemanager.NewWorker,
-			NewStore:       leasemanager.NewStore,
+			AgentName:         agentName,
+			ClockName:         clockName,
+			CentralHubName:    centralHubName,
+			FSM:               leaseFSM,
+			RequestTopic:      leaseRequestTopic,
+			Logger:            loggo.GetLogger("juju.worker.lease.raft"),
+			MetricsRegisterer: config.PrometheusRegisterer,
+			NewWorker:         leasemanager.NewWorker,
+			NewStore:          leasemanager.NewStore,
 		})),
 
 		validCredentialFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -290,7 +290,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	controllerTag := agentConfig.Controller()
 
 	leaseFSM := raftlease.NewFSM()
-	raft.RegisterMetrics(config.PrometheusRegisterer)
+	if config.PrometheusRegisterer != nil {
+		raft.RegisterMetrics(config.PrometheusRegisterer)
+	}
 
 	manifolds := dependency.Manifolds{
 		// The agent manifold references the enclosing agent, and is the

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -290,6 +290,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	controllerTag := agentConfig.Controller()
 
 	leaseFSM := raftlease.NewFSM()
+	raft.RegisterMetrics(config.PrometheusRegisterer)
 
 	manifolds := dependency.Manifolds{
 		// The agent manifold references the enclosing agent, and is the

--- a/core/raftlease/metrics.go
+++ b/core/raftlease/metrics.go
@@ -21,7 +21,7 @@ func newMetricsCollector() *metricsCollector {
 	return &metricsCollector{
 		requests: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Namespace: "juju_raftlease",
-			Name:      "request_time",
+			Name:      "request",
 			Help:      "Request times for lease store operations in ms",
 			Objectives: map[float64]float64{
 				0.5:  0.05,
@@ -35,10 +35,12 @@ func newMetricsCollector() *metricsCollector {
 	}
 }
 
+// Describe is part of prometheus.Collector.
 func (c *metricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	c.requests.Describe(ch)
 }
 
+// Collect is part of prometheus.Collector.
 func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 	c.requests.Collect(ch)
 }

--- a/core/raftlease/metrics.go
+++ b/core/raftlease/metrics.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_raftlease"
+)
+
+// metricsCollector is a prometheus.Collector that collects metrics
+// about lease store operations.
+type metricsCollector struct {
+	requests *prometheus.SummaryVec
+}
+
+func newMetricsCollector() *metricsCollector {
+	return &metricsCollector{
+		requests: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace: "juju_raftlease",
+			Name:      "request_time",
+			Help:      "Request times for lease store operations in ms",
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		}, []string{
+			"operation", // claim, extend, pin, unpin or settime
+			"result",    // success, failure, timeout or error
+		}),
+	}
+}
+
+func (c *metricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.requests.Describe(ch)
+}
+
+func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
+	c.requests.Collect(ch)
+}

--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft
+
+import (
+	"github.com/armon/go-metrics"
+	pmetrics "github.com/armon/go-metrics/prometheus"
+	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// RegisterMetrics connects the metrics gathered in the
+// hashicorp/raft library code with our prometheus collector.
+func RegisterMetrics(registerer prometheus.Registerer) error {
+	sink, err := pmetrics.NewPrometheusSink()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	registerer.Unregister(sink)
+	if err := registerer.Register(sink); err != nil {
+		return errors.Trace(err)
+	}
+	_, err = metrics.NewGlobal(metrics.DefaultConfig("jujumetrics"), sink)
+	return errors.Trace(err)
+}

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -132,6 +132,7 @@ func (w *forwarder) handleRequest(_ string, req raftlease.ForwardRequest, err er
 func (w *forwarder) processRequest(command string) (raftlease.ForwardResponse, error) {
 	var empty raftlease.ForwardResponse
 	future := w.config.Raft.Apply([]byte(command), applyTimeout)
+	w.config.Logger.Tracef("%d: after apply", w.id)
 	if err := future.Error(); err != nil {
 		return empty, errors.Trace(err)
 	}
@@ -140,7 +141,9 @@ func (w *forwarder) processRequest(command string) (raftlease.ForwardResponse, e
 	if !ok {
 		return empty, errors.Errorf("expected an FSMResponse, got %T: %#v", respValue, respValue)
 	}
+	w.config.Logger.Tracef("%d: after fsm response", w.id)
 	response.Notify(w.config.Target)
+	w.config.Logger.Tracef("%d: after notify", w.id)
 	return responseFromError(response.Error()), nil
 }
 


### PR DESCRIPTION
## Description of change

Using raft leases on a controller with much slower IO revealed that the lease commands were being applied one-at-a-time - I didn't realise it, but pubsub callbacks are processed sequentially, not as the messages come in. This doesn't cause an apparent problem on a machine where the disk is very fast (even when in HA and with lots of applications) but with a slow disk and many applications it can mean that requests come in faster than they're applied, and all the lease operations start timing out. 

Change the forwarder to apply commands in parallel - the raft library expects this and puts more commands into the heartbeat messages to dramatically improve throughput.

Adds lots of trace logging and Prometheus metrics to provide more insight into what's happening in the raft lease store and inside the raft node.

## QA steps

* Bootstrap a controller on a machine with slow disk and enable HA.
* Deploy more than 100 applications.
* Monitor the raft lease request times with Prometheus or juju_metrics.
* Ensure that the values are well under the 5 second threshold.
* Watch for timeouts - we shouldn't see these increasing unless the controller is still starting or there has just been a raft leader election.
* Create a new unit and remove the current leader - ensure that leadership is transferred.

## Documentation changes
None
