### PR TITLE
Change to State for Model Generations.

### DIFF
--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package model
 
 // GenerationVersion indicates a generation to use for model config.

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -1,0 +1,15 @@
+package model
+
+// GenerationVersion indicates a generation to use for model config.
+type GenerationVersion string
+
+const (
+	// GenerationCurrent indicates the current generation for model config.
+	// This is the default state of a model.
+	GenerationCurrent GenerationVersion = "current"
+
+	// GenerationNext indicates the next generation of model config.
+	// Models with an active "next" generation apply the generation config
+	// selectively to units added to the generation.
+	GenerationNext GenerationVersion = "next"
+)

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -432,6 +432,14 @@ func allCollections() collectionSchema {
 		// unit relation settings, model config, etc etc etc.
 		settingsC: {},
 
+		// The generations collection holds data about
+		// active and completed "next" model generations.
+		generationsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
+
 		constraintsC:        {},
 		storageConstraintsC: {},
 		deviceConstraintsC:  {},
@@ -578,6 +586,7 @@ const (
 	applicationsC              = "applications"
 	endpointBindingsC          = "endpointbindings"
 	settingsC                  = "settings"
+	generationsC               = "generations"
 	refcountsC                 = "refcounts"
 	sshHostKeysC               = "sshhostkeys"
 	spacesC                    = "spaces"

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -436,7 +436,7 @@ func allCollections() collectionSchema {
 		// active and completed "next" model generations.
 		generationsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"model-uuid"},
+				Key: []string{"model-uuid", "completed"},
 			}},
 		},
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -26,6 +26,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		modelUserLastConnectionC,
 		permissionsC,
 		settingsC,
+		generationsC,
 		sequenceC,
 		sshHostKeysC,
 		statusesC,
@@ -519,7 +520,7 @@ func (s *MigrationSuite) TestRelationScopeDocFields(c *gc.C) {
 	s.AssertExportedFields(c, relationScopeDoc{}, fields)
 }
 
-func (s *MigrationSuite) TestAnnatatorDocFields(c *gc.C) {
+func (s *MigrationSuite) TestAnnotatorDocFields(c *gc.C) {
 	fields := set.NewStrings(
 		// ModelUUID shouldn't be exported, and is inherited
 		// from the model definition.

--- a/state/model.go
+++ b/state/model.go
@@ -28,7 +28,7 @@ import (
 // settings and constraints.
 const modelGlobalKey = "e"
 
-// modelKey will create the kei for a given model using the modelGlobalKey.
+// modelKey will create the key for a given model using the modelGlobalKey.
 func modelKey(modelUUID string) string {
 	return fmt.Sprintf("%s#%s", modelGlobalKey, modelUUID)
 }

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -107,7 +107,10 @@ func (g *Generation) canComplete(allowEmpty bool) (bool, error) {
 	}
 
 	for app, units := range g.doc.AssignedUnits {
-		if allowEmpty && len(units) == 0 {
+		if len(units) == 0 {
+			if !allowEmpty {
+				return false, nil
+			}
 			continue
 		}
 

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package state
 
 import (

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -95,20 +95,20 @@ func (m *Model) AddGeneration() error {
 // A new generation can not be added for a model that has an existing
 // generation that is not completed.
 func (st *State) AddGeneration() error {
-	if _, err := st.NextGeneration(); err != nil {
-		if !errors.IsNotFound(err) {
-			return errors.Annotatef(err, "checking for next model generation")
-		}
-	} else {
-		return errors.Errorf("model has a next generation that is not completed")
-	}
-
 	seq, err := sequence(st, "generation")
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if _, err := st.NextGeneration(); err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, errors.Annotatef(err, "checking for next model generation")
+			}
+		} else {
+			return nil, errors.Errorf("model has a next generation that is not completed")
+		}
+
 		return insertGenerationTxnOps(strconv.Itoa(seq)), nil
 	}
 	err = st.db().Run(buildTxn)

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -82,7 +82,6 @@ func (st *State) getNextGenerationDoc(modelUUID string) (*generationDoc, error) 
 
 	var err error
 	doc := &generationDoc{}
-
 	err = col.Find(bson.D{
 		{"model-uuid", modelUUID},
 		{"completed", 0},
@@ -122,7 +121,7 @@ func (st *State) AddGeneration(modelUUID string) error {
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if _, err := st.NextGeneration(modelUUID); err != nil {
-			if err != mgo.ErrNotFound {
+			if errors.IsNotFound(err) {
 				return nil, errors.Annotatef(err, "checking model %q for next generation", modelUUID)
 			}
 		} else {

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -1,8 +1,9 @@
 package state
 
 import (
+	"strconv"
+
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -10,6 +11,8 @@ import (
 
 // generationDoc represents the state of a model generation in MongoDB.
 type generationDoc struct {
+	Id string `bson:"generation-id"`
+
 	// ModelUUID indicates the model to which this generation applies.
 	ModelUUID string `bson:"model-uuid"`
 
@@ -32,13 +35,18 @@ type generationDoc struct {
 
 	// Completed, if set, indicates when this generation was completed and
 	// effectively became the current model generation.
-	Completed int64 `bson:"updated"`
+	Completed int64 `bson:"completed"`
 }
 
 // Generation represents the state of a model generation.
 type Generation struct {
 	st  *State
 	doc generationDoc
+}
+
+// Id is unique ID for the generation within a model.
+func (g *Generation) Id() string {
+	return g.doc.Id
 }
 
 // ModelUUID returns the ID of the model to which this generation applies.
@@ -61,53 +69,54 @@ func (g *Generation) AssignedUnits() map[string]string {
 
 // AddGeneration creates a new "next" generation for the model.
 func (m *Model) AddGeneration() error {
-	return errors.Trace(m.st.AddGeneration(m.UUID()))
+	return errors.Trace(m.st.AddGeneration())
 }
 
 // AddGeneration creates a new "next" generation for the input model ID.
 // The inserted generation is active, meaning the model's current generation
 // becomes "next" immediately.
-// A new generation can be added for a model that has an existing generation
-// that is not completed.
-func (st *State) AddGeneration(modelUUID string) error {
-	if !names.IsValidModel(modelUUID) {
-		return errors.Errorf("%q is not a valid model UUID", modelUUID)
+// A new generation can not be added for a model that has an existing
+// generation that is not completed.
+func (st *State) AddGeneration() error {
+	if _, err := st.NextGeneration(); err != nil {
+		if !errors.IsNotFound(err) {
+			mod, _ := st.modelName()
+			return errors.Annotatef(err, "checking model %q for next generation", mod)
+		}
+	} else {
+		mod, _ := st.modelName()
+		return errors.Errorf("model %q has a next generation that is not completed", mod)
+	}
+
+	seq, err := sequence(st, "generation")
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		if _, err := st.NextGeneration(modelUUID); err != nil {
-			if errors.IsNotFound(err) {
-				return nil, errors.Annotatef(err, "checking model %q for next generation", modelUUID)
-			}
-		} else {
-			return nil, errors.Errorf("model %q has a next generation that is not completed", modelUUID)
-		}
-		return insertGenerationOps(modelUUID), nil
+		return insertGenerationOps(strconv.Itoa(seq)), nil
 	}
 
-	err := st.db().Run(buildTxn)
+	err = st.db().Run(buildTxn)
 	if err != nil {
 		err = onAbort(err, ErrDead)
-		logger.Errorf("cannot create new generation for model %q: %v", modelUUID, err)
+		mod, _ := st.modelName()
+		logger.Errorf("cannot create new generation for model %q: %v", mod, err)
 	}
 	return err
 }
 
-func insertGenerationOps(modelUUID string) []txn.Op {
+func insertGenerationOps(id string) []txn.Op {
 	doc := &generationDoc{
-		ModelUUID:     modelUUID,
+		Id:            id,
 		Active:        true,
 		AssignedUnits: map[string]string{},
 	}
 
 	return []txn.Op{
 		{
-			C:      modelsC,
-			Id:     modelUUID,
-			Assert: txn.DocExists,
-		},
-		{
-			C:      machineUpgradeSeriesLocksC,
+			C:      generationsC,
+			Id:     id,
 			Insert: doc,
 		},
 	}
@@ -116,38 +125,37 @@ func insertGenerationOps(modelUUID string) []txn.Op {
 // NextGeneration returns the model's "next" generation
 // if one exists that is not yet completed.
 func (m *Model) NextGeneration() (*Generation, error) {
-	gen, err := m.st.NextGeneration(m.UUID())
+	gen, err := m.st.NextGeneration()
 	return gen, errors.Trace(err)
 }
 
 // NextGeneration returns the "next" generation
 // if one exists for the input model, that is not yet completed.
-func (st *State) NextGeneration(modelUUID string) (*Generation, error) {
-	doc, err := st.getNextGenerationDoc(modelUUID)
+func (st *State) NextGeneration() (*Generation, error) {
+	doc, err := st.getNextGenerationDoc()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return newGeneration(st, doc), nil
 }
 
-func (st *State) getNextGenerationDoc(modelUUID string) (*generationDoc, error) {
+func (st *State) getNextGenerationDoc() (*generationDoc, error) {
 	col, closer := st.db().GetCollection(generationsC)
 	defer closer()
 
 	var err error
 	doc := &generationDoc{}
-	err = col.Find(bson.D{
-		{"model-uuid", modelUUID},
-		{"completed", 0},
-	}).One(doc)
+	err = col.Find(bson.D{{"completed", 0}}).One(doc)
 
 	switch err {
 	case nil:
 		return doc, nil
 	case mgo.ErrNotFound:
-		return nil, errors.NotFoundf("active model generation for %s", modelUUID)
+		mod, _ := st.modelName()
+		return nil, errors.NotFoundf("next generation for %q", mod)
 	default:
-		return nil, errors.Annotatef(err, "retrieving active model generation for %s", modelUUID)
+		mod, _ := st.modelName()
+		return nil, errors.Annotatef(err, "retrieving next generation for %q", mod)
 	}
 }
 

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -2,14 +2,14 @@ package state
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // generationDoc represents the state of a model generation in MongoDB.
 type generationDoc struct {
-	UUID string `bson:"_id"`
-
 	// ModelUUID indicates the model to which this generation applies.
 	ModelUUID string `bson:"model-uuid"`
 
@@ -85,7 +85,7 @@ func (st *State) getNextGenerationDoc(modelUUID string) (*generationDoc, error) 
 
 	err = col.Find(bson.D{
 		{"model-uuid", modelUUID},
-		{"completed", bson.D{{"$exists", false}}},
+		{"completed", 0},
 	}).One(doc)
 
 	switch err {
@@ -102,5 +102,59 @@ func newGeneration(st *State, doc *generationDoc) *Generation {
 	return &Generation{
 		st:  st,
 		doc: *doc,
+	}
+}
+
+// AddGeneration creates a new "next" generation for the model.
+func (m *Model) AddGeneration() error {
+	return errors.Trace(m.st.AddGeneration(m.UUID()))
+}
+
+// AddGeneration creates a new "next" generation for the input model ID.
+// The inserted generation is active, meaning the model's current generation
+// becomes "next" immediately.
+// A new generation can be added for a model that has an existing generation
+// that is not completed.
+func (st *State) AddGeneration(modelUUID string) error {
+	if !names.IsValidModel(modelUUID) {
+		return errors.Errorf("%q is not a valid model UUID", modelUUID)
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if _, err := st.NextGeneration(modelUUID); err != nil {
+			if err != mgo.ErrNotFound {
+				return nil, errors.Annotatef(err, "checking model %q for next generation", modelUUID)
+			}
+		} else {
+			return nil, errors.Errorf("model %q has a next generation that is not completed", modelUUID)
+		}
+		return insertGenerationOps(modelUUID), nil
+	}
+
+	err := st.db().Run(buildTxn)
+	if err != nil {
+		err = onAbort(err, ErrDead)
+		logger.Errorf("cannot create new generation for model %q: %v", modelUUID, err)
+	}
+	return err
+}
+
+func insertGenerationOps(modelUUID string) []txn.Op {
+	doc := &generationDoc{
+		ModelUUID:     modelUUID,
+		Active:        true,
+		AssignedUnits: map[string]string{},
+	}
+
+	return []txn.Op{
+		{
+			C:      modelsC,
+			Id:     modelUUID,
+			Assert: txn.DocExists,
+		},
+		{
+			C:      machineUpgradeSeriesLocksC,
+			Insert: doc,
+		},
 	}
 }

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -1,0 +1,106 @@
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// generationDoc represents the state of a model generation in MongoDB.
+type generationDoc struct {
+	UUID string `bson:"_id"`
+
+	// ModelUUID indicates the model to which this generation applies.
+	ModelUUID string `bson:"model-uuid"`
+
+	// Active indicates whether this generation is currently the
+	// active one for the model.
+	// If true, the current model generation is indicated as "next" and
+	// configuration values applied to this generation are
+	// represented in its assigned units.
+	// If false, the current model generation is "current";
+	// configuration changes are applied in the standard fashion
+	// and apply as usual to units not yet in the generation.
+	Active bool `bson:"active"`
+
+	// AssignedUnits is a map of unit IDs that are in the generation,
+	// keyed by application ID.
+	// An application ID can be present without any unit IDs,
+	// which indicates that it has configuration changes applied in the
+	// generation, but no units currently set to be in it.
+	AssignedUnits map[string]string `bson:"assigned-units"`
+
+	// Completed, if set, indicates when this generation was completed and
+	// effectively became the current model generation.
+	Completed int64 `bson:"updated"`
+}
+
+// Generation represents the state of a model generation.
+type Generation struct {
+	st  *State
+	doc generationDoc
+}
+
+// ModelUUID returns the ID of the model to which this generation applies.
+func (g *Generation) ModelUUID() string {
+	return g.doc.ModelUUID
+}
+
+// Active indicates the whether the model generation is currently active.
+// true:  active model generation = "next"
+// false: active model generation = "current"
+func (g *Generation) Active() bool {
+	return g.doc.Active
+}
+
+// AssignedUnits returns the unit IDs, keyed by application ID
+// that have been assigned to this generation.
+func (g *Generation) AssignedUnits() map[string]string {
+	return g.doc.AssignedUnits
+}
+
+// NextGeneration returns the model's "next" generation
+// if one exists that is not yet completed.
+func (m *Model) NextGeneration() (*Generation, error) {
+	gen, err := m.st.NextGeneration(m.UUID())
+	return gen, errors.Trace(err)
+}
+
+// NextGeneration returns the "next" generation
+// if one exists for the input model, that is not yet completed.
+func (st *State) NextGeneration(modelUUID string) (*Generation, error) {
+	doc, err := st.getNextGenerationDoc(modelUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return newGeneration(st, doc), nil
+}
+
+func (st *State) getNextGenerationDoc(modelUUID string) (*generationDoc, error) {
+	col, closer := st.db().GetCollection(generationsC)
+	defer closer()
+
+	var err error
+	doc := &generationDoc{}
+
+	err = col.Find(bson.D{
+		{"model-uuid", modelUUID},
+		{"completed", bson.D{{"$exists", false}}},
+	}).One(doc)
+
+	switch err {
+	case nil:
+		return doc, nil
+	case mgo.ErrNotFound:
+		return nil, errors.NotFoundf("active model generation for %s", modelUUID)
+	default:
+		return nil, errors.Annotatef(err, "retrieving active model generation for %s", modelUUID)
+	}
+}
+
+func newGeneration(st *State, doc *generationDoc) *Generation {
+	return &Generation{
+		st:  st,
+		doc: *doc,
+	}
+}

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -65,3 +65,24 @@ func (s *generationSuite) TestActiveGenerationSwitchSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(v, gc.Equals, model.GenerationCurrent)
 }
+
+func (s *generationSuite) TestCanAutoCompleteAndCanCancel(c *gc.C) {
+	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+
+	gen, err := s.Model.NextGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+
+	comp, err := gen.CanCancel()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(comp, jc.IsTrue)
+
+	auto, err := gen.CanAutoComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(auto, jc.IsFalse)
+
+	// TODO (manadart 2018-12-07) Implement AddApplication and AddUnit.
+	// Check CanCancel and CanAutoComplete with:
+	// - 2 apps, all units from one and none from the other.
+	// - 2 apps, all units from one and some from the other.
+	// - 2 apps, all units from both.
+}

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/model"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -26,6 +27,11 @@ func (s *generationSuite) TestNextGenerationSuccess(c *gc.C) {
 
 	// A newly created generation is immediately the active one.
 	c.Check(gen.Active(), jc.IsTrue)
+
+	v, err := s.Model.ActiveGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, gc.Equals, model.GenerationNext)
+
 	c.Check(gen.ModelUUID(), gc.Equals, s.Model.UUID())
 	c.Check(gen.Id(), gc.Not(gc.Equals), "")
 }
@@ -36,5 +42,23 @@ func (s *generationSuite) TestNextGenerationExistsError(c *gc.C) {
 	_, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.Model.AddGeneration(), gc.ErrorMatches, ".* has a next generation that is not completed$")
+	c.Assert(s.Model.AddGeneration(), gc.ErrorMatches, "model has a next generation that is not completed")
+}
+
+func (s *generationSuite) TestActiveGenerationSwitchSuccess(c *gc.C) {
+	v, err := s.Model.ActiveGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, gc.Equals, model.GenerationCurrent)
+
+	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+
+	v, err = s.Model.ActiveGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, gc.Equals, model.GenerationNext)
+
+	c.Assert(s.Model.SwitchGeneration(model.GenerationCurrent), jc.ErrorIsNil)
+
+	v, err = s.Model.ActiveGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(v, gc.Equals, model.GenerationCurrent)
 }

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package state_test
 
 import (

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -1,0 +1,40 @@
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type generationSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&generationSuite{})
+
+func (s *generationSuite) TestNextGenerationNotFound(c *gc.C) {
+	_, err := s.Model.NextGeneration()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *generationSuite) TestNextGenerationSuccess(c *gc.C) {
+	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+
+	gen, err := s.Model.NextGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gen, gc.NotNil)
+
+	// A newly created generation is immediately the active one.
+	c.Check(gen.Active(), jc.IsTrue)
+	c.Check(gen.ModelUUID(), gc.Equals, s.Model.UUID())
+	c.Check(gen.Id(), gc.Not(gc.Equals), "")
+}
+
+func (s *generationSuite) TestNextGenerationExistsError(c *gc.C) {
+	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+
+	_, err := s.Model.NextGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.Model.AddGeneration(), gc.ErrorMatches, ".* has a next generation that is not completed$")
+}


### PR DESCRIPTION
## Description of change

- Adds the "generations" collection to MongoDB.
- Creates a new type and doc definitions in the State package, for _model generations_.

## QA steps

No materialised changes yet, just unit tests.

## Documentation changes

Ultimately yes, but not yet.

## Bug reference

N/A
