### PR TITLE
Prevent accidental cross channel charm upgrades.

### DIFF
--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -87,6 +87,7 @@ func (api *APIBase) getConfig(
 		ApplicationConfig: appConfigInfo,
 		Constraints:       constraints,
 		Series:            app.Series(),
+		Channel:           string(app.Channel()),
 	}, nil
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -437,6 +437,7 @@ type ApplicationGetResults struct {
 	ApplicationConfig map[string]interface{} `json:"application-config,omitempty"`
 	Constraints       constraints.Value      `json:"constraints"`
 	Series            string                 `json:"series"`
+	Channel           string                 `json:"channel"`
 }
 
 // ApplicationConfigSetArgs holds the parameters for

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -337,13 +337,16 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	charmAdder := c.NewCharmAdder(apiRoot, bakeryClient, csURL, c.Channel)
-	charmRepo := c.getCharmStore(bakeryClient, csURL, modelConfig)
-
 	applicationInfo, err := charmUpgradeClient.Get(c.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if c.Channel == "" {
+		c.Channel = csclientparams.Channel(applicationInfo.Channel)
+	}
+	charmAdder := c.NewCharmAdder(apiRoot, bakeryClient, csURL, c.Channel)
+	charmRepo := c.getCharmStore(bakeryClient, csURL, modelConfig)
+
 	deployedSeries := applicationInfo.Series
 
 	chID, csMac, err := c.addCharm(charmAdder, charmRepo, modelConfig, oldURL, newRef, deployedSeries, c.Force)


### PR DESCRIPTION
## Description of change

When running upgrade charm without specifying a channel there was chance that a charm would be upgraded across channels. For example, a charm that was originally obtained from the Beta channel could be accidentally upgraded to a charm from the Stable channel.

## QA steps

Release a charm to the beta channel:

`juju release <charm> --channel beta`

Deploy the charm:

`juju deploy <charm>`

Release a revision to stable channel

`juju release <charm> --channel stable`

Release a revision to beta channel

`juju release <charm> --channel beta`

Upgrade the charm of the deployed application without specifying a channel

`juju upgrade-charm <application>`

Notice that after this patch the beta channel's revision should be deployed and not the stable channel's revision. This because the previous deployment's channel should be respected by the `upgrade-charm` command.

## Documentation changes

It may be useful to specifically note that the previous deployment's/upgrade's channel will be respected by this command and if another channel is desired it must be specified.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1804669
