### PR TITLE
Parallelise the raft apply calls and hook up metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,11 +81,14 @@
   source = "github.com/juju/gosigma"
 
 [[projects]]
-  digest = "1:8e384478a0e2aa016605896748d186832db7b7350a975bb26aa53ca702d19573"
+  digest = "1:0a776e52fa4deb432e3c382436ed79c2e20fb6fd02061782c11e3e3a58b86d78"
   name = "github.com/armon/go-metrics"
-  packages = ["."]
+  packages = [
+    ".",
+    "prometheus",
+  ]
   pruneopts = ""
-  revision = "93f237eba9b0602f3e73710416558854a81d9337"
+  revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[projects]]
   digest = "1:de184b64adb3054bea074db0b1be1327c7dc3aaa04e3fd6cb01f62f339caecd5"
@@ -313,11 +316,27 @@
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
+  digest = "1:c5466dfad4c14bf8e52a34b0eb98f1301acc1e304e0f0ff2c51c356ca1b86747"
+  name = "github.com/hashicorp/go-immutable-radix"
+  packages = ["."]
+  pruneopts = ""
+  revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:6396690228a7560bf9247cb90e5ae9c797bd630b01e7d2acab430bbca9a1ecb3"
   name = "github.com/hashicorp/go-msgpack"
   packages = ["codec"]
   pruneopts = ""
   revision = "fa3f63826f7c23912c15263591e65d54d080b458"
+
+[[projects]]
+  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
+  name = "github.com/hashicorp/golang-lru"
+  packages = ["simplelru"]
+  pruneopts = ""
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
   digest = "1:3dea8a64498e503e13eaa87133ab0c5423988a67f739e52273631230cf15a428"
@@ -1770,6 +1789,8 @@
     "github.com/altoros/gosigma",
     "github.com/altoros/gosigma/data",
     "github.com/altoros/gosigma/mock",
+    "github.com/armon/go-metrics",
+    "github.com/armon/go-metrics/prometheus",
     "github.com/bmizerany/pat",
     "github.com/coreos/go-systemd/dbus",
     "github.com/coreos/go-systemd/unit",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -203,7 +203,7 @@
 
 [[override]]
   name = "github.com/armon/go-metrics"
-  revision = "93f237eba9b0602f3e73710416558854a81d9337"
+  revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[override]]
   name = "github.com/beorn7/perks"

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -857,14 +857,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The global lease manager tracks lease information in the raft
 		// cluster rather than in mongo.
 		leaseManagerName: ifController(leasemanager.Manifold(leasemanager.ManifoldConfig{
-			AgentName:      agentName,
-			ClockName:      clockName,
-			CentralHubName: centralHubName,
-			FSM:            leaseFSM,
-			RequestTopic:   leaseRequestTopic,
-			Logger:         loggo.GetLogger("juju.worker.lease.raft"),
-			NewWorker:      leasemanager.NewWorker,
-			NewStore:       leasemanager.NewStore,
+			AgentName:         agentName,
+			ClockName:         clockName,
+			CentralHubName:    centralHubName,
+			FSM:               leaseFSM,
+			RequestTopic:      leaseRequestTopic,
+			Logger:            loggo.GetLogger("juju.worker.lease.raft"),
+			MetricsRegisterer: config.PrometheusRegisterer,
+			NewWorker:         leasemanager.NewWorker,
+			NewStore:          leasemanager.NewStore,
 		})),
 
 		validCredentialFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -290,7 +290,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	controllerTag := agentConfig.Controller()
 
 	leaseFSM := raftlease.NewFSM()
-	raft.RegisterMetrics(config.PrometheusRegisterer)
+	if config.PrometheusRegisterer != nil {
+		raft.RegisterMetrics(config.PrometheusRegisterer)
+	}
 
 	manifolds := dependency.Manifolds{
 		// The agent manifold references the enclosing agent, and is the

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -290,9 +290,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	controllerTag := agentConfig.Controller()
 
 	leaseFSM := raftlease.NewFSM()
-	if config.PrometheusRegisterer != nil {
-		raft.RegisterMetrics(config.PrometheusRegisterer)
-	}
 
 	manifolds := dependency.Manifolds{
 		// The agent manifold references the enclosing agent, and is the
@@ -814,12 +811,13 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		raftName: ifFullyUpgraded(raft.Manifold(raft.ManifoldConfig{
-			ClockName:     clockName,
-			AgentName:     agentName,
-			TransportName: raftTransportName,
-			FSM:           leaseFSM,
-			Logger:        loggo.GetLogger("juju.worker.raft"),
-			NewWorker:     raft.NewWorker,
+			ClockName:            clockName,
+			AgentName:            agentName,
+			TransportName:        raftTransportName,
+			FSM:                  leaseFSM,
+			Logger:               loggo.GetLogger("juju.worker.raft"),
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewWorker:            raft.NewWorker,
 		})),
 
 		raftFlagName: raftflag.Manifold(raftflag.ManifoldConfig{

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -858,15 +858,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The global lease manager tracks lease information in the raft
 		// cluster rather than in mongo.
 		leaseManagerName: ifController(leasemanager.Manifold(leasemanager.ManifoldConfig{
-			AgentName:         agentName,
-			ClockName:         clockName,
-			CentralHubName:    centralHubName,
-			FSM:               leaseFSM,
-			RequestTopic:      leaseRequestTopic,
-			Logger:            loggo.GetLogger("juju.worker.lease.raft"),
-			MetricsRegisterer: config.PrometheusRegisterer,
-			NewWorker:         leasemanager.NewWorker,
-			NewStore:          leasemanager.NewStore,
+			AgentName:            agentName,
+			ClockName:            clockName,
+			CentralHubName:       centralHubName,
+			FSM:                  leaseFSM,
+			RequestTopic:         leaseRequestTopic,
+			Logger:               loggo.GetLogger("juju.worker.lease.raft"),
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewWorker:            leasemanager.NewWorker,
+			NewStore:             leasemanager.NewStore,
 		})),
 
 		validCredentialFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -290,6 +290,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	controllerTag := agentConfig.Controller()
 
 	leaseFSM := raftlease.NewFSM()
+	raft.RegisterMetrics(config.PrometheusRegisterer)
 
 	manifolds := dependency.Manifolds{
 		// The agent manifold references the enclosing agent, and is the

--- a/core/raftlease/metrics.go
+++ b/core/raftlease/metrics.go
@@ -21,7 +21,7 @@ func newMetricsCollector() *metricsCollector {
 	return &metricsCollector{
 		requests: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Namespace: "juju_raftlease",
-			Name:      "request_time",
+			Name:      "request",
 			Help:      "Request times for lease store operations in ms",
 			Objectives: map[float64]float64{
 				0.5:  0.05,
@@ -35,10 +35,12 @@ func newMetricsCollector() *metricsCollector {
 	}
 }
 
+// Describe is part of prometheus.Collector.
 func (c *metricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	c.requests.Describe(ch)
 }
 
+// Collect is part of prometheus.Collector.
 func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 	c.requests.Collect(ch)
 }

--- a/core/raftlease/metrics.go
+++ b/core/raftlease/metrics.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_raftlease"
+)
+
+// metricsCollector is a prometheus.Collector that collects metrics
+// about lease store operations.
+type metricsCollector struct {
+	requests *prometheus.SummaryVec
+}
+
+func newMetricsCollector() *metricsCollector {
+	return &metricsCollector{
+		requests: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace: "juju_raftlease",
+			Name:      "request_time",
+			Help:      "Request times for lease store operations in ms",
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		}, []string{
+			"operation", // claim, extend, pin, unpin or settime
+			"result",    // success, failure, timeout or error
+		}),
+	}
+}
+
+func (c *metricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.requests.Describe(ch)
+}
+
+func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
+	c.requests.Collect(ch)
+}

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -43,7 +43,7 @@ func (s *storeSuite) SetUpTest(c *gc.C) {
 		globalTime: s.clock.Now(),
 	}
 	s.hub = pubsub.NewStructuredHub(nil)
-	store, err := raftlease.NewStore(raftlease.StoreConfig{
+	s.store = raftlease.NewStore(raftlease.StoreConfig{
 		FSM:          s.fsm,
 		Hub:          s.hub,
 		Trapdoor:     FakeTrapdoor,
@@ -54,8 +54,6 @@ func (s *storeSuite) SetUpTest(c *gc.C) {
 		Clock:          s.clock,
 		ForwardTimeout: time.Second,
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.store = store
 }
 
 func (s *storeSuite) TestClaim(c *gc.C) {

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -83,8 +83,7 @@ func (config ManagerConfig) Validate() error {
 	if config.MaxSleep <= 0 {
 		return errors.NotValidf("non-positive MaxSleep")
 	}
-	if config.PrometheusRegisterer == nil {
-		return errors.NotValidf("nil PrometheusRegisterer")
-	}
+	// TODO: make the PrometheusRegisterer required when we no longer
+	// have state workers managing leases.
 	return nil
 }

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/lease"
 )
@@ -60,6 +61,8 @@ type ManagerConfig struct {
 	// EntityUUID is the entity that we are running this Manager for. Used for
 	// logging purposes.
 	EntityUUID string
+
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // Validate returns an error if the configuration contains invalid information
@@ -79,6 +82,9 @@ func (config ManagerConfig) Validate() error {
 	}
 	if config.MaxSleep <= 0 {
 		return errors.NotValidf("non-positive MaxSleep")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
 	}
 	return nil
 }

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -141,7 +141,7 @@ func (manager *Manager) Wait() error {
 
 // loop runs until the manager is stopped.
 func (manager *Manager) loop() error {
-	if collector, ok := manager.config.Store.(prometheus.Collector); ok {
+	if collector, ok := manager.config.Store.(prometheus.Collector); ok && manager.config.PrometheusRegisterer != nil {
 		// The store implements the collector interface, but the lease.Store
 		// doen't expose those.
 		manager.config.PrometheusRegisterer.Register(collector)

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1/catacomb"
 	"gopkg.in/retry.v1"
 
@@ -140,6 +141,13 @@ func (manager *Manager) Wait() error {
 
 // loop runs until the manager is stopped.
 func (manager *Manager) loop() error {
+	if collector, ok := manager.config.Store.(prometheus.Collector); ok {
+		// The store implements the collector interface, but the lease.Store
+		// doen't expose those.
+		manager.config.PrometheusRegisterer.Register(collector)
+		defer manager.config.PrometheusRegisterer.Unregister(collector)
+	}
+
 	defer manager.wg.Wait()
 	blocks := make(blocks)
 	for {

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -193,8 +193,9 @@ func (s *CrossSuite) TestDifferentNamespaceValidation(c *gc.C) {
 				return nil, errors.Errorf("bad namespace!")
 			}
 		},
-		MaxSleep: defaultMaxSleep,
-		Logger:   loggo.GetLogger("lease_test"),
+		MaxSleep:             defaultMaxSleep,
+		Logger:               loggo.GetLogger("lease_test"),
+		PrometheusRegisterer: noopRegisterer{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -80,10 +80,9 @@ func (s *ValidationSuite) TestMissingSecretary(c *gc.C) {
 
 func (s *ValidationSuite) TestMissingPrometheusRegisterer(c *gc.C) {
 	s.config.PrometheusRegisterer = nil
-	manager, err := lease.NewManager(s.config)
-	c.Check(err, gc.ErrorMatches, "nil PrometheusRegisterer not valid")
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(manager, gc.IsNil)
+	err := s.config.Validate()
+	// Find to miss this out for now.
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ValidationSuite) TestMissingMaxSleep(c *gc.C) {

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
 
 	corelease "github.com/juju/juju/core/lease"
@@ -20,87 +21,82 @@ import (
 
 type ValidationSuite struct {
 	testing.IsolationSuite
+
+	config lease.ManagerConfig
 }
 
 var _ = gc.Suite(&ValidationSuite{})
 
-func (s *ValidationSuite) TestMissingStore(c *gc.C) {
-	manager, err := lease.NewManager(lease.ManagerConfig{
+func (s *ValidationSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = lease.ManagerConfig{
+		Store: struct{ corelease.Store }{},
 		Clock: struct{ clock.Clock }{},
 		Secretary: func(string) (lease.Secretary, error) {
 			return nil, nil
 		},
-		MaxSleep: time.Minute,
-		Logger:   loggo.GetLogger("lease_test"),
-	})
+		MaxSleep:             time.Minute,
+		Logger:               loggo.GetLogger("lease_test"),
+		PrometheusRegisterer: struct{ prometheus.Registerer }{},
+	}
+}
+
+func (s *ValidationSuite) TestConfigValid(c *gc.C) {
+	err := s.config.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ValidationSuite) TestMissingStore(c *gc.C) {
+	s.config.Store = nil
+	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "nil Store not valid")
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(manager, gc.IsNil)
 }
 
 func (s *ValidationSuite) TestMissingClock(c *gc.C) {
-	manager, err := lease.NewManager(lease.ManagerConfig{
-		Store: struct{ corelease.Store }{},
-		Secretary: func(string) (lease.Secretary, error) {
-			return nil, nil
-		},
-		MaxSleep: time.Minute,
-		Logger:   loggo.GetLogger("lease_test"),
-	})
+	s.config.Clock = nil
+	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "nil Clock not valid")
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(manager, gc.IsNil)
 }
 
 func (s *ValidationSuite) TestMissingLogger(c *gc.C) {
-	manager, err := lease.NewManager(lease.ManagerConfig{
-		Store: struct{ corelease.Store }{},
-		Secretary: func(string) (lease.Secretary, error) {
-			return nil, nil
-		},
-		Clock:    struct{ clock.Clock }{},
-		MaxSleep: time.Minute,
-	})
+	s.config.Logger = nil
+	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "nil Logger not valid")
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(manager, gc.IsNil)
 }
 
 func (s *ValidationSuite) TestMissingSecretary(c *gc.C) {
-	manager, err := lease.NewManager(lease.ManagerConfig{
-		Store:  struct{ corelease.Store }{},
-		Clock:  struct{ clock.Clock }{},
-		Logger: loggo.GetLogger("lease_test"),
-	})
+	s.config.Secretary = nil
+	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "nil Secretary not valid")
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(manager, gc.IsNil)
 }
 
+func (s *ValidationSuite) TestMissingPrometheusRegisterer(c *gc.C) {
+	s.config.PrometheusRegisterer = nil
+	manager, err := lease.NewManager(s.config)
+	c.Check(err, gc.ErrorMatches, "nil PrometheusRegisterer not valid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(manager, gc.IsNil)
+}
+
 func (s *ValidationSuite) TestMissingMaxSleep(c *gc.C) {
-	manager, err := lease.NewManager(lease.ManagerConfig{
-		Store: NewStore(nil, nil),
-		Secretary: func(string) (lease.Secretary, error) {
-			return nil, nil
-		},
-		Clock:  testclock.NewClock(time.Now()),
-		Logger: loggo.GetLogger("lease_test"),
-	})
+	s.config.MaxSleep = 0
+	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "non-positive MaxSleep not valid")
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(manager, gc.IsNil)
 }
 
 func (s *ValidationSuite) TestNegativeMaxSleep(c *gc.C) {
-	manager, err := lease.NewManager(lease.ManagerConfig{
-		Store: NewStore(nil, nil),
-		Clock: testclock.NewClock(time.Now()),
-		Secretary: func(string) (lease.Secretary, error) {
-			return nil, nil
-		},
-		Logger:   loggo.GetLogger("lease_test"),
-		MaxSleep: -time.Nanosecond,
-	})
+	s.config.MaxSleep = -time.Nanosecond
+	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "non-positive MaxSleep not valid")
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(manager, gc.IsNil)

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/dependency"
 
@@ -22,9 +23,10 @@ type ManifoldConfig struct {
 	AgentName     string
 	TransportName string
 
-	FSM       raft.FSM
-	Logger    Logger
-	NewWorker func(Config) (worker.Worker, error)
+	FSM                  raft.FSM
+	Logger               Logger
+	PrometheusRegisterer prometheus.Registerer
+	NewWorker            func(Config) (worker.Worker, error)
 }
 
 // Validate validates the manifold configuration.
@@ -91,12 +93,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	raftDir := filepath.Join(agentConfig.DataDir(), "raft")
 
 	return config.NewWorker(Config{
-		FSM:        config.FSM,
-		Logger:     config.Logger,
-		StorageDir: raftDir,
-		LocalID:    raft.ServerID(agentConfig.Tag().Id()),
-		Transport:  transport,
-		Clock:      clk,
+		FSM:                  config.FSM,
+		Logger:               config.Logger,
+		StorageDir:           raftDir,
+		LocalID:              raft.ServerID(agentConfig.Tag().Id()),
+		Transport:            transport,
+		Clock:                clk,
+		PrometheusRegisterer: config.PrometheusRegisterer,
 	})
 }
 

--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -17,7 +17,7 @@ func registerMetrics(registerer prometheus.Registerer) (prometheus.Collector, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, err = metrics.NewGlobal(metrics.DefaultConfig("jujumetrics"), sink)
+	_, err = metrics.NewGlobal(metrics.DefaultConfig("juju"), sink)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raft
+
+import (
+	"github.com/armon/go-metrics"
+	pmetrics "github.com/armon/go-metrics/prometheus"
+	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// RegisterMetrics connects the metrics gathered in the
+// hashicorp/raft library code with our prometheus collector.
+func RegisterMetrics(registerer prometheus.Registerer) error {
+	sink, err := pmetrics.NewPrometheusSink()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	registerer.Unregister(sink)
+	if err := registerer.Register(sink); err != nil {
+		return errors.Trace(err)
+	}
+	_, err = metrics.NewGlobal(metrics.DefaultConfig("jujumetrics"), sink)
+	return errors.Trace(err)
+}

--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -10,17 +10,19 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// RegisterMetrics connects the metrics gathered in the
+// registerMetrics connects the metrics gathered in the
 // hashicorp/raft library code with our prometheus collector.
-func RegisterMetrics(registerer prometheus.Registerer) error {
+func registerMetrics(registerer prometheus.Registerer) (prometheus.Collector, error) {
 	sink, err := pmetrics.NewPrometheusSink()
 	if err != nil {
-		return errors.Trace(err)
-	}
-	registerer.Unregister(sink)
-	if err := registerer.Register(sink); err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	_, err = metrics.NewGlobal(metrics.DefaultConfig("jujumetrics"), sink)
-	return errors.Trace(err)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := registerer.Register(sink); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return sink, nil
 }

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -132,6 +132,7 @@ func (w *forwarder) handleRequest(_ string, req raftlease.ForwardRequest, err er
 func (w *forwarder) processRequest(command string) (raftlease.ForwardResponse, error) {
 	var empty raftlease.ForwardResponse
 	future := w.config.Raft.Apply([]byte(command), applyTimeout)
+	w.config.Logger.Tracef("%d: after apply", w.id)
 	if err := future.Error(); err != nil {
 		return empty, errors.Trace(err)
 	}
@@ -140,7 +141,9 @@ func (w *forwarder) processRequest(command string) (raftlease.ForwardResponse, e
 	if !ok {
 		return empty, errors.Errorf("expected an FSMResponse, got %T: %#v", respValue, respValue)
 	}
+	w.config.Logger.Tracef("%d: after fsm response", w.id)
 	response.Notify(w.config.Target)
+	w.config.Logger.Tracef("%d: after notify", w.id)
 	return responseFromError(response.Error()), nil
 }
 


### PR DESCRIPTION
This work is is a combination of work from myself and @babbageclunk.

If using spinning rust for disks rather than SSDs, the i/o time significantly impacts how raft performs. This branch parallelises the requests from the raftforwarder to the underlying raft FSM.

Also extra debugging was added, and prometheus metrics added for the lease manager, and hooked up to the metrics available from raft.