### PR TITLE
Handle proxy settings during bootstrap

### DIFF
--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -20,7 +20,9 @@ import (
 
 const (
 	// fileSchemePrefix is the prefix for file:// URLs.
-	fileSchemePrefix = "file://"
+	fileSchemePrefix  = "file://"
+	httpSchemePrefix  = "http://"
+	httpsSchemePrefix = "https://"
 
 	// NonceFile is written by cloud-init as the last thing it does.
 	// The file will contain the machine's nonce. The filename is


### PR DESCRIPTION
## Description of change

Use proxy model-configs (legacy and juju-{http,https,no}-proxy) in the curl command used in the bootstrap process to download Juju tools.

## QA steps

A proxy server, e.g. squid (installed via squid and squid-deb-proxy packages), has to be set up on the same subnet as the container under test is going to reside on (could be a manually set up container as well). The point is that a default route will be deleted from the container under test, however, it will have a directly connected route for the subnet it will get an IP on automatically and hence will be able to connect the proxy server. This prevents any traffic from being forwarded anywhere but a single subnet and hence is a good reproducer for a proxy-only scenario.

cat modelconfig-proxy-nomirror.yaml
cloudinit-userdata: |
  preruncmd:
    - ip route del default
juju-http-proxy: http://192.0.2.30:3128
juju-https-proxy: http://192.0.2.30:3128
apt-http-proxy: http://192.0.2.30:8000
apt-https-proxy: http://192.0.2.30:8000

juju bootstrap localhost --config=modelconfig-proxy-nomirror.yaml --no-gui --debug

## Documentation changes

Document that juju-http-proxy and juju-https-proxy will affect Juju tools downloads in release notes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1807361