### PR TITLE
scripts/copyright.bash: use grep and find options available on both ubuntu and macOS

### DIFF
--- a/scripts/copyright.bash
+++ b/scripts/copyright.bash
@@ -3,7 +3,7 @@
 # Copyright 2013 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
 exitstatus=0
-result=$(find -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs head -n 1 | grep -v -E '// (Copyright|Code generated)' | xargs echo | sed 's/==>/\n==>/g' | sed 's/<==/<==\n/g' | grep -Pzo "==> (.*) <==\n.*\S+.*\n" | grep -Pzo "==> (.*) <==\n" | sed 's/==> \(.*\) <==/\1/')
+result=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs grep -L -E '// (Copyright|Code generated)')
 missing=$(echo "$result" | wc -w)
 if [ $missing != 0 ]; then
     echo "The following files are missing copyright headers"

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -64,6 +64,9 @@ go tool vet \
    -printfuncs=$all_prints \
     $FILES || [ -n "$IGNORE_VET_WARNINGS" ]
 
+echo "checking: copyright notices are in place ..."
+./scripts/copyright.bash
+
 echo "checking: dependency files ..."
 dep check
 
@@ -80,6 +83,3 @@ go build $(go list github.com/juju/juju/... | grep -v /vendor/)
 
 echo "checking: tests are wired up ..."
 ./scripts/checktesting.bash
-
-echo "checking: copyright notices are in place ..."
-./scripts/copyright.bash


### PR DESCRIPTION
## Description of change

scripts/copyright.bash: use grep and find options available on both ubuntu and macOS
scripts/verify.bash: move copyright earlier in the checks

## QA steps

1. make pre-check <-- succeeds
2. remove first 3 lines of state/machine.go
3. make pre-check   <-- should fail because file doesn't have Copyright
