### PR TITLE
Fix deadlocks in shutdown.

### DIFF
--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -304,7 +304,10 @@ func (sm *storeManager) respond() {
 
 		req.changes = changes
 		w.revno = sm.all.latestRevno
-		req.reply <- true
+		select {
+		case req.reply <- true:
+		case <-sm.tomb.Dying():
+		}
 		sm.removeWaitingReq(w, req)
 		sm.seen(revno)
 	}

--- a/state/open.go
+++ b/state/open.go
@@ -205,13 +205,10 @@ func (st *State) Close() (err error) {
 }
 
 func (st *State) stopWorkers() (err error) {
-	defer errors.DeferredAnnotatef(&err, "closing state failed")
-
 	if st.workers != nil {
 		if err := worker.Stop(st.workers); err != nil {
 			return errors.Annotatef(err, "failed to stop workers")
 		}
-		st.workers = nil
 	}
 	return nil
 }

--- a/state/pool.go
+++ b/state/pool.go
@@ -341,6 +341,12 @@ func (p *StatePool) maybeRemoveItem(item *PoolItem) (bool, error) {
 
 // SystemState returns the State passed in to NewStatePool.
 func (p *StatePool) SystemState() *State {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// State pool is closed, no more access to the system state.
+	if p.pool == nil {
+		return nil
+	}
 	return p.systemState
 }
 


### PR DESCRIPTION
While doing excessive testing of another branch, I found that there were a few different deadlocks that were possible during shutdown of machine agents. These deadlocks only occurred sometimes, and only with a bunch of preconditions, so they are quite hard to reproduce, especially to write test cases for.

The multiwatcher has a naked channel send, and the reciever of this channel may not be listening as the listener has a select that includes tome.Dying.

The state change is to allow the workers for the state objects in the pool to be stopped before we actually close the state objects. This is because if there has been a multiwatcher created on the state object, an all watcher worker is started. If this all watcher is processing an event while the pool is being closed, it may want to get a state object out of the pool for processing, but the mutex blocks this. So the pool shutdown is now much more careful about how long it holds the locks for, and also checks against a closing state pool in more places.