### PR TITLE
Add core cache package.

### DIFF
--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -1,0 +1,61 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cachetest
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/state"
+)
+
+// ModelChangeFromState returns a ModelChange representing the current
+// model for the state object.
+func ModelChangeFromState(c *gc.C, st *state.State) cache.ModelChange {
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	return ModelChange(c, model)
+}
+
+// ModelChangeFromStateErr returns a ModelChange representing the current
+// model for the state object. May return an error.
+func ModelChangeFromStateErr(st *state.State) (cache.ModelChange, error) {
+	model, err := st.Model()
+	if err != nil {
+		return cache.ModelChange{}, errors.Trace(err)
+	}
+	return ModelChangeErr(model)
+}
+
+// ModelChange returns a ModelChange representing the current state of the model.
+func ModelChange(c *gc.C, model *state.Model) cache.ModelChange {
+	change, err := ModelChangeErr(model)
+	c.Assert(err, jc.ErrorIsNil)
+	return change
+}
+
+// ModelChangeErr returns a ModelChange representing the current state of the model.
+// May return an error if unable to load config or status.
+func ModelChangeErr(model *state.Model) (cache.ModelChange, error) {
+	change := cache.ModelChange{
+		ModelUUID: model.UUID(),
+		Name:      model.Name(),
+		Life:      life.Value(model.Life().String()),
+		Owner:     model.Owner().Name(),
+	}
+	config, err := model.Config()
+	if err != nil {
+		return cache.ModelChange{}, errors.Trace(err)
+	}
+	change.Config = config.AllAttrs()
+	status, err := model.Status()
+	if err != nil {
+		return cache.ModelChange{}, errors.Trace(err)
+	}
+	change.Status = status
+	return change, nil
+}

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+)
+
+// ModelChange represents either a new model, or a change
+// to an existing model.
+type ModelChange struct {
+	ModelUUID string
+	Name      string
+	Life      life.Value
+	Owner     string // tag maybe?
+	Config    map[string]interface{}
+	Status    status.StatusInfo
+}
+
+// RemoveModel represents the situation when a model is removed
+// from the database.
+type RemoveModel struct {
+	ModelUUID string
+}

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -1,0 +1,151 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"gopkg.in/tomb.v2"
+)
+
+// We use a package level logger here because the cache is only
+// ever in machine agents, so will never need to be in an alternative
+// logging context.
+
+// ControllerConfig is a simple config value struct for the controller.
+type ControllerConfig struct {
+	// Changes from the event source come over this channel.
+	// The changes channel must be non-nil.
+	Changes <-chan interface{}
+
+	// Notify is a callback function used primariy for testing, and is
+	// called by the controller main processing loop after processing a change.
+	// The change processed is passed in as the arg to notify.
+	Notify func(interface{})
+}
+
+// Validate ensures the controller has the right values to be created.
+func (c *ControllerConfig) Validate() error {
+	if c.Changes == nil {
+		return errors.NotValidf("nil Changes")
+	}
+	return nil
+}
+
+// Controller is the primary cached object.
+type Controller struct {
+	config  ControllerConfig
+	tomb    tomb.Tomb
+	mu      sync.Mutex
+	models  map[string]*Model
+	hub     *pubsub.SimpleHub
+	metrics *ControllerGauges
+}
+
+// NewController creates a new cached controller intance.
+// The changes channel is what is used to supply the cache with the changes
+// in order for the cache to be kept up to date.
+func NewController(config ControllerConfig) (*Controller, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	c := &Controller{
+		config: config,
+		models: make(map[string]*Model),
+		hub: pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
+			// TODO: (thumper) add a get child method to loggers.
+			Logger: loggo.GetLogger("juju.core.cache.hub"),
+		}),
+		metrics: createControllerGauges(),
+	}
+	c.tomb.Go(c.loop)
+	return c, nil
+}
+
+func (c *Controller) loop() error {
+	for {
+		select {
+		case <-c.tomb.Dying():
+			return nil
+		case change := <-c.config.Changes:
+			switch ch := change.(type) {
+			case ModelChange:
+				c.updateModel(ch)
+			case RemoveModel:
+				c.removeModel(ch)
+			}
+			if c.config.Notify != nil {
+				c.config.Notify(change)
+			}
+		}
+	}
+}
+
+// Report returns information that is used in the dependency engine report.
+func (c *Controller) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for uuid, model := range c.models {
+		result[uuid] = model.Report()
+	}
+	return result
+}
+
+// ModelUUIDs returns the UUIDs of the models in the cache.
+func (c *Controller) ModelUUIDs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]string, 0, len(c.models))
+	for uuid := range c.models {
+		result = append(result, uuid)
+	}
+	return result
+}
+
+// Kill is part of the worker.Worker interface.
+func (c *Controller) Kill() {
+	c.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (c *Controller) Wait() error {
+	return c.tomb.Wait()
+}
+
+// Model return the model for the specified UUID.
+// If the model isn't found, a NotFoundError is returned.
+func (c *Controller) Model(uuid string) (*Model, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	model, found := c.models[uuid]
+	if !found {
+		return nil, errors.NotFoundf("model %q", uuid)
+	}
+	return model, nil
+}
+
+// updateModel will add or update the model details as
+// described in the ModelChange.
+func (c *Controller) updateModel(ch ModelChange) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	model, found := c.models[ch.ModelUUID]
+	if !found {
+		model = newModel(c.metrics, c.hub)
+		c.models[ch.ModelUUID] = model
+	}
+	model.setDetails(ch)
+}
+
+// removeModel removes the model from the cache.
+func (c *Controller) removeModel(ch RemoveModel) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.models, ch.ModelUUID)
+}

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -1,0 +1,136 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package cache_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/life"
+)
+
+type ControllerSuite struct {
+	testing.IsolationSuite
+
+	gauges *cache.ControllerGauges
+
+	changes chan interface{}
+	config  cache.ControllerConfig
+}
+
+var _ = gc.Suite(&ControllerSuite{})
+
+func (s *ControllerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.changes = make(chan interface{})
+	s.config = cache.ControllerConfig{
+		Changes: s.changes,
+	}
+}
+
+func (s *ControllerSuite) TestConfigValid(c *gc.C) {
+	err := s.config.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ControllerSuite) TestConfigMissingChanges(c *gc.C) {
+	s.config.Changes = nil
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, "nil Changes not valid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *ControllerSuite) TestController(c *gc.C) {
+	controller, err := cache.NewController(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(controller.ModelUUIDs(), gc.HasLen, 0)
+	c.Check(controller.Report(), gc.HasLen, 0)
+
+	workertest.CleanKill(c, controller)
+}
+
+func (s *ControllerSuite) new(c *gc.C) (*cache.Controller, <-chan interface{}) {
+	events := s.captureModelEvents(c)
+	controller, err := cache.NewController(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
+	return controller, events
+}
+
+func (s *ControllerSuite) TestAddModel(c *gc.C) {
+	controller, events := s.new(c)
+	s.processChange(c, modelChange, events)
+
+	c.Check(controller.ModelUUIDs(), jc.SameContents, []string{"model-uuid"})
+	c.Check(controller.Report(), gc.DeepEquals, map[string]interface{}{
+		"model-uuid": map[string]interface{}{
+			"name": "model-owner/test-model",
+			"life": life.Value("alive"),
+		}})
+}
+
+func (s *ControllerSuite) TestRemoveModel(c *gc.C) {
+	controller, events := s.new(c)
+	s.processChange(c, modelChange, events)
+
+	remove := cache.RemoveModel{ModelUUID: "model-uuid"}
+	s.processChange(c, remove, events)
+
+	c.Check(controller.ModelUUIDs(), gc.HasLen, 0)
+	c.Check(controller.Report(), gc.HasLen, 0)
+}
+
+func (s *ControllerSuite) processChange(c *gc.C, change interface{}, notify <-chan interface{}) {
+	select {
+	case s.changes <- change:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("contoller did not read change")
+	}
+	select {
+	case obtained := <-notify:
+		c.Check(obtained, jc.DeepEquals, change)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("contoller did not handle change")
+	}
+}
+
+func (s *ControllerSuite) captureModelEvents(c *gc.C) <-chan interface{} {
+	events := make(chan interface{})
+	s.config.Notify = func(change interface{}) {
+		send := false
+		switch change.(type) {
+		case cache.ModelChange:
+			send = true
+		case cache.RemoveModel:
+			send = true
+		default:
+			// no-op
+		}
+		if send {
+			c.Logf("sending %#v", change)
+			select {
+			case events <- change:
+			case <-time.After(testing.LongWait):
+				c.Fatalf("change not processed by test")
+			}
+		}
+	}
+	return events
+}
+
+func (s *ControllerSuite) nextChange(c *gc.C, changes <-chan interface{}) interface{} {
+	var obtained interface{}
+	select {
+	case obtained = <-changes:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("no change")
+	}
+	return obtained
+}

--- a/core/cache/doc.go
+++ b/core/cache/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package cache is responsible for keeping an in memory representation of the
+// controller's models.
+//
+// The Controller is kept up to date with the database though a changes channel.
+//
+// Instances in the cache package also provide watchers. These watchers are
+// checking for changes in the in-memory representation and can be used to avoid
+// excess database reads.
+package cache

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+var (
+	CreateControllerGauges = createControllerGauges
+	NewModel               = newModel
+)
+
+// Expose SetDetails for testing.
+func (m *Model) SetDetails(details ModelChange) {
+	m.setDetails(details)
+}

--- a/core/cache/hash.go
+++ b/core/cache/hash.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// hash returns a hash of the yaml serialized settings.
+// If the settings are not able to be serialized an error is returned.
+func hash(settings map[string]interface{}) (string, error) {
+	bytes, err := yaml.Marshal(settings)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	hash := sha256.New()
+	_, err = hash.Write(bytes)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -1,0 +1,201 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"github.com/juju/loggo"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_cache"
+
+	statusLabel           = "status"
+	lifeLabel             = "life"
+	disabledLabel         = "disabled"
+	deletedLabel          = "deleted"
+	controllerAccessLabel = "controller_access"
+	domainLabel           = "domain"
+	agentStatusLabel      = "agent_status"
+	machineStatusLabel    = "machine_status"
+)
+
+var (
+	machineLabelNames = []string{
+		agentStatusLabel,
+		lifeLabel,
+		machineStatusLabel,
+	}
+
+	modelLabelNames = []string{
+		lifeLabel,
+		statusLabel,
+	}
+
+	userLabelNames = []string{
+		controllerAccessLabel,
+		deletedLabel,
+		disabledLabel,
+		domainLabel,
+	}
+
+	logger = loggo.GetLogger("juju.core.cache")
+)
+
+// ControllerGauges holds the prometheus gauges for ever increasing
+// values used by the controller.
+type ControllerGauges struct {
+	ModelConfigReads   prometheus.Gauge
+	ModelHashCacheHit  prometheus.Gauge
+	ModelHashCacheMiss prometheus.Gauge
+}
+
+func createControllerGauges() *ControllerGauges {
+	return &ControllerGauges{
+		ModelConfigReads: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "model_config_reads",
+				Help:      "The number of times the model config is read.",
+			},
+		),
+		ModelHashCacheHit: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "model_hash_cache_hit",
+				Help:      "The number of times the model config change hash was determined using the cached value.",
+			},
+		),
+		ModelHashCacheMiss: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "model_hash_cache_miss",
+				Help:      "The number of times the model config change hash was generated.",
+			},
+		),
+	}
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
+	c.ModelConfigReads.Collect(ch)
+	c.ModelHashCacheHit.Collect(ch)
+	c.ModelHashCacheMiss.Collect(ch)
+}
+
+// Collector is a prometheus.Collector that collects metrics about
+// the Juju global state.
+type Collector struct {
+	controller *Controller
+
+	scrapeDuration prometheus.Gauge
+	scrapeErrors   prometheus.Gauge
+
+	models   *prometheus.GaugeVec
+	machines *prometheus.GaugeVec
+	users    *prometheus.GaugeVec
+}
+
+// NewMetricsCollector returns a new Collector.
+func NewMetricsCollector(controller *Controller) *Collector {
+	return &Collector{
+		controller: controller,
+		scrapeDuration: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "scrape_duration_seconds",
+				Help:      "Amount of time taken to collect state metrics.",
+			},
+		),
+		scrapeErrors: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "scrape_errors",
+				Help:      "Number of errors observed while collecting state metrics.",
+			},
+		),
+
+		models: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "models",
+				Help:      "Number of models in the controller.",
+			},
+			modelLabelNames,
+		),
+		machines: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "machines",
+				Help:      "Number of machines managed by the controller.",
+			},
+			machineLabelNames,
+		),
+		users: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "users",
+				Help:      "Number of local users in the controller.",
+			},
+			userLabelNames,
+		),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.machines.Describe(ch)
+	c.models.Describe(ch)
+	c.users.Describe(ch)
+
+	c.scrapeErrors.Describe(ch)
+	c.scrapeDuration.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(c.scrapeDuration.Set))
+	defer c.scrapeDuration.Collect(ch)
+	defer timer.ObserveDuration()
+	c.scrapeErrors.Set(0)
+	defer c.scrapeErrors.Collect(ch)
+
+	c.machines.Reset()
+	c.models.Reset()
+	c.users.Reset()
+
+	c.updateMetrics()
+
+	c.controller.metrics.Collect(ch)
+	c.machines.Collect(ch)
+	c.models.Collect(ch)
+	c.users.Collect(ch)
+}
+
+func (c *Collector) updateMetrics() {
+	logger.Tracef("updating cache metrics")
+	defer logger.Tracef("updated cache metrics")
+
+	modelUUIDs := c.controller.ModelUUIDs()
+	for _, m := range modelUUIDs {
+		c.updateModelMetrics(m)
+	}
+
+	// TODO: add user metrics.
+}
+
+func (c *Collector) updateModelMetrics(modelUUID string) {
+	model, err := c.controller.Model(modelUUID)
+	if err != nil {
+		logger.Debugf("error getting model: %v", err)
+		return
+	}
+
+	// TODO: add machines, applications and units.
+
+	c.models.With(prometheus.Labels{
+		lifeLabel:   string(model.details.Life),
+		statusLabel: string(model.details.Status.Status),
+	}).Inc()
+}

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -1,0 +1,219 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/juju/pubsub"
+	"gopkg.in/tomb.v2"
+)
+
+const modelConfigChange = "model-config-change"
+
+func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Model {
+	m := &Model{
+		metrics: metrics,
+		hub:     hub,
+	}
+	return m
+}
+
+// Model is a cached model in the controller. The model is kept up to
+// date with changes flowing into the cached controller.
+type Model struct {
+	metrics *ControllerGauges
+	hub     *pubsub.SimpleHub
+	mu      sync.Mutex
+
+	details    ModelChange
+	configHash string
+	hashCache  *modelConfigHashCache
+}
+
+// Report returns information that is used in the dependency engine report.
+func (m *Model) Report() map[string]interface{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return map[string]interface{}{
+		"name": m.details.Owner + "/" + m.details.Name,
+		"life": m.details.Life,
+	}
+}
+
+// modelTopic prefixes the topic with the model UUID.
+func (m *Model) modelTopic(topic string) string {
+	return m.details.ModelUUID + ":" + topic
+}
+
+func (m *Model) setDetails(details ModelChange) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.details = details
+
+	hashCache, configHash := newModelConfigHashCache(m.metrics, details.Config)
+	if configHash != m.configHash {
+		m.configHash = configHash
+		m.hashCache = hashCache
+		m.hub.Publish(m.modelTopic(modelConfigChange), hashCache)
+	}
+}
+
+// Config returns the current model config.
+func (m *Model) Config() map[string]interface{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.metrics.ModelConfigReads.Inc()
+	return m.details.Config
+}
+
+// WatchConfig creates a watcher for the model config.
+// If keys are specified, the watcher is only signals a change when
+// those keys change values. If no keys are specified, any change in the
+// config will trigger the watcher.
+func (m *Model) WatchConfig(keys ...string) *modelConfigWatcher {
+	// We use a single entry buffered channel for the changes.
+	// This allows the config changed handler to send a value when there
+	// is a change, but if that value hasn't been consumed before the
+	// next change, the second change is discarded.
+	sort.Strings(keys)
+	watcher := &modelConfigWatcher{
+		keys:    keys,
+		changes: make(chan struct{}, 1),
+	}
+	watcher.hash = m.hashCache.getHash(keys)
+	// Send initial event down the channel. We know that this will
+	// execute immediately because it is a buffered channel.
+	watcher.changes <- struct{}{}
+
+	unsub := m.hub.Subscribe(m.modelTopic(modelConfigChange), watcher.configChanged)
+
+	watcher.tomb.Go(func() error {
+		<-watcher.tomb.Dying()
+		unsub()
+		return nil
+	})
+
+	return watcher
+}
+
+type modelConfigHashCache struct {
+	metrics *ControllerGauges
+	config  map[string]interface{}
+	// The key to the hash map is the stringified keys of the watcher.
+	// They should be sorted and comma delimited.
+	hash map[string]string
+	mu   sync.Mutex
+}
+
+func newModelConfigHashCache(metrics *ControllerGauges, config map[string]interface{}) (*modelConfigHashCache, string) {
+	configCache := &modelConfigHashCache{
+		metrics: metrics,
+		config:  config,
+		hash:    make(map[string]string),
+	}
+	// Generate the hash for the entire config.
+	allHash := configCache.generateHash(nil)
+	configCache.hash[""] = allHash
+	return configCache, allHash
+}
+
+func (c *modelConfigHashCache) getHash(keys []string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := strings.Join(keys, ",")
+	value, found := c.hash[key]
+	if found {
+		c.metrics.ModelHashCacheHit.Inc()
+		return value
+	}
+	value = c.generateHash(keys)
+	c.hash[key] = value
+	return value
+}
+
+func (c *modelConfigHashCache) generateHash(keys []string) string {
+	// We are generating a hash, so call it a miss.
+	c.metrics.ModelHashCacheMiss.Inc()
+
+	interested := c.config
+	if len(keys) > 0 {
+		interested = make(map[string]interface{})
+		for _, key := range keys {
+			if value, found := c.config[key]; found {
+				interested[key] = value
+			}
+		}
+	}
+	h, err := hash(interested)
+	if err != nil {
+		logger.Errorf("invariant error - model config should be yaml serializable and hashable, %v", err)
+		return ""
+	}
+	return h
+}
+
+type modelConfigWatcher struct {
+	keys    []string
+	hash    string
+	tomb    tomb.Tomb
+	changes chan struct{}
+	// We can't send down a closed channel, so protect the sending
+	// with a mutex and bool. Since you can't really even ask a channel
+	// if it is closed.
+	closed bool
+	mu     sync.Mutex
+}
+
+func (w *modelConfigWatcher) configChanged(topic string, value interface{}) {
+	hashCache, ok := value.(*modelConfigHashCache)
+	if !ok {
+		logger.Errorf("programming error, value not a *modelConfigHashCache")
+	}
+	hash := hashCache.getHash(w.keys)
+	if hash == w.hash {
+		// Nothing that we care about has changed, so we're done.
+		return
+	}
+	// Let the listener know.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+
+	select {
+	case w.changes <- struct{}{}:
+	default:
+		// Already a pending change, so do nothing.
+	}
+}
+
+// Changes is part of the core watcher definition.
+// The changes channel is never closed.
+func (w *modelConfigWatcher) Changes() <-chan struct{} {
+	return w.changes
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *modelConfigWatcher) Kill() {
+	w.mu.Lock()
+	w.closed = true
+	close(w.changes)
+	w.mu.Unlock()
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *modelConfigWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Stop is currently required by the Resources wrapper in the apiserver.
+func (w *modelConfigWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -1,0 +1,155 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package cache_test
+
+import (
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+)
+
+type ModelSuite struct {
+	testing.IsolationSuite
+
+	gauges *cache.ControllerGauges
+
+	hub *pubsub.SimpleHub
+}
+
+var _ = gc.Suite(&ModelSuite{})
+
+func (s *ModelSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.gauges = cache.CreateControllerGauges()
+	logger := loggo.GetLogger("test")
+	logger.SetLogLevel(loggo.TRACE)
+	s.hub = pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
+		Logger: logger,
+	})
+
+}
+
+func (s *ModelSuite) newModel(details cache.ModelChange) *cache.Model {
+	m := cache.NewModel(s.gauges, s.hub)
+	m.SetDetails(details)
+	return m
+}
+
+func (s *ModelSuite) TestReport(c *gc.C) {
+	m := s.newModel(modelChange)
+	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
+		"name": "model-owner/test-model",
+		"life": life.Value("alive"),
+	})
+}
+
+func (s *ModelSuite) TestConfig(c *gc.C) {
+	m := s.newModel(modelChange)
+	c.Assert(m.Config(), jc.DeepEquals, map[string]interface{}{
+		"key":     "value",
+		"another": "foo",
+	})
+}
+
+func (s *ModelSuite) TestNewModelGeneratesHash(c *gc.C) {
+	s.newModel(modelChange)
+	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(1))
+}
+
+func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
+	m := s.newModel(modelChange)
+	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(0))
+	m.Config()
+	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(1))
+	m.Config()
+	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(2))
+}
+
+func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
+	m := s.newModel(modelChange)
+	w := m.WatchConfig()
+	wc := NewNotifyWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange()
+	wc.AssertStops()
+}
+
+func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
+	m := s.newModel(modelChange)
+	w := m.WatchConfig()
+	defer workertest.CleanKill(c, w)
+	wc := NewNotifyWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange()
+
+	change := modelChange
+	change.Config = map[string]interface{}{
+		"key": "changed",
+	}
+
+	m.SetDetails(change)
+	wc.AssertOneChange()
+
+	// The hash is generated each time we set the details.
+	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(2))
+	// The value is retrieved from the cache when the watcher is created and notified.
+	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheHit), gc.Equals, float64(2))
+}
+
+func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
+	m := s.newModel(modelChange)
+	w := m.WatchConfig("key")
+	defer workertest.CleanKill(c, w)
+	wc := NewNotifyWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange()
+
+	change := modelChange
+	change.Config = map[string]interface{}{
+		"key":     "changed",
+		"another": "foo",
+	}
+
+	m.SetDetails(change)
+	wc.AssertOneChange()
+}
+
+func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
+	m := s.newModel(modelChange)
+	w := m.WatchConfig("key")
+	defer workertest.CleanKill(c, w)
+	wc := NewNotifyWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange()
+
+	change := modelChange
+	change.Config = map[string]interface{}{
+		"key":     "value",
+		"another": "changed",
+	}
+
+	m.SetDetails(change)
+	wc.AssertNoChange()
+}
+
+var modelChange = cache.ModelChange{
+	ModelUUID: "model-uuid",
+	Name:      "test-model",
+	Life:      life.Alive,
+	Owner:     "model-owner",
+	Config: map[string]interface{}{
+		"key":     "value",
+		"another": "foo",
+	},
+	Status: status.StatusInfo{
+		Status: status.Active,
+	},
+}

--- a/core/cache/notifywatcher_test.go
+++ b/core/cache/notifywatcher_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/testing"
+)
+
+func NewNotifyWatcherC(c *gc.C, watcher cache.NotifyWatcher) NotifyWatcherC {
+	return NotifyWatcherC{
+		C:       c,
+		Watcher: watcher,
+	}
+}
+
+type NotifyWatcherC struct {
+	*gc.C
+	Watcher cache.NotifyWatcher
+}
+
+// AssertOneChange fails if no change is sent before a long time has passed; or
+// if, subsequent to that, any further change is sent before a short time has
+// passed.
+func (c NotifyWatcherC) AssertOneChange() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher did not send change")
+	}
+	c.AssertNoChange()
+}
+
+// AssertNoChange fails if it manages to read a value from Changes before a
+// short time has passed.
+func (c NotifyWatcherC) AssertNoChange() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		if ok {
+			c.Fatalf("watcher sent unexpected change")
+		}
+		c.Fatalf("watcher changes channel closed")
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertStops Kills the watcher and asserts (1) that Wait completes without
+// error before a long time has passed; and (2) that Changes channel is closed.
+func (c NotifyWatcherC) AssertStops() {
+	c.Watcher.Kill()
+	wait := make(chan error)
+	go func() {
+		wait <- c.Watcher.Wait()
+	}()
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher never stopped")
+	case err := <-wait:
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		if ok {
+			c.Fatalf("watcher sent unexpected change")
+		}
+	default:
+		c.Fatalf("channel not closed")
+	}
+}

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"gopkg.in/juju/worker.v1"
+)
+
+// The watchers used in the cache package are closer to state watchers
+// than core watchers. The core watchers never close their changes channel,
+// which leads to issues in the apiserver facade methods dealing with
+// watchers. So the watchers in this package do close their changes channels.
+
+// Watcher is the common methods
+type Watcher interface {
+	worker.Worker
+	// Stop is currently needed by the apiserver until the resources
+	// work on workers instead of things that can be stopped.
+	Stop() error
+}
+
+// NotifyWatcher will only say something changed.
+type NotifyWatcher interface {
+	Watcher
+	Changes() <-chan struct{}
+}


### PR DESCRIPTION
The core/cache package is the start of the in-memory representation of the controller's models.

This package will serve eventually as the business logic tier with logic moving down from the apiserver package, and up out of the state package.

The core/cache package will provide database-less access to both information about the entities in the controller and watchers for them.

This work will provide the basis for some of the upcoming generations work.