### PR TITLE
LXD missing methods - 2.5beta

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -780,6 +780,41 @@ func (api *APIBase) SetCharmProfile(args params.ApplicationSetCharmProfile) erro
 	return application.SetCharmProfile(args.CharmURL)
 }
 
+// WatchLXDProfileUpgradeNotifications returns a watcher that fires on LXD
+// profile events.
+func (api *APIBase) WatchLXDProfileUpgradeNotifications(entity params.Entity) (params.NotifyWatchResult, error) {
+	if err := api.checkCanRead(); err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	tag, err := names.ParseApplicationTag(entity.Tag)
+	if err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	app, err := api.backend.Application(tag.Id())
+	if err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	w, err := app.WatchLXDProfileUpgradeNotifications()
+	if err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	return params.NotifyWatchResult{
+		NotifyWatcherId: api.resources.Register(w),
+	}, nil
+}
+
+// GetLXDProfileUpgradeMessages returns the lxd profile messages associated with
+// a application and set of machines
+func (api *APIBase) GetLXDProfileUpgradeMessages(arg params.LXDProfileUpgradeMessages) (params.LXDProfileUpgradeMessagesResults, error) {
+	if err := api.checkCanRead(); err != nil {
+		return params.LXDProfileUpgradeMessagesResults{}, errors.Trace(err)
+	}
+	results := params.LXDProfileUpgradeMessagesResults{
+		Results: make([]params.LXDProfileUpgradeMessagesResult, 0),
+	}
+	return results, nil
+}
+
 // GetConfig returns the charm config for each of the
 // applications asked for.
 func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -76,6 +76,7 @@ type Application interface {
 	SetExposed() error
 	SetCharmProfile(string) error
 	SetMetricCredentials([]byte) error
+	WatchLXDProfileUpgradeNotifications() (state.NotifyWatcher, error)
 	SetMinUnits(int) error
 	UpdateApplicationSeries(string, bool) error
 	UpdateCharmConfig(charm.Settings) error

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -490,6 +490,27 @@ type ApplicationGetConfigResults struct {
 	Results []ConfigResult
 }
 
+// LXDProfileUpgradeMessages holds the parameters for an application
+// lxd profile machines	// lxd profile machines
+type LXDProfileUpgradeMessages struct {
+	ApplicationTag Entity `json:"application"`
+	WatcherId      string `json:"watcher-id"`
+}
+
+// LXDProfileUpgradeMessagesResult holds the result for an application
+// lxd profile upgrade message
+type LXDProfileUpgradeMessagesResult struct {
+	UnitName string `json:"unit-name"`
+	Message  string `json:"message"`
+	Error    *Error `json:"error,omitempty"`
+}
+
+// LXDProfileUpgradeMessagesResults holds the parameters for retrieving
+// the associated lxd profile messages from a machine for a application
+type LXDProfileUpgradeMessagesResults struct {
+	Results []LXDProfileUpgradeMessagesResult `json:"args"`
+}
+
 // LXDProfileUpgrade holds the parameters for an application
 // lxd profile machines
 type LXDProfileUpgrade struct {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1937,6 +1937,36 @@ func (u *Unit) WatchMeterStatus() NotifyWatcher {
 // WatchLXDProfileUpgradeNotifications returns a watcher that observes the status
 // of a lxd profile upgrade by monitoring changes on the unit machine's lxd profile
 // upgrade completed field that is specific to an application name.
+// Note: this is deprecated in favour of Machine.WatchLXDProfileUpgradeNotifications
+func (a *Application) WatchLXDProfileUpgradeNotifications() (NotifyWatcher, error) {
+	return newNoopWatcher(), nil
+}
+
+type noopWatcher struct {
+	commonWatcher
+	out chan struct{}
+}
+
+var _ Watcher = (*noopWatcher)(nil)
+
+func newNoopWatcher() NotifyWatcher {
+	w := &noopWatcher{
+		out: make(chan struct{}),
+	}
+	w.tomb.Go(func() error {
+		defer close(w.out)
+		return nil
+	})
+	return w
+}
+
+func (w *noopWatcher) Changes() <-chan struct{} {
+	return w.out
+}
+
+// WatchLXDProfileUpgradeNotifications returns a watcher that observes the status
+// of a lxd profile upgrade by monitoring changes on the unit machine's lxd profile
+// upgrade completed field that is specific to an application name.
 func (m *Machine) WatchLXDProfileUpgradeNotifications(applicationName string) (NotifyWatcher, error) {
 	machineIds := set.NewStrings()
 	machineIds.Add(m.doc.DocID)


### PR DESCRIPTION
## Description of change

Implement missing methods for 2.5-beta2

The following are required to allow operators to upgrade from
2.5-beta2 to 2.5rc. The reason why we need the following no-op
operations is because we no longer utilise the client to monitor
the upgrading of a charm. Instead we use the uniter to oversee
the correct upgrade path (logical in he insight), but in early betas
the client expects to be able to call and watch upgrading. In the 
following code we just still allow those methods to be called, but
we just perform a no-op.

## QA steps

deploy with 2.5-rc or equivalent
```
juju bootstrap localhost
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
```
using the 2.5-beta2 client attempt to upload
``` 
juju upgrade lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt
```

## Documentation changes

This should allow clients on beta2.5 to move to rc1

## Bug reference

N/A
