### PR TITLE
Only start lxd profile watcher on iaas models

### DIFF
--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -158,7 +158,9 @@ func (s *WatcherSuite) TestInitialSignal(c *gc.C) {
 	if s.st.unit.upgradeSeriesWatcher != nil {
 		s.st.unit.upgradeSeriesWatcher.changes <- struct{}{}
 	}
-	s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- struct{}{}
+	if s.st.unit.upgradeLXDProfileUpgradeWatcher != nil {
+		s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- struct{}{}
+	}
 	s.st.unit.storageWatcher.changes <- []string{}
 	s.st.unit.actionWatcher.changes <- []string{}
 	if s.st.unit.application.applicationWatcher != nil {
@@ -185,8 +187,8 @@ func (s *WatcherSuite) signalAll() {
 	if s.st.modelType == model.IAAS {
 		s.applicationWatcher.changes <- struct{}{}
 		s.st.unit.upgradeSeriesWatcher.changes <- struct{}{}
+		s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- struct{}{}
 	}
-	s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- struct{}{}
 }
 
 func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
@@ -231,7 +233,7 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 		LeaderSettingsVersion:     1,
 		Leader:                    true,
 		UpgradeSeriesStatus:       "",
-		UpgradeCharmProfileStatus: lxdprofile.NotRequiredStatus,
+		UpgradeCharmProfileStatus: "",
 	})
 }
 
@@ -280,15 +282,14 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	if s.modelType == model.IAAS {
 		s.st.unit.upgradeSeriesWatcher.changes <- struct{}{}
 		assertOneChange()
+		s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- struct{}{}
+		assertOneChange()
 
 		s.st.unit.application.forceUpgrade = true
 		s.applicationWatcher.changes <- struct{}{}
 		assertOneChange()
 		c.Assert(s.watcher.Snapshot().ForceCharmUpgrade, jc.IsTrue)
 	}
-
-	s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- struct{}{}
-	assertOneChange()
 
 	s.clock.Advance(5 * time.Minute)
 	assertOneChange()


### PR DESCRIPTION
## Description of change

https://github.com/juju/juju/pull/9513 breaks k8s deployments because it starts an IAAS only LXD profile watcher

## QA steps

deploy a k8s charm and ensure it starts

