### PR TITLE
cmd: Fix help text does not include --debug

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -111,7 +111,13 @@ Example help commands:
     `[1:] + "`juju help`" + `          This help page
     ` + "`juju help commands`" + ` Lists all commands
     ` + "`juju help deploy`" + `   Shows help for command 'deploy'
-`
+
+Debug mode:
+  --debug flag enable debug mode for each command.
+
+  example:
+    ` + "`juju add-cloud --debug`" + ` execute add-cloud in debug mode
+ `
 
 var x = []byte("\x96\x8c\x8a\x91\x93\x9a\x9e\x8c\x97\x99\x8a\x9c\x94\x96\x91\x98\xdf\x9e\x92\x9e\x85\x96\x91\x98\xf5")
 


### PR DESCRIPTION
Add info about ``--debug`` flag
## Description of change

The help text output for list **now** the --debug option along with the other options available for a command.

## QA steps
`juju help` shoud show improved help message.

``juju --debug`` should show some debug infos as also `juju add-cloud --debug` etc. (but this commands should already working).

## Documentation changes
`Cmd` juju shows now the debug option.

## Bug reference
Fix https://bugs.launchpad.net/juju/+bug/1628151

## add info:

I'm open if you have a better layout/description for the cmd helper output