### PR TITLE
juju client no longer calls SetCharmProfile on upgrade-charm.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -869,20 +869,6 @@ func (c *Client) ResolveUnitErrors(units []string, all, retry bool) error {
 	return errors.Trace(results.Combine())
 }
 
-// SetCharmProfile a new charm's url on deployed machines for changing the
-// profile used on those machine.
-func (c *Client) SetCharmProfile(applicationName string, charmID charmstore.CharmID) error {
-	if c.BestAPIVersion() < 8 {
-		return errors.NotSupportedf("SetCharmProfile not supported by this version of Juju")
-	}
-	args := params.ApplicationSetCharmProfile{
-		ApplicationName: applicationName,
-		CharmURL:        charmID.URL.String(),
-	}
-	var results params.ErrorResults
-	return c.facade.FacadeCall("SetCharmProfile", args, &results)
-}
-
 func validateApplicationScale(scale, scaleChange int) error {
 	if scale == 0 && scaleChange == 0 {
 		return errors.NotValidf("scale of 0")

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1288,17 +1288,3 @@ func (s *applicationSuite) TestScaleApplicationCallError(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
-
-func (s *applicationSuite) TestSetCharmProfileError(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "SetCharmProfile")
-			return errors.New("boom")
-		},
-	)
-	client := newClient(apiCaller)
-	err := client.SetCharmProfile("foo", charmstore.CharmID{
-		URL: charm.MustParseURL("local:testing-1"),
-	})
-	c.Assert(err, gc.ErrorMatches, "boom")
-}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -739,6 +739,10 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if err := application.SetCharmProfile(args.CharmURL); err != nil {
+		return errors.Annotatef(err, "unable to set charm profile")
+	}
+
 	channel := csparams.Channel(args.Channel)
 	return api.applicationSetCharm(
 		args.ApplicationName,
@@ -755,8 +759,11 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	)
 }
 
-// SetCharmProfile a new charm's url on deployed machines for changing the profile used
-// on those machine.
+// SetCharmProfile a new charm's url on deployed machines for changing the
+// profile used on those machine.
+//
+// TODO: consider removing this public method as it is now done as part of
+// SetCharm.
 func (api *APIBase) SetCharmProfile(args params.ApplicationSetCharmProfile) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -759,34 +759,6 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	)
 }
 
-// SetCharmProfile a new charm's url on deployed machines for changing the
-// profile used on those machine.
-//
-// TODO: consider removing this public method as it is now done as part of
-// SetCharm.
-func (api *APIBase) SetCharmProfile(args params.ApplicationSetCharmProfile) error {
-	if err := api.checkCanWrite(); err != nil {
-		return err
-	}
-	// TODO (hml) 3-oct-2018
-	// We should do this....
-	// when forced units in error, don't block
-	//if !args.ForceUnits {
-	//	if err := api.check.ChangeAllowed(); err != nil {
-	//		return errors.Trace(err)
-	//	}
-	//}
-
-	// Don't verify the charm lxd profile, the watcher must be able to
-	// determine if a profile has been removed from the charm.
-
-	application, err := api.backend.Application(args.ApplicationName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return application.SetCharmProfile(args.CharmURL)
-}
-
 // GetConfig returns the charm config for each of the
 // applications asked for.
 func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -209,8 +209,9 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "Application", "Charm")
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "SetCharm")
-	app.CheckCall(c, 0, "SetCharm", state.SetCharmConfig{
+	app.CheckCallNames(c, "SetCharmProfile", "SetCharm")
+	app.CheckCall(c, 0, "SetCharmProfile", "cs:postgresql")
+	app.CheckCall(c, 1, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
 		StorageConstraints: map[string]state.StorageConstraints{
 			"a": {},
@@ -231,8 +232,9 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	s.backend.CheckCallNames(c, "Application", "Charm")
 	s.backend.charm.CheckCallNames(c, "Config")
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "SetCharm")
-	app.CheckCall(c, 0, "SetCharm", state.SetCharmConfig{
+	app.CheckCallNames(c, "SetCharmProfile", "SetCharm")
+	app.CheckCall(c, 0, "SetCharmProfile", "cs:postgresql")
+	app.CheckCall(c, 1, "SetCharm", state.SetCharmConfig{
 		Charm:          &state.Charm{},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
@@ -251,8 +253,9 @@ postgresql:
 	s.backend.CheckCallNames(c, "Application", "Charm")
 	s.backend.charm.CheckCallNames(c, "Config")
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "SetCharm")
-	app.CheckCall(c, 0, "SetCharm", state.SetCharmConfig{
+	app.CheckCallNames(c, "SetCharmProfile", "SetCharm")
+	app.CheckCall(c, 0, "SetCharmProfile", "cs:postgresql")
+	app.CheckCall(c, 1, "SetCharm", state.SetCharmConfig{
 		Charm:          &state.Charm{},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -117,6 +117,11 @@ func (a *mockApplication) AllUnits() ([]application.Unit, error) {
 	return units, nil
 }
 
+func (a *mockApplication) SetCharmProfile(charmURL string) error {
+	a.MethodCall(a, "SetCharmProfile", charmURL)
+	return a.NextErr()
+}
+
 func (a *mockApplication) SetCharm(cfg state.SetCharmConfig) error {
 	a.MethodCall(a, "SetCharm", cfg)
 	return a.NextErr()

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -393,16 +393,6 @@ type ApplicationSetCharm struct {
 	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
 }
 
-// ApplicationSetCharmProfile holds the parameters for making the
-// application SetCharmProfile call.
-type ApplicationSetCharmProfile struct {
-	// ApplicationName is the name of the application to set the profile on.
-	ApplicationName string `json:"application"`
-
-	// CharmURL is the new charm's url.
-	CharmURL string `json:"charm-url"`
-}
-
 // ApplicationExpose holds the parameters for making the application Expose call.
 type ApplicationExpose struct {
 	ApplicationName string `json:"application"`

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -76,7 +76,6 @@ type CharmUpgradeClient interface {
 	GetCharmURL(string) (*charm.URL, error)
 	Get(string) (*params.ApplicationGetResults, error)
 	SetCharm(application.SetCharmConfig) error
-	SetCharmProfile(string, charmstore.CharmID) error
 }
 
 // CharmClient defines a subset of the charms facade, as required
@@ -357,12 +356,6 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	ids, err := c.upgradeResources(apiRoot, charmsClient, resourceLister, chID, csMac)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Next, upgrade the lxd-profile if appropriate.
-	err = charmUpgradeClient.SetCharmProfile(c.ApplicationName, chID)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -175,8 +175,8 @@ func (s *UpgradeCharmSuite) runUpgradeCharm(c *gc.C, args ...string) (*cmd.Conte
 func (s *UpgradeCharmSuite) TestStorageConstraints(c *gc.C) {
 	_, err := s.runUpgradeCharm(c, "foo", "--storage", "bar=baz")
 	c.Assert(err, jc.ErrorIsNil)
-	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharmProfile", "SetCharm")
-	s.charmAPIClient.CheckCall(c, 3, "SetCharm", application.SetCharmConfig{
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -224,8 +224,8 @@ func (s *UpgradeCharmSuite) TestConfigSettings(c *gc.C) {
 
 	_, err = s.runUpgradeCharm(c, "foo", "--config", configFile)
 	c.Assert(err, jc.ErrorIsNil)
-	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharmProfile", "SetCharm")
-	s.charmAPIClient.CheckCall(c, 3, "SetCharm", application.SetCharmConfig{
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -924,11 +924,6 @@ func (m *mockCharmAPIClient) SetCharm(cfg application.SetCharmConfig) error {
 func (m *mockCharmAPIClient) Get(applicationName string) (*params.ApplicationGetResults, error) {
 	m.MethodCall(m, "Get", applicationName)
 	return &params.ApplicationGetResults{}, m.NextErr()
-}
-
-func (m *mockCharmAPIClient) SetCharmProfile(appName string, charmID jujucharmstore.CharmID) error {
-	m.MethodCall(m, "SetCharmProfile", appName, charmID)
-	return m.NextErr()
 }
 
 type mockNotifyWatcher struct {

--- a/state/application.go
+++ b/state/application.go
@@ -901,6 +901,10 @@ func (a *Application) DeployedMachines() ([]*Machine, error) {
 		// whether principal or subordinate.
 		id, err := u.AssignedMachineId()
 		if err != nil {
+			if errors.IsNotAssigned(err) {
+				// We aren't interested in this unit at this time.
+				continue
+			}
 			return nil, errors.Trace(err)
 		}
 		if machineIds.Contains(id) {


### PR DESCRIPTION
The setting of the charm profile is now done on the apiserver when SetCharm is called.

This means older clients will just do the right thing, and newer clients will work with older controllers.

## QA steps

- bootstrap both 2.4.7 controller and 2.5-rc1 controller
- deploy test charm to both: ./testcharms/charm-repo/quantal/lxd-profile-alt
- upgrade-charm --path to both

## Bug reference

https://bugs.launchpad.net/juju/+bug/1807666