### PR TITLE
Get the caas operator image from the charmstore not docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ check-deps:
 	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
 
 # CAAS related targets
-DOCKER_USERNAME?=jujusolutions
+DOCKER_REGISTRY?=registry.jujucharms.com
+DOCKER_USERNAME?=juju
 JUJUD_STAGING_DIR?=/tmp/jujud-operator
 JUJUD_BIN_DIR=${GOPATH}/bin
 OPERATOR_IMAGE_TAG = $(shell jujud version | cut -d- -f1,2)
@@ -148,11 +149,11 @@ operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requi
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
-	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
+	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_REGISTRY}/${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
-	docker push ${DOCKER_USERNAME}/caas-jujud-operator
+	docker push ${DOCKER_REGISTRY}/${DOCKER_USERNAME}/caas-jujud-operator
 
 check-k8s-model:
 	@:$(if $(value JUJU_K8S_MODEL),, $(error Undefined JUJU_K8S_MODEL))

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -100,7 +100,7 @@ func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error
 	vers := version.Current
 	vers.Build = 0
 	if imagePath == "" {
-		imagePath = fmt.Sprintf("%s/caas-jujud-operator:%s", "jujusolutions", vers.String())
+		imagePath = fmt.Sprintf("registry.jujucharms.com/juju/caas-jujud-operator:%s", vers.String())
 	}
 	charmStorageParams, err := charmStorageParams(a.storagePoolManager, a.storageProviderRegistry)
 	if err != nil {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -125,7 +125,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
+		ImagePath:    fmt.Sprintf("registry.jujucharms.com/juju/caas-jujud-operator:%s", version.Current.String()),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
@@ -143,7 +143,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 }
 
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
-	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	s.st.operatorImage = "registry.jujucharms.com/juju/caas-jujud-operator"
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
@@ -166,7 +166,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
-	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	s.st.operatorImage = "registry.jujucharms.com/juju/caas-jujud-operator"
 	_, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -212,14 +212,14 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
 		"juju-operator": "gitlab",
 	}
-	pod := provider.OperatorPod("gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator", "2.99.0", tags)
+	pod := provider.OperatorPod("gitlab", "/var/lib/juju", "registry.jujucharms.com/juju/caas-jujud-operator", "2.99.0", tags)
 	c.Assert(pod.Name, gc.Equals, "juju-operator-gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
 		"juju-operator": "gitlab",
 		"juju-version":  "2.99.0",
 	})
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
-	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/caas-jujud-operator")
+	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "registry.jujucharms.com/juju/caas-jujud-operator")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 1)
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/template-agent.conf")
 }


### PR DESCRIPTION
## Description of change

Get the k8s operator image from the charm store's docker repo, not docker hub.

## QA steps

Deploy a k8s charm.

