### PR TITLE
Fixes lp#162815: show some supported super command options.

### DIFF
--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -29,6 +29,8 @@ Show help on a Juju charm hook tool.
 Options:
 --debug  (= false)
     equivalent to --show-log --logging-config=<root>=DEBUG
+-h, --help  (= false)
+    Show help on a command or other topic.
 --logging-config (= "")
     specify log levels for modules
 --quiet  (= false)

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -21,10 +21,22 @@ var _ = gc.Suite(&HelpToolSuite{})
 
 func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
 	output := badrun(c, 0, "help", "help-tool")
-	c.Assert(output, gc.Equals, `Usage: juju hook-tool [tool]
+	c.Assert(output, gc.Equals, `Usage: juju hook-tool [options] [tool]
 
 Summary:
 Show help on a Juju charm hook tool.
+
+Options:
+--debug  (= false)
+    equivalent to --show-log --logging-config=<root>=DEBUG
+--logging-config (= "")
+    specify log levels for modules
+--quiet  (= false)
+    show no informational output
+--show-log  (= false)
+    if set, write the log file to stderr
+--verbose  (= false)
+    show more verbose output
 
 Details:
 Juju charms can access a series of built-in helpers called 'hook-tools'.

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -252,15 +252,14 @@ func juju2xConfigDataExists() bool {
 	return err == nil
 }
 
-// NewJujuCommand ...
+// NewJujuCommand constructs a super command for Juju CLI.
 func NewJujuCommand(ctx *cmd.Context) cmd.Command {
-	jcmd := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
-		Name:                "juju",
-		Doc:                 jujuDoc,
-		MissingCallback:     RunPlugin,
-		UserAliasesFilename: osenv.JujuXDGDataHomePath("aliases"),
-		FlagKnownAs:         "option",
-	})
+	p := jujucmd.MinimumJujuCommandParameters()
+	p.Doc = jujuDoc
+	p.MissingCallback = RunPlugin
+	p.UserAliasesFilename = osenv.JujuXDGDataHomePath("aliases")
+
+	jcmd := jujucmd.NewSuperCommand(p)
 	jcmd.AddHelpTopic("basics", "Basic Help Summary", usageHelp)
 	registerCommands(jcmd, ctx)
 	return jcmd

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -44,10 +45,11 @@ var _ = gc.Suite(&MainSuite{})
 
 func helpText(command cmd.Command, name string) string {
 	buff := &bytes.Buffer{}
-	info := command.Info()
+	subCommand := jujucmd.NewJujuSubCommand(command)
+	info := subCommand.Info()
 	info.Name = name
 	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, cmd.FlagAlias(command, "option"))
-	command.SetFlags(f)
+	subCommand.SetFlags(f)
 	buff.Write(info.Help(f))
 	return buff.String()
 }

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -75,7 +75,9 @@ func (c *JujuSubCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.super.SetFlags(supported)
 	supported.VisitAll(func(flag *gnuflag.Flag) {
 		if desiredFlags.Contains(flag.Name) {
-			f.Var(flag.Value, flag.Name, flag.Usage)
+			if found := f.Lookup(flag.Name); found == nil {
+				f.Var(flag.Value, flag.Name, flag.Usage)
+			}
 		}
 	})
 	c.Command.SetFlags(f)


### PR DESCRIPTION
## Description of change

'juju' as a super command has some options that are globally available to all juju subcommands, for example --show-log.

This PR ensures that these global options are visible on 'juju help <command>'.

## QA steps

'juju help <juju command>'

For example, 'juju help add-model' AFTER and BEFORE: https://pastebin.ubuntu.com/p/WjVCBNd6S3/

## Bug reference

https://bugs.launchpad.net/juju/+bug/1628151
