### PR TITLE
Test commit for 2.5 edge snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,4 @@ To enable strict mode, the following bugs need to be resolved, and the snap upda
  * Missing support for abstract unix sockets (https://bugs.launchpad.net/snappy/+bug/1604967)
  * Juju plugin support (https://bugs.launchpad.net/juju/+bug/1628538)
  
+


### PR DESCRIPTION
Test readme change to validate the auto building of the edge snap on the juju 2.5 branch. 