### PR TITLE
Fix charm revision updater test.

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/juju/utils/arch"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -188,7 +186,7 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 	cloud, err := s.State.Cloud(model.Cloud())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedHeader := []string{
-		"arch=" + arch.HostArch(),
+		"arch=amd64", // This is the architecture of the deployed applications.
 		"cloud=" + model.Cloud(),
 		"cloud_region=" + model.CloudRegion(),
 		"controller_uuid=" + s.State.ControllerUUID(),


### PR DESCRIPTION
The headers sent to identify new charm revisions includes the architectures that the charms are deployed with. The test was asserting against the host architecture running the tests for this, which is wrong.