### PR TITLE
update assess_upgrade.py. 

### DIFF
--- a/acceptancetests/README.md
+++ b/acceptancetests/README.md
@@ -14,6 +14,13 @@ $ sudo apt-get install make
 $ make install-deps
 ```
 
+It may also be necessary to install simplestreams to run tests like assess_upgrade.py.
+```bash
+$ sudo apt update
+$ sudo apt install python3-simplestreams
+$ sudo apt install python-simplestreams
+```
+
 ### Required Environment Variables
 
   * **JUJU_HOME**: The directory the test will use to:
@@ -140,6 +147,11 @@ juju bootstrap lxd testing-feature-x
 
 Normally a test script will teardown any bootstrapped controllers, if you wish to investigate the environment after a run use ```--keep-env```.  
 Using the ```--keep-env``` option will skip any teardown of an environment at the end of a test.
+
+To view juju status output of the current model, if JUJU_DATA not set
+```bash
+JUJU_DATA=$JUJU_HOME/juju-homes/<controller_name> juju status
+```
 
 ### Use of environments.yaml<a name="envs"></a>
 

--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -7,7 +7,8 @@ to the new one.
   - Spins up a local streams server (requires to be run on lxd or on a machine
      with an externally routable interface.
   - Bootstraps using the 'stable' juju then upgrades to the 'devel' version.
-  - Deploys mediawiki and mysql to ensure workloads continue working.
+  - Deploys keystone and percona-cluster to ensure
+     workloads continue working.
 """
 
 from __future__ import print_function
@@ -48,8 +49,8 @@ from jujupy.wait_condition import (
     wait_until_model_upgrades,
 )
 from jujupy.workloads import (
-    deploy_mediawiki_with_db,
-    assert_mediawiki_is_responding
+    deploy_keystone_with_db,
+    assert_keystone_is_responding
     )
 
 
@@ -118,10 +119,10 @@ def assert_upgrade_is_successful(
         raise ValueError("extra_upgrade_args must be a tuple")
     assert_stable_model_is_correct(stable_client)
 
-    deploy_mediawiki_with_db(stable_client)
-    assert_mediawiki_is_responding(stable_client)
+    deploy_keystone_with_db(stable_client)
+    assert_keystone_is_responding(stable_client)
     upgrade_stable_to_devel_version(devel_client, extra_upgrade_args)
-    assert_mediawiki_is_responding(devel_client)
+    assert_keystone_is_responding(devel_client)
 
 
 def upgrade_stable_to_devel_version(client, extra_args):


### PR DESCRIPTION
## Description of change

media wiki appears to be an unmaintained charm and is causing issues in the success of assess_upgrade.py.  replace with keystone which is maintained.

## QA steps

1. Setup up a snap version of juju at the beta channel
2. Setup environment per acceptancetests/Readme.md
3. Run with:  ./assess_upgrade.py lxd $GOPATH/bin/juju /tmp/artifacts testme --stable-juju-bin /snap/juju/current/bin/juju

