### PR TITLE
Prevent error when using Legacy Leases

### DIFF
--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -475,7 +475,7 @@ func (ctx *facadeContext) LeadershipChecker() (leadership.Checker, error) {
 // Pinning functionality is only available with the Raft leases implementation.
 func (ctx *facadeContext) LeadershipPinner(modelUUID string) (leadership.Pinner, error) {
 	if ctx.r.shared.featureEnabled(feature.LegacyLeases) {
-		return nil, errors.Errorf(
+		return nil, errors.NotImplementedf(
 			"unable to get leadership pinner; pinning is not available with the legacy lease manager")
 	}
 	pinner, err := ctx.r.shared.leaseManager.Pinner(

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/service"
 	"github.com/juju/os/series"
@@ -356,9 +357,9 @@ func (w *upgradeSeriesWorker) pinLeaders() (err error) {
 		// utilising the legacy leases store, then we should display the warning
 		// in the log and return out. Unpinning leaders should be safe as that
 		// should be considered a no-op
-		if errors.IsNotImplemented(errors.Cause(err)) {
-			w.logger.Warningf("failed to pin machine applications %+v", err)
-			return
+		if params.IsCodeNotImplemented(err) {
+			w.logger.Infof("failed to pin machine applications %+v", err)
+			return nil
 		}
 		return errors.Trace(err)
 	}

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -358,7 +358,7 @@ func (w *upgradeSeriesWorker) pinLeaders() (err error) {
 		// in the log and return out. Unpinning leaders should be safe as that
 		// should be considered a no-op
 		if params.IsCodeNotImplemented(err) {
-			w.logger.Infof("failed to pin machine applications %+v", err)
+			w.logger.Infof("failed to pin machine applications, with legacy lease manager leadership pinning is not implemented")
 			return nil
 		}
 		return errors.Trace(err)

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -352,6 +352,14 @@ func (w *upgradeSeriesWorker) pinLeaders() (err error) {
 
 	results, err := w.PinMachineApplications()
 	if err != nil {
+		// If pin machine applications method return not implemented because it's
+		// utilising the legacy leases store, then we should display the warning
+		// in the log and return out. Unpinning leaders should be safe as that
+		// should be considered a no-op
+		if errors.IsNotImplemented(errors.Cause(err)) {
+			w.logger.Warningf("failed to pin machine applications %+v", err)
+			return
+		}
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
## Description of change

The following code ensures that we don't fail when attempting to
use the old legacy leases.

## QA steps

```
juju bootstrap localhost test --debug --build-agent=true --config features="[legacy-leases]" --bootstrap-series="xenial"
juju add-machine --series=xenial
juju upgrade-series 0 prepare bionic -y
```

## Documentation changes

This is a bug fix, not functionality has changed.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1808324
