### PR TITLE
Fix other addmodel sites.

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -312,7 +312,7 @@ def ensure_superuser_can_migrate_other_user_models(
         source_client, dest_client, tmp_dir):
 
     norm_source_client, norm_dest_client = create_user_on_controllers(
-        source_client, dest_client, tmp_dir, 'normaluser', 'addmodel')
+        source_client, dest_client, tmp_dir, 'normaluser', 'add-model')
 
     attempt_client = deploy_dummy_source_to_new_model(
         norm_source_client, 'supernormal-test')

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -570,7 +570,7 @@ class ModelClient:
 
     model_permissions = frozenset(['read', 'write', 'admin'])
 
-    controller_permissions = frozenset(['login', 'addmodel', 'superuser'])
+    controller_permissions = frozenset(['login', 'add-model', 'superuser'])
 
     # Granting 'login' will error as a created user has that at creation.
     ignore_permissions = frozenset(['login'])


### PR DESCRIPTION
Python has single quoted strings as well as double. Test was failing because code was checking internal frozenset prior to making call.