### PR TITLE
fix for broken juju causing failures in nw-charm-resources* ci tests

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -288,15 +288,6 @@ func (s *uniterResolver) nextOp(
 	// inform the uniter workers to run the upgrade hook.
 	if charmModified(localState, remoteState) {
 		if s.config.ModelType == model.IAAS {
-			// Ensure that we have upgraded the charm profile before we action
-			// the upgrading of the charm.
-			op, err := s.config.UpgradeCharmProfile.NextOp(localState, remoteState, opFactory)
-			if errors.Cause(err) != resolver.ErrNoOperation {
-				if errors.Cause(err) == resolver.ErrDoNotProceed {
-					return nil, resolver.ErrNoOperation
-				}
-				return op, err
-			}
 			return opFactory.NewUpgrade(remoteState.CharmURL)
 		}
 		return opFactory.NewNoOpUpgrade(remoteState.CharmURL)


### PR DESCRIPTION
## Description of change

No need to wait for a charm profile to be applied when charmModified is
true.  A new lxd profile will only come when a new charm is uploaded,
triggering an operation.Upgrade.  Waiting at charmModified for profiles
only breaks things like resource changes which trigger the upgrade
charm hook, not a full charm upgrade.

## QA steps

./assess_resources.py lxd $GOPATH/bin/juju /tmp/artifacts testme

charm pull ubuntu
cd $GOPATH/github.com/juju/juju
juju bootstrap localhost --build-agent --config logging-config="<root>=DEBUG;unit=DEBUG
juju deploy ~/ubuntu ; juju deploy neutron-openvswitch-252 
juju add-relation neutron-openvswitch ubuntu 
juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd 
juju deploy ./testcharms/charm-repo/quantal/lxd-profile 
juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate
juju add-relation lxd-profile-subordinate lxd-profile 
juju add-relation lxd-profile-subordinate ubuntu
juju deploy percona-cluster-270
Commands to test; check 'lxc profile list' to see profiles being added and removed, matching the charm rev number; :
juju upgrade-charm lxd-profile-subordinate --path ./testcharms/charm-repo/quantal/lxd-profile-subordinate <-- run multiple times
juju upgrade-charm ubuntu --path ~/ubuntu <-- run multiple times
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile <-- run multiple times
juju upgrade-charm neutron-opensvswitch <-- charm rev 255 should install an lxd-profile
juju add-unit ubuntu
juju upgrade-charm percona-cluster
juju add-unit lxd-profile-alt --to <machine with percona-cluster> <-- check that profile added to machine
juju remove-unit lxd-profile-alt/<unit added to percona-cluster> <-- check that profile removed from machine.

Test break profile and fix it:
cp ./testcharms/charm-repo/quantal/lxd-profile/lxd-profile.yaml ./testcharms/charm-repo/quantal/lxd-profile-alt/.
juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt <-- this will cause a machine error where the lxd-profile-alt/0 is deployed.
juju add-unit lxd-profile-alt <-- machine should not be in an error state
git checkout testcharms/charm-repo/quantal/lxd-profile-alt/lxd-profile.yaml
juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt <-- will resolve the machine error lxd-profile-alt/0 and cause one for lxd-profile-alt/1
juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt <-- both units shouldn't have a machine error.