### PR TITLE
Add modelcache worker

### DIFF
--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -15,12 +15,13 @@ import (
 
 // Logger describes the logging methods used in this package by the worker.
 type Logger interface {
+	IsTraceEnabled() bool
 	Tracef(string, ...interface{})
 	Errorf(string, ...interface{})
 }
 
-// ManifoldConfig holds the information necessary to run an apiserver
-// worker in a dependency.Engine.
+// ManifoldConfig holds the information necessary to run a model cache worker in
+// a dependency.Engine.
 type ManifoldConfig struct {
 	StateName string
 	Logger    Logger
@@ -47,16 +48,16 @@ func (config ManifoldConfig) Validate() error {
 	return nil
 }
 
-// Manifold returns a dependency.Manifold that will run an apiserver
-// worker. The manifold outputs an *apiserverhttp.Mux, for other workers
-// to register handlers against.
+// Manifold returns a dependency.Manifold that will run a model cache
+// worker. The manifold outputs a *cache.Controller, primarily for
+// the apiserver to depend on and use.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
 			config.StateName,
 		},
 		Start:  config.start,
-		Output: OutputFunc,
+		Output: ExtractCacheController,
 	}
 }
 
@@ -71,8 +72,6 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	// Get the state pool after grabbing dependencies so we don't need
-	// to remember to call Done on it if they're not running yet.
 	statePool, err := stTracker.Use()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -93,8 +92,8 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	return w, nil
 }
 
-// OutputFunc extracts a *cache.Controller from a *cacheWorker.
-func OutputFunc(in worker.Worker, out interface{}) error {
+// ExtractCacheController extracts a *cache.Controller from a *cacheWorker.
+func ExtractCacheController(in worker.Worker, out interface{}) error {
 	inWorker, _ := in.(*cacheWorker)
 	if inWorker == nil {
 		return errors.Errorf("in should be a %T; got %T", inWorker, in)

--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -1,0 +1,110 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcache
+
+import (
+	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+
+	"github.com/juju/juju/core/cache"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// Logger describes the logging methods used in this package by the worker.
+type Logger interface {
+	Tracef(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// ManifoldConfig holds the information necessary to run an apiserver
+// worker in a dependency.Engine.
+type ManifoldConfig struct {
+	StateName string
+	Logger    Logger
+
+	PrometheusRegisterer prometheus.Registerer
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("missing PrometheusRegisterer")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("missing NewWorker func")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run an apiserver
+// worker. The manifold outputs an *apiserverhttp.Mux, for other workers
+// to register handlers against.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start:  config.start,
+		Output: OutputFunc,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Get the state pool after grabbing dependencies so we don't need
+	// to remember to call Done on it if they're not running yet.
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w, err := config.NewWorker(Config{
+		Logger:               config.Logger,
+		StatePool:            statePool,
+		PrometheusRegisterer: config.PrometheusRegisterer,
+		Cleanup: func() {
+			stTracker.Done()
+		},
+	})
+	if err != nil {
+		stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// OutputFunc extracts a *cache.Controller from a *cacheWorker.
+func OutputFunc(in worker.Worker, out interface{}) error {
+	inWorker, _ := in.(*cacheWorker)
+	if inWorker == nil {
+		return errors.Errorf("in should be a %T; got %T", inWorker, in)
+	}
+
+	switch outPointer := out.(type) {
+	case **cache.Controller:
+		*outPointer = inWorker.controller
+	default:
+		return errors.Errorf("out should be *cache.Controller; got %T", out)
+	}
+	return nil
+}

--- a/worker/modelcache/manifold_test.go
+++ b/worker/modelcache/manifold_test.go
@@ -1,0 +1,163 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcache_test
+
+import (
+	"unsafe"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/modelcache"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	config modelcache.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = modelcache.ManifoldConfig{
+		StateName:            "state",
+		Logger:               loggo.GetLogger("test"),
+		PrometheusRegisterer: noopRegisterer{},
+		NewWorker: func(modelcache.Config) (worker.Worker, error) {
+			return nil, errors.New("boom")
+		},
+	}
+}
+
+func (s *ManifoldSuite) manifold() dependency.Manifold {
+	return modelcache.Manifold(s.config)
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold().Inputs, jc.DeepEquals, []string{"state"})
+}
+
+func (s *ManifoldSuite) TestConfigValidation(c *gc.C) {
+	err := s.config.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingStateName(c *gc.C) {
+	s.config.StateName = ""
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "empty StateName not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingPrometheusRegisterer(c *gc.C) {
+	s.config.PrometheusRegisterer = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing PrometheusRegisterer not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Logger not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing NewWorker func not valid")
+}
+
+func (s *ManifoldSuite) TestManifoldCallsValidate(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{})
+	s.config.Logger = nil
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `missing Logger not valid`)
+}
+
+func (s *ManifoldSuite) TestAgentMissing(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state": dependency.ErrMissing,
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(worker, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestNewWorkerArgs(c *gc.C) {
+	var config modelcache.Config
+	s.config.NewWorker = func(c modelcache.Config) (worker.Worker, error) {
+		config = c
+		return &fakeWorker{}, nil
+	}
+
+	tracker := &fakeStateTracker{}
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state": tracker,
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.NotNil)
+
+	c.Check(config.Validate(), jc.ErrorIsNil)
+	c.Check(config.StatePool, gc.Equals, tracker.pool())
+	c.Check(config.Logger, gc.Equals, s.config.Logger)
+	c.Check(config.PrometheusRegisterer, gc.Equals, s.config.PrometheusRegisterer)
+
+	c.Check(tracker.released, jc.IsFalse)
+	config.Cleanup()
+	c.Check(tracker.released, jc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestNewWorkerErrorReleasesState(c *gc.C) {
+	tracker := &fakeStateTracker{}
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state": tracker,
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(err, gc.ErrorMatches, "boom")
+	c.Check(worker, gc.IsNil)
+	c.Check(tracker.released, jc.IsTrue)
+}
+
+type fakeWorker struct {
+	worker.Worker
+}
+
+type fakeStateTracker struct {
+	workerstate.StateTracker
+	released bool
+}
+
+// Return an invalid but non-zero state pool pointer.
+// Is only ever used for comparison.
+func (f *fakeStateTracker) Use() (*state.StatePool, error) {
+	return f.pool(), nil
+}
+
+func (f *fakeStateTracker) pool() *state.StatePool {
+	return (*state.StatePool)(unsafe.Pointer(f))
+}
+
+// Done tracks that the used pool is released.
+func (f *fakeStateTracker) Done() error {
+	f.released = true
+	return nil
+}

--- a/worker/modelcache/package_test.go
+++ b/worker/modelcache/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcache_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -1,0 +1,246 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcache
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/kr/pretty"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/catacomb"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
+)
+
+// Config describes the necessary fields for NewWorker.
+type Config struct {
+	Logger               Logger
+	StatePool            *state.StatePool
+	PrometheusRegisterer prometheus.Registerer
+	Cleanup              func()
+	// Notify is used primarily for testing, and is passed through
+	// to the cache.Controller. It is called every time the controller
+	// processes an event.
+	Notify func(interface{})
+}
+
+// Validate ensures all the necessary values are specified
+func (c *Config) Validate() error {
+	if c.Logger == nil {
+		return errors.NotValidf("missing logger")
+	}
+	if c.StatePool == nil {
+		return errors.NotValidf("missing state pool")
+	}
+	if c.PrometheusRegisterer == nil {
+		return errors.NotValidf("missing prometheus registerer")
+	}
+	if c.Cleanup == nil {
+		return errors.NotValidf("missing cleanup func")
+	}
+	return nil
+}
+
+type cacheWorker struct {
+	config     Config
+	catacomb   catacomb.Catacomb
+	controller *cache.Controller
+	changes    chan interface{}
+	watcher    *state.Multiwatcher
+	mu         sync.Mutex
+}
+
+// NewWorker creates a new cacheWorker, and starts an
+// all model watcher.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &cacheWorker{
+		config:  config,
+		changes: make(chan interface{}),
+	}
+	controller, err := cache.NewController(
+		cache.ControllerConfig{
+			Changes: w.changes,
+			Notify:  config.Notify,
+		})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	w.controller = controller
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{w.controller},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Report returns information that is used in the dependency engine report.
+func (c *cacheWorker) Report() map[string]interface{} {
+	return c.controller.Report()
+}
+
+func (c *cacheWorker) loop() error {
+	defer c.config.Cleanup()
+	pool := c.config.StatePool
+
+	allWatcherStarts := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "juju_worker_modelcache",
+			Name:      "watcher_starts",
+			Help:      "The number of times the all model watcher has been started.",
+		},
+	)
+
+	collector := cache.NewMetricsCollector(c.controller)
+	c.config.PrometheusRegisterer.Register(collector)
+	c.config.PrometheusRegisterer.Register(allWatcherStarts)
+	defer c.config.PrometheusRegisterer.Unregister(allWatcherStarts)
+	defer c.config.PrometheusRegisterer.Unregister(collector)
+
+	watcherChanges := make(chan []multiwatcher.Delta)
+	// This worker needs to be robust with respect to the multiwatcher
+	// errors. If we get an unexpected error we should get a new allWatcher.
+	// We don't want a weird error in the multiwatcher taking down the apiserver,
+	// which is what would happen if this worker errors out.
+	// We do need to consider cache invalidation for multiwatcher entities
+	// that may be in our cache but when we restart the watcher, they aren't there.
+	// Cache invalidtion is a hard problem, but here at least we should perhaps
+	// be able to do some form of mark and sweep. When we create a new watcher
+	// we should mark entities in the controller, and when we are done with the
+	// first call to Next(), which returns the state of the world, we can issue
+	// a sweep to remove anything that wasn't updated since the Mark.
+	// TODO: This is left for upcoming work.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer func() {
+		c.mu.Lock()
+		c.watcher.Stop()
+		c.mu.Unlock()
+		wg.Wait()
+	}()
+	go func() {
+		// Ensure we don't leave the main loop until the goroutine is done.
+		defer wg.Done()
+		for {
+			c.mu.Lock()
+			select {
+			case <-c.catacomb.Dying():
+				c.mu.Unlock()
+				return
+			default:
+				// Continue through.
+			}
+			allWatcherStarts.Inc()
+			watcher := pool.SystemState().WatchAllModels(pool)
+			c.watcher = watcher
+			c.mu.Unlock()
+
+			err := c.processWatcher(watcher, watcherChanges)
+			if err == nil {
+				// We are done, so exit
+				watcher.Stop()
+				return
+			}
+			c.config.Logger.Errorf("watcher error, %v, getting new watcher", err)
+			watcher.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-c.catacomb.Dying():
+			return c.catacomb.ErrDying()
+		case deltas := <-watcherChanges:
+			// Process changes and send info down changes channel
+			for _, d := range deltas {
+				c.config.Logger.Tracef(pretty.Sprint(d))
+				value := c.translate(d)
+				if value != nil {
+					select {
+					case c.changes <- value:
+					case <-c.catacomb.Dying():
+						return nil
+					}
+				}
+			}
+		}
+	}
+}
+
+func (c *cacheWorker) processWatcher(w *state.Multiwatcher, watcherChanges chan<- []multiwatcher.Delta) error {
+	for {
+		deltas, err := w.Next()
+		if err != nil {
+			if errors.Cause(err) == state.ErrStopped {
+				return nil
+			} else {
+				return errors.Trace(err)
+			}
+		}
+		select {
+		case <-c.catacomb.Dying():
+			return nil
+		case watcherChanges <- deltas:
+		}
+	}
+}
+
+func coreStatus(info multiwatcher.StatusInfo) status.StatusInfo {
+	return status.StatusInfo{
+		Status:  info.Current,
+		Message: info.Message,
+		Data:    info.Data,
+		Since:   info.Since,
+	}
+}
+
+func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
+	id := d.Entity.EntityId()
+	switch id.Kind {
+	case "model":
+		if d.Removed {
+			return cache.RemoveModel{
+				ModelUUID: id.ModelUUID,
+			}
+		}
+		value, ok := d.Entity.(*multiwatcher.ModelInfo)
+		if !ok {
+			c.config.Logger.Errorf("unexpected type %T", d.Entity)
+			return nil
+		}
+		return cache.ModelChange{
+			ModelUUID: value.ModelUUID,
+			Name:      value.Name,
+			Life:      life.Value(value.Life),
+			Owner:     value.Owner,
+			Config:    value.Config,
+			Status:    coreStatus(value.Status),
+			// TODO: constraints, sla
+		}
+
+	default:
+		return nil
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (c *cacheWorker) Kill() {
+	c.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (c *cacheWorker) Wait() error {
+	return c.catacomb.Wait()
+}

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -1,0 +1,256 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcache_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/modelcache"
+)
+
+type WorkerSuite struct {
+	statetesting.StateSuite
+	logger loggo.Logger
+	config modelcache.Config
+	notify func(interface{})
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.notify = nil
+	s.logger = loggo.GetLogger("test")
+	s.logger.SetLogLevel(loggo.TRACE)
+	s.config = modelcache.Config{
+		Logger:               s.logger,
+		StatePool:            s.StatePool,
+		PrometheusRegisterer: noopRegisterer{},
+		Cleanup:              func() {},
+	}
+}
+
+func (s *WorkerSuite) TestConfigMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing logger not valid")
+}
+
+func (s *WorkerSuite) TestConfigMissingStatePool(c *gc.C) {
+	s.config.StatePool = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing state pool not valid")
+}
+
+func (s *WorkerSuite) TestConfigMissingRegisterer(c *gc.C) {
+	s.config.PrometheusRegisterer = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing prometheus registerer not valid")
+}
+
+func (s *WorkerSuite) TestConfigMissingCleanup(c *gc.C) {
+	s.config.Cleanup = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing cleanup func not valid")
+}
+
+func (s *WorkerSuite) getController(c *gc.C, w worker.Worker) *cache.Controller {
+	var controller *cache.Controller
+	err := modelcache.OutputFunc(w, &controller)
+	c.Assert(err, jc.ErrorIsNil)
+	return controller
+}
+
+func (s *WorkerSuite) start(c *gc.C) worker.Worker {
+	config := s.config
+	config.Notify = s.notify
+	w, err := modelcache.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.CleanKill(c, w)
+	})
+	return w
+}
+
+func (s *WorkerSuite) captureModelEvents(c *gc.C) <-chan interface{} {
+	events := make(chan interface{})
+	s.notify = func(change interface{}) {
+		send := false
+		switch change.(type) {
+		case cache.ModelChange:
+			send = true
+		case cache.RemoveModel:
+			send = true
+		default:
+			// no-op
+		}
+		if send {
+			c.Logf("sending %#v", change)
+			select {
+			case events <- change:
+			case <-time.After(testing.LongWait):
+				c.Fatalf("change not processed by test")
+			}
+		}
+	}
+	return events
+}
+
+func (s *WorkerSuite) checkModel(c *gc.C, obtained interface{}, model *state.Model) {
+	change, ok := obtained.(cache.ModelChange)
+	c.Assert(ok, jc.IsTrue)
+
+	c.Check(change.ModelUUID, gc.Equals, model.UUID())
+	c.Check(change.Name, gc.Equals, model.Name())
+	c.Check(change.Life, gc.Equals, life.Value(model.Life().String()))
+	c.Check(change.Owner, gc.Equals, model.Owner().Name())
+	cfg, err := model.Config()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(change.Config, jc.DeepEquals, cfg.AllAttrs())
+	status, err := model.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(change.Status, jc.DeepEquals, status)
+}
+
+func (s *WorkerSuite) nextChange(c *gc.C, changes <-chan interface{}) interface{} {
+	var obtained interface{}
+	select {
+	case obtained = <-changes:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("no change")
+	}
+	return obtained
+}
+
+func (s *WorkerSuite) TestInitialModel(c *gc.C) {
+	changes := s.captureModelEvents(c)
+	s.start(c)
+
+	obtained := s.nextChange(c, changes)
+	expected, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkModel(c, obtained, expected)
+}
+
+func (s *WorkerSuite) TestModelConfigChange(c *gc.C) {
+	changes := s.captureModelEvents(c)
+	w := s.start(c)
+	// discard initial event
+	s.nextChange(c, changes)
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Logf("\nupdating status\n\n")
+
+	// Add a different logging config value.
+	expected := "juju=INFO;missing=DEBUG;unit=DEBUG"
+	err = model.UpdateModelConfig(map[string]interface{}{
+		"logging-config": expected,
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.StartSync()
+
+	// Wait for the change.
+	s.nextChange(c, changes)
+
+	controller := s.getController(c, w)
+	cachedModel, err := controller.Model(s.State.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cachedModel.Config()["logging-config"], gc.Equals, expected)
+}
+
+func (s *WorkerSuite) TestNewModel(c *gc.C) {
+	changes := s.captureModelEvents(c)
+	w := s.start(c)
+	// grab and discard the event for the initial model
+	s.nextChange(c, changes)
+
+	newState := s.Factory.MakeModel(c, nil)
+	s.State.StartSync()
+	defer newState.Close()
+
+	obtained := s.nextChange(c, changes)
+	expected, err := newState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkModel(c, obtained, expected)
+
+	controller := s.getController(c, w)
+	c.Assert(controller.ModelUUIDs(), gc.HasLen, 2)
+}
+
+func (s *WorkerSuite) TestRemovedModel(c *gc.C) {
+	changes := s.captureModelEvents(c)
+	w := s.start(c)
+
+	// grab and discard the event for the initial model
+	s.nextChange(c, changes)
+
+	st := s.Factory.MakeModel(c, nil)
+	s.State.StartSync()
+	defer st.Close()
+
+	// grab and discard the event for the new model
+	s.nextChange(c, changes)
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Destroy(state.DestroyModelParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.StartSync()
+
+	// grab and discard the event for the new model
+	obtained := s.nextChange(c, changes)
+	modelChange, ok := obtained.(cache.ModelChange)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(modelChange.Life, gc.Equals, life.Value("dying"))
+
+	err = st.ProcessDyingModel()
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.StartSync()
+
+	err = st.RemoveDyingModel()
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.StartSync()
+
+	obtained = s.nextChange(c, changes)
+
+	change, ok := obtained.(cache.RemoveModel)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(change.ModelUUID, gc.Equals, model.UUID())
+
+	// Controller just has the system state again.
+	controller := s.getController(c, w)
+	c.Assert(controller.ModelUUIDs(), jc.SameContents, []string{s.State.ModelUUID()})
+}
+
+type noopRegisterer struct {
+	prometheus.Registerer
+}
+
+func (noopRegisterer) Register(prometheus.Collector) error {
+	return nil
+}
+
+func (noopRegisterer) Unregister(prometheus.Collector) bool {
+	return true
+}

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -74,9 +74,16 @@ func (s *WorkerSuite) TestConfigMissingCleanup(c *gc.C) {
 
 func (s *WorkerSuite) getController(c *gc.C, w worker.Worker) *cache.Controller {
 	var controller *cache.Controller
-	err := modelcache.OutputFunc(w, &controller)
+	err := modelcache.ExtractCacheController(w, &controller)
 	c.Assert(err, jc.ErrorIsNil)
 	return controller
+}
+
+func (s *WorkerSuite) TestExtractCacheController(c *gc.C) {
+	var controller *cache.Controller
+	var empty worker.Worker
+	err := modelcache.ExtractCacheController(empty, &controller)
+	c.Assert(err.Error(), gc.Equals, "in should be a *modelcache.cacheWorker; got <nil>")
 }
 
 func (s *WorkerSuite) start(c *gc.C) worker.Worker {


### PR DESCRIPTION
This branch builds on the core/cache work and introduces the worker responsible for creating a cache.Controller and keeping it up to date with changes.

This branch does not hook up the worker, but just introduces it. The next branch hooks it all up.
