### PR TITLE
Un-place missing upgrade charm profile data

### DIFF
--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -674,6 +674,10 @@ func (s *UniterSuite) TestUpdateResourceCausesUpgrade(c *gc.C) {
 	// adding a "wp-content" filesystem store. We do it here rather
 	// than in the charm itself to avoid modifying all of the other
 	// scenarios.
+	// NOTE: this test does not expect the charm profile data to be
+	// in place for the resource charm upgrade. In fact it's important
+	// that we don't have it there, otherwise it causes the resource
+	// changes to stall out in real world scenarios.
 	appendResource := func(c *gc.C, ctx *context, path string) {
 		f, err := os.OpenFile(filepath.Join(path, "metadata.yaml"), os.O_RDWR|os.O_APPEND, 0644)
 		c.Assert(err, jc.ErrorIsNil)
@@ -701,7 +705,6 @@ resources:
 			waitUnitAgent{status: status.Idle},
 			waitHooks(startupHooks(false)),
 			verifyCharm{},
-			setUpgradeCharmProfile{},
 
 			pushResource{},
 			waitHooks{"upgrade-charm", "config-changed"},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1018,19 +1018,6 @@ func (s verifyCharm) step(c *gc.C, ctx *context) {
 	c.Assert(url, gc.DeepEquals, curl(checkRevision))
 }
 
-type setUpgradeCharmProfile struct{}
-
-func (s setUpgradeCharmProfile) step(c *gc.C, ctx *context) {
-	id, err := ctx.unit.AssignedMachineId()
-	c.Assert(err, gc.IsNil)
-	machine, err := ctx.st.Machine(id)
-	c.Assert(err, gc.IsNil)
-	url, ok := ctx.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
-	err = machine.SetUpgradeCharmProfile(ctx.application.Name(), url.String())
-	c.Assert(err, gc.IsNil)
-}
-
 type pushResource struct{}
 
 func (s pushResource) step(c *gc.C, ctx *context) {


### PR DESCRIPTION
## Description of change

This is a revert of 38b5255759be8578010c04a132cb23224f8c2789 with
added notes to prevent people from making the same mistake that I
did.

Although the code is generalised for other users to use, if nobody
else is using it, then we should delete it for the sake of our
sanity.

This is analogous to https://github.com/juju/juju/pull/9584 so that we 
have more tests around this feature.

## QA steps

N/A

