### PR TITLE
2.4 txn update

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -126,15 +126,29 @@ const (
 	// MaxTxnLogSize is the maximum size the of capped txn log collection, eg "10M"
 	MaxTxnLogSize = "max-txn-log-size"
 
-	// MaxPruneTxnBatchSize is the maximum number of transactions we will evaluate in one go when pruning
-	// Default is 1M transactions. A value <= 0 indicates to do all transactions at once.
+	// MaxPruneTxnBatchSize (deprecated) is the maximum number of transactions
+	// we will evaluate in one go when pruning. Default is 1M transactions.
+	// A value <= 0 indicates to do all transactions at once.
 	MaxPruneTxnBatchSize = "max-prune-txn-batch-size"
 
-	// MaxPruneTxnPasses is the maximum number of batches that we will process. So total number of transactions that can
-	// be processed is MaxPruneTxnBatchSize * MaxPruneTxnPasses.
+	// MaxPruneTxnPasses (deprecated) is the maximum number of batches that we will process.
+	// So total number of transactions that can be processed is MaxPruneTxnBatchSize * MaxPruneTxnPasses.
 	// A value <= 0 implies 'do a single pass'. If both MaxPruneTxnBatchSize and MaxPruneTxnPasses are 0, then the
 	// default value of 1M BatchSize and 100 passes will be used instead.
 	MaxPruneTxnPasses = "max-prune-txn-passes"
+
+	// PruneTxnQueryCount is the number of transactions to read in a single query.
+	// Minimum of 10, a value of 0 will indicate to use the default value (1000)
+	PruneTxnQueryCount = "prune-txn-query-count"
+
+	// PruneTxnSleepTime is the amount of time to sleep between processing each
+	// batch query. This is used to reduce load on the system, allowing other queries
+	// to time to operate. On large controllers, processing 1000 txs seems to take
+	// about 100ms, so a sleep time of 10ms represents a 10% slowdown, but allows
+	// other systems to operate concurrently.
+	// A negative number will indicate to use the default, a value of 0 indicates
+	// to not sleep at all.
+	PruneTxnSleepTime = "prune-txn-sleep-time"
 
 	// Attribute Defaults
 
@@ -181,11 +195,21 @@ const (
 	// DefaultMaxTxnLogCollectionMB is the maximum size the txn log collection.
 	DefaultMaxTxnLogCollectionMB = 10 // 10 MB
 
-	// DefaultMaxPruneTxnBatchSize is the normal number of transaction we will prune in a given pass (1M)
+	// DefaultMaxPruneTxnBatchSize is the normal number of transaction we will prune in a given pass (1M) (deprecated)
 	DefaultMaxPruneTxnBatchSize = 1 * 1000 * 1000
 
-	// DefaultMaxPruneTxnPasses is the default number of batches we will process
+	// DefaultMaxPruneTxnPasses is the default number of batches we will process (deprecated)
 	DefaultMaxPruneTxnPasses = 100
+
+	// DefaultPruneTxnQueryCount is the number of transactions to read in a single query.
+	DefaultPruneTxnQueryCount = 1000
+
+	// DefaultPruneTxnSleepTime is the amount of time to sleep between processing each
+	// batch query. This is used to reduce load on the system, allowing other queries
+	// to time to operate. On large controllers, processing 1000 txs seems to take
+	// about 100ms, so a sleep time of 10ms represents a 10% slowdown, but allows
+	// other systems to operate concurrently.
+	DefaultPruneTxnSleepTime = "10ms"
 
 	// JujuHASpace is the network space within which the MongoDB replica-set
 	// should communicate.
@@ -225,6 +249,8 @@ var (
 		MaxTxnLogSize,
 		MaxPruneTxnBatchSize,
 		MaxPruneTxnPasses,
+		PruneTxnQueryCount,
+		PruneTxnSleepTime,
 		JujuHASpace,
 		JujuManagementSpace,
 		AuditingEnabled,
@@ -251,6 +277,8 @@ var (
 		MaxPruneTxnPasses,
 		MaxLogsSize,
 		MaxLogsAge,
+		PruneTxnQueryCount,
+		PruneTxnSleepTime,
 		JujuHASpace,
 		JujuManagementSpace,
 		CAASOperatorImagePath,
@@ -545,6 +573,17 @@ func (c Config) MaxPruneTxnPasses() int {
 	return c.intOrDefault(MaxPruneTxnPasses, DefaultMaxPruneTxnPasses)
 }
 
+// PruneTxnQueryCount is the size of small batches for pruning
+func (c Config) PruneTxnQueryCount() int {
+	return c.intOrDefault(PruneTxnQueryCount, DefaultPruneTxnQueryCount)
+}
+
+// PruneTxnSleepTime is the amount of time to sleep between batches.
+func (c Config) PruneTxnSleepTime() time.Duration {
+	val, _ := time.ParseDuration(c.mustString(PruneTxnSleepTime))
+	return val
+}
+
 // JujuHASpace is the network space within which the MongoDB replica-set
 // should communicate.
 func (c Config) JujuHASpace() string {
@@ -619,6 +658,12 @@ func Validate(c Config) error {
 	if v, ok := c[MaxTxnLogSize].(string); ok {
 		if _, err := utils.ParseSize(v); err != nil {
 			return errors.Annotate(err, "invalid max txn log size in configuration")
+		}
+	}
+
+	if v, ok := c[PruneTxnSleepTime].(string); ok {
+		if _, err := time.ParseDuration(v); err != nil {
+			return errors.Annotatef(err, `%s must be a valid duration (eg "10ms")`, PruneTxnSleepTime)
 		}
 	}
 
@@ -775,6 +820,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxTxnLogSize:           schema.String(),
 	MaxPruneTxnBatchSize:    schema.ForceInt(),
 	MaxPruneTxnPasses:       schema.ForceInt(),
+	PruneTxnQueryCount:      schema.ForceInt(),
+	PruneTxnSleepTime:       schema.String(),
 	JujuHASpace:             schema.String(),
 	JujuManagementSpace:     schema.String(),
 	CAASOperatorImagePath:   schema.String(),
@@ -801,6 +848,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxTxnLogSize:           fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
 	MaxPruneTxnBatchSize:    DefaultMaxPruneTxnBatchSize,
 	MaxPruneTxnPasses:       DefaultMaxPruneTxnPasses,
+	PruneTxnQueryCount:      DefaultPruneTxnQueryCount,
+	PruneTxnSleepTime:       DefaultPruneTxnSleepTime,
 	JujuHASpace:             schema.Omit,
 	JujuManagementSpace:     schema.Omit,
 	CAASOperatorImagePath:   schema.Omit,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -259,6 +259,13 @@ var validateTests = []struct {
 		controller.APIPortOpenDelay: "15",
 	},
 	expectError: `api-port-open-delay value "15" must be a valid duration`,
+}, {
+	about: "txn-prune-sleep-time not a duration",
+	config: controller.Config{
+		controller.CACertKey:         testing.CACert,
+		controller.PruneTxnSleepTime: "15",
+	},
+	expectError: `prune-txn-sleep-time must be a valid duration \(eg "10ms"\): time: missing unit in duration 15`,
 }}
 
 func (s *ConfigSuite) TestValidate(c *gc.C) {
@@ -340,6 +347,20 @@ func (s *ConfigSuite) TestMaxPruneTxnConfigValue(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cfg.MaxPruneTxnBatchSize(), gc.Equals, 12345678)
 	c.Check(cfg.MaxPruneTxnPasses(), gc.Equals, 10)
+}
+
+func (s *ConfigSuite) TestPruneTxnQueryCount(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"prune-txn-query-count": "500",
+			"prune-txn-sleep-time":  "5ms",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.PruneTxnQueryCount(), gc.Equals, 500)
+	c.Check(cfg.PruneTxnSleepTime(), gc.Equals, 5*time.Millisecond)
 }
 
 func (s *ConfigSuite) TestNetworkSpaceConfigValues(c *gc.C) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -65,7 +65,7 @@ github.com/juju/romulus	git	5b6f449d5c36ed6927c417c68379ab5acb7d7b46	2018-03-27T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	c84dd6ba038a9012fb7830d206a006915b6e7937	2018-08-07T04:45:55Z
-github.com/juju/txn	git	8ecde6e13ca4f2c6a69ae3ff795c43a80442243f	2018-12-20T09:04:28Z
+github.com/juju/txn	git	79cdf4663070226316f3bc6c66de7babbb3fb899	2018-12-20T17:44:48Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	2000ea4ff0431598aec2b7e1d11d5d49b5384d63	2018-04-24T09:41:59Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,12 +42,13 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	8a8cec793ba70659ba95f1b9a491ba807169bfc3	2018-09-20T03:00:11Z
+github.com/juju/gomaasapi	git	8a8cec793ba70659ba95f1b9a491ba807169bfc3	2018-09-19T15:00:11Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	fb1dc7175251ac8e2dc460897313e05175cbbc0d	2016-11-07T14:02:50Z
 github.com/juju/jsonschema	git	a0ef8b74ebcffeeff9fc374854deb4af388f037e	2016-11-02T18:19:19Z
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
+github.com/juju/lru	git	305dec07bf2f69353bb05fa849e2a0834e220f94	2018-12-05T13:23:44Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/mutex	git	1fe2a4bf0a3a2c10881501233ff7c6aed7790082	2017-11-10T02:00:13Z
 github.com/juju/naturalsort	git	5b81707e882b8293e6cf77854b4cd49f29776e11	2018-04-23T03:48:42Z
@@ -64,7 +65,7 @@ github.com/juju/romulus	git	5b6f449d5c36ed6927c417c68379ab5acb7d7b46	2018-03-27T
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/terms-client	git	9b925afd677234e4146dde3cb1a11e187cbed64e	2016-08-09T13:19:00Z
 github.com/juju/testing	git	c84dd6ba038a9012fb7830d206a006915b6e7937	2018-08-07T04:45:55Z
-github.com/juju/txn	git	43be63df1fb67abe617877d8fbe7238344f1f820	2018-08-20T12:57:51Z
+github.com/juju/txn	git	8ecde6e13ca4f2c6a69ae3ff795c43a80442243f	2018-12-20T09:04:28Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	2000ea4ff0431598aec2b7e1d11d5d49b5384d63	2018-04-24T09:41:59Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
@@ -101,7 +102,7 @@ github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-0
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 github.com/satori/go.uuid	git	b2ce2384e17bbe0c6d34077efa39dbab3e09123b	2018-10-28T12:50:25Z
 github.com/vmware/govmomi	git	05504416e95561e1478196d7058721c827a7bb8c	2018-03-06T20:02:55Z
-go.opencensus.io/	git	91a0276ece6ad4cbdc4b46116f88d2b47a5f58e5	2018-11-12T17:26:09Z
+go.opencensus.io	git	91a0276ece6ad4cbdc4b46116f88d2b47a5f58e5	2018-11-12T17:26:09Z
 golang.org/x/crypto	git	650f4a345ab4e5b245a3034b110ebc7299e68186	2018-02-14T00:00:28Z
 golang.org/x/net	git	61147c48b25b599e5b561d2e9c4f3e1ef489ca41	2018-04-06T21:48:16Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -38,6 +38,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AuditLogExcludeMethods,
 		controller.MaxPruneTxnBatchSize,
 		controller.MaxPruneTxnPasses,
+		controller.PruneTxnQueryCount,
+		controller.PruneTxnSleepTime,
 		controller.MaxLogsSize,
 		controller.MaxLogsAge,
 		controller.CAASOperatorImagePath,

--- a/state/txns.go
+++ b/state/txns.go
@@ -44,16 +44,16 @@ func (st *State) MaybePruneTransactions() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	maxBatchSize := cfg.MaxPruneTxnBatchSize()
-	maxPasses := cfg.MaxPruneTxnPasses()
 	// Prune txns when txn count has increased by 10% since last prune.
 	return runner.MaybePruneTransactions(jujutxn.PruneOptions{
-		PruneFactor:          1.1,
-		MinNewTransactions:   1000,
-		MaxNewTransactions:   100000,
-		MaxTime:              time.Now().Add(-time.Hour),
-		MaxBatchTransactions: maxBatchSize,
-		MaxBatches:           maxPasses,
+		PruneFactor:                1.1,
+		MinNewTransactions:         1000,
+		MaxNewTransactions:         100000,
+		MaxTime:                    time.Now().Add(-time.Hour),
+		MaxBatchTransactions:       cfg.MaxPruneTxnBatchSize(),
+		MaxBatches:                 cfg.MaxPruneTxnPasses(),
+		SmallBatchTransactionCount: cfg.PruneTxnQueryCount(),
+		BatchTransactionSleepTime:  cfg.PruneTxnSleepTime(),
 	})
 }
 


### PR DESCRIPTION
## Description of change

This updates or juju/txn dependency to include the new transaction pruning code. It further exposes 2 new settings that affect how the transaction pruning will operate.

## QA steps

```
$ juju bootstrap --debug lxd lxd
$ juju controller-config
# see the new parameters
...
prune-txn-query-count     1000
prune-txn-sleep-time      10ms
$ juju controller-config prune-txn-query-count=1500 prune-txn-sleep-time=1ms
# wait 1hr for the pruner to decide to wake up, and then
$ juju debug-log -m controller --include-module juju.txn
# will show at DEBUG level the parameters:
machine-0: 16:45:11 DEBUG juju.txn validated pruneOpts: txn.PruneOptions{PruneFactor:1.1, MinNewTransactions:1000, MaxNewTransactions:100000, ... SmallBatchTransactionCount:1500, BatchTransactionSleepTime:1000000}
```

## Documentation changes

@pmatulis we'll want to add documentation for the new controller configuration options
`prune-txn-queury-count` and `prune-txn-sleep-time`.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1771906

Also depends on:
https://github.com/juju/txn/pull/47
