### PR TITLE
Create an /etc/fstab entry when storage is attached

### DIFF
--- a/storage/provider/dirfuncs.go
+++ b/storage/provider/dirfuncs.go
@@ -15,6 +15,7 @@ import (
 // dirFuncs is used to allow the real directory operations to
 // be stubbed out for testing.
 type dirFuncs interface {
+	etcDir() string
 	mkDirAll(path string, perm os.FileMode) error
 	lstat(path string) (fi os.FileInfo, err error)
 	fileCount(path string) (int, error)
@@ -39,6 +40,10 @@ type dirFuncs interface {
 // filesystem.
 type osDirFuncs struct {
 	run runCommandFunc
+}
+
+func (*osDirFuncs) etcDir() string {
+	return "/etc"
 }
 
 func (*osDirFuncs) mkDirAll(path string, perm os.FileMode) error {

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -85,6 +85,7 @@ func (s *loopSuite) TestScope(c *gc.C) {
 func (s *loopSuite) loopVolumeSource(c *gc.C) (storage.VolumeSource, *provider.MockDirFuncs) {
 	s.commands = &mockRunCommand{c: c}
 	return provider.LoopVolumeSource(
+		c.MkDir(),
 		s.storageDir,
 		s.commands.run,
 	)

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -25,6 +25,7 @@ type rootfsSuite struct {
 	storageDir   string
 	commands     *mockRunCommand
 	mockDirFuncs *provider.MockDirFuncs
+	fakeEtcDir   string
 
 	callCtx context.ProviderCallContext
 }
@@ -35,6 +36,7 @@ func (s *rootfsSuite) SetUpTest(c *gc.C) {
 	}
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
+	s.fakeEtcDir = c.MkDir()
 	s.callCtx = context.NewCloudCallContext()
 }
 
@@ -87,7 +89,7 @@ func (s *rootfsSuite) TestScope(c *gc.C) {
 
 func (s *rootfsSuite) rootfsFilesystemSource(c *gc.C) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
-	source, d := provider.RootfsFilesystemSource(s.storageDir, s.commands.run)
+	source, d := provider.RootfsFilesystemSource(s.fakeEtcDir, s.storageDir, s.commands.run)
 	s.mockDirFuncs = d
 	return source
 }
@@ -346,7 +348,7 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirClaimed(c *gc.C)
 
 func (s *rootfsSuite) TestDetachFilesystems(c *gc.C) {
 	source := s.rootfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, true)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, true, s.fakeEtcDir, "")
 }
 
 func (s *rootfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
@@ -355,5 +357,5 @@ func (s *rootfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
 	// either case, there is no attachment-specific filesystem
 	// mount.
 	source := s.rootfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, false)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, false, s.fakeEtcDir, "")
 }

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -23,6 +23,7 @@ type tmpfsSuite struct {
 	testing.BaseSuite
 	storageDir string
 	commands   *mockRunCommand
+	fakeEtcDir string
 
 	callCtx context.ProviderCallContext
 }
@@ -33,6 +34,7 @@ func (s *tmpfsSuite) SetUpTest(c *gc.C) {
 	}
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
+	s.fakeEtcDir = c.MkDir()
 	s.callCtx = context.NewCloudCallContext()
 }
 
@@ -86,6 +88,7 @@ func (s *tmpfsSuite) TestScope(c *gc.C) {
 func (s *tmpfsSuite) tmpfsFilesystemSource(c *gc.C) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
 	return provider.TmpfsFilesystemSource(
+		s.fakeEtcDir,
 		s.storageDir,
 		s.commands.run,
 	)
@@ -276,10 +279,10 @@ func (s *tmpfsSuite) TestAttachFilesystemsNoFilesystem(c *gc.C) {
 
 func (s *tmpfsSuite) TestDetachFilesystems(c *gc.C) {
 	source := s.tmpfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, true)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, true, s.fakeEtcDir, "")
 }
 
 func (s *tmpfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
 	source := s.tmpfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, false)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, false, s.fakeEtcDir, "")
 }


### PR DESCRIPTION
## Description of change

When a block device is attached for storage, create an /etc/fstab entry.
Delete the /etc/fstab entry when storage is detached.

## QA steps

bootstrap aws
deploy postgresql with storage
ssh into the postgresql machine and check that there's an fstab entry matching the mtab entry
detach the storage
ensure that the fstab entry is removed

## Bug reference

https://bugs.launchpad.net/juju/+bug/1783419
