### PR TITLE
Webscale logging config

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """ Test webscale deployment
 
-    1. deploying kubenetes core and asserting it is `healthy`
+    1. deploying kubernetes core and asserting it is `healthy`
     2. inspect the logs to parse timings from trace logs
 """
 

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -100,7 +100,7 @@ def parse_args(argv):
     parser.add_argument(
         '--logging-config',
         help="Override logging configuration for a deploy",
-        default="<root>=TRACE;unit=TRACE",
+        default="juju.state.txn=TRACE;<root>=INFO;unit=INFO",
     )
     parser.add_argument(
         '--logging-module',

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -813,6 +813,8 @@ class BootstrapManager:
                                         soft_deadline=args.deadline)
             if args.to is not None:
                 client.env.bootstrap_to = args.to
+            if args.logging_config is not None:
+                client.env.logging_config = args.logging_config
         return cls.from_client(args, client)
 
     @classmethod

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -163,10 +163,12 @@ class JujuData:
             self.kvm = (bool(self._config.get('container') == 'kvm'))
             self.maas = bool(provider == 'maas')
             self.joyent = bool(provider == 'joyent')
+            self.logging_config = self._config.get('logging-config')
         else:
             self.kvm = False
             self.maas = False
             self.joyent = False
+            self.logging_config = None
         self.credentials = {}
         self.clouds = {}
         self._cloud_name = cloud_name
@@ -199,6 +201,7 @@ class JujuData:
         result.credentials = deepcopy(self.credentials)
         result.clouds = deepcopy(self.clouds)
         result._cloud_name = self._cloud_name
+        result.logging_config = self.logging_config
         return result
 
     @classmethod
@@ -2237,6 +2240,9 @@ def make_safe_config(client):
     # Explicitly set 'name', which Juju implicitly sets to env.environment to
     # ensure MAASAccount knows what the name will be.
     config['name'] = unqualified_model_name(client.env.environment)
+    # Pass the logging config into the yaml file
+    if client.env.logging_config is not None:
+        config['logging-config'] = client.env.logging_config
 
     return config
 


### PR DESCRIPTION
## Description of change

The following PR extracts the mongo transactional timings from deploying the
kubernetes core. All the timings are in seconds to 3 decimal places, so accuracy 
isn't that high, as it's possible that nanoseconds are available instead of [seconds](https://github.com/juju/juju/blob/develop/state/database.go#L343).

## QA steps

```
cd acceptancetests
./assess_deploy_webscale.py
```
