### PR TITLE
upgrade-model: Upgrades are always available if --build-agent is set

### DIFF
--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -458,7 +458,9 @@ func (c *upgradeJujuCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool
 func (c *upgradeJujuCommand) initVersions(
 	client upgradeJujuAPI, cfg *config.Config, agentVersion version.Number, filterOnPrior bool,
 ) (*upgradeContext, bool, error) {
-	if c.Version == agentVersion {
+	// If build-agent is set then we're always going to increment the
+	// build number.
+	if c.Version == agentVersion && !c.BuildAgent {
 		return nil, false, errUpToDate
 	}
 	filterVersion := jujuversion.Current

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -278,6 +278,13 @@ var upgradeJujuTests = []struct {
 	expectVersion:  "2.7.3.1",
 	expectUploaded: []string{"2.7.3.1-quantal-amd64", "2.7.3.1-%LTS%-amd64", "2.7.3.1-raring-amd64"},
 }, {
+	about:          "upload dev version, currently on edge snap",
+	currentVersion: "2.5-rc2-quantal-amd64",
+	agentVersion:   "2.5-rc2",
+	args:           []string{"--build-agent"},
+	expectVersion:  "2.5-rc2.1",
+	expectUploaded: []string{"2.5-rc2.1-quantal-amd64", "2.5-rc2.1-%LTS%-amd64", "2.5-rc2.1-raring-amd64"},
+}, {
 	about:          "upload dev version, currently on release version",
 	currentVersion: "2.1.0-quantal-amd64",
 	agentVersion:   "2.0.0",


### PR DESCRIPTION
## Description of change

Since we'll always increment the build number when uploading newly-built binaries, we shouldn't bail early if the versions match. This means you can still upgrade to a dev version if you bootstrapped with an edge snap.

## QA steps

* Bootstrap with the edge snap.
* Checkout and build the tip of the same branch.
* Upgrade the controller with `juju upgrade-model -m controller --build-agent --debug`.
* The local tree should be built and uploaded, then the upgrade to the .1 build version should succeed.

## Documentation changes
None
