### PR TITLE
Handle deployments with storage and placement on maas

### DIFF
--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1081,6 +1081,58 @@ func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageCleanAvailable(c *
 	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
 }
 
+func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageAndMachinePlacementDirective(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
+	sb, err := state.NewStorageBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	storageAttachments, err := sb.UnitStorageAttachments(unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+
+	// Add a clean machine.
+	clean, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assign the unit to a machine, requesting clean/empty. Since
+	// the unit has non dynamic storage instances associated,
+	// it will be forced onto a new machine.
+	placement := &instance.Placement{
+		instance.MachineScope, clean.Id(),
+	}
+	err = s.State.AssignUnitWithPlacement(unit, placement)
+	c.Assert(
+		err, gc.ErrorMatches,
+		`cannot assign unit "storage-filesystem/0" to machine 0: "static" storage provider does not support dynamic storage`,
+	)
+}
+
+func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageAndZonePlacementDirective(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
+	sb, err := state.NewStorageBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	storageAttachments, err := sb.UnitStorageAttachments(unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+
+	// Add a clean machine.
+	clean, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assign the unit to a machine, requesting clean/empty. Since
+	// the unit has non dynamic storage instances associated,
+	// it will be forced onto a new machine.
+	placement := &instance.Placement{
+		s.State.ModelUUID(), "zone=test",
+	}
+	err = s.State.AssignUnitWithPlacement(unit, placement)
+
+	// Check the machine on the unit is set.
+	machineId, err := unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	// Check that the machine isn't our clean one.
+	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
+}
+
 func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.C) {
 	_, unit, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
 	sb, err := state.NewStorageBackend(s.State)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1831,34 +1831,6 @@ func (s *StateSuite) TestAddApplicationWithInvalidBindings(c *gc.C) {
 	}
 }
 
-func (s *StateSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C) {
-	machine, err := s.State.AddMachine("xenial", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-
-	name := "lxd-profile"
-	charm := state.AddTestingCharmForSeries(c, s.State, "xenial", name)
-	application := s.AddTestingApplication(c, name, charm)
-	c.Assert(err, jc.ErrorIsNil)
-	unit, err := application.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.State.AssignUnitWithPlacement(unit,
-		&instance.Placement{
-			instance.MachineScope, machine.Id(),
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-
-	chAppName, err := machine.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, name)
-	chCharmURL, err := machine.UpgradeCharmProfileCharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chCharmURL, gc.Equals, charm.URL().String())
-}
-
 func (s *StateSuite) TestAddApplicationMachinePlacementInvalidSeries(c *gc.C) {
 	m, err := s.State.AddMachine("trusty", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -2080,6 +2080,13 @@ func (u *Unit) AssignToNewMachineOrContainer() (err error) {
 // time of unit creation.
 func (u *Unit) AssignToNewMachine() (err error) {
 	defer assignContextf(&err, u.Name(), "new machine")
+	return u.assignToNewMachine("")
+}
+
+// assignToNewMachine assigns the unit to a new machine with the
+// optional placement directive, with constraints determined according
+// to the application and model constraints at the time of unit creation.
+func (u *Unit) assignToNewMachine(placement string) error {
 	if u.doc.Principal != "" {
 		return fmt.Errorf("unit is a subordinate")
 	}
@@ -2109,6 +2116,8 @@ func (u *Unit) AssignToNewMachine() (err error) {
 			Series:                u.doc.Series,
 			Constraints:           *cons,
 			Jobs:                  []MachineJob{JobHostUnits},
+			Placement:             placement,
+			Dirty:                 placement != "",
 			Volumes:               storageParams.volumes,
 			VolumeAttachments:     storageParams.volumeAttachments,
 			Filesystems:           storageParams.filesystems,


### PR DESCRIPTION
## Description of change

Deploying a charm with storage to maas fails if a placement directive is used, eg --to zone=<blah>.
The PR fixes the underlying  deployment logic to support that case.

As a driveby, move a test for placement with lxd profiles next to the other similar tests.

## QA steps

bootstrap on maas
juju deploy postgresql --storage pgdata=1G,maas --to zone=<blah>

## Bug reference
https://bugs.launchpad.net/juju/+bug/1765959
