### PR TITLE
Running 'juju status' shouldn't end up with INFO messages in the controller log

### DIFF
--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -47,7 +47,7 @@ func UnitChainPredicateFn(
 		for _, subName := range unit.SubordinateNames() {
 			// A master match supercedes any subordinate match.
 			if matches {
-				logger.Infof("%s is a subordinate to a match.", subName)
+				logger.Debugf("%s is a subordinate to a match.", subName)
 				considered[subName] = true
 				continue
 			}


### PR DESCRIPTION
## Description of change

When investigating controller logs at INFO level, I noticed a lot of messages about "is a subordinate match". This triggers when you run "juju status", but it doesn't make sense to default to printing it all the time.

## QA steps

```
$ juju bootstrap --model-defaults logging-config="<root>=INFO"
$ juju deploy ubuntu
$ juju deploy telegraf:juju-info ubuntu:juju-info
$ juju relate subordinate ubuntu
$ juju status
```
Prior to this, you should see the message in "juju debug-log -m controller", and after it should default to DEBUG level.

## Documentation changes

None.

## Bug reference

None.
