### PR TITLE
Ensure we pass a logging config

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -117,11 +117,6 @@ def parse_args(argv):
         help="Override the charm bundle to deploy",
     )
     parser.add_argument(
-        '--logging-config',
-        help="Override logging configuration for a deploy",
-        default="juju.state.txn=TRACE;<root>=INFO;unit=INFO",
-    )
-    parser.add_argument(
         '--logging-module',
         help="Override default module to extract",
         default="juju.state.txn",

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -122,6 +122,10 @@ def parse_args(argv):
         default="juju.state.txn",
     )
     add_basic_testing_arguments(parser, existing=False)
+    # Override the default logging_config default value set by adding basic
+    # testing arguments. This way we can have a default value for all tests,
+    # then override it again just for this test.
+    parser.set_defaults(logging_config="juju.state.txn=TRACE;<root>=INFO;unit=INFO")
     return parser.parse_args(argv)
 
 def main(argv=None):

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -297,7 +297,7 @@ def add_basic_testing_arguments(
                         help='Keep the Juju environment after the test'
                         ' completes.')
     parser.add_argument('--logging-config',
-                        help="Override logging configuration for a deploy",
+                        help="Override logging configuration for a deployment.",
                         default="<root>=INFO;unit=INFO")
     if existing:
         parser.add_argument(

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -224,7 +224,6 @@ def add_arg_juju_bin(parser):
                         ' will use $PATH/juju',
                         default=None)
 
-
 def add_basic_testing_arguments(
         parser, using_jes=False, deadline=True, env=True, existing=True):
     """Returns the parser loaded with basic testing arguments.
@@ -297,6 +296,9 @@ def add_basic_testing_arguments(
     parser.add_argument('--keep-env', action='store_true',
                         help='Keep the Juju environment after the test'
                         ' completes.')
+    parser.add_argument('--logging-config',
+                        help="Override logging configuration for a deploy",
+                        default="<root>=INFO;unit=INFO")
     if existing:
         parser.add_argument(
             '--existing',


### PR DESCRIPTION
## Description of change

The following breaks if no logging config is set on the arg value

## QA steps

Run any acceptance test that isn't `assess_deploy_webscale.py` and it should
run without error.