### PR TITLE
WIP: Institute timeouts for calls to LXD operation.Wait()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -12,6 +12,14 @@
   revision = "3b1ae45394a234c385be014e9a488f2bb6eef821"
 
 [[projects]]
+  branch = "master"
+  digest = "1:3dbee55971def1e4aa600dac9e3398ddb1b20ee4ca729aa08c985692b2bd1fc8"
+  name = "code.cloudfoundry.org/systemcerts"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ca00b2f806f2fa1ded784ade357bad1ea3f1fbbe"
+
+[[projects]]
   digest = "1:e1b859e3d9e90007d5fbf25edf57733b224f1857f6592636130afab3af8cfae7"
   name = "contrib.go.opencensus.io/exporter/ocagent"
   packages = ["."]
@@ -182,6 +190,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "145fabdb1ab757076a70a886d092a3af27f66f4c"
+
+[[projects]]
+  digest = "1:9fdd67ccb34e94602b72547c9943981458e76ba8eb6e43a5876a48dc7af1e5cb"
+  name = "github.com/flosch/pongo2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5e81b817a0c48c1c57cdf1a9056cf76bdee02ca9"
+  version = "v3.0"
 
 [[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
@@ -862,7 +878,7 @@
   revision = "4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36"
 
 [[projects]]
-  digest = "1:6afa560a3ad5e47aea2d986fd87123bfc74fe89541f197861a071e6454f06f04"
+  digest = "1:3d2c2224d419c7b4297378a7cc422dcd775a080e6d838649182c386a0ab6708e"
   name = "github.com/lxc/lxd"
   packages = [
     "client",
@@ -875,7 +891,7 @@
     "shared/simplestreams",
   ]
   pruneopts = ""
-  revision = "d0d66b4842f459c6c3e039a9e2f25eff02174ab1"
+  revision = "41a8bcbff8f12cb7861588bf881d6e3502581b43"
 
 [[projects]]
   digest = "1:f95025d583786875a71183888acc9d0987fc96f12d4f5afab3d7558797ea1c5a"
@@ -1598,6 +1614,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "87155f248cf6ea9e38ae7613f9ea1e5bb397ac83"
+
+[[projects]]
+  branch = "v2"
+  digest = "1:92a9d3d81fc5b50d5ccf0c72b9888cd27acf277894f8aa18f4c9c41de8311555"
+  name = "gopkg.in/robfig/cron.v2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "be2e0b0deed5a68ffee390b4583a13aff8321535"
 
 [[projects]]
   branch = "v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -127,7 +127,7 @@
 
 [[constraint]]
   name = "github.com/lxc/lxd"
-  revision = "d0d66b4842f459c6c3e039a9e2f25eff02174ab1"
+  revision = "41a8bcbff8f12cb7861588bf881d6e3502581b43"
 
 [[constraint]]
   name = "github.com/oracle/oci-go-sdk"

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -177,7 +177,7 @@ func (s *Server) CopyRemoteImage(
 	// Block until we either complete successfully or time out.
 	select {
 	case <-abort:
-		return ServerFatalf("image download progress stalled; aborting operation")
+		return errors.New("image download progress stalled; aborting operation")
 	case err := <-complete:
 		if err != nil {
 			return errors.Trace(err)

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -77,7 +77,6 @@ func (s *imageSuite) TestCopyImageCallbackTimeoutError(c *gc.C) {
 	err = jujuSvr.CopyRemoteImage(
 		sourced, []string{"local/image/alias"}, lxdtesting.NoOpCallback, time.Microsecond)
 	c.Assert(err, gc.ErrorMatches, "image download progress stalled; aborting operation")
-	c.Assert(lxd.IsServerFatal(err), jc.IsTrue)
 }
 
 func (s *imageSuite) TestFindImageLocalServer(c *gc.C) {


### PR DESCRIPTION
## Description of change

This is some code that allowed me to create containers when loosely simulating conditions in the attached Launchpad bug.

I don't think it should be merged as is, but I've put it here for illustrative purposes while I attempt to broach the issue with the LXD team.

The main issue is that there is some condition (in our case restarting the LXD daemon), that causes our long running LXD server to block forever on all future calls to `operation.Wait()`. All the operations that are waited on eventually succeed - images are downloaded, containers created and started; we just don't get any returns.

## QA steps

- Bootstrap
- `juju add-machine`
- Set up a terminal to watch status via `watch -c juju status --color`
- When quiesced, SSH to machine 0 in another terminal and be ready to run commands there.
- `for i in `seq 4`; do juju add-machine lxd:0; done`
- Change to the machine-0 SSH session and take note of the juju status terminal.
- Once the first of the machines begins reporting image download progress, run `sudo systemctl restart lxd`
- Just wait. It will take a while and various cycling through errors, but the machines will eventually be provisioned.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1796709
