### PR TITLE
Bug 1808947

### DIFF
--- a/core/lxdprofile/status.go
+++ b/core/lxdprofile/status.go
@@ -24,6 +24,9 @@ const (
 
 	// ErrorStatus defines when the lxd profile is in an error state
 	ErrorStatus = "Error"
+
+	// NotSupportedStatus defines when a machine does not support lxd profiles.
+	NotSupportedStatus = "Not Supported"
 )
 
 // AnnotateErrorStatus annotates an existing error with the correct status
@@ -33,7 +36,7 @@ func AnnotateErrorStatus(err error) string {
 
 // UpgradeStatusFinished defines if the upgrade has completed
 func UpgradeStatusFinished(status string) bool {
-	if status == SuccessStatus || status == NotRequiredStatus {
+	if status == SuccessStatus || status == NotRequiredStatus || status == NotSupportedStatus {
 		return true
 	}
 	return false

--- a/core/lxdprofile/status_test.go
+++ b/core/lxdprofile/status_test.go
@@ -34,6 +34,10 @@ func (*LXDProfileStatusSuite) TestUpgradeStatusFinished(c *gc.C) {
 			output: true,
 		},
 		{
+			input:  lxdprofile.NotSupportedStatus,
+			output: true,
+		},
+		{
 			input:  lxdprofile.NotKnownStatus,
 			output: false,
 		},
@@ -63,6 +67,10 @@ func (*LXDProfileStatusSuite) TestUpgradeStatusTerminal(c *gc.C) {
 		},
 		{
 			input:  lxdprofile.NotRequiredStatus,
+			output: true,
+		},
+		{
+			input:  lxdprofile.NotSupportedStatus,
 			output: true,
 		},
 		{

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -311,6 +311,9 @@ func (s *AssignSuite) TestPrincipals(c *gc.C) {
 func (s *AssignSuite) TestAssignMachinePrincipalsChange(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(machine)

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -319,6 +319,8 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineUnit(c *gc.C) {
 	// Create a machine.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a relation with a unit in scope and assigned to the machine.
 	pr := newPeerRelation(c, s.State)
@@ -401,6 +403,9 @@ func (s *CleanupSuite) TestCleanupForceDestroyMachineCleansStorageAttachments(c 
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDoesNotNeedCleanup(c)
 
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	ch := s.AddTestingCharm(c, "storage-block")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),
@@ -447,10 +452,14 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineWithContainer(c *gc.C) {
 	// Create a machine with a container.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
 	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}, machine.Id(), instance.LXD)
+	c.Assert(err, jc.ErrorIsNil)
+	err = container.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create active units (in relation scope, with subordinates).

--- a/state/unit.go
+++ b/state/unit.go
@@ -724,8 +724,6 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 			return nil, err
 		}
 		if profile != "" {
-			// TODO (hml) 09-jan-2019
-			// how do we know when to clean this doc up?
 			logger.Tracef("Setup to remove charm profile %q, removing unit from machine %s", profile, m.Id())
 			ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
 		}

--- a/state/unit.go
+++ b/state/unit.go
@@ -703,8 +703,8 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 				Assert: txn.DocExists,
 				Remove: true,
 			})
-		} else if errors.IsNotFound(err) {
-			logger.Tracef("Error getting instance charm profile data for machine %s, %s", m.Id(), err.Error())
+		} else if !errors.IsNotFound(err) {
+			logger.Errorf("Error getting instance charm profile data for machine %s, %s", m.Id(), err.Error())
 		}
 	} else {
 		machineAssert = bson.D{{"$or", []bson.D{

--- a/state/unit.go
+++ b/state/unit.go
@@ -692,14 +692,43 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 			{{"jobs", bson.D{{"$nin", []MachineJob{JobManageModel}}}}},
 			{{"hasvote", bson.D{{"$ne", true}}}},
 		}}}
+		// Clean up any instanceCharmProfileData docs for this machine before
+		// it is destroyed.
+		_, err := getInstanceCharmProfileData(m.st, m.doc.DocID)
+		if err == nil {
+			logger.Tracef("Remove instance charm profile data for machine %s", m.Id())
+			ops = append(ops, txn.Op{
+				C:      instanceCharmProfileDataC,
+				Id:     m.doc.DocID,
+				Assert: txn.DocExists,
+				Remove: true,
+			})
+		} else if errors.IsNotFound(err) {
+			logger.Tracef("Error getting instance charm profile data for machine %s, %s", m.Id(), err.Error())
+		}
 	} else {
 		machineAssert = bson.D{{"$or", []bson.D{
 			{{"principals", bson.D{{"$ne", []string{u.doc.Name}}}}},
 			{{"jobs", bson.D{{"$in", []MachineJob{JobManageModel}}}}},
 			{{"hasvote", true}},
 		}}}
-		logger.Tracef("Remove charm profile from machine %s for %s", m.Id(), a.Name())
-		ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
+		// Remove any charm profile applied to the machine for this unit,
+		// if this is a unit removal from a machine which will not be
+		// destroyed.
+		machineProfiles, err := m.CharmProfiles()
+		if err != nil {
+			return nil, err
+		}
+		profile, err := lxdprofile.MatchProfileNameByAppName(machineProfiles, u.ApplicationName())
+		if err != nil {
+			return nil, err
+		}
+		if profile != "" {
+			// TODO (hml) 09-jan-2019
+			// how do we know when to clean this doc up?
+			logger.Tracef("Setup to remove charm profile %q, removing unit from machine %s", profile, m.Id())
+			ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
+		}
 	}
 
 	// If removal conditions satisfied by machine & container docs, we can

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
@@ -624,10 +625,15 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
+
 	colocated, err := applicationWithProfile.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(colocated.AssignToMachine(host), gc.IsNil)
 
+	// Set a profile name on the machine, destroyHostOps will only
+	// set up to remove a profile from the machine it if it exists.
+	profileName := lxdprofile.Name("default", applicationWithProfile.Name(), charmWithProfile.Revision())
+	host.SetCharmProfiles([]string{profileName})
 	c.Assert(colocated.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Alive)
 
@@ -639,6 +645,71 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 	c.Assert(chCharmURL, gc.Equals, "")
 
 	c.Assert(host.Destroy(), gc.NotNil)
+}
+
+func (s *UnitSuite) TestRemoveUnitMachineNoDestroy(c *gc.C) {
+	charmWithOut := s.AddTestingCharm(c, "mysql")
+	applicationWithOutProfile := s.AddTestingApplication(c, "mysql", charmWithOut)
+
+	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	target, err := s.application.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(target.AssignToMachine(host), gc.IsNil)
+
+	colocated, err := applicationWithOutProfile.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(colocated.AssignToMachine(host), gc.IsNil)
+	c.Assert(colocated.Destroy(), gc.IsNil)
+	assertLife(c, host, state.Alive)
+
+	// "", nil is equivalent to IsNotFound, which is what we
+	// expect here
+	chAppName, err := host.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chAppName, gc.Equals, "")
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chCharmURL, gc.Equals, "")
+
+	c.Assert(host.Destroy(), gc.NotNil)
+}
+
+func (s *UnitSuite) TestRemoveUnitMachineDestroyCleanUpProfileDoc(c *gc.C) {
+	charmWithProfile := s.AddTestingCharm(c, "lxd-profile")
+	applicationWithProfile := s.AddTestingApplication(c, "lxd-profile", charmWithProfile)
+
+	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	unit, err := applicationWithProfile.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.AssignToMachine(host), gc.IsNil)
+
+	// create a instanceCharmProfileData which hasn't been completed
+	// to check it's been deleted.
+	err = host.SetUpgradeCharmProfile(applicationWithProfile.Name(), charmWithProfile.URL().String())
+	c.Assert(err, jc.ErrorIsNil)
+	chAppName, err := host.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chAppName, gc.Equals, applicationWithProfile.Name())
+
+	c.Assert(unit.Destroy(), gc.IsNil)
+	assertLife(c, host, state.Dying)
+
+	// "", nil is equivalent to IsNotFound, which is what we
+	// expect here
+	chAppName, err = host.UpgradeCharmProfileApplication()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chAppName, gc.Equals, "")
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(chCharmURL, gc.Equals, "")
 }
 
 func (s *UnitSuite) setMachineVote(c *gc.C, id string, hasVote bool) {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -580,6 +580,8 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 func (s *UnitSuite) TestRemoveUnitMachineFastForwardDestroy(c *gc.C) {
 	for _, tc := range s.destroyMachineTestCases(c) {
 		c.Log(tc.desc)
+		err := tc.host.SetProvisioned("inst-id", "fake_nonce", nil)
+		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.Destroy(), gc.IsNil)
 		if tc.destroyed {
 			assertLife(c, tc.host, state.Dying)
@@ -594,6 +596,8 @@ func (s *UnitSuite) TestRemoveUnitMachineFastForwardDestroy(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineNoFastForwardDestroy(c *gc.C) {
 	for _, tc := range s.destroyMachineTestCases(c) {
 		c.Log(tc.desc)
+		err := tc.host.SetProvisioned("inst-id", "fake_nonce", nil)
+		c.Assert(err, jc.ErrorIsNil)
 		preventUnitDestroyRemove(c, tc.target)
 		c.Assert(tc.target.Destroy(), gc.IsNil)
 		c.Assert(tc.target.EnsureDead(), gc.IsNil)
@@ -614,6 +618,9 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
@@ -643,6 +650,8 @@ func (s *UnitSuite) setMachineVote(c *gc.C, id string, hasVote bool) {
 func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
@@ -666,6 +675,8 @@ func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.AssignToMachine(host), gc.IsNil)
@@ -680,6 +691,8 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {
 
 func (s *UnitSuite) TestRemoveUnitMachineRetryNoVoter(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -724,6 +737,8 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryContainer(c *gc.C) {
 
 func (s *UnitSuite) TestRemoveUnitMachineRetryOrCond(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -936,6 +951,8 @@ func (s *UnitSuite) TestDestroyChangeCharmRetry(c *gc.C) {
 
 func (s *UnitSuite) TestDestroyAssignRetry(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetRetryHooks(c, s.State, func() {
@@ -1548,6 +1565,8 @@ func (s *UnitSuite) TestRemoveLastUnitOnMachineRemovesAllPorts(c *gc.C) {
 
 func (s *UnitSuite) TestRemoveUnitRemovesItsPortsOnly(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2032,7 +2032,7 @@ func (w *instanceCharmProfileDataWatcher) merge(change watcher.Change) (bool, er
 			logger.Debugf("instanceCharmProfileData NOT mgo err not found")
 			return false, err
 		}
-		logger.Debugf("instanceCharmProfileData mgo err not found")
+		logger.Tracef("instanceCharmProfileData for %s on machine %s: mgo err not found", w.applicationName, machineId)
 		return false, nil
 	}
 

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -330,6 +330,22 @@ func (task *provisionerTask) processMachines(ids []string) error {
 	return task.startMachines(pending)
 }
 
+// processProfileChanges adds, removes, or updates lxc profiles changes to
+// existing machines, if supported by the machine's broker.
+//
+// If this action is triggered by a charm upgrade, the instance charm profile
+// data doc is always created.  Allowing the uniter to determine if the
+// profile upgrade is in a terminal state before proceeding with charm
+// upgrade itself.
+//
+// If this action is triggered by a new 2nd unit added to an existing machine,
+// clean up of the instance charm profile data doc happens here in the case
+// of lxd profile support in the machine's broker.
+//
+// If the broker does not support lxd profiles, it is harder to determine if
+// the instance charm profile data doc should be cleaned up.  Therefore it
+// gets set to NotSupportedStatus, which then is deleted by the uniter at
+// it's installation.
 func (task *provisionerTask) processProfileChanges(ids []string) error {
 	logger.Tracef("processProfileChanges(%v)", ids)
 	if len(ids) == 0 {
@@ -369,7 +385,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 		} else if err != nil {
 			logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
 			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
-				return errors.Annotatef(err2, "cannot set error status for instance charm profile data", m)
+				return errors.Annotatef(err2, "cannot set error status for instance charm profile data for machine %q", m)
 			}
 			// If Error, SetInstanceStatus in the provisioner api will also call
 			// SetStatus.
@@ -386,7 +402,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 				return errors.Annotatef(err2, "cannot set error status for machine %q agent", m)
 			}
 			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus); err2 != nil {
-				return errors.Annotatef(err2, "cannot set success status for instance charm profile data", m)
+				return errors.Annotatef(err2, "cannot set success status for instance charm profile data for machine %q", m)
 			}
 		}
 	}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -350,7 +350,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	profileBroker, ok := task.broker.(environs.LXDProfiler)
 	if !ok {
 		logger.Debugf("Attempting to update the profile of a machine that doesn't support profiles")
-		profileUpgradeNotRequired(machines)
+		profileUpgradeNotSupported(machines)
 		return nil
 	}
 	for i, mResult := range machines {
@@ -368,7 +368,9 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			}
 		} else if err != nil {
 			logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
-			m.SetUpgradeCharmProfileComplete(lxdprofile.AnnotateErrorStatus(err))
+			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
+				return errors.Annotatef(err2, "cannot set error status for instance charm profile data", m)
+			}
 			// If Error, SetInstanceStatus in the provisioner api will also call
 			// SetStatus.
 			if err2 := m.SetInstanceStatus(status.Error, "cannot upgrade machine's lxd profile: "+err.Error(), nil); err2 != nil {
@@ -383,16 +385,18 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			if err2 := m.SetStatus(status.Started, "", nil); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for machine %q agent", m)
 			}
-			m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
+			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus); err2 != nil {
+				return errors.Annotatef(err2, "cannot set success status for instance charm profile data", m)
+			}
 		}
 	}
 	return nil
 }
 
-func profileUpgradeNotRequired(machines []apiprovisioner.MachineResult) {
+func profileUpgradeNotSupported(machines []apiprovisioner.MachineResult) {
 	for _, mResult := range machines {
-		if err := mResult.Machine.SetUpgradeCharmProfileComplete(lxdprofile.NotRequiredStatus); err != nil {
-			logger.Errorf("cannot set charm profile upgrade not required: %s", err.Error())
+		if err := mResult.Machine.SetUpgradeCharmProfileComplete(lxdprofile.NotSupportedStatus); err != nil {
+			logger.Errorf("cannot set not supported status for instance charm profile data: %s", err.Error())
 		}
 	}
 }

--- a/worker/uniter/operation/deploy.go
+++ b/worker/uniter/operation/deploy.go
@@ -51,6 +51,17 @@ func (d *deploy) Prepare(state State) (*State, error) {
 	if err := d.checkAlreadyDone(state); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if d.kind == Install {
+		// When a 2nd principal or subordinate unit having an lxd profile,
+		// is added to a machine, it is installed on the machine via the same
+		// mechanism as a charm upgrade with a profile.  However there is not
+		// a watcher waiting for the instanceCharmProfileData doc status to
+		// go into a terminal state so it can be deleted.
+		//
+		if err := d.callbacks.RemoveUpgradeCharmProfileData(); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
 	info, err := d.callbacks.GetArchiveInfo(d.charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

Some instanceCharmProfileData docs were not removed as they should have been causing failures in destroying machines.  Using a subordinate charm with a profile on a machine in a cloud that doesn't support lxd profiles caused one doc left behind.  Added code in the uniter's install code flow to remove any instanceCharmProfileData for the machine.  Also enhanced checking in destroyHostOps to remove stray instanceCharmProfileData.

## QA steps

First do these steps with an lxd cloud, then a maas or was cloud:
```sh
juju bootstrap 
juju deploy cs:nova-compute
juju deploy cs:neutron-openvswitch-255
juju add-relation neutron-openvswitch nova-compute
```

once it's settled, `juju destroy-model`

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1808947