### PR TITLE
raft: Set a timeout when starting raft-transport

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1639,7 +1639,7 @@ func (env *azureEnviron) deleteControllerManagedResourceGroups(controllerUUID st
 	errs := make([]error, len(groupNames))
 	for i, name := range groupNames {
 		groupName := to.String(name)
-		logger.Debugf("  - deleting resource group %q", name)
+		logger.Debugf("  - deleting resource group %q", groupName)
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/worker/raft/rafttransport/manifold.go
+++ b/worker/raft/rafttransport/manifold.go
@@ -4,6 +4,8 @@
 package rafttransport
 
 import (
+	"time"
+
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/pubsub"
@@ -16,6 +18,10 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 )
+
+// raftNetworkTimeout is how long the transport should wait before
+// failing a network interaction.
+const raftNetworkTimeout = 30 * time.Second
 
 // ManifoldConfig holds the information necessary to run an apiserver-based
 // raft transport worker in a dependency.Engine.
@@ -125,6 +131,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		LocalID:       raft.ServerID(agent.CurrentConfig().Tag().Id()),
 		TLSConfig:     api.NewTLSConfig(certPool),
 		Clock:         clk,
+		Timeout:       raftNetworkTimeout,
 	})
 }
 

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -149,6 +149,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		Path:          "raft/path",
 		LocalID:       "123",
 		Clock:         s.clock,
+		Timeout:       30 * time.Second,
 	})
 }
 


### PR DESCRIPTION
## Description of change

We were seeing a problem where the raft worker would occasionally hang during shutdown, and looking at a goroutine dump of the hung agent and experimenting with a similar situation extracted from a test that sometimes hangs in the same way lead to the discovery that no timeout was being set on the transport. The worker passes the timeout value from its config into the transport, but the manifold doesn't initialise it.

## QA steps

I haven't managed to directly reproduce the hang in an agent, so I haven't verified this other than in the test scenario. But it passes a smoke test:
* Bootstrap and enable HA.
* Upgrade the controller so it shuts down and starts again.
* The upgrade completes successfully.

## Documentation changes

None.