### PR TITLE
Handle aws xen pv block devices

### DIFF
--- a/apiserver/common/storagecommon/blockdevices.go
+++ b/apiserver/common/storagecommon/blockdevices.go
@@ -41,6 +41,7 @@ func MatchingBlockDevice(
 	for _, dev := range blockDevices {
 		if volumeInfo.WWN != "" {
 			if volumeInfo.WWN == dev.WWN {
+				logger.Tracef("wwn match on %v", volumeInfo.WWN)
 				return &dev, true
 			}
 			logger.Tracef("no match for block device WWN: %v", dev.WWN)
@@ -48,6 +49,7 @@ func MatchingBlockDevice(
 		}
 		if volumeInfo.HardwareId != "" {
 			if volumeInfo.HardwareId == dev.HardwareId {
+				logger.Tracef("hwid match on %v", volumeInfo.HardwareId)
 				return &dev, true
 			}
 			logger.Tracef("no match for block device hardware id: %v", dev.HardwareId)
@@ -55,14 +57,18 @@ func MatchingBlockDevice(
 		}
 		if attachmentInfo.BusAddress != "" {
 			if attachmentInfo.BusAddress == dev.BusAddress {
+				logger.Tracef("bus address match on %v", attachmentInfo.BusAddress)
 				return &dev, true
 			}
 			logger.Tracef("no match for block device bus address: %v", dev.BusAddress)
 			continue
 		}
-		if attachmentInfo.DeviceLink != "" {
+		// Only match on block device link if the block device is published
+		// with device link information.
+		if attachmentInfo.DeviceLink != "" && len(dev.DeviceLinks) > 0 {
 			for _, link := range dev.DeviceLinks {
 				if attachmentInfo.DeviceLink == link {
+					logger.Tracef("device link match on %v", attachmentInfo.DeviceLink)
 					return &dev, true
 				}
 			}
@@ -70,6 +76,7 @@ func MatchingBlockDevice(
 			continue
 		}
 		if attachmentInfo.DeviceName == dev.DeviceName {
+			logger.Tracef("device name match on %v", attachmentInfo.DeviceName)
 			return &dev, true
 		}
 		logger.Tracef("no match for block device name: %v", dev.DeviceName)

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -239,9 +239,11 @@ func volumeAttachmentDevicePath(
 		volumeAttachmentInfo.DeviceName != "" ||
 		volumeAttachmentInfo.DeviceLink != "" {
 		// Prefer the volume attachment's information over what is
-		// in the published block device information.
+		// in the published block device information, but only if the
+		// block device information actually has any device links. In
+		// some cases, the block device has very little hw info published.
 		var deviceLinks []string
-		if volumeAttachmentInfo.DeviceLink != "" {
+		if volumeAttachmentInfo.DeviceLink != "" && len(blockDevice.DeviceLinks) > 0 {
 			deviceLinks = []string{volumeAttachmentInfo.DeviceLink}
 		}
 		return storage.BlockDevicePath(storage.BlockDevice{

--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -86,6 +86,20 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceNa
 	})
 }
 
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceNameIgnoresEmptyLinks(c *gc.C) {
+	s.volumeAttachment.info.DeviceLink = "/dev/disk/by-id/verbatim"
+	s.volumeAttachment.info.DeviceName = "sda"
+	// Clear the machine block device link to force a match on name.
+	s.blockDevices[0].DeviceLinks = nil
+	info, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
+	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
+		Kind:     storage.StorageKindBlock,
+		Location: "/dev/sda",
+	})
+}
+
 func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoMissingBlockDevice(c *gc.C) {
 	// If the block device has not shown up yet,
 	// then we should get a NotProvisioned error.


### PR DESCRIPTION
## Description of change

AWS can provision xen pv volumes such that udev info is missing any hardware identifying characteristics. In this case, we need to force a fallback to match on device name, which is not perfect but it's all we can do.

## QA steps

bootstrap aws
juju deploy postgresql --storage pgdata=1G,ebs

Also test google and maas clouds

## Bug reference

https://bugs.launchpad.net/juju/+bug/1809478
