### PR TITLE
Backport storage fixes

### DIFF
--- a/apiserver/common/storagecommon/blockdevices.go
+++ b/apiserver/common/storagecommon/blockdevices.go
@@ -42,23 +42,27 @@ func MatchingBlockDevice(
 	for _, dev := range blockDevices {
 		if planBlockInfo.HardwareId != "" {
 			if planBlockInfo.HardwareId == dev.HardwareId {
+				logger.Tracef("plan hwid match on %v", volumeInfo.HardwareId)
 				return &dev, true
 			}
 		}
 		if planBlockInfo.WWN != "" {
 			if planBlockInfo.WWN == dev.WWN {
+				logger.Tracef("plan wwn match on %v", volumeInfo.WWN)
 				return &dev, true
 			}
 			continue
 		}
 		if planBlockInfo.DeviceName != "" {
 			if planBlockInfo.DeviceName == dev.DeviceName {
+				logger.Tracef("plan device name match on %v", attachmentInfo.DeviceName)
 				return &dev, true
 			}
 			continue
 		}
 		if volumeInfo.WWN != "" {
 			if volumeInfo.WWN == dev.WWN {
+				logger.Tracef("wwn match on %v", volumeInfo.WWN)
 				return &dev, true
 			}
 			logger.Tracef("no match for block device WWN: %v", dev.WWN)
@@ -66,6 +70,7 @@ func MatchingBlockDevice(
 		}
 		if volumeInfo.HardwareId != "" {
 			if volumeInfo.HardwareId == dev.HardwareId {
+				logger.Tracef("hwid match on %v", volumeInfo.HardwareId)
 				return &dev, true
 			}
 			logger.Tracef("no match for block device hardware id: %v", dev.HardwareId)
@@ -73,14 +78,18 @@ func MatchingBlockDevice(
 		}
 		if attachmentInfo.BusAddress != "" {
 			if attachmentInfo.BusAddress == dev.BusAddress {
+				logger.Tracef("bus address match on %v", attachmentInfo.BusAddress)
 				return &dev, true
 			}
 			logger.Tracef("no match for block device bus address: %v", dev.BusAddress)
 			continue
 		}
-		if attachmentInfo.DeviceLink != "" {
+		// Only match on block device link if the block device is published
+		// with device link information.
+		if attachmentInfo.DeviceLink != "" && len(dev.DeviceLinks) > 0 {
 			for _, link := range dev.DeviceLinks {
 				if attachmentInfo.DeviceLink == link {
+					logger.Tracef("device link match on %v", attachmentInfo.DeviceLink)
 					return &dev, true
 				}
 			}
@@ -88,6 +97,7 @@ func MatchingBlockDevice(
 			continue
 		}
 		if attachmentInfo.DeviceName == dev.DeviceName {
+			logger.Tracef("device name match on %v", attachmentInfo.DeviceName)
 			return &dev, true
 		}
 		logger.Tracef("no match for block device name: %v", dev.DeviceName)

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -217,9 +217,11 @@ func volumeAttachmentDevicePath(
 		volumeAttachmentInfo.DeviceName != "" ||
 		volumeAttachmentInfo.DeviceLink != "" {
 		// Prefer the volume attachment's information over what is
-		// in the published block device information.
+		// in the published block device information, but only if the
+		// block device information actually has any device links. In
+		// some cases, the block device has very little hw info published.
 		var deviceLinks []string
-		if volumeAttachmentInfo.DeviceLink != "" {
+		if volumeAttachmentInfo.DeviceLink != "" && len(blockDevice.DeviceLinks) > 0 {
 			deviceLinks = []string{volumeAttachmentInfo.DeviceLink}
 		}
 		var deviceName string

--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -123,6 +123,20 @@ func (s *VolumeStorageAttachmentInfoSuite) TestStorageAttachmentInfoMissingBlock
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "VolumeAttachmentPlan", "BlockDevices")
 }
 
+func (s *VolumeStorageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceNameIgnoresEmptyLinks(c *gc.C) {
+	s.volumeAttachment.info.DeviceLink = "/dev/disk/by-id/verbatim"
+	s.volumeAttachment.info.DeviceName = "sda"
+	// Clear the machine block device link to force a match on name.
+	s.blockDevices[0].DeviceLinks = nil
+	info, err := storagecommon.StorageAttachmentInfo(s.st, s.st, s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "VolumeAttachmentPlan", "BlockDevices")
+	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
+		Kind:     storage.StorageKindBlock,
+		Location: "/dev/sda",
+	})
+}
+
 func (s *VolumeStorageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceLink(c *gc.C) {
 	s.volumeAttachment.info.DeviceLink = "/dev/disk/by-id/verbatim"
 	info, err := storagecommon.StorageAttachmentInfo(s.st, s.st, s.st, s.storageAttachment, s.machineTag)

--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -47,7 +47,7 @@ func UnitChainPredicateFn(
 		for _, subName := range unit.SubordinateNames() {
 			// A master match supercedes any subordinate match.
 			if matches {
-				logger.Infof("%s is a subordinate to a match.", subName)
+				logger.Debugf("%s is a subordinate to a match.", subName)
 				considered[subName] = true
 				continue
 			}

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1084,6 +1084,58 @@ func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageCleanAvailable(c *
 	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
 }
 
+func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageAndMachinePlacementDirective(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
+	sb, err := state.NewStorageBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	storageAttachments, err := sb.UnitStorageAttachments(unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+
+	// Add a clean machine.
+	clean, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assign the unit to a machine, requesting clean/empty. Since
+	// the unit has non dynamic storage instances associated,
+	// it will be forced onto a new machine.
+	placement := &instance.Placement{
+		instance.MachineScope, clean.Id(),
+	}
+	err = s.State.AssignUnitWithPlacement(unit, placement)
+	c.Assert(
+		err, gc.ErrorMatches,
+		`cannot assign unit "storage-filesystem/0" to machine 0: "static" storage provider does not support dynamic storage`,
+	)
+}
+
+func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageAndZonePlacementDirective(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
+	sb, err := state.NewStorageBackend(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	storageAttachments, err := sb.UnitStorageAttachments(unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+
+	// Add a clean machine.
+	clean, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assign the unit to a machine, requesting clean/empty. Since
+	// the unit has non dynamic storage instances associated,
+	// it will be forced onto a new machine.
+	placement := &instance.Placement{
+		s.State.ModelUUID(), "zone=test",
+	}
+	err = s.State.AssignUnitWithPlacement(unit, placement)
+
+	// Check the machine on the unit is set.
+	machineId, err := unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	// Check that the machine isn't our clean one.
+	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
+}
+
 func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.C) {
 	_, unit, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
 	sb, err := state.NewStorageBackend(s.State)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1831,34 +1831,6 @@ func (s *StateSuite) TestAddApplicationWithInvalidBindings(c *gc.C) {
 	}
 }
 
-func (s *StateSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C) {
-	machine, err := s.State.AddMachine("xenial", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-
-	name := "lxd-profile"
-	charm := state.AddTestingCharmForSeries(c, s.State, "xenial", name)
-	application := s.AddTestingApplication(c, name, charm)
-	c.Assert(err, jc.ErrorIsNil)
-	unit, err := application.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.State.AssignUnitWithPlacement(unit,
-		&instance.Placement{
-			instance.MachineScope, machine.Id(),
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-
-	chAppName, err := machine.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, name)
-	chCharmURL, err := machine.UpgradeCharmProfileCharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chCharmURL, gc.Equals, charm.URL().String())
-}
-
 func (s *StateSuite) TestAddApplicationMachinePlacementInvalidSeries(c *gc.C) {
 	m, err := s.State.AddMachine("trusty", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -2107,6 +2107,13 @@ func (u *Unit) AssignToNewMachineOrContainer() (err error) {
 // time of unit creation.
 func (u *Unit) AssignToNewMachine() (err error) {
 	defer assignContextf(&err, u.Name(), "new machine")
+	return u.assignToNewMachine("")
+}
+
+// assignToNewMachine assigns the unit to a new machine with the
+// optional placement directive, with constraints determined according
+// to the application and model constraints at the time of unit creation.
+func (u *Unit) assignToNewMachine(placement string) error {
 	if u.doc.Principal != "" {
 		return fmt.Errorf("unit is a subordinate")
 	}
@@ -2136,6 +2143,8 @@ func (u *Unit) AssignToNewMachine() (err error) {
 			Series:                u.doc.Series,
 			Constraints:           *cons,
 			Jobs:                  []MachineJob{JobHostUnits},
+			Placement:             placement,
+			Dirty:                 placement != "",
 			Volumes:               storageParams.volumes,
 			VolumeAttachments:     storageParams.volumeAttachments,
 			Filesystems:           storageParams.filesystems,

--- a/storage/provider/dirfuncs.go
+++ b/storage/provider/dirfuncs.go
@@ -15,6 +15,7 @@ import (
 // dirFuncs is used to allow the real directory operations to
 // be stubbed out for testing.
 type dirFuncs interface {
+	etcDir() string
 	mkDirAll(path string, perm os.FileMode) error
 	lstat(path string) (fi os.FileInfo, err error)
 	fileCount(path string) (int, error)
@@ -39,6 +40,10 @@ type dirFuncs interface {
 // filesystem.
 type osDirFuncs struct {
 	run runCommandFunc
+}
+
+func (*osDirFuncs) etcDir() string {
+	return "/etc"
 }
 
 func (*osDirFuncs) mkDirAll(path string, perm os.FileMode) error {

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -85,6 +85,7 @@ func (s *loopSuite) TestScope(c *gc.C) {
 func (s *loopSuite) loopVolumeSource(c *gc.C) (storage.VolumeSource, *provider.MockDirFuncs) {
 	s.commands = &mockRunCommand{c: c}
 	return provider.LoopVolumeSource(
+		c.MkDir(),
 		s.storageDir,
 		s.commands.run,
 	)

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -25,6 +25,7 @@ type rootfsSuite struct {
 	storageDir   string
 	commands     *mockRunCommand
 	mockDirFuncs *provider.MockDirFuncs
+	fakeEtcDir   string
 
 	callCtx context.ProviderCallContext
 }
@@ -35,6 +36,7 @@ func (s *rootfsSuite) SetUpTest(c *gc.C) {
 	}
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
+	s.fakeEtcDir = c.MkDir()
 	s.callCtx = context.NewCloudCallContext()
 }
 
@@ -87,7 +89,7 @@ func (s *rootfsSuite) TestScope(c *gc.C) {
 
 func (s *rootfsSuite) rootfsFilesystemSource(c *gc.C) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
-	source, d := provider.RootfsFilesystemSource(s.storageDir, s.commands.run)
+	source, d := provider.RootfsFilesystemSource(s.fakeEtcDir, s.storageDir, s.commands.run)
 	s.mockDirFuncs = d
 	return source
 }
@@ -346,7 +348,7 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirClaimed(c *gc.C)
 
 func (s *rootfsSuite) TestDetachFilesystems(c *gc.C) {
 	source := s.rootfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, true)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, true, s.fakeEtcDir, "")
 }
 
 func (s *rootfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
@@ -355,5 +357,5 @@ func (s *rootfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
 	// either case, there is no attachment-specific filesystem
 	// mount.
 	source := s.rootfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, false)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, false, s.fakeEtcDir, "")
 }

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -23,6 +23,7 @@ type tmpfsSuite struct {
 	testing.BaseSuite
 	storageDir string
 	commands   *mockRunCommand
+	fakeEtcDir string
 
 	callCtx context.ProviderCallContext
 }
@@ -33,6 +34,7 @@ func (s *tmpfsSuite) SetUpTest(c *gc.C) {
 	}
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
+	s.fakeEtcDir = c.MkDir()
 	s.callCtx = context.NewCloudCallContext()
 }
 
@@ -86,6 +88,7 @@ func (s *tmpfsSuite) TestScope(c *gc.C) {
 func (s *tmpfsSuite) tmpfsFilesystemSource(c *gc.C) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
 	return provider.TmpfsFilesystemSource(
+		s.fakeEtcDir,
 		s.storageDir,
 		s.commands.run,
 	)
@@ -276,10 +279,10 @@ func (s *tmpfsSuite) TestAttachFilesystemsNoFilesystem(c *gc.C) {
 
 func (s *tmpfsSuite) TestDetachFilesystems(c *gc.C) {
 	source := s.tmpfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, true)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, true, s.fakeEtcDir, "")
 }
 
 func (s *tmpfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
 	source := s.tmpfsFilesystemSource(c)
-	testDetachFilesystems(c, s.commands, source, s.callCtx, false)
+	testDetachFilesystems(c, s.commands, source, s.callCtx, false, s.fakeEtcDir, "")
 }


### PR DESCRIPTION
## Description of change

Backport some storage fixes from develop:

https://github.com/juju/juju/pull/9599 
When a block device is attached for storage, create an /etc/fstab entry.
Delete the /etc/fstab entry when storage is detached.

https://github.com/juju/juju/pull/9607
Deploying a charm with storage to maas fails if a placement directive is used, eg --to zone=<blah>.
The PR fixes the underlying deployment logic to support that case.

Also forward port AWS storage fix from 2.4:

https://github.com/juju/juju/pull/9620
AWS can provision xen pv volumes such that udev info is missing any hardware identifying characteristics. In this case, we need to force a fallback to match on device name, which is not perfect but it's all we can do.

## QA steps

bootstrap aws and maas and test postgresql deployments with storage

## Bug reference

https://bugs.launchpad.net/juju/+bug/1783419
https://bugs.launchpad.net/juju/+bug/1765959
https://bugs.launchpad.net/juju/+bug/1809478
