### PR TITLE
Webscale: Ensure that we send the charm revisions

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -4,6 +4,7 @@
     1. deploying kubernetes core and asserting it is `healthy`
     2. inspect the logs to parse timings from trace logs
     3. send timings to the reporting client
+       a. include charm revisions in the tags
 """
 
 from __future__ import print_function
@@ -114,6 +115,16 @@ def calculate_max_time(timings):
     """
     return functools.reduce(lambda x, y: x if x > y else y, timings)
 
+def extract_charm_urls(client):
+    """Extract the bundle with revisions
+    """
+    status = client.get_status()
+    application_info = status.get_applications()
+    charms = []
+    for charm in application_info:
+        charms.append(charm["charm"])
+    return charms
+
 def parse_args(argv):
     """Parse all arguments."""
     parser = argparse.ArgumentParser(description="Webscale charm deployment CI test")
@@ -160,14 +171,17 @@ def main(argv=None):
             calculate_max_time(timings),
             (time.time() - begin),
         )
-
         log.info("Metrics for deployment: {}".format(metrics))
+
+        # Extract the charm bundle and revision numbers
+        charm_str = ",".join(extract_charm_urls(client))
 
         try:
             rclient = get_reporting_client(args.reporting_uri)
             rclient.report(metrics, tags={
                 "git-sha": args.git_sha,
                 "charm-bundle": args.charm_bundle,
+                "charms": charm_str,
             })
         except:
             raise JujuAssertionError("Error reporting metrics")


### PR DESCRIPTION
## Description of change

Ensure that we send the charm revisions to the db behind the scenes.
That way we can inspect the information later.