### PR TITLE
Support multi-cloud controllers

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1003,10 +1003,6 @@ func (s *modelManagerStateSuite) TestCreateModelBadConfig(c *gc.C) {
 			key:      "uuid",
 			value:    "anything",
 			errMatch: `failed to create config: uuid is generated, you cannot specify one`,
-		}, {
-			key:      "type",
-			value:    "fake",
-			errMatch: `failed to create config: specified type "fake" does not match controller "dummy"`,
 		},
 	} {
 		c.Logf("%d: %s", i, test.key)

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -8,6 +8,8 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/jujuclient"
 )
@@ -15,6 +17,23 @@ import (
 var (
 	ShouldFinalizeCredential = shouldFinalizeCredential
 )
+
+func NewAddCloudCommandForTest(
+	cloudMetadataStore CloudMetadataStore,
+	store jujuclient.ClientStore,
+	cloudAPI func() (AddCloudAPI, error),
+) *AddCloudCommand {
+	cloudCallCtx := context.NewCloudCallContext()
+	return &AddCloudCommand{
+		cloudMetadataStore: cloudMetadataStore,
+		CloudCallCtx:       cloudCallCtx,
+		Ping: func(p environs.EnvironProvider, endpoint string) error {
+			return nil
+		},
+		store:           store,
+		addCloudAPIFunc: cloudAPI,
+	}
+}
 
 func NewUpdateCloudsCommandForTest(publicCloudURL string) *updateCloudsCommand {
 	return &updateCloudsCommand{

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -352,7 +352,7 @@ func (c *modelsCommand) tabularColumns(tw *ansiterm.TabWriter, w output.Wrapper)
 	if c.listUUID {
 		w.Print("UUID")
 	}
-	w.Print("Cloud/Region", "Status")
+	w.Print("Cloud/Region", "Type", "Status")
 	printColumnHeader := func(columnName string, columnNumber int) {
 		w.Print(columnName)
 		offset := 0
@@ -363,11 +363,11 @@ func (c *modelsCommand) tabularColumns(tw *ansiterm.TabWriter, w output.Wrapper)
 	}
 
 	if c.runVars.hasMachinesCount {
-		printColumnHeader("Machines", 3)
+		printColumnHeader("Machines", 4)
 	}
 
 	if c.runVars.hasCoresCount {
-		printColumnHeader("Cores", 4)
+		printColumnHeader("Cores", 5)
 	}
 	w.Println("Access", "Last connection")
 }
@@ -399,7 +399,7 @@ func (c *modelsCommand) tabularSummaries(writer io.Writer, modelSet ModelSummary
 		if model.Status != nil && model.Status.Current.String() != "" {
 			status = model.Status.Current.String()
 		}
-		w.Print(cloudRegion, status)
+		w.Print(cloudRegion, model.ProviderType, status)
 		if c.runVars.hasMachinesCount {
 			if v, ok := model.Counts[string(params.Machines)]; ok {
 				w.Print(v)

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -189,7 +189,7 @@ func (f *fakeModelMgrAPIClient) convertInfosToUserModels() []base.UserModel {
 	models := make([]base.UserModel, len(f.infos))
 	for i, info := range f.infos {
 		if info.Error == nil {
-			models[i] = base.UserModel{UUID: info.Result.UUID}
+			models[i] = base.UserModel{UUID: info.Result.UUID, Type: "local"}
 		}
 	}
 	return models
@@ -261,10 +261,10 @@ func (s *BaseModelsSuite) TestModelsOwner(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"test-model1*                 dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"Model                        Cloud/Region  Type   Status      Access  Last connection\n"+
+		"test-model1*                 dummy         local  active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         local  active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         local  destroying  -       never connected\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -304,10 +304,10 @@ func (s *BaseModelsSuite) TestModelsNonOwner(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"admin/test-model1*           dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"Model                        Cloud/Region  Type   Status      Access  Last connection\n"+
+		"admin/test-model1*           dummy         local  active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         local  active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         local  destroying  -       never connected\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -320,10 +320,10 @@ func (s *BaseModelsSuite) TestModelsNoneCurrent(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"test-model1                  dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"Model                        Cloud/Region  Type   Status      Access  Last connection\n"+
+		"test-model1                  dummy         local  active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         local  active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         local  destroying  -       never connected\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -340,10 +340,10 @@ func (s *BaseModelsSuite) TestModelsUUID(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                        UUID              Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
-		"test-model1*                 test-model1-UUID  dummy         active             2      1  read    2015-03-20\n"+
-		"carlotta/test-model2         test-model2-UUID  dummy         active             0      -  write   2015-03-01\n"+
-		"daiwik@external/test-model3  test-model3-UUID  dummy         destroying         0      -  -       never connected\n"+
+		"Model                        UUID              Cloud/Region  Type   Status      Machines  Cores  Access  Last connection\n"+
+		"test-model1*                 test-model1-UUID  dummy         local  active             2      1  read    2015-03-20\n"+
+		"carlotta/test-model2         test-model2-UUID  dummy         local  active             0      -  write   2015-03-01\n"+
+		"daiwik@external/test-model3  test-model3-UUID  dummy         local  destroying         0      -  -       never connected\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -360,10 +360,10 @@ func (s *BaseModelsSuite) TestModelsMachineInfo(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                        Cloud/Region  Status      Machines  Cores  Access  Last connection\n"+
-		"test-model1*                 dummy         active             2      1  read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active             0      -  write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying         0      -  -       never connected\n"+
+		"Model                        Cloud/Region  Type   Status      Machines  Cores  Access  Last connection\n"+
+		"test-model1*                 dummy         local  active             2      1  read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         local  active             0      -  write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         local  destroying         0      -  -       never connected\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -422,11 +422,11 @@ func (s *BaseModelsSuite) TestWithIncompleteModels(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 Controller: fake
 
-Model              Cloud/Region           Status  Machines  Access  Last connection
-owner/basic-model  altostratus/mid-level  -              0  -       never connected
-owner/basic-model  altostratus/mid-level  busy           0  -       never connected
-owner/basic-model  altostratus/mid-level  -              0  admin   never connected
-owner/basic-model  altostratus/mid-level  -              2  -       never connected
+Model              Cloud/Region           Type   Status  Machines  Access  Last connection
+owner/basic-model  altostratus/mid-level  local  -              0  -       never connected
+owner/basic-model  altostratus/mid-level  local  busy           0  -       never connected
+owner/basic-model  altostratus/mid-level  local  -              0  admin   never connected
+owner/basic-model  altostratus/mid-level  local  -              2  -       never connected
 
 `[1:])
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
@@ -451,7 +451,7 @@ func (s *BaseModelsSuite) TestNoModelsMessage(c *gc.C) {
 		c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 Controller: fake
 
-Model  Cloud/Region  Status  Access  Last connection
+Model  Cloud/Region  Type  Status  Access  Last connection
 
 `[1:])
 		c.Assert(cmdtesting.Stderr(context), gc.Equals, controller.NoModelsMessage+"\n")
@@ -513,6 +513,7 @@ func createBasicModelInfo() *params.ModelInfo {
 		Name:           "basic-model",
 		UUID:           testing.ModelTag.Id(),
 		Type:           "iaas",
+		ProviderType:   "local",
 		ControllerUUID: testing.ControllerTag.Id(),
 		OwnerTag:       names.NewUserTag("owner").String(),
 		Life:           params.Dead,
@@ -533,6 +534,7 @@ func convert(models []base.UserModel) []params.ModelInfoResult {
 			Type:         model.Type.String(),
 			OwnerTag:     names.NewUserTag(model.Owner).String(),
 			CloudTag:     "cloud-dummy",
+			ProviderType: "local",
 			AgentVersion: &agentVersion,
 			Status:       params.EntityStatus{Status: status.Active},
 		}
@@ -559,9 +561,9 @@ func (s *ModelsSuiteV3) TestModelsWithOneUnauthorised(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                 Cloud/Region  Status  Access  Last connection\n"+
-		"test-model1*          dummy         active  read    2015-03-20\n"+
-		"carlotta/test-model2  dummy         active  write   2015-03-01\n"+
+		"Model                 Cloud/Region  Type   Status  Access  Last connection\n"+
+		"test-model1*          dummy         local  active  read    2015-03-20\n"+
+		"carlotta/test-model2  dummy         local  active  write   2015-03-01\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
@@ -574,7 +576,7 @@ func (s *ModelsSuiteV3) TestModelsWithOneUnauthorised(c *gc.C) {
 func (s *ModelsSuiteV3) TestModelsJson(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","type":"local","life":"","status":{"current":"active"},"users":{"admin":{"access":"read","last-connection":"2015-03-20"}},"agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","type":"local","life":"","status":{"current":"active"},"users":{"admin":{"access":"write","last-connection":"2015-03-01"}},"agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","type":"local","life":"","status":{"current":"destroying"},"agent-version":"2.55.5"}],"current-model":"test-model1"}
 `)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -593,6 +595,7 @@ models:
   controller-name: fake
   owner: admin
   cloud: dummy
+  type: local
   life: ""
   status:
     current: active
@@ -609,6 +612,7 @@ models:
   controller-name: fake
   owner: carlotta
   cloud: dummy
+  type: local
   life: ""
   status:
     current: active
@@ -625,6 +629,7 @@ models:
   controller-name: fake
   owner: daiwik@external
   cloud: dummy
+  type: local
   life: ""
   status:
     current: destroying
@@ -642,10 +647,10 @@ func (s *ModelsSuiteV3) TestAllModels(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                        Cloud/Region  Status      Access  Last connection\n"+
-		"test-model1*                 dummy         active      read    2015-03-20\n"+
-		"carlotta/test-model2         dummy         active      write   2015-03-01\n"+
-		"daiwik@external/test-model3  dummy         destroying  -       never connected\n"+
+		"Model                        Cloud/Region  Type   Status      Access  Last connection\n"+
+		"test-model1*                 dummy         local  active      read    2015-03-20\n"+
+		"carlotta/test-model2         dummy         local  active      write   2015-03-01\n"+
+		"daiwik@external/test-model3  dummy         local  destroying  -       never connected\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{
@@ -665,7 +670,7 @@ func (s *ModelsSuiteV4) SetUpTest(c *gc.C) {
 func (s *ModelsSuiteV4) TestModelsJson(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"life":"","status":{"current":"active"},"access":"read","last-connection":"2015-03-20","agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"life":"","status":{"current":"active"},"access":"write","last-connection":"2015-03-01","agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"life":"","status":{"current":"destroying"},"access":"","last-connection":"never connected","agent-version":"2.55.5"}],"current-model":"test-model1"}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, `{"models":[{"name":"admin/test-model1","short-name":"test-model1","model-uuid":"test-model1-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"admin","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"type":"local","life":"","status":{"current":"active"},"access":"read","last-connection":"2015-03-20","agent-version":"2.55.5"},{"name":"carlotta/test-model2","short-name":"test-model2","model-uuid":"test-model2-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"carlotta","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"type":"local","life":"","status":{"current":"active"},"access":"write","last-connection":"2015-03-01","agent-version":"2.55.5"},{"name":"daiwik@external/test-model3","short-name":"test-model3","model-uuid":"test-model3-UUID","model-type":"iaas","controller-uuid":"","controller-name":"fake","owner":"daiwik@external","cloud":"dummy","credential":{"name":"one","owner":"bob","cloud":"foo"},"type":"local","life":"","status":{"current":"destroying"},"access":"","last-connection":"never connected","agent-version":"2.55.5"}],"current-model":"test-model1"}
 `)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "ModelInfo", "Close")
@@ -688,6 +693,7 @@ models:
     name: one
     owner: bob
     cloud: foo
+  type: local
   life: ""
   status:
     current: active
@@ -706,6 +712,7 @@ models:
     name: one
     owner: bob
     cloud: foo
+  type: local
   life: ""
   status:
     current: active
@@ -724,6 +731,7 @@ models:
     name: one
     owner: bob
     cloud: foo
+  type: local
   life: ""
   status:
     current: destroying
@@ -747,9 +755,9 @@ func (s *ModelsSuiteV4) TestModelsWithOneModelInError(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: fake\n"+
 		"\n"+
-		"Model                 Cloud/Region  Status  Access  Last connection\n"+
-		"test-model1*          dummy         active  read    2015-03-20\n"+
-		"carlotta/test-model2  dummy         active  write   2015-03-01\n"+
+		"Model                 Cloud/Region  Type   Status  Access  Last connection\n"+
+		"test-model1*          dummy         local  active  read    2015-03-20\n"+
+		"carlotta/test-model2  dummy         local  active  write   2015-03-01\n"+
 		"\n")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "some model error\n")
 	c.Assert(s.store.Models["fake"].Models, gc.DeepEquals, map[string]jujuclient.ModelDetails{

--- a/cmd/juju/controller/listmodelsold.go
+++ b/cmd/juju/controller/listmodelsold.go
@@ -201,7 +201,7 @@ func (c *modelsCommand) tabularSet(writer io.Writer, modelSet ModelSet) error {
 		if model.Status != nil {
 			status = model.Status.Current.String()
 		}
-		w.Print(cloudRegion, status)
+		w.Print(cloudRegion, model.ProviderType, status)
 		if c.runVars.hasMachinesCount {
 			w.Print(fmt.Sprintf("%d", len(model.Machines)))
 		}

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -90,9 +90,9 @@ func (s *cmdControllerSuite) TestCreateModelAdminUser(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
-		"Model        Cloud/Region        Status     Access  Last connection\n"+
-		"controller*  dummy/dummy-region  available  admin   just now\n"+
-		"new-model    dummy/dummy-region  available  admin   never connected\n"+
+		"Model        Cloud/Region        Type   Status     Access  Last connection\n"+
+		"controller*  dummy/dummy-region  dummy  available  admin   just now\n"+
+		"new-model    dummy/dummy-region  dummy  available  admin   never connected\n"+
 		"\n")
 }
 
@@ -102,9 +102,9 @@ func (s *cmdControllerSuite) TestAddModelNormalUser(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
-		"Model           Cloud/Region        Status     Access  Last connection\n"+
-		"controller*     dummy/dummy-region  available  admin   just now\n"+
-		"test/new-model  dummy/dummy-region  available  -       never connected\n"+
+		"Model           Cloud/Region        Type   Status     Access  Last connection\n"+
+		"controller*     dummy/dummy-region  dummy  available  admin   just now\n"+
+		"test/new-model  dummy/dummy-region  dummy  available  -       never connected\n"+
 		"\n")
 }
 
@@ -166,9 +166,9 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
 		"Controller: kontroll\n"+
 		"\n"+
-		"Model        Cloud/Region        Status      Access  Last connection\n"+
-		"controller*  dummy/dummy-region  available   admin   just now\n"+
-		"new-model    dummy/dummy-region  destroying  admin   never connected\n"+
+		"Model        Cloud/Region        Type   Status      Access  Last connection\n"+
+		"controller*  dummy/dummy-region  dummy  available   admin   just now\n"+
+		"new-model    dummy/dummy-region  dummy  destroying  admin   never connected\n"+
 		"\n")
 }
 


### PR DESCRIPTION
## Description of change

Support multi-cloud controllers.
Juju controllers already supported deploying models to different clouds - we were simply not allowing a new cloud to be added that differed from the controller cloud, and there was no CLI to do so.

This PR enhances add-model to allow a controller to be specified with -c | --controller. In that case, the cloud details plus a credential will be uploaded to the controller. If there's more than one credential available, use the --credential arg to specify which one to use.

On the server side, restrictions that limit new models to having the same cloud type as the controller were removed.

Also, if a cloud only has one region, we default to that if add-model doesn't specify a region.

## QA steps

bootstrap to aws
juju add-cloud localhost 
juju add-model test localhost/localhost
deploy a workload to the lxd model
deploy a workload to the aws model

## Documentation changes

CLI doc for add-model will need to be updated