### PR TITLE
Webscale: Bump the timeout to 12 hours

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -64,6 +64,7 @@ def deploy_bundle(client, charm_bundle):
         path=bundle,
         client=client,
         charm=(not not charm_bundle),
+        timeout=43200,
     )
 
     if not caas_client.is_cluster_healthy:


### PR DESCRIPTION
## Description of change

Bump the timeout of the webscale tests to allow the deployment
to settle of kubernetes-core, before timing out.