### PR TITLE
Fixes lp# 1628151: Display globally available 'juju' command options for all sub-commands.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -428,14 +428,14 @@
   revision = "bab88fc672997ef02d03f85310182d97a93dee21"
 
 [[projects]]
-  digest = "1:f624cc391243b5ceb94a5b1ea7dfd8c7680627e7e78069ed7506db5eb6e102fb"
+  digest = "1:760e8f7e7dc275407516bf0c0cfcec9f946810f28da4952bbb46de8391d6a348"
   name = "github.com/juju/cmd"
   packages = [
     ".",
     "cmdtesting",
   ]
   pruneopts = ""
-  revision = "fd568e4a4120f7d5a417252d701daff61a6322b4"
+  revision = "a8c88215d37e4d65036822bca0522d11f888f7eb"
 
 [[projects]]
   digest = "1:243ec2217cb77ad028a956bf4d886b0f070d2dbfe861ceadfcf270412c2e7b90"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -287,7 +287,7 @@
 
 [[constraint]]
   name = "github.com/juju/cmd"
-  revision = "fd568e4a4120f7d5a417252d701daff61a6322b4"
+  revision = "a8c88215d37e4d65036822bca0522d11f888f7eb"
 
 [[constraint]]
   name = "github.com/juju/collections"

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -26,6 +26,20 @@ func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
 Summary:
 Show help on a Juju charm hook tool.
 
+Global Options:
+--debug  (= false)
+    equivalent to --show-log --logging-config=<root>=DEBUG
+-h, --help  (= false)
+    Show help on a command or other topic.
+--logging-config (= "")
+    specify log levels for modules
+--quiet  (= false)
+    show no informational output
+--show-log  (= false)
+    if set, write the log file to stderr
+--verbose  (= false)
+    show more verbose output
+
 Details:
 Juju charms can access a series of built-in helpers called 'hook-tools'.
 These are useful for the charm to be able to inspect its running environment.

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -48,7 +49,15 @@ func helpText(command cmd.Command, name string) string {
 	info.Name = name
 	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, cmd.FlagAlias(command, "option"))
 	command.SetFlags(f)
-	buff.Write(info.Help(f))
+
+	superJuju := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "juju",
+		FlagKnownAs: "option",
+	})
+	superF := gnuflag.NewFlagSetWithFlagKnownAs("juju", gnuflag.ContinueOnError, "option")
+	superJuju.SetFlags(superF)
+
+	buff.Write(info.HelpWithSuperFlags(superF, f))
 	return buff.String()
 }
 

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -58,7 +58,8 @@ For cs:~user/trusty/mysql
 Where the series is not supplied, the series from your local host is used.
 Thus the above examples imply that the local series is trusty.
 `,
-		FlagKnownAs: "option",
+		FlagKnownAs:    "option",
+		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
 	})
 }
 

--- a/cmd/juju/resource/list_charm_resources_test.go
+++ b/cmd/juju/resource/list_charm_resources_test.go
@@ -58,8 +58,9 @@ For cs:~user/trusty/mysql
 Where the series is not supplied, the series from your local host is used.
 Thus the above examples imply that the local series is trusty.
 `,
-		Aliases:     []string{"list-resources"},
-		FlagKnownAs: "option",
+		Aliases:        []string{"list-resources"},
+		FlagKnownAs:    "option",
+		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
 	})
 }
 

--- a/cmd/juju/resource/list_test.go
+++ b/cmd/juju/resource/list_test.go
@@ -71,7 +71,8 @@ This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any
 updates available for resources from the charmstore.
 `,
-		FlagKnownAs: "option",
+		FlagKnownAs:    "option",
+		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
 	})
 }
 

--- a/cmd/juju/resource/upload_test.go
+++ b/cmd/juju/resource/upload_test.go
@@ -97,8 +97,9 @@ func (s *UploadSuite) TestInfo(c *gc.C) {
 This command uploads a file from your local disk to the juju controller to be
 used as a resource for an application.
 `,
-		Aliases:     []string{"attach"},
-		FlagKnownAs: "option",
+		Aliases:        []string{"attach"},
+		FlagKnownAs:    "option",
+		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
 	})
 }
 

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -61,5 +61,6 @@ func runNotifier(name string) {
 func Info(i *cmd.Info) *cmd.Info {
 	info := *i
 	info.FlagKnownAs = "option"
+	info.ShowSuperFlags = []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"}
 	return &info
 }

--- a/payload/status/list_test.go
+++ b/payload/status/list_test.go
@@ -66,8 +66,9 @@ will be checked against the following info in Juju:
 - payload tag
 - payload status
 `,
-		Aliases:     []string{"list-payloads"},
-		FlagKnownAs: "option",
+		Aliases:        []string{"list-payloads"},
+		FlagKnownAs:    "option",
+		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
 	})
 }
 


### PR DESCRIPTION
## Description of change

All 'juju' sub-commands inherit 'juju' options such as '--debug', '--show-log', etc. However, until now, they were not easily discoverable.

This PR ensures that all commands display global options on help. These options are grouped separately from command specific options. Sample  'juju help add-model' output -  https://pastebin.ubuntu.com/p/hgmHW2b4Hd/

All the work is done by 1-line in  juju/juju/cmd/juju/supercommand.go. The rest of the PR are test updates.

## QA steps

Run any command help to see global options available.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1628151
