### PR TITLE
2.5 - Updates LXD dependency, with associated mocks and tests.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -12,6 +12,14 @@
   revision = "3b1ae45394a234c385be014e9a488f2bb6eef821"
 
 [[projects]]
+  branch = "master"
+  digest = "1:3dbee55971def1e4aa600dac9e3398ddb1b20ee4ca729aa08c985692b2bd1fc8"
+  name = "code.cloudfoundry.org/systemcerts"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ca00b2f806f2fa1ded784ade357bad1ea3f1fbbe"
+
+[[projects]]
   digest = "1:e1b859e3d9e90007d5fbf25edf57733b224f1857f6592636130afab3af8cfae7"
   name = "contrib.go.opencensus.io/exporter/ocagent"
   packages = ["."]
@@ -182,6 +190,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "145fabdb1ab757076a70a886d092a3af27f66f4c"
+
+[[projects]]
+  digest = "1:9fdd67ccb34e94602b72547c9943981458e76ba8eb6e43a5876a48dc7af1e5cb"
+  name = "github.com/flosch/pongo2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5e81b817a0c48c1c57cdf1a9056cf76bdee02ca9"
+  version = "v3.0"
 
 [[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
@@ -869,7 +885,7 @@
   revision = "4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36"
 
 [[projects]]
-  digest = "1:6afa560a3ad5e47aea2d986fd87123bfc74fe89541f197861a071e6454f06f04"
+  digest = "1:9ab3794bfaaf6e5d195027f3e3d6c53018420de5ccb759d7721926bc80211c67"
   name = "github.com/lxc/lxd"
   packages = [
     "client",
@@ -882,7 +898,7 @@
     "shared/simplestreams",
   ]
   pruneopts = ""
-  revision = "d0d66b4842f459c6c3e039a9e2f25eff02174ab1"
+  revision = "4c2bbb608e7a90a9f175a566b9e638069424f0f7"
 
 [[projects]]
   digest = "1:f95025d583786875a71183888acc9d0987fc96f12d4f5afab3d7558797ea1c5a"
@@ -1605,6 +1621,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "87155f248cf6ea9e38ae7613f9ea1e5bb397ac83"
+
+[[projects]]
+  branch = "v2"
+  digest = "1:92a9d3d81fc5b50d5ccf0c72b9888cd27acf277894f8aa18f4c9c41de8311555"
+  name = "gopkg.in/robfig/cron.v2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "be2e0b0deed5a68ffee390b4583a13aff8321535"
 
 [[projects]]
   branch = "v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -127,7 +127,7 @@
 
 [[constraint]]
   name = "github.com/lxc/lxd"
-  revision = "d0d66b4842f459c6c3e039a9e2f25eff02174ab1"
+  revision = "4c2bbb608e7a90a9f175a566b9e638069424f0f7"
 
 [[constraint]]
   name = "github.com/oracle/oci-go-sdk"

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -47,7 +47,7 @@ func (c *ContainerSpec) ApplyConstraints(cons constraints.Value) {
 		c.Config["limits.cpu"] = fmt.Sprintf("%d", *cons.CpuCores)
 	}
 	if cons.HasMem() {
-		c.Config["limits.memory"] = fmt.Sprintf("%dMB", *cons.Mem)
+		c.Config["limits.memory"] = fmt.Sprintf("%dMiB", *cons.Mem)
 	}
 }
 

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -48,11 +48,11 @@ func (s *containerSuite) TestContainerCPUs(c *gc.C) {
 func (s *containerSuite) TestContainerMem(c *gc.C) {
 	container := lxd.Container{}
 
-	container.Config = map[string]string{"limits.memory": "1MB"}
-	c.Check(container.Mem(), gc.Equals, uint(1))
+	container.Config = map[string]string{"limits.memory": "1MiB"}
+	c.Check(int(container.Mem()), gc.Equals, 1)
 
-	container.Config = map[string]string{"limits.memory": "2GB"}
-	c.Check(container.Mem(), gc.Equals, uint(2048))
+	container.Config = map[string]string{"limits.memory": "2GiB"}
+	c.Check(int(container.Mem()), gc.Equals, 2048)
 }
 
 func (s *containerSuite) TestContainerAddDiskNoDevices(c *gc.C) {
@@ -470,7 +470,7 @@ func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 
 	exp := map[string]string{
 		lxd.AutoStartKey: "true",
-		"limits.memory":  "2046MB",
+		"limits.memory":  "2046MiB",
 		"limits.cpu":     "4",
 	}
 	c.Check(spec.Config, gc.DeepEquals, exp)

--- a/container/lxd/testing/lxd_mock.go
+++ b/container/lxd/testing/lxd_mock.go
@@ -477,16 +477,16 @@ func (mr *MockContainerServerMockRecorder) CopyContainer(arg0, arg1, arg2 interf
 }
 
 // CopyContainerSnapshot mocks base method
-func (m *MockContainerServer) CopyContainerSnapshot(arg0 client.ContainerServer, arg1 api.ContainerSnapshot, arg2 *client.ContainerSnapshotCopyArgs) (client.RemoteOperation, error) {
-	ret := m.ctrl.Call(m, "CopyContainerSnapshot", arg0, arg1, arg2)
+func (m *MockContainerServer) CopyContainerSnapshot(arg0 client.ContainerServer, arg1 string, arg2 api.ContainerSnapshot, arg3 *client.ContainerSnapshotCopyArgs) (client.RemoteOperation, error) {
+	ret := m.ctrl.Call(m, "CopyContainerSnapshot", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(client.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CopyContainerSnapshot indicates an expected call of CopyContainerSnapshot
-func (mr *MockContainerServerMockRecorder) CopyContainerSnapshot(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyContainerSnapshot", reflect.TypeOf((*MockContainerServer)(nil).CopyContainerSnapshot), arg0, arg1, arg2)
+func (mr *MockContainerServerMockRecorder) CopyContainerSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyContainerSnapshot", reflect.TypeOf((*MockContainerServer)(nil).CopyContainerSnapshot), arg0, arg1, arg2, arg3)
 }
 
 // CopyImage mocks base method
@@ -678,6 +678,18 @@ func (mr *MockContainerServerMockRecorder) CreateProfile(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfile", reflect.TypeOf((*MockContainerServer)(nil).CreateProfile), arg0)
 }
 
+// CreateProject mocks base method
+func (m *MockContainerServer) CreateProject(arg0 api.ProjectsPost) error {
+	ret := m.ctrl.Call(m, "CreateProject", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateProject indicates an expected call of CreateProject
+func (mr *MockContainerServerMockRecorder) CreateProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockContainerServer)(nil).CreateProject), arg0)
+}
+
 // CreateStoragePool mocks base method
 func (m *MockContainerServer) CreateStoragePool(arg0 api.StoragePoolsPost) error {
 	ret := m.ctrl.Call(m, "CreateStoragePool", arg0)
@@ -700,6 +712,19 @@ func (m *MockContainerServer) CreateStoragePoolVolume(arg0 string, arg1 api.Stor
 // CreateStoragePoolVolume indicates an expected call of CreateStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) CreateStoragePoolVolume(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).CreateStoragePoolVolume), arg0, arg1)
+}
+
+// CreateStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) CreateStoragePoolVolumeSnapshot(arg0, arg1, arg2 string, arg3 api.StorageVolumeSnapshotsPost) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "CreateStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateStoragePoolVolumeSnapshot indicates an expected call of CreateStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) CreateStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).CreateStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
 }
 
 // DeleteCertificate mocks base method
@@ -874,6 +899,18 @@ func (mr *MockContainerServerMockRecorder) DeleteProfile(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfile", reflect.TypeOf((*MockContainerServer)(nil).DeleteProfile), arg0)
 }
 
+// DeleteProject mocks base method
+func (m *MockContainerServer) DeleteProject(arg0 string) error {
+	ret := m.ctrl.Call(m, "DeleteProject", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteProject indicates an expected call of DeleteProject
+func (mr *MockContainerServerMockRecorder) DeleteProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockContainerServer)(nil).DeleteProject), arg0)
+}
+
 // DeleteStoragePool mocks base method
 func (m *MockContainerServer) DeleteStoragePool(arg0 string) error {
 	ret := m.ctrl.Call(m, "DeleteStoragePool", arg0)
@@ -896,6 +933,19 @@ func (m *MockContainerServer) DeleteStoragePoolVolume(arg0, arg1, arg2 string) e
 // DeleteStoragePoolVolume indicates an expected call of DeleteStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) DeleteStoragePoolVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).DeleteStoragePoolVolume), arg0, arg1, arg2)
+}
+
+// DeleteStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) DeleteStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "DeleteStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteStoragePoolVolumeSnapshot indicates an expected call of DeleteStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) DeleteStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).DeleteStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
 }
 
 // ExecContainer mocks base method
@@ -1258,6 +1308,19 @@ func (mr *MockContainerServerMockRecorder) GetContainers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainers", reflect.TypeOf((*MockContainerServer)(nil).GetContainers))
 }
 
+// GetContainersFull mocks base method
+func (m *MockContainerServer) GetContainersFull() ([]api.ContainerFull, error) {
+	ret := m.ctrl.Call(m, "GetContainersFull")
+	ret0, _ := ret[0].([]api.ContainerFull)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContainersFull indicates an expected call of GetContainersFull
+func (mr *MockContainerServerMockRecorder) GetContainersFull() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainersFull", reflect.TypeOf((*MockContainerServer)(nil).GetContainersFull))
+}
+
 // GetEvents mocks base method
 func (m *MockContainerServer) GetEvents() (*client.EventListener, error) {
 	ret := m.ctrl.Call(m, "GetEvents")
@@ -1430,6 +1493,19 @@ func (mr *MockContainerServerMockRecorder) GetNetworkNames() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkNames", reflect.TypeOf((*MockContainerServer)(nil).GetNetworkNames))
 }
 
+// GetNetworkState mocks base method
+func (m *MockContainerServer) GetNetworkState(arg0 string) (*api.NetworkState, error) {
+	ret := m.ctrl.Call(m, "GetNetworkState", arg0)
+	ret0, _ := ret[0].(*api.NetworkState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworkState indicates an expected call of GetNetworkState
+func (mr *MockContainerServerMockRecorder) GetNetworkState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkState", reflect.TypeOf((*MockContainerServer)(nil).GetNetworkState), arg0)
+}
+
 // GetNetworks mocks base method
 func (m *MockContainerServer) GetNetworks() ([]api.Network, error) {
 	ret := m.ctrl.Call(m, "GetNetworks")
@@ -1468,6 +1544,20 @@ func (m *MockContainerServer) GetOperationUUIDs() ([]string, error) {
 // GetOperationUUIDs indicates an expected call of GetOperationUUIDs
 func (mr *MockContainerServerMockRecorder) GetOperationUUIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationUUIDs", reflect.TypeOf((*MockContainerServer)(nil).GetOperationUUIDs))
+}
+
+// GetOperationWait mocks base method
+func (m *MockContainerServer) GetOperationWait(arg0 string, arg1 int) (*api.Operation, string, error) {
+	ret := m.ctrl.Call(m, "GetOperationWait", arg0, arg1)
+	ret0, _ := ret[0].(*api.Operation)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOperationWait indicates an expected call of GetOperationWait
+func (mr *MockContainerServerMockRecorder) GetOperationWait(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationWait", reflect.TypeOf((*MockContainerServer)(nil).GetOperationWait), arg0, arg1)
 }
 
 // GetOperationWebsocket mocks base method
@@ -1563,6 +1653,46 @@ func (mr *MockContainerServerMockRecorder) GetProfiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfiles", reflect.TypeOf((*MockContainerServer)(nil).GetProfiles))
 }
 
+// GetProject mocks base method
+func (m *MockContainerServer) GetProject(arg0 string) (*api.Project, string, error) {
+	ret := m.ctrl.Call(m, "GetProject", arg0)
+	ret0, _ := ret[0].(*api.Project)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetProject indicates an expected call of GetProject
+func (mr *MockContainerServerMockRecorder) GetProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockContainerServer)(nil).GetProject), arg0)
+}
+
+// GetProjectNames mocks base method
+func (m *MockContainerServer) GetProjectNames() ([]string, error) {
+	ret := m.ctrl.Call(m, "GetProjectNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjectNames indicates an expected call of GetProjectNames
+func (mr *MockContainerServerMockRecorder) GetProjectNames() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectNames", reflect.TypeOf((*MockContainerServer)(nil).GetProjectNames))
+}
+
+// GetProjects mocks base method
+func (m *MockContainerServer) GetProjects() ([]api.Project, error) {
+	ret := m.ctrl.Call(m, "GetProjects")
+	ret0, _ := ret[0].([]api.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjects indicates an expected call of GetProjects
+func (mr *MockContainerServerMockRecorder) GetProjects() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockContainerServer)(nil).GetProjects))
+}
+
 // GetServer mocks base method
 func (m *MockContainerServer) GetServer() (*api.Server, string, error) {
 	ret := m.ctrl.Call(m, "GetServer")
@@ -1655,6 +1785,46 @@ func (m *MockContainerServer) GetStoragePoolVolumeNames(arg0 string) ([]string, 
 // GetStoragePoolVolumeNames indicates an expected call of GetStoragePoolVolumeNames
 func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeNames(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeNames", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeNames), arg0)
+}
+
+// GetStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) GetStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string) (*api.StorageVolumeSnapshot, string, error) {
+	ret := m.ctrl.Call(m, "GetStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*api.StorageVolumeSnapshot)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetStoragePoolVolumeSnapshot indicates an expected call of GetStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
+}
+
+// GetStoragePoolVolumeSnapshotNames mocks base method
+func (m *MockContainerServer) GetStoragePoolVolumeSnapshotNames(arg0, arg1, arg2 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "GetStoragePoolVolumeSnapshotNames", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolVolumeSnapshotNames indicates an expected call of GetStoragePoolVolumeSnapshotNames
+func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeSnapshotNames(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeSnapshotNames", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeSnapshotNames), arg0, arg1, arg2)
+}
+
+// GetStoragePoolVolumeSnapshots mocks base method
+func (m *MockContainerServer) GetStoragePoolVolumeSnapshots(arg0, arg1, arg2 string) ([]api.StorageVolumeSnapshot, error) {
+	ret := m.ctrl.Call(m, "GetStoragePoolVolumeSnapshots", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]api.StorageVolumeSnapshot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolVolumeSnapshots indicates an expected call of GetStoragePoolVolumeSnapshots
+func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeSnapshots(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeSnapshots", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeSnapshots), arg0, arg1, arg2)
 }
 
 // GetStoragePoolVolumes mocks base method
@@ -1900,6 +2070,19 @@ func (mr *MockContainerServerMockRecorder) RenameProfile(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameProfile", reflect.TypeOf((*MockContainerServer)(nil).RenameProfile), arg0, arg1)
 }
 
+// RenameProject mocks base method
+func (m *MockContainerServer) RenameProject(arg0 string, arg1 api.ProjectPost) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "RenameProject", arg0, arg1)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameProject indicates an expected call of RenameProject
+func (mr *MockContainerServerMockRecorder) RenameProject(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameProject", reflect.TypeOf((*MockContainerServer)(nil).RenameProject), arg0, arg1)
+}
+
 // RenameStoragePoolVolume mocks base method
 func (m *MockContainerServer) RenameStoragePoolVolume(arg0, arg1, arg2 string, arg3 api.StorageVolumePost) error {
 	ret := m.ctrl.Call(m, "RenameStoragePoolVolume", arg0, arg1, arg2, arg3)
@@ -1910,6 +2093,19 @@ func (m *MockContainerServer) RenameStoragePoolVolume(arg0, arg1, arg2 string, a
 // RenameStoragePoolVolume indicates an expected call of RenameStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) RenameStoragePoolVolume(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).RenameStoragePoolVolume), arg0, arg1, arg2, arg3)
+}
+
+// RenameStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) RenameStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string, arg4 api.StorageVolumeSnapshotPost) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "RenameStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameStoragePoolVolumeSnapshot indicates an expected call of RenameStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) RenameStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).RenameStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3, arg4)
 }
 
 // RequireAuthenticated mocks base method
@@ -2045,6 +2241,18 @@ func (mr *MockContainerServerMockRecorder) UpdateProfile(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProfile", reflect.TypeOf((*MockContainerServer)(nil).UpdateProfile), arg0, arg1, arg2)
 }
 
+// UpdateProject mocks base method
+func (m *MockContainerServer) UpdateProject(arg0 string, arg1 api.ProjectPut, arg2 string) error {
+	ret := m.ctrl.Call(m, "UpdateProject", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateProject indicates an expected call of UpdateProject
+func (mr *MockContainerServerMockRecorder) UpdateProject(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProject", reflect.TypeOf((*MockContainerServer)(nil).UpdateProject), arg0, arg1, arg2)
+}
+
 // UpdateServer mocks base method
 func (m *MockContainerServer) UpdateServer(arg0 api.ServerPut, arg1 string) error {
 	ret := m.ctrl.Call(m, "UpdateServer", arg0, arg1)
@@ -2079,6 +2287,30 @@ func (m *MockContainerServer) UpdateStoragePoolVolume(arg0, arg1, arg2 string, a
 // UpdateStoragePoolVolume indicates an expected call of UpdateStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) UpdateStoragePoolVolume(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).UpdateStoragePoolVolume), arg0, arg1, arg2, arg3, arg4)
+}
+
+// UpdateStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) UpdateStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string, arg4 api.StorageVolumeSnapshotPut, arg5 string) error {
+	ret := m.ctrl.Call(m, "UpdateStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStoragePoolVolumeSnapshot indicates an expected call of UpdateStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) UpdateStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).UpdateStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// UseProject mocks base method
+func (m *MockContainerServer) UseProject(arg0 string) client.ContainerServer {
+	ret := m.ctrl.Call(m, "UseProject", arg0)
+	ret0, _ := ret[0].(client.ContainerServer)
+	return ret0
+}
+
+// UseProject indicates an expected call of UseProject
+func (mr *MockContainerServerMockRecorder) UseProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseProject", reflect.TypeOf((*MockContainerServer)(nil).UseProject), arg0)
 }
 
 // UseTarget mocks base method

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -280,7 +280,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 		if cfg["limits.cpu"] != "2" {
 			return false
 		}
-		if cfg["limits.memory"] != "2048MB" {
+		if cfg["limits.memory"] != "2048MiB" {
 			return false
 		}
 		return spec.InstanceType == "t2.micro"

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -277,7 +277,7 @@ func (s *lxdFilesystemSource) createFilesystem(
 		// by LXD. Ideally LXD would be able to tell us the total size of
 		// the filesystem on which the directory was created, though.
 	default:
-		config["size"] = fmt.Sprintf("%dMB", arg.Size)
+		config["size"] = fmt.Sprintf("%dMiB", arg.Size)
 	}
 
 	if err := s.env.server.CreateVolume(cfg.lxdPool, volumeName, config); err != nil {
@@ -285,9 +285,8 @@ func (s *lxdFilesystemSource) createFilesystem(
 	}
 
 	filesystem := storage.Filesystem{
-		arg.Tag,
-		names.VolumeTag{},
-		storage.FilesystemInfo{
+		Tag: arg.Tag,
+		FilesystemInfo: storage.FilesystemInfo{
 			FilesystemId: filesystemId,
 			Size:         arg.Size,
 		},

--- a/provider/lxd/storage_test.go
+++ b/provider/lxd/storage_test.go
@@ -128,9 +128,8 @@ func (s *storageSuite) TestCreateFilesystems(c *gc.C) {
 	c.Assert(results, gc.HasLen, 1)
 	c.Assert(results[0].Error, jc.ErrorIsNil)
 	c.Assert(results[0].Filesystem, jc.DeepEquals, &storage.Filesystem{
-		names.NewFilesystemTag("0"),
-		names.VolumeTag{},
-		storage.FilesystemInfo{
+		Tag: names.NewFilesystemTag("0"),
+		FilesystemInfo: storage.FilesystemInfo{
 			FilesystemId: "radiance:juju-f75cba-filesystem-0",
 			Size:         1024,
 		},
@@ -140,7 +139,7 @@ func (s *storageSuite) TestCreateFilesystems(c *gc.C) {
 	s.Stub.CheckCall(c, 0, "CreatePool", "radiance", "btrfs", map[string]string(nil))
 	s.Stub.CheckCall(c, 1, "CreateVolume", "radiance", "juju-f75cba-filesystem-0", map[string]string{
 		"user.key": "value",
-		"size":     "1024MB",
+		"size":     "1024MiB",
 	})
 }
 
@@ -566,7 +565,7 @@ func (s *storageSuite) TestImportFilesystem(c *gc.C) {
 			Name: "bar",
 			StorageVolumePut: api.StorageVolumePut{
 				Config: map[string]string{
-					"size": "10GB",
+					"size": "10GiB",
 				},
 			},
 		}},
@@ -584,7 +583,7 @@ func (s *storageSuite) TestImportFilesystem(c *gc.C) {
 
 	update := api.StorageVolumePut{
 		Config: map[string]string{
-			"size":     "10GB",
+			"size":     "10GiB",
 			"user.baz": "qux",
 		},
 	}
@@ -624,7 +623,7 @@ func (s *storageSuite) TestImportFilesystemInvalidCredentialsUpdatePool(c *gc.C)
 			Name: "bar",
 			StorageVolumePut: api.StorageVolumePut{
 				Config: map[string]string{
-					"size": "10GB",
+					"size": "10GiB",
 				},
 			},
 		}},


### PR DESCRIPTION
## Description of change

This patch: 
- updates the "github.com/lxc/lxd" dependency to the latest version and;
- modifies mocks and tests for changes since our last utilised version.

It is the same change as https://github.com/juju/juju/pull/9617, except for using a later version of the library containing fixes discovered since.

## QA steps

In addition to those for #9617:
- Bootstrap a LXD controller and gradually add 3/4 machines over the course of a couple of minutes.
- Ensure that the machines are fully provisioned without error.
- `juju destroy-model default -y`.
- Ensure that the model is torn down without error.

## Documentation changes

None

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1796709
- https://bugs.launchpad.net/lxd/+bug/1811703

Possibly also https://bugs.launchpad.net/juju/+bug/1806440 and others.
