### PR TITLE
Add support for setting k8s service annotations

### DIFF
--- a/caas/config.go
+++ b/caas/config.go
@@ -66,6 +66,9 @@ func ConfigDefaults(providerDefaults schema.Defaults) schema.Defaults {
 		JujuApplicationPath: JujuDefaultApplicationPath,
 	}
 	for key, value := range providerDefaults {
+		if value == schema.Omit {
+			continue
+		}
 		defaults[key] = value
 	}
 	return defaults

--- a/caas/kubernetes/provider/config.go
+++ b/caas/kubernetes/provider/config.go
@@ -22,6 +22,7 @@ const (
 	serviceLoadBalancerIPKey           = "kubernetes-service-loadbalancer-ip"
 	serviceLoadBalancerSourceRangesKey = "kubernetes-service-loadbalancer-sourceranges"
 	serviceExternalNameKey             = "kubernetes-service-externalname"
+	serviceAnnotationsKey              = "kubernetes-service-annotations"
 
 	ingressClassKey          = "kubernetes-ingress-class"
 	ingressSSLRedirectKey    = "kubernetes-ingress-ssl-redirect"
@@ -33,6 +34,11 @@ var configFields = environschema.Fields{
 	serviceTypeConfigKey: {
 		Description: "determines how the Service is exposed",
 		Type:        environschema.Tstring,
+		Group:       environschema.ProviderGroup,
+	},
+	serviceAnnotationsKey: {
+		Description: "a space separated set of annotations to add to the service",
+		Type:        environschema.Tattrs,
 		Group:       environschema.ProviderGroup,
 	},
 	serviceExternalIPsConfigKey: {
@@ -84,6 +90,7 @@ var configFields = environschema.Fields{
 
 var schemaDefaults = schema.Defaults{
 	serviceTypeConfigKey:     defaultServiceType,
+	serviceAnnotationsKey:    schema.Omit,
 	ingressClassKey:          defaultIngressClass,
 	ingressSSLRedirectKey:    defaultIngressSSLRedirect,
 	ingressSSLPassthroughKey: defaultIngressSSLPassthrough,

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1338,10 +1338,16 @@ func (k *kubernetesClient) configureService(
 	}
 
 	serviceType := core.ServiceType(config.GetString(serviceTypeConfigKey, defaultServiceType))
+	annotations, err := config.GetStringMap(serviceAnnotationsKey, nil)
+	if err != nil {
+		return errors.Annotatef(err, "unexpected annotations: %#v", config.Get(serviceAnnotationsKey, nil))
+	}
 	service := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   deploymentName(appName),
-			Labels: tags},
+			Name:        deploymentName(appName),
+			Labels:      tags,
+			Annotations: annotations,
+		},
 		Spec: core.ServiceSpec{
 			Selector:                 map[string]string{labelApplication: appName},
 			Type:                     serviceType,

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	testclock "github.com/juju/clock/testclock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
@@ -653,7 +653,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	}
 	serviceArg := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "juju-app-name",
+			Name:        "juju-app-name",
+			Annotations: map[string]string{"a": "b"},
 			Labels: map[string]string{
 				"juju-application": "app-name",
 				"fred":             "mary",
@@ -696,6 +697,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 		"kubernetes-service-type":            "nodeIP",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
+		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/core/application/config.go
+++ b/core/application/config.go
@@ -4,13 +4,15 @@
 package application
 
 import (
+	"fmt"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 )
 
-// ConfigAttributes is the config for an application.
+// ConfigAttributes is the config for an applcore/application/config.goication.
 type ConfigAttributes map[string]interface{}
 
 // Config encapsulates config for an application.
@@ -117,4 +119,25 @@ func (c ConfigAttributes) GetString(attrName string, defaultValue string) string
 		return val.(string)
 	}
 	return defaultValue
+}
+
+// GetStringMap gets the specified map attribute as map[string]string.
+func (c ConfigAttributes) GetStringMap(attrName string, defaultValue map[string]string) (map[string]string, error) {
+	if valData, ok := c[attrName]; ok {
+		result := make(map[string]string)
+		switch val := valData.(type) {
+		case map[string]string:
+			for k, v := range val {
+				result[k] = v
+			}
+		case map[string]interface{}:
+			for k, v := range val {
+				result[k] = fmt.Sprintf("%v", v)
+			}
+		default:
+			return nil, errors.NotValidf("string map value of type %T", val)
+		}
+		return result, nil
+	}
+	return defaultValue, nil
 }

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -188,6 +188,10 @@ application-config:
     source: default
     type: bool
     value: false
+  kubernetes-service-annotations:
+    description: a space separated set of annotations to add to the service
+    source: unset
+    type: attrs
   kubernetes-service-external-ips:
     description: list of IP addresses for which nodes in the cluster will also accept
       traffic


### PR DESCRIPTION
## Description of change

When deploying k8s services, add support for setting annotations.

## QA steps

deploy a k8s charm
juju deploy cs:~juju/mariadb-k8s --storage database=10M,mariadb-pv --config kubernetes-service-annotations="a=b c=d e="
describe the k8s service
```
Name:              juju-mariadb-k8s
Namespace:         test
Labels:            juju-application=mariadb-k8s
                   juju-controller-uuid=9f1cd160-8e29-4079-882d-4eeff7032b39
                   juju-model-uuid=1e89754c-461b-4175-828a-0cad0c633cd0
Annotations:       a: b
                   c: d
                   e: 
Selector:          juju-application=mariadb-k8s
```

## Documentation changes

Need to document the additional k8s application config parameter.
