### PR TITLE
Fix Test Failures in Firewaller Worker

### DIFF
--- a/api/firewaller/application_test.go
+++ b/api/firewaller/application_test.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/firewaller"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/watcher/watchertest"
 )
 
@@ -43,8 +42,6 @@ func (s *applicationSuite) TestTag(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
-
 	w, err := s.apiApplication.Watch()
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewNotifyWatcherC(c, w, s.BackingState.StartSync)

--- a/api/firewaller/application_test.go
+++ b/api/firewaller/application_test.go
@@ -64,18 +64,6 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 	wc.AssertOneChange()
 }
 
-func (s *applicationSuite) TestRefresh(c *gc.C) {
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
-
-	err := s.application.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
-
-	err = s.apiApplication.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Dying)
-}
-
 func (s *applicationSuite) TestIsExposed(c *gc.C) {
 	err := s.application.SetExposed()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/firewaller/unit.go
+++ b/api/firewaller/unit.go
@@ -53,11 +53,6 @@ func (u *Unit) Application() (*Application, error) {
 		st:  u.st,
 		tag: applicationTag,
 	}
-	// Call Refresh() immediately to get the up-to-date
-	// life and other needed locally cached fields.
-	if err := app.Refresh(); err != nil {
-		return nil, err
-	}
 	return app, nil
 }
 

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -528,7 +528,7 @@ func (fw *Firewaller) reconcileGlobal() error {
 }
 
 // reconcileInstances compares the initially started watcher for machines,
-// units and appications with the opened and closed ports of the instances and
+// units and applications with the opened and closed ports of the instances and
 // opens and closes the appropriate ports for each instance.
 func (fw *Firewaller) reconcileInstances() error {
 	for _, machined := range fw.machineds {
@@ -1120,14 +1120,11 @@ func (ad *applicationData) watchLoop(exposed bool) error {
 			if !ok {
 				return errors.New("application watcher closed")
 			}
-			if err := ad.application.Refresh(); err != nil {
-				if !params.IsCodeNotFound(err) {
-					return errors.Trace(err)
-				}
-				return nil
-			}
 			change, err := ad.application.IsExposed()
 			if err != nil {
+				if errors.IsNotFound(err) {
+					return nil
+				}
 				return errors.Trace(err)
 			}
 			if change == exposed {
@@ -1611,14 +1608,14 @@ func (p *remoteRelationPoller) pollLoop() error {
 			logger.Debugf("token %v for application id: %v", appToken, p.applicationTag.Id())
 
 			// relation and application are ready.
-			releationInfo := remoteRelationInfo{
+			relationInfo := remoteRelationInfo{
 				relationToken:    relToken,
 				applicationToken: appToken,
 			}
 			select {
 			case <-p.catacomb.Dying():
 				return p.catacomb.ErrDying()
-			case p.relationReady <- releationInfo:
+			case p.relationReady <- relationInfo:
 			}
 			return nil
 		}


### PR DESCRIPTION
## Description of change

Intermittent unit test failures were exposing a race in the _firewaller_ worker whereby an application could be removed in between an API to refresh it's cached _life_ status, and an API call to check whether it is exposed.

This patch removes some superfluous caching of local state and instead makes the API call directly, terminating the worker loop without error if the application is not found.

## QA steps

Fairly easy to reproduce by running `InstanceModeSuite.TestRemoveApplication` in a loop.

Consistently passes with this change.

## Documentation changes

None

## Bug reference

N/A
