### PR TITLE
Deploy a default IAAS bundle

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -52,8 +52,17 @@ def deploy_bundle(client, charm_bundle, stack_type):
     """
     bundle = None
     if not charm_bundle:
+        # Depending on the stack type, use a different bundle definition for
+        # one that's not already included.
+        if stack_type == "iaas":
+            default_charm = "basic-openstack-lxd.yaml"
+        elif stack_type == "caas":
+            default_charm = "bundles-kubernetes-core-lxd.yaml"
+        else:
+            raise JujuAssertionError('invalid stack type {}'.format(stack_type))
+
         bundle = local_charm_path(
-            charm='bundles-kubernetes-core-lxd.yaml',
+            charm=default_charm,
             repository=os.environ['JUJU_REPOSITORY'],
             juju_ver=client.version,
         )

--- a/acceptancetests/reporting.py
+++ b/acceptancetests/reporting.py
@@ -76,6 +76,7 @@ def get_reporting_client(uri):
         port=parsed_uri.port,
         username=parsed_uri.username,
         password=parsed_uri.password,
+        database=DBNAME,
     )
     try:
         client.switch_database(DBNAME)

--- a/acceptancetests/repository/basic-openstack-lxd.yaml
+++ b/acceptancetests/repository/basic-openstack-lxd.yaml
@@ -1,0 +1,133 @@
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - neutron-api:shared-db
+  - mysql:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - glance:shared-db
+  - mysql:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:quantum-network-service
+  - neutron-gateway:quantum-network-service
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - nova-compute:lxd
+  - lxd:lxd
+series: xenial
+services:
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: cs:glance
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: cs:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+  mysql:
+    annotations:
+      gui-x: '0'
+      gui-y: '250'
+    charm: cs:percona-cluster
+    num_units: 1
+    options:
+      max-connections: 20000
+      innodb-buffer-pool-size: 50%
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: cs:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      overlay-network-type: "gre vxlan"
+      openstack-origin: cloud:xenial-queens
+      flat-network-providers: physnet1
+  neutron-gateway:
+    annotations:
+      gui-x: '0'
+      gui-y: '0'
+    charm: cs:neutron-gateway
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+      dns-servers: 10.101.0.1
+  neutron-openvswitch:
+    annotations:
+      gui-x: '250'
+      gui-y: '500'
+    charm: cs:neutron-openvswitch
+    num_units: 0
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: cs:nova-compute
+    num_units: 1
+    options:
+      enable-live-migration: False
+      enable-resize: False
+      virt-type: lxd
+      openstack-origin: cloud:xenial-queens
+  lxd:
+    charm: cs:xenial/lxd
+    options:
+      block-devices: None
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: cs:rabbitmq-server
+    num_units: 1


### PR DESCRIPTION
## Description of change

Instead of deploying a kubernetes core for all stacks, instead
pick a different default bundle per stack. So for IAAS, the stack
is based on https://github.com/conjure-up/spells/blob/master/openstack-novalxd/bundle.yaml
with changes to ensure that it has a better chance of deploying
on the CI setup.

