### PR TITLE
Install fake ensure mongo is per suite not test.

### DIFF
--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -67,7 +67,6 @@ func (s *commonMachineSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&stateWorkerDialOpts, mongotest.DialOpts())
-	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
 }
 
 func (s *commonMachineSuite) SetUpTest(c *gc.C) {
@@ -84,6 +83,7 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 	fakeCmd(filepath.Join(testpath, "stop"))
 
 	s.PatchValue(&upstart.InitDir, c.MkDir())
+	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
 }
 
 func (s *commonMachineSuite) assertChannelActive(c *gc.C, aChannel chan struct{}, intent string) {

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -67,10 +67,7 @@ func (s *commonMachineSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&stateWorkerDialOpts, mongotest.DialOpts())
-}
-
-func (s *commonMachineSuite) TearDownSuite(c *gc.C) {
-	s.AgentSuite.TearDownSuite(c)
+	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
 }
 
 func (s *commonMachineSuite) SetUpTest(c *gc.C) {
@@ -87,8 +84,6 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 	fakeCmd(filepath.Join(testpath, "stop"))
 
 	s.PatchValue(&upstart.InitDir, c.MkDir())
-
-	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
 }
 
 func (s *commonMachineSuite) assertChannelActive(c *gc.C, aChannel chan struct{}, intent string) {

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -99,8 +99,6 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	})
 	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
-	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
-	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 }
 
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
@@ -120,6 +118,8 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.logDir = c.MkDir()
 	s.bootstrapParamsFile = filepath.Join(s.dataDir, "bootstrap-params")
 	s.mongoOplogSize = "1234"
+	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
+	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 	s.makeTestModel(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -99,6 +99,8 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	})
 	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
+	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
+	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 }
 
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
@@ -118,8 +120,6 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.logDir = c.MkDir()
 	s.bootstrapParamsFile = filepath.Join(s.dataDir, "bootstrap-params")
 	s.mongoOplogSize = "1234"
-	s.fakeEnsureMongo = agenttest.InstallFakeEnsureMongo(s)
-	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 	s.makeTestModel(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -30,10 +30,12 @@ type introspectionSuite struct {
 }
 
 func (s *introspectionSuite) SetUpSuite(c *gc.C) {
-	s.AgentSuite.SetUpSuite(c)
 	if runtime.GOOS != "linux" {
 		c.Skip(fmt.Sprintf("the introspection worker does not support %q", runtime.GOOS))
 	}
+	s.AgentSuite.SetUpSuite(c)
+	agenttest.InstallFakeEnsureMongo(s)
+	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 }
 
 func (s *introspectionSuite) SetUpTest(c *gc.C) {
@@ -46,9 +48,6 @@ func (s *introspectionSuite) SetUpTest(c *gc.C) {
 		err := logsender.UninstallBufferedLogWriter()
 		c.Assert(err, jc.ErrorIsNil)
 	})
-
-	agenttest.InstallFakeEnsureMongo(s)
-	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 }
 
 // startMachineAgent starts a controller machine agent and returns the path

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -62,6 +62,9 @@ func (s *upgradeSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	// Speed up the watcher frequency to make the test much faster.
 	s.PatchValue(&watcher.Period, 200*time.Millisecond)
+
+	agenttest.InstallFakeEnsureMongo(s)
+	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 }
 
 func (s *upgradeSuite) SetUpTest(c *gc.C) {
@@ -88,10 +91,6 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 		for range aptCmds {
 		}
 	}()
-
-	agenttest.InstallFakeEnsureMongo(s)
-	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
-
 }
 
 func (s *upgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {


### PR DESCRIPTION
## Description of change

For efficiency, setting up and confirming mongo is installed is better done per suite rather than per test.

Prior to this change, I could not stress test [1]  upgradeSuite at all. It still fails after 3 runs but at least it has the 3 runs now. I'll keep digging into failures but this change is aimed to make flaky tests less flaky.

[1] https://github.com/juju/juju/wiki/Stress-Test

