### PR TITLE
Don't swallow register error.

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -126,8 +126,11 @@ func (c *registerCommand) Init(args []string) error {
 // Run implements Command.Run.
 func (c *registerCommand) Run(ctx *cmd.Context) error {
 	err := c.run(ctx)
-	if err != nil && c.onRunError != nil {
-		c.onRunError()
+	if err != nil {
+		ctx.Warningf("could not register user: %v", err)
+		if c.onRunError != nil {
+			c.onRunError()
+		}
 	}
 	return err
 }


### PR DESCRIPTION
## Description of change

Register user command clears out macaroon if an error occurred during user registration and currently our CI fails to do that.
However, during the investigation it was discovered that the actual error that is causing the clean up was never visible.

