### PR TITLE
Updates LXD dependency, regenerates mocks, fixes MB/MiB conversions.

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -47,7 +47,7 @@ func (c *ContainerSpec) ApplyConstraints(cons constraints.Value) {
 		c.Config["limits.cpu"] = fmt.Sprintf("%d", *cons.CpuCores)
 	}
 	if cons.HasMem() {
-		c.Config["limits.memory"] = fmt.Sprintf("%dMB", *cons.Mem)
+		c.Config["limits.memory"] = fmt.Sprintf("%dMiB", *cons.Mem)
 	}
 }
 

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -47,8 +47,8 @@ func (s *containerSuite) TestContainerCPUs(c *gc.C) {
 
 func (s *containerSuite) TestContainerMem(c *gc.C) {
 	container := lxd.Container{}
-	container.Config = map[string]string{"limits.memory": "1MB"}
-	c.Check(container.Mem(), gc.Equals, uint(1))
+	container.Config = map[string]string{"limits.memory": "1MiB"}
+	c.Check(int(container.Mem()), gc.Equals, 1)
 }
 
 func (s *containerSuite) TestContainerAddDiskNoDevices(c *gc.C) {
@@ -466,7 +466,7 @@ func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 
 	exp := map[string]string{
 		lxd.AutoStartKey: "true",
-		"limits.memory":  "2046MB",
+		"limits.memory":  "2046MiB",
 		"limits.cpu":     "4",
 	}
 	c.Check(spec.Config, gc.DeepEquals, exp)

--- a/container/lxd/testing/lxd_mock.go
+++ b/container/lxd/testing/lxd_mock.go
@@ -477,16 +477,16 @@ func (mr *MockContainerServerMockRecorder) CopyContainer(arg0, arg1, arg2 interf
 }
 
 // CopyContainerSnapshot mocks base method
-func (m *MockContainerServer) CopyContainerSnapshot(arg0 client.ContainerServer, arg1 api.ContainerSnapshot, arg2 *client.ContainerSnapshotCopyArgs) (client.RemoteOperation, error) {
-	ret := m.ctrl.Call(m, "CopyContainerSnapshot", arg0, arg1, arg2)
+func (m *MockContainerServer) CopyContainerSnapshot(arg0 client.ContainerServer, arg1 string, arg2 api.ContainerSnapshot, arg3 *client.ContainerSnapshotCopyArgs) (client.RemoteOperation, error) {
+	ret := m.ctrl.Call(m, "CopyContainerSnapshot", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(client.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CopyContainerSnapshot indicates an expected call of CopyContainerSnapshot
-func (mr *MockContainerServerMockRecorder) CopyContainerSnapshot(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyContainerSnapshot", reflect.TypeOf((*MockContainerServer)(nil).CopyContainerSnapshot), arg0, arg1, arg2)
+func (mr *MockContainerServerMockRecorder) CopyContainerSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyContainerSnapshot", reflect.TypeOf((*MockContainerServer)(nil).CopyContainerSnapshot), arg0, arg1, arg2, arg3)
 }
 
 // CopyImage mocks base method
@@ -678,6 +678,18 @@ func (mr *MockContainerServerMockRecorder) CreateProfile(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfile", reflect.TypeOf((*MockContainerServer)(nil).CreateProfile), arg0)
 }
 
+// CreateProject mocks base method
+func (m *MockContainerServer) CreateProject(arg0 api.ProjectsPost) error {
+	ret := m.ctrl.Call(m, "CreateProject", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateProject indicates an expected call of CreateProject
+func (mr *MockContainerServerMockRecorder) CreateProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockContainerServer)(nil).CreateProject), arg0)
+}
+
 // CreateStoragePool mocks base method
 func (m *MockContainerServer) CreateStoragePool(arg0 api.StoragePoolsPost) error {
 	ret := m.ctrl.Call(m, "CreateStoragePool", arg0)
@@ -700,6 +712,19 @@ func (m *MockContainerServer) CreateStoragePoolVolume(arg0 string, arg1 api.Stor
 // CreateStoragePoolVolume indicates an expected call of CreateStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) CreateStoragePoolVolume(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).CreateStoragePoolVolume), arg0, arg1)
+}
+
+// CreateStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) CreateStoragePoolVolumeSnapshot(arg0, arg1, arg2 string, arg3 api.StorageVolumeSnapshotsPost) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "CreateStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateStoragePoolVolumeSnapshot indicates an expected call of CreateStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) CreateStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).CreateStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
 }
 
 // DeleteCertificate mocks base method
@@ -874,6 +899,18 @@ func (mr *MockContainerServerMockRecorder) DeleteProfile(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfile", reflect.TypeOf((*MockContainerServer)(nil).DeleteProfile), arg0)
 }
 
+// DeleteProject mocks base method
+func (m *MockContainerServer) DeleteProject(arg0 string) error {
+	ret := m.ctrl.Call(m, "DeleteProject", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteProject indicates an expected call of DeleteProject
+func (mr *MockContainerServerMockRecorder) DeleteProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockContainerServer)(nil).DeleteProject), arg0)
+}
+
 // DeleteStoragePool mocks base method
 func (m *MockContainerServer) DeleteStoragePool(arg0 string) error {
 	ret := m.ctrl.Call(m, "DeleteStoragePool", arg0)
@@ -896,6 +933,19 @@ func (m *MockContainerServer) DeleteStoragePoolVolume(arg0, arg1, arg2 string) e
 // DeleteStoragePoolVolume indicates an expected call of DeleteStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) DeleteStoragePoolVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).DeleteStoragePoolVolume), arg0, arg1, arg2)
+}
+
+// DeleteStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) DeleteStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "DeleteStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteStoragePoolVolumeSnapshot indicates an expected call of DeleteStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) DeleteStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).DeleteStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
 }
 
 // ExecContainer mocks base method
@@ -1258,6 +1308,19 @@ func (mr *MockContainerServerMockRecorder) GetContainers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainers", reflect.TypeOf((*MockContainerServer)(nil).GetContainers))
 }
 
+// GetContainersFull mocks base method
+func (m *MockContainerServer) GetContainersFull() ([]api.ContainerFull, error) {
+	ret := m.ctrl.Call(m, "GetContainersFull")
+	ret0, _ := ret[0].([]api.ContainerFull)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContainersFull indicates an expected call of GetContainersFull
+func (mr *MockContainerServerMockRecorder) GetContainersFull() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainersFull", reflect.TypeOf((*MockContainerServer)(nil).GetContainersFull))
+}
+
 // GetEvents mocks base method
 func (m *MockContainerServer) GetEvents() (*client.EventListener, error) {
 	ret := m.ctrl.Call(m, "GetEvents")
@@ -1430,6 +1493,19 @@ func (mr *MockContainerServerMockRecorder) GetNetworkNames() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkNames", reflect.TypeOf((*MockContainerServer)(nil).GetNetworkNames))
 }
 
+// GetNetworkState mocks base method
+func (m *MockContainerServer) GetNetworkState(arg0 string) (*api.NetworkState, error) {
+	ret := m.ctrl.Call(m, "GetNetworkState", arg0)
+	ret0, _ := ret[0].(*api.NetworkState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworkState indicates an expected call of GetNetworkState
+func (mr *MockContainerServerMockRecorder) GetNetworkState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkState", reflect.TypeOf((*MockContainerServer)(nil).GetNetworkState), arg0)
+}
+
 // GetNetworks mocks base method
 func (m *MockContainerServer) GetNetworks() ([]api.Network, error) {
 	ret := m.ctrl.Call(m, "GetNetworks")
@@ -1468,6 +1544,20 @@ func (m *MockContainerServer) GetOperationUUIDs() ([]string, error) {
 // GetOperationUUIDs indicates an expected call of GetOperationUUIDs
 func (mr *MockContainerServerMockRecorder) GetOperationUUIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationUUIDs", reflect.TypeOf((*MockContainerServer)(nil).GetOperationUUIDs))
+}
+
+// GetOperationWait mocks base method
+func (m *MockContainerServer) GetOperationWait(arg0 string, arg1 int) (*api.Operation, string, error) {
+	ret := m.ctrl.Call(m, "GetOperationWait", arg0, arg1)
+	ret0, _ := ret[0].(*api.Operation)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOperationWait indicates an expected call of GetOperationWait
+func (mr *MockContainerServerMockRecorder) GetOperationWait(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationWait", reflect.TypeOf((*MockContainerServer)(nil).GetOperationWait), arg0, arg1)
 }
 
 // GetOperationWebsocket mocks base method
@@ -1563,6 +1653,46 @@ func (mr *MockContainerServerMockRecorder) GetProfiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfiles", reflect.TypeOf((*MockContainerServer)(nil).GetProfiles))
 }
 
+// GetProject mocks base method
+func (m *MockContainerServer) GetProject(arg0 string) (*api.Project, string, error) {
+	ret := m.ctrl.Call(m, "GetProject", arg0)
+	ret0, _ := ret[0].(*api.Project)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetProject indicates an expected call of GetProject
+func (mr *MockContainerServerMockRecorder) GetProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockContainerServer)(nil).GetProject), arg0)
+}
+
+// GetProjectNames mocks base method
+func (m *MockContainerServer) GetProjectNames() ([]string, error) {
+	ret := m.ctrl.Call(m, "GetProjectNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjectNames indicates an expected call of GetProjectNames
+func (mr *MockContainerServerMockRecorder) GetProjectNames() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectNames", reflect.TypeOf((*MockContainerServer)(nil).GetProjectNames))
+}
+
+// GetProjects mocks base method
+func (m *MockContainerServer) GetProjects() ([]api.Project, error) {
+	ret := m.ctrl.Call(m, "GetProjects")
+	ret0, _ := ret[0].([]api.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjects indicates an expected call of GetProjects
+func (mr *MockContainerServerMockRecorder) GetProjects() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockContainerServer)(nil).GetProjects))
+}
+
 // GetServer mocks base method
 func (m *MockContainerServer) GetServer() (*api.Server, string, error) {
 	ret := m.ctrl.Call(m, "GetServer")
@@ -1655,6 +1785,46 @@ func (m *MockContainerServer) GetStoragePoolVolumeNames(arg0 string) ([]string, 
 // GetStoragePoolVolumeNames indicates an expected call of GetStoragePoolVolumeNames
 func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeNames(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeNames", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeNames), arg0)
+}
+
+// GetStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) GetStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string) (*api.StorageVolumeSnapshot, string, error) {
+	ret := m.ctrl.Call(m, "GetStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*api.StorageVolumeSnapshot)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetStoragePoolVolumeSnapshot indicates an expected call of GetStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
+}
+
+// GetStoragePoolVolumeSnapshotNames mocks base method
+func (m *MockContainerServer) GetStoragePoolVolumeSnapshotNames(arg0, arg1, arg2 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "GetStoragePoolVolumeSnapshotNames", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolVolumeSnapshotNames indicates an expected call of GetStoragePoolVolumeSnapshotNames
+func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeSnapshotNames(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeSnapshotNames", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeSnapshotNames), arg0, arg1, arg2)
+}
+
+// GetStoragePoolVolumeSnapshots mocks base method
+func (m *MockContainerServer) GetStoragePoolVolumeSnapshots(arg0, arg1, arg2 string) ([]api.StorageVolumeSnapshot, error) {
+	ret := m.ctrl.Call(m, "GetStoragePoolVolumeSnapshots", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]api.StorageVolumeSnapshot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolVolumeSnapshots indicates an expected call of GetStoragePoolVolumeSnapshots
+func (mr *MockContainerServerMockRecorder) GetStoragePoolVolumeSnapshots(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumeSnapshots", reflect.TypeOf((*MockContainerServer)(nil).GetStoragePoolVolumeSnapshots), arg0, arg1, arg2)
 }
 
 // GetStoragePoolVolumes mocks base method
@@ -1900,6 +2070,19 @@ func (mr *MockContainerServerMockRecorder) RenameProfile(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameProfile", reflect.TypeOf((*MockContainerServer)(nil).RenameProfile), arg0, arg1)
 }
 
+// RenameProject mocks base method
+func (m *MockContainerServer) RenameProject(arg0 string, arg1 api.ProjectPost) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "RenameProject", arg0, arg1)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameProject indicates an expected call of RenameProject
+func (mr *MockContainerServerMockRecorder) RenameProject(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameProject", reflect.TypeOf((*MockContainerServer)(nil).RenameProject), arg0, arg1)
+}
+
 // RenameStoragePoolVolume mocks base method
 func (m *MockContainerServer) RenameStoragePoolVolume(arg0, arg1, arg2 string, arg3 api.StorageVolumePost) error {
 	ret := m.ctrl.Call(m, "RenameStoragePoolVolume", arg0, arg1, arg2, arg3)
@@ -1910,6 +2093,19 @@ func (m *MockContainerServer) RenameStoragePoolVolume(arg0, arg1, arg2 string, a
 // RenameStoragePoolVolume indicates an expected call of RenameStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) RenameStoragePoolVolume(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).RenameStoragePoolVolume), arg0, arg1, arg2, arg3)
+}
+
+// RenameStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) RenameStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string, arg4 api.StorageVolumeSnapshotPost) (client.Operation, error) {
+	ret := m.ctrl.Call(m, "RenameStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(client.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameStoragePoolVolumeSnapshot indicates an expected call of RenameStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) RenameStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).RenameStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3, arg4)
 }
 
 // RequireAuthenticated mocks base method
@@ -2045,6 +2241,18 @@ func (mr *MockContainerServerMockRecorder) UpdateProfile(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProfile", reflect.TypeOf((*MockContainerServer)(nil).UpdateProfile), arg0, arg1, arg2)
 }
 
+// UpdateProject mocks base method
+func (m *MockContainerServer) UpdateProject(arg0 string, arg1 api.ProjectPut, arg2 string) error {
+	ret := m.ctrl.Call(m, "UpdateProject", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateProject indicates an expected call of UpdateProject
+func (mr *MockContainerServerMockRecorder) UpdateProject(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProject", reflect.TypeOf((*MockContainerServer)(nil).UpdateProject), arg0, arg1, arg2)
+}
+
 // UpdateServer mocks base method
 func (m *MockContainerServer) UpdateServer(arg0 api.ServerPut, arg1 string) error {
 	ret := m.ctrl.Call(m, "UpdateServer", arg0, arg1)
@@ -2079,6 +2287,30 @@ func (m *MockContainerServer) UpdateStoragePoolVolume(arg0, arg1, arg2 string, a
 // UpdateStoragePoolVolume indicates an expected call of UpdateStoragePoolVolume
 func (mr *MockContainerServerMockRecorder) UpdateStoragePoolVolume(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStoragePoolVolume", reflect.TypeOf((*MockContainerServer)(nil).UpdateStoragePoolVolume), arg0, arg1, arg2, arg3, arg4)
+}
+
+// UpdateStoragePoolVolumeSnapshot mocks base method
+func (m *MockContainerServer) UpdateStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string, arg4 api.StorageVolumeSnapshotPut, arg5 string) error {
+	ret := m.ctrl.Call(m, "UpdateStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStoragePoolVolumeSnapshot indicates an expected call of UpdateStoragePoolVolumeSnapshot
+func (mr *MockContainerServerMockRecorder) UpdateStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).UpdateStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// UseProject mocks base method
+func (m *MockContainerServer) UseProject(arg0 string) client.ContainerServer {
+	ret := m.ctrl.Call(m, "UseProject", arg0)
+	ret0, _ := ret[0].(client.ContainerServer)
+	return ret0
+}
+
+// UseProject indicates an expected call of UseProject
+func (mr *MockContainerServerMockRecorder) UseProject(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseProject", reflect.TypeOf((*MockContainerServer)(nil).UseProject), arg0)
 }
 
 // UseTarget mocks base method

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,3 +1,4 @@
+code.cloudfoundry.org/systemcerts	git	ca00b2f806f2fa1ded784ade357bad1ea3f1fbbe	2018-09-17T15:40:49Z
 contrib.go.opencensus.io/exporter/ocagent	git	b8ece14a43f0cda76036504e4a4fd7fa27ce1869	2018-10-24T04:13:55Z
 github.com/Azure/azure-sdk-for-go	git	9699bdefa481d47c5c7638a1cc05d87ce53601fd	2018-11-14T17:11:15Z
 github.com/Azure/go-autorest	git	528b76fd0ebec0682f3e3da7c808cd472b999615	2018-11-12T18:30:27Z
@@ -13,6 +14,7 @@ github.com/cloud-green/monitoring	git	666e3beca3cb4f6b5c8f176ba80daf2b3adbd84e	2
 github.com/coreos/go-systemd	git	7b2428fec40033549c68f54e26e89e7ca9a9ce31	2016-02-02T21:14:25Z
 github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07-05T20:30:06Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
+github.com/flosch/pongo2	git	79872a7b27692599b259dc751bed8b03581dd0de	2018-12-25T14:00:29Z
 github.com/godbus/dbus	git	32c6cc29c14570de4cf6d7e7737d68fb2d01ad15	2016-05-06T22:25:50Z
 github.com/golang/glog	git	23def4e6c14b4da8ac2ed8007337bc5eb5007998	2016-01-26T23:53:08Z
 github.com/golang/mock	git	69521b3833175dfcfb1cc1fdb0c9be92e66faa81	2018-04-03T23:54:22Z
@@ -82,7 +84,7 @@ github.com/lestrrat/go-jsval	git	b1258a10419fe0693f7b35ad65cd5074bc0ba1e5	2016-1
 github.com/lestrrat/go-pdebug	git	2e6eaaa5717f81bda41d27070d3c966f40a1e75f	2016-08-17T06:33:33Z
 github.com/lestrrat/go-structinfo	git	f74c056fe41f860aa6264478c664a6fff8a64298	2016-03-08T13:11:05Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
-github.com/lxc/lxd	git	d0d66b4842f459c6c3e039a9e2f25eff02174ab1	2018-05-15T16:43:15Z
+github.com/lxc/lxd	git	4c2bbb608e7a90a9f175a566b9e638069424f0f7	2019-01-08T20:53:13Z
 github.com/marstr/guid	git	8bdf7d1a087ccc975cf37dd6507da50698fd19ca	2017-04-27T23:51:15Z
 github.com/masterzen/azure-sdk-for-go	git	ee4f0065d00cd12b542f18f5bc45799e88163b12	2016-10-14T13:56:28Z
 github.com/masterzen/simplexml	git	4572e39b1ab9fe03ee513ce6fc7e289e98482190	2016-06-08T18:30:07Z
@@ -138,6 +140,7 @@ gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18
 gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z
 gopkg.in/natefinch/npipe.v2	git	c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6	2016-06-21T03:49:01Z
 gopkg.in/retry.v1	git	01631078ef2fdce601e38cfe5f527fab24c9a6d2	2017-05-31T09:12:38Z
+gopkg.in/robfig/cron.v2	git	be2e0b0deed5a68ffee390b4583a13aff8321535	2015-01-07T22:02:07Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
 gopkg.in/yaml.v2	git	1be3d31502d6eabc0dd7ce5b0daab022e14a5538	2017-07-12T05:45:46Z

--- a/provider/lxd/storage_test.go
+++ b/provider/lxd/storage_test.go
@@ -388,7 +388,7 @@ func (s *storageSuite) TestImportFilesystem(c *gc.C) {
 			Name: "bar",
 			StorageVolumePut: api.StorageVolumePut{
 				Config: map[string]string{
-					"size": "10GB",
+					"size": "10GiB",
 				},
 			},
 		}},
@@ -407,7 +407,7 @@ func (s *storageSuite) TestImportFilesystem(c *gc.C) {
 		Name: "bar",
 		StorageVolumePut: api.StorageVolumePut{
 			Config: map[string]string{
-				"size":     "10GB",
+				"size":     "10GiB",
 				"user.baz": "qux",
 			},
 		},

--- a/tools/lxdclient/instance_test.go
+++ b/tools/lxdclient/instance_test.go
@@ -28,7 +28,7 @@ var templateContainerInfo = lxdapi.Container{
 		Architecture: "x86_64",
 		Config: map[string]string{
 			"limits.cpu":     "2",
-			"limits.memory":  "256MB",
+			"limits.memory":  "256MiB",
 			"user.something": "something value",
 		},
 		Devices: map[string]map[string]string{
@@ -91,11 +91,11 @@ func (s *instanceSuite) TestNewInstanceSummaryMemory(c *gc.C) {
 	summary = lxdclient.NewInstanceSummary(infoWithMemory("blah"))
 	c.Check(summary.Hardware.MemoryMB, gc.Equals, uint(0))
 	// Too big to fit in uint
-	tooBig := fmt.Sprintf("%vMB", uint64(math.MaxUint32)+1)
+	tooBig := fmt.Sprintf("%vMiB", uint64(math.MaxUint32)+1)
 	summary = lxdclient.NewInstanceSummary(infoWithMemory(tooBig))
 	c.Check(summary.Hardware.MemoryMB, gc.Equals, uint(math.MaxUint32))
 	// Just big enough
-	justEnough := fmt.Sprintf("%vMB", uint(math.MaxUint32)-1)
+	justEnough := fmt.Sprintf("%vMiB", uint(math.MaxUint32)-1)
 	summary = lxdclient.NewInstanceSummary(infoWithMemory(justEnough))
 	c.Check(summary.Hardware.MemoryMB, gc.Equals, uint(math.MaxUint32-1))
 }


### PR DESCRIPTION
## Description of change

In essence this patch is the same as #9617, with the following changes:
- LXD is updated to a later hash that includes a client bug fix. 
- It accommodates use of Godeps plus slight differences in the 2.4 code-base. 

## QA steps

Same as for #9617

## Documentation changes

None.

## Bug reference

See #9617
