### PR TITLE
Webscale: Report the MongoVersion from the controller

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -129,6 +129,14 @@ def extract_charm_urls(client):
         charms.append(charm["charm"])
     return charms
 
+def extract_mongo_version(client):
+    """Extract the mongo version from the controller.
+    """
+
+    ctrl_info = client.get_controllers()
+    ctrl_details = ctrl_info.get_controller(client.env.controller.name).get_details()
+    return ctrl_details.mongo_version
+
 def get_stack_client(stack_type, path, client, timeout=3600, charm=False):
     """Get the stack client dependant on the type of stack we want to deploy on
     """
@@ -181,6 +189,9 @@ def main(argv=None):
     bs_manager = BootstrapManager.from_args(args)
     with bs_manager.booted_context(args.upload_tools):
         client = bs_manager.client
+        mongo_version = extract_mongo_version(client)
+        log.info("MongoVersion used for deployment: {}".format(mongo_version))
+
         deploy_bundle(client,
             charm_bundle=args.charm_bundle,
             stack_type=args.stack_type,
@@ -206,6 +217,7 @@ def main(argv=None):
                 "git-sha": args.git_sha,
                 "charm-bundle": args.charm_bundle,
                 "charm-urls": charm_urls,
+                "mongo-version": mongo_version,
             })
         except:
             raise JujuAssertionError("Error reporting metrics")

--- a/acceptancetests/jujupy/__init__.py
+++ b/acceptancetests/jujupy/__init__.py
@@ -57,6 +57,9 @@ from jujupy.fake import (
 from jujupy.status import (
     Status,
 )
+from jujupy.controller import (
+    Controllers,
+)
 from jujupy.utility import (
     get_timeout_prefix,
 )

--- a/acceptancetests/jujupy/controller.py
+++ b/acceptancetests/jujupy/controller.py
@@ -1,0 +1,64 @@
+# This file is part of JujuPy, a library for driving the Juju CLI.
+# Copyright 2013-2019 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the Lesser GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the Lesser
+# GNU General Public License for more details.
+#
+# You should have received a copy of the Lesser GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import re
+import yaml
+
+__metaclass__ = type
+
+class Controllers:
+
+    def __init__(self, info, text):
+        self.info = info
+        self.text = text
+    
+    @classmethod
+    def from_text(cls, text):
+        try:
+            # Parsing as JSON is much faster than parsing as YAML, so try
+            # parsing as JSON first and fall back to YAML.
+            info = json.loads(text)
+        except ValueError:
+            info = yaml.safe_load(text)
+        return cls(info, text)
+    
+    def get_controller(self, name):
+        """Controller returns the controller associated with the name provided
+
+        :param name: name associated with the controller
+        """
+        return Controller(self.info[name])
+
+class Controller:
+
+    def __init__(self, info):
+        self.info = info
+    
+    def get_details(self):
+        return ControllerDetails(self.info["details"])
+
+class ControllerDetails:
+
+    def __init__(self, info):
+        self.info = info
+
+    @property
+    def agent_version(self):
+        return self.info["agent-version"]
+    
+    @property
+    def mongo_version(self):
+        return self.info["mongo-version"]

--- a/acceptancetests/jujupy/exceptions.py
+++ b/acceptancetests/jujupy/exceptions.py
@@ -25,6 +25,8 @@ __metaclass__ = type
 class StatusTimeout(Exception):
     """Raised when 'juju status' timed out."""
 
+class ControllersTimeout(Exception):
+    """Raised when 'juju show-controller' timed out."""
 
 class SoftDeadlineExceeded(Exception):
     """Raised when an overall client operation takes too long."""

--- a/api/controller/mongo.go
+++ b/api/controller/mongo.go
@@ -1,0 +1,22 @@
+// Copyright 2012-2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// MongoVersion returns the mongo version associated with the state session.
+func (c *Client) MongoVersion() (string, error) {
+	var result params.StringResult
+	err := c.facade.FacadeCall("MongoVersion", nil, &result)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}

--- a/api/controller/mongo_test.go
+++ b/api/controller/mongo_test.go
@@ -1,0 +1,67 @@
+// Copyright 2012-2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+func (s *Suite) TestMongoVersionCallError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := controller.NewClient(apiCaller)
+	result, err := client.MongoVersion()
+	c.Check(result, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestMongoVersion(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 4,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "MongoVersion")
+			c.Check(result, gc.FitsTypeOf, &params.StringResult{})
+
+			out := result.(*params.StringResult)
+			out.Result = "3.5.12"
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	result, err := client.MongoVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, "3.5.12")
+}
+
+func (s *Suite) TestMongoVersionWithErrorResult(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 4,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "MongoVersion")
+			c.Check(result, gc.FitsTypeOf, &params.StringResult{})
+
+			out := result.(*params.StringResult)
+			out.Result = "3.5.12"
+			out.Error = common.ServerError(errors.New("version error"))
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	_, err := client.MongoVersion()
+	c.Assert(err, gc.ErrorMatches, "version error")
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -34,7 +34,7 @@ var facadeVersions = map[string]int{
 	"Cleaner":                      2,
 	"Client":                       2,
 	"Cloud":                        3,
-	"Controller":                   5,
+	"Controller":                   6,
 	"CredentialManager":            1,
 	"CredentialValidator":          2,
 	"CrossController":              1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -173,6 +173,7 @@ func AllFacades() *facade.Registry {
 	reg("Controller", 3, controller.NewControllerAPIv3)
 	reg("Controller", 4, controller.NewControllerAPIv4)
 	reg("Controller", 5, controller.NewControllerAPIv5)
+	reg("Controller", 6, controller.NewControllerAPIv6)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
 	reg("CredentialManager", 1, credentialmanager.NewCredentialManagerAPI)

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -56,7 +56,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPIv5(
+	controller, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -75,7 +75,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPIv5(
+	endpoint, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -100,7 +100,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	}
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
-	endpoint, err := controller.NewControllerAPIv5(
+	endpoint, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -45,11 +45,17 @@ type ControllerAPI struct {
 	hub        facade.Hub
 }
 
+// ControllerAPIv5 provides the v5 Controller API. The only difference
+// between this and v6 is that v5 doesn't have the MongoVersion method.
+type ControllerAPIv5 struct {
+	*ControllerAPI
+}
+
 // ControllerAPIv4 provides the v4 Controller API. The only difference
 // between this and v5 is that v4 doesn't have the
 // UpdateControllerConfig method.
 type ControllerAPIv4 struct {
-	*ControllerAPI
+	*ControllerAPIv5
 }
 
 // ControllerAPIv3 provides the v3 Controller API.
@@ -57,8 +63,8 @@ type ControllerAPIv3 struct {
 	*ControllerAPIv4
 }
 
-// NewControllerAPIv5 creates a new ControllerAPIv5.
-func NewControllerAPIv5(ctx facade.Context) (*ControllerAPI, error) {
+// NewControllerAPIv6 creates a new ControllerAPIv6
+func NewControllerAPIv6(ctx facade.Context) (*ControllerAPI, error) {
 	st := ctx.State()
 	authorizer := ctx.Auth()
 	pool := ctx.StatePool()
@@ -74,6 +80,15 @@ func NewControllerAPIv5(ctx facade.Context) (*ControllerAPI, error) {
 		presence,
 		hub,
 	)
+}
+
+// NewControllerAPIv5 creates a new ControllerAPIv5.
+func NewControllerAPIv5(ctx facade.Context) (*ControllerAPIv5, error) {
+	v6, err := NewControllerAPIv6(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIv5{v6}, nil
 }
 
 // NewControllerAPIv4 creates a new ControllerAPIv4.
@@ -163,6 +178,20 @@ func (c *ControllerAPIv3) ModelStatus(req params.Entities) (params.ModelStatusRe
 		}
 	}
 	return results, nil
+}
+
+// MongoVersion allows the introspection of the mongo version per controller
+func (c *ControllerAPI) MongoVersion() (params.StringResult, error) {
+	result := params.StringResult{}
+	if err := c.checkHasAdmin(); err != nil {
+		return result, errors.Trace(err)
+	}
+	version, err := c.state.MongoVersion()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	result.Result = version
+	return result, nil
 }
 
 // AllModels allows controller administrators to get the list of all the

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -64,7 +64,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	}
 	s.hub = pubsub.NewStructuredHub(nil)
 
-	controller, err := controller.NewControllerAPIv5(
+	controller, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,
@@ -976,4 +976,15 @@ func (s *controllerSuite) TestConfigSetPublishesEvent(c *gc.C) {
 	}
 
 	c.Assert(config.Features().SortedValues(), jc.DeepEquals, []string{"bar", "foo"})
+}
+
+func (s *controllerSuite) TestMongoVersion(c *gc.C) {
+	result, err := s.controller.MongoVersion()
+	c.Assert(err, jc.ErrorIsNil)
+
+	var resErr *params.Error
+	c.Assert(result.Error, gc.Equals, resErr)
+	// We can't guarantee which version of mongo is running, so let's just
+	// attempt to match it to a very basic version (major.minor.patch)
+	c.Assert(result.Result, gc.Matches, "^([0-9]{1,}).([0-9]{1,}).([0-9]{1,})$")
 }

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -55,7 +55,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPIv5(
+	controller, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -55,6 +55,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
 `
 	s.createTestClientStore(c)
 
@@ -67,6 +68,7 @@ mallards:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc
@@ -95,6 +97,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
 `
 	s.createTestClientStore(c)
 
@@ -107,6 +110,7 @@ mallards:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc
@@ -137,6 +141,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
     cloud: mallards
     region: mallards1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
 `
 	store := s.createTestClientStore(c)
 	store.BootstrapConfig["mallards"] = jujuclient.BootstrapConfig{
@@ -162,6 +167,7 @@ mallards:
     cloud: mallards
     region: mallards1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc
@@ -195,6 +201,7 @@ aws-test:
     cloud: aws
     region: us-east-1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   controller-machines:
     "0":
       instance-id: id-0
@@ -231,6 +238,7 @@ aws-test:
     cloud: aws
     region: us-east-1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   controller-machines:
     "0":
       instance-id: id-0
@@ -259,6 +267,7 @@ mark-test-prodstack:
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   account:
     user: admin
     access: superuser
@@ -271,7 +280,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
@@ -280,7 +289,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99","mongo-version":"3.5.12"},"account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
@@ -303,7 +312,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store.CurrentControllerName = "aws-test"
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json")
 }
@@ -403,6 +412,10 @@ func (c *fakeController) ModelStatus(models ...names.ModelTag) (result []base.Mo
 		})
 	}
 	return result, nil
+}
+
+func (c *fakeController) MongoVersion() (string, error) {
+	return "3.5.12", nil
 }
 
 func (c *fakeController) AllModels() (result []base.UserModel, _ error) {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -72,7 +72,7 @@ const (
 	Upgrading StorageEngine = "Upgrading"
 )
 
-// Version represents the major.minor version of the runnig mongo.
+// Version represents the major.minor version of the running mongo.
 type Version struct {
 	Major         int
 	Minor         int


### PR DESCRIPTION
## Description of change

The following files allows the inspection of the MongoVersion for
the controller, so that we can then verify the mongo version from
the CLI.

This work is required when reporting which version of mongo
transactions we using in the future.

## QA steps

Steps to reproduce:
```
juju bootstrap lxd test
juju show-controller
```

Outputs:
```yaml
test:
  details:
    uuid: cdfbe881-4652-4ef0-8a03-480465b831e7
    controller-uuid: cdfbe881-4652-4ef0-8a03-480465b831e7
    api-endpoints: ['10.178.104.166:17070']
    ca-cert: {}
    cloud: localhost
    region: localhost
    agent-version: 2.6-beta1.1
    mongo-version: 3.6.3
  controller-machines:
    "0":
      instance-id: juju-ef7ccc-0
  models:
    controller:
      uuid: 6ef1ac21-4802-4340-8b44-66e89cef7ccc
      model-uuid: 6ef1ac21-4802-4340-8b44-66e89cef7ccc
      machine-count: 1
    default:
      uuid: d0eebf5b-b818-4a6d-89ee-c76894e25585
      model-uuid: d0eebf5b-b818-4a6d-89ee-c76894e25585
  current-model: admin/default
  account:
    user: admin
    access: superuser
```

## Documentation changes

This changes the juju show-controller command to output the mongo version.
