### PR TITLE
add aks credentials support

### DIFF
--- a/caas/kubernetes/clientconfig/plugins_test.go
+++ b/caas/kubernetes/clientconfig/plugins_test.go
@@ -16,18 +16,18 @@ import (
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 )
 
-type K8sRawClientSuite struct {
+type k8sRawClientSuite struct {
 	BaseSuite
 }
 
-var _ = gc.Suite(&K8sRawClientSuite{})
+var _ = gc.Suite(&k8sRawClientSuite{})
 
-func (s *K8sRawClientSuite) SetUpSuite(c *gc.C) {
+func (s *k8sRawClientSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.namespace = "kube-system"
 }
 
-func (s *K8sRawClientSuite) TestEnsureJujuAdminServiceAccount(c *gc.C) {
+func (s *k8sRawClientSuite) TestEnsureJujuAdminServiceAccount(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -128,7 +128,7 @@ func (s *K8sRawClientSuite) TestEnsureJujuAdminServiceAccount(c *gc.C) {
 
 }
 
-func (s *K8sRawClientSuite) TestEnsureJujuServiceAdminAccountIdempotent(c *gc.C) {
+func (s *k8sRawClientSuite) TestEnsureJujuServiceAdminAccountIdempotent(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -227,7 +227,7 @@ func (s *K8sRawClientSuite) TestEnsureJujuServiceAdminAccountIdempotent(c *gc.C)
 
 }
 
-func (s *K8sRawClientSuite) TestEnsureClusterRole(c *gc.C) {
+func (s *k8sRawClientSuite) TestEnsureClusterRole(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -269,7 +269,7 @@ func (s *K8sRawClientSuite) TestEnsureClusterRole(c *gc.C) {
 
 }
 
-func (s *K8sRawClientSuite) TestEnsureServiceAccount(c *gc.C) {
+func (s *k8sRawClientSuite) TestEnsureServiceAccount(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -301,7 +301,7 @@ func (s *K8sRawClientSuite) TestEnsureServiceAccount(c *gc.C) {
 	c.Assert(saOut, jc.DeepEquals, sa)
 }
 
-func (s *K8sRawClientSuite) TestEnsureClusterRoleBinding(c *gc.C) {
+func (s *k8sRawClientSuite) TestEnsureClusterRoleBinding(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -364,7 +364,7 @@ func (s *K8sRawClientSuite) TestEnsureClusterRoleBinding(c *gc.C) {
 	c.Assert(clusterRoleBindingOut, jc.DeepEquals, clusterRoleBinding)
 }
 
-func (s *K8sRawClientSuite) TestGetServiceAccountSecret(c *gc.C) {
+func (s *k8sRawClientSuite) TestGetServiceAccountSecret(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -401,7 +401,7 @@ func (s *K8sRawClientSuite) TestGetServiceAccountSecret(c *gc.C) {
 	c.Assert(secretOut, jc.DeepEquals, secret)
 }
 
-func (s *K8sRawClientSuite) TestReplaceAuthProviderWithServiceAccountAuthData(c *gc.C) {
+func (s *k8sRawClientSuite) TestReplaceAuthProviderWithServiceAccountAuthData(c *gc.C) {
 	cfg := newClientConfig()
 	contextName := reflect.ValueOf(cfg.Contexts).MapKeys()[0].Interface().(string)
 	authName := cfg.Contexts[contextName].AuthInfo

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -16,7 +16,7 @@ const (
 	CredAttrPassword              = "password"
 	CredAttrClientCertificateData = "ClientCertificateData"
 	CredAttrClientKeyData         = "ClientKeyData"
-	Token                         = "Token"
+	CredAttrToken                 = "Token"
 )
 
 var k8sCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
@@ -32,7 +32,7 @@ var k8sCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
 			},
 		},
 	},
-	cloud.CertificateAuthType: {
+	cloud.OAuth2WithCertAuthType: {
 		{
 			Name: CredAttrClientCertificateData,
 			CredentialAttr: cloud.CredentialAttr{
@@ -46,8 +46,15 @@ var k8sCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
 				Hidden:      true,
 			},
 		},
+		{
+			Name: CredAttrToken,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "the kubernetes token",
+				Hidden:      true,
+			},
+		},
 	},
-	cloud.OAuth2WithCertAuthType: {
+	cloud.CertificateAuthType: {
 		{
 			Name: CredAttrClientCertificateData,
 			CredentialAttr: cloud.CredentialAttr{
@@ -55,7 +62,7 @@ var k8sCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
 			},
 		},
 		{
-			Name: Token,
+			Name: CredAttrToken,
 			CredentialAttr: cloud.CredentialAttr{
 				Description: "the kubernetes service account bearer token",
 				Hidden:      true,

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -44,8 +44,8 @@ func (s *credentialsSuite) TestCredentialsValid(c *gc.C) {
 
 func (s *credentialsSuite) TestHiddenAttributes(c *gc.C) {
 	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "userpass", "password")
-	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "oauth2withcert", "Token")
-	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "certificate", "ClientKeyData")
+	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "oauth2withcert", "Token", "ClientKeyData")
+	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "certificate", "Token")
 }
 
 var singleConfigYAML = `

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -60,7 +60,7 @@ func cloudSpecToK8sRestConfig(cloudSpec environs.CloudSpec) (*rest.Config, error
 		Host:        cloudSpec.Endpoint,
 		Username:    credentialAttrs[CredAttrUsername],
 		Password:    credentialAttrs[CredAttrPassword],
-		BearerToken: credentialAttrs[Token],
+		BearerToken: credentialAttrs[CredAttrToken],
 		TLSClientConfig: rest.TLSClientConfig{
 			CertData: []byte(credentialAttrs[CredAttrClientCertificateData]),
 			KeyData:  []byte(credentialAttrs[CredAttrClientKeyData]),

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -29,7 +29,7 @@ See also:
     add-k8s
 `
 
-// Implemented by cloudapi.Client
+// RemoveCloudAPI is implemented by cloudapi.Client.
 type RemoveCloudAPI interface {
 	RemoveCloud(string) error
 	Close() error


### PR DESCRIPTION

## Description of change

`Juju` now understands `aks` credentials correctly.

## QA steps

- prepare an aks cluster;
- `juju add-k8s myk8scloud --cluster-name=<the-aks-cluster-name>`;
- `juju add-model <model-name> myk8scloud`;
- `juju create-storage-pool operator-storage kubernetes storage-class=juju-operator-storage storage-provisioner=kubernetes.io/azure-disk parameters.storageaccounttype=Standard_LRS parameters.kind=Managed`;
- `juju deploy cs:~juju/gitlab-k8s-0`;

## Documentation changes

None.

## Bug reference

None.
