### PR TITLE
PruneTxnSleepTime was meant to be optional.

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -580,7 +580,15 @@ func (c Config) PruneTxnQueryCount() int {
 
 // PruneTxnSleepTime is the amount of time to sleep between batches.
 func (c Config) PruneTxnSleepTime() time.Duration {
-	val, _ := time.ParseDuration(c.mustString(PruneTxnSleepTime))
+	asInterface, ok := c[PruneTxnSleepTime]
+	if !ok {
+		asInterface = DefaultPruneTxnSleepTime
+	}
+	asStr, ok := asInterface.(string)
+	if !ok {
+		asStr = DefaultPruneTxnSleepTime
+	}
+	val, _ := time.ParseDuration(asStr)
 	return val
 }
 


### PR DESCRIPTION
## Description of change

The other field used 'intOrDefault' which properly handles the default
vaule when the parameter isn't available. But sleep time was a string,
and doesn't have a strOrDefault. So this does an inline "if we don't
have it, use the default".

## QA steps

Upgrade from a version that doesn't have 'prune-txn-sleep-time' set, and see that when the pruner wakes up, it doesn't panic.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812954
