### PR TITLE
Fixes for backup and restore

### DIFF
--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -113,21 +113,6 @@ def assess_ha_recovery(bs_manager, client):
     log.info("HA recovered from leader failure.")
     log.info("PASS")
 
-
-def restore_present_state_server(controller_client, backup_file):
-    """juju-restore won't restore when the state-server is still present."""
-    try:
-        controller_client.restore_backup(backup_file)
-    except CalledProcessError:
-        log.info(
-            "juju-restore correctly refused to restore "
-            "because the state-server was still up.")
-        return
-    else:
-        raise Exception(
-            "juju-restore restored to an operational state-serve")
-
-
 def delete_controller_members(bs_manager, client, leader_only=False):
     """Delete controller members.
 
@@ -163,9 +148,9 @@ def delete_controller_members(bs_manager, client, leader_only=False):
     return deleted_machines
 
 
-def restore_missing_state_server(bs_manager, controller_client, backup_file,
+def restore_state_server(bs_manager, controller_client, backup_file,
                                  check_controller=True):
-    """juju-restore creates a replacement state-server for the services."""
+    """juju-restore creates a state-server for the services."""
     log.info("Starting restore.")
     try:
         controller_client.restore_backup(backup_file)
@@ -227,7 +212,6 @@ def assess_recovery(bs_manager, strategy, charm_series):
         enable_ha(bs_manager, controller_client)
     if strategy in ('ha-backup', 'backup'):
         backup_file = controller_client.backup()
-        restore_present_state_server(controller_client, backup_file)
     if strategy == 'ha':
         leader_only = True
     else:
@@ -238,7 +222,7 @@ def assess_recovery(bs_manager, strategy, charm_series):
         assess_ha_recovery(bs_manager, client)
     else:
         check_controller = strategy != 'ha-backup'
-        restore_missing_state_server(
+        restore_state_server(
             bs_manager, controller_client, backup_file,
             check_controller=check_controller)
     log.info("Test complete.")

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1691,7 +1691,8 @@ class ModelClient:
 
     def backup(self):
         try:
-            output = self.get_juju_output('create-backup')
+            # merge_stderr is required for creating a backup
+            output = self.get_juju_output('create-backup', merge_stderr=True)
         except subprocess.CalledProcessError as e:
             log.info(e.output)
             raise
@@ -1710,11 +1711,10 @@ class ModelClient:
     def restore_backup(self, backup_file):
         self.juju(
             'restore-backup',
-            ('-b', '--constraints', 'mem=2G', '--file', backup_file))
+            ('--file', backup_file))
 
     def restore_backup_async(self, backup_file):
-        return self.juju_async('restore-backup', ('-b', '--constraints',
-                                                  'mem=2G', '--file', backup_file))
+        return self.juju_async('restore-backup', ('--file', backup_file))
 
     def enable_ha(self):
         self.juju(

--- a/acceptancetests/jujupy/exceptions.py
+++ b/acceptancetests/jujupy/exceptions.py
@@ -28,6 +28,9 @@ class StatusTimeout(Exception):
 class ControllersTimeout(Exception):
     """Raised when 'juju show-controller' timed out."""
 
+class BackupTimeout(Exception):
+    """Raised when 'juju create-backup' timed out."""
+
 class SoftDeadlineExceeded(Exception):
     """Raised when an overall client operation takes too long."""
 

--- a/acceptancetests/jujupy/exceptions.py
+++ b/acceptancetests/jujupy/exceptions.py
@@ -28,9 +28,6 @@ class StatusTimeout(Exception):
 class ControllersTimeout(Exception):
     """Raised when 'juju show-controller' timed out."""
 
-class BackupTimeout(Exception):
-    """Raised when 'juju create-backup' timed out."""
-
 class SoftDeadlineExceeded(Exception):
     """Raised when an overall client operation takes too long."""
 

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -2687,7 +2687,7 @@ class TestModelClient(ClientTest):
             client.restore_backup('quxx')
         gjo_mock.assert_called_once_with(
             'restore-backup',
-            ('-b', '--constraints', 'mem=2G', '--file', 'quxx'))
+            ('--file', 'quxx'))
 
     def test_restore_backup_async(self):
         env = JujuData('qux')
@@ -2695,7 +2695,7 @@ class TestModelClient(ClientTest):
         with patch.object(client, 'juju_async') as gjo_mock:
             result = client.restore_backup_async('quxx')
         gjo_mock.assert_called_once_with('restore-backup', (
-            '-b', '--constraints', 'mem=2G', '--file', 'quxx'))
+           '--file', 'quxx'))
         self.assertIs(gjo_mock.return_value, result)
 
     def test_enable_ha(self):


### PR DESCRIPTION
## Description of change

The following changes update to the new backup and restore commands.
The removal of `-b` and the invalid `-constraint` flags.
