### PR TITLE
If SetSupportedContainers doesn't change the value, don't write to the db

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -98,6 +98,14 @@ func SetBeforeHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChec
 	return txntesting.SetBeforeHooks(c, newRunnerForHooks(st), fs...)
 }
 
+// SetFailIfTransaction will set a transaction hook that marks the test as an error
+// if there is a transaction run. This is used if you know a given set of operations
+// should *not* trigger database updates.
+func SetFailIfTransaction(c *gc.C, st *State) txntesting.TransactionChecker {
+	EnsureWorkersStarted(st)
+	return txntesting.SetFailIfTransaction(c, newRunnerForHooks(st))
+}
+
 func SetAfterHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
 	EnsureWorkersStarted(st)
 	return txntesting.SetAfterHooks(c, newRunnerForHooks(st), fs...)

--- a/state/machine.go
+++ b/state/machine.go
@@ -1847,6 +1847,20 @@ func isSupportedContainer(container instance.ContainerType, supportedContainers 
 
 // updateSupportedContainers sets the supported containers on this host machine.
 func (m *Machine) updateSupportedContainers(supportedContainers []instance.ContainerType) (err error) {
+	if m.doc.SupportedContainersKnown {
+		if len(m.doc.SupportedContainers) == len(supportedContainers) {
+			equal := true
+			for i := range m.doc.SupportedContainers {
+				if m.doc.SupportedContainers[i] != supportedContainers[i] {
+					equal = false
+					break
+				}
+			}
+			if equal {
+				return nil
+			}
+		}
+	}
 	ops := []txn.Op{
 		{
 			C:      machinesC,

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2253,6 +2253,11 @@ func (s *MachineSuite) TestSupportsNoContainersOverwritesExisting(c *gc.C) {
 	err := machine.SupportsNoContainers()
 	c.Assert(err, jc.ErrorIsNil)
 	assertSupportedContainers(c, machine, []instance.ContainerType{})
+	// Calling it a second time should not invoke a db transaction
+	defer state.SetFailIfTransaction(c, s.State).Check()
+	err = machine.SupportsNoContainers()
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{})
 }
 
 func (s *MachineSuite) TestSetSupportedContainersSingle(c *gc.C) {
@@ -2267,6 +2272,7 @@ func (s *MachineSuite) TestSetSupportedContainersSingle(c *gc.C) {
 func (s *MachineSuite) TestSetSupportedContainersSame(c *gc.C) {
 	machine := s.addMachineWithSupportedContainer(c, instance.LXD)
 
+	defer state.SetFailIfTransaction(c, s.State).Check()
 	err := machine.SetSupportedContainers([]instance.ContainerType{instance.LXD})
 	c.Assert(err, jc.ErrorIsNil)
 	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD})
@@ -2293,6 +2299,11 @@ func (s *MachineSuite) TestSetSupportedContainersMultipleExisting(c *gc.C) {
 	machine := s.addMachineWithSupportedContainer(c, instance.LXD)
 
 	err := machine.SetSupportedContainers([]instance.ContainerType{instance.LXD, instance.KVM})
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD, instance.KVM})
+	// Setting it again will be a no-op
+	defer state.SetFailIfTransaction(c, s.State).Check()
+	err = machine.SetSupportedContainers([]instance.ContainerType{instance.LXD, instance.KVM})
 	c.Assert(err, jc.ErrorIsNil)
 	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD, instance.KVM})
 }


### PR DESCRIPTION
## Description of change

On startup, machine agents call `SetSupportedContainers`. If that doesn't actually change the supported containers, no need to write to the database.

Note the test infrastructure requires https://github.com/juju/txn/pull/49

## QA steps

You can use:
```
$ juju bootstrap lxd lxd
$ juju add-machine
$ juju model-config -m controller logging-config='<root>=INFO;juju.state.txn=TRACE'
# restart machine-0 in either the model or the controller, see what txns are run
```
## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812981
