### PR TITLE
add generation data for each model to .local 

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/core/model"
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/keyvalues"
 	"github.com/juju/utils/set"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
@@ -419,7 +419,22 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 	if len(results.ApplicationConfig) > 0 {
 		resultsMap["application-config"] = results.ApplicationConfig
 	}
-	return c.out.Write(ctx, resultsMap)
+
+	err = c.out.Write(ctx, resultsMap)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if featureflag.Enabled(feature.Generations) {
+		gen, err := c.ModelGeneration()
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		ctx.Stdout.Write([]byte(fmt.Sprintf("changes will be targeted to generation: %s\n", gen)))
+	}
+	return nil
+
 }
 
 // validateValues reads the values provided as args and validates that they are

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -431,7 +431,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 			return errors.Trace(err)
 		}
 
-		ctx.Stdout.Write([]byte(fmt.Sprintf("changes will be targeted to generation: %s\n", gen)))
+		ctx.Stdout.Write([]byte(fmt.Sprintf("\nchanges will be targeted to generation: %s\n", gen)))
 	}
 	return nil
 

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -89,15 +89,17 @@ var getTests = []struct {
 					"value":       "ext-host",
 				},
 			},
-			"settings": charmSettings,
+			"settings":                               charmSettings,
+			"changes will be targeted to generation": interface{}(nil),
 		},
 	}, {
 		"dummy-application",
 		false,
 		map[string]interface{}{
-			"application": "dummy-application",
-			"charm":       "dummy",
-			"settings":    charmSettings,
+			"application":                            "dummy-application",
+			"charm":                                  "dummy",
+			"settings":                               charmSettings,
+			"changes will be targeted to generation": interface{}(nil),
 		},
 	},
 }
@@ -160,6 +162,7 @@ func (s *configCommandSuite) TestGetCommandInitWithGeneration(c *gc.C) {
 }
 
 func (s *configCommandSuite) TestGetConfig(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
 	for _, t := range getTests {
 		if !t.useAppConfig {
 			s.fake.appValues = nil

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -546,7 +546,11 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if err := store.UpdateModel(
 			c.controllerName,
 			c.hostedModelName,
-			jujuclient.ModelDetails{ModelUUID: hostedModelUUID.String(), ModelType: model.IAAS},
+			jujuclient.ModelDetails{
+				ModelUUID:       hostedModelUUID.String(),
+				ModelType:       model.IAAS,
+				ModelGeneration: model.GenerationCurrent,
+			},
 		); err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -543,14 +543,17 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 
 		// Set the current model to the initial hosted model.
+		modelDetails := jujuclient.ModelDetails{
+			ModelUUID: hostedModelUUID.String(),
+			ModelType: model.IAAS,
+		}
+		if featureflag.Enabled(feature.Generations) {
+			modelDetails.ModelGeneration = model.GenerationCurrent
+		}
 		if err := store.UpdateModel(
 			c.controllerName,
 			c.hostedModelName,
-			jujuclient.ModelDetails{
-				ModelUUID:       hostedModelUUID.String(),
-				ModelType:       model.IAAS,
-				ModelGeneration: model.GenerationCurrent,
-			},
+			modelDetails,
 		); err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
@@ -247,8 +248,9 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 
 	if modelOwner == accountDetails.User {
 		if err := store.UpdateModel(controllerName, c.Name, jujuclient.ModelDetails{
-			ModelUUID: model.UUID,
-			ModelType: model.Type,
+			ModelUUID:       model.UUID,
+			ModelType:       model.Type,
+			ModelGeneration: coremodel.GenerationCurrent, // This is the default generation.
 		}); err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
@@ -27,6 +28,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -246,12 +248,15 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	messageFormat := "Added '%s' model"
 	messageArgs := []interface{}{c.Name}
 
+	details := jujuclient.ModelDetails{
+		ModelUUID: model.UUID,
+		ModelType: model.Type,
+	}
+	if featureflag.Enabled(feature.Generations) {
+		details.ModelGeneration = coremodel.GenerationCurrent // This is the default generation.
+	}
 	if modelOwner == accountDetails.User {
-		if err := store.UpdateModel(controllerName, c.Name, jujuclient.ModelDetails{
-			ModelUUID:       model.UUID,
-			ModelType:       model.Type,
-			ModelGeneration: coremodel.GenerationCurrent, // This is the default generation.
-		}); err != nil {
+		if err := store.UpdateModel(controllerName, c.Name, details); err != nil {
 			return errors.Trace(err)
 		}
 		if !c.noSwitch {

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -200,7 +200,10 @@ func (s *AddModelSuite) TestAddExistingName(c *gc.C) {
 	details, err := s.store.ModelByName("test-master", "bob/test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{
-		ModelUUID: "fake-model-uuid", ModelType: model.IAAS})
+		ModelUUID:       "fake-model-uuid",
+		ModelType:       model.IAAS,
+		ModelGeneration: model.GenerationCurrent,
+	})
 }
 
 func (s *AddModelSuite) TestAddModelUnauthorizedMentionsJujuGrant(c *gc.C) {
@@ -560,7 +563,11 @@ func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
 
 	m, err := s.store.ModelByName(controllerName, modelName)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, jc.DeepEquals, &jujuclient.ModelDetails{ModelUUID: "fake-model-uuid", ModelType: model.IAAS})
+	c.Assert(m, jc.DeepEquals, &jujuclient.ModelDetails{
+		ModelUUID:       "fake-model-uuid",
+		ModelType:       model.IAAS,
+		ModelGeneration: model.GenerationCurrent,
+	})
 }
 
 func (s *AddModelSuite) TestNoSwitch(c *gc.C) {
@@ -579,7 +586,11 @@ func (s *AddModelSuite) TestNoSwitch(c *gc.C) {
 	checkNoModelSelected()
 	m, err := s.store.ModelByName(controllerName, "bob/test")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m, jc.DeepEquals, &jujuclient.ModelDetails{ModelUUID: "fake-model-uuid", ModelType: model.IAAS})
+	c.Assert(m, jc.DeepEquals, &jujuclient.ModelDetails{
+		ModelUUID:       "fake-model-uuid",
+		ModelType:       model.IAAS,
+		ModelGeneration: model.GenerationCurrent,
+	})
 }
 
 func (s *AddModelSuite) TestNoEnvCacheOtherUser(c *gc.C) {

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -185,6 +185,7 @@ func (s *AddModelSuite) TestInit(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestAddExistingName(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
 	// If there's any model details existing, we just overwrite them. The
 	// controller will error out if the model already exists. Overwriting
 	// means we'll replace any stale details from an previously existing
@@ -552,6 +553,7 @@ func (s *AddModelSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
 	const controllerName = "test-master"
 
 	_, err := s.run(c, "test")
@@ -572,6 +574,7 @@ func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestNoSwitch(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
 	const controllerName = "test-master"
 	checkNoModelSelected := func() {
 		_, err := s.store.CurrentModel(controllerName)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/model/addgeneration.go
+++ b/cmd/juju/model/addgeneration.go
@@ -98,7 +98,7 @@ func (c *addGenerationCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	modelName, modelDetails, err := c.ModelCommandBase.ModelDetails()
+	_, modelDetails, err := c.ModelCommandBase.ModelDetails()
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}
@@ -110,13 +110,7 @@ func (c *addGenerationCommand) Run(ctx *cmd.Context) error {
 
 	// Now update the model store with the 'next' generation for this
 	// model.
-	ctrlName, err := c.ControllerName()
-	if err != nil {
-		return err
-	}
-	store := c.ClientStore()
-	modelDetails.ModelGeneration = model.GenerationNext
-	if err = store.UpdateModel(ctrlName, modelName, *modelDetails); err != nil {
+	if err = c.SetModelGeneration(model.GenerationNext); err != nil {
 		return err
 	}
 

--- a/cmd/juju/model/addgeneration_test.go
+++ b/cmd/juju/model/addgeneration_test.go
@@ -4,21 +4,17 @@
 package model_test
 
 import (
-	"os"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/juju/model/mocks"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
@@ -32,10 +28,7 @@ var _ = gc.Suite(&AddGenerationSuite{})
 
 func (s *AddGenerationSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Generations); err != nil {
-		panic(err)
-	}
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	s.SetFeatureFlags(feature.Generations)
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
@@ -43,8 +36,9 @@ func (s *AddGenerationSuite) SetUpTest(c *gc.C) {
 		User: "admin",
 	}
 	err := s.store.UpdateModel("testing", "admin/mymodel", jujuclient.ModelDetails{
-		ModelUUID: testing.ModelTag.Id(),
-		ModelType: coremodel.IAAS,
+		ModelUUID:       testing.ModelTag.Id(),
+		ModelType:       coremodel.IAAS,
+		ModelGeneration: coremodel.GenerationCurrent,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.store.Models["testing"].CurrentModel = "admin/mymodel"
@@ -86,6 +80,11 @@ func (s *AddGenerationSuite) TestRunCommand(c *gc.C) {
 	ctx, err := s.runCommand(c, mockAddGenerationCommandAPI)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "target generation set to next\n")
+
+	// ensure the model's store has been updated to 'next'.
+	details, err := s.store.ModelByName(s.store.CurrentControllerName, s.store.Models[s.store.CurrentControllerName].CurrentModel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.ModelGeneration, gc.Equals, coremodel.GenerationNext)
 }
 
 func (s *AddGenerationSuite) TestRunCommandFail(c *gc.C) {

--- a/cmd/juju/model/advancegeneration.go
+++ b/cmd/juju/model/advancegeneration.go
@@ -110,7 +110,7 @@ func (c *advanceGenerationCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	modelName, modelDetails, err := c.ModelDetails()
+	_, modelDetails, err := c.ModelDetails()
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}
@@ -122,13 +122,7 @@ func (c *advanceGenerationCommand) Run(ctx *cmd.Context) error {
 
 	// Now update the model store with the 'current' generation for this
 	// model.
-	ctrlName, err := c.ControllerName()
-	if err != nil {
-		return err
-	}
-	store := c.ClientStore()
-	modelDetails.ModelGeneration = model.GenerationCurrent
-	if err = store.UpdateModel(ctrlName, modelName, *modelDetails); err != nil {
+	if err = c.SetModelGeneration(model.GenerationCurrent); err != nil {
 		return err
 	}
 

--- a/cmd/juju/model/advancegeneration.go
+++ b/cmd/juju/model/advancegeneration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/modelgeneration"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 )
 
 const (
@@ -109,11 +110,27 @@ func (c *advanceGenerationCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	_, modelDetails, err := c.ModelCommandBase.ModelDetails()
+	modelName, modelDetails, err := c.ModelDetails()
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}
 
 	modelTag := names.NewModelTag(modelDetails.ModelUUID)
-	return client.AdvanceGeneration(modelTag, c.entities)
+	if err := client.AdvanceGeneration(modelTag, c.entities); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Now update the model store with the 'current' generation for this
+	// model.
+	ctrlName, err := c.ControllerName()
+	if err != nil {
+		return err
+	}
+	store := c.ClientStore()
+	modelDetails.ModelGeneration = model.GenerationCurrent
+	if err = store.UpdateModel(ctrlName, modelName, *modelDetails); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/juju/model/cancelgeneration.go
+++ b/cmd/juju/model/cancelgeneration.go
@@ -105,7 +105,7 @@ func (c *cancelGenerationCommand) Run(ctx *cmd.Context) error {
 	if err = client.CancelGeneration(modelTag); err != nil {
 		return err
 	}
-	
+
 	// Now update the model store with the 'current' generation for this
 	// model.
 	modelName, modelDetails, err := c.ModelDetails()

--- a/cmd/juju/model/cancelgeneration.go
+++ b/cmd/juju/model/cancelgeneration.go
@@ -108,17 +108,7 @@ func (c *cancelGenerationCommand) Run(ctx *cmd.Context) error {
 
 	// Now update the model store with the 'current' generation for this
 	// model.
-	modelName, modelDetails, err := c.ModelDetails()
-	if err != nil {
-		return errors.Annotate(err, "getting model details")
-	}
-	ctrlName, err := c.ControllerName()
-	if err != nil {
-		return err
-	}
-	store := c.ClientStore()
-	modelDetails.ModelGeneration = model.GenerationCurrent
-	if err = store.UpdateModel(ctrlName, modelName, *modelDetails); err != nil {
+	if err = c.SetModelGeneration(model.GenerationCurrent); err != nil {
 		return err
 	}
 

--- a/cmd/juju/model/cancelgeneration_test.go
+++ b/cmd/juju/model/cancelgeneration_test.go
@@ -4,21 +4,17 @@
 package model_test
 
 import (
-	"os"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/juju/model/mocks"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
@@ -32,10 +28,7 @@ var _ = gc.Suite(&cancelGenerationSuite{})
 
 func (s *cancelGenerationSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Generations); err != nil {
-		panic(err)
-	}
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	s.SetFeatureFlags(feature.Generations)
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
@@ -43,8 +36,9 @@ func (s *cancelGenerationSuite) SetUpTest(c *gc.C) {
 		User: "admin",
 	}
 	err := s.store.UpdateModel("testing", "admin/mymodel", jujuclient.ModelDetails{
-		ModelUUID: testing.ModelTag.Id(),
-		ModelType: coremodel.IAAS,
+		ModelUUID:       testing.ModelTag.Id(),
+		ModelType:       coremodel.IAAS,
+		ModelGeneration: coremodel.GenerationCurrent,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.store.Models["testing"].CurrentModel = "admin/mymodel"
@@ -86,6 +80,11 @@ func (s *cancelGenerationSuite) TestRunCommand(c *gc.C) {
 	ctx, err := s.runCommand(c, mockCancelGenerationCommandAPI)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "remaining incomplete changes dropped and target generation set to current\n")
+
+	// ensure the model's store has been updated to 'current'.
+	details, err := s.store.ModelByName(s.store.CurrentControllerName, s.store.Models[s.store.CurrentControllerName].CurrentModel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.ModelGeneration, gc.Equals, coremodel.GenerationCurrent)
 }
 
 func (s *cancelGenerationSuite) TestRunCommandFail(c *gc.C) {

--- a/cmd/juju/model/switchgeneration.go
+++ b/cmd/juju/model/switchgeneration.go
@@ -106,7 +106,7 @@ func (c *switchGenerationCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	modelName, modelDetails, err := c.ModelDetails()
+	_, modelDetails, err := c.ModelDetails()
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}
@@ -118,13 +118,7 @@ func (c *switchGenerationCommand) Run(ctx *cmd.Context) error {
 
 	// Now update the model store with the generation switched to for this
 	// model.
-	ctrlName, err := c.ControllerName()
-	if err != nil {
-		return err
-	}
-	store := c.ClientStore()
-	modelDetails.ModelGeneration = model.GenerationVersion(c.generation)
-	if err = store.UpdateModel(ctrlName, modelName, *modelDetails); err != nil {
+	if err = c.SetModelGeneration(model.GenerationVersion(c.generation)); err != nil {
 		return err
 	}
 

--- a/cmd/juju/model/switchgeneration.go
+++ b/cmd/juju/model/switchgeneration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/modelgeneration"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 )
 
 const (
@@ -105,13 +106,25 @@ func (c *switchGenerationCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	_, modelDetails, err := c.ModelCommandBase.ModelDetails()
+	modelName, modelDetails, err := c.ModelDetails()
 	if err != nil {
 		return errors.Annotate(err, "getting model details")
 	}
 
 	modelTag := names.NewModelTag(modelDetails.ModelUUID)
 	if err = client.SwitchGeneration(modelTag, c.generation); err != nil {
+		return err
+	}
+
+	// Now update the model store with the generation switched to for this
+	// model.
+	ctrlName, err := c.ControllerName()
+	if err != nil {
+		return err
+	}
+	store := c.ClientStore()
+	modelDetails.ModelGeneration = model.GenerationVersion(c.generation)
+	if err = store.UpdateModel(ctrlName, modelName, *modelDetails); err != nil {
 		return err
 	}
 

--- a/cmd/juju/model/switchgeneration_test.go
+++ b/cmd/juju/model/switchgeneration_test.go
@@ -4,21 +4,17 @@
 package model_test
 
 import (
-	"os"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/juju/model/mocks"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
 )
@@ -32,10 +28,7 @@ var _ = gc.Suite(&switchGenerationSuite{})
 
 func (s *switchGenerationSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Generations); err != nil {
-		panic(err)
-	}
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	s.SetFeatureFlags(feature.Generations)
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
@@ -43,8 +36,9 @@ func (s *switchGenerationSuite) SetUpTest(c *gc.C) {
 		User: "admin",
 	}
 	err := s.store.UpdateModel("testing", "admin/mymodel", jujuclient.ModelDetails{
-		ModelUUID: testing.ModelTag.Id(),
-		ModelType: coremodel.IAAS,
+		ModelUUID:       testing.ModelTag.Id(),
+		ModelType:       coremodel.IAAS,
+		ModelGeneration: coremodel.GenerationCurrent,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.store.Models["testing"].CurrentModel = "admin/mymodel"
@@ -91,6 +85,11 @@ func (s *switchGenerationSuite) TestRunCommandCurrent(c *gc.C) {
 	ctx, err := s.runCommand(c, mockSwitchGenerationCommandAPI, "current")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "target generation set to current\n")
+
+	// ensure the model's store has been updated to 'current'.
+	details, err := s.store.ModelByName(s.store.CurrentControllerName, s.store.Models[s.store.CurrentControllerName].CurrentModel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.ModelGeneration, gc.Equals, coremodel.GenerationCurrent)
 }
 
 func (s *switchGenerationSuite) TestRunCommandNext(c *gc.C) {
@@ -102,6 +101,11 @@ func (s *switchGenerationSuite) TestRunCommandNext(c *gc.C) {
 	ctx, err := s.runCommand(c, mockSwitchGenerationCommandAPI, "next")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "target generation set to next\n")
+
+	// ensure the model's store has been updated to 'next'.
+	details, err := s.store.ModelByName(s.store.CurrentControllerName, s.store.Models[s.store.CurrentControllerName].CurrentModel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.ModelGeneration, gc.Equals, coremodel.GenerationNext)
 }
 
 func (s *switchGenerationSuite) TestRunCommandFail(c *gc.C) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -232,12 +232,12 @@ func (c *ModelCommandBase) ModelType() (model.ModelType, error) {
 	return c._modelType, nil
 }
 
-// ModelType implements the ModelCommand interface.
+// ModelGeneration implements the ModelCommand interface.
 func (c *ModelCommandBase) ModelGeneration() (model.GenerationVersion, error) {
 	if c._modelGeneration != "" {
 		return c._modelGeneration, nil
 	}
-	// If we need to look up the model type, we need to ensure we
+	// If we need to look up the model generation, we need to ensure we
 	// have access to the model details.
 	if err := c.maybeInitModel(); err != nil {
 		return "", errors.Trace(err)
@@ -253,9 +253,6 @@ func (c *ModelCommandBase) ModelGeneration() (model.GenerationVersion, error) {
 		}
 	}
 	c._modelGeneration = details.ModelGeneration
-	if c._modelGeneration != "" {
-		return model.GenerationCurrent, nil
-	}
 	return c._modelGeneration, nil
 }
 

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -234,7 +234,7 @@ func (c *ModelCommandBase) ModelType() (model.ModelType, error) {
 
 // ModelType implements the ModelCommand interface.
 func (c *ModelCommandBase) ModelGeneration() (model.GenerationVersion, error) {
-	if c._modelType != "" {
+	if c._modelGeneration != "" {
 		return c._modelGeneration, nil
 	}
 	// If we need to look up the model type, we need to ensure we
@@ -253,6 +253,9 @@ func (c *ModelCommandBase) ModelGeneration() (model.GenerationVersion, error) {
 		}
 	}
 	c._modelGeneration = details.ModelGeneration
+	if c._modelGeneration != "" {
+		return model.GenerationCurrent, nil
+	}
 	return c._modelGeneration, nil
 }
 

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -68,7 +68,11 @@ type ModelCommand interface {
 	// ModelType returns the type of the model.
 	ModelType() (model.ModelType, error)
 
-	// ModelGeneration return the generation of the model.
+	// ModelGeneration sets the model generation for this command and updates
+	// the store.
+	SetModelGeneration(model.GenerationVersion) error
+
+	// ModelGeneration returns the generation of the model.
 	ModelGeneration() (model.GenerationVersion, error)
 
 	// ControllerName returns the name of the controller that contains
@@ -230,6 +234,20 @@ func (c *ModelCommandBase) ModelType() (model.ModelType, error) {
 	}
 	c._modelType = details.ModelType
 	return c._modelType, nil
+}
+
+// SetModelGeneration implements the ModelCommand interface.
+func (c *ModelCommandBase) SetModelGeneration(generation model.GenerationVersion) error {
+	_, modelDetails, err := c.ModelDetails()
+	if err != nil {
+		return errors.Annotate(err, "getting model details")
+	}
+	modelDetails.ModelGeneration = generation
+	if err = c.store.UpdateModel(c._controllerName, c._modelName, *modelDetails); err != nil {
+		return err
+	}
+	c._modelGeneration = generation
+	return nil
 }
 
 // ModelGeneration implements the ModelCommand interface.

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -68,6 +68,9 @@ type ModelCommand interface {
 	// ModelType returns the type of the model.
 	ModelType() (model.ModelType, error)
 
+	// ModelGeneration return the generation of the model.
+	ModelGeneration() (model.GenerationVersion, error)
+
 	// ControllerName returns the name of the controller that contains
 	// the model returned by ModelName().
 	ControllerName() (string, error)
@@ -87,14 +90,15 @@ type ModelCommandBase struct {
 	// about controllers, models, etc.
 	store jujuclient.ClientStore
 
-	// _modelName, _modelType, and _controllerName hold the current
-	// model and controller names and model type. They are only valid
-	// after maybeInitModel is called, and should in general
-	// not be accessed directly, but through ModelName and
-	// ControllerName respectively.
-	_modelName      string
-	_modelType      model.ModelType
-	_controllerName string
+	// _modelName, _modelType, _modelGeneration and _controllerName hold the
+	// current model and controller names, model type and generation. They
+	// are only valid after maybeInitModel is called, and should in general
+	// not be accessed directly, but through ModelName and ControllerName
+	// respectively.
+	_modelName       string
+	_modelType       model.ModelType
+	_modelGeneration model.GenerationVersion
+	_controllerName  string
 
 	allowDefaultModel bool
 
@@ -226,6 +230,30 @@ func (c *ModelCommandBase) ModelType() (model.ModelType, error) {
 	}
 	c._modelType = details.ModelType
 	return c._modelType, nil
+}
+
+// ModelType implements the ModelCommand interface.
+func (c *ModelCommandBase) ModelGeneration() (model.GenerationVersion, error) {
+	if c._modelType != "" {
+		return c._modelGeneration, nil
+	}
+	// If we need to look up the model type, we need to ensure we
+	// have access to the model details.
+	if err := c.maybeInitModel(); err != nil {
+		return "", errors.Trace(err)
+	}
+	details, err := c.store.ModelByName(c._controllerName, c._modelName)
+	if err != nil {
+		if !c.runStarted {
+			return "", errors.Trace(err)
+		}
+		details, err = c.modelDetails(c._controllerName, c._modelName)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+	c._modelGeneration = details.ModelGeneration
+	return c._modelGeneration, nil
 }
 
 // ControllerName implements the ModelCommand interface.

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -174,6 +174,11 @@ func (s *ModelCommandSuite) TestModelGeneration(c *gc.C) {
 	modelGeneration, err := cmd.ModelGeneration()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelGeneration, gc.Equals, model.GenerationNext)
+
+	c.Assert(cmd.SetModelGeneration(model.GenerationCurrent), jc.ErrorIsNil)
+	modelGeneration, err = cmd.ModelGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(modelGeneration, gc.Equals, model.GenerationCurrent)
 }
 
 func (s *ModelCommandSuite) TestBootstrapContext(c *gc.C) {

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -157,6 +157,25 @@ func (s *ModelCommandSuite) TestModelType(c *gc.C) {
 	c.Assert(modelType, gc.Equals, model.IAAS)
 }
 
+func (s *ModelCommandSuite) TestModelGeneration(c *gc.C) {
+	s.store.Controllers["foo"] = jujuclient.ControllerDetails{}
+	s.store.CurrentControllerName = "foo"
+	s.store.Accounts["foo"] = jujuclient.AccountDetails{
+		User: "bar", Password: "hunter2",
+	}
+	err := s.store.UpdateModel("foo", "adminfoo/currentfoo",
+		jujuclient.ModelDetails{ModelUUID: "uuidfoo1", ModelType: model.IAAS, ModelGeneration: model.GenerationNext})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.SetCurrentModel("foo", "adminfoo/currentfoo")
+	c.Assert(err, jc.ErrorIsNil)
+
+	cmd, err := runTestCommand(c, s.store)
+	c.Assert(err, jc.ErrorIsNil)
+	modelGeneration, err := cmd.ModelGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(modelGeneration, gc.Equals, model.GenerationNext)
+}
+
 func (s *ModelCommandSuite) TestBootstrapContext(c *gc.C) {
 	ctx := modelcmd.BootstrapContext(&cmd.Context{})
 	c.Assert(ctx.ShouldVerifyCredentials(), jc.IsTrue)

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -16,3 +16,7 @@ const (
 	// selectively to units added to the generation.
 	GenerationNext GenerationVersion = "next"
 )
+
+func (g GenerationVersion) String() string {
+	return string(g)
+}

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -5,6 +5,7 @@ package bootstrap
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/caas"
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/permission"
 )
@@ -223,7 +225,9 @@ func prepare(
 	details.Password = args.AdminSecret
 	details.LastKnownAccess = string(permission.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
-	details.ModelGeneration = model.GenerationCurrent
+	if featureflag.Enabled(feature.Generations) {
+		details.ModelGeneration = model.GenerationCurrent
+	}
 	details.ControllerDetails.Cloud = args.Cloud.Name
 	details.ControllerDetails.CloudRegion = args.Cloud.Region
 	details.BootstrapConfig.CloudType = args.Cloud.Type

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -223,6 +223,7 @@ func prepare(
 	details.Password = args.AdminSecret
 	details.LastKnownAccess = string(permission.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
+	details.ModelGeneration = model.GenerationCurrent
 	details.ControllerDetails.Cloud = args.Cloud.Name
 	details.ControllerDetails.CloudRegion = args.Cloud.Region
 	details.BootstrapConfig.CloudType = args.Cloud.Type

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -609,6 +609,13 @@ func (s *store) SetModels(controllerName string, models map[string]ModelDetails)
 			if ok && details == oldDetails {
 				continue
 			}
+			if details.ModelGeneration.String() == "" {
+				if oldDetails.ModelGeneration.String() != "" {
+					details.ModelGeneration = oldDetails.ModelGeneration
+				} else {
+					details.ModelGeneration = model.GenerationCurrent
+				}
+			}
 			storedModels.Models[modelName] = details
 			changed = true
 		}

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -72,6 +72,9 @@ type ModelDetails struct {
 
 	// ModelType is the type of model.
 	ModelType model.ModelType `yaml:"type"`
+
+	// ModelGeneration is the generation of the model.
+	ModelGeneration model.GenerationVersion `yaml:"generation"`
 }
 
 // AccountDetails holds details of an account.

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 )
 
@@ -45,8 +47,10 @@ func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	if err := addModelType(models); err != nil {
 		return nil, err
 	}
-	if err := addGeneration(models); err != nil {
-		return nil, err
+	if featureflag.Enabled(feature.Generations) {
+		if err := addGeneration(models); err != nil {
+			return nil, err
+		}
 	}
 	return models, nil
 }

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -57,7 +57,7 @@ func addGeneration(models map[string]*ControllerModels) error {
 	changes := false
 	for _, cm := range models {
 		for name, m := range cm.Models {
-			if m.ModelType == "" {
+			if m.ModelGeneration == "" {
 				changes = true
 				m.ModelGeneration = model.GenerationCurrent
 				cm.Models[name] = m

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -45,7 +45,29 @@ func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	if err := addModelType(models); err != nil {
 		return nil, err
 	}
+	if err := addGeneration(models); err != nil {
+		return nil, err
+	}
 	return models, nil
+}
+
+// addGeneration add missing generation version data if necessary.
+// Default to 'current'.
+func addGeneration(models map[string]*ControllerModels) error {
+	changes := false
+	for _, cm := range models {
+		for name, m := range cm.Models {
+			if m.ModelType == "" {
+				changes = true
+				m.ModelGeneration = model.GenerationCurrent
+				cm.Models[name] = m
+			}
+		}
+	}
+	if changes {
+		return WriteModelsFile(models)
+	}
+	return nil
 }
 
 // addModelType adds missing model type data if necessary.

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -105,7 +105,7 @@ func (s *ModelsSuite) TestSetCurrentModel(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestUpdateModelNewController(c *gc.C) {
-	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS}
+	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
 	err := s.store.UpdateModel("new-controller", "admin/new-model", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := s.store.AllModels("new-controller")
@@ -116,7 +116,7 @@ func (s *ModelsSuite) TestUpdateModelNewController(c *gc.C) {
 }
 
 func (s *ModelsSuite) TestUpdateModelExistingControllerAndModelNewModel(c *gc.C) {
-	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS}
+	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
 	err := s.store.UpdateModel("kontroll", "admin/new-model", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := s.store.AllModels("kontroll")
@@ -129,7 +129,7 @@ func (s *ModelsSuite) TestUpdateModelExistingControllerAndModelNewModel(c *gc.C)
 }
 
 func (s *ModelsSuite) TestUpdateModelOverwrites(c *gc.C) {
-	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS}
+	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
 	for i := 0; i < 2; i++ {
 		// Twice so we exercise the code path of updating with
 		// identical details.
@@ -158,7 +158,7 @@ controllers:
 `[1:]), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS}
+	testModelDetails := jujuclient.ModelDetails{ModelUUID: "test.uuid", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
 	err = s.store.UpdateModel("ctrl", "admin/admin", testModelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := s.store.AllModels("ctrl")

--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing"
@@ -98,6 +99,7 @@ func (s *ModelsFileSuite) TestReadEmptyFile(c *gc.C) {
 }
 
 func (s *ModelsFileSuite) TestMigrateLegacyLocal(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
 	err := ioutil.WriteFile(jujuclient.JujuModelsPath(), []byte(testLegacyModelsYAML), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -28,14 +28,17 @@ controllers:
       admin/admin:
         uuid: ghi
         type: iaas
+        generation: current
   kontroll:
     models:
       admin/admin:
         uuid: abc
         type: iaas
+        generation: current
       admin/my-model:
         uuid: def
         type: iaas
+        generation: current
     current-model: admin/my-model
 `
 
@@ -69,9 +72,9 @@ var testControllerModels = map[string]*jujuclient.ControllerModels{
 	},
 }
 
-var kontrollAdminModelDetails = jujuclient.ModelDetails{ModelUUID: "abc", ModelType: model.IAAS}
-var kontrollMyModelModelDetails = jujuclient.ModelDetails{ModelUUID: "def", ModelType: model.IAAS}
-var ctrlAdminModelDetails = jujuclient.ModelDetails{ModelUUID: "ghi", ModelType: model.IAAS}
+var kontrollAdminModelDetails = jujuclient.ModelDetails{ModelUUID: "abc", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
+var kontrollMyModelModelDetails = jujuclient.ModelDetails{ModelUUID: "def", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
+var ctrlAdminModelDetails = jujuclient.ModelDetails{ModelUUID: "ghi", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
 
 func (s *ModelsFileSuite) TestWriteFile(c *gc.C) {
 	writeTestModelsFile(c)

--- a/jujuclient/setmodels_test.go
+++ b/jujuclient/setmodels_test.go
@@ -116,7 +116,7 @@ func (s *SetModelsSuite) TestSetModelsAddUpdateDeleteCombination(c *gc.C) {
 		"admin/update-model": detailsToUpdate,
 	}
 	after := map[string]jujuclient.ModelDetails{
-		"admin/new-model":    {ModelUUID: "test.model.uuid", ModelType: model.IAAS},
+		"admin/new-model":    {ModelUUID: "test.model.uuid", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent},
 		"admin/update-model": detailsToUpdate,
 	}
 
@@ -150,7 +150,7 @@ func (s *SetModelsSuite) TestSetModelsControllerIsolated(c *gc.C) {
 	err := s.store.AddController("another-kontroller", s.controller)
 	c.Assert(err, jc.ErrorIsNil)
 	otherModels := map[string]jujuclient.ModelDetails{
-		"admin/foreign-model": {ModelUUID: "test.foreign.model.uuid", ModelType: model.IAAS},
+		"admin/foreign-model": {ModelUUID: "test.foreign.model.uuid", ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent},
 	}
 	err = s.store.SetModels("another-kontroller", otherModels)
 	c.Assert(err, jc.ErrorIsNil)
@@ -170,7 +170,7 @@ func (s *SetModelsSuite) assertSetModels(c *gc.C, models map[string]jujuclient.M
 }
 
 func (s *SetModelsSuite) assertUpdateModel(c *gc.C, modelName, modelUUID string) jujuclient.ModelDetails {
-	modelDetails := jujuclient.ModelDetails{ModelUUID: modelUUID, ModelType: model.IAAS}
+	modelDetails := jujuclient.ModelDetails{ModelUUID: modelUUID, ModelType: model.IAAS, ModelGeneration: model.GenerationCurrent}
 	err := s.store.UpdateModel(s.controllerName, modelName, modelDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	return modelDetails


### PR DESCRIPTION
## Description of change

Keep track of the model's generation per user in .local.  The generation commands will update it appropriately.  The ModelGeneration() can be used by all commands using ModelCommandBase to get the current-model generation. 

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=generations
2. juju bootstrap localhost
3. check ~/.local/share/juju/models.yaml, generation for each model should be 'current'.
3. juju add-model one
3.  check ~/.local/share/juju/models.yaml, generation for model 'one' should be 'current'.
5. juju add-generation
3.  check ~/.local/share/juju/models.yaml, generation for model 'one' should be 'next'.
4. juju switch-generation current
3.  check ~/.local/share/juju/models.yaml, generation for model 'one' should be 'current'.
4. juju switch-generation next
3.  check ~/.local/share/juju/models.yaml, generation for model 'one' should be 'next'.
5. juju cancel-generation
3.  check ~/.local/share/juju/models.yaml, generation for model 'one' should be 'current'.
3. juju deploy percona-cluster mysql
3. juju add-generation
3.  check ~/.local/share/juju/models.yaml, generation for model 'one' should be 'next'.
3. juju config mysql  <- should end with note that changes will be to next generation.

## Documentation changes

In the future.