### PR TITLE
New Command: show-application, first cut.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -881,8 +881,8 @@ func validateApplicationScale(scale, scaleChange int) error {
 
 // ApplicationsInfo retrieves applications information.
 func (c *Client) ApplicationsInfo(applications []names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
-	if c.BestAPIVersion() < 9 {
-		return nil, errors.NotSupportedf("ApplicationsInfo not supported by this version of Juju")
+	if apiVersion := c.BestAPIVersion(); apiVersion < 9 {
+		return nil, errors.NotSupportedf("ApplicationsInfo for Application facade v%v", apiVersion)
 	}
 	all := make([]params.Entity, len(applications))
 	for i, one := range applications {

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -64,7 +64,6 @@ func (c *Client) ModelUUID() string {
 
 // DeployArgs holds the arguments to be sent to Client.ApplicationDeploy.
 type DeployArgs struct {
-
 	// CharmID identifies the charm to deploy.
 	CharmID charmstore.CharmID
 
@@ -878,4 +877,25 @@ func validateApplicationScale(scale, scaleChange int) error {
 		return errors.NotValidf("requesting both scale and scale-change")
 	}
 	return nil
+}
+
+// ApplicationsInfo retrieves applications information.
+func (c *Client) ApplicationsInfo(applications []names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+	if c.BestAPIVersion() < 9 {
+		return nil, errors.NotSupportedf("ApplicationsInfo not supported by this version of Juju")
+	}
+	all := make([]params.Entity, len(applications))
+	for i, one := range applications {
+		all[i] = params.Entity{Tag: one.String()}
+	}
+	in := params.Entities{all}
+	var out params.ApplicationInfoResults
+	err := c.facade.FacadeCall("ApplicationsInfo", in, &out)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if resultsLen := len(out.Results); resultsLen != len(applications) {
+		return nil, errors.Errorf("expected %d results, got %d", len(applications), resultsLen)
+	}
+	return out.Results, nil
 }

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1301,7 +1301,7 @@ func (s *applicationSuite) TestApplicationsInfoPriorV9(c *gc.C) {
 	)
 	client := application.NewClient(apiCaller)
 	_, err := client.ApplicationsInfo(nil)
-	c.Assert(err, gc.ErrorMatches, "ApplicationsInfo not supported by this version of Juju not supported")
+	c.Assert(err, gc.ErrorMatches, "ApplicationsInfo for Application facade v0 not supported")
 	c.Assert(called, jc.IsFalse)
 }
 

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/application"
 	basetesting "github.com/juju/juju/api/base/testing"
@@ -1287,4 +1288,131 @@ func (s *applicationSuite) TestScaleApplicationCallError(c *gc.C) {
 		Scale:           5,
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *applicationSuite) TestApplicationsInfoPriorV9(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "ApplicationsInfo")
+			return nil
+		},
+	)
+	client := application.NewClient(apiCaller)
+	_, err := client.ApplicationsInfo(nil)
+	c.Assert(err, gc.ErrorMatches, "ApplicationsInfo not supported by this version of Juju not supported")
+	c.Assert(called, jc.IsFalse)
+}
+
+func apiForApplicationsInfo(f basetesting.APICallerFunc) basetesting.BestVersionCaller {
+	return basetesting.BestVersionCaller{
+		BestVersion:   9,
+		APICallerFunc: f,
+	}
+}
+
+func (s *applicationSuite) TestApplicationsInfoCallError(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "ApplicationsInfo")
+			return errors.New("boom")
+		},
+	)
+
+	client := application.NewClient(apiForApplicationsInfo(apiCaller))
+	_, err := client.ApplicationsInfo(nil)
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *applicationSuite) TestApplicationsInfo(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "ApplicationsInfo")
+			args, ok := a.(params.Entities)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(args, jc.DeepEquals, params.Entities{
+				Entities: []params.Entity{
+					{Tag: "application-foo"},
+					{Tag: "application-bar"},
+				}})
+
+			result, ok := response.(*params.ApplicationInfoResults)
+			c.Assert(ok, jc.IsTrue)
+			result.Results = []params.ApplicationInfoResult{
+				{Error: &params.Error{Message: "boom"}},
+				{Result: &params.ApplicationInfo{
+					Tag:       "application-bar",
+					Charm:     "charm-bar",
+					Series:    "bionic",
+					Channel:   "development",
+					Principal: true,
+					EndpointBindings: map[string]string{
+						"juju-info": "myspace",
+					},
+					Remote: true,
+				},
+				},
+			}
+			return nil
+		},
+	)
+
+	client := application.NewClient(apiForApplicationsInfo(apiCaller))
+	results, err := client.ApplicationsInfo(
+		[]names.ApplicationTag{
+			names.NewApplicationTag("foo"),
+			names.NewApplicationTag("bar"),
+		},
+	)
+	c.Check(called, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, []params.ApplicationInfoResult{
+		{Error: &params.Error{Message: "boom"}},
+		{Result: &params.ApplicationInfo{
+			Tag:       "application-bar",
+			Charm:     "charm-bar",
+			Series:    "bionic",
+			Channel:   "development",
+			Principal: true,
+			EndpointBindings: map[string]string{
+				"juju-info": "myspace",
+			},
+			Remote: true,
+		}},
+	})
+}
+
+func (s *applicationSuite) TestApplicationsInfoResultMismatch(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "ApplicationsInfo")
+
+			result, ok := response.(*params.ApplicationInfoResults)
+			c.Assert(ok, jc.IsTrue)
+			result.Results = []params.ApplicationInfoResult{
+				{Error: &params.Error{Message: "boom"}},
+				{Error: &params.Error{Message: "boom again"}},
+				{Result: &params.ApplicationInfo{Tag: "application-bar"}},
+			}
+			return nil
+		},
+	)
+
+	client := application.NewClient(apiForApplicationsInfo(apiCaller))
+	_, err := client.ApplicationsInfo(
+		[]names.ApplicationTag{
+			names.NewApplicationTag("foo"),
+			names.NewApplicationTag("bar"),
+		},
+	)
+	c.Check(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 3")
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  8,
+	"Application":                  9,
 	"ApplicationOffers":            2,
 	"ApplicationScaler":            1,
 	"Backups":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -145,6 +145,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 6, application.NewFacadeV6)
 	reg("Application", 7, application.NewFacadeV7)
 	reg("Application", 8, application.NewFacadeV8)
+	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -49,7 +49,7 @@ type applicationSuite struct {
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.APIv8
+	applicationAPI *application.APIv9
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 }
@@ -86,7 +86,7 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv8 {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
 	storageAccess, err := application.GetStorageState(s.State)
@@ -109,7 +109,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv8 {
 		common.NewResources(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return &application.APIv8{api}
+	return &application.APIv9{api}
 }
 
 func (s *applicationSuite) TestGetConfig(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -60,16 +60,22 @@ type BlockChecker interface {
 type Application interface {
 	AddUnit(state.AddUnitParams) (Unit, error)
 	AllUnits() ([]Unit, error)
+	ApplicationConfig() (application.ConfigAttributes, error)
 	Charm() (Charm, bool, error)
 	CharmURL() (*charm.URL, bool)
+	ChangeScale(int) (int, error)
 	Channel() csparams.Channel
 	ClearExposed() error
 	CharmConfig() (charm.Settings, error)
 	Constraints() (constraints.Value, error)
 	Destroy() error
 	DestroyOperation() *state.DestroyApplicationOperation
+	EndpointBindings() (map[string]string, error)
 	Endpoints() ([]state.Endpoint, error)
+	IsExposed() bool
 	IsPrincipal() bool
+	IsRemote() bool
+	Scale(int) error
 	Series() string
 	SetCharm(state.SetCharmConfig) error
 	SetConstraints(constraints.Value) error
@@ -79,10 +85,7 @@ type Application interface {
 	SetMinUnits(int) error
 	UpdateApplicationSeries(string, bool) error
 	UpdateCharmConfig(charm.Settings) error
-	ApplicationConfig() (application.ConfigAttributes, error)
 	UpdateApplicationConfig(application.ConfigAttributes, []string, environschema.Fields, schema.Defaults) error
-	Scale(int) error
-	ChangeScale(int) (int, error)
 }
 
 // Charm defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -15,6 +15,6 @@ func GetState(st *state.State) Backend {
 	return stateShim{st}
 }
 
-func SetModelType(api *APIv8, modelType state.ModelType) {
+func SetModelType(api *APIv9, modelType state.ModelType) {
 	api.modelType = modelType
 }

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -29,7 +29,7 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	applicationAPI *application.APIv8
+	applicationAPI *application.APIv9
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -59,12 +59,12 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		common.NewResources(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.applicationAPI = &application.APIv8{api}
+	s.applicationAPI = &application.APIv9{api}
 }
 
 func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{s.applicationAPI}}}}
+	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}}
 	results, err := v4.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -84,7 +84,7 @@ func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 
 func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v5 := &application.APIv5{&application.APIv6{&application.APIv7{s.applicationAPI}}}
+	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}
 	results, err := v5.Get(params.ApplicationGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -198,7 +198,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 		common.NewResources(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	apiV8 := &application.APIv8{api}
+	apiV8 := &application.APIv8{&application.APIv9{api}}
 
 	results, err := apiV8.Get(params.ApplicationGet{"dashboard4miner"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -1,0 +1,381 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+import (
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/devices"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/storage"
+)
+
+// ApplicationsDeploy holds the parameters for deploying one or more applications.
+type ApplicationsDeploy struct {
+	Applications []ApplicationDeploy `json:"applications"`
+}
+
+// ApplicationDeploy holds the parameters for making the application Deploy call.
+type ApplicationDeploy struct {
+	ApplicationName  string                         `json:"application"`
+	Series           string                         `json:"series"`
+	CharmURL         string                         `json:"charm-url"`
+	Channel          string                         `json:"channel"`
+	NumUnits         int                            `json:"num-units"`
+	Config           map[string]string              `json:"config,omitempty"`
+	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Constraints      constraints.Value              `json:"constraints"`
+	Placement        []*instance.Placement          `json:"placement,omitempty"`
+	Policy           string                         `json:"policy,omitempty"`
+	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	Devices          map[string]devices.Constraints `json:"devices,omitempty"`
+	AttachStorage    []string                       `json:"attach-storage,omitempty"`
+	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
+	Resources        map[string]string              `json:"resources,omitempty"`
+}
+
+// ApplicationsDeployV5 holds the parameters for deploying one or more applications.
+type ApplicationsDeployV5 struct {
+	Applications []ApplicationDeployV5 `json:"applications"`
+}
+
+// ApplicationDeployV5 holds the parameters for making the application Deploy call for
+// application facades older than v6. Missing the newer Policy arg.
+type ApplicationDeployV5 struct {
+	ApplicationName  string                         `json:"application"`
+	Series           string                         `json:"series"`
+	CharmURL         string                         `json:"charm-url"`
+	Channel          string                         `json:"channel"`
+	NumUnits         int                            `json:"num-units"`
+	Config           map[string]string              `json:"config,omitempty"`
+	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Constraints      constraints.Value              `json:"constraints"`
+	Placement        []*instance.Placement          `json:"placement,omitempty"`
+	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	AttachStorage    []string                       `json:"attach-storage,omitempty"`
+	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
+	Resources        map[string]string              `json:"resources,omitempty"`
+}
+
+// ApplicationsDeployV6 holds the parameters for deploying one or more applications.
+type ApplicationsDeployV6 struct {
+	Applications []ApplicationDeployV6 `json:"applications"`
+}
+
+// ApplicationDeployV6 holds the parameters for making the application Deploy call for
+// application facades older than v6. Missing the newer Device arg.
+type ApplicationDeployV6 struct {
+	ApplicationName  string                         `json:"application"`
+	Series           string                         `json:"series"`
+	CharmURL         string                         `json:"charm-url"`
+	Channel          string                         `json:"channel"`
+	NumUnits         int                            `json:"num-units"`
+	Config           map[string]string              `json:"config,omitempty"`
+	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Constraints      constraints.Value              `json:"constraints"`
+	Placement        []*instance.Placement          `json:"placement,omitempty"`
+	Policy           string                         `json:"policy,omitempty"`
+	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	AttachStorage    []string                       `json:"attach-storage,omitempty"`
+	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
+	Resources        map[string]string              `json:"resources,omitempty"`
+}
+
+// ApplicationUpdate holds the parameters for making the application Update call.
+type ApplicationUpdate struct {
+	ApplicationName string             `json:"application"`
+	CharmURL        string             `json:"charm-url"`
+	ForceCharmURL   bool               `json:"force-charm-url"`
+	ForceSeries     bool               `json:"force-series"`
+	Force           bool               `json:"force"`
+	MinUnits        *int               `json:"min-units,omitempty"`
+	SettingsStrings map[string]string  `json:"settings,omitempty"`
+	SettingsYAML    string             `json:"settings-yaml"` // Takes precedence over SettingsStrings if both are present.
+	Constraints     *constraints.Value `json:"constraints,omitempty"`
+}
+
+// ApplicationSetCharm sets the charm for a given application.
+type ApplicationSetCharm struct {
+	// ApplicationName is the name of the application to set the charm on.
+	ApplicationName string `json:"application"`
+
+	// CharmURL is the new url for the charm.
+	CharmURL string `json:"charm-url"`
+
+	// Channel is the charm store channel from which the charm came.
+	Channel string `json:"channel"`
+
+	// ConfigSettings is the charm settings to set during the upgrade.
+	// This field is only understood by Application facade version 2
+	// and greater.
+	ConfigSettings map[string]string `json:"config-settings,omitempty"`
+
+	// ConfigSettingsYAML is the charm settings in YAML format to set
+	// during the upgrade. If this is non-empty, it will take precedence
+	// over ConfigSettings. This field is only understood by Application
+	// facade version 2
+	ConfigSettingsYAML string `json:"config-settings-yaml,omitempty"`
+
+	// Force forces the lxd profile validation overriding even if it's fails.
+	Force bool `json:"force"`
+
+	// ForceUnits forces the upgrade on units in an error state.
+	ForceUnits bool `json:"force-units"`
+
+	// ForceSeries forces the use of the charm even if it doesn't match the
+	// series of the unit.
+	ForceSeries bool `json:"force-series"`
+
+	// ResourceIDs is a map of resource names to resource IDs to activate during
+	// the upgrade.
+	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
+
+	// StorageConstraints is a map of storage names to storage constraints to
+	// update during the upgrade. This field is only understood by Application
+	// facade version 2 and greater.
+	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
+}
+
+// ApplicationExpose holds the parameters for making the application Expose call.
+type ApplicationExpose struct {
+	ApplicationName string `json:"application"`
+}
+
+// ApplicationSet holds the parameters for an application Set
+// command. Options contains the configuration data.
+type ApplicationSet struct {
+	ApplicationName string            `json:"application"`
+	Options         map[string]string `json:"options"`
+}
+
+// ApplicationUnset holds the parameters for an application Unset
+// command. Options contains the option attribute names
+// to unset.
+type ApplicationUnset struct {
+	ApplicationName string   `json:"application"`
+	Options         []string `json:"options"`
+}
+
+// ApplicationGet holds parameters for making the Get or
+// GetCharmURL calls.
+type ApplicationGet struct {
+	ApplicationName string `json:"application"`
+}
+
+// ApplicationGetResults holds results of the application Get call.
+type ApplicationGetResults struct {
+	Application       string                 `json:"application"`
+	Charm             string                 `json:"charm"`
+	CharmConfig       map[string]interface{} `json:"config"`
+	ApplicationConfig map[string]interface{} `json:"application-config,omitempty"`
+	Constraints       constraints.Value      `json:"constraints"`
+	Series            string                 `json:"series"`
+	Channel           string                 `json:"channel"`
+}
+
+// ApplicationConfigSetArgs holds the parameters for
+// setting application config values for specified applications.
+type ApplicationConfigSetArgs struct {
+	Args []ApplicationConfigSet
+}
+
+// ApplicationConfigSet holds the parameters for an application
+// config set command.
+type ApplicationConfigSet struct {
+	ApplicationName string            `json:"application"`
+	Config          map[string]string `json:"config"`
+}
+
+// ApplicationConfigUnsetArgs holds the parameters for
+// resetting application config values for specified applications.
+type ApplicationConfigUnsetArgs struct {
+	Args []ApplicationUnset
+}
+
+// ApplicationCharmRelations holds parameters for making the application CharmRelations call.
+type ApplicationCharmRelations struct {
+	ApplicationName string `json:"application"`
+}
+
+// ApplicationCharmRelationsResults holds the results of the application CharmRelations call.
+type ApplicationCharmRelationsResults struct {
+	CharmRelations []string `json:"charm-relations"`
+}
+
+// ApplicationUnexpose holds parameters for the application Unexpose call.
+type ApplicationUnexpose struct {
+	ApplicationName string `json:"application"`
+}
+
+// ApplicationMetricCredential holds parameters for the SetApplicationCredentials call.
+type ApplicationMetricCredential struct {
+	ApplicationName   string `json:"application"`
+	MetricCredentials []byte `json:"metrics-credentials"`
+}
+
+// ApplicationMetricCredentials holds multiple ApplicationMetricCredential parameters.
+type ApplicationMetricCredentials struct {
+	Creds []ApplicationMetricCredential `json:"creds"`
+}
+
+// ApplicationGetConfigResults holds the return values for application GetConfig.
+type ApplicationGetConfigResults struct {
+	Results []ConfigResult
+}
+
+// UpdateApplicationServiceArgs holds the parameters for
+// updating application services.
+type UpdateApplicationServiceArgs struct {
+	Args []UpdateApplicationServiceArg `json:"args"`
+}
+
+// UpdateApplicationServiceArg holds parameters used to update
+// an application's service definition for the cloud.
+type UpdateApplicationServiceArg struct {
+	ApplicationTag string    `json:"application-tag"`
+	ProviderId     string    `json:"provider-id"`
+	Addresses      []Address `json:"addresses"`
+}
+
+// ApplicationDestroy holds the parameters for making the deprecated
+// Application.Destroy call.
+type ApplicationDestroy struct {
+	ApplicationName string `json:"application"`
+}
+
+// DestroyApplicationsParams holds bulk parameters for the
+// Application.DestroyApplication call.
+type DestroyApplicationsParams struct {
+	Applications []DestroyApplicationParams `json:"applications"`
+}
+
+// DestroyApplicationParams holds parameters for the
+// Application.DestroyApplication call.
+type DestroyApplicationParams struct {
+	// ApplicationTag holds the tag of the application to destroy.
+	ApplicationTag string `json:"application-tag"`
+
+	// DestroyStorage controls whether or not storage attached to
+	// units of the application should be destroyed.
+	DestroyStorage bool `json:"destroy-storage,omitempty"`
+}
+
+// DestroyConsumedApplicationsParams holds bulk parameters for the
+// Application.DestroyConsumedApplication call.
+type DestroyConsumedApplicationsParams struct {
+	Applications []DestroyConsumedApplicationParams `json:"applications"`
+}
+
+// DestroyConsumedApplicationParams holds the parameters for the
+// RemoteApplication.Destroy call.
+type DestroyConsumedApplicationParams struct {
+	ApplicationTag string `json:"application-tag"`
+}
+
+// GetApplicationConstraints stores parameters for making the GetApplicationConstraints call.
+type GetApplicationConstraints struct {
+	ApplicationName string `json:"application"`
+}
+
+// ApplicationGetConstraintsResults holds the multiple return values for GetConstraints call.
+type ApplicationGetConstraintsResults struct {
+	Results []ApplicationConstraint `json:"results"`
+}
+
+// ApplicationConstraint holds the constraints value for a single application, or
+// an error for trying to get it.
+type ApplicationConstraint struct {
+	Constraints constraints.Value `json:"constraints"`
+	Error       *Error            `json:"error,omitempty"`
+}
+
+// DestroyApplicationResults contains the results of a DestroyApplication
+// API request.
+type DestroyApplicationResults struct {
+	Results []DestroyApplicationResult `json:"results,omitempty"`
+}
+
+// DestroyApplicationResult contains one of the results of a
+// DestroyApplication API request.
+type DestroyApplicationResult struct {
+	Error *Error                  `json:"error,omitempty"`
+	Info  *DestroyApplicationInfo `json:"info,omitempty"`
+}
+
+// DestroyApplicationInfo contains information related to the removal of
+// an application.
+type DestroyApplicationInfo struct {
+	// DetachedStorage is the tags of storage instances that will be
+	// detached from the application's units, and will remain in the
+	// model after the units are removed.
+	DetachedStorage []Entity `json:"detached-storage,omitempty"`
+
+	// DestroyedStorage is the tags of storage instances that will be
+	// destroyed as a result of destroying the application.
+	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
+
+	// DestroyedUnits is the tags of units that will be destroyed
+	// as a result of destroying the application.
+	DestroyedUnits []Entity `json:"destroyed-units,omitempty"`
+}
+
+// ScaleApplicationsParams holds bulk parameters for the Application.ScaleApplication call.
+type ScaleApplicationsParams struct {
+	Applications []ScaleApplicationParams `json:"applications"`
+}
+
+// ScaleApplicationParams holds parameters for the Application.ScaleApplication call.
+type ScaleApplicationParams struct {
+	// ApplicationTag holds the tag of the application to scale.
+	ApplicationTag string `json:"application-tag"`
+
+	// Scale is the number of units which should be running.
+	Scale int `json:"scale"`
+
+	// Scale is the number of units which should be added/removed from the existing count.
+	ScaleChange int `json:"scale-change,omitempty"`
+}
+
+// ScaleApplicationResults contains the results of a ScaleApplication
+// API request.
+type ScaleApplicationResults struct {
+	Results []ScaleApplicationResult `json:"results,omitempty"`
+}
+
+// ScaleApplicationResult contains one of the results of a
+// ScaleApplication API request.
+type ScaleApplicationResult struct {
+	Error *Error                `json:"error,omitempty"`
+	Info  *ScaleApplicationInfo `json:"info,omitempty"`
+}
+
+// ScaleApplicationInfo contains information related to the scaling of
+// an application.
+type ScaleApplicationInfo struct {
+	// Scale is the number of units which should be running.
+	Scale int `json:"num-units"`
+}
+
+// ApplicationInfo holds an application info.
+type ApplicationInfo struct {
+	Tag              string            `json:"tag"`
+	Charm            string            `json:"charm,omitempty"`
+	Series           string            `json:"series,omitempty"`
+	Channel          string            `json:"channel,omitempty"`
+	Constraints      constraints.Value `json:"constraints,omitempty"`
+	Principal        bool              `json:"principal"`
+	Exposed          bool              `json:"exposed"`
+	Remote           bool              `json:"remote"`
+	EndpointBindings map[string]string `json:"endpoint-bindings,omitempty"`
+}
+
+// ApplicationInfoResults holds an application info result or a retrieval error.
+type ApplicationInfoResult struct {
+	Result *ApplicationInfo `json:"result,omitempty"`
+	Error  *Error           `json:"error,omitempty"`
+}
+
+// ApplicationInfoResults holds applications associated with entities.
+type ApplicationInfoResults struct {
+	Results []ApplicationInfoResult `json:"results"`
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/network"
@@ -249,90 +248,6 @@ type DestroyMachinesParams struct {
 	Keep        bool     `json:"keep,omitempty"`
 }
 
-// ApplicationsDeploy holds the parameters for deploying one or more applications.
-type ApplicationsDeploy struct {
-	Applications []ApplicationDeploy `json:"applications"`
-}
-
-// ApplicationDeploy holds the parameters for making the application Deploy call.
-type ApplicationDeploy struct {
-	ApplicationName  string                         `json:"application"`
-	Series           string                         `json:"series"`
-	CharmURL         string                         `json:"charm-url"`
-	Channel          string                         `json:"channel"`
-	NumUnits         int                            `json:"num-units"`
-	Config           map[string]string              `json:"config,omitempty"`
-	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
-	Constraints      constraints.Value              `json:"constraints"`
-	Placement        []*instance.Placement          `json:"placement,omitempty"`
-	Policy           string                         `json:"policy,omitempty"`
-	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
-	Devices          map[string]devices.Constraints `json:"devices,omitempty"`
-	AttachStorage    []string                       `json:"attach-storage,omitempty"`
-	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
-	Resources        map[string]string              `json:"resources,omitempty"`
-}
-
-// ApplicationsDeployV5 holds the parameters for deploying one or more applications.
-type ApplicationsDeployV5 struct {
-	Applications []ApplicationDeployV5 `json:"applications"`
-}
-
-// ApplicationDeployV5 holds the parameters for making the application Deploy call for
-// application facades older than v6. Missing the newer Policy arg.
-type ApplicationDeployV5 struct {
-	ApplicationName  string                         `json:"application"`
-	Series           string                         `json:"series"`
-	CharmURL         string                         `json:"charm-url"`
-	Channel          string                         `json:"channel"`
-	NumUnits         int                            `json:"num-units"`
-	Config           map[string]string              `json:"config,omitempty"`
-	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
-	Constraints      constraints.Value              `json:"constraints"`
-	Placement        []*instance.Placement          `json:"placement,omitempty"`
-	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
-	AttachStorage    []string                       `json:"attach-storage,omitempty"`
-	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
-	Resources        map[string]string              `json:"resources,omitempty"`
-}
-
-// ApplicationsDeployV6 holds the parameters for deploying one or more applications.
-type ApplicationsDeployV6 struct {
-	Applications []ApplicationDeployV6 `json:"applications"`
-}
-
-// ApplicationDeployV6 holds the parameters for making the application Deploy call for
-// application facades older than v6. Missing the newer Device arg.
-type ApplicationDeployV6 struct {
-	ApplicationName  string                         `json:"application"`
-	Series           string                         `json:"series"`
-	CharmURL         string                         `json:"charm-url"`
-	Channel          string                         `json:"channel"`
-	NumUnits         int                            `json:"num-units"`
-	Config           map[string]string              `json:"config,omitempty"`
-	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
-	Constraints      constraints.Value              `json:"constraints"`
-	Placement        []*instance.Placement          `json:"placement,omitempty"`
-	Policy           string                         `json:"policy,omitempty"`
-	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
-	AttachStorage    []string                       `json:"attach-storage,omitempty"`
-	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
-	Resources        map[string]string              `json:"resources,omitempty"`
-}
-
-// ApplicationUpdate holds the parameters for making the application Update call.
-type ApplicationUpdate struct {
-	ApplicationName string             `json:"application"`
-	CharmURL        string             `json:"charm-url"`
-	ForceCharmURL   bool               `json:"force-charm-url"`
-	ForceSeries     bool               `json:"force-series"`
-	Force           bool               `json:"force"`
-	MinUnits        *int               `json:"min-units,omitempty"`
-	SettingsStrings map[string]string  `json:"settings,omitempty"`
-	SettingsYAML    string             `json:"settings-yaml"` // Takes precedence over SettingsStrings if both are present.
-	Constraints     *constraints.Value `json:"constraints,omitempty"`
-}
-
 // UpdateSeriesArg holds the parameters for updating the series for the
 // specified application or machine. For Application, only known by facade
 // version 5 and greater. For MachineManger, only known by facade version
@@ -349,135 +264,6 @@ type UpdateSeriesArg struct {
 // version 4 or greater.
 type UpdateSeriesArgs struct {
 	Args []UpdateSeriesArg `json:"args"`
-}
-
-// ApplicationSetCharm sets the charm for a given application.
-type ApplicationSetCharm struct {
-	// ApplicationName is the name of the application to set the charm on.
-	ApplicationName string `json:"application"`
-
-	// CharmURL is the new url for the charm.
-	CharmURL string `json:"charm-url"`
-
-	// Channel is the charm store channel from which the charm came.
-	Channel string `json:"channel"`
-
-	// ConfigSettings is the charm settings to set during the upgrade.
-	// This field is only understood by Application facade version 2
-	// and greater.
-	ConfigSettings map[string]string `json:"config-settings,omitempty"`
-
-	// ConfigSettingsYAML is the charm settings in YAML format to set
-	// during the upgrade. If this is non-empty, it will take precedence
-	// over ConfigSettings. This field is only understood by Application
-	// facade version 2
-	ConfigSettingsYAML string `json:"config-settings-yaml,omitempty"`
-
-	// Force forces the lxd profile validation overriding even if it's fails.
-	Force bool `json:"force"`
-
-	// ForceUnits forces the upgrade on units in an error state.
-	ForceUnits bool `json:"force-units"`
-
-	// ForceSeries forces the use of the charm even if it doesn't match the
-	// series of the unit.
-	ForceSeries bool `json:"force-series"`
-
-	// ResourceIDs is a map of resource names to resource IDs to activate during
-	// the upgrade.
-	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
-
-	// StorageConstraints is a map of storage names to storage constraints to
-	// update during the upgrade. This field is only understood by Application
-	// facade version 2 and greater.
-	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
-}
-
-// ApplicationExpose holds the parameters for making the application Expose call.
-type ApplicationExpose struct {
-	ApplicationName string `json:"application"`
-}
-
-// ApplicationSet holds the parameters for an application Set
-// command. Options contains the configuration data.
-type ApplicationSet struct {
-	ApplicationName string            `json:"application"`
-	Options         map[string]string `json:"options"`
-}
-
-// ApplicationUnset holds the parameters for an application Unset
-// command. Options contains the option attribute names
-// to unset.
-type ApplicationUnset struct {
-	ApplicationName string   `json:"application"`
-	Options         []string `json:"options"`
-}
-
-// ApplicationGet holds parameters for making the Get or
-// GetCharmURL calls.
-type ApplicationGet struct {
-	ApplicationName string `json:"application"`
-}
-
-// ApplicationGetResults holds results of the application Get call.
-type ApplicationGetResults struct {
-	Application       string                 `json:"application"`
-	Charm             string                 `json:"charm"`
-	CharmConfig       map[string]interface{} `json:"config"`
-	ApplicationConfig map[string]interface{} `json:"application-config,omitempty"`
-	Constraints       constraints.Value      `json:"constraints"`
-	Series            string                 `json:"series"`
-	Channel           string                 `json:"channel"`
-}
-
-// ApplicationConfigSetArgs holds the parameters for
-// setting application config values for specified applications.
-type ApplicationConfigSetArgs struct {
-	Args []ApplicationConfigSet
-}
-
-// ApplicationConfigSet holds the parameters for an application
-// config set command.
-type ApplicationConfigSet struct {
-	ApplicationName string            `json:"application"`
-	Config          map[string]string `json:"config"`
-}
-
-// ApplicationConfigUnsetArgs holds the parameters for
-// resetting application config values for specified applications.
-type ApplicationConfigUnsetArgs struct {
-	Args []ApplicationUnset
-}
-
-// ApplicationCharmRelations holds parameters for making the application CharmRelations call.
-type ApplicationCharmRelations struct {
-	ApplicationName string `json:"application"`
-}
-
-// ApplicationCharmRelationsResults holds the results of the application CharmRelations call.
-type ApplicationCharmRelationsResults struct {
-	CharmRelations []string `json:"charm-relations"`
-}
-
-// ApplicationUnexpose holds parameters for the application Unexpose call.
-type ApplicationUnexpose struct {
-	ApplicationName string `json:"application"`
-}
-
-// ApplicationMetricCredential holds parameters for the SetApplicationCredentials call.
-type ApplicationMetricCredential struct {
-	ApplicationName   string `json:"application"`
-	MetricCredentials []byte `json:"metrics-credentials"`
-}
-
-// ApplicationMetricCredentials holds multiple ApplicationMetricCredential parameters.
-type ApplicationMetricCredentials struct {
-	Creds []ApplicationMetricCredential `json:"creds"`
-}
-
-// ApplicationGetConfigResults holds the return values for application GetConfig.
-type ApplicationGetConfigResults struct {
-	Results []ConfigResult
 }
 
 // LXDProfileUpgrade holds the parameters for an application
@@ -603,20 +389,6 @@ type ApplicationUnitParams struct {
 	Data           map[string]interface{}     `json:"data,omitempty"`
 }
 
-// UpdateApplicationServiceArgs holds the parameters for
-// updating application services.
-type UpdateApplicationServiceArgs struct {
-	Args []UpdateApplicationServiceArg `json:"args"`
-}
-
-// UpdateApplicationServiceArg holds parameters used to update
-// an application's service definition for the cloud.
-type UpdateApplicationServiceArg struct {
-	ApplicationTag string    `json:"application-tag"`
-	ProviderId     string    `json:"provider-id"`
-	Addresses      []Address `json:"addresses"`
-}
-
 // DestroyApplicationUnits holds parameters for the deprecated
 // Application.DestroyUnits call.
 type DestroyApplicationUnits struct {
@@ -636,41 +408,6 @@ type DestroyUnitParams struct {
 	// DestroyStorage controls whether or not storage
 	// attached to the unit should be destroyed.
 	DestroyStorage bool `json:"destroy-storage,omitempty"`
-}
-
-// ApplicationDestroy holds the parameters for making the deprecated
-// Application.Destroy call.
-type ApplicationDestroy struct {
-	ApplicationName string `json:"application"`
-}
-
-// DestroyApplicationsParams holds bulk parameters for the
-// Application.DestroyApplication call.
-type DestroyApplicationsParams struct {
-	Applications []DestroyApplicationParams `json:"applications"`
-}
-
-// DestroyApplicationParams holds parameters for the
-// Application.DestroyApplication call.
-type DestroyApplicationParams struct {
-	// ApplicationTag holds the tag of the application to destroy.
-	ApplicationTag string `json:"application-tag"`
-
-	// DestroyStorage controls whether or not storage attached to
-	// units of the application should be destroyed.
-	DestroyStorage bool `json:"destroy-storage,omitempty"`
-}
-
-// DestroyConsumedApplicationsParams holds bulk parameters for the
-// Application.DestroyConsumedApplication call.
-type DestroyConsumedApplicationsParams struct {
-	Applications []DestroyConsumedApplicationParams `json:"applications"`
-}
-
-// DestroyConsumedApplicationParams holds the parameters for the
-// RemoteApplication.Destroy call.
-type DestroyConsumedApplicationParams struct {
-	ApplicationTag string `json:"application-tag"`
 }
 
 // Creds holds credentials for identifying an entity.
@@ -719,26 +456,9 @@ type SetAnnotations struct {
 	Pairs map[string]string `json:"annotations"`
 }
 
-// GetApplicationConstraints stores parameters for making the GetApplicationConstraints call.
-type GetApplicationConstraints struct {
-	ApplicationName string `json:"application"`
-}
-
 // GetConstraintsResults holds results of the GetConstraints call.
 type GetConstraintsResults struct {
 	Constraints constraints.Value `json:"constraints"`
-}
-
-// ApplicationGetConstraintsResults holds the multiple return values for GetConstraints call.
-type ApplicationGetConstraintsResults struct {
-	Results []ApplicationConstraint `json:"results"`
-}
-
-// ApplicationConstraint holds the constraints value for a single application, or
-// an error for trying to get it.
-type ApplicationConstraint struct {
-	Constraints constraints.Value `json:"constraints"`
-	Error       *Error            `json:"error,omitempty"`
 }
 
 // SetConstraints stores parameters for making the SetConstraints call.
@@ -1248,36 +968,6 @@ type DestroyMachineInfo struct {
 	DestroyedUnits []Entity `json:"destroyed-units,omitempty"`
 }
 
-// DestroyApplicationResults contains the results of a DestroyApplication
-// API request.
-type DestroyApplicationResults struct {
-	Results []DestroyApplicationResult `json:"results,omitempty"`
-}
-
-// DestroyApplicationResult contains one of the results of a
-// DestroyApplication API request.
-type DestroyApplicationResult struct {
-	Error *Error                  `json:"error,omitempty"`
-	Info  *DestroyApplicationInfo `json:"info,omitempty"`
-}
-
-// DestroyApplicationInfo contains information related to the removal of
-// an application.
-type DestroyApplicationInfo struct {
-	// DetachedStorage is the tags of storage instances that will be
-	// detached from the application's units, and will remain in the
-	// model after the units are removed.
-	DetachedStorage []Entity `json:"detached-storage,omitempty"`
-
-	// DestroyedStorage is the tags of storage instances that will be
-	// destroyed as a result of destroying the application.
-	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
-
-	// DestroyedUnits is the tags of units that will be destroyed
-	// as a result of destroying the application.
-	DestroyedUnits []Entity `json:"destroyed-units,omitempty"`
-}
-
 // DestroyUnitResults contains the results of a DestroyUnit API request.
 type DestroyUnitResults struct {
 	Results []DestroyUnitResult `json:"results,omitempty"`
@@ -1301,43 +991,6 @@ type DestroyUnitInfo struct {
 	// DestroyedStorage is the tags of storage instances that will be
 	// destroyed as a result of destroying the unit.
 	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
-}
-
-// ScaleApplicationsParams holds bulk parameters for the Application.ScaleApplication call.
-type ScaleApplicationsParams struct {
-	Applications []ScaleApplicationParams `json:"applications"`
-}
-
-// ScaleApplicationParams holds parameters for the Application.ScaleApplication call.
-type ScaleApplicationParams struct {
-	// ApplicationTag holds the tag of the application to scale.
-	ApplicationTag string `json:"application-tag"`
-
-	// Scale is the number of units which should be running.
-	Scale int `json:"scale"`
-
-	// Scale is the number of units which should be added/removed from the existing count.
-	ScaleChange int `json:"scale-change,omitempty"`
-}
-
-// ScaleApplicationResults contains the results of a ScaleApplication
-// API request.
-type ScaleApplicationResults struct {
-	Results []ScaleApplicationResult `json:"results,omitempty"`
-}
-
-// ScaleApplicationResult contains one of the results of a
-// ScaleApplication API request.
-type ScaleApplicationResult struct {
-	Error *Error                `json:"error,omitempty"`
-	Info  *ScaleApplicationInfo `json:"info,omitempty"`
-}
-
-// ScaleApplicationInfo contains information related to the scaling of
-// an application.
-type ScaleApplicationInfo struct {
-	// Scale is the number of units which should be running.
-	Scale int `json:"num-units"`
 }
 
 // DumpModelRequest wraps the request for a dump-model call.

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -153,3 +153,11 @@ func NewBundleDiffCommandForTest(api base.APICallCloser, charmStore BundleResolv
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
 }
+
+func NewShowCommandForTest(api ApplicationsInfoAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &showApplicationCommand{newAPIFunc: func() (ApplicationsInfoAPI, error) {
+		return api, nil
+	}}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}

--- a/cmd/juju/application/show.go
+++ b/cmd/juju/application/show.go
@@ -1,0 +1,206 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/juju/core/constraints"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+const showApplicationDoc = `
+The command takes deployed application names or aliases as an argument.
+
+The command does an exact search. It does not support wildcards.
+
+Examples:
+    $ juju show-application mysql
+    $ juju show-application mysql wordpress
+
+    $ juju show-application myapplication
+        where "myapplication" is the application name alias, see "juju help deploy" for more information
+
+`
+
+// NewShowApplicationCommand returns a command that displays applications info.
+func NewShowApplicationCommand() cmd.Command {
+	s := &showApplicationCommand{}
+	s.newAPIFunc = func() (ApplicationsInfoAPI, error) {
+		return s.newApplicationAPI()
+	}
+	return modelcmd.Wrap(s)
+}
+
+// showApplicationCommand displays application information.
+type showApplicationCommand struct {
+	modelcmd.ModelCommandBase
+
+	out        cmd.Output
+	apps       []string
+	newAPIFunc func() (ApplicationsInfoAPI, error)
+}
+
+// Info implements Command.Info.
+func (c *showApplicationCommand) Info() *cmd.Info {
+	showCmd := &cmd.Info{
+		Name:    "show-application",
+		Args:    "<application name or alias>",
+		Purpose: "Displays information about an application.",
+		Doc:     showApplicationDoc,
+	}
+	return jujucmd.Info(showCmd)
+}
+
+// Init implements Command.Init.
+func (c *showApplicationCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.Errorf("an application name must be supplied")
+	}
+	c.apps = args
+	var invalid []string
+	for _, one := range c.apps {
+		if !names.IsValidApplication(one) {
+			invalid = append(invalid, one)
+		}
+	}
+	if len(invalid) == 0 {
+		return nil
+	}
+	plural := "s"
+	if len(invalid) == 1 {
+		plural = ""
+	}
+	return errors.NotValidf(`application name%v %v`, plural, strings.Join(invalid, `, `))
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *showApplicationCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
+}
+
+// ApplicationsInfoAPI defines the API methods that show-application command uses.
+type ApplicationsInfoAPI interface {
+	Close() error
+	BestAPIVersion() int
+	ApplicationsInfo([]names.ApplicationTag) ([]params.ApplicationInfoResult, error)
+}
+
+func (c *showApplicationCommand) newApplicationAPI() (ApplicationsInfoAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return application.NewClient(root), nil
+}
+
+func (c *showApplicationCommand) Run(ctx *cmd.Context) error {
+	client, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if v := client.BestAPIVersion(); v < 9 {
+		// old client does not support showing applications.
+		return errors.NotSupportedf("show applications on API server version %v", v)
+	}
+
+	tags, err := c.getApplicationTags()
+	if err != nil {
+		return err
+	}
+
+	results, err := client.ApplicationsInfo(tags)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var errs params.ErrorResults
+	var valid []params.ApplicationInfo
+	for _, result := range results {
+		if result.Error != nil {
+			errs.Results = append(errs.Results, params.ErrorResult{result.Error})
+			continue
+		}
+		valid = append(valid, *result.Result)
+	}
+	if len(errs.Results) > 0 {
+		return errs.Combine()
+	}
+
+	output, err := formatApplicationInfos(valid)
+	if err != nil {
+		return err
+	}
+	return c.out.Write(ctx, output)
+}
+
+func (c *showApplicationCommand) getApplicationTags() ([]names.ApplicationTag, error) {
+	tags := make([]names.ApplicationTag, len(c.apps))
+	for i, one := range c.apps {
+		if !names.IsValidApplication(one) {
+			return nil, errors.Errorf("invalid application name %v", one)
+		}
+		tags[i] = names.NewApplicationTag(one)
+	}
+	return tags, nil
+}
+
+// formatApplicationInfos takes a set of params.ApplicationInfo and
+// creates a mapping from storage ID application name to application info.
+func formatApplicationInfos(all []params.ApplicationInfo) (map[string]ApplicationInfo, error) {
+	if len(all) == 0 {
+		return nil, nil
+	}
+	output := make(map[string]ApplicationInfo)
+	for _, one := range all {
+		tag, info, err := createApplicationInfo(one)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		output[tag.Name] = info
+	}
+	return output, nil
+}
+
+// ApplicationInfo defines the serialization behaviour of the application information.
+type ApplicationInfo struct {
+	Charm            string            `yaml:"charm,omitempty" json:"charm,omitempty"`
+	Series           string            `yaml:"series,omitempty" json:"series,omitempty"`
+	Channel          string            `yaml:"channel,omitempty" json:"channel,omitempty"`
+	Constraints      constraints.Value `yaml:"constraints,omitempty" json:"constraints,omitempty"`
+	Principal        bool              `yaml:"principal" json:"principal"`
+	Exposed          bool              `yaml:"exposed" json:"exposed"`
+	Remote           bool              `yaml:"remote" json:"remote"`
+	EndpointBindings map[string]string `yaml:"endpoint-bindings,omitempty" json:"endpoint-bindings,omitempty"`
+}
+
+func createApplicationInfo(details params.ApplicationInfo) (names.ApplicationTag, ApplicationInfo, error) {
+	tag, err := names.ParseApplicationTag(details.Tag)
+	if err != nil {
+		return names.ApplicationTag{}, ApplicationInfo{}, errors.Trace(err)
+	}
+
+	info := ApplicationInfo{
+		Charm:            details.Charm,
+		Series:           details.Series,
+		Channel:          details.Channel,
+		Constraints:      details.Constraints,
+		Principal:        details.Principal,
+		Exposed:          details.Exposed,
+		Remote:           details.Remote,
+		EndpointBindings: details.EndpointBindings,
+	}
+	return tag, info, nil
+}

--- a/cmd/juju/application/show.go
+++ b/cmd/juju/application/show.go
@@ -4,7 +4,6 @@
 package application
 
 import (
-	"github.com/juju/juju/core/constraints"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/constraints"
 )
 
 const showApplicationDoc = `

--- a/cmd/juju/application/show_test.go
+++ b/cmd/juju/application/show_test.go
@@ -1,0 +1,263 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"fmt"
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/core/constraints"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient"
+	_ "github.com/juju/juju/provider/dummy"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+type ShowSuite struct {
+	jujutesting.FakeJujuXDGDataHomeSuite
+	store *jujuclient.MemStore
+
+	mockAPI *mockShowAPI
+}
+
+var _ = gc.Suite(&ShowSuite{})
+
+func (s *ShowSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	s.store = jujuclient.NewMemStore()
+	s.store.CurrentControllerName = "testing"
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Models["testing"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/controller": {},
+		},
+		CurrentModel: "admin/controller",
+	}
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin",
+	}
+
+	s.mockAPI = &mockShowAPI{
+		version:              9,
+		applicationsInfoFunc: func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) { return nil, nil },
+	}
+}
+
+func (s *ShowSuite) runShow(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, application.NewShowCommandForTest(s.mockAPI, s.store), args...)
+}
+
+type showTest struct {
+	args   []string
+	err    string
+	stdout string
+	stderr string
+}
+
+func (s *ShowSuite) assertRunShow(c *gc.C, t showTest) {
+	context, err := s.runShow(c, t.args...)
+	if t.err == "" {
+		c.Assert(err, jc.ErrorIsNil)
+	} else {
+		c.Assert(err, gc.ErrorMatches, t.err)
+	}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, t.stdout)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, t.stderr)
+}
+
+func (s *ShowSuite) TestShowNoArguments(c *gc.C) {
+	msg := "an application name must be supplied"
+	s.assertRunShow(c, showTest{
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowSuite) TestShowInvalidName(c *gc.C) {
+	msg := "application name so-42-far-not-good not valid"
+	s.assertRunShow(c, showTest{
+		args:   []string{"so-42-far-not-good"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowSuite) TestShowInvalidValidNames(c *gc.C) {
+	msg := "application name so-42-far-not-good not valid"
+	s.assertRunShow(c, showTest{
+		args:   []string{"so-42-far-not-good", "wordpress"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowSuite) TestShowInvalidNames(c *gc.C) {
+	msg := "application names so-42-far-not-good, oo/42 not valid"
+	s.assertRunShow(c, showTest{
+		args:   []string{"so-42-far-not-good", "oo/42"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowSuite) TestShowInvalidAndValidNames(c *gc.C) {
+	msg := "application names so-42-far-not-good, oo/42 not valid"
+	s.assertRunShow(c, showTest{
+		args:   []string{"so-42-far-not-good", "wordpress", "oo/42"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowSuite) TestShowUnsupported(c *gc.C) {
+	s.mockAPI.version = 8
+	s.assertRunShow(c, showTest{
+		args: []string{"wordpress"},
+		err:  "show applications on API server version 8 not supported",
+	})
+}
+
+func (s *ShowSuite) TestShowApiError(c *gc.C) {
+	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+		return []params.ApplicationInfoResult{
+			{Error: &params.Error{Message: "boom"}},
+		}, nil
+	}
+	msg := "boom"
+	s.assertRunShow(c, showTest{
+		args: []string{"wordpress"},
+		err:  fmt.Sprintf("%v", msg),
+	})
+}
+
+func (s *ShowSuite) createTestApplicationInfo(name string, suffix string) *params.ApplicationInfo {
+	app := fmt.Sprintf("%v%v", name, suffix)
+	return &params.ApplicationInfo{
+		Tag:         fmt.Sprintf("application-%v", app),
+		Charm:       fmt.Sprintf("charm-%v", app),
+		Series:      "quantal",
+		Channel:     "development",
+		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
+		Principal:   true,
+		EndpointBindings: map[string]string{
+			"juju-info": "myspace",
+		},
+	}
+}
+
+func (s *ShowSuite) TestShow(c *gc.C) {
+	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+		return []params.ApplicationInfoResult{
+			{Result: s.createTestApplicationInfo("wordpress", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showTest{
+		args: []string{"wordpress"},
+		stdout: `
+wordpress:
+  charm: charm-wordpress
+  series: quantal
+  channel: development
+  constraints:
+    arch: amd64
+    cores: 1
+    mem: 4096
+    root-disk: 8192
+  principal: true
+  exposed: false
+  remote: false
+  endpoint-bindings:
+    juju-info: myspace
+`[1:],
+	})
+}
+func (s *ShowSuite) TestShowJSON(c *gc.C) {
+	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+		return []params.ApplicationInfoResult{
+			{Result: s.createTestApplicationInfo("wordpress", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showTest{
+		args:   []string{"wordpress", "--format", "json"},
+		stdout: "{\"wordpress\":{\"charm\":\"charm-wordpress\",\"series\":\"quantal\",\"channel\":\"development\",\"constraints\":{\"arch\":\"amd64\",\"cores\":1,\"mem\":4096,\"root-disk\":8192},\"principal\":true,\"exposed\":false,\"remote\":false,\"endpoint-bindings\":{\"juju-info\":\"myspace\"}}}\n",
+	})
+}
+
+func (s *ShowSuite) TestShowMix(c *gc.C) {
+	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+		return []params.ApplicationInfoResult{
+			{Result: s.createTestApplicationInfo("wordpress", "")},
+			{Error: &params.Error{Message: "boom"}},
+		}, nil
+	}
+	s.assertRunShow(c, showTest{
+		args: []string{"wordpress", "logging"},
+		err:  "boom",
+	})
+}
+
+func (s *ShowSuite) TestShowMany(c *gc.C) {
+	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+		return []params.ApplicationInfoResult{
+			{Result: s.createTestApplicationInfo("wordpress", "")},
+			{Result: s.createTestApplicationInfo("logging", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showTest{
+		args: []string{"wordpress", "logging"},
+		stdout: `
+logging:
+  charm: charm-logging
+  series: quantal
+  channel: development
+  constraints:
+    arch: amd64
+    cores: 1
+    mem: 4096
+    root-disk: 8192
+  principal: true
+  exposed: false
+  remote: false
+  endpoint-bindings:
+    juju-info: myspace
+wordpress:
+  charm: charm-wordpress
+  series: quantal
+  channel: development
+  constraints:
+    arch: amd64
+    cores: 1
+    mem: 4096
+    root-disk: 8192
+  principal: true
+  exposed: false
+  remote: false
+  endpoint-bindings:
+    juju-info: myspace
+`[1:],
+	})
+}
+
+type mockShowAPI struct {
+	version              int
+	applicationsInfoFunc func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error)
+}
+
+func (s mockShowAPI) Close() error {
+	return nil
+}
+
+func (s mockShowAPI) BestAPIVersion() int {
+	return s.version
+}
+
+func (s mockShowAPI) ApplicationsInfo(tags []names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+	return s.applicationsInfoFunc(tags)
+}

--- a/cmd/juju/application/show_test.go
+++ b/cmd/juju/application/show_test.go
@@ -5,15 +5,16 @@ package application_test
 
 import (
 	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/juju/core/constraints"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
 	jujutesting "github.com/juju/juju/testing"

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -409,6 +409,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewApplicationGetConstraintsCommand())
 	r.Register(application.NewApplicationSetConstraintsCommand())
 	r.Register(application.NewBundleDiffCommand())
+	r.Register(application.NewShowApplicationCommand())
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -559,6 +559,7 @@ var commandNames = []string{
 	"set-wallet",
 	"show-action-output",
 	"show-action-status",
+	"show-application",
 	"show-backup",
 	"show-cloud",
 	"show-controller",

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -1,0 +1,120 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/cmd/juju/application"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type CmdApplicationSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *CmdApplicationSuite) setupApplications(c *gc.C) {
+	s.Factory.MakeSpace(c, &factory.SpaceParams{Name: "vlan2"})
+	// make an application with 2 endpoints
+	application1 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
+			Name:     "wordpress",
+			Revision: "23",
+		}),
+	})
+	endpoint1, err := application1.Endpoint("juju-info")
+	c.Assert(err, jc.ErrorIsNil)
+	endpoint2, err := application1.Endpoint("logging-dir")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// make another application with 2 endpoints
+	application2 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
+			Name:     "logging",
+			Revision: "43",
+		}),
+		CharmConfig:      map[string]interface{}{"foo": "bar"},
+		EndpointBindings: map[string]string{"info": "vlan2"},
+	})
+	endpoint3, err := application2.Endpoint("info")
+	c.Assert(err, jc.ErrorIsNil)
+	endpoint4, err := application2.Endpoint("logging-directory")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// create relation between a1:e1 and a2:e3
+	relation1 := s.Factory.MakeRelation(c, &factory.RelationParams{
+		Endpoints: []state.Endpoint{endpoint1, endpoint3},
+	})
+	c.Assert(relation1, gc.NotNil)
+
+	// create relation between a1:e2 and a2:e4
+	relation2 := s.Factory.MakeRelation(c, &factory.RelationParams{
+		Endpoints: []state.Endpoint{endpoint2, endpoint4},
+	})
+	c.Assert(relation2, gc.NotNil)
+}
+
+func (s *CmdApplicationSuite) TestShowApplicationOne(c *gc.C) {
+	s.setupApplications(c)
+
+	ctx, err := cmdtesting.RunCommand(c, application.NewShowApplicationCommand(), "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	output := cmdtesting.Stdout(ctx)
+	c.Assert(output, gc.Equals, `
+wordpress:
+  charm: wordpress
+  series: quantal
+  principal: true
+  exposed: false
+  remote: false
+  endpoint-bindings:
+    admin-api: ""
+    cache: ""
+    db: ""
+    db-client: ""
+    foo-bar: ""
+    logging-dir: ""
+    monitoring-port: ""
+    url: ""
+`[1:])
+}
+
+func (s *CmdApplicationSuite) TestShowApplicationManyYaml(c *gc.C) {
+	s.setupApplications(c)
+
+	ctx, err := cmdtesting.RunCommand(c, application.NewShowApplicationCommand(), "wordpress", "logging", "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	output := cmdtesting.Stdout(ctx)
+	c.Assert(output, gc.Equals, `
+logging:
+  charm: logging
+  series: quantal
+  principal: false
+  exposed: false
+  remote: false
+  endpoint-bindings:
+    info: vlan2
+    logging-client: ""
+    logging-directory: ""
+wordpress:
+  charm: wordpress
+  series: quantal
+  principal: true
+  exposed: false
+  remote: false
+  endpoint-bindings:
+    admin-api: ""
+    cache: ""
+    db: ""
+    db-client: ""
+    foo-bar: ""
+    logging-dir: ""
+    monitoring-port: ""
+    url: ""
+`[1:])
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -34,6 +34,7 @@ func init() {
 	}
 	// Initialize all suites here.
 	gc.Suite(&annotationsSuite{})
+	gc.Suite(&CmdApplicationSuite{})
 	gc.Suite(&CloudAPISuite{})
 	gc.Suite(&apiEnvironmentSuite{})
 	gc.Suite(&apiLoggerSuite{})


### PR DESCRIPTION
## Description of change

Until recently, Juju had no means of displaying some application-level information, like bindings see bug 1742550.
This command is a central place to get deploy application details and this PR is the first cut for it. 

## QA steps

1. bootstrap
2. deploy an application
2. run 'show-application'

Sample output: https://pastebin.ubuntu.com/p/fczqyHJ2jN/

## Documentation changes

@pmatulis  new command
