### PR TITLE
Application API Client Support for Config with --generation Option

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -162,9 +162,12 @@ func (c *Client) Deploy(args DeployArgs) error {
 
 // GetCharmURL returns the charm URL the given application is
 // running at present.
-func (c *Client) GetCharmURL(applicationName string) (*charm.URL, error) {
+func (c *Client) GetCharmURL(generation model.GenerationVersion, applicationName string) (*charm.URL, error) {
 	result := new(params.StringResult)
-	args := params.ApplicationGet{ApplicationName: applicationName}
+	args := params.ApplicationGet{
+		ApplicationName: applicationName,
+		Generation:      generation,
+	}
 	err := c.facade.FacadeCall("GetCharmURL", args, result)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -293,7 +296,7 @@ type SetCharmConfig struct {
 }
 
 // SetCharm sets the charm for a given application.
-func (c *Client) SetCharm(cfg SetCharmConfig) error {
+func (c *Client) SetCharm(generation model.GenerationVersion, cfg SetCharmConfig) error {
 	var storageConstraints map[string]params.StorageConstraints
 	if len(cfg.StorageConstraints) > 0 {
 		storageConstraints = make(map[string]params.StorageConstraints)
@@ -324,6 +327,7 @@ func (c *Client) SetCharm(cfg SetCharmConfig) error {
 		ForceUnits:         cfg.ForceUnits,
 		ResourceIDs:        cfg.ResourceIDs,
 		StorageConstraints: storageConstraints,
+		Generation:         generation,
 	}
 	return c.facade.FacadeCall("SetCharm", args, nil)
 }
@@ -694,7 +698,10 @@ func (c *Client) Unexpose(application string) error {
 // Get returns the configuration for the named application.
 func (c *Client) Get(generation model.GenerationVersion, application string) (*params.ApplicationGetResults, error) {
 	var results params.ApplicationGetResults
-	args := params.ApplicationGet{ApplicationName: application}
+	args := params.ApplicationGet{
+		ApplicationName: application,
+		Generation:      generation,
+	}
 	err := c.facade.FacadeCall("Get", args, &results)
 	return &results, err
 }

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -44,7 +44,7 @@ func (c *Client) SetMetricCredentials(application string, credentials []byte) er
 	creds := []params.ApplicationMetricCredential{
 		{application, credentials},
 	}
-	p := params.ApplicationMetricCredentials{creds}
+	p := params.ApplicationMetricCredentials{Creds: creds}
 	results := new(params.ErrorResults)
 	err := c.facade.FacadeCall("SetMetricCredentials", p, results)
 	if err != nil {
@@ -203,7 +203,7 @@ func (c *Client) GetConfig(appNames ...string) ([]map[string]interface{}, error)
 	var args params.Entities
 	for _, appName := range appNames {
 		args.Entities = append(args.Entities,
-			params.Entity{names.NewApplicationTag(appName).String()})
+			params.Entity{Tag: names.NewApplicationTag(appName).String()})
 	}
 	err := c.facade.FacadeCall(apiName, args, &results)
 	if err != nil {
@@ -412,8 +412,8 @@ func (c *Client) AddUnits(args AddUnitsParams) ([]string, error) {
 // TODO(axw) 2017-03-16 #1673323
 // Drop this in Juju 3.0.
 func (c *Client) DestroyUnitsDeprecated(unitNames ...string) error {
-	params := params.DestroyApplicationUnits{unitNames}
-	return c.facade.FacadeCall("DestroyUnits", params, nil)
+	args := params.DestroyApplicationUnits{UnitNames: unitNames}
+	return c.facade.FacadeCall("DestroyUnits", args, nil)
 }
 
 // DestroyUnitsParams contains parameters for the DestroyUnits API method.
@@ -487,10 +487,10 @@ func (c *Client) DestroyUnits(in DestroyUnitsParams) ([]params.DestroyUnitResult
 // TODO(axw) 2017-03-16 #1673323
 // Drop this in Juju 3.0.
 func (c *Client) DestroyDeprecated(application string) error {
-	params := params.ApplicationDestroy{
+	args := params.ApplicationDestroy{
 		ApplicationName: application,
 	}
-	return c.facade.FacadeCall("Destroy", params, nil)
+	return c.facade.FacadeCall("Destroy", args, nil)
 }
 
 // DestroyApplicationsParams contains parameters for the DestroyApplications
@@ -637,7 +637,8 @@ func (c *Client) GetConstraints(applications ...string) ([]constraints.Value, er
 	if c.BestAPIVersion() < 5 {
 		for _, application := range applications {
 			var result params.GetConstraintsResults
-			err := c.facade.FacadeCall("GetConstraints", params.GetApplicationConstraints{application}, &result)
+			err := c.facade.FacadeCall(
+				"GetConstraints", params.GetApplicationConstraints{ApplicationName: application}, &result)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -651,7 +652,7 @@ func (c *Client) GetConstraints(applications ...string) ([]constraints.Value, er
 	var args params.Entities
 	for _, application := range applications {
 		args.Entities = append(args.Entities,
-			params.Entity{names.NewApplicationTag(application).String()})
+			params.Entity{Tag: names.NewApplicationTag(application).String()})
 	}
 	err := c.facade.FacadeCall("GetConstraints", args, &results)
 	if err != nil {
@@ -668,32 +669,32 @@ func (c *Client) GetConstraints(applications ...string) ([]constraints.Value, er
 
 // SetConstraints specifies the constraints for the given application.
 func (c *Client) SetConstraints(application string, constraints constraints.Value) error {
-	params := params.SetConstraints{
+	args := params.SetConstraints{
 		ApplicationName: application,
 		Constraints:     constraints,
 	}
-	return c.facade.FacadeCall("SetConstraints", params, nil)
+	return c.facade.FacadeCall("SetConstraints", args, nil)
 }
 
 // Expose changes the juju-managed firewall to expose any ports that
 // were also explicitly marked by units as open.
 func (c *Client) Expose(application string) error {
-	params := params.ApplicationExpose{ApplicationName: application}
-	return c.facade.FacadeCall("Expose", params, nil)
+	args := params.ApplicationExpose{ApplicationName: application}
+	return c.facade.FacadeCall("Expose", args, nil)
 }
 
 // Unexpose changes the juju-managed firewall to unexpose any ports that
 // were also explicitly marked by units as open.
 func (c *Client) Unexpose(application string) error {
-	params := params.ApplicationUnexpose{ApplicationName: application}
-	return c.facade.FacadeCall("Unexpose", params, nil)
+	args := params.ApplicationUnexpose{ApplicationName: application}
+	return c.facade.FacadeCall("Unexpose", args, nil)
 }
 
 // Get returns the configuration for the named application.
 func (c *Client) Get(application string) (*params.ApplicationGetResults, error) {
 	var results params.ApplicationGetResults
-	params := params.ApplicationGet{ApplicationName: application}
-	err := c.facade.FacadeCall("Get", params, &results)
+	args := params.ApplicationGet{ApplicationName: application}
+	err := c.facade.FacadeCall("Get", args, &results)
 	return &results, err
 }
 
@@ -718,29 +719,29 @@ func (c *Client) Unset(application string, options []string) error {
 // CharmRelations returns the application's charms relation names.
 func (c *Client) CharmRelations(application string) ([]string, error) {
 	var results params.ApplicationCharmRelationsResults
-	params := params.ApplicationCharmRelations{ApplicationName: application}
-	err := c.facade.FacadeCall("CharmRelations", params, &results)
+	args := params.ApplicationCharmRelations{ApplicationName: application}
+	err := c.facade.FacadeCall("CharmRelations", args, &results)
 	return results.CharmRelations, err
 }
 
 // AddRelation adds a relation between the specified endpoints and returns the relation info.
 func (c *Client) AddRelation(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
 	var addRelRes params.AddRelationResults
-	params := params.AddRelation{Endpoints: endpoints, ViaCIDRs: viaCIDRs}
-	err := c.facade.FacadeCall("AddRelation", params, &addRelRes)
+	args := params.AddRelation{Endpoints: endpoints, ViaCIDRs: viaCIDRs}
+	err := c.facade.FacadeCall("AddRelation", args, &addRelRes)
 	return &addRelRes, err
 }
 
 // DestroyRelation removes the relation between the specified endpoints.
 func (c *Client) DestroyRelation(endpoints ...string) error {
-	params := params.DestroyRelation{Endpoints: endpoints}
-	return c.facade.FacadeCall("DestroyRelation", params, nil)
+	args := params.DestroyRelation{Endpoints: endpoints}
+	return c.facade.FacadeCall("DestroyRelation", args, nil)
 }
 
 // DestroyRelationId removes the relation with the specified id.
 func (c *Client) DestroyRelationId(relationId int) error {
-	params := params.DestroyRelation{RelationId: relationId}
-	return c.facade.FacadeCall("DestroyRelation", params, nil)
+	args := params.DestroyRelation{RelationId: relationId}
+	return c.facade.FacadeCall("DestroyRelation", args, nil)
 }
 
 // SetRelationSuspended updates the suspended status of the relation with the specified id.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -896,7 +896,7 @@ func (s *applicationSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	result, err := s.applicationAPI.GetCharmURL(params.ApplicationGet{"wordpress"})
+	result, err := s.applicationAPI.GetCharmURL(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result, gc.Equals, "local:quantal/wordpress-3")

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -21,6 +21,7 @@ import (
 	k8s "github.com/juju/juju/caas/kubernetes/provider"
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/model"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -65,7 +66,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}}
-	results, err := v4.Get(params.ApplicationGet{"wordpress"})
+	results, err := v4.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -85,7 +86,7 @@ func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}
-	results, err := v5.Get(params.ApplicationGet{"wordpress"})
+	results, err := v5.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -106,7 +107,7 @@ func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetIAASModelSmoketest(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	results, err := s.applicationAPI.Get(params.ApplicationGet{"wordpress"})
+	results, err := s.applicationAPI.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -200,7 +201,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{&application.APIv9{api}}
 
-	results, err := apiV8.Get(params.ApplicationGet{"dashboard4miner"})
+	results, err := apiV8.Get(params.ApplicationGet{ApplicationName: "dashboard4miner"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "dashboard4miner",
@@ -220,7 +221,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 }
 
 func (s *getSuite) TestApplicationGetUnknownApplication(c *gc.C) {
-	_, err := s.applicationAPI.Get(params.ApplicationGet{"unknown"})
+	_, err := s.applicationAPI.Get(params.ApplicationGet{ApplicationName: "unknown"})
 	c.Assert(err, gc.ErrorMatches, `application "unknown" not found`)
 }
 
@@ -378,7 +379,7 @@ func (s *getSuite) TestApplicationGet(c *gc.C) {
 		expect.Application = app.Name()
 		expect.Charm = ch.Meta().Name
 		client := apiapplication.NewClient(s.APIState)
-		got, err := client.Get(app.Name())
+		got, err := client.Get(model.GenerationCurrent, app.Name())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(*got, jc.DeepEquals, expect)
 	}
@@ -401,7 +402,7 @@ func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 	err := app.UpdateCharmConfig(map[string]interface{}{"skill-level": nonFloatInt})
 	c.Assert(err, jc.ErrorIsNil)
 	client := apiapplication.NewClient(s.APIState)
-	got, err := client.Get(app.Name())
+	got, err := client.Get(model.GenerationCurrent, app.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got.CharmConfig["skill-level"], jc.DeepEquals, map[string]interface{}{
 		"description": "A number indicating skill.",

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 )
@@ -238,7 +239,7 @@ func opClientServiceSet(c *gc.C, st api.Connection, mst *state.State) (func(), e
 }
 
 func opClientServiceGet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := application.NewClient(st).Get("wordpress")
+	_, err := application.NewClient(st).Get(model.GenerationCurrent, "wordpress")
 	if err != nil {
 		return func() {}, err
 	}
@@ -335,7 +336,7 @@ func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func
 			URL: charm.MustParseURL("local:quantal/wordpress"),
 		},
 	}
-	err := application.NewClient(st).SetCharm(cfg)
+	err := application.NewClient(st).SetCharm(model.GenerationCurrent, cfg)
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/storage"
 )
 
@@ -92,12 +93,20 @@ type ApplicationUpdate struct {
 	SettingsStrings map[string]string  `json:"settings,omitempty"`
 	SettingsYAML    string             `json:"settings-yaml"` // Takes precedence over SettingsStrings if both are present.
 	Constraints     *constraints.Value `json:"constraints,omitempty"`
+
+	// Generation is the generation version in which this
+	// request will update the application.
+	Generation model.GenerationVersion `json:"generation"`
 }
 
 // ApplicationSetCharm sets the charm for a given application.
 type ApplicationSetCharm struct {
 	// ApplicationName is the name of the application to set the charm on.
 	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this
+	// request will set the application charm for.
+	Generation model.GenerationVersion `json:"generation"`
 
 	// CharmURL is the new url for the charm.
 	CharmURL string `json:"charm-url"`
@@ -144,22 +153,36 @@ type ApplicationExpose struct {
 // ApplicationSet holds the parameters for an application Set
 // command. Options contains the configuration data.
 type ApplicationSet struct {
-	ApplicationName string            `json:"application"`
-	Options         map[string]string `json:"options"`
+	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this request
+	// will set application configuration options for.
+	Generation model.GenerationVersion `json:"generation"`
+
+	Options map[string]string `json:"options"`
 }
 
 // ApplicationUnset holds the parameters for an application Unset
 // command. Options contains the option attribute names
 // to unset.
 type ApplicationUnset struct {
-	ApplicationName string   `json:"application"`
-	Options         []string `json:"options"`
+	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this request
+	// will unset application configuration options for.
+	Generation model.GenerationVersion `json:"generation"`
+
+	Options []string `json:"options"`
 }
 
 // ApplicationGet holds parameters for making the Get or
 // GetCharmURL calls.
 type ApplicationGet struct {
 	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this
+	// request will retrieve application data for.
+	Generation model.GenerationVersion `json:"generation"`
 }
 
 // ApplicationGetResults holds results of the application Get call.
@@ -182,8 +205,13 @@ type ApplicationConfigSetArgs struct {
 // ApplicationConfigSet holds the parameters for an application
 // config set command.
 type ApplicationConfigSet struct {
-	ApplicationName string            `json:"application"`
-	Config          map[string]string `json:"config"`
+	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this request
+	// will set application configuration for.
+	Generation model.GenerationVersion `json:"generation"`
+
+	Config map[string]string `json:"config"`
 }
 
 // ApplicationConfigUnsetArgs holds the parameters for

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -903,12 +903,14 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 			return errors.Trace(err)
 		}
 	}
+
 	cfg := application.SetCharmConfig{
 		ApplicationName: p.Application,
 		CharmID:         chID,
 		ResourceIDs:     resNames2IDs,
 	}
-	if err := h.api.SetCharm(cfg); err != nil {
+	// Bundles only ever deal with the current generation.
+	if err := h.api.SetCharm(model.GenerationCurrent, cfg); err != nil {
 		return errors.Trace(err)
 	}
 	h.writeAddedResources(resNames2IDs)

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -89,9 +89,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 		Name:  "test",
 		Owner: names.NewUserTag("admin"),
 	})
-	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
+	s.CleanupSuite.AddCleanup(func(*gc.C) { _ = st.Close() })
+
 	// Close the state pool before the state object itself.
-	s.StatePool.Close()
+	c.Assert(s.StatePool.Close(), jc.ErrorIsNil)
 	s.StatePool = nil
 	err := s.State.Close()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/juju/core/model"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charmrepo.v3"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
@@ -262,8 +263,10 @@ func (e *extractorImpl) GetConstraints(applications ...string) ([]constraints.Va
 }
 
 // GetConfig is part of ModelExtractor.
-func (e *extractorImpl) GetConfig(applications ...string) ([]map[string]interface{}, error) {
-	return e.application.GetConfig(applications...)
+func (e *extractorImpl) GetConfig(
+	generation model.GenerationVersion, applications ...string,
+) ([]map[string]interface{}, error) {
+	return e.application.GetConfig(generation, applications...)
 }
 
 // Sequences is part of ModelExtractor.

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/core/model"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charmrepo.v3"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
@@ -22,6 +21,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/model"
 )
 
 const bundleDiffDoc = `

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -117,6 +118,7 @@ func (s *configCommandSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.fake = &fakeApplicationAPI{
+		generation:  model.GenerationCurrent,
 		name:        "dummy-application",
 		charmName:   "dummy",
 		charmValues: s.defaultCharmValues,
@@ -208,7 +210,8 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
 
 func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "juju-external-hostname"})
+	code := cmd.Main(application.NewConfigCommandForTest(
+		s.fake, s.store), ctx, []string{"dummy-application", "juju-external-hostname"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host")
@@ -314,6 +317,8 @@ func (s *configCommandSuite) TestSetCharmConfigSuccess(c *gc.C) {
 		"username": "hello",
 		"outlook":  "hello@world.tld",
 	})
+
+	s.fake.generation = model.GenerationNext
 	s.assertSetSuccess(c, s.dir, []string{
 		"username=hello",
 		"outlook=hello@world.tld",

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -9,10 +9,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/utils/featureflag"
-
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -23,6 +19,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
@@ -106,9 +103,7 @@ var getTests = []struct {
 
 func (s *configCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-
-	c.Assert(os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Generations), jc.ErrorIsNil)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	s.SetFeatureFlags(feature.Generations)
 
 	s.defaultCharmValues = map[string]interface{}{
 		"title":           "Nearly There",

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -60,7 +60,7 @@ type ApplicationAPI interface {
 	AddUnits(application.AddUnitsParams) ([]string, error)
 	Expose(application string) error
 	GetAnnotations(tags []string) ([]apiparams.AnnotationsGetResult, error)
-	GetConfig(appNames ...string) ([]map[string]interface{}, error)
+	GetConfig(generation model.GenerationVersion, appNames ...string) ([]map[string]interface{}, error)
 	GetConstraints(appNames ...string) ([]constraints.Value, error)
 	GetCharmURL(applicationName string) (*charm.URL, error)
 	SetAnnotation(annotations map[string]map[string]string) ([]apiparams.ErrorResult, error)

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -62,9 +62,8 @@ type ApplicationAPI interface {
 	GetAnnotations(tags []string) ([]apiparams.AnnotationsGetResult, error)
 	GetConfig(generation model.GenerationVersion, appNames ...string) ([]map[string]interface{}, error)
 	GetConstraints(appNames ...string) ([]constraints.Value, error)
-	GetCharmURL(applicationName string) (*charm.URL, error)
 	SetAnnotation(annotations map[string]map[string]string) ([]apiparams.ErrorResult, error)
-	SetCharm(application.SetCharmConfig) error
+	SetCharm(model.GenerationVersion, application.SetCharmConfig) error
 	SetConstraints(application string, constraints constraints.Value) error
 	Update(apiparams.ApplicationUpdate) error
 	ScaleApplication(application.ScaleApplicationParams) (apiparams.ScaleApplicationResult, error)
@@ -214,7 +213,7 @@ func (a *deployAPIAdapter) GetAnnotations(tags []string) ([]apiparams.Annotation
 	return a.annotationsClient.Get(tags)
 }
 
-// NewDeployCommandForTest returns a command to deploy applications inteded to be used only in tests.
+// NewDeployCommandForTest returns a command to deploy applications intended to be used only in tests.
 func NewDeployCommandForTest(newAPIRoot func() (DeployAPI, error), steps []DeployStep) modelcmd.ModelCommand {
 	deployCmd := &DeployCommand{
 		Steps:      steps,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -19,12 +19,6 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/caas"
-	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/state/stateenvirons"
-	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -47,15 +41,21 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/charms"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	jjcharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/juju/version"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
+	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -2067,13 +2067,8 @@ func (f *fakeDeployAPI) SetAnnotation(annotations map[string]map[string]string) 
 	return results[0].([]params.ErrorResult), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) GetCharmURL(applicationName string) (*charm.URL, error) {
-	results := f.MethodCall(f, "GetCharmURL", applicationName)
-	return results[0].(*charm.URL), jujutesting.TypeAssertError(results[1])
-}
-
-func (f *fakeDeployAPI) SetCharm(cfg application.SetCharmConfig) error {
-	results := f.MethodCall(f, "SetCharm", cfg)
+func (f *fakeDeployAPI) SetCharm(generation model.GenerationVersion, cfg application.SetCharmConfig) error {
+	results := f.MethodCall(f, "SetCharm", generation, cfg)
 	return jujutesting.TypeAssertError(results[0])
 }
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2021,9 +2021,13 @@ func (f *fakeDeployAPI) Deploy(args application.DeployArgs) error {
 func (f *fakeDeployAPI) GetAnnotations(tags []string) ([]params.AnnotationsGetResult, error) {
 	return nil, nil
 }
-func (f *fakeDeployAPI) GetConfig(appNames ...string) ([]map[string]interface{}, error) {
+
+func (f *fakeDeployAPI) GetConfig(
+	generation model.GenerationVersion, appNames ...string,
+) ([]map[string]interface{}, error) {
 	return nil, nil
 }
+
 func (f *fakeDeployAPI) GetConstraints(appNames ...string) ([]constraints.Value, error) {
 	return nil, nil
 }

--- a/cmd/juju/application/fakeapplication_test.go
+++ b/cmd/juju/application/fakeapplication_test.go
@@ -16,6 +16,7 @@ import (
 // fakeApplicationAPI is the fake application API for testing the application
 // update command.
 type fakeApplicationAPI struct {
+	generation  model.GenerationVersion
 	name        string
 	charmName   string
 	charmValues map[string]interface{}
@@ -49,6 +50,10 @@ func (f *fakeApplicationAPI) Close() error {
 func (f *fakeApplicationAPI) Get(
 	generation model.GenerationVersion, application string,
 ) (*params.ApplicationGetResults, error) {
+	if generation != f.generation {
+		return nil, errors.Errorf("expected generation %q, got %q", f.generation, generation)
+	}
+
 	if application != f.name {
 		return nil, errors.NotFoundf("application %q", application)
 	}
@@ -105,6 +110,9 @@ func (f *fakeApplicationAPI) Set(application string, options map[string]string) 
 func (f *fakeApplicationAPI) SetApplicationConfig(
 	generation model.GenerationVersion, application string, config map[string]string,
 ) error {
+	if generation != f.generation {
+		return errors.Errorf("expected generation %q, got %q", f.generation, generation)
+	}
 	return f.Set(application, config)
 }
 
@@ -138,5 +146,8 @@ func (f *fakeApplicationAPI) Unset(application string, options []string) error {
 func (f *fakeApplicationAPI) UnsetApplicationConfig(
 	generation model.GenerationVersion, application string, options []string,
 ) error {
+	if generation != f.generation {
+		return errors.Errorf("expected generation %q, got %q", f.generation, generation)
+	}
 	return f.Unset(application, options)
 }

--- a/cmd/juju/application/fakeapplication_test.go
+++ b/cmd/juju/application/fakeapplication_test.go
@@ -6,6 +6,8 @@ package application_test
 import (
 	"fmt"
 
+	"github.com/juju/juju/core/model"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
@@ -45,7 +47,9 @@ func (f *fakeApplicationAPI) Close() error {
 	return nil
 }
 
-func (f *fakeApplicationAPI) Get(application string) (*params.ApplicationGetResults, error) {
+func (f *fakeApplicationAPI) Get(
+	generation model.GenerationVersion, application string,
+) (*params.ApplicationGetResults, error) {
 	if application != f.name {
 		return nil, errors.NotFoundf("application %q", application)
 	}
@@ -99,7 +103,9 @@ func (f *fakeApplicationAPI) Set(application string, options map[string]string) 
 	return nil
 }
 
-func (f *fakeApplicationAPI) SetApplicationConfig(application string, config map[string]string) error {
+func (f *fakeApplicationAPI) SetApplicationConfig(
+	generation model.GenerationVersion, application string, config map[string]string,
+) error {
 	return f.Set(application, config)
 }
 
@@ -130,6 +136,8 @@ func (f *fakeApplicationAPI) Unset(application string, options []string) error {
 	return nil
 }
 
-func (f *fakeApplicationAPI) UnsetApplicationConfig(application string, options []string) error {
+func (f *fakeApplicationAPI) UnsetApplicationConfig(
+	generation model.GenerationVersion, application string, options []string,
+) error {
 	return f.Unset(application, options)
 }

--- a/cmd/juju/application/fakeapplication_test.go
+++ b/cmd/juju/application/fakeapplication_test.go
@@ -6,12 +6,11 @@ package application_test
 import (
 	"fmt"
 
-	"github.com/juju/juju/core/model"
-
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
 )
 
 // fakeApplicationAPI is the fake application API for testing the application

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/application"
@@ -81,7 +80,6 @@ type removeApplicationAPI interface {
 	DestroyDeprecated(appName string) error
 	DestroyUnits(application.DestroyUnitsParams) ([]params.DestroyUnitResult, error)
 	DestroyUnitsDeprecated(unitNames ...string) error
-	GetCharmURL(appName string) (*charm.URL, error)
 	ModelUUID() string
 	BestAPIVersion() int
 }

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourceadapters"
@@ -74,7 +75,7 @@ type CharmAPIClient interface {
 // by the upgrade-charm command.
 type CharmUpgradeClient interface {
 	GetCharmURL(string) (*charm.URL, error)
-	Get(string) (*params.ApplicationGetResults, error)
+	Get(model.GenerationVersion, string) (*params.ApplicationGetResults, error)
 	SetCharm(application.SetCharmConfig) error
 }
 
@@ -328,10 +329,13 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	applicationInfo, err := charmUpgradeClient.Get(c.ApplicationName)
+
+	generation := model.GenerationCurrent
+	applicationInfo, err := charmUpgradeClient.Get(generation, c.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	if c.Channel == "" {
 		c.Channel = csclientparams.Channel(applicationInfo.Channel)
 	}

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/juju/core/model"
-
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -38,6 +36,7 @@ import (
 	jujucharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
@@ -177,7 +176,10 @@ func (s *UpgradeCharmSuite) TestStorageConstraints(c *gc.C) {
 	_, err := s.runUpgradeCharm(c, "foo", "--storage", "bar=baz")
 	c.Assert(err, jc.ErrorIsNil)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
-	s.charmAPIClient.CheckCall(c, 2, "SetCharm", application.SetCharmConfig{
+
+	// TODO (manadart 2019-01-24) Once we are retrieving the active generation
+	// from the local store, this test should flex that behaviour.
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationCurrent, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -226,7 +228,10 @@ func (s *UpgradeCharmSuite) TestConfigSettings(c *gc.C) {
 	_, err = s.runUpgradeCharm(c, "foo", "--config", configFile)
 	c.Assert(err, jc.ErrorIsNil)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
-	s.charmAPIClient.CheckCall(c, 2, "SetCharm", application.SetCharmConfig{
+
+	// TODO (manadart 2019-01-24) Once we are retrieving the active generation
+	// from the local store, this test should flex that behaviour.
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationCurrent, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -912,13 +917,13 @@ type mockCharmAPIClient struct {
 	charmURL *charm.URL
 }
 
-func (m *mockCharmAPIClient) GetCharmURL(applicationName string) (*charm.URL, error) {
-	m.MethodCall(m, "GetCharmURL", applicationName)
+func (m *mockCharmAPIClient) GetCharmURL(generation model.GenerationVersion, appName string) (*charm.URL, error) {
+	m.MethodCall(m, "GetCharmURL", generation, appName)
 	return m.charmURL, m.NextErr()
 }
 
-func (m *mockCharmAPIClient) SetCharm(cfg application.SetCharmConfig) error {
-	m.MethodCall(m, "SetCharm", cfg)
+func (m *mockCharmAPIClient) SetCharm(generation model.GenerationVersion, cfg application.SetCharmConfig) error {
+	m.MethodCall(m, "SetCharm", generation, cfg)
 	return m.NextErr()
 }
 

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/juju/juju/core/model"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -36,7 +38,6 @@ import (
 	jujucharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/watcher"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/network"
@@ -921,25 +922,11 @@ func (m *mockCharmAPIClient) SetCharm(cfg application.SetCharmConfig) error {
 	return m.NextErr()
 }
 
-func (m *mockCharmAPIClient) Get(applicationName string) (*params.ApplicationGetResults, error) {
+func (m *mockCharmAPIClient) Get(
+	generation model.GenerationVersion, applicationName string,
+) (*params.ApplicationGetResults, error) {
 	m.MethodCall(m, "Get", applicationName)
 	return &params.ApplicationGetResults{}, m.NextErr()
-}
-
-type mockNotifyWatcher struct {
-	watcher.NotifyWatcher
-	testing.Stub
-	ch chan struct{}
-}
-
-func (w *mockNotifyWatcher) Changes() watcher.NotifyChannel {
-	return w.ch
-}
-
-func (w *mockNotifyWatcher) Kill() {}
-
-func (w *mockNotifyWatcher) Wait() error {
-	return nil
 }
 
 type mockModelConfigGetter struct {

--- a/cmd/juju/romulus/setplan/set_plan.go
+++ b/cmd/juju/romulus/setplan/set_plan.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"net/url"
 
+	"github.com/juju/juju/core/model"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	api "github.com/juju/romulus/api/plan"
@@ -22,7 +24,7 @@ import (
 )
 
 // authorizationClient defines the interface of an api client that
-// the comand uses to create an authorization macaroon.
+// the command uses to create an authorization macaroon.
 type authorizationClient interface {
 	// Authorize returns the authorization macaroon for the specified environment,
 	// charm url, application name and plan.
@@ -84,8 +86,7 @@ func (c *setPlanCommand) Init(args []string) error {
 }
 
 func (c *setPlanCommand) requestMetricCredentials(client *application.Client, ctx *cmd.Context) ([]byte, error) {
-	modelUUID := client.ModelUUID()
-	charmURL, err := client.GetCharmURL(c.Application)
+	charmURL, err := client.GetCharmURL(model.GenerationCurrent, c.Application)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -102,7 +103,7 @@ func (c *setPlanCommand) requestMetricCredentials(client *application.Client, ct
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	m, err := authClient.Authorize(modelUUID, charmURL.String(), c.Application, c.Plan, hc.VisitWebPage)
+	m, err := authClient.Authorize(client.ModelUUID(), charmURL.String(), c.Application, c.Plan, hc.VisitWebPage)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

This patch threads the active generation through API clients from application commands.

- Commands for _deploy_ (including bundles), _bundle-diff_ and _set-plan_ always assume the current generation.
- Commands for application and charm config allow the user to add a _--generation_ option, which if not set will use the active generation from from local storage (defaulting to "current" here).
- Resources are not dealt with by the patch but will be generational in future.

Patches will follow this one to:
- Retrieve the active generation from local storage (depends on #9661).
- Ensure all usages of generation are passed in calls to the API server.

## QA steps

At this time, we want to ensure that all client operations involving generational settings are operational, but not backward-breaking. So we test a new client against an old controller.

- Bootstrap a controller with a version prior to this patch - develop HEAD will do fine.
- Build and install Juju from this patch.
- `export JUJU_DEV_FEATURE_FLAGS=generations`
- Deploy an old version of an application, for example `juju deploy cs:trusty/mariadb-6`
- Check that the following commands work correctly with and without the _--generation_ option:
  - `juju config mariadb` (plus get, set and unset).
  - `juju upgrade-charm` (should cause an upgrade in this example to cs:trusty/mariadb-7).
  - `juju export-bundle > temp.yaml` runs without error.
  - `juju diff-bundle temp.yaml` runs without error.
  - `juju set-plan mariadb www.google.com` will return an error due to the URL, but will run correctly.

## Documentation changes

To come with _Generations_ feature generally.

## Bug reference

N/A
