### PR TITLE
Fixing missing fallback API for MongoVersion

### DIFF
--- a/api/controller/mongo.go
+++ b/api/controller/mongo.go
@@ -10,6 +10,9 @@ import (
 
 // MongoVersion returns the mongo version associated with the state session.
 func (c *Client) MongoVersion() (string, error) {
+	if c.BestAPIVersion() < 6 {
+		return "", errors.NotSupportedf("MongoVersion not supported by this version of Juju")
+	}
 	var result params.StringResult
 	err := c.facade.FacadeCall("MongoVersion", nil, &result)
 	if err != nil {

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -180,6 +180,9 @@ func (c *ControllerAPIv3) ModelStatus(req params.Entities) (params.ModelStatusRe
 	return results, nil
 }
 
+// MongoVersion isn't on the v5 API.
+func (c *ControllerAPIv5) MongoVersion() {}
+
 // MongoVersion allows the introspection of the mongo version per controller
 func (c *ControllerAPI) MongoVersion() (params.StringResult, error) {
 	result := params.StringResult{}


### PR DESCRIPTION
## Description of change

Adding missing MongoVersion API for older api and api server
controllers.
