### PR TITLE
Removes dead code from collectmetrics.

### DIFF
--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -11,12 +11,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	actionapi "github.com/juju/juju/api/action"
-	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/action"
@@ -122,14 +120,6 @@ func parseActionResult(result params.ActionResult) (string, error) {
 		return "", errors.New("no collect application listening: does application support metric collection?")
 	}
 	return tag.Id(), nil
-}
-
-type applicationClient interface {
-	GetCharmURL(application string) (*charm.URL, error)
-}
-
-var newApplicationClient = func(root api.Connection) applicationClient {
-	return application.NewClient(root)
 }
 
 var newAPIConn = func(cmd modelcmd.ModelCommandBase) (api.Connection, error) {

--- a/cmd/juju/metricsdebug/collectmetrics_test.go
+++ b/cmd/juju/metricsdebug/collectmetrics_test.go
@@ -303,7 +303,6 @@ func (s *collectMetricsSuite) TestCollectMetricsLocal(c *gc.C) {
 	applicationClient.charmURL = "local:quantal/charm"
 	s.PatchValue(metricsdebug.NewAPIConn, noConn)
 	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
-	s.PatchValue(metricsdebug.NewApplicationClient, metricsdebug.NewApplicationClientFnc(applicationClient))
 
 	for i, test := range tests {
 		c.Logf("running test %d: %v", i, test.about)
@@ -328,7 +327,6 @@ func (s *collectMetricsSuite) TestCollectMetricsRemote(c *gc.C) {
 	applicationClient.charmURL = "quantal/charm"
 	s.PatchValue(metricsdebug.NewAPIConn, noConn)
 	s.PatchValue(metricsdebug.NewRunClient, metricsdebug.NewRunClientFnc(runClient))
-	s.PatchValue(metricsdebug.NewApplicationClient, metricsdebug.NewApplicationClientFnc(applicationClient))
 
 	for i, test := range tests {
 		c.Logf("running test %d: %v", i, test.about)

--- a/cmd/juju/metricsdebug/export_test.go
+++ b/cmd/juju/metricsdebug/export_test.go
@@ -16,10 +16,9 @@ import (
 )
 
 var (
-	NewClient            = &newClient
-	NewRunClient         = &newRunClient
-	NewApplicationClient = &newApplicationClient
-	NewAPIConn           = &newAPIConn
+	NewClient    = &newClient
+	NewRunClient = &newRunClient
+	NewAPIConn   = &newAPIConn
 )
 
 // NewRunClientFnc returns a function that returns a struct that implements the
@@ -27,15 +26,6 @@ var (
 // variable in tests.
 func NewRunClientFnc(client runClient) func(api.Connection) runClient {
 	return func(_ api.Connection) runClient {
-		return client
-	}
-}
-
-// NewApplicationClientFnc returns a function that returns a struct that implements the
-// applicationClient interface. This function can be used to patch the NewApplicationClient
-// variable in tests.
-func NewApplicationClientFnc(client applicationClient) func(api.Connection) applicationClient {
-	return func(_ api.Connection) applicationClient {
 		return client
 	}
 }


### PR DESCRIPTION
## Description of change

In the course of updating API client signatures for generations, I came across this dead code.

## QA steps

- Bootstrap
- `juju deploy kafka`
- `juju deploy zookeeper`
- `juju add-relation kafka zookeeper`
- `juju collect-metrics kafka`
- `juju show-action-status` and check that the hook ran.

## Documentation changes

None.

## Bug reference

N/A
