### PR TITLE
Fix generation of operator image tag for released juju version strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ check-deps:
 DOCKER_USERNAME?=jujusolutions
 JUJUD_STAGING_DIR?=/tmp/jujud-operator
 JUJUD_BIN_DIR=${GOPATH}/bin
-OPERATOR_IMAGE_TAG = $(shell jujud version | cut -d- -f1,2)
+OPERATOR_IMAGE_TAG = $(shell jujud version | rev | cut -d- -f3- | rev)
 
 operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requirements.txt
 	rm -rf ${JUJUD_STAGING_DIR}


### PR DESCRIPTION
## Description of change

The incorrect operator image tag was being generated for released juju versions.
ie 2.5.1 returned in a tag of 2.5.1-cosmic
2.5-rc1 worked correctly

This PR tweaks the cut script used to transform the output of `juju version`

## QA steps

make push-operator-image
