### PR TITLE
Fix goroutine and websocket leak in logsink handler

### DIFF
--- a/apiserver/logsink/export_test.go
+++ b/apiserver/logsink/export_test.go
@@ -1,0 +1,32 @@
+// Copyright 2015-2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsink
+
+import (
+	"net/http"
+
+	gc "gopkg.in/check.v1"
+)
+
+func NewHTTPHandlerForTest(
+	newLogWriteCloser NewLogWriteCloserFunc,
+	abort <-chan struct{},
+	ratelimit *RateLimitConfig,
+	makeChannel func() (chan struct{}, func()),
+) http.Handler {
+	return &logSinkHandler{
+		newLogWriteCloser: newLogWriteCloser,
+		abort:             abort,
+		ratelimit:         ratelimit,
+		newStopChannel:    makeChannel,
+	}
+}
+
+func ReceiverStopped(c *gc.C, handler http.Handler) bool {
+	h, ok := handler.(*logSinkHandler)
+	c.Assert(ok, gc.Equals, true)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.receiverStopped
+}


### PR DESCRIPTION
## Description of change

If the ServeHTTP handler finishes before the receiveLogs goroutine, it can be stuck in the select trying to send on logCh. Add a stop channel to the goroutine that is always closed when the handler finishes and include that in the select.

This should fix the leak we see in prodstack, although we don't understand why it's happening now - none of the logsink code has changed between 2.4 and 2.5

## QA steps

* Basic smoketest - bootstrapped a controller, deployed some applications and ensured that logging was still getting to the database using debug-log.
* Haven't verified the goroutine leak because we haven't been able to reproduce that.

## Documentation changes
None

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1813104
