### PR TITLE
If SetSupportedContainers doesn't change the value, don't write to the db

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -726,14 +726,14 @@
   revision = "472a3e8b2073fb3cd67c12d2bc5f3cd28e5f4116"
 
 [[projects]]
-  digest = "1:4857e53a05abe24af8487f892dc316449de7f350c462081560d4e223a6616f3d"
+  digest = "1:c6f38e78f835dfbf9e7bfd48a7d9827b74390bc9c6e7de833287951dfda562ac"
   name = "github.com/juju/txn"
   packages = [
     ".",
     "testing",
   ]
   pruneopts = ""
-  revision = "79cdf4663070226316f3bc6c66de7babbb3fb899"
+  revision = "0735533e000d6c33a901ee30cc1964ac2721fd39"
 
 [[projects]]
   digest = "1:cf637806c17846b1660d388cfbee501ed64734526fe2e6176f16f9cd950e7c62"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -343,7 +343,7 @@
 
 [[constraint]]
   name = "github.com/juju/txn"
-  revision = "79cdf4663070226316f3bc6c66de7babbb3fb899"
+  revision = "0735533e000d6c33a901ee30cc1964ac2721fd39"
 
 [[override]]
   name = "github.com/juju/usso"

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -100,6 +100,14 @@ func SetBeforeHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChec
 	return txntesting.SetBeforeHooks(c, newRunnerForHooks(st), fs...)
 }
 
+// SetFailIfTransaction will set a transaction hook that marks the test as an error
+// if there is a transaction run. This is used if you know a given set of operations
+// should *not* trigger database updates.
+func SetFailIfTransaction(c *gc.C, st *State) txntesting.TransactionChecker {
+	EnsureWorkersStarted(st)
+	return txntesting.SetFailIfTransaction(c, newRunnerForHooks(st))
+}
+
 func SetAfterHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
 	EnsureWorkersStarted(st)
 	return txntesting.SetAfterHooks(c, newRunnerForHooks(st), fs...)

--- a/state/machine.go
+++ b/state/machine.go
@@ -2010,6 +2010,20 @@ func isSupportedContainer(container instance.ContainerType, supportedContainers 
 
 // updateSupportedContainers sets the supported containers on this host machine.
 func (m *Machine) updateSupportedContainers(supportedContainers []instance.ContainerType) (err error) {
+	if m.doc.SupportedContainersKnown {
+		if len(m.doc.SupportedContainers) == len(supportedContainers) {
+			equal := true
+			for i := range m.doc.SupportedContainers {
+				if m.doc.SupportedContainers[i] != supportedContainers[i] {
+					equal = false
+					break
+				}
+			}
+			if equal {
+				return nil
+			}
+		}
+	}
 	ops := []txn.Op{
 		{
 			C:      machinesC,

--- a/state/machine.go
+++ b/state/machine.go
@@ -2013,8 +2013,12 @@ func (m *Machine) updateSupportedContainers(supportedContainers []instance.Conta
 	if m.doc.SupportedContainersKnown {
 		if len(m.doc.SupportedContainers) == len(supportedContainers) {
 			equal := true
-			for i := range m.doc.SupportedContainers {
-				if m.doc.SupportedContainers[i] != supportedContainers[i] {
+			types := make(map[instance.ContainerType]struct{}, len(m.doc.SupportedContainers))
+			for _, v := range m.doc.SupportedContainers {
+				types[v] = struct{}{}
+			}
+			for _, v := range supportedContainers {
+				if _, ok := types[v]; !ok {
 					equal = false
 					break
 				}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2468,6 +2468,30 @@ func (s *MachineSuite) TestSetSupportedContainersMultipleExisting(c *gc.C) {
 	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD, instance.KVM})
 }
 
+func (s *MachineSuite) TestSetSupportedContainersMultipleExistingInvertedOrder(c *gc.C) {
+	machine := s.addMachineWithSupportedContainer(c, instance.LXD)
+
+	err := machine.SetSupportedContainers([]instance.ContainerType{instance.KVM, instance.LXD})
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{instance.KVM, instance.LXD})
+	// Setting it again will be a no-op
+	defer state.SetFailIfTransaction(c, s.State).Check()
+	err = machine.SetSupportedContainers([]instance.ContainerType{instance.KVM, instance.LXD})
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{instance.KVM, instance.LXD})
+}
+
+func (s *MachineSuite) TestSetSupportedContainersMultipleExistingWithDifferentInstanceType(c *gc.C) {
+	machine := s.addMachineWithSupportedContainer(c, instance.LXD)
+
+	err := machine.SetSupportedContainers([]instance.ContainerType{instance.LXD, instance.KVM})
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD, instance.KVM})
+	// Setting it again will be a no-op
+	err = machine.SetSupportedContainers([]instance.ContainerType{instance.LXD, instance.ContainerType("FOO")})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *MachineSuite) TestSetSupportedContainersSetsUnknownToError(c *gc.C) {
 	// Create a machine and add lxd and kvm containers prior to calling SetSupportedContainers
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2413,6 +2413,11 @@ func (s *MachineSuite) TestSupportsNoContainersOverwritesExisting(c *gc.C) {
 	err := machine.SupportsNoContainers()
 	c.Assert(err, jc.ErrorIsNil)
 	assertSupportedContainers(c, machine, []instance.ContainerType{})
+	// Calling it a second time should not invoke a db transaction
+	defer state.SetFailIfTransaction(c, s.State).Check()
+	err = machine.SupportsNoContainers()
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{})
 }
 
 func (s *MachineSuite) TestSetSupportedContainersSingle(c *gc.C) {
@@ -2427,6 +2432,7 @@ func (s *MachineSuite) TestSetSupportedContainersSingle(c *gc.C) {
 func (s *MachineSuite) TestSetSupportedContainersSame(c *gc.C) {
 	machine := s.addMachineWithSupportedContainer(c, instance.LXD)
 
+	defer state.SetFailIfTransaction(c, s.State).Check()
 	err := machine.SetSupportedContainers([]instance.ContainerType{instance.LXD})
 	c.Assert(err, jc.ErrorIsNil)
 	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD})
@@ -2453,6 +2459,11 @@ func (s *MachineSuite) TestSetSupportedContainersMultipleExisting(c *gc.C) {
 	machine := s.addMachineWithSupportedContainer(c, instance.LXD)
 
 	err := machine.SetSupportedContainers([]instance.ContainerType{instance.LXD, instance.KVM})
+	c.Assert(err, jc.ErrorIsNil)
+	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD, instance.KVM})
+	// Setting it again will be a no-op
+	defer state.SetFailIfTransaction(c, s.State).Check()
+	err = machine.SetSupportedContainers([]instance.ContainerType{instance.LXD, instance.KVM})
 	c.Assert(err, jc.ErrorIsNil)
 	assertSupportedContainers(c, machine, []instance.ContainerType{instance.LXD, instance.KVM})
 }


### PR DESCRIPTION
## Description of change

On startup, machine agents call SetSupportedContainers. If that
doesn't actually change the supported containers, no need to write
to the database.

This supersedes https://github.com/juju/juju/pull/9660 as it contains
the full PR required - includes the landed https://github.com/juju/txn/pull/49
changes as well.
## QA steps

You can use:
```
$ juju bootstrap lxd lxd
$ juju add-machine
$ juju model-config -m controller logging-config='<root>=INFO;juju.state.txn=TRACE'
# restart machine-0 in either the model or the controller, see what txns are run
```
## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812981