### PR TITLE
Add API calls and expose state settings functions.

### DIFF
--- a/apiserver/facades/client/storage/export_test.go
+++ b/apiserver/facades/client/storage/export_test.go
@@ -1,13 +1,13 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2015, 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package storage
 
 var (
-	ValidatePoolListFilter   = (*APIv4).validatePoolListFilter
-	ValidateNameCriteria     = (*APIv4).validateNameCriteria
-	ValidateProviderCriteria = (*APIv4).validateProviderCriteria
-	EnsureStoragePoolFilter  = (*APIv4).ensureStoragePoolFilter
+	ValidatePoolListFilter   = (*APIv5).validatePoolListFilter
+	ValidateNameCriteria     = (*APIv5).validateNameCriteria
+	ValidateProviderCriteria = (*APIv5).validateProviderCriteria
+	EnsureStoragePoolFilter  = (*APIv5).ensureStoragePoolFilter
 )
 
 type (

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -20,6 +20,7 @@ type mockPoolManager struct {
 	createPool func(name string, providerType jujustorage.ProviderType, attrs map[string]interface{}) (*jujustorage.Config, error)
 	deletePool func(name string) error
 	listPools  func() ([]*jujustorage.Config, error)
+	updatePool func(name string, attrs map[string]interface{}) error
 }
 
 func (m *mockPoolManager) Get(name string) (*jujustorage.Config, error) {
@@ -36,6 +37,10 @@ func (m *mockPoolManager) Delete(name string) error {
 
 func (m *mockPoolManager) List() ([]*jujustorage.Config, error) {
 	return m.listPools()
+}
+
+func (m *mockPoolManager) Update(name string, attrs map[string]interface{}) error {
+	return m.updatePool(name, attrs)
 }
 
 type mockStorageAccessor struct {

--- a/apiserver/facades/client/storage/pooldelete_test.go
+++ b/apiserver/facades/client/storage/pooldelete_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+type poolDeleteSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&poolDeleteSuite{})
+
+func (s *poolDeleteSuite) createPools(c *gc.C, num int) {
+	var err error
+	for i := 0; i < num; i++ {
+		poolName := fmt.Sprintf("%v%v", tstName, i)
+		s.baseStorageSuite.pools[poolName], err =
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *poolDeleteSuite) TestDeletePool(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+
+	err := s.api.DeletePool(poolName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 0)
+}
+
+func (s *poolDeleteSuite) TestDeleteErrorNotExists(c *gc.C) {
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+
+	err := s.api.DeletePool(poolName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 0)
+}

--- a/apiserver/facades/client/storage/poolupdate_test.go
+++ b/apiserver/facades/client/storage/poolupdate_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+type poolUpdateSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&poolUpdateSuite{})
+
+func (s *poolUpdateSuite) createPools(c *gc.C, num int) {
+	var err error
+	for i := 0; i < num; i++ {
+		poolName := fmt.Sprintf("%v%v", tstName, i)
+		s.baseStorageSuite.pools[poolName], err =
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *poolUpdateSuite) TestUpdatePool(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	newAttrs := map[string]interface{}{
+		"foo1": "bar1",
+		"zip":  "zoom",
+	}
+
+	err := s.api.UpdatePool(params.StoragePool{
+		Name:  poolName,
+		Attrs: newAttrs,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected, err := storage.NewConfig(poolName, provider.LoopProviderType, newAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
+	c.Assert(pools[0], gc.DeepEquals, expected)
+}
+
+func (s *poolUpdateSuite) TestUpdatePoolError(c *gc.C) {
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	err := s.api.UpdatePool(params.StoragePool{
+		Name: poolName,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/state/settings.go
+++ b/state/settings.go
@@ -373,6 +373,17 @@ func removeSettingsOp(collection, key string) txn.Op {
 	}
 }
 
+// updateSettings updates the Settings for key.
+func updateSettings(db Database, collection, key string, values map[string]interface{}) error {
+	existing, err := readSettings(db, collection, key)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	existing.Update(values)
+	_, err = existing.Write()
+	return errors.Trace(err)
+}
+
 // listSettings returns all the settings with the specified key prefix.
 func listSettings(backend modelBackend, collection, keyPrefix string) (map[string]map[string]interface{}, error) {
 	settings, closer := backend.db().GetRawCollection(collection)
@@ -482,6 +493,11 @@ func (s *StateSettings) ReadSettings(key string) (map[string]interface{}, error)
 // RemoveSettings exposes removeSettings on state for use outside the state package.
 func (s *StateSettings) RemoveSettings(key string) error {
 	return removeSettings(s.backend.db(), s.collection, key)
+}
+
+// UpdateSettings exposes updateSettings on state for use outside the state package.
+func (s *StateSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+	return updateSettings(s.backend.db(), s.collection, key, settings)
 }
 
 // ListSettings exposes listSettings on state for use outside the state package.

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -511,6 +511,35 @@ func (s *SettingsSuite) TestList(c *gc.C) {
 	})
 }
 
+func (s *SettingsSuite) TestUpdateSettings(c *gc.C) {
+	_, err := s.createSettings(s.key, map[string]interface{}{"foo1": "bar1", "foo2": "bar2"})
+	c.Assert(err, jc.ErrorIsNil)
+	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
+	err = updateSettings(s.state.db(), s.collection, s.key, options)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check MongoDB state.
+	var mgoData struct {
+		Settings settingsMap
+	}
+	settings, closer := s.state.db().GetCollection(settingsC)
+	defer closer()
+	err = settings.FindId(s.key).One(&mgoData)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(
+		map[string]interface{}(mgoData.Settings),
+		gc.DeepEquals,
+		map[string]interface{}{
+			"foo1": "bar1", "alpha": "beta", "foo2": "zap100",
+		})
+}
+
+func (s *SettingsSuite) TestUpdateSettingsErrorsNotFound(c *gc.C) {
+	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
+	err := updateSettings(s.state.db(), s.collection, s.key, options)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *SettingsSuite) TestUpdatingInterfaceSliceValue(c *gc.C) {
 	// When storing config values that are coerced from schemas as
 	// List(Something), the value will always be a []interface{}. Make

--- a/storage/poolmanager/interface.go
+++ b/storage/poolmanager/interface.go
@@ -19,6 +19,9 @@ type PoolManager interface {
 	// Delete removes the pool with name from state.
 	Delete(name string) error
 
+	// Update updates existing pool configuration with new or changed values
+	Update(name string, attrs map[string]interface{}) error
+
 	// Get returns the pool with name from state.
 	Get(name string) (*storage.Config, error)
 
@@ -28,6 +31,7 @@ type PoolManager interface {
 
 type SettingsManager interface {
 	CreateSettings(key string, settings map[string]interface{}) error
+	UpdateSettings(key string, settings map[string]interface{}) error
 	ReadSettings(key string) (map[string]interface{}, error)
 	RemoveSettings(key string) error
 	ListSettings(keyPrefix string) (map[string]map[string]interface{}, error)
@@ -43,6 +47,15 @@ type MemSettings struct {
 func (m MemSettings) CreateSettings(key string, settings map[string]interface{}) error {
 	if _, ok := m.Settings[key]; ok {
 		return errors.AlreadyExistsf("settings with key %q", key)
+	}
+	m.Settings[key] = settings
+	return nil
+}
+
+// UpdateSettings is part of the SettingsManager interface.
+func (m MemSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+	if _, ok := m.Settings[key]; !ok {
+		return errors.NotFoundf("settings with key %q", key)
 	}
 	m.Settings[key] = settings
 	return nil

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -78,6 +78,14 @@ func (pm *poolManager) Delete(name string) error {
 	return errors.Annotatef(err, "deleting pool %q", name)
 }
 
+// Update is defined on PoolManager interface.
+func (pm *poolManager) Update(name string, attrs map[string]interface{}) error {
+	if name == "" {
+		return MissingNameError
+	}
+	return pm.settings.UpdateSettings(globalKey(name), attrs)
+}
+
 // Get is defined on PoolManager interface.
 func (pm *poolManager) Get(name string) (*storage.Config, error) {
 	settings, err := pm.settings.ReadSettings(globalKey(name))


### PR DESCRIPTION
## Description of change

Expose the ability to update and delete storage pools on the api.

## QA steps

This branch doesn't expose the functionality to the cli, just enables it via api calls. There are unit tests.

## Documentation changes

The followup PR will address the documentation additions as it will actually enable the CLI access to the functionality.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812350