### PR TITLE
api-server: Add raft-transport to dependencies

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -749,15 +749,20 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		apiServerName: apiserver.Manifold(apiserver.ManifoldConfig{
-			AgentName:                         agentName,
-			AuthenticatorName:                 httpServerArgsName,
-			ClockName:                         clockName,
-			StateName:                         stateName,
-			MuxName:                           httpServerArgsName,
-			LeaseManagerName:                  leaseManagerName,
-			UpgradeGateName:                   upgradeStepsGateName,
-			RestoreStatusName:                 restoreWatcherName,
-			AuditConfigUpdaterName:            auditConfigUpdaterName,
+			AgentName:              agentName,
+			AuthenticatorName:      httpServerArgsName,
+			ClockName:              clockName,
+			StateName:              stateName,
+			MuxName:                httpServerArgsName,
+			LeaseManagerName:       leaseManagerName,
+			UpgradeGateName:        upgradeStepsGateName,
+			RestoreStatusName:      restoreWatcherName,
+			AuditConfigUpdaterName: auditConfigUpdaterName,
+			// Synthetic dependency - if raft-transport bounces we
+			// need to bounce api-server too, otherwise http-server
+			// can't shutdown properly.
+			RaftTransportName: raftTransportName,
+
 			PrometheusRegisterer:              config.PrometheusRegisterer,
 			RegisterIntrospectionHTTPHandlers: config.RegisterIntrospectionHTTPHandlers,
 			Hub:                               config.CentralHub,

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -308,6 +308,7 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"http-server-args",
 		"is-controller-flag",
 		"lease-manager",
+		"raft-transport",
 		"restore-watcher",
 		"state",
 		"state-config-watcher",

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -79,6 +79,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		UpgradeGateName:                   "upgrade",
 		AuditConfigUpdaterName:            "auditconfig-updater",
 		LeaseManagerName:                  "lease-manager",
+		RaftTransportName:                 "raft-transport",
 		PrometheusRegisterer:              &s.prometheusRegisterer,
 		RegisterIntrospectionHTTPHandlers: func(func(string, http.Handler)) {},
 		Hub:                               &s.hub,
@@ -98,6 +99,7 @@ func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Co
 		"upgrade":             &s.upgradeGate,
 		"auditconfig-updater": s.auditConfig.get,
 		"lease-manager":       s.leaseManager,
+		"raft-transport":      nil,
 	}
 	for k, v := range overlay {
 		resources[k] = v
@@ -119,7 +121,7 @@ func (s *ManifoldSuite) newWorker(config apiserver.Config) (worker.Worker, error
 }
 
 var expectedInputs = []string{
-	"agent", "authenticator", "clock", "mux", "restore-status", "state", "upgrade", "auditconfig-updater", "lease-manager",
+	"agent", "authenticator", "clock", "mux", "restore-status", "state", "upgrade", "auditconfig-updater", "lease-manager", "raft-transport",
 }
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -100,8 +100,6 @@ type Worker struct {
 	url      chan string
 	holdable *heldListener
 
-	unsub func()
-
 	// mu controls access to both status and reporter.
 	mu     sync.Mutex
 	status string


### PR DESCRIPTION
## Description of change

This should prevent the situation where the http-server gets stuck in the "stopping" state. This happened because the raft-transport bounced but the api-server didn't, so the http-server is waiting for the mux to
report all clients are finished which will never happen.

Having raft-transport as a synthetic dependency of api-server means that if raft-transport bounces for some reason, both api-server and http-server will be stopped and started, so the http-server won't get stuck waiting for the mux indefinitely.

## QA steps

* Bootstrap a controller with a wrench in the raft-transport that causes it to crash and restart if the relevant wrench file is found.
* Trigger the wrench.
* See the api-server and http-server bounce and start up cleanly again - the restarts should be apparent in the engine report and their start counts should have incremented.

## Documentation changes

None

## Bug reference

Fixes part of https://bugs.launchpad.net/juju/+bug/1813261