### PR TITLE
Changes to the meter status watcher.

### DIFF
--- a/featuretests/api_meterstatus_test.go
+++ b/featuretests/api_meterstatus_test.go
@@ -75,7 +75,17 @@ func (s *meterStatusIntegrationSuite) TestWatchMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
+	// meter status does not change on every failed
+	// attempt to send metrics - on three consecutive
+	// fails, we get a meter status change
 	err = mm.IncrementConsecutiveErrors()
 	c.Assert(err, jc.ErrorIsNil)
+
+	err = mm.IncrementConsecutiveErrors()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = mm.IncrementConsecutiveErrors()
+	c.Assert(err, jc.ErrorIsNil)
+
 	wc.AssertOneChange()
 }

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -49,8 +49,11 @@ func (s *MeterStateSuite) TestMeterStatusIncludesModelUUID(c *gc.C) {
 	var docs []bson.M
 	err := meterStatus.Find(nil).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(docs, gc.HasLen, 1)
+	// we now expect two meter status docs - one for the unit and one
+	// for the model - both should have the model-uuid filled in.
+	c.Assert(docs, gc.HasLen, 2)
 	c.Assert(docs[0]["model-uuid"], gc.Equals, s.State.ModelUUID())
+	c.Assert(docs[1]["model-uuid"], gc.Equals, s.State.ModelUUID())
 }
 
 func (s *MeterStateSuite) TestSetMeterStatusIncorrect(c *gc.C) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1928,8 +1928,8 @@ func (u *Unit) WatchMeterStatus() NotifyWatcher {
 			meterStatusC,
 			u.st.docID(u.globalMeterStatusKey()),
 		}, {
-			metricsManagerC,
-			metricsManagerKey,
+			meterStatusC,
+			metricsManagerKey(u.st),
 		},
 	})
 }


### PR DESCRIPTION
## Description of change

Added a model meter status. Instead of units watching a document, where we record failed metric send attempts and timestamps of last successful sends, which tends to change every 5 min as we send metrics, units will now watch a model meter status doc, which only changes when it needs to (eg. failing 3 consecutive metric sends, restoring connection and successfully sending metrics, )..
 
## QA steps

Need to look at metrics to see if units still overload the controller every 5 min.. here's a guideline on how to set that up:

1. Bootstrap a controller with this patch.
2. Deploy canonical-kubernetes into a model managed by this controller.
3. Set an SLA (`juju sla essential`) on the model.
4. Observe that GetMeterStatus is NOT called every ~5 minutes when metrics are sent. 

## Documentation changes

None needed afaik.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1811700
