### PR TITLE
WIP: Ensure Raft Leases are Synchronised with State

### DIFF
--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -147,7 +147,7 @@ func (s *ApplicationStatusGetter) Status(args params.Entities) (params.Applicati
 		// ...so we can check the unit's application leadership...
 		checker := s.st.LeadershipChecker()
 		token := checker.LeadershipCheck(applicationId, unitId)
-		if err := token.Check(nil); err != nil {
+		if err := token.Check(nil, false); err != nil {
 			// TODO(fwereade) this should probably be ErrPerm is certain cases,
 			// but I don't think I implemented an exported ErrNotLeader. I
 			// should have done, though.

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -94,7 +94,7 @@ func (s *ApplicationStatusSetter) SetStatus(args params.SetStatus) (params.Error
 		token := checker.LeadershipCheck(serviceId, unitId)
 
 		// TODO(fwereade) pass token into SetStatus instead of checking here.
-		if err := token.Check(nil); err != nil {
+		if err := token.Check(nil, false); err != nil {
 			// TODO(fwereade) this should probably be ErrPerm is certain cases,
 			// but I don't think I implemented an exported ErrNotLeader. I
 			// should have done, though.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1581,7 +1581,7 @@ func (u *UniterAPI) SetRelationStatus(args params.RelationStatusArgs) (params.Er
 			return err
 		}
 		token := checker.LeadershipCheck(unit.ApplicationName(), unit.Name())
-		if err := token.Check(nil); err != nil {
+		if err := token.Check(nil, false); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -35,8 +35,8 @@ type leadershipToken struct {
 }
 
 // Check is part of the leadership.Token interface.
-func (t leadershipToken) Check(out interface{}) error {
-	err := t.token.Check(out)
+func (t leadershipToken) Check(out interface{}, sync bool) error {
+	err := t.token.Check(out, sync)
 	if errors.Cause(err) == lease.ErrNotHeld {
 		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
 	}

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -74,7 +74,7 @@ type Token interface {
 	//
 	// In practice, most Token implementations will likely expect *[]txn.Op,
 	// so that they can be used to gate mgo/txn-based state changes.
-	Check(interface{}) error
+	Check(interface{}, bool) error
 }
 
 // Checker exposes leadership testing capabilities.

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -85,10 +85,15 @@ type Token interface {
 	//
 	// If the token represents a true fact and trapdoorKey is *not* nil, it will
 	// be passed through layers for the attention of the underlying lease.Client
-	// implementation. If you need to do this, consult the documentation for the
-	// particular Client you're using to determine what key should be passed and
+	// implementation.
+	// Passing a sync value of true signals that a the lease implementation
+	// should re-assert its claim to the token's lease and synchronise this fact
+	// with state.
+	// If you need to do this, consult the documentation for the particular
+	// Client you're using to determine what key should be passed and
 	// what errors that might induce.
-	Check(trapdoorKey interface{}) error
+
+	Check(trapdoorKey interface{}, sync bool) error
 }
 
 // Manager describes methods for acquiring objects that manipulate and query

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -98,11 +98,13 @@ type Info struct {
 
 // Trapdoor allows a store to use pre-agreed special knowledge to communicate
 // with a Store substrate by passing a key with suitable properties.
-type Trapdoor func(key interface{}) error
+// passing a non-nil lease store is intended to re-assert the claim for the
+// trapdoor's source lease.
+type Trapdoor func(out interface{}, leaseStore Store) error
 
 // LockedTrapdoor is a Trapdoor suitable for use by substrates that don't want
 // or need to expose their internals.
-func LockedTrapdoor(key interface{}) error {
+func LockedTrapdoor(key interface{}, _ Claimer) error {
 	if key != nil {
 		return errors.New("lease substrate not accessible")
 	}

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -32,15 +32,20 @@ type Store interface {
 	// have passed. If it returns ErrInvalid, check Leases() for updated state.
 	ExpireLease(lease Key) error
 
-	// Leases returns a recent snapshot of lease state. Expiry times are
-	// expressed according to the Clock the store was configured with.
-	Leases() map[Key]Info
-
 	// TODO (jam) 2017-10-31: Many callers of Leases() actually only want
 	// exactly 1 lease, we should have a way to do a query to return exactly
 	// that lease, instead of having to read all of them to pull one out of the
 	// map. (Worst case it is implemented as exactly this, best case avoids
 	// reading lots of unused data.)
+
+	// Leases returns a recent snapshot of lease state. Expiry times are
+	// expressed according to the Clock the store was configured with.
+	Leases() map[Key]Info
+
+	// Trapdoor returns the Trapdoor for the input lease,
+	// if the supplied holder currently holds it.
+	// Otherwise an error is returned.
+	Trapdoor(lease Key, holder string) (Trapdoor, error)
 
 	// Refresh reads all lease state from the database.
 	Refresh() error

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -119,6 +119,17 @@ func (s *leaseStore) Leases() map[lease.Key]lease.Info {
 	return results
 }
 
+func (s *leaseStore) Trapdoor(leaseKey lease.Key, holder string) (lease.Trapdoor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	l, found := s.Leases()[leaseKey]
+	if !found || l.Holder != holder {
+		return nil, lease.ErrNotHeld
+	}
+	return s.trapdoor(leaseKey, holder), nil
+}
+
 // Refresh is part of lease.Store.
 func (s *leaseStore) Refresh() error {
 	return nil

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -50,7 +50,8 @@ func (st *State) LeadershipChecker() leadership.Checker {
 func buildTxnWithLeadership(buildTxn jujutxn.TransactionSource, token leadership.Token) jujutxn.TransactionSource {
 	return func(attempt int) ([]txn.Op, error) {
 		var prereqs []txn.Op
-		if err := token.Check(&prereqs); err != nil {
+		sync := attempt > 0
+		if err := token.Check(&prereqs, sync); err != nil {
 			return nil, errors.Annotatef(err, "prerequisites failed")
 		}
 		ops, err := buildTxn(attempt)
@@ -86,8 +87,8 @@ type leadershipToken struct {
 }
 
 // Check is part of the leadership.Token interface.
-func (t leadershipToken) Check(out interface{}) error {
-	err := t.token.Check(out)
+func (t leadershipToken) Check(out interface{}, sync bool) error {
+	err := t.token.Check(out, sync)
 	if errors.Cause(err) == lease.ErrNotHeld {
 		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
 	}

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -473,6 +473,9 @@ func (store *store) expireLeaseOps(name string) ([]txn.Op, error) {
 
 // assertOpTrapdoor returns a lease.Trapdoor that will replace a supplied
 // *[]txn.Op with one that asserts that the holder still holds the named lease.
+// The state-based lease implementation is implicitly in sync with itself,
+// so such Trapdoors ignore any supplied store intended for re-asserting the
+// lease.
 func (store *store) assertOpTrapdoor(name, holder string) lease.Trapdoor {
 	op := txn.Op{
 		C:  store.config.Collection,
@@ -481,7 +484,7 @@ func (store *store) assertOpTrapdoor(name, holder string) lease.Trapdoor {
 			fieldHolder: holder,
 		},
 	}
-	return func(out interface{}) error {
+	return func(out interface{}, _ lease.Store) error {
 		outPtr, ok := out.(*[]txn.Op)
 		if !ok {
 			return errors.NotValidf("expected *[]txn.Op; %T", out)

--- a/state/workers.go
+++ b/state/workers.go
@@ -234,6 +234,6 @@ type errorToken struct {
 }
 
 // Check is part of the lease.Token interface.
-func (t errorToken) Check(key interface{}) error {
+func (t errorToken) Check(_ interface{}, _ bool) error {
 	return t.err
 }

--- a/worker/lease/check.go
+++ b/worker/lease/check.go
@@ -19,7 +19,7 @@ type token struct {
 }
 
 // Check is part of the lease.Token interface.
-func (t token) Check(trapdoorKey interface{}) error {
+func (t token) Check(trapdoorKey interface{}, sync bool) error {
 
 	// This validation, which could be done at Token creation time, is deferred
 	// until this point for historical reasons. In particular, this code was
@@ -39,6 +39,7 @@ func (t token) Check(trapdoorKey interface{}) error {
 		leaseKey:    t.leaseKey,
 		holderName:  t.holderName,
 		trapdoorKey: trapdoorKey,
+		sync:        sync,
 		response:    make(chan error),
 		stop:        t.stop,
 	}.invoke(t.checks)
@@ -50,6 +51,7 @@ type check struct {
 	leaseKey    lease.Key
 	holderName  string
 	trapdoorKey interface{}
+	sync        bool
 	response    chan error
 	stop        <-chan struct{}
 }

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -317,7 +317,11 @@ func (manager *Manager) handleCheck(check check) error {
 
 	trapdoor, err := store.Trapdoor(check.leaseKey, check.holderName)
 	if err == nil {
-		err = trapdoor(check.trapdoorKey)
+		var syncStore lease.Store
+		if check.sync {
+			syncStore = store
+		}
+		err = trapdoor(check.trapdoorKey, syncStore)
 	} else if err != lease.ErrNotHeld {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Ensure that if a trapdoor from a Raft-sourced lease has a failing assertion on the first attempt, then the Raft lease-holder is re-sync'd with state.

## QA steps

TBC.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1810331
