### PR TITLE
Expose update delete storage pools CLI

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -90,6 +90,20 @@ func (c *Client) CreatePool(pname, provider string, attrs map[string]interface{}
 	return c.facade.FacadeCall("CreatePool", args, nil)
 }
 
+// DeletePool deletes the named pool
+func (c *Client) DeletePool(pname string) error {
+	return c.facade.FacadeCall("DeletePool", pname, nil)
+}
+
+// UpdatePool updates a  pool with specified parameters.
+func (c *Client) UpdatePool(pname string, attrs map[string]interface{}) error {
+	args := params.StoragePool{
+		Name:  pname,
+		Attrs: attrs,
+	}
+	return c.facade.FacadeCall("UpdatePool", args, nil)
+}
+
 // ListVolumes lists volumes for desired machines.
 // If no machines provided, a list of all volumes is returned.
 func (c *Client) ListVolumes(machines []string) ([]params.VolumeDetailsListResult, error) {

--- a/apiserver/facades/client/storage/export_test.go
+++ b/apiserver/facades/client/storage/export_test.go
@@ -1,13 +1,13 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2015, 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package storage
 
 var (
-	ValidatePoolListFilter   = (*APIv4).validatePoolListFilter
-	ValidateNameCriteria     = (*APIv4).validateNameCriteria
-	ValidateProviderCriteria = (*APIv4).validateProviderCriteria
-	EnsureStoragePoolFilter  = (*APIv4).ensureStoragePoolFilter
+	ValidatePoolListFilter   = (*APIv5).validatePoolListFilter
+	ValidateNameCriteria     = (*APIv5).validateNameCriteria
+	ValidateProviderCriteria = (*APIv5).validateProviderCriteria
+	EnsureStoragePoolFilter  = (*APIv5).ensureStoragePoolFilter
 )
 
 type (

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -20,6 +20,7 @@ type mockPoolManager struct {
 	createPool func(name string, providerType jujustorage.ProviderType, attrs map[string]interface{}) (*jujustorage.Config, error)
 	deletePool func(name string) error
 	listPools  func() ([]*jujustorage.Config, error)
+	updatePool func(name string, attrs map[string]interface{}) error
 }
 
 func (m *mockPoolManager) Get(name string) (*jujustorage.Config, error) {
@@ -36,6 +37,10 @@ func (m *mockPoolManager) Delete(name string) error {
 
 func (m *mockPoolManager) List() ([]*jujustorage.Config, error) {
 	return m.listPools()
+}
+
+func (m *mockPoolManager) Update(name string, attrs map[string]interface{}) error {
+	return m.updatePool(name, attrs)
 }
 
 type mockStorageAccessor struct {

--- a/apiserver/facades/client/storage/pooldelete_test.go
+++ b/apiserver/facades/client/storage/pooldelete_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+type poolDeleteSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&poolDeleteSuite{})
+
+func (s *poolDeleteSuite) createPools(c *gc.C, num int) {
+	var err error
+	for i := 0; i < num; i++ {
+		poolName := fmt.Sprintf("%v%v", tstName, i)
+		s.baseStorageSuite.pools[poolName], err =
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *poolDeleteSuite) TestDeletePool(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+
+	err := s.api.DeletePool(poolName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 0)
+}
+
+func (s *poolDeleteSuite) TestDeleteErrorNotExists(c *gc.C) {
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+
+	err := s.api.DeletePool(poolName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 0)
+}

--- a/apiserver/facades/client/storage/poolupdate_test.go
+++ b/apiserver/facades/client/storage/poolupdate_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+type poolUpdateSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&poolUpdateSuite{})
+
+func (s *poolUpdateSuite) createPools(c *gc.C, num int) {
+	var err error
+	for i := 0; i < num; i++ {
+		poolName := fmt.Sprintf("%v%v", tstName, i)
+		s.baseStorageSuite.pools[poolName], err =
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *poolUpdateSuite) TestUpdatePool(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	newAttrs := map[string]interface{}{
+		"foo1": "bar1",
+		"zip":  "zoom",
+	}
+
+	err := s.api.UpdatePool(params.StoragePool{
+		Name:  poolName,
+		Attrs: newAttrs,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected, err := storage.NewConfig(poolName, provider.LoopProviderType, newAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
+	c.Assert(pools[0], gc.DeepEquals, expected)
+}
+
+func (s *poolUpdateSuite) TestUpdatePoolError(c *gc.C) {
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	err := s.api.UpdatePool(params.StoragePool{
+		Name: poolName,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/cmd/juju/storage/export_test.go
+++ b/cmd/juju/storage/export_test.go
@@ -31,6 +31,22 @@ func NewPoolCreateCommandForTest(api PoolCreateAPI, store jujuclient.ClientStore
 	return modelcmd.Wrap(cmd)
 }
 
+func NewPoolDeleteCommandForTest(api PoolDeleteAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &poolDeleteCommand{newAPIFunc: func() (PoolDeleteAPI, error) {
+		return api, nil
+	}}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
+func NewPoolUpdateCommandForTest(api PoolUpdateAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &poolUpdateCommand{newAPIFunc: func() (PoolUpdateAPI, error) {
+		return api, nil
+	}}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
 func NewShowCommandForTest(api StorageShowAPI, store jujuclient.ClientStore) cmd.Command {
 	cmd := &showCommand{newAPIFunc: func() (StorageShowAPI, error) {
 		return api, nil

--- a/cmd/juju/storage/pooldelete.go
+++ b/cmd/juju/storage/pooldelete.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// PoolDeleteAPI defines the API methods that the storage commands use.
+type PoolDeleteAPI interface {
+	Close() error
+	DeletePool(name string) error
+}
+
+const poolDeleteCommandDoc = `
+Delete a single existing storage pool.
+`
+
+// NewPoolDeleteCommand returns a command that deletes the named storage pool.
+func NewPoolDeleteCommand() cmd.Command {
+	cmd := &poolDeleteCommand{}
+	cmd.newAPIFunc = func() (PoolDeleteAPI, error) {
+		return cmd.NewStorageAPI()
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// poolDeleteCommand deletes a storage pool.
+type poolDeleteCommand struct {
+	PoolCommandBase
+	newAPIFunc func() (PoolDeleteAPI, error)
+	poolName   string
+}
+
+// Init implements Command.Init.
+func (c *poolDeleteCommand) Init(args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("pool deletion requires storage pool name")
+	}
+
+	c.poolName = args[0]
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *poolDeleteCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "delete-storage-pool",
+		Purpose: "Delete an existing storage pool.",
+		Doc:     poolDeleteCommandDoc,
+	})
+}
+
+// Run implements Command.Run.
+func (c *poolDeleteCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+	err = api.DeletePool(c.poolName)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/juju/storage/pooldelete_test.go
+++ b/cmd/juju/storage/pooldelete_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/storage"
+	_ "github.com/juju/juju/provider/dummy"
+)
+
+type PoolDeleteSuite struct {
+	SubStorageSuite
+	mockAPI *mockPoolDeleteAPI
+}
+
+var _ = gc.Suite(&PoolDeleteSuite{})
+
+func (s *PoolDeleteSuite) SetUpTest(c *gc.C) {
+	s.SubStorageSuite.SetUpTest(c)
+
+	s.mockAPI = &mockPoolDeleteAPI{}
+}
+
+func (s *PoolDeleteSuite) runPoolDelete(c *gc.C, args []string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, storage.NewPoolDeleteCommandForTest(s.mockAPI, s.store), args...)
+}
+
+func (s *PoolDeleteSuite) TestPoolDeleteOneArg(c *gc.C) {
+	_, err := s.runPoolDelete(c, []string{"sunshine"})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *PoolDeleteSuite) TestPoolDeleteNoArgs(c *gc.C) {
+	_, err := s.runPoolDelete(c, []string{})
+	c.Check(err, gc.ErrorMatches, "pool deletion requires storage pool name")
+}
+
+func (s *PoolDeleteSuite) TestPoolDeleteErrorsManyArgs(c *gc.C) {
+	_, err := s.runPoolDelete(c, []string{"sunshine", "lollypop"})
+	c.Check(err, gc.ErrorMatches, "pool deletion requires storage pool name")
+}
+
+type mockPoolDeleteAPI struct {
+}
+
+func (s mockPoolDeleteAPI) DeletePool(pname string) error {
+	return nil
+}
+
+func (s mockPoolDeleteAPI) Close() error {
+	return nil
+}

--- a/cmd/juju/storage/poolupdate.go
+++ b/cmd/juju/storage/poolupdate.go
@@ -1,0 +1,86 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/utils/keyvalues"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// PoolUpdateAPI defines the API methods that the storage commands use.
+type PoolUpdateAPI interface {
+	Close() error
+	UpdatePool(name string, attr map[string]interface{}) error
+}
+
+const poolUpdateCommandDoc = `
+Update configuration attributes for a single existing storage pool.
+`
+
+// NewPoolUpdateCommand returns a command that updates the named storage pools' attributes.
+func NewPoolUpdateCommand() cmd.Command {
+	cmd := &poolUpdateCommand{}
+	cmd.newAPIFunc = func() (PoolUpdateAPI, error) {
+		return cmd.NewStorageAPI()
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// poolUpdateCommand updates a storage pool configuration attributes.
+type poolUpdateCommand struct {
+	PoolCommandBase
+	newAPIFunc  func() (PoolUpdateAPI, error)
+	poolName    string
+	configAttrs map[string]interface{}
+}
+
+// Init implements Command.Init.
+func (c *poolUpdateCommand) Init(args []string) (err error) {
+	if len(args) < 2 {
+		return errors.New("pool update requires name and configuration attributes")
+	}
+
+	c.poolName = args[0]
+
+	config, err := keyvalues.Parse(args[1:], false)
+	if err != nil {
+		return err
+	}
+	if len(config) == 0 {
+		return errors.New("pool update requires configuration attributes")
+	}
+
+	c.configAttrs = make(map[string]interface{})
+	for key, value := range config {
+		c.configAttrs[key] = value
+	}
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *poolUpdateCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "update-storage-pool",
+		Purpose: "Update storage pool attributes.",
+		Doc:     poolUpdateCommandDoc,
+	})
+}
+
+// Run implements Command.Run.
+func (c *poolUpdateCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+	err = api.UpdatePool(c.poolName, c.configAttrs)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/juju/storage/poolupdate_test.go
+++ b/cmd/juju/storage/poolupdate_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/storage"
+	_ "github.com/juju/juju/provider/dummy"
+)
+
+type PoolUpdateSuite struct {
+	SubStorageSuite
+	mockAPI *mockPoolUpdateAPI
+}
+
+var _ = gc.Suite(&PoolUpdateSuite{})
+
+func (s *PoolUpdateSuite) SetUpTest(c *gc.C) {
+	s.SubStorageSuite.SetUpTest(c)
+
+	s.mockAPI = &mockPoolUpdateAPI{}
+}
+
+func (s *PoolUpdateSuite) runPoolUpdate(c *gc.C, args []string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, storage.NewPoolUpdateCommandForTest(s.mockAPI, s.store), args...)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateOneArg(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine"})
+	c.Check(err, gc.ErrorMatches, "pool update requires name and configuration attributes")
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateNoArgs(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{""})
+	c.Check(err, gc.ErrorMatches, "pool update requires name and configuration attributes")
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateWithAttrArgs(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", "lollypop=true"})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateAttrMissingKey(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", "=too"})
+	c.Check(err, gc.ErrorMatches, `expected "key=value", got "=too"`)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateAttrMissingValue(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", "something="})
+	c.Check(err, gc.ErrorMatches, `expected "key=value", got "something="`)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateAttrEmptyValue(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", `something=""`})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateOneAttr(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", "something=too"})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateEmptyAttr(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", ""})
+	c.Check(err, gc.ErrorMatches, `expected "key=value", got ""`)
+}
+
+func (s *PoolUpdateSuite) TestPoolUpdateManyAttrs(c *gc.C) {
+	_, err := s.runPoolUpdate(c, []string{"sunshine", "something=too", "another=one"})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+type mockPoolUpdateAPI struct {
+}
+
+func (s mockPoolUpdateAPI) UpdatePool(pname string, pconfig map[string]interface{}) error {
+	return nil
+}
+
+func (s mockPoolUpdateAPI) Close() error {
+	return nil
+}

--- a/state/settings.go
+++ b/state/settings.go
@@ -373,6 +373,17 @@ func removeSettingsOp(collection, key string) txn.Op {
 	}
 }
 
+// updateSettings updates the Settings for key.
+func updateSettings(db Database, collection, key string, values map[string]interface{}) error {
+	existing, err := readSettings(db, collection, key)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	existing.Update(values)
+	_, err = existing.Write()
+	return errors.Trace(err)
+}
+
 // listSettings returns all the settings with the specified key prefix.
 func listSettings(backend modelBackend, collection, keyPrefix string) (map[string]map[string]interface{}, error) {
 	settings, closer := backend.db().GetRawCollection(collection)
@@ -482,6 +493,11 @@ func (s *StateSettings) ReadSettings(key string) (map[string]interface{}, error)
 // RemoveSettings exposes removeSettings on state for use outside the state package.
 func (s *StateSettings) RemoveSettings(key string) error {
 	return removeSettings(s.backend.db(), s.collection, key)
+}
+
+// UpdateSettings exposes updateSettings on state for use outside the state package.
+func (s *StateSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+	return updateSettings(s.backend.db(), s.collection, key, settings)
 }
 
 // ListSettings exposes listSettings on state for use outside the state package.

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -511,6 +511,35 @@ func (s *SettingsSuite) TestList(c *gc.C) {
 	})
 }
 
+func (s *SettingsSuite) TestUpdateSettings(c *gc.C) {
+	_, err := s.createSettings(s.key, map[string]interface{}{"foo1": "bar1", "foo2": "bar2"})
+	c.Assert(err, jc.ErrorIsNil)
+	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
+	err = updateSettings(s.state.db(), s.collection, s.key, options)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check MongoDB state.
+	var mgoData struct {
+		Settings settingsMap
+	}
+	settings, closer := s.state.db().GetCollection(settingsC)
+	defer closer()
+	err = settings.FindId(s.key).One(&mgoData)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(
+		map[string]interface{}(mgoData.Settings),
+		gc.DeepEquals,
+		map[string]interface{}{
+			"foo1": "bar1", "alpha": "beta", "foo2": "zap100",
+		})
+}
+
+func (s *SettingsSuite) TestUpdateSettingsErrorsNotFound(c *gc.C) {
+	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
+	err := updateSettings(s.state.db(), s.collection, s.key, options)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *SettingsSuite) TestUpdatingInterfaceSliceValue(c *gc.C) {
 	// When storing config values that are coerced from schemas as
 	// List(Something), the value will always be a []interface{}. Make

--- a/storage/poolmanager/interface.go
+++ b/storage/poolmanager/interface.go
@@ -19,6 +19,9 @@ type PoolManager interface {
 	// Delete removes the pool with name from state.
 	Delete(name string) error
 
+	// Update updates existing pool configuration with new or changed values
+	Update(name string, attrs map[string]interface{}) error
+
 	// Get returns the pool with name from state.
 	Get(name string) (*storage.Config, error)
 
@@ -28,6 +31,7 @@ type PoolManager interface {
 
 type SettingsManager interface {
 	CreateSettings(key string, settings map[string]interface{}) error
+	UpdateSettings(key string, settings map[string]interface{}) error
 	ReadSettings(key string) (map[string]interface{}, error)
 	RemoveSettings(key string) error
 	ListSettings(keyPrefix string) (map[string]map[string]interface{}, error)
@@ -43,6 +47,15 @@ type MemSettings struct {
 func (m MemSettings) CreateSettings(key string, settings map[string]interface{}) error {
 	if _, ok := m.Settings[key]; ok {
 		return errors.AlreadyExistsf("settings with key %q", key)
+	}
+	m.Settings[key] = settings
+	return nil
+}
+
+// UpdateSettings is part of the SettingsManager interface.
+func (m MemSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+	if _, ok := m.Settings[key]; !ok {
+		return errors.NotFoundf("settings with key %q", key)
 	}
 	m.Settings[key] = settings
 	return nil

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -78,6 +78,14 @@ func (pm *poolManager) Delete(name string) error {
 	return errors.Annotatef(err, "deleting pool %q", name)
 }
 
+// Update is defined on PoolManager interface.
+func (pm *poolManager) Update(name string, attrs map[string]interface{}) error {
+	if name == "" {
+		return MissingNameError
+	}
+	return pm.settings.UpdateSettings(globalKey(name), attrs)
+}
+
 // Get is defined on PoolManager interface.
 func (pm *poolManager) Get(name string) (*storage.Config, error) {
 	settings, err := pm.settings.ReadSettings(globalKey(name))


### PR DESCRIPTION
## Description of change

Builds on my branch that exposes update/delete via the API (https://github.com/juju/juju/pull/9674).
Exposes the storage-pool update/delete functionality via the command line commands.

## QA steps

Unit tests included.

## Documentation changes

Command document text included .

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812350
