### PR TITLE
Enable storage-pool update/delete API support.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -94,7 +94,7 @@ var facadeVersions = map[string]int{
 	"Spaces":                       3,
 	"SSHClient":                    2,
 	"StatusHistory":                2,
-	"Storage":                      4,
+	"Storage":                      5,
 	"StorageProvisioner":           4,
 	"StringsWatcher":               1,
 	"Subnets":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -269,6 +269,7 @@ func AllFacades() *facade.Registry {
 
 	reg("Storage", 3, storage.NewFacadeV3)
 	reg("Storage", 4, storage.NewFacadeV4) // changes Destroy() method signature.
+	reg("Storage", 5, storage.NewFacadeV5) // adds Update() and Delete()
 
 	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
 	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -267,9 +267,9 @@ func AllFacades() *facade.Registry {
 
 	reg("StatusHistory", 2, statushistory.NewAPI)
 
-	reg("Storage", 3, storage.NewFacadeV3)
-	reg("Storage", 4, storage.NewFacadeV4) // changes Destroy() method signature.
-	reg("Storage", 5, storage.NewFacadeV5) // adds Update() and Delete()
+	reg("Storage", 3, storage.NewStorageAPIV3)
+	reg("Storage", 4, storage.NewStorageAPIV4) // changes Destroy() method signature.
+	reg("Storage", 5, storage.NewStorageAPI)   // Update and Delete storage pools
 
 	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
 	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -26,9 +26,9 @@ type baseStorageSuite struct {
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 
-	api             *storage.APIv5
-	apiCaas         *storage.APIv5
-	apiv3           *storage.APIv3
+	api             *storage.StorageAPI
+	apiCaas         *storage.StorageAPI
+	apiv3           *storage.StorageAPIv3
 	storageAccessor *mockStorageAccessor
 	state           *mockState
 
@@ -67,12 +67,14 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.poolManager = s.constructPoolManager()
 
 	s.callContext = context.NewCloudCallContext()
-	var err error
-	s.api, err = storage.NewAPIv5(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer, s.callContext)
-	s.apiCaas, err = storage.NewAPIv5(s.state, state.ModelTypeCAAS, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer, s.callContext)
-	c.Assert(err, jc.ErrorIsNil)
-	s.apiv3, err = storage.NewAPIv3(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.resources, s.authorizer, s.callContext)
-	c.Assert(err, jc.ErrorIsNil)
+	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
+	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
+	newAPI := storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
+	s.apiv3 = &storage.StorageAPIv3{
+		StorageAPIv4: storage.StorageAPIv4{
+			StorageAPI: *newAPI,
+		},
+	}
 }
 
 // TODO(axw) get rid of assertCalls, use stub directly everywhere.
@@ -357,13 +359,9 @@ func (s *baseStorageSuite) constructPoolManager() *mockPoolManager {
 			}
 			return result, nil
 		},
-		updatePool: func(name string, attrs map[string]interface{}) error {
+		replacePool: func(name string, attrs map[string]interface{}) error {
 			if p, ok := s.pools[name]; ok {
-				updatedAttr := p.Attrs()
-				for k, v := range attrs {
-					updatedAttr[k] = v
-				}
-				newPool, err := jujustorage.NewConfig(name, p.Provider(), updatedAttr)
+				newPool, err := jujustorage.NewConfig(name, p.Provider(), attrs)
 				s.pools[name] = newPool
 				return err
 			}

--- a/apiserver/facades/client/storage/export_test.go
+++ b/apiserver/facades/client/storage/export_test.go
@@ -1,13 +1,13 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2015, 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package storage
 
 var (
-	ValidatePoolListFilter   = (*APIv4).validatePoolListFilter
-	ValidateNameCriteria     = (*APIv4).validateNameCriteria
-	ValidateProviderCriteria = (*APIv4).validateProviderCriteria
-	EnsureStoragePoolFilter  = (*APIv4).ensureStoragePoolFilter
+	ValidatePoolListFilter   = (*APIv5).validatePoolListFilter
+	ValidateNameCriteria     = (*APIv5).validateNameCriteria
+	ValidateProviderCriteria = (*APIv5).validateProviderCriteria
+	EnsureStoragePoolFilter  = (*APIv5).ensureStoragePoolFilter
 )
 
 type (

--- a/apiserver/facades/client/storage/export_test.go
+++ b/apiserver/facades/client/storage/export_test.go
@@ -1,13 +1,14 @@
-// Copyright 2015, 2019 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package storage
 
 var (
-	ValidatePoolListFilter   = (*APIv5).validatePoolListFilter
-	ValidateNameCriteria     = (*APIv5).validateNameCriteria
-	ValidateProviderCriteria = (*APIv5).validateProviderCriteria
-	EnsureStoragePoolFilter  = (*APIv5).ensureStoragePoolFilter
+	ValidatePoolListFilter   = (*StorageAPI).validatePoolListFilter
+	ValidateNameCriteria     = (*StorageAPI).validateNameCriteria
+	ValidateProviderCriteria = (*StorageAPI).validateProviderCriteria
+	EnsureStoragePoolFilter  = (*StorageAPI).ensureStoragePoolFilter
+	NewStorageAPIForTest     = newStorageAPI
 )
 
 type (

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -20,6 +20,7 @@ type mockPoolManager struct {
 	createPool func(name string, providerType jujustorage.ProviderType, attrs map[string]interface{}) (*jujustorage.Config, error)
 	deletePool func(name string) error
 	listPools  func() ([]*jujustorage.Config, error)
+	updatePool func(name string, attrs map[string]interface{}) error
 }
 
 func (m *mockPoolManager) Get(name string) (*jujustorage.Config, error) {
@@ -36,6 +37,10 @@ func (m *mockPoolManager) Delete(name string) error {
 
 func (m *mockPoolManager) List() ([]*jujustorage.Config, error) {
 	return m.listPools()
+}
+
+func (m *mockPoolManager) Update(name string, attrs map[string]interface{}) error {
+	return m.updatePool(name, attrs)
 }
 
 type mockStorageAccessor struct {

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 type mockPoolManager struct {
-	getPool    func(name string) (*jujustorage.Config, error)
-	createPool func(name string, providerType jujustorage.ProviderType, attrs map[string]interface{}) (*jujustorage.Config, error)
-	deletePool func(name string) error
-	listPools  func() ([]*jujustorage.Config, error)
-	updatePool func(name string, attrs map[string]interface{}) error
+	getPool     func(name string) (*jujustorage.Config, error)
+	createPool  func(name string, providerType jujustorage.ProviderType, attrs map[string]interface{}) (*jujustorage.Config, error)
+	deletePool  func(name string) error
+	listPools   func() ([]*jujustorage.Config, error)
+	replacePool func(name string, attrs map[string]interface{}) error
 }
 
 func (m *mockPoolManager) Get(name string) (*jujustorage.Config, error) {
@@ -39,8 +39,8 @@ func (m *mockPoolManager) List() ([]*jujustorage.Config, error) {
 	return m.listPools()
 }
 
-func (m *mockPoolManager) Update(name string, attrs map[string]interface{}) error {
-	return m.updatePool(name, attrs)
+func (m *mockPoolManager) Replace(name string, attrs map[string]interface{}) error {
+	return m.replacePool(name, attrs)
 }
 
 type mockStorageAccessor struct {

--- a/apiserver/facades/client/storage/pooldelete_test.go
+++ b/apiserver/facades/client/storage/pooldelete_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 )
 
@@ -41,7 +41,7 @@ func (s *poolDeleteSuite) TestDeletePool(c *gc.C) {
 	c.Assert(pools, gc.HasLen, 0)
 }
 
-func (s *poolDeleteSuite) TestDeleteErrorNotExists(c *gc.C) {
+func (s *poolDeleteSuite) TestDeleteNotExists(c *gc.C) {
 	poolName := fmt.Sprintf("%v%v", tstName, 0)
 
 	err := s.api.DeletePool(poolName)

--- a/apiserver/facades/client/storage/pooldelete_test.go
+++ b/apiserver/facades/client/storage/pooldelete_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+type poolDeleteSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&poolDeleteSuite{})
+
+func (s *poolDeleteSuite) createPools(c *gc.C, num int) {
+	var err error
+	for i := 0; i < num; i++ {
+		poolName := fmt.Sprintf("%v%v", tstName, i)
+		s.baseStorageSuite.pools[poolName], err =
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *poolDeleteSuite) TestDeletePool(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+
+	err := s.api.DeletePool(poolName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 0)
+}
+
+func (s *poolDeleteSuite) TestDeleteErrorNotExists(c *gc.C) {
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+
+	err := s.api.DeletePool(poolName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 0)
+}

--- a/apiserver/facades/client/storage/poolupdate_test.go
+++ b/apiserver/facades/client/storage/poolupdate_test.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+type poolUpdateSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&poolUpdateSuite{})
+
+func (s *poolUpdateSuite) createPools(c *gc.C, num int) {
+	var err error
+	for i := 0; i < num; i++ {
+		poolName := fmt.Sprintf("%v%v", tstName, i)
+		s.baseStorageSuite.pools[poolName], err =
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *poolUpdateSuite) TestUpdatePool(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	newAttrs := map[string]interface{}{
+		"foo1": "bar1",
+		"zip":  "zoom",
+	}
+
+	err := s.api.UpdatePool(params.StoragePool{
+		Name:  poolName,
+		Attrs: newAttrs,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected, err := storage.NewConfig(poolName, provider.LoopProviderType, newAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
+	c.Assert(pools[0], gc.DeepEquals, expected)
+}
+
+func (s *poolUpdateSuite) TestUpdatePoolError(c *gc.C) {
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	err := s.api.UpdatePool(params.StoragePool{
+		Name: poolName,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/apiserver/facades/client/storage/poolupdate_test.go
+++ b/apiserver/facades/client/storage/poolupdate_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	storage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 )
 
@@ -26,7 +26,10 @@ func (s *poolUpdateSuite) createPools(c *gc.C, num int) {
 	for i := 0; i < num; i++ {
 		poolName := fmt.Sprintf("%v%v", tstName, i)
 		s.baseStorageSuite.pools[poolName], err =
-			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+			storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{
+				"zip":  "zap",
+				"beep": "boop",
+			})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -8,103 +8,13 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
-	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/caas"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
-	"github.com/juju/juju/storage/poolmanager"
 )
 
 // This file contains untested shims to let us wrap state in a sensible
 // interface and avoid writing tests that depend on mongodb. If you were
 // to change any part of it so that it were no longer *obviously* and
 // *trivially* correct, you would be Doing It Wrong.
-
-// NewFacadeV5 provides the signature required for facade registration.
-func NewFacadeV5(
-	st *state.State,
-	resources facade.Resources,
-	authorizer facade.Authorizer,
-) (*APIv5, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	registry, err := stateenvirons.NewStorageProviderRegistryForModel(
-		model,
-		stateenvirons.GetNewEnvironFunc(environs.New),
-		stateenvirons.GetNewCAASBrokerFunc(caas.New))
-	pm := poolmanager.New(state.NewStateSettings(st), registry)
-
-	storageAccessor, err := getStorageAccessor(st)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting backend")
-	}
-	return NewAPIv5(
-		stateShim{st},
-		model.Type(),
-		storageAccessor,
-		registry, pm, resources, authorizer,
-		state.CallContext(st))
-}
-
-// NewFacadeV4 provides the signature required for facade registration.
-func NewFacadeV4(
-	st *state.State,
-	resources facade.Resources,
-	authorizer facade.Authorizer,
-) (*APIv4, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	registry, err := stateenvirons.NewStorageProviderRegistryForModel(
-		model,
-		stateenvirons.GetNewEnvironFunc(environs.New),
-		stateenvirons.GetNewCAASBrokerFunc(caas.New))
-	pm := poolmanager.New(state.NewStateSettings(st), registry)
-
-	storageAccessor, err := getStorageAccessor(st)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting backend")
-	}
-	return NewAPIv4(
-		stateShim{st},
-		model.Type(),
-		storageAccessor,
-		registry, pm, resources, authorizer,
-		state.CallContext(st))
-}
-
-// NewFacadeV3 provides the signature required for facade registration.
-func NewFacadeV3(
-	st *state.State,
-	resources facade.Resources,
-	authorizer facade.Authorizer,
-) (*APIv3, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(st)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting environ")
-	}
-	registry := stateenvirons.NewStorageProviderRegistry(env)
-	pm := poolmanager.New(state.NewStateSettings(st), registry)
-
-	storageAccessor, err := getStorageAccessor(st)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting backend")
-	}
-	return NewAPIv3(
-		stateShim{st},
-		model.Type(),
-		storageAccessor,
-		registry, pm, resources, authorizer,
-		state.CallContext(st))
-}
 
 type storageAccess interface {
 	storageInterface

--- a/state/settings.go
+++ b/state/settings.go
@@ -153,6 +153,11 @@ func (s *Settings) Update(kv map[string]interface{}) {
 	}
 }
 
+// Replace overwrites the existing settings with new onesl
+func (s *Settings) Replace(kv map[string]interface{}) {
+	s.core = kv
+}
+
 // Delete removes key.
 func (s *Settings) Delete(key string) {
 	delete(s.core, key)
@@ -373,13 +378,13 @@ func removeSettingsOp(collection, key string) txn.Op {
 	}
 }
 
-// updateSettings updates the Settings for key.
-func updateSettings(db Database, collection, key string, values map[string]interface{}) error {
+// replaceSettings replaces the settings value for key.
+func replaceSettings(db Database, collection, key string, values map[string]interface{}) error {
 	existing, err := readSettings(db, collection, key)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	existing.Update(values)
+	existing.Replace(values)
 	_, err = existing.Write()
 	return errors.Trace(err)
 }
@@ -495,9 +500,9 @@ func (s *StateSettings) RemoveSettings(key string) error {
 	return removeSettings(s.backend.db(), s.collection, key)
 }
 
-// UpdateSettings exposes updateSettings on state for use outside the state package.
-func (s *StateSettings) UpdateSettings(key string, settings map[string]interface{}) error {
-	return updateSettings(s.backend.db(), s.collection, key, settings)
+// ReplaceSettings exposes replaceSettings on state for use outside the state package.
+func (s *StateSettings) ReplaceSettings(key string, settings map[string]interface{}) error {
+	return replaceSettings(s.backend.db(), s.collection, key, settings)
 }
 
 // ListSettings exposes listSettings on state for use outside the state package.

--- a/state/settings.go
+++ b/state/settings.go
@@ -373,6 +373,17 @@ func removeSettingsOp(collection, key string) txn.Op {
 	}
 }
 
+// updateSettings updates the Settings for key.
+func updateSettings(db Database, collection, key string, values map[string]interface{}) error {
+	existing, err := readSettings(db, collection, key)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	existing.Update(values)
+	_, err = existing.Write()
+	return errors.Trace(err)
+}
+
 // listSettings returns all the settings with the specified key prefix.
 func listSettings(backend modelBackend, collection, keyPrefix string) (map[string]map[string]interface{}, error) {
 	settings, closer := backend.db().GetRawCollection(collection)
@@ -482,6 +493,11 @@ func (s *StateSettings) ReadSettings(key string) (map[string]interface{}, error)
 // RemoveSettings exposes removeSettings on state for use outside the state package.
 func (s *StateSettings) RemoveSettings(key string) error {
 	return removeSettings(s.backend.db(), s.collection, key)
+}
+
+// UpdateSettings exposes updateSettings on state for use outside the state package.
+func (s *StateSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+	return updateSettings(s.backend.db(), s.collection, key, settings)
 }
 
 // ListSettings exposes listSettings on state for use outside the state package.

--- a/state/settings.go
+++ b/state/settings.go
@@ -373,7 +373,7 @@ func removeSettingsOp(collection, key string) txn.Op {
 	}
 }
 
-// replaceSettings replaces the settings value for key.
+// replaceSettings replaces the settings values for key.
 func replaceSettings(db Database, collection, key string, values map[string]interface{}) error {
 	op, _, err := replaceSettingsOp(db, collection, key, values)
 	if err != nil {

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -511,11 +511,11 @@ func (s *SettingsSuite) TestList(c *gc.C) {
 	})
 }
 
-func (s *SettingsSuite) TestUpdateSettings(c *gc.C) {
+func (s *SettingsSuite) TestReplaceSettings(c *gc.C) {
 	_, err := s.createSettings(s.key, map[string]interface{}{"foo1": "bar1", "foo2": "bar2"})
 	c.Assert(err, jc.ErrorIsNil)
 	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
-	err = updateSettings(s.state.db(), s.collection, s.key, options)
+	err = replaceSettings(s.state.db(), s.collection, s.key, options)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check MongoDB state.
@@ -530,13 +530,13 @@ func (s *SettingsSuite) TestUpdateSettings(c *gc.C) {
 		map[string]interface{}(mgoData.Settings),
 		gc.DeepEquals,
 		map[string]interface{}{
-			"foo1": "bar1", "alpha": "beta", "foo2": "zap100",
+			"alpha": "beta", "foo2": "zap100",
 		})
 }
 
-func (s *SettingsSuite) TestUpdateSettingsErrorsNotFound(c *gc.C) {
+func (s *SettingsSuite) TestReplaceSettingsNotFound(c *gc.C) {
 	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
-	err := updateSettings(s.state.db(), s.collection, s.key, options)
+	err := replaceSettings(s.state.db(), s.collection, s.key, options)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -511,6 +511,35 @@ func (s *SettingsSuite) TestList(c *gc.C) {
 	})
 }
 
+func (s *SettingsSuite) TestUpdateSettings(c *gc.C) {
+	_, err := s.createSettings(s.key, map[string]interface{}{"foo1": "bar1", "foo2": "bar2"})
+	c.Assert(err, jc.ErrorIsNil)
+	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
+	err = updateSettings(s.state.db(), s.collection, s.key, options)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check MongoDB state.
+	var mgoData struct {
+		Settings settingsMap
+	}
+	settings, closer := s.state.db().GetCollection(settingsC)
+	defer closer()
+	err = settings.FindId(s.key).One(&mgoData)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(
+		map[string]interface{}(mgoData.Settings),
+		gc.DeepEquals,
+		map[string]interface{}{
+			"foo1": "bar1", "alpha": "beta", "foo2": "zap100",
+		})
+}
+
+func (s *SettingsSuite) TestUpdateSettingsErrorsNotFound(c *gc.C) {
+	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
+	err := updateSettings(s.state.db(), s.collection, s.key, options)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *SettingsSuite) TestUpdatingInterfaceSliceValue(c *gc.C) {
 	// When storing config values that are coerced from schemas as
 	// List(Something), the value will always be a []interface{}. Make

--- a/storage/poolmanager/interface.go
+++ b/storage/poolmanager/interface.go
@@ -19,6 +19,9 @@ type PoolManager interface {
 	// Delete removes the pool with name from state.
 	Delete(name string) error
 
+	// Update updates existing pool configuration with new or changed values
+	Update(name string, attrs map[string]interface{}) error
+
 	// Get returns the pool with name from state.
 	Get(name string) (*storage.Config, error)
 
@@ -28,6 +31,7 @@ type PoolManager interface {
 
 type SettingsManager interface {
 	CreateSettings(key string, settings map[string]interface{}) error
+	UpdateSettings(key string, settings map[string]interface{}) error
 	ReadSettings(key string) (map[string]interface{}, error)
 	RemoveSettings(key string) error
 	ListSettings(keyPrefix string) (map[string]map[string]interface{}, error)
@@ -43,6 +47,15 @@ type MemSettings struct {
 func (m MemSettings) CreateSettings(key string, settings map[string]interface{}) error {
 	if _, ok := m.Settings[key]; ok {
 		return errors.AlreadyExistsf("settings with key %q", key)
+	}
+	m.Settings[key] = settings
+	return nil
+}
+
+// UpdateSettings is part of the SettingsManager interface.
+func (m MemSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+	if _, ok := m.Settings[key]; !ok {
+		return errors.NotFoundf("settings with key %q", key)
 	}
 	m.Settings[key] = settings
 	return nil

--- a/storage/poolmanager/interface.go
+++ b/storage/poolmanager/interface.go
@@ -19,8 +19,8 @@ type PoolManager interface {
 	// Delete removes the pool with name from state.
 	Delete(name string) error
 
-	// Update updates existing pool configuration with new or changed values
-	Update(name string, attrs map[string]interface{}) error
+	// Replace replaces pool configuration with the newly provided values.
+	Replace(name string, attrs map[string]interface{}) error
 
 	// Get returns the pool with name from state.
 	Get(name string) (*storage.Config, error)
@@ -31,7 +31,7 @@ type PoolManager interface {
 
 type SettingsManager interface {
 	CreateSettings(key string, settings map[string]interface{}) error
-	UpdateSettings(key string, settings map[string]interface{}) error
+	ReplaceSettings(key string, settings map[string]interface{}) error
 	ReadSettings(key string) (map[string]interface{}, error)
 	RemoveSettings(key string) error
 	ListSettings(keyPrefix string) (map[string]map[string]interface{}, error)
@@ -52,8 +52,8 @@ func (m MemSettings) CreateSettings(key string, settings map[string]interface{})
 	return nil
 }
 
-// UpdateSettings is part of the SettingsManager interface.
-func (m MemSettings) UpdateSettings(key string, settings map[string]interface{}) error {
+// ReplaceSettings is part of the SettingsManager interface.
+func (m MemSettings) ReplaceSettings(key string, settings map[string]interface{}) error {
 	if _, ok := m.Settings[key]; !ok {
 		return errors.NotFoundf("settings with key %q", key)
 	}

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -78,6 +78,14 @@ func (pm *poolManager) Delete(name string) error {
 	return errors.Annotatef(err, "deleting pool %q", name)
 }
 
+// Update is defined on PoolManager interface.
+func (pm *poolManager) Update(name string, attrs map[string]interface{}) error {
+	if name == "" {
+		return MissingNameError
+	}
+	return pm.settings.UpdateSettings(globalKey(name), attrs)
+}
+
 // Get is defined on PoolManager interface.
 func (pm *poolManager) Get(name string) (*storage.Config, error) {
 	settings, err := pm.settings.ReadSettings(globalKey(name))

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -78,12 +78,12 @@ func (pm *poolManager) Delete(name string) error {
 	return errors.Annotatef(err, "deleting pool %q", name)
 }
 
-// Update is defined on PoolManager interface.
-func (pm *poolManager) Update(name string, attrs map[string]interface{}) error {
+// Replace is defined on PoolManager interface.
+func (pm *poolManager) Replace(name string, attrs map[string]interface{}) error {
 	if name == "" {
 		return MissingNameError
 	}
-	return pm.settings.UpdateSettings(globalKey(name), attrs)
+	return pm.settings.ReplaceSettings(globalKey(name), attrs)
 }
 
 // Get is defined on PoolManager interface.


### PR DESCRIPTION
## Description of change

Expose the ability to update and delete storage pools on the api.

## QA steps

This branch doesn't expose the functionality to the cli, just enables it via api calls. There are unit tests.

## Documentation changes

The followup PR will address the documentation additions as it will actually enable the CLI access to the functionality.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812350