### PR TITLE
raft-leases: Handle failures writing lease state to the database

### DIFF
--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -147,7 +147,7 @@ func (s *ApplicationStatusGetter) Status(args params.Entities) (params.Applicati
 		// ...so we can check the unit's application leadership...
 		checker := s.st.LeadershipChecker()
 		token := checker.LeadershipCheck(applicationId, unitId)
-		if err := token.Check(nil); err != nil {
+		if err := token.Check(0, nil); err != nil {
 			// TODO(fwereade) this should probably be ErrPerm is certain cases,
 			// but I don't think I implemented an exported ErrNotLeader. I
 			// should have done, though.

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -94,7 +94,7 @@ func (s *ApplicationStatusSetter) SetStatus(args params.SetStatus) (params.Error
 		token := checker.LeadershipCheck(serviceId, unitId)
 
 		// TODO(fwereade) pass token into SetStatus instead of checking here.
-		if err := token.Check(nil); err != nil {
+		if err := token.Check(0, nil); err != nil {
 			// TODO(fwereade) this should probably be ErrPerm is certain cases,
 			// but I don't think I implemented an exported ErrNotLeader. I
 			// should have done, though.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1581,7 +1581,7 @@ func (u *UniterAPI) SetRelationStatus(args params.RelationStatusArgs) (params.Er
 			return err
 		}
 		token := checker.LeadershipCheck(unit.ApplicationName(), unit.Name())
-		if err := token.Check(nil); err != nil {
+		if err := token.Check(0, nil); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -35,8 +35,8 @@ type leadershipToken struct {
 }
 
 // Check is part of the leadership.Token interface.
-func (t leadershipToken) Check(out interface{}) error {
-	err := t.token.Check(out)
+func (t leadershipToken) Check(attempt int, out interface{}) error {
+	err := t.token.Check(attempt, out)
 	if errors.Cause(err) == lease.ErrNotHeld {
 		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
 	}

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -866,6 +866,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:            agentName,
 			ClockName:            clockName,
 			CentralHubName:       centralHubName,
+			StateName:            stateName,
 			FSM:                  leaseFSM,
 			RequestTopic:         leaseRequestTopic,
 			Logger:               loggo.GetLogger("juju.worker.lease.raft"),

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -64,9 +64,10 @@ type Pinner interface {
 // Token represents a unit's leadership of its application.
 type Token interface {
 
-	// Check returns an error if the condition it embodies no longer holds.
-	// If you pass a non-nil value into Check, it must be a pointer to data
-	// of the correct type, into which the token's content will be copied.
+	// Check returns an error if the condition it embodies no longer
+	// holds.  If you pass a non-nil trapdoorKey value into Check, it
+	// must be a pointer to data of the correct type, into which the
+	// token's content will be copied.
 	//
 	// The "correct type" is implementation-specific, and no implementation
 	// is obliged to accept any non-nil parameter; but methods that return
@@ -74,7 +75,13 @@ type Token interface {
 	//
 	// In practice, most Token implementations will likely expect *[]txn.Op,
 	// so that they can be used to gate mgo/txn-based state changes.
-	Check(interface{}) error
+	//
+	// If a non-nil trapdoorKey value is passed, attempt should be how
+	// many times this check has been tried previously (for example,
+	// in a buildTxn function it'll be the transaction attempt). This
+	// enables the token to generate different ops for the second
+	// attempt (the raft lease implementation uses this).
+	Check(attempt int, trapdoorKey interface{}) error
 }
 
 // Checker exposes leadership testing capabilities.

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -79,16 +79,25 @@ type Checker interface {
 // holder's ownership of some lease.
 type Token interface {
 
-	// Check returns ErrNotHeld if the lease it represents is not held by the
-	// holder it represents. If trapdoorKey is nil, and Check returns nil, then
-	// the token continues to represent a true fact.
+	// Check returns ErrNotHeld if the lease it represents is not held
+	// by the holder it represents. If attempt is 0, trapdoorKey is
+	// nil, and Check returns nil, then the token continues to
+	// represent a true fact.
 	//
-	// If the token represents a true fact and trapdoorKey is *not* nil, it will
-	// be passed through layers for the attention of the underlying lease.Client
-	// implementation. If you need to do this, consult the documentation for the
-	// particular Client you're using to determine what key should be passed and
-	// what errors that might induce.
-	Check(trapdoorKey interface{}) error
+	// Attempt is the number of times this check has been tried (not
+	// necessarily with this token instance). This enables an
+	// implementation to vary how it deals with trapdoorKey across
+	// attempts. For example, the raft implementation generates
+	// different ops for the first attempt than for subsequent
+	// attempts.
+	//
+	// If the token represents a true fact and trapdoorKey is *not*
+	// nil, it will be passed through layers for the attention of the
+	// underlying lease.Client implementation. If you need to do this,
+	// consult the documentation for the particular Client you're
+	// using to determine what key should be passed and what errors
+	// that might induce.
+	Check(attempt int, trapdoorKey interface{}) error
 }
 
 // Manager describes methods for acquiring objects that manipulate and query

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -93,11 +93,11 @@ type Info struct {
 
 // Trapdoor allows a store to use pre-agreed special knowledge to communicate
 // with a Store substrate by passing a key with suitable properties.
-type Trapdoor func(key interface{}) error
+type Trapdoor func(attempt int, key interface{}) error
 
 // LockedTrapdoor is a Trapdoor suitable for use by substrates that don't want
 // or need to expose their internals.
-func LockedTrapdoor(key interface{}) error {
+func LockedTrapdoor(attempt int, key interface{}) error {
 	if key != nil {
 		return errors.New("lease substrate not accessible")
 	}

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -231,6 +231,8 @@ func (r *response) Error() error {
 
 // Notify is part of FSMResponse.
 func (r *response) Notify(target NotifyTarget) {
+	// This response is either for a claim (in which case claimer will
+	// be set) or a set-time (so it will have zero or more expiries).
 	if r.claimer != "" {
 		target.Claimed(r.claimed, r.claimer)
 	}

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -213,7 +213,7 @@ func (s *storeSuite) TestLeases(c *gc.C) {
 
 	// Can't compare trapdoors directly.
 	var out string
-	err := r1.Trapdoor(&out)
+	err := r1.Trapdoor(0, &out)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, "{quam olim abrahe} held by verdi")
 
@@ -221,7 +221,7 @@ func (s *storeSuite) TestLeases(c *gc.C) {
 	c.Assert(r2.Holder, gc.Equals, "mozart")
 	c.Assert(r2.Expiry, gc.Equals, in5Seconds)
 
-	err = r2.Trapdoor(&out)
+	err = r2.Trapdoor(0, &out)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, "{la cry mosa} held by mozart")
 }
@@ -511,7 +511,7 @@ func (f *fakeFSM) GlobalTime() time.Time {
 }
 
 func FakeTrapdoor(key lease.Key, holder string) lease.Trapdoor {
-	return func(out interface{}) error {
+	return func(attempt int, out interface{}) error {
 		if s, ok := out.(*string); ok {
 			*s = fmt.Sprintf("%v held by %s", key, holder)
 			return nil

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -955,7 +955,7 @@ func leaseManager(controllerUUID string, st *state.State) (*lease.Manager, error
 		ioutil.Discard,
 		loggo.GetLogger("juju.state.raftlease"),
 	)
-	dummyStore := newLeaseStore(clock.WallClock, target, state.LeaseTrapdoorFunc())
+	dummyStore := newLeaseStore(clock.WallClock, target, st.LeaseTrapdoorFunc())
 	return lease.NewManager(lease.ManagerConfig{
 		Secretary:            lease.SecretaryFinder(controllerUUID),
 		Store:                dummyStore,

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -50,7 +50,7 @@ func (st *State) LeadershipChecker() leadership.Checker {
 func buildTxnWithLeadership(buildTxn jujutxn.TransactionSource, token leadership.Token) jujutxn.TransactionSource {
 	return func(attempt int) ([]txn.Op, error) {
 		var prereqs []txn.Op
-		if err := token.Check(&prereqs); err != nil {
+		if err := token.Check(attempt, &prereqs); err != nil {
 			return nil, errors.Annotatef(err, "prerequisites failed")
 		}
 		ops, err := buildTxn(attempt)
@@ -86,8 +86,8 @@ type leadershipToken struct {
 }
 
 // Check is part of the leadership.Token interface.
-func (t leadershipToken) Check(out interface{}) error {
-	err := t.token.Check(out)
+func (t leadershipToken) Check(attempt int, out interface{}) error {
+	err := t.token.Check(attempt, out)
 	if errors.Cause(err) == lease.ErrNotHeld {
 		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
 	}

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -441,7 +441,7 @@ func (store *store) assertOpTrapdoor(name, holder string) lease.Trapdoor {
 			fieldHolder: holder,
 		},
 	}
-	return func(out interface{}) error {
+	return func(_ int, out interface{}) error {
 		outPtr, ok := out.(*[]txn.Op)
 		if !ok {
 			return errors.NotValidf("expected *[]txn.Op; %T", out)

--- a/state/lease/store_assert_test.go
+++ b/state/lease/store_assert_test.go
@@ -43,7 +43,7 @@ func (s *StoreAssertSuite) TestPassesWhenLeaseHeld(c *gc.C) {
 	info := s.fix.Store.Leases()[key("name")]
 
 	var ops []txn.Op
-	err := info.Trapdoor(&ops)
+	err := info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
 	err = s.fix.Runner.RunTransaction(ops)
 	c.Check(err, jc.ErrorIsNil)
@@ -57,7 +57,7 @@ func (s *StoreAssertSuite) TestPassesWhenLeaseStillHeldDespiteWriterChange(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 
 	var ops []txn.Op
-	err = info.Trapdoor(&ops)
+	err = info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
 	err = s.fix.Runner.RunTransaction(ops)
 	c.Check(err, gc.IsNil)
@@ -71,7 +71,7 @@ func (s *StoreAssertSuite) TestPassesWhenLeaseStillHeldDespitePassingExpiry(c *g
 	c.Assert(err, jc.ErrorIsNil)
 
 	var ops []txn.Op
-	err = info.Trapdoor(&ops)
+	err = info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
 	err = s.fix.Runner.RunTransaction(ops)
 	c.Check(err, gc.IsNil)
@@ -85,7 +85,7 @@ func (s *StoreAssertSuite) TestAbortsWhenLeaseVacant(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var ops []txn.Op
-	err = info.Trapdoor(&ops)
+	err = info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
 	err = s.fix.Runner.RunTransaction(ops)
 	c.Check(err, gc.Equals, txn.ErrAborted)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1233,7 +1233,7 @@ func (s *MigrationExportSuite) TestActionsSkipped(c *gc.C) {
 type goodToken struct{}
 
 // Check implements leadership.Token
-func (*goodToken) Check(interface{}) error {
+func (*goodToken) Check(int, interface{}) error {
 	return nil
 }
 

--- a/state/raftlease/export_test.go
+++ b/state/raftlease/export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/lease"
+)
+
+func AssertLeaseholderDocEquals(c *gc.C, doc interface{}, key lease.Key, holder string) {
+	actual, ok := doc.(*leaseHolderDoc)
+	c.Assert(ok, gc.Equals, true)
+	expected, err := newLeaseHolderDoc(key.Namespace, key.ModelUUID, key.Lease, holder)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actual, gc.DeepEquals, expected)
+}

--- a/state/raftlease/target.go
+++ b/state/raftlease/target.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/raftlease"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/wrench"
 )
 
 const (
@@ -174,10 +173,10 @@ func (t *notifyTarget) Claimed(key lease.Key, holder string) {
 	docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
 	// Use this wrench to simulate a failure writing the claimed info
 	// to the database.
-	if wrench.IsActive("raftlease-notifytarget", "fail-claim") {
-		t.errorLogger.Errorf("wrench failing claimed of %q for %q", docId, holder)
-		return
-	}
+	// if wrench.IsActive("raftlease-notifytarget", "fail-claim") {
+	// 	t.errorLogger.Errorf("wrench failing claimed of %q for %q", docId, holder)
+	// 	return
+	// }
 	err := applyClaimed(t.mongo, t.collection, docId, key, holder)
 	if err != nil {
 		t.errorLogger.Errorf("couldn't claim lease %q for %q: %s", docId, holder, err.Error())

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -252,10 +252,10 @@ func (s *targetSuite) TestExpiredError(c *gc.C) {
 	})
 }
 
-func (s *targetSuite) TestTrapdoor(c *gc.C) {
-	trapdoor := raftlease.MakeTrapdoorFunc(collection)(lease.Key{"ns", "model", "landfall"}, "roy")
+func (s *targetSuite) TestTrapdoorAttempt0(c *gc.C) {
+	trapdoor := raftlease.MakeTrapdoorFunc(s.mongo, collection)(lease.Key{"ns", "model", "landfall"}, "roy")
 	var result []txn.Op
-	err := trapdoor(&result)
+	err := trapdoor(0, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []txn.Op{{
 		C:      collection,
@@ -263,7 +263,91 @@ func (s *targetSuite) TestTrapdoor(c *gc.C) {
 		Assert: bson.M{"holder": "roy"},
 	}})
 	var bad int
-	c.Assert(trapdoor(&bad), gc.ErrorMatches, `expected \*\[\]txn\.Op; \*int not valid`)
+	c.Assert(trapdoor(0, &bad), gc.ErrorMatches, `expected \*\[\]txn\.Op; \*int not valid`)
+}
+
+func (s *targetSuite) TestTrapdoorAttempt1NoHolderInDB(c *gc.C) {
+	key := lease.Key{"ns", "model", "landfall"}
+	trapdoor := raftlease.MakeTrapdoorFunc(s.mongo, collection)(key, "roy")
+	var result []txn.Op
+	err := trapdoor(1, &result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	op := result[0]
+	c.Assert(op.C, gc.Equals, collection)
+	c.Assert(op.Id, gc.Equals, "model:ns#landfall#")
+	c.Assert(op.Assert, gc.Equals, "d-")
+	raftlease.AssertLeaseholderDocEquals(c, op.Insert, key, "roy")
+
+	err = s.mongo.RunTransaction(func(int) ([]txn.Op, error) {
+		return result, nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:ns#landfall#",
+		"namespace":  "ns",
+		"model-uuid": "model",
+		"lease":      "landfall",
+		"holder":     "roy",
+	}})
+}
+
+func (s *targetSuite) TestTrapdoorAttempt1DifferentHolderInDB(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:ns#landfall#",
+			"namespace":  "ns",
+			"model-uuid": "model",
+			"lease":      "landfall",
+			"holder":     "george",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	key := lease.Key{"ns", "model", "landfall"}
+	trapdoor := raftlease.MakeTrapdoorFunc(s.mongo, collection)(key, "roy")
+	var result []txn.Op
+	err = trapdoor(1, &result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Assert(result, gc.DeepEquals, []txn.Op{{
+		C:      collection,
+		Id:     "model:ns#landfall#",
+		Assert: bson.M{"holder": "george"},
+		Update: bson.M{"$set": bson.M{"holder": "roy"}},
+	}})
+	err = s.mongo.RunTransaction(func(int) ([]txn.Op, error) {
+		return result, nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:ns#landfall#",
+		"namespace":  "ns",
+		"model-uuid": "model",
+		"lease":      "landfall",
+		"holder":     "roy",
+	}})
+}
+
+func (s *targetSuite) TestTrapdoorAttempt1ThisHolderInDB(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:ns#landfall#",
+			"namespace":  "ns",
+			"model-uuid": "model",
+			"lease":      "landfall",
+			"holder":     "roy",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	trapdoor := raftlease.MakeTrapdoorFunc(s.mongo, collection)(lease.Key{"ns", "model", "landfall"}, "roy")
+	var result []txn.Op
+	err = trapdoor(0, &result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, []txn.Op{{
+		C:      collection,
+		Id:     "model:ns#landfall#",
+		Assert: bson.M{"holder": "roy"},
+	}})
 }
 
 func (s *targetSuite) TestLeaseHolders(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -554,8 +554,8 @@ func (st *State) LeaseNotifyTarget(logDest io.Writer, errorLogger raftleasestore
 
 // LeaseTrapdoorFunc returns a raftlease.TrapdoorFunc for checking
 // lease state in a database.
-func LeaseTrapdoorFunc() raftlease.TrapdoorFunc {
-	return raftleasestore.MakeTrapdoorFunc(leaseHoldersC)
+func (st *State) LeaseTrapdoorFunc() raftlease.TrapdoorFunc {
+	return raftleasestore.MakeTrapdoorFunc(&environMongo{st}, leaseHoldersC)
 }
 
 // ModelUUID returns the model UUID for the model

--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -60,14 +60,14 @@ func (s *LeadershipSuite) TestClaimValidateDuration(c *gc.C) {
 
 func (s *LeadershipSuite) TestCheckValidatesApplicationname(c *gc.C) {
 	token := s.checker.LeadershipCheck("not/a/application", "u/0")
-	err := token.Check(nil)
+	err := token.Check(0, nil)
 	c.Check(err, gc.ErrorMatches, `cannot check lease "not/a/application": not an application name`)
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *LeadershipSuite) TestCheckValidatesUnitName(c *gc.C) {
 	token := s.checker.LeadershipCheck("application", "not/a/unit")
-	err := token.Check(nil)
+	err := token.Check(0, nil)
 	c.Check(err, gc.ErrorMatches, `cannot check holder "not/a/unit": not a unit name`)
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
@@ -107,7 +107,7 @@ func (s *LeadershipSuite) TestCheck(c *gc.C) {
 
 	// Check token reports current leadership state.
 	var ops []txn.Op
-	err = token.Check(&ops)
+	err = token.Check(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(ops, gc.HasLen, 1)
 
@@ -116,7 +116,7 @@ func (s *LeadershipSuite) TestCheck(c *gc.C) {
 
 	// Check leadership still reported accurately.
 	var ops2 []txn.Op
-	err = token.Check(&ops2)
+	err = token.Check(1, &ops2)
 	c.Check(err, gc.ErrorMatches, `"application/0" is not leader of "application"`)
 	c.Check(ops2, gc.IsNil)
 }
@@ -154,7 +154,7 @@ func (s *LeadershipSuite) TestLeadershipCheckerRestarts(c *gc.C) {
 	s.State.SetClockForTesting(testclock.NewClock(time.Time{}))
 
 	token := s.checker.LeadershipCheck("application", "application/0")
-	err = token.Check(nil)
+	err = token.Check(0, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/workers.go
+++ b/state/workers.go
@@ -234,6 +234,6 @@ type errorToken struct {
 }
 
 // Check is part of the lease.Token interface.
-func (t errorToken) Check(key interface{}) error {
+func (t errorToken) Check(attempt int, key interface{}) error {
 	return t.err
 }

--- a/worker/lease/check.go
+++ b/worker/lease/check.go
@@ -19,7 +19,7 @@ type token struct {
 }
 
 // Check is part of the lease.Token interface.
-func (t token) Check(trapdoorKey interface{}) error {
+func (t token) Check(attempt int, trapdoorKey interface{}) error {
 
 	// This validation, which could be done at Token creation time, is deferred
 	// until this point for historical reasons. In particular, this code was
@@ -38,6 +38,7 @@ func (t token) Check(trapdoorKey interface{}) error {
 	return check{
 		leaseKey:    t.leaseKey,
 		holderName:  t.holderName,
+		attempt:     attempt,
 		trapdoorKey: trapdoorKey,
 		response:    make(chan error),
 		stop:        t.stop,
@@ -49,6 +50,7 @@ func (t token) Check(trapdoorKey interface{}) error {
 type check struct {
 	leaseKey    lease.Key
 	holderName  string
+	attempt     int
 	trapdoorKey interface{}
 	response    chan error
 	stop        <-chan struct{}

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -331,7 +331,7 @@ func (manager *Manager) handleCheck(check check) error {
 			manager.logContext, check.leaseKey.Lease, check.holderName)
 		response = lease.ErrNotHeld
 	} else if check.trapdoorKey != nil {
-		response = info.Trapdoor(check.trapdoorKey)
+		response = info.Trapdoor(check.attempt, check.trapdoorKey)
 	}
 	check.respond(errors.Trace(response))
 	return nil

--- a/worker/lease/manager_block_test.go
+++ b/worker/lease/manager_block_test.go
@@ -114,7 +114,7 @@ func (s *WaitUntilExpiredSuite) TestLeadershipExpiredEarly(c *gc.C) {
 		// lease had already been expired by someone else.
 		checker, err := manager.Checker("namespace", "model")
 		c.Assert(err, jc.ErrorIsNil)
-		checker.Token("redis", "redis/99").Check(nil)
+		checker.Token("redis", "redis/99").Check(0, nil)
 		err = blockTest.assertUnblocked(c)
 		c.Check(err, jc.ErrorIsNil)
 	})

--- a/worker/lease/manager_check_test.go
+++ b/worker/lease/manager_check_test.go
@@ -34,7 +34,7 @@ func (s *TokenSuite) TestSuccess(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(nil)
+		err := token.Check(0, nil)
 		c.Check(err, jc.ErrorIsNil)
 	})
 }
@@ -54,7 +54,7 @@ func (s *TokenSuite) TestMissingRefresh_Success(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(nil)
+		err := token.Check(0, nil)
 		c.Check(err, jc.ErrorIsNil)
 	})
 }
@@ -74,7 +74,7 @@ func (s *TokenSuite) TestOtherHolderRefresh_Success(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(nil)
+		err := token.Check(0, nil)
 		c.Check(err, jc.ErrorIsNil)
 	})
 }
@@ -87,7 +87,7 @@ func (s *TokenSuite) TestRefresh_Failure_Missing(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(nil)
+		err := token.Check(0, nil)
 		c.Check(errors.Cause(err), gc.Equals, corelease.ErrNotHeld)
 	})
 }
@@ -107,7 +107,7 @@ func (s *TokenSuite) TestRefresh_Failure_OtherHolder(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(nil)
+		err := token.Check(0, nil)
 		c.Check(errors.Cause(err), gc.Equals, corelease.ErrNotHeld)
 	})
 }
@@ -122,7 +122,7 @@ func (s *TokenSuite) TestRefresh_Error(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		c.Check(token.Check(nil), gc.ErrorMatches, "lease manager stopped")
+		c.Check(token.Check(0, nil), gc.ErrorMatches, "lease manager stopped")
 		err := manager.Wait()
 		c.Check(err, gc.ErrorMatches, "crunch squish")
 	})

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -155,10 +155,10 @@ func (s *CrossSuite) testChecks(c *gc.C, lease1, lease2 corelease.Key) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		t1 := checker1.Token(lease1.Lease, "sgt-howie")
-		c.Assert(t1.Check(nil), gc.Equals, nil)
+		c.Assert(t1.Check(0, nil), gc.Equals, nil)
 
 		t2 := checker2.Token(lease2.Lease, "sgt-howie")
-		err = t2.Check(nil)
+		err = t2.Check(0, nil)
 		c.Assert(errors.Cause(err), gc.Equals, corelease.ErrNotHeld)
 	})
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1652,7 +1652,7 @@ func (s setLeaderSettings) step(c *gc.C, ctx *context) {
 
 type successToken struct{}
 
-func (successToken) Check(interface{}) error {
+func (successToken) Check(int, interface{}) error {
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

If the raftlease trapdoor notices that the DB leaseholder state is out of sync, it updates the database with the right holder. This is safe to do because trapdoor is only ever called when we've checked the current state in raft is good.

To avoid load on the DB for something that should only happen occasionally, we only check the leaseholder state on the second attempt at building+running a leadership transaction. This requires that `lease.Token.Check`, `lease.Trapdoor` and `leadership.Token.Check` get passed in the attempt (we can't keep it as closure state because the trapdoor is recreated each time).

The lease manager manifold now needs the state worker, because the trapdoor factory needs a *state.State so that it can update leaseholders when needed.

## QA steps

* Compile this with the wrench in notifyTarget.Claimed uncommented. 
* Bootstrap a controller and enable HA.
* Run `echo fail-claim > /var/lib/juju/wrench/raftlease-notifytarget` on each controller to prevent the DB from being updated when a lease is claimed in raft.
* Watch the controller debug-log for errors.
* Deploy leadership-flex (https://github.com/mitechie/leadership-charm) - it sets leadership settings when a unit is elected leader.
* When the first unit is deployed you should see the wrench error in the controller log (on the raft leader) indicating that we couldn't update the database with the new lease.
* The new unit should still start up successfully, including setting leadership settings - its state will be "ready to go". No hooks should fail, and status should indicate it's the leader.
* The database should contain the leaseholder record for leadership-flex.
* Add another unit of leadership-flex.
* Once it's running, remove the original unit.
* When the lease expires the new unit should claim the leadership, no hooks fail.
* The controller error log will show the claim couldn't be written to the db when the raft change occurred (because of the wrench).
* Status will indicate the new unit is the leader, and the database will indicate the new lease holder.

## Documentation changes

None

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1810331
