### PR TITLE
Exit http server worker after a time even if client mux still in use

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -582,6 +582,7 @@ func (a *MachineAgent) makeEngineCreator(agentName string, previousAgentVersion 
 			RegisterIntrospectionHTTPHandlers: registerIntrospectionHandlers,
 			NewModelWorker:                    a.startModelWorkers,
 			ControllerSupportsSpaces:          controllerSupportsSpaces,
+			MuxShutdownWait:                   1 * time.Minute,
 		})
 		if err := dependency.Install(engine, manifolds); err != nil {
 			if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -243,6 +243,11 @@ type ManifoldsConfig struct {
 	// This is used by a number of workers to ensure serialisation of actions
 	// across the machine.
 	MachineLock machinelock.Lock
+
+	// MuxShutdownWait is the maximum time the http-server worker will wait
+	// for all mux clients to gracefully terminate before the http-worker
+	// exits regardless.
+	MuxShutdownWait time.Duration
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -743,6 +748,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			AgentName:            config.AgentName,
 			Clock:                config.Clock,
+			MuxShutdownWait:      config.MuxShutdownWait,
+			LogDir:               "/var/log/juju", //agentConfig.LogDir(),
 			GetControllerConfig:  httpserver.GetControllerConfig,
 			NewTLSConfig:         httpserver.NewTLSConfig,
 			NewWorker:            httpserver.NewWorkerShim,

--- a/cmd/jujud/agent/machine/servinginfo_setter_test.go
+++ b/cmd/jujud/agent/machine/servinginfo_setter_test.go
@@ -241,3 +241,7 @@ func (mc *mockConfig) SetStateServingInfo(info params.StateServingInfo) {
 	mc.ssiSet = true
 	mc.ssi = info
 }
+
+func (mc *mockConfig) LogDir() string {
+	return "log-dir"
+}

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -72,6 +72,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		RaftTransportName:    "raft-transport",
 		Clock:                s.clock,
 		PrometheusRegisterer: &s.prometheusRegisterer,
+		MuxShutdownWait:      1 * time.Minute,
+		LogDir:               "log-dir",
 		GetControllerConfig:  s.getControllerConfig,
 		NewTLSConfig:         s.newTLSConfig,
 		NewWorker:            s.newWorker,
@@ -164,6 +166,8 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		APIPort:              1024,
 		APIPortOpenDelay:     5 * time.Second,
 		ControllerAPIPort:    2048,
+		MuxShutdownWait:      1 * time.Minute,
+		LogDir:               "log-dir",
 	})
 }
 
@@ -184,6 +188,12 @@ func (s *ManifoldSuite) TestValidate(c *gc.C) {
 	}, {
 		func(cfg *httpserver.ManifoldConfig) { cfg.MuxName = "" },
 		"empty MuxName not valid",
+	}, {
+		func(cfg *httpserver.ManifoldConfig) { cfg.MuxShutdownWait = 0 },
+		"MuxShutdownWait 0s not valid",
+	}, {
+		func(cfg *httpserver.ManifoldConfig) { cfg.LogDir = "" },
+		"empty LogDir not valid",
 	}, {
 		func(cfg *httpserver.ManifoldConfig) { cfg.RaftTransportName = "" },
 		"empty RaftTransportName not valid",

--- a/worker/httpserver/mock_test.go
+++ b/worker/httpserver/mock_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/testing"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/state"
 )
 
@@ -59,8 +58,4 @@ type stubCertWatcher struct {
 func (w *stubCertWatcher) get() *tls.Certificate {
 	w.MethodCall(w, "get")
 	return &w.cert
-}
-
-type mockLocalMacaroonAuthenticator struct {
-	httpcontext.LocalMacaroonAuthenticator
 }

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -7,9 +7,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
 	"strconv"
 	"sync"
 	"time"
@@ -33,6 +37,8 @@ type Config struct {
 	Clock                clock.Clock
 	TLSConfig            *tls.Config
 	Mux                  *apiserverhttp.Mux
+	MuxShutdownWait      time.Duration
+	LogDir               string
 	PrometheusRegisterer prometheus.Registerer
 	Hub                  *pubsub.StructuredHub
 	APIPort              int
@@ -181,13 +187,44 @@ func (w *Worker) loop() error {
 			// to process all pending requests without having to deal with
 			// new ones.
 			w.holdable.hold()
-			// Asked to shutdown - make sure we wait until all clients
-			// have finished up.
-			w.config.Mux.Wait()
-			return w.catacomb.ErrDying()
+			return w.shutdown()
 		case w.url <- w.holdable.URL():
 		}
 	}
+}
+
+func (w *Worker) shutdown() error {
+	muxDone := make(chan struct{})
+	go func() {
+		// Asked to shutdown - make sure we wait until all clients
+		// have finished up.
+		w.config.Mux.Wait()
+		close(muxDone)
+	}()
+	select {
+	case <-muxDone:
+	case <-w.config.Clock.After(w.config.MuxShutdownWait):
+		msg := "timeout waiting for apiserver shutdown"
+		dumpFile, err := w.dumpDebug()
+		if err == nil {
+			logger.Warningf("%v\ndebug info written to %v", msg, dumpFile)
+		} else {
+			logger.Warningf("%v\nerror writing debug info: %v", msg, err)
+		}
+	}
+	return w.catacomb.ErrDying()
+}
+
+func (w *Worker) dumpDebug() (string, error) {
+	dumpFile, err := os.OpenFile(filepath.Join(w.config.LogDir, "apiserver-debug.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	defer dumpFile.Close()
+	if _, err = io.WriteString(dumpFile, fmt.Sprintf("goroutime dump %v\n", time.Now().Format(time.RFC3339))); err != nil {
+		return "", errors.Annotate(err, "writing header to apiserver log file")
+	}
+	return dumpFile.Name(), pprof.Lookup("goroutine").WriteTo(dumpFile, 1)
 }
 
 type heldListener struct {


### PR DESCRIPTION
## Description of change

The http-server worker waits for (tracked) users of its http muxer to all exit before the worker loop terminates. Even though all the tracked workers are supposed to terminate when the server's dying channel is closed, some appear to stay stuck, maybe in a blocking read (not sure).

This PR will exit the http-server work after 1 minute even if not all mux clients have exited. The expectation is that any which are blocked on reads will then exit because the http socket will close.
If such an exit does occur, we dump the goroutines to /var/log/juju/apiserver-debug.log for further analysis.

## QA steps

QA is to ensure nothing is broken - bootstrap a controller, upgrade juju on it etc.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813261
