### PR TITLE
2.5 - Filtered Access to Leases in Store

### DIFF
--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -34,13 +34,8 @@ type Store interface {
 
 	// Leases returns a recent snapshot of lease state. Expiry times are
 	// expressed according to the Clock the store was configured with.
-	Leases() map[Key]Info
-
-	// TODO (jam) 2017-10-31: Many callers of Leases() actually only want
-	// exactly 1 lease, we should have a way to do a query to return exactly
-	// that lease, instead of having to read all of them to pull one out of the
-	// map. (Worst case it is implemented as exactly this, best case avoids
-	// reading lots of unused data.)
+	// Supplying any lease keys will filter the return for those requested.
+	Leases(keys ...Key) map[Key]Info
 
 	// Refresh reads all lease state from the database.
 	Refresh() error

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -161,8 +161,6 @@ func (f *FSM) GlobalTime() time.Time {
 // Leases gets information about all of the leases in the system,
 // optionally filtered by the input lease keys.
 func (f *FSM) Leases(localTime time.Time, keys ...lease.Key) map[lease.Key]lease.Info {
-	f.mu.Lock()
-
 	filter := make(map[lease.Key]bool)
 	filtering := len(keys) > 0
 	if filtering {
@@ -172,6 +170,7 @@ func (f *FSM) Leases(localTime time.Time, keys ...lease.Key) map[lease.Key]lease
 	}
 
 	results := make(map[lease.Key]lease.Info)
+	f.mu.Lock()
 	for key, entry := range f.entries {
 		if filtering && !filter[key] {
 			continue

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -44,7 +44,7 @@ type TrapdoorFunc func(lease.Key, string) lease.Trapdoor
 // ReadonlyFSM defines the methods of the lease FSM the store can use
 // - any writes must go through the hub.
 type ReadonlyFSM interface {
-	Leases(time.Time) map[lease.Key]lease.Info
+	Leases(time.Time, ...lease.Key) map[lease.Key]lease.Info
 	GlobalTime() time.Time
 	Pinned() map[lease.Key][]string
 }
@@ -119,8 +119,8 @@ func (s *Store) ExpireLease(key lease.Key) error {
 }
 
 // Leases is part of lease.Store.
-func (s *Store) Leases() map[lease.Key]lease.Info {
-	leaseMap := s.fsm.Leases(s.config.Clock.Now())
+func (s *Store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
+	leaseMap := s.fsm.Leases(s.config.Clock.Now(), keys...)
 	result := make(map[lease.Key]lease.Info, len(leaseMap))
 	// Add trapdoors into the information from the FSM.
 	for k, v := range leaseMap {

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -496,8 +496,8 @@ type fakeFSM struct {
 	pinned     map[lease.Key][]string
 }
 
-func (f *fakeFSM) Leases(t time.Time) map[lease.Key]lease.Info {
-	f.AddCall("Leases", t)
+func (f *fakeFSM) Leases(t time.Time, keys ...lease.Key) map[lease.Key]lease.Info {
+	f.AddCall("Leases", t, keys)
 	return f.leases
 }
 

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -505,8 +505,8 @@ type fakeFSM struct {
 	pinned     map[lease.Key][]string
 }
 
-func (f *fakeFSM) Leases(t time.Time, keys ...lease.Key) map[lease.Key]lease.Info {
-	f.AddCall("Leases", t, keys)
+func (f *fakeFSM) Leases(t func() time.Time, keys ...lease.Key) map[lease.Key]lease.Info {
+	f.AddCall("Leases", t(), keys)
 	return f.leases
 }
 

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -226,6 +226,15 @@ func (s *storeSuite) TestLeases(c *gc.C) {
 	c.Assert(out, gc.Equals, "{la cry mosa} held by mozart")
 }
 
+func (s *storeSuite) TestLeasesFilter(c *gc.C) {
+	lease1 := lease.Key{Namespace: "quam", ModelUUID: "olim", Lease: "abrahe"}
+	lease2 := lease.Key{Namespace: "la", ModelUUID: "cry", Lease: "mosa"}
+
+	_ = s.store.Leases(lease1, lease2)
+	s.fsm.CheckCallNames(c, "Leases")
+	c.Check(s.fsm.Calls()[0].Args[1], jc.SameContents, []lease.Key{lease1, lease2})
+}
+
 func (s *storeSuite) TestPin(c *gc.C) {
 	machine := names.NewMachineTag("0").String()
 	s.handleHubRequest(c,

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -79,11 +79,8 @@ func (store *store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 		}
 	}
 
-	localTime := store.config.LocalClock.Now()
-
 	store.mu.Lock()
-	defer store.mu.Unlock()
-
+	localTime := store.config.LocalClock.Now()
 	leases := make(map[lease.Key]lease.Info)
 	for name, entry := range store.entries {
 		if filtering && !limit.Contains(name) {
@@ -104,6 +101,8 @@ func (store *store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 			Trapdoor: store.assertOpTrapdoor(name, entry.holder),
 		}
 	}
+	defer store.mu.Unlock()
+
 	return leases
 }
 

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -8,11 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/utils/set"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/set"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -188,7 +188,7 @@ func (s *raftSuite) TestMigrateLegacyLeases(c *gc.C) {
 		// FSM.
 		var leases map[lease.Key]lease.Info
 		for a := coretesting.LongAttempt.Start(); a.Next(); {
-			leases = fsm.Leases(zero)
+			leases = fsm.Leases(func() time.Time { return zero })
 			if reflect.DeepEqual(leases, expectedLeases) {
 				return
 			}
@@ -221,7 +221,7 @@ func (s *raftSuite) TestMigrateLegacyLeases(c *gc.C) {
 	withRaft(c, dataDir, fsm, func(r *raft.Raft) {
 		var leases map[lease.Key]lease.Info
 		for a := coretesting.LongAttempt.Start(); a.Next(); {
-			leases = fsm.Leases(zero)
+			leases = fsm.Leases(func() time.Time { return zero })
 			// The leases haven't been updated with the changed one.
 			if reflect.DeepEqual(leases, expectedLeases) {
 				return

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -89,11 +89,22 @@ func (store *Store) Wait(c *gc.C) {
 }
 
 // Leases is part of the lease.Store interface.
-func (store *Store) Leases() map[lease.Key]lease.Info {
+func (store *Store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
+	filter := make(map[lease.Key]bool)
+	filtering := len(keys) > 0
+	if filtering {
+		for _, key := range keys {
+			filter[key] = true
+		}
+	}
+
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	result := make(map[lease.Key]lease.Info)
 	for k, v := range store.leases {
+		if filtering && !filter[k] {
+			continue
+		}
 		result[k] = v
 	}
 	return result


### PR DESCRIPTION
## Description of change

This patch modifies lease access in `lease.Store` implementations so that specific leases can be retrieved directly instead of materialising the full store and selecting leases of interest.

## QA steps

1. Bootstrap to LXD.
2. `juju deploy redis -n 3`.
3. Stop the container for the unit leader with `lxc stop <instance>`.
4. After leadership switches, start it again.
5. Repeat steps 3/4 to your satisfaction.

## Documentation changes

None.

## Bug reference

N/A
