### PR TITLE
Thread Generation Arguments through to API Server

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -145,7 +145,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 6, application.NewFacadeV6)
 	reg("Application", 7, application.NewFacadeV7)
 	reg("Application", 8, application.NewFacadeV8)
-	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo
+	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo, generational config.
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -774,48 +774,6 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	)
 }
 
-// GetConfig returns the charm config for each of the
-// applications asked for.
-func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
-	if err := api.checkCanRead(); err != nil {
-		return params.ApplicationGetConfigResults{}, err
-	}
-	results := params.ApplicationGetConfigResults{
-		Results: make([]params.ConfigResult, len(args.Entities)),
-	}
-	for i, arg := range args.Entities {
-		config, err := api.getCharmConfig(arg.Tag)
-		results.Results[i].Config = config
-		results.Results[i].Error = common.ServerError(err)
-	}
-	return results, nil
-}
-
-func (api *APIBase) getCharmConfig(entity string) (map[string]interface{}, error) {
-	tag, err := names.ParseTag(entity)
-	if err != nil {
-		return nil, err
-	}
-	switch kind := tag.Kind(); kind {
-	case names.ApplicationTagKind:
-		app, err := api.backend.Application(tag.Id())
-		if err != nil {
-			return nil, err
-		}
-		settings, err := app.CharmConfig()
-		if err != nil {
-			return nil, err
-		}
-		charm, _, err := app.Charm()
-		if err != nil {
-			return nil, err
-		}
-		return describe(settings, charm.Config()), nil
-	default:
-		return nil, errors.Errorf("unexpected tag type, expected application, got %s", kind)
-	}
-}
-
 // applicationSetCharm sets the charm for the given for the application.
 func (api *APIBase) applicationSetCharm(
 	appName string,
@@ -1864,9 +1822,71 @@ func (api *APIv4) GetConstraints(args params.GetApplicationConstraints) (params.
 // CharmConfig isn't on the v5 API.
 func (u *APIv5) CharmConfig(_, _ struct{}) {}
 
-// CharmConfig is a shim to GetConfig on APIv5. It returns just the charm config.
-func (api *APIBase) CharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+// CharmConfig is a shim to GetConfig on APIv5. It returns only charm config.
+// Version 8 and below accept params.Entities, where later versions must accept
+// a model generation
+func (api *APIv8) CharmConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
 	return api.GetConfig(args)
+}
+
+// CharmConfig returns charm config for the input list of applications and
+// model generations.
+func (api *APIBase) CharmConfig(args params.ApplicationGetArgs) (params.ApplicationGetConfigResults, error) {
+	if err := api.checkCanRead(); err != nil {
+		return params.ApplicationGetConfigResults{}, err
+	}
+	results := params.ApplicationGetConfigResults{
+		Results: make([]params.ConfigResult, len(args.Args)),
+	}
+	for i, arg := range args.Args {
+		config, err := api.getCharmConfig(arg.ApplicationName)
+		results.Results[i].Config = config
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results, nil
+}
+
+// GetConfig returns the charm config for each of the input applications.
+func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+	if err := api.checkCanRead(); err != nil {
+		return params.ApplicationGetConfigResults{}, err
+	}
+	results := params.ApplicationGetConfigResults{
+		Results: make([]params.ConfigResult, len(args.Entities)),
+	}
+	for i, arg := range args.Entities {
+		tag, err := names.ParseTag(arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		if tag.Kind() != names.ApplicationTagKind {
+			results.Results[i].Error = common.ServerError(
+				errors.Errorf("unexpected tag type, expected application, got %s", tag.Kind()))
+			continue
+		}
+
+		config, err := api.getCharmConfig(tag.Id())
+		results.Results[i].Config = config
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results, nil
+}
+
+func (api *APIBase) getCharmConfig(appName string) (map[string]interface{}, error) {
+	app, err := api.backend.Application(appName)
+	if err != nil {
+		return nil, err
+	}
+	settings, err := app.CharmConfig()
+	if err != nil {
+		return nil, err
+	}
+	ch, _, err := app.Charm()
+	if err != nil {
+		return nil, err
+	}
+	return describe(settings, ch.Config()), nil
 }
 
 // SetApplicationsConfig isn't on the v5 API.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/core/model"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -32,6 +30,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -117,7 +116,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {
 	s.setUpConfigTest(c)
 
-	// TODO (manadart 2018-02-04): When upstream methods receive a generation,
+	// TODO (manadart 2019-02-04): When upstream methods receive a generation,
 	// refactor these tests to account for it.
 	results, err := s.applicationAPI.CharmConfig(params.ApplicationGetArgs{
 		Args: []params.ApplicationGet{

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -175,11 +175,14 @@ type ApplicationUnset struct {
 	Options []string `json:"options"`
 }
 
+// ApplicationGetArgs is used to request config for
+// multiple application/generation pairs.
 type ApplicationGetArgs struct {
 	Args []ApplicationGet `json:"args"`
 }
 
-// ApplicationGet holds parameters for making the Get or GetCharmURL calls.
+// ApplicationGet holds parameters for making the singular Get or GetCharmURL
+// calls, and bulk calls to CharmConfig in the V9 API.
 type ApplicationGet struct {
 	ApplicationName string `json:"application"`
 

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -175,8 +175,11 @@ type ApplicationUnset struct {
 	Options []string `json:"options"`
 }
 
-// ApplicationGet holds parameters for making the Get or
-// GetCharmURL calls.
+type ApplicationGetArgs struct {
+	Args []ApplicationGet `json:"args"`
+}
+
+// ApplicationGet holds parameters for making the Get or GetCharmURL calls.
 type ApplicationGet struct {
 	ApplicationName string `json:"application"`
 

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1539,16 +1539,12 @@ func buildModelRepresentation(
 		return nil, errors.Annotate(err, "getting model sequences")
 	}
 
-	// Now get all the application config.
-	// TODO (manadart 2019-01-23) Retrieve this value from the local store
-	// (generally ~/.local/share/juju).
-	generation := model.GenerationCurrent
-
-	configValues, err := apiRoot.GetConfig(generation, appNames...)
+	// When dealing with bundles the current model generation is always used.
+	configValues, err := apiRoot.GetConfig(model.GenerationCurrent, appNames...)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting application options")
 	}
-	for i, config := range configValues {
+	for i, cfg := range configValues {
 		options := make(map[string]interface{})
 		// The config map has values that looks like this:
 		//  map[string]interface {}{
@@ -1558,7 +1554,7 @@ func buildModelRepresentation(
 		//        "type":        "string",
 		//    },
 		// We want the value iff default is false.
-		for key, valueMap := range config {
+		for key, valueMap := range cfg {
 			value, err := applicationConfigValue(key, valueMap)
 			if err != nil {
 				return nil, errors.Annotatef(err, "bad application config for %q", appNames[i])

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -935,14 +935,15 @@ func (h *bundleHandler) setOptions(change *bundlechanges.SetOptionsChange) error
 	}
 
 	// We know that there wouldn't be any setOptions if there were no options.
-	config, err := yaml.Marshal(map[string]map[string]interface{}{p.Application: p.Options})
+	cfg, err := yaml.Marshal(map[string]map[string]interface{}{p.Application: p.Options})
 	if err != nil {
 		return errors.Annotatef(err, "cannot marshal options for application %q", p.Application)
 	}
 
 	if err := h.api.Update(params.ApplicationUpdate{
 		ApplicationName: p.Application,
-		SettingsYAML:    string(config),
+		SettingsYAML:    string(cfg),
+		Generation:      model.GenerationCurrent,
 	}); err != nil {
 		return errors.Annotatef(err, "cannot update options for application %q", p.Application)
 	}

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -32,6 +32,9 @@ same way as the deploy command) before comparing with the model.
 The map-machines option works similarly as for the deploy command, but
 existing is always assumed, so it doesn't need to be specified.
 
+Config values for comparison are always source from the "current" model
+generation.
+
 Examples:
     juju diff-bundle localbundle.yaml
     juju diff-bundle canonical-kubernetes

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -179,10 +179,11 @@ func (c *configCommand) Init(args []string) error {
 
 func (c *configCommand) validateGeneration() error {
 	if c.generation == "" {
-		// TODO (manadart 2018-01-23) If unspecified via the --generation
-		// option, this value will be retrieved from the local store
-		// (generally ~/.local/share/juju).
-		c.generation = string(model.GenerationCurrent)
+		gen, err := c.ModelGeneration()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.generation = string(gen)
 	}
 	if !set.NewStrings(string(model.GenerationCurrent), string(model.GenerationNext)).Contains(c.generation) {
 		return errors.New(`generation option must be "current" or "next"`)
@@ -421,20 +422,15 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 	}
 
 	err = c.out.Write(ctx, resultsMap)
-	if err != nil {
-		return errors.Trace(err)
-	}
 
-	if featureflag.Enabled(feature.Generations) {
-		gen, err := c.ModelGeneration()
-		if err != nil {
-			return errors.Trace(err)
+	if featureflag.Enabled(feature.Generations) && err == nil {
+		var gen model.GenerationVersion
+		gen, err = c.ModelGeneration()
+		if err == nil {
+			_, err = ctx.Stdout.Write([]byte(fmt.Sprintf("\nchanges will be targeted to generation: %s\n", gen)))
 		}
-
-		ctx.Stdout.Write([]byte(fmt.Sprintf("\nchanges will be targeted to generation: %s\n", gen)))
 	}
-	return nil
-
+	return errors.Trace(err)
 }
 
 // validateValues reads the values provided as args and validates that they are

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -186,7 +186,16 @@ func (c *configCommand) validateGeneration() error {
 		c.generation = string(gen)
 	}
 	if !set.NewStrings(string(model.GenerationCurrent), string(model.GenerationNext)).Contains(c.generation) {
-		return errors.New(`generation option must be "current" or "next"`)
+		// TODO (manadart 2019-02-04): If the generation feature is inactive,
+		// we set a default in lieu of empty values. This is an expediency
+		// during development. When we remove the flag, there will be tests
+		// (particularly feature tests) that will need to accommodate a value
+		// for generation in the local store.
+		if !featureflag.Enabled(feature.Generations) && c.generation == "" {
+			c.generation = string(model.GenerationCurrent)
+		} else {
+			return errors.New(`generation option must be "current" or "next"`)
+		}
 	}
 	return nil
 }

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -90,7 +90,7 @@ var getTests = []struct {
 				},
 			},
 			"settings":                               charmSettings,
-			"changes will be targeted to generation": interface{}(nil),
+			"changes will be targeted to generation": interface{}("current"),
 		},
 	}, {
 		"dummy-application",
@@ -99,7 +99,7 @@ var getTests = []struct {
 			"application":                            "dummy-application",
 			"charm":                                  "dummy",
 			"settings":                               charmSettings,
-			"changes will be targeted to generation": interface{}(nil),
+			"changes will be targeted to generation": interface{}("current"),
 		},
 	},
 }

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -126,7 +126,7 @@ func (s *UpgradeCharmSuite) SetUpTest(c *gc.C) {
 	}
 	store.Models["foo"] = &jujuclient.ControllerModels{
 		CurrentModel: "admin/bar",
-		Models:       map[string]jujuclient.ModelDetails{"admin/bar": {}},
+		Models:       map[string]jujuclient.ModelDetails{"admin/bar": {ModelGeneration: model.GenerationNext}},
 	}
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
 		s.AddCall("OpenAPI")
@@ -177,9 +177,7 @@ func (s *UpgradeCharmSuite) TestStorageConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 
-	// TODO (manadart 2019-01-24) Once we are retrieving the active generation
-	// from the local store, this test should flex that behaviour.
-	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationCurrent, application.SetCharmConfig{
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationNext, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,
@@ -229,9 +227,7 @@ func (s *UpgradeCharmSuite) TestConfigSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 
-	// TODO (manadart 2019-01-24) Once we are retrieving the active generation
-	// from the local store, this test should flex that behaviour.
-	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationCurrent, application.SetCharmConfig{
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationNext, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: jujucharmstore.CharmID{
 			URL:     s.resolvedCharmURL,

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -5,8 +5,6 @@ package featuretests
 
 import (
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/testing/factory"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
@@ -18,7 +16,9 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
 )
 
 // cmdJujuSuite tests the connectivity of juju commands.  These tests

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -5,6 +5,7 @@ package featuretests
 
 import (
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/testing/factory"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -248,6 +249,15 @@ settings:
     value: admin001
 `
 	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{Name: "caas-model"})
+
+	// Ensure the new CAAS model is in the local store.
+	modelDetails := jujuclient.ModelDetails{
+		ModelUUID:       st.ModelUUID(),
+		ModelType:       "caas",
+		ModelGeneration: "current",
+	}
+	c.Assert(s.ControllerStore.UpdateModel("kontroll", "admin/caas-model", modelDetails), jc.ErrorIsNil)
+
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
 	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})

--- a/jujuclient/jujuclienttesting/simple.go
+++ b/jujuclient/jujuclienttesting/simple.go
@@ -20,7 +20,8 @@ func MinimalStore() *jujuclient.MemStore {
 	store.Models["arthur"] = &jujuclient.ControllerModels{
 		CurrentModel: "king/sword",
 		Models: map[string]jujuclient.ModelDetails{"king/sword": {
-			ModelType: model.IAAS,
+			ModelType:       model.IAAS,
+			ModelGeneration: model.GenerationCurrent,
 		}},
 	}
 	store.Accounts["arthur"] = jujuclient.AccountDetails{


### PR DESCRIPTION
## Description of change

This patch does the following:
- Sources the active generation from the local store for config and upgrade-charm commands.
- Ensures that API clients pass generation through to the API server for such commands.
- Ensures that bundle handling of data for applications and config always passes through `model.GenerationCurrent`.
- Disallows use of the --generation option when dealing with controllers where it is unsupported.
- Sets `model.GenerationCurrent` as the generation in model details in the the simple store used for client testing.

## QA steps

Same as for https://github.com/juju/juju/pull/9663, but in addition:
- Run the steps both with and without the generations flag set.
- Destroy the controller and repeat with a controller bootstrapped using the patched code.

## Documentation changes

None in addition to the generation feature documentation generally.

## Bug reference

N/A
