### PR TITLE
raft: Ensure we still get metrics after a worker bounce

### DIFF
--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -10,19 +10,52 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// registerMetrics connects the metrics gathered in the
-// hashicorp/raft library code with our prometheus collector.
-func registerMetrics(registerer prometheus.Registerer) (prometheus.Collector, error) {
+// newMetricsCollector returns a collector for the metrics gathered in the
+// hashicorp/raft library code.
+func newMetricsCollector() (prometheus.Collector, error) {
 	sink, err := pmetrics.NewPrometheusSink()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// go-metrics always registers the sink it returns in the default
+	// registry, which we don't collect metrics from - unregister it
+	// so subsequent calls don't fail because it's already registered
+	// there.
+	prometheus.DefaultRegisterer.Unregister(sink)
 	_, err = metrics.NewGlobal(metrics.DefaultConfig("juju"), sink)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := registerer.Register(sink); err != nil {
-		return nil, errors.Trace(err)
-	}
 	return sink, nil
+}
+
+func registerMetrics(registry prometheus.Registerer, logger Logger) {
+	collector, err := newMetricsCollector()
+	if err != nil {
+		// It isn't a fatal error to fail to set up metrics, so
+		// log and continue
+		logger.Warningf("creating a raft metrics collector failed: %v", err)
+		return
+	}
+
+	// We use unregister/register rather than
+	// register/defer-unregister to avoid this scenario:
+	// * raft.newWorker is called, which starts loop in a
+	//   goroutine.
+	// * loop registers the collector and defers unregistering.
+	// * loop gets delayed starting raft (possibly it's taking a
+	//   long time for the peergrouper to publish the api addresses).
+	// * newWorker times out waiting for loop to be ready, kills the
+	//   catacomb and returns a timeout error - at this point loop
+	//   hasn't finished, so the collector hasn't been unregistered.
+	// * The dep-engine calls newWorker again, it starts a new loop
+	//   goroutine.
+	// * The new run of loop can't register the collector, and we
+	//   never see raft metrics for this controller.
+	registry.Unregister(collector)
+	err = registry.Register(collector)
+	if err != nil {
+		logger.Warningf("registering metrics collector failed: %v", err)
+	}
+
 }

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -294,14 +294,7 @@ func (w *Worker) Wait() error {
 func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 	// Register the metrics.
 	if w.config.PrometheusRegisterer != nil {
-		collector, err := registerMetrics(w.config.PrometheusRegisterer)
-		if err != nil {
-			// It isn't a fatal error to fail to register the metrics, so
-			// log and continue
-			w.config.Logger.Warningf("registration of raft metrics failed: %v", err)
-		} else {
-			defer w.config.PrometheusRegisterer.Unregister(collector)
-		}
+		registerMetrics(w.config.PrometheusRegisterer, w.config.Logger)
 	}
 
 	rawLogStore, err := NewLogStore(w.config.StorageDir)

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -18,6 +18,7 @@ import (
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/statemetrics"
+	"github.com/juju/juju/wrench"
 )
 
 var logger = loggo.GetLogger("juju.worker.state")
@@ -193,6 +194,12 @@ func (w *stateWorker) loop() error {
 				); err != nil {
 					return errors.Trace(err)
 				}
+			}
+		// Useful for tracking down some bugs that occur when
+		// mongo is overloaded.
+		case <-time.After(30 * time.Second):
+			if wrench.IsActive("state-worker", "io-timeout") {
+				return errors.Errorf("wrench simulating i/o timeout!")
 			}
 		}
 	}


### PR DESCRIPTION
## Description of change

The go-metrics library registers the returned collector with the default registry (which we don't use). Unregister it so we don't lose metrics after the worker restarts, for example if a mongo i/o timeout causes the state worker to bounce. 

When raft times out starting up we can get a situation where a second loop is started before the old one finishes (so it hasn't yet unregistered). Use unregister/register rather than register/defer-unregister to handle this.

## QA steps

* Bootstrap a controller, enable HA.
* Use the `juju_metrics` command to check that `juju_raft_fsm_apply_count` is increasing over time on all controllers (setTime commands being applied on the leader and replicated to followers). `juju_metrics 2>&1 | grep juju_raft_fsm_apply_count`
* Watch the controller debug-log for errors.
* Trigger a state worker bounce on controller machine 1 by creating the necessary wrench file: `sudo echo io-timeout > /var/lib/juju/wrench/state-worker`
* Remove the wrench after seeing wrench error in the controller log.
* Check that the raft worker start-count has increased on controller 1: `juju_engine_report | less +/raft:`
* Check that the fsm_apply_count metric is still increasing over time on controller 1: `juju_metrics 2>&1 | grep juju_raft_fsm_apply_count`

## Documentation changes
None

## Bug reference
Fixes https://bugs.launchpad.net/juju/+bug/1813992