### PR TITLE
Ensure k8s charm upgrades get processed

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -365,6 +365,10 @@ func (op *caasOperator) loop() (err error) {
 				if err != nil {
 					return errors.Annotatef(err, "error downloading updated charm %v", localState.CharmURL)
 				}
+				// Reset the application's "Downloading..." message.
+				if err := op.setStatus(status.Active, ""); err != nil {
+					return errors.Trace(err)
+				}
 				// Notify all uniters of the change so they run the upgrade-charm hook.
 				for unitId, changedChan := range aliveUnits {
 					logger.Debugf("trigger upgrade charm for caas unit %v", unitId)

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -260,6 +260,12 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 		lxdProfileChanges    watcher.StringsChannel
 	)
 
+	// CAAS models don't use an application watcher
+	// which fires an initial event.
+	if w.modelType == model.CAAS {
+		seenApplicationChange = true
+	}
+
 	if w.modelType == model.IAAS {
 		// This is in IAAS model so we need to watch state for application
 		// charm changes instead of being informed by the operator.

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -284,12 +284,11 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 		assertOneChange()
 		s.st.unit.upgradeLXDProfileUpgradeWatcher.changes <- []string{lxdprofile.SuccessStatus}
 		assertOneChange()
-
-		s.st.unit.application.forceUpgrade = true
-		s.applicationWatcher.changes <- struct{}{}
-		assertOneChange()
-		c.Assert(s.watcher.Snapshot().ForceCharmUpgrade, jc.IsTrue)
 	}
+	s.st.unit.application.forceUpgrade = true
+	s.applicationWatcher.changes <- struct{}{}
+	assertOneChange()
+	c.Assert(s.watcher.Snapshot().ForceCharmUpgrade, jc.IsTrue)
 
 	s.clock.Advance(5 * time.Minute)
 	assertOneChange()


### PR DESCRIPTION
## Description of change

k8s charm upgrades were not running the upgrade-charm hook. There was also a stale message in status about downloading the charm.

NB When upgrading to a local charm you do need to supply the docker image resource as with a straight deploy

## QA steps

deploy k8s model
deploy a charm from the store
run juju upgrade-charm using a local copy of the charm
juju show-status-log shows the upgrade hook as run

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813884
