### PR TITLE
Add support for more k8 sspecific pod attributes

### DIFF
--- a/caas/containers.go
+++ b/caas/containers.go
@@ -61,6 +61,14 @@ type PodSpec struct {
 	Containers                []ContainerSpec            `yaml:"-"`
 	OmitServiceFrontend       bool                       `yaml:"omitServiceFrontend"`
 	CustomResourceDefinitions []CustomResourceDefinition `yaml:"customResourceDefinition,omitempty"`
+
+	// ProviderPod defines config which is specific to a substrate, eg k8s
+	ProviderPod `yaml:"-"`
+}
+
+// ProviderPod defines a provider specific pod.
+type ProviderPod interface {
+	Validate() error
 }
 
 // CustomResourceDefinitionValidation defines the custom resource definition validation schema.
@@ -105,6 +113,9 @@ func (spec *PodSpec) Validate() error {
 		if err := crd.Validate(); err != nil {
 			return errors.Trace(err)
 		}
+	}
+	if spec.ProviderPod != nil {
+		return spec.ProviderPod.Validate()
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1922,6 +1922,25 @@ func makeUnitSpec(appName string, podSpec *caas.PodSpec) (*unitSpec, error) {
 		}
 	}
 	unitSpec.Pod.ImagePullSecrets = imageSecretNames
+	if podSpec.ProviderPod != nil {
+		spec, ok := podSpec.ProviderPod.(*K8sPodSpec)
+		if !ok {
+			return nil, errors.Errorf("unexpected kubernetes pod spec type %T", podSpec.ProviderPod)
+		}
+		unitSpec.Pod.ActiveDeadlineSeconds = spec.ActiveDeadlineSeconds
+		unitSpec.Pod.ServiceAccountName = spec.ServiceAccountName
+		unitSpec.Pod.TerminationGracePeriodSeconds = spec.TerminationGracePeriodSeconds
+		unitSpec.Pod.Hostname = spec.Hostname
+		unitSpec.Pod.Subdomain = spec.Subdomain
+		unitSpec.Pod.DNSConfig = spec.DNSConfig
+		unitSpec.Pod.DNSPolicy = spec.DNSPolicy
+		unitSpec.Pod.Priority = spec.Priority
+		unitSpec.Pod.PriorityClassName = spec.PriorityClassName
+		unitSpec.Pod.SecurityContext = spec.SecurityContext
+		unitSpec.Pod.RestartPolicy = spec.RestartPolicy
+		unitSpec.Pod.AutomountServiceAccountToken = spec.AutomountServiceAccountToken
+		unitSpec.Pod.ReadinessGates = spec.ReadinessGates
+	}
 	return &unitSpec, nil
 }
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -44,6 +44,27 @@ var _ = gc.Suite(&K8sSuite{})
 
 func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 	podSpec := caas.PodSpec{
+		ProviderPod: &provider.K8sPodSpec{
+			ActiveDeadlineSeconds:         int64Ptr(10),
+			ServiceAccountName:            "serviceAccount",
+			Hostname:                      "host",
+			Subdomain:                     "sub",
+			DNSPolicy:                     core.DNSClusterFirst,
+			TerminationGracePeriodSeconds: int64Ptr(20),
+			RestartPolicy:                 core.RestartPolicyOnFailure,
+			AutomountServiceAccountToken:  boolPtr(true),
+			Priority:                      int32Ptr(30),
+			PriorityClassName:             "top",
+			DNSConfig: &core.PodDNSConfig{
+				Nameservers: []string{"ns1", "n2"},
+			},
+			SecurityContext: &core.PodSecurityContext{
+				RunAsNonRoot: boolPtr(true),
+			},
+			ReadinessGates: []core.PodReadinessGate{
+				{ConditionType: core.PodInitialized},
+			},
+		},
 		Containers: []caas.ContainerSpec{{
 			Name:  "test",
 			Ports: []caas.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
@@ -68,6 +89,25 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 	spec, err := provider.MakeUnitSpec("app-name", &podSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.PodSpec(spec), jc.DeepEquals, core.PodSpec{
+		ActiveDeadlineSeconds:         int64Ptr(10),
+		ServiceAccountName:            "serviceAccount",
+		Hostname:                      "host",
+		Subdomain:                     "sub",
+		DNSPolicy:                     core.DNSClusterFirst,
+		TerminationGracePeriodSeconds: int64Ptr(20),
+		RestartPolicy:                 core.RestartPolicyOnFailure,
+		AutomountServiceAccountToken:  boolPtr(true),
+		Priority:                      int32Ptr(30),
+		PriorityClassName:             "top",
+		DNSConfig: &core.PodDNSConfig{
+			Nameservers: []string{"ns1", "n2"},
+		},
+		SecurityContext: &core.PodSecurityContext{
+			RunAsNonRoot: boolPtr(true),
+		},
+		ReadinessGates: []core.PodReadinessGate{
+			{ConditionType: core.PodInitialized},
+		},
 		Containers: []core.Container{
 			{
 				Name:            "test",

--- a/state/status.go
+++ b/state/status.go
@@ -197,8 +197,9 @@ func caasUnitDisplayStatus(unitStatus status.StatusInfo, containerStatus status.
 	}
 	if containerStatus.Status == "" {
 		// No container update received from k8s yet.
-		// Unit may have set status.
-		if unitStatus.Status != "" {
+		// Unit may have set status, (though final status
+		// can only be active if a container status has come through).
+		if unitStatus.Status != "" && unitStatus.Status != status.Active {
 			return unitStatus
 		}
 

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -418,6 +418,11 @@ func (s *UnitCloudStatusSuite) TestContainerOrUnitStatusChoice(c *gc.C) {
 			unitStatus:           status.StatusInfo{},
 			messageCheck:         status.MessageWaitForContainer,
 		},
+		{
+			cloudContainerStatus: status.StatusInfo{},
+			unitStatus:           status.StatusInfo{Status: status.Active},
+			messageCheck:         status.MessageWaitForContainer,
+		},
 	}
 
 	for i, check := range checks {


### PR DESCRIPTION
## Description of change

Users need juju k8s to expose more pod configuration attributes.
A bunch more are now supported, including serviceAccountName and securityContext

## QA steps

Deploy a k8s charm which sends a pod spec with the new attribute sset
kubectl describe the pod

## Documentation changes

We'll need to update the discourse posts
