### PR TITLE
Log try-again errors at the INFO level

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1521,7 +1521,7 @@
   revision = "fd59336b4621bc2a70bf96d9e2f49954115ad19b"
 
 [[projects]]
-  digest = "1:88607626f1e84febb15a0f76146c30075e12fffd92836cb3cdc6e6441862c65d"
+  digest = "1:deb1b0b9f4c4a65246fc1cd82b9d9a3c2ac834a04ef899055853d44770e4c31d"
   name = "gopkg.in/juju/worker.v1"
   packages = [
     ".",
@@ -1531,7 +1531,7 @@
     "workertest",
   ]
   pruneopts = ""
-  revision = "9becf9b2c7057a1043a513b4a177fa33046f4535"
+  revision = "187c8117684679e0e261b1d6f488a404d1d093c9"
 
 [[projects]]
   digest = "1:01aef8078808543c15a4cc0e669d92d37215564600e19ebabbd694939b727977"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -499,7 +499,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/worker.v1"
-  revision = "9becf9b2c7057a1043a513b4a177fa33046f4535"
+  revision = "187c8117684679e0e261b1d6f488a404d1d093c9"
 
 [[override]]
   name = "gopkg.in/macaroon-bakery.v1"


### PR DESCRIPTION
## Description of change

This PR bumps worker.v1 so try-again errors can be logged at the `INFO` level (see: https://github.com/juju/worker/pull/10)

## QA steps

The bug manifests under load when lots of concurrent agent requests trigger the rate limiter. The QA steps below tweak the rate limit configuration so that the rate limit can be triggered with a small number of units

```
juju bootstrap localhost lxd-test
juju run -m controller --machine 0 "sudo sed -i '/values:/a \ \ AGENT_LOGIN_RATE_LIMIT: 1' /var/lib/juju/agents/machine-0/agent.conf && sudo service jujud-machine-0 restart"

juju deploy redis -n 6

# restart all default model machines (you may need to repeat these steps a few times till the rate limit is triggered)
lxc list -c n --format csv | tail -n +2 | xargs lxc stop 
lxc list -c n --format csv | tail -n +2 | xargs lxc start

juju debug-log -l INFO --replay --include-module juju.worker.dependency -m default
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1812980