### PR TITLE
Omit model list when attempting to show controller for user with login access

### DIFF
--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -139,6 +139,15 @@ func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 		}
 
 		var details ShowControllerDetails
+
+		// If user lacks sufficient access level to display controller details,
+		// append the empty controller details and attach a permission error.
+		if !permission.Access(access).EqualOrGreaterControllerAccessThan(permission.SuperuserAccess) {
+			details.Errors = append(details.Errors, errors.Unauthorizedf("permission denied").Error())
+			controllers[controllerName] = details
+			continue
+		}
+
 		allModels, err := client.AllModels()
 		if err != nil {
 			details.Errors = append(details.Errors, err.Error())

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -381,11 +381,21 @@ func (s *ShowControllerSuite) TestShowControllerForUserWithLoginAccess(c *gc.C) 
 `
 	s.expectedOutput = `
 mallards:
-  errors:
-  - permission denied
+  details:
+    uuid: this-is-another-uuid
+    controller-uuid: this-is-another-uuid
+    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    ca-cert: this-is-another-ca-cert
+    cloud: mallards
+    agent-version: 999.99.99
+  current-model: admin/my-model
+  account:
+    user: admin
+    access: login
 `[1:]
 
-	s.createTestClientStore(c)
+	store := s.createTestClientStore(c)
+	c.Assert(store.Models["mallards"].Models, gc.HasLen, 2)
 	s.setAccess(permission.LoginAccess)
 	s.assertShowController(c, "mallards")
 }

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -25,6 +25,7 @@ type ShowControllerSuite struct {
 	baseControllerSuite
 	fakeController *fakeController
 	api            func(string) controller.ControllerAccessAPI
+	setAccess      func(permission.Access)
 }
 
 var _ = gc.Suite(&ShowControllerSuite{})
@@ -40,10 +41,14 @@ func (s *ShowControllerSuite) SetUpTest(c *gc.C) {
 				{Id: "3", InstanceId: "id-3", HasVote: false, WantsVote: false, Status: "active"},
 			},
 		},
+		access: permission.SuperuserAccess,
 	}
 	s.api = func(controllerName string) controller.ControllerAccessAPI {
 		s.fakeController.controllerName = controllerName
 		return s.fakeController
+	}
+	s.setAccess = func(access permission.Access) {
+		s.fakeController.access = access
 	}
 }
 
@@ -365,6 +370,26 @@ func (s *ShowControllerSuite) TestShowControllerRefreshesStoreModels(c *gc.C) {
 	})
 }
 
+func (s *ShowControllerSuite) TestShowControllerForUserWithLoginAccess(c *gc.C) {
+	s.controllersYaml = `controllers:
+  mallards:
+    uuid: this-is-another-uuid
+    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    ca-cert: this-is-another-ca-cert
+    cloud: mallards
+    agent-version: 999.99.99
+`
+	s.expectedOutput = `
+mallards:
+  errors:
+  - permission denied
+`[1:]
+
+	s.createTestClientStore(c)
+	s.setAccess(permission.LoginAccess)
+	s.assertShowController(c, "mallards")
+}
+
 func (s *ShowControllerSuite) runShowController(c *gc.C, args ...string) (*cmd.Context, error) {
 	return cmdtesting.RunCommand(c, controller.NewShowControllerCommandForTest(s.store, s.api), args...)
 }
@@ -383,10 +408,11 @@ func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 type fakeController struct {
 	controllerName string
 	machines       map[string][]base.Machine
+	access         permission.Access
 }
 
-func (*fakeController) GetControllerAccess(user string) (permission.Access, error) {
-	return "superuser", nil
+func (c *fakeController) GetControllerAccess(user string) (permission.Access, error) {
+	return c.access, nil
 }
 
 func (*fakeController) ModelConfig() (map[string]interface{}, error) {


### PR DESCRIPTION
## Description of change

Prior to this PR, when a user with login access attempted to `juju show-controller` they would get back `{}` as the result. The current implementation attempts to fetch the controller models; the call fails with a permission denied error which gets suppressed and the code moves to the next controller. If the command is invoked without an argument then the code only iterates the active controller which results in the empty set being returned to the client.

This PR introduces a permission check to the show controller implementation. When the check fails, the code defaults to an empty model list which allows users to access non-model controller details which may be already cached locally (see the commit log of f39ccd1 for additional info why this fix will not work for users with the `add-model` permission).

## QA steps
```
juju bootstrap localhost lxd-test
juju add-user foo
juju logout
juju login -u foo -c lxd-test
juju show-controller

lxd-test:
  details:
    uuid: 321f8195-3e34-4676-8ca9-05a5697acafe
    controller-uuid: 321f8195-3e34-4676-8ca9-05a5697acafe
    api-endpoints: ['10.153.103.93:17070']
    ca-cert: |
      -----BEGIN CERTIFICATE-----
      ...
      -----END CERTIFICATE-----
    cloud: localhost
    region: localhost
    agent-version: (unauthorized access)
  current-model: admin/default
  account:
    user: foo
    access: login
``` 

## Bug reference
https://bugs.launchpad.net/juju/+bug/1808202