### PR TITLE
raft-lease: make file logging more useful

### DIFF
--- a/state/raftlease/target.go
+++ b/state/raftlease/target.go
@@ -181,12 +181,6 @@ func applyClaimed(mongo Mongo, collection string, docId string, key lease.Key, h
 func (t *notifyTarget) Claimed(key lease.Key, holder string) {
 	docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
 	t.log("claimed %q for %q", docId, holder)
-	// Use this wrench to simulate a failure writing the claimed info
-	// to the database.
-	// if wrench.IsActive("raftlease-notifytarget", "fail-claim") {
-	// 	t.errorLogger.Errorf("wrench failing claimed of %q for %q", docId, holder)
-	// 	return
-	// }
 	_, err := applyClaimed(t.mongo, t.collection, docId, key, holder)
 	if err != nil {
 		t.errorLogger.Errorf("couldn't claim lease %q for %q in db: %s", docId, holder, err.Error())

--- a/state/raftlease/target.go
+++ b/state/raftlease/target.go
@@ -180,6 +180,7 @@ func applyClaimed(mongo Mongo, collection string, docId string, key lease.Key, h
 // Claimed is part of raftlease.NotifyTarget.
 func (t *notifyTarget) Claimed(key lease.Key, holder string) {
 	docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
+	t.log("claimed %q for %q", docId, holder)
 	// Use this wrench to simulate a failure writing the claimed info
 	// to the database.
 	// if wrench.IsActive("raftlease-notifytarget", "fail-claim") {
@@ -188,10 +189,10 @@ func (t *notifyTarget) Claimed(key lease.Key, holder string) {
 	// }
 	_, err := applyClaimed(t.mongo, t.collection, docId, key, holder)
 	if err != nil {
-		t.errorLogger.Errorf("couldn't claim lease %q for %q: %s", docId, holder, err.Error())
+		t.errorLogger.Errorf("couldn't claim lease %q for %q in db: %s", docId, holder, err.Error())
+		t.log("couldn't claim lease %q for %q in db: %s", docId, holder, err.Error())
 		return
 	}
-	t.log("claimed %q for %q", docId, holder)
 }
 
 // Expired is part of raftlease.NotifyTarget.
@@ -199,6 +200,7 @@ func (t *notifyTarget) Expired(key lease.Key) {
 	coll, closer := t.mongo.GetCollection(t.collection)
 	defer closer()
 	docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
+	t.log("expired %q", docId)
 	err := t.mongo.RunTransaction(func(_ int) ([]txn.Op, error) {
 		existingDoc, err := getRecord(coll, docId)
 		if err == mgo.ErrNotFound {
@@ -218,10 +220,10 @@ func (t *notifyTarget) Expired(key lease.Key) {
 	})
 
 	if err != nil {
-		t.errorLogger.Errorf("couldn't expire lease %q: %s", docId, err.Error())
+		t.errorLogger.Errorf("couldn't expire lease %q in db: %s", docId, err.Error())
+		t.log("couldn't expire lease %q in db: %s", docId, err.Error())
 		return
 	}
-	t.log("expired %q", docId)
 }
 
 // MakeTrapdoorFunc returns a raftlease.TrapdoorFunc for the specified

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -177,8 +177,12 @@ func (s *targetSuite) TestClaimedError(c *gc.C) {
 	s.newTarget().Claimed(lease.Key{"ns", "model", "lease"}, "me")
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 	c.Assert(logWriter.Log(), jc.LogMatches, []string{
-		`couldn't claim lease "model:ns#lease#" for "me": oh no!`,
+		`couldn't claim lease "model:ns#lease#" for "me" in db: oh no!`,
 	})
+	s.assertLogMatches(c,
+		`claimed "model:ns#lease#" for "me"`,
+		`couldn't claim lease "model:ns#lease#" for "me" in db: oh no!`,
+	)
 }
 
 func (s *targetSuite) assertLogMatches(c *gc.C, expectLines ...string) {
@@ -248,8 +252,12 @@ func (s *targetSuite) TestExpiredError(c *gc.C) {
 	s.mongo.txnErr = errors.Errorf("oops!")
 	s.newTarget().Expired(lease.Key{"leadership", "model", "twin"})
 	c.Assert(logWriter.Log(), jc.LogMatches, []string{
-		`couldn't expire lease "model:leadership#twin#": oops!`,
+		`couldn't expire lease "model:leadership#twin#" in db: oops!`,
 	})
+	s.assertLogMatches(c,
+		`expired "model:leadership#twin#"`,
+		`couldn't expire lease "model:leadership#twin#" in db: oops!`,
+	)
 }
 
 func (s *targetSuite) TestTrapdoorAttempt0(c *gc.C) {


### PR DESCRIPTION
## Description of change

Lease changes wouldn't get written to the lease-specific log file if writing to the db failed, which made it hard to see the real state of the system. Always log the change to the file, also log if the db write fails.

## QA steps

* Add a wrench like the one below to cause a DB write to fail when we claim a lease.
```patch
diff --git a/state/raftlease/target.go b/state/raftlease/target.go
index b6ccc54..d239501 100644
--- a/state/raftlease/target.go
+++ b/state/raftlease/target.go
@@ -181,6 +181,10 @@ func applyClaimed(mongo Mongo, collection string, docId string, key lease.Key, h
 func (t *notifyTarget) Claimed(key lease.Key, holder string) {
        docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
        t.log("claimed %q for %q", docId, holder)
+       if wrench.IsActive("raftlease-notifytarget", "fail-claim") {
+               t.errorLogger.Errorf("wrench failing claimed of %q for %q", docId, holder)
+               return
+       }
        _, err := applyClaimed(t.mongo, t.collection, docId, key, holder)
        if err != nil {
                t.errorLogger.Errorf("couldn't claim lease %q for %q in db: %s", docId, holder, err.Error())
```
* Bootstrap a controller and set the wrench.
* Deploy a unit (which will claim leadership when it starts).
* The claim and db failure are written to /var/log/juju/lease.log

## Documentation changes
None

## Bug reference
None