### PR TITLE
Bug 1813044 Changing instanceCharmProfileData docID to <machine>#<unit>

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -80,7 +80,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  7,
+	"Provisioner":                  8,
 	"ProxyUpdater":                 2,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -120,7 +120,7 @@ type MachineProvisioner interface {
 	WatchContainersCharmProfiles(ctype instance.ContainerType) (watcher.StringsWatcher, error)
 
 	// CharmProfileChangeInfo retrieves the info necessary to change a charm
-	// profile used by a machine, for the give unit.
+	// profile used by a machine, for the given unit.
 	CharmProfileChangeInfo(string) (CharmProfileChangeInfo, error)
 
 	// SetCharmProfiles records the given slice of charm profile names.
@@ -128,7 +128,7 @@ type MachineProvisioner interface {
 
 	// SetUpgradeCharmProfileComplete records the result of updating
 	// the machine's charm profile(s), for the given unit.
-	SetUpgradeCharmProfileComplete(string, string) error
+	SetUpgradeCharmProfileComplete(unitName string, message string) error
 
 	// RemoveUpgradeCharmProfileData completely removes the instance charm profile
 	// data for a machine and the given unit, even if the machine is dead.

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -120,19 +120,19 @@ type MachineProvisioner interface {
 	WatchContainersCharmProfiles(ctype instance.ContainerType) (watcher.StringsWatcher, error)
 
 	// CharmProfileChangeInfo retrieves the info necessary to change a charm
-	// profile used by a machine.
-	CharmProfileChangeInfo() (CharmProfileChangeInfo, error)
+	// profile used by a machine, for the give application.
+	CharmProfileChangeInfo(string) (CharmProfileChangeInfo, error)
 
 	// SetCharmProfiles records the given slice of charm profile names.
 	SetCharmProfiles([]string) error
 
-	// SetUpgradeCharmProfileComplete recorded that the result of updating
-	// the machine's charm profile(s)
-	SetUpgradeCharmProfileComplete(string) error
+	// SetUpgradeCharmProfileComplete records the result of updating
+	// the machine's charm profile(s), for the given application.
+	SetUpgradeCharmProfileComplete(appName string, msg string) error
 
 	// RemoveUpgradeCharmProfileData completely removes the instance charm profile
-	// data for a machine, even if the machine is dead.
-	RemoveUpgradeCharmProfileData() error
+	// data for a machine and the provided application, even if the machine is dead.
+	RemoveUpgradeCharmProfileData(string) error
 }
 
 // Machine represents a juju machine as seen by the provisioner worker.
@@ -572,11 +572,16 @@ type CharmProfileChangeInfo struct {
 }
 
 // CharmProfileChangeInfo implements MachineProvisioner.CharmProfileChangeInfo.
-func (m *Machine) CharmProfileChangeInfo() (CharmProfileChangeInfo, error) {
+func (m *Machine) CharmProfileChangeInfo(appName string) (CharmProfileChangeInfo, error) {
 	var results params.ProfileChangeResults
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: m.tag.String()},
-	}}
+	args := params.ProfileArgs{
+		Args: []params.ProfileArg{
+			{
+				Entity:  params.Entity{Tag: m.tag.String()},
+				AppName: appName,
+			},
+		},
+	}
 	err := m.st.facade.FacadeCall("CharmProfileChangeInfo", args, &results)
 	if err != nil {
 		return CharmProfileChangeInfo{}, err
@@ -627,12 +632,13 @@ func (m *Machine) SetCharmProfiles(profiles []string) error {
 }
 
 // SetUpgradeCharmProfileComplete implements MachineProvisioner.SetUpgradeCharmProfileComplete.
-func (m *Machine) SetUpgradeCharmProfileComplete(message string) error {
+func (m *Machine) SetUpgradeCharmProfileComplete(appName, message string) error {
 	var results params.ErrorResults
 	args := params.SetProfileUpgradeCompleteArgs{
 		Args: []params.SetProfileUpgradeCompleteArg{
 			{
 				Entity:  params.Entity{Tag: m.tag.String()},
+				AppName: appName,
 				Message: message,
 			},
 		},
@@ -652,12 +658,13 @@ func (m *Machine) SetUpgradeCharmProfileComplete(message string) error {
 }
 
 // RemoveUpgradeCharmProfileData implements MachineProvisioner.RemoveUpgradeCharmProfileData.
-func (m *Machine) RemoveUpgradeCharmProfileData() error {
+func (m *Machine) RemoveUpgradeCharmProfileData(appName string) error {
 	var results params.ErrorResults
-	args := params.Entities{
-		Entities: []params.Entity{
+	args := params.ProfileArgs{
+		Args: []params.ProfileArg{
 			{
-				Tag: m.tag.String(),
+				Entity:  params.Entity{Tag: m.tag.String()},
+				AppName: appName,
 			},
 		},
 	}

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -120,7 +120,7 @@ type MachineProvisioner interface {
 	WatchContainersCharmProfiles(ctype instance.ContainerType) (watcher.StringsWatcher, error)
 
 	// CharmProfileChangeInfo retrieves the info necessary to change a charm
-	// profile used by a machine, for the give application.
+	// profile used by a machine, for the give unit.
 	CharmProfileChangeInfo(string) (CharmProfileChangeInfo, error)
 
 	// SetCharmProfiles records the given slice of charm profile names.
@@ -572,13 +572,13 @@ type CharmProfileChangeInfo struct {
 }
 
 // CharmProfileChangeInfo implements MachineProvisioner.CharmProfileChangeInfo.
-func (m *Machine) CharmProfileChangeInfo(appName string) (CharmProfileChangeInfo, error) {
+func (m *Machine) CharmProfileChangeInfo(unitName string) (CharmProfileChangeInfo, error) {
 	var results params.ProfileChangeResults
 	args := params.ProfileArgs{
 		Args: []params.ProfileArg{
 			{
-				Entity:  params.Entity{Tag: m.tag.String()},
-				AppName: appName,
+				Entity:   params.Entity{Tag: m.tag.String()},
+				UnitName: unitName,
 			},
 		},
 	}
@@ -637,9 +637,9 @@ func (m *Machine) SetUpgradeCharmProfileComplete(appName, message string) error 
 	args := params.SetProfileUpgradeCompleteArgs{
 		Args: []params.SetProfileUpgradeCompleteArg{
 			{
-				Entity:  params.Entity{Tag: m.tag.String()},
-				AppName: appName,
-				Message: message,
+				Entity:   params.Entity{Tag: m.tag.String()},
+				UnitName: appName,
+				Message:  message,
 			},
 		},
 	}
@@ -663,8 +663,8 @@ func (m *Machine) RemoveUpgradeCharmProfileData(appName string) error {
 	args := params.ProfileArgs{
 		Args: []params.ProfileArg{
 			{
-				Entity:  params.Entity{Tag: m.tag.String()},
-				AppName: appName,
+				Entity:   params.Entity{Tag: m.tag.String()},
+				UnitName: appName,
 			},
 		},
 	}

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -127,11 +127,11 @@ type MachineProvisioner interface {
 	SetCharmProfiles([]string) error
 
 	// SetUpgradeCharmProfileComplete records the result of updating
-	// the machine's charm profile(s), for the given application.
-	SetUpgradeCharmProfileComplete(appName string, msg string) error
+	// the machine's charm profile(s), for the given unit.
+	SetUpgradeCharmProfileComplete(string, string) error
 
 	// RemoveUpgradeCharmProfileData completely removes the instance charm profile
-	// data for a machine and the provided application, even if the machine is dead.
+	// data for a machine and the given unit, even if the machine is dead.
 	RemoveUpgradeCharmProfileData(string) error
 }
 
@@ -632,13 +632,13 @@ func (m *Machine) SetCharmProfiles(profiles []string) error {
 }
 
 // SetUpgradeCharmProfileComplete implements MachineProvisioner.SetUpgradeCharmProfileComplete.
-func (m *Machine) SetUpgradeCharmProfileComplete(appName, message string) error {
+func (m *Machine) SetUpgradeCharmProfileComplete(unitName, message string) error {
 	var results params.ErrorResults
 	args := params.SetProfileUpgradeCompleteArgs{
 		Args: []params.SetProfileUpgradeCompleteArg{
 			{
 				Entity:   params.Entity{Tag: m.tag.String()},
-				UnitName: appName,
+				UnitName: unitName,
 				Message:  message,
 			},
 		},
@@ -658,13 +658,13 @@ func (m *Machine) SetUpgradeCharmProfileComplete(appName, message string) error 
 }
 
 // RemoveUpgradeCharmProfileData implements MachineProvisioner.RemoveUpgradeCharmProfileData.
-func (m *Machine) RemoveUpgradeCharmProfileData(appName string) error {
+func (m *Machine) RemoveUpgradeCharmProfileData(unitName string) error {
 	var results params.ErrorResults
 	args := params.ProfileArgs{
 		Args: []params.ProfileArg{
 			{
 				Entity:   params.Entity{Tag: m.tag.String()},
-				UnitName: appName,
+				UnitName: unitName,
 			},
 		},
 	}

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -53,16 +53,16 @@ func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
 }
 
 // CharmProfileChangeInfo mocks base method
-func (m *MockMachineProvisioner) CharmProfileChangeInfo() (provisioner.CharmProfileChangeInfo, error) {
-	ret := m.ctrl.Call(m, "CharmProfileChangeInfo")
+func (m *MockMachineProvisioner) CharmProfileChangeInfo(arg0 string) (provisioner.CharmProfileChangeInfo, error) {
+	ret := m.ctrl.Call(m, "CharmProfileChangeInfo", arg0)
 	ret0, _ := ret[0].(provisioner.CharmProfileChangeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmProfileChangeInfo indicates an expected call of CharmProfileChangeInfo
-func (mr *MockMachineProvisionerMockRecorder) CharmProfileChangeInfo() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfileChangeInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).CharmProfileChangeInfo))
+func (mr *MockMachineProvisionerMockRecorder) CharmProfileChangeInfo(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfileChangeInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).CharmProfileChangeInfo), arg0)
 }
 
 // DistributionGroup mocks base method
@@ -229,15 +229,15 @@ func (mr *MockMachineProvisionerMockRecorder) Remove() *gomock.Call {
 }
 
 // RemoveUpgradeCharmProfileData mocks base method
-func (m *MockMachineProvisioner) RemoveUpgradeCharmProfileData() error {
-	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData")
+func (m *MockMachineProvisioner) RemoveUpgradeCharmProfileData(arg0 string) error {
+	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveUpgradeCharmProfileData indicates an expected call of RemoveUpgradeCharmProfileData
-func (mr *MockMachineProvisionerMockRecorder) RemoveUpgradeCharmProfileData() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockMachineProvisioner)(nil).RemoveUpgradeCharmProfileData))
+func (mr *MockMachineProvisionerMockRecorder) RemoveUpgradeCharmProfileData(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockMachineProvisioner)(nil).RemoveUpgradeCharmProfileData), arg0)
 }
 
 // SetCharmProfiles mocks base method
@@ -317,15 +317,15 @@ func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...int
 }
 
 // SetUpgradeCharmProfileComplete mocks base method
-func (m *MockMachineProvisioner) SetUpgradeCharmProfileComplete(arg0 string) error {
-	ret := m.ctrl.Call(m, "SetUpgradeCharmProfileComplete", arg0)
+func (m *MockMachineProvisioner) SetUpgradeCharmProfileComplete(arg0, arg1 string) error {
+	ret := m.ctrl.Call(m, "SetUpgradeCharmProfileComplete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUpgradeCharmProfileComplete indicates an expected call of SetUpgradeCharmProfileComplete
-func (mr *MockMachineProvisionerMockRecorder) SetUpgradeCharmProfileComplete(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeCharmProfileComplete", reflect.TypeOf((*MockMachineProvisioner)(nil).SetUpgradeCharmProfileComplete), arg0)
+func (mr *MockMachineProvisionerMockRecorder) SetUpgradeCharmProfileComplete(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeCharmProfileComplete", reflect.TypeOf((*MockMachineProvisioner)(nil).SetUpgradeCharmProfileComplete), arg0, arg1)
 }
 
 // Status mocks base method

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -422,12 +422,12 @@ func (s *provisionerSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
 	err := apiMachine.SetCharmProfiles(profiles)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = apiMachine.SetUpgradeCharmProfileComplete("testme")
+	err = apiMachine.SetUpgradeCharmProfileComplete(application.Name(), "testme")
 	c.Assert(err, jc.ErrorIsNil)
 
 	mach, err := s.State.Machine(apiMachine.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	status, err := mach.UpgradeCharmProfileComplete()
+	status, err := mach.UpgradeCharmProfileComplete(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, "testme")
 }
@@ -439,7 +439,7 @@ func (s *provisionerSuite) TestCharmProfileChangeInfo(c *gc.C) {
 
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	info, err := apiMachine.CharmProfileChangeInfo()
+	info, err := apiMachine.CharmProfileChangeInfo(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, provisioner.CharmProfileChangeInfo{
 		OldProfileName: "",
@@ -482,7 +482,7 @@ func (s *provisionerSuite) TestCharmProfileChangeInfoSubordinate(c *gc.C) {
 
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	info, err := apiMachine.CharmProfileChangeInfo()
+	info, err := apiMachine.CharmProfileChangeInfo(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, provisioner.CharmProfileChangeInfo{
 		OldProfileName: "",
@@ -514,7 +514,7 @@ func (s *provisionerSuite) TestRemoveUpgradeCharmProfileData(c *gc.C) {
 
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	err := apiMachine.RemoveUpgradeCharmProfileData()
+	err := apiMachine.RemoveUpgradeCharmProfileData(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -741,9 +741,9 @@ func (s *provisionerSuite) TestWatchContainersCharmProfiles(c *gc.C) {
 	defer wc.AssertStops()
 
 	// Update the upgrade-charm charm profile to trigger watcher.
-	container.SetUpgradeCharmProfile("app-name", "local:quantal/lxd-profile-0")
+	container.SetUpgradeCharmProfile(app.Name(), "local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(container.Id())
+	wc.AssertChange(container.Id() + "#" + app.Name())
 }
 
 func (s *provisionerSuite) TestWatchContainersAcceptsSupportedContainers(c *gc.C) {
@@ -1001,9 +1001,9 @@ func (s *provisionerSuite) TestWatchModelMachinesCharmProfiles(c *gc.C) {
 	defer wc.AssertStops()
 
 	// Trigger the watcher.
-	err = s.machine.SetUpgradeCharmProfile("lxd-profile", "local:quantal/lxd-profile-0")
+	err = s.machine.SetUpgradeCharmProfile(app.Name(), "local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(s.machine.Id())
+	wc.AssertChange(s.machine.Id() + "#" + app.Name())
 }
 
 var _ = gc.Suite(&provisionerContainerSuite{})

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -246,6 +246,7 @@ func AllFacades() *facade.Registry {
 	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5) // v5 adds DistributionGroupByMachineId()
 	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6) // v6 adds more proxy settings
 	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7) // v7 adds charm profile watcher
+	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8) // v8 adds changes charm profile
 
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)
 	reg("ProxyUpdater", 2, proxyupdater.NewFacadeV2)

--- a/apiserver/facades/agent/provisioner/export_test.go
+++ b/apiserver/facades/agent/provisioner/export_test.go
@@ -13,6 +13,6 @@ func NewContainerProfileContext(result params.ContainerProfileResults, modelName
 	return &containerProfileContext{result: result, modelName: modelName}
 }
 
-func MachineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend, appName string) (params.ProfileChangeResult, error) {
-	return machineChangeProfileChangeInfo(machine, st, appName)
+func MachineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend, unitName string) (params.ProfileChangeResult, error) {
+	return machineChangeProfileChangeInfo(machine, st, unitName)
 }

--- a/apiserver/facades/agent/provisioner/export_test.go
+++ b/apiserver/facades/agent/provisioner/export_test.go
@@ -13,6 +13,6 @@ func NewContainerProfileContext(result params.ContainerProfileResults, modelName
 	return &containerProfileContext{result: result, modelName: modelName}
 }
 
-func MachineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend) (params.ProfileChangeResult, error) {
-	return machineChangeProfileChangeInfo(machine, st)
+func MachineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend, appName string) (params.ProfileChangeResult, error) {
+	return machineChangeProfileChangeInfo(machine, st, appName)
 }

--- a/apiserver/facades/agent/provisioner/mocks/profile_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/profile_mock.go
@@ -71,30 +71,17 @@ func (mr *MockProfileMachineMockRecorder) ModelName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelName", reflect.TypeOf((*MockProfileMachine)(nil).ModelName))
 }
 
-// UpgradeCharmProfileApplication mocks base method
-func (m *MockProfileMachine) UpgradeCharmProfileApplication() (string, error) {
-	ret := m.ctrl.Call(m, "UpgradeCharmProfileApplication")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpgradeCharmProfileApplication indicates an expected call of UpgradeCharmProfileApplication
-func (mr *MockProfileMachineMockRecorder) UpgradeCharmProfileApplication() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCharmProfileApplication", reflect.TypeOf((*MockProfileMachine)(nil).UpgradeCharmProfileApplication))
-}
-
 // UpgradeCharmProfileCharmURL mocks base method
-func (m *MockProfileMachine) UpgradeCharmProfileCharmURL() (string, error) {
-	ret := m.ctrl.Call(m, "UpgradeCharmProfileCharmURL")
+func (m *MockProfileMachine) UpgradeCharmProfileCharmURL(arg0 string) (string, error) {
+	ret := m.ctrl.Call(m, "UpgradeCharmProfileCharmURL", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpgradeCharmProfileCharmURL indicates an expected call of UpgradeCharmProfileCharmURL
-func (mr *MockProfileMachineMockRecorder) UpgradeCharmProfileCharmURL() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCharmProfileCharmURL", reflect.TypeOf((*MockProfileMachine)(nil).UpgradeCharmProfileCharmURL))
+func (mr *MockProfileMachineMockRecorder) UpgradeCharmProfileCharmURL(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCharmProfileCharmURL", reflect.TypeOf((*MockProfileMachine)(nil).UpgradeCharmProfileCharmURL), arg0)
 }
 
 // MockProfileBackend is a mock of ProfileBackend interface

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -167,6 +167,11 @@ type ProvisionerAPIV7 struct {
 	*ProvisionerAPI
 }
 
+// ProvisionerAPIV8 provides v8 of the provisioner facade.
+type ProvisionerAPIV8 struct {
+	*ProvisionerAPI
+}
+
 // NewProvisionerAPIV4 creates a new server-side version 4 Provisioner API facade.
 func NewProvisionerAPIV4(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPIV4, error) {
 	provisionerAPI, err := NewProvisionerAPIV5(st, resources, authorizer)
@@ -201,6 +206,15 @@ func NewProvisionerAPIV7(st *state.State, resources facade.Resources, authorizer
 		return nil, errors.Trace(err)
 	}
 	return &ProvisionerAPIV7{provisionerAPI}, nil
+}
+
+// NewProvisionerAPIV8 creates a new server-side Provisioner API facade.
+func NewProvisionerAPIV8(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPIV8, error) {
+	provisionerAPI, err := NewProvisionerAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ProvisionerAPIV8{provisionerAPI}, nil
 }
 
 func (p *ProvisionerAPI) getMachine(canAccess common.AuthFunc, tag names.MachineTag) (*state.Machine, error) {
@@ -1314,7 +1328,6 @@ func (p *ProvisionerAPI) InstanceStatus(args params.Entities) (params.StatusResu
 }
 
 func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg params.EntityStatusArgs) error {
-	logger.Debugf("SetInstanceStatus called with: %#v", arg)
 	mTag, err := names.ParseMachineTag(arg.Tag)
 	if err != nil {
 		logger.Warningf("SetInstanceStatus called with %q which is not a valid machine tag: %v", arg.Tag, err)
@@ -1322,8 +1335,7 @@ func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg par
 	}
 	machine, err := p.getMachine(canAccess, mTag)
 	if err != nil {
-		logger.Debugf("SetInstanceStatus unable to get machine %q", mTag)
-		return err
+		return errors.Trace(err)
 	}
 	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
@@ -1344,7 +1356,6 @@ func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg par
 	if status.Status(arg.Status) == status.ProvisioningError ||
 		status.Status(arg.Status) == status.Error {
 		s.Status = status.Error
-		logger.Debugf("SetInstanceStatus triggering SetStatus for %#v", s)
 		if err = machine.SetStatus(s); err != nil {
 			return err
 		}
@@ -1414,15 +1425,15 @@ func (a *ProvisionerAPI) CACert() (params.BytesResult, error) {
 
 // CharmProfileChangeInfo retrieves the info necessary to change a charm
 // profile used by a machine.
-func (p *ProvisionerAPI) CharmProfileChangeInfo(machines params.Entities) (params.ProfileChangeResults, error) {
-	results := make([]params.ProfileChangeResult, len(machines.Entities))
+func (p *ProvisionerAPI) CharmProfileChangeInfo(args params.ProfileArgs) (params.ProfileChangeResults, error) {
+	results := make([]params.ProfileChangeResult, len(args.Args))
 	canAccess, err := p.getAuthFunc()
 	if err != nil {
 		logger.Errorf("failed to get an authorisation function: %v", err)
 		return params.ProfileChangeResults{}, errors.Trace(err)
 	}
-	for i, machine := range machines.Entities {
-		mTag, err := names.ParseMachineTag(machine.Tag)
+	for i, arg := range args.Args {
+		mTag, err := names.ParseMachineTag(arg.Entity.Tag)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -1432,7 +1443,7 @@ func (p *ProvisionerAPI) CharmProfileChangeInfo(machines params.Entities) (param
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		result, err := machineChangeProfileChangeInfo(&profileMachineShim{Machine: machine}, &profileBackendShim{p.st})
+		result, err := machineChangeProfileChangeInfo(&profileMachineShim{Machine: machine}, &profileBackendShim{p.st}, arg.AppName)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -1442,13 +1453,9 @@ func (p *ProvisionerAPI) CharmProfileChangeInfo(machines params.Entities) (param
 	return params.ProfileChangeResults{Results: results}, nil
 }
 
-func machineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend) (params.ProfileChangeResult, error) {
+func machineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend, appName string) (params.ProfileChangeResult, error) {
 	nothing := params.ProfileChangeResult{}
 
-	appName, err := machine.UpgradeCharmProfileApplication()
-	if err != nil {
-		return nothing, errors.Trace(err)
-	}
 	if appName == "" {
 		return nothing, errors.Trace(errors.New("no appname for profile charm upgrade"))
 	}
@@ -1463,7 +1470,7 @@ func machineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend) (
 		return nothing, errors.Trace(err)
 	}
 
-	url, err := machine.UpgradeCharmProfileCharmURL()
+	url, err := machine.UpgradeCharmProfileCharmURL(appName)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}
@@ -1557,12 +1564,12 @@ func (p *ProvisionerAPI) SetUpgradeCharmProfileComplete(args params.SetProfileUp
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 	for i, a := range args.Args {
-		results[i].Error = common.ServerError(p.oneUpgradeCharmProfileComplete(a.Entity.Tag, a.Message, canAccess))
+		results[i].Error = common.ServerError(p.oneUpgradeCharmProfileComplete(a.Entity.Tag, a.AppName, a.Message, canAccess))
 	}
 	return params.ErrorResults{Results: results}, nil
 }
 
-func (p *ProvisionerAPI) oneUpgradeCharmProfileComplete(machineTag string, msg string, canAccess common.AuthFunc) error {
+func (p *ProvisionerAPI) oneUpgradeCharmProfileComplete(machineTag, appName, msg string, canAccess common.AuthFunc) error {
 	mTag, err := names.ParseMachineTag(machineTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1571,25 +1578,25 @@ func (p *ProvisionerAPI) oneUpgradeCharmProfileComplete(machineTag string, msg s
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return machine.SetUpgradeCharmProfileComplete(msg)
+	return machine.SetUpgradeCharmProfileComplete(appName, msg)
 }
 
 // RemoveUpgradeCharmProfileData completely removes the instance charm profile
 // data for a machine, even if the machine is dead.
-func (p *ProvisionerAPI) RemoveUpgradeCharmProfileData(args params.Entities) (params.ErrorResults, error) {
-	results := make([]params.ErrorResult, len(args.Entities))
+func (p *ProvisionerAPI) RemoveUpgradeCharmProfileData(args params.ProfileArgs) (params.ErrorResults, error) {
+	results := make([]params.ErrorResult, len(args.Args))
 	canAccess, err := p.getAuthFunc()
 	if err != nil {
 		logger.Errorf("failed to get an authorisation function: %v", err)
 		return params.ErrorResults{}, errors.Trace(err)
 	}
-	for i, a := range args.Entities {
-		results[i].Error = common.ServerError(p.oneRemoveUpgradeCharmProfileData(a.Tag, canAccess))
+	for i, a := range args.Args {
+		results[i].Error = common.ServerError(p.oneRemoveUpgradeCharmProfileData(a.Entity.Tag, a.AppName, canAccess))
 	}
 	return params.ErrorResults{Results: results}, nil
 }
 
-func (p *ProvisionerAPI) oneRemoveUpgradeCharmProfileData(machineTag string, canAccess common.AuthFunc) error {
+func (p *ProvisionerAPI) oneRemoveUpgradeCharmProfileData(machineTag, appName string, canAccess common.AuthFunc) error {
 	mTag, err := names.ParseMachineTag(machineTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1598,5 +1605,5 @@ func (p *ProvisionerAPI) oneRemoveUpgradeCharmProfileData(machineTag string, can
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return machine.RemoveUpgradeCharmProfileData()
+	return machine.RemoveUpgradeCharmProfileData(appName)
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -863,27 +863,6 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 
 // WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies when
 // the provisioner should update the charm profiles used by a machine.
-func (p *ProvisionerAPIV7) WatchModelMachinesCharmProfiles() (params.StringsWatchResult, error) {
-	result := params.StringsWatchResult{}
-	if !p.authorizer.AuthController() {
-		return result, common.ErrPerm
-	}
-	watch, err := p.st.WatchModelMachinesCharmProfiles()
-	if err != nil {
-		return result, common.ErrPerm
-	}
-	// Consume any initial event and forward it to the result.
-	if changes, ok := <-watch.Changes(); ok {
-		result.StringsWatcherId = p.resources.Register(watch)
-		result.Changes = changes
-	} else {
-		return result, watcher.EnsureErr(watch)
-	}
-	return result, nil
-}
-
-// WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies when
-// the provisioner should update the charm profiles used by a machine.
 func (p *ProvisionerAPI) WatchModelMachinesCharmProfiles() (params.StringsWatchResult, error) {
 	result := params.StringsWatchResult{}
 	if !p.authorizer.AuthController() {

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -2012,9 +2012,9 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemoveUn
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return("", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt/0").Return("", nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")
@@ -2031,7 +2031,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemovePr
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt/0").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 
 	cExp := s.charm.EXPECT()
@@ -2043,7 +2043,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemovePr
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")
@@ -2060,7 +2060,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoAddProfi
 		"juju-testme",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt/0").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 	mExp.ModelName().Return("testme")
 
@@ -2076,7 +2076,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoAddProfi
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.NewProfileName, gc.Equals, "juju-testme-lxd-profile-alt-3")
@@ -2099,7 +2099,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoChangePr
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt/0").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 
 	cExp := s.charm.EXPECT()
@@ -2114,7 +2114,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoChangePr
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -2012,10 +2012,9 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemoveUn
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return("", nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return("", nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")
@@ -2032,8 +2031,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemovePr
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return(charmURLString, nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 
 	cExp := s.charm.EXPECT()
@@ -2045,7 +2043,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemovePr
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")
@@ -2062,8 +2060,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoAddProfi
 		"juju-testme",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return(charmURLString, nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 	mExp.ModelName().Return("testme")
 
@@ -2079,7 +2076,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoAddProfi
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.NewProfileName, gc.Equals, "juju-testme-lxd-profile-alt-3")
@@ -2102,8 +2099,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoChangePr
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return(charmURLString, nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 
 	cExp := s.charm.EXPECT()
@@ -2118,7 +2114,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoChangePr
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")

--- a/apiserver/facades/agent/provisioner/shim.go
+++ b/apiserver/facades/agent/provisioner/shim.go
@@ -36,8 +36,7 @@ type profileMachineShim struct {
 
 //go:generate mockgen -package mocks -destination mocks/profile_mock.go github.com/juju/juju/apiserver/facades/agent/provisioner ProfileMachine,ProfileBackend,ProfileCharm
 type ProfileMachine interface {
-	UpgradeCharmProfileApplication() (string, error)
-	UpgradeCharmProfileCharmURL() (string, error)
+	UpgradeCharmProfileCharmURL(string) (string, error)
 	CharmProfiles() ([]string, error)
 	ModelName() string
 	Id() string

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -35,7 +35,7 @@ type LXDProfileMachine interface {
 type LXDProfileUnit interface {
 	Tag() names.Tag
 	AssignedMachineId() (string, error)
-	ApplicationName() string
+	Name() string
 }
 
 type LXDProfileAPI struct {
@@ -206,7 +206,7 @@ func (u *LXDProfileAPI) RemoveUpgradeCharmProfileData(args params.Entities) (par
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		err = machine.RemoveUpgradeCharmProfileData(unit.ApplicationName())
+		err = machine.RemoveUpgradeCharmProfileData(unit.Name())
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -27,7 +27,7 @@ type LXDProfileBackend interface {
 type LXDProfileMachine interface {
 	WatchLXDProfileUpgradeNotifications(string) (state.StringsWatcher, error)
 	Units() ([]LXDProfileUnit, error)
-	RemoveUpgradeCharmProfileData() error
+	RemoveUpgradeCharmProfileData(string) error
 }
 
 // LXDProfileUnit describes unit-receiver state methods
@@ -35,6 +35,7 @@ type LXDProfileMachine interface {
 type LXDProfileUnit interface {
 	Tag() names.Tag
 	AssignedMachineId() (string, error)
+	ApplicationName() string
 }
 
 type LXDProfileAPI struct {
@@ -200,7 +201,12 @@ func (u *LXDProfileAPI) RemoveUpgradeCharmProfileData(args params.Entities) (par
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		err = machine.RemoveUpgradeCharmProfileData()
+		unit, err := u.getUnit(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		err = machine.RemoveUpgradeCharmProfileData(unit.ApplicationName())
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -149,8 +149,16 @@ func (u *LXDProfileAPI) WatchLXDProfileUpgradeNotifications(args params.LXDProfi
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-
-		watcherId, initial, err := u.watchOneChangeLXDProfileUpgradeNotifications(machine, args.ApplicationName)
+		// WatchLXDProfileUpgradeNotifications now requires a unit name
+		// instead of an application name.  Rather than rev LXDProfileAPI,
+		// ignore the args[i].applicationName and determine the unit name
+		// from the tag
+		unit, err := u.getUnit(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		watcherId, initial, err := u.watchOneChangeLXDProfileUpgradeNotifications(machine, unit.Name())
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -162,8 +170,8 @@ func (u *LXDProfileAPI) WatchLXDProfileUpgradeNotifications(args params.LXDProfi
 	return result, nil
 }
 
-func (u *LXDProfileAPI) watchOneChangeLXDProfileUpgradeNotifications(machine LXDProfileMachine, applicationName string) (string, []string, error) {
-	watch, err := machine.WatchLXDProfileUpgradeNotifications(applicationName)
+func (u *LXDProfileAPI) watchOneChangeLXDProfileUpgradeNotifications(machine LXDProfileMachine, unitName string) (string, []string, error) {
+	watch, err := machine.WatchLXDProfileUpgradeNotifications(unitName)
 	if err != nil {
 		return "", nil, errors.Trace(err)
 	}
@@ -201,6 +209,10 @@ func (u *LXDProfileAPI) RemoveUpgradeCharmProfileData(args params.Entities) (par
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
+		// WatchLXDProfileUpgradeNotifications now requires a unit name
+		// instead of an application name.  Rather than rev LXDProfileAPI,
+		// ignore the args[i].applicationName and determine the unit name
+		// from the tag
 		unit, err := u.getUnit(tag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)

--- a/apiserver/facades/agent/uniter/lxdprofile_test.go
+++ b/apiserver/facades/agent/uniter/lxdprofile_test.go
@@ -140,9 +140,9 @@ func (s *lxdProfileSuite) TestRemoveUpgradeCharmProfileDataUnitTag(c *gc.C) {
 
 	mockBackend.EXPECT().Machine(s.machineTag1.Id()).Return(mockMachine1, nil)
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit1, nil).Times(2)
-	mockMachine1.EXPECT().RemoveUpgradeCharmProfileData("mysql").Return(nil)
+	mockMachine1.EXPECT().RemoveUpgradeCharmProfileData("mysql/1").Return(nil)
 	mockUnit1.EXPECT().AssignedMachineId().Return(s.machineTag1.Id(), nil)
-	mockUnit1.EXPECT().ApplicationName().Return("mysql")
+	mockUnit1.EXPECT().Name().Return("mysql/1")
 
 	args := params.Entities{
 		Entities: []params.Entity{

--- a/apiserver/facades/agent/uniter/mocks/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/lxdprofile.go
@@ -145,18 +145,6 @@ func (m *MockLXDProfileUnit) EXPECT() *MockLXDProfileUnitMockRecorder {
 	return m.recorder
 }
 
-// ApplicationName mocks base method
-func (m *MockLXDProfileUnit) ApplicationName() string {
-	ret := m.ctrl.Call(m, "ApplicationName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ApplicationName indicates an expected call of ApplicationName
-func (mr *MockLXDProfileUnitMockRecorder) ApplicationName() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockLXDProfileUnit)(nil).ApplicationName))
-}
-
 // AssignedMachineId mocks base method
 func (m *MockLXDProfileUnit) AssignedMachineId() (string, error) {
 	ret := m.ctrl.Call(m, "AssignedMachineId")
@@ -168,6 +156,18 @@ func (m *MockLXDProfileUnit) AssignedMachineId() (string, error) {
 // AssignedMachineId indicates an expected call of AssignedMachineId
 func (mr *MockLXDProfileUnitMockRecorder) AssignedMachineId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachineId", reflect.TypeOf((*MockLXDProfileUnit)(nil).AssignedMachineId))
+}
+
+// Name mocks base method
+func (m *MockLXDProfileUnit) Name() string {
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockLXDProfileUnitMockRecorder) Name() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLXDProfileUnit)(nil).Name))
 }
 
 // Tag mocks base method

--- a/apiserver/facades/agent/uniter/mocks/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/lxdprofile.go
@@ -85,15 +85,15 @@ func (m *MockLXDProfileMachine) EXPECT() *MockLXDProfileMachineMockRecorder {
 }
 
 // RemoveUpgradeCharmProfileData mocks base method
-func (m *MockLXDProfileMachine) RemoveUpgradeCharmProfileData() error {
-	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData")
+func (m *MockLXDProfileMachine) RemoveUpgradeCharmProfileData(arg0 string) error {
+	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveUpgradeCharmProfileData indicates an expected call of RemoveUpgradeCharmProfileData
-func (mr *MockLXDProfileMachineMockRecorder) RemoveUpgradeCharmProfileData() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockLXDProfileMachine)(nil).RemoveUpgradeCharmProfileData))
+func (mr *MockLXDProfileMachineMockRecorder) RemoveUpgradeCharmProfileData(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockLXDProfileMachine)(nil).RemoveUpgradeCharmProfileData), arg0)
 }
 
 // Units mocks base method
@@ -143,6 +143,18 @@ func NewMockLXDProfileUnit(ctrl *gomock.Controller) *MockLXDProfileUnit {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileUnit) EXPECT() *MockLXDProfileUnitMockRecorder {
 	return m.recorder
+}
+
+// ApplicationName mocks base method
+func (m *MockLXDProfileUnit) ApplicationName() string {
+	ret := m.ctrl.Call(m, "ApplicationName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ApplicationName indicates an expected call of ApplicationName
+func (mr *MockLXDProfileUnitMockRecorder) ApplicationName() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockLXDProfileUnit)(nil).ApplicationName))
 }
 
 // AssignedMachineId mocks base method

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -908,11 +908,16 @@ func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	numUnits := 3
+	for i := 0; i < numUnits; i++ {
+		_, err := s.State.AddMachine("quantal", state.JobHostUnits)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			ApplicationName: "application",
-			NumUnits:        3,
+			NumUnits:        numUnits,
 		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -921,6 +926,13 @@ func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 	err = application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
 		URL: curl.String(),
 	})
+	c.Assert(err, jc.ErrorIsNil)
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{
+		names.NewUnitTag("application/0"),
+		names.NewUnitTag("application/1"),
+		names.NewUnitTag("application/2"),
+	})
+	c.Assert(errs, gc.DeepEquals, []error{error(nil), error(nil), error(nil)})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",
@@ -942,16 +954,28 @@ func (s *applicationSuite) setupApplicationSetCharm(c *gc.C) {
 	err := application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
 		URL: curl.String(),
 	})
+	numUnits := 3
+	for i := 0; i < numUnits; i++ {
+		_, err := s.State.AddMachine("quantal", state.JobHostUnits)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			ApplicationName: "application",
-			NumUnits:        3,
+			NumUnits:        numUnits,
 		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{
+		names.NewUnitTag("application/0"),
+		names.NewUnitTag("application/1"),
+		names.NewUnitTag("application/2"),
+	})
+	c.Assert(errs, gc.DeepEquals, []error{error(nil), error(nil), error(nil)})
+	c.Assert(err, jc.ErrorIsNil)
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
 	err = application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
 		URL: curl.String(),
@@ -1006,11 +1030,16 @@ func (s *applicationSuite) TestApplicationSetCharmForceUnits(c *gc.C) {
 		URL: curl.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	numUnits := 3
+	for i := 0; i < numUnits; i++ {
+		_, err := s.State.AddMachine("quantal", state.JobHostUnits)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			ApplicationName: "application",
-			NumUnits:        3,
+			NumUnits:        numUnits,
 		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -1019,6 +1048,13 @@ func (s *applicationSuite) TestApplicationSetCharmForceUnits(c *gc.C) {
 	err = application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
 		URL: curl.String(),
 	})
+	c.Assert(err, jc.ErrorIsNil)
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{
+		names.NewUnitTag("application/0"),
+		names.NewUnitTag("application/1"),
+		names.NewUnitTag("application/2"),
+	})
+	c.Assert(errs, gc.DeepEquals, []error{error(nil), error(nil), error(nil)})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.applicationAPI.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "application",

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -100,8 +100,8 @@ type Charm interface {
 type Machine interface {
 	IsLockedForSeriesUpgrade() (bool, error)
 	IsParentLockedForSeriesUpgrade() (bool, error)
-	UpgradeCharmProfileComplete() (string, error)
-	RemoveUpgradeCharmProfileData() error
+	UpgradeCharmProfileComplete(string) (string, error)
+	RemoveUpgradeCharmProfileData(string) error
 }
 
 // Relation defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -385,13 +385,13 @@ func (m *mockMachine) Id() string {
 	return m.id
 }
 
-func (m *mockMachine) UpgradeCharmProfileComplete() (string, error) {
-	m.MethodCall(m, "UpgradeCharmProfileComplete")
+func (m *mockMachine) UpgradeCharmProfileComplete(appName string) (string, error) {
+	m.MethodCall(m, "UpgradeCharmProfileComplete", appName)
 	return m.upgradeCharmProfileComplete, m.NextErr()
 }
 
-func (m *mockMachine) RemoveUpgradeCharmProfileData() error {
-	m.MethodCall(m, "RemoveUpgradeCharmProfileData")
+func (m *mockMachine) RemoveUpgradeCharmProfileData(appName string) error {
+	m.MethodCall(m, "RemoveUpgradeCharmProfileData", appName)
 	return m.NextErr()
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1405,8 +1405,8 @@ type UpgradeSeriesUnitsResult struct {
 }
 
 type ProfileArg struct {
-	Entity  Entity `json:"entity"`
-	AppName string `json:"app-name"`
+	Entity   Entity `json:"entity"`
+	UnitName string `json:"unit-name"`
 }
 
 type ProfileArgs struct {
@@ -1439,7 +1439,7 @@ type SetProfileUpgradeCompleteArgs struct {
 }
 
 type SetProfileUpgradeCompleteArg struct {
-	Entity  Entity `json:"entity"`
-	AppName string `json:"app-name"`
-	Message string `json:"message"`
+	Entity   Entity `json:"entity"`
+	UnitName string `json:"unit-name"`
+	Message  string `json:"message"`
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1404,6 +1404,15 @@ type UpgradeSeriesUnitsResult struct {
 	UnitNames []string `json:"unit-names"`
 }
 
+type ProfileArg struct {
+	Entity  Entity `json:"entity"`
+	AppName string `json:"app-name"`
+}
+
+type ProfileArgs struct {
+	Args []ProfileArg `json:"args"`
+}
+
 type ProfileChangeResult struct {
 	OldProfileName string           `json:"old-profile-name,omitempty"`
 	NewProfileName string           `json:"new-profile-name,omitempty"`
@@ -1431,5 +1440,6 @@ type SetProfileUpgradeCompleteArgs struct {
 
 type SetProfileUpgradeCompleteArg struct {
 	Entity  Entity `json:"entity"`
+	AppName string `json:"app-name"`
 	Message string `json:"message"`
 }

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 )
 
-// AppName here is used as the application prefix name. We can't use names.Juju
+// UnitName here is used as the application prefix name. We can't use names.Juju
 // as that changes depending on platform.
 const AppName = "juju"
 

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 )
 
-// UnitName here is used as the application prefix name. We can't use names.Juju
+// AppName here is used as the application prefix name. We can't use names.Juju
 // as that changes depending on platform.
 const AppName = "juju"
 

--- a/state/application.go
+++ b/state/application.go
@@ -873,12 +873,20 @@ func (a *Application) changeCharmOps(
 // If the application is a subordinate, the charm profile is applied
 // to the machine of the principal's unit.
 func (a *Application) SetCharmProfile(charmURL string) error {
-	machines, err := a.DeployedMachines()
+	units, err := a.AllUnits()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, m := range machines {
-		if err := m.SetUpgradeCharmProfile(a.Name(), charmURL); err != nil {
+	for _, u := range units {
+		id, err := u.AssignedMachineId()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		m, err := a.st.Machine(id)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if err := m.SetUpgradeCharmProfile(u.Name(), charmURL); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -1622,7 +1630,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 			}),
 			Update: bson.D{{"$addToSet", bson.D{{"subordinates", name}}}},
 		})
-		subCharmProfileOps, err := a.addUnitSubordinateCharmProfileOp(args.principalName, charm.LXDProfile())
+		subCharmProfileOps, err := a.addUnitSubordinateCharmProfileOp(name, args.principalName, charm.LXDProfile())
 		if err != nil && err != jujutxn.ErrNoOperations {
 			return "", nil, errors.Trace(err)
 		}
@@ -1649,7 +1657,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 
 // addUnitSubordinateCharmProfileOp returns a transaction to an LXD profile
 // to the principal's machine if the charm has a non-empty charm profile.
-func (a *Application) addUnitSubordinateCharmProfileOp(principalName string, profile *charm.LXDProfile) ([]txn.Op, error) {
+func (a *Application) addUnitSubordinateCharmProfileOp(subName, principalName string, profile *charm.LXDProfile) ([]txn.Op, error) {
 	// Because this is not part of a charm upgrade path, it is okay to
 	// short circuit here.
 	if profile == nil || (profile != nil && profile.Empty()) {
@@ -1667,8 +1675,8 @@ func (a *Application) addUnitSubordinateCharmProfileOp(principalName string, pro
 		return nil, err
 	}
 
-	logger.Tracef("Set up to add new subordinate charm profile to existing machine %s for %s", machine.Id(), unit.Name())
-	return machine.SetUpgradeCharmProfileTxns(a.doc.Name, a.doc.CharmURL.String())
+	logger.Tracef("Set up to add new subordinate charm profile to existing machine %s for %s", machine.Id(), subName)
+	return machine.SetUpgradeCharmProfileTxns(subName, a.doc.CharmURL.String())
 }
 
 func (a *Application) addUnitStorageOps(

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2080,7 +2080,7 @@ func (s *ApplicationSuite) TestSetCharmProfile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertUpgradeCharmProfile(c, machine, profileApp.Name(), "local:quantal/quantal-lxd-profile-0")
 
-	err = machine.RemoveUpgradeCharmProfileData(subApp.Name())
+	err = machine.RemoveUpgradeCharmProfileData(subApp.Name() + "/0")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subApp.SetCharmProfile("local:quantal/quantal-lxd-profile-subordinate-0")
@@ -2119,7 +2119,7 @@ func assertUpgradeCharmProfile(c *gc.C, m *state.Machine, appName, charmURL stri
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	chCharmURL, err := m.UpgradeCharmProfileCharmURL(appName)
+	chCharmURL, err := m.UpgradeCharmProfileCharmURL(appName + "/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, charmURL)
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2073,14 +2073,14 @@ func (s *ApplicationSuite) TestAddSubordinateUnitCharmProfile(c *gc.C) {
 func (s *ApplicationSuite) TestSetCharmProfile(c *gc.C) {
 	machine, profileApp, subApp := s.assertCharmProfileSubordinate(c)
 
-	err := machine.RemoveUpgradeCharmProfileData()
+	err := machine.RemoveUpgradeCharmProfileData(profileApp.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = profileApp.SetCharmProfile("local:quantal/quantal-lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
 	assertUpgradeCharmProfile(c, machine, profileApp.Name(), "local:quantal/quantal-lxd-profile-0")
 
-	err = machine.RemoveUpgradeCharmProfileData()
+	err = machine.RemoveUpgradeCharmProfileData(subApp.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subApp.SetCharmProfile("local:quantal/quantal-lxd-profile-subordinate-0")
@@ -2119,10 +2119,7 @@ func assertUpgradeCharmProfile(c *gc.C, m *state.Machine, appName, charmURL stri
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	chAppName, err := m.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, appName)
-	chCharmURL, err := m.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := m.UpgradeCharmProfileCharmURL(appName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, charmURL)
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -262,68 +263,6 @@ func getInstanceData(st *State, id string) (instanceData, error) {
 		return instanceData{}, fmt.Errorf("cannot get instance data for machine %v: %v", id, err)
 	}
 	return instData, nil
-}
-
-// instanceCharmProfileDataC holds attributes relevant to a lxd charm profile
-// data that's on the machine
-type instanceCharmProfileData struct {
-	// DocID = <machine-id>#<application-name>
-	DocID     string `bson:"_id"`
-	MachineId string `bson:"machineid"`
-
-	// UpgradeCharmProfileCharmURL holds the charm URL when there is an charm
-	// upgrade event with a charm profile.  This is used before the application
-	// contains the new charm URL during a charm upgrade.
-	UpgradeCharmProfileCharmURL string `bson:",omitempty"`
-
-	// UpgradeCharmProfileComplete holds the outcome of charm upgrade event
-	// with a charm profile in play.  Success, Not Required or the Error.
-	UpgradeCharmProfileComplete string `bson:",omitempty"`
-}
-
-func getInstanceCharmProfileData(st *State, id string) (instanceCharmProfileData, error) {
-	collection, closer := st.db().GetCollection(instanceCharmProfileDataC)
-	defer closer()
-
-	var instData instanceCharmProfileData
-	err := collection.FindId(id).One(&instData)
-	if err == mgo.ErrNotFound {
-		return instanceCharmProfileData{}, errors.NotFoundf("instance charm profile data %v", id)
-	}
-	if err != nil {
-		return instanceCharmProfileData{}, errors.Annotatef(err, "cannot get instance charm profile data for machine %v", id)
-	}
-	return instData, nil
-}
-
-// TODO (stickupkid): We can no longer cache the information directly on the
-// machine and reuse that in other places, instead we could potentially optimise
-// the following calls, so that we return both UpgradeCharmProfileApplication
-// and UpgradeCharmProfileCharmURL as one call, instead of double requesting the
-// data.
-
-// UpgradeCharmProfileCharmURL returns the charm url for the replacement profile for the machine.
-func (m *Machine) UpgradeCharmProfileCharmURL(appName string) (string, error) {
-	instData, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(appName))
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	return instData.UpgradeCharmProfileCharmURL, nil
-}
-
-// UpgradeCharmProfileComplete returns the charm upgrade with profile completion message
-func (m *Machine) UpgradeCharmProfileComplete(appName string) (string, error) {
-	instData, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(appName))
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return lxdprofile.NotKnownStatus, nil
-		}
-		return "", err
-	}
-	return instData.UpgradeCharmProfileComplete, nil
 }
 
 // Tag returns a tag identifying the machine. The String method provides a
@@ -2216,10 +2155,79 @@ func (m *Machine) VerifyUnitsSeries(unitNames []string, series string, force boo
 	return results, nil
 }
 
-// SetUpgradeCharmProfile sets an application name and a charm url for
-// machine's needing a charm profile change.  For an LXD container or
-// machine only.
-func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
+// instanceCharmProfileDataC holds attributes relevant to a lxd charm profile
+// data that's on the machine
+type instanceCharmProfileData struct {
+	// DocID = <machine-id>#<unit-name>
+	DocID     string `bson:"_id"`
+	MachineId string `bson:"machineid"`
+
+	// UpgradeCharmProfileUnit holds the name of the unit that has a
+	// charm upgrade event and a charm profile, even if there is no charm
+	// profile.
+	UpgradeCharmProfileUnit string `bson:",omitempty"`
+
+	// UpgradeCharmProfileCharmURL holds the charm URL when there is an charm
+	// upgrade event with a charm profile.  This is used before the application
+	// contains the new charm URL during a charm upgrade.
+	UpgradeCharmProfileCharmURL string `bson:",omitempty"`
+
+	// UpgradeCharmProfileComplete holds the outcome of charm upgrade event
+	// with a charm profile in play.  Success, Not Required or the Error.
+	UpgradeCharmProfileComplete string `bson:",omitempty"`
+
+	// For backward compat.
+	BeingUsed bool `bson:"being-used"`
+}
+
+func getInstanceCharmProfileData(st *State, id string) (instanceCharmProfileData, error) {
+	collection, closer := st.db().GetCollection(instanceCharmProfileDataC)
+	defer closer()
+
+	var instData instanceCharmProfileData
+	err := collection.FindId(id).One(&instData)
+	if err == mgo.ErrNotFound {
+		return instanceCharmProfileData{}, errors.NotFoundf("instance charm profile data %v", id)
+	}
+	if err != nil {
+		return instanceCharmProfileData{}, errors.Annotatef(err, "cannot get instance charm profile data for machine %v", id)
+	}
+	return instData, nil
+}
+
+func getNextInstanceCharmProfileData(st *State, id string, used bool) (instanceCharmProfileData, error) {
+	logger.Debugf("trying to get next instance charm profile data for machine %s here", id)
+	collection, closer := st.db().GetCollection(instanceCharmProfileDataC)
+	defer closer()
+
+	machineRegExp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), id, names.UnitSnippet)
+	query := bson.D{{"_id", bson.D{{"$regex", machineRegExp}}}, {"being-used", used}}
+	var instData instanceCharmProfileData
+	err := collection.Find(query).One(&instData)
+	if err == mgo.ErrNotFound {
+		return instanceCharmProfileData{}, errors.NotFoundf("instance charm profile data for machine %v", id)
+	}
+	if err != nil {
+		return instanceCharmProfileData{}, errors.Annotatef(err, "cannot get instance charm profile data for machine %v", id)
+	}
+	return instData, nil
+}
+
+// NextUpgradeCharmProfileApplicationName returns an application name for
+// the machine's instanceCharmProfileData doc.
+func (m *Machine) NextUpgradeCharmProfileUnitName() (string, error) {
+	instData, err := getNextInstanceCharmProfileData(m.st, m.Id(), false)
+	if err != nil {
+		return "", errors.Annotatef(err, "cannot get instance charm profile data for machine %v", m.Id())
+	}
+	err = m.markBeingUsedUpgradeCharmProfileDataTrue(instData.UpgradeCharmProfileUnit)
+	if err != nil {
+		return "", errors.Annotatef(err, "cannot mark delete me. instance charm profile data for machine %v", m.Id())
+	}
+	return instData.UpgradeCharmProfileUnit, nil
+}
+
+func (m *Machine) markBeingUsedUpgradeCharmProfileDataTrue(unitName string) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := m.Refresh(); err != nil {
@@ -2230,7 +2238,92 @@ func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
 		if life == Dead || life == Dying {
 			return nil, ErrDead
 		}
-		return m.SetUpgradeCharmProfileTxns(appName, chURL)
+		docId := m.instanceCharmProfileDataId(unitName)
+		data, err := getInstanceCharmProfileData(m.st, docId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data.BeingUsed {
+			return nil, jujutxn.ErrNoOperations
+		}
+		return []txn.Op{
+			{
+				C:      machinesC,
+				Id:     m.doc.DocID,
+				Assert: isAliveDoc,
+			},
+			{
+				C:      instanceCharmProfileDataC,
+				Id:     docId,
+				Assert: bson.D{{"being-used", false}},
+				Update: bson.D{{"$set", bson.D{{"being-used", true}}}},
+			},
+		}, nil
+	}
+	err := m.st.db().Run(buildTxn)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+
+}
+
+func (m *Machine) NextUpgradeCharmProfileCharmURL() (string, error) {
+	instData, err := getNextInstanceCharmProfileData(m.st, m.Id(), true)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return instData.UpgradeCharmProfileCharmURL, nil
+}
+
+// TODO (stickupkid): We can no longer cache the information directly on the
+// machine and reuse that in other places, instead we could potentially optimise
+// the following calls, so that we return both UpgradeCharmProfileUnit
+// and UpgradeCharmProfileCharmURL as one call, instead of double requesting the
+// data.
+
+// UpgradeCharmProfileCharmURL returns the charm url for the replacement profile for the machine.
+func (m *Machine) UpgradeCharmProfileCharmURL(unitName string) (string, error) {
+	instData, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(unitName))
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return instData.UpgradeCharmProfileCharmURL, nil
+}
+
+// UpgradeCharmProfileComplete returns the charm upgrade with profile completion message
+func (m *Machine) UpgradeCharmProfileComplete(unitName string) (string, error) {
+	instData, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(unitName))
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return lxdprofile.NotKnownStatus, nil
+		}
+		return "", err
+	}
+	return instData.UpgradeCharmProfileComplete, nil
+}
+
+// SetUpgradeCharmProfile sets an application name and a charm url for
+// machine's needing a charm profile change.  For an LXD container or
+// machine only.
+func (m *Machine) SetUpgradeCharmProfile(unitName, chURL string) error {
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := m.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		life := m.Life()
+		if life == Dead || life == Dying {
+			return nil, ErrDead
+		}
+		return m.SetUpgradeCharmProfileTxns(unitName, chURL)
 	}
 	err := m.st.db().Run(buildTxn)
 	if err != nil {
@@ -2241,16 +2334,17 @@ func (m *Machine) SetUpgradeCharmProfile(appName, chURL string) error {
 
 // SetUpgradeCharmProfileTxns does the checks and creates the txns to
 // write an instanceCharmProfileDoc to trigger a profile change on a
-// machine.  AppName and Charm with an LXDProfile, adds or updates
-// the charm lxd profile on the machine. AppName and Charm without
+// machine.  UnitName and Charm with an LXDProfile, adds or updates
+// the charm lxd profile on the machine. UnitName and Charm without
 // an LXDProfile, removes the charm lxd profile from the machine if
-// was previously applied.  AppName without a Charm URL causes a
+// was previously applied.  UnitName without a Charm URL causes a
 // previously applied lxd profile for the charm to be removed from
 // the machine.
-func (m *Machine) SetUpgradeCharmProfileTxns(appName, chURL string) ([]txn.Op, error) {
+func (m *Machine) SetUpgradeCharmProfileTxns(unitName, chURL string) ([]txn.Op, error) {
+	logger.Debugf("upgrade charm profile txns for %q, %q, %q", unitName, chURL, debug.Stack())
 	// Check to see if the doc created in these txn already exists
 	// and has expected data.
-	err := m.verifyInstanceCharmProfileData(appName, chURL)
+	err := m.verifyInstanceCharmProfileData(unitName, chURL)
 	if err != nil {
 		return nil, err
 	}
@@ -2313,12 +2407,16 @@ func (m *Machine) SetUpgradeCharmProfileTxns(appName, chURL string) ([]txn.Op, e
 	// already has a profile applied to the machine, if not, we can
 	// set NotRequiredStatus.
 	if emptyProfile {
+		appName, err := names.UnitApplication(unitName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		appliedProfileName, err := lxdprofile.MatchProfileNameByAppName(profiles, appName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		if appliedProfileName == "" {
-			return append(ops, m.SetUpgradeCharmProfileOp(appName, "", lxdprofile.NotRequiredStatus)), nil
+			return append(ops, m.SetUpgradeCharmProfileOp(unitName, "", lxdprofile.NotRequiredStatus)), nil
 		}
 	}
 
@@ -2326,17 +2424,18 @@ func (m *Machine) SetUpgradeCharmProfileTxns(appName, chURL string) ([]txn.Op, e
 	// change triggered by this transaction was make.  Or should have
 	// been. Either during charm upgrade or when a new unit was added
 	// to an existing machine, perhaps a subordinate.
-	return append(ops, m.SetUpgradeCharmProfileOp(appName, chURL, lxdprofile.EmptyStatus)),
+	return append(ops, m.SetUpgradeCharmProfileOp(unitName, chURL, lxdprofile.EmptyStatus)),
 		nil
 }
 
 // SetUpgradeCharmProfileOp returns a transaction for the machine to
 // trigger a change to its LXD Profile(s).
-func (m *Machine) SetUpgradeCharmProfileOp(appName, chURL, status string) txn.Op {
-	docID := m.instanceCharmProfileDataId(appName)
+func (m *Machine) SetUpgradeCharmProfileOp(unitName, chURL, status string) txn.Op {
+	docID := m.instanceCharmProfileDataId(unitName)
 	instanceData := instanceCharmProfileData{
 		DocID:                       docID,
 		MachineId:                   m.doc.Id,
+		UpgradeCharmProfileUnit:     unitName,
 		UpgradeCharmProfileCharmURL: chURL,
 		UpgradeCharmProfileComplete: status,
 	}
@@ -2351,24 +2450,27 @@ func (m *Machine) SetUpgradeCharmProfileOp(appName, chURL, status string) txn.Op
 	}
 }
 
-func (m *Machine) instanceCharmProfileDataId(appName string) string {
-	return m.st.docID(fmt.Sprint(m.doc.Id + "#" + appName))
+func (m *Machine) instanceCharmProfileDataId(unitName string) string {
+	return m.st.docID(fmt.Sprint(m.doc.Id + "#" + unitName))
 }
 
 // verifyInstanceCharmProfileData checks to see if there is any InstanceCharmProfileData
 // for the machine with provided appName and chURL.  If one exists, does it contain
 // expected data?  If does not exist, returns nil.  If exists as expected return
 // jujutxn.ErrNoOperations.  Otherwise return the error.
-func (m *Machine) verifyInstanceCharmProfileData(appName, chURL string) error {
-	data, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(appName))
+func (m *Machine) verifyInstanceCharmProfileData(unitName, chURL string) error {
+	data, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(unitName))
 	if errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return errors.Trace(err)
 	}
-	if (data.UpgradeCharmProfileCharmURL == chURL &&
+	if (data.UpgradeCharmProfileUnit == unitName &&
+		data.UpgradeCharmProfileCharmURL == chURL &&
 		data.UpgradeCharmProfileComplete == lxdprofile.EmptyStatus) ||
-		data.UpgradeCharmProfileComplete == lxdprofile.NotRequiredStatus {
+		(data.UpgradeCharmProfileUnit == unitName &&
+			data.UpgradeCharmProfileComplete == lxdprofile.NotRequiredStatus) {
+
 		logger.Tracef("Instance charm profile data already exists with expected values for machine %s and %q", data.MachineId, chURL)
 		return jujutxn.ErrNoOperations
 	}
@@ -2396,7 +2498,7 @@ func (m *Machine) checkCharmProfilesIsEmptyOp() txn.Op {
 // SetUpgradeCharmProfileComplete on the instance charm profile data.
 // If the profile has been removed, then this will throw an error upon
 // running the transaction
-func (m *Machine) SetUpgradeCharmProfileComplete(appName, msg string) error {
+func (m *Machine) SetUpgradeCharmProfileComplete(unitName, msg string) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := m.Refresh(); err != nil {
@@ -2407,7 +2509,8 @@ func (m *Machine) SetUpgradeCharmProfileComplete(appName, msg string) error {
 		if life == Dead || life == Dying {
 			return nil, ErrDead
 		}
-		data, err := getInstanceCharmProfileData(m.st, m.instanceCharmProfileDataId(appName))
+		docId := m.instanceCharmProfileDataId(unitName)
+		data, err := getInstanceCharmProfileData(m.st, docId)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -2422,7 +2525,7 @@ func (m *Machine) SetUpgradeCharmProfileComplete(appName, msg string) error {
 			},
 			{
 				C:      instanceCharmProfileDataC,
-				Id:     m.instanceCharmProfileDataId(appName),
+				Id:     docId,
 				Assert: txn.DocExists,
 				Update: bson.D{{"$set", bson.D{{"upgradecharmprofilecomplete", msg}}}},
 			},
@@ -2437,9 +2540,9 @@ func (m *Machine) SetUpgradeCharmProfileComplete(appName, msg string) error {
 
 // RemoveUpgradeCharmProfileData completely removes the instance charm profile
 // data for a machine, even if the machine is dead.
-func (m *Machine) RemoveUpgradeCharmProfileData(appName string) error {
+func (m *Machine) RemoveUpgradeCharmProfileData(unitName string) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		docId := m.instanceCharmProfileDataId(appName)
+		docId := m.instanceCharmProfileDataId(unitName)
 		data, err := getInstanceCharmProfileData(m.st, docId)
 		// If the instance data is removed already, just log it
 		if errors.IsNotFound(err) {
@@ -2472,6 +2575,28 @@ func (m *Machine) RemoveUpgradeCharmProfileData(appName string) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func (m *Machine) NextRemoveUpgradeCharmProfileData() error {
+	logger.Debugf("trying deleted instance charm profile data for machine %s here", m.Id())
+	instData, err := getNextInstanceCharmProfileData(m.st, m.Id(), true)
+	if err != nil {
+		return errors.Annotatef(err, "cannot get instance charm profile data for machine %v", m.Id())
+	}
+	return m.RemoveUpgradeCharmProfileData(instData.UpgradeCharmProfileUnit)
+}
+
+func (m *Machine) NextSetUpgradeCharmProfileComplete(msg string) error {
+	logger.Debugf("trying set complete message on instance charm profile data for machine %s here", m.Id())
+	instData, err := getNextInstanceCharmProfileData(m.st, m.Id(), true)
+	if err != nil {
+		return errors.Annotatef(err, "cannot get instance charm profile data for machine %v", m.Id())
+	}
+	err = m.markBeingUsedUpgradeCharmProfileDataTrue(instData.UpgradeCharmProfileUnit)
+	if err != nil {
+		return errors.Annotatef(err, "cannot mark delete me. instance charm profile data for machine %v", m.Id())
+	}
+	return m.SetUpgradeCharmProfileComplete(instData.UpgradeCharmProfileUnit, msg)
 }
 
 // UpdateOperation returns a model operation that will update the machine.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -216,16 +216,16 @@ func (s *MachineSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
 	err = unit.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m.SetUpgradeCharmProfile("app-name", "local:quantal/quantal-lxd-profile-0")
+	err = m.SetUpgradeCharmProfile(app.Name(), "local:quantal/quantal-lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
+	err = m.SetUpgradeCharmProfileComplete(app.Name(), lxdprofile.SuccessStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, err := m.UpgradeCharmProfileComplete()
+	status, err := m.UpgradeCharmProfileComplete(app.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, lxdprofile.SuccessStatus)
 }
@@ -234,13 +234,10 @@ func assertUpgradeCharmProfileNotRequired(c *gc.C, m *state.Machine, expectedApp
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedAppName, err := m.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedAppName, gc.Equals, expectedAppName)
-	charmURL, err := m.UpgradeCharmProfileCharmURL()
+	charmURL, err := m.UpgradeCharmProfileCharmURL(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, gc.Equals, "")
-	status, err := m.UpgradeCharmProfileComplete()
+	status, err := m.UpgradeCharmProfileComplete(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, lxdprofile.NotRequiredStatus)
 }
@@ -249,13 +246,10 @@ func assertUpgradeCharmProfileRequired(c *gc.C, m *state.Machine, expectedAppNam
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedAppName, err := m.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedAppName, gc.Equals, expectedAppName)
-	obtainedCharmURL, err := m.UpgradeCharmProfileCharmURL()
+	obtainedCharmURL, err := m.UpgradeCharmProfileCharmURL(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedCharmURL, gc.Equals, expectedCharmURL)
-	status, err := m.UpgradeCharmProfileComplete()
+	status, err := m.UpgradeCharmProfileComplete(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, lxdprofile.EmptyStatus)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -204,7 +204,7 @@ func (s *MachineSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
 	c.Assert(status, gc.Equals, lxdprofile.SuccessStatus)
 }
 
-func (s *MachineSuite) TestNextUpgradeCharmProfileApplicationName(c *gc.C) {
+func (s *MachineSuite) TestNextUpgradeCharmProfileUnitName(c *gc.C) {
 	s.assertSetUpUnitSetUpgradeCharmProfile(c)
 
 	name, err := s.machine.NextUpgradeCharmProfileUnitName()
@@ -212,7 +212,7 @@ func (s *MachineSuite) TestNextUpgradeCharmProfileApplicationName(c *gc.C) {
 	c.Assert(name, gc.Equals, s.unit.Name())
 }
 
-func (s *MachineSuite) TestNextUpgradeCharmProfileApplicationNameZero(c *gc.C) {
+func (s *MachineSuite) TestNextUpgradeCharmProfileUnitNameZero(c *gc.C) {
 	s.assertSetUpUnitForLXDProfile(c)
 	m := s.machine
 
@@ -221,31 +221,27 @@ func (s *MachineSuite) TestNextUpgradeCharmProfileApplicationNameZero(c *gc.C) {
 	c.Assert(name, gc.Equals, "")
 }
 
-//func (s *MachineSuite) TestSingleUpgradeCharmProfileApplicationNameMoreThanOne(c *gc.C) {
-//	m := s.machine
-//
-//	ch := s.AddTestingCharm(c, "lxd-profile")
-//	app := s.AddTestingApplication(c, "lxd-profile", ch)
-//	unit, err := app.AddUnit(state.AddUnitParams{})
-//	c.Assert(err, jc.ErrorIsNil)
-//	err = unit.AssignToMachine(m)
-//	c.Assert(err, jc.ErrorIsNil)
-//
-//	app2 := s.AddTestingApplication(c, "lxd-profile-two", ch)
-//	unit2, err := app2.AddUnit(state.AddUnitParams{})
-//	c.Assert(err, jc.ErrorIsNil)
-//	err = unit2.AssignToMachine(m)
-//	c.Assert(err, jc.ErrorIsNil)
-//
-//	err = m.SetUpgradeCharmProfile(app.Name(), "local:quantal/quantal-lxd-profile-0")
-//	c.Assert(err, jc.ErrorIsNil)
-//	err = m.SetUpgradeCharmProfile(app2.Name(), "local:quantal/quantal-lxd-profile-0")
-//	c.Assert(err, jc.ErrorIsNil)
-//
-//	name, err := m.NextUpgradeCharmProfileApplicationName()
-//	c.Assert(err, gc.ErrorMatches, "more than one instance charm profile data for machine 1")
-//	c.Assert(name, gc.Equals, "")
-//}
+func (s *MachineSuite) TestNextUpgradeCharmProfileUnitNameMoreThanOne(c *gc.C) {
+	s.assertSetUpUnitSetUpgradeCharmProfile(c)
+
+	charm, _, err := s.application.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	application := s.AddTestingApplication(c, "lxd-profile-alt", charm)
+	unit, err := application.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetUpgradeCharmProfile(unit.Name(), "local:quantal/quantal-lxd-profile-0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	name, err := s.machine.NextUpgradeCharmProfileUnitName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, unit.Name())
+
+	name, err = s.machine.NextUpgradeCharmProfileUnitName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, s.unit.Name())
+}
 
 func (s *MachineSuite) assertUpgradeCharmProfileNotRequired(c *gc.C, expectedUnitName string) {
 	err := s.machine.Refresh()

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -370,11 +370,13 @@ func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
 
 func (s *MigrationSuite) TestInstanceCharmProfileDataFields(c *gc.C) {
 	ignored := set.NewStrings(
-		// DocID is the model + machine id
+		// DocID is the model + unit name
 		"DocID",
 		"MachineId",
+		"UpgradeCharmProfileUnit",
 		"UpgradeCharmProfileCharmURL",
 		"UpgradeCharmProfileComplete",
+		"BeingUsed",
 	)
 	migrated := set.NewStrings()
 	s.AssertExportedFields(c, instanceCharmProfileData{}, migrated.Union(ignored))

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -373,7 +373,6 @@ func (s *MigrationSuite) TestInstanceCharmProfileDataFields(c *gc.C) {
 		// DocID is the model + machine id
 		"DocID",
 		"MachineId",
-		"UpgradeCharmProfileApplication",
 		"UpgradeCharmProfileCharmURL",
 		"UpgradeCharmProfileComplete",
 	)

--- a/state/state.go
+++ b/state/state.go
@@ -1788,7 +1788,7 @@ func (st *State) maybeApplyCharmProfileToMachine(unit *Unit, machine *Machine) e
 		return nil
 	}
 	logger.Tracef("Set up to add new charm profile to existing machine %s for %s", machine.Id(), unit.Name())
-	return machine.SetUpgradeCharmProfile(app.Name(), ch.URL().String())
+	return machine.SetUpgradeCharmProfile(unit.Name(), ch.URL().String())
 }
 
 // Application returns a application state by name.

--- a/state/unit.go
+++ b/state/unit.go
@@ -694,17 +694,18 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 		}}}
 		// Clean up any instanceCharmProfileData docs for this machine before
 		// it is destroyed.
-		_, err := getInstanceCharmProfileData(m.st, m.doc.DocID)
+		docId := m.instanceCharmProfileDataId(u.ApplicationName())
+		_, err := getInstanceCharmProfileData(m.st, docId)
 		if err == nil {
-			logger.Tracef("Remove instance charm profile data for machine %s", m.Id())
+			logger.Tracef("Remove instance charm profile data for %q", docId)
 			ops = append(ops, txn.Op{
 				C:      instanceCharmProfileDataC,
-				Id:     m.doc.DocID,
+				Id:     docId,
 				Assert: txn.DocExists,
 				Remove: true,
 			})
 		} else if !errors.IsNotFound(err) {
-			logger.Errorf("Error getting instance charm profile data for machine %s, %s", m.Id(), err.Error())
+			logger.Errorf("Error getting instance charm profile data for %q, %s", docId, err.Error())
 		}
 	} else {
 		machineAssert = bson.D{{"$or", []bson.D{
@@ -3022,5 +3023,6 @@ func (u *Unit) RemoveUpgradeCharmProfileData() error {
 	if err != nil {
 		return err
 	}
-	return machine.RemoveUpgradeCharmProfileData()
+
+	return machine.RemoveUpgradeCharmProfileData(u.doc.Application)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -694,7 +694,7 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 		}}}
 		// Clean up any instanceCharmProfileData docs for this machine before
 		// it is destroyed.
-		docId := m.instanceCharmProfileDataId(u.ApplicationName())
+		docId := m.instanceCharmProfileDataId(u.Name())
 		_, err := getInstanceCharmProfileData(m.st, docId)
 		if err == nil {
 			logger.Tracef("Remove instance charm profile data for %q", docId)
@@ -726,7 +726,7 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 		}
 		if profile != "" {
 			logger.Tracef("Setup to remove charm profile %q, removing unit from machine %s", profile, m.Id())
-			ops = append(ops, m.SetUpgradeCharmProfileOp(a.Name(), "", lxdprofile.EmptyStatus))
+			ops = append(ops, m.SetUpgradeCharmProfileOp(u.Name(), "", lxdprofile.EmptyStatus))
 		}
 	}
 

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -151,10 +151,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	chAppName, err := machine.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, name)
-	chCharmURL, err := machine.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := machine.UpgradeCharmProfileCharmURL(name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, charm.URL().String())
 }

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -151,7 +151,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	chCharmURL, err := machine.UpgradeCharmProfileCharmURL(name)
+	chCharmURL, err := machine.UpgradeCharmProfileCharmURL(unit.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, charm.URL().String())
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -632,12 +632,12 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 
 	// Set a profile name on the machine, destroyHostOps will only
 	// set up to remove a profile from the machine it if it exists.
-	profileName := lxdprofile.Name("default", applicationWithProfile.Name(), charmWithProfile.Revision())
+	profileName := lxdprofile.Name("default", target.Name(), charmWithProfile.Revision())
 	host.SetCharmProfiles([]string{profileName})
 	c.Assert(colocated.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Alive)
 
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithProfile.Name())
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(target.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
@@ -665,7 +665,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroy(c *gc.C) {
 
 	// "", nil is equivalent to IsNotFound, which is what we
 	// expect here
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithOutProfile.Name())
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(colocated.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
@@ -687,7 +687,7 @@ func (s *UnitSuite) TestRemoveUnitMachineDestroyCleanUpProfileDoc(c *gc.C) {
 
 	// create a instanceCharmProfileData which hasn't been completed
 	// to check it's been deleted.
-	err = host.SetUpgradeCharmProfile(applicationWithProfile.Name(), charmWithProfile.URL().String())
+	err = host.SetUpgradeCharmProfile(unit.Name(), charmWithProfile.URL().String())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(unit.Destroy(), gc.IsNil)
@@ -695,7 +695,8 @@ func (s *UnitSuite) TestRemoveUnitMachineDestroyCleanUpProfileDoc(c *gc.C) {
 
 	// "", nil is equivalent to IsNotFound, which is what we
 	// expect here
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithProfile.Name())
+	host.Refresh()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(unit.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -637,10 +637,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 	c.Assert(colocated.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Alive)
 
-	chAppName, err := host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, "lxd-profile")
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithProfile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
@@ -668,10 +665,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroy(c *gc.C) {
 
 	// "", nil is equivalent to IsNotFound, which is what we
 	// expect here
-	chAppName, err := host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, "")
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithOutProfile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
@@ -695,19 +689,13 @@ func (s *UnitSuite) TestRemoveUnitMachineDestroyCleanUpProfileDoc(c *gc.C) {
 	// to check it's been deleted.
 	err = host.SetUpgradeCharmProfile(applicationWithProfile.Name(), charmWithProfile.URL().String())
 	c.Assert(err, jc.ErrorIsNil)
-	chAppName, err := host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, applicationWithProfile.Name())
 
 	c.Assert(unit.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Dying)
 
 	// "", nil is equivalent to IsNotFound, which is what we
 	// expect here
-	chAppName, err = host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, "")
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithProfile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -803,19 +803,37 @@ func (w *minUnitsWatcher) Changes() <-chan []string {
 // WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
 // changes to the upgrade charm profile charm url for a machine.
 func (st *State) WatchModelMachinesCharmProfiles() (StringsWatcher, error) {
-	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.ApplicationSnippet)
-	return st.watchCharmProfiles(isMachineRegexp)
+	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.UnitSnippet)
+	return st.watchCharmProfiles(isMachineRegexp, true)
 }
 
 // WatchContainersCharmProfiles starts a StringsWatcher to notify when
 // the provisioner should update the charm profiles used by any container on
 // the machine.
 func (m *Machine) WatchContainersCharmProfiles(ctype instance.ContainerType) (StringsWatcher, error) {
-	isChildRegexp := fmt.Sprintf("^%s/%s/%s#%s$", m.doc.DocID, ctype, names.NumberSnippet, names.ApplicationSnippet)
-	return m.st.watchCharmProfiles(isChildRegexp)
+	isChildRegexp := fmt.Sprintf("^%s/%s/%s#%s$", m.doc.DocID, ctype, names.NumberSnippet, names.UnitSnippet)
+	return m.st.watchCharmProfiles(isChildRegexp, true)
 }
 
-func (st *State) watchCharmProfiles(regExp string) (StringsWatcher, error) {
+// WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
+// changes to the upgrade charm profile charm url for a machine.
+//
+// TODO - is this needed?  2019-02-01
+// the provisioner calling this lives on the controller
+func (st *State) WatchModelMachinesCharmProfilesNewFormat() (StringsWatcher, error) {
+	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.UnitSnippet)
+	return st.watchCharmProfiles(isMachineRegexp, false)
+}
+
+// WatchContainersCharmProfiles starts a StringsWatcher to notify when
+// the provisioner should update the charm profiles used by any container on
+// the machine.
+func (m *Machine) WatchContainersCharmProfilesNewFormat(ctype instance.ContainerType) (StringsWatcher, error) {
+	isChildRegexp := fmt.Sprintf("^%s/%s/%s#%s$", m.doc.DocID, ctype, names.NumberSnippet, names.UnitSnippet)
+	return m.st.watchCharmProfiles(isChildRegexp, false)
+}
+
+func (st *State) watchCharmProfiles(regExp string, useMachineId bool) (StringsWatcher, error) {
 	members := bson.D{{"_id", bson.D{{"$regex", regExp}}}}
 	compiled, err := regexp.Compile(regExp)
 	if err != nil {
@@ -833,14 +851,23 @@ func (st *State) watchCharmProfiles(regExp string) (StringsWatcher, error) {
 		}
 		return compiled.MatchString(k)
 	}
-	accessor := func(doc instanceCharmProfileData) string {
-		return doc.UpgradeCharmProfileCharmURL
+	var accessor profileAccessorFunc
+	if useMachineId {
+		accessor = func(doc instanceCharmProfileData) (string, string) {
+			return doc.UpgradeCharmProfileCharmURL, doc.MachineId
+		}
+	} else {
+		accessor = func(doc instanceCharmProfileData) (string, string) {
+			return doc.UpgradeCharmProfileCharmURL, st.localID(doc.DocID)
+		}
 	}
 	completed := func(doc instanceCharmProfileData) bool {
 		return lxdprofile.UpgradeStatusTerminal(doc.UpgradeCharmProfileComplete)
 	}
 	return newModelFieldChangeWatcher(st, members, filter, accessor, completed), nil
 }
+
+type profileAccessorFunc func(doc instanceCharmProfileData) (string, string)
 
 // modelFieldChangeWatcher notifies about charm changes where a
 // machine or container's field may need to be changed. At startup, the
@@ -854,8 +881,9 @@ type modelFieldChangeWatcher struct {
 	// filter returns true, if the entity should be watched
 	filter func(key interface{}) bool
 	// accessor is used to extract the field from the instance charm profile
-	// data doc in a generic way.
-	accessor func(instanceCharmProfileData) string
+	// data doc in a generic way.  The second value returned, is what to pass
+	// as the string from the watcher.
+	accessor profileAccessorFunc
 	// completed is used to determine if the state watched for has
 	// occurred
 	completed func(instanceCharmProfileData) bool
@@ -869,7 +897,7 @@ func newModelFieldChangeWatcher(
 	backend modelBackend,
 	members bson.D,
 	filter func(key interface{}) bool,
-	accessor func(instanceCharmProfileData) string,
+	accessor profileAccessorFunc,
 	completed func(instanceCharmProfileData) bool,
 ) StringsWatcher {
 	w := &modelFieldChangeWatcher{
@@ -893,7 +921,7 @@ func (w *modelFieldChangeWatcher) initial() (set.Strings, error) {
 	defer closer()
 
 	var doc instanceCharmProfileData
-	machineIds := make(set.Strings)
+	watchSet := make(set.Strings)
 	iter := collection.Find(w.members).Iter()
 	for iter.Next(&doc) {
 		// If no members criteria is specified, use the filter
@@ -907,25 +935,26 @@ func (w *modelFieldChangeWatcher) initial() (set.Strings, error) {
 			continue
 		}
 
-		docField := w.accessor(doc)
+		docField, returnID := w.accessor(doc)
 		docId := w.backend.localID(doc.DocID)
 		w.known[docId] = docField
-		machineIds.Add(docId)
+		watchSet.Add(returnID)
 	}
-	if machineIds.Size() > 0 {
-		logger.Debugf("started field change watching %s", machineIds.Values())
+	if watchSet.Size() > 0 {
+		logger.Debugf("started field change watching %s", watchSet.Values())
 	}
-	return machineIds, iter.Close()
+	return watchSet, iter.Close()
 }
 
-func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.Change) error {
+func (w *modelFieldChangeWatcher) merge(watchSet set.Strings, change watcher.Change) error {
 	docId := w.backend.localID(change.Id.(string))
 	if change.Revno == -1 {
 		if _, ok := w.known[docId]; ok {
 			logger.Tracef("stopped field change watching for %q", docId)
 		}
 		delete(w.known, docId)
-		machineIds.Remove(docId)
+		// TODO - check this correct.
+		watchSet.Remove(docId)
 		return nil
 	}
 
@@ -938,14 +967,14 @@ func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.C
 	}
 
 	// get the document field from the accessor
-	docField := w.accessor(doc)
+	docField, returnField := w.accessor(doc)
 
 	// check the field before adding to the docId
 	field, isKnown := w.known[docId]
 	w.known[docId] = docField
 	if !w.completed(doc) && (!isKnown || docField != field) {
 		logger.Debugf("added field change watching for %q", docId)
-		machineIds.Add(docId)
+		watchSet.Add(returnField)
 	}
 	return nil
 }
@@ -955,7 +984,7 @@ func (w *modelFieldChangeWatcher) loop() error {
 	w.watcher.WatchCollectionWithFilter(instanceCharmProfileDataC, ch, w.filter)
 	defer w.watcher.UnwatchCollection(instanceCharmProfileDataC, ch)
 
-	machineIds, err := w.initial()
+	watchSet, err := w.initial()
 	if err != nil {
 		return err
 	}
@@ -968,15 +997,15 @@ func (w *modelFieldChangeWatcher) loop() error {
 		case <-w.tomb.Dying():
 			return tomb.ErrDying
 		case change := <-ch:
-			if err = w.merge(machineIds, change); err != nil {
+			if err = w.merge(watchSet, change); err != nil {
 				return err
 			}
-			if !machineIds.IsEmpty() {
+			if !watchSet.IsEmpty() {
 				out = w.out
 			}
-		case out <- machineIds.Values():
+		case out <- watchSet.Values():
 			out = nil
-			machineIds = set.NewStrings()
+			watchSet = set.NewStrings()
 		}
 	}
 }
@@ -1937,28 +1966,28 @@ func (u *Unit) WatchMeterStatus() NotifyWatcher {
 
 // WatchLXDProfileUpgradeNotifications returns a watcher that observes the status
 // of a lxd profile upgrade by monitoring changes on the unit machine's lxd profile
-// upgrade completed field that is specific to an application name.
-func (m *Machine) WatchLXDProfileUpgradeNotifications(applicationName string) (StringsWatcher, error) {
+// upgrade completed field that is specific to the unit.
+func (m *Machine) WatchLXDProfileUpgradeNotifications(unitName string) (StringsWatcher, error) {
 	filter := func(id interface{}) bool {
 		docId, err := m.st.strictLocalID(id.(string))
 		if err != nil {
 			return false
 		}
-		return docId == m.doc.Id+"#"+applicationName
+		return docId == m.instanceCharmProfileDataId(unitName)
 	}
-	docId := m.instanceCharmProfileDataId(applicationName)
+	docId := m.instanceCharmProfileDataId(unitName)
 	return newInstanceCharmProfileDataWatcher(m.st, docId, filter), nil
 }
 
 // WatchLXDProfileUpgradeNotifications returns a watcher that observes the status
 // of a lxd profile upgrade by monitoring changes on the unit machine's lxd profile
-// upgrade completed field.
-func (u *Unit) WatchLXDProfileUpgradeNotifications(applicationName string) (StringsWatcher, error) {
+// upgrade completed field that is specific to itself.
+func (u *Unit) WatchLXDProfileUpgradeNotifications() (StringsWatcher, error) {
 	m, err := u.machine()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return m.WatchLXDProfileUpgradeNotifications(applicationName)
+	return m.WatchLXDProfileUpgradeNotifications(u.Name())
 }
 
 // instanceCharmProfileDataWatcher notifies about any changes to the

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -803,7 +803,7 @@ func (w *minUnitsWatcher) Changes() <-chan []string {
 // WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
 // changes to the upgrade charm profile charm url for a machine.
 func (st *State) WatchModelMachinesCharmProfiles() (StringsWatcher, error) {
-	isMachineRegexp := fmt.Sprintf("^%s:%s$", st.ModelUUID(), names.NumberSnippet)
+	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.ApplicationSnippet)
 	return st.watchCharmProfiles(isMachineRegexp)
 }
 
@@ -811,7 +811,7 @@ func (st *State) WatchModelMachinesCharmProfiles() (StringsWatcher, error) {
 // the provisioner should update the charm profiles used by any container on
 // the machine.
 func (m *Machine) WatchContainersCharmProfiles(ctype instance.ContainerType) (StringsWatcher, error) {
-	isChildRegexp := fmt.Sprintf("^%s/%s/%s$", m.doc.DocID, ctype, names.NumberSnippet)
+	isChildRegexp := fmt.Sprintf("^%s/%s/%s#%s$", m.doc.DocID, ctype, names.NumberSnippet, names.ApplicationSnippet)
 	return m.st.watchCharmProfiles(isChildRegexp)
 }
 
@@ -898,33 +898,34 @@ func (w *modelFieldChangeWatcher) initial() (set.Strings, error) {
 	for iter.Next(&doc) {
 		// If no members criteria is specified, use the filter
 		// to reject any unsuitable initial elements.
-		if w.members == nil && w.filter != nil && !w.filter(doc.MachineId) {
+		if w.members == nil && w.filter != nil && !w.filter(doc.DocID) {
 			continue
 		}
 
 		if w.completed(doc) {
-			logger.Tracef("field change NOT watching machine %s", doc.MachineId)
+			logger.Tracef("field change NOT watching %s", doc.DocID)
 			continue
 		}
 
 		docField := w.accessor(doc)
-		w.known[doc.MachineId] = docField
-		machineIds.Add(doc.MachineId)
+		docId := w.backend.localID(doc.DocID)
+		w.known[docId] = docField
+		machineIds.Add(docId)
 	}
 	if machineIds.Size() > 0 {
-		logger.Debugf("started field change watching of machines %s", machineIds.Values())
+		logger.Debugf("started field change watching %s", machineIds.Values())
 	}
 	return machineIds, iter.Close()
 }
 
 func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.Change) error {
-	machineId := w.backend.localID(change.Id.(string))
+	docId := w.backend.localID(change.Id.(string))
 	if change.Revno == -1 {
-		if _, ok := w.known[machineId]; ok {
-			logger.Tracef("stopped field change watching for machine %q", machineId)
+		if _, ok := w.known[docId]; ok {
+			logger.Tracef("stopped field change watching for %q", docId)
 		}
-		delete(w.known, machineId)
-		machineIds.Remove(machineId)
+		delete(w.known, docId)
+		machineIds.Remove(docId)
 		return nil
 	}
 
@@ -939,12 +940,12 @@ func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.C
 	// get the document field from the accessor
 	docField := w.accessor(doc)
 
-	// check the field before adding to the machineId
-	field, isKnown := w.known[machineId]
-	w.known[machineId] = docField
+	// check the field before adding to the docId
+	field, isKnown := w.known[docId]
+	w.known[docId] = docField
 	if !w.completed(doc) && (!isKnown || docField != field) {
-		logger.Debugf("added field change watching for machine %q", machineId)
-		machineIds.Add(machineId)
+		logger.Debugf("added field change watching for %q", docId)
+		machineIds.Add(docId)
 	}
 	return nil
 }
@@ -1939,13 +1940,14 @@ func (u *Unit) WatchMeterStatus() NotifyWatcher {
 // upgrade completed field that is specific to an application name.
 func (m *Machine) WatchLXDProfileUpgradeNotifications(applicationName string) (StringsWatcher, error) {
 	filter := func(id interface{}) bool {
-		machineId, err := m.st.strictLocalID(id.(string))
+		docId, err := m.st.strictLocalID(id.(string))
 		if err != nil {
 			return false
 		}
-		return machineId == m.doc.Id
+		return docId == m.doc.Id+"#"+applicationName
 	}
-	return newInstanceCharmProfileDataWatcher(m.st, applicationName, m.doc.DocID, filter), nil
+	docId := m.instanceCharmProfileDataId(applicationName)
+	return newInstanceCharmProfileDataWatcher(m.st, docId, filter), nil
 }
 
 // WatchLXDProfileUpgradeNotifications returns a watcher that observes the status
@@ -1971,23 +1973,21 @@ func (u *Unit) WatchLXDProfileUpgradeNotifications(applicationName string) (Stri
 // data document.
 type instanceCharmProfileDataWatcher struct {
 	commonWatcher
-	// members is used to select the initial set of interesting entities.
-	memberId        string
-	known           string
-	applicationName string
-	filter          func(interface{}) bool
-	out             chan []string
+	// docId is used to select the initial interesting entities.
+	docId  string
+	known  string
+	filter func(interface{}) bool
+	out    chan []string
 }
 
 var _ Watcher = (*instanceCharmProfileDataWatcher)(nil)
 
-func newInstanceCharmProfileDataWatcher(backend modelBackend, applicationName, memberId string, filter func(interface{}) bool) StringsWatcher {
+func newInstanceCharmProfileDataWatcher(backend modelBackend, memberId string, filter func(interface{}) bool) StringsWatcher {
 	w := &instanceCharmProfileDataWatcher{
-		commonWatcher:   newCommonWatcher(backend),
-		memberId:        memberId,
-		applicationName: applicationName,
-		filter:          filter,
-		out:             make(chan []string),
+		commonWatcher: newCommonWatcher(backend),
+		docId:         memberId,
+		filter:        filter,
+		out:           make(chan []string),
 	}
 	w.tomb.Go(func() error {
 		defer close(w.out)
@@ -2004,14 +2004,13 @@ func (w *instanceCharmProfileDataWatcher) initial() error {
 
 	var instanceData instanceCharmProfileData
 	if err := instanceDataCol.Find(bson.D{
-		{"_id", w.memberId},
-		{"upgradecharmprofileapplication", w.applicationName},
+		{"_id", w.docId},
 	}).One(&instanceData); err == nil {
 		statusField = instanceData.UpgradeCharmProfileComplete
 	}
 	w.known = statusField
 
-	logger.Tracef("Started watching instanceCharmProfileData for machine %s and application %q: %q", w.memberId, w.applicationName, statusField)
+	logger.Tracef("Started watching instanceCharmProfileData for %q: %q", w.docId, statusField)
 	return nil
 }
 
@@ -2025,14 +2024,13 @@ func (w *instanceCharmProfileDataWatcher) merge(change watcher.Change) (bool, er
 
 	var instanceData instanceCharmProfileData
 	if err := instanceDataCol.Find(bson.D{
-		{"_id", machineId},
-		{"upgradecharmprofileapplication", w.applicationName},
+		{"_id", w.docId},
 	}).One(&instanceData); err != nil {
 		if err != mgo.ErrNotFound {
 			logger.Debugf("instanceCharmProfileData NOT mgo err not found")
 			return false, err
 		}
-		logger.Tracef("instanceCharmProfileData for %s on machine %s: mgo err not found", w.applicationName, machineId)
+		logger.Tracef("instanceCharmProfileData for %q: mgo err not found", machineId)
 		return false, nil
 	}
 
@@ -2041,7 +2039,7 @@ func (w *instanceCharmProfileDataWatcher) merge(change watcher.Change) (bool, er
 	if w.known != currentField {
 		w.known = currentField
 
-		logger.Tracef("Changes in watching instanceCharmProfileData for machine %s and application %q: %q", w.memberId, w.applicationName, currentField)
+		logger.Tracef("Changes in watching instanceCharmProfileData for %q: %q", w.docId, currentField)
 		return true, nil
 	}
 	return false, nil

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -953,8 +953,6 @@ func (w *modelFieldChangeWatcher) merge(watchSet set.Strings, change watcher.Cha
 			logger.Tracef("stopped field change watching for %q", docId)
 		}
 		delete(w.known, docId)
-		// TODO - check this correct.
-		watchSet.Remove(docId)
 		return nil
 	}
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -800,16 +800,12 @@ func (w *minUnitsWatcher) Changes() <-chan []string {
 	return w.out
 }
 
-// WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
-// changes to the upgrade charm profile charm url for a machine.
-func (st *State) WatchModelMachinesCharmProfiles() (StringsWatcher, error) {
-	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.UnitSnippet)
-	return st.watchCharmProfiles(isMachineRegexp, true)
-}
-
 // WatchContainersCharmProfiles starts a StringsWatcher to notify when
 // the provisioner should update the charm profiles used by any container on
 // the machine.
+//
+// This is needed for compatibility with ProvisionerAPIV7 related to container
+// provisioning on a machine.
 func (m *Machine) WatchContainersCharmProfiles(ctype instance.ContainerType) (StringsWatcher, error) {
 	isChildRegexp := fmt.Sprintf("^%s/%s/%s#%s$", m.doc.DocID, ctype, names.NumberSnippet, names.UnitSnippet)
 	return m.st.watchCharmProfiles(isChildRegexp, true)
@@ -817,9 +813,6 @@ func (m *Machine) WatchContainersCharmProfiles(ctype instance.ContainerType) (St
 
 // WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
 // changes to the upgrade charm profile charm url for a machine.
-//
-// TODO - is this needed?  2019-02-01
-// the provisioner calling this lives on the controller
 func (st *State) WatchModelMachinesCharmProfilesNewFormat() (StringsWatcher, error) {
 	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.UnitSnippet)
 	return st.watchCharmProfiles(isMachineRegexp, false)

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -75,6 +75,6 @@ func ProcessProfileChanges(p ProvisionerTask, ids []string) error {
 	return p.(*provisionerTask).processProfileChanges(ids)
 }
 
-func ProcessOneMachineProfileChanges(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler) (bool, error) {
-	return processOneMachineProfileChange(m, profileBroker)
+func ProcessOneProfileChanges(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler, appName string) (bool, error) {
+	return processOneProfileChange(m, profileBroker, appName)
 }

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -75,6 +75,6 @@ func ProcessProfileChanges(p ProvisionerTask, ids []string) error {
 	return p.(*provisionerTask).processProfileChanges(ids)
 }
 
-func ProcessOneProfileChanges(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler, appName string) (bool, error) {
-	return processOneProfileChange(m, profileBroker, appName)
+func ProcessOneProfileChange(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler, unitName string) (bool, error) {
+	return processOneProfileChange(m, profileBroker, unitName)
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -464,7 +464,7 @@ func processOneProfileChange(
 			// We can remove the instance charm profile data here, knowning that
 			// the ProvisionerAPI will attempt to write it when getting
 			// the machine lxd profile names.
-			if err := m.RemoveUpgradeCharmProfileData(); err != nil {
+			if err := m.RemoveUpgradeCharmProfileData(unitName); err != nil {
 				logger.Tracef("cannot remove machine upgrade charm profile data: %s", err.Error())
 			}
 			// There is nothing we can do with this machine at this point. The

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -356,8 +356,14 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	}
 
 	machineTags := make([]names.MachineTag, len(ids))
+	appNames := make([]string, len(ids))
 	for i, id := range ids {
-		machineTags[i] = names.NewMachineTag(id)
+		machineId, appName, err := machineIdAndAppName(id)
+		if err != nil {
+			return errors.Annotatef(err, "failed to parse ids: %v", ids)
+		}
+		machineTags[i] = names.NewMachineTag(machineId)
+		appNames[i] = appName
 	}
 	machines, err := task.machineGetter.Machines(machineTags...)
 	if err != nil {
@@ -366,7 +372,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	profileBroker, ok := task.broker.(environs.LXDProfiler)
 	if !ok {
 		logger.Debugf("Attempting to update the profile of a machine that doesn't support profiles")
-		profileUpgradeNotSupported(machines)
+		profileUpgradeNotSupported(machines, appNames)
 		return nil
 	}
 	for i, mResult := range machines {
@@ -374,7 +380,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			return errors.Annotatef(err, "failed to get machine %v", machineTags[i])
 		}
 		m := mResult.Machine
-		removeDoc, err := processOneMachineProfileChange(m, profileBroker)
+		removeDoc, err := processOneProfileChange(m, profileBroker, appNames[i])
 		// The machine is not provisioned yet, therefore we can continue and
 		// the profile will be applied when the machine is provisioned.
 		if err != nil && (errors.IsNotProvisioned(err) || errors.IsNotValid(err)) {
@@ -385,12 +391,12 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			if err != nil {
 				logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
 			}
-			if err := m.RemoveUpgradeCharmProfileData(); err != nil {
+			if err := m.RemoveUpgradeCharmProfileData(appNames[i]); err != nil {
 				logger.Errorf("cannot remove subordinates upgrade charm profile data: %s", err.Error())
 			}
 		} else if err != nil {
 			logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
-			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
+			if err2 := m.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for instance charm profile data for machine %q", m)
 			}
 			// If Error, SetInstanceStatus in the provisioner api will also call
@@ -407,7 +413,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			if err2 := m.SetStatus(status.Started, "", nil); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for machine %q agent", m)
 			}
-			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus); err2 != nil {
+			if err2 := m.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.SuccessStatus); err2 != nil {
 				return errors.Annotatef(err2, "cannot set success status for instance charm profile data for machine %q", m)
 			}
 		}
@@ -415,17 +421,26 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	return nil
 }
 
-func profileUpgradeNotSupported(machines []apiprovisioner.MachineResult) {
-	for _, mResult := range machines {
-		if err := mResult.Machine.SetUpgradeCharmProfileComplete(lxdprofile.NotSupportedStatus); err != nil {
+func machineIdAndAppName(id string) (string, string, error) {
+	parts := strings.Split(id, "#")
+	if len(parts) != 2 {
+		return "", "", errors.Errorf("%q not in machine#application format", id)
+	}
+	return parts[0], parts[1], nil
+}
+
+func profileUpgradeNotSupported(machines []apiprovisioner.MachineResult, appNames []string) {
+	for i, mResult := range machines {
+		if err := mResult.Machine.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.NotSupportedStatus); err != nil {
 			logger.Errorf("cannot set not supported status for instance charm profile data: %s", err.Error())
 		}
 	}
 }
 
-func processOneMachineProfileChange(
+func processOneProfileChange(
 	m apiprovisioner.MachineProvisioner,
 	profileBroker environs.LXDProfiler,
+	appName string,
 ) (bool, error) {
 	ident := m.Id()
 	logger.Tracef("processOneMachineProfileChange(%s)", ident)
@@ -457,7 +472,7 @@ func processOneMachineProfileChange(
 			return false, errors.NotProvisionedf("machine %q", ident)
 		}
 	}
-	info, err := m.CharmProfileChangeInfo()
+	info, err := m.CharmProfileChangeInfo(appName)
 	if err != nil {
 		return false, err
 	}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -356,14 +356,14 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	}
 
 	machineTags := make([]names.MachineTag, len(ids))
-	appNames := make([]string, len(ids))
+	unitNames := make([]string, len(ids))
 	for i, id := range ids {
-		machineId, appName, err := machineIdAndAppName(id)
+		machineId, unitName, err := machineIdAndUnitName(id)
 		if err != nil {
 			return errors.Annotatef(err, "failed to parse ids: %v", ids)
 		}
 		machineTags[i] = names.NewMachineTag(machineId)
-		appNames[i] = appName
+		unitNames[i] = unitName
 	}
 	machines, err := task.machineGetter.Machines(machineTags...)
 	if err != nil {
@@ -372,7 +372,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	profileBroker, ok := task.broker.(environs.LXDProfiler)
 	if !ok {
 		logger.Debugf("Attempting to update the profile of a machine that doesn't support profiles")
-		profileUpgradeNotSupported(machines, appNames)
+		profileUpgradeNotSupported(machines, unitNames)
 		return nil
 	}
 	for i, mResult := range machines {
@@ -380,7 +380,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			return errors.Annotatef(err, "failed to get machine %v", machineTags[i])
 		}
 		m := mResult.Machine
-		removeDoc, err := processOneProfileChange(m, profileBroker, appNames[i])
+		removeDoc, err := processOneProfileChange(m, profileBroker, unitNames[i])
 		// The machine is not provisioned yet, therefore we can continue and
 		// the profile will be applied when the machine is provisioned.
 		if err != nil && (errors.IsNotProvisioned(err) || errors.IsNotValid(err)) {
@@ -391,12 +391,12 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			if err != nil {
 				logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
 			}
-			if err := m.RemoveUpgradeCharmProfileData(appNames[i]); err != nil {
+			if err := m.RemoveUpgradeCharmProfileData(unitNames[i]); err != nil {
 				logger.Errorf("cannot remove subordinates upgrade charm profile data: %s", err.Error())
 			}
 		} else if err != nil {
 			logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
-			if err2 := m.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
+			if err2 := m.SetUpgradeCharmProfileComplete(unitNames[i], lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for instance charm profile data for machine %q", m)
 			}
 			// If Error, SetInstanceStatus in the provisioner api will also call
@@ -413,7 +413,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			if err2 := m.SetStatus(status.Started, "", nil); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for machine %q agent", m)
 			}
-			if err2 := m.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.SuccessStatus); err2 != nil {
+			if err2 := m.SetUpgradeCharmProfileComplete(unitNames[i], lxdprofile.SuccessStatus); err2 != nil {
 				return errors.Annotatef(err2, "cannot set success status for instance charm profile data for machine %q", m)
 			}
 		}
@@ -421,10 +421,10 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	return nil
 }
 
-func machineIdAndAppName(id string) (string, string, error) {
+func machineIdAndUnitName(id string) (string, string, error) {
 	parts := strings.Split(id, "#")
 	if len(parts) != 2 {
-		return "", "", errors.Errorf("%q not in machine#application format", id)
+		return "", "", errors.Errorf("%q not in machine#unit format", id)
 	}
 	return parts[0], parts[1], nil
 }
@@ -440,10 +440,10 @@ func profileUpgradeNotSupported(machines []apiprovisioner.MachineResult, appName
 func processOneProfileChange(
 	m apiprovisioner.MachineProvisioner,
 	profileBroker environs.LXDProfiler,
-	appName string,
+	unitName string,
 ) (bool, error) {
 	ident := m.Id()
-	logger.Tracef("processOneMachineProfileChange(%s)", ident)
+	logger.Tracef("processOneMachineProfileChange(%s) %s", ident, unitName)
 	// We need to check for the life of the machine here, as the machine
 	// might have been dying when the watcher fired, but is now dead by
 	// the time this is triggered. We still want to clean up dying machines
@@ -472,7 +472,7 @@ func processOneProfileChange(
 			return false, errors.NotProvisionedf("machine %q", ident)
 		}
 	}
-	info, err := m.CharmProfileChangeInfo(appName)
+	info, err := m.CharmProfileChangeInfo(unitName)
 	if err != nil {
 		return false, err
 	}

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -253,7 +253,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChanges(c *gc.C) {
 	).Return([]string{"default", "juju-default", "juju-default-different-0", info3.NewProfileName}, nil)
 
 	task := s.newProvisionerTaskWithBroker(c, mockBroker, nil)
-	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0", "1", "2", "3"}), jc.ErrorIsNil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile", "1#lxd-profile", "2#lxd-profile", "3#lxd-profile"}), jc.ErrorIsNil)
 }
 
 func (s *ProvisionerTaskSuite) TestProcessProfileChangesNotProvisioned(c *gc.C) {
@@ -331,17 +331,17 @@ func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string,
 		LXDProfile:     nil,
 		Subordinate:    sub,
 	}
-	mExp.CharmProfileChangeInfo().Return(info, nil)
+	mExp.CharmProfileChangeInfo("lxd-profile").Return(info, nil)
 	mExp.Id().Return(num)
 	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id(num), nil)
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	if old == "" && sub {
-		mExp.RemoveUpgradeCharmProfileData().Return(nil)
+		mExp.RemoveUpgradeCharmProfileData("lxd-profile").Return(nil)
 	} else {
 		mExp.SetInstanceStatus(status.Running, "Running", nil).Return(nil)
 		mExp.SetStatus(status.Started, "", nil).Return(nil)
-		mExp.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus).Return(nil)
+		mExp.SetUpgradeCharmProfileComplete("lxd-profile", lxdprofile.SuccessStatus).Return(nil)
 	}
 
 	return mockMachine, info
@@ -350,12 +350,12 @@ func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string,
 func setUpFailureMockProfileMachine(ctrl *gomock.Controller, num string) *apiprovisionermock.MockMachineProvisioner {
 	mockMachine := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine.EXPECT()
-	mExp.CharmProfileChangeInfo().Return(apiprovisioner.CharmProfileChangeInfo{}, errors.New("fail me"))
+	mExp.CharmProfileChangeInfo(gomock.Any()).Return(apiprovisioner.CharmProfileChangeInfo{}, errors.New("fail me"))
 	mExp.Id().Return(num)
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.Life().Return(params.Alive)
 	mExp.SetInstanceStatus(status.Error, gomock.Any(), nil).Return(nil)
-	mExp.SetUpgradeCharmProfileComplete(gomock.Any()).Return(nil)
+	mExp.SetUpgradeCharmProfileComplete(gomock.Any(), gomock.Any()).Return(nil)
 
 	return mockMachine
 }
@@ -366,7 +366,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesNoLXDBroker(c *gc.C) {
 
 	mockMachine := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine.EXPECT()
-	mExp.SetUpgradeCharmProfileComplete(lxdprofile.NotSupportedStatus).Return(nil)
+	mExp.SetUpgradeCharmProfileComplete("lxd-profile", lxdprofile.NotSupportedStatus).Return(nil)
 
 	s.machinesResults = []apiprovisioner.MachineResult{
 		{Machine: mockMachine, Err: nil},
@@ -379,7 +379,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesNoLXDBroker(c *gc.C) {
 	)
 	defer workertest.CleanKill(c, task)
 
-	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0"}), jc.ErrorIsNil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile"}), jc.ErrorIsNil)
 }
 
 func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *gc.C, sub bool) {
@@ -395,7 +395,7 @@ func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *g
 		LXDProfile:     nil,
 		Subordinate:    sub,
 	}
-	mExp.CharmProfileChangeInfo().Return(info, nil)
+	mExp.CharmProfileChangeInfo("lxd-profile").Return(info, nil)
 	mExp.Id().Return("0")
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.Life().Return(params.Alive)
@@ -410,7 +410,7 @@ func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *g
 		"0", info.OldProfileName, info.NewProfileName, info.LXDProfile,
 	).Return(machineCharmProfiles, nil)
 
-	remove, err := provisioner.ProcessOneMachineProfileChanges(mockMachineProvisioner, mockLXDProfiler)
+	remove, err := provisioner.ProcessOneProfileChanges(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(remove, gc.Equals, sub)
 }
@@ -434,7 +434,7 @@ func (s *ProvisionerTaskSuite) TestProcessOneMachineProfileChangeRemoveProfileSu
 	ctrl, mockMachineProvisioner, mockLXDProfiler := setUpMocksProcessOneMachineProfileChange(c, info)
 	defer ctrl.Finish()
 
-	remove, err := provisioner.ProcessOneMachineProfileChanges(mockMachineProvisioner, mockLXDProfiler)
+	remove, err := provisioner.ProcessOneProfileChanges(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(remove, gc.Equals, false)
 }
@@ -450,7 +450,7 @@ func (s *ProvisionerTaskSuite) TestProcessOneMachineProfileChangeChangeProfile(c
 	ctrl, mockMachineProvisioner, mockLXDProfiler := setUpMocksProcessOneMachineProfileChange(c, info)
 	defer ctrl.Finish()
 
-	remove, err := provisioner.ProcessOneMachineProfileChanges(mockMachineProvisioner, mockLXDProfiler)
+	remove, err := provisioner.ProcessOneProfileChanges(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(remove, gc.Equals, false)
 }
@@ -460,7 +460,7 @@ func setUpMocksProcessOneMachineProfileChange(c *gc.C, info apiprovisioner.Charm
 
 	mockMachineProvisioner := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachineProvisioner.EXPECT()
-	mExp.CharmProfileChangeInfo().Return(info, nil)
+	mExp.CharmProfileChangeInfo("lxd-profile").Return(info, nil)
 	mExp.Id().Return("0")
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.Life().Return(params.Alive)

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -214,21 +214,21 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChanges(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	// Setup mockMachine0 to successfully change from an
-	// old profile to a new profile.
+	// Setup mockMachine0 to successfully change from an old profile to a new
+	// profile.  Machine number and unit number will be the same.
 	mockMachine0, info0 := setUpSuccessfulMockProfileMachine(ctrl, "0", "juju-default-lxd-profile-0", false)
 	mockMachine0.EXPECT().SetCharmProfiles([]string{info0.NewProfileName, "juju-default-different-0"}).Return(nil)
 
-	// Setup mockMachine1 to successfully change from an
-	// old profile to a new profile.
+	// Setup mockMachine1 to successfully change from an old profile to a new
+	// profile.  Machine number and unit number will be the same.
 	mockMachine1, info1 := setUpSuccessfulMockProfileMachine(ctrl, "1", "juju-default-lxd-profile-0", true)
 	mockMachine1.EXPECT().SetCharmProfiles([]string{info1.NewProfileName, "juju-default-different-0"}).Return(nil)
 
 	// Setup mockMachine2 to have a failure from CharmProfileChangeInfo()
 	mockMachine2 := setUpFailureMockProfileMachine(ctrl, "2")
 
-	// Setup mockMachine3 to be a new subordinate unit adding
-	// an lxd profile.
+	// Setup mockMachine3 to successfully change from an old profile to a new
+	// profile.  Machine number and unit number will be the same.
 	mockMachine3, info3 := setUpSuccessfulMockProfileMachine(ctrl, "3", "", true)
 	mockMachine3.EXPECT().SetCharmProfiles([]string{"juju-default-different-0", info3.NewProfileName}).Return(nil)
 
@@ -253,26 +253,26 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChanges(c *gc.C) {
 	).Return([]string{"default", "juju-default", "juju-default-different-0", info3.NewProfileName}, nil)
 
 	task := s.newProvisionerTaskWithBroker(c, mockBroker, nil)
-	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile", "1#lxd-profile", "2#lxd-profile", "3#lxd-profile"}), jc.ErrorIsNil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile/0", "1#lxd-profile/1", "2#lxd-profile/2", "3#lxd-profile/3"}), jc.ErrorIsNil)
 }
 
 func (s *ProvisionerTaskSuite) TestProcessProfileChangesNotProvisioned(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	// Setup mockMachine0 to successfully change from an
-	// old profile to a new profile.
+	// Setup mockMachine0 to successfully change from an old profile to a new
+	// profile.  Machine number and unit number will be the same.
 	mockMachine0, info0 := setUpSuccessfulMockProfileMachine(ctrl, "0", "juju-default-lxd-profile-0", false)
 	mockMachine0.EXPECT().SetCharmProfiles([]string{info0.NewProfileName, "juju-default-different-0"}).Return(nil)
 
 	// Setup mockMachine1 to have a failure from CharmProfileChangeInfo()
 	mockMachine1 := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine1.EXPECT()
-	mExp.Id().Return("1")
+	mExp.Id().Return("1").AnyTimes()
 	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id("1"), params.Error{Code: params.CodeNotProvisioned})
 	mExp.InstanceStatus().Return(status.Error, "Error", nil)
-	mExp.RemoveUpgradeCharmProfileData().Return(nil)
+	mExp.RemoveUpgradeCharmProfileData("lxd-profile/1").Return(nil)
 
 	s.machinesResults = []apiprovisioner.MachineResult{
 		{Machine: mockMachine0, Err: nil},
@@ -287,7 +287,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesNotProvisioned(c *gc.C) 
 	).Return(machineCharmProfiles, nil)
 
 	task := s.newProvisionerTaskWithBroker(c, mockBroker, nil)
-	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile", "1#lxd-profile"}), jc.ErrorIsNil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile/0", "1#lxd-profile/1"}), jc.ErrorIsNil)
 }
 
 func (s *ProvisionerTaskSuite) TestProcessProfileChangesWithDeadMachine(c *gc.C) {
@@ -331,17 +331,18 @@ func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string,
 		LXDProfile:     nil,
 		Subordinate:    sub,
 	}
-	mExp.CharmProfileChangeInfo("lxd-profile").Return(info, nil)
-	mExp.Id().Return(num)
+	unitName := fmt.Sprintf("lxd-profile/%s", num)
+	mExp.CharmProfileChangeInfo(unitName).Return(info, nil)
+	mExp.Id().Return(num).AnyTimes()
 	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id(num), nil)
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	if old == "" && sub {
-		mExp.RemoveUpgradeCharmProfileData("lxd-profile").Return(nil)
+		mExp.RemoveUpgradeCharmProfileData(unitName).Return(nil)
 	} else {
 		mExp.SetInstanceStatus(status.Running, "Running", nil).Return(nil)
 		mExp.SetStatus(status.Started, "", nil).Return(nil)
-		mExp.SetUpgradeCharmProfileComplete("lxd-profile", lxdprofile.SuccessStatus).Return(nil)
+		mExp.SetUpgradeCharmProfileComplete(unitName, lxdprofile.SuccessStatus).Return(nil)
 	}
 
 	return mockMachine, info
@@ -351,7 +352,7 @@ func setUpFailureMockProfileMachine(ctrl *gomock.Controller, num string) *apipro
 	mockMachine := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine.EXPECT()
 	mExp.CharmProfileChangeInfo(gomock.Any()).Return(apiprovisioner.CharmProfileChangeInfo{}, errors.New("fail me"))
-	mExp.Id().Return(num)
+	mExp.Id().Return(num).AnyTimes()
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.Life().Return(params.Alive)
 	mExp.SetInstanceStatus(status.Error, gomock.Any(), nil).Return(nil)
@@ -366,7 +367,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesNoLXDBroker(c *gc.C) {
 
 	mockMachine := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine.EXPECT()
-	mExp.SetUpgradeCharmProfileComplete("lxd-profile", lxdprofile.NotSupportedStatus).Return(nil)
+	mExp.SetUpgradeCharmProfileComplete("lxd-profile/1", lxdprofile.NotSupportedStatus).Return(nil)
 
 	s.machinesResults = []apiprovisioner.MachineResult{
 		{Machine: mockMachine, Err: nil},
@@ -379,7 +380,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesNoLXDBroker(c *gc.C) {
 	)
 	defer workertest.CleanKill(c, task)
 
-	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile"}), jc.ErrorIsNil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile/1"}), jc.ErrorIsNil)
 }
 
 func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *gc.C, sub bool) {
@@ -395,8 +396,8 @@ func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *g
 		LXDProfile:     nil,
 		Subordinate:    sub,
 	}
-	mExp.CharmProfileChangeInfo("lxd-profile").Return(info, nil)
-	mExp.Id().Return("0")
+	mExp.CharmProfileChangeInfo("lxd-profile/0").Return(info, nil)
+	mExp.Id().Return("0").AnyTimes()
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id("0"), nil)
@@ -410,7 +411,7 @@ func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *g
 		"0", info.OldProfileName, info.NewProfileName, info.LXDProfile,
 	).Return(machineCharmProfiles, nil)
 
-	remove, err := provisioner.ProcessOneProfileChanges(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
+	remove, err := provisioner.ProcessOneProfileChange(mockMachineProvisioner, mockLXDProfiler, "lxd-profile/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(remove, gc.Equals, sub)
 }
@@ -434,7 +435,7 @@ func (s *ProvisionerTaskSuite) TestProcessOneMachineProfileChangeRemoveProfileSu
 	ctrl, mockMachineProvisioner, mockLXDProfiler := setUpMocksProcessOneMachineProfileChange(c, info)
 	defer ctrl.Finish()
 
-	remove, err := provisioner.ProcessOneProfileChanges(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
+	remove, err := provisioner.ProcessOneProfileChange(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(remove, gc.Equals, false)
 }
@@ -450,7 +451,7 @@ func (s *ProvisionerTaskSuite) TestProcessOneMachineProfileChangeChangeProfile(c
 	ctrl, mockMachineProvisioner, mockLXDProfiler := setUpMocksProcessOneMachineProfileChange(c, info)
 	defer ctrl.Finish()
 
-	remove, err := provisioner.ProcessOneProfileChanges(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
+	remove, err := provisioner.ProcessOneProfileChange(mockMachineProvisioner, mockLXDProfiler, "lxd-profile")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(remove, gc.Equals, false)
 }
@@ -461,7 +462,7 @@ func setUpMocksProcessOneMachineProfileChange(c *gc.C, info apiprovisioner.Charm
 	mockMachineProvisioner := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachineProvisioner.EXPECT()
 	mExp.CharmProfileChangeInfo("lxd-profile").Return(info, nil)
-	mExp.Id().Return("0")
+	mExp.Id().Return("0").AnyTimes()
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id("0"), nil)

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -294,8 +294,8 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesWithDeadMachine(c *gc.C)
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	// Setup mockMachine0 to successfully change from an
-	// old profile to a new profile.
+	// Setup mockMachine0 to successfully change from an old profile to a new
+	// profile.  Machine number and unit number will be the same.
 	mockMachine0, info0 := setUpSuccessfulMockProfileMachine(ctrl, "0", "juju-default-lxd-profile-0", false)
 	mockMachine0.EXPECT().SetCharmProfiles([]string{info0.NewProfileName, "juju-default-different-0"}).Return(nil)
 
@@ -318,7 +318,7 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesWithDeadMachine(c *gc.C)
 	).Return(machineCharmProfiles, nil)
 
 	task := s.newProvisionerTaskWithBroker(c, mockBroker, nil)
-	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile", "1#lxd-profile"}), jc.ErrorIsNil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile/0", "1#lxd-profile/1"}), jc.ErrorIsNil)
 }
 
 func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string, sub bool) (*apiprovisionermock.MockMachineProvisioner, apiprovisioner.CharmProfileChangeInfo) {


### PR DESCRIPTION
## Description of change

Change instanceCharmProfileData to be per machine and per unit, rather than simply per machine.  This avoids collisions when upgrading multiple charms at once, and while deploying bundles.

`SetUpgradeCharmProfileComplete()` and `RemoveUpgradeCharmProfileData()` now require an unit name.  `WatchModelMachinesCharmProfiles()` and `WatchContainersCharmProfiles()` now pass a new string of `"<machine-id>#<unit-name>"` when triggered to the provisioner.

## QA steps

1. `juju deploy -n 6 ./testcharms/charm-repo/quantal/lxd-profile`
1. wait for the machines to start provisioning
3. `juju deploy ~/charms/ubuntu --to 0 ; juju add-unit ubuntu -n 5 --to 1,2,3,4,5`
2. `juju deploy ~/charms/ntp`
3. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate`
4. `juju add-relation lxd-profile lxd-profile-subordinate`
5. `juju add-relation ntp ubuntu`
4. once settled:
```juju upgrade-charm lxd-profile-subordinate --path ./testcharms/charm-repo/quantal/lxd-profile-subordinate; juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile ; juju upgrade-charm ntp --path ~/charms/ntp ; juju upgrade-charm ubuntu --path ~/charms/ubuntu```

Also test with deploy --to lxd.  With PR version server and client; as well as 2.5.0 server and PR version client.


## Documentation changes

n/a

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813044
