### PR TITLE
Support long tokens in dummy-sink and dummy-source

### DIFF
--- a/acceptancetests/repository/charms/dummy-sink/hooks/source-relation-changed
+++ b/acceptancetests/repository/charms/dummy-sink/hooks/source-relation-changed
@@ -4,10 +4,10 @@ set -eux
 mkdir -p /var/run/dummy-sink
 token=$(relation-get token)
 echo "$token" > /var/run/dummy-sink/token
-if [[ -z $token ]]; then
+if [[ -z "$token" ]]; then
   juju-log -l INFO "Waiting for token"
   status-set waiting "Waiting for token" || true
 else
   juju-log -l INFO "Token is $token"
-  status-set active "Token is $token" || true
+  status-set active "Token is $(echo $token | cut -c 1-20)" || true
 fi

--- a/acceptancetests/repository/charms/dummy-source/hooks/config-changed
+++ b/acceptancetests/repository/charms/dummy-source/hooks/config-changed
@@ -7,10 +7,10 @@ token="$(config-get token)"
 for relation_id in $(relation-ids sink); do
   relation-set -r $relation_id token="$token"
 done
-if [[ -z $token ]]; then
+if [[ -z "$token" ]]; then
   juju-log -l WARNING "Blocked: set the token"
   status-set blocked "Set the token" || true
 else
   juju-log -l INFO "Token is $token"
-  status-set active "Token is $token" || true
+  status-set active "Token is $(echo $token | cut -c 1-20)" || true
 fi


### PR DESCRIPTION
## Description of change

We are calling status-set, but if the token is 12kB it will do bad
things. So instead we print with a cut to shorter length. Also handle
when the token has spaces in it.

This is only a tweak to our dummy charms for testing purposes.

## QA steps

```
$ juju bootstrap lxd lxd --debug
$ juju deploy ./dummy-sink
$ juju deploy ./dummy-source
$ juju relate dummy-source dummy-sink
$ juju config dummy-source token="this is a very long token that would otherwise overflow status"
$ watch juju status
```

You should see the status message for dummy-source ends up being trimmed rather than causing any problems with the display.

## Documentation changes

None.

## Bug reference

None.