### PR TITLE
switch back to default websocket buffer sizes

### DIFF
--- a/apiserver/websocket/websocket.go
+++ b/apiserver/websocket/websocket.go
@@ -18,11 +18,6 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.websocket")
 
-// Use a 64k frame size for the websockets while we need to deal
-// with x/net/websocket connections that don't deal with receiving
-// fragmented messages.
-const websocketFrameSize = 65536
-
 const (
 	// PongDelay is how long the server will wait for a pong to be sent
 	// before the websocket is considered broken.
@@ -41,10 +36,6 @@ const (
 
 var websocketUpgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
-	// In order to deal with the remote side not handling message
-	// fragmentation, we default to largeish frames.
-	ReadBufferSize:  websocketFrameSize,
-	WriteBufferSize: websocketFrameSize,
 }
 
 // Conn wraps a gorilla/websocket.Conn, providing additional Juju-specific


### PR DESCRIPTION
## Description of change

In 2.2 we tried to maintain more compatibility with 2.1 which didn't support negotiating websocket frame size. However, we've supported it since 2.2 so we should be comfortable going back to the default 4096 buffer size instead of 65536. Saving 60kB*2 per connection which is 2x per agent.

## QA steps

To ensure compatibility between agent versions I did:
```
$ git checkout juju-2.4.7 # and build
$ juju-2.4 bootstrap lxd lxd --no-gui
$ juju deploy ./dummy-sink
$ juju deploy ./dummy-source
$ juju relate dummy-sink dummy-source
$ juju config dummy-source token=@dependencies.tsv
# doesn't matter what it is, but I wanted to make sure it was *big*
$ watch --color juju status --color
$ git co 2.5-websockets # and build
$ juju upgrade-juju -m controller --build-agent
# This should leave a controller at 2.5.1 and agents at 2.4.7
$ juju status # confirm that everything is started up again
$ juju config dummy-source token=""
$ watch juju status
# see that they go back into "blocked, missing token"
$ juju config dummy-source token=@Gopkg.lock
# even bigger
$ watch --color juju status --color
# see that everything comes back happily, with the long tokens
```

I then also checked old clients with
```
$ git checkout juju-2.2.9 # and build
$ juju-2.2.9 --version
2.2.9-bionic-amd64
$ juju-2.2.9 config dummy-source
# you should happily see the big content of dummy-source
$ git co juju-2.1.3 # and build
$ juju-2.1.3 --version
2.1.3-bionic-amd64
$ juju-2.1.3 status
ERROR codec.ReadHeader error: error receiving message: unexpected end of JSON input
$ juju-2.1.3 config dummy-source
ERROR codec.ReadHeader error: error receiving message: unexpected end of JSON input
```

So as expected, clients older than 2.2 are unable to handle the new page sizes, but 2.2 and newer work fine.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/bugs/1813868