### PR TITLE
LXDProfile -  Don't apply when not provisioned

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -80,7 +80,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  7,
+	"Provisioner":                  8,
 	"ProxyUpdater":                 2,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -120,19 +120,19 @@ type MachineProvisioner interface {
 	WatchContainersCharmProfiles(ctype instance.ContainerType) (watcher.StringsWatcher, error)
 
 	// CharmProfileChangeInfo retrieves the info necessary to change a charm
-	// profile used by a machine.
-	CharmProfileChangeInfo() (CharmProfileChangeInfo, error)
+	// profile used by a machine, for the give application.
+	CharmProfileChangeInfo(string) (CharmProfileChangeInfo, error)
 
 	// SetCharmProfiles records the given slice of charm profile names.
 	SetCharmProfiles([]string) error
 
-	// SetUpgradeCharmProfileComplete recorded that the result of updating
-	// the machine's charm profile(s)
-	SetUpgradeCharmProfileComplete(string) error
+	// SetUpgradeCharmProfileComplete records the result of updating
+	// the machine's charm profile(s), for the given application.
+	SetUpgradeCharmProfileComplete(appName string, msg string) error
 
 	// RemoveUpgradeCharmProfileData completely removes the instance charm profile
-	// data for a machine, even if the machine is dead.
-	RemoveUpgradeCharmProfileData() error
+	// data for a machine and the provided application, even if the machine is dead.
+	RemoveUpgradeCharmProfileData(string) error
 }
 
 // Machine represents a juju machine as seen by the provisioner worker.
@@ -572,11 +572,16 @@ type CharmProfileChangeInfo struct {
 }
 
 // CharmProfileChangeInfo implements MachineProvisioner.CharmProfileChangeInfo.
-func (m *Machine) CharmProfileChangeInfo() (CharmProfileChangeInfo, error) {
+func (m *Machine) CharmProfileChangeInfo(appName string) (CharmProfileChangeInfo, error) {
 	var results params.ProfileChangeResults
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: m.tag.String()},
-	}}
+	args := params.ProfileArgs{
+		Args: []params.ProfileArg{
+			{
+				Entity:  params.Entity{Tag: m.tag.String()},
+				AppName: appName,
+			},
+		},
+	}
 	err := m.st.facade.FacadeCall("CharmProfileChangeInfo", args, &results)
 	if err != nil {
 		return CharmProfileChangeInfo{}, err
@@ -627,12 +632,13 @@ func (m *Machine) SetCharmProfiles(profiles []string) error {
 }
 
 // SetUpgradeCharmProfileComplete implements MachineProvisioner.SetUpgradeCharmProfileComplete.
-func (m *Machine) SetUpgradeCharmProfileComplete(message string) error {
+func (m *Machine) SetUpgradeCharmProfileComplete(appName, message string) error {
 	var results params.ErrorResults
 	args := params.SetProfileUpgradeCompleteArgs{
 		Args: []params.SetProfileUpgradeCompleteArg{
 			{
 				Entity:  params.Entity{Tag: m.tag.String()},
+				AppName: appName,
 				Message: message,
 			},
 		},
@@ -652,12 +658,13 @@ func (m *Machine) SetUpgradeCharmProfileComplete(message string) error {
 }
 
 // RemoveUpgradeCharmProfileData implements MachineProvisioner.RemoveUpgradeCharmProfileData.
-func (m *Machine) RemoveUpgradeCharmProfileData() error {
+func (m *Machine) RemoveUpgradeCharmProfileData(appName string) error {
 	var results params.ErrorResults
-	args := params.Entities{
-		Entities: []params.Entity{
+	args := params.ProfileArgs{
+		Args: []params.ProfileArg{
 			{
-				Tag: m.tag.String(),
+				Entity:  params.Entity{Tag: m.tag.String()},
+				AppName: appName,
 			},
 		},
 	}

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -53,16 +53,16 @@ func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
 }
 
 // CharmProfileChangeInfo mocks base method
-func (m *MockMachineProvisioner) CharmProfileChangeInfo() (provisioner.CharmProfileChangeInfo, error) {
-	ret := m.ctrl.Call(m, "CharmProfileChangeInfo")
+func (m *MockMachineProvisioner) CharmProfileChangeInfo(arg0 string) (provisioner.CharmProfileChangeInfo, error) {
+	ret := m.ctrl.Call(m, "CharmProfileChangeInfo", arg0)
 	ret0, _ := ret[0].(provisioner.CharmProfileChangeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmProfileChangeInfo indicates an expected call of CharmProfileChangeInfo
-func (mr *MockMachineProvisionerMockRecorder) CharmProfileChangeInfo() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfileChangeInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).CharmProfileChangeInfo))
+func (mr *MockMachineProvisionerMockRecorder) CharmProfileChangeInfo(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfileChangeInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).CharmProfileChangeInfo), arg0)
 }
 
 // DistributionGroup mocks base method
@@ -229,15 +229,15 @@ func (mr *MockMachineProvisionerMockRecorder) Remove() *gomock.Call {
 }
 
 // RemoveUpgradeCharmProfileData mocks base method
-func (m *MockMachineProvisioner) RemoveUpgradeCharmProfileData() error {
-	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData")
+func (m *MockMachineProvisioner) RemoveUpgradeCharmProfileData(arg0 string) error {
+	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveUpgradeCharmProfileData indicates an expected call of RemoveUpgradeCharmProfileData
-func (mr *MockMachineProvisionerMockRecorder) RemoveUpgradeCharmProfileData() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockMachineProvisioner)(nil).RemoveUpgradeCharmProfileData))
+func (mr *MockMachineProvisionerMockRecorder) RemoveUpgradeCharmProfileData(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockMachineProvisioner)(nil).RemoveUpgradeCharmProfileData), arg0)
 }
 
 // SetCharmProfiles mocks base method
@@ -317,15 +317,15 @@ func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...int
 }
 
 // SetUpgradeCharmProfileComplete mocks base method
-func (m *MockMachineProvisioner) SetUpgradeCharmProfileComplete(arg0 string) error {
-	ret := m.ctrl.Call(m, "SetUpgradeCharmProfileComplete", arg0)
+func (m *MockMachineProvisioner) SetUpgradeCharmProfileComplete(arg0, arg1 string) error {
+	ret := m.ctrl.Call(m, "SetUpgradeCharmProfileComplete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUpgradeCharmProfileComplete indicates an expected call of SetUpgradeCharmProfileComplete
-func (mr *MockMachineProvisionerMockRecorder) SetUpgradeCharmProfileComplete(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeCharmProfileComplete", reflect.TypeOf((*MockMachineProvisioner)(nil).SetUpgradeCharmProfileComplete), arg0)
+func (mr *MockMachineProvisionerMockRecorder) SetUpgradeCharmProfileComplete(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeCharmProfileComplete", reflect.TypeOf((*MockMachineProvisioner)(nil).SetUpgradeCharmProfileComplete), arg0, arg1)
 }
 
 // Status mocks base method

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -422,12 +422,12 @@ func (s *provisionerSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
 	err := apiMachine.SetCharmProfiles(profiles)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = apiMachine.SetUpgradeCharmProfileComplete("testme")
+	err = apiMachine.SetUpgradeCharmProfileComplete(application.Name(), "testme")
 	c.Assert(err, jc.ErrorIsNil)
 
 	mach, err := s.State.Machine(apiMachine.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	status, err := mach.UpgradeCharmProfileComplete()
+	status, err := mach.UpgradeCharmProfileComplete(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, "testme")
 }
@@ -439,7 +439,7 @@ func (s *provisionerSuite) TestCharmProfileChangeInfo(c *gc.C) {
 
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	info, err := apiMachine.CharmProfileChangeInfo()
+	info, err := apiMachine.CharmProfileChangeInfo(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, provisioner.CharmProfileChangeInfo{
 		OldProfileName: "",
@@ -482,7 +482,7 @@ func (s *provisionerSuite) TestCharmProfileChangeInfoSubordinate(c *gc.C) {
 
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	info, err := apiMachine.CharmProfileChangeInfo()
+	info, err := apiMachine.CharmProfileChangeInfo(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, provisioner.CharmProfileChangeInfo{
 		OldProfileName: "",
@@ -514,7 +514,7 @@ func (s *provisionerSuite) TestRemoveUpgradeCharmProfileData(c *gc.C) {
 
 	apiMachine := s.assertGetOneMachine(c, s.machine.MachineTag())
 
-	err := apiMachine.RemoveUpgradeCharmProfileData()
+	err := apiMachine.RemoveUpgradeCharmProfileData(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -741,9 +741,9 @@ func (s *provisionerSuite) TestWatchContainersCharmProfiles(c *gc.C) {
 	defer wc.AssertStops()
 
 	// Update the upgrade-charm charm profile to trigger watcher.
-	container.SetUpgradeCharmProfile("app-name", "local:quantal/lxd-profile-0")
+	container.SetUpgradeCharmProfile(app.Name(), "local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(container.Id())
+	wc.AssertChange(container.Id() + "#" + app.Name())
 }
 
 func (s *provisionerSuite) TestWatchContainersAcceptsSupportedContainers(c *gc.C) {
@@ -1001,9 +1001,9 @@ func (s *provisionerSuite) TestWatchModelMachinesCharmProfiles(c *gc.C) {
 	defer wc.AssertStops()
 
 	// Trigger the watcher.
-	err = s.machine.SetUpgradeCharmProfile("lxd-profile", "local:quantal/lxd-profile-0")
+	err = s.machine.SetUpgradeCharmProfile(app.Name(), "local:quantal/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(s.machine.Id())
+	wc.AssertChange(s.machine.Id() + "#" + app.Name())
 }
 
 var _ = gc.Suite(&provisionerContainerSuite{})

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -246,6 +246,7 @@ func AllFacades() *facade.Registry {
 	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5) // v5 adds DistributionGroupByMachineId()
 	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6) // v6 adds more proxy settings
 	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7) // v7 adds charm profile watcher
+	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8) // v8 adds changes charm profile
 
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)
 	reg("ProxyUpdater", 2, proxyupdater.NewFacadeV2)

--- a/apiserver/facades/agent/provisioner/export_test.go
+++ b/apiserver/facades/agent/provisioner/export_test.go
@@ -13,6 +13,6 @@ func NewContainerProfileContext(result params.ContainerProfileResults, modelName
 	return &containerProfileContext{result: result, modelName: modelName}
 }
 
-func MachineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend) (params.ProfileChangeResult, error) {
-	return machineChangeProfileChangeInfo(machine, st)
+func MachineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend, appName string) (params.ProfileChangeResult, error) {
+	return machineChangeProfileChangeInfo(machine, st, appName)
 }

--- a/apiserver/facades/agent/provisioner/mocks/profile_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/profile_mock.go
@@ -71,30 +71,17 @@ func (mr *MockProfileMachineMockRecorder) ModelName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelName", reflect.TypeOf((*MockProfileMachine)(nil).ModelName))
 }
 
-// UpgradeCharmProfileApplication mocks base method
-func (m *MockProfileMachine) UpgradeCharmProfileApplication() (string, error) {
-	ret := m.ctrl.Call(m, "UpgradeCharmProfileApplication")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpgradeCharmProfileApplication indicates an expected call of UpgradeCharmProfileApplication
-func (mr *MockProfileMachineMockRecorder) UpgradeCharmProfileApplication() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCharmProfileApplication", reflect.TypeOf((*MockProfileMachine)(nil).UpgradeCharmProfileApplication))
-}
-
 // UpgradeCharmProfileCharmURL mocks base method
-func (m *MockProfileMachine) UpgradeCharmProfileCharmURL() (string, error) {
-	ret := m.ctrl.Call(m, "UpgradeCharmProfileCharmURL")
+func (m *MockProfileMachine) UpgradeCharmProfileCharmURL(arg0 string) (string, error) {
+	ret := m.ctrl.Call(m, "UpgradeCharmProfileCharmURL", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpgradeCharmProfileCharmURL indicates an expected call of UpgradeCharmProfileCharmURL
-func (mr *MockProfileMachineMockRecorder) UpgradeCharmProfileCharmURL() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCharmProfileCharmURL", reflect.TypeOf((*MockProfileMachine)(nil).UpgradeCharmProfileCharmURL))
+func (mr *MockProfileMachineMockRecorder) UpgradeCharmProfileCharmURL(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCharmProfileCharmURL", reflect.TypeOf((*MockProfileMachine)(nil).UpgradeCharmProfileCharmURL), arg0)
 }
 
 // MockProfileBackend is a mock of ProfileBackend interface

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -167,6 +167,11 @@ type ProvisionerAPIV7 struct {
 	*ProvisionerAPI
 }
 
+// ProvisionerAPIV8 provides v8 of the provisioner facade.
+type ProvisionerAPIV8 struct {
+	*ProvisionerAPI
+}
+
 // NewProvisionerAPIV4 creates a new server-side version 4 Provisioner API facade.
 func NewProvisionerAPIV4(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPIV4, error) {
 	provisionerAPI, err := NewProvisionerAPIV5(st, resources, authorizer)
@@ -201,6 +206,15 @@ func NewProvisionerAPIV7(st *state.State, resources facade.Resources, authorizer
 		return nil, errors.Trace(err)
 	}
 	return &ProvisionerAPIV7{provisionerAPI}, nil
+}
+
+// NewProvisionerAPIV8 creates a new server-side Provisioner API facade.
+func NewProvisionerAPIV8(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPIV8, error) {
+	provisionerAPI, err := NewProvisionerAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ProvisionerAPIV8{provisionerAPI}, nil
 }
 
 func (p *ProvisionerAPI) getMachine(canAccess common.AuthFunc, tag names.MachineTag) (*state.Machine, error) {
@@ -1314,7 +1328,6 @@ func (p *ProvisionerAPI) InstanceStatus(args params.Entities) (params.StatusResu
 }
 
 func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg params.EntityStatusArgs) error {
-	logger.Debugf("SetInstanceStatus called with: %#v", arg)
 	mTag, err := names.ParseMachineTag(arg.Tag)
 	if err != nil {
 		logger.Warningf("SetInstanceStatus called with %q which is not a valid machine tag: %v", arg.Tag, err)
@@ -1322,8 +1335,7 @@ func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg par
 	}
 	machine, err := p.getMachine(canAccess, mTag)
 	if err != nil {
-		logger.Debugf("SetInstanceStatus unable to get machine %q", mTag)
-		return err
+		return errors.Trace(err)
 	}
 	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
@@ -1344,7 +1356,6 @@ func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg par
 	if status.Status(arg.Status) == status.ProvisioningError ||
 		status.Status(arg.Status) == status.Error {
 		s.Status = status.Error
-		logger.Debugf("SetInstanceStatus triggering SetStatus for %#v", s)
 		if err = machine.SetStatus(s); err != nil {
 			return err
 		}
@@ -1414,15 +1425,15 @@ func (a *ProvisionerAPI) CACert() (params.BytesResult, error) {
 
 // CharmProfileChangeInfo retrieves the info necessary to change a charm
 // profile used by a machine.
-func (p *ProvisionerAPI) CharmProfileChangeInfo(machines params.Entities) (params.ProfileChangeResults, error) {
-	results := make([]params.ProfileChangeResult, len(machines.Entities))
+func (p *ProvisionerAPI) CharmProfileChangeInfo(args params.ProfileArgs) (params.ProfileChangeResults, error) {
+	results := make([]params.ProfileChangeResult, len(args.Args))
 	canAccess, err := p.getAuthFunc()
 	if err != nil {
 		logger.Errorf("failed to get an authorisation function: %v", err)
 		return params.ProfileChangeResults{}, errors.Trace(err)
 	}
-	for i, machine := range machines.Entities {
-		mTag, err := names.ParseMachineTag(machine.Tag)
+	for i, arg := range args.Args {
+		mTag, err := names.ParseMachineTag(arg.Entity.Tag)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -1432,7 +1443,7 @@ func (p *ProvisionerAPI) CharmProfileChangeInfo(machines params.Entities) (param
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		result, err := machineChangeProfileChangeInfo(&profileMachineShim{Machine: machine}, &profileBackendShim{p.st})
+		result, err := machineChangeProfileChangeInfo(&profileMachineShim{Machine: machine}, &profileBackendShim{p.st}, arg.AppName)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -1442,13 +1453,9 @@ func (p *ProvisionerAPI) CharmProfileChangeInfo(machines params.Entities) (param
 	return params.ProfileChangeResults{Results: results}, nil
 }
 
-func machineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend) (params.ProfileChangeResult, error) {
+func machineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend, appName string) (params.ProfileChangeResult, error) {
 	nothing := params.ProfileChangeResult{}
 
-	appName, err := machine.UpgradeCharmProfileApplication()
-	if err != nil {
-		return nothing, errors.Trace(err)
-	}
 	if appName == "" {
 		return nothing, errors.Trace(errors.New("no appname for profile charm upgrade"))
 	}
@@ -1463,7 +1470,7 @@ func machineChangeProfileChangeInfo(machine ProfileMachine, st ProfileBackend) (
 		return nothing, errors.Trace(err)
 	}
 
-	url, err := machine.UpgradeCharmProfileCharmURL()
+	url, err := machine.UpgradeCharmProfileCharmURL(appName)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}
@@ -1557,12 +1564,12 @@ func (p *ProvisionerAPI) SetUpgradeCharmProfileComplete(args params.SetProfileUp
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 	for i, a := range args.Args {
-		results[i].Error = common.ServerError(p.oneUpgradeCharmProfileComplete(a.Entity.Tag, a.Message, canAccess))
+		results[i].Error = common.ServerError(p.oneUpgradeCharmProfileComplete(a.Entity.Tag, a.AppName, a.Message, canAccess))
 	}
 	return params.ErrorResults{Results: results}, nil
 }
 
-func (p *ProvisionerAPI) oneUpgradeCharmProfileComplete(machineTag string, msg string, canAccess common.AuthFunc) error {
+func (p *ProvisionerAPI) oneUpgradeCharmProfileComplete(machineTag, appName, msg string, canAccess common.AuthFunc) error {
 	mTag, err := names.ParseMachineTag(machineTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1571,25 +1578,25 @@ func (p *ProvisionerAPI) oneUpgradeCharmProfileComplete(machineTag string, msg s
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return machine.SetUpgradeCharmProfileComplete(msg)
+	return machine.SetUpgradeCharmProfileComplete(appName, msg)
 }
 
 // RemoveUpgradeCharmProfileData completely removes the instance charm profile
 // data for a machine, even if the machine is dead.
-func (p *ProvisionerAPI) RemoveUpgradeCharmProfileData(args params.Entities) (params.ErrorResults, error) {
-	results := make([]params.ErrorResult, len(args.Entities))
+func (p *ProvisionerAPI) RemoveUpgradeCharmProfileData(args params.ProfileArgs) (params.ErrorResults, error) {
+	results := make([]params.ErrorResult, len(args.Args))
 	canAccess, err := p.getAuthFunc()
 	if err != nil {
 		logger.Errorf("failed to get an authorisation function: %v", err)
 		return params.ErrorResults{}, errors.Trace(err)
 	}
-	for i, a := range args.Entities {
-		results[i].Error = common.ServerError(p.oneRemoveUpgradeCharmProfileData(a.Tag, canAccess))
+	for i, a := range args.Args {
+		results[i].Error = common.ServerError(p.oneRemoveUpgradeCharmProfileData(a.Entity.Tag, a.AppName, canAccess))
 	}
 	return params.ErrorResults{Results: results}, nil
 }
 
-func (p *ProvisionerAPI) oneRemoveUpgradeCharmProfileData(machineTag string, canAccess common.AuthFunc) error {
+func (p *ProvisionerAPI) oneRemoveUpgradeCharmProfileData(machineTag, appName string, canAccess common.AuthFunc) error {
 	mTag, err := names.ParseMachineTag(machineTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -1598,5 +1605,5 @@ func (p *ProvisionerAPI) oneRemoveUpgradeCharmProfileData(machineTag string, can
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return machine.RemoveUpgradeCharmProfileData()
+	return machine.RemoveUpgradeCharmProfileData(appName)
 }

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -2012,10 +2012,9 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemoveUn
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return("", nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return("", nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")
@@ -2032,8 +2031,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemovePr
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return(charmURLString, nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 
 	cExp := s.charm.EXPECT()
@@ -2045,7 +2043,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoRemovePr
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")
@@ -2062,8 +2060,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoAddProfi
 		"juju-testme",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return(charmURLString, nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 	mExp.ModelName().Return("testme")
 
@@ -2079,7 +2076,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoAddProfi
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.NewProfileName, gc.Equals, "juju-testme-lxd-profile-alt-3")
@@ -2102,8 +2099,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoChangePr
 		"juju-testme-lxd-profile-alt-2",
 		"juju-testme-application-1",
 	}, nil)
-	mExp.UpgradeCharmProfileCharmURL().Return(charmURLString, nil)
-	mExp.UpgradeCharmProfileApplication().Return("lxd-profile-alt", nil)
+	mExp.UpgradeCharmProfileCharmURL("lxd-profile-alt").Return(charmURLString, nil)
 	mExp.Id().Return("2")
 
 	cExp := s.charm.EXPECT()
@@ -2118,7 +2114,7 @@ func (s *provisionerProfileMockSuite) TestMachineChangeProfileChangeInfoChangePr
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().Charm(gomock.Eq(chURL)).Return(s.charm, nil)
 
-	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend)
+	result, err := provisioner.MachineChangeProfileChangeInfo(s.machine, s.backend, "lxd-profile-alt")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.OldProfileName, gc.Equals, "juju-testme-lxd-profile-alt-2")

--- a/apiserver/facades/agent/provisioner/shim.go
+++ b/apiserver/facades/agent/provisioner/shim.go
@@ -36,8 +36,7 @@ type profileMachineShim struct {
 
 //go:generate mockgen -package mocks -destination mocks/profile_mock.go github.com/juju/juju/apiserver/facades/agent/provisioner ProfileMachine,ProfileBackend,ProfileCharm
 type ProfileMachine interface {
-	UpgradeCharmProfileApplication() (string, error)
-	UpgradeCharmProfileCharmURL() (string, error)
+	UpgradeCharmProfileCharmURL(string) (string, error)
 	CharmProfiles() ([]string, error)
 	ModelName() string
 	Id() string

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -27,7 +27,7 @@ type LXDProfileBackend interface {
 type LXDProfileMachine interface {
 	WatchLXDProfileUpgradeNotifications(string) (state.StringsWatcher, error)
 	Units() ([]LXDProfileUnit, error)
-	RemoveUpgradeCharmProfileData() error
+	RemoveUpgradeCharmProfileData(string) error
 }
 
 // LXDProfileUnit describes unit-receiver state methods
@@ -35,6 +35,7 @@ type LXDProfileMachine interface {
 type LXDProfileUnit interface {
 	Tag() names.Tag
 	AssignedMachineId() (string, error)
+	ApplicationName() string
 }
 
 type LXDProfileAPI struct {
@@ -200,7 +201,12 @@ func (u *LXDProfileAPI) RemoveUpgradeCharmProfileData(args params.Entities) (par
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		err = machine.RemoveUpgradeCharmProfileData()
+		unit, err := u.getUnit(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		err = machine.RemoveUpgradeCharmProfileData(unit.ApplicationName())
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/agent/uniter/mocks/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/lxdprofile.go
@@ -85,15 +85,15 @@ func (m *MockLXDProfileMachine) EXPECT() *MockLXDProfileMachineMockRecorder {
 }
 
 // RemoveUpgradeCharmProfileData mocks base method
-func (m *MockLXDProfileMachine) RemoveUpgradeCharmProfileData() error {
-	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData")
+func (m *MockLXDProfileMachine) RemoveUpgradeCharmProfileData(arg0 string) error {
+	ret := m.ctrl.Call(m, "RemoveUpgradeCharmProfileData", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveUpgradeCharmProfileData indicates an expected call of RemoveUpgradeCharmProfileData
-func (mr *MockLXDProfileMachineMockRecorder) RemoveUpgradeCharmProfileData() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockLXDProfileMachine)(nil).RemoveUpgradeCharmProfileData))
+func (mr *MockLXDProfileMachineMockRecorder) RemoveUpgradeCharmProfileData(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockLXDProfileMachine)(nil).RemoveUpgradeCharmProfileData), arg0)
 }
 
 // Units mocks base method
@@ -143,6 +143,18 @@ func NewMockLXDProfileUnit(ctrl *gomock.Controller) *MockLXDProfileUnit {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileUnit) EXPECT() *MockLXDProfileUnitMockRecorder {
 	return m.recorder
+}
+
+// ApplicationName mocks base method
+func (m *MockLXDProfileUnit) ApplicationName() string {
+	ret := m.ctrl.Call(m, "ApplicationName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ApplicationName indicates an expected call of ApplicationName
+func (mr *MockLXDProfileUnitMockRecorder) ApplicationName() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockLXDProfileUnit)(nil).ApplicationName))
 }
 
 // AssignedMachineId mocks base method

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -100,8 +100,8 @@ type Charm interface {
 type Machine interface {
 	IsLockedForSeriesUpgrade() (bool, error)
 	IsParentLockedForSeriesUpgrade() (bool, error)
-	UpgradeCharmProfileComplete() (string, error)
-	RemoveUpgradeCharmProfileData() error
+	UpgradeCharmProfileComplete(string) (string, error)
+	RemoveUpgradeCharmProfileData(string) error
 }
 
 // Relation defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -385,13 +385,13 @@ func (m *mockMachine) Id() string {
 	return m.id
 }
 
-func (m *mockMachine) UpgradeCharmProfileComplete() (string, error) {
-	m.MethodCall(m, "UpgradeCharmProfileComplete")
+func (m *mockMachine) UpgradeCharmProfileComplete(appName string) (string, error) {
+	m.MethodCall(m, "UpgradeCharmProfileComplete", appName)
 	return m.upgradeCharmProfileComplete, m.NextErr()
 }
 
-func (m *mockMachine) RemoveUpgradeCharmProfileData() error {
-	m.MethodCall(m, "RemoveUpgradeCharmProfileData")
+func (m *mockMachine) RemoveUpgradeCharmProfileData(appName string) error {
+	m.MethodCall(m, "RemoveUpgradeCharmProfileData", appName)
 	return m.NextErr()
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1404,6 +1404,15 @@ type UpgradeSeriesUnitsResult struct {
 	UnitNames []string `json:"unit-names"`
 }
 
+type ProfileArg struct {
+	Entity  Entity `json:"entity"`
+	AppName string `json:"app-name"`
+}
+
+type ProfileArgs struct {
+	Args []ProfileArg `json:"args"`
+}
+
 type ProfileChangeResult struct {
 	OldProfileName string           `json:"old-profile-name,omitempty"`
 	NewProfileName string           `json:"new-profile-name,omitempty"`
@@ -1431,5 +1440,6 @@ type SetProfileUpgradeCompleteArgs struct {
 
 type SetProfileUpgradeCompleteArg struct {
 	Entity  Entity `json:"entity"`
+	AppName string `json:"app-name"`
 	Message string `json:"message"`
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2073,14 +2073,14 @@ func (s *ApplicationSuite) TestAddSubordinateUnitCharmProfile(c *gc.C) {
 func (s *ApplicationSuite) TestSetCharmProfile(c *gc.C) {
 	machine, profileApp, subApp := s.assertCharmProfileSubordinate(c)
 
-	err := machine.RemoveUpgradeCharmProfileData()
+	err := machine.RemoveUpgradeCharmProfileData(profileApp.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = profileApp.SetCharmProfile("local:quantal/quantal-lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
 	assertUpgradeCharmProfile(c, machine, profileApp.Name(), "local:quantal/quantal-lxd-profile-0")
 
-	err = machine.RemoveUpgradeCharmProfileData()
+	err = machine.RemoveUpgradeCharmProfileData(subApp.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subApp.SetCharmProfile("local:quantal/quantal-lxd-profile-subordinate-0")
@@ -2119,10 +2119,7 @@ func assertUpgradeCharmProfile(c *gc.C, m *state.Machine, appName, charmURL stri
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	chAppName, err := m.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, appName)
-	chCharmURL, err := m.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := m.UpgradeCharmProfileCharmURL(appName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, charmURL)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -216,16 +216,16 @@ func (s *MachineSuite) TestSetUpgradeCharmProfileComplete(c *gc.C) {
 	err = unit.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m.SetUpgradeCharmProfile("app-name", "local:quantal/quantal-lxd-profile-0")
+	err = m.SetUpgradeCharmProfile(app.Name(), "local:quantal/quantal-lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
+	err = m.SetUpgradeCharmProfileComplete(app.Name(), lxdprofile.SuccessStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, err := m.UpgradeCharmProfileComplete()
+	status, err := m.UpgradeCharmProfileComplete(app.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, lxdprofile.SuccessStatus)
 }
@@ -234,13 +234,10 @@ func assertUpgradeCharmProfileNotRequired(c *gc.C, m *state.Machine, expectedApp
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedAppName, err := m.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedAppName, gc.Equals, expectedAppName)
-	charmURL, err := m.UpgradeCharmProfileCharmURL()
+	charmURL, err := m.UpgradeCharmProfileCharmURL(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, gc.Equals, "")
-	status, err := m.UpgradeCharmProfileComplete()
+	status, err := m.UpgradeCharmProfileComplete(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, lxdprofile.NotRequiredStatus)
 }
@@ -249,13 +246,10 @@ func assertUpgradeCharmProfileRequired(c *gc.C, m *state.Machine, expectedAppNam
 	err := m.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedAppName, err := m.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedAppName, gc.Equals, expectedAppName)
-	obtainedCharmURL, err := m.UpgradeCharmProfileCharmURL()
+	obtainedCharmURL, err := m.UpgradeCharmProfileCharmURL(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedCharmURL, gc.Equals, expectedCharmURL)
-	status, err := m.UpgradeCharmProfileComplete()
+	status, err := m.UpgradeCharmProfileComplete(expectedAppName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, lxdprofile.EmptyStatus)
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -373,7 +373,6 @@ func (s *MigrationSuite) TestInstanceCharmProfileDataFields(c *gc.C) {
 		// DocID is the model + machine id
 		"DocID",
 		"MachineId",
-		"UpgradeCharmProfileApplication",
 		"UpgradeCharmProfileCharmURL",
 		"UpgradeCharmProfileComplete",
 	)

--- a/state/unit.go
+++ b/state/unit.go
@@ -3022,5 +3022,6 @@ func (u *Unit) RemoveUpgradeCharmProfileData() error {
 	if err != nil {
 		return err
 	}
-	return machine.RemoveUpgradeCharmProfileData()
+
+	return machine.RemoveUpgradeCharmProfileData(u.doc.Application)
 }

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -151,10 +151,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementAddCharmProfile(c *gc.C
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	chAppName, err := machine.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, name)
-	chCharmURL, err := machine.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := machine.UpgradeCharmProfileCharmURL(name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, charm.URL().String())
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -637,10 +637,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 	c.Assert(colocated.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Alive)
 
-	chAppName, err := host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, "lxd-profile")
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithProfile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
@@ -668,10 +665,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroy(c *gc.C) {
 
 	// "", nil is equivalent to IsNotFound, which is what we
 	// expect here
-	chAppName, err := host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, "")
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithOutProfile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
@@ -695,19 +689,13 @@ func (s *UnitSuite) TestRemoveUnitMachineDestroyCleanUpProfileDoc(c *gc.C) {
 	// to check it's been deleted.
 	err = host.SetUpgradeCharmProfile(applicationWithProfile.Name(), charmWithProfile.URL().String())
 	c.Assert(err, jc.ErrorIsNil)
-	chAppName, err := host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, applicationWithProfile.Name())
 
 	c.Assert(unit.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Dying)
 
 	// "", nil is equivalent to IsNotFound, which is what we
 	// expect here
-	chAppName, err = host.UpgradeCharmProfileApplication()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(chAppName, gc.Equals, "")
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL()
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(applicationWithProfile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -803,7 +803,7 @@ func (w *minUnitsWatcher) Changes() <-chan []string {
 // WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies of
 // changes to the upgrade charm profile charm url for a machine.
 func (st *State) WatchModelMachinesCharmProfiles() (StringsWatcher, error) {
-	isMachineRegexp := fmt.Sprintf("^%s:%s$", st.ModelUUID(), names.NumberSnippet)
+	isMachineRegexp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), names.NumberSnippet, names.ApplicationSnippet)
 	return st.watchCharmProfiles(isMachineRegexp)
 }
 
@@ -811,7 +811,7 @@ func (st *State) WatchModelMachinesCharmProfiles() (StringsWatcher, error) {
 // the provisioner should update the charm profiles used by any container on
 // the machine.
 func (m *Machine) WatchContainersCharmProfiles(ctype instance.ContainerType) (StringsWatcher, error) {
-	isChildRegexp := fmt.Sprintf("^%s/%s/%s$", m.doc.DocID, ctype, names.NumberSnippet)
+	isChildRegexp := fmt.Sprintf("^%s/%s/%s#%s$", m.doc.DocID, ctype, names.NumberSnippet, names.ApplicationSnippet)
 	return m.st.watchCharmProfiles(isChildRegexp)
 }
 
@@ -898,33 +898,34 @@ func (w *modelFieldChangeWatcher) initial() (set.Strings, error) {
 	for iter.Next(&doc) {
 		// If no members criteria is specified, use the filter
 		// to reject any unsuitable initial elements.
-		if w.members == nil && w.filter != nil && !w.filter(doc.MachineId) {
+		if w.members == nil && w.filter != nil && !w.filter(doc.DocID) {
 			continue
 		}
 
 		if w.completed(doc) {
-			logger.Tracef("field change NOT watching machine %s", doc.MachineId)
+			logger.Tracef("field change NOT watching %s", doc.DocID)
 			continue
 		}
 
 		docField := w.accessor(doc)
-		w.known[doc.MachineId] = docField
-		machineIds.Add(doc.MachineId)
+		docId := w.backend.localID(doc.DocID)
+		w.known[docId] = docField
+		machineIds.Add(docId)
 	}
 	if machineIds.Size() > 0 {
-		logger.Debugf("started field change watching of machines %s", machineIds.Values())
+		logger.Debugf("started field change watching %s", machineIds.Values())
 	}
 	return machineIds, iter.Close()
 }
 
 func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.Change) error {
-	machineId := w.backend.localID(change.Id.(string))
+	docId := w.backend.localID(change.Id.(string))
 	if change.Revno == -1 {
-		if _, ok := w.known[machineId]; ok {
-			logger.Tracef("stopped field change watching for machine %q", machineId)
+		if _, ok := w.known[docId]; ok {
+			logger.Tracef("stopped field change watching for %q", docId)
 		}
-		delete(w.known, machineId)
-		machineIds.Remove(machineId)
+		delete(w.known, docId)
+		machineIds.Remove(docId)
 		return nil
 	}
 
@@ -939,12 +940,12 @@ func (w *modelFieldChangeWatcher) merge(machineIds set.Strings, change watcher.C
 	// get the document field from the accessor
 	docField := w.accessor(doc)
 
-	// check the field before adding to the machineId
-	field, isKnown := w.known[machineId]
-	w.known[machineId] = docField
+	// check the field before adding to the docId
+	field, isKnown := w.known[docId]
+	w.known[docId] = docField
 	if !w.completed(doc) && (!isKnown || docField != field) {
-		logger.Debugf("added field change watching for machine %q", machineId)
-		machineIds.Add(machineId)
+		logger.Debugf("added field change watching for %q", docId)
+		machineIds.Add(docId)
 	}
 	return nil
 }
@@ -1939,13 +1940,14 @@ func (u *Unit) WatchMeterStatus() NotifyWatcher {
 // upgrade completed field that is specific to an application name.
 func (m *Machine) WatchLXDProfileUpgradeNotifications(applicationName string) (StringsWatcher, error) {
 	filter := func(id interface{}) bool {
-		machineId, err := m.st.strictLocalID(id.(string))
+		docId, err := m.st.strictLocalID(id.(string))
 		if err != nil {
 			return false
 		}
-		return machineId == m.doc.Id
+		return docId == m.doc.Id+"#"+applicationName
 	}
-	return newInstanceCharmProfileDataWatcher(m.st, applicationName, m.doc.DocID, filter), nil
+	docId := m.instanceCharmProfileDataId(applicationName)
+	return newInstanceCharmProfileDataWatcher(m.st, docId, filter), nil
 }
 
 // WatchLXDProfileUpgradeNotifications returns a watcher that observes the status
@@ -1971,23 +1973,21 @@ func (u *Unit) WatchLXDProfileUpgradeNotifications(applicationName string) (Stri
 // data document.
 type instanceCharmProfileDataWatcher struct {
 	commonWatcher
-	// members is used to select the initial set of interesting entities.
-	memberId        string
-	known           string
-	applicationName string
-	filter          func(interface{}) bool
-	out             chan []string
+	// docId is used to select the initial interesting entities.
+	docId  string
+	known  string
+	filter func(interface{}) bool
+	out    chan []string
 }
 
 var _ Watcher = (*instanceCharmProfileDataWatcher)(nil)
 
-func newInstanceCharmProfileDataWatcher(backend modelBackend, applicationName, memberId string, filter func(interface{}) bool) StringsWatcher {
+func newInstanceCharmProfileDataWatcher(backend modelBackend, memberId string, filter func(interface{}) bool) StringsWatcher {
 	w := &instanceCharmProfileDataWatcher{
-		commonWatcher:   newCommonWatcher(backend),
-		memberId:        memberId,
-		applicationName: applicationName,
-		filter:          filter,
-		out:             make(chan []string),
+		commonWatcher: newCommonWatcher(backend),
+		docId:         memberId,
+		filter:        filter,
+		out:           make(chan []string),
 	}
 	w.tomb.Go(func() error {
 		defer close(w.out)
@@ -2004,14 +2004,13 @@ func (w *instanceCharmProfileDataWatcher) initial() error {
 
 	var instanceData instanceCharmProfileData
 	if err := instanceDataCol.Find(bson.D{
-		{"_id", w.memberId},
-		{"upgradecharmprofileapplication", w.applicationName},
+		{"_id", w.docId},
 	}).One(&instanceData); err == nil {
 		statusField = instanceData.UpgradeCharmProfileComplete
 	}
 	w.known = statusField
 
-	logger.Tracef("Started watching instanceCharmProfileData for machine %s and application %q: %q", w.memberId, w.applicationName, statusField)
+	logger.Tracef("Started watching instanceCharmProfileData for %q: %q", w.docId, statusField)
 	return nil
 }
 
@@ -2025,14 +2024,13 @@ func (w *instanceCharmProfileDataWatcher) merge(change watcher.Change) (bool, er
 
 	var instanceData instanceCharmProfileData
 	if err := instanceDataCol.Find(bson.D{
-		{"_id", machineId},
-		{"upgradecharmprofileapplication", w.applicationName},
+		{"_id", w.docId},
 	}).One(&instanceData); err != nil {
 		if err != mgo.ErrNotFound {
 			logger.Debugf("instanceCharmProfileData NOT mgo err not found")
 			return false, err
 		}
-		logger.Tracef("instanceCharmProfileData for %s on machine %s: mgo err not found", w.applicationName, machineId)
+		logger.Tracef("instanceCharmProfileData for %q: mgo err not found", machineId)
 		return false, nil
 	}
 
@@ -2041,7 +2039,7 @@ func (w *instanceCharmProfileDataWatcher) merge(change watcher.Change) (bool, er
 	if w.known != currentField {
 		w.known = currentField
 
-		logger.Tracef("Changes in watching instanceCharmProfileData for machine %s and application %q: %q", w.memberId, w.applicationName, currentField)
+		logger.Tracef("Changes in watching instanceCharmProfileData for %q: %q", w.docId, currentField)
 		return true, nil
 	}
 	return false, nil

--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -138,6 +138,14 @@ func findDNSServerConfig() (*network.DNSConfig, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		// network.ParseResolvConf returns nil error and nil dnsConfig if the
+		// file isn't found, which can lead to a panic when attemptting to
+		// access the dnsConfig.Nameservers. So instead, just continue and
+		// exhaust the resolvConfFiles slice.
+		if dnsConfig == nil {
+			logger.Tracef("The DNS configuration from %s returned no dnsConfig")
+			continue
+		}
 		for _, nameServer := range dnsConfig.Nameservers {
 			if nameServer.Scope != network.ScopeMachineLocal {
 				logger.Debugf("The DNS configuration from %s has been selected for use", dnsConfigFile)

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -75,6 +75,6 @@ func ProcessProfileChanges(p ProvisionerTask, ids []string) error {
 	return p.(*provisionerTask).processProfileChanges(ids)
 }
 
-func ProcessOneMachineProfileChanges(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler) (bool, error) {
-	return processOneMachineProfileChange(m, profileBroker)
+func ProcessOneProfileChanges(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler, appName string) (bool, error) {
+	return processOneProfileChange(m, profileBroker, appName)
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -356,8 +356,14 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	}
 
 	machineTags := make([]names.MachineTag, len(ids))
+	appNames := make([]string, len(ids))
 	for i, id := range ids {
-		machineTags[i] = names.NewMachineTag(id)
+		machineId, appName, err := machineIdAndAppName(id)
+		if err != nil {
+			return errors.Annotatef(err, "failed to parse ids: %v", ids)
+		}
+		machineTags[i] = names.NewMachineTag(machineId)
+		appNames[i] = appName
 	}
 	machines, err := task.machineGetter.Machines(machineTags...)
 	if err != nil {
@@ -366,7 +372,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	profileBroker, ok := task.broker.(environs.LXDProfiler)
 	if !ok {
 		logger.Debugf("Attempting to update the profile of a machine that doesn't support profiles")
-		profileUpgradeNotSupported(machines)
+		profileUpgradeNotSupported(machines, appNames)
 		return nil
 	}
 	for i, mResult := range machines {
@@ -374,17 +380,17 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			return errors.Annotatef(err, "failed to get machine %v", machineTags[i])
 		}
 		m := mResult.Machine
-		removeDoc, err := processOneMachineProfileChange(m, profileBroker)
+		removeDoc, err := processOneProfileChange(m, profileBroker, appNames[i])
 		if removeDoc {
 			if err != nil {
 				logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
 			}
-			if err := m.RemoveUpgradeCharmProfileData(); err != nil {
+			if err := m.RemoveUpgradeCharmProfileData(appNames[i]); err != nil {
 				logger.Errorf("cannot remove subordinates upgrade charm profile data: %s", err.Error())
 			}
 		} else if err != nil {
 			logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
-			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
+			if err2 := m.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.AnnotateErrorStatus(err)); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for instance charm profile data for machine %q", m)
 			}
 			// If Error, SetInstanceStatus in the provisioner api will also call
@@ -401,7 +407,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 			if err2 := m.SetStatus(status.Started, "", nil); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for machine %q agent", m)
 			}
-			if err2 := m.SetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus); err2 != nil {
+			if err2 := m.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.SuccessStatus); err2 != nil {
 				return errors.Annotatef(err2, "cannot set success status for instance charm profile data for machine %q", m)
 			}
 		}
@@ -409,20 +415,29 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 	return nil
 }
 
-func profileUpgradeNotSupported(machines []apiprovisioner.MachineResult) {
-	for _, mResult := range machines {
-		if err := mResult.Machine.SetUpgradeCharmProfileComplete(lxdprofile.NotSupportedStatus); err != nil {
+func machineIdAndAppName(id string) (string, string, error) {
+	parts := strings.Split(id, "#")
+	if len(parts) != 2 {
+		return "", "", errors.Errorf("%q not in machine#application format", id)
+	}
+	return parts[0], parts[1], nil
+}
+
+func profileUpgradeNotSupported(machines []apiprovisioner.MachineResult, appNames []string) {
+	for i, mResult := range machines {
+		if err := mResult.Machine.SetUpgradeCharmProfileComplete(appNames[i], lxdprofile.NotSupportedStatus); err != nil {
 			logger.Errorf("cannot set not supported status for instance charm profile data: %s", err.Error())
 		}
 	}
 }
 
-func processOneMachineProfileChange(
+func processOneProfileChange(
 	m apiprovisioner.MachineProvisioner,
 	profileBroker environs.LXDProfiler,
+	appName string,
 ) (bool, error) {
-	logger.Debugf("processOneMachineProfileChange(%s)", m.Id())
-	info, err := m.CharmProfileChangeInfo()
+	logger.Debugf("processOneProfileChange(%s) %q", m.Id(), appName)
+	info, err := m.CharmProfileChangeInfo(appName)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Description of change

Don't apply when not provisioned  …
The following changes ensure that we don't attempt to apply a
charm profile to a machine that isn't either running or that isn't
provisioned.

Interestingly the charm profile will be written later on when ensuring
that the profile is there, by the provisioner API. So we don't have
to write any other code that to stop the applying of the charm
profile.

 - Add tests around provisioner task

## QA steps

Run the following commands to ensure that add machines correctly.
```sh
juju bootstrap lxd
juju deploy ~/bundle-no-sub.yaml
watch --color -n 1 juju status --color
```

You should see the following output in status:
```
Model    Controller  Cloud/Region  Version  SLA          Timestamp
default  xxx         lxd/default   2.5.1.1  unsupported  16:21:56Z

App          Version  Status  Scale  Charm        Store  Rev  OS      Notes
lxd-profile  18.04    active      9  lxd-profile  local    0  ubuntu  
ubuntu       18.04    active      9  ubuntu-lite  local    0  ubuntu  

Unit            Workload  Agent  Machine  Public address  Ports  Message
lxd-profile/0*  active    idle   0        10.178.104.238         load: 0.54, 1.18, 1.39
lxd-profile/1   active    idle   1        10.178.104.176         load: 0.50, 1.16, 1.38
lxd-profile/2   active    idle   2        10.178.104.163         load: 1.13, 1.14, 1.33
lxd-profile/3   active    idle   3        10.178.104.151         load: 1.26, 1.21, 1.35
lxd-profile/4   active    idle   4        10.178.104.226         load: 1.28, 1.17, 1.35
lxd-profile/5   active    idle   5        10.178.104.253         load: 1.26, 1.21, 1.35
lxd-profile/6   active    idle   6        10.178.104.47          load: 1.28, 1.17, 1.35
lxd-profile/7   active    idle   7        10.178.104.43          load: 1.16, 1.19, 1.34
lxd-profile/8   active    idle   8        10.178.104.185         load: 1.28, 1.17, 1.35
ubuntu/0*       active    idle   0        10.178.104.238         load: 1.06, 1.16, 1.33
ubuntu/1        active    idle   1        10.178.104.176         load: 1.13, 1.14, 1.33
ubuntu/2        active    idle   2        10.178.104.163         load: 0.66, 1.15, 1.37
ubuntu/3        active    idle   3        10.178.104.151         load: 0.66, 1.15, 1.37
ubuntu/4        active    idle   4        10.178.104.226         load: 1.13, 1.18, 1.33
ubuntu/5        active    idle   5        10.178.104.253         load: 0.66, 1.15, 1.37
ubuntu/6        active    idle   6        10.178.104.47          load: 0.61, 1.13, 1.37
ubuntu/7        active    idle   7        10.178.104.43          load: 1.13, 1.18, 1.33
ubuntu/8        active    idle   8        10.178.104.185         load: 1.13, 1.18, 1.33

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.178.104.238  juju-c02210-0  bionic      Running
1        started  10.178.104.176  juju-c02210-1  bionic      Running
2        started  10.178.104.163  juju-c02210-2  bionic      Running
3        started  10.178.104.151  juju-c02210-3  bionic      Running
4        started  10.178.104.226  juju-c02210-4  bionic      Running
5        started  10.178.104.253  juju-c02210-5  bionic      Running
6        started  10.178.104.47   juju-c02210-6  bionic      Running
7        started  10.178.104.43   juju-c02210-7  bionic      Running
8        started  10.178.104.185  juju-c02210-8  bionic      Running
```

And the `lxc profile list` should also state:
```
+----------------------------+---------+
|            NAME            | USED BY |
+----------------------------+---------+
| default                    | 10      |
+----------------------------+---------+
| juju-controller            | 1       |
+----------------------------+---------+
| juju-default               | 9       |
+----------------------------+---------+
| juju-default-lxd-profile-0 | 8       |
+----------------------------+---------+
``` 

bundle-no-sub.yaml
```yaml
series: bionic
applications:
  lxd-profile:
    charm: ~/go/src/github.com/juju/juju/testcharms/charm-repo/quantal/lxd-profile
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
  ubuntu:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
machines:
  "0": {}
  "1": {}
  "2": {}
  "3": {}
  "4": {}
  "5": {}
  "6": {}
  "7": {}
  "8": {}
```

## Documentation changes



## Bug reference
https://bugs.launchpad.net/juju/+bug/1813044

