### PR TITLE
raft-leases: don't try to expire leases when the store will expire them itself

### DIFF
--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -57,6 +57,11 @@ type Store interface {
 	// The return consists of each pinned lease and the collection of entities
 	// requiring its pinned behaviour.
 	Pinned() map[Key][]string
+
+	// Autoexpire indicates whether this store expires leases
+	// automatically as time is updated, or whether the client code
+	// needs to remove expired leases.
+	Autoexpire() bool
 }
 
 // Key fully identifies a lease, including the namespace and

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -126,13 +126,12 @@ func (s *Store) ExpireLease(key lease.Key) error {
 // Leases is part of lease.Store.
 func (s *Store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	leaseMap := s.fsm.Leases(s.config.Clock.Now, keys...)
-	result := make(map[lease.Key]lease.Info, len(leaseMap))
 	// Add trapdoors into the information from the FSM.
 	for k, v := range leaseMap {
 		v.Trapdoor = s.config.Trapdoor(k, v.Holder)
-		result[k] = v
+		leaseMap[k] = v
 	}
-	return result
+	return leaseMap
 }
 
 // Refresh is part of lease.Store.

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -86,6 +86,9 @@ type Store struct {
 	prevTime   time.Time
 }
 
+// Autoexpire is part of lease.Store.
+func (*Store) Autoexpire() bool { return true }
+
 // ClaimLease is part of lease.Store.
 func (s *Store) ClaimLease(key lease.Key, req lease.Request) error {
 	err := s.runOnLeader(&Command{

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -46,6 +46,9 @@ func newLeaseStore(clock clock.Clock, target raftlease.NotifyTarget, trapdoor ra
 	}
 }
 
+// Autoexpire is part of lease.Store.
+func (*leaseStore) Autoexpire() bool { return false }
+
 // ClaimLease is part of lease.Store.
 func (s *leaseStore) ClaimLease(key lease.Key, req lease.Request) error {
 	s.mu.Lock()

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -61,6 +61,9 @@ type store struct {
 	globalTime time.Time
 }
 
+// Autoexpire is part of the lease.Store interface.
+func (*store) Autoexpire() bool { return false }
+
 // Leases is part of the lease.Store interface.
 func (store *store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	cfg := store.config

--- a/worker/lease/fixture_test.go
+++ b/worker/lease/fixture_test.go
@@ -80,13 +80,16 @@ type Fixture struct {
 	// to the extent that it returns an error on Wait(); tests that don't set
 	// this flag will check that the manager's shutdown error is nil.
 	expectDirty bool
+
+	// autoexpire is whether the store should autoexpire.
+	autoexpire bool
 }
 
 // RunTest sets up a Manager and a Clock and passes them into the supplied
 // test function. The manager will be cleaned up afterwards.
 func (fix *Fixture) RunTest(c *gc.C, test func(*lease.Manager, *testclock.Clock)) {
 	clock := testclock.NewClock(defaultClockStart)
-	store := NewStore(fix.leases, fix.expectCalls)
+	store := NewStore(fix.autoexpire, fix.leases, fix.expectCalls)
 	manager, err := lease.NewManager(lease.ManagerConfig{
 		Clock: clock,
 		Store: store,

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -175,8 +175,13 @@ func (manager *Manager) choose(blocks blocks) error {
 	case check := <-manager.checks:
 		return manager.handleCheck(check)
 	case manager.now = <-manager.nextTick(manager.now):
-		manager.wg.Add(1)
-		go manager.retryingTick(manager.now)
+		// If we need to expire leases we should do it, otherwise this
+		// is just an opportunity to check for blocks that need to be
+		// notified.
+		if !manager.config.Store.Autoexpire() {
+			manager.wg.Add(1)
+			go manager.retryingTick(manager.now)
+		}
 	case claim := <-manager.claims:
 		manager.wg.Add(1)
 		go manager.retryingClaim(claim)

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -179,7 +179,7 @@ func (s *CrossSuite) TestCheckAcrossModels(c *gc.C) {
 
 func (s *CrossSuite) TestDifferentNamespaceValidation(c *gc.C) {
 	clock := testclock.NewClock(defaultClockStart)
-	store := NewStore(nil, nil)
+	store := NewStore(false, nil, nil)
 	manager, err := lease.NewManager(lease.ManagerConfig{
 		Clock: clock,
 		Store: store,

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -47,6 +47,7 @@ func (Secretary) CheckDuration(duration time.Duration) error {
 // Store implements corelease.Store for testing purposes.
 type Store struct {
 	mu           sync.Mutex
+	autoexpire   bool
 	leases       map[lease.Key]lease.Info
 	expect       []call
 	failed       chan error
@@ -56,7 +57,7 @@ type Store struct {
 
 // NewStore initializes and returns a new store configured to report
 // the supplied leases and expect the supplied calls.
-func NewStore(leases map[lease.Key]lease.Info, expect []call) *Store {
+func NewStore(autoexpire bool, leases map[lease.Key]lease.Info, expect []call) *Store {
 	if leases == nil {
 		leases = make(map[lease.Key]lease.Info)
 	}
@@ -65,10 +66,11 @@ func NewStore(leases map[lease.Key]lease.Info, expect []call) *Store {
 		close(done)
 	}
 	return &Store{
-		leases: leases,
-		expect: expect,
-		done:   done,
-		failed: make(chan error, 1000),
+		leases:     leases,
+		expect:     expect,
+		done:       done,
+		failed:     make(chan error, 1000),
+		autoexpire: autoexpire,
 	}
 }
 
@@ -86,6 +88,11 @@ func (store *Store) Wait(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("Store test took way too long")
 	}
+}
+
+// Autoexpire is part of the lease.Store interface.
+func (store *Store) Autoexpire() bool {
+	return store.autoexpire
 }
 
 // Leases is part of the lease.Store interface.


### PR DESCRIPTION
## Description of change

The raft lease store will automatically expire leases as time advances - it doesn't need the lease manager to do it. Avoiding this reduces the number of store.Leases() calls the manager needs to make, which should make it faster under heavy load.

Add an Autoexpire() method to the lease store interface - this returns false for the mongo store but true for the raft lease store. If autoexpire is true for a store we still wake up for ticks (so we can signal blocks that are waiting for leases to expire) but we don't scan all the leases looking for ones that need to be expired.

## QA steps

* Bootstrap and deploy multiple units of an app.
* Remove the leader unit.
* The lease should expire as usual and one of the other units should claim leadership.
* There shouldn't be any errors in the lease manager log about it trying to expire leases.

## Documentation changes

None

## Bug reference

None