### PR TITLE
Only delete storage pools that are not in use.

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -86,7 +86,7 @@ func (s *baseStorageSuite) assertCalls(c *gc.C, expectedCalls []string) {
 
 const (
 	allStorageInstancesCall                 = "allStorageInstances"
-	storagePoolsInUseCall                   = "storagePoolsInUseCall"
+	deleteStoragePoolCall                   = "deleteStoragePool"
 	storageInstanceAttachmentsCall          = "storageInstanceAttachments"
 	storageInstanceCall                     = "StorageInstance"
 	storageInstanceFilesystemCall           = "StorageInstanceFilesystem"
@@ -174,16 +174,14 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 			s.stub.AddCall(allStorageInstancesCall)
 			return []state.StorageInstance{s.storageInstance}, nil
 		},
-		storagePoolsInUse: func(pools []string) (map[string]bool, error) {
-			s.stub.AddCall(storagePoolsInUseCall, pools)
-			inUse := make(map[string]bool)
-			for _, p := range pools {
-				inUse[p] = false
-			}
+		deleteStoragePool: func(poolName string) error {
+			s.stub.AddCall(deleteStoragePoolCall)
 			for _, p := range s.poolsInUse {
-				inUse[p] = true
+				if p == poolName {
+					return errors.Errorf("storage pool %q in use", poolName)
+				}
 			}
-			return inUse, nil
+			return s.poolManager.Delete(poolName)
 		},
 		storageInstance: func(sTag names.StorageTag) (state.StorageInstance, error) {
 			s.stub.AddCall(storageInstanceCall, sTag)

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -86,7 +86,7 @@ func (s *baseStorageSuite) assertCalls(c *gc.C, expectedCalls []string) {
 
 const (
 	allStorageInstancesCall                 = "allStorageInstances"
-	deleteStoragePoolCall                   = "deleteStoragePool"
+	removeStoragePoolCall                   = "removeStoragePool"
 	storageInstanceAttachmentsCall          = "storageInstanceAttachments"
 	storageInstanceCall                     = "StorageInstance"
 	storageInstanceFilesystemCall           = "StorageInstanceFilesystem"
@@ -174,8 +174,8 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 			s.stub.AddCall(allStorageInstancesCall)
 			return []state.StorageInstance{s.storageInstance}, nil
 		},
-		deleteStoragePool: func(poolName string) error {
-			s.stub.AddCall(deleteStoragePoolCall)
+		removeStoragePool: func(poolName string) error {
+			s.stub.AddCall(removeStoragePoolCall)
 			for _, p := range s.poolsInUse {
 				if p == poolName {
 					return errors.Errorf("storage pool %q in use", poolName)

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -45,7 +45,7 @@ func (m *mockPoolManager) Replace(name, provider string, attrs map[string]interf
 
 type mockStorageAccessor struct {
 	storageInstance                     func(names.StorageTag) (state.StorageInstance, error)
-	deleteStoragePool                   func(string) error
+	removeStoragePool                   func(string) error
 	allStorageInstances                 func() ([]state.StorageInstance, error)
 	storageInstanceAttachments          func(names.StorageTag) ([]state.StorageAttachment, error)
 	storageInstanceVolume               func(names.StorageTag) (state.Volume, error)
@@ -83,8 +83,8 @@ func (st *mockStorageAccessor) StorageInstance(s names.StorageTag) (state.Storag
 	return st.storageInstance(s)
 }
 
-func (st *mockStorageAccessor) DeleteStoragePool(pool string) error {
-	return st.deleteStoragePool(pool)
+func (st *mockStorageAccessor) RemoveStoragePool(pool string) error {
+	return st.removeStoragePool(pool)
 }
 
 func (st *mockStorageAccessor) AllStorageInstances() ([]state.StorageInstance, error) {

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -45,8 +45,8 @@ func (m *mockPoolManager) Replace(name, provider string, attrs map[string]interf
 
 type mockStorageAccessor struct {
 	storageInstance                     func(names.StorageTag) (state.StorageInstance, error)
+	deleteStoragePool                   func(string) error
 	allStorageInstances                 func() ([]state.StorageInstance, error)
-	storagePoolsInUse                   func([]string) (map[string]bool, error)
 	storageInstanceAttachments          func(names.StorageTag) ([]state.StorageAttachment, error)
 	storageInstanceVolume               func(names.StorageTag) (state.Volume, error)
 	volumeAttachment                    func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
@@ -83,11 +83,12 @@ func (st *mockStorageAccessor) StorageInstance(s names.StorageTag) (state.Storag
 	return st.storageInstance(s)
 }
 
+func (st *mockStorageAccessor) DeleteStoragePool(pool string) error {
+	return st.deleteStoragePool(pool)
+}
+
 func (st *mockStorageAccessor) AllStorageInstances() ([]state.StorageInstance, error) {
 	return st.allStorageInstances()
-}
-func (st *mockStorageAccessor) StoragePoolsInUse(pools []string) (map[string]bool, error) {
-	return st.storagePoolsInUse(pools)
 }
 
 func (st *mockStorageAccessor) StorageAttachments(tag names.StorageTag) ([]state.StorageAttachment, error) {
@@ -433,12 +434,11 @@ func (u *mockUnit) AssignedMachineId() (string, error) {
 }
 
 type mockState struct {
-	modelTag         names.ModelTag
-	getBlockForType  func(t state.BlockType) (state.Block, bool, error)
-	unitName         string
-	unitErr          string
-	assignedMachine  string
-	applicationNames []string
+	modelTag        names.ModelTag
+	getBlockForType func(t state.BlockType) (state.Block, bool, error)
+	unitName        string
+	unitErr         string
+	assignedMachine string
 }
 
 func (st *mockState) ControllerTag() names.ControllerTag {
@@ -461,13 +461,4 @@ func (st *mockState) Unit(unitName string) (storage.Unit, error) {
 		return &mockUnit{assignedMachine: st.assignedMachine}, nil
 	}
 	return nil, errors.NotFoundf(unitName)
-}
-
-func (st *mockState) AllApplications() ([]*state.Application, error) {
-	var apps []*state.Application
-	for _ = range st.applicationNames {
-		apps = append(apps, &state.Application{})
-	}
-
-	return apps, nil
 }

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -46,6 +46,7 @@ func (m *mockPoolManager) Replace(name, provider string, attrs map[string]interf
 type mockStorageAccessor struct {
 	storageInstance                     func(names.StorageTag) (state.StorageInstance, error)
 	allStorageInstances                 func() ([]state.StorageInstance, error)
+	storagePoolsInUse                   func([]string) (map[string]bool, error)
 	storageInstanceAttachments          func(names.StorageTag) ([]state.StorageAttachment, error)
 	storageInstanceVolume               func(names.StorageTag) (state.Volume, error)
 	volumeAttachment                    func(names.Tag, names.VolumeTag) (state.VolumeAttachment, error)
@@ -84,6 +85,9 @@ func (st *mockStorageAccessor) StorageInstance(s names.StorageTag) (state.Storag
 
 func (st *mockStorageAccessor) AllStorageInstances() ([]state.StorageInstance, error) {
 	return st.allStorageInstances()
+}
+func (st *mockStorageAccessor) StoragePoolsInUse(pools []string) (map[string]bool, error) {
+	return st.storagePoolsInUse(pools)
 }
 
 func (st *mockStorageAccessor) StorageAttachments(tag names.StorageTag) ([]state.StorageAttachment, error) {
@@ -429,11 +433,12 @@ func (u *mockUnit) AssignedMachineId() (string, error) {
 }
 
 type mockState struct {
-	modelTag        names.ModelTag
-	getBlockForType func(t state.BlockType) (state.Block, bool, error)
-	unitName        string
-	unitErr         string
-	assignedMachine string
+	modelTag         names.ModelTag
+	getBlockForType  func(t state.BlockType) (state.Block, bool, error)
+	unitName         string
+	unitErr          string
+	assignedMachine  string
+	applicationNames []string
 }
 
 func (st *mockState) ControllerTag() names.ControllerTag {
@@ -456,4 +461,13 @@ func (st *mockState) Unit(unitName string) (storage.Unit, error) {
 		return &mockUnit{assignedMachine: st.assignedMachine}, nil
 	}
 	return nil, errors.NotFoundf(unitName)
+}
+
+func (st *mockState) AllApplications() ([]*state.Application, error) {
+	var apps []*state.Application
+	for _ = range st.applicationNames {
+		apps = append(apps, &state.Application{})
+	}
+
+	return apps, nil
 }

--- a/apiserver/facades/client/storage/pooldelete_test.go
+++ b/apiserver/facades/client/storage/pooldelete_test.go
@@ -30,6 +30,13 @@ func (s *poolDeleteSuite) createPools(c *gc.C, num int) {
 	}
 }
 
+func (s *poolDeleteSuite) createOperatorStorage(c *gc.C) {
+	poolName := "operator-storage"
+	pool, err := storage.NewConfig(poolName, provider.LoopProviderType, map[string]interface{}{"zip": "zap"})
+	c.Assert(err, jc.ErrorIsNil)
+	s.baseStorageSuite.pools[poolName] = pool
+}
+
 func (s *poolDeleteSuite) TestRemovePool(c *gc.C) {
 	s.createPools(c, 1)
 	poolName := fmt.Sprintf("%v%v", tstName, 0)
@@ -65,4 +72,108 @@ func (s *poolDeleteSuite) TestDeleteNotExists(c *gc.C) {
 	pools, err := s.poolManager.List()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pools, gc.HasLen, 0)
+}
+
+func (s *poolDeleteSuite) TestDeleteInUse(c *gc.C) {
+	s.createPools(c, 1)
+	poolName := fmt.Sprintf("%v%v", tstName, 0)
+	s.poolsInUse = []string{poolName}
+	args := params.StoragePoolDeleteArgs{
+		Pools: []params.StoragePoolDeleteArg{{
+			Name: poolName,
+		}},
+	}
+	results, err := s.api.DeletePool(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, fmt.Sprintf("pool %q in use", poolName))
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
+}
+
+func (s *poolDeleteSuite) TestDeleteSomeInUse(c *gc.C) {
+	s.createPools(c, 2)
+	poolNameInUse := fmt.Sprintf("%v%v", tstName, 0)
+	poolNameNotInUse := fmt.Sprintf("%v%v", tstName, 1)
+	s.poolsInUse = []string{poolNameInUse}
+	args := params.StoragePoolDeleteArgs{
+		Pools: []params.StoragePoolDeleteArg{{
+			Name: poolNameInUse,
+		}, {
+			Name: poolNameNotInUse,
+		}},
+	}
+	results, err := s.api.DeletePool(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, fmt.Sprintf("pool %q in use", poolNameInUse))
+	c.Assert(results.Results[1].Error, gc.IsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
+}
+
+func (s *poolDeleteSuite) TestDeleteOperatorStorageInUse(c *gc.C) {
+	s.createPools(c, 1)
+	s.createOperatorStorage(c)
+	s.state.applicationNames = []string{"mariadb"}
+	poolNameInUse := "operator-storage"
+	// operator-storage is not included in the results of the StoragePoolsInUse call.
+	args := params.StoragePoolDeleteArgs{
+		Pools: []params.StoragePoolDeleteArg{{
+			Name: poolNameInUse,
+		}},
+	}
+	results, err := s.apiCaas.DeletePool(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, fmt.Sprintf("pool %q in use", poolNameInUse))
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 2)
+}
+
+func (s *poolDeleteSuite) TestDeleteOperatorStorageNotInUse(c *gc.C) {
+	s.createPools(c, 1)
+	s.createOperatorStorage(c)
+	poolNameInUse := "operator-storage"
+	// operator-storage is not included in the results of the StoragePoolsInUse call.
+	args := params.StoragePoolDeleteArgs{
+		Pools: []params.StoragePoolDeleteArg{{
+			Name: poolNameInUse,
+		}},
+	}
+	results, err := s.apiCaas.DeletePool(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
+}
+
+func (s *poolDeleteSuite) TestDeleteOperatorStorageIgnoresIAAS(c *gc.C) {
+	s.createPools(c, 1)
+	s.createOperatorStorage(c)
+	s.state.applicationNames = []string{"mariadb"}
+	poolNameInUse := "operator-storage"
+	// operator-storage is not included in the results of the StoragePoolsInUse call.
+	args := params.StoragePoolDeleteArgs{
+		Pools: []params.StoragePoolDeleteArg{{
+			Name: poolNameInUse,
+		}},
+	}
+	results, err := s.api.DeletePool(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	pools, err := s.poolManager.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pools, gc.HasLen, 1)
 }

--- a/apiserver/facades/client/storage/poolremove_test.go
+++ b/apiserver/facades/client/storage/poolremove_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/juju/juju/storage/provider"
 )
 
-type poolDeleteSuite struct {
+type poolRemoveSuite struct {
 	baseStorageSuite
 }
 
-var _ = gc.Suite(&poolDeleteSuite{})
+var _ = gc.Suite(&poolRemoveSuite{})
 
-func (s *poolDeleteSuite) createPools(c *gc.C, num int) {
+func (s *poolRemoveSuite) createPools(c *gc.C, num int) {
 	var err error
 	for i := 0; i < num; i++ {
 		poolName := fmt.Sprintf("%v%v", tstName, i)
@@ -30,7 +30,7 @@ func (s *poolDeleteSuite) createPools(c *gc.C, num int) {
 	}
 }
 
-func (s *poolDeleteSuite) TestRemovePool(c *gc.C) {
+func (s *poolRemoveSuite) TestRemovePool(c *gc.C) {
 	s.createPools(c, 1)
 	poolName := fmt.Sprintf("%v%v", tstName, 0)
 
@@ -49,7 +49,7 @@ func (s *poolDeleteSuite) TestRemovePool(c *gc.C) {
 	c.Assert(pools, gc.HasLen, 0)
 }
 
-func (s *poolDeleteSuite) TestDeleteNotExists(c *gc.C) {
+func (s *poolRemoveSuite) TestRemoveNotExists(c *gc.C) {
 	poolName := fmt.Sprintf("%v%v", tstName, 0)
 
 	args := params.StoragePoolDeleteArgs{
@@ -67,7 +67,7 @@ func (s *poolDeleteSuite) TestDeleteNotExists(c *gc.C) {
 	c.Assert(pools, gc.HasLen, 0)
 }
 
-func (s *poolDeleteSuite) TestDeleteInUse(c *gc.C) {
+func (s *poolRemoveSuite) TestRemoveInUse(c *gc.C) {
 	s.createPools(c, 1)
 	poolName := fmt.Sprintf("%v%v", tstName, 0)
 	s.poolsInUse = []string{poolName}
@@ -86,7 +86,7 @@ func (s *poolDeleteSuite) TestDeleteInUse(c *gc.C) {
 	c.Assert(pools, gc.HasLen, 1)
 }
 
-func (s *poolDeleteSuite) TestDeleteSomeInUse(c *gc.C) {
+func (s *poolRemoveSuite) TestRemoveSomeInUse(c *gc.C) {
 	s.createPools(c, 2)
 	poolNameInUse := fmt.Sprintf("%v%v", tstName, 0)
 	poolNameNotInUse := fmt.Sprintf("%v%v", tstName, 1)

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -33,6 +33,9 @@ type storageInterface interface {
 	// AllStorageInstances is required for storage functionality.
 	AllStorageInstances() ([]state.StorageInstance, error)
 
+	// StoragePoolsInUse is required to sanity check pool deletions
+	StoragePoolsInUse([]string) (map[string]bool, error)
+
 	// StorageAttachments is required for storage functionality.
 	StorageAttachments(names.StorageTag) ([]state.StorageAttachment, error)
 
@@ -141,6 +144,7 @@ func unitAssignedMachine(backend backend, tag names.UnitTag) (names.MachineTag, 
 }
 
 type backend interface {
+	AllApplications() ([]*state.Application, error)
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	Unit(string) (Unit, error)

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -33,8 +33,8 @@ type storageInterface interface {
 	// AllStorageInstances is required for storage functionality.
 	AllStorageInstances() ([]state.StorageInstance, error)
 
-	// DeleteStoragePool removes a pool only if its not currently in use
-	DeleteStoragePool(poolName string) error
+	// RemoveStoragePool removes a pool only if its not currently in use
+	RemoveStoragePool(poolName string) error
 
 	// StorageAttachments is required for storage functionality.
 	StorageAttachments(names.StorageTag) ([]state.StorageAttachment, error)

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -33,8 +33,8 @@ type storageInterface interface {
 	// AllStorageInstances is required for storage functionality.
 	AllStorageInstances() ([]state.StorageInstance, error)
 
-	// StoragePoolsInUse is required to sanity check pool deletions
-	StoragePoolsInUse([]string) (map[string]bool, error)
+	// DeleteStoragePool removes a pool only if its not currently in use
+	DeleteStoragePool(poolName string) error
 
 	// StorageAttachments is required for storage functionality.
 	StorageAttachments(names.StorageTag) ([]state.StorageAttachment, error)

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -144,7 +144,6 @@ func unitAssignedMachine(backend backend, tag names.UnitTag) (names.MachineTag, 
 }
 
 type backend interface {
-	AllApplications() ([]*state.Application, error)
 	ControllerTag() names.ControllerTag
 	ModelTag() names.ModelTag
 	Unit(string) (Unit, error)

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -26,10 +26,6 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
-const (
-	operatorStorage = "operator-storage"
-)
-
 // StorageAPI implements the latest version (v5) of the Storage API which adds Update and Delete.
 type StorageAPI struct {
 	backend       backend
@@ -1150,11 +1146,10 @@ func (a *StorageAPI) RemovePool(p params.StoragePoolDeleteArgs) (params.ErrorRes
 		return results, errors.Trace(err)
 	}
 	for i, pool := range p.Pools {
-		err := a.poolManager.Delete(pool.Name)
+		err := a.storageAccess.DeleteStoragePool(pool.Name)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 		}
-
 	}
 	return results, nil
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -26,6 +26,10 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
+const (
+	operatorStorage = "operator-storage"
+)
+
 // StorageAPI implements the latest version (v5) of the Storage API which adds Update and Delete.
 type StorageAPI struct {
 	backend       backend
@@ -1145,7 +1149,16 @@ func (a *StorageAPI) RemovePool(p params.StoragePoolDeleteArgs) (params.ErrorRes
 	if err := a.checkCanWrite(); err != nil {
 		return results, errors.Trace(err)
 	}
+	poolsInUse, err := a.storagePoolsInUse(p.Pools)
+	if err != nil {
+		return results, errors.Trace(err)
+	}
+
 	for i, pool := range p.Pools {
+		if poolsInUse[pool.Name] {
+			results.Results[i].Error = common.ServerError(errors.Errorf("pool %q in use", pool.Name))
+			continue
+		}
 		err := a.poolManager.Delete(pool.Name)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
@@ -1153,6 +1166,31 @@ func (a *StorageAPI) RemovePool(p params.StoragePoolDeleteArgs) (params.ErrorRes
 
 	}
 	return results, nil
+}
+
+func (a *StorageAPI) storagePoolsInUse(pools []params.StoragePoolDeleteArg) (map[string]bool, error) {
+	// Has a specific check for operator-storage as the operator doesn't
+	// assign storage to a Unit in the traditional way
+	var (
+		poolNames    []string
+		operatorPool bool
+	)
+	for _, p := range pools {
+		poolNames = append(poolNames, p.Name)
+		operatorPool = p.Name == operatorStorage
+	}
+	poolsInUse, err := a.storageAccess.StoragePoolsInUse(poolNames)
+	if err != nil {
+		return poolsInUse, errors.Trace(err)
+	}
+	apps, err := a.backend.AllApplications()
+	if err != nil {
+		return poolsInUse, errors.Trace(err)
+	}
+	if a.modelType == state.ModelTypeCAAS && len(apps) > 0 && operatorPool {
+		poolsInUse[operatorStorage] = true
+	}
+	return poolsInUse, nil
 }
 
 // UpdatePool deletes the named pool

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -1146,7 +1146,7 @@ func (a *StorageAPI) RemovePool(p params.StoragePoolDeleteArgs) (params.ErrorRes
 		return results, errors.Trace(err)
 	}
 	for i, pool := range p.Pools {
-		err := a.storageAccess.DeleteStoragePool(pool.Name)
+		err := a.storageAccess.RemoveStoragePool(pool.Name)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 		}

--- a/state/storage.go
+++ b/state/storage.go
@@ -295,6 +295,23 @@ func (sb *storageBackend) AllStorageInstances() ([]StorageInstance, error) {
 	return out, nil
 }
 
+// StoragePoolsInUse provides a lookup of which pools are actively in use.
+func (sb *storageBackend) StoragePoolsInUse(poolNames []string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	for _, s := range poolNames {
+		out[s] = false
+	}
+	poolFinder := bson.D{{"constraints.pool", bson.D{{"$in", poolNames}}}}
+	storageInstances, err := sb.storageInstances(poolFinder)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, s := range storageInstances {
+		out[s.Pool()] = true
+	}
+	return out, nil
+}
+
 func (sb *storageBackend) storageInstances(query bson.D) (storageInstances []*storageInstance, err error) {
 	storageCollection, closer := sb.mb.db().GetCollection(storageInstancesC)
 	defer closer()

--- a/state/storage.go
+++ b/state/storage.go
@@ -298,8 +298,8 @@ func (sb *storageBackend) AllStorageInstances() ([]StorageInstance, error) {
 	return out, nil
 }
 
-// DeleteStoragePool removes a pool only if its not currently in use
-func (sb *storageBackend) DeleteStoragePool(poolName string) error {
+// RemoveStoragePool removes a pool only if its not currently in use
+func (sb *storageBackend) RemoveStoragePool(poolName string) error {
 	storageCollection, closer := sb.mb.db().GetCollection(storageInstancesC)
 	defer closer()
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -664,23 +664,23 @@ func (s *StorageStateSuite) TestAllStorageInstances(c *gc.C) {
 	}
 }
 
-func (s *StorageStateSuite) TestDeleteStoragePool(c *gc.C) {
+func (s *StorageStateSuite) TestRemoveStoragePool(c *gc.C) {
 	poolName := "loop-pool"
 	_, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.storageBackend.DeleteStoragePool(poolName)
+	err = s.storageBackend.RemoveStoragePool(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.pm.Get(poolName)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("pool %q not found", poolName))
 }
 
-func (s *StorageStateSuite) TestDeleteStoragePoolInUse(c *gc.C) {
+func (s *StorageStateSuite) TestRemoveStoragePoolInUse(c *gc.C) {
 	poolName := "loop-pool"
 	s.assertStorageUnitsAdded(c)
 	_, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DeleteStoragePool(poolName)
+	err = s.storageBackend.RemoveStoragePool(poolName)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("storage pool %q in use", poolName))
 	pool, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -689,7 +689,7 @@ func (s *StorageStateSuite) TestDeleteStoragePoolInUse(c *gc.C) {
 	// pool does not exist at all, poolmanager swallows NotFound errors.
 	_, err = s.pm.Get("nope-pool")
 	c.Assert(err, gc.ErrorMatches, `pool "nope-pool" not found`)
-	err = s.storageBackend.DeleteStoragePool("nope-pool")
+	err = s.storageBackend.RemoveStoragePool("nope-pool")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.pm.Get("nope-pool")
 	c.Assert(err, gc.ErrorMatches, `pool "nope-pool" not found`)
@@ -1394,12 +1394,12 @@ func (s *StorageStateSuiteCaas) SetUpTest(c *gc.C) {
 	s.StorageStateSuiteBase.SetUpTest(c)
 }
 
-func (s *StorageStateSuiteCaas) TestDeleteStoragePool(c *gc.C) {
+func (s *StorageStateSuiteCaas) TestRemoveStoragePool(c *gc.C) {
 	poolName := "operator-storage"
 	_, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.storageBackend.DeleteStoragePool(poolName)
+	err = s.storageBackend.RemoveStoragePool(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -1407,7 +1407,7 @@ func (s *StorageStateSuiteCaas) TestDeleteStoragePool(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("pool %q not found", poolName))
 }
 
-func (s *StorageStateSuiteCaas) TestDeleteStoragePoolInUse(c *gc.C) {
+func (s *StorageStateSuiteCaas) TestRemoveStoragePoolInUse(c *gc.C) {
 	poolName := "operator-storage"
 	_, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1418,13 +1418,13 @@ func (s *StorageStateSuiteCaas) TestDeleteStoragePoolInUse(c *gc.C) {
 
 	s.setupSingleStorage(c, "filesystem", "loop-pool")
 
-	err = s.storageBackend.DeleteStoragePool(poolName)
+	err = s.storageBackend.RemoveStoragePool(poolName)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("storage pool %q in use", poolName))
 	pool, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pool.Name(), gc.Equals, poolName)
 
-	err = s.storageBackend.DeleteStoragePool(appPoolName)
+	err = s.storageBackend.RemoveStoragePool(appPoolName)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("storage pool %q in use", appPoolName))
 	pool, err = s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -658,6 +658,30 @@ func (s *StorageStateSuite) TestAllStorageInstances(c *gc.C) {
 	}
 }
 
+func (s *StorageStateSuite) TestStoragePoolsInUse(c *gc.C) {
+	s.assertStorageUnitsAdded(c)
+
+	toCheck := []string{"loop-pool", "swimming-pool"}
+	inUse, err := s.storageBackend.StoragePoolsInUse(toCheck)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(inUse, gc.HasLen, 2)
+	c.Assert(inUse["loop-pool"], jc.IsTrue)
+	c.Assert(inUse["swimming-pool"], jc.IsFalse)
+
+	toCheck = []string{"swimming-pool", "another-pool"}
+	inUse, err = s.storageBackend.StoragePoolsInUse(toCheck)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(inUse, gc.HasLen, 2)
+	c.Assert(inUse["another-pool"], jc.IsFalse)
+	c.Assert(inUse["swimming-pool"], jc.IsFalse)
+
+	toCheck = []string{"loop-pool"}
+	inUse, err = s.storageBackend.StoragePoolsInUse(toCheck)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(inUse, gc.HasLen, 1)
+	c.Assert(inUse["loop-pool"], jc.IsTrue)
+}
+
 func (s *StorageStateSuite) TestStorageAttachments(c *gc.C) {
 	s.assertStorageUnitsAdded(c)
 


### PR DESCRIPTION
## Description of change

Add a check when deleting a storage pool that it isn't in use. If it is in use do not delete that pool.
Note this PR builds off of: https://github.com/juju/juju/pull/9682

## QA steps

Unit tests included.
Manual test: 
  - Follow the steps found here: https://discourse.jujucharms.com/t/juju-kubernetes-and-microk8s/226
    - At the point of creating the ```operator-storage```, run: ```juju delete-storage-pool operator-storage```
    - Run: ```juju list-storage-pools``` to show its gone
    - Create the pool again and continue with the instructions
    - Once the application has been deployed attempt to delete the storage pool
      - ```juju delete-storage-pool mariadb-pv``` must result in an error 'ERROR pool "mariadb-pv" in use'
      - ```juju delete-storage-pool operator-storage``` must result in an error 'ERROR pool "operator-storage" in use'

## Documentation changes
n/a

## Bug reference
n/a