### PR TITLE
Use the newer testing clock.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -434,14 +434,14 @@
   revision = "b8d279cc30ffcc57dab7a51c4bc39be08fb2b569"
 
 [[projects]]
-  digest = "1:acc1f840c3b249910754a9d5f5cb825674ca2d2011f185c6130b78f7c5ea0df8"
+  digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"
   name = "github.com/juju/clock"
   packages = [
     ".",
     "testclock",
   ]
   pruneopts = ""
-  revision = "88c0f736129fcaaf89fff406fefec1a3c8a99340"
+  revision = "9c5c9712527c7986f012361e7d13756b4d99543d"
 
 [[projects]]
   digest = "1:760e8f7e7dc275407516bf0c0cfcec9f946810f28da4952bbb46de8391d6a348"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -434,14 +434,14 @@
   revision = "b8d279cc30ffcc57dab7a51c4bc39be08fb2b569"
 
 [[projects]]
-  digest = "1:3d4df54c1d5e1be4d7aab3e6e3a3807b4ddbeebd0bf7a87ea363fe41e6aec0ac"
+  digest = "1:acc1f840c3b249910754a9d5f5cb825674ca2d2011f185c6130b78f7c5ea0df8"
   name = "github.com/juju/clock"
   packages = [
     ".",
     "testclock",
   ]
   pruneopts = ""
-  revision = "bab88fc672997ef02d03f85310182d97a93dee21"
+  revision = "88c0f736129fcaaf89fff406fefec1a3c8a99340"
 
 [[projects]]
   digest = "1:760e8f7e7dc275407516bf0c0cfcec9f946810f28da4952bbb46de8391d6a348"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -283,7 +283,7 @@
 
 [[constraint]]
   name = "github.com/juju/clock"
-  revision = "88c0f736129fcaaf89fff406fefec1a3c8a99340"
+  revision = "9c5c9712527c7986f012361e7d13756b4d99543d"
 
 [[constraint]]
   name = "github.com/juju/cmd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -283,7 +283,7 @@
 
 [[constraint]]
   name = "github.com/juju/clock"
-  revision = "bab88fc672997ef02d03f85310182d97a93dee21"
+  revision = "88c0f736129fcaaf89fff406fefec1a3c8a99340"
 
 [[constraint]]
   name = "github.com/juju/cmd"

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -48,8 +48,8 @@ func (s *machineSuite) TestSetsInstanceInfoInitially(c *gc.C) {
 
 	clock := newTestClock()
 	go runMachine(context, m, nil, died, clock)
-	c.Assert(clock.WaitAdvance(LongPoll, 0, 1), jc.ErrorIsNil)
-	c.Assert(clock.WaitAdvance(LongPoll, 0, 1), jc.ErrorIsNil)
+	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 
 	killMachineLoop(c, m, context.dyingc, died)
 	c.Assert(context.killErr, gc.Equals, nil)
@@ -73,8 +73,8 @@ func (s *machineSuite) TestSetsInstanceInfoDeadMachineInitially(c *gc.C) {
 
 	clock := newTestClock()
 	go runMachine(context, m, nil, died, clock)
-	c.Assert(clock.WaitAdvance(LongPoll, 0, 1), jc.ErrorIsNil)
-	c.Assert(clock.WaitAdvance(LongPoll, 0, 1), jc.ErrorIsNil)
+	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 
 	killMachineLoop(c, m, context.dyingc, died)
 	c.Assert(context.killErr, gc.Equals, nil)
@@ -102,7 +102,7 @@ func (s *machineSuite) testShortPoll(
 	clock := newTestClock()
 	testRunMachine(c, addrs, instId, instStatus, machineStatus, clock, func() {
 		c.Assert(clock.WaitAdvance(
-			time.Duration(float64(ShortPoll)*ShortPollBackoff), 0, 1),
+			time.Duration(float64(ShortPoll)*ShortPollBackoff), coretesting.ShortWait, 1),
 			jc.ErrorIsNil,
 		)
 	})
@@ -138,7 +138,7 @@ func (s *machineSuite) TestNoPollWhenNotProvisioned(c *gc.C) {
 	go runMachine(context, m, changed, died, clock)
 
 	expectPoll := func() {
-		c.Assert(clock.WaitAdvance(ShortPoll, 0, 1), jc.ErrorIsNil)
+		c.Assert(clock.WaitAdvance(ShortPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 	}
 
 	expectPoll()
@@ -178,7 +178,7 @@ func (s *machineSuite) TestShortPollBackoffLimit(c *gc.C) {
 	clock := newTestClock()
 	testRunMachine(c, nil, "i1234", "", status.Started, clock, func() {
 		for _, d := range pollDurations {
-			c.Assert(clock.WaitAdvance(time.Duration(d), 0, 1), jc.ErrorIsNil)
+			c.Assert(clock.WaitAdvance(time.Duration(d), coretesting.ShortWait, 1), jc.ErrorIsNil)
 		}
 	})
 	for i, d := range pollDurations {
@@ -189,7 +189,7 @@ func (s *machineSuite) TestShortPollBackoffLimit(c *gc.C) {
 func (s *machineSuite) TestLongPollIntervalWhenHasAllInstanceInfo(c *gc.C) {
 	clock := newTestClock()
 	testRunMachine(c, testAddrs, "i1234", "running", status.Started, clock, func() {
-		c.Assert(clock.WaitAdvance(LongPoll, 0, 1), jc.ErrorIsNil)
+		c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 	})
 	clock.CheckCall(c, 0, "After", LongPoll)
 }
@@ -251,7 +251,7 @@ func (*machineSuite) TestChangedRefreshes(c *gc.C) {
 	clock := newTestClock()
 	go runMachine(context, m, changed, died, clock)
 
-	c.Assert(clock.WaitAdvance(LongPoll, 0, 1), jc.ErrorIsNil)
+	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 	select {
 	case <-died:
 		c.Fatalf("machine died prematurely")


### PR DESCRIPTION
## Description of change

The testing clock now iterates faster when given a long timeout, and
gives stack traces when the waiters don't match expectations.

This is just cleanup of the testing clock that helped when I was debugging something else, but we may as well get it into our core code. Only changes the testing clock, so it may change the test suite, but doesn't change production code.

https://github.com/juju/clock/pull/3
https://github.com/juju/clock/pull/4

We need (4) https://github.com/juju/juju/pull/9712

## QA steps

None.

## Documentation changes

None.

## Bug reference

None.
