### PR TITLE
Remove juju- from k8s artifact names

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -153,6 +153,10 @@ type ProvisioningInfo struct {
 	Tags        map[string]string
 }
 
+// ErrNoUnits is returned when trying to provision a caas app but
+// there are no units defined in the model.
+var ErrNoUnits = errors.New("no units to provision")
+
 // ProvisioningInfo returns the provisioning info for the specified CAAS
 // application in the current model.
 func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
@@ -173,6 +177,9 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 		return nil, maybeNotFound(err)
 	}
 	result := results.Results[0].Result
+	if result == nil {
+		return nil, ErrNoUnits
+	}
 	info := &ProvisioningInfo{
 		PodSpec:     result.PodSpec,
 		Placement:   result.Placement,

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -122,6 +122,19 @@ func (s *unitprovisionerSuite) TestProvisioningInfoError(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *unitprovisionerSuite) TestProvisioningInfoNoUnits(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.KubernetesProvisioningInfoResults)) = params.KubernetesProvisioningInfoResults{
+			Results: []params.KubernetesProvisioningInfoResult{{}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	_, err := client.ProvisioningInfo("gitlab")
+	c.Assert(err, jc.DeepEquals, caasunitprovisioner.ErrNoUnits)
+}
+
 func (s *unitprovisionerSuite) TestProvisioningInfoInvalidApplicationName(c *gc.C) {
 	client := caasunitprovisioner.NewClient(basetesting.APICallerFunc(func(_ string, _ int, _, _ string, _, _ interface{}) error {
 		return errors.New("should not be called")

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -260,9 +260,11 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Should never happen, but just in case.
+	// Can happen if scale is set to 0 in k8s, outside of Juju.
+	// In this case, there is no provisioning info to return.
 	if len(units) == 0 {
-		return nil, errors.Errorf("cannot provision application %q with no units", appTag.Id())
+		logger.Debugf("cannot provision application %q with no units", appTag.Id())
+		return nil, nil
 	}
 	modelConfig, err := model.ModelConfig()
 	if err != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -215,6 +215,23 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	s.storagePoolManager.CheckCallNames(c, "Get")
 }
 
+func (s *CAASProvisionerSuite) TestProvisioningInfoNoUnits(c *gc.C) {
+	s.st.application.units = []caasunitprovisioner.Unit{}
+
+	results, err := s.facade.ProvisioningInfo(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "application-gitlab"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.KubernetesProvisioningInfoResults{
+		Results: []params.KubernetesProvisioningInfoResult{{}}})
+	s.st.CheckCallNames(c, "Model", "Application")
+	s.storage.CheckNoCalls(c)
+	s.storageProviderRegistry.CheckNoCalls(c)
+	s.storagePoolManager.CheckNoCalls(c)
+}
+
 func (s *CAASProvisionerSuite) TestApplicationScale(c *gc.C) {
 	results, err := s.facade.ApplicationsScale(params.Entities{
 		Entities: []params.Entity{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -86,7 +86,7 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 			Image: "juju/image2",
 		}},
 	}
-	spec, err := provider.MakeUnitSpec("app-name", &podSpec)
+	spec, err := provider.MakeUnitSpec("app-name", "app-name", &podSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.PodSpec(spec), jc.DeepEquals, core.PodSpec{
 		ActiveDeadlineSeconds:         int64Ptr(10),
@@ -161,20 +161,20 @@ var operatorPodspec = core.PodSpec{
 			{Name: "JUJU_APPLICATION", Value: "test"},
 		},
 		VolumeMounts: []core.VolumeMount{{
-			Name:      "juju-operator-test-config-volume",
+			Name:      "test-operator-config",
 			MountPath: "path/to/agent/agents/application-test/template-agent.conf",
 			SubPath:   "template-agent.conf",
 		}, {
-			Name:      "test-operator-volume",
+			Name:      "charm",
 			MountPath: "path/to/agent/agents",
 		}},
 	}},
 	Volumes: []core.Volume{{
-		Name: "juju-operator-test-config-volume",
+		Name: "test-operator-config",
 		VolumeSource: core.VolumeSource{
 			ConfigMap: &core.ConfigMapVolumeSource{
 				LocalObjectReference: core.LocalObjectReference{
-					Name: "juju-operator-test-config",
+					Name: "test-operator-config",
 				},
 				Items: []core.KeyToPath{{
 					Key:  "test-agent.conf",
@@ -221,7 +221,7 @@ func (s *K8sBrokerSuite) secretArg(c *gc.C, labels map[string]string) *core.Secr
 }
 
 func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
-	spec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	spec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.PodSpec(spec), jc.DeepEquals, core.PodSpec{
 		ImagePullSecrets: []core.LocalObjectReference{{Name: "app-name-test-secret"}},
@@ -252,8 +252,8 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
 		"juju-operator": "gitlab",
 	}
-	pod := provider.OperatorPod("gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator", "2.99.0", tags)
-	c.Assert(pod.Name, gc.Equals, "juju-operator-gitlab")
+	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator", "2.99.0", tags)
+	c.Assert(pod.Name, gc.Equals, "gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
 		"juju-operator": "gitlab",
 		"juju-version":  "2.99.0",
@@ -400,11 +400,13 @@ func (s *K8sBrokerSuite) TestDeleteOperator(c *gc.C) {
 
 	// Delete operations below return a not found to ensure it's treated as a no-op.
 	gomock.InOrder(
-		s.mockConfigMaps.EXPECT().Delete("juju-operator-test-config", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockConfigMaps.EXPECT().Delete("test-operator-config", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
 		s.mockConfigMaps.EXPECT().Delete("test-configurations-config", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Delete("juju-operator-test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
+		s.mockStatefulSets.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
 		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).
 			Return(&core.PodList{Items: []core.Pod{{
@@ -426,7 +428,7 @@ func (s *K8sBrokerSuite) TestDeleteOperator(c *gc.C) {
 			Return(s.k8sNotFoundError()),
 		s.mockPersistentVolumes.EXPECT().Delete("test-operator-volume", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Delete("juju-operator-test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
+		s.mockDeployments.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
 	)
 
@@ -437,7 +439,7 @@ func (s *K8sBrokerSuite) TestDeleteOperator(c *gc.C) {
 func operatorStatefulSetArg(numUnits int32, scName string) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "juju-operator-test",
+			Name: "test-operator",
 			Labels: map[string]string{
 				"juju-operator": "test",
 				"juju-version":  "2.99.0",
@@ -460,7 +462,7 @@ func operatorStatefulSetArg(numUnits int32, scName string) *appsv1.StatefulSet {
 			},
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "test-operator-volume",
+					Name: "charm",
 					Labels: map[string]string{
 						"juju-operator": "test",
 						"foo":           "bar",
@@ -498,10 +500,11 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 			},
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "juju-database-0",
+					Name: "database-0",
 					Labels: map[string]string{
 						"juju-application": "app-name",
 						"foo":              "bar",
+						"juju-storage":     "database",
 					}},
 				Spec: core.PersistentVolumeClaimSpec{
 					StorageClassName: &scName,
@@ -524,7 +527,7 @@ func (s *K8sBrokerSuite) TestEnsureOperator(c *gc.C) {
 
 	configMapArg := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "juju-operator-test-config",
+			Name: "test-operator-config",
 		},
 		Data: map[string]string{
 			"test-agent.conf": "agent-conf-data",
@@ -534,6 +537,8 @@ func (s *K8sBrokerSuite) TestEnsureOperator(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockNamespaces.EXPECT().Update(&core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}}).Times(1),
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockConfigMaps.EXPECT().Update(configMapArg).Times(1),
 		s.mockStorageClass.EXPECT().Get("test-juju-operator-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-juju-operator-storage"}}, nil),
@@ -565,7 +570,9 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfig(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockNamespaces.EXPECT().Update(&core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}}).Times(1),
-		s.mockConfigMaps.EXPECT().Get("juju-operator-test-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
 			Return(nil, nil),
 		s.mockStorageClass.EXPECT().Get("test-juju-operator-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-juju-operator-storage"}}, nil),
@@ -594,7 +601,9 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfigMissingConfigMap(c *gc.C
 
 	gomock.InOrder(
 		s.mockNamespaces.EXPECT().Update(&core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}}).Times(1),
-		s.mockConfigMaps.EXPECT().Get("juju-operator-test-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 	)
 
@@ -615,6 +624,8 @@ func (s *K8sBrokerSuite) TestDeleteService(c *gc.C) {
 
 	// Delete operations below return a not found to ensure it's treated as a no-op.
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockServices.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
@@ -645,6 +656,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoUnits(c *gc.C) {
 	emptyDc := dc
 	emptyDc.Spec.Replicas = &zero
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
@@ -663,7 +676,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	defer ctrl.Finish()
 
 	numUnits := int32(2)
-	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 
@@ -713,6 +726,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 
 	secretArg := s.secretArg(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockSecrets.EXPECT().Update(secretArg).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
@@ -955,16 +970,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 	podSpec.Containers[0].VolumeMounts = []core.VolumeMount{{
-		Name:      "juju-database-0",
+		Name:      "database-0",
 		MountPath: "path/to/here",
 	}}
 	statefulSetArg := unitStatefulSetArg(2, "juju-unit-storage", podSpec)
 
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1008,7 +1025,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 	defer ctrl.Finish()
 
 	numUnits := int32(2)
-	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 	podSpec.NodeSelector = map[string]string{"accelerator": "nvidia-tesla-p100"}
@@ -1043,6 +1060,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 	}
 
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
@@ -1081,11 +1100,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 	podSpec.Containers[0].VolumeMounts = []core.VolumeMount{{
-		Name:      "juju-database-0",
+		Name:      "database-0",
 		MountPath: "path/to/here",
 	}}
 	podSpec.NodeSelector = map[string]string{"accelerator": "nvidia-tesla-p100"}
@@ -1102,6 +1121,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "juju-unit-storage", podSpec)
 
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1151,11 +1172,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 	podSpec.Containers[0].VolumeMounts = []core.VolumeMount{{
-		Name:      "juju-database-0",
+		Name:      "database-0",
 		MountPath: "path/to/here",
 	}}
 	for i := range podSpec.Containers {
@@ -1169,6 +1190,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "juju-unit-storage", podSpec)
 
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1212,17 +1235,19 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithPlacement(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	unitSpec, err := provider.MakeUnitSpec("app-name", basicPodspec)
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(unitSpec)
 	podSpec.Containers[0].VolumeMounts = []core.VolumeMount{{
-		Name:      "juju-database-0",
+		Name:      "database-0",
 		MountPath: "path/to/here",
 	}}
 	podSpec.NodeSelector = map[string]string{"a": "b"}
 	statefulSetArg := unitStatefulSetArg(2, "juju-unit-storage", podSpec)
 
 	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStorageClass.EXPECT().Get("test-juju-unit-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1268,7 +1293,7 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 
 	opPod := core.Pod{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "juju-operator-test",
+			Name: "test-operator",
 		},
 		Status: core.PodStatus{
 			Phase:   core.PodPending,


### PR DESCRIPTION
## Description of change

When creating k8s artifacts like pods, volume claims, services etc, do not use the "juju-" prefix.
So that 2.5.0 deployed models continue to work, when an app is acted on, first see if it has been created using the legacy naming, and if so, continue to use the "juju-" prefixes for that app.

This started as just a change to k8s.go
When doing QA, I noticed that Juju doesn't handle well the case where the cluster is scaled down to 0 pods outside Juju. So add extra handling for that case.

## QA steps

bootstrap 2.5.0
deploy a k8s model with apps with storage
upgrade juju to 2.5.1
ensure that kubectl and juju status reflect a running model using the legacy names
scale out some apps and check
deploy some new apps with 2.5.1
ensure juju status shows a working system
scale out some apps and check
