### PR TITLE
only load leases on next tick

### DIFF
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -102,7 +102,7 @@ type Manager struct {
 	// if supplied
 	logContext string
 
-	// nextTimeout is the next time that has a possibly expiry that we would care
+	// nextTimeout is the next time that has a possible expiry that we would care
 	// about, capped at the maximum time.
 	nextTimeout time.Time
 
@@ -455,8 +455,8 @@ func (manager *Manager) ensureNextTimeout(d time.Duration) {
 	proposed := manager.config.Clock.Now().Add(d)
 	if next.After(proposed) {
 		manager.config.Logger.Tracef("[%s] ensuring we wake up before %v at %v\n",
-			manager.logContext, d, next)
-		manager.nextTimeout = next
+			manager.logContext, d, proposed)
+		manager.nextTimeout = proposed
 		manager.timer.Reset(d)
 	}
 	manager.muNextTimeout.Unlock()

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -442,7 +442,10 @@ func (manager *Manager) retryingExpire(now time.Time, expired chan struct{}) {
 	for a := manager.startRetry(); a.Next(); {
 		err = manager.expire(now)
 		// We've done at least 1 attempt
-		close(expired)
+		if expired != nil {
+			close(expired)
+			expired = nil
+		}
 		if !lease.IsTimeout(err) {
 			break
 		}

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -353,6 +353,13 @@ func (manager *Manager) handleCheck(check check) error {
 			return errors.Trace(err)
 		}
 		info, found = manager.lookupLease(key)
+		if !found {
+			// Someone thought they were the leader and held a Claim or they wouldn't
+			// have tried to do a mutating operation. However, when they actually
+			// got to this point, we detected that they were, actually, out of
+			// date. Schedule a sync
+			manager.ensureNextTimeout(time.Millisecond)
+		}
 	}
 
 	var response error

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -74,12 +74,12 @@ func (s *AsyncSuite) TestExpirySlow(c *gc.C) {
 				select {
 				case slowStarted <- struct{}{}:
 				case <-time.After(coretesting.LongWait):
-					c.Fatalf("timed out sending slowStarted")
+					c.Errorf("timed out sending slowStarted")
 				}
 				select {
 				case <-slowFinish:
 				case <-time.After(coretesting.LongWait):
-					c.Fatalf("timed out waiting for slowFinish")
+					c.Errorf("timed out waiting for slowFinish")
 				}
 
 			},

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -354,8 +354,9 @@ func (s *AsyncSuite) TestClaimSlow(c *gc.C) {
 			response2 <- claimer.Claim("antiquisearchers", "art", time.Minute)
 		}()
 
-		// response1 should have failed its claim, and no be waiting to retry
-		c.Assert(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 4), jc.ErrorIsNil)
+		// response1 should have failed its claim, and now be waiting to retry
+		// only 1 waiter, which is the 'when should we expire next' timer.
+		c.Assert(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 1), jc.ErrorIsNil)
 
 		// We should be able to get the response for the second claim
 		// even though the first hasn't come back yet.
@@ -370,8 +371,7 @@ func (s *AsyncSuite) TestClaimSlow(c *gc.C) {
 
 		close(slowFinish)
 
-		// response1 should have failed its claim again, and no be waiting longer to retry
-		c.Assert(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 4), jc.ErrorIsNil)
+		c.Assert(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 1), jc.ErrorIsNil)
 
 		// Now response1 should come back.
 		select {

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -307,12 +307,12 @@ func (s *AsyncSuite) TestClaimSlow(c *gc.C) {
 				select {
 				case slowStarted <- struct{}{}:
 				case <-time.After(coretesting.LongWait):
-					c.Fatalf("timed out sending slowStarted")
+					c.Errorf("timed out sending slowStarted")
 				}
 				select {
 				case <-slowFinish:
 				case <-time.After(coretesting.LongWait):
-					c.Fatalf("timed out waiting for slowFinish")
+					c.Errorf("timed out waiting for slowFinish")
 				}
 				mu.Lock()
 				leases[key("dmdc")] = corelease.Info{

--- a/worker/lease/manager_block_test.go
+++ b/worker/lease/manager_block_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -21,10 +23,18 @@ type WaitUntilExpiredSuite struct {
 
 var _ = gc.Suite(&WaitUntilExpiredSuite{})
 
+func (s *WaitUntilExpiredSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	logger := loggo.GetLogger("juju.worker.lease")
+	logger.SetLogLevel(loggo.TRACE)
+	logger = loggo.GetLogger("lease_test")
+	logger.SetLogLevel(loggo.TRACE)
+}
+
 func (s *WaitUntilExpiredSuite) TestLeadershipNotHeld(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		blockTest := newBlockTest(manager, key("redis"))
+		blockTest := newBlockTest(c, manager, key("redis"))
 		err := blockTest.assertUnblocked(c)
 		c.Check(err, jc.ErrorIsNil)
 	})
@@ -49,11 +59,11 @@ func (s *WaitUntilExpiredSuite) TestLeadershipExpires(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
-		blockTest := newBlockTest(manager, key("redis"))
+		blockTest := newBlockTest(c, manager, key("redis"))
 		blockTest.assertBlocked(c)
 
 		// Trigger expiry.
-		clock.Advance(time.Second)
+		c.Assert(clock.WaitAdvance(time.Second, testing.ShortWait, 1), jc.ErrorIsNil)
 		err := blockTest.assertUnblocked(c)
 		c.Check(err, jc.ErrorIsNil)
 	})
@@ -82,7 +92,7 @@ func (s *WaitUntilExpiredSuite) TestLeadershipChanged(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
-		blockTest := newBlockTest(manager, key("redis"))
+		blockTest := newBlockTest(c, manager, key("redis"))
 		blockTest.assertBlocked(c)
 
 		// Trigger abortive expiry.
@@ -107,7 +117,7 @@ func (s *WaitUntilExpiredSuite) TestLeadershipExpiredEarly(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
-		blockTest := newBlockTest(manager, key("redis"))
+		blockTest := newBlockTest(c, manager, key("redis"))
 		blockTest.assertBlocked(c)
 
 		// Induce a refresh by making an unexpected check; it turns out the
@@ -152,13 +162,13 @@ func (s *WaitUntilExpiredSuite) TestMultiple(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
-		redisTest1 := newBlockTest(manager, key("redis"))
+		redisTest1 := newBlockTest(c, manager, key("redis"))
 		redisTest1.assertBlocked(c)
-		redisTest2 := newBlockTest(manager, key("redis"))
+		redisTest2 := newBlockTest(c, manager, key("redis"))
 		redisTest2.assertBlocked(c)
-		storeTest1 := newBlockTest(manager, key("store"))
+		storeTest1 := newBlockTest(c, manager, key("store"))
 		storeTest1.assertBlocked(c)
-		storeTest2 := newBlockTest(manager, key("store"))
+		storeTest2 := newBlockTest(c, manager, key("store"))
 		storeTest2.assertBlocked(c)
 
 		// Induce attempted expiry; redis was expired already, store was
@@ -183,7 +193,7 @@ func (s *WaitUntilExpiredSuite) TestKillManager(c *gc.C) {
 		},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		blockTest := newBlockTest(manager, key("redis"))
+		blockTest := newBlockTest(c, manager, key("redis"))
 		blockTest.assertBlocked(c)
 
 		manager.Kill()
@@ -202,7 +212,7 @@ func (s *WaitUntilExpiredSuite) TestCancelWait(c *gc.C) {
 		},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		blockTest := newBlockTest(manager, key("redis"))
+		blockTest := newBlockTest(c, manager, key("redis"))
 		blockTest.assertBlocked(c)
 		blockTest.cancelWait()
 
@@ -223,7 +233,7 @@ type blockTest struct {
 
 // newBlockTest starts a test goroutine blocking until the manager confirms
 // expiry of the named lease.
-func newBlockTest(manager *lease.Manager, key corelease.Key) *blockTest {
+func newBlockTest(c *gc.C, manager *lease.Manager, key corelease.Key) *blockTest {
 	bt := &blockTest{
 		manager: manager,
 		done:    make(chan error),
@@ -232,14 +242,23 @@ func newBlockTest(manager *lease.Manager, key corelease.Key) *blockTest {
 	}
 	claimer, err := bt.manager.Claimer(key.Namespace, key.ModelUUID)
 	if err != nil {
-		panic("couldn't get claimer")
+		c.Errorf("couldn't get claimer: %v", err)
 	}
+	started := make(chan struct{})
 	go func() {
+		close(started)
 		select {
 		case <-bt.abort:
 		case bt.done <- claimer.WaitUntilExpired(key.Lease, bt.cancel):
+		case <-time.After(testing.LongWait):
+			c.Errorf("block not aborted or expired after %v", testing.LongWait)
 		}
 	}()
+	select {
+	case <-started:
+	case <-bt.abort:
+		c.Errorf("bt.aborted before even started")
+	}
 	return bt
 }
 
@@ -250,8 +269,12 @@ func (bt *blockTest) cancelWait() {
 func (bt *blockTest) assertBlocked(c *gc.C) {
 	select {
 	case err := <-bt.done:
-		c.Fatalf("unblocked unexpectedly with %v", err)
-	default:
+		c.Errorf("unblocked unexpectedly with %v", err)
+	case <-time.After(time.Millisecond):
+		// happy that we are still blocked, success
+		// TODO(jam): 2019-02-05 should this be testing.ShortWait? It used to be
+		//  just plain 'default:', which didn't even give the helper goroutine
+		//  a timeslice to start to even evaluate if WaitUntilExpired had returned.
 	}
 }
 
@@ -260,7 +283,7 @@ func (bt *blockTest) assertUnblocked(c *gc.C) error {
 	case err := <-bt.done:
 		return err
 	case <-bt.abort:
-		c.Fatalf("timed out before unblocking")
+		c.Errorf("timed out before unblocking")
+		return errors.Errorf("timed out")
 	}
-	panic("unreachable")
 }

--- a/worker/lease/manager_claim_test.go
+++ b/worker/lease/manager_claim_test.go
@@ -86,7 +86,7 @@ func (s *ClaimSuite) TestClaimLease_Success_SameHolder(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			wg.Done()
 		}()
-		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 3), jc.ErrorIsNil)
+		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 2), jc.ErrorIsNil)
 		wg.Wait()
 	})
 }
@@ -124,7 +124,7 @@ func (s *ClaimSuite) TestClaimLease_Failure_OtherHolder(c *gc.C) {
 			c.Check(err, gc.Equals, corelease.ErrClaimDenied)
 			wg.Done()
 		}()
-		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 3), jc.ErrorIsNil)
+		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 2), jc.ErrorIsNil)
 		wg.Wait()
 	})
 }
@@ -225,7 +225,7 @@ func (s *ClaimSuite) TestExtendLease_Success_Expired(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			wg.Done()
 		}()
-		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 3), jc.ErrorIsNil)
+		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 2), jc.ErrorIsNil)
 		wg.Wait()
 	})
 }
@@ -269,7 +269,7 @@ func (s *ClaimSuite) TestExtendLease_Failure_OtherHolder(c *gc.C) {
 			c.Check(err, gc.Equals, corelease.ErrClaimDenied)
 			wg.Done()
 		}()
-		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 3), jc.ErrorIsNil)
+		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 2), jc.ErrorIsNil)
 		wg.Wait()
 	})
 }

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -107,8 +107,8 @@ func (s *CrossSuite) testWaits(c *gc.C, lease1, lease2 corelease.Key) {
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
-		b1 := newBlockTest(manager, lease1)
-		b2 := newBlockTest(manager, lease2)
+		b1 := newBlockTest(c, manager, lease1)
+		b2 := newBlockTest(c, manager, lease2)
 
 		b1.assertBlocked(c)
 		b2.assertBlocked(c)

--- a/worker/lease/manager_expire_test.go
+++ b/worker/lease/manager_expire_test.go
@@ -224,11 +224,9 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture(c *gc.C) {
 		// Ask for a minute, actually get 63s. Don't expire early.
 		err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		// Three waiters:
-		// - the alarm from the first call to choose
-		// - the retry timer from the claim call
-		// - the alarm from the second time in choose.
-		waitAdvance(c, clock, almostSeconds(newLeaseSecs), 3)
+		// One waiters:
+		// - the timer in the main loop
+		waitAdvance(c, clock, almostSeconds(newLeaseSecs), 1)
 	})
 }
 
@@ -261,7 +259,7 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 		// Ask for a minute, actually get 63s. Expire on time.
 		err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		waitAdvance(c, clock, justAfterSeconds(newLeaseSecs), 3)
+		waitAdvance(c, clock, justAfterSeconds(newLeaseSecs), 1)
 	})
 }
 
@@ -292,7 +290,8 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 		// Ask for a minute, actually get 63s. Don't expire early.
 		err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		waitAdvance(c, clock, almostSeconds(newLeaseSecs), 3)
+		// Only the main loop waiter
+		waitAdvance(c, clock, almostSeconds(newLeaseSecs), 1)
 	})
 }
 
@@ -331,8 +330,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 		// Ask for a minute, actually get 63s. Expire on time.
 		err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		// See TestClaim_ExpiryInFuture_TimePasses for why 3.
-		waitAdvance(c, clock, justAfterSeconds(newLeaseSecs), 3)
+		waitAdvance(c, clock, justAfterSeconds(newLeaseSecs), 1)
 	})
 }
 

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -82,7 +82,7 @@ func (store *Store) Wait(c *gc.C) {
 	case <-store.done:
 		select {
 		case err := <-store.failed:
-			c.Fatalf(err.Error())
+			c.Errorf(err.Error())
 		default:
 		}
 	case <-time.After(coretesting.LongWait):
@@ -147,6 +147,11 @@ func (store *Store) call(method string, args []interface{}) error {
 	}
 	defer store.closeIfEmpty()
 
+	if len(store.expect) < 1 {
+		err := errors.Errorf("store.%s called but was not expected", method)
+		store.failed <- err
+		return err
+	}
 	expect := store.expect[0]
 	store.expect = store.expect[1:]
 	if expect.parallelCallback != nil {


### PR DESCRIPTION
## Description of change

This changes how we handle unblocking and how we determine nextTick.

Instead of checking blocks on *every* pass through the loop(), we only check when we get a tick and trigger potential expiration. Christian and I discussed why it was safe, which boils down to. If someone adds a claim that would expire to a different controller, we would only care about expiring it if we had someone blocked on it expiring. Which we can tell from our blocks (arguably we can immediately unblock a block if it isn't in our Leases, which we could easily check without looking at all leases.).

I renamed tick() to expire() and retryingTick to retryingExpire, because that code is only the expiration path, while tick() is now tracking the timer and handling unblocking people.

There is probably also a lot of extra logging in there, and we should audit what is actually useful in practice vs just what was immediately developer focused.

This currently needs: 
  https://github.com/juju/juju/pull/9709
Though we could update the tests if we decide not to do it.

expire() now informs the main loop that it is a good time to process its blocks() once it has gone through the processing. Further, handleCheck() now notices if it saw stale data, and then causes the expire() to tick faster than it would otherwise, which will speed up things getting unblocked.
 
## QA steps

The test suite should cover the important cases. The other thing you could do is run up the leadershipclaimer I wrote and try to abuse leases with it, and see if we are able to get into any bad conditions.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1814556