### PR TITLE
Add --controller arg to list-clouds command

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -316,6 +316,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close()
 	err = api.AddCloud(*newCloud)
 	if err != nil && params.ErrCode(err) != params.CodeAlreadyExists {
 		return err

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -362,7 +362,7 @@ func (s *addSuite) TestAddToController(c *gc.C) {
 	_, err := cmdtesting.RunCommand(
 		c, cmd, "garage-maas", cloudFileName, "-c", "mycontroller")
 	c.Assert(err, jc.ErrorIsNil)
-	api.CheckCallNames(c, "AddCloud", "AddCredential")
+	api.CheckCallNames(c, "AddCloud", "AddCredential", "Close")
 	api.CheckCall(c, 0, "AddCloud", jujucloud.Cloud{
 		Name:        "garage-maas",
 		Type:        "maas",

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -35,6 +35,13 @@ func NewAddCloudCommandForTest(
 	}
 }
 
+func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (ListCloudsAPI, error)) *listCloudsCommand {
+	return &listCloudsCommand{
+		store:             store,
+		listCloudsAPIFunc: cloudAPI,
+	}
+}
+
 func NewUpdateCloudsCommandForTest(publicCloudURL string) *updateCloudsCommand {
 	return &updateCloudsCommand{
 		// TODO(wallyworld) - move testing key elsewhere

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -35,7 +35,7 @@ func NewAddCloudCommandForTest(
 	}
 }
 
-func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (ListCloudsAPI, error)) *listCloudsCommand {
+func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (ListCloudsAPI, error)) *listCloudsCommand {
 	return &listCloudsCommand{
 		store:             store,
 		listCloudsAPIFunc: cloudAPI,

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -32,7 +32,7 @@ type listCloudsCommand struct {
 	// Used when querying a controller for its cloud details
 	controllerName    string
 	store             jujuclient.ClientStore
-	listCloudsAPIFunc func() (ListCloudsAPI, error)
+	listCloudsAPIFunc func(controllerName string) (ListCloudsAPI, error)
 }
 
 // listCloudsDoc is multi-line since we need to use ` to denote
@@ -59,7 +59,7 @@ Examples:
 
     juju clouds
     juju clouds --format yaml
-    juju add-cloud --controller mycontroller
+    juju clouds --controller mycontroller
 
 See also:
     add-cloud
@@ -83,8 +83,8 @@ func NewListCloudsCommand() cmd.Command {
 	return modelcmd.WrapBase(c)
 }
 
-func (c *listCloudsCommand) cloudAPI() (ListCloudsAPI, error) {
-	root, err := c.NewAPIRoot(c.store, c.controllerName, "")
+func (c *listCloudsCommand) cloudAPI(controllerName string) (ListCloudsAPI, error) {
+	root, err := c.NewAPIRoot(c.store, controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -122,7 +122,7 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 		return details, nil
 	}
 
-	api, err := c.listCloudsAPIFunc()
+	api, err := c.listCloudsAPIFunc(c.controllerName)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +134,7 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 	details := newCloudList()
 	for name, cloud := range controllerClouds {
 		cloudDetails := makeCloudDetails(cloud)
+		// TODO: Better categorization than public.
 		details.public[name.String()] = cloudDetails
 	}
 	return details, nil


### PR DESCRIPTION
## Description of change

Add the option argument ```--controlller <name>``` to ```juju list-clouds``` so one can view which clouds the controller knows about (i..e added with ```juju add-cloud --controller mycontroller . . .```).

## QA steps

Unit tests included.

Manual testing:

  - Bootstrap a controller 'testing'
  - Add a cloud to the controller (here I use a caas cloud as per https://discourse.jujucharms.com/t/juju-kubernetes-and-microk8s/226)
    - juju add-cloud -c testing k8stest
  - List clouds on that controller:
    - juju list-clouds --controller testing
  - Observe the added cloud in the output:
      Cloud            Regions  Default    Type        Description
      cloud-k8stest          0             kubernetes  
      cloud-localhost        1  localhost  lxd  

## Documentation changes

Command documentation updated.

## Bug reference

n/a