### PR TITLE
No longer require storage pools got k8s models - use cluster default

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -103,10 +103,12 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv8 {
 		blockChecker,
 		model.ModelTag(),
 		model.Type(),
+		model.Name(),
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		pm,
 		common.NewResources(),
+		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return &application.APIv8{api}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -4,6 +4,8 @@
 package application_test
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -40,6 +42,7 @@ type ApplicationSuite struct {
 	application        mockApplication
 	storagePoolManager *mockStoragePoolManager
 
+	caasBroker   *mockCaasBroker
 	env          environs.Environ
 	blockChecker mockBlockChecker
 	authorizer   apiservertesting.FakeAuthorizer
@@ -52,6 +55,7 @@ var _ = gc.Suite(&ApplicationSuite{})
 func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authorizer.Tag = user
 	s.storagePoolManager = &mockStoragePoolManager{storageType: k8s.K8s_ProviderType}
+	s.caasBroker = &mockCaasBroker{storageClassName: "storage"}
 	api, err := application.NewAPIBase(
 		&s.backend,
 		&s.backend,
@@ -59,6 +63,7 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		&s.blockChecker,
 		names.NewModelTag(utils.MustNewUUID().String()),
 		state.ModelTypeIAAS,
+		"caasmodel",
 		func(application.Charm) *state.Charm {
 			return &state.Charm{}
 		},
@@ -68,6 +73,7 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		},
 		s.storagePoolManager,
 		common.NewResources(),
+		s.caasBroker,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &application.APIv8{api}
@@ -551,6 +557,7 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 func (s *ApplicationSuite) TestDeployCAASModelNoOperatorStorage(c *gc.C) {
 	application.SetModelType(s.api, state.ModelTypeCAAS)
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
+	s.caasBroker.SetErrors(errors.NotFoundf("storage class"))
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "foo",
@@ -558,8 +565,27 @@ func (s *ApplicationSuite) TestDeployCAASModelNoOperatorStorage(c *gc.C) {
 			NumUnits:        1,
 		}},
 	}
-	_, err := s.api.Deploy(args)
-	c.Assert(err, gc.ErrorMatches, `deploying a Kubernetes application requires a storage pool called "operator-storage": .*`)
+	result, err := s.api.Deploy(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	msg := result.OneError().Error()
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, `deploying a Kubernetes application requires a suitable storage class.*`)
+}
+
+func (s *ApplicationSuite) TestDeployCAASModelDefaultOperatorStorageClass(c *gc.C) {
+	application.SetModelType(s.api, state.ModelTypeCAAS)
+	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
+	args := params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{{
+			ApplicationName: "foo",
+			CharmURL:        "local:foo-0",
+			NumUnits:        1,
+		}},
+	}
+	result, err := s.api.Deploy(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
 }
 
 func (s *ApplicationSuite) TestDeployCAASModelWrongOperatorStorageType(c *gc.C) {
@@ -572,11 +598,15 @@ func (s *ApplicationSuite) TestDeployCAASModelWrongOperatorStorageType(c *gc.C) 
 			NumUnits:        1,
 		}},
 	}
-	_, err := s.api.Deploy(args)
-	c.Assert(err, gc.ErrorMatches, `the "operator-storage" storage pool requires a provider type of "kubernetes", not "rootfs"`)
+	result, err := s.api.Deploy(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	msg := result.OneError().Error()
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, `the "operator-storage" storage pool requires a provider type of "kubernetes", not "rootfs"`)
 }
 
 func (s *ApplicationSuite) TestDeployCAASModelNoStoragePool(c *gc.C) {
+	s.caasBroker.SetErrors(errors.NotFoundf("storage class"))
 	application.SetModelType(s.api, state.ModelTypeCAAS)
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
@@ -590,7 +620,25 @@ func (s *ApplicationSuite) TestDeployCAASModelNoStoragePool(c *gc.C) {
 	}
 	result, err := s.api.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.ErrorMatches, `storage pool for "database" must be specified`)
+	msg := result.OneError().Error()
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, `storage pool for "database" must be specified since there's no cluster default storage class`)
+}
+
+func (s *ApplicationSuite) TestDeployCAASModelDefaultStorageClass(c *gc.C) {
+	application.SetModelType(s.api, state.ModelTypeCAAS)
+	args := params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{{
+			ApplicationName: "foo",
+			CharmURL:        "local:foo-0",
+			NumUnits:        1,
+			Storage: map[string]storage.Constraints{
+				"database": {},
+			},
+		}},
+	}
+	result, err := s.api.Deploy(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results[0].Error, gc.IsNil)
 }
 
 func (s *ApplicationSuite) TestDeployCAASModelWrongStorageType(c *gc.C) {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -53,10 +53,12 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		blockChecker,
 		model.ModelTag(),
 		model.Type(),
+		model.Name(),
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
 		common.NewResources(),
+		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.applicationAPI = &application.APIv8{api}
@@ -192,10 +194,12 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 		blockChecker,
 		names.NewModelTag(st.ModelUUID()),
 		state.ModelTypeCAAS,
+		"caasmodel",
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
 		common.NewResources(),
+		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{api}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/schema"
 	jtesting "github.com/juju/testing"
@@ -791,4 +792,18 @@ func (m *mockStoragePoolManager) Get(name string) (*storage.Config, error) {
 		storageType = provider.RootfsProviderType
 	}
 	return storage.NewConfig(name, storageType, map[string]interface{}{"foo": "bar"})
+}
+
+type mockCaasBroker struct {
+	jtesting.Stub
+	caas.Broker
+	storageClassName string
+}
+
+func (m *mockCaasBroker) GetStorageClassName(labels ...string) (string, error) {
+	m.MethodCall(m, "GetStorageClassName", labels)
+	if err := m.NextErr(); err != nil {
+		return "", err
+	}
+	return m.storageClassName, m.NextErr()
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -149,15 +150,17 @@ func charmStorageParams(
 	var size uint64 = 1024
 
 	result := params.KubernetesFilesystemParams{
-		Size: size,
+		Size:     size,
+		Provider: string(provider.K8s_ProviderType),
 	}
 
 	providerType, cfg, err := storagecommon.StoragePoolConfig(pool, poolManager, registry)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return params.KubernetesFilesystemParams{}, errors.Trace(err)
 	}
-
-	result.Provider = string(providerType)
-	result.Attributes = cfg.Attrs()
+	if err == nil {
+		result.Provider = string(providerType)
+		result.Attributes = cfg.Attrs()
+	}
 	return result, nil
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -167,8 +167,23 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
 	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
-	_, err := s.api.OperatorProvisioningInfo()
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	result, err := s.api.OperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
+		ImagePath:    s.st.operatorImage,
+		Version:      version.Current,
+		APIAddresses: []string{"10.0.0.1:1"},
+		Tags: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id()},
+		CharmStorage: params.KubernetesFilesystemParams{
+			Size:     uint64(1024),
+			Provider: "kubernetes",
+			Tags: map[string]string{
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id()},
+		},
+	})
 }
 
 func (s *CAASProvisionerSuite) TestAddresses(c *gc.C) {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -109,6 +109,10 @@ type Broker interface {
 	// EnsureNamespace ensures this broker's namespace is created.
 	EnsureNamespace() error
 
+	// GetStorageClassName returns the name of a storage class with the specified
+	// labels, or else the cluster default storage class, or else a NotFound error.
+	GetStorageClassName(labels ...string) (string, error)
+
 	// EnsureOperator creates or updates an operator pod for running
 	// a charm for the specified application.
 	EnsureOperator(appName, agentPath string, config *OperatorConfig) error

--- a/caas/config.go
+++ b/caas/config.go
@@ -4,6 +4,8 @@
 package caas
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -72,4 +74,18 @@ func ConfigDefaults(providerDefaults schema.Defaults) schema.Defaults {
 		defaults[key] = value
 	}
 	return defaults
+}
+
+// OperatorStorageClassLabels returns possible labels used to search for a
+// storage class used to provision operator storage.
+func OperatorStorageClassLabels(appName, model string) []string {
+	volStorageLabel := fmt.Sprintf("%s-operator-storage", appName)
+	return []string{volStorageLabel, model, "default"}
+}
+
+// UnitStorageClassLabels returns possible labels used to search for a
+// storage class used to provision unit storage.
+func UnitStorageClassLabels(appName, model string) []string {
+	volStorageLabel := fmt.Sprintf("%s-unit-storage", appName)
+	return []string{volStorageLabel, model, "default"}
 }

--- a/caas/config_test.go
+++ b/caas/config_test.go
@@ -93,3 +93,13 @@ func (s *ConfigSuite) TestConfigSchemaProviderDefaults(c *gc.C) {
 	}
 	c.Assert(defaults, jc.DeepEquals, expectedDefaults)
 }
+
+func (s *ConfigSuite) TestOperatorStorageClassLabels(c *gc.C) {
+	labels := caas.OperatorStorageClassLabels("gitlab", "test")
+	c.Assert(labels, jc.DeepEquals, []string{"gitlab-operator-storage", "test", "default"})
+}
+
+func (s *ConfigSuite) TestUnitStorageClassLabels(c *gc.C) {
+	labels := caas.UnitStorageClassLabels("gitlab", "test")
+	c.Assert(labels, jc.DeepEquals, []string{"gitlab-unit-storage", "test", "default"})
+}


### PR DESCRIPTION
## Description of change

When deploying k8s application, use any storage classes that have been set up on the cluster - either as labelled by the user, or the cluster default. Only require a storage pool to be defined in juju is no such default storage class can be found.

## QA steps

bootstrap a k8s cluster on microk8s
deploy mariadb-k8s without setting up any storage pools
check that it deploys and the PVC comes off the hostpath storage class

## Documentation changes

discourse update required
