### PR TITLE
WIP: Add Cached Applications

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/juju/pubsub"
+)
+
+func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Application {
+	m := &Application{
+		metrics: metrics,
+		hub:     hub,
+	}
+	return m
+}
+
+// Application represents an application in a model.
+type Application struct {
+	// Link to model?
+	metrics *ControllerGauges
+	hub     *pubsub.SimpleHub
+	mu      sync.Mutex
+
+	details    ApplicationChange
+	configHash string
+}
+
+func (m *Application) setDetails(details ApplicationChange) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.details = details
+
+	configHash, err := hash(details.Config)
+	if err != nil {
+		logger.Errorf("invariant error - application config should be yaml serializable and hashable, %v", err)
+		configHash = ""
+	}
+	if configHash != m.configHash {
+		m.configHash = configHash
+		// TODO: publish config change...
+	}
+}

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package cache_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+)
+
+type ApplicationSuite struct {
+	entitySuite
+}
+
+var _ = gc.Suite(&ApplicationSuite{})
+
+func (s *ApplicationSuite) SetUpTest(c *gc.C) {
+	s.entitySuite.SetUpTest(c)
+}
+
+var appChange = cache.ApplicationChange{
+	ModelUUID:   "model-uuid",
+	Name:        "application-name",
+	Exposed:     false,
+	CharmURL:    "www.charm-url.com",
+	Life:        life.Alive,
+	MinUnits:    0,
+	Constraints: constraints.Value{},
+	Config: map[string]interface{}{
+		"key":     "value",
+		"another": "foo",
+	},
+	Subordinate:     false,
+	Status:          status.StatusInfo{Status: status.Active},
+	WorkloadVersion: "666",
+}

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -4,6 +4,7 @@
 package cache
 
 import (
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 )
@@ -23,4 +24,27 @@ type ModelChange struct {
 // from the database.
 type RemoveModel struct {
 	ModelUUID string
+}
+
+// ApplicationChange represents either a new application, or a change
+// to an existing application in a model.
+type ApplicationChange struct {
+	ModelUUID       string
+	Name            string
+	Exposed         bool
+	CharmURL        string
+	Life            life.Value
+	MinUnits        int
+	Constraints     constraints.Value
+	Config          map[string]interface{}
+	Subordinate     bool
+	Status          status.StatusInfo
+	WorkloadVersion string
+}
+
+// RemoveApplication represents the situation when an application
+// is removed from a model in the database.
+type RemoveApplication struct {
+	ModelUUID string
+	Name      string
 }

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -6,9 +6,62 @@ package cache_test
 import (
 	"testing"
 
+	"github.com/juju/loggo"
+	"github.com/juju/pubsub"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+// baseSuite is the foundation for test suites in this package.
+type baseSuite struct {
+	jujutesting.IsolationSuite
+
+	gauges *cache.ControllerGauges
+}
+
+func (s *baseSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.gauges = cache.CreateControllerGauges()
+}
+
+// entitySuite is the base suite for testing cached entities
+// (models, applications, machines).
+type entitySuite struct {
+	baseSuite
+
+	hub *pubsub.SimpleHub
+}
+
+func (s *entitySuite) SetUpTest(c *gc.C) {
+	s.baseSuite.SetUpTest(c)
+
+	logger := loggo.GetLogger("test")
+	logger.SetLogLevel(loggo.TRACE)
+	s.hub = pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
+		Logger: logger,
+	})
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/cache")
+
+	// This package only brings in other core packages.
+	c.Assert(found, jc.SameContents, []string{
+		"core/constraints",
+		"core/instance",
+		"core/life",
+		"core/status",
+	})
 }

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -233,7 +233,31 @@ func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
 			Status:    coreStatus(value.Status),
 			// TODO: constraints, sla
 		}
-
+	case "application":
+		if d.Removed {
+			return cache.RemoveApplication{
+				ModelUUID: id.ModelUUID,
+				Name:      id.Id,
+			}
+		}
+		value, ok := d.Entity.(*multiwatcher.ApplicationInfo)
+		if !ok {
+			c.config.Logger.Errorf("unexpected type %T", d.Entity)
+			return nil
+		}
+		return cache.ApplicationChange{
+			ModelUUID:       value.ModelUUID,
+			Name:            value.Name,
+			Exposed:         value.Exposed,
+			CharmURL:        value.CharmURL,
+			Life:            life.Value(value.Life),
+			MinUnits:        value.MinUnits,
+			Constraints:     value.Constraints,
+			Config:          value.Config,
+			Subordinate:     value.Subordinate,
+			Status:          coreStatus(value.Status),
+			WorkloadVersion: value.WorkloadVersion,
+		}
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Description of change

This patch builds on @howbazaar's inclusion of applications in the cached controller.

- The worker processes application add/update/remove deltas from the multi-watcher and represents them in the cache.
- Applications can be retrieved from a cached model.

## QA steps

Behaviour is verified with unit tests. Manual QA steps will accompany future patches that watch applications via the cache.

## Documentation changes

None.

## Bug reference

N/A
