### PR TITLE
LXDProfile - Don't apply when not provisioned

### DIFF
--- a/worker/provisioner/broker.go
+++ b/worker/provisioner/broker.go
@@ -138,6 +138,14 @@ func findDNSServerConfig() (*network.DNSConfig, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		// network.ParseResolvConf returns nil error and nil dnsConfig if the
+		// file isn't found, which can lead to a panic when attemptting to
+		// access the dnsConfig.Nameservers. So instead, just continue and
+		// exhaust the resolvConfFiles slice.
+		if dnsConfig == nil {
+			logger.Tracef("The DNS configuration from %s returned no dnsConfig")
+			continue
+		}
 		for _, nameServer := range dnsConfig.Nameservers {
 			if nameServer.Scope != network.ScopeMachineLocal {
 				logger.Debugf("The DNS configuration from %s has been selected for use", dnsConfigFile)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -375,8 +375,8 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 		}
 		m := mResult.Machine
 		removeDoc, err := processOneMachineProfileChange(m, profileBroker)
-		// The machine is not provisioned yet, so we should continue on
-		// and apply the information at a later stage.
+		// The machine is not provisioned yet, therefore we can continue and
+		// the profile will be applied when the machine is provisioned.
 		if err != nil && errors.IsNotProvisioned(err) {
 			continue
 		}
@@ -433,11 +433,14 @@ func processOneMachineProfileChange(
 	} else if machineStatus != status.Running {
 		if _, err := m.InstanceId(); err != nil && params.IsCodeNotProvisioned(err) {
 			logger.Tracef("Attempting to apply a profile to a machine that isn't provisioned %q", ident)
+			// We can remove the instance charm profile data here, knowning that
+			// the ProvisionerAPI will attempt to write it when getting
+			// the machine lxd profile names.
 			if err := m.RemoveUpgradeCharmProfileData(); err != nil {
 				logger.Tracef("cannot remove machine upgrade charm profile data: %s", err.Error())
 			}
-			// There is nothing we can do with this machine, we could continue
-			// on and let the uniter apply the profile at a later stage.
+			// There is nothing we can do with this machine at this point. The
+			// profiles will be applied when the machine is provisioned.
 			return false, errors.NotProvisionedf("machine %q", ident)
 		}
 	}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -377,7 +377,7 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 		removeDoc, err := processOneMachineProfileChange(m, profileBroker)
 		// The machine is not provisioned yet, so we should continue on
 		// and apply the information at a later stage.
-		if errors.IsNotProvisioned(err) {
+		if err != nil && errors.IsNotProvisioned(err) {
 			continue
 		}
 		if removeDoc {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -375,6 +375,11 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 		}
 		m := mResult.Machine
 		removeDoc, err := processOneMachineProfileChange(m, profileBroker)
+		// The machine is not provisioned yet, so we should continue on
+		// and apply the information at a later stage.
+		if errors.IsNotProvisioned(err) {
+			continue
+		}
 		if removeDoc {
 			if err != nil {
 				logger.Errorf("cannot upgrade machine's lxd profile: %s", err.Error())
@@ -421,7 +426,21 @@ func processOneMachineProfileChange(
 	m apiprovisioner.MachineProvisioner,
 	profileBroker environs.LXDProfiler,
 ) (bool, error) {
-	logger.Debugf("processOneMachineProfileChange(%s)", m.Id())
+	ident := m.Id()
+	logger.Debugf("processOneMachineProfileChange(%s)", ident)
+	if machineStatus, _, err := m.InstanceStatus(); err != nil {
+		return false, errors.Annotatef(err, "failed to get machine status %q", ident)
+	} else if machineStatus != status.Running {
+		if _, err := m.InstanceId(); err != nil && params.IsCodeNotProvisioned(err) {
+			logger.Tracef("Attempting to apply a profile to a machine that isn't provisioned %q", ident)
+			if err := m.RemoveUpgradeCharmProfileData(); err != nil {
+				logger.Tracef("cannot remove machine upgrade charm profile data: %s", err.Error())
+			}
+			// There is nothing we can do with this machine, we could continue
+			// on and let the uniter apply the profile at a later stage.
+			return false, errors.NotProvisionedf("machine %q", ident)
+		}
+	}
 	info, err := m.CharmProfileChangeInfo()
 	if err != nil {
 		return false, err

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -256,6 +256,39 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChanges(c *gc.C) {
 	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0", "1", "2", "3"}), jc.ErrorIsNil)
 }
 
+func (s *ProvisionerTaskSuite) TestProcessProfileChangesNotProvisioned(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// Setup mockMachine0 to successfully change from an
+	// old profile to a new profile.
+	mockMachine0, info0 := setUpSuccessfulMockProfileMachine(ctrl, "0", "juju-default-lxd-profile-0", false)
+	mockMachine0.EXPECT().SetCharmProfiles([]string{info0.NewProfileName, "juju-default-different-0"}).Return(nil)
+
+	// Setup mockMachine1 to have a failure from CharmProfileChangeInfo()
+	mockMachine1 := apiprovisionermock.NewMockMachineProvisioner(ctrl)
+	mExp := mockMachine1.EXPECT()
+	mExp.Id().Return("1")
+	mExp.InstanceId().Return(instance.Id("1"), params.Error{Code: params.CodeNotProvisioned})
+	mExp.InstanceStatus().Return(status.Error, "Error", nil)
+	mExp.RemoveUpgradeCharmProfileData().Return(nil)
+
+	s.machinesResults = []apiprovisioner.MachineResult{
+		{Machine: mockMachine0, Err: nil},
+		{Machine: mockMachine1, Err: nil},
+	}
+
+	mockBroker := provisionermocks.NewMockLXDProfileInstanceBroker(ctrl)
+	lExp := mockBroker.EXPECT()
+	machineCharmProfiles := []string{"default", "juju-default", info0.NewProfileName, "juju-default-different-0"}
+	lExp.ReplaceOrAddInstanceProfile(
+		"0", info0.OldProfileName, info0.NewProfileName, info0.LXDProfile,
+	).Return(machineCharmProfiles, nil)
+
+	task := s.newProvisionerTaskWithBroker(c, mockBroker, nil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile", "1#lxd-profile"}), jc.ErrorIsNil)
+}
+
 func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string, sub bool) (*apiprovisionermock.MockMachineProvisioner, apiprovisioner.CharmProfileChangeInfo) {
 	mockMachine := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine.EXPECT()
@@ -269,6 +302,7 @@ func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string,
 	mExp.CharmProfileChangeInfo().Return(info, nil)
 	mExp.Id().Return(num)
 	mExp.InstanceId().Return(instance.Id(num), nil)
+	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	if old == "" && sub {
 		mExp.RemoveUpgradeCharmProfileData().Return(nil)
 	} else {
@@ -285,6 +319,7 @@ func setUpFailureMockProfileMachine(ctrl *gomock.Controller, num string) *apipro
 	mExp := mockMachine.EXPECT()
 	mExp.CharmProfileChangeInfo().Return(apiprovisioner.CharmProfileChangeInfo{}, errors.New("fail me"))
 	mExp.Id().Return(num)
+	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.SetInstanceStatus(status.Error, gomock.Any(), nil).Return(nil)
 	mExp.SetUpgradeCharmProfileComplete(gomock.Any()).Return(nil)
 
@@ -328,6 +363,7 @@ func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *g
 	}
 	mExp.CharmProfileChangeInfo().Return(info, nil)
 	mExp.Id().Return("0")
+	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.InstanceId().Return(instance.Id("0"), nil)
 	differentProfileName := "juju-default-different-0"
 	mExp.SetCharmProfiles([]string{differentProfileName, newProfileName}).Return(nil)
@@ -391,6 +427,7 @@ func setUpMocksProcessOneMachineProfileChange(c *gc.C, info apiprovisioner.Charm
 	mExp := mockMachineProvisioner.EXPECT()
 	mExp.CharmProfileChangeInfo().Return(info, nil)
 	mExp.Id().Return("0")
+	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	mExp.InstanceId().Return(instance.Id("0"), nil)
 
 	differentProfileName := "juju-default-different-0"


### PR DESCRIPTION
## Description of change

Don't apply when not provisioned  …
The following changes ensure that we don't attempt to apply a
charm profile to a machine that isn't either running or that isn't
provisioned.

Interestingly the charm profile will be written later on when ensuring
that the profile is there, by the provisioner API. So we don't have
to write any other code that to stop the applying of the charm
profile.

 - Add tests around provisioner task

## QA steps

Run the following commands to ensure that add machines correctly.
```sh
juju bootstrap lxd
juju deploy ~/bundle-no-sub.yaml
watch --color -n 1 juju status --color
```

You should see the following output in status:
```
Model    Controller  Cloud/Region  Version  SLA          Timestamp
default  xxx         lxd/default   2.5.1.1  unsupported  16:21:56Z

App          Version  Status  Scale  Charm        Store  Rev  OS      Notes
lxd-profile  18.04    active      9  lxd-profile  local    0  ubuntu  
ubuntu       18.04    active      9  ubuntu-lite  local    0  ubuntu  

Unit            Workload  Agent  Machine  Public address  Ports  Message
lxd-profile/0*  active    idle   0        10.178.104.238         load: 0.54, 1.18, 1.39
lxd-profile/1   active    idle   1        10.178.104.176         load: 0.50, 1.16, 1.38
lxd-profile/2   active    idle   2        10.178.104.163         load: 1.13, 1.14, 1.33
lxd-profile/3   active    idle   3        10.178.104.151         load: 1.26, 1.21, 1.35
lxd-profile/4   active    idle   4        10.178.104.226         load: 1.28, 1.17, 1.35
lxd-profile/5   active    idle   5        10.178.104.253         load: 1.26, 1.21, 1.35
lxd-profile/6   active    idle   6        10.178.104.47          load: 1.28, 1.17, 1.35
lxd-profile/7   active    idle   7        10.178.104.43          load: 1.16, 1.19, 1.34
lxd-profile/8   active    idle   8        10.178.104.185         load: 1.28, 1.17, 1.35
ubuntu/0*       active    idle   0        10.178.104.238         load: 1.06, 1.16, 1.33
ubuntu/1        active    idle   1        10.178.104.176         load: 1.13, 1.14, 1.33
ubuntu/2        active    idle   2        10.178.104.163         load: 0.66, 1.15, 1.37
ubuntu/3        active    idle   3        10.178.104.151         load: 0.66, 1.15, 1.37
ubuntu/4        active    idle   4        10.178.104.226         load: 1.13, 1.18, 1.33
ubuntu/5        active    idle   5        10.178.104.253         load: 0.66, 1.15, 1.37
ubuntu/6        active    idle   6        10.178.104.47          load: 0.61, 1.13, 1.37
ubuntu/7        active    idle   7        10.178.104.43          load: 1.13, 1.18, 1.33
ubuntu/8        active    idle   8        10.178.104.185         load: 1.13, 1.18, 1.33

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.178.104.238  juju-c02210-0  bionic      Running
1        started  10.178.104.176  juju-c02210-1  bionic      Running
2        started  10.178.104.163  juju-c02210-2  bionic      Running
3        started  10.178.104.151  juju-c02210-3  bionic      Running
4        started  10.178.104.226  juju-c02210-4  bionic      Running
5        started  10.178.104.253  juju-c02210-5  bionic      Running
6        started  10.178.104.47   juju-c02210-6  bionic      Running
7        started  10.178.104.43   juju-c02210-7  bionic      Running
8        started  10.178.104.185  juju-c02210-8  bionic      Running
```

And the `lxc profile list` should also state:
```
+----------------------------+---------+
|            NAME            | USED BY |
+----------------------------+---------+
| default                    | 10      |
+----------------------------+---------+
| juju-controller            | 1       |
+----------------------------+---------+
| juju-default               | 9       |
+----------------------------+---------+
| juju-default-lxd-profile-0 | 8       |
+----------------------------+---------+
``` 

bundle-no-sub.yaml
```yaml
series: bionic
applications:
  lxd-profile:
    charm: ~/go/src/github.com/juju/juju/testcharms/charm-repo/quantal/lxd-profile
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
  ubuntu:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
machines:
  "0": {}
  "1": {}
  "2": {}
  "3": {}
  "4": {}
  "5": {}
  "6": {}
  "7": {}
  "8": {}
```

## Documentation changes



## Bug reference
https://bugs.launchpad.net/juju/+bug/1813044

