### PR TITLE
LXDProfile - Don't attempt to remove profiles on dead machines

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -377,7 +377,8 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 		removeDoc, err := processOneMachineProfileChange(m, profileBroker)
 		// The machine is not provisioned yet, therefore we can continue and
 		// the profile will be applied when the machine is provisioned.
-		if err != nil && errors.IsNotProvisioned(err) {
+		if err != nil && (errors.IsNotProvisioned(err) || errors.IsNotValid(err)) {
+			// If the machine is not valid, then continue onwards.
 			continue
 		}
 		if removeDoc {
@@ -427,7 +428,19 @@ func processOneMachineProfileChange(
 	profileBroker environs.LXDProfiler,
 ) (bool, error) {
 	ident := m.Id()
-	logger.Debugf("processOneMachineProfileChange(%s)", ident)
+	logger.Tracef("processOneMachineProfileChange(%s)", ident)
+	// We need to check for the life of the machine here, as the machine
+	// might have been dying when the watcher fired, but is now dead by
+	// the time this is triggered. We still want to clean up dying machines
+	// of the charm profile data, so that the we don't leave any orphan
+	// documents. If the machine is dead, we can't clean up the document
+	// as the machine is dead and we'll return an error doing so.
+	if m.Life() == params.Dead {
+		// Machine is dead, continue onwards as we can't do anything in this
+		// position.
+		logger.Tracef("failed to process profile changes as the machine is dead %q", ident)
+		return false, errors.NotValidf("machine %q", ident)
+	}
 	if machineStatus, _, err := m.InstanceStatus(); err != nil {
 		return false, errors.Annotatef(err, "failed to get machine status %q", ident)
 	} else if machineStatus != status.Running {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -269,9 +269,41 @@ func (s *ProvisionerTaskSuite) TestProcessProfileChangesNotProvisioned(c *gc.C) 
 	mockMachine1 := apiprovisionermock.NewMockMachineProvisioner(ctrl)
 	mExp := mockMachine1.EXPECT()
 	mExp.Id().Return("1")
+	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id("1"), params.Error{Code: params.CodeNotProvisioned})
 	mExp.InstanceStatus().Return(status.Error, "Error", nil)
 	mExp.RemoveUpgradeCharmProfileData().Return(nil)
+
+	s.machinesResults = []apiprovisioner.MachineResult{
+		{Machine: mockMachine0, Err: nil},
+		{Machine: mockMachine1, Err: nil},
+	}
+
+	mockBroker := provisionermocks.NewMockLXDProfileInstanceBroker(ctrl)
+	lExp := mockBroker.EXPECT()
+	machineCharmProfiles := []string{"default", "juju-default", info0.NewProfileName, "juju-default-different-0"}
+	lExp.ReplaceOrAddInstanceProfile(
+		"0", info0.OldProfileName, info0.NewProfileName, info0.LXDProfile,
+	).Return(machineCharmProfiles, nil)
+
+	task := s.newProvisionerTaskWithBroker(c, mockBroker, nil)
+	c.Assert(provisioner.ProcessProfileChanges(task, []string{"0#lxd-profile", "1#lxd-profile"}), jc.ErrorIsNil)
+}
+
+func (s *ProvisionerTaskSuite) TestProcessProfileChangesWithDeadMachine(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// Setup mockMachine0 to successfully change from an
+	// old profile to a new profile.
+	mockMachine0, info0 := setUpSuccessfulMockProfileMachine(ctrl, "0", "juju-default-lxd-profile-0", false)
+	mockMachine0.EXPECT().SetCharmProfiles([]string{info0.NewProfileName, "juju-default-different-0"}).Return(nil)
+
+	// Setup mockMachine1 to have a failure from CharmProfileChangeInfo()
+	mockMachine1 := apiprovisionermock.NewMockMachineProvisioner(ctrl)
+	mExp := mockMachine1.EXPECT()
+	mExp.Id().Return("1")
+	mExp.Life().Return(params.Dead)
 
 	s.machinesResults = []apiprovisioner.MachineResult{
 		{Machine: mockMachine0, Err: nil},
@@ -301,6 +333,7 @@ func setUpSuccessfulMockProfileMachine(ctrl *gomock.Controller, num, old string,
 	}
 	mExp.CharmProfileChangeInfo().Return(info, nil)
 	mExp.Id().Return(num)
+	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id(num), nil)
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
 	if old == "" && sub {
@@ -320,6 +353,7 @@ func setUpFailureMockProfileMachine(ctrl *gomock.Controller, num string) *apipro
 	mExp.CharmProfileChangeInfo().Return(apiprovisioner.CharmProfileChangeInfo{}, errors.New("fail me"))
 	mExp.Id().Return(num)
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
+	mExp.Life().Return(params.Alive)
 	mExp.SetInstanceStatus(status.Error, gomock.Any(), nil).Return(nil)
 	mExp.SetUpgradeCharmProfileComplete(gomock.Any()).Return(nil)
 
@@ -364,6 +398,7 @@ func (s *ProvisionerTaskSuite) testProcessOneMachineProfileChangeAddProfile(c *g
 	mExp.CharmProfileChangeInfo().Return(info, nil)
 	mExp.Id().Return("0")
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
+	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id("0"), nil)
 	differentProfileName := "juju-default-different-0"
 	mExp.SetCharmProfiles([]string{differentProfileName, newProfileName}).Return(nil)
@@ -428,6 +463,7 @@ func setUpMocksProcessOneMachineProfileChange(c *gc.C, info apiprovisioner.Charm
 	mExp.CharmProfileChangeInfo().Return(info, nil)
 	mExp.Id().Return("0")
 	mExp.InstanceStatus().Return(status.Running, "Running", nil)
+	mExp.Life().Return(params.Alive)
 	mExp.InstanceId().Return(instance.Id("0"), nil)
 
 	differentProfileName := "juju-default-different-0"


### PR DESCRIPTION
## Description of change

The following commit attempts to ensure that we don't process
dead machines when applying profiles. If the machine is dead,
we will continue onwards as if that machine is no longer around.

Note this means that we could end up leaving profiles in an orphaned
state. Cleaning up these orphaned profiles shouldn't do any harm,
as each one is unique to a application on a host/container. If
there is a chance that a conflict arises and all machines have been
blown away, then you can safely remove them directly from LXC.

## QA steps

Run the following commands to ensure that add machines correctly.
```sh
juju bootstrap lxd
juju deploy ~/bundle-no-sub.yaml
watch --color -n 1 juju status --color
```

Once all of the instances have been created, run the following:

```sh
juju destroy lxd -y --destroy-all-models
```

bundle-no-sub.yaml
```yaml
series: bionic
applications:
  lxd-profile:
    charm: ~/go/src/github.com/juju/juju/testcharms/charm-repo/quantal/lxd-profile
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
  ubuntu:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
machines:
  "0": {}
  "1": {}
  "2": {}
  "3": {}
  "4": {}
  "5": {}
  "6": {}
  "7": {}
  "8": {}
```

## Documentation changes



## Bug reference
https://bugs.launchpad.net/juju/+bug/1813044



