### PR TITLE
LXDProfile - Provision profile error

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1341,7 +1341,10 @@ func (p *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg par
 		logger.Debugf("failed to SetInstanceStatus for %q: %v", mTag, err)
 		return err
 	}
+	// When the status passed is an error condition, also set the status to
+	// that error condition.
 	if status.Status(arg.Status) == status.ProvisioningError ||
+		status.Status(arg.Status) == status.ProvisioningProfileError ||
 		status.Status(arg.Status) == status.Error {
 		s.Status = status.Error
 		logger.Debugf("SetInstanceStatus triggering SetStatus for %#v", s)

--- a/core/status/status.go
+++ b/core/status/status.go
@@ -219,6 +219,12 @@ const (
 	Provisioning      Status = "allocating"
 	Running           Status = "running"
 	ProvisioningError Status = "provisioning error"
+
+	// ProvisioningProfileError represents a charm profile error when
+	// attemptting to apply a charm profile to a machine. The issue occurs when
+	// the LXD profile returns an error, but the LXC instance states that the
+	// container is running.
+	ProvisioningProfileError Status = "provisioning profile error"
 )
 
 const (

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -388,8 +388,14 @@ func (task *provisionerTask) processProfileChanges(ids []string) error {
 				return errors.Annotatef(err2, "cannot set error status for instance charm profile data for machine %q", m)
 			}
 			// If Error, SetInstanceStatus in the provisioner api will also call
-			// SetStatus.
-			if err2 := m.SetInstanceStatus(status.Error, "cannot upgrade machine's lxd profile: "+err.Error(), nil); err2 != nil {
+			// SetStatus. The ProvisioningProfileError will ensure that the
+			// machine won't return back to status.Running, until intervention
+			// from an operator has happened.
+			// This is because the pollInstanceInfo checks the underlying LXC
+			// container instance for it's status, which returns Running, but
+			// in reality the profile wasn't applied and we can't provide what
+			// the operator wanted, so we force the machine into a profile error.
+			if err2 := m.SetInstanceStatus(status.ProvisioningProfileError, "cannot upgrade machine's lxd profile: "+err.Error(), nil); err2 != nil {
 				return errors.Annotatef(err2, "cannot set error status for machine %q", m)
 			}
 		} else {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -285,7 +285,7 @@ func setUpFailureMockProfileMachine(ctrl *gomock.Controller, num string) *apipro
 	mExp := mockMachine.EXPECT()
 	mExp.CharmProfileChangeInfo().Return(apiprovisioner.CharmProfileChangeInfo{}, errors.New("fail me"))
 	mExp.Id().Return(num)
-	mExp.SetInstanceStatus(status.Error, gomock.Any(), nil).Return(nil)
+	mExp.SetInstanceStatus(status.ProvisioningProfileError, gomock.Any(), nil).Return(nil)
 	mExp.SetUpgradeCharmProfileComplete(gomock.Any()).Return(nil)
 
 	return mockMachine


### PR DESCRIPTION
## Description of change

The following commit changes how the instance poller works, because
of the fact that LXC reports a container running even if the LXD
profile applied failed.

So when applying a profile change to a container, the profile is
first added to LXD. The profile name is then added to the container
spec. Once the container is started it can sometimes error out
with an error. The problem occurs when the instance poller comes
around and asks for the instance status. LXD returns that response
as running, as it doesn't know that applying a profile that fails
should be a terminal state. We could attempt to apply the profile
again, but the LXD client doesn't tell us what the error is and
what was the cause. So retrying a profile might not be worth it,
missing device vs just unable to apply the profile at that time.

Instead we find out when the profile didn't apply and we put the
machine in to a profile error status, which can then be picked up
by the poller, which in turn can then work out if we should keep
the current error message and prevent it from become running or
we should move along.

The underlying fix for this is to get LXD to go into an ERROR state
if when applying a profile it fails, instead of a RUNNING state.

## QA steps

```sh
juju bootstrap lxd 
juju deploy ~/bundle-no-sub.yaml 
watch --color -n 1 juju status --color
```

Check that the error is kept when the machine `0` can't apply the
profile.

```
Model    Controller  Cloud/Region  Version  SLA          Timestamp
default  xxx         lxd/default   2.5.1.1  unsupported  17:42:05Z

App          Version  Status   Scale  Charm        Store  Rev  OS      Notes
lxd-profile  18.04    waiting    2/5  lxd-profile  local    0  ubuntu  
ubuntu       18.04    waiting    2/5  ubuntu-lite  local    0  ubuntu  

Unit            Workload  Agent       Machine  Public address  Ports  Message
lxd-profile/0*  active    idle        0        10.178.104.124         ready
lxd-profile/1   active    idle        1        10.178.104.226         ready
lxd-profile/2   waiting   allocating  2                               waiting for machine
lxd-profile/3   waiting   allocating  3                               waiting for machine
lxd-profile/4   waiting   allocating  4                               waiting for machine
ubuntu/0*       active    idle        0        10.178.104.124         ready
ubuntu/1        active    idle        1        10.178.104.226         ready
ubuntu/2        waiting   allocating  2                               waiting for machine
ubuntu/3        waiting   allocating  3                               waiting for machine
ubuntu/4        waiting   allocating  4                               waiting for machine

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.178.104.124  juju-be6237-0  bionic      cannot upgrade machine's lxd profile: Failed to add mount for device: Failed to run: /snap/lxd/current/bin/lxd forkmount lxc-mount juju-be6237-0 /var/snap/lxd/common/lxd/containers /var/snap/lxd/common/lxd/logs/juju-be6237-0/lxc.conf /var/snap/lxd/common/lxd/devices/juju-be6237-0/unix.tun.dev-net-tun /dev/net/tun none 4096: 
1        started  10.178.104.226  juju-be6237-1  bionic      Running
2        down                     pending        bionic      cannot upgrade machine's lxd profile: machine 2 not provisioned
3        down                     pending        bionic      cannot upgrade machine's lxd profile: machine 3 not provisioned
4        down                     pending        bionic      cannot upgrade machine's lxd profile: machine 4 not provisioned
```

bundle-no-sub.yaml
```yaml
series: bionic
applications:
  lxd-profile:
    charm: ~/go/src/github.com/juju/juju/testcharms/charm-repo/quantal/lxd-profile
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
  ubuntu:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 9
    to:
    - "0"
    - "1"
    - "2"
    - "3"
    - "4"
    - "5"
    - "6"
    - "7"
    - "8"
machines:
  "0": {}
  "1": {}
  "2": {}
  "3": {}
  "4": {}
  "5": {}
  "6": {}
  "7": {}
  "8": {}
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813044