### PR TITLE
Remove HA backup/restore

### DIFF
--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -130,7 +130,7 @@ def assess_recovery(bs_manager, strategy, charm_series):
 
     # ha-backup allows us to still backup in HA mode, so allow us to still
     # create a cluster of controllers.
-    if strategy in ('ha-backup'):
+    if strategy == 'ha-backup':
         enable_ha(bs_manager, controller_client)
         backup_file = controller_client.backup()
         # at the moment we can't currently restore a backup in HA without

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1603,11 +1603,6 @@ class ModelClient:
         reporter = GroupReporter(sys.stdout, desired_state)
         self._wait_for_status(reporter, status_to_ha, VotingNotEnabled,
                               timeout=timeout, start=start)
-        # XXX sinzui 2014-12-04: bug 1399277 happens because
-        # juju claims HA is ready when the monogo replica sets
-        # are not. Juju is not fully usable. The replica set
-        # lag might be 5 minutes.
-        self._backend.pause(300)
 
     def wait_for_deploy_started(self, service_count=1, timeout=1200):
         """Wait until service_count services are 'started'.

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1603,6 +1603,11 @@ class ModelClient:
         reporter = GroupReporter(sys.stdout, desired_state)
         self._wait_for_status(reporter, status_to_ha, VotingNotEnabled,
                               timeout=timeout, start=start)
+        # XXX sinzui 2014-12-04: bug 1399277 happens because
+        # juju claims HA is ready when the monogo replica sets
+        # are not. Juju is not fully usable. The replica set
+        # lag might be 5 minutes.
+        self._backend.pause(300)
 
     def wait_for_deploy_started(self, service_count=1, timeout=1200):
         """Wait until service_count services are 'started'.


### PR DESCRIPTION
## Description of change

The following changes removes the HA backup/restore of the
acceptance test as we no longer support it. Having talked to Rick
about this, we decided to remove this until we can re-add it back
to the CLI. This way we can then get the recovery CI tests going
green.

## QA steps

```
mkdir /tmp/test-run
mkdir /tmp/artifacts
export JUJU_HOME=/tmp/test-run
export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository
vim $JUJU_HOME/environments.yaml
```

Local LXD environments.yaml
```yaml
environments:
    lxd:
        type: lxd
        test-mode: true
        default-series: bionic
```

AWS environments.yaml
```yaml
environments:
    myaws:
        type: ec2
        test-mode: true
        default-series: bionic
        region: us-east-1
```

Run the following (substitute the right arg):
```
cd acceptancetests
./assess_recovery.py <lxd|myaws>
```