### PR TITLE
raft-leases: Skip legacy leases with blank name/holder when upgrading

### DIFF
--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -178,6 +178,10 @@ func MigrateLegacyLeases(context Context) error {
 
 	// Populate the snapshot and the leaseholders collection.
 	for key, info := range legacyLeases {
+		if key.Lease == "" || info.Holder == "" {
+			logger.Debugf("not migrating blank lease %#v holder %q", key, info.Holder)
+			continue
+		}
 		entries[raftlease.SnapshotKey{
 			Namespace: key.Namespace,
 			ModelUUID: key.ModelUUID,


### PR DESCRIPTION
## Description of change

These were causing errors reported from migrating the leases to raft during the upgrade. The leases wouldn't cause a problem other than a delay, because nothing would be extending them.

It's not clear why some production systems have these (possibly they used to be created in some much earlier version and have lasted through upgrades), but they're not valid for raft leases so don't try to migrate them.

## QA steps

* Bootstrap a 2.4.x controller.
* Monkey with the database to create some leases with blank names and/or holders.
* Upgrade the controller to this version of Juju.
* There should be no errors about invalid lease names or holders in the controller log, or blank leases in the leaseholders collection.
* There shouldn't be any blank leases in the raft snapshot created when migrating the leases.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813995
