### PR TITLE
User Feedback for advance-generation Invoking Generation Completion

### DIFF
--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -36,6 +36,6 @@ type Generation interface {
 	AssignAllUnits(string) error
 	AssignUnit(string) error
 	MakeCurrent() error
-	AutoComplete() error
+	AutoComplete() (bool, error)
 	Refresh() error
 }

--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -35,9 +35,7 @@ type GenerationModel interface {
 type Generation interface {
 	AssignAllUnits(string) error
 	AssignUnit(string) error
-	CanMakeCurrent() (bool, []string, error)
 	MakeCurrent() error
-	CanAutoComplete() (bool, error)
 	AutoComplete() error
 	Refresh() error
 }

--- a/apiserver/facades/client/modelgeneration/mocks/generation_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/generation_mock.go
@@ -57,10 +57,11 @@ func (mr *MockGenerationMockRecorder) AssignUnit(arg0 interface{}) *gomock.Call 
 }
 
 // AutoComplete mocks base method
-func (m *MockGeneration) AutoComplete() error {
+func (m *MockGeneration) AutoComplete() (bool, error) {
 	ret := m.ctrl.Call(m, "AutoComplete")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AutoComplete indicates an expected call of AutoComplete

--- a/apiserver/facades/client/modelgeneration/mocks/generation_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/generation_mock.go
@@ -68,33 +68,6 @@ func (mr *MockGenerationMockRecorder) AutoComplete() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutoComplete", reflect.TypeOf((*MockGeneration)(nil).AutoComplete))
 }
 
-// CanAutoComplete mocks base method
-func (m *MockGeneration) CanAutoComplete() (bool, error) {
-	ret := m.ctrl.Call(m, "CanAutoComplete")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CanAutoComplete indicates an expected call of CanAutoComplete
-func (mr *MockGenerationMockRecorder) CanAutoComplete() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanAutoComplete", reflect.TypeOf((*MockGeneration)(nil).CanAutoComplete))
-}
-
-// CanMakeCurrent mocks base method
-func (m *MockGeneration) CanMakeCurrent() (bool, []string, error) {
-	ret := m.ctrl.Call(m, "CanMakeCurrent")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].([]string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CanMakeCurrent indicates an expected call of CanMakeCurrent
-func (mr *MockGenerationMockRecorder) CanMakeCurrent() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanMakeCurrent", reflect.TypeOf((*MockGeneration)(nil).CanMakeCurrent))
-}
-
 // MakeCurrent mocks base method
 func (m *MockGeneration) MakeCurrent() error {
 	ret := m.ctrl.Call(m, "MakeCurrent")

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/state"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.modelgeneration")
@@ -153,12 +152,10 @@ func (m *ModelGenerationAPI) AdvanceGeneration(arg params.AdvanceGenerationArg) 
 	result := params.AdvanceGenerationResult{AdvanceResults: results}
 
 	// Complete the generation if possible.
-	if err := generation.AutoComplete(); err != nil {
-		if errors.Cause(err) != state.ErrGenerationNoAutoComplete {
-			result.CompleteResult.Error = common.ServerError(err)
-		}
-	} else {
-		result.CompleteResult.Result = true
+	completed, err := generation.AutoComplete()
+	result.CompleteResult = params.BoolResult{
+		Result: completed,
+		Error:  common.ServerError(err),
 	}
 	return result, nil
 }

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/modelgeneration"
 	"github.com/juju/juju/apiserver/facades/client/modelgeneration/mocks"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 )
 
 var _ = gc.Suite(&modelGenerationSuite{})
@@ -73,7 +72,7 @@ func (s *modelGenerationSuite) TestAdvanceGenerationErrorNoAutoComplete(c *gc.C)
 		gExp := mockGeneration.EXPECT()
 		gExp.AssignAllUnits("ghost").Return(nil)
 		gExp.AssignUnit("mysql/0").Return(nil)
-		gExp.AutoComplete().Return(state.ErrGenerationNoAutoComplete)
+		gExp.AutoComplete().Return(false, nil)
 		gExp.Refresh().Return(nil).Times(3)
 
 		mExp := mockModel.EXPECT()
@@ -104,7 +103,7 @@ func (s *modelGenerationSuite) TestAdvanceGenerationSuccessAutoComplete(c *gc.C)
 		gExp := mockGeneration.EXPECT()
 		gExp.AssignAllUnits("ghost").Return(nil)
 		gExp.AssignUnit("mysql/0").Return(nil)
-		gExp.AutoComplete().Return(nil)
+		gExp.AutoComplete().Return(true, nil)
 		gExp.Refresh().Return(nil).Times(2)
 
 		mExp := mockModel.EXPECT()

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1100,3 +1100,16 @@ type AdvanceGenerationArg struct {
 	Model    Entity   `json:"model"`
 	Entities []Entity `json:"entities"`
 }
+
+// AdvanceGenerationResult contains the results of a call to AdvanceGeneration.
+type AdvanceGenerationResult struct {
+	// AdvanceResults contains the results from advancing each of the supplied
+	// entities to the next generation.
+	AdvanceResults ErrorResults `json:"advance-results"`
+
+	// CompletedResult will be non-empty when advancing units to the next
+	// generation invokes the generation's auto-completion.
+	// The results of rolling the next generation into the current will be
+	// represented here.
+	CompleteResult BoolResult `json:"complete-result,omitempty"`
+}

--- a/cmd/juju/model/mocks/advancegeneration_mock.go
+++ b/cmd/juju/model/mocks/advancegeneration_mock.go
@@ -33,10 +33,11 @@ func (m *MockAdvanceGenerationCommandAPI) EXPECT() *MockAdvanceGenerationCommand
 }
 
 // AdvanceGeneration mocks base method
-func (m *MockAdvanceGenerationCommandAPI) AdvanceGeneration(arg0 string, arg1 []string) error {
+func (m *MockAdvanceGenerationCommandAPI) AdvanceGeneration(arg0 string, arg1 []string) (bool, error) {
 	ret := m.ctrl.Call(m, "AdvanceGeneration", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AdvanceGeneration indicates an expected call of AdvanceGeneration

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -187,15 +187,19 @@ func (s *generationSuite) TestAutoCompleteSuccess(c *gc.C) {
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Assert(gen.IsCompleted(), jc.IsFalse)
 
-	c.Assert(gen.AutoComplete(), jc.ErrorIsNil)
+	completed, err := gen.AutoComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.IsTrue)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	c.Assert(gen.IsCompleted(), jc.IsTrue)
+	c.Check(gen.IsCompleted(), jc.IsTrue)
 
 	// Idempotent.
-	c.Assert(gen.AutoComplete(), jc.ErrorIsNil)
+	completed, err = gen.AutoComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.IsTrue)
 }
 
-func (s *generationSuite) TestAutoCompleteGenerationIncompleteError(c *gc.C) {
+func (s *generationSuite) TestAutoCompleteGenerationIncomplete(c *gc.C) {
 	s.setupAssignAllUnits(c)
 
 	gen, err := s.Model.NextGeneration()
@@ -203,7 +207,11 @@ func (s *generationSuite) TestAutoCompleteGenerationIncompleteError(c *gc.C) {
 
 	c.Assert(gen.AssignUnit("riak/0"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	c.Assert(errors.Cause(gen.AutoComplete()), gc.Equals, state.ErrGenerationNoAutoComplete)
+
+	completed, err := gen.AutoComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.IsFalse)
+
 }
 
 func (s *generationSuite) TestMakeCurrentSuccess(c *gc.C) {
@@ -247,7 +255,9 @@ func (s *generationSuite) TestAppNoUnitsAutoCompleteErrorMakeCurrentSuccess(c *g
 
 	// Can not auto-complete.
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	c.Assert(errors.Cause(gen.AutoComplete()), gc.Equals, state.ErrGenerationNoAutoComplete)
+	completed, err := gen.AutoComplete()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.IsFalse)
 
 	// But can cancel.
 	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -45,77 +45,6 @@ func (s *generationSuite) TestNextGenerationExistsError(c *gc.C) {
 	c.Assert(s.Model.AddGeneration(), gc.ErrorMatches, "model has a next generation that is not completed")
 }
 
-func (s *generationSuite) TestCanAutoCompleteAndCanMakeCurrent(c *gc.C) {
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
-
-	gen, err := s.Model.NextGeneration()
-	c.Assert(err, jc.ErrorIsNil)
-
-	comp, values, err := gen.CanMakeCurrent()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(comp, jc.IsTrue)
-	c.Check(values, gc.DeepEquals, []string{})
-
-	auto, err := gen.CanAutoComplete()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(auto, jc.IsFalse)
-
-	mySqlCharm := s.AddTestingCharm(c, "mysql")
-	mySqlApp := s.AddTestingApplication(c, "mysql", mySqlCharm)
-	_, err = mySqlApp.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	riakCharm := s.AddTestingCharm(c, "riak")
-	riakApp := s.AddTestingApplication(c, "riak", riakCharm)
-	_, err = riakApp.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = riakApp.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// 2 apps; all units from one and none from the other.
-	// Can cancel, but not auto-complete.
-	c.Assert(gen.AssignUnit("mysql/0"), jc.ErrorIsNil)
-	c.Assert(gen.AssignApplication("riak"), jc.ErrorIsNil)
-	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-
-	comp, values, err = gen.CanMakeCurrent()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(comp, jc.IsTrue)
-	c.Check(values, gc.DeepEquals, []string{})
-
-	auto, err = gen.CanAutoComplete()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(auto, jc.IsFalse)
-
-	// 2 apps; all units from one and some from the other.
-	// Can not cancel or auto-complete.
-	c.Assert(gen.AssignUnit("riak/0"), jc.ErrorIsNil)
-	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-
-	comp, values, err = gen.CanMakeCurrent()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(comp, jc.IsFalse)
-	c.Check(values, gc.DeepEquals, []string{"riak/1"})
-
-	auto, err = gen.CanAutoComplete()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(auto, jc.IsFalse)
-
-	// 2 apps; all units from both.
-	// Can cancel and auto-complete.
-	c.Assert(gen.AssignUnit("riak/1"), jc.ErrorIsNil)
-	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-
-	comp, values, err = gen.CanMakeCurrent()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(comp, jc.IsTrue)
-	c.Check(values, gc.DeepEquals, []string{})
-
-	auto, err = gen.CanAutoComplete()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(auto, jc.IsTrue)
-}
-
 func (s *generationSuite) TestAssignApplicationGenCompletedError(c *gc.C) {
 	s.setupClockForComplete(c)
 	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
@@ -274,7 +203,7 @@ func (s *generationSuite) TestAutoCompleteGenerationIncompleteError(c *gc.C) {
 
 	c.Assert(gen.AssignUnit("riak/0"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	c.Assert(gen.AutoComplete(), gc.ErrorMatches, "generation can not be completed")
+	c.Assert(errors.Cause(gen.AutoComplete()), gc.Equals, state.ErrGenerationNoAutoComplete)
 }
 
 func (s *generationSuite) TestMakeCurrentSuccess(c *gc.C) {
@@ -301,7 +230,27 @@ func (s *generationSuite) TestMakeCurrentCanNotCancelError(c *gc.C) {
 
 	c.Assert(gen.AssignUnit("riak/0"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	c.Assert(gen.MakeCurrent(), gc.ErrorMatches, "cannot cancel generation, there are units behind a generation: riak/1, riak/2, riak/3")
+	c.Assert(gen.MakeCurrent(), gc.ErrorMatches,
+		"cannot cancel generation, there are units behind a generation: riak/1, riak/2, riak/3")
+}
+
+func (s *generationSuite) TestAppNoUnitsAutoCompleteErrorMakeCurrentSuccess(c *gc.C) {
+	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+
+	gen, err := s.Model.NextGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// One application with changes, no units.
+	mySqlCharm := s.AddTestingCharm(c, "mysql")
+	mySqlApp := s.AddTestingApplication(c, "mysql", mySqlCharm)
+	c.Assert(gen.AssignApplication(mySqlApp.Name()), jc.ErrorIsNil)
+
+	// Can not auto-complete.
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Assert(errors.Cause(gen.AutoComplete()), gc.Equals, state.ErrGenerationNoAutoComplete)
+
+	// But can cancel.
+	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
 }
 
 func (s *generationSuite) TestHasNextGeneration(c *gc.C) {


### PR DESCRIPTION
## Description of change

- When an operator uses the `advance-generation` command and unit advancement causes auto-completion to be invoked, this result is reported via stdout.
- If the generation is successfully completed, the active generation is set as "current" in the local store.

Depends on https://github.com/juju/juju/pull/9725.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- Bootstrap.
- `juju deploy redis -n 2`
- `juju add-generation` will set the target generation to "next".
- `juju advance-generation redis/0` will result in no extra stdout feedback.
- `juju advance-generation redis` (all remaining will auto-complete generation).
- Ensure that the completion notification is written to stdout.
- Ensure that ~/.local/share/juju/models shows generation "current".

## Documentation changes

None.

## Bug reference

N/A
