### PR TITLE
Add tcp keep alive to client connections.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -617,7 +617,9 @@ func gorillaDialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Con
 	// TODO(rogpeppe) We'd like to set Deadline here
 	// but that would break lots of tests that rely on
 	// setting a zero timeout.
-	netDialer := net.Dialer{}
+	netDialer := net.Dialer{
+		KeepAlive: 30 * time.Second,
+	}
 	dialer := &websocket.Dialer{
 		NetDial: func(netw, addr string) (net.Conn, error) {
 			if addr == url.Host {


### PR DESCRIPTION
This just adds keep alives at the tcp layer for client api connections.

We have observed in the wild situations where the client connection is trying to call the api, and is blocked in a low level tcp write. Somehow the tcp stack doesn't realise that the other side went away. TCP keep alives will help keep track of this.