### PR TITLE
leases: Only run global-clock-updater if legacy-leases is set

### DIFF
--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -70,6 +70,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"is-primary-controller-flag",
 		"lease-clock-updater",
 		"lease-manager",
+		"legacy-leases-flag",
 		"log-pruner",
 		"log-sender",
 		"logging-config-updater",
@@ -145,6 +146,7 @@ func (*ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"is-primary-controller-flag",
 		"lease-clock-updater",
 		"lease-manager",
+		"legacy-leases-flag",
 		"log-forwarder",
 		"model-worker-manager",
 		"peer-grouper",
@@ -194,6 +196,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"audit-config-updater",
 		"is-primary-controller-flag",
 		"lease-manager",
+		"legacy-leases-flag",
 		"raft-transport",
 	)
 	primaryControllerWorkers := set.NewStrings(
@@ -386,6 +389,8 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 	"global-clock-updater": {
 		"agent",
 		"clock",
+		"is-controller-flag",
+		"legacy-leases-flag",
 		"state",
 		"state-config-watcher"},
 
@@ -461,6 +466,13 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"clock",
+		"is-controller-flag",
+		"state",
+		"state-config-watcher",
+	},
+
+	"legacy-leases-flag": {
+		"agent",
 		"is-controller-flag",
 		"state",
 		"state-config-watcher",


### PR DESCRIPTION
## Description of change

If we're using raft leases there's no need to have the global-clock-updater writing to the db once a second.

## QA steps

* Spin up a controller.
* Check that global-clock-updater isn't running in the engine report.
* Switch to legacy-leases: `juju controller-config features="[legacy-leases]"`
* The engine report shows global-clock-updater is started.
* Switch back to raft leases: `juju controller-config features="[]"`
* global-clock-updater is stopped again.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813996