### PR TITLE
Clarify error when StateServingInfo is unavailable

### DIFF
--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -88,7 +88,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, err
 			}
 			if !haveStateConfig {
-				return nil, dependency.ErrMissing
+				return nil, errors.Annotate(dependency.ErrMissing, "no StateServingInfo in config")
 			}
 
 			pool, err := config.OpenStatePool(agent.CurrentConfig())

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -116,7 +116,8 @@ func (s *ManifoldSuite) TestStartNotStateServer(c *gc.C) {
 	s.resources["state-config-watcher"] = dt.NewStubResource(false)
 	w, err := s.startManifold(c)
 	c.Check(w, gc.IsNil)
-	c.Check(err, gc.Equals, dependency.ErrMissing)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(err, gc.ErrorMatches, "no StateServingInfo in config: dependency not available")
 }
 
 func (s *ManifoldSuite) TestStartOpenStateFails(c *gc.C) {


### PR DESCRIPTION
## Description of change

When investigating a production problem we could see that the state worker reported missing dependencies even though both of its deps were running. The state manifold does an additional check that one of its dependencies returns true before starting, but the error is a generic "dependency not available" which is confusing. Annotate the error with some more context about what specifically is wrong - this is the same technique that engine.Housing.Decorate uses to indicate when a worker isn't running because a flag isn't set.

## QA steps

* Bootstrap a controller.
* SSH to the controller machine and edit /var/lib/juju/agents/machine-0/agent.conf (save a backup first!) - remove the controllerkey field.
* Restart the controller agent.
* Run juju_engine_report and look at the section for the state worker - it should report "no StateServingInfo in config: dependency not available"

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815405