### PR TITLE
Fix a flaky test.

### DIFF
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -270,12 +270,14 @@ func (manager *Manager) retryingClaim(claim claim) {
 			claim.respond(lease.ErrClaimDenied)
 			return
 		}
-		claim.respond(nil)
 		// now, this isn't strictly true, as the lease can be given for longer
 		// than the requested duration. However, it cannot be shorter.
 		// Doing it this way, we'll wake up, and then see we can sleep
 		// for a bit longer. But we'll always wake up in time.
 		manager.ensureNextTimeout(claim.duration)
+		// respond after ensuring the timeout, at least for the test suite to be sure
+		// the timer has been updated by the time it gets Claim() to return.
+		claim.respond(nil)
 	} else {
 		// Stop the main loop because we got an abnormal error
 		err := errors.Trace(err)

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -86,7 +86,13 @@ func (store *Store) Wait(c *gc.C) {
 		default:
 		}
 	case <-time.After(coretesting.LongWait):
-		c.Errorf("Store test took way too long")
+		store.mu.Lock()
+		remaining := make([]string, len(store.expect))
+		for i := range store.expect {
+			remaining[i] = store.expect[i].method
+		}
+		store.mu.Unlock()
+		c.Errorf("Store test took way too long, still expecting %v", remaining)
 	}
 }
 


### PR DESCRIPTION
## Description of change

The test that we notice when a Claim has a timeout newer than our
current expiry timeout had a race. The timeout was updated after the
Claim had been processed, which meant the ensureTimeout could happen
arbitrarily far in the future.

Just changing the code to call ensureTimeout before the claim is
returned handles the race. This shouldn't affect production deployments,
because if all the claims have the same timeout, then any 'new' claim
will always be later than any other claims that we already have. And
even if we didn't, at worst it would backstop the expiry to the poll
timeout. So we might be a second behind expiring, but nothing that would
be a problem in production.

## QA steps

```
$ go test -race -count=10000 -failfast -test.timeout=10m -check.v -check.f Early
```

If you include this patch, it fails every time:
```
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -271,6 +271,7 @@ func (manager *Manager) retryingClaim(claim claim) {
                        return
                }
                claim.respond(nil)
+               time.Sleep(10 * time.Millisecond)
                // now, this isn't strictly true, as the lease can be given for longer
                // than the requested duration. However, it cannot be shorter.
                // Doing it this way, we'll wake up, and then see we can sleep
```

With the patch, you can't put a sleep there, as the order is changed. But the 'run this test 10,000 times with the race detector' shouldn't fail, while even without the patch it failed occasionally.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815468