### PR TITLE
Add Units to Cached Models

### DIFF
--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -48,3 +48,30 @@ type RemoveApplication struct {
 	ModelUUID string
 	Name      string
 }
+
+// UnitChange represents either a new unit, or a change
+// to an existing unit in a model.
+type UnitChange struct {
+	ModelUUID      string
+	Name           string
+	Application    string
+	Series         string
+	CharmURL       string
+	PublicAddress  string
+	PrivateAddress string
+	MachineId      string
+	// TODO (manadart 2019-02-11): How should we handle these given that
+	// non-core packages must not be imported in this package.
+	// Ports          []network.Port
+	// PortRanges     []network.PortRange
+	Subordinate    bool
+	WorkloadStatus status.StatusInfo
+	AgentStatus    status.StatusInfo
+}
+
+// RemoveUnit represents the situation when a unit
+// is removed from a model in the database.
+type RemoveUnit struct {
+	ModelUUID string
+	Name      string
+}

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -6,6 +6,7 @@ package cache
 import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 )
 
@@ -60,10 +61,8 @@ type UnitChange struct {
 	PublicAddress  string
 	PrivateAddress string
 	MachineId      string
-	// TODO (manadart 2019-02-11): How should we handle these given that
-	// non-core packages must not be imported in this package.
-	// Ports          []network.Port
-	// PortRanges     []network.PortRange
+	Ports          []network.Port
+	PortRanges     []network.PortRange
 	Subordinate    bool
 	WorkloadStatus status.StatusInfo
 	AgentStatus    status.StatusInfo

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -67,15 +67,15 @@ func (m *Model) Application(appName string) (*Application, error) {
 	return app, nil
 }
 
-// Unit returns the unit for the input identifier.
+// Unit returns the unit with the input name.
 // If the unit is not found, a NotFoundError is returned.
-func (m *Model) Unit(unitId string) (*Unit, error) {
+func (m *Model) Unit(unitName string) (*Unit, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	unit, found := m.units[unitId]
+	unit, found := m.units[unitName]
 	if !found {
-		return nil, errors.NotFoundf("unit %q", unitId)
+		return nil, errors.NotFoundf("unit %q", unitName)
 	}
 	return unit, nil
 }

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -36,6 +36,7 @@ func (s *ModelSuite) TestReport(c *gc.C) {
 		"name":              "model-owner/test-model",
 		"life":              life.Value("alive"),
 		"application-count": 0,
+		"unit-count":        0,
 	})
 }
 

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -62,6 +62,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/constraints",
 		"core/instance",
 		"core/life",
+		"core/network",
 		"core/status",
 	})
 }

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/juju/pubsub"
+)
+
+// Unit represents an unit in a cached model.
+type Unit struct {
+	metrics *ControllerGauges
+	hub     *pubsub.SimpleHub
+	mu      sync.Mutex
+
+	details    UnitChange
+	configHash string
+}
+
+func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
+	u := &Unit{
+		metrics: metrics,
+		hub:     hub,
+	}
+	return u
+}
+
+func (u *Unit) setDetails(details UnitChange) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.details = details
+
+	// TODO (manadart 2019-02-11): Maintain hash and publish changes.
+}

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -28,6 +28,8 @@ var unitChange = cache.UnitChange{
 	PublicAddress:  "",
 	PrivateAddress: "",
 	MachineId:      "0",
+	Ports:          nil,
+	PortRanges:     nil,
 	Subordinate:    false,
 	WorkloadStatus: status.StatusInfo{Status: status.Active},
 	AgentStatus:    status.StatusInfo{Status: status.Active},

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package cache_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/status"
+)
+
+type UnitSuite struct {
+	entitySuite
+}
+
+var _ = gc.Suite(&UnitSuite{})
+
+func (s *UnitSuite) SetUpTest(c *gc.C) {
+	s.entitySuite.SetUpTest(c)
+}
+
+var unitChange = cache.UnitChange{
+	ModelUUID:      "model-uuid",
+	Name:           "application-name/0",
+	Application:    "application-name",
+	Series:         "bionic",
+	CharmURL:       "www.charm-url.com",
+	PublicAddress:  "",
+	PrivateAddress: "",
+	MachineId:      "0",
+	Subordinate:    false,
+	WorkloadStatus: status.StatusInfo{Status: status.Active},
+	AgentStatus:    status.StatusInfo{Status: status.Active},
+}

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -6,8 +6,6 @@ package modelcache
 import (
 	"sync"
 
-	"github.com/juju/juju/network"
-
 	"github.com/juju/errors"
 	"github.com/kr/pretty"
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -272,8 +271,8 @@ func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
 			PublicAddress:  value.PublicAddress,
 			PrivateAddress: value.PrivateAddress,
 			MachineId:      value.MachineId,
-			// Ports:          networkPorts(value.Ports),
-			// PortRanges:     networkPortRanges(value.PortRanges),
+			Ports:          coreNetworkPorts(value.Ports),
+			PortRanges:     coreNetworkPortRanges(value.PortRanges),
 			Subordinate:    value.Subordinate,
 			WorkloadStatus: coreStatus(value.WorkloadStatus),
 			AgentStatus:    coreStatus(value.AgentStatus),
@@ -303,7 +302,7 @@ func coreStatus(info multiwatcher.StatusInfo) status.StatusInfo {
 	}
 }
 
-func networkPorts(delta []multiwatcher.Port) []network.Port {
+func coreNetworkPorts(delta []multiwatcher.Port) []network.Port {
 	ports := make([]network.Port, len(delta))
 	for i, d := range delta {
 		ports[i] = network.Port{
@@ -314,7 +313,7 @@ func networkPorts(delta []multiwatcher.Port) []network.Port {
 	return ports
 }
 
-func networkPortRanges(delta []multiwatcher.PortRange) []network.PortRange {
+func coreNetworkPortRanges(delta []multiwatcher.PortRange) []network.PortRange {
 	ports := make([]network.PortRange, len(delta))
 	for i, d := range delta {
 		ports[i] = network.PortRange{


### PR DESCRIPTION
## Description of change

This patch adds units to cached models, with deltas maintained by the model-cache worker.

## QA steps

New passing unit tests.

## Documentation changes

None.

## Bug reference

N/A
