### PR TITLE
Fix cmr relations where there are 2 offers on the one app

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -71,7 +71,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logger.Debugf("application tag for token %+v is %v", change.ApplicationToken, applicationTag)
+	logger.Debugf("application tag for token %+v is %v in model %v", change.ApplicationToken, applicationTag, backend.ModelUUID())
 
 	// If the remote model has destroyed the relation, do it here also.
 	forceCleanUp := change.ForceCleanup != nil && *change.ForceCleanup
@@ -118,7 +118,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 		logger.Infof("no remote application found for %v", relationTag.Id())
 		return nil
 	}
-	logger.Debugf("remote application for changed relation %v is %v", relationTag.Id(), applicationTag.Id())
+	logger.Debugf("remote application for changed relation %v is %v in model %v", relationTag.Id(), applicationTag.Id(), backend.ModelUUID())
 
 	for _, id := range change.DepartedUnits {
 		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -57,6 +57,9 @@ type Backend interface {
 	// GetRemoteEntity returns the tag of the entity associated with the given token.
 	GetRemoteEntity(string) (names.Tag, error)
 
+	// GetToken returns the token associated with the entity with the given tag.
+	GetToken(entity names.Tag) (string, error)
+
 	// ExportLocalEntity adds an entity to the remote entities collection,
 	// returning an opaque token that uniquely identifies the entity within
 	// the model.

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -136,6 +136,11 @@ func (st stateShim) GetRemoteEntity(token string) (names.Tag, error) {
 	return r.GetRemoteEntity(token)
 }
 
+func (st stateShim) GetToken(entity names.Tag) (string, error) {
+	r := st.State.RemoteEntities()
+	return r.GetToken(entity)
+}
+
 func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
 	r := st.State.RemoteEntities()
 	return r.ExportLocalEntity(entity)

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -226,7 +226,7 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Error, gc.IsNil)
-	c.Check(result.Result.Token, gc.Equals, "token-offeredapp")
+	c.Check(result.Result.Token, gc.Equals, "token-offered")
 	declared := checkers.InferDeclared(macaroon.Slice{result.Result.Macaroon})
 	c.Assert(declared, jc.DeepEquals, checkers.Declared{
 		"source-model-uuid": "deadbeef-0bad-400d-8000-4b1d0d06f00d",
@@ -250,7 +250,7 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 	expectedRel.Stub = testing.Stub{} // don't care about api calls
 	c.Check(expectedRel, jc.DeepEquals, &mockRelation{id: 0, key: "offeredapp:local remote-apptoken:remote"})
 	c.Check(s.st.remoteEntities, gc.HasLen, 2)
-	c.Check(s.st.remoteEntities[names.NewApplicationTag("offeredapp")], gc.Equals, "token-offeredapp")
+	c.Check(s.st.remoteEntities[names.NewApplicationTag("offered")], gc.Equals, "token-offered")
 	c.Check(s.st.remoteEntities[names.NewRelationTag("offeredapp:local remote-apptoken:remote")], gc.Equals, "rel-token")
 	c.Assert(s.st.offerConnections, gc.HasLen, 1)
 	offerConnection := s.st.offerConnections[0]

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -193,6 +193,19 @@ func (st *mockState) GetRemoteEntity(token string) (names.Tag, error) {
 	return nil, errors.NotFoundf("token %v", token)
 }
 
+func (st *mockState) GetToken(entity names.Tag) (string, error) {
+	st.MethodCall(st, "GetToken", entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	for e, t := range st.remoteEntities {
+		if e.Id() == entity.Id() {
+			return t, nil
+		}
+	}
+	return "", errors.NotFoundf("entity %v", entity)
+}
+
 func (st *mockState) KeyRelation(key string) (commoncrossmodel.Relation, error) {
 	st.MethodCall(st, "KeyRelation", key)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/facades/controller/remoterelations/state.go
+++ b/apiserver/facades/controller/remoterelations/state.go
@@ -33,9 +33,6 @@ type RemoteRelationsState interface {
 	// RemoveRemoteEntity removes the specified entity from the remote entities collection.
 	RemoveRemoteEntity(entity names.Tag) error
 
-	// GetToken returns the token associated with the entity with the given tag.
-	GetToken(names.Tag) (string, error)
-
 	// SaveMacaroon saves the given macaroon for the specified entity.
 	SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error
 }

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -618,6 +618,20 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	wc.AssertOneChange()
 	wc.AssertNoChange()
 
+	u := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	err = u.SetStatus(status.StatusInfo{
+		Status: status.Blocked,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+	wc.AssertNoChange()
+	err = u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+	wc.AssertNoChange()
+
 	err = ao.Remove(offer.OfferName, false)
 	c.Assert(err, jc.ErrorIsNil)
 	err = app.Destroy()

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -84,6 +84,7 @@ func (w *remoteApplicationWorker) checkOfferPermissionDenied(err error, appToken
 				"updating remote application %v status from remote model %v: %v",
 				w.applicationName, w.remoteModelUUID, err)
 		}
+		logger.Debugf("discharge required error: app token: %v rel token: %v", appToken, relationToken)
 		// If we know a specific relation, update that too.
 		if relationToken != "" {
 			suspended := true
@@ -495,7 +496,7 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 	applicationTag, relationTag names.Tag, offerUUID string,
 	localEndpointInfo params.RemoteEndpoint, remoteEndpointName string,
 ) (applicationToken, offeringAppToken, relationToken string, _ *macaroon.Macaroon, _ error) {
-	logger.Debugf("register remote relation %v", relationTag.Id())
+	logger.Debugf("register remote relation %v to local application %v", relationTag.Id(), applicationTag.Id())
 
 	fail := func(err error) (string, string, string, *macaroon.Macaroon, error) {
 		return "", "", "", nil, err


### PR DESCRIPTION
## Description of change

Creating 2 offers off the one app was failing when relations were processed. To fix, change the token generated on the offer side to be based on the offer name, not the app name.

Also, fix the offer status watcher so that status changes to an offering app's units also trigger a status update in the consuming model.

Note: existing single app offers will continue to work with this fix (it's backwards compatible).
But multi-offers on the same app will need to be redeployed.

## QA steps

juju bootstrap lxd test
juju switch controller
juju model-config logging-juju switch default
juju deploy memcached
juju deploy mariadb
juju add-model foo
juju deploy mediawiki
juju offer mediawiki:cache mw-cache
juju offer mediawiki:db mw-db
juju switch default
juju consume foo.mw-db
juju consume foo.mw-cache
juju relate mw-db mariadb:db
juju relate mw-cache memcached

Check controller logs for cmr relation errors.
Check workloads

juju remove-relation mariadb:db mw-db

Check SAAS status

Upgrade a 2.5.0 cmr deployment and check operations.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813151
https://bugs.launchpad.net/juju/+bug/1815179