### PR TITLE
Update controller api to indicate configured identity provider

### DIFF
--- a/api/controller/identity_url.go
+++ b/api/controller/identity_url.go
@@ -1,0 +1,27 @@
+// Copyright 2012-2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// IdentityProviderURL returns the URL of the configured external identity
+// provider for this controller or an empty string if no external identity
+// provider has been configured when the controller was bootstrapped.
+func (c *Client) IdentityProviderURL() (string, error) {
+	if c.BestAPIVersion() < 7 {
+		return "", errors.NotSupportedf("IdentityProviderURL not supported by this version of Juju")
+	}
+	var result params.StringResult
+	err := c.facade.FacadeCall("IdentityProviderURL", nil, &result)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}

--- a/api/controller/identity_url_test.go
+++ b/api/controller/identity_url_test.go
@@ -1,0 +1,88 @@
+// Copyright 2012-2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+func (s *Suite) TestIdentityProviderURLPriorV7(c *gc.C) {
+	called := false
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 6,
+		APICallerFunc: func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "IdentityProviderURL")
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	_, err := client.IdentityProviderURL()
+	c.Assert(err, gc.ErrorMatches, "IdentityProviderURL not supported by this version of Juju not supported")
+	c.Assert(called, jc.IsFalse)
+}
+
+func (s *Suite) TestIdentityProviderURLCallError(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 7,
+		APICallerFunc: func(string, int, string, string, interface{}, interface{}) error {
+			return errors.New("boom")
+		},
+	}
+	client := controller.NewClient(apiCaller)
+	result, err := client.IdentityProviderURL()
+	c.Check(result, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestIdentityProviderURL(c *gc.C) {
+	expURL := "https://api.jujucharms.com/identity"
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 7,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "IdentityProviderURL")
+			c.Check(result, gc.FitsTypeOf, &params.StringResult{})
+
+			out := result.(*params.StringResult)
+			out.Result = expURL
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	result, err := client.IdentityProviderURL()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, expURL)
+}
+
+func (s *Suite) TestIdentityProviderURLWithErrorResult(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 7,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "IdentityProviderURL")
+			c.Check(result, gc.FitsTypeOf, &params.StringResult{})
+
+			out := result.(*params.StringResult)
+			out.Result = "garbage"
+			out.Error = common.ServerError(errors.New("version error"))
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	_, err := client.IdentityProviderURL()
+	c.Assert(err, gc.ErrorMatches, "version error")
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -34,7 +34,7 @@ var facadeVersions = map[string]int{
 	"Cleaner":                      2,
 	"Client":                       2,
 	"Cloud":                        3,
-	"Controller":                   6,
+	"Controller":                   7,
 	"CredentialManager":            1,
 	"CredentialValidator":          2,
 	"CrossController":              1,

--- a/api/firewaller/application_test.go
+++ b/api/firewaller/application_test.go
@@ -42,6 +42,8 @@ func (s *applicationSuite) TestTag(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
 	w, err := s.apiApplication.Watch()
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewNotifyWatcherC(c, w, s.BackingState.StartSync)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -176,6 +176,7 @@ func AllFacades() *facade.Registry {
 	reg("Controller", 4, controller.NewControllerAPIv4)
 	reg("Controller", 5, controller.NewControllerAPIv5)
 	reg("Controller", 6, controller.NewControllerAPIv6)
+	reg("Controller", 7, controller.NewControllerAPIv7)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
 	reg("CredentialManager", 1, credentialmanager.NewCredentialManagerAPI)

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -56,7 +56,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPIv6(
+	controller, err := controller.NewControllerAPIv7(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -55,7 +55,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPIv6(
+	controller, err := controller.NewControllerAPIv7(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -512,6 +512,9 @@ func (c *fakeController) ModelStatus(models ...names.ModelTag) (result []base.Mo
 }
 
 func (c *fakeController) MongoVersion() (string, error) {
+	if c.bestAPIVersion < 3 {
+		return "", errors.NotSupportedf("requires APIVersion >= 3")
+	}
 	return "3.5.12", nil
 }
 
@@ -530,10 +533,6 @@ func (c *fakeController) AllModels() (result []base.UserModel, _ error) {
 		return result, nil
 	}
 	return all, nil
-}
-
-func (c *fakeController) BestAPIVersion() int {
-	return c.bestAPIVersion
 }
 
 func (c *fakeController) IdentityProviderURL() (string, error) {


### PR DESCRIPTION
## Description of change

This PR adds a new method to the controller API that returns the value for the `identity-url` config param that was specified while bootstrapping the controller or a blank value if no `identity-url` was specified. Contrary to other controller API methods, the implementation of `IdentityProviderURL` **does not** require `SuperuserAccess` for the caller as the identity URL is more or less public and known even to users with just login access.

The new method can be used by the UI to decide whether to display the _login with USSO_ link.

Finally, the `show-controller` implementation has been updated to include `identity-url` (if non-empty) into its output.

## QA steps

```console
$ juju bootstrap localhost lxd-no-ident
$ juju show-controller --format yaml | grep identity-url
# no output

$ juju bootstrap localhost lxd-with-ident --config identity-url=https://api.jujucharms.com/identity
$ juju show-controller --format yaml | grep identity-url
 identity-url: https://api.jujucharms.com/identity

# Check for non-admin users too
$ juju add-user foo
$ # set passwords and logout admin
$ juju login -c lxd-with-ident -u foo
$ juju show-controller --format yaml | grep identity-url
 identity-url: https://api.jujucharms.com/identity
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1771618
