### PR TITLE
2.5 worker lease 1815471

### DIFF
--- a/state/watcher/watcher_test.go
+++ b/state/watcher/watcher_test.go
@@ -698,9 +698,9 @@ func (s *SlowPeriodSuite) TestWatchBeforeRemoveKnown(c *gc.C) {
 	s.w.Watch("test", "a", s.ch)
 	revno1 := s.insert(c, "test", "a")
 	s.w.StartSync()
-	revno2 := s.remove(c, "test", "a")
 
 	assertChange(c, s.ch, watcher.Change{"test", "a", revno1})
+	revno2 := s.remove(c, "test", "a")
 	s.w.StartSync()
 	assertChange(c, s.ch, watcher.Change{"test", "a", revno2})
 

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -427,7 +427,7 @@ func (manager *Manager) computeNextTimeout(lastTick time.Time, leases map[lease.
 		}
 		nextTick = info.Expiry
 	}
-	manager.config.Logger.Tracef("[%s] next expire decided on %v %v",
+	manager.config.Logger.Tracef("[%s] next expire in %v %v",
 		manager.logContext, nextTick.Sub(now).Round(time.Millisecond), nextTick)
 	manager.setNextTimeout(nextTick)
 }

--- a/worker/lease/manager_expire_test.go
+++ b/worker/lease/manager_expire_test.go
@@ -236,6 +236,7 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture(c *gc.C) {
 
 func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 	const newLeaseSecs = 63
+	firstRelease := make(chan struct{})
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "ClaimLease",
@@ -251,6 +252,11 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 			},
 		}, {
 			method: "Refresh",
+			callback: func(leases map[corelease.Key]corelease.Info) {
+				close(firstRelease)
+			},
+		}, {
+			method: "Refresh",
 		}, {
 			method: "ExpireLease",
 			args:   []interface{}{key("redis")},
@@ -263,7 +269,17 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 		// Ask for a minute, actually get 63s. Expire on time.
 		err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		waitAdvance(c, clock, justAfterSeconds(newLeaseSecs), 1)
+		// Move forward 1 minute, and we should wake up to Refresh, but this doesn't
+		// trigger any expiration. It does cause us to notice that it will expire
+		// in 3 more seconds
+		waitAdvance(c, clock, time.Minute, 1)
+		select {
+		case <-firstRelease:
+		case <-time.After(testing.LongWait):
+			c.Errorf("waited too long")
+		}
+		// Now we move forward the remaining 3 seconds and wake up to refresh and expire
+		waitAdvance(c, clock, 3*time.Second, 1)
 	})
 }
 
@@ -288,6 +304,9 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 					Expiry: offset(newLeaseSecs * time.Second),
 				}
 			},
+		}, {
+			// We do trigger a Refresh, but we don't expire the key.
+			method: "Refresh",
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
@@ -301,6 +320,7 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 
 func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 	const newLeaseSecs = 63
+	firstRelease := make(chan struct{})
 	fix := &Fixture{
 		leases: map[corelease.Key]corelease.Info{
 			key("redis"): {
@@ -322,6 +342,11 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 			},
 		}, {
 			method: "Refresh",
+			callback: func(leases map[corelease.Key]corelease.Info) {
+				close(firstRelease)
+			},
+		}, {
+			method: "Refresh",
 		}, {
 			method: "ExpireLease",
 			args:   []interface{}{key("redis")},
@@ -334,7 +359,14 @@ func (s *ExpireSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 		// Ask for a minute, actually get 63s. Expire on time.
 		err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 		c.Assert(err, jc.ErrorIsNil)
-		waitAdvance(c, clock, justAfterSeconds(newLeaseSecs), 1)
+		// Notice the first wakeup, but no expirations, and queued up a second wakeup
+		waitAdvance(c, clock, time.Minute, 1)
+		select {
+		case <-firstRelease:
+		case <-time.After(testing.LongWait):
+			c.Errorf("waited too long")
+		}
+		waitAdvance(c, clock, 3*time.Second, 1)
 	})
 }
 

--- a/worker/lease/manager_expire_test.go
+++ b/worker/lease/manager_expire_test.go
@@ -218,6 +218,10 @@ func (s *ExpireSuite) TestClaim_ExpiryInFuture(c *gc.C) {
 					Expiry: offset(newLeaseSecs * time.Second),
 				}
 			},
+		}, {
+			// We should call Refresh at 1 min because that was the requested
+			// time, but we shouldn't expire the lease.
+			method: "Refresh",
 		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {


### PR DESCRIPTION
## Description of change

Fix at least 5 flaky tests around Lease behavior.
* The Manager.setupInitialTimer was allowing the test loops to think that setup had finished, but really it was only that setup had started and had done the initial NewTimer() call.
* Timer.Reset() is unsafe to call without first Stopping the timer according to the time docs. (race condition with the trigger firing.)
* Several tests were only passing because they exited the main loop 'fast enough'. They wanted to test that we weren't expiring a claim that got a longer-than-requested duration. However, because Claim doesn't actually tell you how long the Lease was given for, unless we did an extra lookup we can't actually set the timeout trivially. And we want to avoid lookups on every Extend. (And in practice we don't give out arbitrarily longer claims.) Update the tests to sync with the expected Refresh and note that nothing gets expired.
* Also test the fact that it *will* expire the Lease at the appropriate times.

## QA steps

To trigger the race in setupInitialTimer you could use this patch:
```
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -437,6 +437,7 @@ func (manager *Manager) setupInitialTimer() {
        manager.muNextTimeout.Lock()
        manager.timer = manager.config.Clock.NewTimer(manager.config.MaxSleep)
        manager.muNextTimeout.Unlock()
+       time.Sleep(0 * time.Millisecond)
        // lastTick has never happened, so pass in the epoch time
        manager.computeNextTimeout(time.Time{}, manager.config.Store.Leases())
 }
```
That extends the chance that the test loop will sync on the NewTimer and not on the timer.Reset that is immediately called after that.

For all the tests, the easiest way to see the flakiness is:
```
$ go test -race -count=2000 -failfast -test.timeout=20m -check.v
$ go test -race -count=2000 -failfast -test.timeout=20m -check.v -check.f Expiry
```

With this patch, I didn't get any failures after 2000 loops. (though, as always, there could still be issues.)

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815471