### PR TITLE
update UniterAPI to v10 for LXDProfileAPI changes; improve machine.NextUpgradeCharmProfileUnitName()

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -100,7 +100,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       9,
+	"Uniter":                       10,
 	"Upgrader":                     1,
 	"UpgradeSeries":                1,
 	"UserManager":                  2,

--- a/api/uniter/lxdprofile.go
+++ b/api/uniter/lxdprofile.go
@@ -25,15 +25,14 @@ func NewLXDProfileAPI(facade base.FacadeCaller, tag names.Tag) *LXDProfileAPI {
 	return &LXDProfileAPI{facade: facade, tag: tag}
 }
 
-// WatchLXDProfileUpgradeNotifications returns a StringsWatcher for observing the state of
+// WatchUnitLXDProfileUpgradeNotifications returns a StringsWatcher for observing the state of
 // a LXD profile upgrade
-func (u *LXDProfileAPI) WatchLXDProfileUpgradeNotifications(applicationName string) (watcher.StringsWatcher, error) {
+func (u *LXDProfileAPI) WatchUnitLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
-	args := params.LXDProfileUpgrade{
-		Entities:        []params.Entity{{Tag: u.tag.String()}},
-		ApplicationName: applicationName,
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.facade.FacadeCall("WatchLXDProfileUpgradeNotifications", args, &results)
+	err := u.facade.FacadeCall("WatchUnitLXDProfileUpgradeNotifications", args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/uniter/lxdprofile_test.go
+++ b/api/uniter/lxdprofile_test.go
@@ -25,15 +25,14 @@ func (s *lxdProfileSuite) SetUpTest(c *gc.C) {
 	s.tag = names.NewMachineTag("0")
 }
 
-func (s *lxdProfileSuite) TestWatchLXDProfileUpgradeNotifications(c *gc.C) {
+func (s *lxdProfileSuite) TestWatchUnitLXDProfileUpgradeNotifications(c *gc.C) {
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
 	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
-		c.Assert(name, gc.Equals, "WatchLXDProfileUpgradeNotifications")
-		c.Assert(args, jc.DeepEquals, params.LXDProfileUpgrade{
+		c.Assert(name, gc.Equals, "WatchUnitLXDProfileUpgradeNotifications")
+		c.Assert(args, jc.DeepEquals, params.Entities{
 			Entities: []params.Entity{
 				{Tag: s.tag.String()},
 			},
-			ApplicationName: "foo-bar",
 		})
 		*(response.(*params.StringsWatchResults)) = params.StringsWatchResults{
 			Results: []params.StringsWatchResult{{
@@ -59,6 +58,6 @@ func (s *lxdProfileSuite) TestWatchLXDProfileUpgradeNotifications(c *gc.C) {
 	facadeCaller.ReturnRawAPICaller = apitesting.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 1}
 
 	api := uniter.NewLXDProfileAPI(&facadeCaller, s.tag)
-	_, err := api.WatchLXDProfileUpgradeNotifications("foo-bar")
+	_, err := api.WatchUnitLXDProfileUpgradeNotifications()
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -647,8 +647,8 @@ func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus, reason s
 
 // WatchLXDProfileUpgradeNotifications returns a StringsWatcher for observing the
 // state of a lxd profile upgrade
-func (u *Unit) WatchLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error) {
-	return u.st.WatchLXDProfileUpgradeNotifications(u.ApplicationName())
+func (u *Unit) WatchUnitLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error) {
+	return u.st.WatchUnitLXDProfileUpgradeNotifications()
 }
 
 // RemoveUpgradeCharmProfileData removes the upgrade charm profile data

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -282,7 +282,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 6, uniter.NewUniterAPIV6)
 	reg("Uniter", 7, uniter.NewUniterAPIV7)
 	reg("Uniter", 8, uniter.NewUniterAPIV8)
-	reg("Uniter", 9, uniter.NewUniterAPI)
+	reg("Uniter", 9, uniter.NewUniterAPIV9)
+	reg("Uniter", 10, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UpgradeSeries", 1, upgradeseries.NewAPI)

--- a/apiserver/facades/agent/uniter/mocks/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/lxdprofile.go
@@ -96,19 +96,6 @@ func (mr *MockLXDProfileMachineMockRecorder) RemoveUpgradeCharmProfileData(arg0 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeCharmProfileData", reflect.TypeOf((*MockLXDProfileMachine)(nil).RemoveUpgradeCharmProfileData), arg0)
 }
 
-// Units mocks base method
-func (m *MockLXDProfileMachine) Units() ([]uniter.LXDProfileUnit, error) {
-	ret := m.ctrl.Call(m, "Units")
-	ret0, _ := ret[0].([]uniter.LXDProfileUnit)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Units indicates an expected call of Units
-func (mr *MockLXDProfileMachineMockRecorder) Units() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockLXDProfileMachine)(nil).Units))
-}
-
 // WatchLXDProfileUpgradeNotifications mocks base method
 func (m *MockLXDProfileMachine) WatchLXDProfileUpgradeNotifications(arg0 string) (state.StringsWatcher, error) {
 	ret := m.ctrl.Call(m, "WatchLXDProfileUpgradeNotifications", arg0)
@@ -180,4 +167,17 @@ func (m *MockLXDProfileUnit) Tag() names_v2.Tag {
 // Tag indicates an expected call of Tag
 func (mr *MockLXDProfileUnitMockRecorder) Tag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockLXDProfileUnit)(nil).Tag))
+}
+
+// WatchLXDProfileUpgradeNotifications mocks base method
+func (m *MockLXDProfileUnit) WatchLXDProfileUpgradeNotifications() (state.StringsWatcher, error) {
+	ret := m.ctrl.Call(m, "WatchLXDProfileUpgradeNotifications")
+	ret0, _ := ret[0].(state.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchLXDProfileUpgradeNotifications indicates an expected call of WatchLXDProfileUpgradeNotifications
+func (mr *MockLXDProfileUnitMockRecorder) WatchLXDProfileUpgradeNotifications() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileUpgradeNotifications", reflect.TypeOf((*MockLXDProfileUnit)(nil).WatchLXDProfileUpgradeNotifications))
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -34,9 +34,8 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.uniter")
 
-// UniterAPI implements the latest version (v9) of the Uniter API,
-// which adds WatchConfigSettingsHash, WatchTrustConfigSettingsHash
-// and WatchUnitAddressesHash.
+// UniterAPI implements the latest version (v10) of the Uniter API,
+// which adds WatchUnitLXDProfileUpgradeNotifications.
 type UniterAPI struct {
 	*common.LifeGetter
 	*StatusAPI
@@ -66,11 +65,18 @@ type UniterAPI struct {
 	cloudSpec       cloudspec.CloudSpecAPI
 }
 
+// UniterAPIV9 adds WatchConfigSettingsHash, WatchTrustConfigSettingsHash,
+// WatchUnitAddressesHash, WatchLXDProfileUpgradeNotifications, and
+// RemoveUpgradeCharmProfileData.
+type UniterAPIV9 struct {
+	UniterAPI
+}
+
 // UniterAPIV8 adds SetContainerSpec, GoalStates, CloudSpec,
 // WatchTrustConfigSettings, WatchActionNotifications,
 // UpgradeSeriesStatus, SetUpgradeSeriesStatus.
 type UniterAPIV8 struct {
-	UniterAPI
+	UniterAPIV9
 }
 
 // UniterAPIV7 adds CMR support to NetworkInfo.
@@ -242,7 +248,7 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 		ModelWatcher:               common.NewModelWatcher(m, resources, authorizer),
 		RebootRequester:            common.NewRebootRequester(st, accessMachine),
 		UpgradeSeriesAPI:           common.NewExternalUpgradeSeriesAPI(st, resources, authorizer, accessMachine, accessUnit, logger),
-		LXDProfileAPI:              NewExternalLXDProfileAPI(st, resources, authorizer, accessMachine, accessUnit, logger),
+		LXDProfileAPI:              NewExternalLXDProfileAPI(st, resources, authorizer, accessUnit, logger),
 		LeadershipSettingsAccessor: leadershipSettingsAccessorFactory(st, leadershipChecker, resources, authorizer),
 		MeterStatus:                msAPI,
 		// TODO(fwereade): so *every* unit should be allowed to get/set its
@@ -263,14 +269,25 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	}, nil
 }
 
-// NewUniterAPIV8 creates an instance of the V8 uniter API.
-func NewUniterAPIV8(context facade.Context) (*UniterAPIV8, error) {
+// NewUniterAPIV9 creates an instance of the V9 uniter API.
+func NewUniterAPIV9(context facade.Context) (*UniterAPIV9, error) {
 	uniterAPI, err := NewUniterAPI(context)
 	if err != nil {
 		return nil, err
 	}
-	return &UniterAPIV8{
+	return &UniterAPIV9{
 		UniterAPI: *uniterAPI,
+	}, nil
+}
+
+// NewUniterAPIV8 creates an instance of the V8 uniter API.
+func NewUniterAPIV8(context facade.Context) (*UniterAPIV8, error) {
+	uniterAPI, err := NewUniterAPIV9(context)
+	if err != nil {
+		return nil, err
+	}
+	return &UniterAPIV8{
+		UniterAPIV9: *uniterAPI,
 	}, nil
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -2519,21 +2519,24 @@ func (m *Machine) RemoveUpgradeCharmProfileData(unitName string) error {
 // when a request has been made to delete on all of them.
 
 func getNextInstanceCharmProfileData(st *State, id string, used bool) (instanceCharmProfileData, error) {
-	logger.Debugf("trying to get next instance charm profile data for machine %s here", id)
+	logger.Tracef("trying to get next instance charm profile data for machine %s here", id)
 	collection, closer := st.db().GetCollection(instanceCharmProfileDataC)
 	defer closer()
 
-	// machineRegExp and query to find one charmInstaceProfileDoc in the current model and machine
-	// where being-used the same as the passed in bool.
+	// machineRegExp and query to find one charmInstanceProfileDataDoc
+	// in the current model and machine where being-used the same as
+	// the passed in bool.
 	machineRegExp := fmt.Sprintf("^%s:%s#%s$", st.ModelUUID(), id, names.UnitSnippet)
 	query := bson.D{{"_id", bson.D{{"$regex", machineRegExp}}}, {"being-used", used}}
 	var instData instanceCharmProfileData
 	err := collection.Find(query).One(&instData)
 	if err == mgo.ErrNotFound {
-		return instanceCharmProfileData{}, errors.NotFoundf("instance charm profile data for machine %v", id)
+		return instanceCharmProfileData{},
+			errors.NotFoundf("instance charm profile data for machine %v", id)
 	}
 	if err != nil {
-		return instanceCharmProfileData{}, errors.Annotatef(err, "cannot get instance charm profile data for machine %v", id)
+		return instanceCharmProfileData{},
+			errors.Annotatef(err, "cannot get instance charm profile data for machine %v", id)
 	}
 	return instData, nil
 }
@@ -2541,22 +2544,7 @@ func getNextInstanceCharmProfileData(st *State, id string, used bool) (instanceC
 // NextUpgradeCharmProfileUnitName returns the first unit name
 // relate to the first instanceCharmProfileData doc for this machine.
 func (m *Machine) NextUpgradeCharmProfileUnitName() (string, error) {
-	instData, err := getNextInstanceCharmProfileData(m.st, m.Id(), false)
-	if err != nil {
-		return "", errors.Annotatef(err, "cannot get instance charm profile data for machine %v", m.Id())
-	}
-	err = m.markBeingUsedUpgradeCharmProfileDataTrue(instData.UpgradeCharmProfileUnit)
-	if err != nil {
-		return "", errors.Annotatef(err, "cannot mark delete me. instance charm profile data for machine %v", m.Id())
-	}
-	return instData.UpgradeCharmProfileUnit, nil
-}
-
-// markBeingUsedUpgradeCharmProfileDataTrue changes BeingUsed to true, so that
-// the application name associated with the instanceCharmProfileDoc for this
-// machine and the given unitName is not returned again with
-// UpgradeCharmApplication
-func (m *Machine) markBeingUsedUpgradeCharmProfileDataTrue(unitName string) error {
+	var unitName string
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := m.Refresh(); err != nil {
@@ -2567,14 +2555,14 @@ func (m *Machine) markBeingUsedUpgradeCharmProfileDataTrue(unitName string) erro
 		if life == Dead || life == Dying {
 			return nil, ErrDead
 		}
-		docId := m.instanceCharmProfileDataId(unitName)
-		data, err := getInstanceCharmProfileData(m.st, docId)
+		instData, err := getNextInstanceCharmProfileData(m.st, m.Id(), false)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "did not find unused instance charm profile data for machine %s", m.Id())
 		}
-		if data.BeingUsed {
-			return nil, jujutxn.ErrNoOperations
+		if instData.BeingUsed {
+			return nil, errors.Errorf("received instance charm profile data already being used %q", instData.DocID)
 		}
+		unitName = instData.UpgradeCharmProfileUnit
 		return []txn.Op{
 			{
 				C:      machinesC,
@@ -2583,7 +2571,7 @@ func (m *Machine) markBeingUsedUpgradeCharmProfileDataTrue(unitName string) erro
 			},
 			{
 				C:      instanceCharmProfileDataC,
-				Id:     docId,
+				Id:     instData.DocID,
 				Assert: bson.D{{"being-used", false}},
 				Update: bson.D{{"$set", bson.D{{"being-used", true}}}},
 			},
@@ -2591,10 +2579,9 @@ func (m *Machine) markBeingUsedUpgradeCharmProfileDataTrue(unitName string) erro
 	}
 	err := m.st.db().Run(buildTxn)
 	if err != nil {
-		return errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-	return nil
-
+	return unitName, nil
 }
 
 // NextRemoveUpgradeCharmProfileData remove the doc for the first found on
@@ -2619,6 +2606,29 @@ func (m *Machine) NextSetUpgradeCharmProfileComplete(msg string) error {
 		return errors.Annotatef(err, "cannot set complete status of instance charm profile data for machine %v", m.Id())
 	}
 	return m.SetUpgradeCharmProfileComplete(instData.UpgradeCharmProfileUnit, msg)
+}
+
+// LXDProfileUpgradeUnitToWatch returns the docID that the call to
+// machine.WatchLXDProfileUpgradeNotifications() should watch based
+// on the current machine and the application name provided.
+//
+// NOTE: This function is for backwards compatibility with UniterAPIV9.
+// If there 2 units of the same application on the machine, only the
+// first found will be returned.  This is a known flaw in the logic
+// and roughly maps to previous broken behavior.
+func (m *Machine) LXDProfileUpgradeUnitToWatch(appName string) (string, error) {
+	units, err := m.Units()
+	if err != nil {
+		return "", err
+	}
+	var unitName string
+	for _, unit := range units {
+		if unit.ApplicationName() == appName {
+			unitName = unit.Name()
+			break
+		}
+	}
+	return unitName, nil
 }
 
 // UpdateOperation returns a model operation that will update the machine.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -217,7 +217,7 @@ func (s *MachineSuite) TestNextUpgradeCharmProfileUnitNameZero(c *gc.C) {
 	m := s.machine
 
 	name, err := m.NextUpgradeCharmProfileUnitName()
-	c.Assert(err, gc.ErrorMatches, "cannot get instance charm profile data for machine 1: instance charm profile data for machine 1 not found")
+	c.Assert(err, gc.ErrorMatches, "did not find unused instance charm profile data for machine 1: instance charm profile data for machine 1 not found")
 	c.Assert(name, gc.Equals, "")
 }
 
@@ -297,6 +297,13 @@ func (s *MachineSuite) TestNextSetUpgradeCharmProfileCompleteNoBeingUsed(c *gc.C
 
 	err := s.machine.NextSetUpgradeCharmProfileComplete(lxdprofile.SuccessStatus)
 	c.Assert(err, gc.ErrorMatches, "cannot set complete status of instance charm profile data for machine 1: instance charm profile data for machine 1 not found")
+}
+
+func (s *MachineSuite) TestLXDProfileUpgradeUnitToWatch(c *gc.C) {
+	s.assertSetUpUnitForLXDProfile(c)
+	unitName, err := s.machine.LXDProfileUpgradeUnitToWatch("lxd-profile")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitName, gc.Equals, "lxd-profile/0")
 }
 
 func (s *MachineSuite) assertUpgradeCharmProfileNotRequired(c *gc.C, expectedUnitName string) {

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -270,7 +270,7 @@ func (u *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) erro
 	return nil
 }
 
-func (u *mockUnit) WatchLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchUnitLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error) {
 	return u.upgradeLXDProfileUpgradeWatcher, nil
 }
 

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -43,7 +43,7 @@ type Unit interface {
 	WatchConfigSettingsHash() (watcher.StringsWatcher, error)
 	WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error)
 	WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error)
-	WatchLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error)
+	WatchUnitLXDProfileUpgradeNotifications() (watcher.StringsWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)
 	WatchActionNotifications() (watcher.StringsWatcher, error)
 	// WatchRelation returns a watcher that fires when relations

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -291,7 +291,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 		upgradeSeriesChanges = upgradeSeriesw.Changes()
 		requiredEvents++
 
-		lxdProfilew, err := w.unit.WatchLXDProfileUpgradeNotifications()
+		lxdProfilew, err := w.unit.WatchUnitLXDProfileUpgradeNotifications()
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

Follow on to PR9699.  Update the UniterAPI to v10 for LXDProfileAPI changes.  LXDProfileAPI changes to allow for backwards compatibility when the uniter is watching for lxd profiles to be applied.

machine.NextUpgradeCharmProfileUnitName() improved to avoid potential race conditions where the
same unit name maybe returned twice.

## QA steps

1. `juju deploy -n 6 ./testcharms/charm-repo/quantal/lxd-profile`
1. wait for the machines to start provisioning
3. `juju deploy ~/charms/ubuntu --to 0 ; juju add-unit ubuntu -n 5 --to 1,2,3,4,5`
2. `juju deploy ~/charms/ntp`
3. `juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate`
4. `juju add-relation lxd-profile lxd-profile-subordinate`
5. `juju add-relation ntp ubuntu`
4. once settled:
```juju upgrade-charm lxd-profile-subordinate --path ./testcharms/charm-repo/quantal/lxd-profile-subordinate; juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile ; juju upgrade-charm ntp --path ~/charms/ntp ; juju upgrade-charm ubuntu --path ~/charms/ubuntu```

Also test with deploy --to lxd.  With PR version server and client; as well as 2.5.0 server and PR version client.



