### PR TITLE
vsphere: Allow specifying resource pools in the zones constraint or placement directive

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -22,6 +22,7 @@ type DialFunc func(_ context.Context, _ *url.URL, datacenter string) (Client, er
 type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
+	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
 	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
 	Datastores(context.Context) ([]*mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -4,7 +4,10 @@
 package vsphere
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/environs"
@@ -13,13 +16,35 @@ import (
 	"github.com/juju/juju/provider/common"
 )
 
+// poolPathPrefixParts is the number of path components to chop off a
+// resource pool's path to get its availability zone path. The paths
+// look like:
+// /<datacenter name>/host/<compute resource name>/Resources/<pool path...>
+// So there are 5 parts to the prefix (counting the
+// blank one from the leading /).
+const poolPathPrefixParts = 5
+
 type vmwareAvailZone struct {
-	r mo.ComputeResource
+	r    mo.ComputeResource
+	pool *object.ResourcePool
 }
 
 // Name implements common.AvailabilityZone
 func (z *vmwareAvailZone) Name() string {
-	return z.r.Name
+	// The name for this zone is the compute resource name and the
+	// path of the pool without the prefix, so for
+	// /QA/host/aron.internal/Resources/High/Child, the name should be
+	// aron.internal/High/Child.
+	path := strings.TrimRight(z.pool.InventoryPath, "/")
+	parts := strings.Split(path, "/")
+	poolPath := ""
+	if len(parts) > poolPathPrefixParts {
+		// This isn't the root pool for this compute resource, include
+		// the pool's path.
+		poolPath = "/" + strings.Join(parts[poolPathPrefixParts:], "/")
+	}
+
+	return z.r.Name + poolPath
 }
 
 // Available implements common.AvailabilityZone
@@ -44,9 +69,24 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([
 			HandleCredentialError(err, ctx)
 			return nil, errors.Trace(err)
 		}
-		zones := make([]common.AvailabilityZone, len(computeResources))
-		for i, cr := range computeResources {
-			zones[i] = &vmwareAvailZone{*cr}
+		var zones []common.AvailabilityZone
+		for _, cr := range computeResources {
+			if cr.Summary.GetComputeResourceSummary().EffectiveCpu == 0 {
+				logger.Debugf("skipping empty compute resource %q", cr.Name)
+			}
+			pools, err := env.client.ResourcePools(env.ctx, cr.Name+"/...")
+			if err != nil {
+				HandleCredentialError(err, ctx)
+				return nil, errors.Trace(err)
+			}
+			for _, pool := range pools {
+				zone := &vmwareAvailZone{
+					r:    *cr,
+					pool: pool,
+				}
+				logger.Tracef("zone: %q", zone.Name())
+				zones = append(zones, zone)
+			}
 		}
 		env.zones = zones
 	}
@@ -85,9 +125,9 @@ func (env *sessionEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCal
 		}
 		vm := inst.(*environInstance).base
 		for _, zone := range zones {
-			cr := &zone.(*vmwareAvailZone).r
-			if cr.ResourcePool.Value == vm.ResourcePool.Value {
-				results[i] = cr.Name
+			pool := zone.(*vmwareAvailZone).pool
+			if pool.Reference().Value == vm.ResourcePool.Value {
+				results[i] = zone.Name()
 				break
 			}
 		}
@@ -119,14 +159,14 @@ func (env *sessionEnviron) DeriveAvailabilityZones(ctx context.ProviderCallConte
 	return nil, nil
 }
 
-func (env *sessionEnviron) availZone(ctx context.ProviderCallContext, name string) (common.AvailabilityZone, error) {
+func (env *sessionEnviron) availZone(ctx context.ProviderCallContext, name string) (*vmwareAvailZone, error) {
 	zones, err := env.AvailabilityZones(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	for _, z := range zones {
 		if z.Name() == name {
-			return z, nil
+			return z.(*vmwareAvailZone), nil
 		}
 	}
 	return nil, errors.NotFoundf("availability zone %q", name)

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -5,6 +5,7 @@ package vsphere_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	gc "gopkg.in/check.v1"
 
@@ -25,32 +26,58 @@ func (s *environAvailzonesSuite) TestAvailabilityZones(c *gc.C) {
 		newComputeResource("z1"),
 		newComputeResource("z2"),
 	}
+	s.client.resourcePools = map[string][]*object.ResourcePool{
+		"z1/...": {makeResourcePool("pool-1", "/DC/host/z1/Resources")},
+		"z2/...": {
+			// Check we don't get broken by trailing slashes.
+			makeResourcePool("pool-2", "/DC/host/z2/Resources/"),
+			makeResourcePool("pool-3", "/DC/host/z2/Resources/child"),
+			makeResourcePool("pool-4", "/DC/host/z2/Resources/child/nested"),
+			makeResourcePool("pool-5", "/DC/host/z2/Resources/child/nested/other/"),
+		},
+	}
 
 	c.Assert(s.env, gc.Implements, new(common.ZonedEnviron))
 	zonedEnviron := s.env.(common.ZonedEnviron)
 	zones, err := zonedEnviron.AvailabilityZones(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(zones), gc.Equals, 2)
+	c.Assert(len(zones), gc.Equals, 5)
 	c.Assert(zones[0].Name(), gc.Equals, "z1")
 	c.Assert(zones[1].Name(), gc.Equals, "z2")
+	c.Assert(zones[2].Name(), gc.Equals, "z2/child")
+	c.Assert(zones[3].Name(), gc.Equals, "z2/child/nested")
+	c.Assert(zones[4].Name(), gc.Equals, "z2/child/nested/other")
 }
 
 func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 	z1 := newComputeResource("z1")
 	z2 := newComputeResource("z2")
-	s.client.computeResources = []*mo.ComputeResource{z1, z2}
+	z3 := newComputeResource("z3")
+	s.client.computeResources = []*mo.ComputeResource{z1, z2, z3}
+
+	childPool := makeResourcePool("rp-child", "/DC/host/z3/Resources/child")
+	childRef := childPool.Reference()
+	s.client.resourcePools = map[string][]*object.ResourcePool{
+		"z1/...": {makeResourcePool("rp-z1", "/DC/host/z1/Resources")},
+		"z2/...": {makeResourcePool("rp-z2", "/DC/host/z2/Resources")},
+		"z3/...": {
+			makeResourcePool("rp-z3", "/DC/host/z3/Resources"),
+			childPool,
+		},
+	}
 
 	s.client.virtualMachines = []*mo.VirtualMachine{
 		buildVM("inst-0").resourcePool(z2.ResourcePool).vm(),
 		buildVM("inst-1").resourcePool(z1.ResourcePool).vm(),
 		buildVM("inst-2").vm(),
+		buildVM("inst-3").resourcePool(&childRef).vm(),
 	}
-	ids := []instance.Id{"inst-0", "inst-1", "inst-2", "inst-3"}
+	ids := []instance.Id{"inst-0", "inst-1", "inst-2", "inst-3", "inst-4"}
 
 	zonedEnviron := s.env.(common.ZonedEnviron)
 	zones, err := zonedEnviron.InstanceAvailabilityZoneNames(s.callCtx, ids)
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
-	c.Assert(zones, jc.DeepEquals, []string{"z2", "z1", "", ""})
+	c.Assert(zones, jc.DeepEquals, []string{"z2", "z1", "", "z3/child", ""})
 }
 
 func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNamesNoInstances(c *gc.C) {
@@ -62,6 +89,9 @@ func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNamesNoInstances(c 
 func (s *environAvailzonesSuite) TestDeriveAvailabilityZones(c *gc.C) {
 	s.client.computeResources = []*mo.ComputeResource{
 		newComputeResource("test-available"),
+	}
+	s.client.resourcePools = map[string][]*object.ResourcePool{
+		"test-available/...": {makeResourcePool("pool-23", "/DC/host/test-available/Resources")},
 	}
 
 	c.Assert(s.env, gc.Implements, new(common.ZonedEnviron))

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -236,7 +236,9 @@ func (env *sessionEnviron) newRawInstance(
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	createVMArgs.ComputeResource = &availZone.(*vmwareAvailZone).r
+
+	createVMArgs.ComputeResource = &availZone.r
+	createVMArgs.ResourcePool = availZone.pool.Reference()
 
 	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
 	if err != nil {

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -118,7 +118,7 @@ func (env *sessionEnviron) parsePlacement(ctx context.ProviderCallContext, place
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return zone.(*vmwareAvailZone), nil
+		return zone, nil
 	}
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -211,6 +211,25 @@ func (c *Client) Datastores(ctx context.Context) ([]*mo.Datastore, error) {
 	return datastores, nil
 }
 
+// ResourcePools returns a list of all of the resource pools (possibly
+// nested) under the given path.
+func (c *Client) ResourcePools(ctx context.Context, path string) ([]*object.ResourcePool, error) {
+	finder, _, err := c.finder(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.logger.Tracef("listing resource pools under %q", path)
+	items, err := finder.ResourcePoolList(ctx, path)
+	if err != nil {
+		if _, ok := err.(*find.NotFoundError); ok {
+			c.logger.Debugf("no resource pools for path %q", path)
+			return nil, nil
+		}
+		return nil, errors.Annotate(err, "listing resource pools")
+	}
+	return items, nil
+}
+
 // EnsureVMFolder creates the a VM folder with the given path if it doesn't
 // already exist.
 func (c *Client) EnsureVMFolder(ctx context.Context, folderPath string) (*object.Folder, error) {

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -75,6 +75,10 @@ type CreateVirtualMachineParams struct {
 	// to create the VM.
 	ComputeResource *mo.ComputeResource
 
+	// ResourcePool is a reference to the pool the VM should be
+	// created in.
+	ResourcePool types.ManagedObjectReference
+
 	// Datastore is the name of the datastore in which to create the VM.
 	// If this is empty, any accessible datastore will be used.
 	Datastore string
@@ -161,7 +165,7 @@ func (c *Client) CreateVirtualMachine(
 
 	// Ensure the VMDK is present in the datastore, uploading it if it
 	// doesn't already exist.
-	resourcePool := object.NewResourcePool(c.client.Client, *args.ComputeResource.ResourcePool)
+	resourcePool := object.NewResourcePool(c.client.Client, args.ResourcePool)
 	taskWaiter := &taskWaiter{args.Clock, args.UpdateProgress, args.UpdateProgressInterval}
 	vmdkDatastorePath, releaseVMDK, err := c.ensureVMDK(ctx, args, datastore, datacenter, taskWaiter)
 	if err != nil {
@@ -303,9 +307,7 @@ func (c *Client) createImportSpec(
 	}
 
 	ovfManager := ovf.NewManager(c.client.Client)
-	resourcePool := object.NewReference(c.client.Client, *args.ComputeResource.ResourcePool)
-
-	spec, err := ovfManager.CreateImportSpec(ctx, UbuntuOVF, resourcePool, datastore, cisp)
+	spec, err := ovfManager.CreateImportSpec(ctx, UbuntuOVF, args.ResourcePool, datastore, cisp)
 	if err != nil {
 		return nil, errors.Trace(err)
 	} else if spec.Error != nil {

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -468,6 +468,10 @@ func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 				Value: "dvportgroup-0",
 			}},
 		},
+		ResourcePool: types.ManagedObjectReference{
+			Type:  "ResourcePool",
+			Value: "FakeResourcePool1",
+		},
 		Metadata:               map[string]string{"k": "v"},
 		Constraints:            constraints.Value{},
 		UpdateProgress:         func(status string) {},


### PR DESCRIPTION
## Description of change

VSphere has the concept of resource pools, which are a way to divide up the resources of a host or cluster so that adding a lot of VMs in one pool won't affect VMs in a different pool in the cluster (as well as a number of [other uses](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-AA95D1D1-55C0-419D-9E1A-C523C138CC65.html)). They can also be nested hierarchically.

Cluster or host could already be selected by specifying the zones constraint or zone placement directive when deploying. This change enables targeting a specific resource pool within that host/cluster by adding the path to the pool from the compute resource.

As a driveby we now skip compute resources with no effective CPUs (so empty clusters).

## QA steps

* In the vsphere console, add some resource pools eg Parent, containing Child.
* Bootstrap a controller
* Deploy an application into Parent using the zones constraint: `juju deploy ubuntu --constraints zones=aron.internal/Parent`
* The VM hosting the unit should be created in the right resource pool.
* Adding a unit to the application also creates the VM in the same pool.
* Deploy an application using a placement directive: `juju deploy ubuntu u2 --to zone=aron.internal/Parent/Child`
* The VM is created in the right pool.

## Documentation changes

The vsphere documentation should be updated to reflect that we can deploy to resource pools, and to illustrate the zones constraint as well. This was added after the vsphere provider but it means that all of the units of an application can be deployed to the same cluster or resource pool without needing to specify placement for each one.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1807961
