### PR TITLE
Tweak the worker/lease retry code.

### DIFF
--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -31,6 +31,7 @@ type Secretary interface {
 type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
 	Warningf(string, ...interface{})
 	Errorf(string, ...interface{})
 }

--- a/worker/lease/export_test.go
+++ b/worker/lease/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+const (
+	MaxRetries         = maxRetries
+	InitialRetryDelay  = initialRetryDelay
+	RetryBackoffFactor = retryBackoffFactor
+)


### PR DESCRIPTION
## Description of change

It wasn't properly handling if we got 5 ErrInvalid responses in a row.
Now we require 10 invalid responses, and if we end up getting all
failures, we just deny the claim, because clearly the Primary node knows
something we don't. Ultimately, it is a failure that we are failing to
Sync with the master node. However, having a Claim fail 5 (10) times
shouldn't cause the Manager to fail. So instead, we just issue a ClaimDenied.

That response means that the client should go into
BlockUntilLeadership call. And if we have gotten in sync by then, we
will block them. If we still haven't then they will be immediately
unblocked, and they'll try to do another claim. But it should still be
a) Correct
b) With delay backoff shouldn't introduce too much load.

This does impact other retry loops, but it shouldn't be a problem. For
Expire, we don't have ErrInvalid, as we treat that the same as if we
successfully expired it (at the very least, we know that our existing
lease is incorrect, even if it is now just owned by someone else.)

## QA steps

A Unit test was added which exhibits the failing behavior. 

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815719