### PR TITLE
Support leader units in juju run

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1699,6 +1699,7 @@ func (s *withControllerSuite) TestCACert(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	s.PatchValue(&provisioner.ErrorRetryWaitDelay, 2*coretesting.ShortWait)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 


### PR DESCRIPTION
## Description of change

This PR adds support for `<application>/leader` syntax to `juju run`.

## QA steps

```console 
$ juju bootstrap localhost lxd-test 
$ juju deploy ubuntu -n 2
$ juju run --unit ubuntu/leader hostname
juju-00febd-0
```

## Documentation changes
The PR updates the cli command man page but we probably have to update online man pages to reflect the change

## Bug reference
https://bugs.launchpad.net/juju/+bug/1814962
