### PR TITLE
Fix autocompletion for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,20 @@ Installing bash completion for juju
 
     make install-etc
 
-Will install Bash completion for `juju` cli to `/etc/bash_completion.d/juju`. It does
+Will install Bash completion for `juju` cli to `/usr/share/bash-completion/completions/juju`. It does
 dynamic completion for commands requiring service, unit or machine names (like e.g.
 juju status <service>, juju ssh <instance>, juju terminate-machine <machine#>, etc),
 by parsing cached `juju status` output for speedup. It also does command flags
 completion by parsing `juju help ...` output.
+
+If you are using zsh instead of bash you can follow the steps above and add the
+following lines to the end of your `.zshrc` file:
+
+```bash
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+[ -f /usr/share/bash-completion/completions/juju ] && source /usr/share/bash-completion/completions/juju
+```
 
 Building Juju as a Snap Package
 ===============================

--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -341,13 +341,17 @@ export _JUJU_2_cache_TTL=2
 # Detect juju built from source (highest priority)
 if [ -x "$GOPATH/bin/juju" ]; then 
     export _juju_cmd_JUJU_2="$GOPATH/bin/juju"
+elif [ -x "$GOROOT/bin/juju" ]; then
+    export _juju_cmd_JUJU_2="$GOROOT/bin/juju"
 # Detect installed juju-2 binary (next highest priority)
 elif [ -x "/usr/bin/juju-2" ]; then
     export _juju_cmd_JUJU_2="/usr/bin/juju-2"
 # Snap version of juju
 elif [ -x "/snap/bin/juju" ]; then
     export _juju_cmd_JUJU_2="/snap/bin/juju"
-# Use /usr/bin/juju as a last resort.
+# Look for juju in the user's path and fallback to /usr/bin/juju as a last resort.
+elif [ -x "$(which juju)" ]; then
+    export _juju_cmd_JUJU_2=$(which juju)
 else
     export _juju_cmd_JUJU_2="/usr/bin/juju"
 fi

--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -12,6 +12,108 @@
 #   juju ssh --model <TAB> [... will complete with proper model's units/etc ...]
 #
 
+# use complete instead of compopt for zsh
+if [ -n "$BASH_VERSION" ]; then
+  COMP_OPT_CMD=compopt
+elif [ -n "$ZSH_VERSION" ]; then
+  COMP_OPT_CMD=complete
+else
+  COMP_OPT_CMD=compopt
+fi
+
+# The following functions are provided by bash_completion and are not available
+# when using zsh bashcompinit/compinit which breaks autocompletion. The following
+# ZSH-safe functions have been extracted from github.com/git/git-completion.bash
+# and github.com/scop/bash-completion.
+if ! type __reassemble_comp_words_by_ref >/dev/null 2>&1; then
+  __reassemble_comp_words_by_ref() {
+    local exclude i j first
+    # Which word separators to exclude?
+    exclude="${1//[^$COMP_WORDBREAKS]}"
+    cword_=$COMP_CWORD
+    if [ -z "$exclude" ]; then
+      words_=("${COMP_WORDS[@]}")
+      return
+    fi
+    # List of word completion separators has shrunk;
+    # re-assemble words to complete.
+    for ((i=0, j=0; i < ${#COMP_WORDS[@]}; i++, j++)); do
+      # Append each nonempty word consisting of just
+      # word separator characters to the current word.
+      first=t
+      while
+        [ $i -gt 0 ] &&
+        [ -n "${COMP_WORDS[$i]}" ] &&
+        # word consists of excluded word separators
+        [ "${COMP_WORDS[$i]//[^$exclude]}" = "${COMP_WORDS[$i]}" ]
+      do
+        # Attach to the previous token,
+        # unless the previous token is the command name.
+        if [ $j -ge 2 ] && [ -n "$first" ]; then
+          ((j--))
+        fi
+        first=
+        words_[$j]=${words_[j]}${COMP_WORDS[i]}
+        if [ $i = $COMP_CWORD ]; then
+          cword_=$j
+        fi
+        if (($i < ${#COMP_WORDS[@]} - 1)); then
+          ((i++))
+        else
+          # Done.
+          return
+        fi
+      done
+      words_[$j]=${words_[j]}${COMP_WORDS[i]}
+      if [ $i = $COMP_CWORD ]; then
+        cword_=$j
+      fi
+    done
+  }
+fi
+
+if ! type _get_comp_words_by_ref >/dev/null 2>&1; then
+  _get_comp_words_by_ref () {
+    local exclude cur_ words_ cword_
+    if [ "$1" = "-n" ]; then
+      exclude=$2
+      shift 2
+    fi
+    __reassemble_comp_words_by_ref "$exclude"
+    cur_=${words_[cword_]}
+    while [ $# -gt 0 ]; do
+      case "$1" in
+      cur)
+        cur=$cur_
+        ;;
+      prev)
+        prev=${words_[$cword_-1]}
+        ;;
+      words)
+        words=("${words_[@]}")
+        ;;
+      cword)
+        cword=$cword_
+        ;;
+      esac
+      shift
+    done
+  }
+fi
+
+if ! type __ltrim_colon_completions >/dev/null 2>&1; then
+  __ltrim_colon_completions() {
+    if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+        # Remove colon-word prefix from COMPREPLY items
+        local colon_word=${1%"${1##*:}"}
+        local i=${#COMPREPLY[*]}
+        while [[ $((--i)) -ge 0 ]]; do
+            COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+        done
+    fi
+  }
+fi
+
 # Print (return) cache filename for "juju status"
 _JUJU_2_juju_status_cache_fname() {
     local model=$(_get_current_model)
@@ -290,7 +392,7 @@ _JUJU_2_complete_with_func() {
     if [[ ${action} == scp ]]; then
         postfix_str=':'
         compgen_xtra='-A file'
-        compopt -o nospace
+        $COMP_OPT_CMD -o nospace
     fi
 
     # build COMPREPLY from passed function stdout, and _JUJU_2_flags_for $action
@@ -311,7 +413,7 @@ _JUJU_2_complete_with_func() {
     __ltrim_colon_completions "$cur"
 
     if [[ ${action} == scp ]]; then
-        compopt +o nospace
+        $COMP_OPT_CMD +o nospace
     fi
 
 


### PR DESCRIPTION
## Description of change

Fix broken autocomplete support for zsh (see: https://discourse.jujucharms.com/t/zsh-juju-tab-completion/579) and improve the juju binary detection code with a `which juju` fallback.

## QA steps

```console 
$ make install-etc 
```

Add the following lines to your `.zshrc`:
```bash
autoload -U +X compinit && compinit
autoload -U +X bashcompinit && bashcompinit
[ -f /usr/share/bash-completion/completions/juju ] && source /usr/share/bash-completion/completions/juju
```

Then restart your shell (you may need to `source ~/.zshrc` twice if already running in zsh)

NOTE: for the autocompletion to work, the juju binary **must** be present in your `$PATH`. If autocompletion _silently fails_ try running `which juju` and update your `$PATH` if you get an empty result.