### PR TITLE
Do not exit from a bootcmd shell prematurely

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -325,17 +325,17 @@ if [ ! -f /sbin/ifup ]; then
     echo "No /sbin/ifup, applying netplan configuration."
     netplan generate
     netplan apply
-    exit 0
-fi
-if [ -f /usr/bin/python ]; then
-    python %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
 else
-    python3 %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+  if [ -f /usr/bin/python ]; then
+      python %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+  else
+      python3 %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+  fi
+  ifdown -a
+  sleep 1.5
+  mv %[1]s.out %[1]s
+  ifup -a
 fi
-ifdown -a
-sleep 1.5
-mv %[1]s.out %[1]s
-ifup -a
 `
 	return fmt.Sprintf(s, networkFile)
 }

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -203,17 +203,17 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
       echo "No /sbin/ifup, applying netplan configuration."
       netplan generate
       netplan apply
-      exit 0
-  fi
-  if [ -f /usr/bin/python ]; then
-      python %[2]s --interfaces-file %[1]s --output-file %[1]s.out
   else
-      python3 %[2]s --interfaces-file %[1]s --output-file %[1]s.out
+    if [ -f /usr/bin/python ]; then
+        python %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+    else
+        python3 %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+    fi
+    ifdown -a
+    sleep 1.5
+    mv %[1]s.out %[1]s
+    ifup -a
   fi
-  ifdown -a
-  sleep 1.5
-  mv %[1]s.out %[1]s
-  ifup -a
 `[1:]
 	s.expectedFullNetplanYaml = `
 - install -D -m 644 /dev/null '%[1]s'


### PR DESCRIPTION
## Description of change

    Do not exit from a bootcmd shell prematurely
    
    The bootcmd for generating netplan or /e/n/i contains 'exit 0' in the
    netplan code-path and on bionic exits the shell used to run bootcmds.
    Turns on the bootcmd for writing the proxy settings file to
    /etc/apt/apt.conf.d/95-juju-proxy-settings is the last bootcmd in
    user-data generated by Juju and is never executed on bionic systems as a
    result of 'exit 0' in the bootcmd above it.
    
    95-juju-proxy-settings is later written by proxyupdater so ext4 crtime
    timestamp for the file are always greater than cloud-init's bootcmd
    timestamps (including the one saying that this module has finished
    running). In other words, this file is always created after bootcmd
    finishes.
    
    This results in apt updates in modules that follow to fail
    (specifically cc_package_update_upgrade_install) if only proxied access
    to apt mirrors is available (e.g. no default gateway configured). Which
    then results in charm failures as they have no repository index. It
    seems that some charms have workarounds for this behavior already.
    
    cloud-init uses subprocess.communicate() when it waits for a
    child process (/bin/sh in this case) to finish so all file descriptors
    are closed in all child processes that could have been forked/exec-ed
    from bootcmds and the processes themselves are gone (unless they
    daemonized which is not the case). So the issue is in premature exit,
    not buffering.


## QA steps

1) In MAAS remove a default gateway from the subnet(s) used by the server;

2) Apply the following model-config to a new model:

```
juju-http-proxy: http://192.0.2:3128
juju-https-proxy: http://192.0.2:3128
snap-http-proxy: http://192.0.2:3128
snap-https-proxy: http://192.0.2:3128
apt-http-proxy: http://192.0.2:3128
apt-https-proxy: http://192.0.2:3128
```

3) `juju deploy openstack-dashboard --to lxd:0`

4) Validate that default gateway is not present via `ip route` in a container and by looking at `/var/log/cloud-init-output.log`.

It should only contain a directly connected route over which the proxy server is accessible.
```
ci-info: +++++++++++++++++++++++++++Route IPv4 info+++++++++++++++++++++++++++
ci-info: +-------+-------------+---------+---------------+-----------+-------+
ci-info: | Route | Destination | Gateway |    Genmask    | Interface | Flags |
ci-info: +-------+-------------+---------+---------------+-----------+-------+
ci-info: |   0   |  192.0.2.0 | 0.0.0.0 | 255.255.255.0 |    eth1   |   U   |
```
5) Validate that crtime (file creation timestamp) is <= "config-bootcmd ran successfully" timestamp in /var/log/cloud-init.log and that there are no apt update errors in the log for cc_package_update_upgrade_install module.

```
juju ssh 0

sudo debugfs -R 'stat /var/lib/lxd/storage-pools/default/containers/juju-6d9aac-0-lxd-0/rootfs/etc/apt/apt.conf.d/95-juju-proxy-settings' /dev/sda1 2>/dev/null | grep -P 'crtime|mtime'

mtime: 0x5c655cb0:8cd912b8 -- Thu Feb 14 12:18:56 2019
crtime: 0x5c655cb0:8cd912b8 -- Thu Feb 14 12:18:56 2019

juju ssh openstack-dashboard/0

grep -RiP 'finish: init-network/config-bootcmd: SUCCESS: config-bootcmd ran successfully' /var/log/cloud-init* 
/var/log/cloud-init.log:2019-02-14 12:18:56,594 - handlers.py[DEBUG]: finish: init-network/config-bootcmd: SUCCESS: config-bootcmd ran successfully

```

## Documentation changes

No changes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1807615