### PR TITLE
1815842 - Verify if we have a nic

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -57,7 +57,6 @@ func (ci *containerInitialiser) Initialise() error {
 	if err := ensureDependencies(localSeries); err != nil {
 		return errors.Trace(err)
 	}
-
 	err = configureLXDBridge()
 	if err != nil {
 		return errors.Trace(err)
@@ -154,6 +153,11 @@ var configureLXDBridge = func() error {
 		profile, eTag, err := server.GetProfile(lxdDefaultProfileName)
 		if err != nil {
 			return errors.Trace(err)
+		}
+		// If there are no suitable bridged NICs in the profile,
+		// ensure the bridge is set up and create one.
+		if err := server.verifyNICsWithAPI(getProfileNICs(profile)); err == nil {
+			return nil
 		}
 		return server.ensureDefaultNetworking(profile, eTag)
 	}

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -156,7 +156,7 @@ var configureLXDBridge = func() error {
 		}
 		// If there are no suitable bridged NICs in the profile,
 		// ensure the bridge is set up and create one.
-		if err := server.verifyNICsWithAPI(getProfileNICs(profile)); err == nil {
+		if server.verifyNICsWithAPI(getProfileNICs(profile)) == nil {
 			return nil
 		}
 		return server.ensureDefaultNetworking(profile, eTag)


### PR DESCRIPTION
## Description of change

The following code checks to see if we already have a nic, before
going through and ensuring a default nic. By checking that the 
nics exist before configureLXDBridge we check the current existing
available nics before attempting to create our own.

Also added a new test suite, so we can test the configureLXDBridge,
without it being patched by SetupTest.

## QA steps

Manually provision LXD and ensure it can't reach the lxd snap, so that
it causes it to restart.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815842
