### PR TITLE
1815842 - Verify if we have a nic - 2.4 backport

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -153,6 +153,11 @@ var configureLXDBridge = func() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		// If there are no suitable bridged NICs in the profile,
+		// ensure the bridge is set up and create one.
+		if server.verifyNICsWithAPI(getProfileNICs(profile)) == nil {
+			return nil
+		}
 		return server.ensureDefaultNetworking(profile, eTag)
 	}
 	return configureLXDBridgeForOlderLXD()


### PR DESCRIPTION
This is a backport of https://github.com/juju/juju/pull/9752

## Description of change

The following code checks to see if we already have a nic, before
going through and ensuring a default nic. By checking that the
nics exist before configureLXDBridge we check the current existing
available nics before attempting to create our own.

Also added a new test suite, so we can test the configureLXDBridge,
without it being patched by SetupTest.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815842
