### PR TITLE
Add support for k8s init containers

### DIFF
--- a/caas/containers.go
+++ b/caas/containers.go
@@ -59,6 +59,7 @@ type ContainerSpec struct {
 // a pod on the CAAS substrate.
 type PodSpec struct {
 	Containers                []ContainerSpec            `yaml:"-"`
+	InitContainers            []ContainerSpec            `yaml:"-"`
 	OmitServiceFrontend       bool                       `yaml:"omitServiceFrontend"`
 	CustomResourceDefinitions []CustomResourceDefinition `yaml:"customResourceDefinition,omitempty"`
 
@@ -105,6 +106,11 @@ func (crd *CustomResourceDefinition) Validate() error {
 // Validate returns an error if the spec is not valid.
 func (spec *PodSpec) Validate() error {
 	for _, c := range spec.Containers {
+		if err := c.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	for _, c := range spec.InitContainers {
 		if err := c.Validate(); err != nil {
 			return errors.Trace(err)
 		}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1017,6 +1017,21 @@ func (k *kubernetesClient) EnsureService(
 		}
 	}
 	if !params.PodSpec.OmitServiceFrontend {
+		// Merge any service annotations from the charm.
+		if unitSpec.Service != nil && len(unitSpec.Service.Annotations) > 0 {
+			annotations := make(map[string]string)
+			for k, v := range unitSpec.Service.Annotations {
+				annotations[k] = v
+			}
+			deployAnnotations, err := config.GetStringMap(serviceAnnotationsKey, nil)
+			if err != nil {
+				return errors.Annotatef(err, "unexpected annotations: %#v", config.Get(serviceAnnotationsKey, nil))
+			}
+			for k, v := range deployAnnotations {
+				annotations[k] = v
+			}
+			config[serviceAnnotationsKey] = annotations
+		}
 		if err := k.configureService(appName, deploymentName, ports, resourceTags, config); err != nil {
 			return errors.Annotatef(err, "creating or updating service for %v", appName)
 		}
@@ -1871,13 +1886,11 @@ func operatorConfigMap(appName, operatorName string, config *caas.OperatorConfig
 }
 
 type unitSpec struct {
-	Pod core.PodSpec `json:"pod"`
+	Pod     core.PodSpec `json:"pod"`
+	Service *K8sServiceSpec
 }
 
-var defaultPodTemplate = `
-pod:
-  containers:
-  {{- range .Containers }}
+var containerTemplate = `
   - name: {{.Name}}
     {{if .Ports}}
     ports:
@@ -1903,8 +1916,21 @@ pod:
           value: {{$v}}
     {{- end}}
     {{end}}
+`
+
+var defaultPodTemplate = fmt.Sprintf(`
+pod:
+  containers:
+  {{- range .Containers }}
+%s
   {{- end}}
-`[1:]
+  {{if .InitContainers}}
+  initContainers:
+  {{- range .InitContainers }}
+%s
+  {{- end}}
+  {{end}}
+`[1:], containerTemplate, containerTemplate)
 
 func makeUnitSpec(appName, deploymentName string, podSpec *caas.PodSpec) (*unitSpec, error) {
 	// Fill out the easy bits using a template.
@@ -1922,35 +1948,14 @@ func makeUnitSpec(appName, deploymentName string, podSpec *caas.PodSpec) (*unitS
 		return nil, errors.Trace(err)
 	}
 
-	var imageSecretNames []core.LocalObjectReference
 	// Now fill in the hard bits progamatically.
-	for i, c := range podSpec.Containers {
-		if c.Image != "" {
-			logger.Warningf("Image parameter deprecated, use ImageDetails")
-			unitSpec.Pod.Containers[i].Image = c.Image
-		} else {
-			unitSpec.Pod.Containers[i].Image = c.ImageDetails.ImagePath
-		}
-		if c.ImageDetails.Password != "" {
-			imageSecretNames = append(imageSecretNames, core.LocalObjectReference{Name: appSecretName(deploymentName, c.Name)})
-		}
-
-		if c.ProviderContainer == nil {
-			continue
-		}
-		spec, ok := c.ProviderContainer.(*K8sContainerSpec)
-		if !ok {
-			return nil, errors.Errorf("unexpected kubernetes container spec type %T", c.ProviderContainer)
-		}
-		unitSpec.Pod.Containers[i].ImagePullPolicy = spec.ImagePullPolicy
-		if spec.LivenessProbe != nil {
-			unitSpec.Pod.Containers[i].LivenessProbe = spec.LivenessProbe
-		}
-		if spec.ReadinessProbe != nil {
-			unitSpec.Pod.Containers[i].ReadinessProbe = spec.ReadinessProbe
-		}
+	if err := populateContainerDetails(deploymentName, &unitSpec.Pod, unitSpec.Pod.Containers, podSpec.Containers); err != nil {
+		return nil, errors.Trace(err)
 	}
-	unitSpec.Pod.ImagePullSecrets = imageSecretNames
+	if err := populateContainerDetails(deploymentName, &unitSpec.Pod, unitSpec.Pod.InitContainers, podSpec.InitContainers); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if podSpec.ProviderPod != nil {
 		spec, ok := podSpec.ProviderPod.(*K8sPodSpec)
 		if !ok {
@@ -1969,8 +1974,39 @@ func makeUnitSpec(appName, deploymentName string, podSpec *caas.PodSpec) (*unitS
 		unitSpec.Pod.RestartPolicy = spec.RestartPolicy
 		unitSpec.Pod.AutomountServiceAccountToken = spec.AutomountServiceAccountToken
 		unitSpec.Pod.ReadinessGates = spec.ReadinessGates
+		unitSpec.Service = spec.Service
 	}
 	return &unitSpec, nil
+}
+
+func populateContainerDetails(deploymentName string, pod *core.PodSpec, podContainers []core.Container, containers []caas.ContainerSpec) error {
+	for i, c := range containers {
+		if c.Image != "" {
+			logger.Warningf("Image parameter deprecated, use ImageDetails")
+			podContainers[i].Image = c.Image
+		} else {
+			podContainers[i].Image = c.ImageDetails.ImagePath
+		}
+		if c.ImageDetails.Password != "" {
+			pod.ImagePullSecrets = append(pod.ImagePullSecrets, core.LocalObjectReference{Name: appSecretName(deploymentName, c.Name)})
+		}
+
+		if c.ProviderContainer == nil {
+			continue
+		}
+		spec, ok := c.ProviderContainer.(*K8sContainerSpec)
+		if !ok {
+			return errors.Errorf("unexpected kubernetes container spec type %T", c.ProviderContainer)
+		}
+		podContainers[i].ImagePullPolicy = spec.ImagePullPolicy
+		if spec.LivenessProbe != nil {
+			podContainers[i].LivenessProbe = spec.LivenessProbe
+		}
+		if spec.ReadinessProbe != nil {
+			podContainers[i].ReadinessProbe = spec.ReadinessProbe
+		}
+	}
+	return nil
 }
 
 // legacyAppName returns true if there are any artifacts for


### PR DESCRIPTION
## Description of change

The pod spec file sent by the charm to Juju now supports init containers and service annotations.
Add something like this to the pod spec:
```
initContainers:
  - name: foo-init
    imageDetails:
      imagePath: %(docker_image_path)s
      username: %(docker_image_username)s
      password: %(docker_image_password)s
    imagePullPolicy: Always
    command: ["sh", "-c"]
service:
  annotations:
    foo: bar
```
## QA steps

Deploy a k8s charm with a podspec containing the service annotations and init containers.
Use kubectl to ensure that the pod runs the init containers and service has the annotations.

## Documentation changes

Doc on discourse

