### PR TITLE
Allow admins to access storage API for all models

### DIFF
--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -122,6 +122,13 @@ func (a *StorageAPI) checkCanRead() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	// Controller admins should have implicit read access to all models
+	// in the controller, even the ones they do not own.
+	if !canRead {
+		canRead, _ = a.authorizer.HasPermission(permission.SuperuserAccess, a.backend.ControllerTag())
+	}
+
 	if !canRead {
 		return common.ErrPerm
 	}

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -150,7 +150,7 @@ func (a *StorageAPI) checkCanWrite() error {
 // storage identified by supplied tags. If specified storage cannot be
 // retrieved, individual error is returned instead of storage information.
 func (a *StorageAPI) StorageDetails(entities params.Entities) (params.StorageDetailsResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanRead(); err != nil {
 		return params.StorageDetailsResults{}, errors.Trace(err)
 	}
 	results := make([]params.StorageDetailsResult, len(entities.Entities))


### PR DESCRIPTION
## Description of change

The code in the storage facades that handles listing storage-related details checks whether the user has read-access to models. This check currently fails when a super user (should have implicit access to all models of the controller) tries to list storage details for a _model created by another user_.

This PR adds logic to the permission-checking code that will  allow super users to list storage details for models they do not own but belong to the controller they are an admin of.

## QA steps

```console
$ juju bootstrap lxd lxd-test
$ juju add-user foo
$ juju change-user-password foo
# enter password for user foo
$ juju grant-user foo add-model
$ juju change-user-password
# enter password for admin
$ juju logout

# Create model as user foo and deploy something with attached storage
$ juju login -c lxd-test -u foo
$ juju add-credential lxd-test
# create a credential named "foo"
$ juju add-model foo-model --credential foo
$ juju deploy postgresql --storage pgdata=lxd,100M,1
$ juju logout

# Switch back to the admin user and try the following storage commands
# (all should work without a permission error)
$ juju login -c lxd-test -u admin
$ juju storage -m foo/foo-model --format yaml
$ juju show-storage -m foo/foo-model pgdata/0 --format yaml
$ juju list-storage -m foo/foo-model --format yaml
$ juju status --format yaml
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1815154