### PR TITLE
Application charm profile

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1008,8 +1008,7 @@ func (context *statusContext) processApplication(application *state.Application)
 	}
 
 	var charmProfileName string
-	// Ensure the profile isn't empty.
-	if !lxdprofile.IsEmpty(applicationCharm) {
+	if lxdprofile.NotEmpty(applicationCharm) {
 		charmProfileName = lxdprofile.Name(context.model.Name(), application.Name(), applicationCharm.Revision())
 	}
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1007,12 +1007,19 @@ func (context *statusContext) processApplication(application *state.Application)
 		return params.ApplicationStatus{Err: common.ServerError(err)}
 	}
 
+	var charmProfileName string
+	// Ensure the profile isn't empty.
+	if !lxdprofile.IsEmpty(applicationCharm) {
+		charmProfileName = lxdprofile.Name(context.model.Name(), application.Name(), applicationCharm.Revision())
+	}
+
 	var processedStatus = params.ApplicationStatus{
 		Charm:        applicationCharm.URL().String(),
 		Series:       application.Series(),
 		Exposed:      application.IsExposed(),
 		Life:         processLife(application),
 		CharmVersion: applicationCharm.Version(),
+		CharmProfile: charmProfileName,
 	}
 
 	if latestCharm, ok := context.allAppsUnitsCharmBindings.latestCharms[*applicationCharm.URL().WithRevision(-1)]; ok && latestCharm != nil {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -141,6 +141,7 @@ type ApplicationStatus struct {
 	Status           DetailedStatus         `json:"status"`
 	WorkloadVersion  string                 `json:"workload-version"`
 	CharmVersion     string                 `json:"charm-verion"`
+	CharmProfile     string                 `json:"charm-profile"`
 	EndpointBindings map[string]string      `json:"endpoint-bindings"`
 
 	// The following are for CAAS models.

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -111,6 +111,7 @@ type applicationStatus struct {
 	CharmName        string                `json:"charm-name" yaml:"charm-name"`
 	CharmRev         int                   `json:"charm-rev" yaml:"charm-rev"`
 	CharmVersion     string                `json:"charm-version,omitempty" yaml:"charm-version,omitempty"`
+	CharmProfile     string                `json:"charm-profile,omitempty" yaml:"charm-profile,omitempty"`
 	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
 	Scale            int                   `json:"scale,omitempty" yaml:"scale,omitempty"`
 	Placement        string                `json:"placement,omitempty" yaml:"placement,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -236,6 +236,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		CharmName:        charmName,
 		CharmRev:         charmRev,
 		CharmVersion:     application.CharmVersion,
+		CharmProfile:     application.CharmProfile,
 		Exposed:          application.Exposed,
 		Life:             application.Life,
 		Scale:            application.Scale,

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -3522,26 +3522,21 @@ func mysqlCharm(extras M) M {
 		"os":           "ubuntu",
 		"exposed":      false,
 	}
-	for key, value := range extras {
-		charm[key] = value
-	}
-	return charm
+	return composeCharms(charm, extras)
 }
 
 func lxdProfileCharm(extras M) M {
 	charm := M{
-		"charm":        "cs:quantal/lxd-profile-0",
-		"charm-origin": "jujucharms",
-		"charm-name":   "lxd-profile",
-		"charm-rev":    1,
-		"series":       "quantal",
-		"os":           "ubuntu",
-		"exposed":      false,
+		"charm":         "cs:quantal/lxd-profile-0",
+		"charm-origin":  "jujucharms",
+		"charm-name":    "lxd-profile",
+		"charm-rev":     1,
+		"charm-profile": "juju-controller-lxd-profile-1",
+		"series":        "quantal",
+		"os":            "ubuntu",
+		"exposed":       false,
 	}
-	for key, value := range extras {
-		charm[key] = value
-	}
-	return charm
+	return composeCharms(charm, extras)
 }
 
 func meteredCharm(extras M) M {
@@ -3554,10 +3549,7 @@ func meteredCharm(extras M) M {
 		"os":           "ubuntu",
 		"exposed":      false,
 	}
-	for key, value := range extras {
-		charm[key] = value
-	}
-	return charm
+	return composeCharms(charm, extras)
 }
 
 func dummyCharm(extras M) M {
@@ -3570,10 +3562,7 @@ func dummyCharm(extras M) M {
 		"os":           "ubuntu",
 		"exposed":      false,
 	}
-	for key, value := range extras {
-		charm[key] = value
-	}
-	return charm
+	return composeCharms(charm, extras)
 }
 
 func wordpressCharm(extras M) M {
@@ -3586,10 +3575,18 @@ func wordpressCharm(extras M) M {
 		"os":           "ubuntu",
 		"exposed":      false,
 	}
-	for key, value := range extras {
-		charm[key] = value
+	return composeCharms(charm, extras)
+}
+
+func composeCharms(origin, extras M) M {
+	result := make(M, len(origin))
+	for key, value := range origin {
+		result[key] = value
 	}
-	return charm
+	for key, value := range extras {
+		result[key] = value
+	}
+	return result
 }
 
 // TODO(dfc) test failing components by destructively mutating the state under the hood
@@ -3970,7 +3967,6 @@ type setApplicationCharm struct {
 }
 
 func (ssc setApplicationCharm) step(c *gc.C, ctx *context) {
-	fmt.Println("HERE")
 	ch, err := ctx.st.Charm(charm.MustParseURL(ssc.charm))
 	c.Assert(err, jc.ErrorIsNil)
 	s, err := ctx.st.Application(ssc.name)

--- a/core/lxdprofile/validate.go
+++ b/core/lxdprofile/validate.go
@@ -46,12 +46,12 @@ func ValidateCharmInfoLXDProfile(info *apicharms.CharmInfo) error {
 	return nil
 }
 
-// IsEmpty will return true if the profiler containers a profile, that is
-// empty. If the profile isn't empty, we'll return false.
-// If there is no valid profile in the profiler, it will return true
-func IsEmpty(profiler charm.LXDProfiler) bool {
+// NotEmpty will return false if the profiler containers a profile, that is
+// empty. If the profile is empty, we'll return false.
+// If there is no valid profile in the profiler, it will return false
+func NotEmpty(profiler charm.LXDProfiler) bool {
 	if profile := profiler.LXDProfile(); profile != nil {
-		return len(profile.Devices) == 0 && len(profile.Config) == 0 && len(profile.Description) == 0
+		return !profile.Empty()
 	}
-	return true
+	return false
 }

--- a/core/lxdprofile/validate.go
+++ b/core/lxdprofile/validate.go
@@ -45,3 +45,13 @@ func ValidateCharmInfoLXDProfile(info *apicharms.CharmInfo) error {
 	}
 	return nil
 }
+
+// IsEmpty will return true if the profiler containers a profile, that is
+// empty. If the profile isn't empty, we'll return false.
+// If there is no valid profile in the profiler, it will return true
+func IsEmpty(profiler charm.LXDProfiler) bool {
+	if profile := profiler.LXDProfile(); profile != nil {
+		return len(profile.Devices) == 0 && len(profile.Config) == 0 && len(profile.Description) == 0
+	}
+	return true
+}

--- a/core/lxdprofile/validate_test.go
+++ b/core/lxdprofile/validate_test.go
@@ -6,6 +6,7 @@ package lxdprofile_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	charm "gopkg.in/juju/charm.v6"
 
@@ -67,4 +68,49 @@ func (*LXDProfileSuite) TestValidateCharmInfoWithInvalidConfig(c *gc.C) {
 
 	err := lxdprofile.ValidateCharmInfoLXDProfile(info)
 	c.Assert(err, gc.NotNil)
+}
+
+func (*LXDProfileSuite) TestIsEmpty(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	profile := &charm.LXDProfile{}
+
+	lxdprofiler := NewMockLXDProfiler(ctrl)
+	lxdprofiler.EXPECT().LXDProfile().Return(profile)
+
+	result := lxdprofile.IsEmpty(lxdprofiler)
+	c.Assert(result, jc.IsTrue)
+}
+
+func (*LXDProfileSuite) TestIsEmptyWithConfigProfiles(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	profile := &charm.LXDProfile{
+		Config: map[string]string{
+			"boot": "foobar",
+		},
+	}
+
+	lxdprofiler := NewMockLXDProfiler(ctrl)
+	lxdprofiler.EXPECT().LXDProfile().Return(profile)
+
+	result := lxdprofile.IsEmpty(lxdprofiler)
+	c.Assert(result, jc.IsFalse)
+}
+
+func (*LXDProfileSuite) TestIsEmptyWithDescription(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	profile := &charm.LXDProfile{
+		Description: "lxd profile",
+	}
+
+	lxdprofiler := NewMockLXDProfiler(ctrl)
+	lxdprofiler.EXPECT().LXDProfile().Return(profile)
+
+	result := lxdprofile.IsEmpty(lxdprofiler)
+	c.Assert(result, jc.IsFalse)
 }

--- a/core/lxdprofile/validate_test.go
+++ b/core/lxdprofile/validate_test.go
@@ -70,7 +70,7 @@ func (*LXDProfileSuite) TestValidateCharmInfoWithInvalidConfig(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 }
 
-func (*LXDProfileSuite) TestIsEmpty(c *gc.C) {
+func (*LXDProfileSuite) TestNotEmpty(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -79,11 +79,11 @@ func (*LXDProfileSuite) TestIsEmpty(c *gc.C) {
 	lxdprofiler := NewMockLXDProfiler(ctrl)
 	lxdprofiler.EXPECT().LXDProfile().Return(profile)
 
-	result := lxdprofile.IsEmpty(lxdprofiler)
-	c.Assert(result, jc.IsTrue)
+	result := lxdprofile.NotEmpty(lxdprofiler)
+	c.Assert(result, jc.IsFalse)
 }
 
-func (*LXDProfileSuite) TestIsEmptyWithConfigProfiles(c *gc.C) {
+func (*LXDProfileSuite) TestNotEmptyWithConfigProfiles(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -96,14 +96,16 @@ func (*LXDProfileSuite) TestIsEmptyWithConfigProfiles(c *gc.C) {
 	lxdprofiler := NewMockLXDProfiler(ctrl)
 	lxdprofiler.EXPECT().LXDProfile().Return(profile)
 
-	result := lxdprofile.IsEmpty(lxdprofiler)
-	c.Assert(result, jc.IsFalse)
+	result := lxdprofile.NotEmpty(lxdprofiler)
+	c.Assert(result, jc.IsTrue)
 }
 
-func (*LXDProfileSuite) TestIsEmptyWithDescription(c *gc.C) {
+func (*LXDProfileSuite) TestNotEmptyWithDescription(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
+	// Having a description doesn't imply changes, so a description alone
+	// will cause it to be considered empty.
 	profile := &charm.LXDProfile{
 		Description: "lxd profile",
 	}
@@ -111,6 +113,6 @@ func (*LXDProfileSuite) TestIsEmptyWithDescription(c *gc.C) {
 	lxdprofiler := NewMockLXDProfiler(ctrl)
 	lxdprofiler.EXPECT().LXDProfile().Return(profile)
 
-	result := lxdprofile.IsEmpty(lxdprofiler)
+	result := lxdprofile.NotEmpty(lxdprofiler)
 	c.Assert(result, jc.IsFalse)
 }


### PR DESCRIPTION
## Description of change

The following exports the charm-profile if it's not empty. We
can't use valid, as that always passes back a profile even if it's
empty. So in this instance it's more important to know if it's
empty and if it's not empty then show the application-charm profile.

The driver behind this is so we can marry what is intended to be
applied vs what is actually been applied from just looking at the
status output.

## QA steps

```
juju bootstrap lxd
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
juju status --format=yaml
```

Expected output:
```yaml
model:
  name: default
  type: iaas
  controller: yyy
  cloud: lxd
  region: default
  version: 2.5.1.1
  model-status:
    current: available
    since: 15 Feb 2019 13:45:28Z
  sla: unsupported
machines:
  "0":
    juju-status:
      current: started
      since: 15 Feb 2019 13:48:05Z
      version: 2.5.1.1
    dns-name: 10.178.104.99
    ip-addresses:
    - 10.178.104.99
    instance-id: juju-e1e85b-0
    machine-status:
      current: running
      message: Running
      since: 15 Feb 2019 13:46:53Z
    series: bionic
    network-interfaces:
      eth0:
        ip-addresses:
        - 10.178.104.99
        mac-address: 00:16:3e:40:fd:93
        gateway: 10.178.104.1
        is-up: true
    hardware: arch=amd64 cores=0 mem=0M
    lxd-profiles:
      juju-default-lxd-profile-0:
        config:
          environment.http_proxy: ""
          linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
          security.nesting: "true"
          security.privileged: "true"
        description: lxd profile for testing, will pass validation
        devices:
          bdisk:
            source: /dev/loop0
            type: unix-block
          gpu:
            type: gpu
          sony:
            productid: 51da
            type: usb
            vendorid: 0fce
          tun:
            path: /dev/net/tun
            type: unix-char
applications:
  lxd-profile:
    charm: local:bionic/lxd-profile-0
    series: bionic
    os: ubuntu
    charm-origin: local
    charm-name: lxd-profile
    charm-rev: 0
    charm-profile: juju-default-lxd-profile-0
    exposed: false
    application-status:
      current: active
      message: 'load: 1.13, 1.42, 1.64'
      since: 15 Feb 2019 16:35:57Z
    units:
      lxd-profile/0:
        workload-status:
          current: active
          message: 'load: 1.13, 1.42, 1.64'
          since: 15 Feb 2019 16:35:57Z
        juju-status:
          current: idle
          since: 15 Feb 2019 13:48:10Z
          version: 2.5.1.1
        leader: true
        machine: "0"
        public-address: 10.178.104.99
    version: "18.04"
    endpoint-bindings:
      another: ""
      ubuntu: ""
storage: {}
controller:
  timestamp: 16:36:36Z
```
