### PR TITLE
Add support for k8s rootfs and tmpfs storage

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -504,15 +504,6 @@ func deployApplication(
 			if cons.Pool == "" && *defaultStorageClass == "" {
 				return errors.Errorf("storage pool for %q must be specified since there's no cluster default storage class", storageName)
 			}
-			if cons.Pool != "" {
-				sp, err := storagePoolManager.Get(cons.Pool)
-				if err != nil {
-					return errors.Trace(err)
-				}
-				if sp.Provider() != k8s.K8s_ProviderType {
-					return errors.Errorf("invalid storage provider type %q for %q", sp.Provider(), storageName)
-				}
-			}
 		}
 	}
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -641,23 +641,6 @@ func (s *ApplicationSuite) TestDeployCAASModelDefaultStorageClass(c *gc.C) {
 	c.Assert(result.Results[0].Error, gc.IsNil)
 }
 
-func (s *ApplicationSuite) TestDeployCAASModelWrongStorageType(c *gc.C) {
-	application.SetModelType(s.api, state.ModelTypeCAAS)
-	args := params.ApplicationsDeploy{
-		Applications: []params.ApplicationDeploy{{
-			ApplicationName: "foo",
-			CharmURL:        "local:foo-0",
-			NumUnits:        1,
-			Storage: map[string]storage.Constraints{
-				"database": {Pool: "db"},
-			},
-		}},
-	}
-	result, err := s.api.Deploy(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.ErrorMatches, `invalid storage provider type "rootfs" for "database"`)
-}
-
 func (s *ApplicationSuite) TestAddUnits(c *gc.C) {
 	results, err := s.api.AddUnits(params.AddApplicationUnits{
 		ApplicationName: "postgresql",

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -259,6 +259,7 @@ type mockStorage struct {
 	storageFilesystems map[names.StorageTag]names.FilesystemTag
 	storageVolumes     map[names.StorageTag]names.VolumeTag
 	storageAttachments map[names.UnitTag]names.StorageTag
+	backingVolume      names.VolumeTag
 }
 
 func (m *mockStorage) StorageInstance(tag names.StorageTag) (state.StorageInstance, error) {
@@ -273,7 +274,7 @@ func (m *mockStorage) AllFilesystems() ([]state.Filesystem, error) {
 	m.MethodCall(m, "AllFilesystems")
 	var result []state.Filesystem
 	for _, fsTag := range m.storageFilesystems {
-		result = append(result, &mockFilesystem{Stub: &m.Stub, tag: fsTag})
+		result = append(result, &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume})
 	}
 	return result, nil
 }
@@ -295,7 +296,7 @@ func (m *mockStorage) DestroyVolume(tag names.VolumeTag) (err error) {
 
 func (m *mockStorage) Filesystem(fsTag names.FilesystemTag) (state.Filesystem, error) {
 	m.MethodCall(m, "Filesystem", fsTag)
-	return &mockFilesystem{Stub: &m.Stub, tag: fsTag}, nil
+	return &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume}, nil
 }
 
 func (m *mockStorage) FilesystemAttachment(hostTag names.Tag, fsTag names.FilesystemTag) (state.FilesystemAttachment, error) {
@@ -304,7 +305,7 @@ func (m *mockStorage) FilesystemAttachment(hostTag names.Tag, fsTag names.Filesy
 }
 
 func (m *mockStorage) StorageInstanceFilesystem(tag names.StorageTag) (state.Filesystem, error) {
-	return &mockFilesystem{Stub: &m.Stub, tag: m.storageFilesystems[tag]}, nil
+	return &mockFilesystem{Stub: &m.Stub, tag: m.storageFilesystems[tag], volTag: m.backingVolume}, nil
 }
 
 func (m *mockStorage) UnitStorageAttachments(unit names.UnitTag) ([]state.StorageAttachment, error) {
@@ -400,7 +401,8 @@ func (a *mockStorageAttachment) StorageInstance() names.StorageTag {
 type mockFilesystem struct {
 	*testing.Stub
 	state.Filesystem
-	tag names.FilesystemTag
+	tag    names.FilesystemTag
+	volTag names.VolumeTag
 }
 
 func (f *mockFilesystem) Tag() names.Tag {
@@ -412,7 +414,10 @@ func (f *mockFilesystem) FilesystemTag() names.FilesystemTag {
 }
 
 func (f *mockFilesystem) Volume() (names.VolumeTag, error) {
-	return names.NewVolumeTag("66"), nil
+	if f.volTag.Id() == "" {
+		return f.volTag, state.ErrNoBackingVolume
+	}
+	return f.volTag, nil
 }
 
 func (f *mockFilesystem) Params() (state.FilesystemParams, bool) {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -845,24 +845,27 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 					Data:    fsInfo.Data,
 				}
 
-				vol, err := a.storage.StorageInstanceVolume(sa.StorageInstance())
-				if err != nil {
-					return errors.Trace(err)
-				}
-				if fsInfo.Volume.Status != status.Pending.String() {
-					volumeUpdates[vol.VolumeTag().String()] = volumeInfo{
-						unitTag:    unitTag,
-						providerId: unitParams.ProviderId,
-						size:       fsInfo.Volume.Size,
-						volumeId:   fsInfo.Volume.VolumeId,
-						persistent: fsInfo.Volume.Persistent,
-						readOnly:   fsInfo.ReadOnly,
+				// If the filesystem has a backing volume, get that info also.
+				if _, err := fs.Volume(); err == nil {
+					vol, err := a.storage.StorageInstanceVolume(sa.StorageInstance())
+					if err != nil {
+						return errors.Trace(err)
 					}
-				}
-				volumeStatus[vol.VolumeTag().String()] = status.StatusInfo{
-					Status:  status.Status(fsInfo.Volume.Status),
-					Message: fsInfo.Volume.Info,
-					Data:    fsInfo.Volume.Data,
+					if fsInfo.Volume.Status != status.Pending.String() {
+						volumeUpdates[vol.VolumeTag().String()] = volumeInfo{
+							unitTag:    unitTag,
+							providerId: unitParams.ProviderId,
+							size:       fsInfo.Volume.Size,
+							volumeId:   fsInfo.Volume.VolumeId,
+							persistent: fsInfo.Volume.Persistent,
+							readOnly:   fsInfo.ReadOnly,
+						}
+					}
+					volumeStatus[vol.VolumeTag().String()] = status.StatusInfo{
+						Status:  status.Status(fsInfo.Volume.Status),
+						Message: fsInfo.Volume.Info,
+						Data:    fsInfo.Volume.Data,
+					}
 				}
 
 				infos = infos[1:]

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -51,6 +51,7 @@ import (
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 )
 
 var logger = loggo.GetLogger("juju.kubernetes.provider")
@@ -456,11 +457,15 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		operatorVolumeClaim = fmt.Sprintf("%v-operator-volume", appName)
 	}
 
+	fsSize, err := resource.ParseQuantity(fmt.Sprintf("%dMi", config.CharmStorage.Size))
+	if err != nil {
+		return errors.Annotatef(err, "invalid volume size %v", config.CharmStorage.Size)
+	}
 	params := volumeParams{
 		storageConfig:       &storageConfig{existingStorageClass: defaultOperatorStorageClassName},
 		storageLabels:       caas.OperatorStorageClassLabels(appName, k.namespace),
 		pvcName:             operatorVolumeClaim,
-		requestedVolumeSize: fmt.Sprintf("%dMi", config.CharmStorage.Size),
+		requestedVolumeSize: fsSize,
 	}
 	if config.CharmStorage.Provider != K8s_ProviderType {
 		return errors.Errorf("expected charm storage provider %q, got %q", K8s_ProviderType, config.CharmStorage.Provider)
@@ -468,7 +473,6 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	if storageLabel, ok := config.CharmStorage.Attributes[storageLabel]; ok {
 		params.storageLabels = append([]string{fmt.Sprintf("%v", storageLabel)}, params.storageLabels...)
 	}
-	var err error
 	params.storageConfig, err = newStorageConfig(config.CharmStorage.Attributes, defaultOperatorStorageClassName)
 	if err != nil {
 		return errors.Annotatef(err, "invalid storage configuration for %v operator", appName)
@@ -581,7 +585,7 @@ type volumeParams struct {
 	storageLabels       []string
 	storageConfig       *storageConfig
 	pvcName             string
-	requestedVolumeSize string
+	requestedVolumeSize resource.Quantity
 	accessMode          core.PersistentVolumeAccessMode
 }
 
@@ -636,15 +640,11 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.P
 	if accessMode == "" {
 		accessMode = core.ReadWriteOnce
 	}
-	fsSize, err := resource.ParseQuantity(params.requestedVolumeSize)
-	if err != nil {
-		return nil, errors.Annotatef(err, "invalid volume size %v", params.requestedVolumeSize)
-	}
 	return &core.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClassName,
 		Resources: core.ResourceRequirements{
 			Requests: core.ResourceList{
-				core.ResourceStorage: fsSize,
+				core.ResourceStorage: params.requestedVolumeSize,
 			},
 		},
 		AccessModes: []core.PersistentVolumeAccessMode{accessMode},
@@ -1081,9 +1081,6 @@ func (k *kubernetesClient) configureStorage(
 	}
 	logger.Debugf("configuring pod filesystems: %+v with rand %v", filesystems, randPrefix)
 	for i, fs := range filesystems {
-		if fs.Provider != K8s_ProviderType {
-			return errors.Errorf("invalid storage provider type %q for %v", fs.Provider, fs.StorageName)
-		}
 		var mountPath string
 		if fs.Attachment != nil {
 			mountPath = fs.Attachment.Path
@@ -1091,6 +1088,48 @@ func (k *kubernetesClient) configureStorage(
 		if mountPath == "" {
 			mountPath = fmt.Sprintf("%s/fs/%s/%s/%d", baseDir, appName, fs.StorageName, i)
 		}
+		fsSize, err := resource.ParseQuantity(fmt.Sprintf("%dMi", fs.Size))
+		if err != nil {
+			return errors.Annotatef(err, "invalid volume size %v", fs.Size)
+		}
+
+		var volumeSource *core.VolumeSource
+		switch fs.Provider {
+		case K8s_ProviderType:
+		case provider.RootfsProviderType:
+			volumeSource = &core.VolumeSource{
+				EmptyDir: &core.EmptyDirVolumeSource{
+					SizeLimit: &fsSize,
+				},
+			}
+		case provider.TmpfsProviderType:
+			medium, ok := fs.Attributes[storageMedium]
+			if !ok {
+				medium = core.StorageMediumMemory
+			}
+			volumeSource = &core.VolumeSource{
+				EmptyDir: &core.EmptyDirVolumeSource{
+					Medium:    core.StorageMedium(fmt.Sprintf("%v", medium)),
+					SizeLimit: &fsSize,
+				},
+			}
+		default:
+			return errors.NotValidf("charm storage provider type %q for %v", fs.Provider, fs.StorageName)
+		}
+		if volumeSource != nil {
+			logger.Debugf("using emptyDir for %s filesystem %s", appName, fs.StorageName)
+			volName := fmt.Sprintf("%s-%d", fs.StorageName, i)
+			podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, core.VolumeMount{
+				Name:      volName,
+				MountPath: mountPath,
+			})
+			podSpec.Volumes = append(podSpec.Volumes, core.Volume{
+				Name:         volName,
+				VolumeSource: *volumeSource,
+			})
+			continue
+		}
+
 		pvcNamePrefix := fmt.Sprintf("%s-%s", fs.StorageName, randPrefix)
 		if legacy {
 			pvcNamePrefix = fmt.Sprintf("juju-%s-%d", fs.StorageName, i)
@@ -1098,7 +1137,7 @@ func (k *kubernetesClient) configureStorage(
 		params := volumeParams{
 			storageLabels:       caas.UnitStorageClassLabels(appName, k.namespace),
 			pvcName:             pvcNamePrefix,
-			requestedVolumeSize: fmt.Sprintf("%dMi", fs.Size),
+			requestedVolumeSize: fsSize,
 		}
 		if storageLabel, ok := fs.Attributes[storageLabel]; ok {
 			params.storageLabels = append([]string{fmt.Sprintf("%v", storageLabel)}, params.storageLabels...)
@@ -1609,7 +1648,6 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 		for _, pv := range p.Spec.Volumes {
 			volumesByName[pv.Name] = pv
 		}
-		pVolumes := k.CoreV1().PersistentVolumes()
 
 		// Gather info about how filesystems are attached/mounted to the pod.
 		// The mount name represents the filesystem tag name used by Juju.
@@ -1619,91 +1657,139 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 				logger.Warningf("volume for volume mount %q not found", volMount.Name)
 				continue
 			}
-			if vol.PersistentVolumeClaim == nil || vol.PersistentVolumeClaim.ClaimName == "" {
+			var fsInfo *caas.FilesystemInfo
+			if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName != "" {
+				fsInfo, err = k.volumeInfoForPVC(vol, volMount, vol.PersistentVolumeClaim.ClaimName, now)
+			} else if vol.EmptyDir != nil {
+				fsInfo, err = k.volumeInfoForEmptyDir(vol, volMount, now)
+			} else {
 				// Ignore volumes which are not Juju managed filesystems.
-				logger.Debugf("Ignoring blank PersistentVolumeClaim or ClaimName")
-				continue
-			}
-			pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
-			pvc, err := pvClaims.Get(vol.PersistentVolumeClaim.ClaimName, v1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				// Ignore claims which don't exist (yet).
+				logger.Debugf("Ignoring blank EmptyDir, PersistentVolumeClaim or ClaimName")
 				continue
 			}
 			if err != nil {
-				return nil, errors.Annotate(err, "unable to get persistent volume claim")
+				return nil, errors.Annotatef(err, "finding filesystem info for %v", volMount.Name)
 			}
-
-			if pvc.Status.Phase == core.ClaimPending {
-				logger.Debugf(fmt.Sprintf("PersistentVolumeClaim for %v is pending", vol.PersistentVolumeClaim.ClaimName))
+			if fsInfo == nil {
 				continue
 			}
-			pv, err := pVolumes.Get(pvc.Spec.VolumeName, v1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				// Ignore volumes which don't exist (yet).
-				continue
-			}
-			if err != nil {
-				return nil, errors.Annotate(err, "unable to get persistent volume")
-			}
-
-			storageName := pvc.Labels[labelStorage]
-			if storageName == "" {
+			if fsInfo.StorageName == "" {
 				if valid := legacyJujuPVNameRegexp.MatchString(volMount.Name); valid {
-					storageName = legacyJujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")
+					fsInfo.StorageName = legacyJujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")
 				} else if valid := jujuPVNameRegexp.MatchString(volMount.Name); valid {
-					storageName = jujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")
+					fsInfo.StorageName = jujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")
 				}
 			}
-			statusMessage := ""
-			since = now
-			if len(pvc.Status.Conditions) > 0 {
-				statusMessage = pvc.Status.Conditions[0].Message
-				since = pvc.Status.Conditions[0].LastProbeTime.Time
-			}
-			if statusMessage == "" {
-				// If there are any events for this pvc we can use the
-				// most recent to set the status.
-				events := k.CoreV1().Events(k.namespace)
-				eventList, err := events.List(v1.ListOptions{
-					IncludeUninitialized: true,
-					FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", pvc.Name).String(),
-				})
-				if err != nil {
-					return nil, errors.Annotate(err, "unable to get events for PVC")
-				}
-				// Take the most recent event.
-				if count := len(eventList.Items); count > 0 {
-					statusMessage = eventList.Items[count-1].Message
-				}
-			}
-
-			unitInfo.FilesystemInfo = append(unitInfo.FilesystemInfo, caas.FilesystemInfo{
-				StorageName:  storageName,
-				Size:         uint64(vol.PersistentVolumeClaim.Size()),
-				FilesystemId: string(pvc.UID),
-				MountPoint:   volMount.MountPath,
-				ReadOnly:     volMount.ReadOnly,
-				Status: status.StatusInfo{
-					Status:  k.jujuFilesystemStatus(pvc.Status.Phase),
-					Message: statusMessage,
-					Since:   &since,
-				},
-				Volume: caas.VolumeInfo{
-					VolumeId:   pv.Name,
-					Size:       uint64(pv.Size()),
-					Persistent: pv.Spec.PersistentVolumeReclaimPolicy == core.PersistentVolumeReclaimRetain,
-					Status: status.StatusInfo{
-						Status:  k.jujuVolumeStatus(pv.Status.Phase),
-						Message: pv.Status.Message,
-						Since:   &since,
-					},
-				},
-			})
+			unitInfo.FilesystemInfo = append(unitInfo.FilesystemInfo, *fsInfo)
 		}
 		units = append(units, unitInfo)
 	}
 	return units, nil
+}
+
+func (k *kubernetesClient) volumeInfoForEmptyDir(vol core.Volume, volMount core.VolumeMount, now time.Time) (*caas.FilesystemInfo, error) {
+	size := uint64(vol.EmptyDir.SizeLimit.Size())
+	return &caas.FilesystemInfo{
+		Size:         size,
+		FilesystemId: vol.Name,
+		MountPoint:   volMount.MountPath,
+		ReadOnly:     volMount.ReadOnly,
+		Status: status.StatusInfo{
+			Status: status.Attached,
+			Since:  &now,
+		},
+		Volume: caas.VolumeInfo{
+			VolumeId:   vol.Name,
+			Size:       size,
+			Persistent: false,
+			Status: status.StatusInfo{
+				Status: status.Attached,
+				Since:  &now,
+			},
+		},
+	}, nil
+}
+
+func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.VolumeMount, claimName string, now time.Time) (*caas.FilesystemInfo, error) {
+	pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
+	pvc, err := pvClaims.Get(claimName, v1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		// Ignore claims which don't exist (yet).
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get persistent volume claim")
+	}
+
+	if pvc.Status.Phase == core.ClaimPending {
+		logger.Debugf(fmt.Sprintf("PersistentVolumeClaim for %v is pending", claimName))
+		return nil, nil
+	}
+
+	storageName := pvc.Labels[labelStorage]
+	if storageName == "" {
+		if valid := legacyJujuPVNameRegexp.MatchString(volMount.Name); valid {
+			storageName = legacyJujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")
+		} else if valid := jujuPVNameRegexp.MatchString(volMount.Name); valid {
+			storageName = jujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")
+		}
+	}
+
+	statusMessage := ""
+	since := now
+	if len(pvc.Status.Conditions) > 0 {
+		statusMessage = pvc.Status.Conditions[0].Message
+		since = pvc.Status.Conditions[0].LastProbeTime.Time
+	}
+	if statusMessage == "" {
+		// If there are any events for this pvc we can use the
+		// most recent to set the status.
+		events := k.CoreV1().Events(k.namespace)
+		eventList, err := events.List(v1.ListOptions{
+			IncludeUninitialized: true,
+			FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", pvc.Name).String(),
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "unable to get events for PVC")
+		}
+		// Take the most recent event.
+		if count := len(eventList.Items); count > 0 {
+			statusMessage = eventList.Items[count-1].Message
+		}
+	}
+
+	pVolumes := k.CoreV1().PersistentVolumes()
+	pv, err := pVolumes.Get(vol.Name, v1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		// Ignore volumes which don't exist (yet).
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get persistent volume")
+	}
+
+	return &caas.FilesystemInfo{
+		StorageName:  storageName,
+		Size:         uint64(vol.PersistentVolumeClaim.Size()),
+		FilesystemId: string(pvc.UID),
+		MountPoint:   volMount.MountPath,
+		ReadOnly:     volMount.ReadOnly,
+		Status: status.StatusInfo{
+			Status:  k.jujuFilesystemStatus(pvc.Status.Phase),
+			Message: statusMessage,
+			Since:   &since,
+		},
+		Volume: caas.VolumeInfo{
+			VolumeId:   pv.Name,
+			Size:       uint64(pv.Size()),
+			Persistent: pv.Spec.PersistentVolumeReclaimPolicy == core.PersistentVolumeReclaimRetain,
+			Status: status.StatusInfo{
+				Status:  k.jujuVolumeStatus(pv.Status.Phase),
+				Message: pv.Status.Message,
+				Since:   &since,
+			},
+		},
+	}, nil
 }
 
 // Operator returns an Operator with current status and life details.

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
+	storageprovider "github.com/juju/juju/storage/provider"
 )
 
 var _ = gc.Suite(&storageSuite{})
@@ -194,4 +195,32 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, []storage.DescribeVolumesResult{{
 		VolumeInfo: &storage.VolumeInfo{VolumeId: "vol-id", Size: 68, Persistent: true},
 	}})
+}
+
+func (s *storageSuite) TestValidateStorageProvider(c *gc.C) {
+	for _, t := range []struct {
+		providerType storage.ProviderType
+		attrs        map[string]interface{}
+		err          string
+	}{
+		{
+			providerType: storageprovider.RootfsProviderType,
+		}, {
+			providerType: storageprovider.TmpfsProviderType,
+		}, {
+			providerType: storageprovider.LoopProviderType,
+			err:          `storage provider type "loop" not valid`,
+		}, {
+			providerType: storageprovider.TmpfsProviderType,
+			attrs:        map[string]interface{}{"storage-medium": "foo"},
+			err:          `storage medium "foo" not valid`,
+		},
+	} {
+		err := provider.ValidateStorageProvider(t.providerType, t.attrs)
+		if t.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.err)
+		}
+	}
 }

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -471,7 +471,7 @@ func (st *State) machineTemplateVolumeAttachmentParams(t MachineTemplate) ([]sto
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		providerType, _, err := poolStorageProvider(sb, volumeInfo.Pool)
+		providerType, _, _, err := poolStorageProvider(sb, volumeInfo.Pool)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -574,7 +574,7 @@ func (f *filesystem) pool() string {
 // storage pool will create a filesystem that is not inherently
 // bound to a machine, and therefore can be detached.
 func isDetachableFilesystemPool(sb *storageBackend, pool string) (bool, error) {
-	_, provider, err := poolStorageProvider(sb, pool)
+	_, provider, _, err := poolStorageProvider(sb, pool)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
@@ -982,7 +982,7 @@ func validateAddExistingFilesystem(
 			)
 		}
 	}
-	_, provider, err := poolStorageProvider(sb, info.Pool)
+	_, provider, _, err := poolStorageProvider(sb, info.Pool)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1068,7 +1068,7 @@ func (sb *storageBackend) addFilesystemOps(params FilesystemParams, hostId strin
 	var volumeId string
 	var volumeTag names.VolumeTag
 	var ops []txn.Op
-	_, provider, err := poolStorageProvider(sb, params.Pool)
+	_, provider, _, err := poolStorageProvider(sb, params.Pool)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
 	}

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -185,7 +185,7 @@ func (s *FilesystemStateSuite) maybeAssignUnit(c *gc.C, u *state.Unit) names.Tag
 }
 
 func (s *FilesystemStateSuite) TestSetFilesystemInfoNoFilesystemId(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "loop-pool")
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "tmpfs-pool")
 	s.maybeAssignUnit(c, u)
 	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()

--- a/state/state.go
+++ b/state/state.go
@@ -1496,7 +1496,7 @@ func (st *State) processIAASModelApplicationArgs(args *AddApplicationArgs) error
 					// so it cannot be attached.
 					continue
 				}
-				providerType, _, err := poolStorageProvider(sb, volumeInfo.Pool)
+				providerType, _, _, err := poolStorageProvider(sb, volumeInfo.Pool)
 				if err != nil {
 					return errors.Annotatef(err, "cannot attach %s", names.ReadableString(storageTag))
 				}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1902,7 +1902,7 @@ func validateDynamicMachineStoragePools(sb *storageBackend, m *Machine, pools se
 // support dynamic storage, then an IsNotSupported error is returned.
 func validateDynamicStoragePools(sb *storageBackend, pools set.Strings) error {
 	for pool := range pools {
-		providerType, provider, err := poolStorageProvider(sb, pool)
+		providerType, provider, _, err := poolStorageProvider(sb, pool)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/volume.go
+++ b/state/volume.go
@@ -673,7 +673,7 @@ func detachableVolumeDoc(doc *volumeDoc) bool {
 // pool will create a volume that is not inherently bound to a machine,
 // and therefore can be detached.
 func isDetachableVolumePool(im *storageBackend, pool string) (bool, error) {
-	_, provider, err := poolStorageProvider(im, pool)
+	_, provider, _, err := poolStorageProvider(im, pool)
 	if err != nil {
 		return false, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

k8s storage now supports rootfs and tmpfs storage types. These are mapped to emptyDir volumes.
Since k8s now supports other storage types, the create-storage-pool command defaults to "kubernetes" unless otherwise specified.

## QA steps

create a k8s model
juju deploy cs:~juju/mariadb-k8s --storage database=tmpfs
juju deploy cs:~juju/mariadb-k8s --storage database=rootfs
