### PR TITLE
Add support for uploading local snaps

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -143,6 +143,14 @@ type BootstrapParams struct {
 
 	// DialOpts contains the bootstrap dial options.
 	DialOpts environs.BootstrapDialOpts
+
+	// JujuDbSnapPath is the path to a local .snap file that will be used
+	// to run the juju-db service.
+	JujuDbSnapPath string
+
+	// JujuDbSnapAssertionsPath is the path to a local .assertfile that
+	// will be used to test the contents of the .snap at JujuDbSnap.
+	JujuDbSnapAssertionsPath string
 }
 
 // Validate validates the bootstrap parameters.
@@ -498,6 +506,11 @@ func bootstrapIAAS(
 	if err := instanceConfig.SetTools(selectedToolsList); err != nil {
 		return errors.Trace(err)
 	}
+
+	if err := instanceConfig.SetSnapSource(args.JujuDbSnapPath, args.JujuDbSnapAssertionsPath); err != nil {
+		return errors.Trace(err)
+	}
+
 	var environVersion int
 	if e, ok := environ.(environs.Environ); ok {
 		environVersion = e.Provider().Version()
@@ -608,6 +621,8 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, func(msg string) {
 		ctx.Infof(msg)
 	})
+	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
+	icfg.Bootstrap.JujuDbSnapAssertionsPath = args.JujuDbSnapAssertionsPath
 	return nil
 }
 

--- a/service/snap/snap_test.go
+++ b/service/snap/snap_test.go
@@ -56,7 +56,7 @@ func (*validationSuite) TestValidateJujuDbSnap(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 
 	// via NewService
-	jujudbService, err := snap.NewService("juju-db", common.Conf{Desc: "juju-db snap"}, snap.Command, "edge", "jailmode", []snap.BackgroundService{}, []snap.App{})
+	jujudbService, err := snap.NewService("juju-db", "", common.Conf{Desc: "juju-db snap"}, snap.Command, "edge", "jailmode", []snap.BackgroundService{}, []snap.App{})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(jujudbService.Validate(), jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

Allow users to specify `--juju-db-snap={absolute_path}` during the bootstrap process and for that file to be sent to the controller instance. 

## QA steps

Step 1: Set the `mongodb-snap` featureflag.

```plain
$ export JUJU_DEV_FEATURE_FLAGS=mongodb-snap
```

Step 2: Verify that the output of `juju help bootstrap` includes two new options:

```plain
$ juju help bootstrap
[...]
Command Options:
[...]
--db-snap (= "")
    Path to a locally built .snap to use as the internal juju-db service.
--db-snap-assertions (= "")
    Path to a local .assert file. Requires --juju-db-snap
[...]
```

Step 3: Download `juju-db` locally. 

```plain
$ snap download --edge juju-db
Fetching snap "juju-db"
Fetching assertions for "juju-db"
Install the snap with:
   snap ack juju-db_6.assert
   snap install juju-db_6.snap
```

Step 4: Bootstrap when pointing to the snap

```plain
$ juju bootstrap --db-snap=`pwd`/juju-db_6.snap localhost c-localsnap # <1>

# <1> `pwd` is required because of a Go-ism where it does not want to do shell expansion 
```

Step 5: Move the .assert file outside of the local directory, then use the `--db-snap-assert` argument

## Documentation changes

Not required yet (all changes are behind a feature flag)
