### PR TITLE
Use latest charm.v6 that includes support for .jujuignore files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -208,6 +208,22 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:9ab1b1c637d7c8f49e39d8538a650d7eb2137b076790cff69d160823b505964c"
+  name = "github.com/gobwas/glob"
+  packages = [
+    "compiler",
+    "match",
+    "syntax",
+    "syntax/ast",
+    "syntax/lexer",
+    "util/runes",
+    "util/strings",
+  ]
+  pruneopts = ""
+  revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
+  version = "v0.2.3"
+
+[[projects]]
   digest = "1:54a4707220eda534720dd6fffa7170a8102fb43068cb4a33abede14da10d27dd"
   name = "github.com/godbus/dbus"
   packages = ["."]
@@ -1377,6 +1393,14 @@
   revision = "442357a80af5c6bf9b6d51ae791a39c3421004f3"
 
 [[projects]]
+  digest = "1:9ab1b1c637d7c8f49e39d8538a650d7eb2137b076790cff69d160823b505964c"
+  name = "gopkg.in/gobwas/glob.v0"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
+  version = "v0.2.3"
+
+[[projects]]
   digest = "1:9a9b8033b631d8cf0d16e71fd815a6e90a8133efc81543784127a1e8d8b4687e"
   name = "gopkg.in/goose.v2"
   packages = [
@@ -1435,7 +1459,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:718d4426f5c825bb9d321473e3f547643ed33031b03e2d03acb2f571e0a72be4"
+  digest = "1:96b43bfe348be6362e66b0c98dc2fe590d822633da7df13fba644f44e710a57e"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1443,7 +1467,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "dd3e82d4f34c956e7c3b20a82e96dc533cc96fb7"
+  revision = "ba56c9482e6c71e9ed79b1551754831bf9af8854"
 
 [[projects]]
   digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "dd3e82d4f34c956e7c3b20a82e96dc533cc96fb7"
+  revision = "ba56c9482e6c71e9ed79b1551754831bf9af8854"
 
 [[constraint]]
   revision = "7778a447283bd71109671c20818544514e16e9d9"

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -202,10 +202,16 @@ func (s *charmsSuite) TestUploadBumpsRevision(c *gc.C) {
 }
 
 func (s *charmsSuite) TestUploadVersion(c *gc.C) {
-	// Add the dummy charm with version "juju-2.4-beta3-146-g725cfd3-dirty".
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-
 	expectedVersion := "dummy-146-g725cfd3-dirty"
+
+	// Add the dummy charm with version "juju-2.4-beta3-146-g725cfd3-dirty".
+	pathToArchive := testcharms.Repo.CharmArchivePath(c.MkDir(), "dummy")
+	err := testcharms.InjectFilesToCharmArchive(pathToArchive, map[string]string{
+		"version": expectedVersion,
+	})
+	c.Assert(err, gc.IsNil)
+	ch, err := charm.ReadCharmArchive(pathToArchive)
+	c.Assert(err, gc.IsNil)
 
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/charmstore_test.go
+++ b/apiserver/facades/client/application/charmstore_test.go
@@ -224,7 +224,14 @@ func (s *CharmStoreSuite) TestAddVersionedCharmWithAuthorization(c *gc.C) {
 	mockStorage := mocks.NewMockStorage(ctrl)
 	mockInterface := mocks.NewMockInterface(ctrl)
 
-	charm := testcharms.Repo.CharmArchive(cacheDir, "versioned")
+	expVersion := "929903d"
+	pathToArchive := testcharms.Repo.CharmArchivePath(cacheDir, "versioned")
+	err = testcharms.InjectFilesToCharmArchive(pathToArchive, map[string]string{
+		"version": expVersion,
+	})
+	c.Assert(err, gc.IsNil)
+	charm, err := charm.ReadCharmArchive(pathToArchive)
+	c.Assert(err, gc.IsNil)
 
 	// inject the mock as a back handed dependency
 	s.PatchValue(application.NewStateStorage, func(uuid string, session *mgo.Session) storage.Storage {
@@ -235,7 +242,7 @@ func (s *CharmStoreSuite) TestAddVersionedCharmWithAuthorization(c *gc.C) {
 	sExp.PrepareStoreCharmUpload(charmURL).Return(mockStateCharm, nil)
 	sExp.ModelUUID().Return("model-id")
 	sExp.MongoSession().Return(&mgo.Session{})
-	sExp.UpdateUploadedCharm(charmVersionMatcher{"929903d"}).Return(nil, nil)
+	sExp.UpdateUploadedCharm(charmVersionMatcher{expVersion}).Return(nil, nil)
 
 	cExp := mockStateCharm.EXPECT()
 	cExp.IsUploaded().Return(false)


### PR DESCRIPTION
## Description of change

This PR bumps the `charm.v6` dependency version to bring in support for `.jujuignore` files (see: https://github.com/juju/charm/pull/271 for details)

## QA steps
```console
$ juju bootstrap localhost lxd-test

# Create charm with absolute symlink
$ charm create foo
$ cd foo 
$ mkdir hooks
# copy some hooks
$ mkdir .tox && cd .tox
# Create an absolute symlink
$ ln -s /usr/local/bin/python3 python3 

# Attempting to deploy without a .jujuignore file should fail
$ juju deploy $path-to-local-foo
ERROR cannot repackage charm: symlink ".tox/python" is absolute: "/usr/local/bin/python3"

# Add .jujuignore file and re-deploy
$ echo '.tox/' > $path-to-local-foo/.jujuignore
$ juju deploy $path-to-local-foo
Deploying charm "local:bionic/foo-0".
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1813799