### PR TITLE
LXD Profile acceptance tests

### DIFF
--- a/acceptancetests/assess_deploy_lxd_profile_bundle.py
+++ b/acceptancetests/assess_deploy_lxd_profile_bundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """ Assess using bundle that have various charms with lxd-profiles, testing
     different deployment scenarios.
@@ -83,7 +83,7 @@ def align_machine_profiles(machine_profiles):
             b = set(items[1])
             result[charm_profile].extend(b.difference(a))
         else:
-            result[charm_profile] = items[1].copy()
+            result[charm_profile] = list(items[1])
     return result
 
 def parse_args(argv):

--- a/acceptancetests/assess_deploy_lxd_profile_bundle.py
+++ b/acceptancetests/assess_deploy_lxd_profile_bundle.py
@@ -50,17 +50,19 @@ def deploy_bundle(client, charm_bundle):
 def assess_profile_machines(client):
     """Assess the machines
     """
+    # Ensure we wait for everything to start before checking the profiles,
+    # that way we can ensure that things have been installed.
+    client.wait_for_started()
+
     charm_profiles = []
     status = client.get_status()
     apps = status.get_applications()
     for _, info in apps.items():
-        charm_profile = info['charm-profile']
-        if charm_profile:
-            charm_profiles.append(charm_profile)
-
-    if len(charm_profiles) == 0:
-        client.wait_for(AgentsIdle)
-    else:
+        if 'charm-profile' in info:
+            charm_profile = info['charm-profile']
+            if charm_profile:
+                charm_profiles.append(charm_profile)
+    if len(charm_profiles) > 0:
         client.wait_for(WaitForLXDProfilesConditions(charm_profiles))
 
 def parse_args(argv):

--- a/acceptancetests/assess_deploy_lxd_profile_bundle.py
+++ b/acceptancetests/assess_deploy_lxd_profile_bundle.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+""" Assess using bundle that have various charms with lxd-profiles, testing
+    different deployment scenarios.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+from deploy_stack import (
+    BootstrapManager,
+)
+from jujucharm import (
+    local_charm_path,
+)
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    JujuAssertionError,
+)
+
+__metaclass__ = type
+
+log = logging.getLogger("assess_lxdprofile_charm")
+
+def deploy_bundle(client, charm_bundle):
+    """Deploy the given charm bundle
+    :param client: Jujupy ModelClient object
+    :param charm_bundle: Optional charm bundle string
+    """
+    bundle = local_charm_path(
+        charm=charm_bundle,
+        juju_ver=client.version,
+        repository=os.environ['JUJU_REPOSITORY']
+    )
+    _, primary = client.deploy(bundle)
+    client.wait_for(primary)
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Test juju lxd profile bundle deploys.")
+    parser.add_argument(
+        '--charm-bundle',
+        help="Override the charm bundle to deploy",
+    )
+    add_basic_testing_arguments(parser)
+    return parser.parse_args(argv)
+
+def main(argv=None):
+    args = parse_args(argv)
+    configure_logging(args.verbose)
+    bs_manager = BootstrapManager.from_args(args)
+    with bs_manager.booted_context(args.upload_tools):
+        client = bs_manager.client
+
+        deploy_bundle(client, charm_bundle=args.charm_bundle)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/acceptancetests/assess_deploy_lxd_profile_bundle.py
+++ b/acceptancetests/assess_deploy_lxd_profile_bundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ Assess using bundle that have various charms with lxd-profiles, testing
     different deployment scenarios.

--- a/acceptancetests/jujupy/exceptions.py
+++ b/acceptancetests/jujupy/exceptions.py
@@ -131,6 +131,16 @@ class LXDProfileNotAvailable(Exception):
     def __str__(self):
         return self._fmt.format(env=self.profile_name)
 
+class LXDProfilesNotAvailable(Exception):
+
+    _fmt = 'Timed out waiting for LXDProfiles {profile_names}'
+
+    def __init__(self, profile_names):
+        self.profile_names = profile_names
+
+    def __str__(self):
+        return self._fmt.format(env=self.profile_names)
+
 class StatusError(Exception):
     """Generic error for Status."""
 

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -480,13 +480,14 @@ class WaitForLXDProfilesConditions(BaseCondition):
         """Wait until 'profiles' listed in machine lxd-profiles from status.
         """
         states = {}
-        for _, status in status.iter_machines():
-            if not status['lxd-profiles']:
+        for _, status in status.iter_machines(containers=True):
+            if not 'lxd-profiles' in status:
                continue
             lxd_profile_names = self.profile_names(status['lxd-profiles'])
             union = self.intersection(lxd_profile_names, self.profiles)
-            states.update(union)
-        
+            for key in union:
+                states[key] = key
+
         # check to see if all profiles exist in the states dict
         cond_met = True
         for profile_name in self.profiles:

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -23,6 +23,7 @@ from jujupy.exceptions import (
     AgentsNotStarted,
     StatusNotMet,
     LXDProfileNotAvailable,
+    LXDProfilesNotAvailable,
     )
 from jujupy.status import (
     Status,
@@ -462,3 +463,61 @@ class WaitForLXDProfileCondition(BaseCondition):
 
     def do_raise(self, model_name, status):
         raise LXDProfileNotAvailable(self.machine, self.profile)
+
+class WaitForLXDProfilesConditions(BaseCondition):
+
+    def __init__(self, profiles, *args, **kwargs):
+        """WaitForLXDProfilesConditions attempts to test if the profile at least
+           shows up in at least one machine, as there isn't currently a way to
+           know where the profile should be applied, just that it should.
+
+        :param profiles: names of the LXD profiles to find.
+        """
+        self.profiles = profiles
+        super(WaitForLXDProfilesConditions, self).__init__(*args, **kwargs)
+    
+    def iter_blocking_state(self, status):
+        """Wait until 'profiles' listed in machine lxd-profiles from status.
+        """
+        states = {}
+        for _, status in status.iter_machines():
+            if not status['lxd-profiles']:
+               continue
+            lxd_profile_names = self.profile_names(status['lxd-profiles'])
+            union = self.intersection(lxd_profile_names, self.profiles)
+            states.update(union)
+        
+        # check to see if all profiles exist in the states dict
+        cond_met = True
+        for profile_name in self.profiles:
+            if not profile_name in states:
+                cond_met = False
+                break
+        if not cond_met:
+            yield ('lxd-profiles ({})'.format(self.profiles),
+                    'not on machines ({})'.format(states))
+    
+    def do_raise(self, model_name, status):
+        raise LXDProfilesNotAvailable(self.profiles)
+
+    def profile_names(self, profiles):
+        """profile names returns all the profile names from applied machines 
+           status
+        
+        :param profiles: profile configurations applied to machines
+        """
+        names = []
+        for name in profiles.keys():
+            names.append(name)
+        return names
+
+    def intersection(self, profiles, names):
+        """intersection checks the intersection of the profiles vs the profile
+           names being offered.
+        
+        :param profiles: profile configurations applied to machines
+        :param names: profile names expected to be applied
+        """
+        a = set(profiles)
+        b = set(names)
+        return a.intersection(b)

--- a/acceptancetests/repository/bundles-lxd-profile.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile.yaml
@@ -6,7 +6,7 @@ machines:
   '3': {}
 applications:
   lxd-profile:
-    charm: cs:~juju-qa/bionic/lxd-profile-0
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-0
     num_units: 4
     to:
       - lxd:0

--- a/acceptancetests/repository/bundles-lxd-profile.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile.yaml
@@ -1,0 +1,23 @@
+series: bionic
+machines:
+  '0': {}
+  '1': {}
+  '2': {}
+  '3': {}
+applications:
+  lxd-profile:
+    charm: cs:~juju-qa/bionic/lxd-profile-0
+    num_units: 4
+    to:
+      - lxd:0
+      - lxd:1
+      - lxd:2
+      - lxd:3
+  ubuntu:
+    charm: cs:~jameinel/ubuntu-lite
+    num_units: 4
+    to:
+      - "0"
+      - "1"
+      - "2"
+      - "3"

--- a/acceptancetests/repository/bundles-lxd-profile.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile.yaml
@@ -7,8 +7,12 @@ machines:
 applications:
   lxd-profile:
     charm: cs:~juju-qa/bionic/lxd-profile-without-devices-0
-    num_units: 4
+    num_units: 8
     to:
+      - lxd:0
+      - lxd:1
+      - lxd:2
+      - lxd:3
       - lxd:0
       - lxd:1
       - lxd:2


### PR DESCRIPTION
## Description of change

The following acceptance test provides a generic way to see
if deploying LXD profiles generate errors. If no errors are found
it will then inspect the applications to locate any potential charm
profiles, then validating that they have been applied.

## QA steps

```
mkdir /tmp/test-run
mkdir /tmp/artifacts
export JUJU_HOME=/tmp/test-run
export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository
vim $JUJU_HOME/environments.yaml
```

Local LXD environments.yaml
```yaml
environments:
    lxd:
        type: lxd
        test-mode: true
        default-series: bionic
```

Run the following (substitute the right arg):
```
cd acceptancetests
./assess_deploy_lxd_profile_bundle.py
```