### PR TITLE
Accomodation of "container-inherit-properties" for MAAS 2.5+

### DIFF
--- a/cloudconfig/export_test.go
+++ b/cloudconfig/export_test.go
@@ -3,8 +3,4 @@
 
 package cloudconfig
 
-var (
-	ToolsDownloadCommand      = toolsDownloadCommand
-	GetMachineCloudCfgDirData = getMachineCloudCfgDirData
-	GetMachineData            = getMachineData
-)
+var ToolsDownloadCommand = toolsDownloadCommand

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -262,14 +262,14 @@ func extractPropertiesFromConfig(props []string, cfg map[string]interface{}, log
 					}
 				}
 			} else {
-				log.Debugf("%s not found in machine cloud-init data", key)
+				log.Debugf("%s not found in machine init data", key)
 			}
 		case "ca-certs":
 			// No translation needed, ca-certs the same in both versions of Cloud-Init.
 			if val, ok := cfg[key]; ok {
 				foundDataMap[key] = val
 			} else {
-				log.Debugf("%s not found in machine cloud-init data", key)
+				log.Debugf("%s not found in machine init data", key)
 			}
 		}
 	}

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -18,35 +18,315 @@ import (
 	"github.com/juju/juju/juju/paths"
 )
 
-// GetMachineCloudInitData returns a map of all cloud init data on the machine.
-func GetMachineCloudInitData(series string) (map[string]interface{}, error) {
+// InitReader describes methods for extracting machine provisioning config,
+// and extracting keys from config based on properties sourced from
+// "container-inherit-properties" in model config.
+type InitReader interface {
+	// GetInitConfig aggregates and returns provisioning data from the machine.
+	GetInitConfig() (map[string]interface{}, error)
+
+	// ExtractPropertiesFromConfig filters the input config data according to
+	// the input list of properties and returns the result
+	ExtractPropertiesFromConfig([]string, map[string]interface{}, loggo.Logger) map[string]interface{}
+}
+
+// MachineInitReaderConfig holds configuration values required by
+// MachineInitReader to retrieve initialisation configuration for
+// a single machine.
+type MachineInitReaderConfig struct {
+	// Series is the OS series of the machine.
+	Series string
+
+	// CloudInitConfigDir is the directory where cloud configuration resides
+	// on MAAS hosts.
+	CloudInitConfigDir string
+
+	// CloudInitInstanceConfigDir is the directory where cloud-init data for
+	// the instance resides. Cloud-Init user-data supplied to Juju lives here.
+	CloudInitInstanceConfigDir string
+
+	// CurtinInstallConfigFile is the file containing initialisation config
+	// written by Curtin.
+	// Apt configuration for MAAS versions 2.5+ resides here.
+	CurtinInstallConfigFile string
+}
+
+// MachineInitReader accesses Cloud-Init and Curtin configuration data,
+// and extracts from it values for keys set in model configuration as
+// "container-inherit-properties".
+type MachineInitReader struct {
+	config MachineInitReaderConfig
+}
+
+// NewMachineInitReader creates and returns a new MachineInitReader for the
+// input series.
+func NewMachineInitReader(series string) (InitReader, error) {
+	cloudInitConfigDir, err := paths.CloudInitCfgDir(series)
+	if err != nil {
+		return nil, errors.Annotate(err, "determining CloudInitCfgDir for the machine")
+	}
+	cloudInitInstanceConfigDir, err := paths.MachineCloudInitDir(series)
+	if err != nil {
+		return nil, errors.Annotate(err, "determining MachineCloudInitDir for the machine")
+	}
+	curtinInstallConfigFile, err := paths.CurtinInstallConfig(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cfg := MachineInitReaderConfig{
+		Series:                     series,
+		CloudInitConfigDir:         cloudInitConfigDir,
+		CloudInitInstanceConfigDir: cloudInitInstanceConfigDir,
+		CurtinInstallConfigFile:    curtinInstallConfigFile,
+	}
+	return NewMachineInitReaderFromConfig(cfg), nil
+}
+
+// NewMachineInitReader creates and returns a new MachineInitReader using
+// the input configuration.
+func NewMachineInitReaderFromConfig(cfg MachineInitReaderConfig) InitReader {
+	return &MachineInitReader{config: cfg}
+}
+
+// GetInitConfig returns a map of configuration data used to provision the
+// machine. It is sourced from both Cloud-Init and Curtin data.
+func (r *MachineInitReader) GetInitConfig() (map[string]interface{}, error) {
+	series := r.config.Series
+
 	containerOS, err := utilsseries.GetOSFromSeries(series)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	switch containerOS {
 	case utilsos.Ubuntu, utilsos.CentOS, utilsos.OpenSUSE:
 		if series != utilsseries.MustHostSeries() {
-			logger.Debugf("not attempting to get cloudinit data for %s, series of machine and container differ", series)
+			logger.Debugf("not attempting to get init config for %s, series of machine and container differ", series)
 			return nil, nil
 		}
 	default:
-		logger.Debugf("not attempting to get cloudinit data for %s container", series)
+		logger.Debugf("not attempting to get init config for %s container", series)
 		return nil, nil
 	}
 
-	machineCloudInitData, err := getMachineCloudCfgDirData(series)
+	machineCloudInitData, err := r.getMachineCloudCfgDirData()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	vendorData, err := getMachineVendorData(series)
+
+	file := filepath.Join(r.config.CloudInitInstanceConfigDir, "vendor-data.txt")
+	vendorData, err := r.unmarshallConfigFile(file)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	for k, v := range vendorData {
 		machineCloudInitData[k] = v
 	}
+
+	_, curtinData, err := fileAsConfigMap(r.config.CurtinInstallConfigFile)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for k, v := range curtinData {
+		machineCloudInitData[k] = v
+	}
+
 	return machineCloudInitData, nil
+}
+
+func (r *MachineInitReader) ExtractPropertiesFromConfig(
+	keys []string, cfg map[string]interface{}, log loggo.Logger,
+) map[string]interface{} {
+	if r.config.Series == "trusty" {
+		return extractPropertiesFromConfigLegacy(keys, cfg, log)
+	}
+
+	// There is a big assumption that supported CentOS and OpenSUSE versions
+	// supported by juju are using cloud-init version >= 0.7.8
+	return extractPropertiesFromConfig(keys, cfg, log)
+}
+
+// getMachineCloudCfgDirData returns a map of the combined machine's Cloud-Init
+// cloud.cfg.d config files. Files are read in lexical order.
+func (r *MachineInitReader) getMachineCloudCfgDirData() (map[string]interface{}, error) {
+	dir := r.config.CloudInitConfigDir
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot determine files in CloudInitCfgDir for the machine")
+	}
+	sortedFiles := sortableFileInfos(files)
+	sort.Sort(sortedFiles)
+
+	cloudInit := make(map[string]interface{})
+	for _, file := range files {
+		name := file.Name()
+		if !strings.HasSuffix(name, ".cfg") {
+			continue
+		}
+		_, cloudCfgData, err := fileAsConfigMap(filepath.Join(dir, name))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for k, v := range cloudCfgData {
+			cloudInit[k] = v
+		}
+	}
+	return cloudInit, nil
+}
+
+// unmarshallConfigFile reads the file at the input path,
+// decompressing it if required, and converts the contents to a map of
+// configuration key-values.
+func (r *MachineInitReader) unmarshallConfigFile(file string) (map[string]interface{}, error) {
+	raw, config, err := fileAsConfigMap(file)
+	if err == nil {
+		return config, nil
+	}
+
+	// The data maybe be gzipped, base64 encoded, both, or neither.
+	// If both, it has been gzipped, then base64 encoded.
+	logger.Tracef("unmarshall failed (%s), file may be compressed", err.Error())
+
+	zippedData, err := utils.Gunzip(raw)
+	if err == nil {
+		cfg, err := bytesAsConfigMap(zippedData)
+		return cfg, errors.Trace(err)
+	}
+	logger.Tracef("Gunzip of %q failed (%s), maybe it is encoded", file, err)
+
+	decodedData, err := base64.StdEncoding.DecodeString(string(raw))
+	if err == nil {
+		if buf, err := bytesAsConfigMap(decodedData); err == nil {
+			return buf, nil
+		}
+	}
+	logger.Tracef("Decoding of %q failed (%s), maybe it is encoded and gzipped", file, err)
+
+	decodedZippedBuf, err := utils.Gunzip(decodedData)
+	if err != nil {
+		// During testing, it was found that the trusty vendor-data.txt.i file
+		// can contain only the text "NONE", which doesn't unmarshall or decompress
+		// we don't want to fail in that case.
+		if r.config.Series == "trusty" {
+			logger.Debugf("failed to unmarshall or decompress %q: %s", file, err)
+			return nil, nil
+		}
+		return nil, errors.Annotatef(err, "cannot unmarshall or decompress %q", file)
+	}
+
+	cfg, err := bytesAsConfigMap(decodedZippedBuf)
+	return cfg, errors.Trace(err)
+}
+
+// fileAsConfigMap reads the file at the input path and returns its contents as
+// raw bytes, and if possible a map of config key-values.
+func fileAsConfigMap(file string) ([]byte, map[string]interface{}, error) {
+	raw, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "reading config from %q", file)
+	}
+	if len(raw) == 0 {
+		return nil, nil, nil
+	}
+
+	cfg, err := bytesAsConfigMap(raw)
+	return raw, cfg, errors.Annotatef(err, "converting %q contents to map", file)
+}
+
+// extractPropertiesFromConfig filters the input config based on the
+// input properties and returns a map of cloud-init data, compatible with
+// version 0.7.8 and above.
+func extractPropertiesFromConfig(props []string, cfg map[string]interface{}, log loggo.Logger) map[string]interface{} {
+	foundDataMap := make(map[string]interface{})
+	for _, k := range props {
+		key := strings.TrimSpace(k)
+		switch key {
+		case "apt-security", "apt-primary", "apt-sources_list":
+			if val, ok := cfg["apt"]; ok {
+				for k, v := range nestedAptConfig(key, val, log) {
+					// security, sources, and primary all nest under apt, ensure
+					// we don't overwrite prior translated data.
+					if apt, ok := foundDataMap["apt"].(map[string]interface{}); ok {
+						apt[k] = v
+					} else {
+						foundDataMap["apt"] = map[string]interface{}{
+							k: v,
+						}
+					}
+				}
+			} else {
+				log.Debugf("%s not found in machine cloud-init data", key)
+			}
+		case "ca-certs":
+			// no translation needed, ca-certs the same in both versions of cloudinit
+			if val, ok := cfg[key]; ok {
+				foundDataMap[key] = val
+			} else {
+				log.Debugf("%s not found in machine cloud-init data", key)
+			}
+		}
+	}
+	return foundDataMap
+}
+
+func nestedAptConfig(key string, val interface{}, log loggo.Logger) map[string]interface{} {
+	split := strings.Split(key, "-")
+	secondary := split[1]
+
+	for k, v := range interfaceToMapStringInterface(val) {
+		if k == secondary {
+			foundDataMap := make(map[string]interface{})
+			foundDataMap[k] = v
+			return foundDataMap
+		}
+	}
+
+	log.Debugf("%s not found in machine init data", key)
+	return nil
+}
+
+// extractPropertiesFromConfigLegacy filters the input config based on the
+// input properties and returns a map of cloud-init data, compatible with
+// version 0.7.7 and below.
+func extractPropertiesFromConfigLegacy(
+	props []string, cfg map[string]interface{}, log loggo.Logger,
+) map[string]interface{} {
+	foundDataMap := make(map[string]interface{})
+	aptProcessed := false
+
+	for _, k := range props {
+		key := strings.TrimSpace(k)
+		switch key {
+		case "apt-primary", "apt-sources":
+			if aptProcessed {
+				continue
+			}
+			for _, aptKey := range []string{"apt_mirror", "apt_mirror_search", "apt_mirror_search_dns", "apt_sources"} {
+				if val, ok := cfg[aptKey]; ok {
+					foundDataMap[aptKey] = val
+				} else {
+					log.Debugf("%s not found in machine init data", key)
+				}
+			}
+			aptProcessed = true
+		case "apt-sources_list":
+			// TODO (manadart 2018-02-18): Test whether this key is handled in
+			// legacy cloud-init versions.
+
+		case "apt-security":
+			// Translation for apt-security unknown at this time.
+			log.Debugf("%s not found in machine init data", key)
+		case "ca-certs":
+			// no translation needed, ca-certs the same in both versions of cloudinit
+			if val, ok := cfg[key]; ok {
+				foundDataMap[key] = val
+			} else {
+				log.Debugf("%s not found in machine init data", key)
+			}
+		}
+	}
+	return foundDataMap
 }
 
 type sortableFileInfos []os.FileInfo
@@ -63,215 +343,10 @@ func (fil sortableFileInfos) Swap(i, j int) {
 	fil[i], fil[j] = fil[j], fil[i]
 }
 
-// CloudInitCfgDir is for testing purposes.
-var CloudInitCfgDir = paths.CloudInitCfgDir
-
-// getMachineCloudCfgDirData returns a map of the combined machine's cloud init
-// cloud.cfg.d config files.  Files are read in lexical order.
-func getMachineCloudCfgDirData(series string) (map[string]interface{}, error) {
-	dir, err := CloudInitCfgDir(series)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot determine CloudInitCfgDir for the machine")
-	}
-	fileInfo, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot determine files in CloudInitCfgDir for the machine")
-	}
-	sortedFileInfos := sortableFileInfos(fileInfo)
-	sort.Sort(sortedFileInfos)
-	cloudInit := make(map[string]interface{})
-	for _, file := range fileInfo {
-		name := file.Name()
-		if !strings.HasSuffix(name, ".cfg") {
-			continue
-		}
-		data, err := ioutil.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			return nil, errors.Annotatef(err, "cannot read %q from machine", name)
-		}
-		cloudCfgData, err := unmarshallContainerCloudInit(data)
-		if err != nil {
-			return nil, errors.Annotatef(err, "cannot unmarshall %q from machine", name)
-		}
-		for k, v := range cloudCfgData {
-			cloudInit[k] = v
-		}
-	}
-	return cloudInit, nil
-}
-
-// getMachineVendorData returns a map of machine's cloud init vendor-data.txt.
-func getMachineVendorData(series string) (map[string]interface{}, error) {
-	// vendor-data.txt may or may not be compressed.
-	return getMachineData(series, "vendor-data.txt")
-}
-
-// MachineCloudInitDir is for testing purposes.
-var MachineCloudInitDir = paths.MachineCloudInitDir
-
-func getMachineData(series, file string) (map[string]interface{}, error) {
-	dir, err := MachineCloudInitDir(series)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot determine MachineCloudInitDir for the machine")
-	}
-	data, err := ioutil.ReadFile(filepath.Join(dir, file))
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot read %q from machine", file)
-	}
-
-	if len(data) == 0 {
-		// vendor-data.txt is sometimes empty
-		return nil, nil
-	}
-	// The userdata maybe be gzip'd, base64 encoded, both, or neither.
-	// If both, it's been gzip'd, then base64 encoded.
-	rawBuf, err := unmarshallContainerCloudInit(data)
-	if err == nil {
-		return rawBuf, nil
-	}
-	logger.Tracef("unmarshal of %q failed (%s), maybe it is compressed", file, err)
-
-	zippedData, err := utils.Gunzip(data)
-	if err == nil {
-		return unmarshallContainerCloudInit(zippedData)
-	}
-	logger.Tracef("Gunzip of %q failed (%s), maybe it is encoded", file, err)
-
-	decodedData, err := base64.StdEncoding.DecodeString(string(data))
-	if err == nil {
-		// it could still be gzip'd.
-		buf, err := unmarshallContainerCloudInit(decodedData)
-		if err == nil {
-			return buf, nil
-		}
-	}
-	logger.Tracef("Decoding of %q failed (%s), maybe it is encoded and gzipped", file, err)
-
-	decodedZippedBuf, err := utils.Gunzip(decodedData)
-	if err != nil {
-		// During testing, it was found that the trusty vendor-data.txt.i file
-		// can contain only the text "NONE", which doesn't unmarshall or decompress
-		// we don't want to fail in that case.
-		if series == "trusty" {
-			logger.Debugf("failed to unmarshall or decompress %q: %s", file, err)
-			return nil, nil
-		}
-		return nil, errors.Annotatef(err, "cannot unmarshall or decompress %q", file)
-	}
-	return unmarshallContainerCloudInit(decodedZippedBuf)
-}
-
-func unmarshallContainerCloudInit(raw []byte) (map[string]interface{}, error) {
+func bytesAsConfigMap(raw []byte) (map[string]interface{}, error) {
 	dataMap := make(map[string]interface{})
 	err := yaml.Unmarshal(raw, &dataMap)
-	if err != nil {
-		return nil, err
-	}
-	return dataMap, nil
-}
-
-type cloudConfigTranslateFunc func(string, map[string]interface{}, loggo.Logger) map[string]interface{}
-
-// CloudConfigByVersionFunc returns the correct function to translate
-// container-inherit-properties to cloud-init data based on series.
-func CloudConfigByVersionFunc(series string) cloudConfigTranslateFunc {
-	if series == "trusty" {
-		return machineCloudConfigV077
-	}
-	// There is a big assumption that supported CentOS and OpenSUSE versions
-	// supported by juju are using cloud-init version >= 0.7.8
-	return machineCloudConfigV078
-}
-
-// machineCloudConfigV078 finds the containerInheritProperties properties and
-// values in the given dataMap and returns a cloud-init v0.7.8 formatted map.
-func machineCloudConfigV078(containerInheritProperties string, dataMap map[string]interface{}, log loggo.Logger) map[string]interface{} {
-	if containerInheritProperties == "" {
-		return nil
-	}
-	foundDataMap := make(map[string]interface{})
-	for _, k := range strings.Split(containerInheritProperties, ",") {
-		key := strings.TrimSpace(k)
-		switch key {
-		case "apt-security", "apt-sources", "apt-primary":
-			if val, ok := dataMap["apt"]; ok {
-				for k, v := range machineCloudConfigAptV078(key, val, log) {
-					// security, sources, and primary all nest under apt, ensure
-					// we don't overwrite prior translated data.
-					if apt, ok := foundDataMap["apt"].(map[string]interface{}); ok {
-						apt[k] = v
-					} else {
-						foundDataMap["apt"] = map[string]interface{}{
-							k: v,
-						}
-					}
-				}
-			} else {
-				log.Debugf("%s not found in machine cloud-init data", key)
-			}
-		case "ca-certs":
-			// no translation needed, ca-certs the same in both versions of cloudinit
-			if val, ok := dataMap[key]; ok {
-				foundDataMap[key] = val
-			} else {
-				log.Debugf("%s not found in machine cloud-init data", key)
-			}
-		}
-	}
-	return foundDataMap
-}
-
-func machineCloudConfigAptV078(key string, val interface{}, log loggo.Logger) map[string]interface{} {
-	split := strings.Split(key, "-")
-	secondary := split[1]
-
-	for k, v := range interfaceToMapStringInterface(val) {
-		if k == secondary {
-			foundDataMap := make(map[string]interface{})
-			foundDataMap[k] = v
-			return foundDataMap
-		}
-	}
-
-	log.Debugf("%s not found in machine cloud-init data", key)
-	return nil
-}
-
-var aptPrimaryKeys = []string{"apt_mirror", "apt_mirror_search", "apt_mirror_search_dns"}
-var aptSourcesKeys = []string{"apt_sources"}
-
-// machineCloudConfigV077 finds the containerInheritProperties properties and
-// values in the given dataMap and returns a cloud-init v0.7.7 formatted map.
-func machineCloudConfigV077(containerInheritProperties string, dataMap map[string]interface{}, log loggo.Logger) map[string]interface{} {
-	if containerInheritProperties == "" {
-		return nil
-	}
-	foundDataMap := make(map[string]interface{})
-	keySplit := strings.Split(containerInheritProperties, ",")
-	for _, k := range keySplit {
-		key := strings.TrimSpace(k)
-		switch key {
-		case "apt-primary", "apt-sources":
-			for _, aptKey := range append(aptPrimaryKeys, aptSourcesKeys...) {
-				if val, ok := dataMap[aptKey]; ok {
-					foundDataMap[aptKey] = val
-				} else {
-					log.Debugf("%s not found as part of %s, in machine cloud-init data", strings.Join(keySplit, "-"), key)
-				}
-			}
-		case "apt-security":
-			// Translation for apt-security unknown at this time.
-			log.Debugf("%s not found in machine cloud-init data", key)
-		case "ca-certs":
-			// no translation needed, ca-certs the same in both versions of cloudinit
-			if val, ok := dataMap[key]; ok {
-				foundDataMap[key] = val
-			} else {
-				log.Debugf("%s not found in machine cloud-init data", key)
-			}
-		}
-	}
-	return foundDataMap
+	return dataMap, errors.Trace(err)
 }
 
 func interfaceToMapStringInterface(in interface{}) map[string]interface{} {

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -248,7 +248,7 @@ func extractPropertiesFromConfig(props []string, cfg map[string]interface{}, log
 	for _, k := range props {
 		key := strings.TrimSpace(k)
 		switch key {
-		case "apt-security", "apt-primary", "apt-sources_list":
+		case "apt-security", "apt-primary", "apt-sources", "apt-sources_list":
 			if val, ok := cfg["apt"]; ok {
 				for k, v := range nestedAptConfig(key, val, log) {
 					// security, sources, and primary all nest under apt, ensure
@@ -265,7 +265,7 @@ func extractPropertiesFromConfig(props []string, cfg map[string]interface{}, log
 				log.Debugf("%s not found in machine cloud-init data", key)
 			}
 		case "ca-certs":
-			// no translation needed, ca-certs the same in both versions of cloudinit
+			// No translation needed, ca-certs the same in both versions of Cloud-Init.
 			if val, ok := cfg[key]; ok {
 				foundDataMap[key] = val
 			} else {
@@ -312,19 +312,23 @@ func extractPropertiesFromConfigLegacy(
 				if val, ok := cfg[aptKey]; ok {
 					foundDataMap[aptKey] = val
 				} else {
-					log.Debugf("%s not found in machine init data", key)
+					log.Debugf("%s not found in machine init data", aptKey)
 				}
 			}
 			aptProcessed = true
 		case "apt-sources_list":
-			// TODO (manadart 2018-02-18): Test whether this key is handled in
-			// legacy cloud-init versions.
-
+			// Testing series trusty on MAAS 2.5+ shows that this could be
+			// treated in the same way as the non-legacy property
+			// extraction, but we would then be mixing techniques.
+			// Legacy handling is left unchanged here under the assumption
+			// that provisioning trusty machines on much newer MAAS
+			// versions is highly unlikely.
+			log.Debugf("%q ignored for this machine series", key)
 		case "apt-security":
 			// Translation for apt-security unknown at this time.
-			log.Debugf("%s not found in machine init data", key)
+			log.Debugf("%q ignored for this machine series", key)
 		case "ca-certs":
-			// no translation needed, ca-certs the same in both versions of cloudinit
+			// No translation needed, ca-certs the same in both versions of Cloud-Init.
 			if val, ok := cfg[key]; ok {
 				foundDataMap[key] = val
 			} else {

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -4,10 +4,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	utilsseries "github.com/juju/os/series"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig"
@@ -17,35 +18,37 @@ import (
 type fromHostSuite struct {
 	testing.BaseSuite
 
-	tempCloudCfgDir  string
-	tempCloudInitDir string
+	tempCloudCfgDir   string
+	tempCloudInitDir  string
+	tempCurtinCfgFile string
+
+	reader *cloudconfig.MachineInitReader
 }
 
 var _ = gc.Suite(&fromHostSuite{})
 
-func (s *fromHostSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
+func (s *fromHostSuite) SetUpTest(c *gc.C) {
+	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "xenial" })
 
 	// Pre-seed /etc/cloud/cloud.cfg.d replacement for testing
 	s.tempCloudCfgDir = c.MkDir() // will clean up
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg"), []byte(dpkgLocalCloudConfig078), 0644)
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "50-curtin-networking.cfg"), []byte(curtinNetworking), 0644)
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "10_random.cfg"), []byte(otherConfig), 0644)
-	ioutil.WriteFile(path.Join(s.tempCloudCfgDir, "Readme"), []byte(readmeFile), 0644)
+	seedData(c, s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg", dpkgLocalCloudConfig078)
+	seedData(c, s.tempCloudCfgDir, "50-curtin-networking.cfg", curtinNetworking)
+	seedData(c, s.tempCloudCfgDir, "10_random.cfg", otherConfig)
+	seedData(c, s.tempCloudCfgDir, "Readme", readmeFile)
 
 	// Pre-seed /var/lib/cloud/instance replacement for testing
 	s.tempCloudInitDir = c.MkDir()
-	ioutil.WriteFile(path.Join(s.tempCloudInitDir, "vendor-data.txt"), []byte(vendorData), 0644)
-}
+	seedData(c, s.tempCloudInitDir, "vendor-data.txt", vendorData)
 
-func (s *fromHostSuite) SetUpTest(c *gc.C) {
-	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(_ string) (string, error) { return s.tempCloudCfgDir, nil })
-	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return s.tempCloudInitDir, nil })
-	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "xenial" })
+	curtinDir := c.MkDir()
+	curtinFile := "curtin-install-cfg.yaml"
+	seedData(c, curtinDir, curtinFile, "")
+	s.tempCurtinCfgFile = filepath.Join(curtinDir, curtinFile)
 }
 
 func (s *fromHostSuite) TestGetMachineCloudInitData(c *gc.C) {
-	obtained, err := cloudconfig.GetMachineCloudInitData("xenial")
+	obtained, err := s.newMachineInitReader("xenial").GetInitConfig()
 	c.Assert(err, gc.IsNil)
 	c.Assert(obtained, gc.DeepEquals, expectedResult078)
 }
@@ -104,7 +107,7 @@ func (s *fromHostSuite) TestGetMachineCloudInitDataVerifySeries(c *gc.C) {
 	for i, test := range cloudinitDataVerifyTests {
 		c.Logf("Test %d of %d: %s", i, len(cloudinitDataVerifyTests), test.description)
 		s.PatchValue(&utilsseries.MustHostSeries, func() string { return test.machineSeries })
-		obtained, err := cloudconfig.GetMachineCloudInitData(test.containerSeries)
+		obtained, err := s.newMachineInitReader(test.containerSeries).GetInitConfig()
 		c.Assert(err, gc.IsNil)
 		if test.result != nil {
 			c.Assert(obtained, gc.DeepEquals, expectedResult078)
@@ -116,49 +119,40 @@ func (s *fromHostSuite) TestGetMachineCloudInitDataVerifySeries(c *gc.C) {
 
 func (s *fromHostSuite) TestMissingVendorDataFile(c *gc.C) {
 	dir := c.MkDir()
-	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return dir, nil })
-	obtained, err := cloudconfig.GetMachineData("xenial", "vendor-data.txt")
-	c.Assert(err, gc.ErrorMatches, "cannot read \"vendor-data.txt\" from machine.*")
+	c.Assert(os.RemoveAll(dir), jc.ErrorIsNil)
+	s.tempCloudInitDir = dir
+
+	obtained, err := s.newMachineInitReader("xenial").GetInitConfig()
+	c.Assert(err, gc.ErrorMatches, "reading config from.*vendor-data.txt.*")
 	c.Assert(obtained, gc.IsNil)
 }
 
 func (s *fromHostSuite) TestMissingVendorDataFileTrusty(c *gc.C) {
-	ioutil.WriteFile(path.Join(s.tempCloudInitDir, "vendor-data.txt"), []byte(vendorDataTrusty), 0644)
-	obtained, err := cloudconfig.GetMachineData("trusty", "vendor-data.txt")
+	seedData(c, s.tempCloudInitDir, "vendor-data.txt", vendorDataTrusty)
+
+	obtained, err := s.newMachineInitReader("trusty").GetInitConfig()
 	c.Assert(err, gc.IsNil)
 	c.Assert(obtained, gc.IsNil)
 }
 
 func (s *fromHostSuite) TestGetMachineCloudCfgDirDataReadDirFailed(c *gc.C) {
 	dir := c.MkDir()
-	os.RemoveAll(dir)
-	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(string) (string, error) { return dir, nil })
-	obtained, err := cloudconfig.GetMachineCloudCfgDirData("xenial")
-	c.Assert(err, gc.ErrorMatches, "cannot determine files in CloudInitCfgDir for the machine: .* no such file or directory")
-	c.Assert(obtained, gc.IsNil)
-}
+	c.Assert(os.RemoveAll(dir), jc.ErrorIsNil)
+	s.tempCloudCfgDir = dir
 
-func (s *fromHostSuite) TestGetMachineCloudCfgDirDataReadDirNotFound(c *gc.C) {
-	s.PatchValue(&cloudconfig.CloudInitCfgDir, func(string) (string, error) { return "", errors.New("test failure") })
-	obtained, err := cloudconfig.GetMachineCloudCfgDirData("xenial")
-	c.Assert(err, gc.ErrorMatches, "cannot determine CloudInitCfgDir for the machine: test failure")
-	c.Assert(obtained, gc.IsNil)
-}
-
-func (s *fromHostSuite) TestGetMachineDataReadDirNotFound(c *gc.C) {
-	s.PatchValue(&cloudconfig.MachineCloudInitDir, func(string) (string, error) { return "", errors.New("test failure") })
-	obtained, err := cloudconfig.GetMachineData("xenial", "")
-	c.Assert(err, gc.ErrorMatches, "cannot determine MachineCloudInitDir for the machine: test failure")
+	obtained, err := s.newMachineInitReader("xenial").GetInitConfig()
+	c.Assert(err, gc.ErrorMatches, "determining files in CloudInitCfgDir for the machine: .* no such file or directory")
 	c.Assert(obtained, gc.IsNil)
 }
 
 func (s *fromHostSuite) TestCloudConfigVersionV078(c *gc.C) {
-	obtained, err := cloudconfig.GetMachineCloudInitData("xenial")
+	reader := s.newMachineInitReader("xenial")
+	obtained, err := reader.GetInitConfig()
 	c.Assert(err, gc.IsNil)
 	c.Assert(obtained, gc.DeepEquals, expectedResult078)
 
-	resultMap := cloudconfig.CloudConfigByVersionFunc("xenial")("apt-primary,ca-certs,apt-security", obtained,
-		loggo.GetLogger("juju.machinecloudconfig"))
+	resultMap := reader.ExtractPropertiesFromConfig(
+		[]string{"apt-primary", "ca-certs", "apt-security"}, obtained, loggo.GetLogger("juju.machinecloudconfig"))
 	c.Assert(resultMap, gc.DeepEquals,
 		map[string]interface{}{
 			"apt": map[string]interface{}{
@@ -182,45 +176,50 @@ func (s *fromHostSuite) TestCloudConfigVersionV078(c *gc.C) {
 		})
 }
 
-func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritPropertiesV078(c *gc.C) {
-	resultMap := cloudconfig.CloudConfigByVersionFunc("xenial")("", nil, loggo.GetLogger("juju.machinecloudconfig"))
-	c.Assert(resultMap, gc.IsNil)
+func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritProperties(c *gc.C) {
+	reader := s.newMachineInitReader("xenial")
+	resultMap := reader.ExtractPropertiesFromConfig(nil, nil, loggo.GetLogger("juju.machinecloudconfig"))
+	c.Assert(resultMap, gc.HasLen, 0)
 }
 
 func (s *fromHostSuite) TestCloudConfigVersionV077(c *gc.C) {
 	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "trusty" })
-	obtained, err := cloudconfig.GetMachineCloudInitData("trusty")
-	c.Assert(err, gc.IsNil)
-	c.Assert(obtained, gc.DeepEquals, expectedResult078)
+	seedData(c, s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg", dpkgLocalCloudConfig077)
 
-	resultMap := cloudconfig.CloudConfigByVersionFunc("xenial")("apt-primary,ca-certs,apt-security", obtained,
-		loggo.GetLogger("juju.machinecloudconfig"))
-	c.Assert(resultMap, gc.DeepEquals,
-		map[string]interface{}{
-			"apt": map[string]interface{}{
-				"primary": []interface{}{
-					map[interface{}]interface{}{
-						"arches": []interface{}{"default"},
-						"uri":    "http://archive.ubuntu.com/ubuntu",
-					},
-				},
-				"security": []interface{}{
-					map[interface{}]interface{}{
-						"arches": []interface{}{"default"},
-						"uri":    "http://archive.ubuntu.com/ubuntu",
-					},
-				},
-			},
-			"ca-certs": map[interface{}]interface{}{
-				"remove-defaults": true,
-				"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
-			},
-		})
+	reader := s.newMachineInitReader("trusty")
+	obtained, err := reader.GetInitConfig()
+	c.Assert(err, gc.IsNil)
+
+	resultMap := reader.ExtractPropertiesFromConfig(
+		[]string{"apt-primary", "ca-certs", "apt-security"}, obtained, loggo.GetLogger("juju.machinecloudconfig"))
+
+	// Can't compare map-to-map equality directly due to one of the values
+	// being a slice - it fails intermittently.
+	c.Assert(resultMap, gc.HasLen, 5)
+	c.Assert(resultMap["apt_mirror"], gc.Equals, expectedResult077["apt_mirror"])
+	c.Assert(resultMap["apt_mirror_search_dns"], gc.Equals, expectedResult077["apt_mirror_search_dns"])
+	c.Assert(resultMap["apt_mirror_search"], jc.SameContents, expectedResult077["apt_mirror_search"])
+	c.Assert(resultMap["apt_sources"], gc.DeepEquals, expectedResult077["apt_sources"])
 }
 
-func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritPropertiesV077(c *gc.C) {
-	resultMap := cloudconfig.CloudConfigByVersionFunc("trusty")("", nil, loggo.GetLogger("juju.machinecloudconfig"))
-	c.Assert(resultMap, gc.IsNil)
+func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritPropertiesLegacy(c *gc.C) {
+	reader := s.newMachineInitReader("trusty")
+	resultMap := reader.ExtractPropertiesFromConfig(nil, nil, loggo.GetLogger("juju.machinecloudconfig"))
+	c.Assert(resultMap, gc.HasLen, 0)
+}
+
+func (s *fromHostSuite) newMachineInitReader(series string) cloudconfig.InitReader {
+	cfg := cloudconfig.MachineInitReaderConfig{
+		Series:                     series,
+		CloudInitConfigDir:         s.tempCloudCfgDir,
+		CloudInitInstanceConfigDir: s.tempCloudInitDir,
+		CurtinInstallConfigFile:    s.tempCurtinCfgFile,
+	}
+	return cloudconfig.NewMachineInitReaderFromConfig(cfg)
+}
+
+func seedData(c *gc.C, dir, name, data string) {
+	c.Assert(ioutil.WriteFile(path.Join(dir, name), []byte(data), 0644), jc.ErrorIsNil)
 }
 
 var dpkgLocalCloudConfig077 = `
@@ -361,31 +360,7 @@ var expectedResult078 = map[string]interface{}{
 			"consumer_key": "mpU9YZLWDG7ZQubksN",
 		},
 	},
-	"system_info": map[interface{}]interface{}{
-		"package_mirrors": []interface{}{map[interface{}]interface{}{
-			"arches": []interface{}{"i386", "amd64"},
-			"failsafe": map[interface{}]interface{}{
-				"primary":  "http://archive.ubuntu.com/ubuntu",
-				"security": "http://security.ubuntu.com/ubuntu",
-			},
-			"search": map[interface{}]interface{}{
-				"primary":  []interface{}{"http://archive.ubuntu.com/ubuntu"},
-				"security": []interface{}{"http://archive.ubuntu.com/ubuntu"},
-			},
-		},
-			map[interface{}]interface{}{
-				"arches": []interface{}{"default"},
-				"failsafe": map[interface{}]interface{}{
-					"primary":  "http://ports.ubuntu.com/ubuntu-ports",
-					"security": "http://ports.ubuntu.com/ubuntu-ports",
-				},
-				"search": map[interface{}]interface{}{
-					"primary":  []interface{}{"http://ports.ubuntu.com/ubuntu-ports"},
-					"security": []interface{}{"http://ports.ubuntu.com/ubuntu-ports"},
-				},
-			},
-		},
-	},
+	"system_info": expectedSystemInfoCommon,
 	"ntp": map[interface{}]interface{}{
 		"servers": []interface{}{"10.10.76.2"},
 		"pools":   []interface{}{},
@@ -402,21 +377,91 @@ var expectedResult078 = map[string]interface{}{
 		"remove-defaults": true,
 		"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
 	},
-	"network": map[interface{}]interface{}{
-		"config": []interface{}{map[interface{}]interface{}{
-			"mtu":  1500,
-			"name": "ens3",
-			"subnets": []interface{}{
-				map[interface{}]interface{}{
-					"type":            "static",
-					"address":         "10.10.76.124/24",
-					"dns_nameservers": []interface{}{"10.10.76.45"},
-					"gateway":         "10.10.76.1",
-				},
-			},
-			"type":        "physical",
-			"id":          "ens3",
-			"mac_address": "52:54:00:0c:xx:e0"},
+	"network": expectedNetworkCommon,
+}
+
+var expectedResult077 = map[string]interface{}{
+	"apt_mirror": "http://archive.ubuntu.com/ubuntu",
+	"apt_mirror_search": []interface{}{
+		"http://local-mirror.mydomain",
+		"http://archive.ubuntu.com",
+	},
+	"apt_mirror_search_dns": false,
+	"apt_sources": []interface{}{
+		map[interface{}]interface{}{
+			"source": "deb http://apt.opscode.com/ $RELEASE-0.10 main",
+			"key":    "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1.4.9 (GNU/Linux)\n-----END PGP PUBLIC KEY BLOCK-----\n",
 		},
+	},
+	"reporting": map[interface{}]interface{}{
+		"maas": map[interface{}]interface{}{
+			"endpoint":     "http://10.10.101.2/MAAS/metadata/status/cmfcxx",
+			"token_key":    "tgEn5v5TcakKwWKwCf",
+			"token_secret": "jzLdPTuh7hHqHTG9kGEHSG7F25GMAmzJ",
+			"type":         "webhook",
+			"consumer_key": "mpU9YZLWDG7ZQubksN",
+		},
+	},
+	"system_info": expectedSystemInfoCommon,
+	"ntp": map[interface{}]interface{}{
+		"servers": []interface{}{"10.10.76.2"},
+		"pools":   []interface{}{},
+	},
+	"write_files": []interface{}{
+		map[interface{}]interface{}{
+			"path":        "/tmp/juju-test",
+			"permissions": 420,
+			"content":     "Hello World!\n",
+		}},
+	"apt_preserve_sources_list": true,
+	"packages":                  []interface{}{"‘python-novaclient’"},
+	"ca-certs": map[interface{}]interface{}{
+		"remove-defaults": true,
+		"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+	},
+	"network": expectedNetworkCommon,
+}
+
+var expectedSystemInfoCommon = map[interface{}]interface{}{
+	"package_mirrors": []interface{}{map[interface{}]interface{}{
+		"arches": []interface{}{"i386", "amd64"},
+		"failsafe": map[interface{}]interface{}{
+			"primary":  "http://archive.ubuntu.com/ubuntu",
+			"security": "http://security.ubuntu.com/ubuntu",
+		},
+		"search": map[interface{}]interface{}{
+			"primary":  []interface{}{"http://archive.ubuntu.com/ubuntu"},
+			"security": []interface{}{"http://archive.ubuntu.com/ubuntu"},
+		},
+	},
+		map[interface{}]interface{}{
+			"arches": []interface{}{"default"},
+			"failsafe": map[interface{}]interface{}{
+				"primary":  "http://ports.ubuntu.com/ubuntu-ports",
+				"security": "http://ports.ubuntu.com/ubuntu-ports",
+			},
+			"search": map[interface{}]interface{}{
+				"primary":  []interface{}{"http://ports.ubuntu.com/ubuntu-ports"},
+				"security": []interface{}{"http://ports.ubuntu.com/ubuntu-ports"},
+			},
+		},
+	},
+}
+
+var expectedNetworkCommon = map[interface{}]interface{}{
+	"config": []interface{}{map[interface{}]interface{}{
+		"mtu":  1500,
+		"name": "ens3",
+		"subnets": []interface{}{
+			map[interface{}]interface{}{
+				"type":            "static",
+				"address":         "10.10.76.124/24",
+				"dns_nameservers": []interface{}{"10.10.76.45"},
+				"gateway":         "10.10.76.1",
+			},
+		},
+		"type":        "physical",
+		"id":          "ens3",
+		"mac_address": "52:54:00:0c:xx:e0"},
 	},
 }

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -26,6 +26,7 @@ const (
 	jujuUpdateSeries
 	instanceCloudInitDir
 	cloudInitCfgDir
+	curtinInstallConfig
 )
 
 const (
@@ -51,6 +52,7 @@ var nixVals = map[osVarType]string{
 	uniterStateDir:       "/var/lib/juju/uniter/state",
 	instanceCloudInitDir: "/var/lib/cloud/instance",
 	cloudInitCfgDir:      "/etc/cloud/cloud.cfg.d",
+	curtinInstallConfig:  "/root/curtin-install-cfg.yaml",
 }
 
 var winVals = map[osVarType]string{
@@ -84,7 +86,7 @@ func osVal(ser string, valname osVarType) (string, error) {
 	}
 }
 
-// TempDir returns the path on disk to the corect tmp directory
+// TempDir returns the path on disk to the correct tmp directory
 // for the series. This value will be the same on virtually
 // all linux systems, but will differ on windows
 func TempDir(series string) (string, error) {
@@ -150,6 +152,12 @@ func JujuIntrospect(series string) (string, error) {
 // cloudinit directory for a particular series.
 func MachineCloudInitDir(series string) (string, error) {
 	return osVal(series, instanceCloudInitDir)
+}
+
+// CurtinInstallConfig returns the absolute path the configuration file
+// written by Curtin during machine provisioning.
+func CurtinInstallConfig(series string) (string, error) {
+	return osVal(series, curtinInstallConfig)
 }
 
 // CloudInitCfgDir returns the absolute path to the instance

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -8,8 +8,6 @@ import (
 	"net"
 	"path/filepath"
 
-	"github.com/juju/juju/cloudconfig"
-
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -21,6 +19,7 @@ import (
 
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"

--- a/worker/provisioner/broker_test.go
+++ b/worker/provisioner/broker_test.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"path/filepath"
 
+	"github.com/juju/juju/cloudconfig"
+
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -42,30 +44,7 @@ var _ = gc.Suite(&brokerSuite{})
 
 func (s *brokerSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
-	s.PatchValue(&provisioner.GetMachineCloudInitData, func(_ string) (map[string]interface{}, error) {
-		return map[string]interface{}{
-			"packages":   []interface{}{"python-novaclient"},
-			"fake-entry": []interface{}{"testing-garbage"},
-			"apt": map[interface{}]interface{}{
-				"primary": []interface{}{
-					map[interface{}]interface{}{
-						"arches": []interface{}{"default"},
-						"uri":    "http://archive.ubuntu.com/ubuntu",
-					},
-				},
-				"security": []interface{}{
-					map[interface{}]interface{}{
-						"arches": []interface{}{"default"},
-						"uri":    "http://archive.ubuntu.com/ubuntu",
-					},
-				},
-			},
-			"ca-certs": map[interface{}]interface{}{
-				"remove-defaults": true,
-				"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
-			},
-		}, nil
-	})
+	provisioner.PatchNewMachineInitReader(s, newFakeMachineInitReader)
 }
 
 func (s *brokerSuite) TestCombinedCloudInitDataNoCloudInitUserData(c *gc.C) {
@@ -119,7 +98,7 @@ type fakeAPI struct {
 
 var _ provisioner.APICalls = (*fakeAPI)(nil)
 
-var fakeInterfaceInfo network.InterfaceInfo = network.InterfaceInfo{
+var fakeInterfaceInfo = network.InterfaceInfo{
 	DeviceIndex:    0,
 	MACAddress:     "aa:bb:cc:dd:ee:ff",
 	CIDR:           "0.1.2.0/24",
@@ -131,11 +110,6 @@ var fakeInterfaceInfo network.InterfaceInfo = network.InterfaceInfo{
 	// by patchResolvConf(). See LP bug http://pad.lv/1575940 for more info.
 	DNSServers:       network.NewAddresses("ns1.dummy"),
 	DNSSearchDomains: nil,
-}
-
-var fakeDeviceToBridge network.DeviceToBridge = network.DeviceToBridge{
-	DeviceName: "dummy0",
-	BridgeName: "br-dummy0",
 }
 
 func fakeContainerConfig() params.ContainerConfig {
@@ -387,4 +361,38 @@ func assertCloudInitUserData(obtained, expected map[string]interface{}, c *gc.C)
 			c.Assert(obtainedV, jc.SameContents, expectedV)
 		}
 	}
+}
+
+type fakeMachineInitReader struct {
+	cloudconfig.InitReader
+}
+
+func (r *fakeMachineInitReader) GetInitConfig() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"packages":   []interface{}{"python-novaclient"},
+		"fake-entry": []interface{}{"testing-garbage"},
+		"apt": map[interface{}]interface{}{
+			"primary": []interface{}{
+				map[interface{}]interface{}{
+					"arches": []interface{}{"default"},
+					"uri":    "http://archive.ubuntu.com/ubuntu",
+				},
+			},
+			"security": []interface{}{
+				map[interface{}]interface{}{
+					"arches": []interface{}{"default"},
+					"uri":    "http://archive.ubuntu.com/ubuntu",
+				},
+			},
+		},
+		"ca-certs": map[interface{}]interface{}{
+			"remove-defaults": true,
+			"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
+		},
+	}, nil
+}
+
+var newFakeMachineInitReader = func(series string) (cloudconfig.InitReader, error) {
+	r, err := cloudconfig.NewMachineInitReader(series)
+	return &fakeMachineInitReader{r}, err
 }

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -6,6 +6,8 @@ package provisioner
 import (
 	"sort"
 
+	"github.com/juju/juju/cloudconfig"
+
 	"github.com/juju/version"
 
 	"github.com/juju/juju/api/common"
@@ -77,4 +79,14 @@ func ProcessProfileChanges(p ProvisionerTask, ids []string) error {
 
 func ProcessOneProfileChange(m apiprovisioner.MachineProvisioner, profileBroker environs.LXDProfiler, unitName string) (bool, error) {
 	return processOneProfileChange(m, profileBroker, unitName)
+}
+
+type patcher interface {
+	PatchValue(interface{}, interface{})
+}
+
+// PatchNewMachineInitReader replaces the local init reader factory method
+// with the supplied one.
+func PatchNewMachineInitReader(patcher patcher, factory func(string) (cloudconfig.InitReader, error)) {
+	patcher.PatchValue(&newMachineInitReader, factory)
 }

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -6,13 +6,12 @@ package provisioner
 import (
 	"sort"
 
-	"github.com/juju/juju/cloudconfig"
-
 	"github.com/juju/version"
 
 	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -9,8 +9,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/juju/juju/cloudconfig"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
@@ -21,6 +19,7 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm"

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -52,10 +52,7 @@ func (s *lxdBrokerSuite) SetUpTest(c *gc.C) {
 
 	// To isolate the tests from the host's architecture, we override it here.
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-
-	s.PatchValue(&provisioner.GetMachineCloudInitData, func(_ string) (map[string]interface{}, error) {
-		return nil, nil
-	})
+	provisioner.PatchNewMachineInitReader(s, newBlankMachineInitReader)
 
 	var err error
 	s.agentConfig, err = agent.NewAgentConfig(
@@ -182,30 +179,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithCloudInitUserData(c *gc.C) {
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceWithContainerInheritProperties(c *gc.C) {
-	s.PatchValue(&provisioner.GetMachineCloudInitData, func(_ string) (map[string]interface{}, error) {
-		return map[string]interface{}{
-			"packages":   []interface{}{"python-novaclient"},
-			"fake-entry": []interface{}{"testing-garbage"},
-			"apt": map[interface{}]interface{}{
-				"primary": []interface{}{
-					map[interface{}]interface{}{
-						"arches": []interface{}{"default"},
-						"uri":    "http://archive.ubuntu.com/ubuntu",
-					},
-				},
-				"security": []interface{}{
-					map[interface{}]interface{}{
-						"arches": []interface{}{"default"},
-						"uri":    "http://archive.ubuntu.com/ubuntu",
-					},
-				},
-			},
-			"ca-certs": map[interface{}]interface{}{
-				"remove-defaults": true,
-				"trusted":         []interface{}{"-----BEGIN CERTIFICATE-----\nYOUR-ORGS-TRUSTED-CA-CERT-HERE\n-----END CERTIFICATE-----\n"},
-			},
-		}, nil
-	})
+	provisioner.PatchNewMachineInitReader(s, newFakeMachineInitReader)
 	s.api.fakeContainerConfig.ContainerInheritProperties = "ca-certs,apt-security"
 
 	broker, brokerErr := s.newLXDBroker(c)


### PR DESCRIPTION
## Description of change

This patch accommodates behaviour changes in MAAS 2.5 that use Curtin to write apt settings instead of Cloud-Init. These changes affect the behaviour of model config for _container-inherit-properties_.

If "apt-sources" is specified as an inherited property, "sources_list" is added to the list of keys that will be extracted from the machine's initialisation config. If found, the key/value is passed to the container as Cloud-Init data, resulting in the contents of _/etc/apt/sources.list_ being exacly those of the config value.

The scope of the change excludes trusty host/container pairs. Some further discussion is required around the right way to handle that case.

Behaviour for MAAS versions <2.5 is preserved.

## QA steps

### MAAS 2.5
- Bootstrap to MAAS 2.5 (guimaas works)
- Ensure repository settings are not default (I changed the default to us.archive.ubuntu.com temporarily).
- `juju model-config container-inherit-properties=apt-sources`
- `juju add-machine`
- `juju add-machine 0:lxd`
- `juju ssh 0/lxd/0` and check that _/etc/apt/sources.list_ contains the US archive URLs.

### MAAS <2.5 (Regression)
- Bootstrap to MAAS <2.5 (finfolk is 2.3.2)
- Ensure repository settings are not default (I changed the default to us.archive.ubuntu.com temporarily).
- `juju model-config container-inherit-properties=apt-primary,apt-security`
- `juju add-machine`
- `juju add-machine 0:lxd`
- `juju ssh 0/lxd/0` and check that _/etc/apt/sources.list_ contains the US archive URLs.

## Documentation changes

Yes. It should be noted that for MAAS 2.5, the only relevant apt property for _container-inherit-properties_ is "apt-sources" and that it uses the host _/etc/apt/sources.list_ verbatim.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815636
