### PR TITLE
Reset machine modification status if unit causing error is removed

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -4,6 +4,8 @@
 package provisioner
 
 import (
+	"sync"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -62,6 +64,9 @@ type ProvisionerAPI struct {
 	getAuthFunc             common.GetAuthFunc
 	getCanModify            common.GetAuthFunc
 	providerCallContext     context.ProviderCallContext
+
+	// Used for MaybeWriteLXDProfile()
+	mu sync.Mutex
 }
 
 // NewProvisionerAPI creates a new server-side ProvisionerAPI facade.

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -338,9 +338,13 @@ func (p *ProvisionerAPI) machineLXDProfileNames(m *state.Machine, env environs.E
 			continue
 		}
 		pName := lxdprofile.Name(p.m.Name(), app.Name(), ch.Revision())
+		// Lock here, we get a new env for every call to ProvisioningInfo().
+		p.mu.Lock()
 		if err := profileEnv.MaybeWriteLXDProfile(pName, profile); err != nil {
+			p.mu.Unlock()
 			return nil, errors.Trace(err)
 		}
+		p.mu.Unlock()
 		names = append(names, pName)
 	}
 	return names, nil

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -43,6 +43,8 @@ type containerManager struct {
 	imageMetadataURL string
 	imageStream      string
 	imageMutex       sync.Mutex
+
+	profileMutex sync.Mutex
 }
 
 // containerManager implements container.Manager.
@@ -289,6 +291,8 @@ func (m *containerManager) networkDevicesFromConfig(netConfig *container.Network
 
 // MaybeWriteLXDProfile implements container.LXDProfileManager.
 func (m *containerManager) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+	m.profileMutex.Lock()
+	defer m.profileMutex.Unlock()
 	hasProfile, err := m.server.HasProfile(pName)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/unit.go
+++ b/state/unit.go
@@ -746,7 +746,7 @@ func (u *Unit) keepMachineRemoveProfileOps(m *Machine) ([]txn.Op, error) {
 	var ops []txn.Op
 	modStatus, err := m.ModificationStatus()
 	if err != nil {
-		return ops, err
+		return ops, errors.Trace(err)
 	}
 	if modStatus.Status == status.Idle {
 		// no profiles applied or attempts failed, return early
@@ -757,16 +757,16 @@ func (u *Unit) keepMachineRemoveProfileOps(m *Machine) ([]txn.Op, error) {
 	// applied to the machine for this unit?
 	machineProfiles, err := m.CharmProfiles()
 	if err != nil {
-		return ops, err
+		return ops, errors.Trace(err)
 	}
 	profileName, err := lxdprofile.MatchProfileNameByAppName(machineProfiles, u.ApplicationName())
 	if err != nil {
-		return ops, err
+		return ops, errors.Trace(err)
 	}
 
 	ch, err := u.charm()
 	if err != nil {
-		return ops, err
+		return ops, errors.Trace(err)
 	}
 
 	switch {
@@ -775,7 +775,7 @@ func (u *Unit) keepMachineRemoveProfileOps(m *Machine) ([]txn.Op, error) {
 		// machine modification status when the unit is removed.
 		since, err := u.st.ControllerTimestamp()
 		if err != nil {
-			return ops, err
+			return ops, errors.Trace(err)
 		}
 		// Assume no other profiles on machine, so set to Idle.
 		sDoc := statusDoc{

--- a/state/unit.go
+++ b/state/unit.go
@@ -713,20 +713,13 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 			{{"jobs", bson.D{{"$in", []MachineJob{JobManageModel}}}}},
 			{{"hasvote", true}},
 		}}}
-		// Remove any charm profile applied to the machine for this unit,
-		// if this is a unit removal from a machine which will not be
-		// destroyed.
-		machineProfiles, err := m.CharmProfiles()
+		// Remove any charm profile applied to the machine for this unit.
+		profileOps, err := u.keepMachineRemoveProfileOps(m)
 		if err != nil {
 			return nil, err
 		}
-		profile, err := lxdprofile.MatchProfileNameByAppName(machineProfiles, u.ApplicationName())
-		if err != nil {
-			return nil, err
-		}
-		if profile != "" {
-			logger.Tracef("Setup to remove charm profile %q, removing unit from machine %s", profile, m.Id())
-			ops = append(ops, m.SetUpgradeCharmProfileOp(u.Name(), "", lxdprofile.EmptyStatus))
+		if len(profileOps) > 0 {
+			ops = append(ops, profileOps...)
 		}
 	}
 
@@ -746,6 +739,64 @@ func (u *Unit) destroyHostOps(a *Application) (ops []txn.Op, err error) {
 	})
 	ops = append(ops, cleanupOps...)
 
+	return ops, nil
+}
+
+func (u *Unit) keepMachineRemoveProfileOps(m *Machine) ([]txn.Op, error) {
+	var ops []txn.Op
+	modStatus, err := m.ModificationStatus()
+	if err != nil {
+		return ops, err
+	}
+	if modStatus.Status == status.Idle {
+		// no profiles applied or attempts failed, return early
+		return ops, nil
+	}
+
+	// What's the name of the charm's LXD Profile which was
+	// applied to the machine for this unit?
+	machineProfiles, err := m.CharmProfiles()
+	if err != nil {
+		return ops, err
+	}
+	profileName, err := lxdprofile.MatchProfileNameByAppName(machineProfiles, u.ApplicationName())
+	if err != nil {
+		return ops, err
+	}
+
+	ch, err := u.charm()
+	if err != nil {
+		return ops, err
+	}
+
+	switch {
+	case lxdprofile.NotEmpty(ch) && profileName == "" && modStatus.Status == status.Error:
+		// There was an error applying the profile for this unit.  Reset the
+		// machine modification status when the unit is removed.
+		since, err := u.st.ControllerTimestamp()
+		if err != nil {
+			return ops, err
+		}
+		// Assume no other profiles on machine, so set to Idle.
+		sDoc := statusDoc{
+			Status:     status.Idle,
+			StatusInfo: "",
+			Updated:    timeOrNow(since, m.st.clock()).UnixNano(),
+		}
+		if len(machineProfiles) > 0 {
+			// Oops, there are other profiles, set Applied instead.
+			sDoc.Status = status.Applied
+		}
+		// By not calling setStatus(), a few checks are not made, related
+		// to leadership and updating a status that has not changed.  As
+		// the alternative is to call machine.SetModificationStatus(), we
+		// know there is no leadership question.  We also do not add the
+		// txn unless there is a change to be made.
+		return statusSetOps(m.st.db(), sDoc, m.globalModificationKey())
+	case profileName != "":
+		// remove the profile for this unit from the machine.
+		ops = append(ops, m.SetUpgradeCharmProfileOp(u.Name(), "", lxdprofile.EmptyStatus))
+	}
 	return ops, nil
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -632,16 +632,99 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 
 	// Set a profile name on the machine, destroyHostOps will only
 	// set up to remove a profile from the machine it if it exists.
-	profileName := lxdprofile.Name("default", target.Name(), charmWithProfile.Revision())
+	profileName := lxdprofile.Name("default", colocated.Name(), charmWithProfile.Revision())
 	host.SetCharmProfiles([]string{profileName})
 	c.Assert(colocated.Destroy(), gc.IsNil)
 	assertLife(c, host, state.Alive)
 
-	chCharmURL, err := host.UpgradeCharmProfileCharmURL(target.Name())
+	chCharmURL, err := host.UpgradeCharmProfileCharmURL(colocated.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(chCharmURL, gc.Equals, "")
 
 	c.Assert(host.Destroy(), gc.NotNil)
+}
+
+func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfileErrorToIdle(c *gc.C) {
+	charmWithProfile := s.AddTestingCharm(c, "lxd-profile")
+	applicationWithProfile := s.AddTestingApplication(c, "lxd-profile", charmWithProfile)
+
+	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	target, err := s.application.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(target.AssignToMachine(host), gc.IsNil)
+
+	colocated, err := applicationWithProfile.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(colocated.AssignToMachine(host), gc.IsNil)
+
+	// Set a machine modification status of failed so we can check that it's cleared
+	// when the unit is removed from the machine.
+	now := coretesting.ZeroTime()
+	sInfo := status.StatusInfo{
+		Status:  status.Error,
+		Message: "failme",
+		Since:   &now,
+	}
+	c.Assert(host.SetModificationStatus(sInfo), jc.ErrorIsNil)
+
+	c.Assert(colocated.Destroy(), gc.IsNil)
+	assertLife(c, host, state.Alive)
+
+	machineStatus, err := host.ModificationStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machineStatus.Status, gc.DeepEquals, status.Idle)
+	c.Assert(machineStatus.Message, gc.DeepEquals, "")
+}
+
+func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfileErrorToApplied(c *gc.C) {
+	charmWithProfile := s.AddTestingCharm(c, "lxd-profile")
+	applicationWithProfile := s.AddTestingApplication(c, "lxd-profile", charmWithProfile)
+	applicationWithProfile2 := s.AddTestingApplication(c, "lxd-profile-alt", charmWithProfile)
+
+	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	target, err := s.application.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(target.AssignToMachine(host), gc.IsNil)
+
+	colocated, err := applicationWithProfile.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(colocated.AssignToMachine(host), gc.IsNil)
+
+	colocated2, err := applicationWithProfile2.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(colocated2.AssignToMachine(host), gc.IsNil)
+
+	// Set a machine modification status of failed so we can check that it's cleared
+	// when the unit is removed from the machine.
+	now := coretesting.ZeroTime()
+	sInfo := status.StatusInfo{
+		Status:  status.Error,
+		Message: "failme",
+		Since:   &now,
+	}
+	c.Assert(host.SetModificationStatus(sInfo), jc.ErrorIsNil)
+
+	// Set a profile name on the machine, destroyHostOps will only
+	// set up to remove a profile from the machine it if it exists.
+	// And so the machine modification status is set to Applied.
+	profileName := lxdprofile.Name("default", colocated2.Name(), charmWithProfile.Revision())
+	host.SetCharmProfiles([]string{profileName})
+
+	c.Assert(colocated.Destroy(), gc.IsNil)
+	assertLife(c, host, state.Alive)
+
+	machineStatus, err := host.ModificationStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machineStatus.Status, gc.DeepEquals, status.Applied)
+	c.Assert(machineStatus.Message, gc.DeepEquals, "")
 }
 
 func (s *UnitSuite) TestRemoveUnitMachineNoDestroy(c *gc.C) {


### PR DESCRIPTION
## Description of change

Reset the machine modification based on remaining units if the unit which caused the error is removed.

## QA steps

* bootstrap lxd
* deploy bundle-no-sub.yaml from bug 1813044.
* juju remove-unit of a unit in error state due to profile failure, watch machine error cleared.


