### PR TITLE
Ignore storage failures when forcing machine removal.

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -292,7 +292,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 				if !force {
 					return fail(err)
 				}
-				logger.Warningf("error destroying machine %v but keep instance: %v", machineTag.Id(), err)
+				result.Error = common.ServerError(err)
 			}
 		}
 		var info params.DestroyMachineInfo

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -289,7 +289,10 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 		if keep {
 			logger.Infof("destroy machine %v but keep instance", machineTag.Id())
 			if err := machine.SetKeepInstance(keep); err != nil {
-				return fail(err)
+				if !force {
+					return fail(err)
+				}
+				logger.Warningf("error destroying machine %v but keep instance: %v", machineTag.Id(), err)
 			}
 		}
 		var info params.DestroyMachineInfo

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -271,26 +271,38 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 	if err := mm.check.RemoveAllowed(); err != nil {
 		return params.DestroyMachineResults{}, err
 	}
-	destroyMachine := func(entity params.Entity) (*params.DestroyMachineInfo, error) {
+	destroyMachine := func(entity params.Entity) params.DestroyMachineResult {
+		result := params.DestroyMachineResult{}
+		fail := func(e error) params.DestroyMachineResult {
+			result.Error = common.ServerError(e)
+			return result
+		}
+
 		machineTag, err := names.ParseMachineTag(entity.Tag)
 		if err != nil {
-			return nil, err
+			return fail(err)
 		}
 		machine, err := mm.st.Machine(machineTag.Id())
 		if err != nil {
-			return nil, err
+			return fail(err)
 		}
 		if keep {
 			logger.Infof("destroy machine %v but keep instance", machineTag.Id())
 			if err := machine.SetKeepInstance(keep); err != nil {
-				return nil, err
+				return fail(err)
 			}
 		}
 		var info params.DestroyMachineInfo
 		units, err := machine.Units()
 		if err != nil {
-			return nil, err
+			return fail(err)
 		}
+
+		var storageErrors []params.ErrorResult
+		storageError := func(e error) {
+			storageErrors = append(storageErrors, params.ErrorResult{common.ServerError(e)})
+		}
+
 		storageSeen := names.NewSet()
 		for _, unit := range units {
 			info.DestroyedUnits = append(
@@ -299,7 +311,8 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 			)
 			storage, err := storagecommon.UnitStorage(mm.storageAccess, unit.UnitTag())
 			if err != nil {
-				return nil, err
+				storageError(errors.Annotatef(err, "getting storage for unit %v", unit.UnitTag().Id()))
+				continue
 			}
 
 			// Filter out storage we've already seen. Shared
@@ -318,28 +331,34 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 			destroyed, detached, err := storagecommon.ClassifyDetachedStorage(
 				mm.storageAccess.VolumeAccess(), mm.storageAccess.FilesystemAccess(), storage)
 			if err != nil {
-				return nil, err
+				storageError(errors.Annotatef(err, "classifying storage for destruction for unit %v", unit.UnitTag().Id()))
+				continue
 			}
 			info.DestroyedStorage = append(info.DestroyedStorage, destroyed...)
 			info.DetachedStorage = append(info.DetachedStorage, detached...)
 		}
+
+		if len(storageErrors) != 0 {
+			all := params.ErrorResults{storageErrors}
+			if !force {
+				return fail(all.Combine())
+			}
+			result.Error = common.ServerError(all.Combine())
+		}
+
 		destroy := machine.Destroy
 		if force {
 			destroy = machine.ForceDestroy
 		}
 		if err := destroy(); err != nil {
-			return nil, err
+			return fail(err)
 		}
-		return &info, nil
+		result.Info = &info
+		return result
 	}
 	results := make([]params.DestroyMachineResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		info, err := destroyMachine(entity)
-		if err != nil {
-			results[i].Error = common.ServerError(err)
-			continue
-		}
-		results[i].Info = info
+		results[i] = destroyMachine(entity)
 	}
 	return params.DestroyMachineResults{results}, nil
 }

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -292,7 +292,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 				if !force {
 					return fail(err)
 				}
-				result.Error = common.ServerError(err)
+				logger.Warningf("could not keep instance for machine %v: %v", machineTag.Id(), err)
 			}
 		}
 		var info params.DestroyMachineInfo
@@ -346,7 +346,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 			if !force {
 				return fail(all.Combine())
 			}
-			result.Error = common.ServerError(all.Combine())
+			logger.Warningf("could not deal with units' storage on machine %v: %v", machineTag.Id(), all.Combine())
 		}
 
 		destroy := machine.Destroy


### PR DESCRIPTION
## Description of change

We have noticed that the users could not remove a machine, even with --force, when there were storage failures.

In fact, both storage failures and a failure to set the option to keep cloud instance were not compliant with Juju users --force expectation.

This PR ensures that when --force is desired, all errors are ignored. 

## Bug reference

There are some bugs related to this failure but the root cause pointing at the storage related failures have not been identified.
