### PR TITLE
When add-k8s is run, ensure default storage exists or is created

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	core "k8s.io/api/core/v1"
 
@@ -134,8 +133,8 @@ type Broker interface {
 	// Operator returns an Operator with current status and life details.
 	Operator(string) (*Operator, error)
 
-	// ListHostCloudRegions lists all the cloud regions that this cluster has worker nodes/instances running in.
-	ListHostCloudRegions() (set.Strings, error)
+	// ClusterMetadataChecker provides an API to query cluster metadata.
+	ClusterMetadataChecker
 
 	// NamespaceWatcher provides the API to watch caas namespace.
 	NamespaceWatcher
@@ -201,6 +200,19 @@ type NamespaceGetterSetter interface {
 
 	// GetCurrentNamespace returns current namespace name.
 	GetCurrentNamespace() string
+}
+
+// ClusterMetadataChecker provides an API to query cluster metadata.
+type ClusterMetadataChecker interface {
+	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
+	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
+
+	// CheckDefaultWorkloadStorage returns an error if the opinionated storage defined for
+	// the cluster does not match the specified storage.
+	CheckDefaultWorkloadStorage(cluster string, storageProvisioner *StorageProvisioner) error
+
+	// EnsureStorageProvisioner creates a storage provisioner with the specified config, or returns an existing one.
+	EnsureStorageProvisioner(cfg StorageProvisioner) (*StorageProvisioner, error)
 }
 
 // NamespaceWatcher provides the API to watch caas namespace.

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -15,6 +15,7 @@ const (
 )
 
 var k8sCloudCheckers map[string]k8slabels.Selector
+var clusterPreferredWorkloadStorage map[string]caas.PreferredStorage
 
 func init() {
 	caas.RegisterContainerProvider(providerType, providerInstance)
@@ -22,6 +23,27 @@ func init() {
 	// k8sCloudCheckers is a collection of k8s node selector requirement definitions
 	// used for detecting cloud provider from node labels.
 	k8sCloudCheckers = compileK8sCloudCheckers()
+
+	// clusterPreferredWorkloadStorage defines the opinionated storage
+	// that Juju requires to be available on supported clusters.
+	clusterPreferredWorkloadStorage = map[string]caas.PreferredStorage{
+		"microk8s": {
+			Name:        "hostpath",
+			Provisioner: "microk8s.io/hostpath",
+		},
+		"gce": {
+			Name:        "GCE Persistent Disk",
+			Provisioner: "kubernetes.io/gce-pd",
+		},
+		"azure": {
+			Name:        "Azure Disk",
+			Provisioner: "kubernetes.io/azure-disk",
+		},
+		"ec2": {
+			Name:        "EBS Volume",
+			Provisioner: "kubernetes.io/aws-ebs",
+		},
+	}
 }
 
 // compileK8sCloudCheckers compiles/validates the collection of

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1/workertest"
@@ -325,110 +324,6 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	bootstrapParams.BootstrapSeries = "bionic"
 	result, err = s.broker.Bootstrap(ctx, callCtx, bootstrapParams)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
-}
-
-type hostRegionTestcase struct {
-	expectedOut set.Strings
-	nodes       *core.NodeList
-}
-
-var hostRegionsTestCases = []hostRegionTestcase{
-	{
-		expectedOut: set.NewStrings(),
-		nodes:       newNodeList(map[string]string{}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"cloud.google.com/gke-nodepool": "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"cloud.google.com/gke-os-distribution": "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"cloud.google.com/gke-nodepool":        "",
-			"cloud.google.com/gke-os-distribution": "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"kubernetes.azure.com/cluster": "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"manufacturer": "amazon_ec2",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
-			"cloud.google.com/gke-nodepool":            "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
-			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
-			"cloud.google.com/gke-os-distribution":     "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings("gce/a-fancy-region"),
-		nodes: newNodeList(map[string]string{
-			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
-			"cloud.google.com/gke-nodepool":            "",
-			"cloud.google.com/gke-os-distribution":     "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings("azure/a-fancy-region"),
-		nodes: newNodeList(map[string]string{
-			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
-			"kubernetes.azure.com/cluster":             "",
-		}),
-	},
-	{
-		expectedOut: set.NewStrings("ec2/a-fancy-region"),
-		nodes: newNodeList(map[string]string{
-			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
-			"manufacturer": "amazon_ec2",
-		}),
-	},
-}
-
-func newNodeList(labels map[string]string) *core.NodeList {
-	return &core.NodeList{Items: []core.Node{newNode(labels)}}
-}
-
-func (s *K8sBrokerSuite) TestListHostCloudRegions(c *gc.C) {
-	ctrl := s.setupBroker(c)
-	defer ctrl.Finish()
-
-	for _, v := range hostRegionsTestCases {
-		gomock.InOrder(
-			s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
-				Return(v.nodes, nil),
-		)
-		regions, err := s.broker.ListHostCloudRegions()
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(regions, jc.DeepEquals, v.expectedOut)
-	}
 }
 
 func (s *K8sBrokerSuite) TestEnsureNamespace(c *gc.C) {

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -4,10 +4,17 @@
 package provider
 
 import (
+	"os"
+
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+
+	"github.com/juju/juju/caas"
 )
 
 // newLabelRequirements creates a list of k8s node label requirements.
@@ -39,5 +46,98 @@ func getCloudProviderFromNodeMeta(node core.Node) string {
 			return k
 		}
 	}
+	// TODO - add microk8s node label check when available
+	hostname, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	hostLabel, _ := node.Labels["kubernetes.io/hostname"]
+	if node.Name == hostname && hostLabel == hostname {
+		return "microk8s"
+	}
 	return ""
+}
+
+// GetClusterMetadata implements ClusterMetadataChecker.
+func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.ClusterMetadata, error) {
+	var result caas.ClusterMetadata
+	var err error
+	result.Regions, err = k.listHostCloudRegions()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot determine cluster region")
+	}
+
+	if storageClass != "" {
+		sc, err := k.StorageV1().StorageClasses().Get(storageClass, v1.GetOptions{IncludeUninitialized: true})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		if err == nil {
+			result.NominatedStorageClass = &caas.StorageProvisioner{
+				Provisioner: sc.Provisioner,
+				Parameters:  sc.Parameters,
+			}
+		}
+	} else {
+		storageClasses, err := k.StorageV1().StorageClasses().List(v1.ListOptions{})
+		if err != nil {
+			return nil, errors.Annotate(err, "listing storage classes")
+		}
+		for _, sc := range storageClasses.Items {
+			if v, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && v != "false" {
+				result.NominatedStorageClass = &caas.StorageProvisioner{
+					Provisioner: sc.Provisioner,
+					Parameters:  sc.Parameters,
+				}
+				break
+			}
+		}
+	}
+	return &result, nil
+}
+
+const regionLabelName = "failure-domain.beta.kubernetes.io/region"
+
+// listHostCloudRegions lists all the cloud regions that this cluster has worker nodes/instances running in.
+func (k *kubernetesClient) listHostCloudRegions() (set.Strings, error) {
+	// we only check 5 worker nodes as of now just run in the one region and
+	// we are just looking for a running worker to sniff its region.
+	nodes, err := k.CoreV1().Nodes().List(v1.ListOptions{Limit: 5})
+	if err != nil {
+		return nil, errors.Annotate(err, "listing nodes")
+	}
+	result := set.NewStrings()
+	for _, n := range nodes.Items {
+		var cloudRegion, v string
+		var ok bool
+		if v = getCloudProviderFromNodeMeta(n); v == "" {
+			continue
+		}
+		cloudRegion += v
+		if v, ok = n.Labels[regionLabelName]; ok && v != "" {
+			cloudRegion += "/" + v
+		}
+		result.Add(cloudRegion)
+	}
+	return result, nil
+}
+
+// CheckDefaultWorkloadStorage implements ClusterMetadataChecker.
+func (k *kubernetesClient) CheckDefaultWorkloadStorage(cluster string, storageProvisioner *caas.StorageProvisioner) error {
+	preferredStorage, ok := clusterPreferredWorkloadStorage[cluster]
+	if !ok {
+		return errors.NotFoundf("cluster %q", cluster)
+	}
+	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
+		return &caas.NonPreferredStorageError{PreferredStorage: preferredStorage}
+	}
+	for k, v := range preferredStorage.Parameters {
+		param, ok := storageProvisioner.Parameters[k]
+		if !ok || param != v {
+			return errors.Annotatef(
+				&caas.NonPreferredStorageError{PreferredStorage: preferredStorage},
+				"storage class %q requires parameter %s=%s", preferredStorage.Name, k, v)
+		}
+	}
+	return nil
 }

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -4,10 +4,26 @@
 package provider_test
 
 import (
-	"github.com/juju/juju/caas/kubernetes/provider"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 )
+
+type K8sMetadataSuite struct {
+	BaseSuite
+}
+
+var _ = gc.Suite(&K8sMetadataSuite{})
 
 func newNode(labels map[string]string) core.Node {
 	n := core.Node{}
@@ -56,14 +72,211 @@ var nodesTestCases = []struct {
 	},
 }
 
-func (s *K8sSuite) TestGetCloudProviderFromNodeMeta(c *gc.C) {
+func (s *K8sMetadataSuite) TestGetCloudProviderFromNodeMeta(c *gc.C) {
 	for _, v := range nodesTestCases {
 		c.Check(provider.GetCloudProviderFromNodeMeta(v.node), gc.Equals, v.expectedOut)
 	}
 }
 
-func (s *K8sSuite) TestK8sCloudCheckersValidationPass(c *gc.C) {
+func (s *K8sMetadataSuite) TestMicrok8sFromNodeMeta(c *gc.C) {
+	hostaname, err := os.Hostname()
+	c.Assert(err, jc.ErrorIsNil)
+	node := core.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   hostaname,
+			Labels: map[string]string{"kubernetes.io/hostname": hostaname},
+		},
+	}
+	c.Assert(provider.GetCloudProviderFromNodeMeta(node), gc.Equals, "microk8s")
+}
+
+func (s *K8sMetadataSuite) TestK8sCloudCheckersValidationPass(c *gc.C) {
 	// CompileK8sCloudCheckers will panic if there is invalid requirement definition so check it by calling it.
 	cloudCheckers := provider.CompileK8sCloudCheckers()
 	c.Assert(cloudCheckers, gc.NotNil)
+}
+
+type hostRegionTestcase struct {
+	expectedOut set.Strings
+	nodes       *core.NodeList
+}
+
+var hostRegionsTestCases = []hostRegionTestcase{
+	{
+		expectedOut: set.NewStrings(),
+		nodes:       newNodeList(map[string]string{}),
+	},
+	{
+		expectedOut: set.NewStrings(),
+		nodes: newNodeList(map[string]string{
+			"cloud.google.com/gke-nodepool": "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings(),
+		nodes: newNodeList(map[string]string{
+			"cloud.google.com/gke-os-distribution": "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings("gce"),
+		nodes: newNodeList(map[string]string{
+			"cloud.google.com/gke-nodepool":        "",
+			"cloud.google.com/gke-os-distribution": "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings("azure"),
+		nodes: newNodeList(map[string]string{
+			"kubernetes.azure.com/cluster": "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings("ec2"),
+		nodes: newNodeList(map[string]string{
+			"manufacturer": "amazon_ec2",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings(),
+		nodes: newNodeList(map[string]string{
+			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings(),
+		nodes: newNodeList(map[string]string{
+			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
+			"cloud.google.com/gke-nodepool":            "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings(),
+		nodes: newNodeList(map[string]string{
+			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
+			"cloud.google.com/gke-os-distribution":     "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings("gce/a-fancy-region"),
+		nodes: newNodeList(map[string]string{
+			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
+			"cloud.google.com/gke-nodepool":            "",
+			"cloud.google.com/gke-os-distribution":     "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings("azure/a-fancy-region"),
+		nodes: newNodeList(map[string]string{
+			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
+			"kubernetes.azure.com/cluster":             "",
+		}),
+	},
+	{
+		expectedOut: set.NewStrings("ec2/a-fancy-region"),
+		nodes: newNodeList(map[string]string{
+			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
+			"manufacturer": "amazon_ec2",
+		}),
+	},
+}
+
+func newNodeList(labels map[string]string) *core.NodeList {
+	return &core.NodeList{Items: []core.Node{newNode(labels)}}
+}
+
+func (s *K8sMetadataSuite) TestListHostCloudRegions(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	for i, v := range hostRegionsTestCases {
+		c.Logf("test %d", i)
+		gomock.InOrder(
+			s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+				Return(v.nodes, nil),
+			s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+				Return(&storagev1.StorageClassList{}, nil),
+		)
+		metadata, err := s.broker.GetClusterMetadata("")
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(metadata.Regions, jc.DeepEquals, v.expectedOut)
+	}
+}
+
+func (s *K8sMetadataSuite) TestNoDefaultStorageClasses(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{}, nil),
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{}}}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(metadata.NominatedStorageClass, gc.IsNil)
+}
+
+func (s *K8sMetadataSuite) TestDefaultStorageClasses(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{}, nil),
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
+				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
+				Provisioner: "a-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}}}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "a-provisioner",
+		Parameters:  map[string]string{"foo": "bar"},
+	})
+}
+
+func (s *K8sMetadataSuite) TestUserSpecifiedStorageClasses(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{}, nil),
+		s.mockStorageClass.EXPECT().Get("foo", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(&storagev1.StorageClass{
+				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
+				Provisioner: "a-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("foo")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "a-provisioner",
+		Parameters:  map[string]string{"foo": "bar"},
+	})
+}
+
+func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageUnknownCluster(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	err := s.broker.CheckDefaultWorkloadStorage("foo", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageNonpreferred(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	err := s.broker.CheckDefaultWorkloadStorage("microk8s", &caas.StorageProvisioner{Provisioner: "foo"})
+	c.Assert(err, jc.Satisfies, caas.IsNonPreferredStorageError)
+	npse, ok := errors.Cause(err).(*caas.NonPreferredStorageError)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(npse.Provisioner, gc.Equals, "microk8s.io/hostpath")
 }

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"fmt"
+
+	"github.com/juju/collections/set"
+)
+
+// PreferredStorage defines preferred storage
+// attributes on a given cluster.
+type PreferredStorage struct {
+	Name        string
+	Provisioner string
+	Parameters  map[string]string
+}
+
+// StorageProvisioner defines the a storage provisioner available on a cluster.
+type StorageProvisioner struct {
+	Name          string
+	Provisioner   string
+	Parameters    map[string]string
+	Namespace     string
+	ReclaimPolicy string
+}
+
+// ClusterMetadata defines metadata about a cluster.
+type ClusterMetadata struct {
+	NominatedStorageClass *StorageProvisioner
+	Regions               set.Strings
+}
+
+// NonPreferredStorageError is raised when a cluster does not have
+// the opinionated default storage Juju requires.
+type NonPreferredStorageError struct {
+	PreferredStorage
+}
+
+// Error implements error.
+func (e *NonPreferredStorageError) Error() string {
+	return fmt.Sprintf("preferred storage %q not available", e.Provisioner)
+}
+
+// IsNonPreferredStorageError returns true if err is a NonPreferredStorageError.
+func IsNonPreferredStorageError(err error) bool {
+	_, ok := err.(*NonPreferredStorageError)
+	return ok
+}

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -53,8 +53,6 @@ func NewRemoveCAASCommandForTest(
 	return modelcmd.WrapController(cmd)
 }
 
-type K8sBrokerRegionLister = k8sBrokerRegionLister
-
 type fakeCluster struct {
 	CommandRunner
 


### PR DESCRIPTION
## Description of change

When adding a k8s cluster, query the cluster to get metadata about the cloud/region and also any default storage class. We compare any default storage with what our opinionated defaults for the underlying substrate and if different, prompt the user to create a suitable storage class.

## QA steps

Run juju add-k8s on microk8s which does have a suitable storage class, as well as a CDK deployment on GCE, with and without a suitable storage class.

## Bug

https://bugs.launchpad.net/juju/+bug/1814678