### PR TITLE
Emit errors for invalid credential names

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -106,12 +106,16 @@ func InitializeState(
 	cloudCredentials := make(map[names.CloudCredentialTag]cloud.Credential)
 	var cloudCredentialTag names.CloudCredentialTag
 	if args.ControllerCloudCredential != nil && args.ControllerCloudCredentialName != "" {
-		cloudCredentialTag = names.NewCloudCredentialTag(fmt.Sprintf(
+		id := fmt.Sprintf(
 			"%s/%s/%s",
 			args.ControllerCloud.Name,
 			adminUser.Id(),
 			args.ControllerCloudCredentialName,
-		))
+		)
+		if !names.IsValidCloudCredential(id) {
+			return nil, nil, errors.NotValidf("cloud credential ID %q", id)
+		}
+		cloudCredentialTag = names.NewCloudCredentialTag(id)
 		cloudCredentials[cloudCredentialTag] = *args.ControllerCloudCredential
 	}
 

--- a/api/credentialvalidator/credentialvalidator.go
+++ b/api/credentialvalidator/credentialvalidator.go
@@ -59,6 +59,9 @@ func (c *Facade) ModelCredential() (base.StoredCredential, bool, error) {
 // WatchCredential provides a notify watcher that is responsive to changes
 // to a given cloud credential.
 func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, error) {
+	if !names.IsValidCloudCredential(credentialID) {
+		return nil, errors.NotValidf("cloud credential ID %q", credentialID)
+	}
 	in := names.NewCloudCredentialTag(credentialID).String()
 	var result params.NotifyWatchResult
 	err := c.facade.FacadeCall("WatchCredential", params.Entity{in}, &result)

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -427,6 +427,10 @@ func (api *CloudAPI) UserCredentials(args params.UserClouds) (params.StringsResu
 		}
 		out := make([]string, 0, len(cloudCredentials))
 		for tagId := range cloudCredentials {
+			if !names.IsValidCloudCredential(tagId) {
+				results.Results[i].Error = common.ServerError(errors.NotValidf("cloud credential ID %q", tagId))
+				continue
+			}
 			out = append(out, names.NewCloudCredentialTag(tagId).String())
 		}
 		results.Results[i].Result = out
@@ -1022,6 +1026,12 @@ func (api *CloudAPI) CredentialContents(args params.CloudCredentialArgs) (params
 		result = make([]params.CredentialContentResult, len(args.Credentials))
 		for i, given := range args.Credentials {
 			id := credId(given.CloudName, given.CredentialName)
+			if !names.IsValidCloudCredential(id) {
+				result[i] = params.CredentialContentResult{
+					Error: common.ServerError(errors.NotValidf("cloud credential ID %q", id)),
+				}
+				continue
+			}
 			tag := names.NewCloudCredentialTag(id)
 			credential, err := api.backend.CloudCredential(tag)
 			if err != nil {

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -297,8 +297,11 @@ func (c *AddCAASCommand) addCredentialToController(apiClient AddCloudAPI, newCre
 		return errors.Trace(err)
 	}
 
-	cloudCredTag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s",
-		c.caasName, currentAccountDetails.User, credentialName))
+	id := fmt.Sprintf("%s/%s/%s", c.caasName, currentAccountDetails.User, credentialName)
+	if !names.IsValidCloudCredential(id) {
+		return errors.NotValidf("cloud credential ID %q", id)
+	}
+	cloudCredTag := names.NewCloudCredentialTag(id)
 
 	if err := apiClient.AddCredential(cloudCredTag.String(), newCredential); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -249,8 +249,11 @@ func (c *AddCloudCommand) addCredentialToController(ctx *cmd.Context, cloud juju
 		return errors.Trace(err)
 	}
 
-	cloudCredTag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s",
-		c.Cloud, currentAccountDetails.User, credentialName))
+	id := fmt.Sprintf("%s/%s/%s", c.Cloud, currentAccountDetails.User, credentialName)
+	if !names.IsValidCloudCredential(id) {
+		return errors.NotValidf("cloud credential ID %q", id)
+	}
+	cloudCredTag := names.NewCloudCredentialTag(id)
 
 	if err := apiClient.AddCredential(cloudCredTag.String(), *cred); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/common/cloudcredential.go
+++ b/cmd/juju/common/cloudcredential.go
@@ -132,7 +132,7 @@ func ResolveCloudCredentialTag(user names.UserTag, cloud names.CloudTag, credent
 	}
 	s := fmt.Sprintf("%s/%s", cloud.Id(), credentialName)
 	if !names.IsValidCloudCredential(s) {
-		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential name %q", s)
+		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential ID %q", s)
 	}
 	return names.NewCloudCredentialTag(s), nil
 }

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -272,6 +272,9 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		messageArgs = append(messageArgs, cloudRegion)
 	}
 	if model.CloudCredential != "" {
+		if !names.IsValidCloudCredential(model.CloudCredential) {
+			return errors.NotValidf("cloud credential ID %q", model.CloudCredential)
+		}
 		tag := names.NewCloudCredentialTag(model.CloudCredential)
 		credentialName := tag.Name()
 		if tag.Owner().Id() != modelOwner {

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -287,6 +287,9 @@ func (c *modelsCommand) modelSummaryFromParams(apiSummary base.UserModelSummary,
 
 	}
 	if apiSummary.CloudCredential != "" {
+		if !names.IsValidCloudCredential(apiSummary.CloudCredential) {
+			return ModelSummary{}, errors.NotValidf("cloud credential ID %q", apiSummary.CloudCredential)
+		}
 		credTag := names.NewCloudCredentialTag(apiSummary.CloudCredential)
 		summary.CloudCredential = &common.ModelCredential{
 			Name:  credTag.Name(),

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -801,12 +801,16 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			adminUser := names.NewUserTag("admin@local")
 			var cloudCredentialTag names.CloudCredentialTag
 			if icfg.Bootstrap.ControllerCloudCredentialName != "" {
-				cloudCredentialTag = names.NewCloudCredentialTag(fmt.Sprintf(
+				id := fmt.Sprintf(
 					"%s/%s/%s",
 					icfg.Bootstrap.ControllerCloud.Name,
 					adminUser.Id(),
 					icfg.Bootstrap.ControllerCloudCredentialName,
-				))
+				)
+				if !names.IsValidCloudCredential(id) {
+					return errors.NotValidf("cloud credential ID %q", id)
+				}
+				cloudCredentialTag = names.NewCloudCredentialTag(id)
 			}
 
 			cloudCredentials := make(map[names.CloudCredentialTag]cloud.Credential)

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -244,7 +244,7 @@ func (c cloudCredentialDoc) cloudCredentialTag() (names.CloudCredentialTag, erro
 	ownerTag := names.NewUserTag(c.Owner)
 	id := fmt.Sprintf("%s/%s/%s", c.Cloud, ownerTag.Id(), c.Name)
 	if !names.IsValidCloudCredential(id) {
-		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential ID")
+		return names.CloudCredentialTag{}, errors.NotValidf("cloud credential ID %q", id)
 	}
 	return names.NewCloudCredentialTag(id), nil
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -88,7 +88,7 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 		// tag in the names package from the cloud, owner and name.
 		credID := fmt.Sprintf("%s/%s/%s", creds.Cloud(), creds.Owner(), creds.Name())
 		if !names.IsValidCloudCredential(credID) {
-			return nil, nil, errors.Errorf("model credentials id not valid: %q", credID)
+			return nil, nil, errors.NotValidf("cloud credential ID %q", credID)
 		}
 		credTag := names.NewCloudCredentialTag(credID)
 


### PR DESCRIPTION
## Description of change

Juju currently allows users to add credentials whose name contains spaces even though they are not valid according to the `juju/names.v2` package. This causes a `juju bootstrap` to panic when passing an invalid credential name.

This PR attempts to fix this issue by:
- ensuring that we always validate cloud credentials in all code paths that construct cloud credential tags (names.NewCloudCredentialTag expects a valid ID or it panics)
- preventing users from entering invalid cloud credential names (interactively or via file) when running `juju add-credential`.

NOTE: even if a user with an older juju version _did_ manage to create an invalid credential they could not bootstrap the controller anyway due to the panic. Consequently, these changes are mostly UX improvements and should not break anything for existing users.

## QA steps
```console
# NOTE: I have added a new (lxd) cloud for my tests; it seems like the changes block
# deploy bootstrap attempts on localhost with a "credential not found" message. YMMV
#
# Add a credential whose name contains spaces (e.g "with spaces") using 
# an OLDER juju version (or checkout 80fc578 from this branch)
$ juju add-credential lxd-with-cache
Enter credential name: with spaces

Auth Types
  certificate
  interactive

Select auth type [interactive]: interactive

Enter trust-password:

Loaded client cert/key from "/home/.../.local/share/juju/lxd"
Credential "with spaces" added locally for cloud "lxd-with-cache".

# Boostrap using the invalid credential; we should get an ERROR instead of a panic
$ juju bootstrap lxd-with-cache lxd-test --credential "cred with spaces"
...
ERROR cloud credential ID "lxd-with-cache/admin/cred with spaces" not valid
ERROR failed to bootstrap model: subprocess encountered error code 1

# Now switch to the HEAD of this branch and attempt to add a similar credential either via interactive mode or via a yaml file. You should get an error in both cases.
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1702538
https://bugs.launchpad.net/juju/+bug/1816826