### PR TITLE
Backport leader unit support for juju run

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1760,6 +1760,7 @@ func (s *withControllerSuite) TestCACert(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	s.PatchValue(&provisioner.ErrorRetryWaitDelay, 2*coretesting.ShortWait)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 


### PR DESCRIPTION
## Description of change

This PR backports <application>/leader support for `juju run` (see #9747)