### PR TITLE
Add upgrade lxd profile tests

### DIFF
--- a/acceptancetests/assess_deploy_lxd_profile_bundle.py
+++ b/acceptancetests/assess_deploy_lxd_profile_bundle.py
@@ -20,8 +20,8 @@ from utility import (
     configure_logging,
     JujuAssertionError,
     is_subordinate,
-    subordinate_machines,
-    application_machines,
+    subordinate_machines_from_app_info,
+    application_machines_from_app_info,
     align_machine_profiles,
 )
 from jujupy.wait_condition import (
@@ -65,9 +65,9 @@ def assess_profile_machines(client):
             charm_profile = info['charm-profile']
             if charm_profile:
                 if is_subordinate(info):
-                    machines = subordinate_machines(info, apps)
+                    machines = subordinate_machines_from_app_info(info, apps)
                 else:
-                    machines = application_machines(info)
+                    machines = application_machines_from_app_info(info)
                 machine_profiles.append((charm_profile, machines))
     if len(machine_profiles) > 0:
         aligned_machine_profiles = align_machine_profiles(machine_profiles)

--- a/acceptancetests/assess_upgrade_lxd_profile.py
+++ b/acceptancetests/assess_upgrade_lxd_profile.py
@@ -19,8 +19,8 @@ from utility import (
     configure_logging,
     JujuAssertionError,
     is_subordinate,
-    subordinate_machines,
-    application_machines,
+    subordinate_machines_from_app_info,
+    application_machines_from_app_info,
     align_machine_profiles,
 )
 from jujupy.wait_condition import (
@@ -63,9 +63,9 @@ def assess_profile_machines(client):
             charm_profile = info['charm-profile']
             if charm_profile:
                 if is_subordinate(info):
-                    machines = subordinate_machines(info, apps)
+                    machines = subordinate_machines_from_app_info(info, apps)
                 else:
-                    machines = application_machines(info)
+                    machines = application_machines_from_app_info(info)
                 machine_profiles.append((charm_profile, machines))
     if len(machine_profiles) > 0:
         aligned_machine_profiles = align_machine_profiles(machine_profiles)

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1270,10 +1270,12 @@ class ModelClient:
                     'ResourceId: {} Service or Unit: {} Timeout: {}'.format(
                         resource_id, service_or_unit, timeout))
 
-    def upgrade_charm(self, service, charm_path=None):
+    def upgrade_charm(self, service, charm_path=None, resvision=None):
         args = (service,)
         if charm_path is not None:
             args = args + ('--path', charm_path)
+        if resvision is not None:
+            args = args + ('--revision', resvision)
         self.juju('upgrade-charm', args)
 
     def remove_service(self, service):

--- a/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
@@ -2,21 +2,27 @@ series: bionic
 applications:
   lxd-profile:
     charm: cs:~juju-qa/bionic/lxd-profile-without-devices-0
-    num_units: 2
+    num_units: 4
     to:
       - "0"
       - "1"
+      - "2"
+      - "3"
   lxd-profile-subordinate:
     charm: cs:~juju-qa/bionic/lxd-profile-subordinate-1
   ubuntu:
     charm: cs:~jameinel/ubuntu-lite
-    num_units: 2
+    num_units: 4
     to:
     - "0"
     - "1"
+    - "2"
+    - "3"
 machines:
   "0": {}
   "1": {}
+  "2": {}
+  "3": {}
 relations:
 - - lxd-profile:juju-info
   - lxd-profile-subordinate:juju-info

--- a/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
@@ -1,0 +1,22 @@
+series: bionic
+applications:
+  lxd-profile:
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-0
+    num_units: 2
+    to:
+      - "0"
+      - "1"
+  lxd-profile-subordinate:
+    charm: cs:~juju-qa/bionic/lxd-profile-subordinate-1
+  ubuntu:
+    charm: cs:~jameinel/ubuntu-lite
+    num_units: 2
+    to:
+    - "0"
+    - "1"
+machines:
+  "0": {}
+  "1": {}
+relations:
+- - lxd-profile:juju-info
+  - lxd-profile-subordinate:juju-info

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -470,21 +470,35 @@ def list_models(client):
 def is_subordinate(app_data):
     return (not 'unit' in app_data) and ('subordinate-to' in app_data)
 
-def application_machines(app_data):
-    """Get all the machines used to host the given application."""
+def application_machines_from_app_info(app_data):
+    """Get all the machines used to host the given application from the
+       application info in status.
+
+    :param app_data: application info from status
+    """
     machines = [unit_data['machine'] for unit_data in
                 app_data['units'].values()]
     return machines
 
-def subordinate_machines(app_data, apps):
+def subordinate_machines_from_app_info(app_data, apps):
+    """Get the subordinate machines from a given application from the
+       application info in status.
+
+    :param app_data: application info from status
+    """
     machines = []
     for sub_name in app_data['subordinate-to']:
         for app_name, prim_app_data in apps.items():
             if sub_name == app_name:
-                machines.extend(application_machines(prim_app_data))
+                machines.extend(application_machines_from_app_info(prim_app_data))
     return machines
 
 def align_machine_profiles(machine_profiles):
+    """Align machine profiles will create a dict from a list of machine
+       ensuring that the machines are unique to each charm profile name.
+
+    :param machine_profiles: is a list of machine profiles tuple
+    """
     result = {}
     for items in machine_profiles:
         charm_profile = items[0]

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -466,3 +466,33 @@ def list_models(client):
         log.error('Failed to list current models due to error: {}'.format(e))
         raise e
     return json.loads(raw)
+
+def is_subordinate(app_data):
+    return (not 'unit' in app_data) and ('subordinate-to' in app_data)
+
+def application_machines(app_data):
+    """Get all the machines used to host the given application."""
+    machines = [unit_data['machine'] for unit_data in
+                app_data['units'].values()]
+    return machines
+
+def subordinate_machines(app_data, apps):
+    machines = []
+    for sub_name in app_data['subordinate-to']:
+        for app_name, prim_app_data in apps.items():
+            if sub_name == app_name:
+                machines.extend(application_machines(prim_app_data))
+    return machines
+
+def align_machine_profiles(machine_profiles):
+    result = {}
+    for items in machine_profiles:
+        charm_profile = items[0]
+        if charm_profile in result:
+            # drop duplicates using set difference
+            a = set(result[charm_profile])
+            b = set(items[1])
+            result[charm_profile].extend(b.difference(a))
+        else:
+            result[charm_profile] = list(items[1])
+    return result


### PR DESCRIPTION
## Description of change

The following upgrades a LXD charm from a bundle charm.
Also fixes some potential issues with subordinate units.

## QA steps

```
mkdir /tmp/test-run
mkdir /tmp/artifacts
export JUJU_HOME=/tmp/test-run
export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository
vim $JUJU_HOME/environments.yaml
```

Local LXD environments.yaml
```yaml
environments:
    lxd:
        type: lxd
        test-mode: true
        default-series: bionic
```

Run the following (substitute the right arg):
```
cd acceptancetests
./assess_upgrade_lxd_profile.py
```