### PR TITLE
Fixes critical lp#1786140: Current controller should be determined correctly.

### DIFF
--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -47,7 +47,7 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 
 	controllerName := "test-master"
 	s.store = jujuclient.NewMemStore()
-	s.store.Controllers["testing"] = jujuclient.ControllerDetails{
+	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{
 		ControllerUUID: controllerUUID,
 		CACert:         testing.CACert,
 		Cloud:          "mycloud",

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -102,7 +102,7 @@ type CredentialContentAPI interface {
 }
 
 func (c *showCredentialCommand) NewCredentialAPI() (CredentialContentAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := modelcmd.DetermineCurrentController(c.store)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.New("there is no active controller")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -459,7 +459,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	// Read existing current controller so we can clean up on error.
 	var oldCurrentController string
 	store := c.ClientStore()
-	oldCurrentController, err = store.CurrentController()
+	oldCurrentController, err = modelcmd.DetermineCurrentController(store)
 	if errors.IsNotFound(err) {
 		oldCurrentController = ""
 	} else if err != nil {

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -80,7 +80,7 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 
 	// Get the current name for logging the transition or printing
 	// the current controller/model.
-	currentControllerName, err := store.CurrentController()
+	currentControllerName, err := modelcmd.DetermineCurrentController(store)
 	if errors.IsNotFound(err) {
 		currentControllerName = ""
 	} else if err != nil {

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -101,6 +101,7 @@ func (s *SwitchSimpleSuite) TestSwitchWritesCurrentController(c *gc.C) {
 
 func (s *SwitchSimpleSuite) TestSwitchWithCurrentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
+	s.addController(c, "old")
 	s.addController(c, "new")
 	context, err := s.run(c, "new")
 	c.Assert(err, jc.ErrorIsNil)
@@ -109,6 +110,7 @@ func (s *SwitchSimpleSuite) TestSwitchWithCurrentController(c *gc.C) {
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrent(c *gc.C) {
 	s.store.CurrentControllerName = "old"
+	s.addController(c, "old")
 	s.addController(c, "new")
 	context, err := s.run(c, "new")
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,6 +119,7 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrent(c *gc.C) {
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrentExplicit(c *gc.C) {
 	s.store.CurrentControllerName = "old"
+	s.addController(c, "old")
 	s.addController(c, "new")
 	context, err := s.run(c, "new:")
 	c.Assert(err, jc.ErrorIsNil)
@@ -131,6 +134,7 @@ func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "same (controller) (no change)\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
+		{"ControllerByName", []interface{}{"same"}},
 		{"CurrentModel", []interface{}{"same"}},
 		{"ControllerByName", []interface{}{"same"}},
 	})
@@ -147,6 +151,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "ctrl (controller) -> ctrl:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
+		{"ControllerByName", []interface{}{"ctrl"}},
 		{"CurrentModel", []interface{}{"ctrl"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
 		{"AccountDetails", []interface{}{"ctrl"}},
@@ -157,6 +162,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
+	s.addController(c, "old")
 	s.addController(c, "new")
 	s.store.Models["new"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{"admin/mymodel": {}},
@@ -166,6 +172,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
+		{"ControllerByName", []interface{}{"old"}},
 		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
@@ -210,6 +217,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerSameNameAsModelExplicitModel(c *
 
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(c *gc.C) {
 	s.store.CurrentControllerName = "old"
+	s.addController(c, "old")
 	s.addController(c, "new")
 	s.store.Models["new"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{"admin/mymodel": {}},
@@ -219,6 +227,7 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
+		{"ControllerByName", []interface{}{"old"}},
 		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
@@ -231,6 +240,7 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(
 
 func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentModel(c *gc.C) {
 	s.store.CurrentControllerName = "old"
+	s.addController(c, "old")
 	s.addController(c, "new")
 	s.store.Models["new"] = &jujuclient.ControllerModels{
 		Models:       map[string]jujuclient.ModelDetails{"admin/mymodel": {}},
@@ -241,6 +251,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentMode
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new:admin/mymodel\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
+		{"ControllerByName", []interface{}{"old"}},
 		{"CurrentModel", []interface{}{"old"}},
 		{"ControllerByName", []interface{}{"new:mymodel"}},
 		{"ControllerByName", []interface{}{"new"}},
@@ -344,6 +355,7 @@ func (s *SwitchSimpleSuite) TestSwitchCurrentModelInStore(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "same:admin/mymodel (no change)\n")
 	s.stubStore.CheckCalls(c, []testing.StubCall{
 		{"CurrentController", nil},
+		{"ControllerByName", []interface{}{"same"}},
 		{"CurrentModel", []interface{}{"same"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
 		{"AccountDetails", []interface{}{"same"}},

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -45,6 +45,7 @@ func (s *syncToolsSuite) SetUpTest(c *gc.C) {
 	})
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "ctrl"
+	s.store.Controllers["ctrl"] = jujuclient.ControllerDetails{}
 	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{"admin/test-target": {ModelType: "iaas"}}}
 	s.store.Accounts["ctrl"] = jujuclient.AccountDetails{

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -115,7 +115,7 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 	if len(errs) > 0 {
 		fmt.Fprintln(ctx.Stderr, strings.Join(errs, "\n"))
 	}
-	currentController, err := c.store.CurrentController()
+	currentController, err := modelcmd.DetermineCurrentController(c.store)
 	if errors.IsNotFound(err) {
 		currentController = ""
 	} else if err != nil {

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -107,7 +107,7 @@ func (c *showControllerCommand) getAPI(controllerName string) (ControllerAccessA
 func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 	controllerNames := c.controllerNames
 	if len(controllerNames) == 0 {
-		currentController, err := c.store.CurrentController()
+		currentController, err := modelcmd.DetermineCurrentController(c.store)
 		if errors.IsNotFound(err) {
 			return errors.New("there is no active controller")
 		} else if err != nil {

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -149,7 +149,7 @@ func (c *loginCommand) run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 	switch {
 	case c.controllerName == "" && c.domain == "":
-		current, err := store.CurrentController()
+		current, err := modelcmd.DetermineCurrentController(store)
 		if err != nil && !errors.IsNotFound(err) {
 			return errors.Annotatef(err, "cannot get current controller")
 		}

--- a/cmd/juju/user/whoami.go
+++ b/cmd/juju/user/whoami.go
@@ -84,7 +84,7 @@ func formatWhoAmITabular(writer io.Writer, value interface{}) error {
 
 // Run implements Command.Run
 func (c *whoAmICommand) Run(ctx *cmd.Context) error {
-	controllerName, err := c.store.CurrentController()
+	controllerName, err := modelcmd.DetermineCurrentController(c.store)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -103,22 +103,44 @@ func (c *ControllerCommandBase) initController() error {
 	return c.initControllerError
 }
 
+// DetermineCurrentController returns current controller on this client.
+// The returned result corresponds to, in order of precedence:
+// 1. if JUJU_MODEL env variable exists and its value contains a controller prefix, that controller name;
+// 2. if JUJU_CONTROLLER env variable exists, its value;
+// 3. current controller specified in local controllers.yaml file.
+func DetermineCurrentController(store jujuclient.ClientStore) (string, error) {
+	controllerName, _ := SplitModelName(os.Getenv(osenv.JujuModelEnvKey))
+	if controllerName == "" {
+		controllerName = os.Getenv(osenv.JujuControllerEnvKey)
+	}
+	if controllerName == "" {
+		// 3. Current controller is specified in local controllers.yaml file.
+		var err error
+		controllerName, err = store.CurrentController()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+
+	if _, err := store.ControllerByName(controllerName); err != nil {
+		return "", errors.Trace(err)
+	}
+	return controllerName, nil
+}
+
 func (c *ControllerCommandBase) initController0() error {
 	if c._controllerName == "" && !c.allowDefaultController {
 		return errors.New("no controller specified")
 	}
 	if c._controllerName == "" {
-		c._controllerName = os.Getenv(osenv.JujuControllerEnvKey)
-	}
-	store := c.ClientStore()
-	if c._controllerName == "" {
-		currentController, err := store.CurrentController()
+		controllerName, err := DetermineCurrentController(c.store)
 		if err != nil {
-			return errors.Trace(translateControllerError(store, err))
+			return errors.Trace(translateControllerError(c.store, err))
 		}
-		c._controllerName = currentController
+		c._controllerName = controllerName
 	}
-	if _, err := store.ControllerByName(c._controllerName); err != nil {
+
+	if _, err := c.store.ControllerByName(c._controllerName); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -162,7 +162,7 @@ func (c *ModelCommandBase) initModel0() error {
 	}
 	controllerName, modelName := SplitModelName(c._modelName)
 	if controllerName == "" {
-		currentController, err := c.store.CurrentController()
+		currentController, err := DetermineCurrentController(c.store)
 		if err != nil {
 			return errors.Trace(translateControllerError(c.store, err))
 		}

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -88,9 +88,15 @@ var modelCommandModelTests = []struct {
 	expectController: "bar",
 	expectModel:      "adminbar/currentbar",
 }, {
-	about:            "explicit overrides env var",
-	modelEnvVar:      "bar:noncurrentbar",
+	about:            "explicit overrides model env var",
+	modelEnvVar:      "foo:noncurrentbar",
 	args:             []string{"-m", "noncurrentfoo"},
+	expectController: "foo",
+	expectModel:      "noncurrentfoo",
+}, {
+	about:            "explicit overrides controller & store env var",
+	modelEnvVar:      "bar:noncurrentbar",
+	args:             []string{"-m", "foo:noncurrentfoo"},
 	expectController: "foo",
 	expectModel:      "noncurrentfoo",
 }}


### PR DESCRIPTION
## Description of change

Previous behavior of environment variables had produces surprising for user results.

Juju used $JUJU_CONTROLLER environment variable for controller level commands and not take $JUJU_MODEL value into consideration, even if the controller was supplied there in the form of `<controller name>:<model name>`. 

At the same time, model level commands completely ignored $JUJU_CONTROLLER environment variable even if it was set.

This changes this behavior - current controller, whenever needed i.e. irrespective of the command level, is determined by looking at $JUJU_MODEL env var first, then $JUJU_CONTROLLER and lastly by the last outcome of running 'juju switch'.

The implicit fix here is also that if env var points to the controller that this client is not aware of (for example, 'juju controllers --refresh' needs to be run) Juju will now fail earlier.

In a follow-up PR, I'll be checking whether we always use $JUJU_MODEL correctly to determine current model. The logic will be similar.

## QA steps

1. bootstrap several controllers
2. run 'juju switch' to switch to one of them
3. set $JUJU_CONTROLLER to point to a different controller
4. all subesquent commands should be running against the controller set by env var

Repeat the same by specifying different controller in $JUJU_MODEL via <controller name>:<model name> format. All coomands should run against the controller specified in $JUJU_MODEL.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1786140
https://bugs.launchpad.net/juju/+bug/1813079
