### PR TITLE
Backport Dmitrii's fix to 2.5.

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -325,17 +325,17 @@ if [ ! -f /sbin/ifup ]; then
     echo "No /sbin/ifup, applying netplan configuration."
     netplan generate
     netplan apply
-    exit 0
-fi
-if [ -f /usr/bin/python ]; then
-    python %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
 else
-    python3 %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+  if [ -f /usr/bin/python ]; then
+      python %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+  else
+      python3 %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+  fi
+  ifdown -a
+  sleep 1.5
+  mv %[1]s.out %[1]s
+  ifup -a
 fi
-ifdown -a
-sleep 1.5
-mv %[1]s.out %[1]s
-ifup -a
 `
 	return fmt.Sprintf(s, networkFile)
 }

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -203,17 +203,17 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
       echo "No /sbin/ifup, applying netplan configuration."
       netplan generate
       netplan apply
-      exit 0
-  fi
-  if [ -f /usr/bin/python ]; then
-      python %[2]s --interfaces-file %[1]s --output-file %[1]s.out
   else
-      python3 %[2]s --interfaces-file %[1]s --output-file %[1]s.out
+    if [ -f /usr/bin/python ]; then
+        python %[2]s --interfaces-file %[1]s --output-file %[1]s.out
+    else
+        python3 %[2]s --interfaces-file %[1]s --output-file %[1]s.out
+    fi
+    ifdown -a
+    sleep 1.5
+    mv %[1]s.out %[1]s
+    ifup -a
   fi
-  ifdown -a
-  sleep 1.5
-  mv %[1]s.out %[1]s
-  ifup -a
 `[1:]
 	s.expectedFullNetplanYaml = `
 - install -D -m 644 /dev/null '%[1]s'


### PR DESCRIPTION
## Description of change

Fix the network initialization code so that on Bionic we don't exit 0
after running netplan apply during network setup. That way users that
add their own bootcmd properties still get run.

This is just a backport of https://github.com/juju/juju/pull/9751.

## QA steps

You should be able to supply your own post-bootcmd and have it run on Bionic, rather than bootcmd exiting early once networking is set up.


## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1807615