### PR TITLE
raft: turn off the go runtime stats from hashicorp/raft metrics

### DIFF
--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -22,7 +22,9 @@ func newMetricsCollector() (prometheus.Collector, error) {
 	// so subsequent calls don't fail because it's already registered
 	// there.
 	prometheus.DefaultRegisterer.Unregister(sink)
-	_, err = metrics.NewGlobal(metrics.DefaultConfig("juju"), sink)
+	config := metrics.DefaultConfig("juju")
+	config.EnableRuntimeMetrics = false
+	_, err = metrics.NewGlobal(config, sink)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

We're already gathering these at the top level.

## QA steps

* Bootstrap a controller (or upgrade an existing controller with this code).
* `juju run -m controller --machine 0 -- juju_metrics | grep juju_runtime` shows no metrics.

## Documentation changes

None

## Bug reference

None