### PR TITLE
Prevent influxdb from rejecting points

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -13,9 +13,7 @@ import argparse
 import logging
 import sys
 import os
-import subprocess
 import re
-import requests
 import functools
 import time
 
@@ -28,13 +26,11 @@ from utility import (
     add_basic_testing_arguments,
     configure_logging,
     JujuAssertionError,
-    get_current_model,
 )
 
 from jujucharm import (
     local_charm_path,
 )
-from jujupy.utility import until_timeout
 from reporting import (
     construct_metrics,
     get_reporting_client,
@@ -175,6 +171,11 @@ def parse_args(argv):
         help="Stack type to use when deploying <iaas|caas>",
         default="caas",
     )
+    parser.add_argument(
+        '--juju-version',
+        help="Help the reporting metrics by supplying a target juju version",
+        default="",
+    )
     add_basic_testing_arguments(parser, existing=False)
     # Override the default logging_config default value set by adding basic
     # testing arguments. This way we can have a default value for all tests,
@@ -218,6 +219,7 @@ def main(argv=None):
                 "charm-bundle": args.charm_bundle,
                 "charm-urls": charm_urls,
                 "mongo-version": mongo_version,
+                "juju-version": args.juju_version,
             })
         except:
             raise JujuAssertionError("Error reporting metrics")

--- a/acceptancetests/reporting.py
+++ b/acceptancetests/reporting.py
@@ -78,9 +78,11 @@ def get_reporting_client(uri):
         password=parsed_uri.password,
         database=DBNAME,
     )
-    try:
-        client.switch_database(DBNAME)
-    except InfluxDBClientError:
-        client.create_database(DBNAME)
-        client.create_retention_policy(POLICYNAME, 'INF', '1', DBNAME)
+
+    # Create DB/retention schema and switch to it. If the
+    # DB already exists then the following calls are no-ops.
+    client.create_database(DBNAME)
+    client.create_retention_policy(POLICYNAME, 'INF', '1', DBNAME)
+
+    client.switch_database(DBNAME)
     return InfluxClient(client)

--- a/acceptancetests/reporting.py
+++ b/acceptancetests/reporting.py
@@ -1,5 +1,4 @@
 """Reporting helper class for communicating with influx db."""
-import time
 import datetime
 try:
     import urlparse
@@ -7,24 +6,19 @@ except ImportError:
     import urllib.parse as urlparse
 
 from influxdb import InfluxDBClient
-from influxdb.client import InfluxDBClientError
 
 __metaclass__ = type
 
 DBNAME = 'txn_metrics'
 POLICYNAME = 'txn_metric'
 
+
 class _Reporting:
     """_Reporting represents a class to report metrics upon"""
 
     def __init__(self, client):
         self.client = client
-        self.labels = {
-            "total_time": "txn_metric.total_time",
-            "total_num_txns": "txn_metric.total_num_txns",
-            "max_time": "txn_metric.max_time",
-            "test_duration": "txn_metric.test_duration",
-        }
+
 
 class InfluxClient(_Reporting):
     """InfluxClient represents a influx db reporting client"""
@@ -36,20 +30,20 @@ class InfluxClient(_Reporting):
         """Report the metrics to the underlying reporting client
         """
 
-        now = datetime.datetime.today()
+        now = datetime.datetime.today().isoformat()
         series = []
-        for key, label in self.labels.items():
-            if key in metrics:
-                pointValue = {
-                    "measurement": label,
-                    "tags": tags,
-                    "time": int(now.strftime('%s')),
-                    "fields": {
-                        "value": metrics[key],
-                    },
-                }
-                series.append(pointValue)
+        for key, value in metrics.items():
+            series.append({
+                "measurement": key,
+                "tags": tags,
+                "time": now,
+                "fields": {
+                    "value": value,
+                },
+            })
+
         self.client.write_points(series, retention_policy=POLICYNAME, time_precision='s')
+
 
 def construct_metrics(total_time, total_num_txns, max_time, test_duration):
     """Make metrics creates a dictionary of items to pass to the
@@ -62,6 +56,7 @@ def construct_metrics(total_time, total_num_txns, max_time, test_duration):
         "max_time": max_time,
         "test_duration": test_duration,
     }
+
 
 def get_reporting_client(uri):
     """Reporting client returns a client for reporting metrics to.
@@ -82,7 +77,7 @@ def get_reporting_client(uri):
     # Create DB/retention schema and switch to it. If the
     # DB already exists then the following calls are no-ops.
     client.create_database(DBNAME)
-    client.create_retention_policy(POLICYNAME, 'INF', '1', DBNAME)
+    client.create_retention_policy(POLICYNAME, 'INF', '1', DBNAME, True)
 
     client.switch_database(DBNAME)
     return InfluxClient(client)

--- a/acceptancetests/reporting.py
+++ b/acceptancetests/reporting.py
@@ -49,10 +49,10 @@ class InfluxClient(_Reporting):
                     },
                 }
                 series.append(pointValue)
-        self.client.write_points(series, retention_policy=POLICYNAME)
+        self.client.write_points(series, retention_policy=POLICYNAME, time_precision='s')
 
 def construct_metrics(total_time, total_num_txns, max_time, test_duration):
-    """Make metrics creates a dictionary of items to pass to the 
+    """Make metrics creates a dictionary of items to pass to the
        reporting client.
     """
 
@@ -69,10 +69,10 @@ def get_reporting_client(uri):
 
     :param uri: URI to connect to the client.
     """
-    # Extract the uri 
+    # Extract the uri
     parsed_uri = urlparse.urlsplit(uri)
     client = InfluxDBClient(
-        host=parsed_uri.hostname, 
+        host=parsed_uri.hostname,
         port=parsed_uri.port,
         username=parsed_uri.username,
         password=parsed_uri.password,


### PR DESCRIPTION
## Description of change

The influxdb client is quite picky when it comes to metric submission; unless an explicit `time_precision`  is specified,  influxdb treats the points as outside the retention policy boundaries and drops them. 

Furthermore, the client does not raise an exception when attempting to connect to a non-existing DB so the reporting code has been tweaked to always create the DB/retention policy (if they already exists then the calls behave as no-ops).