### PR TITLE
Move the serving-info-setter manifold.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -35,6 +35,7 @@ import (
 	proxyconfig "github.com/juju/juju/utils/proxy"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/agentconfigupdater"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/apiconfigwatcher"
@@ -543,10 +544,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:     singular.NewWorker,
 		})),
 
-		// The serving-info-setter manifold sets grabs the state
-		// serving info from the API connection and writes it to the
-		// agent config.
-		servingInfoSetterName: ifNotMigrating(ServingInfoSetterManifold(ServingInfoSetterConfig{
+		// The agent-config-updater manifold sets the state serving info from
+		// the API connection and writes it to the agent config.
+		agentConfigUpdaterName: ifNotMigrating(agentconfigupdater.Manifold(agentconfigupdater.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		})),
@@ -966,6 +966,7 @@ var ifLegacyLeasesEnabled = engine.Housing{
 
 const (
 	agentName              = "agent"
+	agentConfigUpdaterName = "agent-config-updater"
 	terminationName        = "termination-signal-handler"
 	stateConfigWatcherName = "state-config-watcher"
 	controllerName         = "controller"
@@ -989,7 +990,6 @@ const (
 	migrationInactiveFlagName = "migration-inactive-flag"
 	migrationMinionName       = "migration-minion"
 
-	servingInfoSetterName         = "serving-info-setter"
 	apiWorkersName                = "unconverted-api-workers"
 	rebootName                    = "reboot-executor"
 	loggingConfigUpdaterName      = "logging-config-updater"

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package machine
+package agentconfigupdater
 
 import (
 	"github.com/juju/errors"
@@ -14,18 +14,18 @@ import (
 	"github.com/juju/juju/api/base"
 )
 
-// ServingInfoSetterConfig provides the dependencies for the
-// servingInfoSetter manifold.
-type ServingInfoSetterConfig struct {
+// ManifoldConfig provides the dependencies for the
+// agent config updater manifold.
+type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 }
 
-// ServingInfoSetterManifold defines a simple start function which
+// Manifold defines a simple start function which
 // runs after the API connection has come up. If the machine agent is
 // a controller, it grabs the state serving info over the API and
 // records it to agent configuration, and then stops.
-func ServingInfoSetterManifold(config ServingInfoSetterConfig) dependency.Manifold {
+func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
 			config.AgentName,

--- a/worker/agentconfigupdater/package_test.go
+++ b/worker/agentconfigupdater/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agentconfigupdater_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Moves the serving info setter manifold into the worker directory.

The rationale for this is to be able to soon add a real worker as well that is responsible for updating agent config with the intent that we have one worker that updates the agent.conf information.

## QA steps

* bootstrapping a controller
* enable ha

