### PR TITLE
Add instance display name to juju show-status

### DIFF
--- a/acceptancetests/assess_juju_output.py
+++ b/acceptancetests/assess_juju_output.py
@@ -34,6 +34,17 @@ __metaclass__ = type
 
 log = logging.getLogger("assess_juju_output")
 
+def verify_juju_status_contains_display_name(client_status):
+    fields_to_test = [
+        "instance-id",
+        "display-name",
+    ]
+    for field in fields_to_test:
+        try:
+            client_status[field]
+        except KeyError:
+            err = "juju status excludes {}".format(field)
+            raise JujuAssertionError(err)
 
 def verify_juju_status_attribute_of_charm(charm_details):
     """Verify the juju-status of the deployed charm
@@ -94,7 +105,9 @@ def assess_juju_status(client, series):
     :param series: String representing charm series
     """
     deploy_charm_with_subordinate_charm(client, series)
-    charm_details = client.get_status().get_applications()['dummy-sink']
+    status = client.get_status()
+    verify_juju_status_fields(status)
+    charm_details = status.get_applications()['dummy-sink']
     verify_juju_status_attribute_of_charm(charm_details)
     verify_juju_status_attribute_of_subordinate_charm(charm_details)
     log.warning("assess juju-status attribute done successfully")

--- a/api/base/types.go
+++ b/api/base/types.go
@@ -41,13 +41,14 @@ type ModelStatus struct {
 
 // Machine holds information about a machine in a juju model.
 type Machine struct {
-	Id         string
-	InstanceId string
-	HasVote    bool
-	WantsVote  bool
-	Status     string
-	Message    string
-	Hardware   *instance.HardwareCharacteristics
+	Id          string
+	InstanceId  string
+	DisplayName string
+	HasVote     bool
+	WantsVote   bool
+	Status      string
+	Message     string
+	Hardware    *instance.HardwareCharacteristics
 }
 
 // ModelInfo holds information about a model.

--- a/api/charmrevisionupdater/updater_test.go
+++ b/api/charmrevisionupdater/updater_test.go
@@ -44,7 +44,7 @@ func (s *versionUpdaterSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("i-manager", "fake_nonce", nil)
+	err = machine.SetProvisioned("i-manager", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAsMachine(c, machine.Tag(), password, "fake_nonce")
 	c.Assert(st, gc.NotNil)

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -102,12 +102,13 @@ func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.Mo
 			result.CoreCount += int(*mm.Hardware.Cores)
 		}
 		result.Machines[j] = base.Machine{
-			Id:         mm.Id,
-			InstanceId: mm.InstanceId,
-			HasVote:    mm.HasVote,
-			WantsVote:  mm.WantsVote,
-			Status:     mm.Status,
-			Message:    mm.Message,
+			Id:          mm.Id,
+			InstanceId:  mm.InstanceId,
+			DisplayName: mm.DisplayName,
+			HasVote:     mm.HasVote,
+			WantsVote:   mm.WantsVote,
+			Status:      mm.Status,
+			Message:     mm.Message,
 		}
 	}
 	return result

--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -52,7 +52,7 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machines[0].SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[0].SetProvisioned("i-manager", "fake_nonce", nil)
+	err = s.machines[0].SetProvisioned("i-manager", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.machines[0].Tag(), password, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -134,11 +134,12 @@ func convertParamsModelInfo(modelInfo params.ModelInfo) (base.ModelInfo, error) 
 	result.Machines = make([]base.Machine, len(modelInfo.Machines))
 	for i, m := range modelInfo.Machines {
 		machine := base.Machine{
-			Id:         m.Id,
-			InstanceId: m.InstanceId,
-			HasVote:    m.HasVote,
-			WantsVote:  m.WantsVote,
-			Status:     m.Status,
+			Id:          m.Id,
+			InstanceId:  m.InstanceId,
+			DisplayName: m.DisplayName,
+			HasVote:     m.HasVote,
+			WantsVote:   m.WantsVote,
+			Status:      m.Status,
 		}
 		if m.Hardware != nil {
 			machine.Hardware = &instance.HardwareCharacteristics{

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -91,7 +91,7 @@ type MachineProvisioner interface {
 	// SetInstanceInfo sets the provider specific instance id, nonce, metadata,
 	// network config for this machine. Once set, the instance id cannot be changed.
 	SetInstanceInfo(
-		id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
+		id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
 		networkConfig []params.NetworkConfig, volumes []params.Volume,
 		volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
 	) error
@@ -403,7 +403,7 @@ func (m *Machine) DistributionGroup() ([]instance.Id, error) {
 
 // SetInstanceInfo implements MachineProvisioner.SetInstanceInfo.
 func (m *Machine) SetInstanceInfo(
-	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
+	id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
 	networkConfig []params.NetworkConfig, volumes []params.Volume,
 	volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
 ) error {
@@ -412,6 +412,7 @@ func (m *Machine) SetInstanceInfo(
 		Machines: []params.InstanceInfo{{
 			Tag:               m.tag.String(),
 			InstanceId:        id,
+			DisplayName:       displayName,
 			Nonce:             nonce,
 			Characteristics:   characteristics,
 			Volumes:           volumes,

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -267,15 +267,15 @@ func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 interface{})
 }
 
 // SetInstanceInfo mocks base method
-func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1 string, arg2 *instance.HardwareCharacteristics, arg3 []params.NetworkConfig, arg4 []params.Volume, arg5 map[string]params.VolumeAttachmentInfo, arg6 []string) error {
-	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
+	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo
-func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SetInstanceStatus mocks base method

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -64,7 +64,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetInstanceInfo("i-manager", "fake_nonce", nil, nil, nil, nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-manager", "", "fake_nonce", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.machine.Tag(), password, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)
@@ -314,7 +314,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	}
 
 	err = apiMachine.SetInstanceInfo(
-		"i-will", "fake_nonce", &hwChars, nil, volumes, volumeAttachments, nil,
+		"i-will", "", "fake_nonce", &hwChars, nil, volumes, volumeAttachments, nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -323,7 +323,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(instanceId, gc.Equals, instance.Id("i-will"))
 
 	// Try it again - should fail.
-	err = apiMachine.SetInstanceInfo("i-wont", "fake", nil, nil, nil, nil, nil)
+	err = apiMachine.SetInstanceInfo("i-wont", "", "fake", nil, nil, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot record provisioning info for "i-wont": cannot set instance data for machine "1": already set`)
 
 	// Now try to get machine 0's instance id.
@@ -374,7 +374,7 @@ func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 	hwChars := instance.MustParseHardware(fmt.Sprintf("availability-zone=%s", availabilityZone))
 
 	err = apiMachine.SetInstanceInfo(
-		"azinst", "nonce", &hwChars, nil, nil, nil, nil,
+		"azinst", "", "nonce", &hwChars, nil, nil, nil, nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -403,7 +403,7 @@ func (s *provisionerSuite) TestSetInstanceInfoProfiles(c *gc.C) {
 
 	profiles := []string{"juju-default-profile-0", "juju-default-lxd-2"}
 	err = apiMachine.SetInstanceInfo(
-		"profileinst", "nonce", &hwChars, nil, nil, nil, profiles,
+		"profileinst", "", "nonce", &hwChars, nil, nil, nil, profiles,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -561,7 +561,7 @@ func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 	apiMachine = s.assertGetOneMachine(c, machine1.MachineTag())
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	err = apiMachine.SetInstanceInfo("i-d", "fake", nil, nil, nil, nil, nil)
+	err = apiMachine.SetInstanceInfo("i-d", "", "fake", nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	instances, err = apiMachine.DistributionGroup()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -92,7 +92,7 @@ func (s *baseLoginSuite) addMachine(c *gc.C, job state.MachineJob) (*state.Machi
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine, password
 }

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -228,7 +228,7 @@ func (s *apiserverBaseSuite) OpenAPIAsNewMachine(c *gc.C, srv *apiserver.Server,
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return s.openAPIAs(c, srv, machine.Tag(), password, "fake_nonce", false), machine
 }

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -42,7 +42,7 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	nonce, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", nonce, nil)
+	err = machine.SetProvisioned("foo", "", nonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -51,7 +51,7 @@ func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	nonce, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", nonce, nil)
+	err = machine.SetProvisioned("foo", "", nonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -93,7 +93,7 @@ func (s *backupsSuite) TestAuthRequiresClientNotMachine(c *gc.C) {
 	// Add a machine and try to login.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -470,6 +470,11 @@ func (m *mockMachine) InstanceId() (instance.Id, error) {
 	return m.instanceIdFunc()
 }
 
+func (m *mockMachine) InstanceNames() (instance.Id, string, error) {
+	instId, err := m.instanceIdFunc()
+	return instId, "", err
+}
+
 func (m *mockMachine) Id() string {
 	return m.id
 }

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -57,6 +57,7 @@ func (st *stateShim) Machine(id string) (Machine, error) {
 type Machine interface {
 	Id() string
 	InstanceId() (instance.Id, error)
+	InstanceNames() (instance.Id, string, error)
 	WantsVote() bool
 	HasVote() bool
 	Status() (status.StatusInfo, error)
@@ -122,10 +123,11 @@ func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachine
 			Status:    status,
 			Message:   statusInfo.Message,
 		}
-		instId, err := m.InstanceId()
+		instId, displayName, err := m.InstanceNames()
 		switch {
 		case err == nil:
 			mInfo.InstanceId = string(instId)
+			mInfo.DisplayName = displayName
 		case errors.IsNotProvisioned(err):
 			// ok, but no instance ID to get.
 		default:

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -134,6 +134,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 		Jobs:            []state.MachineJob{state.JobManageModel},
 		Characteristics: &instance.HardwareCharacteristics{CpuCores: &eight},
 		InstanceId:      "id-4",
+		DisplayName:     "snowflake",
 		Volumes: []state.HostVolumeParams{{
 			Volume: state.VolumeParams{
 				Pool: "modelscoped",
@@ -193,7 +194,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			OwnerTag:           s.Owner.String(),
 			Life:               params.Alive,
 			Machines: []params.ModelMachineInfo{
-				{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", Status: "pending", WantsVote: true},
+				{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", DisplayName: "snowflake", Status: "pending", WantsVote: true},
 				{Id: "1", Hardware: stdHw, InstanceId: "id-5", Status: "pending"},
 			},
 			Volumes: []params.ModelVolumeInfo{{

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -46,7 +46,7 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
 
-	err = s.machine.SetInstanceInfo("i-foo", "FAKE_NONCE", nil, nil, nil, nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-foo", "", "FAKE_NONCE", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	observedConfig := []params.NetworkConfig{{
@@ -101,7 +101,7 @@ func (s *networkConfigSuite) TestSetProviderNetworkConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
 
-	err = s.machine.SetInstanceInfo("i-foo", "FAKE_NONCE", nil, nil, nil, nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-foo", "", "FAKE_NONCE", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -832,7 +832,7 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 		devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(arg.NetworkConfig)
 
 		err = machine.SetInstanceInfo(
-			arg.InstanceId, arg.Nonce, arg.Characteristics,
+			arg.InstanceId, arg.DisplayName, arg.Nonce, arg.Characteristics,
 			devicesArgs, devicesAddrs,
 			volumes, volumeAttachments, arg.CharmProfiles,
 		)

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -532,7 +532,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	err = s.machines[4].SetInstanceStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err = s.machines[4].SetProvisioned("i-am", "fake_nonce", &hwChars)
+	err = s.machines[4].SetProvisioned("i-am", "", "fake_nonce", &hwChars)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.provisioner.MachinesWithTransientErrors()
@@ -1038,7 +1038,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 	setProvisioned := func(id string) {
 		m, err := s.State.Machine(id)
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetProvisioned(instance.Id("machine-"+id+"-inst"), "nonce", nil)
+		err = m.SetProvisioned(instance.Id("machine-"+id+"-inst"), "", "nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -1164,7 +1164,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 	setProvisioned := func(id string) {
 		m, err := s.State.Machine(id)
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetProvisioned(instance.Id("machine-"+id+"-inst"), "nonce", nil)
+		err = m.SetProvisioned(instance.Id("machine-"+id+"-inst"), "", "nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -1311,7 +1311,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 
 	// Provision machine 0 first.
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err = s.machines[0].SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, nil, nil, nil)
+	err = s.machines[0].SetInstanceInfo("i-am", "", "fake_nonce", &hwChars, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	volumesMachine, err := s.State.AddOneMachine(state.MachineTemplate{
@@ -1415,10 +1415,10 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 
 func (s *withoutControllerSuite) TestInstanceId(c *gc.C) {
 	// Provision 2 machines first.
-	err := s.machines[0].SetProvisioned("i-am", "fake_nonce", nil)
+	err := s.machines[0].SetProvisioned("i-am", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err = s.machines[1].SetProvisioned("i-am-not", "fake_nonce", &hwChars)
+	err = s.machines[1].SetProvisioned("i-am-not", "", "fake_nonce", &hwChars)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2712,7 +2712,7 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sb, err := state.NewStorageBackend(s.State)
@@ -3411,7 +3411,7 @@ func (s *uniterNetworkConfigSuite) addProvisionedMachineWithDevicesAndAddresses(
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	devicesArgs, devicesAddrs := s.makeMachineDevicesAndAddressesArgs(addrSuffix)
-	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil, nil)
+	err = machine.SetInstanceInfo("i-am", "", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineAddrs, err := machine.AllAddresses()
@@ -3667,7 +3667,7 @@ func (s *uniterNetworkInfoSuite) addProvisionedMachineWithDevicesAndAddresses(c 
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	devicesArgs, devicesAddrs := s.makeMachineDevicesAndAddressesArgs(addrSuffix)
-	err = machine.SetInstanceInfo("i-am", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil, nil)
+	err = machine.SetInstanceInfo("i-am", "", "fake_nonce", nil, devicesArgs, devicesAddrs, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineAddrs, err := machine.AllAddresses()

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -416,7 +416,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	m, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, names.NewMachineTag("0"))
-	err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
+	err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	setDefaultPassword(c, m)
 	setDefaultStatus(c, m)
@@ -493,7 +493,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 			err = m.SetConstraints(constraints.MustParse("mem=1G"))
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
+		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		setDefaultPassword(c, m)
 		setDefaultStatus(c, m)

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -407,7 +407,7 @@ func (s *serverSuite) TestAbortCurrentUpgrade(c *gc.C) {
 	// Create a provisioned controller.
 	machine, err := s.State.AddMachine("series", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = machine.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start an upgrade.
@@ -447,7 +447,7 @@ func (s *serverSuite) setupAbortCurrentUpgradeBlocked(c *gc.C) {
 	// Create a provisioned controller.
 	machine, err := s.State.AddMachine("series", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = machine.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start an upgrade.
@@ -709,7 +709,7 @@ func (s *clientSuite) TestClientWatchAllReadPermission(c *gc.C) {
 	// all the logic is tested elsewhere.
 	m, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetProvisioned("i-0", agent.BootstrapNonce, nil)
+	err = m.SetProvisioned("i-0", "", agent.BootstrapNonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{
@@ -765,7 +765,7 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 	// all the logic is tested elsewhere.
 	m, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetProvisioned("i-0", agent.BootstrapNonce, nil)
+	err = m.SetProvisioned("i-0", "", agent.BootstrapNonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Include a remote app that needs admin access to see.
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -815,9 +815,10 @@ func (c *statusContext) makeMachineStatus(machine *state.Machine, appStatusInfo 
 	populateStatusFromStatusInfoAndErr(&status.ModificationStatus, sModInfo, err)
 
 	// TODO: fetch all instance data for machines in one go.
-	instid, err := machine.InstanceId()
+	instid, displayName, err := machine.InstanceNames()
 	if err == nil {
 		status.InstanceId = instid
+		status.DisplayName = displayName
 		addr, err := machine.PublicAddress()
 		if err != nil {
 			// Usually this indicates that no addresses have been set on the

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -567,6 +567,31 @@ func (s *statusUnitTestSuite) TestFilterOutRelationsForRelatedApplicationsThatDo
 	c.Assert(status.Relations, gc.HasLen, 0)
 }
 
+func (s *statusUnitTestSuite) TestMachineWithNoDisplayNameHasItsEmptyDisplayNameSent(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		InstanceId: instance.Id("i-123"),
+	})
+
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Machines, gc.HasLen, 1)
+	c.Assert(status.Machines[machine.Id()].DisplayName, gc.Equals, "")
+}
+
+func (s *statusUnitTestSuite) TestMachineWithDisplayNameHasItsDisplayNameSent(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		InstanceId:  instance.Id("i-123"),
+		DisplayName: "snowflake",
+	})
+
+	client := s.APIState.Client()
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Machines, gc.HasLen, 1)
+	c.Assert(status.Machines[machine.Id()].DisplayName, gc.Equals, "snowflake")
+}
+
 func assertApplicationRelations(c *gc.C, appName string, expectedNumber int, relations []params.RelationStatus) {
 	c.Assert(relations, gc.HasLen, expectedNumber)
 	for _, relation := range relations {

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -934,6 +934,10 @@ func (m *mockMachine) InstanceId() (instance.Id, error) {
 	return "", nil
 }
 
+func (m *mockMachine) InstanceNames() (instance.Id, string, error) {
+	return "", "", nil
+}
+
 func (m *mockMachine) WantsVote() bool {
 	return false
 }

--- a/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
+++ b/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
@@ -91,7 +91,7 @@ func (s *CharmSuite) AddMachine(c *gc.C, machineId string, job state.MachineJob)
 	controllerCfg, err := s.jcSuite.State.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	inst, hc := jujutesting.AssertStartInstanceWithConstraints(c, s.jcSuite.Environ, s.jcSuite.ProviderCallContext, controllerCfg.ControllerUUID(), m.Id(), cons)
-	err = m.SetProvisioned(inst.Id(), "fake_nonce", hc)
+	err = m.SetProvisioned(inst.Id(), "", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -157,10 +157,10 @@ func (s *firewallerBaseSuite) testInstanceId(
 	},
 ) {
 	// Provision 2 machines first.
-	err := s.machines[0].SetProvisioned("i-am", "fake_nonce", nil)
+	err := s.machines[0].SetProvisioned("i-am", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err = s.machines[1].SetProvisioned("i-am-not", "fake_nonce", &hwChars)
+	err = s.machines[1].SetProvisioned("i-am-not", "", "fake_nonce", &hwChars)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := addFakeEntities(params.Entities{Entities: []params.Entity{

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -384,11 +384,21 @@ type LifeResults struct {
 	Results []LifeResult `json:"results"`
 }
 
-// InstanceInfo holds a machine tag, provider-specific instance id, a nonce, and
-// network config.
+// InstanceInfo holds information about an instance. Instances are
+// typically virtual machines hosted by a cloud provider but may also
+// be a container.
+//
+// The InstanceInfo struct contains three categories of information:
+//  - interal data, as the machine's tag and the tags of any attached
+//    storage volumes
+//  - naming and other provider-specific information, including the
+//    instance id and display name
+//  - configuration information, including its attached storage volumes,
+//    charm profiles and networking
 type InstanceInfo struct {
 	Tag             string                            `json:"tag"`
 	InstanceId      instance.Id                       `json:"instance-id"`
+	DisplayName     string                            `json:"display-name"`
 	Nonce           string                            `json:"nonce"`
 	Characteristics *instance.HardwareCharacteristics `json:"characteristics"`
 	Volumes         []Volume                          `json:"volumes"`

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -283,13 +283,14 @@ type ModelInfoListResults struct {
 
 // ModelMachineInfo holds information about a machine in a model.
 type ModelMachineInfo struct {
-	Id         string           `json:"id"`
-	Hardware   *MachineHardware `json:"hardware,omitempty"`
-	InstanceId string           `json:"instance-id,omitempty"`
-	Status     string           `json:"status,omitempty"`
-	Message    string           `json:"message,omitempty"`
-	HasVote    bool             `json:"has-vote,omitempty"`
-	WantsVote  bool             `json:"wants-vote,omitempty"`
+	Id          string           `json:"id"`
+	Hardware    *MachineHardware `json:"hardware,omitempty"`
+	InstanceId  string           `json:"instance-id,omitempty"`
+	DisplayName string           `json:"display-name,omitempty"`
+	Status      string           `json:"status,omitempty"`
+	Message     string           `json:"message,omitempty"`
+	HasVote     bool             `json:"has-vote,omitempty"`
+	WantsVote   bool             `json:"wants-vote,omitempty"`
 }
 
 // MachineHardware holds information about a machine's hardware characteristics.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -90,6 +90,9 @@ type MachineStatus struct {
 	// what is supplied by the provider.
 	InstanceId instance.Id `json:"instance-id"`
 
+	// DisplayName is a human-readable name for this machine.
+	DisplayName string `json:"display-name"`
+
 	// Series holds the name of the operating system release installed on
 	// this machine.
 	Series string `json:"series"`

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -126,7 +126,7 @@ func (s *toolsSuite) TestAuthRequiresUser(c *gc.C) {
 	// Add a machine and try to login.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -66,6 +66,7 @@ type machineStatus struct {
 	DNSName            string                        `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
 	IPAddresses        []string                      `json:"ip-addresses,omitempty" yaml:"ip-addresses,omitempty"`
 	InstanceId         instance.Id                   `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`
+	DisplayName        string                        `json:"display-name,omitempty" yaml:"display-name,omitempty"`
 	MachineStatus      statusInfoContents            `json:"machine-status,omitempty" yaml:"machine-status,omitempty"`
 	ModificationStatus statusInfoContents            `json:"modification-status,omitempty" yaml:"modification-status,omitempty"`
 	Series             string                        `json:"series,omitempty" yaml:"series,omitempty"`
@@ -94,6 +95,14 @@ func (s machineStatus) MarshalYAML() (interface{}, error) {
 		return errorStatus{s.Err.Error()}, nil
 	}
 	return machineStatusNoMarshal(s), nil
+}
+
+// machineName returns the InstanceId, unless DisplayName is set.
+func (s machineStatus) machineName() string {
+	if s.DisplayName == "" {
+		return string(s.InstanceId)
+	}
+	return s.DisplayName
 }
 
 // LXDProfile holds status info about a LXDProfile

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -153,6 +153,7 @@ func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineSt
 		DNSName:            machine.DNSName,
 		IPAddresses:        machine.IPAddresses,
 		InstanceId:         machine.InstanceId,
+		DisplayName:        machine.DisplayName,
 		MachineStatus:      sf.getStatusInfoContents(machine.InstanceStatus),
 		ModificationStatus: sf.getStatusInfoContents(machine.ModificationStatus),
 		Series:             machine.Series,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -390,12 +390,13 @@ func printMachine(w output.Wrapper, m machineStatus) {
 	if hw.AvailabilityZone != nil {
 		az = *hw.AvailabilityZone
 	}
-	w.Print(m.Id)
 
 	status, message := getStatusAndMessageFromMachineStatus(m)
 
+	w.Print(m.Id)
 	w.PrintStatus(status)
-	w.Println(m.DNSName, m.InstanceId, m.Series, az, message)
+	w.Println(m.DNSName, m.machineName(), m.Series, az, message)
+
 	for _, name := range naturalsort.Sort(stringKeysFromMap(m.Containers)) {
 		printMachine(w, m.Containers[name])
 	}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -570,7 +570,7 @@ var statusTests = []testCase{
 			},
 		},
 
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setAddresses{"0", []network.Address{
 			network.NewScopedAddress("10.0.0.1", network.ScopePublic),
 			network.NewAddress("10.0.0.2"),
@@ -723,7 +723,7 @@ var statusTests = []testCase{
 			network.NewScopedAddress("10.0.0.1", network.ScopePublic),
 			network.NewAddress("10.0.0.2"),
 		}},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
 			what: "machine 0 has specific hardware characteristics",
@@ -775,7 +775,7 @@ var statusTests = []testCase{
 	test( // 2
 		"instance without addresses",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
 			what: "machine 0 has no dns-name",
@@ -882,7 +882,7 @@ var statusTests = []testCase{
 		// step 0
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"dummy"},
 		addApplication{name: "dummy-application", charm: "dummy"},
@@ -928,11 +928,11 @@ var statusTests = []testCase{
 		// step 10
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		expect{
 			what: "two more machines added",
@@ -1042,7 +1042,7 @@ var statusTests = []testCase{
 		setMachineStatus{"3", status.Stopped, "Really?"},
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("10.0.4.1")},
-		startAliveMachine{"4"},
+		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Error, "Beware the red toys"},
 		ensureDyingUnit{"dummy-application/0"},
 		addMachine{machineId: "5", job: state.JobHostUnits},
@@ -1407,12 +1407,12 @@ var statusTests = []testCase{
 		"a unit with a hook relation error",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
@@ -1515,12 +1515,12 @@ var statusTests = []testCase{
 		"a unit with a hook relation error when the agent is down",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
@@ -1684,7 +1684,7 @@ var statusTests = []testCase{
 		addCharm{"dummy"},
 		addApplication{name: "dummy-application", charm: "dummy"},
 		addMachine{machineId: "0", job: state.JobHostUnits},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addUnit{"dummy-application", "0"},
 		setAgentStatus{"dummy-application/0", status.Idle, "", nil},
@@ -1747,7 +1747,7 @@ var statusTests = []testCase{
 		"complex scenario with multiple related applications",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
@@ -1757,7 +1757,7 @@ var statusTests = []testCase{
 		setApplicationExposed{"project", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"project", "1"},
 		setAgentStatus{"project/0", status.Idle, "", nil},
@@ -1767,7 +1767,7 @@ var statusTests = []testCase{
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
@@ -1777,7 +1777,7 @@ var statusTests = []testCase{
 		setApplicationExposed{"varnish", true},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("10.0.3.1")},
-		startAliveMachine{"3"},
+		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
 		setMachineInstanceStatus{"3", status.Started, "I am number three"},
 		addAliveUnit{"varnish", "3"},
@@ -1786,7 +1786,7 @@ var statusTests = []testCase{
 		setApplicationExposed{"private", true},
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("10.0.4.1")},
-		startAliveMachine{"4"},
+		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Started, ""},
 		addAliveUnit{"private", "4"},
 
@@ -1953,7 +1953,7 @@ var statusTests = []testCase{
 		"simple peer scenario with leader",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"riak"},
 		addCharm{"wordpress"},
@@ -1962,21 +1962,21 @@ var statusTests = []testCase{
 		setApplicationExposed{"riak", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"riak", "1"},
 		setAgentStatus{"riak/0", status.Idle, "", nil},
 		setUnitStatus{"riak/0", status.Active, "", nil},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"riak", "2"},
 		setAgentStatus{"riak/1", status.Idle, "", nil},
 		setUnitStatus{"riak/1", status.Active, "", nil},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("10.0.3.1")},
-		startAliveMachine{"3"},
+		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
 		setMachineInstanceStatus{"3", status.Started, "I am number three"},
 		addAliveUnit{"riak", "3"},
@@ -2068,7 +2068,7 @@ var statusTests = []testCase{
 		"one application with one subordinate application and leader",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
@@ -2078,7 +2078,7 @@ var statusTests = []testCase{
 		setApplicationExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
@@ -2088,7 +2088,7 @@ var statusTests = []testCase{
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
@@ -2415,7 +2415,7 @@ var statusTests = []testCase{
 		// step 0
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"mysql"},
 		addApplication{name: "mysql", charm: "mysql"},
@@ -2424,7 +2424,7 @@ var statusTests = []testCase{
 		// step 7
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"mysql", "1"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
@@ -2433,7 +2433,7 @@ var statusTests = []testCase{
 		// step 14: A container on machine 1.
 		addContainer{"1", "1/lxd/0", state.JobHostUnits},
 		setAddresses{"1/lxd/0", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"1/lxd/0"},
+		startAliveMachine{"1/lxd/0", ""},
 		setMachineStatus{"1/lxd/0", status.Started, ""},
 		addAliveUnit{"mysql", "1/lxd/0"},
 		setAgentStatus{"mysql/1", status.Idle, "", nil},
@@ -2443,7 +2443,7 @@ var statusTests = []testCase{
 		// step 22: A nested container.
 		addContainer{"1/lxd/0", "1/lxd/0/lxd/0", state.JobHostUnits},
 		setAddresses{"1/lxd/0/lxd/0", network.NewAddresses("10.0.3.1")},
-		startAliveMachine{"1/lxd/0/lxd/0"},
+		startAliveMachine{"1/lxd/0/lxd/0", ""},
 		setMachineStatus{"1/lxd/0/lxd/0", status.Started, ""},
 
 		expect{
@@ -2601,11 +2601,11 @@ var statusTests = []testCase{
 		"application with out of date charm",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addApplication{name: "mysql", charm: "mysql"},
@@ -2663,11 +2663,11 @@ var statusTests = []testCase{
 		"unit with out of date charm",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addApplication{name: "mysql", charm: "mysql"},
@@ -2727,11 +2727,11 @@ var statusTests = []testCase{
 		"application and unit with out of date charms",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addApplication{name: "mysql", charm: "mysql"},
@@ -2793,11 +2793,11 @@ var statusTests = []testCase{
 		"application with local charm not shown as out of date",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addCharm{"mysql"},
 		addApplication{name: "mysql", charm: "mysql"},
@@ -2858,28 +2858,28 @@ var statusTests = []testCase{
 		"deploy two applications; set meter statuses on one",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("10.0.3.1")},
-		startAliveMachine{"3"},
+		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
 		setMachineInstanceStatus{"3", status.Started, "I am number three"},
 
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("10.0.4.1")},
-		startAliveMachine{"4"},
+		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Started, ""},
 
 		addCharm{"mysql"},
@@ -3041,7 +3041,7 @@ var statusTests = []testCase{
 		"consistent workload version",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 
 		addCharm{"mysql"},
@@ -3049,7 +3049,7 @@ var statusTests = []testCase{
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"mysql", "1"},
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
@@ -3103,7 +3103,7 @@ var statusTests = []testCase{
 		"mixed workload version",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 
 		addCharm{"mysql"},
@@ -3111,14 +3111,14 @@ var statusTests = []testCase{
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"mysql", "1"},
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setUnitWorkloadVersion{"mysql/1", "not as good"},
@@ -3193,7 +3193,7 @@ var statusTests = []testCase{
 			// loopback.
 			// network.NewScopedAddress("::1", network.ScopeMachineLocal),
 		}},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
 			what: "machine 0 has localhost addresses that should not display",
@@ -3220,7 +3220,7 @@ var statusTests = []testCase{
 			// loopback.
 			// network.NewScopedAddress("::1", network.ScopeMachineLocal),
 		}},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		expect{
 			what: "machine 0 has an IPv6 address",
@@ -3268,11 +3268,11 @@ var statusTests = []testCase{
 		"a remote application",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 
 		addCharm{"wordpress"},
@@ -3420,11 +3420,11 @@ var statusTests = []testCase{
 		"deploy application with endpoint bound to space",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 
 		addSpace{"myspace1"},
@@ -3555,11 +3555,11 @@ var statusTests = []testCase{
 		"application with lxd profiles",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		setCharmProfiles{"1", []string{"juju-controller-lxd-profile-1"}},
 		addCharm{"lxd-profile"},
@@ -3758,7 +3758,7 @@ func (sm startMachine) step(c *gc.C, ctx *context) {
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
-	err = m.SetProvisioned(inst.Id(), "fake_nonce", hc)
+	err = m.SetProvisioned(inst.Id(), "", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -3774,7 +3774,7 @@ func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
-	err = m.SetProvisioned("i-missing", "fake_nonce", hc)
+	err = m.SetProvisioned("i-missing", "", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 	// lp:1558657
 	now := time.Now()
@@ -3788,7 +3788,8 @@ func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 }
 
 type startAliveMachine struct {
-	machineId string
+	machineId   string
+	displayName string
 }
 
 func (sam startAliveMachine) step(c *gc.C, ctx *context) {
@@ -3800,7 +3801,7 @@ func (sam startAliveMachine) step(c *gc.C, ctx *context) {
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
-	err = m.SetProvisioned(inst.Id(), "fake_nonce", hc)
+	err = m.SetProvisioned(inst.Id(), sam.displayName, "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.pingers[m.Id()] = pinger
 }
@@ -3819,9 +3820,31 @@ func (sm startMachineWithHardware) step(c *gc.C, ctx *context) {
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
-	err = m.SetProvisioned(inst.Id(), "fake_nonce", &sm.hc)
+	err = m.SetProvisioned(inst.Id(), "", "fake_nonce", &sm.hc)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.pingers[m.Id()] = pinger
+}
+
+type startAliveMachineWithDisplayName struct {
+	machineId   string
+	displayName string
+}
+
+func (sm startAliveMachineWithDisplayName) step(c *gc.C, ctx *context) {
+	m, err := ctx.st.Machine(sm.machineId)
+	c.Assert(err, jc.ErrorIsNil)
+	pinger := ctx.setAgentPresence(c, m)
+	cons, err := m.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := ctx.st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
+	err = m.SetProvisioned(inst.Id(), sm.displayName, "fake_nonce", hc)
+	c.Assert(err, jc.ErrorIsNil)
+	ctx.pingers[m.Id()] = pinger
+	_, displayName, err := m.InstanceNames()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(displayName, gc.Equals, sm.displayName)
 }
 
 type setMachineInstanceStatus struct {
@@ -4697,7 +4720,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("localhost")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", "snowflake"},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
@@ -4708,7 +4731,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		setApplicationExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("localhost")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
@@ -4717,7 +4740,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
@@ -4766,7 +4789,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", "snowflake"},
 		setMachineStatus{"0", status.Started, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
@@ -4776,7 +4799,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		setApplicationExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
@@ -4786,7 +4809,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
@@ -4855,7 +4878,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		setApplicationExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", "snowflake"},
 		setMachineStatus{"1", status.Started, ""},
 		addAliveUnit{"wordpress", "1"},
 		setAgentStatus{"wordpress/0", status.Idle, "", nil},
@@ -4865,7 +4888,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		addAliveUnit{"mysql", "2"},
 		setAgentStatus{"mysql/0", status.Idle, "", nil},
@@ -4899,7 +4922,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		setUnitAsLeader{"wordpress/0"},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("10.0.3.1")},
-		startAliveMachine{"3"},
+		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
 		setMachineInstanceStatus{"3", status.Started, "I am number three"},
 
@@ -4911,7 +4934,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		// test modification status
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("10.0.3.1")},
-		startAliveMachine{"4"},
+		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Started, ""},
 		setMachineInstanceStatus{"4", status.Started, "I am number four"},
 		setMachineModificationStatus{"4", status.Error, "I am an error"},
@@ -4949,7 +4972,7 @@ wordpress/0*  active       idle   1        10.0.1.1
 
 Machine  State    DNS       Inst id       Series   AZ          Message
 0        started  10.0.0.1  controller-0  quantal  us-east-1a  
-1        started  10.0.1.1  controller-1  quantal              
+1        started  10.0.1.1  snowflake     quantal              
 2        started  10.0.2.1  controller-2  quantal              
 3        started  10.0.3.1  controller-3  quantal              I am number three
 4        error    10.0.3.1  controller-4  quantal              I am an error
@@ -4967,6 +4990,24 @@ wordpress:logging-dir  logging:logging-directory  logging    subordinate
 	output := substituteFakeTimestamp(c, stdout, false)
 	output = substituteSpacingBetweenTimestampAndNotes(c, output)
 	c.Assert(string(output), gc.Equals, expected)
+}
+
+func (s *StatusSuite) TestStatusWithFormatYaml(c *gc.C) {
+	ctx := s.prepareTabularData(c)
+	defer s.resetContext(c, ctx)
+	code, stdout, stderr := runStatus(c, "--format", "yaml")
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "")
+	c.Assert(string(stdout), jc.Contains, "display-name: snowflake")
+}
+
+func (s *StatusSuite) TestStatusWithFormatJson(c *gc.C) {
+	ctx := s.prepareTabularData(c)
+	defer s.resetContext(c, ctx)
+	code, stdout, stderr := runStatus(c, "--format", "json")
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "")
+	c.Assert(string(stdout), jc.Contains, `"display-name":"snowflake"`)
 }
 
 func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
@@ -5148,7 +5189,7 @@ func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 	}
 
@@ -5223,7 +5264,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's ID is "0"
 		// And the machine's job is to manage the environment
 		addMachine{machineId: "0", job: state.JobManageModel},
-		startAliveMachine{"0"},
+		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		// And the machine's address is "10.0.0.1"
 		setAddresses{"0", network.NewAddresses("10.0.0.1")},
@@ -5244,7 +5285,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's ID is "1"
 		// And the machine's job is to host units
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		startAliveMachine{"1"},
+		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		// And the machine's address is "10.0.1.1"
 		setAddresses{"1", network.NewAddresses("10.0.1.1")},
@@ -5258,7 +5299,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's ID is "2"
 		// And the machine's job is to host units
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		startAliveMachine{"2"},
+		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 		// And the machine's address is "10.0.2.1"
 		setAddresses{"2", network.NewAddresses("10.0.2.1")},
@@ -5656,13 +5697,13 @@ var statusTimeTest = test(
 	"status generates timestamps as UTC in ISO format",
 	addMachine{machineId: "0", job: state.JobManageModel},
 	setAddresses{"0", network.NewAddresses("10.0.0.1")},
-	startAliveMachine{"0"},
+	startAliveMachine{"0", ""},
 	setMachineStatus{"0", status.Started, ""},
 	addCharm{"dummy"},
 	addApplication{name: "dummy-application", charm: "dummy"},
 
 	addMachine{machineId: "1", job: state.JobHostUnits},
-	startAliveMachine{"1"},
+	startAliveMachine{"1", ""},
 	setAddresses{"1", network.NewAddresses("10.0.1.1")},
 	setMachineStatus{"1", status.Started, ""},
 

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -151,7 +151,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 
 	// Add a machine and ensure it is provisioned.
 	inst, md := jujutesting.AssertStartInstance(c, s.Environ, context.NewCloudCallContext(), s.ControllerConfig.ControllerUUID(), machineId)
-	c.Assert(m.SetProvisioned(inst.Id(), agent.BootstrapNonce, md), jc.ErrorIsNil)
+	c.Assert(m.SetProvisioned(inst.Id(), "", agent.BootstrapNonce, md), jc.ErrorIsNil)
 
 	// Add an address for the tests in case the initiateMongoServer
 	// codepath is exercised.

--- a/core/instance/instance.go
+++ b/core/instance/instance.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instance
+
+import (
+	"github.com/juju/juju/core/status"
+)
+
+// Id is a provider-specific identifier associated with an
+// instance (physical or virtual machine allocated in the provider).
+type Id string
+
+// Status represents the status for a provider instance.
+type Status struct {
+	Status  status.Status
+	Message string
+}
+
+// UnknownId can be used to explicitly specify the instance Id when it does not matter.
+const UnknownId Id = ""

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -104,6 +104,10 @@ type StartInstanceParams struct {
 // StartInstanceResult holds the result of an
 // InstanceBroker.StartInstance method call.
 type StartInstanceResult struct {
+	// DisplayName is an optional human-readable string that's used
+	// for display purposes only.
+	DisplayName string
+
 	// Instance is an interface representing a cloud instance.
 	Instance instance.Instance
 

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -101,6 +101,19 @@ wordpress:logging-dir  logging:logging-directory  logging    subordinate  joinin
 `[1:])
 }
 
+func (s *StatusSuite) TestMachineDisplayNameIsDisplayed(c *gc.C) {
+	s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs:        []state.MachineJob{state.JobHostUnits},
+		InstanceId:  instance.Id("id1"),
+		DisplayName: "eye-dee-one",
+	})
+	context := s.run(c, "status")
+	c.Assert(cmdtesting.Stdout(context), jc.Contains, "eye-dee-one")
+
+	context2 := s.run(c, "status", "--format=yaml")
+	c.Assert(cmdtesting.Stdout(context2), jc.Contains, "eye-dee-one")
+}
+
 func (s *StatusSuite) setupSeveralUnitsOnAMachine(c *gc.C) {
 	applicationA := s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -275,7 +275,7 @@ func (s *upgradeSuite) configureMachine(c *gc.C, machineId string, vers version.
 	// Provision the machine if it isn't already
 	if _, err := m.InstanceId(); err != nil {
 		inst, md := jujutesting.AssertStartInstance(c, s.Environ, context.NewCloudCallContext(), s.ControllerConfig.ControllerUUID(), machineId)
-		c.Assert(m.SetProvisioned(inst.Id(), agent.BootstrapNonce, md), jc.ErrorIsNil)
+		c.Assert(m.SetProvisioned(inst.Id(), "", agent.BootstrapNonce, md), jc.ErrorIsNil)
 	}
 
 	// Make the machine live

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -317,13 +317,14 @@ func (s *JujuConnSuite) OpenAPIAsNewMachine(c *gc.C, jobs ...state.MachineJob) (
 	if len(jobs) == 0 {
 		jobs = []state.MachineJob{state.JobHostUnits}
 	}
+
 	machine, err := s.State.AddMachine("quantal", jobs...)
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return s.openAPIAs(c, machine.Tag(), password, "fake_nonce", false), machine
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1094,6 +1094,7 @@ func (env *maasEnviron) StartInstance(
 	}
 
 	return &environs.StartInstanceResult{
+		DisplayName:       hostname,
 		Instance:          inst,
 		Hardware:          hc,
 		NetworkInfo:       interfaces,

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -179,9 +179,13 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	// Create node 1: it will be used as instance number 1.
 	suite.newNode(c, "node1", "host1", nil)
 	suite.addSubnet(c, 8, 8, "node1")
-	instance, hc := testing.AssertStartInstance(c, env, suite.callCtx, suite.controllerUUID, "1")
+	params := environs.StartInstanceParams{ControllerUUID: suite.controllerUUID}
+	err = testing.FillInStartInstanceParams(env, "node1", false, &params)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(instance, gc.NotNil)
+	result, err := testing.StartInstanceWithParams(env, suite.callCtx, "1", params)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.DisplayName, gc.Equals, "host1")
+	hc := result.Hardware
 	c.Assert(hc, gc.NotNil)
 	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
 
@@ -211,7 +215,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 
 	// Trash the tools and try to start another instance.
 	suite.PatchValue(&envtools.DefaultBaseURL, "")
-	instance, _, _, err = testing.StartInstance(env, suite.callCtx, suite.controllerUUID, "2")
+	instance, _, _, err := testing.StartInstance(env, suite.callCtx, suite.controllerUUID, "2")
 	c.Check(instance, gc.IsNil)
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -39,18 +39,15 @@ func (mi *maas1Instance) String() string {
 	hostname, err := mi.hostname()
 	if err != nil {
 		// This is meant to be impossible, but be paranoid.
+		logger.Errorf("unable to detect MAAS instance hostname: %q", err)
 		hostname = fmt.Sprintf("<DNSName failed: %q>", err)
 	}
 	return fmt.Sprintf("%s:%s", hostname, mi.Id())
 }
 
 func (mi *maas1Instance) Id() instance.Id {
-	return maasObjectId(mi.maasObject)
-}
-
-func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
-	// Use the node's 'resource_uri' value.
-	return instance.Id(maasObject.URI().String())
+	// Note: URI excludes the hostname
+	return instance.Id(mi.maasObject.URI().String())
 }
 
 func normalizeStatus(statusMsg string) string {

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -457,6 +457,18 @@ func (e *Environ) getCloudInitConfig(series string, apiPort int) (cloudinit.Clou
 	return cloudcfg, nil
 }
 
+func shortenMachineId(machineId *string, nRunesShown int) string {
+	var short string
+	if machineId != nil {
+		short = *machineId
+	}
+	offset := len(short) - nRunesShown
+	if offset > 0 {
+		short = "..." + short[offset:]
+	}
+	return short
+}
+
 // StartInstance implements environs.InstanceBroker.
 func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	if args.ControllerUUID == "" {
@@ -636,6 +648,7 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 		return nil, errors.Trace(err)
 	}
 	logger.Infof("started instance %q", *machineId)
+	displayName := shortenMachineId(machineId, 6)
 
 	if desiredStatus == ociCore.InstanceLifecycleStateRunning {
 		if err := instance.waitForPublicIP(ctx); err != nil {
@@ -645,8 +658,9 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 	}
 
 	result := &environs.StartInstanceResult{
-		Instance: instance,
-		Hardware: instance.hardwareCharacteristics(),
+		DisplayName: displayName,
+		Instance:    instance,
+		Hardware:    instance.hardwareCharacteristics(),
 	}
 
 	return result, nil

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -268,6 +268,26 @@ func (e *environSuite) setupListImagesExpectations() {
 	e.compute.EXPECT().ListShapes(context.Background(), gomock.Any()).Return(shapesResponse, nil).AnyTimes()
 }
 
+func (e *environSuite) TestMachineIdShortening(c *gc.C) {
+	blank := oci.ShortenMachineId(makeStringPointer(""), 6)
+	c.Check(blank, gc.Equals, "")
+
+	null := oci.ShortenMachineId(nil, 6)
+	c.Check(null, gc.Equals, "")
+
+	ocid := oci.ShortenMachineId(makeStringPointer("ocid"), 6)
+	c.Check(ocid, gc.Equals, "ocid")
+
+	id := oci.ShortenMachineId(makeStringPointer("ocid"), 2)
+	c.Check(id, gc.Equals, "...id")
+
+	short := oci.ShortenMachineId(makeStringPointer("ocid......12345678987654321"), 6)
+	c.Check(short, gc.Equals, "...654321")
+
+	shorter := oci.ShortenMachineId(makeStringPointer("ocid......12345678987654321"), 2)
+	c.Check(shorter, gc.Equals, "...21")
+}
+
 func (e *environSuite) TestAvailabilityZones(c *gc.C) {
 	ctrl := e.patchEnv(c)
 	defer ctrl.Finish()

--- a/provider/oci/export_test.go
+++ b/provider/oci/export_test.go
@@ -19,6 +19,7 @@ var (
 	OciStorageProviderType = ociStorageProviderType
 	OciVolumeType          = ociVolumeType
 	IscsiPool              = iscsiPool
+	ShortenMachineId       = shortenMachineId
 )
 
 func (e *Environ) SetClock(clock clock.Clock) {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -76,7 +76,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	err = m.SetHasVote(true)
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(dfc) instance.Id should take a TAG!
-	err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
+	err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	hc, err := m.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
@@ -216,8 +216,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Tag:         fmt.Sprintf("unit-wordpress-%d", i),
 			Annotations: pairs,
 		})
-
-		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
+		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		sInfo := status.StatusInfo{
 			Status:  status.Error,
@@ -973,7 +972,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		Arch: &arch,
 		Mem:  &mem,
 	}
-	err = m0.SetProvisioned("i-0", "bootstrap_nonce", hc)
+	err = m0.SetProvisioned(instance.Id("i-0"), "", "bootstrap_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m1.Remove()
@@ -1155,7 +1154,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				m, err := st.AddMachine("trusty", JobHostUnits)
 				c.Assert(err, jc.ErrorIsNil)
 				c.Assert(m.Id(), gc.Equals, "0")
-				err = m.SetProvisioned("inst-id", "fake_nonce", nil)
+				err = m.SetProvisioned(instance.Id("inst-id"), "", "fake_nonce", nil)
 				c.Assert(err, jc.ErrorIsNil)
 				return 1
 			},
@@ -1853,7 +1852,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 
 	// Make further changes to the state, including the addition of a
 	// new model.
-	err = m00.SetProvisioned("i-0", "bootstrap_nonce", nil)
+	err = m00.SetProvisioned(instance.Id("i-0"), "", "bootstrap_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m10.Remove()
@@ -2169,7 +2168,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("trusty", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			err = m.SetProvisioned("i-0", "bootstrap_nonce", nil)
+			err = m.SetProvisioned("i-0", "", "bootstrap_nonce", nil)
 			c.Assert(err, jc.ErrorIsNil)
 			err = m.SetSupportedContainers([]instance.ContainerType{instance.LXD})
 			c.Assert(err, jc.ErrorIsNil)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -311,7 +311,7 @@ func (s *AssignSuite) TestPrincipals(c *gc.C) {
 func (s *AssignSuite) TestAssignMachinePrincipalsChange(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
@@ -950,7 +950,7 @@ func (s *assignCleanSuite) TestAssignUsingConstraintsToMachine(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		if t.hardwareCharacteristics != "none" {
 			hc := instance.MustParseHardware(t.hardwareCharacteristics)
-			err = m.SetProvisioned("inst-id", "fake_nonce", &hc)
+			err = m.SetProvisioned("inst-id", "", "fake_nonce", &hc)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -319,7 +319,7 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineUnit(c *gc.C) {
 	// Create a machine.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a relation with a unit in scope and assigned to the machine.
@@ -403,7 +403,7 @@ func (s *CleanupSuite) TestCleanupForceDestroyMachineCleansStorageAttachments(c 
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDoesNotNeedCleanup(c)
 
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := s.AddTestingCharm(c, "storage-block")
@@ -452,14 +452,14 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineWithContainer(c *gc.C) {
 	// Create a machine with a container.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}, machine.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
-	err = container.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = container.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create active units (in relation scope, with subordinates).

--- a/state/distribution_test.go
+++ b/state/distribution_test.go
@@ -74,7 +74,7 @@ func (s *InstanceDistributorSuite) setupScenario(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	for i, m := range s.machines {
 		instId := instance.Id(fmt.Sprintf("i-blah-%d", i))
-		err = m.SetProvisioned(instId, "fake-nonce", nil)
+		err = m.SetProvisioned(instId, "", "fake-nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -109,7 +109,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesNoEmptyMachines(c *gc.
 		m, err := unit.AssignToCleanMachine()
 		c.Assert(err, jc.ErrorIsNil)
 		instId := instance.Id(fmt.Sprintf("i-blah-%d", i))
-		err = m.SetProvisioned(instId, "fake-nonce", nil)
+		err = m.SetProvisioned(instId, "", "fake-nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -204,7 +204,7 @@ func (s *InstanceDistributorSuite) TestDistributeInstancesWithZoneConstraints(c 
 			hc = nil
 		}
 
-		err = m.SetProvisioned(instId, "fake-nonce", hc)
+		err = m.SetProvisioned(instId, "", "fake-nonce", hc)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -152,7 +152,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 
 	if _, ok := hostTag.(names.MachineTag); ok {
 		machine := unitMachine(c, s.st, u)
-		err := machine.SetProvisioned("inst-id", "fake_nonce", nil)
+		err := machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -219,7 +219,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 		// filesystem can be attached.
 		machine, err := s.st.Machine(machineTag.Id())
 		c.Assert(err, jc.ErrorIsNil)
-		err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+		err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -343,7 +343,7 @@ func (s *FilesystemIAASModelSuite) TestWatchFilesystemAttachment(c *gc.C) {
 
 	machine, err := s.st.Machine(assignedMachineId)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// filesystem attachment will NOT react to filesystem changes
@@ -375,7 +375,7 @@ func (s *FilesystemStateSuite) TestFilesystemInfo(c *gc.C) {
 	if _, ok := hostTag.(names.MachineTag); ok {
 		machine, err := s.st.Machine(hostTag.Id())
 		c.Assert(err, jc.ErrorIsNil)
-		err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+		err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -1149,7 +1149,7 @@ func (s *FilesystemIAASModelSuite) TestDestroyManualMachineDoesntRemoveNonDetach
 	filesystem, machine := s.setupFilesystemAttachment(c, "loop")
 
 	// Make this a manual machine, so the cleanup.
-	err := machine.SetProvisioned("inst-id", "manual:machine", nil)
+	err := machine.SetProvisioned("inst-id", "", "manual:machine", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Destroy the machine and run cleanups, which should cause the
@@ -1173,7 +1173,7 @@ func (s *FilesystemIAASModelSuite) TestDestroyManualMachineDoesntDetachDetachabl
 	filesystem, machine := s.setupFilesystemAttachment(c, "modelscoped-block")
 
 	// Make this a manual machine, so the cleanup.
-	err := machine.SetProvisioned("inst-id", "manual:machine", nil)
+	err := machine.SetProvisioned("inst-id", "", "manual:machine", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Destroy the machine and run cleanups, which should cause the

--- a/state/machine.go
+++ b/state/machine.go
@@ -220,17 +220,18 @@ func (m *Machine) globalKey() string {
 
 // instanceData holds attributes relevant to a provisioned machine.
 type instanceData struct {
-	DocID      string      `bson:"_id"`
-	MachineId  string      `bson:"machineid"`
-	InstanceId instance.Id `bson:"instanceid"`
-	ModelUUID  string      `bson:"model-uuid"`
-	Arch       *string     `bson:"arch,omitempty"`
-	Mem        *uint64     `bson:"mem,omitempty"`
-	RootDisk   *uint64     `bson:"rootdisk,omitempty"`
-	CpuCores   *uint64     `bson:"cpucores,omitempty"`
-	CpuPower   *uint64     `bson:"cpupower,omitempty"`
-	Tags       *[]string   `bson:"tags,omitempty"`
-	AvailZone  *string     `bson:"availzone,omitempty"`
+	DocID       string      `bson:"_id"`
+	MachineId   string      `bson:"machineid"`
+	InstanceId  instance.Id `bson:"instanceid"`
+	DisplayName string      `bson:"display-name"`
+	ModelUUID   string      `bson:"model-uuid"`
+	Arch        *string     `bson:"arch,omitempty"`
+	Mem         *uint64     `bson:"mem,omitempty"`
+	RootDisk    *uint64     `bson:"rootdisk,omitempty"`
+	CpuCores    *uint64     `bson:"cpucores,omitempty"`
+	CpuPower    *uint64     `bson:"cpupower,omitempty"`
+	Tags        *[]string   `bson:"tags,omitempty"`
+	AvailZone   *string     `bson:"availzone,omitempty"`
 
 	// KeepInstance is set to true if, on machine removal from Juju,
 	// the cloud instance should be retained.
@@ -1167,14 +1168,22 @@ func (m *Machine) SetAgentPresence() (*presence.Pinger, error) {
 // InstanceId returns the provider specific instance id for this
 // machine, or a NotProvisionedError, if not set.
 func (m *Machine) InstanceId() (instance.Id, error) {
+	instId, _, err := m.InstanceNames()
+	return instId, err
+}
+
+// InstanceNames returns both the provider's instance id and a user-friendly
+// display name. The display name is intended used for human input and
+// is ignored internally.
+func (m *Machine) InstanceNames() (instance.Id, string, error) {
 	instData, err := getInstanceData(m.st, m.Id())
 	if errors.IsNotFound(err) {
 		err = errors.NotProvisionedf("machine %v", m.Id())
 	}
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return instData.InstanceId, err
+	return instData.InstanceId, instData.DisplayName, nil
 }
 
 // InstanceStatus returns the provider specific instance status for this machine,
@@ -1368,16 +1377,21 @@ func (m *Machine) DesiredSpaces() (set.Strings, error) {
 	return spaces.Union(bindings), nil
 }
 
-// SetProvisioned sets the provider specific machine id, nonce and also metadata for
-// this machine. Once set, the instance id cannot be changed.
+// SetProvisioned stores the machine's provider-specific details in the
+// database. These details are used to infer that the machine has
+// been provisioned.
 //
 // When provisioning an instance, a nonce should be created and passed
 // when starting it, before adding the machine to the state. This means
 // that if the provisioner crashes (or its connection to the state is
 // lost) after starting the instance, we can be sure that only a single
 // instance will be able to act for that machine.
+//
+// Once set, the instance id cannot be changed. A non-empty instance id
+// will be detected as a provisioned machine.
 func (m *Machine) SetProvisioned(
 	id instance.Id,
+	displayName string,
 	nonce string,
 	characteristics *instance.HardwareCharacteristics,
 ) (err error) {
@@ -1401,17 +1415,18 @@ func (m *Machine) SetProvisioned(
 		characteristics = &instance.HardwareCharacteristics{}
 	}
 	instData := &instanceData{
-		DocID:      m.doc.DocID,
-		MachineId:  m.doc.Id,
-		InstanceId: id,
-		ModelUUID:  m.doc.ModelUUID,
-		Arch:       characteristics.Arch,
-		Mem:        characteristics.Mem,
-		RootDisk:   characteristics.RootDisk,
-		CpuCores:   characteristics.CpuCores,
-		CpuPower:   characteristics.CpuPower,
-		Tags:       characteristics.Tags,
-		AvailZone:  characteristics.AvailabilityZone,
+		DocID:       m.doc.DocID,
+		MachineId:   m.doc.Id,
+		InstanceId:  id,
+		DisplayName: displayName,
+		ModelUUID:   m.doc.ModelUUID,
+		Arch:        characteristics.Arch,
+		Mem:         characteristics.Mem,
+		RootDisk:    characteristics.RootDisk,
+		CpuCores:    characteristics.CpuCores,
+		CpuPower:    characteristics.CpuPower,
+		Tags:        characteristics.Tags,
+		AvailZone:   characteristics.AvailabilityZone,
 	}
 
 	ops := []txn.Op{
@@ -1445,7 +1460,7 @@ func (m *Machine) SetProvisioned(
 // instance id, nonce, hardware characteristics, add link-layer devices and set
 // their addresses as needed.  After, set charm profiles if needed.
 func (m *Machine) SetInstanceInfo(
-	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
+	id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
 	devicesArgs []LinkLayerDeviceArgs, devicesAddrs []LinkLayerDeviceAddress,
 	volumes map[names.VolumeTag]VolumeInfo,
 	volumeAttachments map[names.VolumeTag]VolumeAttachmentInfo,
@@ -1496,7 +1511,7 @@ func (m *Machine) SetInstanceInfo(
 		}
 	}
 
-	if err := m.SetProvisioned(id, nonce, characteristics); err != nil {
+	if err := m.SetProvisioned(id, displayName, nonce, characteristics); err != nil {
 		return errors.Trace(err)
 	}
 	return m.SetCharmProfiles(charmProfiles)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -356,6 +356,7 @@ func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
 		"ModelUUID",
 
 		"InstanceId",
+		"DisplayName",
 		"Arch",
 		"Mem",
 		"RootDisk",

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -331,19 +331,19 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	m0, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m0.Life(), gc.Equals, state.Alive)
-	err = m0.SetInstanceInfo("i-12345", "nonce", &instance.HardwareCharacteristics{
+	err = m0.SetInstanceInfo("i-12345", "", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &onecore,
 	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	m1, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m1.SetInstanceInfo("i-45678", "nonce", &instance.HardwareCharacteristics{
+	err = m1.SetInstanceInfo("i-45678", "", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &twocores,
 	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	m2, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m2.SetInstanceInfo("i-78901", "nonce", &instance.HardwareCharacteristics{
+	err = m2.SetInstanceInfo("i-78901", "", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &threecores,
 	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -353,7 +353,7 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	// Dying instance, should not count to Cores or Machine count
 	mDying, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = mDying.SetInstanceInfo("i-78901", "nonce", &instance.HardwareCharacteristics{
+	err = mDying.SetInstanceInfo("i-78901", "", "nonce", &instance.HardwareCharacteristics{
 		CpuCores: &threecores,
 	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -363,7 +363,7 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	m4, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	arch := "amd64"
-	err = m4.SetInstanceInfo("i-78901", "nonce", &instance.HardwareCharacteristics{
+	err = m4.SetInstanceInfo("i-78901", "", "nonce", &instance.HardwareCharacteristics{
 		Arch: &arch,
 	}, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -621,7 +621,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 			setUpState: func(st *state.State) bool {
 				m, err := st.Machine("0")
 				c.Assert(err, jc.ErrorIsNil)
-				m.SetProvisioned("inst-id", "fake_nonce", nil)
+				m.SetProvisioned("inst-id", "", "fake_nonce", nil)
 				return false
 			},
 			triggerEvent: func(st *state.State) {
@@ -1459,7 +1459,7 @@ func (s *StateSuite) TestAllMachines(c *gc.C) {
 	for i := 0; i < numInserts; i++ {
 		m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetProvisioned(instance.Id(fmt.Sprintf("foo-%d", i)), "fake_nonce", nil)
+		err = m.SetProvisioned(instance.Id(fmt.Sprintf("foo-%d", i)), "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		err = m.SetAgentVersion(version.MustParseBinary("7.8.9-quantal-amd64"))
 		c.Assert(err, jc.ErrorIsNil)
@@ -2322,7 +2322,7 @@ func (s *StateSuite) TestWatchMachinesBulkEvents(c *gc.C) {
 	// Dying machine...
 	dying, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = dying.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = dying.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = dying.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2376,7 +2376,7 @@ func (s *StateSuite) TestWatchMachinesLifecycle(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the machine: not reported.
-	err = machine.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = machine.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -2588,7 +2588,7 @@ func (s *StateSuite) TestWatchMachineHardwareCharacteristics(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Provision a machine: reported.
-	err = machine.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = machine.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -3891,7 +3891,7 @@ func (s *StateSuite) TestSetModelAgentVersionFailsIfUpgrading(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetAgentVersion(version.MustParseBinary(agentVersion.String() + "-quantal-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = machine.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	nextVersion := agentVersion
@@ -3920,7 +3920,7 @@ func (s *StateSuite) TestSetModelAgentVersionFailsReportsCorrectError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetAgentVersion(version.MustParseBinary("9.9.9-quantal-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id("i-blah"), "fake-nonce", nil)
+	err = machine.SetProvisioned(instance.Id("i-blah"), "", "fake-nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	nextVersion := agentVersion

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -119,7 +119,7 @@ func (s *StorageStateSuiteBase) provisionStorageVolume(c *gc.C, u *state.Unit, s
 	c.Assert(err, jc.ErrorIsNil)
 	machine := unitMachine(c, s.st, u)
 	volume := s.storageInstanceVolume(c, storageTag)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -355,7 +355,7 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.Machine(mid)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("i-exist", "fake_nonce", nil)
+	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(network.Address{
 		Type:  network.IPv4Address,
@@ -581,7 +581,7 @@ func (s *UnitSuite) destroyMachineTestCases(c *gc.C) []destroyMachineTestCase {
 func (s *UnitSuite) TestRemoveUnitMachineFastForwardDestroy(c *gc.C) {
 	for _, tc := range s.destroyMachineTestCases(c) {
 		c.Log(tc.desc)
-		err := tc.host.SetProvisioned("inst-id", "fake_nonce", nil)
+		err := tc.host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tc.target.Destroy(), gc.IsNil)
 		if tc.destroyed {
@@ -597,7 +597,7 @@ func (s *UnitSuite) TestRemoveUnitMachineFastForwardDestroy(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineNoFastForwardDestroy(c *gc.C) {
 	for _, tc := range s.destroyMachineTestCases(c) {
 		c.Log(tc.desc)
-		err := tc.host.SetProvisioned("inst-id", "fake_nonce", nil)
+		err := tc.host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		preventUnitDestroyRemove(c, tc.target)
 		c.Assert(tc.target.Destroy(), gc.IsNil)
@@ -619,7 +619,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfile(c *gc.C) {
 
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	target, err := s.application.AddUnit(state.AddUnitParams{})
@@ -650,7 +650,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfileErrorToIdle(c *gc.
 
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	target, err := s.application.AddUnit(state.AddUnitParams{})
@@ -687,7 +687,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroyCharmProfileErrorToApplied(c *
 
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	target, err := s.application.AddUnit(state.AddUnitParams{})
@@ -733,7 +733,7 @@ func (s *UnitSuite) TestRemoveUnitMachineNoDestroy(c *gc.C) {
 
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	target, err := s.application.AddUnit(state.AddUnitParams{})
@@ -761,7 +761,7 @@ func (s *UnitSuite) TestRemoveUnitMachineDestroyCleanUpProfileDoc(c *gc.C) {
 
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	unit, err := applicationWithProfile.AddUnit(state.AddUnitParams{})
@@ -793,7 +793,7 @@ func (s *UnitSuite) setMachineVote(c *gc.C, id string, hasVote bool) {
 func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -818,7 +818,7 @@ func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -835,7 +835,7 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryVoter(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryNoVoter(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -881,7 +881,7 @@ func (s *UnitSuite) TestRemoveUnitMachineRetryContainer(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitMachineRetryOrCond(c *gc.C) {
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = host.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = host.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	target, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1095,7 +1095,7 @@ func (s *UnitSuite) TestDestroyChangeCharmRetry(c *gc.C) {
 func (s *UnitSuite) TestDestroyAssignRetry(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetRetryHooks(c, s.State, func() {
@@ -1262,7 +1262,7 @@ func (s *UnitSuite) TestShortCircuitDestroyWithProvisionedMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.Machine(mid)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("i-malive", "fake_nonce", nil)
+	err = machine.SetProvisioned("i-malive", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1709,7 +1709,7 @@ func (s *UnitSuite) TestRemoveLastUnitOnMachineRemovesAllPorts(c *gc.C) {
 func (s *UnitSuite) TestRemoveUnitRemovesItsPortsOnly(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -36,6 +36,7 @@ func (s *UpgradeSuite) provision(c *gc.C, machineIds ...string) {
 		c.Assert(err, jc.ErrorIsNil)
 		err = machine.SetProvisioned(
 			instance.Id(fmt.Sprintf("instance-%s", machineId)),
+			"",
 			fmt.Sprintf("nonce-%s", machineId),
 			nil,
 		)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -261,7 +261,7 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 
 	machine, err := s.State.Machine(assignedMachineId)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// volume attachment will NOT react to volume changes
@@ -527,7 +527,7 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsVolume(c
 	// attachment does not short-circuit.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		machine := unitMachine(c, s.State, u)
-		err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+		err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.storageBackend.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
 		c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -90,6 +90,7 @@ type MachineParams struct {
 	Nonce           string
 	Constraints     constraints.Value
 	InstanceId      instance.Id
+	DisplayName     string
 	Characteristics *instance.HardwareCharacteristics
 	Addresses       []network.Address
 	Volumes         []state.HostVolumeParams
@@ -311,7 +312,7 @@ func (factory *Factory) MakeMachineNested(c *gc.C, parentId string, params *Mach
 		instance.LXD,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetProvisioned(params.InstanceId, params.Nonce, params.Characteristics)
+	err = m.SetProvisioned(params.InstanceId, params.DisplayName, params.Nonce, params.Characteristics)
 	c.Assert(err, jc.ErrorIsNil)
 	current := version.Binary{
 		Number: jujuversion.Current,
@@ -374,7 +375,7 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 	machine, err := factory.st.AddOneMachine(machineTemplate)
 	c.Assert(err, jc.ErrorIsNil)
 	if setProvisioned {
-		err = machine.SetProvisioned(params.InstanceId, params.Nonce, params.Characteristics)
+		err = machine.SetProvisioned(params.InstanceId, params.DisplayName, params.Nonce, params.Characteristics)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	err = machine.SetPassword(params.Password)

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -103,7 +103,7 @@ func (s *firewallerBaseSuite) setUpTest(c *gc.C, firewallMode string) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.controllerMachine.SetPassword(s.controllerPassword)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.controllerMachine.SetProvisioned("i-manager", "fake_nonce", nil)
+	err = s.controllerMachine.SetProvisioned("i-manager", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.controllerMachine.Tag(), s.controllerPassword, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)
@@ -189,7 +189,7 @@ func (s *firewallerBaseSuite) addUnit(c *gc.C, app *state.Application) (*state.U
 // startInstance starts a new instance for the given machine.
 func (s *firewallerBaseSuite) startInstance(c *gc.C, m *state.Machine) instance.Instance {
 	inst, hc := jujutesting.AssertStartInstance(c, s.Environ, s.callCtx, s.ControllerConfig.ControllerUUID(), m.Id())
-	err := m.SetProvisioned(inst.Id(), "fake_nonce", hc)
+	err := m.SetProvisioned(inst.Id(), "", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 	return inst
 }

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -433,6 +433,11 @@ func (m *testMachine) setInstanceId(id instance.Id) {
 	m.instanceId = id
 }
 
+func (m *testMachine) InstanceNames() (instance.Id, string, error) {
+	instId, err := m.InstanceId()
+	return instId, "", err
+}
+
 // This is stubbed out for testing.
 var MachineStatus = func(m *testMachine) (params.StatusResult, error) {
 	return params.StatusResult{Status: m.status.String()}, nil

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -111,7 +111,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	for i := 0; i < len(insts)/2; i += 2 {
 		m, err := s.State.Machine(machines[i].Id())
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetProvisioned(insts[i].Id(), "nonce", nil)
+		err = m.SetProvisioned(insts[i].Id(), "", "nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		dummy.SetInstanceAddresses(insts[i], s.addressesForIndex(i))
 		dummy.SetInstanceStatus(insts[i], "running")
@@ -140,7 +140,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 		if i%2 == 0 {
 			m, err := s.State.Machine(machines[i].Id())
 			c.Assert(err, jc.ErrorIsNil)
-			err = m.SetProvisioned(insts[i].Id(), "nonce", nil)
+			err = m.SetProvisioned(insts[i].Id(), "", "nonce", nil)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		dummy.SetInstanceAddresses(insts[i], s.addressesForIndex(i))
@@ -191,7 +191,7 @@ func (s *workerSuite) setupScenario(c *gc.C) ([]*apiinstancepoller.Machine, []in
 		apiMachine := machines[i]
 		m, err := s.State.Machine(apiMachine.Id())
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetProvisioned(insts[i].Id(), "nonce", nil)
+		err = m.SetProvisioned(insts[i].Id(), "", "nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	// Associate the first half of the instances with an address and status.

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1376,6 +1376,7 @@ func (task *provisionerTask) startMachine(
 
 	if err := machine.SetInstanceInfo(
 		result.Instance.Id(),
+		result.DisplayName,
 		startInstanceParams.InstanceConfig.MachineNonce,
 		result.Hardware,
 		networkConfig,

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -830,6 +830,11 @@ func (m *testMachine) InstanceId() (instance.Id, error) {
 	return m.instance.Id(), nil
 }
 
+func (m *testMachine) InstanceNames() (instance.Id, string, error) {
+	instId, err := m.InstanceId()
+	return instId, "", err
+}
+
 func (m *testMachine) KeepInstance() (bool, error) {
 	return m.keepInstance, nil
 }
@@ -886,7 +891,7 @@ func (m *testMachine) ModelAgentVersion() (*version.Number, error) {
 }
 
 func (m *testMachine) SetInstanceInfo(
-	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
+	id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
 	networkConfig []params.NetworkConfig, volumes []params.Volume,
 	volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
 ) error {

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -873,6 +873,11 @@ func (m *MockMachine) InstanceId() (instance.Id, error) {
 	return instance.Id(m.id), m.idErr
 }
 
+func (m *MockMachine) InstanceNames() (instance.Id, string, error) {
+	instId, err := m.InstanceId()
+	return instId, "", err
+}
+
 func (m *MockMachine) EnsureDead() error {
 	return m.ensureDeadErr
 }

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -58,7 +58,7 @@ func (s *rebootSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.ct.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.ct.SetProvisioned("foo", "fake_nonce", nil)
+	err = s.ct.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Open api as container

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -42,7 +42,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := s.AddTestingCharm(c, "riak")

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -144,7 +144,7 @@ func (s *HookContextSuite) addUnit(c *gc.C, svc *state.Application) *state.Unit 
 	hwc := instance.HardwareCharacteristics{
 		AvailabilityZone: &zone,
 	}
-	err = s.machine.SetProvisioned("i-exist", "fake_nonce", &hwc)
+	err = s.machine.SetProvisioned("i-exist", "", "fake_nonce", &hwc)
 	c.Assert(err, jc.ErrorIsNil)
 	return unit
 }

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -158,7 +158,7 @@ func (s *ContextSuite) AddUnit(c *gc.C, svc *state.Application) *state.Unit {
 	hwc := instance.HardwareCharacteristics{
 		AvailabilityZone: &zone,
 	}
-	err = s.machine.SetProvisioned("i-exist", "fake_nonce", &hwc)
+	err = s.machine.SetProvisioned("i-exist", "", "fake_nonce", &hwc)
 	c.Assert(err, jc.ErrorIsNil)
 
 	name := strings.Replace(unit.Name(), "/", "-", 1)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -66,7 +66,7 @@ func assertAssignUnit(c *gc.C, st *state.State, u *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := st.Machine(mid)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("i-exist", "fake_nonce", nil)
+	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(network.Address{
 		Type:  network.IPv4Address,

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -477,7 +477,7 @@ func (s *UpgradeSuite) create3Controllers(c *gc.C) (machineIdA, machineIdB, mach
 func (s *UpgradeSuite) setMachineProvisioned(c *gc.C, id string) {
 	machine, err := s.State.Machine(id)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id(id+"-inst"), "nonce", nil)
+	err = machine.SetProvisioned(instance.Id(id+"-inst"), "", "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
This commit makes it possible for provider code to pass through a display name when instances are created. Implementations of InstanceBroker can add DisplayName string to their StartInstanceResult
instance that's returned with StartInstance. That string is propagated through to the database and surfaced up when end-users call `juju status`.

Bugs:

- https://bugs.launchpad.net/juju/+bug/1501475
- https://bugs.launchpad.net/juju/+bug/1792210