### PR TITLE
Add --controller to show-cloud

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -21,6 +21,7 @@ var (
 type (
 	UpdateCloudCommand = updateCloudCommand
 	UpdateCloudAPI     = updateCloudAPI
+	ShowCloudAPI       = showCloudAPI
 )
 
 func NewAddCloudCommandForTest(
@@ -44,6 +45,13 @@ func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(stri
 	return &listCloudsCommand{
 		store:             store,
 		listCloudsAPIFunc: cloudAPI,
+	}
+}
+
+func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (showCloudAPI, error)) *showCloudCommand {
+	return &showCloudCommand{
+		store:            store,
+		showCloudAPIFunc: cloudAPI,
 	}
 }
 

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -109,7 +109,15 @@ func (c *showCloudCommand) Info() *cmd.Info {
 }
 
 func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
-	cloud, err := c.getCloud()
+	var (
+		cloud *cloudDetails
+		err   error
+	)
+	if c.controllerName == "" {
+		cloud, err = c.getLocalCloud()
+	} else {
+		cloud, err = c.getControllerCloud()
+	}
 	if err != nil {
 		return err
 	}
@@ -127,19 +135,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 	return nil
 }
 
-func (c *showCloudCommand) getCloud() (*cloudDetails, error) {
-	if c.controllerName == "" {
-		details, err := getCloudDetails()
-		if err != nil {
-			return nil, err
-		}
-		cloud, ok := details[c.CloudName]
-		if !ok {
-			return nil, errors.NotFoundf("cloud %q", c.CloudName)
-		}
-		return cloud, nil
-	}
-
+func (c *showCloudCommand) getControllerCloud() (*cloudDetails, error) {
 	api, err := c.showCloudAPIFunc(c.controllerName)
 	if err != nil {
 		return nil, err
@@ -150,6 +146,18 @@ func (c *showCloudCommand) getCloud() (*cloudDetails, error) {
 		return nil, err
 	}
 	cloud := makeCloudDetails(controllerCloud)
+	return cloud, nil
+}
+
+func (c *showCloudCommand) getLocalCloud() (*cloudDetails, error) {
+	details, err := getCloudDetails()
+	if err != nil {
+		return nil, err
+	}
+	cloud, ok := details[c.CloudName]
+	if !ok {
+		return nil, errors.NotFoundf("cloud %q", c.CloudName)
+	}
 	return cloud, nil
 }
 

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -65,7 +65,7 @@ regions:
 `[1:])
 }
 
-func (s *showSuite) TestShowController(c *gc.C) {
+func (s *showSuite) TestShowControllerCloud(c *gc.C) {
 	var controllerAPICalled string
 	s.api.cloud = jujucloud.Cloud{
 		Name:        "beehive",
@@ -132,48 +132,6 @@ endpoint: http://homestack
 regions:
   london:
     endpoint: http://london/1.0
-config:
-  bootstrap-timeout: 1800
-  use-default-secgroup: true
-`[1:])
-}
-
-func (s *showSuite) TestShowWithConfigController(c *gc.C) {
-	var controllerAPICalled string
-	s.api.cloud = jujucloud.Cloud{
-		Name:        "beehive",
-		Type:        "openstack",
-		Description: "Bumble Bees",
-		AuthTypes:   []jujucloud.AuthType{"userpass", "access-key"},
-		Endpoint:    "http://myopenstack",
-		Regions: []jujucloud.Region{
-			{
-				Name:     "regionone",
-				Endpoint: "http://boston/1.0",
-			},
-		},
-		Config: map[string]interface{}{"bootstrap-timeout": 1800, "use-default-secgroup": true},
-	}
-	cmd := cloud.NewShowCloudCommandForTest(
-		s.store,
-		func(controllerName string) (cloud.ShowCloudAPI, error) {
-			controllerAPICalled = controllerName
-			return s.api, nil
-		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "beehive")
-	c.Assert(err, jc.ErrorIsNil)
-	s.api.CheckCallNames(c, "Cloud", "Close")
-	c.Assert(controllerAPICalled, gc.Equals, "mycontroller")
-	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, `
-defined: public
-type: openstack
-description: Bumble Bees
-auth-types: [userpass, access-key]
-endpoint: http://myopenstack
-regions:
-  regionone:
-    endpoint: http://boston/1.0
 config:
   bootstrap-timeout: 1800
   use-default-secgroup: true


### PR DESCRIPTION
## Description of change

Add the option argument ```--controlller <name>``` to ```juju show-cloud``` so one can view which detailed cloud information for a cloud the controller knows about (i..e added with ```juju add-cloud --controller mycontroller . . .```).

## QA steps

Unit tests included.

Manual testing:

  - Bootstrap a controller 'testing'
  - Add a cloud to the controller (here I use a caas cloud as per https://discourse.jujucharms.com/t/juju-kubernetes-and-microk8s/226), after the ```juju add-model test k8stest``` step:
    - juju add-cloud -c testing k8stest
  - show the cloud details:
    - juju show-cloud --controller testing
  - Observe the added cloud in the output:
```
defined: public
type: kubernetes
description: ""
auth-types: [userpass]
endpoint: http://10.155.119.54:8080
ca-credentials:
- ""
```

## Documentation changes

Command documentation updated.

## Bug reference

n/a