### PR TITLE
Attempt to cleanup models whether volumes exist or not.

### DIFF
--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -230,6 +230,7 @@ func (s *firewallerBaseSuite) testWatch(
 	allowUnits bool,
 ) {
 	c.Assert(s.resources.Count(), gc.Equals, 0)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	args := addFakeEntities(params.Entities{Entities: []params.Entity{
 		{Tag: s.machines[0].Tag().String()},

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	MachinesC         = machinesC
+	ModelEntityRefsC  = modelEntityRefsC
 	ApplicationsC     = applicationsC
 	EndpointBindingsC = endpointBindingsC
 	ControllersC      = controllersC

--- a/state/model.go
+++ b/state/model.go
@@ -1351,14 +1351,25 @@ func checkModelEntityRefsEmpty(doc *modelEntityRefsDoc) ([]txn.Op, error) {
 		return nil, err
 	}
 
+	isEmpty := func(attribute string) bson.DocElem {
+		// We consider it empty if the array has no entries, or if the attribute doesn't exist
+		return bson.DocElem{
+			"$or", []bson.M{{
+				attribute: bson.M{"$exists": false},
+			}, {
+				attribute: bson.M{"$size": 0},
+			}},
+		}
+	}
+
 	return []txn.Op{{
 		C:  modelEntityRefsC,
 		Id: doc.UUID,
 		Assert: bson.D{
-			{"machines", bson.D{{"$size", 0}}},
-			{"applications", bson.D{{"$size", 0}}},
-			{"volumes", bson.D{{"$size", 0}}},
-			{"filesystems", bson.D{{"$size", 0}}},
+			isEmpty("machines"),
+			isEmpty("applications"),
+			isEmpty("volumes"),
+			isEmpty("filesystems"),
 		},
 	}}, nil
 }


### PR DESCRIPTION
## Description of change

Add a test that shows the issue. Use an $or so that we can handle when
the volumes and/or filesystems don't exist as they didn't on models
upgraded from 2.1.

## QA steps

See the new test that was added. When the change isn't applied it fails as in bug #1800872.

```
... error stack:
	state changing too quickly; try again soon
	github.com/juju/juju/state/model.go:1016: failed to destroy model
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1800872