### PR TITLE
Add --controller to remove-cloud

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -22,6 +22,7 @@ type (
 	UpdateCloudCommand = updateCloudCommand
 	UpdateCloudAPI     = updateCloudAPI
 	ShowCloudAPI       = showCloudAPI
+	RemoveCloudAPI     = removeCloudAPI
 )
 
 func NewAddCloudCommandForTest(
@@ -52,6 +53,13 @@ func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(stri
 	return &showCloudCommand{
 		store:            store,
 		showCloudAPIFunc: cloudAPI,
+	}
+}
+
+func NewRemoveCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (removeCloudAPI, error)) *removeCloudCommand {
+	return &removeCloudCommand{
+		store:              store,
+		removeCloudAPIFunc: cloudAPI,
 	}
 }
 

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -6,9 +6,13 @@ package cloud
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 
+	cloudapi "github.com/juju/juju/api/cloud"
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
 var usageRemoveCloudSummary = `
@@ -25,15 +29,43 @@ See also:
     list-clouds`
 
 type removeCloudCommand struct {
-	cmd.CommandBase
+	modelcmd.CommandBase
 
 	// Cloud is the name fo the cloud to remove.
 	Cloud string
+
+	// Used when querying a controller for its cloud details
+	controllerName     string
+	store              jujuclient.ClientStore
+	removeCloudAPIFunc func(controllerName string) (removeCloudAPI, error)
+}
+
+type removeCloudAPI interface {
+	RemoveCloud(cloud string) error
+	Close() error
 }
 
 // NewRemoveCloudCommand returns a command to remove cloud information.
 func NewRemoveCloudCommand() cmd.Command {
-	return &removeCloudCommand{}
+	c := &removeCloudCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	c.removeCloudAPIFunc = c.cloudAPI
+	return modelcmd.WrapBase(c)
+}
+
+func (c *removeCloudCommand) cloudAPI(controllerName string) (removeCloudAPI, error) {
+	root, err := c.NewAPIRoot(c.store, controllerName, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cloudapi.NewClient(root), nil
+}
+
+func (c *removeCloudCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.controllerName, "c", "", "Controller to operate in")
+	f.StringVar(&c.controllerName, "controller", "", "")
 }
 
 func (c *removeCloudCommand) Info() *cmd.Info {
@@ -54,6 +86,13 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 }
 
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
+	if c.controllerName == "" {
+		return c.removeLocalCloud(ctxt)
+	}
+	return c.removeControllerCloud(ctxt)
+}
+
+func (c *removeCloudCommand) removeLocalCloud(ctxt *cmd.Context) error {
 	personalClouds, err := cloud.PersonalCloudMetadata()
 	if err != nil {
 		return err
@@ -67,5 +106,19 @@ func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	ctxt.Infof("Removed details of personal cloud %q", c.Cloud)
+	return nil
+}
+
+func (c *removeCloudCommand) removeControllerCloud(ctxt *cmd.Context) error {
+	api, err := c.removeCloudAPIFunc(c.controllerName)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+	err = api.RemoveCloud(c.Cloud)
+	if err != nil {
+		return err
+	}
+	ctxt.Infof("Cloud %q on controller %q removed", c.Cloud, c.controllerName)
 	return nil
 }


### PR DESCRIPTION
## Description of change

Add the option argument ```--controlller <name>``` to ```juju remove-cloud``` so one can a cloud on the named controller (i..e added with ```juju add-cloud --controller mycontroller . . .```).

## QA steps

Unit tests included.

Manual testing:

  - Bootstrap a controller 'testing'
  - Using the example yaml file [1]
    - ```juju add-cloud -c testing example-maas /tmp/cloud.yaml``` (this will error re: credentials which is fine)
  - show the cloud details:
    - ```juju list-clouds --controller testing```
  - Observe the added cloud in the output:
  - Remove the cloud: ```juju remove-cloud --controller testing k8stest```
  - Ensure show cloud errors: ```juju list-cloud --controller testing```

[1] save as /tmp/cloud.yaml
```
clouds:
  example-maas:
    type: maas
    auth-types: [oauth1]
    endpoint: http://1.2.3.4/MAAS/
```
## Documentation changes

Command documentation updated.

## Bug reference

n/a