### PR TITLE
Backport MongoVersion API

### DIFF
--- a/api/controller/mongo.go
+++ b/api/controller/mongo.go
@@ -1,0 +1,22 @@
+// Copyright 2012-2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// MongoVersion returns the mongo version associated with the state session.
+func (c *Client) MongoVersion() (string, error) {
+	var result params.StringResult
+	err := c.facade.FacadeCall("MongoVersion", nil, &result)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}

--- a/api/controller/mongo.go
+++ b/api/controller/mongo.go
@@ -10,6 +10,9 @@ import (
 
 // MongoVersion returns the mongo version associated with the state session.
 func (c *Client) MongoVersion() (string, error) {
+	if c.BestAPIVersion() < 6 {
+		return "", errors.NotSupportedf("MongoVersion not supported by this version of Juju")
+	}
 	var result params.StringResult
 	err := c.facade.FacadeCall("MongoVersion", nil, &result)
 	if err != nil {

--- a/api/controller/mongo_test.go
+++ b/api/controller/mongo_test.go
@@ -1,0 +1,67 @@
+// Copyright 2012-2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+func (s *Suite) TestMongoVersionCallError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := controller.NewClient(apiCaller)
+	result, err := client.MongoVersion()
+	c.Check(result, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestMongoVersion(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 4,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "MongoVersion")
+			c.Check(result, gc.FitsTypeOf, &params.StringResult{})
+
+			out := result.(*params.StringResult)
+			out.Result = "3.5.12"
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	result, err := client.MongoVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, "3.5.12")
+}
+
+func (s *Suite) TestMongoVersionWithErrorResult(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 4,
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "MongoVersion")
+			c.Check(result, gc.FitsTypeOf, &params.StringResult{})
+
+			out := result.(*params.StringResult)
+			out.Result = "3.5.12"
+			out.Error = common.ServerError(errors.New("version error"))
+			return nil
+		},
+	}
+
+	client := controller.NewClient(apiCaller)
+	_, err := client.MongoVersion()
+	c.Assert(err, gc.ErrorMatches, "version error")
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -34,7 +34,7 @@ var facadeVersions = map[string]int{
 	"Cleaner":                      2,
 	"Client":                       2,
 	"Cloud":                        4,
-	"Controller":                   5,
+	"Controller":                   6,
 	"CredentialManager":            1,
 	"CredentialValidator":          2,
 	"CrossController":              1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -174,6 +174,7 @@ func AllFacades() *facade.Registry {
 	reg("Controller", 3, controller.NewControllerAPIv3)
 	reg("Controller", 4, controller.NewControllerAPIv4)
 	reg("Controller", 5, controller.NewControllerAPIv5)
+	reg("Controller", 6, controller.NewControllerAPIv6)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)
 	reg("CredentialManager", 1, credentialmanager.NewCredentialManagerAPI)

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -56,7 +56,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 
-	controller, err := controller.NewControllerAPIv5(
+	controller, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -75,7 +75,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPIv5(
+	endpoint, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,
@@ -100,7 +100,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	}
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
-	endpoint, err := controller.NewControllerAPIv5(
+	endpoint, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			Resources_: s.resources,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -45,11 +45,17 @@ type ControllerAPI struct {
 	hub        facade.Hub
 }
 
+// ControllerAPIv5 provides the v5 Controller API. The only difference
+// between this and v6 is that v5 doesn't have the MongoVersion method.
+type ControllerAPIv5 struct {
+	*ControllerAPI
+}
+
 // ControllerAPIv4 provides the v4 Controller API. The only difference
 // between this and v5 is that v4 doesn't have the
 // UpdateControllerConfig method.
 type ControllerAPIv4 struct {
-	*ControllerAPI
+	*ControllerAPIv5
 }
 
 // ControllerAPIv3 provides the v3 Controller API.
@@ -57,8 +63,8 @@ type ControllerAPIv3 struct {
 	*ControllerAPIv4
 }
 
-// NewControllerAPIv5 creates a new ControllerAPIv5.
-func NewControllerAPIv5(ctx facade.Context) (*ControllerAPI, error) {
+// NewControllerAPIv6 creates a new ControllerAPIv6
+func NewControllerAPIv6(ctx facade.Context) (*ControllerAPI, error) {
 	st := ctx.State()
 	authorizer := ctx.Auth()
 	pool := ctx.StatePool()
@@ -74,6 +80,15 @@ func NewControllerAPIv5(ctx facade.Context) (*ControllerAPI, error) {
 		presence,
 		hub,
 	)
+}
+
+// NewControllerAPIv5 creates a new ControllerAPIv5.
+func NewControllerAPIv5(ctx facade.Context) (*ControllerAPIv5, error) {
+	v6, err := NewControllerAPIv6(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIv5{v6}, nil
 }
 
 // NewControllerAPIv4 creates a new ControllerAPIv4.
@@ -163,6 +178,20 @@ func (c *ControllerAPIv3) ModelStatus(req params.Entities) (params.ModelStatusRe
 		}
 	}
 	return results, nil
+}
+
+// MongoVersion allows the introspection of the mongo version per controller
+func (c *ControllerAPI) MongoVersion() (params.StringResult, error) {
+	result := params.StringResult{}
+	if err := c.checkHasAdmin(); err != nil {
+		return result, errors.Trace(err)
+	}
+	version, err := c.state.MongoVersion()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	result.Result = version
+	return result, nil
 }
 
 // AllModels allows controller administrators to get the list of all the

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -180,6 +180,9 @@ func (c *ControllerAPIv3) ModelStatus(req params.Entities) (params.ModelStatusRe
 	return results, nil
 }
 
+// MongoVersion isn't on the v5 API.
+func (c *ControllerAPIv5) MongoVersion() {}
+
 // MongoVersion allows the introspection of the mongo version per controller
 func (c *ControllerAPI) MongoVersion() (params.StringResult, error) {
 	result := params.StringResult{}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -64,7 +64,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	}
 	s.hub = pubsub.NewStructuredHub(nil)
 
-	controller, err := controller.NewControllerAPIv5(
+	controller, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,
@@ -976,4 +976,15 @@ func (s *controllerSuite) TestConfigSetPublishesEvent(c *gc.C) {
 	}
 
 	c.Assert(config.Features().SortedValues(), jc.DeepEquals, []string{"bar", "foo"})
+}
+
+func (s *controllerSuite) TestMongoVersion(c *gc.C) {
+	result, err := s.controller.MongoVersion()
+	c.Assert(err, jc.ErrorIsNil)
+
+	var resErr *params.Error
+	c.Assert(result.Error, gc.Equals, resErr)
+	// We can't guarantee which version of mongo is running, so let's just
+	// attempt to match it to a very basic version (major.minor.patch)
+	c.Assert(result.Result, gc.Matches, "^([0-9]{1,}).([0-9]{1,}).([0-9]{1,})$")
 }

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -55,7 +55,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPIv5(
+	controller, err := controller.NewControllerAPIv6(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -60,6 +60,7 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
 `
 	s.createTestClientStore(c)
 
@@ -72,6 +73,7 @@ mallards:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc
@@ -100,6 +102,7 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
 `
 	s.createTestClientStore(c)
 
@@ -112,6 +115,7 @@ mallards:
     ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc
@@ -142,6 +146,7 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
     cloud: mallards
     region: mallards1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
 `
 	store := s.createTestClientStore(c)
 	store.BootstrapConfig["mallards"] = jujuclient.BootstrapConfig{
@@ -167,6 +172,7 @@ mallards:
     cloud: mallards
     region: mallards1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc
@@ -200,6 +206,7 @@ aws-test:
     cloud: aws
     region: us-east-1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   controller-machines:
     "0":
       instance-id: id-0
@@ -236,6 +243,7 @@ aws-test:
     cloud: aws
     region: us-east-1
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   controller-machines:
     "0":
       instance-id: id-0
@@ -264,6 +272,7 @@ mark-test-prodstack:
     ca-cert: this-is-a-ca-cert
     cloud: prodstack
     agent-version: 999.99.99
+    mongo-version: 3.5.12
   account:
     user: admin
     access: superuser
@@ -276,7 +285,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
@@ -285,7 +294,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99"},"account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99","mongo-version":"3.5.12"},"account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
@@ -308,7 +317,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store.CurrentControllerName = "aws-test"
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json")
 }
@@ -439,6 +448,10 @@ func (c *fakeController) ModelStatus(models ...names.ModelTag) (result []base.Mo
 		})
 	}
 	return result, nil
+}
+
+func (c *fakeController) MongoVersion() (string, error) {
+	return "3.5.12", nil
 }
 
 func (c *fakeController) AllModels() (result []base.UserModel, _ error) {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -72,7 +72,7 @@ const (
 	Upgrading StorageEngine = "Upgrading"
 )
 
-// Version represents the major.minor version of the runnig mongo.
+// Version represents the major.minor version of the running mongo.
 type Version struct {
 	Major         int
 	Minor         int


### PR DESCRIPTION
## Description of change

This PR backports the `MongoVersion` API method from develop. This is needed for running the webscale tests against the `2.5` branch 

## QA steps
```
juju bootstrap lxd test
juju show-controller
```