### PR TITLE
Upgrade series acceptance tests

### DIFF
--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -79,7 +79,7 @@ def reboot_machine(client, machine):
     log.info("wait_for_started()")
     client.wait_for_started()
 
-def set_application_series(client, application, series)
+def set_application_series(client, application, series):
     args = (application, series)
     client.juju('set-series', args)
 


### PR DESCRIPTION
## Description of change

Fix the syntax error

**Note this acceptance doesn't run or work for now. That should be
cleaned up in future commits.**

## QA steps

It expects you to setup the following acceptance tests as [follows](https://github.com/juju/juju/tree/develop/acceptancetests#quick-run-using-lxd)

```
cd acceptancetests
./assess_upgrade_series.py 
```