### PR TITLE
Use constraints not placement for k8s node affinity

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,11 +427,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:16c440010c52d4051e1c9116946759834d55cf98d43fed3c1ddcc47567064c54"
+  digest = "1:9aceaa11417d9c5b31c0e9f47094739723046525efbb932381fe50a674a943f7"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "b8d279cc30ffcc57dab7a51c4bc39be08fb2b569"
+  revision = "a15b892a41663fc698e6fb81c9e3d9e72fbe5c9c"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "b8d279cc30ffcc57dab7a51c4bc39be08fb2b569"
+  revision = "a15b892a41663fc698e6fb81c9e3d9e72fbe5c9c"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]

--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -146,7 +146,6 @@ func (c *Client) WatchPodSpec(application string) (watcher.NotifyWatcher, error)
 // ProvisioningInfo holds unit provisioning info.
 type ProvisioningInfo struct {
 	PodSpec     string
-	Placement   string
 	Constraints constraints.Value
 	Filesystems []storage.KubernetesFilesystemParams
 	Devices     []devices.KubernetesDeviceParams
@@ -182,7 +181,6 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 	}
 	info := &ProvisioningInfo{
 		PodSpec:     result.PodSpec,
-		Placement:   result.Placement,
 		Constraints: result.Constraints,
 		Tags:        result.Tags,
 	}

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -48,7 +48,6 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 				Result: &params.KubernetesProvisioningInfo{
 					PodSpec:     "foo",
 					Tags:        map[string]string{"foo": "bar"},
-					Placement:   "a=b,c=d",
 					Constraints: constraints.MustParse("mem=4G"),
 					Filesystems: []params.KubernetesFilesystemParams{{
 						StorageName: "database",
@@ -81,7 +80,6 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(info, jc.DeepEquals, &caasunitprovisioner.ProvisioningInfo{
 		PodSpec:     "foo",
 		Tags:        map[string]string{"foo": "bar"},
-		Placement:   "a=b,c=d",
 		Constraints: constraints.MustParse("mem=4G"),
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName:  "database",

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -183,7 +183,6 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -204,7 +203,6 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
@@ -224,7 +222,6 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
                 django:
                     charm: django
                     scale: 1
-                    placement: foo=bar
                     options:
                         debug: true
                     storage:
@@ -258,7 +255,6 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			1,
-			"foo=bar",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -279,7 +275,6 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
@@ -329,7 +324,6 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -349,7 +343,6 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
@@ -391,7 +384,6 @@ func (s *bundleSuite) TestGetChangesBundleEndpointBindingsSuccess(c *gc.C) {
 					map[string]string{"url": "public"},
 					map[string]int{},
 					0,
-					"",
 				},
 				Requires: []string{"addCharm-0"},
 			})
@@ -508,16 +500,13 @@ applications:
 
 func (s *bundleSuite) addApplicationToModel(model description.Model, name string, numUnits int) description.Application {
 	series := "xenial"
-	placement := ""
 	if model.Type() == "caas" {
 		series = "kubernetes"
-		placement = "foo=bar"
 	}
 	application := model.AddApplication(description.ApplicationArgs{
 		Tag:                names.NewApplicationTag(name),
 		CharmURL:           "cs:" + name,
 		Series:             series,
-		Placement:          placement,
 		CharmConfig:        map[string]interface{}{},
 		LeadershipSettings: map[string]interface{}{},
 	})
@@ -1129,11 +1118,9 @@ applications:
   mysql:
     charm: cs:mysql
     scale: 1
-    placement: foo=bar
   wordpress:
     charm: cs:wordpress
     scale: 2
-    placement: foo=bar
 relations:
 - - wordpress:db
   - mysql:mysql

--- a/apiserver/facades/client/client/bundles_test.go
+++ b/apiserver/facades/client/client/bundles_test.go
@@ -50,7 +50,6 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -70,7 +69,6 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
-			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1114,7 +1114,6 @@ func (context *statusContext) processApplication(application *state.Application)
 			logger.Debugf("no service details for %v: %v", application.Name(), err)
 		}
 		processedStatus.Scale = application.GetScale()
-		processedStatus.Placement = application.GetPlacement()
 	}
 
 	processedStatus.EndpointBindings = context.allAppsUnitsCharmBindings.endpointBindings[application.Name()]

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -318,7 +318,6 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		Filesystems: filesystemParams,
 		Devices:     devices,
 		Constraints: cons,
-		Placement:   app.GetPlacement(),
 		Tags:        resourceTags,
 	}, nil
 }

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -199,7 +199,6 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 						Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
 					},
 				},
-				Placement:   "placement",
 				Constraints: constraints.MustParse("mem=64G"),
 				Tags: map[string]string{
 					"juju-model-uuid":      coretesting.ModelTag.Id(),

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -11,7 +11,6 @@ import (
 type KubernetesProvisioningInfo struct {
 	PodSpec     string                       `json:"pod-spec"`
 	Constraints constraints.Value            `json:"constraints"`
-	Placement   string                       `json:"placement,omitempty"`
 	Tags        map[string]string            `json:"tags,omitempty"`
 	Filesystems []KubernetesFilesystemParams `json:"filesystems,omitempty"`
 	Volumes     []KubernetesVolumeParams     `json:"volumes,omitempty"`

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -148,7 +148,6 @@ type ApplicationStatus struct {
 
 	// The following are for CAAS models.
 	Scale         int    `json:"int,omitempty"`
-	Placement     string `json:"string,omitempty"`
 	ProviderId    string `json:"provider-id,omitempty"`
 	PublicAddress string `json:"public-address"`
 }

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -81,9 +81,6 @@ type ServiceParams struct {
 	// ResourceTags is a set of tags to set on the created service.
 	ResourceTags map[string]string
 
-	// Placement defines node affinity rules.
-	Placement string
-
 	// Constraints is a set of constraints on
 	// the pod to create.
 	Constraints constraints.Value

--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -10,7 +10,6 @@ import (
 
 var unsupportedConstraints = []string{
 	constraints.Cores,
-	constraints.Tags,
 	constraints.VirtType,
 	constraints.Container,
 	constraints.Arch,

--- a/caas/kubernetes/provider/constraints_test.go
+++ b/caas/kubernetes/provider/constraints_test.go
@@ -76,7 +76,6 @@ func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []string{
-		"tags",
 		"cores",
 		"virt-type",
 		"arch",

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/keyvalues"
 	"gopkg.in/juju/names.v2"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -946,12 +945,80 @@ func (k *kubernetesClient) EnsureService(
 			return errors.Annotatef(err, "configuring cpu constraint for %s", appName)
 		}
 	}
-	if params.Placement != "" {
-		affinityLabels, err := keyvalues.Parse(strings.Split(params.Placement, ","), false)
-		if err != nil {
-			return errors.Annotatef(err, "invalid placement directive %q", params.Placement)
+
+	// Translate tags to node affinity.
+	if params.Constraints.Tags != nil {
+		affinityLabels := *params.Constraints.Tags
+		var (
+			affinityTags     = make(map[string]string)
+			antiAffinityTags = make(map[string]string)
+		)
+		for _, labelPair := range affinityLabels {
+			parts := strings.Split(labelPair, "=")
+			if len(parts) != 2 {
+				return errors.Errorf("invalid node affinity constraints: %v", affinityLabels)
+			}
+			key := strings.Trim(parts[0], " ")
+			value := strings.Trim(parts[1], " ")
+			if strings.HasPrefix(key, "^") {
+				if len(key) == 1 {
+					return errors.Errorf("invalid node affinity constraints: %v", affinityLabels)
+				}
+				antiAffinityTags[key[1:]] = value
+			} else {
+				affinityTags[key] = value
+			}
 		}
-		unitSpec.Pod.NodeSelector = affinityLabels
+
+		updateSelectorTerms := func(nodeSelectorTerm *core.NodeSelectorTerm, tags map[string]string, op core.NodeSelectorOperator) {
+			// Sort for stable ordering.
+			var keys []string
+			for k := range tags {
+				keys = append(keys, k)
+			}
+			for _, tag := range keys {
+				allValues := strings.Split(tags[tag], "|")
+				for i, v := range allValues {
+					allValues[i] = strings.Trim(v, " ")
+				}
+				nodeSelectorTerm.MatchExpressions = append(nodeSelectorTerm.MatchExpressions, core.NodeSelectorRequirement{
+					Key:      tag,
+					Operator: op,
+					Values:   allValues,
+				})
+			}
+		}
+		var nodeSelectorTerm core.NodeSelectorTerm
+		updateSelectorTerms(&nodeSelectorTerm, affinityTags, core.NodeSelectorOpIn)
+		updateSelectorTerms(&nodeSelectorTerm, antiAffinityTags, core.NodeSelectorOpNotIn)
+		unitSpec.Pod.Affinity = &core.Affinity{
+			NodeAffinity: &core.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+					NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
+				},
+			},
+		}
+	}
+	if params.Constraints.Zones != nil {
+		zones := *params.Constraints.Zones
+		affinity := unitSpec.Pod.Affinity
+		if affinity == nil {
+			affinity = &core.Affinity{
+				NodeAffinity: &core.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+						NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+					},
+				},
+			}
+			unitSpec.Pod.Affinity = affinity
+		}
+		nodeSelector := &affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+		nodeSelector.MatchExpressions = append(nodeSelector.MatchExpressions,
+			core.NodeSelectorRequirement{
+				Key:      "failure-domain.beta.kubernetes.io/zone",
+				Operator: core.NodeSelectorOpIn,
+				Values:   zones,
+			})
 	}
 
 	resourceTags := make(map[string]string)

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -624,13 +624,6 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	var placement []*instance.Placement
 	if h.data.Type == "kubernetes" {
 		numUnits = p.NumUnits
-		if p.Placement != "" {
-			p := &instance.Placement{
-				Scope:     h.modelConfig.UUID(),
-				Directive: p.Placement,
-			}
-			placement = []*instance.Placement{p}
-		}
 	}
 	// Deploy the application.
 	if err := h.api.Deploy(application.DeployArgs{
@@ -1469,7 +1462,6 @@ func buildModelRepresentation(
 			Scale:         appStatus.Scale,
 			Exposed:       appStatus.Exposed,
 			Series:        appStatus.Series,
-			Placement:     appStatus.Placement,
 			SubordinateTo: appStatus.SubordinateTo,
 		}
 		for unitName, unit := range appStatus.Units {

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -116,7 +116,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.assertCharmsUploaded(c, "cs:kubernetes/gitlab-47", "cs:kubernetes/mariadb-42")
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"mariadb": {charm: "cs:kubernetes/mariadb-42", config: mysqlch.Config().DefaultSettings()},
-		"gitlab":  {charm: "cs:kubernetes/gitlab-47", config: wpch.Config().DefaultSettings(), placement: "foo=bar", scale: 1},
+		"gitlab":  {charm: "cs:kubernetes/gitlab-47", config: wpch.Config().DefaultSettings(), scale: 1},
 	})
 	s.assertRelationsEstablished(c, "gitlab:db mariadb:server")
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -793,14 +793,8 @@ func (c *DeployCommand) validatePlacementByModelType() error {
 	if modelType == model.IAAS {
 		return nil
 	}
-	if len(c.Placement) > 1 {
-		return errors.Errorf("only 1 placement directive is supported, got %d", len(c.Placement))
-	}
-	if len(c.Placement) == 0 {
-		return nil
-	}
-	if c.Placement[0].Scope == instance.MachineScope || c.Placement[0].Directive == "" {
-		return errors.NotSupportedf("placement directive %q", c.PlacementSpec)
+	if len(c.Placement) > 0 {
+		return errors.New("--to cannot be used on kubernetes models")
 	}
 	return nil
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -115,7 +115,6 @@ type applicationStatus struct {
 	CharmProfile     string                `json:"charm-profile,omitempty" yaml:"charm-profile,omitempty"`
 	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
 	Scale            int                   `json:"scale,omitempty" yaml:"scale,omitempty"`
-	Placement        string                `json:"placement,omitempty" yaml:"placement,omitempty"`
 	ProviderId       string                `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
 	Address          string                `json:"address,omitempty" yaml:"address,omitempty"`
 	Exposed          bool                  `json:"exposed" yaml:"exposed"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -241,7 +241,6 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		Exposed:          application.Exposed,
 		Life:             application.Life,
 		Scale:            application.Scale,
-		Placement:        application.Placement,
 		ProviderId:       application.ProviderId,
 		Address:          application.PublicAddress,
 		Relations:        application.Relations,

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/description"
 	"github.com/juju/errors"
-	"github.com/juju/juju/instance"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
@@ -426,7 +425,6 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 			"app foo": environschema.Attr{Type: environschema.Tstring}},
 		Constraints:  cons,
 		DesiredScale: 3,
-		Placement:    []*instance.Placement{{Scope: st.ModelUUID(), Directive: "foo=bar"}},
 	})
 	err = application.UpdateLeaderSettings(&goodToken{}, map[string]string{
 		"leader": "true",
@@ -491,7 +489,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 		c.Assert(exported.PodSpec(), gc.Equals, "pod spec")
 		c.Assert(exported.CloudService().ProviderId(), gc.Equals, "provider-id")
 		c.Assert(exported.DesiredScale(), gc.Equals, 3)
-		c.Assert(exported.Placement(), gc.Equals, "foo=bar")
+		c.Assert(exported.Placement(), gc.Equals, "")
 		addresses := exported.CloudService().Addresses()
 		addr := addresses[0]
 		c.Assert(addr.Value(), gc.Equals, "192.168.1.1")

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/permission"
@@ -451,7 +450,6 @@ func (s *MigrationImportSuite) setupSourceApplications(
 			"app foo": environschema.Attr{Type: environschema.Tstring}},
 		Constraints:  cons,
 		DesiredScale: 3,
-		Placement:    []*instance.Placement{{Scope: st.ModelUUID(), Directive: "foo=bar"}},
 	})
 	err = application.UpdateLeaderSettings(&goodToken{}, map[string]string{
 		"leader": "true",
@@ -633,7 +631,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	c.Assert(cloudService.ProviderId(), gc.Equals, "provider-id")
 	c.Assert(cloudService.Addresses(), jc.DeepEquals, []network.Address{addr})
 	c.Assert(newApp.GetScale(), gc.Equals, 3)
-	c.Assert(newApp.GetPlacement(), gc.Equals, "foo=bar")
+	c.Assert(newApp.GetPlacement(), gc.Equals, "")
 }
 
 func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1527,30 +1527,15 @@ func (st *State) processCAASModelApplicationArgs(args *AddApplicationArgs) error
 	if err := st.processCommonModelApplicationArgs(args); err != nil {
 		return errors.Trace(err)
 	}
-	if len(args.Placement) > 1 {
-		return errors.Errorf("only 1 placement directive is supported, got %d", len(args.Placement))
+	if len(args.Placement) > 0 {
+		return errors.NotValidf("placement directives on k8s models")
 	}
-	if len(args.Placement) == 0 {
-		return nil
-	}
-	data, err := st.parsePlacement(args.Placement[0])
-	if err != nil {
-		return errors.Trace(err)
-	}
-	switch data.placementType() {
-	case machinePlacement:
-		return errors.NotValidf("machine placement directive %q", args.Placement[0].String())
-	case directivePlacement:
-		if err := st.precheckInstance(
-			args.Series,
-			args.Constraints,
-			data.directive,
-			nil,
-		); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
+	return st.precheckInstance(
+		args.Series,
+		args.Constraints,
+		"",
+		nil,
+	)
 }
 
 // removeNils removes any keys with nil values from the given map.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1568,13 +1568,11 @@ func (s *StateSuite) TestAddCAASApplication(c *gc.C) {
 	inconfig, err := application.NewConfig(application.ConfigAttributes{"outlook": "good"}, sampleApplicationConfigSchema(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	placement := []*instance.Placement{instance.MustParsePlacement(st.ModelUUID() + ":a=b")}
 	gitlab, err := st.AddApplication(
-		state.AddApplicationArgs{Name: "gitlab", Charm: ch, CharmConfig: insettings, ApplicationConfig: inconfig, Placement: placement})
+		state.AddApplicationArgs{Name: "gitlab", Charm: ch, CharmConfig: insettings, ApplicationConfig: inconfig})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gitlab.Name(), gc.Equals, "gitlab")
 	c.Assert(gitlab.GetScale(), gc.Equals, 0)
-	c.Assert(gitlab.GetPlacement(), gc.Equals, "a=b")
 	outsettings, err := gitlab.CharmConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := ch.Config().DefaultSettings()
@@ -1599,7 +1597,7 @@ func (s *StateSuite) TestAddCAASApplication(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 }
 
-func (s *StateSuite) TestAddCAASApplicationBadPlacement(c *gc.C) {
+func (s *StateSuite) TestAddCAASApplicationPlacementNotAllowed(c *gc.C) {
 	st := s.Factory.MakeCAASModel(c, nil)
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -1608,20 +1606,7 @@ func (s *StateSuite) TestAddCAASApplicationBadPlacement(c *gc.C) {
 	placement := []*instance.Placement{instance.MustParsePlacement("#:2")}
 	_, err := st.AddApplication(
 		state.AddApplicationArgs{Name: "gitlab", Charm: ch, Placement: placement})
-	c.Assert(err, gc.ErrorMatches, ".*"+regexp.QuoteMeta(`machine placement directive "#:2" not valid`))
-}
-
-func (s *StateSuite) TestAddCAASApplicationTooManyPlacement(c *gc.C) {
-	st := s.Factory.MakeCAASModel(c, nil)
-	defer st.Close()
-	f := factory.NewFactory(st, s.StatePool)
-	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
-
-	placement := []*instance.Placement{
-		instance.MustParsePlacement("model-uuid:a=b"), instance.MustParsePlacement("model-uuid:c=d")}
-	_, err := st.AddApplication(
-		state.AddApplicationArgs{Name: "gitlab", Charm: ch, Placement: placement})
-	c.Assert(err, gc.ErrorMatches, ".*only 1 placement directive is supported, got 2")
+	c.Assert(err, gc.ErrorMatches, ".*"+regexp.QuoteMeta(`cannot add application "gitlab": placement directives on k8s models not valid`))
 }
 
 func (s *StateSuite) TestAddApplicationWithNilCharmConfigValues(c *gc.C) {

--- a/testcharms/charm-repo/bundle/kubernetes-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/kubernetes-simple/bundle.yaml
@@ -3,7 +3,6 @@ applications:
     gitlab:
         charm: gitlab
         scale: 1
-        placement: foo=bar
     mariadb:
         charm: mariadb
 relations:

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -160,7 +160,6 @@ func (w *deploymentWorker) loop() error {
 		serviceParams := &caas.ServiceParams{
 			PodSpec:      spec,
 			Constraints:  info.Constraints,
-			Placement:    info.Placement,
 			ResourceTags: info.Tags,
 			Filesystems:  info.Filesystems,
 			Devices:      info.Devices,

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -87,7 +87,6 @@ containers:
 	expectedServiceParams = &caas.ServiceParams{
 		PodSpec:      &parsedSpec,
 		ResourceTags: map[string]string{"foo": "bar"},
-		Placement:    "placement",
 		Constraints:  constraints.MustParse("mem=4G"),
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
@@ -122,7 +121,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.podSpecGetter.setProvisioningInfo(apicaasunitprovisioner.ProvisioningInfo{
 		PodSpec:     containerSpec,
 		Tags:        map[string]string{"foo": "bar"},
-		Placement:   "placement",
 		Constraints: constraints.MustParse("mem=4G"),
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",


### PR DESCRIPTION
## Description of change

Instead of using placement (--to) for node affinity, use constraints instead.
We support zones, affinity, and anti-affinity. Anti-affinity is done by prefixing the label key with "^".
Labels for a given key are separated by "|".
eg juju deploy foo --constraints="tags=key1=a|b|c,^key2=c|d|e zones=z1,z2" 

## QA steps

bootstrap k8s and deploy a charm to a node with some labels using constraints