### PR TITLE
Update txn pkg dep and expose retry-count in txn debug logs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -726,14 +726,14 @@
   revision = "472a3e8b2073fb3cd67c12d2bc5f3cd28e5f4116"
 
 [[projects]]
-  digest = "1:471ca3fc247b5b89a11aa88e78805b0bec2226a7b1786e0d39eb398fa78b27d4"
+  digest = "1:d816cd26c23069335c5847492447ce99749f1768c4fe3dbd4cca8fd7a54058e9"
   name = "github.com/juju/txn"
   packages = [
     ".",
     "testing",
   ]
   pruneopts = ""
-  revision = "df6ecfd7d096675fb784bd5a4ebf253eddb7da05"
+  revision = "90cbb53292a84c397765581432d543d6faa404a4"
 
 [[projects]]
   digest = "1:cf637806c17846b1660d388cfbee501ed64734526fe2e6176f16f9cd950e7c62"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -343,7 +343,7 @@
 
 [[constraint]]
   name = "github.com/juju/txn"
-  revision = "df6ecfd7d096675fb784bd5a4ebf253eddb7da05"
+  revision = "90cbb53292a84c397765581432d543d6faa404a4"
 
 [[override]]
   name = "github.com/juju/usso"

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -269,7 +269,7 @@ func (b *storageDBWrapper) txnOpUpdate(id string, updates ...bson.DocElem) txn.O
 
 // runTransaction runs the DB operations within a single transaction.
 func (b *storageDBWrapper) runTransaction(ops []txn.Op) error {
-	err := b.txnRunner.RunTransaction(ops)
+	err := b.txnRunner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 	return errors.Trace(err)
 }
 

--- a/state/database.go
+++ b/state/database.go
@@ -334,13 +334,13 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 			closer = session.Close
 		}
 		observer := func(t jujutxn.Transaction) {
-			txnLogger.Tracef("ran transaction in %.3fs %# v\nerr: %v",
-				t.Duration.Seconds(), pretty.Formatter(t.Ops), t.Error)
+			txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
+				t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
 		}
 		if db.runTransactionObserver != nil {
 			observer = func(t jujutxn.Transaction) {
-				txnLogger.Tracef("ran transaction in %.3fs %# v\nerr: %v",
-					t.Duration.Seconds(), pretty.Formatter(t.Ops), t.Error)
+				txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
+					t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
 				db.runTransactionObserver(
 					db.raw.Name, db.modelUUID,
 					t.Ops, t.Error,

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -126,8 +126,8 @@ func newRunnerForHooks(st *State) jujutxn.Runner {
 		Database: db.raw,
 		Clock:    st.stateClock,
 		RunTransactionObserver: func(t jujutxn.Transaction) {
-			txnLogger.Tracef("ran transaction in %.3fs %# v\nerr: %v",
-				t.Duration.Seconds(), pretty.Formatter(t.Ops), t.Error)
+			txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
+				t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
 		},
 	})
 	db.runner = runner

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -125,7 +125,7 @@ func newRunnerForHooks(st *State) jujutxn.Runner {
 	runner := jujutxn.NewRunner(jujutxn.RunnerParams{
 		Database: db.raw,
 		Clock:    st.stateClock,
-		RunTransactionObserver: func(t jujutxn.ObservedTransaction) {
+		RunTransactionObserver: func(t jujutxn.Transaction) {
 			txnLogger.Tracef("ran transaction in %.3fs %# v\nerr: %v",
 				t.Duration.Seconds(), pretty.Formatter(t.Ops), t.Error)
 		},

--- a/state/lease/store_assert_test.go
+++ b/state/lease/store_assert_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/lease"
+	jujutxn "github.com/juju/txn"
 )
 
 // StoreAssertSuite tests that AssertOp does what it should.
@@ -45,7 +46,7 @@ func (s *StoreAssertSuite) TestPassesWhenLeaseHeld(c *gc.C) {
 	var ops []txn.Op
 	err := info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
-	err = s.fix.Runner.RunTransaction(ops)
+	err = s.fix.Runner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -59,7 +60,7 @@ func (s *StoreAssertSuite) TestPassesWhenLeaseStillHeldDespiteWriterChange(c *gc
 	var ops []txn.Op
 	err = info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
-	err = s.fix.Runner.RunTransaction(ops)
+	err = s.fix.Runner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 	c.Check(err, gc.IsNil)
 }
 
@@ -73,7 +74,7 @@ func (s *StoreAssertSuite) TestPassesWhenLeaseStillHeldDespitePassingExpiry(c *g
 	var ops []txn.Op
 	err = info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
-	err = s.fix.Runner.RunTransaction(ops)
+	err = s.fix.Runner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 	c.Check(err, gc.IsNil)
 }
 
@@ -87,6 +88,6 @@ func (s *StoreAssertSuite) TestAbortsWhenLeaseVacant(c *gc.C) {
 	var ops []txn.Op
 	err = info.Trapdoor(0, &ops)
 	c.Check(err, jc.ErrorIsNil)
-	err = s.fix.Runner.RunTransaction(ops)
+	err = s.fix.Runner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 	c.Check(err, gc.Equals, txn.ErrAborted)
 }

--- a/state/txns.go
+++ b/state/txns.go
@@ -79,8 +79,8 @@ var seenShortStacks = make(map[string]bool)
 // RunTransaction is part of the jujutxn.Runner interface. Operations
 // that affect multi-model collections will be modified to
 // ensure correct interaction with these collections.
-func (r *multiModelRunner) RunTransaction(ops []txn.Op) error {
-	if len(ops) == 0 {
+func (r *multiModelRunner) RunTransaction(tx *jujutxn.Transaction) error {
+	if len(tx.Ops) == 0 {
 		stack := shortStack()
 		// It is a warning that should be reported to us, but we definitely
 		// don't want to clutter up logs so we'll only write it once.
@@ -89,11 +89,12 @@ func (r *multiModelRunner) RunTransaction(ops []txn.Op) error {
 			logger.Warningf("Running no-op transaction - called by %s", stack)
 		}
 	}
-	newOps, err := r.updateOps(ops)
+	newOps, err := r.updateOps(tx.Ops)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return r.rawRunner.RunTransaction(newOps)
+	tx.Ops = newOps
+	return r.rawRunner.RunTransaction(tx)
 }
 
 // Run is part of the jujutxn.Runner interface. Operations returned by

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -256,7 +256,7 @@ func (s *MultiModelRunnerSuite) TestRunTransaction(c *gc.C) {
 		c.Logf("TestRunTransaction %d: %s", i, t.label)
 
 		inOps := []txn.Op{t.input}
-		err := s.multiModelRunner.RunTransaction(inOps)
+		err := s.multiModelRunner.RunTransaction(&jujutxn.Transaction{Ops: inOps})
 		c.Assert(err, jc.ErrorIsNil)
 
 		expected := []txn.Op{t.expected}
@@ -274,7 +274,7 @@ func (s *MultiModelRunnerSuite) TestMultipleOps(c *gc.C) {
 		expectedOps = append(expectedOps, t.expected)
 	}
 
-	err := s.multiModelRunner.RunTransaction(inOps)
+	err := s.multiModelRunner.RunTransaction(&jujutxn.Transaction{Ops: inOps})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.testRunner.seenOps, gc.DeepEquals, expectedOps)
@@ -294,7 +294,7 @@ func (s *MultiModelRunnerSuite) TestWithObjectIds(c *gc.C) {
 		Insert: &objIdDoc{Id: id},
 	}}
 
-	err := s.multiModelRunner.RunTransaction(inOps)
+	err := s.multiModelRunner.RunTransaction(&jujutxn.Transaction{Ops: inOps})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedOps := []txn.Op{{
@@ -314,7 +314,7 @@ func (s *MultiModelRunnerSuite) TestRejectsAttemptToInsertWrongModelUUID(c *gc.C
 		Id:     "1",
 		Insert: &machineDoc{},
 	}}
-	err := s.multiModelRunner.RunTransaction(ops)
+	err := s.multiModelRunner.RunTransaction(txFromOps(ops))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ops = []txn.Op{{
@@ -324,7 +324,7 @@ func (s *MultiModelRunnerSuite) TestRejectsAttemptToInsertWrongModelUUID(c *gc.C
 			ModelUUID: "wrong",
 		},
 	}}
-	err = s.multiModelRunner.RunTransaction(ops)
+	err = s.multiModelRunner.RunTransaction(txFromOps(ops))
 	c.Assert(err, gc.ErrorMatches, `cannot insert into "machines": bad "model-uuid" value.+`)
 }
 
@@ -335,7 +335,7 @@ func (s *MultiModelRunnerSuite) TestRejectsAttemptToChangeModelUUID(c *gc.C) {
 		Id:     "1",
 		Update: bson.M{"$set": &machineDoc{ModelUUID: modelUUID}},
 	}}
-	err := s.multiModelRunner.RunTransaction(ops)
+	err := s.multiModelRunner.RunTransaction(txFromOps(ops))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Using the wrong model UUID isn't allowed.
@@ -344,16 +344,16 @@ func (s *MultiModelRunnerSuite) TestRejectsAttemptToChangeModelUUID(c *gc.C) {
 		Id:     "1",
 		Update: bson.M{"$set": &machineDoc{ModelUUID: "wrong"}},
 	}}
-	err = s.multiModelRunner.RunTransaction(ops)
+	err = s.multiModelRunner.RunTransaction(txFromOps(ops))
 	c.Assert(err, gc.ErrorMatches, `cannot update "machines": bad "model-uuid" value.+`)
 }
 
 func (s *MultiModelRunnerSuite) TestDoesNotAssertReferencedModel(c *gc.C) {
-	err := s.multiModelRunner.RunTransaction([]txn.Op{{
+	err := s.multiModelRunner.RunTransaction(txFromOps([]txn.Op{{
 		C:      modelsC,
 		Id:     modelUUID,
 		Insert: bson.M{},
-	}})
+	}}))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(s.testRunner.seenOps, jc.DeepEquals, []txn.Op{{
 		C:      modelsC,
@@ -363,56 +363,56 @@ func (s *MultiModelRunnerSuite) TestDoesNotAssertReferencedModel(c *gc.C) {
 }
 
 func (s *MultiModelRunnerSuite) TestRejectRawAccessCollection(c *gc.C) {
-	err := s.multiModelRunner.RunTransaction([]txn.Op{{
+	err := s.multiModelRunner.RunTransaction(txFromOps([]txn.Op{{
 		C:      "raw",
 		Id:     "whatever",
 		Assert: bson.D{{"any", "thing"}},
-	}})
+	}}))
 	c.Check(err, gc.ErrorMatches, `forbidden transaction: references raw-access collection "raw"`)
 	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
 func (s *MultiModelRunnerSuite) TestRejectUnknownCollection(c *gc.C) {
-	err := s.multiModelRunner.RunTransaction([]txn.Op{{
+	err := s.multiModelRunner.RunTransaction(txFromOps([]txn.Op{{
 		C:      "unknown",
 		Id:     "whatever",
 		Assert: bson.D{{"any", "thing"}},
-	}})
+	}}))
 	c.Check(err, gc.ErrorMatches, `forbidden transaction: references unknown collection "unknown"`)
 	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
 func (s *MultiModelRunnerSuite) TestRejectStructModelUUIDMismatch(c *gc.C) {
-	err := s.multiModelRunner.RunTransaction([]txn.Op{{
+	err := s.multiModelRunner.RunTransaction(txFromOps([]txn.Op{{
 		C:  machinesC,
 		Id: "uuid:0",
 		Insert: &machineDoc{
 			DocID:     "uuid:0",
 			ModelUUID: "somethingelse",
 		},
-	}})
+	}}))
 	c.Check(err, gc.ErrorMatches,
 		`cannot insert into "machines": bad "model-uuid" value: expected uuid, got somethingelse`)
 	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
 func (s *MultiModelRunnerSuite) TestRejectBsonDModelUUIDMismatch(c *gc.C) {
-	err := s.multiModelRunner.RunTransaction([]txn.Op{{
+	err := s.multiModelRunner.RunTransaction(txFromOps([]txn.Op{{
 		C:      machinesC,
 		Id:     "uuid:0",
 		Insert: bson.D{{"model-uuid", "wtf"}},
-	}})
+	}}))
 	c.Check(err, gc.ErrorMatches,
 		`cannot insert into "machines": bad "model-uuid" value: expected uuid, got wtf`)
 	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
 func (s *MultiModelRunnerSuite) TestRejectBsonMModelUUIDMismatch(c *gc.C) {
-	err := s.multiModelRunner.RunTransaction([]txn.Op{{
+	err := s.multiModelRunner.RunTransaction(txFromOps([]txn.Op{{
 		C:      machinesC,
 		Id:     "uuid:0",
 		Insert: bson.M{"model-uuid": "wtf"},
-	}})
+	}}))
 	c.Check(err, gc.ErrorMatches,
 		`cannot insert into "machines": bad "model-uuid" value: expected uuid, got wtf`)
 	c.Check(s.testRunner.seenOps, gc.IsNil)
@@ -486,8 +486,8 @@ type recordingRunner struct {
 	pruneTransactionsErr     error
 }
 
-func (r *recordingRunner) RunTransaction(ops []txn.Op) error {
-	r.seenOps = ops
+func (r *recordingRunner) RunTransaction(tx *jujutxn.Transaction) error {
+	r.seenOps = tx.Ops
 	return nil
 }
 
@@ -504,4 +504,10 @@ func (r *recordingRunner) ResumeTransactions() error {
 func (r *recordingRunner) MaybePruneTransactions(_ jujutxn.PruneOptions) error {
 	r.pruneTransactionsCalled = true
 	return r.pruneTransactionsErr
+}
+
+func txFromOps(ops []txn.Op) *jujutxn.Transaction {
+	return &jujutxn.Transaction{
+		Ops: ops,
+	}
 }


### PR DESCRIPTION
## Description of change

This PR bumps the `juju/txn` dependency version and updates calls to `RunTransaction` to use the new call signature that expects a `*txn.Transaction` argument.

Furthermore, the PR contains a change to expose the transaction retry count via the transaction debug logs. This change will allow us to capture retry-count metrics in our webscale acceptance test scripts.