### PR TITLE
2.5 Get Application Leader from Raft for "juju status"

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/worker/lease"
 )
 
 const (
@@ -84,7 +83,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 		LogDir:          c.MkDir(),
 		Hub:             centralhub.New(machineTag),
 		Presence:        presence.New(clock.WallClock),
-		LeaseManager:    &lease.Manager{},
+		LeaseManager:    apitesting.StubLeaseManager{},
 		Mux:             s.mux,
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -23,6 +23,7 @@ type Context struct {
 	LeadershipClaimer_ leadership.Claimer
 	LeadershipChecker_ leadership.Checker
 	LeadershipPinner_  leadership.Pinner
+	LeadershipReader_  leadership.Reader
 	SingularClaimer_   lease.Claimer
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
@@ -88,6 +89,11 @@ func (context Context) LeadershipChecker() (leadership.Checker, error) {
 // LeadershipPinner implements facade.Context.
 func (context Context) LeadershipPinner(modelUUID string) (leadership.Pinner, error) {
 	return context.LeadershipPinner_, nil
+}
+
+// LeadershipPinner implements facade.Context.
+func (context Context) LeadershipReader(modelUUID string) (leadership.Reader, error) {
+	return context.LeadershipReader_, nil
 }
 
 // SingularClaimer implements facade.Context.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -91,6 +91,10 @@ type Context interface {
 	// context's model.
 	LeadershipPinner(modelUUID string) (leadership.Pinner, error)
 
+	// LeadershipReader returns a leadership.Reader for this
+	// context's model.
+	LeadershipReader(modelUUID string) (leadership.Reader, error)
+
 	// SingularClaimer returns a lease.Claimer for singular leases for
 	// this context's model.
 	SingularClaimer() (lease.Claimer, error)

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -44,6 +44,7 @@ func (ctx *charmsSuiteContext) Hub() facade.Hub             { return nil }
 func (ctx *charmsSuiteContext) LeadershipClaimer(string) (leadership.Claimer, error) { return nil, nil }
 func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error)       { return nil, nil }
 func (ctx *charmsSuiteContext) LeadershipPinner(string) (leadership.Pinner, error)   { return nil, nil }
+func (ctx *charmsSuiteContext) LeadershipReader(string) (leadership.Reader, error)   { return nil, nil }
 func (ctx *charmsSuiteContext) SingularClaimer() (lease.Claimer, error)              { return nil, nil }
 
 func (s *charmsSuite) SetUpTest(c *gc.C) {

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -43,7 +43,6 @@ type Backend interface {
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([][]network.HostPort, error)
 	Application(string) (*state.Application, error)
-	ApplicationLeaders() (map[string]string, error)
 	Charm(*charm.URL) (*state.Charm, error)
 	ControllerConfig() (controller.Config, error)
 	ControllerTag() names.ControllerTag

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -6,8 +6,6 @@ package client
 import (
 	"fmt"
 
-	"github.com/juju/juju/core/leadership"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/os"
@@ -19,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/facades/client/modelconfig"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -219,7 +219,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		return noStatus, errors.Annotate(err, "could not fetch relations")
 	}
 	if len(context.allAppsUnitsCharmBindings.applications) > 0 {
-		if context.leaders, err = c.api.stateAccessor.ApplicationLeaders(); err != nil {
+		if context.leaders, err = c.api.leadershipReader.Leaders(); err != nil {
 			return noStatus, errors.Annotate(err, "could not fetch leaders")
 		}
 	}

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -38,11 +38,11 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // modelconfig API
 		nil, // resources
 		authorizer,
-		nil, // presence
-		nil, // statusSetter
-		nil, // toolsFinder
-		nil, // newEnviron
-		nil, // blockChecker
+		nil,                           // presence
+		nil,                           // statusSetter
+		nil,                           // toolsFinder
+		nil,                           // newEnviron
+		nil,                           // blockChecker
 		context.NewCloudCallContext(), // ProviderCallContext
 		nil,
 	)

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -38,12 +38,13 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // modelconfig API
 		nil, // resources
 		authorizer,
-		nil,                           // presence
-		nil,                           // statusSetter
-		nil,                           // toolsFinder
-		nil,                           // newEnviron
-		nil,                           // blockChecker
+		nil, // presence
+		nil, // statusSetter
+		nil, // toolsFinder
+		nil, // newEnviron
+		nil, // blockChecker
 		context.NewCloudCallContext(), // ProviderCallContext
+		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -6,6 +6,8 @@ package apiserver
 import (
 	"time"
 
+	"github.com/juju/juju/state"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/leadership"
@@ -88,4 +90,27 @@ func (m leadershipPinner) UnpinLeadership(applicationName string, entity string)
 // pinned behaviour.
 func (m leadershipPinner) PinnedLeadership() map[string][]string {
 	return m.pinner.Pinned()
+}
+
+// leadershipReader implements leadership.Reader by wrapping a lease.Reader.
+type leadershipReader struct {
+	reader lease.Reader
+}
+
+// Leaders (leadership.Reader) returns all application leaders in the
+// current model.
+func (r leadershipReader) Leaders() (map[string]string, error) {
+	return r.reader.Leases(), nil
+}
+
+// legacyLeadershipReader implements leadership.Reader by wrapping state.
+type legacyLeadershipReader struct {
+	st *state.State
+}
+
+// Leaders (leadership.Reader) returns all application leaders in the
+// current model according to state.
+func (r legacyLeadershipReader) Leaders() (map[string]string, error) {
+	l, err := r.st.ApplicationLeaders()
+	return l, errors.Trace(err)
 }

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -6,12 +6,11 @@ package apiserver
 import (
 	"time"
 
-	"github.com/juju/juju/state"
-
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/state"
 )
 
 // leadershipChecker implements leadership.Checker by wrapping a lease.Checker.

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -488,6 +488,23 @@ func (ctx *facadeContext) LeadershipPinner(modelUUID string) (leadership.Pinner,
 	return leadershipPinner{pinner}, nil
 }
 
+// LeadershipReader is part of the facade.Context interface.
+// It returns a reader that can be used to return all application leaders
+// in the model.
+func (ctx *facadeContext) LeadershipReader(modelUUID string) (leadership.Reader, error) {
+	if ctx.r.shared.featureEnabled(feature.LegacyLeases) {
+		return legacyLeadershipReader{ctx.State()}, nil
+	}
+	reader, err := ctx.r.shared.leaseManager.Reader(
+		lease.ApplicationLeadershipNamespace,
+		modelUUID,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return leadershipReader{reader}, nil
+}
+
 // SingularClaimer is part of the facade.Context interface.
 func (ctx *facadeContext) SingularClaimer() (lease.Claimer, error) {
 	if ctx.r.shared.featureEnabled(feature.LegacyLeases) {

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -112,7 +112,7 @@ func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
 	ctx := s.newContext(c)
 
 	msg := controller.ConfigChangedMessage{
-		corecontroller.Config{
+		Config: corecontroller.Config{
 			corecontroller.Features: []string{"foo", "bar"},
 		},
 	}
@@ -140,7 +140,7 @@ func (s *sharedServerContextSuite) TestAddingOldPresenceFeature(c *gc.C) {
 	s.newContext(c)
 
 	msg := controller.ConfigChangedMessage{
-		corecontroller.Config{
+		Config: corecontroller.Config{
 			corecontroller.Features: []string{"foo", "bar", feature.OldPresence},
 		},
 	}
@@ -168,7 +168,7 @@ func (s *sharedServerContextSuite) TestRemovingOldPresenceFeature(c *gc.C) {
 	s.newContext(c)
 
 	msg := controller.ConfigChangedMessage{
-		corecontroller.Config{
+		Config: corecontroller.Config{
 			corecontroller.Features: []string{"foo", "bar"},
 		},
 	}

--- a/apiserver/testing/stub_lease_manager.go
+++ b/apiserver/testing/stub_lease_manager.go
@@ -1,0 +1,22 @@
+package testing
+
+import "github.com/juju/juju/core/lease"
+
+// StubLeaseReader pretends to implement lease.Reader.
+// The non-implemented Leases() method should not be called by tests in the
+// base apiserver package.
+type StubLeaseReader struct {
+	lease.Reader
+}
+
+// StubLeaseManager pretends to implement lease.Manager.
+// The only method called in this package should be Reader(),
+// implemented below.
+type StubLeaseManager struct {
+	lease.Manager
+}
+
+// Reader returns a StubLeaseReader, which will panic if used.
+func (m StubLeaseManager) Reader(namespace string, modelUUID string) (lease.Reader, error) {
+	return StubLeaseReader{}, nil
+}

--- a/apiserver/testing/stub_lease_manager.go
+++ b/apiserver/testing/stub_lease_manager.go
@@ -1,3 +1,6 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package testing
 
 import "github.com/juju/juju/core/lease"

--- a/apiserver/testserver/server.go
+++ b/apiserver/testserver/server.go
@@ -21,12 +21,12 @@ import (
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	"github.com/juju/juju/apiserver/stateauthenticator"
+	apitesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/worker/lease"
 )
 
 // DefaultServerConfig returns the default configuration for starting a test server.
@@ -39,7 +39,7 @@ func DefaultServerConfig(c *gc.C) apiserver.ServerConfig {
 		LogDir:          c.MkDir(),
 		Hub:             hub,
 		Presence:        presence.New(clock.WallClock),
-		LeaseManager:    &lease.Manager{},
+		LeaseManager:    apitesting.StubLeaseManager{},
 		NewObserver:     func() observer.Observer { return &fakeobserver.Instance{} },
 		RateLimitConfig: apiserver.DefaultRateLimitConfig(),
 		GetAuditConfig:  func() auditlog.Config { return auditlog.Config{Enabled: false} },

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/version"
@@ -31,7 +29,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/migration"
 	corepresence "github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
@@ -4217,14 +4214,15 @@ type setUnitAsLeader struct {
 func (s setUnitAsLeader) step(c *gc.C, ctx *context) {
 	u, err := ctx.st.Unit(s.unitName)
 	c.Assert(err, jc.ErrorIsNil)
-	target := ctx.st.LeaseNotifyTarget(
-		ioutil.Discard,
-		loggo.GetLogger("status_internal_test"),
-	)
-	target.Claimed(
-		lease.Key{"application-leadership", ctx.st.ModelUUID(), u.ApplicationName()},
-		u.Name(),
-	)
+
+	// We must use the lease manager from the API server.
+	// Requesting it from state will claim against a *different* legacy lease
+	// manager running in the state workers collection.
+	stater := ctx.env.(testing.GetStater)
+	claimer, err := stater.GetLeaseManagerInAPIServer().Claimer("application-leadership", ctx.st.ModelUUID())
+
+	err = claimer.Claim(u.ApplicationName(), u.Name(), time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 type setUnitStatus struct {

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/errors"
 )
 
-// TODO (manadart 2010-10-05) Add interfaces to the end of this line,
+// TODO (manadart 2018-10-05) Add interfaces to the end of this line,
 // separated by commas, as they become required for mocking in tests.
 //go:generate mockgen -package mocks -destination mocks/leadership_mock.go github.com/juju/juju/core/leadership Pinner
 

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -137,3 +137,13 @@ type Tracker interface {
 	// until the tracker's future leadership can no longer be guaranteed.
 	WaitMinion() Ticket
 }
+
+// Reader describes the capability to read the current state of leadership.
+type Reader interface {
+
+	// Leaders returns all application leaders in the current model.
+	// TODO (manadart 2019-02-27): The return in this signature includes error
+	// in order to support state.ApplicationLeaders for legacy leases.
+	// When legacy leases are removed, so can the error return.
+	Leaders() (map[string]string, error)
+}

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -100,10 +100,17 @@ type Token interface {
 	Check(attempt int, trapdoorKey interface{}) error
 }
 
+// Reader describes retrieval of all leases and holders
+// for a known namespace and model.
+type Reader interface {
+	Leases() map[string]string
+}
+
 // Manager describes methods for acquiring objects that manipulate and query
 // leases for different models.
 type Manager interface {
 	Checker(namespace string, modelUUID string) (Checker, error)
 	Claimer(namespace string, modelUUID string) (Claimer, error)
 	Pinner(namespace string, modelUUID string) (Pinner, error)
+	Reader(namespace string, modelUUID string) (Reader, error)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -239,7 +239,7 @@ type environProvider struct {
 	state                  map[string]*environState
 }
 
-// APIPort returns the randon api port used by the given provider instance.
+// APIPort returns the random api port used by the given provider instance.
 func APIPort(p environs.EnvironProvider) int {
 	return p.(*environProvider).apiPort
 }

--- a/worker/lease/bound.go
+++ b/worker/lease/bound.go
@@ -16,6 +16,7 @@ type broker interface {
 	lease.Checker
 	lease.Claimer
 	lease.Pinner
+	lease.Reader
 }
 
 // boundManager implements the broker interface.
@@ -89,6 +90,12 @@ func (b *boundManager) Pin(leaseName string, entity string) error {
 // Unpin (lease.Pinner) sends an unpin message to the worker loop.
 func (b *boundManager) Unpin(leaseName string, entity string) error {
 	return errors.Trace(b.pinOp(leaseName, entity, b.manager.unpins))
+}
+
+// Leases (lease.Reader) returns all leases and holders
+// in the bound namespace/model.
+func (b *boundManager) Leases() map[string]string {
+	return b.manager.leases(b.namespace, b.modelUUID)
 }
 
 // pinOp creates a pin instance from the input lease name,

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -233,6 +233,11 @@ func (manager *Manager) Pinner(namespace, modelUUID string) (lease.Pinner, error
 	return manager.bind(namespace, modelUUID)
 }
 
+// Reader returns a lease.Reader for the specified namespace and model.
+func (manager *Manager) Reader(namespace, modelUUID string) (lease.Reader, error) {
+	return manager.bind(namespace, modelUUID)
+}
+
 // retryingClaim handles timeouts when claiming, and responds to the
 // claiming party when it eventually succeeds or fails, or if it times
 // out after a number of retries.
@@ -597,6 +602,14 @@ func (manager *Manager) pinned(namespace, modelUUID string) map[string][]string 
 		}
 	}
 	return pinned
+}
+
+func (manager *Manager) leases(namespace, modelUUID string) map[string]string {
+	leases := make(map[string]string)
+	for key, lease := range manager.config.Store.Leases() {
+		leases[key.Lease] = lease.Holder
+	}
+	return leases
 }
 
 func keysLess(a, b lease.Key) bool {

--- a/worker/lease/manager_leases_test.go
+++ b/worker/lease/manager_leases_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/worker/lease"
+)
+
+type LeasesSuite struct {
+	testing.IsolationSuite
+
+	appName string
+	machine string
+	pinArgs []interface{}
+}
+
+var _ = gc.Suite(&LeasesSuite{})
+
+func (s *LeasesSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.appName = "redis"
+}
+
+func (s *LeasesSuite) TestLeases(c *gc.C) {
+	fix := &Fixture{
+		leases: map[corelease.Key]corelease.Info{
+			key(s.appName): {
+				Holder:   "redis/0",
+				Expiry:   offset(time.Second),
+				Trapdoor: corelease.LockedTrapdoor,
+			},
+		},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
+		leases := getReader(c, manager).Leases()
+		c.Check(leases, gc.DeepEquals, map[string]string{s.appName: "redis/0"})
+	})
+}
+
+func getReader(c *gc.C, manager *lease.Manager) corelease.Reader {
+	reader, err := manager.Reader("namespace", "modelUUID")
+	c.Assert(err, jc.ErrorIsNil)
+	return reader
+}

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -212,7 +212,7 @@ func (store *Store) UnpinLease(key lease.Key, entity string, stop <-chan struct{
 }
 
 func (store *Store) Pinned() map[lease.Key][]string {
-	store.call("Pinned", nil)
+	_ = store.call("Pinned", nil)
 	return map[lease.Key][]string{
 		{
 			Namespace: "namespace",


### PR DESCRIPTION
## Description of change

This patch adds logic so that application leaders are retrieved from Raft for the `juju status` client command.

## QA steps

New Behaviour:
- Bootstrap.
- `juju deploy redis -n 3`. Leader should wind up as "redis/0".
- Change the leader lease in Mongo, for example: `db.leaseholders.updateOne({ "_id": "<model-uuid>:application-leadership#redis#"}, {$set:{"holder": "redis/1"}})`
- Observe that the leader is still reported as "redis/0" as per Raft determination.

Regression:
- `juju controller-config features=[legacy-leases]`
- Restart the controller.
- Observe that the leader is "redis/1" as set in the DB.

## Documentation changes

None.

## Bug reference

N/A
