### PR TITLE
Fixes lp#1817745:Err if environment variable controller values conflict.

### DIFF
--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -104,10 +104,6 @@ func (c *ControllerCommandBase) initController() error {
 }
 
 // DetermineCurrentController returns current controller on this client.
-// The returned result corresponds to, in order of precedence:
-// 1. if JUJU_MODEL env variable exists and its value contains a controller prefix, that controller name;
-// 2. if JUJU_CONTROLLER env variable exists, its value;
-// 3. current controller specified in local controllers.yaml file.
 func DetermineCurrentController(store jujuclient.ClientStore) (string, error) {
 	modelController, _ := SplitModelName(os.Getenv(osenv.JujuModelEnvKey))
 	envController := os.Getenv(osenv.JujuControllerEnvKey)
@@ -122,7 +118,6 @@ func DetermineCurrentController(store jujuclient.ClientStore) (string, error) {
 		controllerName = envController
 	}
 	if controllerName == "" {
-		// 3. Current controller is specified in local controllers.yaml file.
 		var err error
 		controllerName, err = store.CurrentController()
 		if err != nil {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -4,7 +4,6 @@
 package modelcmd
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 
@@ -113,11 +112,10 @@ func DetermineCurrentController(store jujuclient.ClientStore) (string, error) {
 	modelController, _ := SplitModelName(os.Getenv(osenv.JujuModelEnvKey))
 	envController := os.Getenv(osenv.JujuControllerEnvKey)
 	if modelController != "" && envController != "" && modelController != envController {
-		return "", errors.Trace(errors.New(
-			fmt.Sprintf("controller name from %v (%v) conflicts with value in %v (%v)",
-				osenv.JujuModelEnvKey, modelController,
-				osenv.JujuControllerEnvKey, envController,
-			)))
+		return "", errors.Errorf("controller name from %v (%v) conflicts with value in %v (%v)",
+			osenv.JujuModelEnvKey, modelController,
+			osenv.JujuControllerEnvKey, envController,
+		)
 	}
 	controllerName := modelController
 	if controllerName == "" {

--- a/featuretests/cmd_juju_current_controller_test.go
+++ b/featuretests/cmd_juju_current_controller_test.go
@@ -4,13 +4,13 @@
 package featuretests
 
 import (
-	gc "gopkg.in/check.v1"
 	"regexp"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/commands"
 	jujutesting "github.com/juju/juju/juju/testing"


### PR DESCRIPTION
## Description of change

If client has $JUJU_MODEL and $JUJU_CONTROLLER environment variables specified and the controller values disagree and no further clarification was provided via command options [1], err out with descriptive message.

As  a drive-by, this PR adds model level commands scenarios that were mentioned in lp#1786140 as internal tests.

[1] -c for controller level command and -m for model level command 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1817745
https://bugs.launchpad.net/juju/+bug/1817744
https://bugs.launchpad.net/bugs/1786140
