### PR TITLE
LXD: Allow juju to target snap v2 lxd

### DIFF
--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -234,7 +234,15 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 // It checks the LXD bridge configuration file and ensure that one of the input
 // devices is suitable for LXD to work with Juju.
 func (s *Server) verifyNICsWithConfigFile(nics map[string]device, reader func(string) ([]byte, error)) error {
-	netName, err := checkBridgeConfigFile(reader)
+	paths := []string{BridgeConfigFile, SnapBridgeConfigFile}
+	var netName string
+	var err error
+	for _, filePath := range paths {
+		netName, err = checkBridgeConfigFile(filePath, reader)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -319,6 +327,7 @@ func isValidNICType(nic device) bool {
 }
 
 const BridgeConfigFile = "/etc/default/lxd-bridge"
+const SnapBridgeConfigFile = "/var/snap/lxd/common/lxd-bridge/config"
 
 // checkBridgeConfigFile verifies that the file configuration for the LXD
 // bridge has a a bridge name, that it is set to be used by LXD and that
@@ -327,10 +336,10 @@ const BridgeConfigFile = "/etc/default/lxd-bridge"
 // installations that pre-date the network API support and that were installed
 // via Snap. The question of the correct user action was posed on the #lxd IRC
 // channel, but has not be answered to-date.
-func checkBridgeConfigFile(reader func(string) ([]byte, error)) (string, error) {
-	bridgeConfig, err := reader(BridgeConfigFile)
+func checkBridgeConfigFile(fileName string, reader func(string) ([]byte, error)) (string, error) {
+	bridgeConfig, err := reader(fileName)
 	if os.IsNotExist(err) {
-		return "", bridgeConfigError("no config file found at " + BridgeConfigFile)
+		return "", bridgeConfigError("no config file found at " + fileName)
 	} else if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -345,12 +354,12 @@ func checkBridgeConfigFile(reader func(string) ([]byte, error)) (string, error) 
 				continue
 			}
 			if !b {
-				return "", bridgeConfigError(fmt.Sprintf("%s has USE_LXD_BRIDGE set to false", BridgeConfigFile))
+				return "", bridgeConfigError(fmt.Sprintf("%s has USE_LXD_BRIDGE set to false", fileName))
 			}
 		} else if strings.HasPrefix(line, "LXD_BRIDGE=") {
 			bridgeName = strings.Trim(line[len("LXD_BRIDGE="):], " \"")
 			if bridgeName == "" {
-				return "", bridgeConfigError(fmt.Sprintf("%s has no LXD_BRIDGE set", BridgeConfigFile))
+				return "", bridgeConfigError(fmt.Sprintf("%s has no LXD_BRIDGE set", fileName))
 			}
 		} else if strings.HasPrefix(line, "LXD_IPV4_ADDR=") {
 			contents := strings.Trim(line[len("LXD_IPV4_ADDR="):], " \"")
@@ -360,7 +369,7 @@ func checkBridgeConfigFile(reader func(string) ([]byte, error)) (string, error) 
 		} else if strings.HasPrefix(line, "LXD_IPV6_ADDR=") {
 			contents := strings.Trim(line[len("LXD_IPV6_ADDR="):], " \"")
 			if len(contents) > 0 {
-				return "", ipv6BridgeConfigError(BridgeConfigFile)
+				return "", ipv6BridgeConfigError(fileName)
 			}
 		}
 	}
@@ -374,16 +383,11 @@ func checkBridgeConfigFile(reader func(string) ([]byte, error)) (string, error) 
 }
 
 func bridgeConfigError(err string) error {
-	return errors.Errorf("%s\nIt looks like your LXD bridge has not yet been configured. Configure it via:\n\n"+
-		"\tsudo dpkg-reconfigure -p medium lxd\n\n"+
-		"and run the command again.", err)
+	return errors.Errorf("%s\nIt looks like your LXD bridge has not yet been configured.", err)
 }
 
 func ipv6BridgeConfigError(fileName string) error {
-	return errors.Errorf("%s has IPv6 enabled.\nJuju doesn't currently support IPv6.\n"+
-		"Disable IPv6 via:\n\n"+
-		"\tsudo dpkg-reconfigure -p medium lxd\n\n"+
-		"and run the command again.", fileName)
+	return errors.Errorf("%s has IPv6 enabled.\nJuju doesn't currently support IPv6", fileName)
 }
 
 // InterfaceInfoFromDevices returns a slice of interface info congruent with the

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -349,7 +349,7 @@ func (s *networkSuite) TestInterfaceInfoFromDevices(c *gc.C) {
 func (s *networkSuite) TestCheckAptLXDBridgeConfiguration(c *gc.C) {
 	lxd.PatchLXDViaSnap(s, false)
 
-	bridgeName, err := lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, validBridgeConfig)
+	bridgeName, err := lxd.CheckBridgeConfigFile(validBridgeConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(bridgeName, gc.Equals, "lxdbr0")
 
@@ -358,7 +358,7 @@ func (s *networkSuite) TestCheckAptLXDBridgeConfiguration(c *gc.C) {
 USE_LXD_BRIDGE="false"
 `), nil
 	}
-	_, err = lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, noBridge)
+	_, err = lxd.CheckBridgeConfigFile(noBridge)
 	c.Assert(err.Error(), gc.Equals, lxd.BridgeConfigFile+` has USE_LXD_BRIDGE set to false
 It looks like your LXD bridge has not yet been configured. Configure it via:
 
@@ -372,7 +372,7 @@ USE_LXD_BRIDGE="true"
 LXD_BRIDGE="br0"
 `), nil
 	}
-	_, err = lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, noSubnets)
+	_, err = lxd.CheckBridgeConfigFile(noSubnets)
 	c.Assert(err.Error(), gc.Equals, `br0 has no ipv4 or ipv6 subnet enabled
 It looks like your LXD bridge has not yet been configured. Configure it via:
 
@@ -388,7 +388,7 @@ LXD_IPV6_ADDR="2001:470:b368:4242::1"
 `), nil
 	}
 
-	_, err = lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, ipv6)
+	_, err = lxd.CheckBridgeConfigFile(ipv6)
 	c.Assert(err.Error(), gc.Equals, lxd.BridgeConfigFile+` has IPv6 enabled.
 Juju doesn't currently support IPv6.
 Disable IPv6 via:
@@ -401,7 +401,7 @@ and run the command again.`)
 func (s *networkSuite) TestCheckSnapLXDBridgeConfiguration(c *gc.C) {
 	lxd.PatchLXDViaSnap(s, true)
 
-	bridgeName, err := lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, validBridgeConfig)
+	bridgeName, err := lxd.CheckBridgeConfigFile(validBridgeConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(bridgeName, gc.Equals, "lxdbr0")
 
@@ -410,7 +410,7 @@ func (s *networkSuite) TestCheckSnapLXDBridgeConfiguration(c *gc.C) {
 USE_LXD_BRIDGE="false"
 `), nil
 	}
-	_, err = lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, noBridge)
+	_, err = lxd.CheckBridgeConfigFile(noBridge)
 	c.Assert(err.Error(), gc.Equals, lxd.SnapBridgeConfigFile+` has USE_LXD_BRIDGE set to false
 It looks like your LXD bridge has not yet been configured.`)
 
@@ -420,7 +420,7 @@ USE_LXD_BRIDGE="true"
 LXD_BRIDGE="br0"
 `), nil
 	}
-	_, err = lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, noSubnets)
+	_, err = lxd.CheckBridgeConfigFile(noSubnets)
 	c.Assert(err.Error(), gc.Equals, `br0 has no ipv4 or ipv6 subnet enabled
 It looks like your LXD bridge has not yet been configured.`)
 
@@ -432,7 +432,7 @@ LXD_IPV6_ADDR="2001:470:b368:4242::1"
 `), nil
 	}
 
-	_, err = lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, ipv6)
+	_, err = lxd.CheckBridgeConfigFile(ipv6)
 	c.Assert(err.Error(), gc.Equals, lxd.SnapBridgeConfigFile+` has IPv6 enabled.
 Juju doesn't currently support IPv6.`)
 }

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -346,8 +346,10 @@ func (s *networkSuite) TestInterfaceInfoFromDevices(c *gc.C) {
 	c.Check(info, jc.DeepEquals, exp)
 }
 
-func (s *networkSuite) TestCheckLXDBridgeConfiguration(c *gc.C) {
-	bridgeName, err := lxd.CheckBridgeConfigFile(validBridgeConfig)
+func (s *networkSuite) TestCheckAptLXDBridgeConfiguration(c *gc.C) {
+	lxd.PatchLXDViaSnap(s, false)
+
+	bridgeName, err := lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, validBridgeConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(bridgeName, gc.Equals, "lxdbr0")
 
@@ -356,8 +358,8 @@ func (s *networkSuite) TestCheckLXDBridgeConfiguration(c *gc.C) {
 USE_LXD_BRIDGE="false"
 `), nil
 	}
-	_, err = lxd.CheckBridgeConfigFile(noBridge)
-	c.Assert(err.Error(), gc.Equals, `/etc/default/lxd-bridge has USE_LXD_BRIDGE set to false
+	_, err = lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, noBridge)
+	c.Assert(err.Error(), gc.Equals, lxd.BridgeConfigFile+` has USE_LXD_BRIDGE set to false
 It looks like your LXD bridge has not yet been configured. Configure it via:
 
 	sudo dpkg-reconfigure -p medium lxd
@@ -370,7 +372,7 @@ USE_LXD_BRIDGE="true"
 LXD_BRIDGE="br0"
 `), nil
 	}
-	_, err = lxd.CheckBridgeConfigFile(noSubnets)
+	_, err = lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, noSubnets)
 	c.Assert(err.Error(), gc.Equals, `br0 has no ipv4 or ipv6 subnet enabled
 It looks like your LXD bridge has not yet been configured. Configure it via:
 
@@ -386,7 +388,7 @@ LXD_IPV6_ADDR="2001:470:b368:4242::1"
 `), nil
 	}
 
-	_, err = lxd.CheckBridgeConfigFile(ipv6)
+	_, err = lxd.CheckBridgeConfigFile(lxd.BridgeConfigFile, ipv6)
 	c.Assert(err.Error(), gc.Equals, lxd.BridgeConfigFile+` has IPv6 enabled.
 Juju doesn't currently support IPv6.
 Disable IPv6 via:
@@ -394,6 +396,45 @@ Disable IPv6 via:
 	sudo dpkg-reconfigure -p medium lxd
 
 and run the command again.`)
+}
+
+func (s *networkSuite) TestCheckSnapLXDBridgeConfiguration(c *gc.C) {
+	lxd.PatchLXDViaSnap(s, true)
+
+	bridgeName, err := lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, validBridgeConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(bridgeName, gc.Equals, "lxdbr0")
+
+	noBridge := func(string) ([]byte, error) {
+		return []byte(`
+USE_LXD_BRIDGE="false"
+`), nil
+	}
+	_, err = lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, noBridge)
+	c.Assert(err.Error(), gc.Equals, lxd.SnapBridgeConfigFile+` has USE_LXD_BRIDGE set to false
+It looks like your LXD bridge has not yet been configured.`)
+
+	noSubnets := func(string) ([]byte, error) {
+		return []byte(`
+USE_LXD_BRIDGE="true"
+LXD_BRIDGE="br0"
+`), nil
+	}
+	_, err = lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, noSubnets)
+	c.Assert(err.Error(), gc.Equals, `br0 has no ipv4 or ipv6 subnet enabled
+It looks like your LXD bridge has not yet been configured.`)
+
+	ipv6 := func(string) ([]byte, error) {
+		return []byte(`
+USE_LXD_BRIDGE="true"
+LXD_BRIDGE="lxdbr0"
+LXD_IPV6_ADDR="2001:470:b368:4242::1"
+`), nil
+	}
+
+	_, err = lxd.CheckBridgeConfigFile(lxd.SnapBridgeConfigFile, ipv6)
+	c.Assert(err.Error(), gc.Equals, lxd.SnapBridgeConfigFile+` has IPv6 enabled.
+Juju doesn't currently support IPv6.`)
 }
 
 func (s *networkSuite) TestVerifyNICsWithConfigFileNICFound(c *gc.C) {


### PR DESCRIPTION
## Description of change

Allow juju to target snap v2

The following ensures that we show a common error message between
Apt vs Snap, but change the instructions with in Snap error
messages to not tell the operator to use commands which probably
won't exist on their system.

## QA steps

```sh
snap install lxd --channel=2.5/stable --classic
sudo lxd init
juju bootstrap lxd test
```

## Documentation changes

Allow juju to work with a snap lxd of v2.
