### PR TITLE
Fix blocking shutdown race.

### DIFF
--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -182,7 +182,15 @@ func (s *JujuConnSuite) hubWatcherIdleFunc(modelUUID string) {
 	if idleChan == nil {
 		return
 	}
-	idleChan <- modelUUID
+	// There is a very small race condition between when the
+	// idle channel is cleared and when the function exits.
+	// Under normal circumstances, there is a goroutine in a tight loop
+	// reading off the idle channel. If the channel isn't read
+	// within a short wait, we don't send the message.
+	select {
+	case idleChan <- modelUUID:
+	case <-time.After(testing.ShortWait):
+	}
 }
 
 func (s *JujuConnSuite) WaitForNextSync(c *gc.C) {


### PR DESCRIPTION
There are some test timeouts for watcher tests where the test gets killed after 25 minutes.

This was due to a bare channel send and nothing listening.

This blocks the idleFunc in the hubwatcher, which stops it processing the main loop, which includes watching the dying channel, which matches where the test is hung, which is in the state.Close() method.
