### PR TITLE
Use "MB" Suffix for Memory Constraints on LXD Versions < 3.10

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -896,6 +896,7 @@
     "shared/logger",
     "shared/osarch",
     "shared/simplestreams",
+    "shared/version",
   ]
   pruneopts = ""
   revision = "4c2bbb608e7a90a9f175a566b9e638069424f0f7"
@@ -1940,6 +1941,7 @@
     "github.com/lxc/lxd/shared/api",
     "github.com/lxc/lxd/shared/logger",
     "github.com/lxc/lxd/shared/osarch",
+    "github.com/lxc/lxd/shared/version",
     "github.com/mattn/go-isatty",
     "github.com/oracle/oci-go-sdk/common",
     "github.com/oracle/oci-go-sdk/core",

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -49,11 +49,15 @@ func (c *ContainerSpec) ApplyConstraints(serverVersion string, cons constraints.
 		c.Config["limits.cpu"] = fmt.Sprintf("%d", *cons.CpuCores)
 	}
 	if cons.HasMem() {
-		// LXD versions < 3 do not recognise the correct "MiB" notation.
-		template := "%dMiB"
-		if v, err := strconv.Atoi(strings.Split(serverVersion, ".")[0]); err == nil && v < 3 {
-			template = "%dMB"
+		// Ensure that for LXD versions 3.10+, we use the correct "MiB" suffix.
+		template := "%dMB"
+		version := strings.Split(serverVersion, ".")
+		if major, _ := strconv.Atoi(version[0]); major > 2 {
+			if minor, _ := strconv.Atoi(version[1]); minor >= 9 || major > 3 {
+				template = "%dMiB"
+			}
 		}
+
 		c.Config["limits.memory"] = fmt.Sprintf(template, *cons.Mem)
 	}
 }

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -6,13 +6,13 @@ package lxd
 import (
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/arch"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/network"
@@ -51,13 +51,13 @@ func (c *ContainerSpec) ApplyConstraints(serverVersion string, cons constraints.
 	if cons.HasMem() {
 		// Ensure that for LXD versions 3.10+, we use the correct "MiB" suffix.
 		template := "%dMB"
-		version := strings.Split(serverVersion, ".")
-		if major, _ := strconv.Atoi(version[0]); major > 2 {
-			if minor, _ := strconv.Atoi(version[1]); minor >= 9 || major > 3 {
-				template = "%dMiB"
+		if current, err := version.Parse(serverVersion); err == nil {
+			if min, err := version.NewDottedVersion("3.10"); err == nil {
+				if current.Compare(min) >= 0 {
+					template = "%dMiB"
+				}
 			}
 		}
-
 		c.Config["limits.memory"] = fmt.Sprintf(template, *cons.Mem)
 	}
 }

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -473,7 +473,7 @@ func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 		"limits.memory":  "2046MiB",
 		"limits.cpu":     "4",
 	}
-	spec.ApplyConstraints("3.10", cons)
+	spec.ApplyConstraints("3.10.0", cons)
 	c.Check(spec.Config, gc.DeepEquals, exp)
 	c.Check(spec.InstanceType, gc.Equals, instType)
 

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -466,13 +466,20 @@ func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 	spec := lxd.ContainerSpec{
 		Config: map[string]string{lxd.AutoStartKey: "true"},
 	}
-	spec.ApplyConstraints(cons)
 
+	// Uses the "MiB" suffix.
 	exp := map[string]string{
 		lxd.AutoStartKey: "true",
 		"limits.memory":  "2046MiB",
 		"limits.cpu":     "4",
 	}
+	spec.ApplyConstraints("3.10", cons)
+	c.Check(spec.Config, gc.DeepEquals, exp)
+	c.Check(spec.InstanceType, gc.Equals, instType)
+
+	// Uses the "MB" suffix.
+	exp["limits.memory"] = "2046MB"
+	spec.ApplyConstraints("2.0.11", cons)
 	c.Check(spec.Config, gc.DeepEquals, exp)
 	c.Check(spec.InstanceType, gc.Equals, instType)
 }

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -230,7 +230,7 @@ func (m *containerManager) getContainerSpec(
 		Profiles: instanceConfig.Profiles,
 		Devices:  nics,
 	}
-	spec.ApplyConstraints(cons)
+	spec.ApplyConstraints(m.server.serverVersion, cons)
 
 	return spec, nil
 }

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	clustered         bool
 	serverCertificate string
 	hostArch          string
+	serverVersion     string
 
 	networkAPISupport bool
 	clusterAPISupport bool
@@ -114,12 +115,17 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 		networkAPISupport: shared.StringInSlice("network", apiExt),
 		clusterAPISupport: shared.StringInSlice("clustering", apiExt),
 		storageAPISupport: shared.StringInSlice("storage", apiExt),
+		serverVersion:     info.Environment.ServerVersion,
 	}, nil
 }
 
 // Name returns the name of this LXD server.
 func (s *Server) Name() string {
 	return s.name
+}
+
+func (s *Server) ServerVersion() string {
+	return s.serverVersion
 }
 
 // UpdateServerConfig updates the server configuration with the input values.

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -125,7 +125,7 @@ func (env *environ) newContainer(
 	}
 	cleanupCallback() // Clean out any long line of completed download status
 
-	cSpec, err := env.getContainerSpec(image, args)
+	cSpec, err := env.getContainerSpec(image, target.ServerVersion(), args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -172,7 +172,7 @@ func (env *environ) getImageSources() ([]lxd.ServerSpec, error) {
 // Cloud-init config is generated based on the network devices in the default
 // profile and included in the spec config.
 func (env *environ) getContainerSpec(
-	image lxd.SourcedImage, args environs.StartInstanceParams,
+	image lxd.SourcedImage, serverVersion string, args environs.StartInstanceParams,
 ) (lxd.ContainerSpec, error) {
 	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)
 	if err != nil {
@@ -184,7 +184,7 @@ func (env *environ) getContainerSpec(
 		Image:    image,
 		Config:   make(map[string]string),
 	}
-	cSpec.ApplyConstraints(args.Constraints)
+	cSpec.ApplyConstraints(serverVersion, args.Constraints)
 
 	cloudCfg, err := cloudinit.New(args.InstanceConfig.Series)
 	if err != nil {

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -91,7 +91,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.ServerVersion().Return("3.10"),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -130,7 +130,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.ServerVersion().Return("3.10"),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -292,7 +292,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.ServerVersion().Return("3.10"),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -337,7 +337,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.ServerVersion().Return("3.10"),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -374,7 +374,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.ServerVersion().Return("3.10"),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),
 	)

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -91,6 +91,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -129,6 +130,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -290,6 +292,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -334,6 +337,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -370,6 +374,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),
 	)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -34,6 +34,7 @@ import (
 type Server interface {
 	FindImage(string, string, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
 	GetServer() (server *lxdapi.Server, ETag string, err error)
+	ServerVersion() string
 	GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error)
 	UpdateServerConfig(map[string]string) error
 	UpdateContainerConfig(string, map[string]string) error

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -496,6 +496,18 @@ func (mr *MockServerMockRecorder) ServerCertificate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerCertificate", reflect.TypeOf((*MockServer)(nil).ServerCertificate))
 }
 
+// ServerVersion mocks base method
+func (m *MockServer) ServerVersion() string {
+	ret := m.ctrl.Call(m, "ServerVersion")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ServerVersion indicates an expected call of ServerVersion
+func (mr *MockServerMockRecorder) ServerVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerVersion", reflect.TypeOf((*MockServer)(nil).ServerVersion))
+}
+
 // StorageSupported mocks base method
 func (m *MockServer) StorageSupported() bool {
 	ret := m.ctrl.Call(m, "StorageSupported")

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -435,6 +435,7 @@ type StubClient struct {
 	Volumes            map[string][]api.StorageVolume
 	ServerCert         string
 	ServerHostArch     string
+	ServerVer          string
 }
 
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
@@ -496,6 +497,11 @@ func (conn *StubClient) GetServer() (*api.Server, string, error) {
 			Certificate: "server-cert",
 		},
 	}, "etag", nil
+}
+
+func (conn *StubClient) ServerVersion() string {
+	conn.AddCall("ServerVersion")
+	return conn.ServerVer
 }
 
 func (conn *StubClient) GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error) {


### PR DESCRIPTION
## Description of change

This patch addresses changes made to work with LXD 3.10+ that now fail for earlier versions.
- `ServerVersion` is exposed on the LXD Server.
- When generating a container spec choose "MiB" or "MB" for memory constraint suffixes based on the version.

## QA steps

Bootstrap against a LXD 2.x server, supplying `constrains mem=2G`. This should succeed.
_Note that Juju now works with Snap installed LXD 2.x._

## Documentation changes

None 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1818039
