### PR TITLE
Improve webscale metrics

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -51,7 +51,7 @@ def deploy_bundle(client, charm_bundle, stack_type):
         # Depending on the stack type, use a different bundle definition for
         # one that's not already included.
         if stack_type == "iaas":
-            default_charm = "basic-openstack-lxd.yaml"
+            default_charm = "webscale-lxd.yaml"
         elif stack_type == "caas":
             default_charm = "bundles-kubernetes-core-lxd.yaml"
         else:

--- a/acceptancetests/reporting.py
+++ b/acceptancetests/reporting.py
@@ -42,25 +42,13 @@ class InfluxClient(_Reporting):
                 },
             })
 
-        self.client.write_points(series, retention_policy=POLICYNAME, time_precision='s')
-
-
-def construct_metrics(total_time, total_num_txns, max_time, test_duration):
-    """Make metrics creates a dictionary of items to pass to the
-       reporting client.
-    """
-
-    return {
-        "total_time": total_time,
-        "total_num_txns": total_num_txns,
-        "max_time": max_time,
-        "test_duration": test_duration,
-    }
+        self.client.write_points(
+            series, retention_policy=POLICYNAME, time_precision='s')
 
 
 def get_reporting_client(uri):
-    """Reporting client returns a client for reporting metrics to.
-       It expects that the uri can be parsed and sent to the client constructor.
+    """Reporting client returns a client for reporting metrics to.  It expects
+    that the uri can be parsed and sent to the client constructor.
 
     :param uri: URI to connect to the client.
     """

--- a/acceptancetests/repository/webscale-lxd.yaml
+++ b/acceptancetests/repository/webscale-lxd.yaml
@@ -1,0 +1,24 @@
+relations:
+- - keystone:shared-db
+  - mysql:shared-db
+series: bionic
+services:
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: cs:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: cloud:bionic-rocky
+      worker-multiplier: 0.25
+  mysql:
+    annotations:
+      gui-x: '0'
+      gui-y: '250'
+    charm: cs:percona-cluster
+    num_units: 1
+    options:
+      max-connections: 20000
+      innodb-buffer-pool-size: 50%


### PR DESCRIPTION
## Description of change

This PR refactors the webscale acceptance test code so that:
- it processes not only timing metrics for executed transactions but also txn retry counts 
- it calculates and emits additional statistics:
  - txn_time_{min,max,mean,median,stddev}
  - txn_retries_{min,max,mean,median,stddev}
 - the python linter is happy 

In addition, the default charm for iaas tests (`--stack-type iaas`) is set to a keystone/mysql bundle which is less resource-intensive than deploying openstack and will allow us to run the iaas webscale tests in ~7m.