### PR TITLE
Add k8s deployment watcher to report scale changes

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -141,6 +141,12 @@ func (a *mockApplication) GetScale() int {
 	return a.scale
 }
 
+func (a *mockApplication) Scale(scale int) error {
+	a.MethodCall(a, "Scale", scale)
+	a.scale = scale
+	return nil
+}
+
 func (a *mockApplication) GetPlacement() string {
 	a.MethodCall(a, "GetPlacement")
 	return "placement"

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -67,6 +67,7 @@ type Model interface {
 // required by the CAAS unit provisioner facade.
 type Application interface {
 	GetScale() int
+	Scale(int) error
 	WatchScale() state.NotifyWatcher
 	ApplicationConfig() (application.ConfigAttributes, error)
 	AllUnits() (units []Unit, err error)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -588,6 +588,7 @@ type UpdateApplicationUnitArgs struct {
 // UpdateApplicationUnits holds unit parameters for a specified application.
 type UpdateApplicationUnits struct {
 	ApplicationTag string                  `json:"application-tag"`
+	Scale          int                     `json:"scale"`
 	Units          []ApplicationUnitParams `json:"units"`
 }
 

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -152,6 +152,10 @@ type Broker interface {
 	// are changes to the operator of the specified application.
 	WatchOperator(string) (watcher.NotifyWatcher, error)
 
+	// WatchService returns a watcher which notifies when there
+	// are changes to the deployment of the specified application.
+	WatchService(appName string) (watcher.NotifyWatcher, error)
+
 	// GetNamespace returns the namespace for the specified name or current namespace.
 	GetNamespace(name string) (*core.Namespace, error)
 
@@ -186,6 +190,7 @@ type NamespaceWatcher interface {
 type Service struct {
 	Id        string
 	Addresses []network.Address
+	Scale     int
 }
 
 // FilesystemInfo represents information about a filesystem

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1515,3 +1515,41 @@ func (s *K8sBrokerSuite) TestOperatorNoPodFound(c *gc.C) {
 	_, err := s.broker.Operator("test")
 	c.Assert(err, gc.ErrorMatches, "operator pod for application \"test\" not found")
 }
+
+func (s *K8sBrokerSuite) TestWatchService(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	ssWatcher := watch.NewRaceFreeFake()
+	deployWatcher := watch.NewRaceFreeFake()
+
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Watch(v1.ListOptions{
+			LabelSelector: "juju-application==test",
+			Watch:         true,
+		}).Return(ssWatcher, nil),
+		s.mockDeployments.EXPECT().Watch(v1.ListOptions{
+			LabelSelector: "juju-application==test",
+			Watch:         true,
+		}).Return(deployWatcher, nil),
+	)
+
+	w, err := s.broker.WatchService("test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Send an event to one of the watchers; multi-watcher should fire.
+	ss := &apps.StatefulSet{ObjectMeta: v1.ObjectMeta{Name: "test"}}
+	go func(w *watch.RaceFreeFakeWatcher, clk *testclock.Clock) {
+		if !w.IsStopped() {
+			clk.WaitAdvance(time.Second, testing.LongWait, 1)
+			w.Modify(ss)
+		}
+	}(ssWatcher, s.clock)
+
+	select {
+	case _, ok := <-w.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for event")
+	}
+}

--- a/caas/kubernetes/provider/k8swatcher.go
+++ b/caas/kubernetes/provider/k8swatcher.go
@@ -50,9 +50,10 @@ func (w *kubernetesWatcher) loop() error {
 	defer close(w.out)
 	defer w.k8watcher.Stop()
 
-	var out chan struct{}
-	// Set delayCh now so that initial event is sent.
-	delayCh := w.clock.After(sendDelay)
+	// Set out now so that initial event is sent.
+	out := w.out
+	var delayCh <-chan time.Time
+
 	for {
 		select {
 		case <-w.catacomb.Dying():

--- a/core/watcher/multinotify.go
+++ b/core/watcher/multinotify.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"sync"
+	"time"
+
+	"gopkg.in/tomb.v2"
+)
+
+// MultiNotifyWatcher implements NotifyWatcher, combining
+// multiple NotifyWatchers.
+type MultiNotifyWatcher struct {
+	tomb     tomb.Tomb
+	watchers []NotifyWatcher
+	changes  chan struct{}
+}
+
+// NewMultiNotifyWatcher creates a NotifyWatcher that combines
+// each of the NotifyWatchers passed in. Each watcher's initial
+// event is consumed, and a single initial event is sent.
+// Subsequent events are not coalesced.
+func NewMultiNotifyWatcher(w ...NotifyWatcher) *MultiNotifyWatcher {
+	m := &MultiNotifyWatcher{
+		watchers: w,
+		changes:  make(chan struct{}),
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(w))
+	staging := make(chan struct{})
+	for _, w := range w {
+		// Consume the first event of each watcher.
+		<-w.Changes()
+		go func(wCopy NotifyWatcher) {
+			defer wg.Done()
+			wCopy.Wait()
+		}(w)
+		// Copy events from the watcher to the staging channel.
+		go copyEvents(staging, w.Changes(), &m.tomb)
+	}
+	m.tomb.Go(func() error {
+		m.loop(staging)
+		wg.Wait()
+		return nil
+	})
+	return m
+}
+
+// loop copies events from the input channel to the output channel,
+// coalescing events by waiting a short time between receiving and
+// sending.
+func (w *MultiNotifyWatcher) loop(in <-chan struct{}) {
+	defer close(w.changes)
+	// out is initialised to m.changes to send the initial event.
+	out := w.changes
+	var timer <-chan time.Time
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return
+		case <-in:
+			if timer == nil {
+				// TODO(fwereade): 2016-03-17 lp:1558657
+				timer = time.After(10 * time.Millisecond)
+			}
+		case <-timer:
+			timer = nil
+			out = w.changes
+		case out <- struct{}{}:
+			out = nil
+		}
+	}
+}
+
+// copyEvents copies channel events from "in" to "out", coalescing.
+func copyEvents(out chan<- struct{}, in <-chan struct{}, tomb *tomb.Tomb) {
+	var outC chan<- struct{}
+	for {
+		select {
+		case <-tomb.Dying():
+			return
+		case _, ok := <-in:
+			if !ok {
+				return
+			}
+			outC = out
+		case outC <- struct{}{}:
+			outC = nil
+		}
+	}
+}
+
+func (w *MultiNotifyWatcher) Kill() {
+	w.tomb.Kill(nil)
+	for _, w := range w.watchers {
+		w.Kill()
+	}
+}
+
+func (w *MultiNotifyWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *MultiNotifyWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *MultiNotifyWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *MultiNotifyWatcher) Changes() NotifyChannel {
+	return w.changes
+}

--- a/core/watcher/multinotify_test.go
+++ b/core/watcher/multinotify_test.go
@@ -1,0 +1,40 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
+)
+
+type multiNotifyWatcherSuite struct{}
+
+var _ = gc.Suite(&multiNotifyWatcherSuite{})
+
+func (*multiNotifyWatcherSuite) TestMultiNotifyWatcher(c *gc.C) {
+	ch0 := make(chan struct{}, 1)
+	w0 := watchertest.NewMockNotifyWatcher(ch0)
+	ch1 := make(chan struct{}, 1)
+	w1 := watchertest.NewMockNotifyWatcher(ch1)
+
+	// Initial events are consumed by the multiwatcher.
+	ch0 <- struct{}{}
+	ch1 <- struct{}{}
+
+	w := watcher.NewMultiNotifyWatcher(w0, w1)
+	wc := watchertest.NewNotifyWatcherC(c, w, nil)
+	defer wc.AssertKilled()
+	wc.AssertOneChange()
+
+	ch0 <- struct{}{}
+	wc.AssertOneChange()
+	ch1 <- struct{}{}
+	wc.AssertOneChange()
+
+	ch0 <- struct{}{}
+	ch1 <- struct{}{}
+	wc.AssertOneChange()
+}

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -84,8 +84,9 @@ func (aw *applicationWorker) loop() error {
 	aw.catacomb.Add(deploymentWorker)
 
 	var (
-		brokerUnitsWatcher watcher.NotifyWatcher
-		appOperatorWatcher watcher.NotifyWatcher
+		brokerUnitsWatcher   watcher.NotifyWatcher
+		appOperatorWatcher   watcher.NotifyWatcher
+		appDeploymentWatcher watcher.NotifyWatcher
 	)
 	// The caas watcher can just die from underneath hence it needs to be
 	// restarted all the time. So we don't abuse the catacomb by adding new
@@ -97,11 +98,15 @@ func (aw *applicationWorker) loop() error {
 		if appOperatorWatcher != nil {
 			worker.Stop(appOperatorWatcher)
 		}
+		if appDeploymentWatcher != nil {
+			worker.Stop(appDeploymentWatcher)
+		}
 	}()
 
 	// Cache the last reported status information
 	// so we only report true changes.
 	lastReportedStatus := make(map[string]status.StatusInfo)
+	lastReportedScale := -1
 
 	for {
 		// The caas watcher can just die from underneath so recreate if needed.
@@ -125,6 +130,16 @@ func (aw *applicationWorker) loop() error {
 				return errors.Annotatef(err, "failed to start operator watcher for %q", aw.application)
 			}
 		}
+		if appDeploymentWatcher == nil {
+			appDeploymentWatcher, err = aw.serviceBroker.WatchService(aw.application)
+			if err != nil {
+				if strings.Contains(err.Error(), "unexpected EOF") {
+					logger.Warningf("k8s cloud hosting %q has disappeared", aw.application)
+					return nil
+				}
+				return errors.Annotatef(err, "failed to start deployment watcher for %q", aw.application)
+			}
+		}
 
 		select {
 		// We must handle any processing due to application being removed prior
@@ -139,73 +154,31 @@ func (aw *applicationWorker) loop() error {
 				brokerUnitsWatcher = nil
 				continue
 			}
-			units, err := aw.containerBroker.Units(aw.application)
+			scale, err := aw.getScale()
 			if err != nil {
 				return errors.Trace(err)
 			}
-			logger.Debugf("units for %v: %+v", aw.application, units)
-			args := params.UpdateApplicationUnits{
-				ApplicationTag: names.NewApplicationTag(aw.application).String(),
+			if err := aw.clusterChanged(scale, lastReportedStatus); err != nil {
+				return errors.Trace(err)
 			}
-			for _, u := range units {
-				// For pods managed by the substrate, any marked as dying
-				// are treated as non-existing.
-				if u.Dying {
-					continue
-				}
-				unitStatus := u.Status
-				lastStatus, ok := lastReportedStatus[u.Id]
-				lastReportedStatus[u.Id] = unitStatus
-				if ok {
-					// If we've seen the same status value previously,
-					// report as unknown as this value is ignored.
-					if reflect.DeepEqual(lastStatus, unitStatus) {
-						unitStatus = status.StatusInfo{
-							Status: status.Unknown,
-						}
-					}
-				}
-				unitParams := params.ApplicationUnitParams{
-					ProviderId: u.Id,
-					Address:    u.Address,
-					Ports:      u.Ports,
-					Stateful:   u.Stateful,
-					Status:     unitStatus.Status.String(),
-					Info:       unitStatus.Message,
-					Data:       unitStatus.Data,
-				}
-				// Fill in any filesystem info for volumes attached to the unit.
-				// A unit will not become active until all required volumes are
-				// provisioned, so it makes sense to send this information along
-				// with the units to which they are attached.
-				for _, info := range u.FilesystemInfo {
-					unitParams.FilesystemInfo = append(unitParams.FilesystemInfo, params.KubernetesFilesystemInfo{
-						StorageName:  info.StorageName,
-						FilesystemId: info.FilesystemId,
-						Size:         info.Size,
-						MountPoint:   info.MountPoint,
-						ReadOnly:     info.ReadOnly,
-						Status:       info.Status.Status.String(),
-						Info:         info.Status.Message,
-						Data:         info.Status.Data,
-						Volume: params.KubernetesVolumeInfo{
-							VolumeId:   info.Volume.VolumeId,
-							Size:       info.Volume.Size,
-							Persistent: info.Volume.Persistent,
-							Status:     info.Volume.Status.Status.String(),
-							Info:       info.Volume.Status.Message,
-							Data:       info.Volume.Status.Data,
-						},
-					})
-
-				}
-				args.Units = append(args.Units, unitParams)
+		case _, ok := <-appDeploymentWatcher.Changes():
+			logger.Debugf("deployment changed: %#v", ok)
+			if !ok {
+				logger.Debugf("%v", appDeploymentWatcher.Wait())
+				worker.Stop(appDeploymentWatcher)
+				appDeploymentWatcher = nil
+				continue
 			}
-			if err := aw.unitUpdater.UpdateUnits(args); err != nil {
-				// We can ignore not found errors as the worker will get stopped anyway.
-				if !errors.IsNotFound(err) {
-					return errors.Trace(err)
-				}
+			scale, err := aw.getScale()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if scale == lastReportedScale {
+				continue
+			}
+			lastReportedScale = scale
+			if err := aw.clusterChanged(scale, lastReportedStatus); err != nil {
+				return errors.Trace(err)
 			}
 		case _, ok := <-appOperatorWatcher.Changes():
 			if !ok {
@@ -231,4 +204,89 @@ func (aw *applicationWorker) loop() error {
 		}
 
 	}
+}
+
+func (aw *applicationWorker) getScale() (int, error) {
+	service, err := aw.serviceBroker.Service(aw.application)
+	if errors.IsNotFound(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	logger.Debugf("service for %v: %+v", aw.application, service)
+	return service.Scale, nil
+}
+
+func (aw *applicationWorker) clusterChanged(scale int, lastReportedStatus map[string]status.StatusInfo) error {
+	units, err := aw.containerBroker.Units(aw.application)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Debugf("units for %v: %+v", aw.application, units)
+	args := params.UpdateApplicationUnits{
+		ApplicationTag: names.NewApplicationTag(aw.application).String(),
+		Scale:          scale,
+	}
+	for _, u := range units {
+		// For pods managed by the substrate, any marked as dying
+		// are treated as non-existing.
+		if u.Dying {
+			continue
+		}
+		unitStatus := u.Status
+		lastStatus, ok := lastReportedStatus[u.Id]
+		lastReportedStatus[u.Id] = unitStatus
+		if ok {
+			// If we've seen the same status value previously,
+			// report as unknown as this value is ignored.
+			if reflect.DeepEqual(lastStatus, unitStatus) {
+				unitStatus = status.StatusInfo{
+					Status: status.Unknown,
+				}
+			}
+		}
+		unitParams := params.ApplicationUnitParams{
+			ProviderId: u.Id,
+			Address:    u.Address,
+			Ports:      u.Ports,
+			Stateful:   u.Stateful,
+			Status:     unitStatus.Status.String(),
+			Info:       unitStatus.Message,
+			Data:       unitStatus.Data,
+		}
+		// Fill in any filesystem info for volumes attached to the unit.
+		// A unit will not become active until all required volumes are
+		// provisioned, so it makes sense to send this information along
+		// with the units to which they are attached.
+		for _, info := range u.FilesystemInfo {
+			unitParams.FilesystemInfo = append(unitParams.FilesystemInfo, params.KubernetesFilesystemInfo{
+				StorageName:  info.StorageName,
+				FilesystemId: info.FilesystemId,
+				Size:         info.Size,
+				MountPoint:   info.MountPoint,
+				ReadOnly:     info.ReadOnly,
+				Status:       info.Status.Status.String(),
+				Info:         info.Status.Message,
+				Data:         info.Status.Data,
+				Volume: params.KubernetesVolumeInfo{
+					VolumeId:   info.Volume.VolumeId,
+					Size:       info.Volume.Size,
+					Persistent: info.Volume.Persistent,
+					Status:     info.Volume.Status.Status.String(),
+					Info:       info.Volume.Status.Message,
+					Data:       info.Volume.Status.Data,
+				},
+			})
+
+		}
+		args.Units = append(args.Units, unitParams)
+	}
+	if err := aw.unitUpdater.UpdateUnits(args); err != nil {
+		// We can ignore not found errors as the worker will get stopped anyway.
+		if !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }

--- a/worker/caasunitprovisioner/broker.go
+++ b/worker/caasunitprovisioner/broker.go
@@ -24,4 +24,5 @@ type ServiceBroker interface {
 	Service(appName string) (*caas.Service, error)
 	DeleteService(appName string) error
 	UnexposeService(appName string) error
+	WatchService(appName string) (watcher.NotifyWatcher, error)
 }

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -170,7 +170,6 @@ func (w *deploymentWorker) loop() error {
 		}
 		logger.Debugf("created/updated deployment for %s for %v units", w.application, currentScale)
 		if !serviceUpdated && !spec.OmitServiceFrontend {
-			// TODO(caas) - add a service watcher
 			service, err := w.broker.Service(w.application)
 			if err != nil && !errors.IsNotFound(err) {
 				return errors.Annotate(err, "cannot get new service details")

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -39,9 +39,10 @@ type fakeClient struct {
 type mockServiceBroker struct {
 	testing.Stub
 	caas.ContainerEnvironProvider
-	ensured chan<- struct{}
-	deleted chan<- struct{}
-	podSpec *caas.PodSpec
+	ensured        chan<- struct{}
+	deleted        chan<- struct{}
+	podSpec        *caas.PodSpec
+	serviceWatcher *watchertest.MockNotifyWatcher
 }
 
 func (m *mockServiceBroker) Provider() caas.ContainerEnvironProvider {
@@ -66,7 +67,12 @@ func (m *mockServiceBroker) EnsureCustomResourceDefinition(appName string, podSp
 
 func (m *mockServiceBroker) Service(appName string) (*caas.Service, error) {
 	m.MethodCall(m, "Service", appName)
-	return &caas.Service{Id: "id", Addresses: []network.Address{{Value: "10.0.0.1"}}}, m.NextErr()
+	return &caas.Service{Id: "id", Scale: 4, Addresses: []network.Address{{Value: "10.0.0.1"}}}, m.NextErr()
+}
+
+func (m *mockServiceBroker) WatchService(appName string) (watcher.NotifyWatcher, error) {
+	m.MethodCall(m, "WatchService", appName)
+	return m.serviceWatcher, m.NextErr()
 }
 
 func (m *mockServiceBroker) DeleteService(appName string) error {


### PR DESCRIPTION
## Description of change

Add a k8s watcher for stateful sets and deployments to report on scale changes.
This allows auto scaling in k8s to be reflected in the Juju model.

Part of the work was to take an existing multi notification watcher from the apiserver package and copy that to core so it can be used in more places.

## QA steps

Deploy a k8s model. Scale from the k8s side and observe the changes in the Juju model.
Scale from the Juju side as well to ensure things still work in that direction.

