### PR TITLE
Fix watcher races by waiting for setup events to be processed.

### DIFF
--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -88,6 +88,8 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(firewallerClient, gc.NotNil)
 	s.firewaller = firewallerClient
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *firewallerSuite) TestWatchEgressAddressesForRelation(c *gc.C) {

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -362,6 +362,9 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
 	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
 	defer stop()
 
@@ -386,6 +389,9 @@ func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
 	defer stop()

--- a/state/application_leader_test.go
+++ b/state/application_leader_test.go
@@ -25,6 +25,8 @@ var _ = gc.Suite(&ApplicationLeaderSuite{})
 func (s *ApplicationLeaderSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.application = s.Factory.MakeApplication(c, nil)
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *ApplicationLeaderSuite) TestReadEmpty(c *gc.C) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -54,6 +54,8 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	}
 	s.charm = s.AddTestingCharm(c, "mysql")
 	s.mysql = s.AddTestingApplication(c, "mysql", s.charm)
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *ApplicationSuite) assertNeedsCleanup(c *gc.C) {

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -602,6 +602,9 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	w, err := s.State.WatchOfferStatus(offer.OfferUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
 	// Initial event.

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -333,6 +333,8 @@ func (s *FilesystemIAASModelSuite) TestWatchFilesystemAttachment(c *gc.C) {
 
 	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchFilesystemAttachment(machineTag, filesystemTag)
 	defer testing.AssertStop(c, w)
@@ -412,6 +414,8 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystems(c *gc.C) {
 		return u
 	}
 	u := addUnit()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchModelFilesystems()
 	defer testing.AssertStop(c, w)
@@ -454,6 +458,8 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystemAttachments(c *gc.C) 
 		return u
 	}
 	u := addUnit()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchModelFilesystemAttachments()
 	defer testing.AssertStop(c, w)
@@ -496,6 +502,8 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystems(c *gc.C) {
 		return u
 	}
 	u := addUnit()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchMachineFilesystems(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
@@ -551,6 +559,8 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystemAttachments(c *gc.C
 		return u, m
 	}
 	_, m0 := addUnit(nil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchMachineFilesystemAttachments(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
@@ -600,6 +610,8 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystems(c *gc.C) {
 		return u
 	}
 	u := addUnit(app)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchUnitFilesystems(app.ApplicationTag())
 	defer testing.AssertStop(c, w)
@@ -656,6 +668,8 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystemAttachments(c *gc.C) {
 		return u
 	}
 	addUnit(app)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchUnitFilesystemAttachments(app.ApplicationTag())
 	defer testing.AssertStop(c, w)

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -30,6 +30,8 @@ func (s *MeterStateSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.metricsManager, err = s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *MeterStateSuite) TestMeterStatus(c *gc.C) {

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -53,6 +53,8 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 			Macaroons:     []macaroon.Slice{{mac}},
 		},
 	}
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.State2.ModelUUID())
 }
 
 func (s *MigrationSuite) TestCreate(c *gc.C) {
@@ -524,6 +526,8 @@ func (s *MigrationSuite) TestWatchForMigrationInProgress(c *gc.C) {
 	// Create a migration.
 	_, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.State2.ModelUUID())
 
 	// Start watching for a migration - the in progress one should be reported.
 	_, wc := s.createMigrationWatcher(c, s.State2)
@@ -538,6 +542,8 @@ func (s *MigrationSuite) TestWatchForMigrationMultiModel(c *gc.C) {
 	// migrations.
 	State3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { State3.Close() })
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, State3.ModelUUID())
 	_, wc3 := s.createMigrationWatcher(c, State3)
 	wc3.AssertOneChange()
 
@@ -600,6 +606,9 @@ func (s *MigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
 
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.State2.ModelUUID())
+
 	_, wc := s.createStatusWatcher(c, s.State2)
 	wc.AssertOneChange()
 }
@@ -612,6 +621,9 @@ func (s *MigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	// migrations.
 	State3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { State3.Close() })
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, State3.ModelUUID())
+
 	_, wc3 := s.createStatusWatcher(c, State3)
 	wc3.AssertOneChange() // initial event
 
@@ -807,6 +819,8 @@ func (s *MigrationSuite) createMigAndWatchReports(c *gc.C, st *state.State) (
 ) {
 	mig, err := st.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, st.ModelUUID())
 
 	w, err := mig.WatchMinionReports()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -614,6 +614,8 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 				m, err := st.AddMachine("trusty", state.JobHostUnits)
 				c.Assert(err, jc.ErrorIsNil)
 				c.Assert(m.Id(), gc.Equals, "0")
+				// Ensure that all the creation events have flowed through the system.
+				s.WaitForModelWatchersIdle(c, st.ModelUUID())
 				return m.Watch()
 			},
 			setUpState: func(st *state.State) bool {
@@ -2180,6 +2182,9 @@ func (s *StateSuite) TestWatchModelsBulkEvents(c *gc.C) {
 	c.Assert(model2.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	err = st2.RemoveDyingModel()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	// All except the removed model are reported in initial event.
 	w := s.State.WatchModels()

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -1194,6 +1194,8 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 	app := s.AddTestingApplicationWithStorage(c, "storage-block2", ch, storage)
 	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchStorageAttachments(u.UnitTag())
 	defer testing.AssertStop(c, w)
@@ -1216,6 +1218,8 @@ func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
 	// is necessary to prevent short-circuit removal of the attachment,
 	// so that we can observe the progression from Alive->Dying->Dead->removed.
 	s.provisionStorageVolume(c, u, storageTag)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchStorageAttachment(storageTag, u.UnitTag())
 	defer testing.AssertStop(c, w)

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -345,6 +345,8 @@ func (s *UpgradeSuite) TestWatchMethod(c *gc.C) {
 
 	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := info.Watch()
 	defer statetesting.AssertStop(c, w)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -251,6 +251,8 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 
 	volume := s.storageInstanceVolume(c, storageTag)
 	volumeTag := volume.VolumeTag()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchVolumeAttachment(machineTag, volumeTag)
 	defer testing.AssertStop(c, w)


### PR DESCRIPTION
There are many tests that would sometimes get multiple events instead of one. This work ensures that pending document changes are processed before the watchers are created.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1750706
https://bugs.launchpad.net/juju/+bug/1649343