### PR TITLE
add-k8s is local by default with -c option

### DIFF
--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -11,14 +11,12 @@ import (
 
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
 
 func NewAddCAASCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
-	fileCredentialStore jujuclient.CredentialStore,
-	clientStore jujuclient.ClientStore,
+	store jujuclient.ClientStore,
 	addCloudAPIFunc func() (AddCloudAPI, error),
 	brokerGetter BrokerGetter,
 	k8sCluster k8sCluster,
@@ -27,30 +25,27 @@ func NewAddCAASCommandForTest(
 ) cmd.Command {
 	cmd := &AddCAASCommand{
 		cloudMetadataStore:    cloudMetadataStore,
-		fileCredentialStore:   fileCredentialStore,
+		store:                 store,
 		addCloudAPIFunc:       addCloudAPIFunc,
 		brokerGetter:          brokerGetter,
 		k8sCluster:            k8sCluster,
 		newClientConfigReader: newClientConfigReaderFunc,
 		getAllCloudDetails:    getAllCloudDetails,
 	}
-	cmd.SetClientStore(clientStore)
-	return modelcmd.WrapController(cmd)
+	return cmd
 }
 
 func NewRemoveCAASCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
-	fileCredentialStore jujuclient.CredentialStore,
-	clientStore jujuclient.ClientStore,
+	store jujuclient.ClientStore,
 	removeCloudAPIFunc func() (RemoveCloudAPI, error),
 ) cmd.Command {
 	cmd := &RemoveCAASCommand{
-		cloudMetadataStore:  cloudMetadataStore,
-		fileCredentialStore: fileCredentialStore,
-		apiFunc:             removeCloudAPIFunc,
+		cloudMetadataStore: cloudMetadataStore,
+		store:              store,
+		apiFunc:            removeCloudAPIFunc,
 	}
-	cmd.SetClientStore(clientStore)
-	return modelcmd.WrapController(cmd)
+	return cmd
 }
 
 type fakeCluster struct {

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -16,11 +17,30 @@ import (
 	"github.com/juju/juju/cmd/juju/caas"
 )
 
+type fakeCredentialStore struct {
+	jujutesting.Stub
+	jujuclient.ClientStore
+}
+
+func (fcs *fakeCredentialStore) CredentialForCloud(string) (*cloud.CloudCredential, error) {
+	panic("unexpected call to CredentialForCloud")
+}
+
+func (fcs *fakeCredentialStore) AllCredentials() (map[string]cloud.CloudCredential, error) {
+	fcs.AddCall("AllCredentials")
+	return map[string]cloud.CloudCredential{}, nil
+}
+
+func (fcs *fakeCredentialStore) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
+	fcs.AddCall("UpdateCredential", cloudName, details)
+	return nil
+}
+
 type removeCAASSuite struct {
 	jujutesting.IsolationSuite
-	fakeCloudAPI        *fakeRemoveCloudAPI
-	store               *fakeCloudMetadataStore
-	fileCredentialStore *fakeCredentialStore
+	fakeCloudAPI       *fakeRemoveCloudAPI
+	cloudMetadataStore *fakeCloudMetadataStore
+	store              *fakeCredentialStore
 }
 
 var _ = gc.Suite(&removeCAASSuite{})
@@ -42,23 +62,24 @@ func (api *fakeRemoveCloudAPI) Close() error {
 func (s *removeCAASSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.fakeCloudAPI = &fakeRemoveCloudAPI{}
-	s.fileCredentialStore = &fakeCredentialStore{}
+	s.store = &fakeCredentialStore{
+		ClientStore: NewMockClientStore(),
+	}
 
 	var logger loggo.Logger
-	s.store = &fakeCloudMetadataStore{CallMocker: jujutesting.NewCallMocker(logger)}
+	s.cloudMetadataStore = &fakeCloudMetadataStore{CallMocker: jujutesting.NewCallMocker(logger)}
 
 	k8sCloud := cloud.Cloud{Name: "myk8s", Type: "kubernetes"}
 	initialCloudMap := map[string]cloud.Cloud{"myk8s": k8sCloud}
 
-	s.store.Call("PersonalCloudMetadata").Returns(initialCloudMap, nil)
-	s.store.Call("WritePersonalCloudMetadata", map[string]cloud.Cloud{}).Returns(nil)
+	s.cloudMetadataStore.Call("PersonalCloudMetadata").Returns(initialCloudMap, nil)
+	s.cloudMetadataStore.Call("WritePersonalCloudMetadata", map[string]cloud.Cloud{}).Returns(nil)
 }
 
 func (s *removeCAASSuite) makeCommand() cmd.Command {
 	removecmd := caas.NewRemoveCAASCommandForTest(
+		s.cloudMetadataStore,
 		s.store,
-		s.fileCredentialStore,
-		NewMockClientStore(),
 		func() (caas.RemoveCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
@@ -84,37 +105,50 @@ func (s *removeCAASSuite) TestMissingName(c *gc.C) {
 
 func (s *removeCAASSuite) TestRemove(c *gc.C) {
 	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s")
+	_, err := s.runCommand(c, cmd, "myk8s", "-c", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")
 	s.fakeCloudAPI.CheckCall(c, 0, "RemoveCloud", "myk8s")
 
-	s.store.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata")
-	s.store.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
+	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata")
+	s.cloudMetadataStore.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
 
-	s.fileCredentialStore.CheckCallNames(c, "UpdateCredential")
-	s.fileCredentialStore.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
+	s.store.CheckCallNames(c, "UpdateCredential")
+	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
+}
+
+func (s *removeCAASSuite) TestRemoveLocalOnly(c *gc.C) {
+	cmd := s.makeCommand()
+	_, err := s.runCommand(c, cmd, "myk8s")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.fakeCloudAPI.CheckNoCalls(c)
+
+	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata")
+	s.cloudMetadataStore.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
+
+	s.store.CheckCallNames(c, "UpdateCredential")
+	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
 
 func (s *removeCAASSuite) TestRemoveNotInController(c *gc.C) {
 	s.fakeCloudAPI.SetErrors(errors.NotFoundf("cloud"))
 	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s")
+	_, err := s.runCommand(c, cmd, "myk8s", "-c", "foo")
 	c.Assert(err, gc.ErrorMatches, "cannot remove k8s cloud from controller.*")
 
-	s.store.CheckNoCalls(c)
-	s.fileCredentialStore.CheckNoCalls(c)
+	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
 
 func (s *removeCAASSuite) TestRemoveNotInLocal(c *gc.C) {
 	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "yourk8s")
+	_, err := s.runCommand(c, cmd, "yourk8s", "-c", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")
 	s.fakeCloudAPI.CheckCall(c, 0, "RemoveCloud", "yourk8s")
 
-	s.store.CheckCallNames(c, "PersonalCloudMetadata")
-	s.fileCredentialStore.CheckCall(c, 0, "UpdateCredential", "yourk8s", cloud.CloudCredential{})
+	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata")
+	s.store.CheckCall(c, 0, "UpdateCredential", "yourk8s", cloud.CloudCredential{})
 }


### PR DESCRIPTION
## Description of change

juju add-k8s and remove-k8s is now only local by default.
It has an optional --controller argument to add/remove to a controller.

## QA steps

Run add-k8s standalone.
Run add-k8s with --controller
Run remove-k8s standalone.
Run remove-k8s with --controller