### PR TITLE
Add synchronisation to the test.

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -790,7 +790,9 @@ func (s *apiclientSuite) TestOpenTimesOutOnLogin(c *gc.C) {
 }
 
 func (s *apiclientSuite) TestOpenTimeoutAffectsDial(c *gc.C) {
+	sync := make(chan struct{})
 	fakeDialer := func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+		close(sync)
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
@@ -810,6 +812,13 @@ func (s *apiclientSuite) TestOpenTimeoutAffectsDial(c *gc.C) {
 		})
 		done <- err
 	}()
+	// Before we advance time, ensure that the parallel try mechanism
+	// has entered the dial function.
+	select {
+	case <-sync:
+	case <-time.After(testing.LongWait):
+		c.Errorf("didn't enter dial")
+	}
 	err := clk.WaitAdvance(5*time.Second, time.Second, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	select {


### PR DESCRIPTION
The test was just using the clock waiters as a synchronisation point. The clock waiter happens outside the parallel try code. If the waiter was signalled before the parallel try goroutine actually started processing, we would get the 'try was stopped' error. This is because the context was cancelled before the try really started. The fix is to ensure that the dial function is entered before we advance time.

## QA steps

Run the tests with the stress.sh script.
Prior to the fix on my machine it failed more often than it succeeded.
After the fix it runs fine.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815800
