### PR TITLE
Fix the WaitForSSH interrupt tests.

### DIFF
--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -556,8 +556,8 @@ func (s *BootstrapSuite) TestWaitSSHTimesOutWaitingForAddresses(c *gc.C) {
 
 func (s *BootstrapSuite) TestWaitSSHKilledWaitingForAddresses(c *gc.C) {
 	ctx := cmdtesting.Context(c)
-	interrupted := make(chan os.Signal, 1)
-	interrupted <- os.Interrupt
+	interrupted := make(chan os.Signal)
+	close(interrupted)
 	_, err := common.WaitSSH(
 		ctx.Stderr, interrupted, ssh.DefaultClient, "/bin/true", neverAddresses{}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
@@ -633,7 +633,10 @@ func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) ([]network.
 	if !i.returned {
 		i.returned = true
 	} else {
-		i.interrupted <- os.Interrupt
+		if i.interrupted != nil {
+			close(i.interrupted)
+			i.interrupted = nil
+		}
 	}
 	return network.NewAddresses(i.name), nil
 }
@@ -642,7 +645,7 @@ func (s *BootstrapSuite) TestWaitSSHKilledWaitingForDial(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	timeout := testSSHTimeout
 	timeout.Timeout = 1 * time.Minute
-	interrupted := make(chan os.Signal, 1)
+	interrupted := make(chan os.Signal)
 	_, err := common.WaitSSH(
 		ctx.Stderr, interrupted, ssh.DefaultClient, "", &interruptOnDial{name: "0.1.2.3", interrupted: interrupted}, s.callCtx, timeout,
 		common.DefaultHostSSHOptions,


### PR DESCRIPTION
## Description of change

Fix the WaitForSSH interrupt tests.

They were sending a message to a buffered channel, but that meant if
they ever got a second attempt at sending to the channel they might
block. And that could happen because we would reset the 'look for
addresseses' timer to re-trigger in 1ms. And if there was any
significant hiccup in any of the Addresses code, the timer would be
ready to fire again as soon as the overall loop came back. In testing,
adding a time.Sleep(3ms) in the Addresses call was able to cause up to
14 calls to Addresses to be made before it noticed the interrupted
channel. (select is not fair on each possibility.)
By closing the channel we can guarantee they never deadlock.

## QA steps

```
$ time go test -count=4000 -race -failfast -check.v -check.f TestWaitSSHKilled.*Dial
```
even better if you add this patch:
```
--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -630,6 +630,7 @@ type interruptOnDial struct {

 func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) ([]network.Address, error) {
        // kill the tomb the second time Addresses is called
+       time.Sleep(2*time.Millisecond)
        if !i.returned {
                i.returned = true
        } else {
```

Without this patch, the test suite can fail once in a while (much more often with the testing patch above), with my pr, it doesn't fail after 8000 attempts, even with the extra sleep.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1777853