### PR TITLE
Add synchronisation to the test.

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -790,7 +790,9 @@ func (s *apiclientSuite) TestOpenTimesOutOnLogin(c *gc.C) {
 }
 
 func (s *apiclientSuite) TestOpenTimeoutAffectsDial(c *gc.C) {
+	sync := make(chan struct{})
 	fakeDialer := func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+		close(sync)
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
@@ -810,6 +812,13 @@ func (s *apiclientSuite) TestOpenTimeoutAffectsDial(c *gc.C) {
 		})
 		done <- err
 	}()
+	// Before we advance time, ensure that the parallel try mechanism
+	// has entered the dial function.
+	select {
+	case <-sync:
+	case <-time.After(testing.LongWait):
+		c.Errorf("didn't enter dial")
+	}
 	err := clk.WaitAdvance(5*time.Second, time.Second, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	select {


### PR DESCRIPTION
## Description of change

Test would intermittently fail if the Dial was not reached by the time we go to check the assertion. This adds synchronization so we know we are in Dial if we get passed the sync point.

This is just Tim's patch (#9825) pointed at 2.5.

## QA steps

See pr #9825.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1815800