### PR TITLE
Fix a test compile issue on non-linux.

### DIFF
--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"github.com/juju/proxy"
+	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/container"
 )
@@ -39,3 +40,7 @@ func ConfigureLXDProxies(proxies proxy.Settings) error {
 var lxdViaSnap = func() bool {
 	return false
 }
+
+// hostSeries is only created because export_test wants to be able to patch it.
+// Patching it has no effect on non-linux
+var hostSeries = series.HostSeries


### PR DESCRIPTION
## Description of change

On my Mac OS X machine, I tried to run 'go test -check.v' in container/lxd but it fails to compile because @manadart had a recent patch for testing that wants to override it in the test suite. And while the test itself isn't run on non-linux, export_test.go *is* compiled on all platforms, and it needs the variable in order to patch it.

## QA steps

On non-linux run
```
$ cd container/linux
$ go test -check.v
```

## Documentation changes

None.

## Bug reference

None.
