### PR TITLE
2.5 into develop

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -912,6 +912,7 @@
     "shared/logger",
     "shared/osarch",
     "shared/simplestreams",
+    "shared/version",
   ]
   pruneopts = ""
   revision = "4c2bbb608e7a90a9f175a566b9e638069424f0f7"
@@ -1974,6 +1975,7 @@
     "github.com/lxc/lxd/shared/api",
     "github.com/lxc/lxd/shared/logger",
     "github.com/lxc/lxd/shared/osarch",
+    "github.com/lxc/lxd/shared/version",
     "github.com/mattn/go-isatty",
     "github.com/oracle/oci-go-sdk/common",
     "github.com/oracle/oci-go-sdk/core",

--- a/api/firewaller/firewaller_test.go
+++ b/api/firewaller/firewaller_test.go
@@ -88,6 +88,8 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(firewallerClient, gc.NotNil)
 	s.firewaller = firewallerClient
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *firewallerSuite) TestWatchEgressAddressesForRelation(c *gc.C) {

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -362,6 +362,9 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
 	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
 	defer stop()
 
@@ -386,6 +389,9 @@ func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
 	defer stop()

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/network"
 	"github.com/juju/utils/arch"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
+
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/network"
 )
 
 const (
@@ -34,12 +36,16 @@ type ContainerSpec struct {
 	InstanceType string
 }
 
+// minMiBVersion is the minimum LXD version that we are sure will recognise the
+// MiB suffix for memory constraints. By default we use "MB".
+var minMiBVersion = &version.DottedVersion{Major: 3, Minor: 10}
+
 // ApplyConstraints applies the input constraints as valid LXD container
 // configuration to the container spec.
 // Note that we pass these through as supplied. If an instance type constraint
 // has been specified along with specific cores/mem constraints,
 // LXD behaviour is to override with the specific ones even when lower.
-func (c *ContainerSpec) ApplyConstraints(cons constraints.Value) {
+func (c *ContainerSpec) ApplyConstraints(serverVersion string, cons constraints.Value) {
 	if cons.HasInstanceType() {
 		c.InstanceType = *cons.InstanceType
 	}
@@ -47,7 +53,14 @@ func (c *ContainerSpec) ApplyConstraints(cons constraints.Value) {
 		c.Config["limits.cpu"] = fmt.Sprintf("%d", *cons.CpuCores)
 	}
 	if cons.HasMem() {
-		c.Config["limits.memory"] = fmt.Sprintf("%dMiB", *cons.Mem)
+		// Ensure that we use the correct "MB"/"MiB" suffix.
+		template := "%dMB"
+		if current, err := version.Parse(serverVersion); err == nil {
+			if current.Compare(minMiBVersion) >= 0 {
+				template = "%dMiB"
+			}
+		}
+		c.Config["limits.memory"] = fmt.Sprintf(template, *cons.Mem)
 	}
 }
 

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -466,13 +466,20 @@ func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 	spec := lxd.ContainerSpec{
 		Config: map[string]string{lxd.AutoStartKey: "true"},
 	}
-	spec.ApplyConstraints(cons)
 
+	// Uses the "MiB" suffix.
 	exp := map[string]string{
 		lxd.AutoStartKey: "true",
 		"limits.memory":  "2046MiB",
 		"limits.cpu":     "4",
 	}
+	spec.ApplyConstraints("3.10.0", cons)
+	c.Check(spec.Config, gc.DeepEquals, exp)
+	c.Check(spec.InstanceType, gc.Equals, instType)
+
+	// Uses the "MB" suffix.
+	exp["limits.memory"] = "2046MB"
+	spec.ApplyConstraints("2.0.11", cons)
 	c.Check(spec.Config, gc.DeepEquals, exp)
 	c.Check(spec.InstanceType, gc.Equals, instType)
 }

--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -7,6 +7,7 @@ package lxd
 
 import (
 	"github.com/juju/proxy"
+	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/container"
 )
@@ -39,3 +40,7 @@ func ConfigureLXDProxies(proxies proxy.Settings) error {
 var lxdViaSnap = func() bool {
 	return false
 }
+
+// hostSeries is only created because export_test wants to be able to patch it.
+// Patching it has no effect on non-linux
+var hostSeries = series.HostSeries

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -231,7 +231,7 @@ func (m *containerManager) getContainerSpec(
 		Profiles: instanceConfig.Profiles,
 		Devices:  nics,
 	}
-	spec.ApplyConstraints(cons)
+	spec.ApplyConstraints(m.server.serverVersion, cons)
 
 	return spec, nil
 }

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	clustered         bool
 	serverCertificate string
 	hostArch          string
+	serverVersion     string
 
 	networkAPISupport bool
 	clusterAPISupport bool
@@ -114,12 +115,17 @@ func NewServer(svr lxd.ContainerServer) (*Server, error) {
 		networkAPISupport: shared.StringInSlice("network", apiExt),
 		clusterAPISupport: shared.StringInSlice("clustering", apiExt),
 		storageAPISupport: shared.StringInSlice("storage", apiExt),
+		serverVersion:     info.Environment.ServerVersion,
 	}, nil
 }
 
 // Name returns the name of this LXD server.
 func (s *Server) Name() string {
 	return s.name
+}
+
+func (s *Server) ServerVersion() string {
+	return s.serverVersion
 }
 
 // UpdateServerConfig updates the server configuration with the input values.

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -126,7 +126,7 @@ func (env *environ) newContainer(
 	}
 	cleanupCallback() // Clean out any long line of completed download status
 
-	cSpec, err := env.getContainerSpec(image, args)
+	cSpec, err := env.getContainerSpec(image, target.ServerVersion(), args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -173,7 +173,7 @@ func (env *environ) getImageSources() ([]lxd.ServerSpec, error) {
 // Cloud-init config is generated based on the network devices in the default
 // profile and included in the spec config.
 func (env *environ) getContainerSpec(
-	image lxd.SourcedImage, args environs.StartInstanceParams,
+	image lxd.SourcedImage, serverVersion string, args environs.StartInstanceParams,
 ) (lxd.ContainerSpec, error) {
 	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)
 	if err != nil {
@@ -185,7 +185,7 @@ func (env *environ) getContainerSpec(
 		Image:    image,
 		Config:   make(map[string]string),
 	}
-	cSpec.ApplyConstraints(args.Constraints)
+	cSpec.ApplyConstraints(serverVersion, args.Constraints)
 
 	cloudCfg, err := cloudinit.New(args.InstanceConfig.Series)
 	if err != nil {

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -91,6 +91,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -129,6 +130,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -290,6 +292,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -334,6 +337,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
 		exp.HostArch().Return(arch.AMD64),
@@ -370,6 +374,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage("bionic", arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),
 	)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -34,6 +34,7 @@ import (
 type Server interface {
 	FindImage(string, string, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
 	GetServer() (server *lxdapi.Server, ETag string, err error)
+	ServerVersion() string
 	GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error)
 	UpdateServerConfig(map[string]string) error
 	UpdateContainerConfig(string, map[string]string) error

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -497,6 +497,18 @@ func (mr *MockServerMockRecorder) ServerCertificate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerCertificate", reflect.TypeOf((*MockServer)(nil).ServerCertificate))
 }
 
+// ServerVersion mocks base method
+func (m *MockServer) ServerVersion() string {
+	ret := m.ctrl.Call(m, "ServerVersion")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ServerVersion indicates an expected call of ServerVersion
+func (mr *MockServerMockRecorder) ServerVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerVersion", reflect.TypeOf((*MockServer)(nil).ServerVersion))
+}
+
 // StorageSupported mocks base method
 func (m *MockServer) StorageSupported() bool {
 	ret := m.ctrl.Call(m, "StorageSupported")

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -436,6 +436,7 @@ type StubClient struct {
 	Volumes            map[string][]api.StorageVolume
 	ServerCert         string
 	ServerHostArch     string
+	ServerVer          string
 }
 
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
@@ -497,6 +498,11 @@ func (conn *StubClient) GetServer() (*api.Server, string, error) {
 			Certificate: "server-cert",
 		},
 	}, "etag", nil
+}
+
+func (conn *StubClient) ServerVersion() string {
+	conn.AddCall("ServerVersion")
+	return conn.ServerVer
 }
 
 func (conn *StubClient) GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error) {

--- a/state/application_leader_test.go
+++ b/state/application_leader_test.go
@@ -25,6 +25,8 @@ var _ = gc.Suite(&ApplicationLeaderSuite{})
 func (s *ApplicationLeaderSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.application = s.Factory.MakeApplication(c, nil)
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *ApplicationLeaderSuite) TestReadEmpty(c *gc.C) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -55,6 +55,8 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	}
 	s.charm = s.AddTestingCharm(c, "mysql")
 	s.mysql = s.AddTestingApplication(c, "mysql", s.charm)
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *ApplicationSuite) assertNeedsCleanup(c *gc.C) {

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -602,6 +602,9 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	w, err := s.State.WatchOfferStatus(offer.OfferUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
 	// Initial event.

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -333,6 +333,8 @@ func (s *FilesystemIAASModelSuite) TestWatchFilesystemAttachment(c *gc.C) {
 
 	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchFilesystemAttachment(machineTag, filesystemTag)
 	defer testing.AssertStop(c, w)
@@ -412,6 +414,8 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystems(c *gc.C) {
 		return u
 	}
 	u := addUnit()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchModelFilesystems()
 	defer testing.AssertStop(c, w)
@@ -454,6 +458,8 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystemAttachments(c *gc.C) 
 		return u
 	}
 	u := addUnit()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchModelFilesystemAttachments()
 	defer testing.AssertStop(c, w)
@@ -496,6 +502,8 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystems(c *gc.C) {
 		return u
 	}
 	u := addUnit()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchMachineFilesystems(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
@@ -551,6 +559,8 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystemAttachments(c *gc.C
 		return u, m
 	}
 	_, m0 := addUnit(nil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchMachineFilesystemAttachments(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
@@ -600,6 +610,8 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystems(c *gc.C) {
 		return u
 	}
 	u := addUnit(app)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchUnitFilesystems(app.ApplicationTag())
 	defer testing.AssertStop(c, w)
@@ -656,6 +668,8 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystemAttachments(c *gc.C) {
 		return u
 	}
 	addUnit(app)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchUnitFilesystemAttachments(app.ApplicationTag())
 	defer testing.AssertStop(c, w)

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -30,6 +30,8 @@ func (s *MeterStateSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.metricsManager, err = s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *MeterStateSuite) TestMeterStatus(c *gc.C) {

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -53,6 +53,8 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 			Macaroons:     []macaroon.Slice{{mac}},
 		},
 	}
+	// Before we get into the tests, ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.State2.ModelUUID())
 }
 
 func (s *MigrationSuite) TestCreate(c *gc.C) {
@@ -524,6 +526,8 @@ func (s *MigrationSuite) TestWatchForMigrationInProgress(c *gc.C) {
 	// Create a migration.
 	_, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.State2.ModelUUID())
 
 	// Start watching for a migration - the in progress one should be reported.
 	_, wc := s.createMigrationWatcher(c, s.State2)
@@ -538,6 +542,8 @@ func (s *MigrationSuite) TestWatchForMigrationMultiModel(c *gc.C) {
 	// migrations.
 	State3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { State3.Close() })
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, State3.ModelUUID())
 	_, wc3 := s.createMigrationWatcher(c, State3)
 	wc3.AssertOneChange()
 
@@ -600,6 +606,9 @@ func (s *MigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
 
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.State2.ModelUUID())
+
 	_, wc := s.createStatusWatcher(c, s.State2)
 	wc.AssertOneChange()
 }
@@ -612,6 +621,9 @@ func (s *MigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	// migrations.
 	State3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { State3.Close() })
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, State3.ModelUUID())
+
 	_, wc3 := s.createStatusWatcher(c, State3)
 	wc3.AssertOneChange() // initial event
 
@@ -807,6 +819,8 @@ func (s *MigrationSuite) createMigAndWatchReports(c *gc.C, st *state.State) (
 ) {
 	mig, err := st.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, st.ModelUUID())
 
 	w, err := mig.WatchMinionReports()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -615,6 +615,8 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 				m, err := st.AddMachine("trusty", state.JobHostUnits)
 				c.Assert(err, jc.ErrorIsNil)
 				c.Assert(m.Id(), gc.Equals, "0")
+				// Ensure that all the creation events have flowed through the system.
+				s.WaitForModelWatchersIdle(c, st.ModelUUID())
 				return m.Watch()
 			},
 			setUpState: func(st *state.State) bool {
@@ -2181,6 +2183,9 @@ func (s *StateSuite) TestWatchModelsBulkEvents(c *gc.C) {
 	c.Assert(model2.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	err = st2.RemoveDyingModel()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	// All except the removed model are reported in initial event.
 	w := s.State.WatchModels()

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -1194,6 +1194,8 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 	app := s.AddTestingApplicationWithStorage(c, "storage-block2", ch, storage)
 	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchStorageAttachments(u.UnitTag())
 	defer testing.AssertStop(c, w)
@@ -1216,6 +1218,8 @@ func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
 	// is necessary to prevent short-circuit removal of the attachment,
 	// so that we can observe the progression from Alive->Dying->Dead->removed.
 	s.provisionStorageVolume(c, u, storageTag)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchStorageAttachment(storageTag, u.UnitTag())
 	defer testing.AssertStop(c, w)

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -346,6 +346,8 @@ func (s *UpgradeSuite) TestWatchMethod(c *gc.C) {
 
 	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := info.Watch()
 	defer statetesting.AssertStop(c, w)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -251,6 +251,8 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 
 	volume := s.storageInstanceVolume(c, storageTag)
 	volumeTag := volume.VolumeTag()
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.storageBackend.WatchVolumeAttachment(machineTag, volumeTag)
 	defer testing.AssertStop(c, w)


### PR DESCRIPTION
## Description of change

Merge the recent LXD changes and a bunch of the test suite fixes from 2.5 into develop.

 * Merge pull request #9828 from jameinel/2.5-hostSeries
 * Merge pull request #9827 from jameinel/2.5-apiclient-try-stopped
 * Merge pull request #9826 from jameinel/2.5-ssh-dial-test-1777853
 * Merge pull request #9820 from howbazaar/2.5-watcher-sync
 * Merge pull request #9812 from manadart/2.5-lxd-memory-constraint-suffix


## QA steps

See individual patches.

## Documentation changes

See individual patches.

## Bug reference

 * https://bugs.launchpad.net/juju/+bug/1815800
 * https://bugs.launchpad.net/juju/+bug/1777853
 * https://bugs.launchpad.net/juju/+bug/1818039
