### PR TITLE
pubsub: Fix lockups when a controller machine goes away

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -306,7 +306,9 @@ func (t *hostSwitchingTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return t.fallback.RoundTrip(req)
 }
 
-// ConnectStream implements StreamConnector.ConnectStream.
+// ConnectStream implements StreamConnector.ConnectStream. The stream
+// returned will apply a 30-second write deadline, so WriteJSON should
+// only be called from one goroutine.
 func (st *state) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
 	path, err := apiPath(st.modelTag, path)
 	if err != nil {
@@ -320,7 +322,10 @@ func (st *state) ConnectStream(path string, attrs url.Values) (base.Stream, erro
 }
 
 // ConnectControllerStream creates a stream connection to an API path
-// that isn't prefixed with /model/uuid.
+// that isn't prefixed with /model/uuid - the target model (if the
+// endpoint needs one) can be specified in the headers. The stream
+// returned will apply a 30-second write deadline, so WriteJSON should
+// only be called from one goroutine.
 func (st *state) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
 	if !strings.HasPrefix(path, "/") {
 		return nil, errors.Errorf("path %q is not absolute", path)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -773,6 +773,19 @@ func (s *clientSuite) TestWebsocketDialWithErrorsOtherError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "jammy pac")
 }
 
+func (s *clientSuite) TestWebsocketDialWithErrorsSetsDeadline(c *gc.C) {
+	// I haven't been able to find a way to actually test the
+	// websocket deadline stream, so instead test that the stream
+	// returned from websocketDialWithErrors is actually a
+	// DeadlineStream with the expected timeout.
+	d := fakeDialer{}
+	stream, err := api.WebsocketDialWithErrors(&d, "something", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	deadlineStream, ok := stream.(*api.DeadlineStream)
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(deadlineStream.Timeout, gc.Equals, 30*time.Second)
+}
+
 // badReader raises err when Read is called.
 type badReader struct {
 	err error

--- a/worker/pubsub/remoteserver.go
+++ b/worker/pubsub/remoteserver.go
@@ -192,7 +192,7 @@ func (r *remoteServer) Publish(message *params.PubSubMessage) {
 			select {
 			case r.data <- struct{}{}:
 			case <-r.connectionReset:
-				// The connection was reset while we were queuing this message.
+				r.logger.Debugf("connection reset while notifying %q for %s", message.Topic, r.target)
 			}
 		}
 	}


### PR DESCRIPTION
## Description of change
Investigating [this bug](https://bugs.launchpad.net/juju/+bug/1816533) revealed that the pubsub forwarder would get blocked if one of the controller machines was stopped (on MAAS - this didn't happen on LXD). That in turn meant that lease operations wouldn't be forwarded to the raft leader to be applied. There were two problems that caused this: 
* Writes to the forwarder's websocket for the dead machine would block indefinitely, although the remoteServer (in the local agent) still believed that it was connected to it.
* Once that was fixed a race in remoteServer.Publish could lead to it getting stuck trying waiting for the new-data notification to be received when the connection had been reset.

This changes the streams returned from `connection.ConnectStream` and `.ConnectControllerStream` to always set a 30s write deadline when calling `WriteJSON`, and fixes the race.

## QA steps
* Bootstrap an HA controller on MAAS.
* Deploy an application with several units (can all be on the same machine).
* Stop one of the controller machines.
* Remove the leader unit and see that a different unit becomes the leader after the previous leader's lease expires.
* Run juju_engine_report on the 2 running controller machines - it should finish, indicating that the pubsub forwarder isn't blocked.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1816533
