### PR TITLE
Sanitize lxd profiles

### DIFF
--- a/acceptancetests/assess_upgrade_lxd_profile.py
+++ b/acceptancetests/assess_upgrade_lxd_profile.py
@@ -46,7 +46,7 @@ def deploy_bundle(client):
     client.wait_for(primary)
 
 def upgrade_charm(client):
-    client.upgrade_charm("lxd-profile", resvision='3')
+    client.upgrade_charm("lxd-profile", revision='3')
 
 def assess_profile_machines(client):
     """Assess the machines

--- a/acceptancetests/assess_upgrade_lxd_profile.py
+++ b/acceptancetests/assess_upgrade_lxd_profile.py
@@ -46,7 +46,7 @@ def deploy_bundle(client):
     client.wait_for(primary)
 
 def upgrade_charm(client):
-    client.upgrade_charm("lxd-profile", resvision='1')
+    client.upgrade_charm("lxd-profile", resvision='3')
 
 def assess_profile_machines(client):
     """Assess the machines

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1270,12 +1270,12 @@ class ModelClient:
                     'ResourceId: {} Service or Unit: {} Timeout: {}'.format(
                         resource_id, service_or_unit, timeout))
 
-    def upgrade_charm(self, service, charm_path=None, resvision=None):
+    def upgrade_charm(self, service, charm_path=None, revision=None):
         args = (service,)
         if charm_path is not None:
             args = args + ('--path', charm_path)
-        if resvision is not None:
-            args = args + ('--revision', resvision)
+        if revision is not None:
+            args = args + ('--revision', revision)
         self.juju('upgrade-charm', args)
 
     def remove_service(self, service):

--- a/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
@@ -1,7 +1,7 @@
 series: bionic
 applications:
   lxd-profile:
-    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-0
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-2
     num_units: 4
     to:
       - "0"
@@ -9,7 +9,7 @@ applications:
       - "2"
       - "3"
   lxd-profile-subordinate:
-    charm: cs:~juju-qa/bionic/lxd-profile-subordinate-1
+    charm: cs:~juju-qa/bionic/lxd-profile-subordinate-2
   ubuntu:
     charm: cs:~jameinel/ubuntu-lite
     num_units: 4

--- a/acceptancetests/repository/bundles-lxd-profile.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile.yaml
@@ -6,7 +6,7 @@ machines:
   '3': {}
 applications:
   lxd-profile:
-    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-0
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-2
     num_units: 8
     to:
       - lxd:0

--- a/acceptancetests/repository/charms/lxd-profile-subordinate/lxd-profile.yaml
+++ b/acceptancetests/repository/charms/lxd-profile-subordinate/lxd-profile.yaml
@@ -1,17 +1,3 @@
 description: lxd profile subordinate for testing
-#config:
-#
-# allowed config
-#
-#  boot.autostart: "false"
-devices:
-#
-# allowed devices
-#
-# use different devices to see if a the lxd-profile correctly picks up the
-# subordinate details correctly (note: sandisk vs sony devices)
-#
-  sandisk:
-    type: usb
-    vendorid: 0781
-    productid: 8181
+config:
+  environment.http_proxy: ""

--- a/acceptancetests/repository/charms/lxd-profile/lxd-profile.yaml
+++ b/acceptancetests/repository/charms/lxd-profile/lxd-profile.yaml
@@ -3,6 +3,6 @@ description: lxd profile for testing
 config:
   security.nesting: "true"
   security.privileged: "true"
-  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+  linux.kernel_modules: nbd,ip_tables,ip6_tables
   environment.http_proxy: ""
 


### PR DESCRIPTION
## Description of change

Some of the infrastructure nodes don't have all the devices and
configurations to be able to run all the permutations, so I've
cleaned them up to a subset of values.

## QA steps

```
mkdir /tmp/test-run
mkdir /tmp/artifacts
export JUJU_HOME=/tmp/test-run
export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository
vim $JUJU_HOME/environments.yaml
```

Local LXD environments.yaml
```yaml
environments:
    lxd:
        type: lxd
        test-mode: true
        default-series: bionic
```

Run the following (substitute the right arg):
```
cd acceptancetests
./assess_deploy_lxd_profile.py
```