### PR TITLE
 Support running webscale tests against user-provided mongo snaps

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -16,6 +16,10 @@ import os
 import re
 import statistics
 import time
+import shutil
+
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
 
 from deploy_stack import (
     BootstrapManager,
@@ -216,6 +220,13 @@ def parse_args(argv):
         help="Help the reporting metrics by supplying a target juju version",
         default="",
     )
+    parser.add_argument(
+        '--db-snap-path',
+        help="URL to a mongo snap to override the mongo version used for the "
+             "test controller; if a URL is specified, it will be download "
+             "locally before bootstrapping",
+        default="",
+    )
     add_basic_testing_arguments(parser, existing=False)
     # Override the default logging_config default value set by adding basic
     # testing arguments. This way we can have a default value for all tests,
@@ -225,12 +236,51 @@ def parse_args(argv):
     return parser.parse_args(argv)
 
 
+def mongo_snap_settings(args):
+    if not args.db_snap_path:
+        log.info("Using built-in mongo")
+        return "", ""
+
+    # NOTE(achilleasa): ideally we should be using client.enable_feature()
+    # but it looks like the current implementation does not pass the
+    # enabled features to the backend; the backend however supports
+    # fetching the features through the JUJU_DEV_FEATURE_FLAGS envvar.
+    log.info("Enabling 'mongodb-snap' feature flag")
+    os.environ["JUJU_DEV_FEATURE_FLAGS"] = "mongodb-snap"
+
+    # Fetch snap if using a remote URL. Juju expects the snap file to match
+    # "juju-db_\d+.snap" so we should rename it accordingly.
+    dst_snap_path = "/tmp/juju-db_1.snap"
+
+    if urlparse(args.db_snap_path).scheme != "":
+        log.info("Downloading db snap from {} to {}".format(
+            args.db_snap_path, dst_snap_path))
+        urlretrieve(args.db_snap_path, dst_snap_path)
+    else:
+        log.info("Copying local db snap {} to {}".format(
+            args.db_snap_path, dst_snap_path))
+        shutil.copy2(args.db_snap_path, dst_snap_path)
+
+    # Create empty assert file and enable appropriate feature flags
+    db_snap_asserts_path = "/tmp/juju-db-empty.asserts"
+    os.close(os.open(db_snap_asserts_path, os.O_CREAT | os.O_APPEND))
+
+    return dst_snap_path, db_snap_asserts_path
+
+
 def main(argv=None):
     args = parse_args(argv)
     configure_logging(args.verbose)
+
+    db_snap_path, db_snap_asserts_path = mongo_snap_settings(args)
+
     begin = time.time()
     bs_manager = BootstrapManager.from_args(args)
-    with bs_manager.booted_context(args.upload_tools):
+    with bs_manager.booted_context(
+        args.upload_tools,
+        db_snap_path=db_snap_path,
+        db_snap_asserts_path=db_snap_asserts_path
+    ):
         client = bs_manager.client
         mongo_version = extract_mongo_version(client)
         log.info("MongoVersion used for deployment: {}".format(mongo_version))

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -306,8 +306,11 @@ def main(argv=None):
                 "git-sha": args.git_sha,
                 "charm-bundle": args.charm_bundle,
                 "charm-urls": charm_urls,
-                "mongo-version": mongo_version,
                 "juju-version": args.juju_version,
+                "mongo-version": mongo_version,
+                # The following are placeholders for now
+                "mongo-profile": "low",
+                "mongo-ss-txns": "false",
             })
         except Exception:
             raise JujuAssertionError("Error reporting metrics")

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -814,7 +814,8 @@ class ModelClient:
     def get_bootstrap_args(
             self, upload_tools, config_filename, bootstrap_series=None,
             credential=None, auto_upgrade=False, metadata_source=None,
-            no_gui=False, agent_version=None):
+            no_gui=False, agent_version=None, db_snap_path=None,
+            db_snap_asserts_path=None):
         """Return the bootstrap arguments for the substrate."""
         constraints = self._get_substrate_constraints()
         cloud_region = self.get_cloud_region(self.env.get_cloud(),
@@ -846,6 +847,9 @@ class ModelClient:
             args.extend(['--to', self.env.bootstrap_to])
         if no_gui:
             args.append('--no-gui')
+        if db_snap_path and db_snap_asserts_path:
+            args.extend(['--db-snap', db_snap_path,
+                         '--db-snap-asserts', db_snap_asserts_path])
         return tuple(args)
 
     def add_model(self, env, cloud_region=None):
@@ -930,13 +934,15 @@ class ModelClient:
 
     def bootstrap(self, upload_tools=False, bootstrap_series=None,
                   credential=None, auto_upgrade=False, metadata_source=None,
-                  no_gui=False, agent_version=None):
+                  no_gui=False, agent_version=None, db_snap_path=None,
+                  db_snap_asserts_path=None):
         """Bootstrap a controller."""
         self._check_bootstrap()
         with self._bootstrap_config() as config_filename:
             args = self.get_bootstrap_args(
                 upload_tools, config_filename, bootstrap_series, credential,
-                auto_upgrade, metadata_source, no_gui, agent_version)
+                auto_upgrade, metadata_source, no_gui, agent_version,
+                db_snap_path, db_snap_asserts_path)
             self.update_user_name()
             retvar, ct = self.juju('bootstrap', args, include_e=False)
             ct.actual_completion()


### PR DESCRIPTION
## Description of change

This PR adds the `--db-snap-path` argument to the webscale test script that allows the CI to override the mongo version that gets deployed to the test controller. This requires enabling the `mongodb-snap` feature flag which activates the `--db-snap` commandline option for `juju bootstrap`. 

The `--db-snap-path` argument to the webscale tests accepts either a local file or a URL. In the latter case, the snap will be downloaded and appropriately renamed to match the format expected by the `--db-snap` argument to `juju bootstrap`.

NOTE: this feature requires resolving of [this](https://bugs.launchpad.net/juju/+bug/1819004) issue before we can turn it on as part of the CI flow.