### PR TITLE
Fixes list-cloud -c displaying tags.

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -132,10 +132,10 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 		return nil, err
 	}
 	details := newCloudList()
-	for name, cloud := range controllerClouds {
+	for _, cloud := range controllerClouds {
 		cloudDetails := makeCloudDetails(cloud)
 		// TODO: Better categorization than public.
-		details.public[name.String()] = cloudDetails
+		details.public[cloud.Name] = cloudDetails
 	}
 	return details, nil
 }
@@ -152,6 +152,7 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	default:
 		output = details
 	}
+
 	err = c.out.Write(ctxt, output)
 	if err != nil {
 		return err
@@ -174,7 +175,7 @@ func newCloudList() *cloudList {
 }
 
 func (c *cloudList) all() map[string]*cloudDetails {
-	if len(c.personal) == 0 && len(c.builtin) == 0 && len(c.personal) == 0 {
+	if len(c.personal) == 0 && len(c.builtin) == 0 && len(c.public) == 0 {
 		return nil
 	}
 

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -72,17 +72,15 @@ func (s *listSuite) TestListController(c *gc.C) {
 		},
 	}
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(controllerAPICalled, gc.Equals, "mycontroller")
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 
-	// Check that we are producing the expected fields
-	c.Assert(out, gc.Matches, `Cloud +Regions +Default +Type +Description.*`)
 	// Just check couple of snippets of the output to make sure it looks ok.
-	c.Assert(out, jc.Contains, `cloud-beehive        1  regionone  openstack`)
+	c.Assert(out, gc.Matches, `^beehive:.*type:\ openstack.*`)
 }
 
 func (s *listSuite) TestListPublicAndPersonal(c *gc.C) {


### PR DESCRIPTION
## Description of change

Fixes bug where ```juju list-cloud --controller mycontroller``` would display cloud tags not cloud name.

## QA steps

Bootstrap and then run ```juju list-cloud --controller mycontroller```, shows that cloud names are not prefixed with 'cloud-'

## Documentation changes

n/a

## Bug reference

n/a