### PR TITLE
Sync before the watch.

### DIFF
--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -599,11 +599,11 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := s.State.WatchOfferStatus(offer.OfferUUID)
-	c.Assert(err, jc.ErrorIsNil)
-
 	// Ensure that all the creation events have flowed through the system.
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
+	w, err := s.State.WatchOfferStatus(offer.OfferUUID)
+	c.Assert(err, jc.ErrorIsNil)
 
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)


### PR DESCRIPTION
The test created the watcher then synced before checking values. The model needs to be idle before creating the watcher.