### PR TITLE
Add cloud api version to hook context

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2072,6 +2072,7 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/yaml",
+    "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/kubernetes",

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -100,7 +100,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       10,
+	"Uniter":                       11,
 	"Upgrader":                     1,
 	"UpgradeSeries":                1,
 	"UserManager":                  2,

--- a/api/uniter/goal-state_test.go
+++ b/api/uniter/goal-state_test.go
@@ -89,7 +89,7 @@ func (s *goalStateSuite) testGoalState(c *gc.C, facadeResult params.GoalStateRes
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 0)
 		c.Check(request, gc.Equals, "GoalStates")
 		c.Check(arg, gc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: "unit-mysql-0"}},

--- a/api/uniter/podspec_test.go
+++ b/api/uniter/podspec_test.go
@@ -31,7 +31,7 @@ func (s *podSpecSuite) TestSetPodSpec(c *gc.C) {
 
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, expectedAPIVersion)
+		c.Assert(version, gc.Equals, 0)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "SetPodSpec")
 		c.Assert(arg, gc.DeepEquals, expected)
@@ -49,7 +49,12 @@ func (s *podSpecSuite) TestSetPodSpec(c *gc.C) {
 }
 
 func (s *podSpecSuite) TestSetPodSpecInvalidApplicationName(c *gc.C) {
-	st := uniter.NewState(nil, names.NewUnitTag("mysql/0"))
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Fail()
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
 	err := st.SetPodSpec("", "spec")
 	c.Assert(err, gc.ErrorMatches, `application name "" not valid`)
 }
@@ -66,7 +71,7 @@ func (s *podSpecSuite) TestSetPodSpecError(c *gc.C) {
 	msg := "yoink"
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, expectedAPIVersion)
+		c.Assert(version, gc.Equals, 0)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "SetPodSpec")
 		c.Assert(arg, gc.DeepEquals, expected)

--- a/api/uniter/sla_test.go
+++ b/api/uniter/sla_test.go
@@ -18,11 +18,6 @@ type slaSuiteV4 struct {
 
 var _ = gc.Suite(&slaSuiteV4{})
 
-func (s *slaSuiteV4) SetUpTest(c *gc.C) {
-	s.uniterSuite.SetUpTest(c)
-	s.PatchValue(&uniter.NewState, uniter.NewStateV4)
-}
-
 func (s *slaSuiteV4) TestSetPodSpecApplication(c *gc.C) {
 	c.Skip("this API not present in V4")
 }
@@ -31,7 +26,7 @@ func (s *slaSuiteV4) TestSLALevelOldFacadeVersion(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
 	})
-	st := uniter.NewState(apiCaller, names.NewUnitTag("wordpress/0"))
+	st := uniter.NewStateV4(apiCaller, names.NewUnitTag("wordpress/0"))
 	level, err := st.SLALevel()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -21,8 +21,6 @@ type storageSuite struct {
 	coretesting.BaseSuite
 }
 
-const expectedVersion = 9
-
 func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	storageAttachmentIds := []params.StorageAttachmentId{{
 		StorageTag: "storage-whatever-0",
@@ -32,7 +30,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "UnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -48,7 +46,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	attachmentIds, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
@@ -59,7 +57,7 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "DestroyUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -73,7 +71,7 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	err := st.DestroyUnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
@@ -86,7 +84,7 @@ func (s *storageSuite) TestStorageAttachmentResultCountMismatch(c *gc.C) {
 		}
 		return nil
 	})
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	_, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
@@ -95,7 +93,7 @@ func (s *storageSuite) TestAPIErrors(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("bad")
 	})
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	_, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "bad")
 }
@@ -104,7 +102,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
@@ -120,7 +118,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	_, err := st.WatchUnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(called, jc.IsTrue)
@@ -130,7 +128,7 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -149,7 +147,7 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	_, err := st.WatchStorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(called, jc.IsTrue)
@@ -167,7 +165,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "StorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -186,7 +184,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	attachment, err := st.StorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
@@ -196,7 +194,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "StorageAttachmentLife")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -214,7 +212,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	results, err := st.StorageAttachmentLife([]params.StorageAttachmentId{{
 		StorageTag: "storage-data-0",
 		UnitTag:    "unit-mysql-0",
@@ -226,7 +224,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "RemoveStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
@@ -244,7 +242,7 @@ func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
 		return nil
 	})
 
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	st := uniter.NewStateV2(apiCaller, names.NewUnitTag("mysql/0"))
 	err := st.RemoveStorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "yoink")
 }

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -471,7 +471,7 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 			return nil
 		}
 		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, expectedVersion)
+		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "NetworkInfo")
 		c.Check(arg, gc.DeepEquals, params.NetworkInfoParams{

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -21,11 +21,9 @@ type unitStorageSuite struct {
 
 var _ = gc.Suite(&unitStorageSuite{})
 
-const expectedAPIVersion = 9
-
 func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesting.APICallerFunc) *uniter.Unit {
 	tag := names.NewUnitTag(t)
-	st := uniter.NewState(apiCaller, tag)
+	st := uniter.NewStateV2(apiCaller, tag)
 	return uniter.CreateUnit(st, tag)
 }
 
@@ -44,7 +42,7 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, expectedAPIVersion)
+		c.Assert(version, gc.Equals, 2)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "AddUnitStorage")
 		c.Assert(arg, gc.DeepEquals, expected)
@@ -77,7 +75,7 @@ func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
 	msg := "yoink"
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(version, gc.Equals, expectedAPIVersion)
+		c.Assert(version, gc.Equals, 2)
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "AddUnitStorage")
 		c.Assert(arg, gc.DeepEquals, expected)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -286,7 +286,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 7, uniter.NewUniterAPIV7)
 	reg("Uniter", 8, uniter.NewUniterAPIV8)
 	reg("Uniter", 9, uniter.NewUniterAPIV9)
-	reg("Uniter", 10, uniter.NewUniterAPI)
+	reg("Uniter", 10, uniter.NewUniterAPIV10)
+	reg("Uniter", 11, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UpgradeSeries", 1, upgradeseries.NewAPI)

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -5,7 +5,7 @@ package cloudspec
 
 import (
 	"github.com/juju/errors"
-	names "gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
@@ -37,7 +37,7 @@ func MakeCloudSpecGetter(pool Pool) func(names.ModelTag) (environs.CloudSpec, er
 		// both state and model but only model.
 		// TODO (manadart 2018-02-15): This potentially frees the state from
 		// the pool. Release is called, but the state reference survives.
-		return stateenvirons.EnvironConfigGetter{st.State, m}.CloudSpec()
+		return stateenvirons.EnvironConfigGetter{State: st.State, Model: m}.CloudSpec()
 	}
 }
 
@@ -51,7 +51,7 @@ func MakeCloudSpecGetterForModel(st *state.State) func(names.ModelTag) (environs
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
-		configGetter := stateenvirons.EnvironConfigGetter{st, m}
+		configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: m}
 
 		if tag.Id() != st.ModelUUID() {
 			return environs.CloudSpec{}, errors.New("cannot get cloud spec for this model")

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -88,7 +88,7 @@ func NewStateShim(st *state.State) (*stateShim, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &stateShim{stateenvirons.EnvironConfigGetter{st, m}, st, m}, nil
+	return &stateShim{stateenvirons.EnvironConfigGetter{State: st, Model: m}, st, m}, nil
 }
 
 // stateShim forwards and adapts state.State methods to Backing

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -55,7 +55,7 @@ func (s *toolsSuite) TestTools(c *gc.C) {
 		}, nil
 	}
 	tg := common.NewToolsGetter(
-		s.State, stateenvirons.EnvironConfigGetter{s.State, s.Model}, s.State, sprintfURLGetter("tools:%s"), getCanRead,
+		s.State, stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model}, s.State, sprintfURLGetter("tools:%s"), getCanRead,
 	)
 	c.Assert(tg, gc.NotNil)
 
@@ -86,7 +86,7 @@ func (s *toolsSuite) TestToolsError(c *gc.C) {
 		return nil, fmt.Errorf("splat")
 	}
 	tg := common.NewToolsGetter(
-		s.State, stateenvirons.EnvironConfigGetter{s.State, s.Model}, s.State, sprintfURLGetter("%s"), getCanRead,
+		s.State, stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model}, s.State, sprintfURLGetter("%s"), getCanRead,
 	)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-42"}},
@@ -191,7 +191,7 @@ func (s *toolsSuite) TestFindTools(c *gc.C) {
 			return envtoolsList, nil
 		})
 		toolsFinder := common.NewToolsFinder(
-			stateenvirons.EnvironConfigGetter{s.State, s.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"),
+			stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"),
 		)
 		result, err := toolsFinder.FindTools(params.FindToolsParams{
 			MajorVersion: 123,
@@ -221,7 +221,7 @@ func (s *toolsSuite) TestFindToolsNotFound(c *gc.C) {
 	s.PatchValue(common.EnvtoolsFindTools, func(e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		return nil, errors.NotFoundf("tools")
 	})
-	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.Model}, s.State, sprintfURLGetter("%s"))
+	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model}, s.State, sprintfURLGetter("%s"))
 	result, err := toolsFinder.FindTools(params.FindToolsParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, jc.Satisfies, params.IsCodeNotFound)
@@ -265,7 +265,7 @@ func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, in
 		}
 		return nil, errors.NotFoundf("tools")
 	})
-	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.Model}, t, sprintfURLGetter("tools:%s"))
+	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model}, t, sprintfURLGetter("tools:%s"))
 	result, err := toolsFinder.FindTools(params.FindToolsParams{
 		Number:       jujuversion.Current,
 		MajorVersion: -1,
@@ -289,7 +289,7 @@ func (s *toolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 		called = true
 		return nil, errors.NotFoundf("tools")
 	})
-	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{s.State, s.Model}, &mockToolsStorage{
+	toolsFinder := common.NewToolsFinder(stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model}, &mockToolsStorage{
 		err: errors.New("AllMetadata failed"),
 	}, sprintfURLGetter("tools:%s"))
 	result, err := toolsFinder.FindTools(params.FindToolsParams{

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -112,7 +112,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 	if err != nil {
 		return nil, err
 	}
-	configGetter := stateenvirons.EnvironConfigGetter{st, model}
+	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
 	env, err := environs.GetEnviron(configGetter, environs.New)
 	if err != nil {
 		return nil, err

--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/meterstatus"
+	"github.com/juju/juju/caas"
 )
 
 var (
@@ -30,4 +31,8 @@ func NewStorageAPI(
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
 	return newStorageAPI(backend, storage, resources, accessUnit)
+}
+
+func SetNewContainerBrokerFunc(api *UniterAPI, newBroker caas.NewContainerBrokerFunc) {
+	api.containerBrokerFunc = newBroker
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -4293,6 +4294,34 @@ func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
 		"password": "secret",
 	}
 	c.Assert(result.Result.Credential.Attributes, gc.DeepEquals, exp)
+}
+
+type fakeBroker struct {
+	caas.Broker
+}
+
+func (*fakeBroker) APIVersion() (string, error) {
+	return "6.66", nil
+}
+
+func (s *cloudSpecUniterSuite) TestCloudAPIVersion(c *gc.C) {
+	_, cm, _, _ := s.setupCAASModel(c)
+	uniterAPI, err := uniter.NewUniterAPI(facadetest.Context{
+		State_:             cm.State(),
+		Resources_:         s.resources,
+		Auth_:              s.authorizer,
+		LeadershipChecker_: s.State.LeadershipChecker(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	uniter.SetNewContainerBrokerFunc(uniterAPI, func(environs.OpenParams) (caas.Broker, error) {
+		return &fakeBroker{}, nil
+	})
+
+	result, err := uniterAPI.CloudAPIVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringResult{
+		Result: "6.66",
+	})
 }
 
 type uniterV8Suite struct {

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -83,7 +83,7 @@ func NewUpgraderAPI(
 		return nil, err
 	}
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{st, model}
+	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
 	return &UpgraderAPI{
 		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, getCanReadWrite),
 		ToolsSetter: common.NewToolsSetter(st, getCanReadWrite),

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -85,7 +85,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		g := stateenvirons.EnvironConfigGetter{st.State, model}
+		g := stateenvirons.EnvironConfigGetter{State: st.State, Model: model}
 		env, err := environs.GetEnviron(g, environs.New)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -144,7 +144,7 @@ func newFacade(ctx facade.Context) (*Client, error) {
 	}
 
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{st, model}
+	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
 	newEnviron := func() (environs.Environ, error) {

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -76,7 +76,7 @@ func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.A
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.newEnviron = func() (environs.Environ, error) {
-		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{st, m}, environs.New)
+		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{State: st, Model: m}, environs.New)
 	}
 	client.SetNewEnviron(apiserverClient, func() (environs.Environ, error) {
 		return s.newEnviron()

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -53,7 +53,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 		return nil, errors.New("no agent version set in model configuration")
 	}
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{st, model}
+	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
 	findToolsResult, err := toolsFinder.FindTools(params.FindToolsParams{
 		Number:       agentVersion,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -146,7 +146,7 @@ func NewFacadeV5(ctx facade.Context) (*ModelManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	configGetter := stateenvirons.EnvironConfigGetter{st, model}
+	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
 
 	ctrlModel, err := ctlrSt.Model()
 	if err != nil {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -893,7 +893,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	modelmanager, err := modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(s.Model, s.StatePool),
 		common.NewModelManagerBackend(s.Model, s.StatePool),
-		stateenvirons.EnvironConfigGetter{s.State, s.Model},
+		stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model},
 		nil,
 		s.authoriser,
 		s.Model,

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -36,7 +36,7 @@ func NewFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{st, m}}, ctx.Auth(), state.CallContext(st))
+	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{State: st, Model: m}}, ctx.Auth(), state.CallContext(st))
 }
 
 func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -97,6 +97,9 @@ type Broker interface {
 	// Provider returns the ContainerEnvironProvider that created this Broker.
 	Provider() ContainerEnvironProvider
 
+	// APIVersion returns the master kubelet API version.
+	APIVersion() (string, error)
+
 	// Destroy terminates all containers and other resources in this broker's namespace.
 	Destroy(context.ProviderCallContext) error
 

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -38,6 +38,7 @@ type BaseSuite struct {
 	cfg *config.Config
 
 	k8sClient                  *mocks.MockInterface
+	mockRestClient             *mocks.MockRestClientInterface
 	mockNamespaces             *mocks.MockNamespaceInterface
 	mockApps                   *mocks.MockAppsV1Interface
 	mockExtensions             *mocks.MockExtensionsV1beta1Interface
@@ -89,6 +90,8 @@ func (s *BaseSuite) setupBroker(c *gc.C) *gomock.Controller {
 	// We make the mock and assign it to the corresponding core getter function.
 	mockCoreV1 := mocks.NewMockCoreV1Interface(ctrl)
 	s.k8sClient.EXPECT().CoreV1().AnyTimes().Return(mockCoreV1)
+	s.mockRestClient = mocks.NewMockRestClientInterface(ctrl)
+	mockCoreV1.EXPECT().RESTClient().AnyTimes().Return(s.mockRestClient)
 
 	s.mockNamespaces = mocks.NewMockNamespaceInterface(ctrl)
 	mockCoreV1.EXPECT().Namespaces().AnyTimes().Return(s.mockNamespaces)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -4,6 +4,7 @@
 package provider_test
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -338,6 +340,18 @@ type K8sBrokerSuite struct {
 }
 
 var _ = gc.Suite(&K8sBrokerSuite{})
+
+func (s *K8sBrokerSuite) TestAPIVersion(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	r := rest.NewRequest(nil, "get", &url.URL{Path: "/path/"}, "", rest.ContentConfig{}, rest.Serializers{}, nil, nil, 0)
+	s.mockRestClient.EXPECT().Get().Times(1).Return(r)
+
+	// The fake request results in an error that shows the expected path was accessed.
+	_, err := s.broker.APIVersion()
+	c.Assert(err, gc.ErrorMatches, `get /path/version: unsupported protocol scheme ""`)
+}
 
 func (s *K8sBrokerSuite) TestConfig(c *gc.C) {
 	ctrl := s.setupBroker(c)

--- a/cmd/juju/storage/poolcreate.go
+++ b/cmd/juju/storage/poolcreate.go
@@ -48,7 +48,7 @@ unless otherwise specified.
 Examples:
 
     juju create-storage-pool ebsrotary ebs volume-type=standard
-    juju create-storage-pool storage-provisioner=kubernetes.io/gce-pd parameters.type=pd-standard
+    juju create-storage-pool gcepd storage-provisioner=kubernetes.io/gce-pd parameters.type=pd-standard
 
 See also:
     remove-storage-pool

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -81,7 +81,7 @@ func mockAPICaller(c *gc.C, callNumber *int32, apiCalls ...apiCall) apitesting.A
 			c.Check(index < len(apiCalls), jc.IsTrue)
 			call := apiCalls[index]
 			c.Logf("request %d, %s", index, request)
-			c.Check(version, gc.Equals, 9)
+			c.Check(version, gc.Equals, 0)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, call.request)
 			c.Check(arg, jc.DeepEquals, call.args)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -231,6 +231,9 @@ type HookContext struct {
 
 	// The cloud specification
 	cloudSpec *params.CloudSpec
+
+	// The cloud API version, if available.
+	cloudAPIVersion string
 }
 
 // Component implements hooks.Context.
@@ -648,6 +651,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 		"JUJU_PRINCIPAL_UNIT="+context.principal,
 		"JUJU_AVAILABILITY_ZONE="+context.availabilityzone,
 		"JUJU_VERSION="+version.Current.String(),
+		"CLOUD_API_VERSION="+context.cloudAPIVersion,
 		// Some of these will be empty, but that is fine, better
 		// to explicitly export them as empty.
 		"JUJU_CHARM_HTTP_PROXY="+context.jujuProxySettings.Http,

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -297,6 +297,12 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 	}
 	ctx.slaLevel = sla
 
+	apiVersion, err := f.state.CloudAPIVersion()
+	if err != nil {
+		logger.Warningf("could not retrieve the cloud API version: %v", err)
+	}
+	ctx.cloudAPIVersion = apiVersion
+
 	// TODO(fwereade) 23-10-2014 bug 1384572
 	// Nothing here should ever be getting the environ config directly.
 	modelConfig, err := f.state.ModelConfig()

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -77,6 +77,7 @@ func (s *EnvSuite) getContext(newProxyOnly bool) (ctx *context.HookContext, expe
 		"JUJU_MACHINE_ID=42",
 		"JUJU_AVAILABILITY_ZONE=some-zone",
 		"JUJU_VERSION=1.2.3",
+		"CLOUD_API_VERSION=6.66",
 	}
 	if newProxyOnly {
 		expected = append(expected,

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -161,6 +161,7 @@ func NewModelHookContext(
 		availabilityzone:   availZone,
 		slaLevel:           slaLevel,
 		principal:          unitName,
+		cloudAPIVersion:    "6.66",
 	}
 }
 


### PR DESCRIPTION
## Description of change

The hook context now includes an env var to report on the underlying cloud api version.
CLOUD_API_VERSION

k8s charms need this because different k8s versions sometimes require slightly different yaml to be sent to configure workloads.

Note: the uniter client api was broken in that it hard coded the version as 9. As a drive by I fixed it to behave like all other facade clients.

## QA steps

deploy  a k8s charm which logs the CLOUD_API_VERSION from the hook context

