### PR TITLE
Wait for the model to be idle before starting the test.

### DIFF
--- a/featuretests/api_meterstatus_test.go
+++ b/featuretests/api_meterstatus_test.go
@@ -34,6 +34,8 @@ func (s *meterStatusIntegrationSuite) SetUpTest(c *gc.C) {
 	state := s.OpenAPIAs(c, s.unit.UnitTag(), password)
 	s.status = meterstatus.NewClient(state, s.unit.UnitTag())
 	c.Assert(s.status, gc.NotNil)
+	// Ensure that all the creation events have flowed through the system.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *meterStatusIntegrationSuite) TestMeterStatus(c *gc.C) {


### PR DESCRIPTION
The meter status feature test needs to sync with the watchers before starting the tests.

Fixes intermitten test failures in featturetests/api_meterstatus_test.go TestWatchMeterStatus.