### PR TITLE
Display 'kubernetes' clouds as 'k8s'

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -303,7 +303,10 @@ func (k *kubernetesClient) APIVersion() (string, error) {
 	if err != nil {
 		return "", errors.Annotatef(err, "got '%s' querying API version", string(body))
 	}
-	return fmt.Sprintf("%s.%s", info.Major, info.Minor), nil
+	version := info.GitVersion
+	// git version is "vX.Y.Z", strip the "v"
+	version = strings.Trim(version, "v")
+	return version, nil
 }
 
 // Namespaces returns names of the namespaces on the cluster.

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -182,7 +182,9 @@ func (c *cloudList) all() map[string]*cloudDetails {
 	result := make(map[string]*cloudDetails)
 	addAll := func(someClouds map[string]*cloudDetails) {
 		for name, cloud := range someClouds {
-			result[name] = cloud
+			displayCloud := cloud
+			displayCloud.CloudType = displayCloudType(displayCloud.CloudType)
+			result[name] = displayCloud
 		}
 	}
 
@@ -266,7 +268,7 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 				description = description[:39]
 			}
 			w.PrintColor(color, name)
-			w.Println(len(info.Regions), defaultRegion, info.CloudType, description)
+			w.Println(len(info.Regions), defaultRegion, displayCloudType(info.CloudType), description)
 		}
 	}
 	printClouds(clouds.public, nil)
@@ -275,4 +277,11 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 
 	tw.Flush()
 	return nil
+}
+
+func displayCloudType(in string) string {
+	if in == "kubernetes" {
+		return "k8s"
+	}
+	return in
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -122,13 +122,17 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 
-	if err := c.out.Write(ctxt, cloud); err != nil {
+	displayCloud := cloud
+	displayCloud.CloudType = displayCloudType(displayCloud.CloudType)
+	if err := c.out.Write(ctxt, displayCloud); err != nil {
 		return err
 	}
 	if c.includeConfig {
 		config := getCloudConfigDetails(cloud.CloudType)
 		if len(config) > 0 {
-			fmt.Fprintln(ctxt.Stdout, fmt.Sprintf("\nThe available config options specific to %s clouds are:", cloud.CloudType))
+			fmt.Fprintln(
+				ctxt.Stdout,
+				fmt.Sprintf("\nThe available config options specific to %s clouds are:", displayCloud.CloudType))
 			return c.out.Write(ctxt, config)
 		}
 	}


### PR DESCRIPTION
## Description of change

When listing or showing clouds, instead of "kubernetes", print "k8s".
Also a couple of drive by fixes: new make target to update microk8s operator image and a tweak to k8s api version reported in hook context.

## QA steps

juju clouds
juju clouds --format yaml
juju show-cloud foo

## Bug reference

https://bugs.launchpad.net/juju/+bug/1814670
