### PR TITLE
Add Generation Creation Time-Stamp

### DIFF
--- a/api/modelgeneration/modelgeneration.go
+++ b/api/modelgeneration/modelgeneration.go
@@ -4,6 +4,8 @@
 package modelgeneration
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -116,25 +118,29 @@ func (c *Client) GenerationInfo(modelUUID string) (model.GenerationSummaries, er
 	if result.Error != nil {
 		return nil, errors.Trace(result.Error)
 	}
-	return generationInfoFromDTO(result.Applications), nil
+	return generationInfoFromResult(result.Generation), nil
 }
 
 func argForModel(modelUUID string) params.Entity {
 	return params.Entity{Tag: names.NewModelTag(modelUUID).String()}
 }
 
-func generationInfoFromDTO(apps []params.GenerationApplication) model.GenerationSummaries {
-	appDeltas := make([]model.GenerationApplication, len(apps))
-	for i, a := range apps {
+func generationInfoFromResult(res params.Generation) model.GenerationSummaries {
+	appDeltas := make([]model.GenerationApplication, len(res.Applications))
+	for i, a := range res.Applications {
 		appDeltas[i] = model.GenerationApplication{
 			ApplicationName: a.ApplicationName,
 			Units:           a.Units,
 			ConfigChanges:   a.ConfigChanges,
 		}
 	}
+	gen := model.Generation{
+		Created:      time.Unix(res.Created, 0).Local(),
+		Applications: appDeltas,
+	}
 
 	// TODO (manadart 2019-02-25): Always deal with the "next" generation.
 	// As generations evolve, this command will allow requesting specific
 	// generation IDs at which time this type should be represented in the DTO.
-	return map[model.GenerationVersion][]model.GenerationApplication{model.GenerationNext: appDeltas}
+	return map[model.GenerationVersion]model.Generation{model.GenerationNext: gen}
 }

--- a/api/modelgeneration/modelgeneration_test.go
+++ b/api/modelgeneration/modelgeneration_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/juju/core/model"
 	jc "github.com/juju/testing/checkers"
 	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/api/modelgeneration"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
 )
 
 type modelGenerationSuite struct {
@@ -190,11 +190,16 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 	s.fCaller.EXPECT().FacadeCall("GenerationInfo", arg, gomock.Any()).SetArg(2, resultSource).Return(nil)
 
 	api := modelgeneration.NewStateFromCaller(s.fCaller)
-	apps, err := api.GenerationInfo(s.tag.Id())
+
+	formatTime := func(t time.Time) string {
+		return t.UTC().Format("2006-01-02 15:04:05")
+	}
+
+	apps, err := api.GenerationInfo(s.tag.Id(), formatTime)
 	c.Assert(err, gc.IsNil)
 	c.Check(apps, jc.DeepEquals, map[model.GenerationVersion]model.Generation{
 		"next": {
-			Created: time.Time{},
+			Created: "0001-01-01 00:00:00",
 			Applications: []model.GenerationApplication{{
 				ApplicationName: "redis",
 				Units:           []string{"redis/0"},

--- a/api/modelgeneration/modelgeneration_test.go
+++ b/api/modelgeneration/modelgeneration_test.go
@@ -4,6 +4,8 @@
 package modelgeneration_test
 
 import (
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/juju/core/model"
 	jc "github.com/juju/testing/checkers"
@@ -173,7 +175,8 @@ func (s *modelGenerationSuite) TestHasNextGeneration(c *gc.C) {
 func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	resultSource := params.GenerationResult{
+	resultSource := params.GenerationResult{Generation: params.Generation{
+		Created: time.Time{}.Unix(),
 		Applications: []params.GenerationApplication{
 			{
 				ApplicationName: "redis",
@@ -181,7 +184,7 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 				ConfigChanges:   map[string]interface{}{"databases": 8},
 			},
 		},
-	}
+	}}
 	arg := params.Entity{Tag: s.tag.String()}
 
 	s.fCaller.EXPECT().FacadeCall("GenerationInfo", arg, gomock.Any()).SetArg(2, resultSource).Return(nil)
@@ -189,11 +192,14 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 	api := modelgeneration.NewStateFromCaller(s.fCaller)
 	apps, err := api.GenerationInfo(s.tag.Id())
 	c.Assert(err, gc.IsNil)
-	c.Check(apps, jc.DeepEquals, map[model.GenerationVersion][]model.GenerationApplication{
-		"next": {{
-			ApplicationName: "redis",
-			Units:           []string{"redis/0"},
-			ConfigChanges:   map[string]interface{}{"databases": 8},
-		}},
+	c.Check(apps, jc.DeepEquals, map[model.GenerationVersion]model.Generation{
+		"next": {
+			Created: time.Time{},
+			Applications: []model.GenerationApplication{{
+				ApplicationName: "redis",
+				Units:           []string{"redis/0"},
+				ConfigChanges:   map[string]interface{}{"databases": 8},
+			}},
+		},
 	})
 }

--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -39,6 +39,7 @@ type Model interface {
 
 // Generation defines the methods used by a generation.
 type Generation interface {
+	Created() int64
 	AssignAllUnits(string) error
 	AssignUnit(string) error
 	AssignedUnits() map[string][]string

--- a/apiserver/facades/client/modelgeneration/mocks/package_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/package_mock.go
@@ -309,6 +309,18 @@ func (mr *MockGenerationMockRecorder) AutoComplete() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutoComplete", reflect.TypeOf((*MockGeneration)(nil).AutoComplete))
 }
 
+// Created mocks base method
+func (m *MockGeneration) Created() int64 {
+	ret := m.ctrl.Call(m, "Created")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// Created indicates an expected call of Created
+func (mr *MockGenerationMockRecorder) Created() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Created", reflect.TypeOf((*MockGeneration)(nil).Created))
+}
+
 // MakeCurrent mocks base method
 func (m *MockGeneration) MakeCurrent() error {
 	ret := m.ctrl.Call(m, "MakeCurrent")

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -234,7 +234,10 @@ func (m *API) GenerationInfo(arg params.Entity) (params.GenerationResult, error)
 		apps = append(apps, genAppDelta)
 	}
 
-	return params.GenerationResult{Applications: apps}, nil
+	return params.GenerationResult{Generation: params.Generation{
+		Created:      gen.Created(),
+		Applications: apps,
+	}}, nil
 }
 
 func generationInfoError(err error) (params.GenerationResult, error) {

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -157,9 +157,8 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 
 	defer s.setupModelGenerationAPI(c, func(ctrl *gomock.Controller, st *mocks.MockState, mod *mocks.MockModel) {
 		gen := mocks.NewMockGeneration(ctrl)
-		gen.EXPECT().AssignedUnits().Return(map[string][]string{
-			"redis": units,
-		})
+		gen.EXPECT().AssignedUnits().Return(map[string][]string{"redis": units})
+		gen.EXPECT().Created().Return(int64(666))
 
 		mod.EXPECT().NextGeneration().Return(gen, nil)
 
@@ -180,9 +179,12 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 	result, err := s.api.GenerationInfo(s.modelArg())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.Applications, gc.HasLen, 1)
 
-	app := result.Applications[0]
+	gen := result.Generation
+	c.Assert(gen.Created, gc.Equals, int64(666))
+	c.Assert(gen.Applications, gc.HasLen, 1)
+
+	app := gen.Applications[0]
 	c.Assert(app.ApplicationName, gc.Equals, "redis")
 	c.Assert(app.Units, jc.SameContents, units)
 	c.Assert(app.ConfigChanges, gc.DeepEquals, map[string]interface{}{"password": "next"})

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1141,11 +1141,20 @@ type GenerationApplication struct {
 	ConfigChanges map[string]interface{} `json:"config"`
 }
 
-// GenerationResult transports the result of the show-generation command.
-type GenerationResult struct {
+// Generation represents a model generation's details including config changes.
+type Generation struct {
+	// Created is the Unix timestamp at generation creation.
+	Created int64 `json:"created"`
+
 	// Applications holds the collection of application changes
 	// made under this generation.
 	Applications []GenerationApplication `json:"applications"`
+}
+
+// GenerationResult transports the result of the show-generation command.
+type GenerationResult struct {
+	// Generation holds the details of the requested generation.
+	Generation Generation `json:"generation"`
 
 	// Error holds the value of any error that occurred processing the request.
 	Error *Error `json:"error,omitempty"`

--- a/cmd/juju/model/mocks/showgeneration_mock.go
+++ b/cmd/juju/model/mocks/showgeneration_mock.go
@@ -46,9 +46,9 @@ func (mr *MockShowGenerationCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // GenerationInfo mocks base method
-func (m *MockShowGenerationCommandAPI) GenerationInfo(arg0 string) (map[model.GenerationVersion][]model.GenerationApplication, error) {
+func (m *MockShowGenerationCommandAPI) GenerationInfo(arg0 string) (map[model.GenerationVersion]model.Generation, error) {
 	ret := m.ctrl.Call(m, "GenerationInfo", arg0)
-	ret0, _ := ret[0].(map[model.GenerationVersion][]model.GenerationApplication)
+	ret0, _ := ret[0].(map[model.GenerationVersion]model.Generation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/cmd/juju/model/mocks/showgeneration_mock.go
+++ b/cmd/juju/model/mocks/showgeneration_mock.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	model "github.com/juju/juju/core/model"
 	reflect "reflect"
+	time "time"
 )
 
 // MockShowGenerationCommandAPI is a mock of ShowGenerationCommandAPI interface
@@ -46,14 +47,14 @@ func (mr *MockShowGenerationCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // GenerationInfo mocks base method
-func (m *MockShowGenerationCommandAPI) GenerationInfo(arg0 string) (map[model.GenerationVersion]model.Generation, error) {
-	ret := m.ctrl.Call(m, "GenerationInfo", arg0)
+func (m *MockShowGenerationCommandAPI) GenerationInfo(arg0 string, arg1 func(time.Time) string) (map[model.GenerationVersion]model.Generation, error) {
+	ret := m.ctrl.Call(m, "GenerationInfo", arg0, arg1)
 	ret0, _ := ret[0].(map[model.GenerationVersion]model.Generation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerationInfo indicates an expected call of GenerationInfo
-func (mr *MockShowGenerationCommandAPIMockRecorder) GenerationInfo(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerationInfo", reflect.TypeOf((*MockShowGenerationCommandAPI)(nil).GenerationInfo), arg0)
+func (mr *MockShowGenerationCommandAPIMockRecorder) GenerationInfo(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerationInfo", reflect.TypeOf((*MockShowGenerationCommandAPI)(nil).GenerationInfo), arg0, arg1)
 }

--- a/cmd/juju/model/showgeneration_test.go
+++ b/cmd/juju/model/showgeneration_test.go
@@ -4,6 +4,8 @@
 package model_test
 
 import (
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
@@ -42,13 +44,14 @@ func (s *showGenerationSuite) TestInitFail(c *gc.C) {
 func (s *showGenerationSuite) TestRunCommandNextGenExists(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result := map[coremodel.GenerationVersion][]coremodel.GenerationApplication{
+	result := map[coremodel.GenerationVersion]coremodel.Generation{
 		coremodel.GenerationNext: {
-			coremodel.GenerationApplication{
+			Created: time.Time{},
+			Applications: []coremodel.GenerationApplication{{
 				ApplicationName: "redis",
 				Units:           []string{"redis/0"},
 				ConfigChanges:   map[string]interface{}{"databases": 8},
-			},
+			}},
 		},
 	}
 	s.api.EXPECT().GenerationInfo(gomock.Any()).Return(result, nil)
@@ -57,11 +60,13 @@ func (s *showGenerationSuite) TestRunCommandNextGenExists(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 next:
-- application: redis
-  units:
-  - redis/0
-  config:
-    databases: 8
+  created: 0001-01-01T00:00:00Z
+  applications:
+  - application: redis
+    units:
+    - redis/0
+    config:
+      databases: 8
 `[1:])
 }
 

--- a/cmd/juju/model/showgeneration_test.go
+++ b/cmd/juju/model/showgeneration_test.go
@@ -4,18 +4,16 @@
 package model_test
 
 import (
-	"time"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	coremodel "github.com/juju/juju/core/model"
 	jc "github.com/juju/testing/checkers"
 	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/juju/model/mocks"
+	coremodel "github.com/juju/juju/core/model"
 )
 
 type showGenerationSuite struct {
@@ -46,7 +44,7 @@ func (s *showGenerationSuite) TestRunCommandNextGenExists(c *gc.C) {
 
 	result := map[coremodel.GenerationVersion]coremodel.Generation{
 		coremodel.GenerationNext: {
-			Created: time.Time{},
+			Created: "0001-01-01 00:00:00Z",
 			Applications: []coremodel.GenerationApplication{{
 				ApplicationName: "redis",
 				Units:           []string{"redis/0"},
@@ -54,13 +52,13 @@ func (s *showGenerationSuite) TestRunCommandNextGenExists(c *gc.C) {
 			}},
 		},
 	}
-	s.api.EXPECT().GenerationInfo(gomock.Any()).Return(result, nil)
+	s.api.EXPECT().GenerationInfo(gomock.Any(), gomock.Any()).Return(result, nil)
 
 	ctx, err := s.runCommand(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 next:
-  created: 0001-01-01T00:00:00Z
+  created: 0001-01-01 00:00:00Z
   applications:
   - application: redis
     units:
@@ -73,7 +71,8 @@ next:
 func (s *showGenerationSuite) TestRunCommandNextNoGenError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.api.EXPECT().GenerationInfo(gomock.Any()).Return(nil, errors.New("this model has no next generation"))
+	s.api.EXPECT().GenerationInfo(gomock.Any(), gomock.Any()).Return(
+		nil, errors.New("this model has no next generation"))
 
 	_, err := s.runCommand(c)
 	c.Assert(err, gc.ErrorMatches, "this model has no next generation")

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -3,6 +3,8 @@
 
 package model
 
+import "time"
+
 // GenerationVersion indicates a generation to use for model config.
 type GenerationVersion string
 
@@ -46,6 +48,16 @@ type GenerationApplication struct {
 	ConfigChanges map[string]interface{} `yaml:"config"`
 }
 
+// Generation represents detail of a model generation including config changes.
+type Generation struct {
+	// Created is the time at generation creation.
+	Created time.Time `yaml:"created"`
+
+	// Applications is a collection of applications with changes in this
+	// generation including advanced units and modified configuration.
+	Applications []GenerationApplication `yaml:"applications"`
+}
+
 // GenerationSummaries is a type alias for a representation
 // of changes-by-generation.
-type GenerationSummaries = map[GenerationVersion][]GenerationApplication
+type GenerationSummaries = map[GenerationVersion]Generation

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -3,8 +3,6 @@
 
 package model
 
-import "time"
-
 // GenerationVersion indicates a generation to use for model config.
 type GenerationVersion string
 
@@ -50,8 +48,8 @@ type GenerationApplication struct {
 
 // Generation represents detail of a model generation including config changes.
 type Generation struct {
-	// Created is the time at generation creation.
-	Created time.Time `yaml:"created"`
+	// Created is the formatted time at generation creation.
+	Created string `yaml:"created"`
 
 	// Applications is a collection of applications with changes in this
 	// generation including advanced units and modified configuration.


### PR DESCRIPTION
## Description of change

This patch adds a creation time-stamp to generations, and exposes it in the `show-generation` client command.

As for status, the `--utc` flag can be provided to alter the date format.

## QA steps

Same as for https://github.com/juju/juju/pull/9790, but check that the correct creation time-stamp is included in the output.

## Documentation changes

None.

## Bug reference

N/A
