### PR TITLE
Use real time for hubwatcher idle, and changes reset idle.

### DIFF
--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1473,6 +1473,7 @@ func (s *MachineSuite) TestMachineDirtyAfterRemovingUnit(c *gc.C) {
 }
 
 func (s *MachineSuite) TestWatchMachine(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := s.machine.Watch()
 	defer testing.AssertStop(c, w)
 
@@ -1503,6 +1504,7 @@ func (s *MachineSuite) TestWatchMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w = s.machine.Watch()
 	defer testing.AssertStop(c, w)
 	testing.NewNotifyWatcherC(c, s.State, w).AssertOneChange()
@@ -1533,6 +1535,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	// TODO(mjs) - MODELUUID - test with multiple models with
 	// identically named units and ensure there's no leakage.
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	// Start a watch on an empty machine; check no units reported.
 	w := s.machine.WatchPrincipalUnits()
 	defer testing.AssertStop(c, w)
@@ -1613,6 +1616,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	testing.AssertStop(c, w)
 	wc.AssertClosed()
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	// Start a fresh watcher; check both principals reported.
 	w = s.machine.WatchPrincipalUnits()
 	defer testing.AssertStop(c, w)
@@ -1650,6 +1654,7 @@ func (s *MachineSuite) TestWatchPrincipalUnitsDiesOnStateClose(c *gc.C) {
 }
 
 func (s *MachineSuite) TestWatchUnits(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	// Start a watch on an empty machine; check no units reported.
 	w := s.machine.WatchUnits()
 	defer testing.AssertStop(c, w)
@@ -1765,6 +1770,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 }
 
 func (s *MachineSuite) TestWatchUnitsHandlesDeletedEntries(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := s.machine.WatchUnits()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
@@ -3010,6 +3016,7 @@ func (s *MachineSuite) TestWatchAddresses(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := machine.WatchAddresses()
 	defer w.Stop()
 	wc := testing.NewNotifyWatcherC(c, s.State, w)

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -91,7 +91,11 @@ func (c NotifyWatcherC) AssertNoChange() {
 	c.State.StartSync()
 	select {
 	case _, ok := <-c.Watcher.Changes():
-		c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+		if ok {
+			c.Fatalf("watcher sent unexpected change")
+		} else {
+			c.Fatalf("watcher closed Changes channel")
+		}
 	case <-time.After(testing.ShortWait):
 	}
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -9,6 +9,7 @@ import (
 	"time" // Only used for time types.
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn"
 	gc "gopkg.in/check.v1"
@@ -122,6 +123,8 @@ func (s *UnitSuite) TestWatchConfigSettingsNeedsCharmURL(c *gc.C) {
 func (s *UnitSuite) TestWatchConfigSettings(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w, err := s.unit.WatchConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	defer testing.AssertStop(c, w)
@@ -181,6 +184,7 @@ func (s *UnitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w, err := s.unit.WatchConfigSettingsHash()
 	c.Assert(err, jc.ErrorIsNil)
 	defer testing.AssertStop(c, w)
@@ -2056,6 +2060,7 @@ func (s *UnitSuite) TestRemovePathologicalWithBuggyUniter(c *gc.C) {
 func (s *UnitSuite) TestWatchSubordinates(c *gc.C) {
 	// TODO(mjs) - ModelUUID - test with multiple models with
 	// identically named units and ensure there's no leakage.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := s.unit.WatchSubordinateUnits()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
@@ -2121,6 +2126,10 @@ func (s *UnitSuite) TestWatchSubordinates(c *gc.C) {
 }
 
 func (s *UnitSuite) TestWatchUnit(c *gc.C) {
+	loggo.GetLogger("juju.state.pool.txnwatcher").SetLogLevel(loggo.TRACE)
+	loggo.GetLogger("juju.state.watcher").SetLogLevel(loggo.TRACE)
+
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := s.unit.Watch()
 	defer testing.AssertStop(c, w)
 
@@ -2151,6 +2160,7 @@ func (s *UnitSuite) TestWatchUnit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w = s.unit.Watch()
 	defer testing.AssertStop(c, w)
 	testing.NewNotifyWatcherC(c, s.State, w).AssertOneChange()
@@ -2550,6 +2560,7 @@ func (s *CAASUnitSuite) TestWatchContainerAddresses(c *gc.C) {
 	unit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := unit.WatchContainerAddresses()
 	defer w.Stop()
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
@@ -2620,6 +2631,7 @@ func (s *CAASUnitSuite) TestWatchContainerAddressesHash(c *gc.C) {
 	unit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := unit.WatchContainerAddressesHash()
 	defer w.Stop()
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)


### PR DESCRIPTION
Noticed a number of test failures in the state package. While reproducing noticed unexpected behaviour with the hubwatcher idle handling.

The changes channel from the txnwatcher wasn't resetting the idle time, as that was only being reset when an event was forwarded. Also we should be using wall clock time rather than whatever the hub watcher was created with as the test clock is often advanced all at once and this isn't conducive to iterative `.After` calls. The idle callback is only used in tests, so this isn't used at all in production code.

Both the unit and machine watchers in the state package were missing sync calls.