### PR TITLE
Restart machine agent if mongo profile changes.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -549,6 +549,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		agentConfigUpdaterName: ifNotMigrating(agentconfigupdater.Manifold(agentconfigupdater.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
+			Logger:        loggo.GetLogger("juju.worker.agentconfigupdater"),
 		})),
 
 		// The apiworkers manifold starts workers which rely on the

--- a/controller/config.go
+++ b/controller/config.go
@@ -872,7 +872,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AutocertURLKey:          schema.Omit,
 	AutocertDNSNameKey:      schema.Omit,
 	AllowModelAccessKey:     schema.Omit,
-	MongoMemoryProfile:      schema.Omit,
+	MongoMemoryProfile:      MongoProfLow,
 	MaxLogsAge:              fmt.Sprintf("%vh", DefaultMaxLogsAgeDays*24),
 	MaxLogsSize:             fmt.Sprintf("%vM", DefaultMaxLogCollectionMB),
 	MaxTxnLogSize:           fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),


### PR DESCRIPTION
When the machine agent starts, it starts an agent config update worker. This worker is used to update the local agent.conf file. Ideally all updates to the file will go through this worker eventually, but for now, we are just changing the worker to get the agent to restart if the mongo memory profile is changed.

This is to record the mongo memory profile in the agent.conf file of any machines that become API servers. The value was written into the bootstrapped machine initially, but any new machines added, like with `enable-ha` didn't set the mongo memory profile.

When the agent restarts, the config file is read, now with the new mongo memory profile, and the mongo service script is updated and mongo restarted.

# QA steps
```
juju bootstrap lxd test  --config mongo-memory-profile=default
juju enable-ha
# wait for machines to start
juju ssh -m controller 0
sudo tail -2 /var/lib/juju/agents/machine-0/agent.conf
# there will be `mongomemoryprofile: default`
sudo grep mongod /etc/systemd/system/juju-db.service
# command line will not have --wiredTigerCacheSizeGB arg

# check the same for machine 1 and 2
juju ssh -m controller 1
sudo tail -2 /var/lib/juju/agents/machine-1/agent.conf
sudo grep mongod /etc/systemd/system/juju-db.service

juju ssh -m controller 2
sudo tail -2 /var/lib/juju/agents/machine-2/agent.conf
sudo grep mongod /etc/systemd/system/juju-db.service

```
