### PR TITLE
Fix the state testing implementation of WaitForModelWatchersIdle.

### DIFF
--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/os/series"
 	"github.com/juju/pubsub"
 	gitjujutesting "github.com/juju/testing"
@@ -211,7 +212,9 @@ func (s *JujuConnSuite) WaitForNextSync(c *gc.C) {
 }
 
 func (s *JujuConnSuite) WaitForModelWatchersIdle(c *gc.C, modelUUID string) {
-	c.Logf("waiting for model %s to be idle", modelUUID)
+	// Use a logger rather than c.Log so we get timestamps.
+	logger := loggo.GetLogger("test")
+	logger.Infof("waiting for model %s to be idle", modelUUID)
 	s.WaitForNextSync(c)
 	s.modelWatcherMutex.Lock()
 	idleChan := make(chan string)
@@ -239,7 +242,7 @@ func (s *JujuConnSuite) WaitForModelWatchersIdle(c *gc.C, modelUUID string) {
 			if uuid == modelUUID {
 				return
 			} else {
-				c.Logf("model %s is idle", uuid)
+				logger.Infof("model %s is idle", uuid)
 			}
 		case <-timeout:
 			c.Fatal("no sync event sent, is the watcher dead?")


### PR DESCRIPTION
One fix and a few drive bys here. Using a logger for the output so we get timestamps in the output.

Also, the state testing implementation needed to wait for the txn watcher sync before creating the idle channel, otherwise we may get notified about idle while the txn watcher is processing but before it has sent any values.

This fixes a cause of intermittent failures in some state watcher tests.