### PR TITLE
Fix TestWatchApplication race

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2886,6 +2886,8 @@ func (s *ApplicationSuite) TestWatchApplication(c *gc.C) {
 	// Remove application, start new watch, check single event.
 	err = application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w = s.mysql.Watch()
 	defer testing.AssertStop(c, w)
 	testing.NewNotifyWatcherC(c, s.State, w).AssertOneChange()

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3605,7 +3605,7 @@ func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
 	s.app = f.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: ch})
 	// Consume the initial construction events from the watchers.
-	s.State.StartSync()
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func strPtr(s string) *string {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2886,7 +2886,9 @@ func (s *ApplicationSuite) TestWatchApplication(c *gc.C) {
 	// Remove application, start new watch, check single event.
 	err = application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-
+	// The destruction needs to have been processed by the txn watcher before the
+	// watcher in the test is started or the destroy notification may come through
+	// as an additional event.
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w = s.mysql.Watch()
 	defer testing.AssertStop(c, w)


### PR DESCRIPTION
There is a race in application_test.go:2855: ApplicationSuite.TestWatchApplication which causes a double event.

The destruction needs to have been processed by the txn watcher before the watcher in the test is started or the destroy notification may come through as an additional event.
