### PR TITLE
Fix race in charmrevision worker test TestDelayedUpdateError

### DIFF
--- a/worker/charmrevision/worker_test.go
+++ b/worker/charmrevision/worker_test.go
@@ -46,7 +46,7 @@ func (s *WorkerSuite) TestUpdatesAfterPeriod(c *gc.C) {
 	fix := newFixture(time.Minute)
 	fix.cleanTest(c, func(_ worker.Worker) {
 		fix.waitCall(c)
-		if err := fix.clock.WaitAdvance(time.Minute, 1*time.Second, 1); err != nil {
+		if err := fix.clock.WaitAdvance(time.Minute, testing.LongWait, 1); err != nil {
 			c.Fatal(err)
 		}
 		fix.waitCall(c)
@@ -76,7 +76,9 @@ func (s *WorkerSuite) TestDelayedUpdateError(c *gc.C) {
 	)
 	fix.dirtyTest(c, func(w worker.Worker) {
 		fix.waitCall(c)
-		fix.clock.Advance(time.Minute)
+		if err := fix.clock.WaitAdvance(time.Minute, testing.LongWait, 1); err != nil {
+			c.Fatal(err)
+		}
 		fix.waitCall(c)
 		c.Check(w.Wait(), gc.ErrorMatches, "no more updates for you")
 		fix.waitNoCall(c)


### PR DESCRIPTION
Race in the test where clock is advancing before the worker is waiting.