### PR TITLE
Write Application to Generation Doc on Generational config Change

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2045,8 +2045,10 @@ func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error 
 		if err := app.UpdateCharmConfig(arg.Generation, charmConfigChanges); err != nil {
 			return errors.Annotate(err, "updating application charm settings")
 		}
-		if err := api.addAppToGeneration(arg.ApplicationName); err != nil {
-			return errors.Trace(err)
+		if arg.Generation == model.GenerationNext {
+			if err := api.addAppToGeneration(arg.ApplicationName); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 	return nil

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1832,6 +1832,33 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsStrings(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
 }
 
+func (s *applicationSuite) TestApplicationUpdateSetSettingsStringsNextGen(c *gc.C) {
+	ch := s.AddTestingCharm(c, "dummy")
+	app := s.AddTestingApplication(c, "dummy", ch)
+
+	c.Assert(s.State.AddGeneration(), jc.ErrorIsNil)
+
+	// Update settings for the application.
+	args := params.ApplicationUpdate{
+		ApplicationName: "dummy",
+		SettingsStrings: map[string]string{"title": "s-title", "username": "s-user"},
+		Generation:      model.GenerationNext,
+	}
+	err := s.applicationAPI.Update(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the settings have been correctly updated.
+	expected := charm.Settings{"title": "s-title", "username": "s-user"}
+	obtained, err := app.CharmConfig(model.GenerationNext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
+
+	// Check that the application is recorded against the generation.
+	gen, err := s.State.NextGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), jc.DeepEquals, map[string][]string{"dummy": {}})
+}
+
 func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
@@ -1850,6 +1877,33 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 	obtained, err := app.CharmConfig(model.GenerationCurrent)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
+}
+
+func (s *applicationSuite) TestApplicationUpdateSetSettingsYAMLNextGen(c *gc.C) {
+	ch := s.AddTestingCharm(c, "dummy")
+	app := s.AddTestingApplication(c, "dummy", ch)
+
+	c.Assert(s.State.AddGeneration(), jc.ErrorIsNil)
+
+	// Update settings for the application.
+	args := params.ApplicationUpdate{
+		ApplicationName: "dummy",
+		SettingsYAML:    "dummy:\n  title: y-title\n  username: y-user",
+		Generation:      model.GenerationNext,
+	}
+	err := s.applicationAPI.Update(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the settings have been correctly updated.
+	expected := charm.Settings{"title": "y-title", "username": "y-user"}
+	obtained, err := app.CharmConfig(model.GenerationNext)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
+
+	// Check that the application is recorded against the generation.
+	gen, err := s.State.NextGeneration()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), jc.DeepEquals, map[string][]string{"dummy": {}})
 }
 
 func (s *applicationSuite) TestClientApplicationUpdateSetSettingsGetYAML(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1297,6 +1297,8 @@ func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
 		"juju-external-hostname": "value",
 	}, []string(nil), schema, defaults)
 	app.CheckCall(c, 2, "UpdateCharmConfig", model.GenerationNext, charm.Settings{"stringOption": "stringVal"})
+
+	s.backend.generation.CheckCall(c, 0, "AssignApplication", "postgresql")
 }
 
 func (s *ApplicationSuite) TestBlockSetApplicationConfig(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1279,6 +1279,38 @@ func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
 				"juju-external-hostname": "value",
 				"stringOption":           "stringVal",
 			},
+			Generation: model.GenerationCurrent,
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "Application")
+	app := s.backend.applications["postgresql"]
+	app.CheckCallNames(c, "UpdateApplicationConfig", "Charm", "UpdateCharmConfig")
+
+	schema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	c.Assert(err, jc.ErrorIsNil)
+	defaults := caas.ConfigDefaults(k8s.ConfigDefaults())
+	schema, defaults, err = application.AddTrustSchemaAndDefaults(schema, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
+		"juju-external-hostname": "value",
+	}, []string(nil), schema, defaults)
+	app.CheckCall(c, 2, "UpdateCharmConfig", model.GenerationCurrent, charm.Settings{"stringOption": "stringVal"})
+
+	// We should never have accessed the generation.
+	c.Check(s.backend.generation, gc.IsNil)
+}
+
+func (s *ApplicationSuite) TestSetApplicationConfigNextGen(c *gc.C) {
+	application.SetModelType(s.api, state.ModelTypeCAAS)
+	result, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
+		Args: []params.ApplicationConfigSet{{
+			ApplicationName: "postgresql",
+			Config: map[string]string{
+				"juju-external-hostname": "value",
+				"stringOption":           "stringVal",
+			},
 			Generation: model.GenerationNext,
 		}}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -44,6 +44,7 @@ type Backend interface {
 	Resources() (Resources, error)
 	OfferConnectionForRelation(string) (OfferConnection, error)
 	SaveEgressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error)
+	NextGeneration() (Generation, error)
 }
 
 // BlockChecker defines the block-checking functionality required by
@@ -158,6 +159,10 @@ type Model interface {
 // the state.Resources type for details on the methods.
 type Resources interface {
 	RemovePendingAppResources(string, map[string]string) error
+}
+
+type Generation interface {
+	AssignApplication(string) error
 }
 
 type stateShim struct {
@@ -340,6 +345,14 @@ func (s stateShim) OfferConnectionForRelation(key string) (OfferConnection, erro
 	return s.State.OfferConnectionForRelation(key)
 }
 
+func (s stateShim) NextGeneration() (Generation, error) {
+	gen, err := s.State.NextGeneration()
+	if err != nil {
+		return nil, err
+	}
+	return Generation(gen), nil
+}
+
 type stateApplicationShim struct {
 	*state.Application
 	st *state.State
@@ -405,15 +418,7 @@ type Subnet interface {
 	ProviderNetworkId() network.Id
 }
 
-type subnetShim struct {
-	*state.Subnet
-}
-
 type Space interface {
 	Name() string
 	ProviderId() network.Id
-}
-
-type spaceShim struct {
-	*state.Space
 }


### PR DESCRIPTION
## Description of change

This patch addresses an omission from https://github.com/juju/juju/pull/9772. When an application has its config modified under a generation, the application name should be added to the generation document.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=generations`
- Bootstrap
- `juju deploy redis`
- `juju add-generation`
- `juju config redis password=pass`
- `juju show-generation` should be:
```
next:
- application: redis
  units: []
  config:
    password: pass
```

## Documentation changes

None.

## Bug reference

N/A
