### PR TITLE
Query mongo profile and export counts in webscale tests

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -230,6 +230,11 @@ def parse_args(argv):
              "locally before bootstrapping",
         default="",
     )
+    parser.add_argument(
+        '--mongo-memory-profile',
+        help="the name of a mongo profile to use when bootstrapping",
+        default="",
+    )
     add_basic_testing_arguments(parser, existing=False)
     # Override the default logging_config default value set by adding basic
     # testing arguments. This way we can have a default value for all tests,
@@ -282,7 +287,8 @@ def main(argv=None):
     with bs_manager.booted_context(
         args.upload_tools,
         db_snap_path=db_snap_path,
-        db_snap_asserts_path=db_snap_asserts_path
+        db_snap_asserts_path=db_snap_asserts_path,
+        mongo_memory_profile=args.mongo_memory_profile,
     ):
         client = bs_manager.client
         mongo_version, mongo_profile = extract_mongo_details(client)

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -120,11 +120,11 @@ def extract_txn_metrics(logs, module):
     }
 
 
-def calc_stats(prefix, values):
+def calc_stats(prefix, values, include_count=False):
     """ Calculate statistics for a list of float values and return them as an
         object where the keys are prefixed using the provided prefix.
     """
-    return {
+    stats = {
         prefix+'min': min(values),
         prefix+'max': max(values),
         prefix+'total': sum(values),
@@ -132,6 +132,11 @@ def calc_stats(prefix, values):
         prefix+'median': statistics.median(values),
         prefix+'stdev': statistics.stdev(values),
     }
+
+    if include_count:
+        stats[prefix+'count'] = len(values)
+
+    return stats
 
 
 def merge_dicts(*args):
@@ -148,7 +153,7 @@ def construct_metrics(txn_metrics, test_duration):
     """
 
     return merge_dicts(
-        calc_stats('txn_time_', txn_metrics['timings']),
+        calc_stats('txn_time_', txn_metrics['timings'], include_count=True),
         calc_stats('txn_retries_', txn_metrics['retries']),
         {'test_duration': test_duration},
     )

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -165,14 +165,17 @@ def extract_charm_urls(client):
     return charms
 
 
-def extract_mongo_version(client):
-    """Extract the mongo version from the controller.
+def extract_mongo_details(client):
+    """Extract the mongo version and profile from the controller.
     """
 
     ctrl_info = client.get_controllers()
     ctrl = ctrl_info.get_controller(client.env.controller.name)
     ctrl_details = ctrl.get_details()
-    return ctrl_details.mongo_version
+
+    ctrl_config = client.get_controller_config(client.env.controller.name)
+
+    return ctrl_details.mongo_version, ctrl_config.mongo_memory_profile
 
 
 def get_stack_client(stack_type, path, client, timeout=3600, charm=False):
@@ -282,8 +285,9 @@ def main(argv=None):
         db_snap_asserts_path=db_snap_asserts_path
     ):
         client = bs_manager.client
-        mongo_version = extract_mongo_version(client)
-        log.info("MongoVersion used for deployment: {}".format(mongo_version))
+        mongo_version, mongo_profile = extract_mongo_details(client)
+        log.info("MongoVersion used for deployment: {} (profile: {})".format(
+            mongo_version, mongo_profile))
 
         deploy_bundle(
                 client,
@@ -308,8 +312,8 @@ def main(argv=None):
                 "charm-urls": charm_urls,
                 "juju-version": args.juju_version,
                 "mongo-version": mongo_version,
+                "mongo-profile": mongo_profile,
                 # The following are placeholders for now
-                "mongo-profile": "low",
                 "mongo-ss-txns": "false",
             })
         except Exception:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -923,8 +923,11 @@ class ModelClient:
         })
 
     @contextmanager
-    def _bootstrap_config(self):
-        with temp_yaml_file(self.make_model_config()) as config_filename:
+    def _bootstrap_config(self, mongo_memory_profile=None):
+        cfg = self.make_model_config()
+        if mongo_memory_profile:
+            cfg['mongo-memory-profile'] = mongo_memory_profile
+        with temp_yaml_file(cfg) as config_filename:
             yield config_filename
 
     def _check_bootstrap(self):
@@ -938,10 +941,10 @@ class ModelClient:
     def bootstrap(self, upload_tools=False, bootstrap_series=None,
                   credential=None, auto_upgrade=False, metadata_source=None,
                   no_gui=False, agent_version=None, db_snap_path=None,
-                  db_snap_asserts_path=None):
+                  db_snap_asserts_path=None, mongo_memory_profile=None):
         """Bootstrap a controller."""
         self._check_bootstrap()
-        with self._bootstrap_config() as config_filename:
+        with self._bootstrap_config(mongo_memory_profile) as config_filename:
             args = self.get_bootstrap_args(
                 upload_tools, config_filename, bootstrap_series, credential,
                 auto_upgrade, metadata_source, no_gui, agent_version,

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -67,6 +67,7 @@ from jujupy.status import (
 )
 from jujupy.controller import (
     Controllers,
+    ControllerConfig,
 )
 from jujupy.utility import (
     _dns_name_for_machine,
@@ -577,6 +578,8 @@ class ModelClient:
 
     controllers_class = Controllers
 
+    controller_config_class = ControllerConfig
+
     agent_metadata_url = 'agent-metadata-url'
 
     model_permissions = frozenset(['read', 'write', 'admin'])
@@ -1085,6 +1088,23 @@ class ModelClient:
                 pass
         raise ControllersTimeout(
             'Timed out waiting for juju show-controllers to succeed')
+
+    def get_controller_config(self, controller_name, timeout=60):
+        """Get controller config."""
+        for ignored in until_timeout(timeout):
+            try:
+                return self.controller_config_class.from_text(
+                    self.get_juju_output(
+                        'controller-config',
+                        '--controller', controller_name,
+                        '--format', 'yaml',
+                        include_e=False,
+                    ).decode('utf-8'),
+                )
+            except subprocess.CalledProcessError:
+                pass
+        raise ControllersTimeout(
+            'Timed out waiting for juju controller-config to succeed')
 
     def show_model(self, model_name=None):
         model_details = self.get_juju_output(

--- a/acceptancetests/jujupy/controller.py
+++ b/acceptancetests/jujupy/controller.py
@@ -14,17 +14,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import re
 import yaml
 
 __metaclass__ = type
+
 
 class Controllers:
 
     def __init__(self, info, text):
         self.info = info
         self.text = text
-    
+
     @classmethod
     def from_text(cls, text):
         try:
@@ -34,7 +34,7 @@ class Controllers:
         except ValueError:
             info = yaml.safe_load(text)
         return cls(info, text)
-    
+
     def get_controller(self, name):
         """Controller returns the controller associated with the name provided
 
@@ -42,13 +42,15 @@ class Controllers:
         """
         return Controller(self.info[name])
 
+
 class Controller:
 
     def __init__(self, info):
         self.info = info
-    
+
     def get_details(self):
         return ControllerDetails(self.info["details"])
+
 
 class ControllerDetails:
 
@@ -58,7 +60,29 @@ class ControllerDetails:
     @property
     def agent_version(self):
         return self.info["agent-version"]
-    
+
     @property
     def mongo_version(self):
         return self.info["mongo-version"]
+
+
+class ControllerConfig:
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    @classmethod
+    def from_text(cls, text):
+        try:
+            # Parsing as JSON is much faster than parsing as YAML, so try
+            # parsing as JSON first and fall back to YAML.
+            cfg = json.loads(text)
+        except ValueError:
+            cfg = yaml.safe_load(text)
+        return cls(cfg)
+
+    @property
+    def mongo_memory_profile(self):
+        if 'mongo-memory-profile' in self.cfg:
+            return self.cfg["mongo-memory-profile"]
+        return "low"


### PR DESCRIPTION
## Description of change

This PR updates the webscale tests to query and report the mongo profile version used for the tests. In addition, the webscale test-runner now exposes the `--mongo-memory-profile` argument that allows us to override the profile name for specific tests making it easy to run matrix builds to gauge deploy times when mongo is running in a less-constrained mode.

Furthermore, the benchmark code has been updated to emit the `txn_count` as part of the collected metrics.