### PR TITLE
Wip storage classification

### DIFF
--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -311,7 +310,9 @@ func ClassifyDetachedStorage(
 	stVolume VolumeAccess,
 	stFile FilesystemAccess,
 	storage []state.StorageInstance,
-) (destroyed, detached []params.Entity, _ error) {
+) (destroyed, detached []names.StorageTag, _ error) {
+	// If anything changes here, the code in state/cleanup.go ClassifyDetachedStorage needs to be
+	// updated too...
 	for _, storage := range storage {
 		var detachable bool
 		switch storage.Kind() {
@@ -340,11 +341,10 @@ func ClassifyDetachedStorage(
 		default:
 			return nil, nil, errors.NotValidf("storage kind %s", storage.Kind())
 		}
-		entity := params.Entity{storage.StorageTag().String()}
 		if detachable {
-			detached = append(detached, entity)
+			detached = append(detached, storage.StorageTag())
 		} else {
-			destroyed = append(destroyed, entity)
+			destroyed = append(destroyed, storage.StorageTag())
 		}
 	}
 	return destroyed, detached, nil

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1272,23 +1272,34 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 			return nil, errors.Trace(err)
 		}
 
+		var destroyStorage []string
+		var detachStorage []string
 		if arg.DestroyStorage {
 			for _, s := range storage {
-				info.DestroyedStorage = append(
-					info.DestroyedStorage,
-					params.Entity{s.StorageTag().String()},
-				)
+				info.DestroyedStorage = append(info.DestroyedStorage, params.Entity{s.StorageTag().String()})
+				destroyStorage = append(destroyStorage, s.StorageTag().String())
 			}
 		} else {
-			info.DestroyedStorage, info.DetachedStorage, err = storagecommon.ClassifyDetachedStorage(
+			destroyed, detached, err := storagecommon.ClassifyDetachedStorage(
 				api.storageAccess.VolumeAccess(), api.storageAccess.FilesystemAccess(), storage,
 			)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
+			for _, tag := range destroyed {
+				info.DestroyedStorage = append(info.DestroyedStorage, params.Entity{tag.String()})
+				destroyStorage = append(destroyStorage, tag.String())
+			}
+			for _, tag := range detached {
+				info.DetachedStorage = append(info.DetachedStorage, params.Entity{tag.String()})
+				detachStorage = append(detachStorage, tag.String())
+			}
 		}
+		fmt.Printf("\n apiserver unit detach %v destroy %v\n", detachStorage, destroyStorage)
 		op := unit.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
+		op.StorageToDetach = detachStorage
+		op.StorageToDestroy = destroyStorage
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1371,6 +1382,8 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 			return nil, err
 		}
 		storageSeen := names.NewSet()
+		var destroyStorage []string
+		var detachStorage []string
 		for _, unit := range units {
 			info.DestroyedUnits = append(
 				info.DestroyedUnits,
@@ -1400,6 +1413,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 						info.DestroyedStorage,
 						params.Entity{s.StorageTag().String()},
 					)
+					destroyStorage = append(destroyStorage, s.StorageTag().String())
 				}
 			} else {
 				destroyed, detached, err := storagecommon.ClassifyDetachedStorage(
@@ -1408,12 +1422,21 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				if err != nil {
 					return nil, err
 				}
-				info.DestroyedStorage = append(info.DestroyedStorage, destroyed...)
-				info.DetachedStorage = append(info.DetachedStorage, detached...)
+				for _, tag := range destroyed {
+					info.DestroyedStorage = append(info.DestroyedStorage, params.Entity{tag.String()})
+					destroyStorage = append(destroyStorage, tag.String())
+				}
+				for _, tag := range detached {
+					info.DetachedStorage = append(info.DetachedStorage, params.Entity{tag.String()})
+					detachStorage = append(detachStorage, tag.String())
+				}
 			}
 		}
+		fmt.Printf("\n apiserver application detach %v destroy %v\n", detachStorage, destroyStorage)
 		op := app.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
+		op.StorageToDestroy = destroyStorage
+		op.StorageToDetach = detachStorage
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, err
 		}

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -337,8 +337,14 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 				storageError(errors.Annotatef(err, "classifying storage for destruction for unit %v", unit.UnitTag().Id()))
 				continue
 			}
-			info.DestroyedStorage = append(info.DestroyedStorage, destroyed...)
-			info.DetachedStorage = append(info.DetachedStorage, detached...)
+			for _, tag := range destroyed {
+				info.DestroyedStorage = append(info.DestroyedStorage, params.Entity{tag.String()})
+			}
+			for _, tag := range detached {
+				info.DetachedStorage = append(info.DetachedStorage, params.Entity{tag.String()})
+			}
+			// TODO (me) These collections need to be passsed to cleanup, collections of storage to destroy/detach
+			fmt.Printf("\n apiserver machine detach %v destroy %v\n", info.DetachedStorage, info.DestroyedStorage)
 		}
 
 		if len(storageErrors) != 0 {

--- a/state/application.go
+++ b/state/application.go
@@ -250,6 +250,12 @@ type DestroyApplicationOperation struct {
 	// then detachable storage will be detached and left in the model.
 	DestroyStorage bool
 
+	// StorageToDestroy contains storage tags of storage instances to be destroyed.
+	StorageToDestroy []string
+
+	// StorageToDetach contains storage tags of storage instances to be detached.
+	StorageToDetach []string
+
 	// RemoveOffers controls whether or not application offers
 	// are removed. If this is false, then the operation will
 	// fail if there are any offers remaining.
@@ -265,7 +271,7 @@ func (op *DestroyApplicationOperation) Build(attempt int) ([]txn.Op, error) {
 			return nil, err
 		}
 	}
-	ops, err := op.app.destroyOps(op.DestroyStorage, op.RemoveOffers)
+	ops, err := op.app.destroyOps(op.DestroyStorage, op.StorageToDetach, op.StorageToDestroy, op.RemoveOffers)
 	switch err {
 	case errRefresh:
 		return nil, jujutxn.ErrTransientFailure
@@ -285,7 +291,7 @@ func (op *DestroyApplicationOperation) Done(err error) error {
 // destroyOps returns the operations required to destroy the application. If it
 // returns errRefresh, the application should be refreshed and the destruction
 // operations recalculated.
-func (a *Application) destroyOps(destroyStorage, removeOffers bool) ([]txn.Op, error) {
+func (a *Application) destroyOps(isDestroyStorage bool, detachStorage []string, destroyStorage []string, removeOffers bool) ([]txn.Op, error) {
 	if a.doc.Life == Dying {
 		return nil, errAlreadyDying
 	}
@@ -360,10 +366,13 @@ func (a *Application) destroyOps(destroyStorage, removeOffers bool) ([]txn.Op, e
 	// as the count's equality with zero does not change, because all we care
 	// about is that *some* unit is, or is not, keeping the application from
 	// being removed: the difference between 1 unit and 1000 is irrelevant.
+	fmt.Printf("\n detach %v destroy %v\n", detachStorage, destroyStorage)
 	if a.doc.UnitCount > 0 {
 		cleanupOp := newCleanupOp(
 			cleanupUnitsForDyingApplication,
 			a.doc.Name,
+			isDestroyStorage,
+			detachStorage,
 			destroyStorage,
 		)
 		ops = append(ops, cleanupOp)

--- a/state/storage.go
+++ b/state/storage.go
@@ -1325,7 +1325,7 @@ func (sb *storageBackend) storageHostAttachment(
 	}
 }
 
-// Remove removes the storage attachment from state, and may remove its storage
+// RemoveStorageAttachment removes the storage attachment from state, and may remove its storage
 // instance as well, if the storage instance is Dying and no other references to
 // it exist. It will fail if the storage attachment is not Dying.
 func (sb *storageBackend) RemoveStorageAttachment(storage names.StorageTag, unit names.UnitTag) (err error) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -491,6 +491,12 @@ type DestroyUnitOperation struct {
 	// to the unit is destroyed. If this is false, then detachable
 	// storage will be detached and left in the model.
 	DestroyStorage bool
+
+	// StorageToDestroy contains storage tags of storage instances to be destroyed.
+	StorageToDestroy []string
+
+	// StorageToDetach contains storage tags of storage instances to be detached.
+	StorageToDetach []string
 }
 
 // Build is part of the ModelOperation interface.
@@ -502,7 +508,7 @@ func (op *DestroyUnitOperation) Build(attempt int) ([]txn.Op, error) {
 			return nil, err
 		}
 	}
-	switch ops, err := op.unit.destroyOps(op.DestroyStorage); err {
+	switch ops, err := op.unit.destroyOps(op.DestroyStorage, op.StorageToDetach, op.StorageToDestroy); err {
 	case errRefresh:
 	case errAlreadyDying:
 		return nil, jujutxn.ErrNoOperations
@@ -541,7 +547,7 @@ func (u *Unit) eraseHistory() error {
 // destroyOps returns the operations required to destroy the unit. If it
 // returns errRefresh, the unit should be refreshed and the destruction
 // operations recalculated.
-func (u *Unit) destroyOps(destroyStorage bool) ([]txn.Op, error) {
+func (u *Unit) destroyOps(isDestroyStorage bool, detachStorage []string, destroyStorage []string) ([]txn.Op, error) {
 	if u.doc.Life != Alive {
 		return nil, errAlreadyDying
 	}
@@ -568,7 +574,9 @@ func (u *Unit) destroyOps(destroyStorage bool) ([]txn.Op, error) {
 	// the number of tests that have to change and defer that improvement to
 	// its own CL.
 	minUnitsOp := minUnitsTriggerOp(u.st, u.ApplicationName())
-	cleanupOp := newCleanupOp(cleanupDyingUnit, u.doc.Name, destroyStorage)
+	fmt.Printf("\n state unit detach %v destroy %v\n", detachStorage, destroyStorage)
+
+	cleanupOp := newCleanupOp(cleanupDyingUnit, u.doc.Name, isDestroyStorage, detachStorage, destroyStorage)
 	setDyingOp := txn.Op{
 		C:      unitsC,
 		Id:     u.doc.DocID,


### PR DESCRIPTION
## Description of change

***
FAIR WARNING :D :dagger: 
This is a WIP and is not ever intended to land yet. It is only provided for team collaboration purposes and to give curious onlookers some visibility into what is happening in this space.
***

While investigating some productions failures around removing applications and units or destroying models, it has been identified that almost always there were underpinning issues detaching and destroying storage.
Tracing the code and the logs, we have discovered that we determine early whether unit storage attachments will be deleted or detached but we throw this information away before we act on it. We return it to the user as a fait-accompli. However, there is no guarantee that this is what we will do in state nor do we provide the actual feedback in terms of 'did it really happen?'.

The goal of this PR is to ensure that we do what we say - here we pass on the storage that we want to destroy/detach to state to avoid duplication of the effort and to ensure consistency. While testing the change, it was actually found that there is a pass through, especially around model destruction, that by-passes the logic that determines what to do with storage, thus further complicating our ability to predict what happens when. This PR changes this as well to ensure that the same code path is exercised.

Being a very early WIP, there are a few known improvements that have not taken place yet:

1.    Refactor classification logic to be available to state and apiserver to avoid duplication;
2.    Accumulate storage instances errors rather than err on the first one;
3.    Remove debugging statements;
4.    Add new and modify existing tests.

