### PR TITLE
Fix race in relation watcher test.

### DIFF
--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1794,6 +1794,7 @@ func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
 	err = mysql0.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	changeSettings(c, mysql0)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	mysqlWatcher, err := rel.WatchUnits("mysql")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Slight race between setting relation config, and starting the watcher to watch it. Ensure that the relation config setting has flowed through before starting the watcher.