### PR TITLE
Ensures only sorted keys are passed to the hash cache.

### DIFF
--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -48,7 +48,7 @@ func (m *Model) Config() map[string]interface{} {
 
 // WatchConfig creates a watcher for the model config.
 func (m *Model) WatchConfig(keys ...string) *ConfigWatcher {
-	w := newConfigWatcher(keys, m.hashCache.getHash(keys))
+	w := newConfigWatcher(keys, m.hashCache)
 
 	unsub := m.hub.Subscribe(m.modelTopic(modelConfigChange), w.configChanged)
 

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -89,6 +89,7 @@ func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
 
 	// The hash is generated each time we set the details.
 	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(2))
+
 	// The value is retrieved from the cache when the watcher is created and notified.
 	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheHit), gc.Equals, float64(2))
 }
@@ -127,6 +128,22 @@ func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
 
 	m.SetDetails(change)
 	wc.AssertNoChange()
+}
+
+func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
+	m := s.newModel(modelChange)
+
+	w := m.WatchConfig("key", "another")
+	defer workertest.CleanKill(c, w)
+
+	w2 := m.WatchConfig("another", "key")
+	defer workertest.CleanKill(c, w2)
+
+	// One cache miss for the "all" hash, and one for the specific fields.
+	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(2))
+
+	// Specific field hash should get a hit despite the field ordering.
+	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheHit), gc.Equals, float64(1))
 }
 
 func (s *ModelSuite) TestApplicationNotFoundError(c *gc.C) {

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -108,14 +108,17 @@ type ConfigWatcher struct {
 	hash string
 }
 
-func newConfigWatcher(keys []string, keyHash string) *ConfigWatcher {
+// newConfigWatcher returns a new watcher for the input config keys
+// with a baseline hash of their config values from the input hash cache.
+// As per the cache requirements, hashes are only generated from sorted keys.
+func newConfigWatcher(keys []string, cache *hashCache) *ConfigWatcher {
 	sort.Strings(keys)
 
 	return &ConfigWatcher{
 		notifyWatcherBase: newNotifyWatcherBase(),
 
 		keys: keys,
-		hash: keyHash,
+		hash: cache.getHash(keys),
 	}
 }
 


### PR DESCRIPTION
## Description of change

This patch fixes a bug patch introduced in #9872. It ensures that unsorted key slices are never used to store a config hash.

## QA steps

Accompanying unit test.

## Documentation changes

None.

## Bug reference

N/A
