### PR TITLE
Add sync points to the watch subordinate test.

### DIFF
--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2089,6 +2089,9 @@ func (s *UnitSuite) TestWatchSubordinates(c *gc.C) {
 		c.Assert(units, gc.HasLen, 1)
 		subUnits = append(subUnits, units[0])
 	}
+	// In order to ensure that both the subordinate creation events
+	// have all been processed, wait for the model to be idle.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	wc.AssertChange(subUnits[0].Name(), subUnits[1].Name())
 	wc.AssertNoChange()
 
@@ -2105,6 +2108,9 @@ func (s *UnitSuite) TestWatchSubordinates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = subUnits[1].Remove()
 	c.Assert(err, jc.ErrorIsNil)
+	// In order to ensure that both the dead and remove operations
+	// have been processed, we need to wait until the model is idle.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	wc.AssertChange(subUnits[0].Name(), subUnits[1].Name())
 	wc.AssertNoChange()
 


### PR DESCRIPTION
This fixes another intermittent failure in the TestWatchSubordinates test.
Since the event processing is happening in other goroutines, assumptions that changes that the test made have been processed by the event subsystem don't actually hold true without the synchronisation.