### PR TITLE
k8s storage is opinionated model config

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -102,14 +102,11 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		model.ModelTag(),
-		model.Type(),
-		model.Name(),
+		model,
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		pm,
 		common.NewResources(),
-		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return &application.APIv9{api}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -107,6 +107,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
 		application.DeployApplication,
 		pm,
 		common.NewResources(),
+		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return &application.APIv9{api}

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
@@ -152,6 +153,7 @@ type Model interface {
 	Owner() names.UserTag
 	Tag() names.Tag
 	Type() state.ModelType
+	ModelConfig() (*config.Config, error)
 }
 
 // Resources defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -55,6 +55,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		application.DeployApplication,
 		&mockStoragePoolManager{},
 		common.NewResources(),
+		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.applicationAPI = &application.APIv9{api}
@@ -195,6 +196,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 		application.DeployApplication,
 		&mockStoragePoolManager{},
 		common.NewResources(),
+		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{&application.APIv9{api}}

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -10,7 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/environschema.v1"
-	"gopkg.in/juju/names.v2"
 
 	apiapplication "github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/common"
@@ -23,7 +22,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -52,14 +50,11 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		model.ModelTag(),
-		model.Type(),
-		model.Name(),
+		model,
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
 		common.NewResources(),
-		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.applicationAPI = &application.APIv9{api}
@@ -188,19 +183,18 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 	storageAccess, err := application.GetStorageState(st)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(st)
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
 	api, err := application.NewAPIBase(
 		application.GetState(st),
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		names.NewModelTag(st.ModelUUID()),
-		state.ModelTypeCAAS,
-		"caasmodel",
+		model,
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
 		common.NewResources(),
-		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{&application.APIv9{api}}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facades/client/application"
+	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
@@ -872,6 +873,16 @@ func (m *mockStoragePoolManager) Get(name string) (*storage.Config, error) {
 		return nil, err
 	}
 	return storage.NewConfig(name, m.storageType, map[string]interface{}{"foo": "bar"})
+}
+
+type mockStorageValidator struct {
+	jtesting.Stub
+	caas.StorageValidator
+}
+
+func (m *mockStorageValidator) ValidateStorageClass(config map[string]interface{}) error {
+	m.MethodCall(m, "ValidateStorageClass", config)
+	return m.NextErr()
 }
 
 type mockGeneration struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -70,16 +70,6 @@ func (st *mockState) Model() (caasoperatorprovisioner.Model, error) {
 	return st.model, nil
 }
 
-type mockStorageProviderRegistry struct {
-	testing.Stub
-	storage.ProviderRegistry
-}
-
-func (m *mockStorageProviderRegistry) StorageProvider(providerType storage.ProviderType) (storage.Provider, error) {
-	m.MethodCall(m, "StorageProvider", providerType)
-	return nil, errors.NotSupportedf("StorageProvider")
-}
-
 type mockStoragePoolManager struct {
 	testing.Stub
 	poolmanager.PoolManager
@@ -104,7 +94,9 @@ func (m *mockModel) UUID() string {
 
 func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
-	return config.New(config.UseDefaults, coretesting.FakeConfig())
+	attrs := coretesting.FakeConfig()
+	attrs["operator-storage"] = "k8s-storage"
+	return config.New(config.UseDefaults, attrs)
 }
 
 type mockApplication struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -25,12 +25,11 @@ var _ = gc.Suite(&CAASProvisionerSuite{})
 type CAASProvisionerSuite struct {
 	coretesting.BaseSuite
 
-	resources               *common.Resources
-	authorizer              *apiservertesting.FakeAuthorizer
-	api                     *caasoperatorprovisioner.API
-	st                      *mockState
-	storageProviderRegistry *mockStorageProviderRegistry
-	storagePoolManager      *mockStoragePoolManager
+	resources          *common.Resources
+	authorizer         *apiservertesting.FakeAuthorizer
+	api                *caasoperatorprovisioner.API
+	st                 *mockState
+	storagePoolManager *mockStoragePoolManager
 }
 
 func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
@@ -45,9 +44,8 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	s.storageProviderRegistry = &mockStorageProviderRegistry{}
 	s.storagePoolManager = &mockStoragePoolManager{}
-	api, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st, s.storageProviderRegistry, s.storagePoolManager)
+	api, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st, s.storagePoolManager)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -56,7 +54,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: names.NewMachineTag("0"),
 	}
-	_, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st, s.storageProviderRegistry, s.storagePoolManager)
+	_, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(s.resources, s.authorizer, s.st, s.storagePoolManager)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -132,9 +130,13 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 			"juju-model-uuid":      coretesting.ModelTag.Id(),
 			"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		CharmStorage: params.KubernetesFilesystemParams{
-			Size:       uint64(1024),
-			Provider:   "kubernetes",
-			Attributes: map[string]interface{}{"foo": "bar"},
+			StorageName: "charm",
+			Size:        uint64(1024),
+			Provider:    "kubernetes",
+			Attributes: map[string]interface{}{
+				"storage-class": "k8s-storage",
+				"foo":           "bar",
+			},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
 				"juju-controller-uuid": coretesting.ControllerTag.Id()},
@@ -154,9 +156,13 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 			"juju-model-uuid":      coretesting.ModelTag.Id(),
 			"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		CharmStorage: params.KubernetesFilesystemParams{
-			Size:       uint64(1024),
-			Provider:   "kubernetes",
-			Attributes: map[string]interface{}{"foo": "bar"},
+			StorageName: "charm",
+			Size:        uint64(1024),
+			Provider:    "kubernetes",
+			Attributes: map[string]interface{}{
+				"storage-class": "k8s-storage",
+				"foo":           "bar",
+			},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
 				"juju-controller-uuid": coretesting.ControllerTag.Id()},
@@ -177,8 +183,12 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C
 			"juju-model-uuid":      coretesting.ModelTag.Id(),
 			"juju-controller-uuid": coretesting.ControllerTag.Id()},
 		CharmStorage: params.KubernetesFilesystemParams{
-			Size:     uint64(1024),
-			Provider: "kubernetes",
+			StorageName: "charm",
+			Size:        uint64(1024),
+			Provider:    "kubernetes",
+			Attributes: map[string]interface{}{
+				"storage-class": "k8s-storage",
+			},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
 				"juju-controller-uuid": coretesting.ControllerTag.Id()},

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -80,7 +80,9 @@ type mockModel struct {
 
 func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
-	return config.New(config.UseDefaults, coretesting.FakeConfig())
+	attrs := coretesting.FakeConfig()
+	attrs["workload-storage"] = "k8s-storage"
+	return config.New(config.UseDefaults, attrs)
 }
 
 func (m *mockModel) PodSpec(tag names.ApplicationTag) (string, error) {
@@ -481,16 +483,6 @@ func (v *mockVolume) SetStatus(statusInfo status.StatusInfo) error {
 
 func (v *mockVolume) Info() (state.VolumeInfo, error) {
 	return state.VolumeInfo{}, errors.NotProvisionedf("volume")
-}
-
-type mockStorageProviderRegistry struct {
-	testing.Stub
-	storage.ProviderRegistry
-}
-
-func (m *mockStorageProviderRegistry) StorageProvider(providerType storage.ProviderType) (storage.Provider, error) {
-	m.MethodCall(m, "StorageProvider", providerType)
-	return nil, errors.NotSupportedf("StorageProvider")
 }
 
 type mockStoragePoolManager struct {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -346,7 +346,11 @@ func filesystemParams(
 		return params.KubernetesFilesystemParams{}, errors.Annotate(err, "computing storage tags")
 	}
 
-	fsParams, err := caasoperatorprovisioner.CharmStorageParams(controllerUUID, provider.WorkloadStorageKey, modelConfig, pool, poolManager)
+	storageClassName, _ := modelConfig.AllAttrs()[provider.WorkloadStorageKey].(string)
+	if pool == "" && storageClassName == "" {
+		return params.KubernetesFilesystemParams{}, errors.Errorf("storage pool for %q must be specified since there's no model default storage class", storageInstance.StorageName())
+	}
+	fsParams, err := caasoperatorprovisioner.CharmStorageParams(controllerUUID, storageClassName, modelConfig, pool, poolManager)
 	if err != nil {
 		return params.KubernetesFilesystemParams{}, errors.Maskf(err, "getting filesystem storage parameters")
 	}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -15,8 +15,10 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facades/controller/caasoperatorprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
@@ -24,7 +26,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 )
 
@@ -32,13 +33,12 @@ var logger = loggo.GetLogger("juju.apiserver.controller.caasunitprovisioner")
 
 type Facade struct {
 	*common.LifeGetter
-	resources               facade.Resources
-	state                   CAASUnitProvisionerState
-	storage                 StorageBackend
-	storageProviderRegistry storage.ProviderRegistry
-	storagePoolManager      poolmanager.PoolManager
-	devices                 DeviceBackend
-	clock                   clock.Clock
+	resources          facade.Resources
+	state              CAASUnitProvisionerState
+	storage            StorageBackend
+	storagePoolManager poolmanager.PoolManager
+	devices            DeviceBackend
+	clock              clock.Clock
 }
 
 // NewStateFacade provides the signature required for facade registration.
@@ -67,7 +67,6 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		stateShim{ctx.State()},
 		sb,
 		db,
-		registry,
 		pm,
 		clock.WallClock,
 	)
@@ -80,7 +79,6 @@ func NewFacade(
 	st CAASUnitProvisionerState,
 	sb StorageBackend,
 	db DeviceBackend,
-	storageProviderRegistry storage.ProviderRegistry,
 	storagePoolManager poolmanager.PoolManager,
 	clock clock.Clock,
 ) (*Facade, error) {
@@ -94,13 +92,12 @@ func NewFacade(
 				common.AuthFuncForTagKind(names.UnitTagKind),
 			),
 		),
-		resources:               resources,
-		state:                   st,
-		storage:                 sb,
-		devices:                 db,
-		storageProviderRegistry: storageProviderRegistry,
-		storagePoolManager:      storagePoolManager,
-		clock:                   clock,
+		resources:          resources,
+		state:              st,
+		storage:            sb,
+		devices:            db,
+		storagePoolManager: storagePoolManager,
+		clock:              clock,
 	}, nil
 }
 
@@ -325,10 +322,9 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 func filesystemParams(
 	f state.Filesystem,
 	storageInstance state.StorageInstance,
-	modelUUID, controllerUUID string,
+	controllerUUID string,
 	modelConfig *config.Config,
 	poolManager poolmanager.PoolManager,
-	registry storage.ProviderRegistry,
 ) (params.KubernetesFilesystemParams, error) {
 
 	var pool string
@@ -345,23 +341,19 @@ func filesystemParams(
 		size = filesystemInfo.Size
 	}
 
-	filesystemTags, err := storagecommon.StorageTags(storageInstance, modelUUID, controllerUUID, modelConfig)
+	filesystemTags, err := storagecommon.StorageTags(storageInstance, modelConfig.UUID(), controllerUUID, modelConfig)
 	if err != nil {
 		return params.KubernetesFilesystemParams{}, errors.Annotate(err, "computing storage tags")
 	}
 
-	providerType, cfg, err := storagecommon.StoragePoolConfig(pool, poolManager, registry)
+	fsParams, err := caasoperatorprovisioner.CharmStorageParams(controllerUUID, provider.WorkloadStorageKey, modelConfig, pool, poolManager)
 	if err != nil {
-		return params.KubernetesFilesystemParams{}, errors.Trace(err)
+		return params.KubernetesFilesystemParams{}, errors.Maskf(err, "getting filesystem storage parameters")
 	}
-	result := params.KubernetesFilesystemParams{
-		Provider:    string(providerType),
-		Attributes:  cfg.Attrs(),
-		Tags:        filesystemTags,
-		Size:        size,
-		StorageName: storageInstance.StorageName(),
-	}
-	return result, nil
+	fsParams.Size = size
+	fsParams.StorageName = storageInstance.StorageName()
+	fsParams.Tags = filesystemTags
+	return fsParams, nil
 }
 
 // applicationFilesystemParams retrieves FilesystemParams for the filesystems
@@ -390,8 +382,8 @@ func (f *Facade) applicationFilesystemParams(
 			return nil, errors.Trace(err)
 		}
 		filesystemParams, err := filesystemParams(
-			fs, si, modelConfig.UUID(), controllerConfig.ControllerUUID(),
-			modelConfig, f.storagePoolManager, f.storageProviderRegistry,
+			fs, si, controllerConfig.ControllerUUID(),
+			modelConfig, f.storagePoolManager,
 		)
 		if err != nil {
 			return nil, errors.Annotatef(err, "getting filesystem %q parameters", fs.Tag().Id())

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -156,8 +156,17 @@ type Broker interface {
 	// NamespaceGetterSetter provides the API to get/set namespace.
 	NamespaceGetterSetter
 
+	// StorageValidator provides methods to validate storage.
+	StorageValidator
+
 	// ServiceGetterSetter provides the API to get/set service.
 	ServiceGetterSetter
+}
+
+// StorageValidator provides methods to validate storage.
+type StorageValidator interface {
+	// ValidateStorageClass returns an error if the storage config is not valid.
+	ValidateStorageClass(config map[string]interface{}) error
 }
 
 // ServiceGetterSetter provides the API to get/set service.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -156,18 +156,8 @@ type Broker interface {
 	// NamespaceGetterSetter provides the API to get/set namespace.
 	NamespaceGetterSetter
 
-	// StorageclassGetterSetter provides the API to get/set storageclass.
-	StorageclassGetterSetter
-
 	// ServiceGetterSetter provides the API to get/set service.
 	ServiceGetterSetter
-}
-
-// StorageclassGetterSetter provides the API to get/set storageclass.
-type StorageclassGetterSetter interface {
-	// GetStorageClassName returns the name of a storage class with the specified
-	// labels, or else the cluster default storage class, or else a NotFound error.
-	GetStorageClassName(labels ...string) (string, error)
 }
 
 // ServiceGetterSetter provides the API to get/set service.

--- a/caas/config.go
+++ b/caas/config.go
@@ -4,18 +4,12 @@
 package caas
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 )
 
 const (
-	// OperatorStoragePoolName is the storage pool used to define
-	// storage for application operators.
-	OperatorStoragePoolName = "operator-storage"
-
 	// JujuExternalHostNameKey specifies the hostname of a CAAS application.
 	JujuExternalHostNameKey = "juju-external-hostname"
 
@@ -74,18 +68,4 @@ func ConfigDefaults(providerDefaults schema.Defaults) schema.Defaults {
 		defaults[key] = value
 	}
 	return defaults
-}
-
-// OperatorStorageClassLabels returns possible labels used to search for a
-// storage class used to provision operator storage.
-func OperatorStorageClassLabels(appName, model string) []string {
-	volStorageLabel := fmt.Sprintf("%s-operator-storage", appName)
-	return []string{volStorageLabel, model, "default"}
-}
-
-// UnitStorageClassLabels returns possible labels used to search for a
-// storage class used to provision unit storage.
-func UnitStorageClassLabels(appName, model string) []string {
-	volStorageLabel := fmt.Sprintf("%s-unit-storage", appName)
-	return []string{volStorageLabel, model, "default"}
 }

--- a/caas/config_test.go
+++ b/caas/config_test.go
@@ -93,13 +93,3 @@ func (s *ConfigSuite) TestConfigSchemaProviderDefaults(c *gc.C) {
 	}
 	c.Assert(defaults, jc.DeepEquals, expectedDefaults)
 }
-
-func (s *ConfigSuite) TestOperatorStorageClassLabels(c *gc.C) {
-	labels := caas.OperatorStorageClassLabels("gitlab", "test")
-	c.Assert(labels, jc.DeepEquals, []string{"gitlab-operator-storage", "test", "default"})
-}
-
-func (s *ConfigSuite) TestUnitStorageClassLabels(c *gc.C) {
-	labels := caas.UnitStorageClassLabels("gitlab", "test")
-	c.Assert(labels, jc.DeepEquals, []string{"gitlab-unit-storage", "test", "default"})
-}

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -84,7 +84,9 @@ func (s *BaseSuite) SetUpSuite(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg, err := config.New(config.UseDefaults, testing.FakeConfig().Merge(testing.Attrs{
-		config.NameKey: s.namespace,
+		config.NameKey:              s.namespace,
+		provider.OperatorStorageKey: "",
+		provider.WorkloadStorageKey: "",
 	}))
 	c.Assert(err, jc.ErrorIsNil)
 	s.cfg = cfg

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -70,19 +70,15 @@ func StorageProvider(k8sClient kubernetes.Interface, namespace string) storage.P
 	return &storageProvider{&kubernetesClient{Interface: k8sClient, namespace: namespace}}
 }
 
-func StorageClass(cfg *storageConfig) string {
+func GetStorageClass(cfg *storageConfig) string {
 	return cfg.storageClass
 }
 
-func ExistingStorageClass(cfg *storageConfig) string {
-	return cfg.existingStorageClass
-}
-
-func StorageProvisioner(cfg *storageConfig) string {
+func GetStorageProvisioner(cfg *storageConfig) string {
 	return cfg.storageProvisioner
 }
 
-func StorageParameters(cfg *storageConfig) map[string]string {
+func GetStorageParameters(cfg *storageConfig) map[string]string {
 	return cfg.parameters
 }
 

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -11,8 +11,8 @@ import (
 )
 
 var k8sCloudCheckers map[string]k8slabels.Selector
-var clusterPreferredWorkloadStorage map[string]caas.PreferredStorage
-var clusterPreferredOperatorStorage map[string]caas.PreferredStorage
+var jujuPreferredWorkloadStorage map[string]caas.PreferredStorage
+var jujuPreferredOperatorStorage map[string]caas.PreferredStorage
 
 func init() {
 	caas.RegisterContainerProvider(CAASProviderType, providerInstance)
@@ -21,9 +21,9 @@ func init() {
 	// used for detecting cloud provider from node labels.
 	k8sCloudCheckers = compileK8sCloudCheckers()
 
-	// clusterPreferredWorkloadStorage defines the opinionated storage
+	// jujuPreferredWorkloadStorage defines the opinionated storage
 	// that Juju requires to be available on supported clusters.
-	clusterPreferredWorkloadStorage = map[string]caas.PreferredStorage{
+	jujuPreferredWorkloadStorage = map[string]caas.PreferredStorage{
 		"microk8s": {
 			Name:        "hostpath",
 			Provisioner: "microk8s.io/hostpath",
@@ -42,11 +42,11 @@ func init() {
 		},
 	}
 
-	// clusterPreferredOperatorStorage defines the opinionated storage
+	// jujuPreferredOperatorStorage defines the opinionated storage
 	// that Juju requires to be available on supported clusters to
 	// provision storage for operators.
 	// TODO - support regional storage for GCE etc
-	clusterPreferredOperatorStorage = clusterPreferredWorkloadStorage
+	jujuPreferredOperatorStorage = jujuPreferredWorkloadStorage
 }
 
 // compileK8sCloudCheckers compiles/validates the collection of

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -12,6 +12,7 @@ import (
 
 var k8sCloudCheckers map[string]k8slabels.Selector
 var clusterPreferredWorkloadStorage map[string]caas.PreferredStorage
+var clusterPreferredOperatorStorage map[string]caas.PreferredStorage
 
 func init() {
 	caas.RegisterContainerProvider(CAASProviderType, providerInstance)
@@ -40,6 +41,12 @@ func init() {
 			Provisioner: "kubernetes.io/aws-ebs",
 		},
 	}
+
+	// clusterPreferredOperatorStorage defines the opinionated storage
+	// that Juju requires to be available on supported clusters to
+	// provision storage for operators.
+	// TODO - support regional storage for GCE etc
+	clusterPreferredOperatorStorage = clusterPreferredWorkloadStorage
 }
 
 // compileK8sCloudCheckers compiles/validates the collection of

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -88,7 +88,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 	}
 
 	// We may have the workload storage but still need to look for operator storage.
-	preferredOperatorStorage, havePreferredOperatorStorage := clusterPreferredOperatorStorage[result.Cloud]
+	preferredOperatorStorage, havePreferredOperatorStorage := jujuPreferredOperatorStorage[result.Cloud]
 	storageClasses, err := k.StorageV1().StorageClasses().List(v1.ListOptions{})
 	if err != nil {
 		return nil, errors.Annotate(err, "listing storage classes")
@@ -150,7 +150,7 @@ func (k *kubernetesClient) listHostCloudRegions() (string, set.Strings, error) {
 
 // CheckDefaultWorkloadStorage implements ClusterMetadataChecker.
 func (k *kubernetesClient) CheckDefaultWorkloadStorage(cluster string, storageProvisioner *caas.StorageProvisioner) error {
-	preferredStorage, ok := clusterPreferredWorkloadStorage[cluster]
+	preferredStorage, ok := jujuPreferredWorkloadStorage[cluster]
 	if !ok {
 		return errors.NotFoundf("cluster %q", cluster)
 	}

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -77,23 +77,49 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 		}
 		if err == nil {
 			result.NominatedStorageClass = &caas.StorageProvisioner{
+				Name:        sc.Name,
 				Provisioner: sc.Provisioner,
 				Parameters:  sc.Parameters,
 			}
-		}
-	} else {
-		storageClasses, err := k.StorageV1().StorageClasses().List(v1.ListOptions{})
-		if err != nil {
-			return nil, errors.Annotate(err, "listing storage classes")
-		}
-		for _, sc := range storageClasses.Items {
-			if v, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && v != "false" {
-				result.NominatedStorageClass = &caas.StorageProvisioner{
-					Provisioner: sc.Provisioner,
-					Parameters:  sc.Parameters,
-				}
-				break
+			if sc.ReclaimPolicy != nil {
+				result.NominatedStorageClass.ReclaimPolicy = string(*sc.ReclaimPolicy)
 			}
+		}
+	}
+
+	// We may have the workload storage but still need to look for operator storage.
+	preferredOperatorStorage, havePreferredOperatorStorage := clusterPreferredOperatorStorage[result.Cloud]
+	storageClasses, err := k.StorageV1().StorageClasses().List(v1.ListOptions{})
+	if err != nil {
+		return nil, errors.Annotate(err, "listing storage classes")
+	}
+	for _, sc := range storageClasses.Items {
+		if havePreferredOperatorStorage && result.OperatorStorageClass == nil {
+			maybeOperatorStorage := &caas.StorageProvisioner{
+				Name:        sc.Name,
+				Provisioner: sc.Provisioner,
+				Parameters:  sc.Parameters,
+			}
+			if sc.ReclaimPolicy != nil {
+				maybeOperatorStorage.ReclaimPolicy = string(*sc.ReclaimPolicy)
+			}
+			if err := storageClassMatches(preferredOperatorStorage, maybeOperatorStorage); err == nil {
+				result.OperatorStorageClass = maybeOperatorStorage
+			}
+		}
+		if result.NominatedStorageClass != nil {
+			continue
+		}
+		if v, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && v != "false" {
+			result.NominatedStorageClass = &caas.StorageProvisioner{
+				Name:        sc.Name,
+				Provisioner: sc.Provisioner,
+				Parameters:  sc.Parameters,
+			}
+			if sc.ReclaimPolicy != nil {
+				result.NominatedStorageClass.ReclaimPolicy = string(*sc.ReclaimPolicy)
+			}
+			break
 		}
 	}
 	return &result, nil
@@ -128,6 +154,10 @@ func (k *kubernetesClient) CheckDefaultWorkloadStorage(cluster string, storagePr
 	if !ok {
 		return errors.NotFoundf("cluster %q", cluster)
 	}
+	return storageClassMatches(preferredStorage, storageProvisioner)
+}
+
+func storageClassMatches(preferredStorage caas.PreferredStorage, storageProvisioner *caas.StorageProvisioner) error {
 	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
 		return &caas.NonPreferredStorageError{PreferredStorage: preferredStorage}
 	}

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -126,21 +126,6 @@ func (p kubernetesEnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 
-func (p kubernetesEnvironProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
-	if err := config.Validate(cfg, old); err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-func (p kubernetesEnvironProvider) newConfig(cfg *config.Config) (*config.Config, error) {
-	valid, err := p.Validate(cfg, nil)
-	if err != nil {
-		return nil, err
-	}
-	return valid, nil
-}
-
 func (p kubernetesEnvironProvider) validateCloudSpec(spec environs.CloudSpec) error {
 
 	if err := spec.Validate(); err != nil {

--- a/caas/kubernetes/provider/provider_test.go
+++ b/caas/kubernetes/provider/provider_test.go
@@ -25,8 +25,10 @@ func fakeConfig(c *gc.C, attrs ...coretesting.Attrs) *config.Config {
 
 func fakeConfigAttrs(attrs ...coretesting.Attrs) coretesting.Attrs {
 	merged := coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"type": "kubernetes",
-		"uuid": utils.MustNewUUID().String(),
+		"type":             "kubernetes",
+		"uuid":             utils.MustNewUUID().String(),
+		"operator-storage": "",
+		"workload-storage": "",
 	})
 	for _, attrs := range attrs {
 		merged = merged.Merge(attrs)

--- a/caas/kubernetes/provider/providerconfig.go
+++ b/caas/kubernetes/provider/providerconfig.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
+
+	"github.com/juju/juju/environs/config"
+)
+
+const (
+	WorkloadStorageKey = "workload-storage"
+	OperatorStorageKey = "operator-storage"
+)
+
+var configSchema = environschema.Fields{
+	WorkloadStorageKey: {
+		Description: "The storage class used to provision workload storage.",
+		Type:        environschema.Tstring,
+		Group:       environschema.AccountGroup,
+	},
+	OperatorStorageKey: {
+		Description: "The storage class used to provision operator storage.",
+		Type:        environschema.Tstring,
+		Group:       environschema.AccountGroup,
+		Immutable:   true,
+	},
+}
+
+var providerConfigFields = func() schema.Fields {
+	fs, _, err := configSchema.ValidationSchema()
+	if err != nil {
+		panic(err)
+	}
+	return fs
+}()
+
+var providerConfigDefaults = schema.Defaults{
+	WorkloadStorageKey: "",
+	OperatorStorageKey: "",
+}
+
+type brokerConfig struct {
+	*config.Config
+	attrs map[string]interface{}
+}
+
+func (c *brokerConfig) storage() string {
+	return c.attrs[WorkloadStorageKey].(string)
+}
+
+func (c *brokerConfig) operatorStorage() string {
+	return c.attrs[OperatorStorageKey].(string)
+}
+
+func (p kubernetesEnvironProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
+	newCfg, err := validateConfig(cfg, old)
+	if err != nil {
+		return nil, fmt.Errorf("invalid k8s provider config: %v", err)
+	}
+	return newCfg.Apply(newCfg.attrs)
+}
+
+func (p kubernetesEnvironProvider) newConfig(cfg *config.Config) (*brokerConfig, error) {
+	valid, err := p.Validate(cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &brokerConfig{valid, valid.UnknownAttrs()}, nil
+}
+
+// Schema returns the configuration schema for an environment.
+func (kubernetesEnvironProvider) Schema() environschema.Fields {
+	fields, err := config.Schema(configSchema)
+	if err != nil {
+		panic(err)
+	}
+	return fields
+}
+
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p kubernetesEnvironProvider) ConfigSchema() schema.Fields {
+	return providerConfigFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p kubernetesEnvironProvider) ConfigDefaults() schema.Defaults {
+	return providerConfigDefaults
+}
+
+func validateConfig(cfg, old *config.Config) (*brokerConfig, error) {
+	// Check for valid changes for the base config values.
+	if err := config.Validate(cfg, old); err != nil {
+		return nil, err
+	}
+	validated, err := cfg.ValidateUnknownAttrs(providerConfigFields, providerConfigDefaults)
+	if err != nil {
+		return nil, err
+	}
+
+	bcfg := &brokerConfig{cfg, validated}
+	return bcfg, nil
+}

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -61,15 +61,6 @@ func (s *storageSuite) TestValidateConfigError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "storage-class must be specified if storage-provisioner is specified")
 }
 
-func (s *storageSuite) TestValidateConfigExistingStorageClass(c *gc.C) {
-	ctrl := s.setupBroker(c)
-	defer ctrl.Finish()
-
-	cfg, err := provider.NewStorageConfig(map[string]interface{}{}, "juju-unit-storage")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(provider.ExistingStorageClass(cfg), gc.Equals, "juju-unit-storage")
-}
-
 func (s *storageSuite) TestNewStorageConfig(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
@@ -78,12 +69,11 @@ func (s *storageSuite) TestNewStorageConfig(c *gc.C) {
 		"storage-class":       "juju-ebs",
 		"storage-provisioner": "ebs",
 		"parameters.type":     "gp2",
-	}, "juju-unit-storage")
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(provider.StorageClass(cfg), gc.Equals, "juju-ebs")
-	c.Assert(provider.StorageProvisioner(cfg), gc.Equals, "ebs")
-	c.Assert(provider.ExistingStorageClass(cfg), gc.Equals, "juju-unit-storage")
-	c.Assert(provider.StorageParameters(cfg), jc.DeepEquals, map[string]string{"type": "gp2"})
+	c.Assert(provider.GetStorageClass(cfg), gc.Equals, "juju-ebs")
+	c.Assert(provider.GetStorageProvisioner(cfg), gc.Equals, "ebs")
+	c.Assert(provider.GetStorageParameters(cfg), jc.DeepEquals, map[string]string{"type": "gp2"})
 }
 
 func (s *storageSuite) TestSupports(c *gc.C) {

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -37,6 +37,7 @@ type StorageProvisioner struct {
 // ClusterMetadata defines metadata about a cluster.
 type ClusterMetadata struct {
 	NominatedStorageClass *StorageProvisioner
+	OperatorStorageClass  *StorageProvisioner
 	Cloud                 string
 	Regions               set.Strings
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -98,6 +98,12 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	err := s.State.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.UpdateModelConfig(map[string]interface{}{
+		"operator-storage": "k8s-storage",
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	_, mysqlch := testcharms.UploadCharmWithSeries(c, s.client, "kubernetes/mariadb-42", "mariadb", "kubernetes")
 	_, wpch := testcharms.UploadCharmWithSeries(c, s.client, "kubernetes/gitlab-47", "gitlab", "kubernetes")

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -25,7 +27,6 @@ import (
 	charmresource "gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/juju/charmrepo.v3"
 	"gopkg.in/juju/charmrepo.v3/csclient"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -86,16 +87,27 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 
 func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C) {
 	// Set up a CAAS model to replace the IAAS one.
+	unregister := caas.RegisterContainerProvider("kubernetes-test", &fakeProvider{})
+	s.AddCleanup(func(_ *gc.C) { unregister() })
+
+	// Set up a CAAS model to replace the IAAS one.
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "caascloud",
+		Type:      "kubernetes-test",
+		AuthTypes: []cloud.AuthType{cloud.UserPassAuthType},
+	}, s.Model.Owner().Id())
+	c.Assert(err, jc.ErrorIsNil)
+
 	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{
-		Name:  "test",
-		Owner: names.NewUserTag("admin"),
+		Name:      "test",
+		CloudName: "caascloud",
 	})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { _ = st.Close() })
 
 	// Close the state pool before the state object itself.
 	c.Assert(s.StatePool.Close(), jc.ErrorIsNil)
 	s.StatePool = nil
-	err := s.State.Close()
+	err = s.State.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 	m, err := st.Model()

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -41,8 +41,6 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/charms"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/caas"
-	"github.com/juju/juju/caas/kubernetes/provider"
 	jjcharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
@@ -54,8 +52,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
-	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -539,13 +535,11 @@ func (s *CAASDeploySuite) TestCaasModelValidatedAtRun(c *gc.C) {
 }
 
 func (s *CAASDeploySuite) TestLocalCharmNeedsResources(c *gc.C) {
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.State)
-	c.Assert(err, jc.ErrorIsNil)
-	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(broker)
-	storagePoolManager := poolmanager.New(state.NewStateSettings(s.State), storageProviderRegistry)
-	_, err = storagePoolManager.Create("operator-storage", provider.K8s_ProviderType, map[string]interface{}{})
-	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.UpdateModelConfig(map[string]interface{}{
+		"operator-storage": "k8s-storage",
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	otherModels := map[string]jujuclient.ModelDetails{
 		"admin/" + m.Name(): {ModelUUID: m.UUID(), ModelType: model.CAAS},
@@ -566,13 +560,11 @@ func (s *CAASDeploySuite) TestLocalCharmNeedsResources(c *gc.C) {
 }
 
 func (s *CAASDeploySuite) TestDevices(c *gc.C) {
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.State)
-	c.Assert(err, jc.ErrorIsNil)
-	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(broker)
-	storagePoolManager := poolmanager.New(state.NewStateSettings(s.State), storageProviderRegistry)
-	_, err = storagePoolManager.Create("operator-storage", provider.K8s_ProviderType, map[string]interface{}{})
-	c.Assert(err, jc.ErrorIsNil)
 	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.UpdateModelConfig(map[string]interface{}{
+		"operator-storage": "k8s-storage",
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	otherModels := map[string]jujuclient.ModelDetails{
 		"admin/" + m.Name(): {ModelUUID: m.UUID(), ModelType: model.CAAS},

--- a/cmd/juju/model/defaultscommand.go
+++ b/cmd/juju/model/defaultscommand.go
@@ -375,10 +375,11 @@ func (c *defaultsCommand) parseCloudRegion(args []string) ([]string, error) {
 	}
 
 	// Ensure we exit early when we have a settings file or key=value.
-	_, err := os.Stat(maybeRegion)
+	info, err := os.Stat(maybeRegion)
+	isFile := err == nil && !info.IsDir()
 	// TODO(redir) 2016-10-05 #1627162
 	// We don't disallow "=" in region names, but probably should.
-	if err == nil || strings.Contains(maybeRegion, "=") {
+	if isFile || strings.Contains(maybeRegion, "=") {
 		return args, nil
 	}
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage"
@@ -306,7 +305,12 @@ func (sb *storageBackend) RemoveStoragePool(poolName string) error {
 	// TODO: Improve the data model to have a count of in use pools so we can
 	// make these checks as an assert and not queries.
 	var inUse bool
-	if sb.modelType == ModelTypeCAAS && poolName == caas.OperatorStoragePoolName {
+	cfg, err := sb.config()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	operatorStorage, ok := cfg.AllAttrs()[k8sprovider.OperatorStorageKey]
+	if sb.modelType == ModelTypeCAAS && ok && operatorStorage == poolName {
 		apps, err := sb.allApplications()
 		if err != nil {
 			return errors.Trace(err)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -75,7 +75,7 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
 		// Create the operator-storage
-		_, err = s.pm.Create("operator-storage", provider.LoopProviderType, map[string]interface{}{})
+		_, err = s.pm.Create("k8s-operator-storage", provider.LoopProviderType, map[string]interface{}{})
 		c.Assert(err, jc.ErrorIsNil)
 
 	}
@@ -1401,7 +1401,7 @@ func (s *StorageStateSuiteCaas) SetUpTest(c *gc.C) {
 }
 
 func (s *StorageStateSuiteCaas) TestRemoveStoragePool(c *gc.C) {
-	poolName := "operator-storage"
+	poolName := "k8s-operator-storage"
 	_, err := s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1414,8 +1414,12 @@ func (s *StorageStateSuiteCaas) TestRemoveStoragePool(c *gc.C) {
 }
 
 func (s *StorageStateSuiteCaas) TestRemoveStoragePoolInUse(c *gc.C) {
-	poolName := "operator-storage"
-	_, err := s.pm.Get(poolName)
+	model, err := s.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.UpdateModelConfig(map[string]interface{}{"operator-storage": "k8s-operator-storage"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	poolName := "k8s-operator-storage"
+	_, err = s.pm.Get(poolName)
 	c.Assert(err, jc.ErrorIsNil)
 
 	appPoolName := "tmpfs-pool"

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -59,6 +59,7 @@ type StateBackend interface {
 	LegacyLeases(time.Time) (map[lease.Key]lease.Info, error)
 	SetEnableDiskUUIDOnVsphere() error
 	UpdateInheritedControllerConfig() error
+	UpdateKubernetesStorageConfig() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -223,4 +224,8 @@ func (s stateBackend) SetEnableDiskUUIDOnVsphere() error {
 
 func (s stateBackend) UpdateInheritedControllerConfig() error {
 	return state.UpdateInheritedControllerConfig(s.pool)
+}
+
+func (s stateBackend) UpdateKubernetesStorageConfig() error {
+	return state.UpdateKubernetesStorageConfig(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -34,6 +34,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.4.0"), stateStepsFor24()},
 		upgradeToVersion{version.MustParse("2.5.0"), stateStepsFor25()},
 		upgradeToVersion{version.MustParse("2.5.3"), stateStepsFor253()},
+		upgradeToVersion{version.MustParse("2.6.0"), stateStepsFor26()},
 	}
 	return steps
 }

--- a/upgrades/steps_26.go
+++ b/upgrades/steps_26.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor26 returns upgrade steps for Juju 2.6 that manipulate state directly.
+func stateStepsFor26() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "update k8s storage config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateKubernetesStorageConfig()
+			},
+		},
+	}
+}

--- a/upgrades/steps_26_test.go
+++ b/upgrades/steps_26_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v26 = version.MustParse("2.6.0")
+
+type steps26Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps26Suite{})
+
+func (s *steps26Suite) TestUpdateInheritedControllerConfig(c *gc.C) {
+	step := findStateStep(c, v26, `update k8s storage config`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -650,6 +650,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.4.0",
 		"2.5.0",
 		"2.5.3",
+		"2.6.0",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Juju now uses opinionated storage defaults when provisioning storage on k8s. The main changes:
- add-k8s queries the cluster and prompts for storage if no suitable storage class can be found
- the k8s provider gains config support for storing the workload and operator storage classes as model default attributes
- a bunch of code used to search for k8s storage classes is deleted

## QA steps

Use add-k8s to import microk8s
check that model-defaults shows hostpath storage for operator and workload
add a model
check that model config shows hostpath storage for operator and workload
deploy a charm with storage
create a storage pool and deploy a charm with pool storage
