### PR TITLE
Adds config watch to cached application.

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -36,7 +36,7 @@ type Application struct {
 // Config returns the current application config.
 func (a *Application) Config() map[string]interface{} {
 	a.mu.Lock()
-	a.metrics.ModelConfigReads.Inc()
+	a.metrics.ApplicationConfigReads.Inc()
 	a.mu.Unlock()
 	return a.details.Config
 }
@@ -50,7 +50,9 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Lock()
 
 	a.details = details
-	hashCache, configHash := newHashCache(details.Config, nil, nil)
+	hashCache, configHash := newHashCache(
+		details.Config, a.metrics.ApplicationHashCacheHit, a.metrics.ApplicationHashCacheMiss)
+
 	if configHash != a.configHash {
 		a.configHash = configHash
 		a.hashCache = hashCache

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -9,12 +9,16 @@ import (
 	"github.com/juju/pubsub"
 )
 
+const (
+	applicationConfigChange = "application-config-change"
+)
+
 func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Application {
-	m := &Application{
+	a := &Application{
 		metrics: metrics,
 		hub:     hub,
 	}
-	return m
+	return a
 }
 
 // Application represents an application in a model.
@@ -26,20 +30,39 @@ type Application struct {
 
 	details    ApplicationChange
 	configHash string
+	hashCache  *hashCache
 }
 
-func (m *Application) setDetails(details ApplicationChange) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.details = details
+// Config returns the current application config.
+func (a *Application) Config() map[string]interface{} {
+	a.mu.Lock()
+	a.metrics.ModelConfigReads.Inc()
+	a.mu.Unlock()
+	return a.details.Config
+}
 
-	configHash, err := hash(details.Config)
-	if err != nil {
-		logger.Errorf("invariant error - application config should be yaml serializable and hashable, %v", err)
-		configHash = ""
+// WatchConfig creates a watcher for the application config.
+func (a *Application) WatchConfig(keys ...string) *ConfigWatcher {
+	return newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange))
+}
+
+func (a *Application) setDetails(details ApplicationChange) {
+	a.mu.Lock()
+
+	a.details = details
+	hashCache, configHash := newHashCache(details.Config, nil, nil)
+	if configHash != a.configHash {
+		a.configHash = configHash
+		a.hashCache = hashCache
+		a.hub.Publish(a.topic(applicationConfigChange), hashCache)
 	}
-	if configHash != m.configHash {
-		m.configHash = configHash
-		// TODO: publish config change...
-	}
+
+	defer a.mu.Unlock()
+}
+
+// topic prefixes the input string with the model ID and application name.
+// TODO (manadart 2019-03-14) The model ID will not be necessary when there is
+// one hub per model.
+func (a *Application) topic(suffix string) string {
+	return a.details.ModelUUID + ":" + a.details.Name + ":" + suffix
 }

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -33,12 +33,16 @@ type Application struct {
 	hashCache  *hashCache
 }
 
-// Config returns the current application config.
+// Config returns a copy of the current application config.
 func (a *Application) Config() map[string]interface{} {
 	a.mu.Lock()
-	a.metrics.ApplicationConfigReads.Inc()
+	cfg := make(map[string]interface{}, len(a.details.Config))
+	for k, v := range a.details.Config {
+		cfg[k] = v
+	}
 	a.mu.Unlock()
-	return a.details.Config
+	a.metrics.ApplicationConfigReads.Inc()
+	return cfg
 }
 
 // WatchConfig creates a watcher for the application config.
@@ -59,7 +63,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 		a.hub.Publish(a.topic(applicationConfigChange), hashCache)
 	}
 
-	defer a.mu.Unlock()
+	a.mu.Unlock()
 }
 
 // topic prefixes the input string with the model ID and application name.

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -4,6 +4,7 @@ package cache_test
 
 import (
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/constraints"
@@ -19,6 +20,29 @@ var _ = gc.Suite(&ApplicationSuite{})
 
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	s.entitySuite.SetUpTest(c)
+}
+
+// See model_test.go for other config watcher tests.
+// Here we just check that WatchConfig is wired up properly.
+func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
+	a := s.newApplication(appChange)
+	w := a.WatchConfig()
+	defer workertest.CleanKill(c, w)
+
+	wc := NewNotifyWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange()
+
+	change := appChange
+	change.Config = map[string]interface{}{"key": "changed"}
+	a.SetDetails(change)
+	wc.AssertOneChange()
+}
+
+func (s *ApplicationSuite) newApplication(details cache.ApplicationChange) *cache.Application {
+	a := cache.NewApplication(s.gauges, s.hub)
+	a.SetDetails(details)
+	return a
 }
 
 var appChange = cache.ApplicationChange{

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -3,6 +3,7 @@
 package cache_test
 
 import (
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1/workertest"
 
@@ -22,6 +23,15 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	s.entitySuite.SetUpTest(c)
 }
 
+func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
+	m := s.newApplication(appChange)
+	c.Check(testutil.ToFloat64(s.gauges.ApplicationConfigReads), gc.Equals, float64(0))
+	m.Config()
+	c.Check(testutil.ToFloat64(s.gauges.ApplicationConfigReads), gc.Equals, float64(1))
+	m.Config()
+	c.Check(testutil.ToFloat64(s.gauges.ApplicationConfigReads), gc.Equals, float64(2))
+}
+
 // See model_test.go for other config watcher tests.
 // Here we just check that WatchConfig is wired up properly.
 func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
@@ -37,6 +47,12 @@ func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
 	change.Config = map[string]interface{}{"key": "changed"}
 	a.SetDetails(change)
 	wc.AssertOneChange()
+
+	// The hash is generated each time we set the details.
+	c.Check(testutil.ToFloat64(s.gauges.ApplicationHashCacheMiss), gc.Equals, float64(2))
+
+	// The value is retrieved from the cache when the watcher is created and notified.
+	c.Check(testutil.ToFloat64(s.gauges.ApplicationHashCacheHit), gc.Equals, float64(2))
 }
 
 func (s *ApplicationSuite) newApplication(details cache.ApplicationChange) *cache.Application {

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -6,9 +6,15 @@ package cache
 var (
 	CreateControllerGauges = createControllerGauges
 	NewModel               = newModel
+	NewApplication         = newApplication
 )
 
 // Expose SetDetails for testing.
+
 func (m *Model) SetDetails(details ModelChange) {
 	m.setDetails(details)
+}
+
+func (a *Application) SetDetails(details ApplicationChange) {
+	a.setDetails(details)
 }

--- a/core/cache/hash.go
+++ b/core/cache/hash.go
@@ -52,7 +52,7 @@ func (c *hashCache) getHash(keys []string) string {
 	key := strings.Join(keys, ",")
 	value, found := c.hash[key]
 	if found {
-		c.cacheHits.Inc()
+		c.incHits()
 		return value
 	}
 
@@ -63,7 +63,7 @@ func (c *hashCache) getHash(keys []string) string {
 
 func (c *hashCache) generateHash(keys []string) string {
 	// We are generating a hash, so call it a miss.
-	c.cacheMisses.Inc()
+	c.incMisses()
 
 	interested := c.config
 	if len(keys) > 0 {
@@ -80,6 +80,18 @@ func (c *hashCache) generateHash(keys []string) string {
 		return ""
 	}
 	return h
+}
+
+func (c *hashCache) incHits() {
+	if c.cacheHits != nil {
+		c.cacheHits.Inc()
+	}
+}
+
+func (c *hashCache) incMisses() {
+	if c.cacheMisses != nil {
+		c.cacheMisses.Inc()
+	}
 }
 
 // hash returns a hash of the yaml serialized settings.

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -49,6 +49,10 @@ type ControllerGauges struct {
 	ModelConfigReads   prometheus.Gauge
 	ModelHashCacheHit  prometheus.Gauge
 	ModelHashCacheMiss prometheus.Gauge
+
+	ApplicationConfigReads   prometheus.Gauge
+	ApplicationHashCacheHit  prometheus.Gauge
+	ApplicationHashCacheMiss prometheus.Gauge
 }
 
 func createControllerGauges() *ControllerGauges {
@@ -74,6 +78,27 @@ func createControllerGauges() *ControllerGauges {
 				Help:      "The number of times the model config change hash was generated.",
 			},
 		),
+		ApplicationConfigReads: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "application_config_reads",
+				Help:      "The number of times the application config is read.",
+			},
+		),
+		ApplicationHashCacheHit: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "application_hash_cache_hit",
+				Help:      "The number of times the application config change hash was determined using the cached value.",
+			},
+		),
+		ApplicationHashCacheMiss: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "application_hash_cache_miss",
+				Help:      "The number of times the application config change hash was generated.",
+			},
+		),
 	}
 }
 
@@ -82,6 +107,10 @@ func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.ModelConfigReads.Collect(ch)
 	c.ModelHashCacheHit.Collect(ch)
 	c.ModelHashCacheMiss.Collect(ch)
+
+	c.ApplicationConfigReads.Collect(ch)
+	c.ApplicationHashCacheHit.Collect(ch)
+	c.ApplicationHashCacheMiss.Collect(ch)
 }
 
 // Collector is a prometheus.Collector that collects metrics about

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -41,9 +41,13 @@ type Model struct {
 // Config returns the current model config.
 func (m *Model) Config() map[string]interface{} {
 	m.mu.Lock()
-	m.metrics.ModelConfigReads.Inc()
+	cfg := make(map[string]interface{}, len(m.details.Config))
+	for k, v := range m.details.Config {
+		cfg[k] = v
+	}
 	m.mu.Unlock()
-	return m.details.Config
+	m.metrics.ModelConfigReads.Inc()
+	return cfg
 }
 
 // WatchConfig creates a watcher for the model config.

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -1,5 +1,6 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 package cache_test
 
 import (
@@ -62,6 +63,9 @@ func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
 	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(2))
 }
 
+// Some of the tested behaviour in the following methods is specific to the
+// watcher, but using a cached model avoids the need to put scaffolding code in
+// export_test.go to create a watcher in isolation.
 func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
 	m := s.newModel(modelChange)
 	w := m.WatchConfig()


### PR DESCRIPTION
## Description of change

This patch adds a config watcher to cached applications in similar fashion to cached models.

## QA steps

No materialised functionality yet. Unit tests cover changes

## Documentation changes

None.

## Bug reference

N/A
