### PR TITLE
Record Creation/Completion User Against Generations

### DIFF
--- a/api/modelgeneration/modelgeneration.go
+++ b/api/modelgeneration/modelgeneration.go
@@ -138,6 +138,7 @@ func generationInfoFromResult(res params.Generation, formatTime func(time.Time) 
 	}
 	gen := model.Generation{
 		Created:      formatTime(time.Unix(res.Created, 0)),
+		CreatedBy:    res.CreatedBy,
 		Applications: appDeltas,
 	}
 

--- a/api/modelgeneration/modelgeneration_test.go
+++ b/api/modelgeneration/modelgeneration_test.go
@@ -176,7 +176,8 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
 	resultSource := params.GenerationResult{Generation: params.Generation{
-		Created: time.Time{}.Unix(),
+		Created:   time.Time{}.Unix(),
+		CreatedBy: "test-user",
 		Applications: []params.GenerationApplication{
 			{
 				ApplicationName: "redis",
@@ -199,7 +200,8 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Check(apps, jc.DeepEquals, map[model.GenerationVersion]model.Generation{
 		"next": {
-			Created: "0001-01-01 00:00:00",
+			Created:   "0001-01-01 00:00:00",
+			CreatedBy: "test-user",
 			Applications: []model.GenerationApplication{{
 				ApplicationName: "redis",
 				Units:           []string{"redis/0"},

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1836,7 +1836,7 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsStringsNextGen(c *gc.
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
 
-	c.Assert(s.State.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.State.AddGeneration("user"), jc.ErrorIsNil)
 
 	// Update settings for the application.
 	args := params.ApplicationUpdate{
@@ -1883,7 +1883,7 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsYAMLNextGen(c *gc.C) 
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
 
-	c.Assert(s.State.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.State.AddGeneration("user"), jc.ErrorIsNil)
 
 	// Update settings for the application.
 	args := params.ApplicationUpdate{

--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -32,7 +32,7 @@ type State interface {
 
 // Model describes model state used by the model generation API.
 type Model interface {
-	AddGeneration() error
+	AddGeneration(string) error
 	NextGeneration() (Generation, error)
 	HasNextGeneration() (bool, error)
 }

--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -40,6 +40,7 @@ type Model interface {
 // Generation defines the methods used by a generation.
 type Generation interface {
 	Created() int64
+	CreatedBy() string
 	AssignAllUnits(string) error
 	AssignUnit(string) error
 	AssignedUnits() map[string][]string

--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -44,8 +44,8 @@ type Generation interface {
 	AssignAllUnits(string) error
 	AssignUnit(string) error
 	AssignedUnits() map[string][]string
-	MakeCurrent() error
-	AutoComplete() (bool, error)
+	MakeCurrent(string) error
+	AutoComplete(string) (bool, error)
 	Refresh() error
 }
 

--- a/apiserver/facades/client/modelgeneration/mocks/package_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/package_mock.go
@@ -200,15 +200,15 @@ func (m *MockModel) EXPECT() *MockModelMockRecorder {
 }
 
 // AddGeneration mocks base method
-func (m *MockModel) AddGeneration() error {
-	ret := m.ctrl.Call(m, "AddGeneration")
+func (m *MockModel) AddGeneration(arg0 string) error {
+	ret := m.ctrl.Call(m, "AddGeneration", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddGeneration indicates an expected call of AddGeneration
-func (mr *MockModelMockRecorder) AddGeneration() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGeneration", reflect.TypeOf((*MockModel)(nil).AddGeneration))
+func (mr *MockModelMockRecorder) AddGeneration(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGeneration", reflect.TypeOf((*MockModel)(nil).AddGeneration), arg0)
 }
 
 // HasNextGeneration mocks base method

--- a/apiserver/facades/client/modelgeneration/mocks/package_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/package_mock.go
@@ -297,16 +297,16 @@ func (mr *MockGenerationMockRecorder) AssignedUnits() *gomock.Call {
 }
 
 // AutoComplete mocks base method
-func (m *MockGeneration) AutoComplete() (bool, error) {
-	ret := m.ctrl.Call(m, "AutoComplete")
+func (m *MockGeneration) AutoComplete(arg0 string) (bool, error) {
+	ret := m.ctrl.Call(m, "AutoComplete", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AutoComplete indicates an expected call of AutoComplete
-func (mr *MockGenerationMockRecorder) AutoComplete() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutoComplete", reflect.TypeOf((*MockGeneration)(nil).AutoComplete))
+func (mr *MockGenerationMockRecorder) AutoComplete(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutoComplete", reflect.TypeOf((*MockGeneration)(nil).AutoComplete), arg0)
 }
 
 // Created mocks base method
@@ -334,15 +334,15 @@ func (mr *MockGenerationMockRecorder) CreatedBy() *gomock.Call {
 }
 
 // MakeCurrent mocks base method
-func (m *MockGeneration) MakeCurrent() error {
-	ret := m.ctrl.Call(m, "MakeCurrent")
+func (m *MockGeneration) MakeCurrent(arg0 string) error {
+	ret := m.ctrl.Call(m, "MakeCurrent", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MakeCurrent indicates an expected call of MakeCurrent
-func (mr *MockGenerationMockRecorder) MakeCurrent() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeCurrent", reflect.TypeOf((*MockGeneration)(nil).MakeCurrent))
+func (mr *MockGenerationMockRecorder) MakeCurrent(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeCurrent", reflect.TypeOf((*MockGeneration)(nil).MakeCurrent), arg0)
 }
 
 // Refresh mocks base method

--- a/apiserver/facades/client/modelgeneration/mocks/package_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/package_mock.go
@@ -321,6 +321,18 @@ func (mr *MockGenerationMockRecorder) Created() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Created", reflect.TypeOf((*MockGeneration)(nil).Created))
 }
 
+// CreatedBy mocks base method
+func (m *MockGeneration) CreatedBy() string {
+	ret := m.ctrl.Call(m, "CreatedBy")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CreatedBy indicates an expected call of CreatedBy
+func (mr *MockGenerationMockRecorder) CreatedBy() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatedBy", reflect.TypeOf((*MockGeneration)(nil).CreatedBy))
+}
+
 // MakeCurrent mocks base method
 func (m *MockGeneration) MakeCurrent() error {
 	ret := m.ctrl.Call(m, "MakeCurrent")

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -87,7 +87,7 @@ func (m *API) AddGeneration(arg params.Entity) (params.ErrorResult, error) {
 		return result, common.ErrPerm
 	}
 
-	result.Error = common.ServerError(m.model.AddGeneration())
+	result.Error = common.ServerError(m.model.AddGeneration(m.apiUser.Name()))
 	return result, nil
 }
 

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -155,7 +155,7 @@ func (m *API) AdvanceGeneration(arg params.AdvanceGenerationArg) (params.Advance
 	result := params.AdvanceGenerationResult{AdvanceResults: results}
 
 	// Complete the generation if possible.
-	completed, err := generation.AutoComplete()
+	completed, err := generation.AutoComplete(m.apiUser.Name())
 	result.CompleteResult = params.BoolResult{
 		Result: completed,
 		Error:  common.ServerError(err),
@@ -179,7 +179,7 @@ func (m *API) CancelGeneration(arg params.Entity) (params.ErrorResult, error) {
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	result.Error = common.ServerError(generation.MakeCurrent())
+	result.Error = common.ServerError(generation.MakeCurrent(m.apiUser.Name()))
 	return result, nil
 }
 

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -236,6 +236,7 @@ func (m *API) GenerationInfo(arg params.Entity) (params.GenerationResult, error)
 
 	return params.GenerationResult{Generation: params.Generation{
 		Created:      gen.Created(),
+		CreatedBy:    gen.CreatedBy(),
 		Applications: apps,
 	}}, nil
 }

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -159,6 +159,7 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 		gen := mocks.NewMockGeneration(ctrl)
 		gen.EXPECT().AssignedUnits().Return(map[string][]string{"redis": units})
 		gen.EXPECT().Created().Return(int64(666))
+		gen.EXPECT().CreatedBy().Return("test-user")
 
 		mod.EXPECT().NextGeneration().Return(gen, nil)
 
@@ -182,6 +183,7 @@ func (s *modelGenerationSuite) TestGenerationInfo(c *gc.C) {
 
 	gen := result.Generation
 	c.Assert(gen.Created, gc.Equals, int64(666))
+	c.Assert(gen.CreatedBy, gc.Equals, "test-user")
 	c.Assert(gen.Applications, gc.HasLen, 1)
 
 	app := gen.Applications[0]

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -73,7 +73,7 @@ func (s *modelGenerationSuite) TestAdvanceGenerationErrorNoAutoComplete(c *gc.C)
 		gExp := mockGeneration.EXPECT()
 		gExp.AssignAllUnits("ghost").Return(nil)
 		gExp.AssignUnit("mysql/0").Return(nil)
-		gExp.AutoComplete().Return(false, nil)
+		gExp.AutoComplete("test-user").Return(false, nil)
 		gExp.Refresh().Return(nil).Times(3)
 
 		mExp := mockModel.EXPECT()
@@ -104,7 +104,7 @@ func (s *modelGenerationSuite) TestAdvanceGenerationSuccessAutoComplete(c *gc.C)
 		gExp := mockGeneration.EXPECT()
 		gExp.AssignAllUnits("ghost").Return(nil)
 		gExp.AssignUnit("mysql/0").Return(nil)
-		gExp.AutoComplete().Return(true, nil)
+		gExp.AutoComplete("test-user").Return(true, nil)
 		gExp.Refresh().Return(nil).Times(2)
 
 		mExp := mockModel.EXPECT()
@@ -124,7 +124,7 @@ func (s *modelGenerationSuite) TestCancelGeneration(c *gc.C) {
 	defer s.setupModelGenerationAPI(c, func(ctrl *gomock.Controller, _ *mocks.MockState, mockModel *mocks.MockModel) {
 		mockGeneration := mocks.NewMockGeneration(ctrl)
 		gExp := mockGeneration.EXPECT()
-		gExp.MakeCurrent().Return(nil)
+		gExp.MakeCurrent("test-user").Return(nil)
 
 		mExp := mockModel.EXPECT()
 		mExp.NextGeneration().Return(mockGeneration, nil)
@@ -141,7 +141,7 @@ func (s *modelGenerationSuite) TestCancelGenerationCanNotMakeCurrent(c *gc.C) {
 	defer s.setupModelGenerationAPI(c, func(ctrl *gomock.Controller, _ *mocks.MockState, mockModel *mocks.MockModel) {
 		mockGeneration := mocks.NewMockGeneration(ctrl)
 		gExp := mockGeneration.EXPECT()
-		gExp.MakeCurrent().Return(errors.New(errMsg))
+		gExp.MakeCurrent("test-user").Return(errors.New(errMsg))
 
 		mExp := mockModel.EXPECT()
 		mExp.NextGeneration().Return(mockGeneration, nil)

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-var _ = gc.Suite(&modelGenerationSuite{})
-
 type modelGenerationSuite struct {
 	modelUUID string
 
 	api *modelgeneration.API
 }
+
+var _ = gc.Suite(&modelGenerationSuite{})
 
 func (s *modelGenerationSuite) SetUpSuite(c *gc.C) {
 	s.modelUUID = "deadbeef-abcd-4fd2-967d-db9663db7bea"
@@ -39,7 +39,7 @@ func (s *modelGenerationSuite) TearDownTest(c *gc.C) {
 func (s *modelGenerationSuite) TestAddGeneration(c *gc.C) {
 	defer s.setupModelGenerationAPI(c, func(_ *gomock.Controller, _ *mocks.MockState, mockModel *mocks.MockModel) {
 		mExp := mockModel.EXPECT()
-		mExp.AddGeneration().Return(nil)
+		mExp.AddGeneration("test-user").Return(nil)
 	}).Finish()
 
 	result, err := s.api.AddGeneration(s.modelArg())
@@ -204,7 +204,7 @@ func (s *modelGenerationSuite) setupModelGenerationAPI(c *gc.C, fn setupFunc) *g
 	mockAuthorizer := facademocks.NewMockAuthorizer(ctrl)
 	aExp := mockAuthorizer.EXPECT()
 	aExp.HasPermission(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
-	aExp.GetAuthTag().Return(names.NewUserTag("testing"))
+	aExp.GetAuthTag().Return(names.NewUserTag("test-user"))
 	aExp.AuthClient().Return(true)
 
 	fn(ctrl, mockState, mockModel)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1146,6 +1146,9 @@ type Generation struct {
 	// Created is the Unix timestamp at generation creation.
 	Created int64 `json:"created"`
 
+	// Created is the user who created the generation.
+	CreatedBy string `json:"created-by"`
+
 	// Applications holds the collection of application changes
 	// made under this generation.
 	Applications []GenerationApplication `json:"applications"`

--- a/cmd/juju/model/showgeneration_test.go
+++ b/cmd/juju/model/showgeneration_test.go
@@ -44,7 +44,8 @@ func (s *showGenerationSuite) TestRunCommandNextGenExists(c *gc.C) {
 
 	result := map[coremodel.GenerationVersion]coremodel.Generation{
 		coremodel.GenerationNext: {
-			Created: "0001-01-01 00:00:00Z",
+			Created:   "0001-01-01 00:00:00Z",
+			CreatedBy: "test-user",
 			Applications: []coremodel.GenerationApplication{{
 				ApplicationName: "redis",
 				Units:           []string{"redis/0"},
@@ -59,6 +60,7 @@ func (s *showGenerationSuite) TestRunCommandNextGenExists(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 next:
   created: 0001-01-01 00:00:00Z
+  created-by: test-user
   applications:
   - application: redis
     units:

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -51,6 +51,9 @@ type Generation struct {
 	// Created is the formatted time at generation creation.
 	Created string `yaml:"created"`
 
+	// Created is the user who created the generation.
+	CreatedBy string `json:"created-by"`
+
 	// Applications is a collection of applications with changes in this
 	// generation including advanced units and modified configuration.
 	Applications []GenerationApplication `yaml:"applications"`

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -52,7 +52,7 @@ type Generation struct {
 	Created string `yaml:"created"`
 
 	// Created is the user who created the generation.
-	CreatedBy string `json:"created-by"`
+	CreatedBy string `yaml:"created-by"`
 
 	// Applications is a collection of applications with changes in this
 	// generation including advanced units and modified configuration.

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -228,8 +228,8 @@ func assignGenerationUnitTxnOps(id, appName, unitName string) []txn.Op {
 // generation. It then becomes the "current" generation, and true is returned.
 // If the criteria above are not met, the generation is not completed and
 // false is returned.
-func (g *Generation) AutoComplete() (bool, error) {
-	completed, err := g.complete(false)
+func (g *Generation) AutoComplete(userName string) (bool, error) {
+	completed, err := g.complete(userName, false)
 	return completed, errors.Trace(err)
 }
 
@@ -238,15 +238,15 @@ func (g *Generation) AutoComplete() (bool, error) {
 // generation, which can be either "current" of "next".
 // This the operation invoked by an operator "cancelling" a generation.
 // It then becomes the "current" generation.
-func (g *Generation) MakeCurrent() error {
-	_, err := g.complete(true)
+func (g *Generation) MakeCurrent(userName string) error {
+	_, err := g.complete(userName, true)
 	return errors.Trace(err)
 }
 
 // TODO (hml) 23-jan-2019
 // When implementing change history, review to see if this is
 // still the best course of action.
-func (g *Generation) complete(allowEmpty bool) (bool, error) {
+func (g *Generation) complete(userName string, allowEmpty bool) (bool, error) {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := g.Refresh(); err != nil {
@@ -263,18 +263,20 @@ func (g *Generation) complete(allowEmpty bool) (bool, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// The generation doc has only 3 elements that change as part of juju
-		// functionality.  We want to assert than none of those have changed
-		// here, however ensuring that no new applications are added to
-		// AssignedUnits, is non trivial.  Therefore just check the txn-revno
-		// instead.
+
+		// As a proxy for checking that the generation has not changed,
+		// Assert that the txn rev-no has not changed since we materialised
+		// this generation object.
 		ops := []txn.Op{
 			{
 				C:      generationsC,
 				Id:     g.doc.Id,
 				Assert: bson.D{{"txn-revno", g.doc.TxnRevno}},
 				Update: bson.D{
-					{"$set", bson.D{{"completed", now.Unix()}}},
+					{"$set", bson.D{
+						{"completed", now.Unix()},
+						{"completed-by", userName},
+					}},
 				},
 			},
 		}
@@ -371,15 +373,15 @@ func (g *Generation) Refresh() error {
 }
 
 // AddGeneration creates a new "next" generation for the model.
-func (m *Model) AddGeneration(user string) error {
-	return errors.Trace(m.st.AddGeneration(user))
+func (m *Model) AddGeneration(userName string) error {
+	return errors.Trace(m.st.AddGeneration(userName))
 }
 
 // AddGeneration creates a new "next" generation for the current model.
 // A new generation can not be added for a model that has an existing
 // generation that is not completed.
 // The input user indicates the operator who invoked the creation.
-func (st *State) AddGeneration(user string) error {
+func (st *State) AddGeneration(userName string) error {
 	seq, err := sequence(st, "generation")
 	if err != nil {
 		return errors.Trace(err)
@@ -398,7 +400,7 @@ func (st *State) AddGeneration(user string) error {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return insertGenerationTxnOps(strconv.Itoa(seq), now, user), nil
+		return insertGenerationTxnOps(strconv.Itoa(seq), now, userName), nil
 	}
 	err = st.db().Run(buildTxn)
 	if err != nil {

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -55,7 +55,7 @@ func (s *generationSuite) TestAssignApplicationGenCompletedError(c *gc.C) {
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
+	c.Assert(gen.MakeCurrent("user"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Assert(gen.AssignApplication("redis"), gc.ErrorMatches, "generation has been completed")
 }
@@ -83,7 +83,7 @@ func (s *generationSuite) TestAssignUnitGenCompletedError(c *gc.C) {
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
+	c.Assert(gen.MakeCurrent("user"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Assert(gen.AssignUnit("redis/0"), gc.ErrorMatches, "generation has been completed")
 }
@@ -166,7 +166,7 @@ func (s *generationSuite) TestAssignAllUnitsGenCompletedError(c *gc.C) {
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
+	c.Assert(gen.MakeCurrent("user"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Assert(gen.AssignAllUnits("riak"), gc.ErrorMatches, "generation has been completed")
 }
@@ -182,14 +182,15 @@ func (s *generationSuite) TestAutoCompleteSuccess(c *gc.C) {
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Assert(gen.IsCompleted(), jc.IsFalse)
 
-	completed, err := gen.AutoComplete()
+	completed, err := gen.AutoComplete("user")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(completed, jc.IsTrue)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Check(gen.IsCompleted(), jc.IsTrue)
+	c.Check(gen.CompletedBy(), gc.Equals, "user")
 
 	// Idempotent.
-	completed, err = gen.AutoComplete()
+	completed, err = gen.AutoComplete("user")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(completed, jc.IsTrue)
 }
@@ -203,10 +204,9 @@ func (s *generationSuite) TestAutoCompleteGenerationIncomplete(c *gc.C) {
 	c.Assert(gen.AssignUnit("riak/0"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 
-	completed, err := gen.AutoComplete()
+	completed, err := gen.AutoComplete("user")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(completed, jc.IsFalse)
-
 }
 
 func (s *generationSuite) TestMakeCurrentSuccess(c *gc.C) {
@@ -217,12 +217,13 @@ func (s *generationSuite) TestMakeCurrentSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(gen.IsCompleted(), jc.IsFalse)
-	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
+	c.Assert(gen.MakeCurrent("user"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
 	c.Assert(gen.IsCompleted(), jc.IsTrue)
+	c.Check(gen.CompletedBy(), gc.Equals, "user")
 
 	// Idempotent.
-	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
+	c.Assert(gen.MakeCurrent("user"), jc.ErrorIsNil)
 }
 
 func (s *generationSuite) TestMakeCurrentCanNotCancelError(c *gc.C) {
@@ -233,7 +234,7 @@ func (s *generationSuite) TestMakeCurrentCanNotCancelError(c *gc.C) {
 
 	c.Assert(gen.AssignUnit("riak/0"), jc.ErrorIsNil)
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	c.Assert(gen.MakeCurrent(), gc.ErrorMatches,
+	c.Assert(gen.MakeCurrent("user"), gc.ErrorMatches,
 		"cannot cancel generation, there are units behind a generation: riak/1, riak/2, riak/3")
 }
 
@@ -250,12 +251,12 @@ func (s *generationSuite) TestAppNoUnitsAutoCompleteErrorMakeCurrentSuccess(c *g
 
 	// Can not auto-complete.
 	c.Assert(gen.Refresh(), jc.ErrorIsNil)
-	completed, err := gen.AutoComplete()
+	completed, err := gen.AutoComplete("user")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(completed, jc.IsFalse)
 
 	// But can cancel.
-	c.Assert(gen.MakeCurrent(), jc.ErrorIsNil)
+	c.Assert(gen.MakeCurrent("user"), jc.ErrorIsNil)
 }
 
 func (s *generationSuite) TestHasNextGeneration(c *gc.C) {

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -29,7 +29,7 @@ func (s *generationSuite) TestNextGenerationNotFound(c *gc.C) {
 func (s *generationSuite) TestNextGenerationSuccess(c *gc.C) {
 	s.setupTestingClock(c)
 
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -37,20 +37,21 @@ func (s *generationSuite) TestNextGenerationSuccess(c *gc.C) {
 	c.Check(gen.ModelUUID(), gc.Equals, s.Model.UUID())
 	c.Check(gen.Id(), gc.Not(gc.Equals), "")
 	c.Check(gen.Created(), gc.Not(gc.Equals), 0)
+	c.Check(gen.CreatedBy(), gc.Equals, "user")
 }
 
 func (s *generationSuite) TestNextGenerationExistsError(c *gc.C) {
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	_, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.Model.AddGeneration(), gc.ErrorMatches, "model has a next generation that is not completed")
+	c.Assert(s.Model.AddGeneration("user"), gc.ErrorMatches, "model has a next generation that is not completed")
 }
 
 func (s *generationSuite) TestAssignApplicationGenCompletedError(c *gc.C) {
 	s.setupTestingClock(c)
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -60,7 +61,7 @@ func (s *generationSuite) TestAssignApplicationGenCompletedError(c *gc.C) {
 }
 
 func (s *generationSuite) TestAssignApplicationSuccess(c *gc.C) {
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,7 +79,7 @@ func (s *generationSuite) TestAssignApplicationSuccess(c *gc.C) {
 
 func (s *generationSuite) TestAssignUnitGenCompletedError(c *gc.C) {
 	s.setupTestingClock(c)
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,7 +89,7 @@ func (s *generationSuite) TestAssignUnitGenCompletedError(c *gc.C) {
 }
 
 func (s *generationSuite) TestAssignUnitSuccess(c *gc.C) {
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -113,7 +114,7 @@ func (s *generationSuite) setupAssignAllUnits(c *gc.C) {
 		_, err := riak.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 }
 
 func (s *generationSuite) TestAssignAllUnitsSuccessAll(c *gc.C) {
@@ -210,7 +211,7 @@ func (s *generationSuite) TestAutoCompleteGenerationIncomplete(c *gc.C) {
 
 func (s *generationSuite) TestMakeCurrentSuccess(c *gc.C) {
 	s.setupTestingClock(c)
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -237,7 +238,7 @@ func (s *generationSuite) TestMakeCurrentCanNotCancelError(c *gc.C) {
 }
 
 func (s *generationSuite) TestAppNoUnitsAutoCompleteErrorMakeCurrentSuccess(c *gc.C) {
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	gen, err := s.Model.NextGeneration()
 	c.Assert(err, jc.ErrorIsNil)
@@ -262,7 +263,7 @@ func (s *generationSuite) TestHasNextGeneration(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(has, jc.IsFalse)
 
-	c.Assert(s.Model.AddGeneration(), jc.ErrorIsNil)
+	c.Assert(s.Model.AddGeneration("user"), jc.ErrorIsNil)
 
 	has, err = s.Model.HasNextGeneration()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

This patch adds `created-by` and `completed-by` user name fields to the generation document. 
- Both fields are populated from the authenticated API user.
- `CreatedBy` is passed though and shown when `show-generation` is run.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- Bootstrap.
- `juju add-generation`
- `juju show-generation` and check that your user appears as the creator.
- `juju cancel-generation`
- The `show-generation` command does not work for completed generations, so check the DB directly to ensure that the `completed-by` is populated.

## Documentation changes

None.

## Bug reference

N/A
