### PR TITLE
Remove old code, fix some issues in migration tests. Add support for local credential detection for LXD.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -100,12 +100,14 @@ func NewDetectCredentialsCommandForTest(
 	registeredProvidersFunc func() []string,
 	allCloudsFunc func() (map[string]jujucloud.Cloud, error),
 	cloudsByNameFunc func(string) (*jujucloud.Cloud, error),
+	cloudType string,
 ) *detectCredentialsCommand {
 	return &detectCredentialsCommand{
 		store:                   testStore,
 		registeredProvidersFunc: registeredProvidersFunc,
 		allCloudsFunc:           allCloudsFunc,
 		cloudByNameFunc:         cloudsByNameFunc,
+		cloudType:               cloudType,
 	}
 }
 

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -150,12 +150,20 @@ func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 
 	remoteCertCredentials, err := p.detectRemoteCredentials(certPEM, keyPEM)
 	if err != nil {
-		logger.Errorf("unable to detect LXC credentials: %s", err)
+		logger.Errorf("unable to detect remote LXC credentials: %s", err)
+	}
+
+	localCertCredentials, err := p.detectLocalCredentials(certPEM, keyPEM)
+	if err != nil {
+		logger.Errorf("unable to detect local LXC credentials: %s", err)
 	}
 
 	authCredentials := make(map[string]cloud.Credential)
 	for k, v := range remoteCertCredentials {
 		authCredentials[k] = v
+	}
+	if localCertCredentials != nil {
+		authCredentials["localhost"] = *localCertCredentials
 	}
 	return &cloud.CloudCredential{
 		AuthCredentials: authCredentials,


### PR DESCRIPTION
## Description of change

The LXD model migration CI test was failing. There was a combination of old code, plus the core issue of missing credential when adding a new user to a controller, meaning the user could not add any models.
To prepare for a fix, the autoload-credentials command has been enhanced to accept a param to filter by cloud type, and LXD now detects local credentials. The CI test needs an update to load a local LXD credential for any new user added as part of the test. For now, these user permission tests are TODO.

## QA steps

assess_model_migration.py now passes

