### PR TITLE
Cloud commands operate on controller by default

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -60,9 +60,14 @@ Adds a k8s endpoint and credential to Juju.`[1:]
 
 var usageAddCAASDetails = `
 Creates a user-defined cloud based on a k8s cluster.
+
 The new k8s cloud can then be used to bootstrap into, or it
-can be added to an existing controller with the --controller option.
-Specify non default kubeconfig file location using $KUBECONFIG
+can be added to an existing controller; the current controller
+is used unless the --controller option is specified. If you just
+want to update the local cache and not a running controller, use
+the --local option.
+
+Specify a non default kubeconfig file location using $KUBECONFIG
 environment variable or pipe in file content from stdin.
 
 The config file can contain definitions for different k8s clusters,
@@ -80,6 +85,7 @@ necessary parameters directly.
 
 Examples:
     juju add-k8s myk8scloud
+    juju add-k8s myk8scloud --local
     juju add-k8s myk8scloud --controller mycontroller
     juju add-k8s --context-name mycontext myk8scloud
     juju add-k8s myk8scloud --region <cloudType/region>
@@ -102,7 +108,7 @@ See also:
 
 // AddCAASCommand is the command that allows you to add a caas and credential
 type AddCAASCommand struct {
-	modelcmd.CommandBase
+	modelcmd.OptionalControllerCommand
 
 	// These attributes are used when adding a cluster to a controller.
 	controllerName  string
@@ -153,9 +159,11 @@ type AddCAASCommand struct {
 
 // NewAddCAASCommand returns a command to add caas information.
 func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
+	store := jujuclient.NewFileClientStore()
 	cmd := &AddCAASCommand{
-		cloudMetadataStore: cloudMetadataStore,
-		store:              jujuclient.NewFileClientStore(),
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		cloudMetadataStore:        cloudMetadataStore,
+		store:                     store,
 		newClientConfigReader: func(caasType string) (clientconfig.ClientConfigFunc, error) {
 			return clientconfig.NewClientConfigReader(caasType)
 		},
@@ -185,9 +193,7 @@ func (c *AddCAASCommand) Info() *cmd.Info {
 
 // SetFlags initializes the flags supported by the command.
 func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.CommandBase.SetFlags(f)
-	f.StringVar(&c.controllerName, "c", "", "Controller to operate in")
-	f.StringVar(&c.controllerName, "controller", "", "")
+	c.OptionalControllerCommand.SetFlags(f)
 	f.StringVar(&c.clusterName, "cluster-name", "", "Specify the k8s cluster to import")
 	f.StringVar(&c.contextName, "context-name", "", "Specify the k8s context to import")
 	f.StringVar(&c.hostCloudRegion, "region", "", "kubernetes cluster cloud and/or region")
@@ -243,6 +249,10 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 		}
 	}
 
+	c.controllerName, err = c.ControllerNameFromArg()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	return cmd.CheckEmpty(args[1:])
 }
 

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -665,7 +665,7 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	cloudRegion := "gce/us-east1"
 
 	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2")
+	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2", "--local")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `k8s substrate "mrcloud2" added as cloud "myk8s"You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 	c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -24,13 +25,14 @@ func NewAddCAASCommandForTest(
 	getAllCloudDetails func() (map[string]*jujucmdcloud.CloudDetails, error),
 ) cmd.Command {
 	cmd := &AddCAASCommand{
-		cloudMetadataStore:    cloudMetadataStore,
-		store:                 store,
-		addCloudAPIFunc:       addCloudAPIFunc,
-		brokerGetter:          brokerGetter,
-		k8sCluster:            k8sCluster,
-		newClientConfigReader: newClientConfigReaderFunc,
-		getAllCloudDetails:    getAllCloudDetails,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		cloudMetadataStore:        cloudMetadataStore,
+		store:                     store,
+		addCloudAPIFunc:           addCloudAPIFunc,
+		brokerGetter:              brokerGetter,
+		k8sCluster:                k8sCluster,
+		newClientConfigReader:     newClientConfigReaderFunc,
+		getAllCloudDetails:        getAllCloudDetails,
 	}
 	return cmd
 }
@@ -41,9 +43,10 @@ func NewRemoveCAASCommandForTest(
 	removeCloudAPIFunc func() (RemoveCloudAPI, error),
 ) cmd.Command {
 	cmd := &RemoveCAASCommand{
-		cloudMetadataStore: cloudMetadataStore,
-		store:              store,
-		apiFunc:            removeCloudAPIFunc,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		cloudMetadataStore:        cloudMetadataStore,
+		store:                     store,
+		apiFunc:                   removeCloudAPIFunc,
 	}
 	return cmd
 }

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -120,7 +120,7 @@ func (s *removeCAASSuite) TestRemove(c *gc.C) {
 
 func (s *removeCAASSuite) TestRemoveLocalOnly(c *gc.C) {
 	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s")
+	_, err := s.runCommand(c, cmd, "myk8s", "--local")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckNoCalls(c)

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -32,8 +32,9 @@ func NewAddCloudCommandForTest(
 ) *AddCloudCommand {
 	cloudCallCtx := context.NewCloudCallContext()
 	return &AddCloudCommand{
-		cloudMetadataStore: cloudMetadataStore,
-		CloudCallCtx:       cloudCallCtx,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		cloudMetadataStore:        cloudMetadataStore,
+		CloudCallCtx:              cloudCallCtx,
 		Ping: func(p environs.EnvironProvider, endpoint string) error {
 			return nil
 		},
@@ -44,22 +45,25 @@ func NewAddCloudCommandForTest(
 
 func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (ListCloudsAPI, error)) *listCloudsCommand {
 	return &listCloudsCommand{
-		store:             store,
-		listCloudsAPIFunc: cloudAPI,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		store:                     store,
+		listCloudsAPIFunc:         cloudAPI,
 	}
 }
 
 func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (showCloudAPI, error)) *showCloudCommand {
 	return &showCloudCommand{
-		store:            store,
-		showCloudAPIFunc: cloudAPI,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		store:                     store,
+		showCloudAPIFunc:          cloudAPI,
 	}
 }
 
 func NewRemoveCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (removeCloudAPI, error)) *removeCloudCommand {
 	return &removeCloudCommand{
-		store:              store,
-		removeCloudAPIFunc: cloudAPI,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		store:                     store,
+		removeCloudAPIFunc:        cloudAPI,
 	}
 }
 
@@ -77,9 +81,10 @@ func NewUpdateCloudCommandForTest(
 	cloudAPI func(string) (UpdateCloudAPI, error),
 ) *updateCloudCommand {
 	return &updateCloudCommand{
-		cloudMetadataStore: cloudMetadataStore,
-		updateCloudAPIFunc: cloudAPI,
-		store:              store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		cloudMetadataStore:        cloudMetadataStore,
+		updateCloudAPIFunc:        cloudAPI,
+		store:                     store,
 	}
 }
 

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -31,7 +31,10 @@ var _ = gc.Suite(&updateCloudSuite{})
 func (s *updateCloudSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.api = &fakeUpdateCloudAPI{}
-	s.store = jujuclient.NewMemStore()
+	store := jujuclient.NewMemStore()
+	store.Controllers["mycontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "mycontroller"
+	s.store = store
 }
 
 func (s *updateCloudSuite) TestBadArgs(c *gc.C) {
@@ -82,7 +85,7 @@ func (s *updateCloudSuite) TestUpdateLocalCacheFromFile(c *gc.C) {
 	cmd, fileName := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
 		return nil, errors.New("")
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
+	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--local")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 }
@@ -103,7 +106,7 @@ func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
 		controllerNameCalled = controllerName
 		return s.api, nil
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--controller", "mycontroller")
+	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "UpdateCloud", "Close")
 	c.Assert(controllerNameCalled, gc.Equals, "mycontroller")


### PR DESCRIPTION
## Description of change

The various cloud commands used to add/remove/list/update clouds are changed to operate by default on the controller rather than the local cache. After bootstrap, the most common use case is to manage clouds on the running controller, so the default command behaviour is now adjusted to cater for that.

If a new cloud is needed to be added to the local cache so another controller can be bootstrapped, there's a new --local option for that.

## QA steps

Run the various cloud commands with/without --local and check that the controller or local cache is updated as specified.

