### PR TITLE
Restore backup from HA mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ vendor/
 .idea/
 *.pyc
 .vscode/
+juju-backup-*.tar.gz

--- a/acceptancetests/README.md
+++ b/acceptancetests/README.md
@@ -43,7 +43,7 @@ To run a test locally with lxd and locally complied juju:
             test-mode: true
             default-series: bionic
     ```
-  * ```export JUJU_REPOSITORY=./path/to/acceptancetests/repository```
+  * ```export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository```
   * ```mkdir /tmp/artifacts```
   * Now you can run the test with:
      * ```$ ./assess_model_migration.py lxd $GOPATH/bin/juju /tmp/artifacts```

--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -62,7 +62,7 @@ def enable_ha(bs_manager, controller_client):
     show_controller(controller_client)
     remote_machines = get_remote_machines(
         controller_client, bs_manager.known_hosts)
-    bs_manager.known_hosts = remote_machines
+    return remote_machines
 
 def disable_ha(bs_manager, controller_client):
     """Disable HA and wait for the controllers to be ready."""
@@ -71,7 +71,7 @@ def disable_ha(bs_manager, controller_client):
     show_controller(controller_client)
     remote_machines = get_remote_machines(
         controller_client, None)
-    bs_manager.known_hosts = remote_machines
+    return remote_machines
 
 def show_controller(client):
     controller_info = client.show_controller(format='yaml')
@@ -140,9 +140,9 @@ def assess_recovery(bs_manager, strategy, charm_series):
     # ha-backup allows us to still backup in HA mode, so allow us to still
     # create a cluster of controllers.
     if strategy == 'ha-backup':
-        enable_ha(bs_manager, controller_client)
+        bs_manager.known_hosts = enable_ha(bs_manager, controller_client)
         backup_file = controller_client.backup()
-        disable_ha(bs_manager, controller_client)
+        bs_manager.known_hosts = disable_ha(bs_manager, controller_client)
     else:
         backup_file = controller_client.backup()
 

--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -70,7 +70,7 @@ def disable_ha(bs_manager, controller_client):
     controller_client.wait_for(controller_client.remove_machines(["1", "2"], controller=True))
     show_controller(controller_client)
     remote_machines = get_remote_machines(
-        controller_client, bs_manager.known_hosts)
+        controller_client, None)
     bs_manager.known_hosts = remote_machines
 
 def show_controller(client):

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -358,7 +358,7 @@ def dump_juju_timings(client, log_directory):
         print_now(str(e))
 
 
-def get_remote_machines(client, known_hosts):
+def get_remote_machines(client, known_hosts=None):
     """Return a dict of machine_id to remote machines.
 
     A bootstrap_host address may be provided as a fallback for machine 0 if
@@ -368,9 +368,10 @@ def get_remote_machines(client, known_hosts):
     # Try to get machine details from environment if possible.
     machines = dict(iter_remote_machines(client))
     # The bootstrap host is added as a fallback in case status failed.
-    for machine_id, address in known_hosts.items():
-        if machine_id not in machines:
-            machines[machine_id] = remote_from_address(address)
+    if known_hosts is not None:
+        for machine_id, address in known_hosts.items():
+            if machine_id not in machines:
+                machines[machine_id] = remote_from_address(address)
     # Update remote machines in place with real addresses if substrate needs.
     resolve_remote_dns_names(client.env, machines.values())
     return machines

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -798,7 +798,7 @@ class ModelClient:
     def remove_machine(self, machine_ids, force=False, controller=False):
         """Remove a machine (or container).
 
-        :param machine_ids: The id of the machine to remove.
+        :param machine_ids: The ids of the machine to remove.
         :return: A WaitMachineNotPresent instance for client.wait_for.
         """
         options = ()

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -86,7 +86,6 @@ from jujupy.wait_condition import (
     NoopCondition,
     WaitAgentsStarted,
     WaitMachineNotPresent,
-    WaitMachinesNotPresent,
     WaitVersion,
 )
 
@@ -796,36 +795,11 @@ class ModelClient:
             timeout = 600
         return WaitMachineNotPresent(machine, timeout)
 
-    def remove_machine(self, machine_id, force=False):
+    def remove_machine(self, machine_ids, force=False, controller=False):
         """Remove a machine (or container).
 
-        :param machine_id: The id of the machine to remove.
+        :param machine_ids: The id of the machine to remove.
         :return: A WaitMachineNotPresent instance for client.wait_for.
-        """
-        if force:
-            options = ('--force',)
-        else:
-            options = ()
-        self.juju('remove-machine', options + (machine_id,))
-        return self.make_remove_machine_condition(machine_id)
-
-    def make_remove_machines_condition(self, machines):
-        """Return a condition object representing a machines removal.
-
-        The timeout varies depending on the provider.
-        See wait_for.
-        """
-        if self.env.provider == 'azure':
-            timeout = 1200
-        else:
-            timeout = 600
-        return WaitMachinesNotPresent(machines, timeout)
-
-    def remove_machines(self, machine_ids, controller=False, force=False):
-        """Remove machines (or containers).
-
-        :param machine_ids: The ids of the machines to remove.
-        :return: A WaitMachinesNotPresent instance for client.wait_for.
         """
         options = ()
         if force:
@@ -833,7 +807,7 @@ class ModelClient:
         if controller:
             options = ('-m', 'controller',)
         self.juju('remove-machine', options + tuple(machine_ids))
-        return self.make_remove_machines_condition(machine_ids)
+        return self.make_remove_machine_condition(machine_ids)
 
     @staticmethod
     def get_cloud_region(cloud, region):

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -86,6 +86,7 @@ from jujupy.wait_condition import (
     NoopCondition,
     WaitAgentsStarted,
     WaitMachineNotPresent,
+    WaitMachinesNotPresent,
     WaitVersion,
 )
 
@@ -807,6 +808,32 @@ class ModelClient:
             options = ()
         self.juju('remove-machine', options + (machine_id,))
         return self.make_remove_machine_condition(machine_id)
+
+    def make_remove_machines_condition(self, machines):
+        """Return a condition object representing a machines removal.
+
+        The timeout varies depending on the provider.
+        See wait_for.
+        """
+        if self.env.provider == 'azure':
+            timeout = 1200
+        else:
+            timeout = 600
+        return WaitMachinesNotPresent(machines, timeout)
+
+    def remove_machines(self, machine_ids, controller=False, force=False):
+        """Remove machines (or containers).
+
+        :param machine_ids: The ids of the machines to remove.
+        :return: A WaitMachinesNotPresent instance for client.wait_for.
+        """
+        options = ()
+        if force:
+            options = ('--force',)
+        if controller:
+            options = ('-m', 'controller',)
+        self.juju('remove-machine', options + tuple(machine_ids))
+        return self.make_remove_machines_condition(machine_ids)
 
     @staticmethod
     def get_cloud_region(cloud, region):

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -227,6 +227,38 @@ class WaitMachineNotPresent(BaseCondition):
                         self.machine)
 
 
+class WaitMachinesNotPresent(BaseCondition):
+    """Condition satisfied when a given machine is not present."""
+
+    def __init__(self, machines, timeout=300):
+        super(WaitMachinesNotPresent, self).__init__(timeout)
+        self.machines = machines
+
+    def __eq__(self, other):
+        if not type(self) is type(other):
+            return False
+        if self.timeout != other.timeout:
+            return False
+        if self.machines != other.machines:
+            return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def iter_blocking_state(self, status):
+        machines = []
+        for machine, info in status.iter_machines():
+            if machine in self.machines:
+                machines.append(machine)
+        if len(machines) > 0:
+            yield machine[0], 'still-present'
+
+    def do_raise(self, model_name, status):
+        raise Exception("Timed out waiting for machines removal %s" %
+                        self.machines)
+
+
 class WaitApplicationNotPresent(BaseCondition):
     """Condition satisfied when a given machine is not present."""
 

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -201,38 +201,12 @@ class AgentsIdle(BaseCondition):
 class WaitMachineNotPresent(BaseCondition):
     """Condition satisfied when a given machine is not present."""
 
-    def __init__(self, machine, timeout=300):
+    def __init__(self, machineOrMachines, timeout=300):
         super(WaitMachineNotPresent, self).__init__(timeout)
-        self.machine = machine
-
-    def __eq__(self, other):
-        if not type(self) is type(other):
-            return False
-        if self.timeout != other.timeout:
-            return False
-        if self.machine != other.machine:
-            return False
-        return True
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def iter_blocking_state(self, status):
-        for machine, info in status.iter_machines():
-            if machine == self.machine:
-                yield machine, 'still-present'
-
-    def do_raise(self, model_name, status):
-        raise Exception("Timed out waiting for machine removal %s" %
-                        self.machine)
-
-
-class WaitMachinesNotPresent(BaseCondition):
-    """Condition satisfied when a given machine is not present."""
-
-    def __init__(self, machines, timeout=300):
-        super(WaitMachinesNotPresent, self).__init__(timeout)
-        self.machines = machines
+        if isinstance(machineOrMachines, list):
+            self.machines = machineOrMachines
+        else:
+            self.machines = [machineOrMachines]
 
     def __eq__(self, other):
         if not type(self) is type(other):
@@ -255,9 +229,12 @@ class WaitMachinesNotPresent(BaseCondition):
             yield machine[0], 'still-present'
 
     def do_raise(self, model_name, status):
-        raise Exception("Timed out waiting for machines removal %s" %
-                        self.machines)
-
+        plural = "s"
+        values = self.machines
+        if len(values) == 1:
+            plural = ""
+            values = self.machines[0]
+        raise Exception("Timed out waiting for machine{} removal {}".format(plural, values))
 
 class WaitApplicationNotPresent(BaseCondition):
     """Condition satisfied when a given machine is not present."""


### PR DESCRIPTION
## Description of change

The following restores backup from HA mode, but will fail because
mongo 3.6.3 (which is what we're using) has a bug in it, that we
can't patch atm.

Anyway, once that patch/fix lands, we can turn on this test!

## QA steps

Setup acceptance tests correctly, then run the following command.

```
./assess_recovery.py --ha-backup
```