### PR TITLE
Use jujud-operator as the k8s docker image; use juju-db:4.1.9 for mongo, new repo config option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,14 @@ operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requi
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
-	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
+	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
-	docker push ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG}
+	docker push ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
 
 microk8s-operator-update: operator-image
-	docker save ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} | microk8s.docker load
+	docker save ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG} | microk8s.docker load
 
 check-k8s-model:
 	@:$(if $(value JUJU_K8S_MODEL),, $(error Undefined JUJU_K8S_MODEL))
@@ -163,9 +163,9 @@ check-k8s-model:
 
 local-operator-update: check-k8s-model operator-image
 	$(eval kubeworkers != juju status -m ${JUJU_K8S_MODEL} kubernetes-worker --format json | jq -c '.machines | keys' | tr  -c '[:digit:]' ' ' 2>&1)
-	docker save ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} | gzip > /tmp/caas-jujud-operator-image.tar.gz
-	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/caas-jujud-operator-image.tar.gz $(wm):/tmp/caas-jujud-operator-image.tar.gz ; )
-	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/caas-jujud-operator-image.tar.gz | docker load" ; )
+	docker save ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG} | gzip > /tmp/jujud-operator-image.tar.gz
+	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/jujud-operator-image.tar.gz $(wm):/tmp/jujud-operator-image.tar.gz ; )
+	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/jujud-operator-image.tar.gz | docker load" ; )
 
 .PHONY: build check install release-install release-build go-build go-install
 .PHONY: clean format simplify

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -269,7 +269,7 @@ def parse_args(argv):
     parser = argparse.ArgumentParser(description="Cass charm deployment CI test")
     parser.add_argument(
         '--caas-image', action='store', default=None,
-        help='Caas operator docker image name to use with format of <username>/caas-jujud-operator:<tag>.'
+        help='Caas operator docker image name to use with format of <username>/jujud-operator:<tag>.'
     )
 
     add_basic_testing_arguments(parser, existing=False)

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -27,7 +27,7 @@ type mockState struct {
 	model              *mockModel
 	applicationWatcher *mockStringsWatcher
 	app                *mockApplication
-	operatorImage      string
+	operatorRepo       string
 }
 
 func newMockState() *mockState {
@@ -51,7 +51,7 @@ func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
 
 func (st *mockState) ControllerConfig() (controller.Config, error) {
 	cfg := coretesting.FakeControllerConfig()
-	cfg[controller.CAASOperatorImagePath] = st.operatorImage
+	cfg[controller.CAASImageRepo] = st.operatorRepo
 	return cfg, nil
 }
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -123,7 +123,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
+		ImagePath:    fmt.Sprintf("jujusolutions/jujud-operator:%s", version.Current.String()),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
@@ -145,11 +145,11 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 }
 
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
-	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	s.st.operatorRepo = "somerepo"
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    s.st.operatorImage,
+		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + version.Current.String(),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
@@ -172,11 +172,11 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
-	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	s.st.operatorRepo = "somerepo"
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    s.st.operatorImage,
+		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + version.Current.String(),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -533,7 +533,7 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 		containerSpec = append(containerSpec, core.Container{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "mongo:3.6.6",
+			Image:           c.pcfg.GetJujuDbOCIImagePath(),
 			Command: []string{
 				"mongod",
 			},

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -309,7 +309,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           s.pcfg.GetJujuDbOCIImagePath(),
+			Image:           "jujusolutions/juju-db:4.1.9",
 			Command: []string{
 				"mongod",
 			},
@@ -384,7 +384,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "api-server",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           s.pcfg.GetControllerImagePath(),
+			Image:           "jujusolutions/jujud-operator:" + jujuversion.Current.String(),
 			Command: []string{
 				"/bin/sh",
 			},

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -11,7 +11,7 @@ import (
 	core "k8s.io/api/core/v1"
 	k8sstorage "k8s.io/api/storage/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
@@ -309,7 +309,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "mongo:3.6.6",
+			Image:           s.pcfg.GetJujuDbOCIImagePath(),
 			Command: []string{
 				"mongod",
 			},

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -337,14 +337,14 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
 		"juju-operator": "gitlab",
 	}
-	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator", "2.99.0", tags)
+	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", tags)
 	c.Assert(pod.Name, gc.Equals, "gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
 		"juju-operator": "gitlab",
 		"juju-version":  "2.99.0",
 	})
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
-	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/caas-jujud-operator")
+	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/jujud-operator")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 1)
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/template-agent.conf")
 }

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -33,7 +33,7 @@ var logger = loggo.GetLogger("juju.cloudconfig.podcfg")
 const (
 	jujudOCINamespace = "jujusolutions"
 	jujudOCIName      = "jujud-operator"
-	jujudbOCIName     = "juju-db:4.1.9"
+	jujudbOCIName     = "juju-db"
 )
 
 // ControllerPodConfig represents initialization information for a new juju caas controller pod.
@@ -233,7 +233,8 @@ func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
 	if imageRepo == "" {
 		imageRepo = jujudOCINamespace
 	}
-	return fmt.Sprintf("%s/%s", imageRepo, jujudbOCIName)
+	v := mongo.Mongo419wt
+	return fmt.Sprintf("%s/%s:%d.%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor, v.Point)
 }
 
 // GetJujuOCIImagePath returns the jujud oci image path.

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -32,7 +32,8 @@ var logger = loggo.GetLogger("juju.cloudconfig.podcfg")
 
 const (
 	jujudOCINamespace = "jujusolutions"
-	jujudOCIName      = "caas-jujud-operator"
+	jujudOCIName      = "jujud-operator"
+	jujudbOCIName     = "juju-db:4.1.9"
 )
 
 // ControllerPodConfig represents initialization information for a new juju caas controller pod.
@@ -226,13 +227,27 @@ func (cfg *ControllerPodConfig) GetControllerImagePath() string {
 	return GetJujuOCIImagePath(cfg.Controller.Config, cfg.JujuVersion)
 }
 
-// GetJujuOCIImagePath returns jujud oci image path.
-func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) string {
-	imagePath := controllerCfg.CAASOperatorImagePath()
-	if imagePath == "" {
-		imagePath = fmt.Sprintf("%s/%s:%s", jujudOCINamespace, jujudOCIName, ver.String())
+// GetJUjuDbOCIImagePath returns the juju-db oci image path.
+func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
+	imageRepo := cfg.Controller.Config.CAASImageRepo()
+	if imageRepo == "" {
+		imageRepo = jujudOCINamespace
 	}
-	return imagePath
+	return fmt.Sprintf("%s/%s", imageRepo, jujudbOCIName)
+}
+
+// GetJujuOCIImagePath returns the jujud oci image path.
+func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) string {
+	// First check the deprecated "caas-operator-image-path" config.
+	imagePath := controllerCfg.CAASOperatorImagePath()
+	if imagePath != "" {
+		return imagePath
+	}
+	imageRepo := controllerCfg.CAASImageRepo()
+	if imageRepo == "" {
+		imageRepo = jujudOCINamespace
+	}
+	return fmt.Sprintf("%s/%s:%s", imageRepo, jujudOCIName, ver.String())
 }
 
 func (cfg *ControllerPodConfig) verifyBootstrapConfig() (err error) {

--- a/controller/config.go
+++ b/controller/config.go
@@ -227,7 +227,12 @@ const (
 
 	// CAASOperatorImagePath sets the url of the docker image
 	// used for the application operator.
+	// Deprecated: use CAASImageRepo
 	CAASOperatorImagePath = "caas-operator-image-path"
+
+	// CAASImageRepo sets the docker repo to use
+	// for the jujud operator and mongo images.
+	CAASImageRepo = "caas-image-repo"
 
 	// Features allows a list of runtime changeable features to be updated.
 	Features = "features"
@@ -269,6 +274,7 @@ var (
 		AuditLogMaxBackups,
 		AuditLogExcludeMethods,
 		CAASOperatorImagePath,
+		CAASImageRepo,
 		Features,
 		MeteringURL,
 	}
@@ -293,6 +299,7 @@ var (
 		JujuHASpace,
 		JujuManagementSpace,
 		CAASOperatorImagePath,
+		CAASImageRepo,
 		Features,
 	)
 
@@ -630,6 +637,12 @@ func (c Config) CAASOperatorImagePath() string {
 	return c.asString(CAASOperatorImagePath)
 }
 
+// CAASImageRepo sets the url of the docker repo
+// used for the jujud operator and mongo images.
+func (c Config) CAASImageRepo() string {
+	return c.asString(CAASImageRepo)
+}
+
 // MeteringURL returns the URL to use for metering api calls.
 func (c Config) MeteringURL() string {
 	url := c.asString(MeteringURL)
@@ -712,7 +725,13 @@ func Validate(c Config) error {
 		return errors.Trace(err)
 	}
 
-	if v, ok := c[CAASOperatorImagePath].(string); ok {
+	if v, ok := c[CAASOperatorImagePath].(string); ok && v != "" {
+		if err := resources.ValidateDockerRegistryPath(v); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	if v, ok := c[CAASImageRepo].(string); ok && v != "" {
 		if err := resources.ValidateDockerRegistryPath(v); err != nil {
 			return errors.Trace(err)
 		}
@@ -853,6 +872,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	JujuHASpace:             schema.String(),
 	JujuManagementSpace:     schema.String(),
 	CAASOperatorImagePath:   schema.String(),
+	CAASImageRepo:           schema.String(),
 	Features:                schema.List(schema.String()),
 	CharmStoreURL:           schema.String(),
 	MeteringURL:             schema.String(),
@@ -883,6 +903,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	JujuHASpace:             schema.Omit,
 	JujuManagementSpace:     schema.Omit,
 	CAASOperatorImagePath:   schema.Omit,
+	CAASImageRepo:           schema.Omit,
 	Features:                schema.Omit,
 	CharmStoreURL:           csclient.ServerURL,
 	MeteringURL:             romulus.DefaultAPIRoot,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -189,45 +189,45 @@ var validateTests = []struct {
 	},
 	expectError: `invalid audit log exclude methods: should be a list of "Facade.Method" names \(or "ReadOnlyMethods"\), got "Sharon Jones" at position 3`,
 }, {
-	about: "invalid CAAS operator docker image path",
+	about: "invalid CAAS docker image repo",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo?bar",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo?bar",
 	},
 	expectError: `docker image path "foo\?bar" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - leading colon",
+	about: "invalid CAAS operator docker image repo - leading colon",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: ":foo",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: ":foo",
 	},
 	expectError: `docker image path ":foo" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - trailing colon",
+	about: "invalid CAAS docker image repo - trailing colon",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo:",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo:",
 	},
 	expectError: `docker image path "foo:" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - extra colon",
+	about: "invalid CAAS docker image repo - extra colon",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo::bar",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo::bar",
 	},
 	expectError: `docker image path "foo::bar" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - leading /",
+	about: "invalid CAAS docker image repo - leading /",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "/foo",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "/foo",
 	},
 	expectError: `docker image path "/foo" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - extra /",
+	about: "invalid CAAS docker image repo - extra /",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo//bar",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo//bar",
 	},
 	expectError: `docker image path "foo//bar" not valid`,
 }, {
@@ -498,25 +498,22 @@ func (s *ConfigSuite) TestConfigNoSpacesNilSpaceConfigPreserved(c *gc.C) {
 	c.Check(cfg.AsSpaceConstraints(nil), gc.IsNil)
 }
 
-func (s *ConfigSuite) TestCAASOperatorImagePath(c *gc.C) {
-	for _, imagePath := range []string{
-		"juju-operator-image",
-		"registry.foo.com/juju-operator-image",
-		"registry.foo.com/me/juju-operator-image",
-		"juju-operator-image:latest",
-		"juju-operator-image:2.4-beta1",
-		"registry.foo.com/juju-operator-image:2.4-beta1",
-		"registry.foo.com/me/juju-operator-image:2.4-beta1",
+func (s *ConfigSuite) TestCAASImageRepo(c *gc.C) {
+	for _, imageRepo := range []string{
+		"", //used to reset since we don't have a --reset option
+		"juju-operator-repo",
+		"registry.foo.com",
+		"registry.foo.com/me",
 	} {
 		cfg, err := controller.NewConfig(
 			testing.ControllerTag.Id(),
 			testing.CACert,
 			map[string]interface{}{
-				controller.CAASOperatorImagePath: imagePath,
+				controller.CAASImageRepo: imageRepo,
 			},
 		)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(cfg.CAASOperatorImagePath(), gc.Equals, imagePath)
+		c.Assert(cfg.CAASImageRepo(), gc.Equals, imageRepo)
 	}
 }
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -89,6 +89,7 @@ const (
 type Version struct {
 	Major         int
 	Minor         int
+	Point         int
 	Patch         string // supports variants like 1-alpha
 	StorageEngine StorageEngine
 }
@@ -110,6 +111,12 @@ func (v Version) NewerThan(ver Version) int {
 		return 1
 	}
 	if v.Minor < ver.Minor {
+		return -1
+	}
+	if v.Point > ver.Point {
+		return 1
+	}
+	if v.Point < ver.Point {
 		return -1
 	}
 	return 0
@@ -146,7 +153,7 @@ func NewVersion(v string) (Version, error) {
 			version.StorageEngine = Upgrading
 		}
 	}
-	vParts := strings.SplitN(parts[0], ".", 3)
+	vParts := strings.SplitN(parts[0], ".", 4)
 
 	if len(vParts) >= 1 {
 		i, err := strconv.Atoi(vParts[0])
@@ -162,8 +169,15 @@ func NewVersion(v string) (Version, error) {
 		}
 		version.Minor = i
 	}
-	if len(vParts) == 3 {
-		version.Patch = vParts[2]
+	if len(vParts) >= 3 {
+		i, err := strconv.Atoi(vParts[2])
+		if err != nil {
+			return Version{}, errors.Annotate(err, "Invalid version string, point is not an int")
+		}
+		version.Point = i
+	}
+	if len(vParts) == 4 {
+		version.Patch = vParts[3]
 	}
 
 	if version.Major == 2 && version.StorageEngine == WiredTiger {
@@ -171,7 +185,7 @@ func NewVersion(v string) (Version, error) {
 	}
 
 	// This deserialises the special "Mongo Upgrading" version
-	if version.Major == 0 && version.Minor == 0 {
+	if version.Major == 0 && version.Minor == 0 && version.Point == 0 {
 		return Version{StorageEngine: Upgrading}, nil
 	}
 
@@ -181,6 +195,9 @@ func NewVersion(v string) (Version, error) {
 // String serializes the version into a string.
 func (v Version) String() string {
 	s := fmt.Sprintf("%d.%d", v.Major, v.Minor)
+	if v.Point > 0 {
+		s = fmt.Sprintf("%s.%d", s, v.Point)
+	}
 	if v.Patch != "" {
 		s = fmt.Sprintf("%s.%s", s, v.Patch)
 	}
@@ -225,6 +242,12 @@ var (
 	Mongo36wt = Version{Major: 3,
 		Minor:         6,
 		Patch:         "",
+		StorageEngine: WiredTiger,
+	}
+	// Mongo419wt represents 'mongodb-server-core' at version 4.1.9 with WiredTiger
+	Mongo419wt = Version{Major: 4,
+		Minor:         1,
+		Point:         9,
 		StorageEngine: WiredTiger,
 	}
 	// MongoUpgrade represents a sepacial case where an upgrade is in
@@ -530,8 +553,8 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 	}
 
 	mongoArgs := generateConfig(mongoPath, args.DataDir, args.StatePort, oplogSizeMB, args.SetNUMAControlPolicy, mongodVersion, args.MemoryProfile)
-	logger.Debugf("creating mongo service configuration for mongo version: %d.%d.%s at %q",
-		mongoArgs.Version.Major, mongoArgs.Version.Minor, mongoArgs.Version.Patch, mongoArgs.MongoPath)
+	logger.Debugf("creating mongo service configuration for mongo version: %d.%d.%d-%s at %q",
+		mongoArgs.Version.Major, mongoArgs.Version.Minor, mongoArgs.Version.Point, mongoArgs.Version.Patch, mongoArgs.MongoPath)
 
 	svc, err := mongoArgs.asService()
 	if err != nil {

--- a/mongo/mongodfinder_test.go
+++ b/mongo/mongodfinder_test.go
@@ -51,7 +51,7 @@ func (s *MongodFinderSuite) TestFindSystemMongo36(c *gc.C) {
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         3,
 		Minor:         6,
-		Patch:         "3",
+		Point:         3,
 		StorageEngine: mongo.WiredTiger,
 	})
 }
@@ -70,7 +70,7 @@ func (s *MongodFinderSuite) TestFindSystemMongo34(c *gc.C) {
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         3,
 		Minor:         4,
-		Patch:         "14",
+		Point:         14,
 		StorageEngine: mongo.WiredTiger,
 	})
 }
@@ -91,7 +91,7 @@ func (s *MongodFinderSuite) TestFindJujuMongodb(c *gc.C) {
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         2,
 		Minor:         4,
-		Patch:         "9",
+		Point:         9,
 		StorageEngine: mongo.MMAPV1,
 	})
 }
@@ -115,7 +115,7 @@ func (s *MongodFinderSuite) TestFindJujuMongodbIgnoringSystemMongodb(c *gc.C) {
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         2,
 		Minor:         4,
-		Patch:         "9",
+		Point:         9,
 		StorageEngine: mongo.MMAPV1,
 	})
 }
@@ -135,7 +135,7 @@ func (s *MongodFinderSuite) TestFindJujuMongodb32(c *gc.C) {
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         3,
 		Minor:         2,
-		Patch:         "15",
+		Point:         15,
 		StorageEngine: mongo.WiredTiger,
 	})
 }
@@ -155,7 +155,6 @@ func (s *MongodFinderSuite) TestFindJujuMongodb32IgnoringFailedVersion(c *gc.C) 
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         3,
 		Minor:         2,
-		Patch:         "",
 		StorageEngine: mongo.WiredTiger,
 	})
 }
@@ -176,7 +175,7 @@ func (s *MongodFinderSuite) TestFindJujuMongodb32IgnoringSystemMongo(c *gc.C) {
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         3,
 		Minor:         2,
-		Patch:         "15",
+		Point:         15,
 		StorageEngine: mongo.WiredTiger,
 	})
 }
@@ -200,21 +199,22 @@ func (s *MongodFinderSuite) TestStatButNoExecSystemMongo(c *gc.C) {
 }
 
 func (s *MongodFinderSuite) TestParseMongoVersion(c *gc.C) {
-	assertVersion := func(major, minor int, patch string, content string) {
+	assertVersion := func(major, minor, point int, patch string, content string) {
 		v, err := mongo.ParseMongoVersion(content)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(v.Major, gc.Equals, major)
 		c.Check(v.Minor, gc.Equals, minor)
+		c.Check(v.Point, gc.Equals, point)
 		c.Check(v.Patch, gc.Equals, patch)
 	}
-	assertVersion(2, 4, "9", mongodb24Version)
-	assertVersion(2, 6, "10", mongodb26Version)
-	assertVersion(3, 2, "15", mongodb32Version)
-	assertVersion(3, 4, "14", mongodb34Version)
-	assertVersion(3, 6, "3", mongodb36Version)
-	assertVersion(3, 4, "0-rc3", "db version v3.4.0-rc3\n")
-	assertVersion(2, 4, "6", "db version v2.4.6\n")
-	assertVersion(2, 4, "", "db version v2.4.")
+	assertVersion(2, 4, 9, "", mongodb24Version)
+	assertVersion(2, 6, 10, "", mongodb26Version)
+	assertVersion(3, 2, 15, "", mongodb32Version)
+	assertVersion(3, 4, 14, "", mongodb34Version)
+	assertVersion(3, 6, 3, "", mongodb36Version)
+	assertVersion(3, 4, 0, "rc3", "db version v3.4.0-rc3\n")
+	assertVersion(2, 4, 6, "", "db version v2.4.6\n")
+	assertVersion(2, 4, 0, "alpha1", "db version v2.4.0.alpha1")
 }
 
 func (s *MongodFinderSuite) TestParseBadVersion(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -43,6 +43,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxLogsSize,
 		controller.MaxLogsAge,
 		controller.CAASOperatorImagePath,
+		controller.CAASImageRepo,
 		controller.CharmStoreURL,
 		controller.Features,
 		controller.MeteringURL,


### PR DESCRIPTION
## Description of change

The jujud operator docker image is renamed to jujud-operator.
There's a new juju-db:4.1.9 image copied from upstream mongo.
The controller config option to override the jujud operator image is deprecated in favour of an option to set the repo, from which the jujud-operator and juju-db images are fetched.

## QA steps

juju bootstrap on k8s

