### PR TITLE
Add --aks param to add-k8s

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -62,7 +62,7 @@ var usageAddCAASDetails = `
 Creates a user-defined cloud based on a k8s cluster.
 The new k8s cloud can then be used to bootstrap into, or it
 can be added to an existing controller with the --controller option.
-Speficify non default kubeconfig file location using $KUBECONFIG
+Specify non default kubeconfig file location using $KUBECONFIG
 environment variable or pipe in file content from stdin.
 
 The config file can contain definitions for different k8s clusters,
@@ -70,12 +70,13 @@ use --cluster-name to pick which one to use.
 It's also possible to select a context by name using --context-name.
 
 When running add-k8s the underlying cloud/region hosting the cluster need to be
-detected to enable storage to be correctly configured.if the cloud/region cannot
+detected to enable storage to be correctly configured. If the cloud/region cannot
 be detected automatically, use --region <cloudType/region> to specify the host
 cloud type and region.
 
-When adding a GKE cluster, you can use the --gke option to interactively be stepped
-through the registration process, or you can supply the necessary parameters directly.
+When adding a GKE or AKS cluster, you can use the --gke or --aks option to
+interactively be stepped through the registration process, or you can supply the
+necessary parameters directly.
 
 Examples:
     juju add-k8s myk8scloud
@@ -90,6 +91,10 @@ Examples:
     juju add-k8s --gke --project=myproject myk8scloud
     juju add-k8s --gke --credential=myaccount --project=myproject myk8scloud
     juju add-k8s --gke --credential=myaccount --project=myproject --region=someregion myk8scloud
+
+    juju add-k8s --aks myk8scloud
+    juju add-k8s --aks --cluster-name mycluster myk8scloud
+    juju add-k8s --aks --cluster-name mycluster --resource-group myrg myk8scloud
 
 See also:
     remove-k8s
@@ -123,6 +128,9 @@ type AddCAASCommand struct {
 	// credential is the credential to use when accessing the cluster.
 	credential string
 
+	// resourceGroup is the resource group name for the cluster.
+	resourceGroup string
+
 	// hostCloudRegion is the cloud region that the nodes of cluster (k8s) are running in.
 	// The format is <cloudType/region>.
 	hostCloudRegion string
@@ -134,6 +142,7 @@ type AddCAASCommand struct {
 	brokerGetter BrokerGetter
 
 	gke        bool
+	aks        bool
 	k8sCluster k8sCluster
 
 	cloudMetadataStore    CloudMetadataStore
@@ -185,7 +194,9 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.workloadStorage, "storage", "", "kubernetes storage class for workload storage")
 	f.StringVar(&c.project, "project", "", "project to which the cluster belongs")
 	f.StringVar(&c.credential, "credential", "", "the credential to use when accessing the cluster")
+	f.StringVar(&c.resourceGroup, "resource-group", "", "the Azure resource group of the AKS cluster")
 	f.BoolVar(&c.gke, "gke", false, "used when adding a GKE cluster")
+	f.BoolVar(&c.aks, "aks", false, "used when adding an AKS cluster")
 }
 
 // Init populates the command with the args from the command line.
@@ -203,7 +214,24 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 		if c.contextName != "" {
 			return errors.New("do not specify context name when adding a GKE cluster")
 		}
+		if c.k8sCluster == nil {
+			c.k8sCluster = newGKECluster()
+		}
+		if err := c.k8sCluster.ensureExecutable(); err != nil {
+			return errors.Trace(err)
+		}
 	} else {
+		if c.aks {
+			if c.contextName != "" {
+				return errors.New("do not specify context name when adding a AKS cluster")
+			}
+			if c.k8sCluster == nil {
+				c.k8sCluster = newAKSCluster()
+			}
+			if err := c.k8sCluster.ensureExecutable(); err != nil {
+				return errors.Trace(err)
+			}
+		}
 		if c.project != "" {
 			return errors.New("do not specify project unless adding a GKE cluster")
 		}
@@ -273,33 +301,52 @@ func (c *AddCAASCommand) newCloudCredentialFromKubeConfig(reader io.Reader, cont
 }
 
 func (c *AddCAASCommand) getConfigReader(ctx *cmd.Context) (io.Reader, string, error) {
-	if !c.gke {
-		rdr, err := getStdinPipe(ctx)
-		return rdr, c.clusterName, err
+	if c.gke {
+		return c.getGKEKubeConfg(ctx)
 	}
+	if c.aks {
+		return c.getAKSKubeConfg(ctx)
+	}
+	rdr, err := getStdinPipe(ctx)
+	return rdr, c.clusterName, err
+}
+
+func (c *AddCAASCommand) getGKEKubeConfg(ctx *cmd.Context) (io.Reader, string, error) {
 	p := &clusterParams{
 		name:       c.clusterName,
 		region:     c.hostCloudRegion,
 		project:    c.project,
 		credential: c.credential,
 	}
-	// TODO - add support for AKS etc
-	cluster := c.k8sCluster
-	if cluster == nil {
-		cluster = newGKECluster()
-	}
 
 	// If any items are missing, prompt for them.
 	if p.name == "" || p.project == "" || p.region == "" {
 		var err error
-		p, err = cluster.interactiveParams(ctx, p)
+		p, err = c.k8sCluster.interactiveParams(ctx, p)
 		if err != nil {
 			return nil, "", errors.Trace(err)
 		}
 	}
 	c.clusterName = p.name
-	c.hostCloudRegion = cluster.cloud() + "/" + p.region
-	return cluster.getKubeConfig(p)
+	c.hostCloudRegion = c.k8sCluster.cloud() + "/" + p.region
+	return c.k8sCluster.getKubeConfig(p)
+}
+
+func (c *AddCAASCommand) getAKSKubeConfg(ctx *cmd.Context) (io.Reader, string, error) {
+	p := &clusterParams{
+		name:          c.clusterName,
+		resourceGroup: c.resourceGroup,
+	}
+
+	if p.name == "" || p.resourceGroup == "" {
+		var err error
+		p, err = c.k8sCluster.interactiveParams(ctx, p)
+		if err != nil {
+			return nil, "", errors.Trace(err)
+		}
+	}
+	c.clusterName = p.name
+	return c.k8sCluster.getKubeConfig(p)
 }
 
 var clusterQueryErrMsg = `
@@ -477,7 +524,7 @@ func (c *AddCAASCommand) addCloudToControllerWithRegion(apiClient AddCloudAPI, n
 
 func (c *AddCAASCommand) newK8sBrokerGetter() BrokerGetter {
 	return func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
-		// To get a k8s client, we need a config will minimal information.
+		// To get a k8s client, we need a config with minimal information.
 		// It's not used unless operating on a real model but we need to supply it.
 		uuid, err := utils.NewUUID()
 		if err != nil {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -845,3 +845,9 @@ func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
 		},
 	)
 }
+
+func (s *addCAASSuite) TestOnlyOneClusterProvider(c *gc.C) {
+	cmd := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--aks", "--gke")
+	c.Assert(err, gc.ErrorMatches, "only one of '--gke' or '--aks' can be supplied")
+}

--- a/cmd/juju/caas/aks.go
+++ b/cmd/juju/caas/aks.go
@@ -1,0 +1,287 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/cmd/juju/interact"
+)
+
+type aks struct {
+	CommandRunner
+	azExecName string
+}
+
+func newAKSCluster() k8sCluster {
+	return &aks{CommandRunner: &defaultRunner{}}
+}
+
+func (a *aks) cloud() string {
+	return "aks"
+}
+
+func (a *aks) ensureExecutable() error {
+	if a.azExecName != "" {
+		return nil
+	}
+
+	cmd := []string{"which", "az"}
+	err := collapseRunError(runCommand(a, cmd, ""))
+	if err != nil {
+		cmd = []string{"which", "azure-cli"}
+		err := collapseRunError(runCommand(a, cmd, ""))
+		errAnnotationMessage := "neither az or azure-cli (version > 2.0.52) found. Please install, login, and try again"
+		if err != nil {
+			return errors.Annotate(err, errAnnotationMessage)
+		}
+		a.azExecName = "azure-cli"
+	} else {
+		a.azExecName = "az"
+	}
+
+	// check that we are logged in, there is no way to provide login details to a separate command.
+	cmd = []string{a.azExecName, "account", "show"}
+	err = collapseRunError(runCommand(a, cmd, ""))
+	errAnnotationMessage := fmt.Sprintf("please run '%s login' to setup account", a.azExecName)
+	if err != nil {
+		return errors.Annotate(err, errAnnotationMessage)
+	}
+	return nil
+}
+
+func (a *aks) getKubeConfig(p *clusterParams) (io.ReadCloser, string, error) {
+	// 'az aks get-credential' ignores KUBECONFIG env var and instead relies on -f.
+	kubeconfig := clientconfig.GetKubeConfigPath()
+	cmd := []string{
+		a.azExecName, "aks", "get-credentials",
+		"--name", p.name, "--resource-group", p.resourceGroup,
+		"--overwrite-existing",
+		"-f", kubeconfig,
+	}
+
+	err := collapseRunError(runCommand(a, cmd, kubeconfig))
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	reader, err := os.Open(kubeconfig)
+	return reader, p.name, err
+}
+
+func (a *aks) interactiveParams(ctxt *cmd.Context, p *clusterParams) (*clusterParams, error) {
+	errout := interact.NewErrWriter(ctxt.Stdout)
+	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, errout)
+
+	var err error
+	if p.name == "" {
+		p.name, p.resourceGroup, err = a.queryCluster(pollster, p.resourceGroup)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	if p.resourceGroup == "" {
+		clusters, err := a.listNamedClusters(p.name, p.resourceGroup)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		if len(clusters) == 0 {
+			resourceGroupMsg := ""
+			if p.resourceGroup != "" {
+				resourceGroupMsg = fmt.Sprintf(" in resource group %s", p.resourceGroup)
+			}
+			return nil, errors.Errorf(
+				"cluster %q not found%s.\nSee '%s aks create --help'", p.name, resourceGroupMsg, a.azExecName)
+		}
+
+		if len(clusters) == 1 {
+			p.resourceGroup = clusters[0].resourceGroup
+		} else {
+			// we have multiple clusters with the same name but different resource groups
+			p.resourceGroup, err = a.queryResourceGroupsForClusters(pollster, clusters)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+	}
+
+	return p, nil
+}
+
+func (a *aks) queryResourceGroupsForClusters(pollster *interact.Pollster, clusters []cluster) (string, error) {
+	groups, err := a.listResourceGroups(clusters)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(groups) == 0 {
+		return "", errors.New("no resource groups found.\n" +
+			fmt.Sprintf("see '%s group --help'", a.azExecName))
+	}
+
+	var displayResourceGroupOptions []string
+	resourceGroupLookup := make(map[string]string)
+	for _, rg := range groups {
+		displayName := fmt.Sprintf("%s in %s", rg.Name, rg.Location)
+		displayResourceGroupOptions = append(displayResourceGroupOptions, displayName)
+		resourceGroupLookup[displayName] = rg.Name
+	}
+	groupDisplayName, err := pollster.Select(interact.List{
+		Singular: "resource group",
+		Plural:   "Available resource groups",
+		Options:  displayResourceGroupOptions,
+		Default:  displayResourceGroupOptions[0],
+	})
+	group := resourceGroupLookup[groupDisplayName]
+	return group, errors.Trace(err)
+}
+
+type resourceGroupDetails struct {
+	Name     string `json:"name"`
+	Location string `json:"location"`
+}
+
+// will list resource groups used by the passed clusters
+func (a *aks) listResourceGroups(clusters []cluster) ([]resourceGroupDetails, error) {
+	usedRG := set.Strings{}
+	for _, c := range clusters {
+		usedRG.Add(c.resourceGroup)
+	}
+
+	// It seems that any resource group that has a non-null 'managedBy' is a
+	// generated RG i.e. via the creation of the cluster itself.
+	cmd := []string{
+		a.azExecName, "group", "list",
+		"--output", "json",
+		"--query", `"[?properties.provisioningState=='Succeeded']"`,
+	}
+	result, err := runCommand(a, cmd, "")
+	err = collapseRunError(result, err)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var groups []resourceGroupDetails
+	if err := json.Unmarshal(result.Stdout, &groups); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var filteredGroups []resourceGroupDetails
+	for _, group := range groups {
+		if usedRG.Contains(group.Name) {
+			filteredGroups = append(filteredGroups, group)
+		}
+	}
+
+	return filteredGroups, nil
+}
+
+func (a *aks) queryCluster(pollster *interact.Pollster, resourceGroup string) (string, string, error) {
+	allClusters, err := a.listClusters(resourceGroup)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+	if len(allClusters) == 0 {
+		resourceGroupMsg := ""
+		if resourceGroup != "" {
+			resourceGroupMsg = fmt.Sprintf(" in resource group %s", resourceGroup)
+		}
+		return "", "", errors.Errorf(
+			"no clusters have been setup%s.\nSee '%s aks create --help'", resourceGroupMsg, a.azExecName)
+	}
+
+	var clusterNamer func(clusterName, resourceGroupName string) string
+	var clusterNamesAndResourceGroups []string
+	clusterRGLookup := make(map[string]cluster)
+	clusterPluralText := "Available clusters"
+
+	// Display the resource group name if there is more than one in the list
+	// of clusters, otherwise just the cluster name is enough
+	clusterNamer = func(clusterName, resourceGroupName string) string {
+		return clusterName
+	}
+	if resourceGroup == "" {
+		groupsMentioned := set.Strings{}
+		for _, cluster := range allClusters {
+			groupsMentioned.Add(cluster.resourceGroup)
+		}
+		if groupsMentioned.Size() > 1 {
+			clusterNamer = func(clusterName, resourceGroupName string) string {
+				return fmt.Sprintf("%s in resource group %s", clusterName, resourceGroupName)
+			}
+		} else {
+			clusterPluralText = fmt.Sprintf("Available clusters in resource group %s", groupsMentioned.Values()[0])
+		}
+	}
+
+	for _, cluster := range allClusters {
+		namedGroup := clusterNamer(cluster.name, cluster.resourceGroup)
+		clusterNamesAndResourceGroups = append(clusterNamesAndResourceGroups, namedGroup)
+		clusterRGLookup[namedGroup] = cluster
+	}
+	cluster, err := pollster.Select(interact.List{
+		Singular: "cluster",
+		Plural:   clusterPluralText,
+		Options:  clusterNamesAndResourceGroups,
+		Default:  clusterNamesAndResourceGroups[0],
+	})
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+	selected := clusterRGLookup[cluster]
+	return selected.name, selected.resourceGroup, nil
+}
+
+type clusterDetails struct {
+	Name          string `json:"name"`
+	ResourceGroup string `json:"resourceGroup"`
+}
+
+func (a *aks) listClusters(resourceGroup string) ([]cluster, error) {
+	cmd := []string{
+		a.azExecName, "aks", "list",
+		"--output", "json",
+	}
+	if resourceGroup != "" {
+		cmd = append(cmd, "--resource-group", resourceGroup)
+	}
+	result, err := runCommand(a, cmd, "")
+	err = collapseRunError(result, err)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var clusterInfo []clusterDetails
+	if err := json.Unmarshal(result.Stdout, &clusterInfo); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var clusters []cluster
+	for _, ci := range clusterInfo {
+		clusters = append(clusters, cluster{
+			name:          ci.Name,
+			resourceGroup: ci.ResourceGroup,
+		})
+	}
+	return clusters, nil
+}
+
+func (a *aks) listNamedClusters(clusterName, resourceGroup string) ([]cluster, error) {
+	allClusters, err := a.listClusters(resourceGroup)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var namedClusters []cluster
+	for _, c := range allClusters {
+		if c.name == clusterName {
+			namedClusters = append(namedClusters, c)
+		}
+	}
+	return namedClusters, nil
+}

--- a/cmd/juju/caas/aks_test.go
+++ b/cmd/juju/caas/aks_test.go
@@ -1,0 +1,573 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/cmd/juju/caas/mocks"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
+	gc "gopkg.in/check.v1"
+)
+
+type aksSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&aksSuite{})
+
+func (s *aksSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	err := os.Setenv("PATH", "/path/to/here")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *aksSuite) TestGetKubeConfig(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	configFile := filepath.Join(c.MkDir(), "config")
+	err := os.Setenv("KUBECONFIG", configFile)
+	c.Assert(err, jc.ErrorIsNil)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	err = ioutil.WriteFile(configFile, []byte("data"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks get-credentials --name mycluster --resource-group resourceGroup --overwrite-existing -f " + configFile,
+			Environment: []string{"KUBECONFIG=" + configFile, "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code: 0,
+			}, nil),
+	)
+
+	rdr, clusterName, err := aks.getKubeConfig(&clusterParams{
+		name:          "mycluster",
+		resourceGroup: "resourceGroup",
+	})
+	c.Check(err, jc.ErrorIsNil)
+	defer rdr.Close()
+
+	c.Assert(clusterName, gc.Equals, "mycluster")
+	data, err := ioutil.ReadAll(rdr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.DeepEquals, "data")
+}
+
+func (s *aksSuite) TestInteractiveParam(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+	clusterJSONResp := fmt.Sprintf(`
+[
+  {
+    "name": "%s",
+    "resourceGroup": "%s"
+  },
+  {
+    "name": "notThisCluster",
+    "resourceGroup": "notThisRG"
+  }
+]
+`, clusterName, resourceGroup)
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks list --output json",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("mycluster in resource group testRG\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Available Clusters
+  mycluster in resource group testRG
+  notThisCluster in resource group notThisRG
+
+Select cluster [mycluster in resource group testRG]: 
+`[1:]
+
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestInteractiveParamResourceGroupDefined(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+	clusterJSONResp := fmt.Sprintf(`
+[
+  {
+    "name": "%s",
+    "resourceGroup": "%s"
+  }
+]
+`, clusterName, resourceGroup)
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks list --output json --resource-group " + resourceGroup,
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("mycluster\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Available Clusters
+  mycluster
+
+Select cluster [mycluster]: 
+`[1:]
+
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{
+		resourceGroup: resourceGroup,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGroupInUse(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+	clusterJSONResp := fmt.Sprintf(`
+[
+  {
+    "name": "%s",
+    "resourceGroup": "%s"
+  },
+  {
+    "name": "notMeSir",
+    "resourceGroup": "%s"
+  }
+]
+`, clusterName, resourceGroup, resourceGroup)
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks list --output json",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("mycluster\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Available Clusters In Resource Group TestRG
+  mycluster
+  notMeSir
+
+Select cluster [mycluster]: 
+`[1:]
+
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGroupsInUse(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+	clusterJSONResp := fmt.Sprintf(`
+[
+  {
+    "name": "%s",
+    "resourceGroup": "%s"
+  },
+  {
+    "name": "notMeSir",
+    "resourceGroup": "MonsterResourceGroup"
+  }
+]
+`, clusterName, resourceGroup)
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks list --output json",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("mycluster in resource group testRG\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Available Clusters
+  mycluster in resource group testRG
+  notMeSir in resource group MonsterResourceGroup
+
+Select cluster [mycluster in resource group testRG]: 
+`[1:]
+
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecifiedSingleGroupInUse(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+	clusterJSONResp := fmt.Sprintf(`
+[
+  {
+    "name": "%s",
+    "resourceGroup": "%s"
+  },
+  {
+    "name": "notMeCluster",
+    "resourceGroup": "%s"
+  }
+]`, clusterName, resourceGroup, resourceGroup)
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks list --output json",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := ""
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{
+		name: clusterName,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecifiedMultiClusterInUse(c *gc.C) {
+	// If a cluster name is given but there are multiple clusters of that
+	// name in different resource groups the user must be prompted to choose
+	// which of those resource groups is the correct one.
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+	clusterJSONResp := fmt.Sprintf(`
+[
+  {
+    "name": "%s",
+    "resourceGroup": "%s"
+  },
+  {
+    "name": "%s",
+    "resourceGroup": "notMeGroup"
+  },
+  {
+    "name": "notMeCluster",
+    "resourceGroup": "differentRG"
+  }
+]`, clusterName, resourceGroup, clusterName)
+
+	resourcegroupJSONResp := fmt.Sprintf(`
+[
+  {
+    "location": "westus2",
+    "name": "%s"
+  },
+  {
+    "location": "westus2",
+    "name": "notMeGroup"
+  }
+]`, resourceGroup)
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az aks list --output json",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    `az group list --output json --query "[?properties.provisioningState=='Succeeded']"`,
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(resourcegroupJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("testRG in westus2")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Available Resource Groups
+  testRG in westus2
+  notMeGroup in westus2
+
+Select resource group [testRG in westus2]: 
+`[1:]
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{
+		name: clusterName,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestInteractiveParamsClusterSpecifiedResourceGroupSpecified(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{
+		CommandRunner: mockRunner,
+		azExecName:    "az",
+	}
+	resourceGroup := "testRG"
+	clusterName := "mycluster"
+
+	stdin := strings.NewReader("")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := ""
+	outParams, err := aks.interactiveParams(ctx, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:          clusterName,
+		resourceGroup: resourceGroup,
+	})
+}
+
+func (s *aksSuite) TestEnsureExecutablePicksAZ(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{CommandRunner: mockRunner}
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "which az",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(""),
+			}, nil),
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az account show",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(""),
+			}, nil),
+	)
+	err := aks.ensureExecutable()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(aks.azExecName, gc.Equals, "az")
+}
+
+func (s *aksSuite) TestEnsureExecutableTriesSnap(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{CommandRunner: mockRunner}
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "which az",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code: 1,
+			}, nil),
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "which azure-cli",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code: 0,
+			}, nil),
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "azure-cli account show",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(""),
+			}, nil),
+	)
+	err := aks.ensureExecutable()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(aks.azExecName, gc.Equals, "azure-cli")
+}
+
+func (s *aksSuite) TestEnsureExecutableRemembersFindings(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	aks := &aks{CommandRunner: mockRunner}
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "which az",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code: 0,
+			}, nil),
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "az account show",
+			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+		}).Times(1).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(""),
+			}, nil),
+	)
+	err := aks.ensureExecutable()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(aks.azExecName, gc.Equals, "az")
+	// 2nd run shouldn't call anything
+	err = aks.ensureExecutable()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(aks.azExecName, gc.Equals, "az")
+}

--- a/cmd/juju/caas/cluster.go
+++ b/cmd/juju/caas/cluster.go
@@ -37,6 +37,9 @@ func collapseRunError(result *exec.ExecResponse, err error) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if result == nil {
+		return nil
+	}
 	if result.Code != 0 {
 		return errors.New(string(result.Stderr))
 	}

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -75,6 +75,10 @@ func (f *fakeCluster) cloud() string {
 	return f.cloudType
 }
 
+func (f *fakeCluster) ensureExecutable() error {
+	return nil
+}
+
 func FakeCluster(config string) k8sCluster {
 	return &fakeCluster{config: config, cloudType: "gce"}
 }

--- a/cmd/juju/caas/gke.go
+++ b/cmd/juju/caas/gke.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/utils/exec"
 
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cmd/juju/interact"
@@ -30,12 +29,8 @@ func (g *gke) cloud() string {
 }
 
 func (g *gke) ensureExecutable() error {
-	path := getEnv("path")
-	checkParams := exec.RunParams{
-		Commands:    "which gcloud",
-		Environment: []string{"PATH=" + path},
-	}
-	err := collapseRunError(exec.RunCommands(checkParams))
+	cmd := []string{"which", "gcloud"}
+	err := collapseRunError(runCommand(g, cmd, ""))
 	errAnnotationMessage := "gcloud command not found, please 'snap install gcloud' then try again"
 	if err != nil {
 		return errors.Annotate(err, errAnnotationMessage)


### PR DESCRIPTION
## Description of change

Ability to add AKS cluster as K8s cloud using interactive prompts or command
arguments.

## QA steps

Create an AKS cluster (either via the web UI or the cli tool), run ```az login``` then run:
    ```juju add-k8s --aks``` (or use any of the provided arguments as per help text.

## Documentation changes

Help text updated.

## Bug reference

n/a