### PR TITLE
Merge pull request #9893 from wallyworld/k8s-image-repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,14 @@ operator-image: install caas/jujud-operator-dockerfile caas/jujud-operator-requi
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
-	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
+	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG} ${JUJUD_STAGING_DIR}
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
-	docker push ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG}
+	docker push ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
 
 microk8s-operator-update: operator-image
-	docker save ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} | microk8s.docker load
+	docker save ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG} | microk8s.docker load
 
 check-k8s-model:
 	@:$(if $(value JUJU_K8S_MODEL),, $(error Undefined JUJU_K8S_MODEL))
@@ -163,9 +163,9 @@ check-k8s-model:
 
 local-operator-update: check-k8s-model operator-image
 	$(eval kubeworkers != juju status -m ${JUJU_K8S_MODEL} kubernetes-worker --format json | jq -c '.machines | keys' | tr  -c '[:digit:]' ' ' 2>&1)
-	docker save ${DOCKER_USERNAME}/caas-jujud-operator:${OPERATOR_IMAGE_TAG} | gzip > /tmp/caas-jujud-operator-image.tar.gz
-	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/caas-jujud-operator-image.tar.gz $(wm):/tmp/caas-jujud-operator-image.tar.gz ; )
-	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/caas-jujud-operator-image.tar.gz | docker load" ; )
+	docker save ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG} | gzip > /tmp/jujud-operator-image.tar.gz
+	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/jujud-operator-image.tar.gz $(wm):/tmp/jujud-operator-image.tar.gz ; )
+	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/jujud-operator-image.tar.gz | docker load" ; )
 
 .PHONY: build check install release-install release-build go-build go-install
 .PHONY: clean format simplify

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -27,7 +27,7 @@ type mockState struct {
 	model              *mockModel
 	applicationWatcher *mockStringsWatcher
 	app                *mockApplication
-	operatorImage      string
+	operatorRepo       string
 }
 
 func newMockState() *mockState {
@@ -51,7 +51,7 @@ func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
 
 func (st *mockState) ControllerConfig() (controller.Config, error) {
 	cfg := coretesting.FakeControllerConfig()
-	cfg[controller.CAASOperatorImagePath] = st.operatorImage
+	cfg[controller.CAASImageRepo] = st.operatorRepo
 	return cfg, nil
 }
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -4,8 +4,6 @@
 package caasoperatorprovisioner
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -97,12 +96,9 @@ func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error
 		return params.OperatorProvisioningInfo{}, err
 	}
 
-	imagePath := cfg.CAASOperatorImagePath()
 	vers := version.Current
 	vers.Build = 0
-	if imagePath == "" {
-		imagePath = fmt.Sprintf("%s/caas-jujud-operator:%s", "jujusolutions", vers.String())
-	}
+	imagePath := podcfg.GetJujuOCIImagePath(cfg, vers)
 	charmStorageParams, err := charmStorageParams(a.storagePoolManager, a.storageProviderRegistry)
 	if err != nil {
 		return params.OperatorProvisioningInfo{}, errors.Annotatef(err, "getting operator storage parameters")

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -125,7 +125,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    fmt.Sprintf("jujusolutions/caas-jujud-operator:%s", version.Current.String()),
+		ImagePath:    fmt.Sprintf("jujusolutions/jujud-operator:%s", version.Current.String()),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
@@ -143,11 +143,11 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 }
 
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
-	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	s.st.operatorRepo = "somerepo"
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    s.st.operatorImage,
+		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + version.Current.String(),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
@@ -166,11 +166,11 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
-	s.st.operatorImage = "jujusolutions/caas-jujud-operator"
+	s.st.operatorRepo = "somerepo"
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    s.st.operatorImage,
+		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + version.Current.String(),
 		Version:      version.Current,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -323,14 +323,14 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
 		"juju-operator": "gitlab",
 	}
-	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/caas-jujud-operator", "2.99.0", tags)
+	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", tags)
 	c.Assert(pod.Name, gc.Equals, "gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
 		"juju-operator": "gitlab",
 		"juju-version":  "2.99.0",
 	})
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
-	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/caas-jujud-operator")
+	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/jujud-operator")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 1)
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/template-agent.conf")
 }

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -4,6 +4,7 @@
 package podcfg
 
 import (
+	"fmt"
 	"net"
 	"path"
 	"strconv"
@@ -24,6 +25,11 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.cloudconfig.podcfg")
+
+const (
+	jujudOCINamespace = "jujusolutions"
+	jujudOCIName      = "jujud-operator"
+)
 
 // ControllerPodConfig represents initialization information for a new juju caas controller pod.
 type ControllerPodConfig struct {
@@ -196,6 +202,20 @@ func (cfg *ControllerPodConfig) VerifyConfig() (err error) {
 		}
 	}
 	return nil
+}
+
+// GetJujuOCIImagePath returns the jujud oci image path.
+func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) string {
+	// First check the deprecated "caas-operator-image-path" config.
+	imagePath := controllerCfg.CAASOperatorImagePath()
+	if imagePath != "" {
+		return imagePath
+	}
+	imageRepo := controllerCfg.CAASImageRepo()
+	if imageRepo == "" {
+		imageRepo = jujudOCINamespace
+	}
+	return fmt.Sprintf("%s/%s:%s", imageRepo, jujudOCIName, ver.String())
 }
 
 func (cfg *ControllerPodConfig) verifyBootstrapConfig() (err error) {

--- a/controller/config.go
+++ b/controller/config.go
@@ -227,7 +227,12 @@ const (
 
 	// CAASOperatorImagePath sets the url of the docker image
 	// used for the application operator.
+	// Deprecated: use CAASImageRepo
 	CAASOperatorImagePath = "caas-operator-image-path"
+
+	// CAASImageRepo sets the docker repo to use
+	// for the jujud operator and mongo images.
+	CAASImageRepo = "caas-image-repo"
 
 	// Features allows a list of runtime changeable features to be updated.
 	Features = "features"
@@ -269,6 +274,7 @@ var (
 		AuditLogMaxBackups,
 		AuditLogExcludeMethods,
 		CAASOperatorImagePath,
+		CAASImageRepo,
 		Features,
 		MeteringURL,
 	}
@@ -293,6 +299,7 @@ var (
 		JujuHASpace,
 		JujuManagementSpace,
 		CAASOperatorImagePath,
+		CAASImageRepo,
 		Features,
 	)
 
@@ -630,6 +637,12 @@ func (c Config) CAASOperatorImagePath() string {
 	return c.asString(CAASOperatorImagePath)
 }
 
+// CAASImageRepo sets the url of the docker repo
+// used for the jujud operator and mongo images.
+func (c Config) CAASImageRepo() string {
+	return c.asString(CAASImageRepo)
+}
+
 // MeteringURL returns the URL to use for metering api calls.
 func (c Config) MeteringURL() string {
 	url := c.asString(MeteringURL)
@@ -712,7 +725,13 @@ func Validate(c Config) error {
 		return errors.Trace(err)
 	}
 
-	if v, ok := c[CAASOperatorImagePath].(string); ok {
+	if v, ok := c[CAASOperatorImagePath].(string); ok && v != "" {
+		if err := resources.ValidateDockerRegistryPath(v); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	if v, ok := c[CAASImageRepo].(string); ok && v != "" {
 		if err := resources.ValidateDockerRegistryPath(v); err != nil {
 			return errors.Trace(err)
 		}
@@ -853,6 +872,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	JujuHASpace:             schema.String(),
 	JujuManagementSpace:     schema.String(),
 	CAASOperatorImagePath:   schema.String(),
+	CAASImageRepo:           schema.String(),
 	Features:                schema.List(schema.String()),
 	CharmStoreURL:           schema.String(),
 	MeteringURL:             schema.String(),
@@ -883,6 +903,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	JujuHASpace:             schema.Omit,
 	JujuManagementSpace:     schema.Omit,
 	CAASOperatorImagePath:   schema.Omit,
+	CAASImageRepo:           schema.Omit,
 	Features:                schema.Omit,
 	CharmStoreURL:           csclient.ServerURL,
 	MeteringURL:             romulus.DefaultAPIRoot,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -189,45 +189,45 @@ var validateTests = []struct {
 	},
 	expectError: `invalid audit log exclude methods: should be a list of "Facade.Method" names \(or "ReadOnlyMethods"\), got "Sharon Jones" at position 3`,
 }, {
-	about: "invalid CAAS operator docker image path",
+	about: "invalid CAAS docker image repo",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo?bar",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo?bar",
 	},
 	expectError: `docker image path "foo\?bar" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - leading colon",
+	about: "invalid CAAS operator docker image repo - leading colon",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: ":foo",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: ":foo",
 	},
 	expectError: `docker image path ":foo" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - trailing colon",
+	about: "invalid CAAS docker image repo - trailing colon",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo:",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo:",
 	},
 	expectError: `docker image path "foo:" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - extra colon",
+	about: "invalid CAAS docker image repo - extra colon",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo::bar",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo::bar",
 	},
 	expectError: `docker image path "foo::bar" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - leading /",
+	about: "invalid CAAS docker image repo - leading /",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "/foo",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "/foo",
 	},
 	expectError: `docker image path "/foo" not valid`,
 }, {
-	about: "invalid CAAS operator docker image path - extra /",
+	about: "invalid CAAS docker image repo - extra /",
 	config: controller.Config{
-		controller.CACertKey:             testing.CACert,
-		controller.CAASOperatorImagePath: "foo//bar",
+		controller.CACertKey:     testing.CACert,
+		controller.CAASImageRepo: "foo//bar",
 	},
 	expectError: `docker image path "foo//bar" not valid`,
 }, {
@@ -498,25 +498,22 @@ func (s *ConfigSuite) TestConfigNoSpacesNilSpaceConfigPreserved(c *gc.C) {
 	c.Check(cfg.AsSpaceConstraints(nil), gc.IsNil)
 }
 
-func (s *ConfigSuite) TestCAASOperatorImagePath(c *gc.C) {
-	for _, imagePath := range []string{
-		"juju-operator-image",
-		"registry.foo.com/juju-operator-image",
-		"registry.foo.com/me/juju-operator-image",
-		"juju-operator-image:latest",
-		"juju-operator-image:2.4-beta1",
-		"registry.foo.com/juju-operator-image:2.4-beta1",
-		"registry.foo.com/me/juju-operator-image:2.4-beta1",
+func (s *ConfigSuite) TestCAASImageRepo(c *gc.C) {
+	for _, imageRepo := range []string{
+		"", //used to reset since we don't have a --reset option
+		"juju-operator-repo",
+		"registry.foo.com",
+		"registry.foo.com/me",
 	} {
 		cfg, err := controller.NewConfig(
 			testing.ControllerTag.Id(),
 			testing.CACert,
 			map[string]interface{}{
-				controller.CAASOperatorImagePath: imagePath,
+				controller.CAASImageRepo: imageRepo,
 			},
 		)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(cfg.CAASOperatorImagePath(), gc.Equals, imagePath)
+		c.Assert(cfg.CAASImageRepo(), gc.Equals, imageRepo)
 	}
 }
 

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -43,6 +43,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxLogsSize,
 		controller.MaxLogsAge,
 		controller.CAASOperatorImagePath,
+		controller.CAASImageRepo,
 		controller.CharmStoreURL,
 		controller.Features,
 		controller.MeteringURL,


### PR DESCRIPTION
## Description of change

Backport https://github.com/juju/juju/pull/9893

The jujud operator docker image is renamed to jujud-operator.
The controller config option to override the jujud operator image is deprecated in favour of an option to set the repo, from which the jujud-operator image is fetched.

## QA steps

juju bootstrap on k8s
