### PR TITLE
k8s bootstrap uses operator-storage from cloud

### DIFF
--- a/acceptancetests/assess_bootstrap.py
+++ b/acceptancetests/assess_bootstrap.py
@@ -80,7 +80,7 @@ def get_controller_hostname(client):
 
 
 def assess_to(bs_manager, to):
-    """Assess bootstraping with the --to option."""
+    """Assess bootstrapping with the --to option."""
     if to is None:
         raise ValueError('--to not given when testing to')
     with thin_booted_context(bs_manager) as client:

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -147,7 +147,7 @@ type Broker interface {
 	// arguments before recording them in state.
 	environs.InstancePrechecker
 
-	// BootstrapEnviron defines methods for bootstraping a controller.
+	// BootstrapEnviron defines methods for bootstrapping a controller.
 	environs.BootstrapEnviron
 
 	// ResourceAdopter defines methods for adopting resources.

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -53,8 +53,8 @@ func (cs controllerStack) GetStorageSize() resource.Quantity {
 	return cs.storageSize
 }
 
-func NewcontrollerStackForTest(stackName string, broker caas.Broker, pcfg *podcfg.ControllerPodConfig) (ControllerStackerForTest, error) {
-	cs, err := newcontrollerStack(stackName, broker.(*kubernetesClient), pcfg)
+func NewcontrollerStackForTest(stackName, storageClass string, broker caas.Broker, pcfg *podcfg.ControllerPodConfig) (ControllerStackerForTest, error) {
+	cs, err := newcontrollerStack(stackName, storageClass, broker.(*kubernetesClient), pcfg)
 	return cs.(controllerStack), err
 }
 

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -113,22 +113,18 @@ func PrepareController(
 		return nil
 	}
 
+	var env environs.BootstrapEnviron
 	if isCAASController {
 		details.ModelType = model.CAAS
-		if err := do(); err != nil {
-			return nil, errors.Trace(err)
-		}
-		return caas.Open(p, environs.OpenParams{Cloud: args.Cloud, Config: cfg})
+		env, err = caas.Open(p, environs.OpenParams{Cloud: args.Cloud, Config: cfg})
+	} else {
+		details.ModelType = model.IAAS
+		env, err = environs.Open(p, environs.OpenParams{Cloud: args.Cloud, Config: cfg})
 	}
-
-	details.ModelType = model.IAAS
-	env, err := environs.Open(p, environs.OpenParams{
-		Cloud:  args.Cloud,
-		Config: cfg,
-	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	if err := env.PrepareForBootstrap(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -265,8 +265,8 @@ type ConfigSetter interface {
 	SetConfig(cfg *config.Config) error
 }
 
-// Bootstraper provides the way for bootstrapping controller.
-type Bootstraper interface {
+// Bootstrapper provides the way for bootstrapping controller.
+type Bootstrapper interface {
 	// This will be called very early in the bootstrap procedure, to
 	// give an Environ a chance to perform interactive operations that
 	// are required for bootstrapping.
@@ -298,7 +298,7 @@ type Configer interface {
 // in order to bootstrap a controller.
 type BootstrapEnviron interface {
 	Configer
-	Bootstraper
+	Bootstrapper
 	ConstraintsChecker
 	ControllerDestroyer
 


### PR DESCRIPTION
## Description of change

When bootstrapping on k8s, the add-k8s command ensures there is operator storage defined in the cloud config. The bootstrap process will use this storage instead of looking for a cluster default. The storage is validating to ensure it exists.

Also fix PrepareController() as there is no functional difference between caas and iaas. cass now implemented PrepareBootstrap()

## QA steps

juju add-k8s
juju bootstrap
