### PR TITLE
2.5 - Ensure Synchronous KVM Image Acquisition

### DIFF
--- a/container/kvm/interface.go
+++ b/container/kvm/interface.go
@@ -30,6 +30,10 @@ type Container interface {
 	// Name returns the name of the container.
 	Name() string
 
+	// EnsureCachedImage ensures that a container image suitable for satisfying
+	// the input start parameters has been cached on disk.
+	EnsureCachedImage(params StartParams) error
+
 	// Start runs the container as a daemon.
 	Start(params StartParams) error
 

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -111,7 +112,7 @@ func NewContainerManager(conf container.ManagerConfig) (container.Manager, error
 	conf.WarnAboutUnused()
 	return &containerManager{
 		namespace:        namespace,
-		logdir:           logDir,
+		logDir:           logDir,
 		availabilityZone: availabilityZone,
 		imageMetadataURL: imageMetaDataURL,
 		imageStream:      imageStream,
@@ -124,10 +125,11 @@ func NewContainerManager(conf container.ManagerConfig) (container.Manager, error
 // from the correct location.
 type containerManager struct {
 	namespace        instance.Namespace
-	logdir           string
+	logDir           string
 	availabilityZone string
 	imageMetadataURL string
 	imageStream      string
+	imageMutex       sync.Mutex
 }
 
 var _ container.Manager = (*containerManager)(nil)
@@ -156,7 +158,7 @@ func (manager *containerManager) CreateContainer(
 
 	defer func() {
 		if err != nil {
-			callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+			_ = callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
 		}
 	}()
 
@@ -213,14 +215,25 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, errors.Annotate(err, "failed to parse hardware")
 	}
 
-	callback(status.Provisioning, "Creating container; it might take some time", nil)
+	_ = callback(status.Provisioning, "Creating container; it might take some time", nil)
 	logger.Tracef("create the container, constraints: %v", cons)
+
+	// Lock around finding an image.
+	// The provisioner works concurrently to create containers.
+	// If an image needs to be copied from a remote, we don't many goroutines
+	// attempting to do it at once.
+	manager.imageMutex.Lock()
+	err = kvmContainer.EnsureCachedImage(startParams)
+	manager.imageMutex.Unlock()
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "acquiring container image")
+	}
+
 	if err := kvmContainer.Start(startParams); err != nil {
-		err = errors.Annotate(err, "kvm container creation failed")
-		return nil, nil, err
+		return nil, nil, errors.Annotate(err, "kvm container creation failed")
 	}
 	logger.Tracef("kvm container created")
-	callback(status.Running, "Container started", nil)
+	_ = callback(status.Running, "Container started", nil)
 	return &kvmInstance{kvmContainer, name}, &hardware, nil
 }
 
@@ -254,14 +267,14 @@ func (manager *containerManager) ListContainers() (result []instance.Instance, e
 		return
 	}
 	managerPrefix := manager.namespace.Prefix()
-	for _, container := range containers {
+	for _, c := range containers {
 		// Filter out those not starting with our name.
-		name := container.Name()
+		name := c.Name()
 		if !strings.HasPrefix(name, managerPrefix) {
 			continue
 		}
-		if container.IsRunning() {
-			result = append(result, &kvmInstance{container, name})
+		if c.IsRunning() {
+			result = append(result, &kvmInstance{c, name})
 		}
 	}
 	return

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -96,19 +96,19 @@ func (s *KVMSuite) TestListMatchesRunningContainers(c *gc.C) {
 }
 
 func (s *KVMSuite) TestCreateContainer(c *gc.C) {
-	instance := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
-	name := string(instance.Id())
+	inst := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
+	name := string(inst.Id())
 	cloudInitFilename := filepath.Join(s.ContainerDir, name, "cloud-init")
 	containertesting.AssertCloudInit(c, cloudInitFilename)
 }
 
 func (s *KVMSuite) TestDestroyContainer(c *gc.C) {
-	instance := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
+	inst := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
 
-	err := s.manager.DestroyContainer(instance.Id())
+	err := s.manager.DestroyContainer(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	name := string(instance.Id())
+	name := string(inst.Id())
 	// Check that the container dir is no longer in the container dir
 	c.Assert(filepath.Join(s.ContainerDir, name), jc.DoesNotExist)
 	// but instead, in the removed container dir
@@ -179,7 +179,9 @@ func (s *KVMSuite) TestStartContainerUtilizesSimpleStream(c *gc.C) {
 		ImageDownloadURL: "mocked-url",
 	}
 	mockedContainer := kvm.NewEmptyKvmContainer()
-	mockedContainer.Start(startParams)
+
+	// We are testing only the logging side-effect, so the error is ignored.
+	_ = mockedContainer.EnsureCachedImage(startParams)
 
 	expectedArgs := fmt.Sprintf(
 		"synchronise images for %s %s %s %s",
@@ -311,7 +313,7 @@ func (s *ConstraintsSuite) TestDefaults(c *gc.C) {
 		params := kvm.ParseConstraintsToStartParams(cons)
 		c.Check(params, gc.DeepEquals, test.expected)
 		c.Check(tw.Log(), jc.LogMatches, test.infoLog)
-		loggo.RemoveWriter("constraint-tester")
+		_, _ = loggo.RemoveWriter("constraint-tester")
 	}
 }
 

--- a/container/kvm/mock/mock-kvm.go
+++ b/container/kvm/mock/mock-kvm.go
@@ -66,6 +66,10 @@ func (mock *mockContainer) Name() string {
 	return mock.name
 }
 
+func (mock *mockContainer) EnsureCachedImage(params kvm.StartParams) error {
+	return nil
+}
+
 func (mock *mockContainer) Start(params kvm.StartParams) error {
 	if mock.started {
 		return fmt.Errorf("container is already running")

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/os/series"
@@ -39,7 +39,7 @@ type Oner interface {
 
 // syncParams conveys the information necessary for calling imagedownloads.One.
 type syncParams struct {
-	arch, series, stream, ftype string
+	arch, series, stream, fType string
 	srcFunc                     func() simplestreams.DataSource
 }
 
@@ -48,24 +48,24 @@ func (p syncParams) One() (*imagedownloads.Metadata, error) {
 	if err := p.exists(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return imagedownloads.One(p.arch, p.series, p.stream, p.ftype, p.srcFunc)
+	return imagedownloads.One(p.arch, p.series, p.stream, p.fType, p.srcFunc)
 }
 
 func (p syncParams) exists() error {
-	fname := backingFileName(p.series, p.arch)
+	fName := backingFileName(p.series, p.arch)
 	baseDir, err := paths.DataDir(series.MustHostSeries())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	path := filepath.Join(baseDir, kvm, guestDir, fname)
+	imagePath := filepath.Join(baseDir, kvm, guestDir, fName)
 
-	if _, err := os.Stat(path); err == nil {
-		return errors.AlreadyExistsf("%q %q image for exists at %q", p.series, p.arch, path)
+	if _, err := os.Stat(imagePath); err == nil {
+		return errors.AlreadyExistsf("%q %q image for exists at %q", p.series, p.arch, imagePath)
 	}
 	return nil
 }
 
-// Validate that our types fulfull their implementations.
+// Validate that our types fulfill their implementations.
 var _ Oner = (*syncParams)(nil)
 var _ Fetcher = (*fetcher)(nil)
 
@@ -119,7 +119,7 @@ func (f *fetcher) Close() {
 type ProgressCallback func(message string)
 
 // Sync updates the local cached images by reading the simplestreams data and
-// caching if an image matching the contrainsts doesn't exist. It retrieves
+// caching if an image matching the constraints doesn't exist. It retrieves
 // metadata information from Oner and updates local cache via Fetcher.
 // A ProgressCallback can optionally be passed which will get update messages
 // as data is copied.
@@ -164,7 +164,7 @@ type progressWriter struct {
 	clock       clock.Clock
 }
 
-var _ (io.Writer) = (*progressWriter)(nil)
+var _ io.Writer = (*progressWriter)(nil)
 
 func (p *progressWriter) Write(content []byte) (n int, err error) {
 	if p.clock == nil {


### PR DESCRIPTION
## Description of change

This patch ensures that parallel provisioning of KVM machines on a single host does not attempt to sync the same backing image to disk multiple times concurrently.

The change involves separating the sync logic from the `Start()` method and calling this separately in the manager, protected by a lock.

The implementation is not ideal - a more elegant solution was abandoned due to the upheaval it caused in the test suite. Ideally this manager would undergo a significant re-write, but we defer to pragmatism.

## QA steps

- Bootstrap to where hosts support KVMs (I used GUIMAAS).
- `juju add-machine`
- `juju deploy redis -n 5 --to kvm:0,kvm:0,kvm:0,kvm:0,kvm:0`
- `watch -c juju status --color`
Observe that only one of the pending machines downloads the image, then all others come up afterwards.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1816170
