### PR TITLE
Issue error for setcharm

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2247,9 +2247,6 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 	if profiler, ok := p.Charm.(charm.LXDProfiler); ok {
 		return profiler.LXDProfile()
 	}
-	if profiler, ok := p.Charm.(lxdprofile.LXDProfiler); ok {
-		return profiler.LXDProfile()
-	}
 	return nil
 }
 
@@ -2289,7 +2286,6 @@ func validateAgentVersions(application Application, cfgAgentVersion ModelConfig)
 		// Check first to see if we have a agent version from the model config.
 		// If we don't have that, then fall back to the agents.
 		cfgVersion, ok := cfgAgentVersion.AgentVersion()
-		fmt.Println(">>", cfgVersion)
 		if ok {
 			if cfgVersion.Compare(epoch) < 0 {
 				return ErrInvalidAgentVersions

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -882,7 +882,7 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 		}
 		// Check to see if an agent version has been found first, before trying
 		// to compare against a zero'd number
-		if noAgentVersion || agentVer.Compare(epoch) > 0 {
+		if noAgentVersion || agentVer.Compare(epoch) >= 0 {
 			units, err := application.AllUnits()
 			if err != nil {
 				return errors.Annotate(err, "cannot retrieve units")
@@ -892,10 +892,10 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 				if err != nil {
 					return errors.Annotate(err, "cannot retrieve unit agent tools")
 				}
-				if unitVer := unitTools.Version; unitVer.Compare(epoch) <= 0 {
+				if unitVer := unitTools.Version; unitVer.Compare(epoch) < 0 {
 					return errors.Errorf(
-						"Unable to upgrade LXDProfile charms with the current version. "+
-							"Please upgrade to greater than %q", epoch)
+						"Unable to upgrade LXDProfile charms with the current model version. " +
+							"Please run juju upgrade-juju to upgrade the current model to match your controller.")
 				}
 			}
 		}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -370,8 +370,8 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 	s.backend.CheckCallNames(c, "Application", "Charm")
 	s.backend.charm.CheckCallNames(c, "LXDProfile", "Config")
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "SetCharmProfile", "AgentTools", "SetCharm")
-	app.CheckCall(c, 0, "SetCharmProfile", "cs:postgresql")
+	app.CheckCallNames(c, "AgentTools", "SetCharmProfile", "SetCharm")
+	app.CheckCall(c, 1, "SetCharmProfile", "cs:postgresql")
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm:          &state.Charm{},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
@@ -394,7 +394,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 
 	s.backend.CheckCallNames(c, "Application", "Charm")
 	app := s.backend.applications["redis"]
-	app.CheckCallNames(c, "SetCharmProfile", "AgentTools")
+	app.CheckCallNames(c, "AgentTools")
 }
 
 func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
@@ -29,11 +30,13 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
 )
 
 type ApplicationSuite struct {
@@ -84,6 +87,20 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.JujuOSEnvSuite.SetUpTest(c)
+	agentTools := &tools.Tools{
+		Version: version.Binary{
+			Number: version.Number{Major: 2, Minor: 6, Patch: 0},
+			Series: "Bionic",
+			Arch:   "x86",
+		},
+	}
+	olderAgentTools := &tools.Tools{
+		Version: version.Binary{
+			Number: version.Number{Major: 2, Minor: 5, Patch: 1},
+			Series: "Bionic",
+			Arch:   "x86",
+		},
+	}
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("admin"),
 	}
@@ -113,14 +130,16 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 				},
 				units: []*mockUnit{
 					{
-						name:      "postgresql/0",
-						tag:       names.NewUnitTag("postgresql/0"),
-						machineId: "machine-0",
+						name:       "postgresql/0",
+						tag:        names.NewUnitTag("postgresql/0"),
+						machineId:  "machine-0",
+						agentTools: agentTools,
 					},
 					{
-						name:      "postgresql/1",
-						tag:       names.NewUnitTag("postgresql/1"),
-						machineId: "machine-1",
+						name:       "postgresql/1",
+						tag:        names.NewUnitTag("postgresql/1"),
+						machineId:  "machine-1",
+						agentTools: agentTools,
 					},
 				},
 				addedUnit: mockUnit{
@@ -132,6 +151,7 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 				bindings: map[string]string{
 					"juju-info": "myspace",
 				},
+				agentTools: agentTools,
 			},
 			"postgresql-subordinate": {
 				name:        "postgresql-subordinate",
@@ -147,8 +167,14 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 					meta: &charm.Meta{Name: "charm-postgresql-subordinate"},
 				},
 				units: []*mockUnit{
-					{tag: names.NewUnitTag("postgresql-subordinate/0")},
-					{tag: names.NewUnitTag("postgresql-subordinate/1")},
+					{
+						tag:        names.NewUnitTag("postgresql-subordinate/0"),
+						agentTools: agentTools,
+					},
+					{
+						tag:        names.NewUnitTag("postgresql-subordinate/1"),
+						agentTools: agentTools,
+					},
 				},
 				addedUnit: mockUnit{
 					tag: names.NewUnitTag("postgresql-subordinate/99"),
@@ -156,6 +182,45 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 				lxdProfileUpgradeChanges: make(chan struct{}),
 				constraints:              constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 				channel:                  csparams.DevelopmentChannel,
+				agentTools:               agentTools,
+			},
+			"redis": {
+				name:        "redis",
+				series:      "quantal",
+				subordinate: false,
+				charm: &mockCharm{
+					config: &charm.Config{
+						Options: map[string]charm.Option{
+							"stringOption": {Type: "string"},
+							"intOption":    {Type: "int", Default: int(123)},
+						},
+					},
+					meta: &charm.Meta{Name: "charm-redis"},
+				},
+				units: []*mockUnit{
+					{
+						name:       "redis/0",
+						tag:        names.NewUnitTag("redis/0"),
+						machineId:  "machine-0",
+						agentTools: olderAgentTools,
+					},
+					{
+						name:       "redis/1",
+						tag:        names.NewUnitTag("redis/1"),
+						machineId:  "machine-1",
+						agentTools: olderAgentTools,
+					},
+				},
+				addedUnit: mockUnit{
+					tag: names.NewUnitTag("redis/99"),
+				},
+				lxdProfileUpgradeChanges: make(chan struct{}),
+				constraints:              constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
+				channel:                  csparams.DevelopmentChannel,
+				bindings: map[string]string{
+					"juju-info": "myspace",
+				},
+				agentTools: agentTools,
 			},
 		},
 		remoteApplications: map[string]application.RemoteApplication{
@@ -280,6 +345,43 @@ postgresql:
 		Charm:          &state.Charm{},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
+}
+
+func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) {
+	s.SetFeatureFlags(feature.InstanceMutater)
+
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "postgresql",
+		CharmURL:        "cs:postgresql",
+		ConfigSettings:  map[string]string{"stringOption": "value"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "Application", "Charm")
+	s.backend.charm.CheckCallNames(c, "Config")
+	app := s.backend.applications["postgresql"]
+	app.CheckCallNames(c, "AgentTools", "AllUnits", "SetCharmProfile", "SetCharm")
+	// We don't care about 0, 1 calls, as they take no arguments.
+	app.CheckCall(c, 2, "SetCharmProfile", "cs:postgresql")
+	app.CheckCall(c, 3, "SetCharm", state.SetCharmConfig{
+		Charm:          &state.Charm{},
+		ConfigSettings: charm.Settings{"stringOption": "value"},
+	})
+}
+
+func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
+	s.SetFeatureFlags(feature.InstanceMutater)
+
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "redis",
+		CharmURL:        "cs:redis",
+		ConfigSettings:  map[string]string{"stringOption": "value"},
+	})
+	c.Assert(err, gc.ErrorMatches, "Unable to upgrade LXDProfile charms with the current model version. "+
+		"Please run juju upgrade-juju to upgrade the current model to match your controller.")
+
+	s.backend.CheckCallNames(c, "Application")
+	app := s.backend.applications["redis"]
+	app.CheckCallNames(c, "AgentTools", "AllUnits")
 }
 
 func (s *ApplicationSuite) TestDestroyRelation(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -5,7 +5,9 @@ package application
 
 import (
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/tools"
 	"github.com/juju/schema"
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/environschema.v1"
@@ -89,6 +91,7 @@ type Application interface {
 	UpdateApplicationConfig(application.ConfigAttributes, []string, environschema.Fields, schema.Defaults) error
 	SetScale(int) error
 	ChangeScale(int) (int, error)
+	AgentTools() (*tools.Tools, error)
 }
 
 // Charm defines a subset of the functionality provided by the
@@ -137,6 +140,7 @@ type Unit interface {
 	IsPrincipal() bool
 	Life() state.Life
 	Resolve(retryHooks bool) error
+	AgentTools() (*tools.Tools, error)
 
 	AssignedMachineId() (string, error)
 	AssignWithPolicy(state.AssignmentPolicy) error
@@ -154,6 +158,7 @@ type Model interface {
 	Tag() names.Tag
 	Type() state.ModelType
 	ModelConfig() (*config.Config, error)
+	LatestToolsVersion() version.Number
 }
 
 // Resources defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -4,10 +4,7 @@
 package application
 
 import (
-	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/tools"
 	"github.com/juju/schema"
-	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/environschema.v1"
@@ -18,10 +15,12 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/tools"
 )
 
 // Backend defines the state functionality required by the application
@@ -158,7 +157,6 @@ type Model interface {
 	Tag() names.Tag
 	Type() state.ModelType
 	ModelConfig() (*config.Config, error)
-	LatestToolsVersion() version.Number
 }
 
 // Resources defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"github.com/juju/schema"
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/environschema.v1"
@@ -157,6 +158,7 @@ type Model interface {
 	Tag() names.Tag
 	Type() state.ModelType
 	ModelConfig() (*config.Config, error)
+	AgentVersion() (version.Number, error)
 }
 
 // Resources defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/schema"
 	jtesting "github.com/juju/testing"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/environschema.v1"
@@ -454,6 +455,19 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig().Merge(m.cfg)
 	return config.New(config.UseDefaults, attrs)
+}
+
+func (m *mockModel) AgentVersion() (version.Number, error) {
+	m.MethodCall(m, "AgentVersion")
+	cfg, err := m.ModelConfig()
+	if err != nil {
+		return version.Number{}, err
+	}
+	ver, ok := cfg.AgentVersion()
+	if !ok {
+		return version.Number{}, errors.NotFoundf("agent version")
+	}
+	return ver, nil
 }
 
 type mockMachine struct {

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -60,19 +61,25 @@ type mockCharm struct {
 	jtesting.Stub
 
 	charm.Charm
-	config *charm.Config
-	meta   *charm.Meta
+	config     *charm.Config
+	meta       *charm.Meta
+	lxdProfile *charm.LXDProfile
 }
 
-func (m *mockCharm) Meta() *charm.Meta {
-	m.MethodCall(m, "Meta")
-	return m.meta
+func (c *mockCharm) Meta() *charm.Meta {
+	c.MethodCall(c, "Meta")
+	return c.meta
 }
 
 func (c *mockCharm) Config() *charm.Config {
 	c.MethodCall(c, "Config")
 	c.PopNoErr()
 	return c.config
+}
+
+func (c *mockCharm) LXDProfile() lxdprofile.LXDProfile {
+	c.MethodCall(c, "LXDProfile")
+	return c.lxdProfile
 }
 
 type mockApplication struct {

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -76,7 +75,7 @@ func (c *mockCharm) Config() *charm.Config {
 	return c.config
 }
 
-func (c *mockCharm) LXDProfile() lxdprofile.LXDProfile {
+func (c *mockCharm) LXDProfile() *charm.LXDProfile {
 	c.MethodCall(c, "LXDProfile")
 	return c.lxdProfile
 }

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/schema"
 	jtesting "github.com/juju/testing"
 	"github.com/juju/utils"
-	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/environschema.v1"
@@ -426,8 +425,8 @@ func newMockModel() mockModel {
 		cfg: map[string]interface{}{
 			"operator-storage": "k8s-operator-storage",
 			"workload-storage": "k8s-storage",
+			"agent-version":    "2.6.0",
 		},
-		latestToolsVersion: version.Number{Major: 2, Minor: 5, Patch: 0},
 	}
 }
 
@@ -435,10 +434,9 @@ type mockModel struct {
 	application.Model
 	jtesting.Stub
 
-	uuid               string
-	modelType          state.ModelType
-	cfg                map[string]interface{}
-	latestToolsVersion version.Number
+	uuid      string
+	modelType state.ModelType
+	cfg       map[string]interface{}
 }
 
 func (m *mockModel) UUID() string {
@@ -457,11 +455,6 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig().Merge(m.cfg)
 	return config.New(config.UseDefaults, attrs)
-}
-
-func (m *mockModel) LatestToolsVersion() version.Number {
-	m.MethodCall(m, "LatestToolsVersion")
-	return m.latestToolsVersion
 }
 
 type mockMachine struct {

--- a/state/application.go
+++ b/state/application.go
@@ -1208,7 +1208,7 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 					if unitVer := unitTools.Version; unitVer.Compare(epoch) <= 0 {
 						return errors.Errorf(
 							"Unable to upgrade LXDProfile charms with the current version. "+
-								"Please upgrade your unit greater than %s", epoch)
+								"Please upgrade to greater than %q", epoch)
 					}
 				}
 			}

--- a/state/application.go
+++ b/state/application.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/schema"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v3/csclient/params"
@@ -31,6 +32,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/feature"
 	mgoutils "github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/presence"
@@ -1180,6 +1182,40 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 	// we don't need to check that this is a charm.LXDProfiler, as we can
 	// state that the function exists.
 	if profile := cfg.Charm.LXDProfile(); profile != nil {
+		// Check if the controller agent tools version is greater than the
+		// version we support for the new LXD profiles.
+		// Then check all the units, to see what their agent tools versions is
+		// so that we can ensure that everyone is aligned. If the units version
+		// is to low (i.e. less than the 2.5.2 epoch), then show an error
+		// message that the operator should upgrade to receive the latest
+		// LXD Profile changes.
+		if featureflag.Enabled(feature.InstanceMutater) {
+			epoch := version.Number{Major: 2, Minor: 5, Patch: 2}
+			tools, err := a.AgentTools()
+			if err != nil {
+				return errors.Annotate(err, "cannot retrieve agent tools")
+			}
+			if ver := tools.Version; ver.Compare(epoch) > 0 {
+				units, err := a.AllUnits()
+				if err != nil {
+					return errors.Annotate(err, "cannot retrieve units")
+				}
+				for _, unit := range units {
+					unitTools, err := unit.AgentTools()
+					if err != nil {
+						return errors.Annotate(err, "cannot retrieve unit agent tools")
+					}
+					if unitVer := unitTools.Version; unitVer.Compare(epoch) <= 0 {
+						return errors.Errorf(
+							"Unable to upgrade LXDProfile charms with the current version. "+
+								"Please upgrade your unit greater than %s", epoch)
+					}
+				}
+			}
+		}
+
+		// Validate the config devices, to ensure we don't apply an invalid
+		// profile, if we know it's never going to work.
 		if err := profile.ValidateConfigDevices(); err != nil && !cfg.Force {
 			return errors.Annotate(err, "validating lxd profile")
 		}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/state"
@@ -180,126 +179,6 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	cfg := state.SetCharmConfig{
 		Charm:      sch,
 		Force:      true,
-		ForceUnits: true,
-	}
-	err = app.SetCharm(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	ch, force, err = app.Charm()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
-	c.Assert(force, jc.IsTrue)
-	url, force = app.CharmURL()
-	c.Assert(url, gc.DeepEquals, sch.URL())
-	c.Assert(force, jc.IsTrue)
-	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
-}
-
-func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
-	s.SetFeatureFlags(feature.InstanceMutater)
-
-	charm := s.AddTestingCharm(c, "lxd-profile")
-	app := s.AddTestingApplication(c, "lxd-profile", charm)
-	c.Assert(charm.LXDProfile(), gc.NotNil)
-
-	_, err := app.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = app.SetAgentVersion(version.Binary{
-		Number: version.Number{
-			Major: 2,
-			Minor: 6,
-			Patch: 0,
-		},
-		Series: "Xenial",
-		Arch:   "x86",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	units, err := app.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	for _, unit := range units {
-		err := unit.SetAgentVersion(version.Binary{
-			Number: version.Number{
-				Major: 2,
-				Minor: 5,
-				Patch: 1,
-			},
-			Series: "Bionic",
-			Arch:   "x86",
-		})
-		c.Assert(err, jc.ErrorIsNil)
-	}
-
-	ch, force, err := app.Charm()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
-	c.Assert(force, jc.IsFalse)
-	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
-
-	url, force := app.CharmURL()
-	c.Assert(url, gc.DeepEquals, charm.URL())
-	c.Assert(force, jc.IsFalse)
-
-	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
-
-	cfg := state.SetCharmConfig{
-		Charm:      sch,
-		ForceUnits: true,
-	}
-	err = app.SetCharm(cfg)
-	c.Assert(err, gc.ErrorMatches, ".*Unable to upgrade LXDProfile charms with the current version.*")
-}
-
-func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) {
-	s.SetFeatureFlags(feature.InstanceMutater)
-
-	charm := s.AddTestingCharm(c, "lxd-profile")
-	app := s.AddTestingApplication(c, "lxd-profile", charm)
-	c.Assert(charm.LXDProfile(), gc.NotNil)
-
-	_, err := app.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = app.SetAgentVersion(version.Binary{
-		Number: version.Number{
-			Major: 2,
-			Minor: 6,
-			Patch: 0,
-		},
-		Series: "Xenial",
-		Arch:   "x86",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	units, err := app.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	for _, unit := range units {
-		err := unit.SetAgentVersion(version.Binary{
-			Number: version.Number{
-				Major: 2,
-				Minor: 5,
-				Patch: 3,
-			},
-			Series: "Bionic",
-			Arch:   "x86",
-		})
-		c.Assert(err, jc.ErrorIsNil)
-	}
-
-	ch, force, err := app.Charm()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
-	c.Assert(force, jc.IsFalse)
-	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
-
-	url, force := app.CharmURL()
-	c.Assert(url, gc.DeepEquals, charm.URL())
-	c.Assert(force, jc.IsFalse)
-
-	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
-
-	cfg := state.SetCharmConfig{
-		Charm:      sch,
 		ForceUnits: true,
 	}
 	err = app.SetCharm(cfg)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn"
@@ -28,6 +27,8 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
@@ -179,6 +180,126 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	cfg := state.SetCharmConfig{
 		Charm:      sch,
 		Force:      true,
+		ForceUnits: true,
+	}
+	err = app.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	ch, force, err = app.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
+	c.Assert(force, jc.IsTrue)
+	url, force = app.CharmURL()
+	c.Assert(url, gc.DeepEquals, sch.URL())
+	c.Assert(force, jc.IsTrue)
+	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
+}
+
+func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
+	s.SetFeatureFlags(feature.InstanceMutater)
+
+	charm := s.AddTestingCharm(c, "lxd-profile")
+	app := s.AddTestingApplication(c, "lxd-profile", charm)
+	c.Assert(charm.LXDProfile(), gc.NotNil)
+
+	_, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = app.SetAgentVersion(version.Binary{
+		Number: version.Number{
+			Major: 2,
+			Minor: 6,
+			Patch: 0,
+		},
+		Series: "Xenial",
+		Arch:   "x86",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	units, err := app.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, unit := range units {
+		err := unit.SetAgentVersion(version.Binary{
+			Number: version.Number{
+				Major: 2,
+				Minor: 5,
+				Patch: 1,
+			},
+			Series: "Bionic",
+			Arch:   "x86",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	ch, force, err := app.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(force, jc.IsFalse)
+	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
+
+	url, force := app.CharmURL()
+	c.Assert(url, gc.DeepEquals, charm.URL())
+	c.Assert(force, jc.IsFalse)
+
+	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
+
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err = app.SetCharm(cfg)
+	c.Assert(err, gc.ErrorMatches, ".*Unable to upgrade LXDProfile charms with the current version.*")
+}
+
+func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) {
+	s.SetFeatureFlags(feature.InstanceMutater)
+
+	charm := s.AddTestingCharm(c, "lxd-profile")
+	app := s.AddTestingApplication(c, "lxd-profile", charm)
+	c.Assert(charm.LXDProfile(), gc.NotNil)
+
+	_, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = app.SetAgentVersion(version.Binary{
+		Number: version.Number{
+			Major: 2,
+			Minor: 6,
+			Patch: 0,
+		},
+		Series: "Xenial",
+		Arch:   "x86",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	units, err := app.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, unit := range units {
+		err := unit.SetAgentVersion(version.Binary{
+			Number: version.Number{
+				Major: 2,
+				Minor: 5,
+				Patch: 3,
+			},
+			Series: "Bionic",
+			Arch:   "x86",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	ch, force, err := app.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(force, jc.IsFalse)
+	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
+
+	url, force := app.CharmURL()
+	c.Assert(url, gc.DeepEquals, charm.URL())
+	c.Assert(force, jc.IsFalse)
+
+	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
+
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
 		ForceUnits: true,
 	}
 	err = app.SetCharm(cfg)

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -6,6 +6,7 @@ package state
 import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs"
@@ -22,6 +23,20 @@ var disallowedModelConfigAttrs = [...]string{
 // ModelConfig returns the complete config for the model
 func (m *Model) ModelConfig() (*config.Config, error) {
 	return getModelConfig(m.st.db(), m.UUID())
+}
+
+// AgentVersion returns the agent version for the model config.
+// If no agent version is found, it returns NotFound error.
+func (m *Model) AgentVersion() (version.Number, error) {
+	cfg, err := m.ModelConfig()
+	if err != nil {
+		return version.Number{}, errors.Trace(err)
+	}
+	ver, ok := cfg.AgentVersion()
+	if !ok {
+		return version.Number{}, errors.NotFoundf("agent version")
+	}
+	return ver, nil
 }
 
 func getModelConfig(db Database, uuid string) (*config.Config, error) {

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -106,6 +107,23 @@ func (s *ModelConfigSuite) TestModelConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(oldCfg, jc.DeepEquals, cfg)
+}
+
+func (s *ModelConfigSuite) TestAgentVersion(c *gc.C) {
+	attrs := map[string]interface{}{
+		"agent-version": "2.2.3",
+		"arbitrary-key": "shazam!",
+	}
+	ver, err := s.Model.AgentVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ver, gc.DeepEquals, version.Number{Major: 1, Minor: 2, Patch: 3})
+
+	err = s.Model.UpdateModelConfig(attrs, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ver, err = s.Model.AgentVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ver, gc.DeepEquals, version.Number{Major: 2, Minor: 2, Patch: 3})
 }
 
 func (s *ModelConfigSuite) TestComposeNewModelConfig(c *gc.C) {


### PR DESCRIPTION
## Description of change

The following will attempt to throw an error if your controller is
greater than 2.5.2, yet your agents are less than and equal too
2.5.2. This prevents a potential version miss-match of LXDProfile
code attempting to use old code vs the new code. From the very
outset we tell the operator that they should upgrade.

## QA steps

Check out `2.5`:

```
export JUJU_DEV_FEATURE_FLAGS=instance-mutater
juju bootstrap lxd test
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
```

Check out to this branch:

```
juju upgrade-model -m controller --build-agent=true
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
```

This should return the following error:

```
Added charm "local:bionic/lxd-profile-1" to the model.
ERROR Unable to upgrade LXDProfile charms with the current model version. Please run juju upgrade-juju to upgrade the current model to match your controller.
```

To fix this, run the following:

```
juju upgrade-model
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
```

This should succeed!

## Documentation changes

This will prevent upgrading of greater than 2.5.2 from units on 2.5.2
or less, to prevent conflicting code running.

