### PR TITLE
Fix interactive add cloud acceptance test

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -491,9 +491,16 @@ func queryName(
 		return "", err
 	}
 
+	verifyCloudName := func(name string) (bool, string, error) {
+		if names.IsValidCloud(name) {
+			return true, "", nil
+		}
+		return false, "Invalid name. Valid names start with a letter, and use only letters, numbers, hyphens, and underscores: ", nil
+	}
+
 	for {
 		if cloudName == "" {
-			name, err := pollster.Enter(fmt.Sprintf("a name for your %s cloud", cloudType))
+			name, err := pollster.EnterVerify(fmt.Sprintf("a name for your %s cloud", cloudType), verifyCloudName)
 			if err != nil {
 				return "", errors.Trace(err)
 			}


### PR DESCRIPTION
## Description of change

This PR updates `acceptancetest/assess_add_clouds.py` to the command's current behaviour. The relevant sections of the tests have been refactored for simplicity. The PR also adds some extra validation steps in the command itself so that cloud name is a valid name.

## QA steps

- Run `juju add-cloud` and attempt to provide an invalid cloud name, such as one that is prefixed by numbers or one uses characters outside of the `[a-zA-Z_-]` range.

## Documentation changes

Nothing should be required, as the CLI should now match expected behaviour.

For completeness, a new error message is presented during a failed validation check: "Invalid name. Valid names start with a letter, and use only letters, numbers, hyphens, and underscores"

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1641970
- https://bugs.launchpad.net/juju/+bug/1641981