### PR TITLE
Better support for choosing k8s storage for add-k8s

### DIFF
--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -61,6 +62,17 @@ func getCloudRegionFromNodeMeta(node core.Node) (string, string) {
 	return "", ""
 }
 
+func isDefaultStorageClass(sc storage.StorageClass) bool {
+	if v, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && v != "false" {
+		return true
+	}
+	// Older clusters still use the beta annotation.
+	if v, ok := sc.Annotations["storageclass.beta.kubernetes.io/is-default-class"]; ok && v != "false" {
+		return true
+	}
+	return false
+}
+
 // GetClusterMetadata implements ClusterMetadataChecker.
 func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.ClusterMetadata, error) {
 	var result caas.ClusterMetadata
@@ -93,8 +105,14 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 	if err != nil {
 		return nil, errors.Annotate(err, "listing storage classes")
 	}
+
+	var (
+		possibleWorkloadStorage []storage.StorageClass
+		possibleOperatorStorage []*caas.StorageProvisioner
+		defaultOperatorStorage  *caas.StorageProvisioner
+	)
 	for _, sc := range storageClasses.Items {
-		if havePreferredOperatorStorage && result.OperatorStorageClass == nil {
+		if havePreferredOperatorStorage {
 			maybeOperatorStorage := &caas.StorageProvisioner{
 				Name:        sc.Name,
 				Provisioner: sc.Provisioner,
@@ -104,13 +122,16 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 				maybeOperatorStorage.ReclaimPolicy = string(*sc.ReclaimPolicy)
 			}
 			if err := storageClassMatches(preferredOperatorStorage, maybeOperatorStorage); err == nil {
-				result.OperatorStorageClass = maybeOperatorStorage
+				possibleOperatorStorage = append(possibleOperatorStorage, maybeOperatorStorage)
+				if isDefaultStorageClass(sc) {
+					defaultOperatorStorage = maybeOperatorStorage
+				}
 			}
 		}
 		if result.NominatedStorageClass != nil {
 			continue
 		}
-		if v, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && v != "false" {
+		if isDefaultStorageClass(sc) {
 			result.NominatedStorageClass = &caas.StorageProvisioner{
 				Name:        sc.Name,
 				Provisioner: sc.Provisioner,
@@ -120,6 +141,28 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 				result.NominatedStorageClass.ReclaimPolicy = string(*sc.ReclaimPolicy)
 			}
 			break
+		}
+		possibleWorkloadStorage = append(possibleWorkloadStorage, sc)
+	}
+
+	// Prefer operator storage from the default storage class.
+	if defaultOperatorStorage != nil {
+		result.OperatorStorageClass = defaultOperatorStorage
+	} else if len(possibleOperatorStorage) > 0 {
+		result.OperatorStorageClass = possibleOperatorStorage[0]
+	}
+
+	// Even if no storage class was marked as default for the cluster, if there's only
+	// one of them, use it for workload storage.
+	if result.NominatedStorageClass == nil && len(possibleWorkloadStorage) == 1 {
+		sc := possibleWorkloadStorage[0]
+		result.NominatedStorageClass = &caas.StorageProvisioner{
+			Name:        sc.Name,
+			Provisioner: sc.Provisioner,
+			Parameters:  sc.Parameters,
+		}
+		if sc.ReclaimPolicy != nil {
+			result.NominatedStorageClass.ReclaimPolicy = string(*sc.ReclaimPolicy)
 		}
 	}
 	return &result, nil

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -176,14 +176,41 @@ func (s *K8sMetadataSuite) TestNoDefaultStorageClasses(c *gc.C) {
 		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
 			Return(&core.NodeList{}, nil),
 		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{}}}, nil),
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
+				Provisioner: "a-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}}}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "a-provisioner",
+		Parameters:  map[string]string{"foo": "bar"},
+	})
+}
+
+func (s *K8sMetadataSuite) TestNoDefaultStorageClassesTooMany(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{}, nil),
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
+				Provisioner: "a-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}, {
+				Provisioner: "b-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}}}, nil),
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(metadata.NominatedStorageClass, gc.IsNil)
 }
 
-func (s *K8sMetadataSuite) TestDefaultStorageClasses(c *gc.C) {
+func (s *K8sMetadataSuite) TestPreferDefaultStorageClass(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -194,6 +221,34 @@ func (s *K8sMetadataSuite) TestDefaultStorageClasses(c *gc.C) {
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
 				Provisioner: "a-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}, {
+				Provisioner: "b-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}}}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "a-provisioner",
+		Parameters:  map[string]string{"foo": "bar"},
+	})
+}
+
+func (s *K8sMetadataSuite) TestBetaDefaultStorageClass(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{}, nil),
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
+				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.beta.kubernetes.io/is-default-class": "true"}},
+				Provisioner: "a-provisioner",
+				Parameters:  map[string]string{"foo": "bar"},
+			}, {
+				Provisioner: "b-provisioner",
 				Parameters:  map[string]string{"foo": "bar"},
 			}}}, nil),
 	)
@@ -233,6 +288,63 @@ func (s *K8sMetadataSuite) TestUserSpecifiedStorageClasses(c *gc.C) {
 	})
 	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
+	})
+}
+
+func (s *K8sMetadataSuite) TestOperatorStorageClassNoDefault(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
+				Labels: map[string]string{"manufacturer": "amazon_ec2"},
+			}}}}, nil),
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
+				Provisioner: "kubernetes.io/aws-ebs",
+			}, {
+				Provisioner: "kubernetes.io/aws-ebs",
+				Parameters:  map[string]string{"foo": "bar"},
+			}}}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("")
+	c.Check(err, jc.ErrorIsNil)
+	// More than one match so need to be explicit for workload storage.
+	c.Check(metadata.NominatedStorageClass, gc.IsNil)
+	// Take the first match for operator storage.
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "kubernetes.io/aws-ebs",
+	})
+}
+
+func (s *K8sMetadataSuite) TestOperatorStorageClassPrefersDefault(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
+				Labels: map[string]string{"manufacturer": "amazon_ec2"},
+			}}}}, nil),
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
+				Provisioner: "kubernetes.io/aws-ebs",
+			}, {
+				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
+				Provisioner: "kubernetes.io/aws-ebs",
+				Parameters:  map[string]string{"foo": "bar"},
+			}}}, nil),
+	)
+	metadata, err := s.broker.GetClusterMetadata("")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "kubernetes.io/aws-ebs",
+		Parameters:  map[string]string{"foo": "bar"},
+	})
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+		Provisioner: "kubernetes.io/aws-ebs",
+		Parameters:  map[string]string{"foo": "bar"},
 	})
 }
 


### PR DESCRIPTION
## Description of change

When add-k8s selects the storage class to use, it now handles default classes with the beta annotation. It will also use the only matching storage class even if it is not annotated as the default. And if there's any matching storage classes for operator storage, the first will be used, preferring one annotated as the default.

## QA steps

juju add-k8s on various substrates.