### PR TITLE
destroy caas model after all done - backport

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -112,6 +112,7 @@ def assess_caas_charm_deployment(caas_client):
     )
 
     k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
+    k8s_model.destroy_model()
 
 
 def parse_args(argv):


### PR DESCRIPTION
## Description of change

backport https://github.com/juju/juju/pull/9902
destroy-model after CI test passes. 

## QA steps

None

## Documentation changes

None

## Bug reference

None