### PR TITLE
Use local endpoint names for goal state

### DIFF
--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -413,6 +413,16 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 		Machine:     s.machine1,
 	})
 
+	// And add another wordpress.
+	wordpress2 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "wordpress2",
+		Charm: s.wpCharm,
+	})
+	wordpressUnit2 := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: wordpress2,
+		Machine:     s.machine1,
+	})
+
 	mysqlCharm1 := s.Factory.MakeCharm(c, &factory.CharmParams{
 		Name: "mysql",
 	})
@@ -427,6 +437,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 	})
 
 	err := s.addRelationEnterScope(c, s.wordpressUnit, "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.addRelationEnterScope(c, wordpressUnit2, "mysql")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.addRelationEnterScope(c, s.mysqlUnit, "logging")
@@ -446,9 +459,11 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 					Units: expectedUnitMysql,
 					Relations: map[string]params.UnitsGoalState{
 						"server": {
-							"wordpress":   expectedRelationStatus,
-							"wordpress/0": expectedUnitStatus,
-							"wordpress/1": expectedUnitStatus,
+							"wordpress":    expectedRelationStatus,
+							"wordpress/0":  expectedUnitStatus,
+							"wordpress/1":  expectedUnitStatus,
+							"wordpress2":   expectedRelationStatus,
+							"wordpress2/0": expectedUnitStatus,
 						},
 						"juju-info": {
 							"logging":   expectedRelationStatus,

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -200,7 +200,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelation(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expectedUnitMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -233,7 +233,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -254,7 +254,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 						"mysql/0": expectedUnitStatus,
 					},
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -307,7 +307,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -332,7 +332,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 						},
 					},
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -358,7 +358,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesCrossModelRelation(c *gc.C) {
 					"mysql/0": expectedUnitStatus,
 				},
 				Relations: map[string]params.UnitsGoalState{
-					"db": {
+					"server": {
 						"wordpress":   expectedRelationStatus,
 						"wordpress/0": expectedUnitStatus,
 					},
@@ -389,11 +389,11 @@ func (s *uniterGoalStateSuite) TestGoalStatesCrossModelRelation(c *gc.C) {
 					"mysql/0": expectedUnitStatus,
 				},
 				Relations: map[string]params.UnitsGoalState{
-					"db": {
+					"server": {
 						"wordpress":   expectedRelationStatus,
 						"wordpress/0": expectedUnitStatus,
 					},
-					"metrics": {
+					"metrics-client": {
 						"ctrl1:admin/default.metrics": expectedRelationStatus,
 					},
 				},
@@ -445,12 +445,12 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expectedUnitMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 							"wordpress/1": expectedUnitStatus,
 						},
-						"info": {
+						"juju-info": {
 							"logging":   expectedRelationStatus,
 							"logging/0": expectedUnitStatus,
 						},

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2638,10 +2638,25 @@ func (u *UniterAPI) goalStateRelations(appName, principalName string, allRelatio
 			return nil, errors.Annotate(err, "getting relation status")
 		}
 		endPoints := r.Endpoints()
+		if len(endPoints) == 1 {
+			// Ignore peer relations here.
+			continue
+		}
+
+		// First determine the local endpoint name to use later
+		// as the key in the result map.
+		var resultEndpointName string
 		for _, e := range endPoints {
-			if e.Relation.Role == "peer" {
-				continue
+			if e.ApplicationName == appName {
+				resultEndpointName = e.Name
 			}
+		}
+		if resultEndpointName == "" {
+			continue
+		}
+
+		// Now gather the goal state.
+		for _, e := range endPoints {
 			var key string
 			app, err := u.st.Application(e.ApplicationName)
 			if err == nil {
@@ -2688,7 +2703,16 @@ func (u *UniterAPI) goalStateRelations(appName, principalName string, allRelatio
 				}
 			}
 
-			result[e.Name] = relationGoalState
+			// Merge in the goal state for the current remote endpoint
+			// with any other goal state already collected for the local endpoint.
+			unitsGoalState := result[resultEndpointName]
+			if unitsGoalState == nil {
+				unitsGoalState = params.UnitsGoalState{}
+			}
+			for k, v := range relationGoalState {
+				unitsGoalState[k] = v
+			}
+			result[resultEndpointName] = unitsGoalState
 		}
 	}
 	return result, nil

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -252,7 +252,7 @@ func (s *InterfaceSuite) TestGoalState(c *gc.C) {
 			},
 		},
 		Relations: map[string]application.UnitsGoalState{
-			"server": {
+			"db": {
 				"db0": application.GoalStateStatus{
 					Status: "joining",
 					Since:  &timestamp,


### PR DESCRIPTION
## Description of change

goal-state was showing remote endpoint names, not local endpoint names.

## QA steps

Deploy mariadb and a mediawiki with "db" endpoint changed to be "server"
relate them
offer mariadb
deploy mediawiki in a different model, relate to mariadb offer
juju run goal-state against all 3 different apps and checkout output

## Bug reference

https://bugs.launchpad.net/juju/+bug/1818245
