### PR TITLE
add-k8s --aks Remove use of quotes in interact Select.

### DIFF
--- a/cmd/juju/caas/aks.go
+++ b/cmd/juju/caas/aks.go
@@ -231,10 +231,10 @@ func (a *aks) queryCluster(pollster *interact.Pollster, resourceGroup string) (s
 		}
 		if groupsMentioned.Size() > 1 {
 			clusterNamer = func(clusterName, resourceGroupName string) string {
-				return fmt.Sprintf(`%s in resource group "%s"`, clusterName, resourceGroupName)
+				return fmt.Sprintf("%s in resource group %s", clusterName, resourceGroupName)
 			}
 		} else {
-			clusterPluralText = fmt.Sprintf(`Available clusters in resource group "%s"`, groupsMentioned.Values()[0])
+			clusterPluralText = fmt.Sprintf("Available clusters in resource group %s", groupsMentioned.Values()[0])
 		}
 	}
 

--- a/cmd/juju/caas/aks_test.go
+++ b/cmd/juju/caas/aks_test.go
@@ -121,7 +121,7 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 				Stdout: []byte(resourcegroupJSONResp),
 			}, nil),
 	)
-	stdin := strings.NewReader("mycluster in resource group \"testRG\"\n")
+	stdin := strings.NewReader("mycluster in resource group testRG\n")
 	out := &bytes.Buffer{}
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
@@ -131,15 +131,15 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 	}
 	expected := `
 Available Clusters
-  mycluster in resource group "testRG"
-  notThisCluster in resource group "notThisRG"
+  mycluster in resource group testRG
+  notThisCluster in resource group notThisRG
 
-Select cluster [mycluster in resource group "testRG"]: 
+Select cluster [mycluster in resource group testRG]: 
 `[1:]
 
 	outParams, err := aks.interactiveParams(ctx, &clusterParams{})
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(strings.Replace(cmdtesting.Stdout(ctx), "&#34;", `"`, -1), gc.Equals, expected)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 	c.Assert(outParams, jc.DeepEquals, &clusterParams{
 		name:          clusterName,
 		resourceGroup: resourceGroup,
@@ -280,7 +280,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGr
 		Stdin:  stdin,
 	}
 	expected := `
-Available Clusters In Resource Group "TestRG"
+Available Clusters In Resource Group TestRG
   mycluster
   notMeSir
 
@@ -289,7 +289,7 @@ Select cluster [mycluster]:
 
 	outParams, err := aks.interactiveParams(ctx, &clusterParams{})
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(strings.Replace(cmdtesting.Stdout(ctx), "&#34;", `"`, -1), gc.Equals, expected)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 	c.Assert(outParams, jc.DeepEquals, &clusterParams{
 		name:          clusterName,
 		resourceGroup: resourceGroup,
@@ -348,7 +348,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 				Stdout: []byte(resourcegroupJSONResp),
 			}, nil),
 	)
-	stdin := strings.NewReader("mycluster in resource group \"testRG\"\n")
+	stdin := strings.NewReader("mycluster in resource group testRG\n")
 	out := &bytes.Buffer{}
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
@@ -358,15 +358,15 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 	}
 	expected := `
 Available Clusters
-  mycluster in resource group "testRG"
-  notMeSir in resource group "MonsterResourceGroup"
+  mycluster in resource group testRG
+  notMeSir in resource group MonsterResourceGroup
 
-Select cluster [mycluster in resource group "testRG"]: 
+Select cluster [mycluster in resource group testRG]: 
 `[1:]
 
 	outParams, err := aks.interactiveParams(ctx, &clusterParams{})
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(strings.Replace(cmdtesting.Stdout(ctx), "&#34;", `"`, -1), gc.Equals, expected)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 	c.Assert(outParams, jc.DeepEquals, &clusterParams{
 		name:          clusterName,
 		resourceGroup: resourceGroup,


### PR DESCRIPTION
## Description of change

Because the pollster Select uses html/template any quotes in the string are replaced with &#34;.

I was unable to make it display the quotes as expected, so I've removed them.
So instead of:
```Available Clusters In Resource Group &#34;someTestGroup&#34;```

we have the expected:
```Available Clusters In Resource Group someTestGroup```

## QA steps

Run ```juju add-k8s --aks testaks --storage default``` and observe the output.

## Documentation changes

n/a
## Bug reference

n/a