### PR TITLE
Merge 2.5 into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ vendor/
 .idea/
 *.pyc
 .vscode/
+juju-backup-*.tar.gz

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -658,11 +658,11 @@
   revision = "5f8741c297b47cba29f747c67f2e31e7c2a36ecb"
 
 [[projects]]
-  digest = "1:76068d833db78ba2419f72e5efd91d1d4ab5e8ffca1f61c5b5a724795fea6572"
+  digest = "1:009e2a6e84e7b6dd187f85e0f26e29e8be0f1154aeaa630c1b24cc0e24b2be3f"
   name = "github.com/juju/pubsub"
   packages = ["."]
   pruneopts = ""
-  revision = "ad5dc02599e01a8409f9b1144e4d759baafd01dc"
+  revision = "5ff05f703d2531147fb927125eea0d61cf4179e5"
 
 [[projects]]
   digest = "1:fbafcd485d270fc069d738bdcbfa3e03676936f837d4b2708f7ba80fa90e1c5a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -323,7 +323,7 @@
 
 [[constraint]]
   name = "github.com/juju/pubsub"
-  revision = "ad5dc02599e01a8409f9b1144e4d759baafd01dc"
+  revision = "5ff05f703d2531147fb927125eea0d61cf4179e5"
 
 [[constraint]]
   name = "github.com/juju/ratelimit"

--- a/acceptancetests/README.md
+++ b/acceptancetests/README.md
@@ -43,7 +43,7 @@ To run a test locally with lxd and locally complied juju:
             test-mode: true
             default-series: bionic
     ```
-  * ```export JUJU_REPOSITORY=./path/to/acceptancetests/repository```
+  * ```export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository```
   * ```mkdir /tmp/artifacts```
   * Now you can run the test with:
      * ```$ ./assess_model_migration.py lxd $GOPATH/bin/juju /tmp/artifacts```

--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -34,6 +34,7 @@ def assess_juju_upgrade_series(client, args):
     target_machine = '0'
     assert_correct_series(client, target_machine, args.from_series)
     upgrade_series_prepare(client, target_machine, args.to_series, agree=True)
+    reboot_machine(client, target_machine)
     do_release_upgrade(client, target_machine)
     reboot_machine(client, target_machine)
     upgrade_series_complete(client, target_machine)
@@ -58,23 +59,15 @@ def do_release_upgrade(client, machine):
         output = client.get_juju_output(
             'ssh', machine, 'sudo do-release-upgrade -f '
             'DistUpgradeViewNonInteractive', timeout=3600)
+        log.info("do-release-upgrade response: ".format(output))
     except subprocess.CalledProcessError as e:
         raise AssertionError(
             "do-release-upgrade failed on {}: {}".format(machine, e))
 
-    log.info("do-release-upgrade response: ".format(output))
-
 
 def reboot_machine(client, machine):
-    try:
-        log.info("Restarting: {}".format(machine))
-        cmd = build_ssh_cmd(client, machine, 'sudo shutdown -r now && exit')
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        log.info("Restarting machine output: {}\n".format(output))
-    except subprocess.CalledProcessError as e:
-        logging.info(
-            "Error running shutdown:\nstdout: %s\nstderr: %s",
-            e.output, getattr(e, 'stderr', None))
+    log.info("Restarting: {}".format(machine))
+    client.juju('run', ('--machine', machine, 'sudo shutdown -r now'))
 
     log.info("wait_for_started()")
     client.wait_for_started()
@@ -82,20 +75,6 @@ def reboot_machine(client, machine):
 def set_application_series(client, application, series):
     args = (application, series)
     client.juju('set-series', args)
-
-
-def build_ssh_cmd(client, machine, command):
-    ssh_opts = [
-        "-o", "User ubuntu",
-        "-o", "UserKnownHostsFile /dev/null",
-        "-o", "StrictHostKeyChecking no",
-        "-o", "PasswordAuthentication no",
-    ]
-
-    status = client.get_status()
-    machine_name = status.get_machine_dns_name(machine)
-    cmd = ["ssh"] + ssh_opts + [machine_name] + [command]
-    return cmd
 
 
 def assert_correct_series(client, machine, expected):

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -311,7 +311,7 @@ def dump_juju_timings(client, log_directory):
         print_now(str(e))
 
 
-def get_remote_machines(client, known_hosts):
+def get_remote_machines(client, known_hosts=None):
     """Return a dict of machine_id to remote machines.
 
     A bootstrap_host address may be provided as a fallback for machine 0 if
@@ -321,9 +321,10 @@ def get_remote_machines(client, known_hosts):
     # Try to get machine details from environment if possible.
     machines = dict(iter_remote_machines(client))
     # The bootstrap host is added as a fallback in case status failed.
-    for machine_id, address in known_hosts.items():
-        if machine_id not in machines:
-            machines[machine_id] = remote_from_address(address)
+    if known_hosts is not None:
+        for machine_id, address in known_hosts.items():
+            if machine_id not in machines:
+                machines[machine_id] = remote_from_address(address)
     # Update remote machines in place with real addresses if substrate needs.
     resolve_remote_dns_names(client.env, machines.values())
     return machines

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -795,18 +795,19 @@ class ModelClient:
             timeout = 600
         return WaitMachineNotPresent(machine, timeout)
 
-    def remove_machine(self, machine_id, force=False):
+    def remove_machine(self, machine_ids, force=False, controller=False):
         """Remove a machine (or container).
 
-        :param machine_id: The id of the machine to remove.
+        :param machine_ids: The ids of the machine to remove.
         :return: A WaitMachineNotPresent instance for client.wait_for.
         """
+        options = ()
         if force:
             options = ('--force',)
-        else:
-            options = ()
-        self.juju('remove-machine', options + (machine_id,))
-        return self.make_remove_machine_condition(machine_id)
+        if controller:
+            options = ('-m', 'controller',)
+        self.juju('remove-machine', options + tuple(machine_ids))
+        return self.make_remove_machine_condition(machine_ids)
 
     @staticmethod
     def get_cloud_region(cloud, region):

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -200,7 +200,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelation(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expectedUnitMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -233,7 +233,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -254,7 +254,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 						"mysql/0": expectedUnitStatus,
 					},
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -307,7 +307,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expected2UnitsMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -332,7 +332,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 						},
 					},
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
+						"server": {
 							"wordpress":   expectedRelationStatus,
 							"wordpress/0": expectedUnitStatus,
 						},
@@ -358,7 +358,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesCrossModelRelation(c *gc.C) {
 					"mysql/0": expectedUnitStatus,
 				},
 				Relations: map[string]params.UnitsGoalState{
-					"db": {
+					"server": {
 						"wordpress":   expectedRelationStatus,
 						"wordpress/0": expectedUnitStatus,
 					},
@@ -389,11 +389,11 @@ func (s *uniterGoalStateSuite) TestGoalStatesCrossModelRelation(c *gc.C) {
 					"mysql/0": expectedUnitStatus,
 				},
 				Relations: map[string]params.UnitsGoalState{
-					"db": {
+					"server": {
 						"wordpress":   expectedRelationStatus,
 						"wordpress/0": expectedUnitStatus,
 					},
-					"metrics": {
+					"metrics-client": {
 						"ctrl1:admin/default.metrics": expectedRelationStatus,
 					},
 				},
@@ -413,6 +413,16 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 		Machine:     s.machine1,
 	})
 
+	// And add another wordpress.
+	wordpress2 := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name:  "wordpress2",
+		Charm: s.wpCharm,
+	})
+	wordpressUnit2 := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: wordpress2,
+		Machine:     s.machine1,
+	})
+
 	mysqlCharm1 := s.Factory.MakeCharm(c, &factory.CharmParams{
 		Name: "mysql",
 	})
@@ -427,6 +437,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 	})
 
 	err := s.addRelationEnterScope(c, s.wordpressUnit, "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.addRelationEnterScope(c, wordpressUnit2, "mysql")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.addRelationEnterScope(c, s.mysqlUnit, "logging")
@@ -445,12 +458,14 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 				Result: &params.GoalState{
 					Units: expectedUnitMysql,
 					Relations: map[string]params.UnitsGoalState{
-						"db": {
-							"wordpress":   expectedRelationStatus,
-							"wordpress/0": expectedUnitStatus,
-							"wordpress/1": expectedUnitStatus,
+						"server": {
+							"wordpress":    expectedRelationStatus,
+							"wordpress/0":  expectedUnitStatus,
+							"wordpress/1":  expectedUnitStatus,
+							"wordpress2":   expectedRelationStatus,
+							"wordpress2/0": expectedUnitStatus,
 						},
-						"info": {
+						"juju-info": {
 							"logging":   expectedRelationStatus,
 							"logging/0": expectedUnitStatus,
 						},

--- a/container/kvm/interface.go
+++ b/container/kvm/interface.go
@@ -30,6 +30,10 @@ type Container interface {
 	// Name returns the name of the container.
 	Name() string
 
+	// EnsureCachedImage ensures that a container image suitable for satisfying
+	// the input start parameters has been cached on disk.
+	EnsureCachedImage(params StartParams) error
+
 	// Start runs the container as a daemon.
 	Start(params StartParams) error
 

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -96,19 +96,19 @@ func (s *KVMSuite) TestListMatchesRunningContainers(c *gc.C) {
 }
 
 func (s *KVMSuite) TestCreateContainer(c *gc.C) {
-	instance := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
-	name := string(instance.Id())
+	inst := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
+	name := string(inst.Id())
 	cloudInitFilename := filepath.Join(s.ContainerDir, name, "cloud-init")
 	containertesting.AssertCloudInit(c, cloudInitFilename)
 }
 
 func (s *KVMSuite) TestDestroyContainer(c *gc.C) {
-	instance := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
+	inst := containertesting.CreateContainer(c, s.manager, "1/kvm/0")
 
-	err := s.manager.DestroyContainer(instance.Id())
+	err := s.manager.DestroyContainer(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	name := string(instance.Id())
+	name := string(inst.Id())
 	// Check that the container dir is no longer in the container dir
 	c.Assert(filepath.Join(s.ContainerDir, name), jc.DoesNotExist)
 	// but instead, in the removed container dir
@@ -179,7 +179,9 @@ func (s *KVMSuite) TestStartContainerUtilizesSimpleStream(c *gc.C) {
 		ImageDownloadURL: "mocked-url",
 	}
 	mockedContainer := kvm.NewEmptyKvmContainer()
-	mockedContainer.Start(startParams)
+
+	// We are testing only the logging side-effect, so the error is ignored.
+	_ = mockedContainer.EnsureCachedImage(startParams)
 
 	expectedArgs := fmt.Sprintf(
 		"synchronise images for %s %s %s %s",
@@ -311,7 +313,7 @@ func (s *ConstraintsSuite) TestDefaults(c *gc.C) {
 		params := kvm.ParseConstraintsToStartParams(cons)
 		c.Check(params, gc.DeepEquals, test.expected)
 		c.Check(tw.Log(), jc.LogMatches, test.infoLog)
-		loggo.RemoveWriter("constraint-tester")
+		_, _ = loggo.RemoveWriter("constraint-tester")
 	}
 }
 

--- a/container/kvm/mock/mock-kvm.go
+++ b/container/kvm/mock/mock-kvm.go
@@ -66,6 +66,10 @@ func (mock *mockContainer) Name() string {
 	return mock.name
 }
 
+func (mock *mockContainer) EnsureCachedImage(params kvm.StartParams) error {
+	return nil
+}
+
 func (mock *mockContainer) Start(params kvm.StartParams) error {
 	if mock.started {
 		return fmt.Errorf("container is already running")

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/os/series"
@@ -39,7 +39,7 @@ type Oner interface {
 
 // syncParams conveys the information necessary for calling imagedownloads.One.
 type syncParams struct {
-	arch, series, stream, ftype string
+	arch, series, stream, fType string
 	srcFunc                     func() simplestreams.DataSource
 }
 
@@ -48,24 +48,24 @@ func (p syncParams) One() (*imagedownloads.Metadata, error) {
 	if err := p.exists(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return imagedownloads.One(p.arch, p.series, p.stream, p.ftype, p.srcFunc)
+	return imagedownloads.One(p.arch, p.series, p.stream, p.fType, p.srcFunc)
 }
 
 func (p syncParams) exists() error {
-	fname := backingFileName(p.series, p.arch)
+	fName := backingFileName(p.series, p.arch)
 	baseDir, err := paths.DataDir(series.MustHostSeries())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	path := filepath.Join(baseDir, kvm, guestDir, fname)
+	imagePath := filepath.Join(baseDir, kvm, guestDir, fName)
 
-	if _, err := os.Stat(path); err == nil {
-		return errors.AlreadyExistsf("%q %q image for exists at %q", p.series, p.arch, path)
+	if _, err := os.Stat(imagePath); err == nil {
+		return errors.AlreadyExistsf("%q %q image for exists at %q", p.series, p.arch, imagePath)
 	}
 	return nil
 }
 
-// Validate that our types fulfull their implementations.
+// Validate that our types fulfill their implementations.
 var _ Oner = (*syncParams)(nil)
 var _ Fetcher = (*fetcher)(nil)
 
@@ -119,7 +119,7 @@ func (f *fetcher) Close() {
 type ProgressCallback func(message string)
 
 // Sync updates the local cached images by reading the simplestreams data and
-// caching if an image matching the contrainsts doesn't exist. It retrieves
+// caching if an image matching the constraints doesn't exist. It retrieves
 // metadata information from Oner and updates local cache via Fetcher.
 // A ProgressCallback can optionally be passed which will get update messages
 // as data is copied.
@@ -164,7 +164,7 @@ type progressWriter struct {
 	clock       clock.Clock
 }
 
-var _ (io.Writer) = (*progressWriter)(nil)
+var _ io.Writer = (*progressWriter)(nil)
 
 func (p *progressWriter) Write(content []byte) (n int, err error) {
 	if p.clock == nil {

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -326,6 +326,7 @@ func (s *EnableHASuite) TestEnableHAConcurrentMore(c *gc.C) {
 func (s *EnableHASuite) TestWatchControllerInfo(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w := s.State.WatchControllerInfo()
 	defer statetesting.AssertStop(c, w)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1794,6 +1794,7 @@ func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {
 	err = mysql0.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	changeSettings(c, mysql0)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	mysqlWatcher, err := rel.WatchUnits("mysql")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -97,6 +97,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	s.model = model
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *StateSuite) TestOpenController(c *gc.C) {
@@ -2254,6 +2255,7 @@ func (s *StateSuite) TestWatchApplicationsBulkEvents(c *gc.C) {
 	err = gone.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	// All except gone are reported in initial event.
 	w := s.State.WatchApplications()
 	defer statetesting.AssertStop(c, w)
@@ -2342,6 +2344,7 @@ func (s *StateSuite) TestWatchMachinesBulkEvents(c *gc.C) {
 	err = gone.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	// All except gone machine are reported in initial event.
 	w := s.State.WatchModelMachines()
 	defer statetesting.AssertStop(c, w)
@@ -2581,6 +2584,7 @@ func (s *StateSuite) TestWatchMachineHardwareCharacteristics(c *gc.C) {
 	// Add a machine: reported.
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := machine.WatchHardwareCharacteristics()
 	defer statetesting.AssertStop(c, w)
 
@@ -2601,9 +2605,6 @@ func (s *StateSuite) TestWatchMachineHardwareCharacteristics(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchControllerConfig(c *gc.C) {
-	_, err := s.State.AddMachine("quantal", state.JobManageModel)
-	c.Assert(err, jc.ErrorIsNil)
-
 	w := s.State.WatchControllerConfig()
 	defer statetesting.AssertStop(c, w)
 
@@ -3027,6 +3028,7 @@ func (s *StateSuite) TestWatchForModelConfigChanges(c *gc.C) {
 	cur := jujuversion.Current
 	err := statetesting.SetAgentVersion(s.State, cur)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	w := s.model.WatchForModelConfigChanges()
 	defer statetesting.AssertStop(c, w)
 
@@ -4562,6 +4564,7 @@ func (s *StateSuite) setUpWatchRelationNetworkScenario(c *gc.C) *state.Relation 
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	return rel
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2075,6 +2075,9 @@ func (s *UnitSuite) TestWatchSubordinates(c *gc.C) {
 		c.Assert(units, gc.HasLen, 1)
 		subUnits = append(subUnits, units[0])
 	}
+	// In order to ensure that both the subordinate creation events
+	// have all been processed, wait for the model to be idle.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	wc.AssertChange(subUnits[0].Name(), subUnits[1].Name())
 	wc.AssertNoChange()
 
@@ -2091,6 +2094,9 @@ func (s *UnitSuite) TestWatchSubordinates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = subUnits[1].Remove()
 	c.Assert(err, jc.ErrorIsNil)
+	// In order to ensure that both the dead and remove operations
+	// have been processed, we need to wait until the model is idle.
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	wc.AssertChange(subUnits[0].Name(), subUnits[1].Name())
 	wc.AssertNoChange()
 

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -725,7 +725,7 @@ func (s *WorkerSuite) TestUnitsChange(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		if len(s.containerBroker.Calls()) > 0 {
+		if len(s.containerBroker.Calls()) >= 2 {
 			break
 		}
 	}
@@ -747,7 +747,7 @@ func (s *WorkerSuite) TestOperatorChange(c *gc.C) {
 	}
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		if len(s.containerBroker.Calls()) > 0 {
+		if len(s.containerBroker.Calls()) >= 2 {
 			break
 		}
 	}

--- a/worker/charmrevision/worker_test.go
+++ b/worker/charmrevision/worker_test.go
@@ -46,7 +46,7 @@ func (s *WorkerSuite) TestUpdatesAfterPeriod(c *gc.C) {
 	fix := newFixture(time.Minute)
 	fix.cleanTest(c, func(_ worker.Worker) {
 		fix.waitCall(c)
-		if err := fix.clock.WaitAdvance(time.Minute, 1*time.Second, 1); err != nil {
+		if err := fix.clock.WaitAdvance(time.Minute, testing.LongWait, 1); err != nil {
 			c.Fatal(err)
 		}
 		fix.waitCall(c)
@@ -76,7 +76,9 @@ func (s *WorkerSuite) TestDelayedUpdateError(c *gc.C) {
 	)
 	fix.dirtyTest(c, func(w worker.Worker) {
 		fix.waitCall(c)
-		fix.clock.Advance(time.Minute)
+		if err := fix.clock.WaitAdvance(time.Minute, testing.LongWait, 1); err != nil {
+			c.Fatal(err)
+		}
 		fix.waitCall(c)
 		c.Check(w.Wait(), gc.ErrorMatches, "no more updates for you")
 		fix.waitNoCall(c)

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -251,7 +251,7 @@ func (s *InterfaceSuite) TestGoalState(c *gc.C) {
 			},
 		},
 		Relations: map[string]application.UnitsGoalState{
-			"server": {
+			"db": {
 				"db0": application.GoalStateStatus{
 					Status: "joining",
 					Since:  &timestamp,


### PR DESCRIPTION
## Description of change

Merge 2.5, bringing in these commits:
#9863 Query mongo profile and export counts in webscale tests
#9860 Fix race is charm revision worker test
#9866 Fix TestWatchControllerInfo race
#9865 Update pubsub dep
#9859 Fix TestWatchApplication race
#9879 Add sync points to watch subordinate test
#9877 Fix race in relation watcher test
#9904 Use local endpoint names for goal state
#9890 Restore backup from HA mode
#9898 Ensure synchronous KVM image acquisition
#9893 Use jujud-operator as the k8s operator image; add mongo image as juju-db
#9892 Fix upgrade series CI test

