### PR TITLE
raftflag: Fix intermittent hang when raft is shutdown

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -371,11 +371,12 @@
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:3dea8a64498e503e13eaa87133ab0c5423988a67f739e52273631230cf15a428"
+  digest = "1:b52f54ecd403c75e91379df33eaa153cd3bf3c9ed123cef823e922c4b6a6f8d2"
   name = "github.com/hashicorp/raft"
   packages = ["."]
   pruneopts = ""
-  revision = "077966dbc90f342107eb723ec52fdb0463ec789b"
+  revision = "834fca2f9ffc153bf038e9333425a40ba515059f"
+  source = "github.com/juju/raft"
 
 [[projects]]
   digest = "1:d2707097c8132df0bfccc3fbbf6973b3b80324e08d6e489edf90efc9d7b5c773"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -263,7 +263,8 @@
 
 [[constraint]]
   name = "github.com/hashicorp/raft"
-  revision = "077966dbc90f342107eb723ec52fdb0463ec789b"
+  revision = "834fca2f9ffc153bf038e9333425a40ba515059f"
+  source = "github.com/juju/raft"
 
 [[constraint]]
   name = "github.com/joyent/gocommon"


### PR DESCRIPTION
## Description of change

Updates hashicorp/raft dependency to use our own fork to respect timeouts when sending RPC requests (at least until our PR is merged upstream). See https://github.com/hashicorp/raft/pull/313 for more detail.

## QA steps

Running the raftflag worker test under stress doesn't hang anymore.

## Documentation changes

None

## Bug reference

None