### PR TITLE
use caa-image-repo to specify jujud image in controller config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ default: build
 # and will only work - when this tree is found on the GOPATH.
 ifeq ($(CURDIR),$(PROJECT_DIR))
 
-ifeq ($(JUJU_ping_DEP),true)
+ifeq ($(JUJU_SKIP_DEP),true)
 dep:
 	@echo "skipping dep"
 else

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -118,8 +118,8 @@ def parse_args(argv):
     """Parse all arguments."""
     parser = argparse.ArgumentParser(description="CAAS charm deployment CI test")
     parser.add_argument(
-        '--caas-image', action='store', default=None,
-        help='CAAS operator docker image name to use with format of <username>/jujud-operator:<tag>.'
+        '--caas-image-repo', action='store', default='jujuqabot',
+        help='CAAS operator docker image repo to use.'
     )
     parser.add_argument(
         '--caas-provider', action='store', default='MICROK8S',
@@ -131,8 +131,8 @@ def parse_args(argv):
     return parser.parse_args(argv)
 
 
-def ensure_operator_image_path(client, image_path):
-    client.controller_juju('controller-config', ('caas-operator-image-path={}'.format(image_path),))
+def ensure_operator_image_path(client, caas_image_repo):
+    client.controller_juju('controller-config', ('caas-image-repo={}'.format(caas_image_repo),))
 
 
 def main(argv=None):
@@ -141,7 +141,7 @@ def main(argv=None):
     bs_manager = BootstrapManager.from_args(args)
     with bs_manager.booted_context(args.upload_tools):
         client = bs_manager.client
-        ensure_operator_image_path(client, image_path=args.caas_image)
+        ensure_operator_image_path(client, caas_image_repo=args.caas_image_repo)
         k8s_provider = providers[args.caas_provider]
         caas_client = k8s_provider(client)
         assess_caas_charm_deployment(caas_client)


### PR DESCRIPTION
## Description of change

update `CAAS` CI tests to use `caa-image-repo` to specify jujud image in `controller config`;

## QA steps

None

## Documentation changes

None

## Bug reference

None
