### PR TITLE
2.5 - Test Concurrent KVM Creation and Appease the Race Checker

### DIFF
--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -3,18 +3,16 @@
 
 package kvm
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/juju/juju/instance"
+)
 
 // This file exports internal package implementations so that tests
 // can utilize them to mock behavior.
 
-var (
-	// KVMPath is exported for use in tests.
-	KVMPath = &kvmPath
-
-	// Used to export the parameters used to call Start on the KVM Container
-	TestStartParams = &startParams
-)
+var KVMPath = &kvmPath
 
 // MakeCreateMachineParamsTestable adds test values to non exported values on
 // CreateMachineParams.
@@ -34,6 +32,13 @@ func NewEmptyKvmContainer() *kvmContainer {
 // NewTestContainer returns a new container for testing.
 func NewTestContainer(name string, runCmd runFunc, pathfinder func(string) (string, error)) *kvmContainer {
 	return &kvmContainer{name: name, runCmd: runCmd, pathfinder: pathfinder}
+}
+
+// ContainerFromInstance extracts the inner container from input instance,
+// so we can access it for test assertions.
+func ContainerFromInstance(inst instance.Instance) Container {
+	kvm := inst.(*kvmInstance)
+	return kvm.container
 }
 
 // NewRunStub is a stub to fake shelling out to os.Exec or utils.RunCommand.

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -139,9 +139,6 @@ func (manager *containerManager) Namespace() instance.Namespace {
 	return manager.namespace
 }
 
-// Exposed so tests can observe our side-effects
-var startParams StartParams
-
 func (manager *containerManager) CreateContainer(
 	instanceConfig *instancecfg.InstanceConfig,
 	cons constraints.Value,
@@ -186,7 +183,7 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, err
 	}
 	// Create the container.
-	startParams = ParseConstraintsToStartParams(cons)
+	startParams := ParseConstraintsToStartParams(cons)
 	startParams.Arch = arch.HostArch()
 	startParams.Series = series
 	startParams.Network = networkConfig
@@ -220,8 +217,8 @@ func (manager *containerManager) CreateContainer(
 
 	// Lock around finding an image.
 	// The provisioner works concurrently to create containers.
-	// If an image needs to be copied from a remote, we don't many goroutines
-	// attempting to do it at once.
+	// If an image needs to be copied from a remote, we don't want many
+	// goroutines attempting to do it at once.
 	manager.imageMutex.Lock()
 	err = kvmContainer.EnsureCachedImage(startParams)
 	manager.imageMutex.Unlock()

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -105,12 +105,14 @@ func (s *KVMSuite) TestCreateContainer(c *gc.C) {
 	containertesting.AssertCloudInit(c, cloudInitFilename)
 }
 
+// This test will pass regular unit tests, but is intended for the
+// race-checking CI job to assert concurrent creation safety.
 func (s *KVMSuite) TestCreateContainerConcurrent(c *gc.C) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(idx int) {
-			containertesting.CreateContainer(c, s.manager, fmt.Sprintf("1/kvm/%d", idx))
+			_ = containertesting.CreateContainer(c, s.manager, fmt.Sprintf("1/kvm/%d", idx))
 			wg.Done()
 		}(i)
 	}

--- a/container/kvm/mock/mock-kvm.go
+++ b/container/kvm/mock/mock-kvm.go
@@ -78,7 +78,7 @@ var imageCacheCalls int
 
 // EnsureCachedImage is the first supply of start-params to the container.
 // We set it here for subsequent test assertions.
-// Start called is by the manager immediately after, with the same argument.
+// Start is called by the manager immediately after, with the same argument.
 func (mock *MockContainer) EnsureCachedImage(params kvm.StartParams) error {
 	imageCacheCalls++
 	mock.StartParams = params

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -158,8 +158,8 @@ func (m *containerManager) getContainerSpec(
 
 	// Lock around finding an image.
 	// The provisioner works concurrently to create containers.
-	// If an image needs to be copied from a remote, we don't many goroutines
-	// attempting to do it at once.
+	// If an image needs to be copied from a remote, we don't want many
+	// goroutines attempting to do it at once.
 	m.imageMutex.Lock()
 	found, err := m.server.FindImage(series, jujuarch.HostArch(), imageSources, true, callback)
 	m.imageMutex.Unlock()

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -30,8 +30,8 @@ func MockMachineConfig(machineId string) (*instancecfg.InstanceConfig, error) {
 	}
 	err = instanceConfig.SetTools(tools.List{
 		&tools.Tools{
-			Version: version.MustParseBinary("2.3.4-quantal-amd64"),
-			URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+			Version: version.MustParseBinary("2.5.2-bionic-amd64"),
+			URL:     "http://tools.testing.invalid/2.5.2-bionic-amd64.tgz",
 		},
 	})
 	if err != nil {
@@ -65,9 +65,9 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
 ) instance.Instance {
-
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
-	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, "quantal", networkConfig, storageConfig, callback)
+	inst, hardware, err := manager.CreateContainer(
+		instanceConfig, constraints.Value{}, "bionic", networkConfig, storageConfig, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")


### PR DESCRIPTION
## Description of change

This patch follows #9898. 

It removes a nasty Goroutine-unsafe pattern used to check `kvm.StartParams`, instead capturing such parameters with `MockContainer` and exposing them to tests.

Various other Goroutine-safety locking is applied to the test infrastructure.

These tests will not fail regular unit tests, but the race-checking CI job will assert correct behaviour.

## QA steps

- Comment out the locking around the manager call to `EnsureCachedImage` and check that running with `-race` fails.
- Restore the locking and check that it passes.

## Documentation changes

None

## Bug reference

N/A
