### PR TITLE
Add Principal to UnitInfo and UnitChange for use in model cache

### DIFF
--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -112,7 +112,7 @@ var marshalTestCases = []struct {
 			},
 		},
 	},
-	json: `["unit","change",{"model-uuid":"uuid","name":"Benji","application":"Shazam","series":"precise","charm-url":"cs:~user/precise/wordpress-42","public-address":"testing.invalid","private-address":"10.0.0.1","machine-id":"1","ports":[{"protocol":"http","number":80}],"port-ranges":[{"from-port":80,"to-port":80,"protocol":"http"}],"subordinate":false,"workload-status":{"current":"active","message":"all good","version":""},"agent-status":{"current":"idle","message":"","version":""}}]`,
+	json: `["unit","change",{"model-uuid":"uuid","name":"Benji","application":"Shazam","series":"precise","charm-url":"cs:~user/precise/wordpress-42","public-address":"testing.invalid","private-address":"10.0.0.1","machine-id":"1","principal":"","ports":[{"protocol":"http","number":80}],"port-ranges":[{"from-port":80,"to-port":80,"protocol":"http"}],"subordinate":false,"workload-status":{"current":"active","message":"all good","version":""},"agent-status":{"current":"idle","message":"","version":""}}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: multiwatcher.Delta{

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -63,6 +63,7 @@ type UnitChange struct {
 	MachineId      string
 	Ports          []network.Port
 	PortRanges     []network.PortRange
+	Principal      string
 	Subordinate    bool
 	WorkloadStatus status.StatusInfo
 	AgentStatus    status.StatusInfo

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -378,6 +378,7 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 		Application: u.Application,
 		Series:      u.Series,
 		MachineId:   u.MachineId,
+		Principal:   u.Principal,
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -271,13 +271,15 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 		c.Assert(lu.IsPrincipal(), jc.IsFalse)
 		deployer, ok = lu.DeployerTag()
 		c.Assert(ok, jc.IsTrue)
-		c.Assert(deployer, gc.Equals, names.NewUnitTag(fmt.Sprintf("wordpress/%d", i)))
+		unitName := fmt.Sprintf("wordpress/%d", i)
+		c.Assert(deployer, gc.Equals, names.NewUnitTag(unitName))
 		add(&multiwatcher.UnitInfo{
 			ModelUUID:   modelUUID,
 			Name:        fmt.Sprintf("logging/%d", i),
 			Application: "logging",
 			Series:      "quantal",
 			Ports:       []multiwatcher.Port{},
+			Principal:   unitName,
 			Subordinate: true,
 			WorkloadStatus: multiwatcher.StatusInfo{
 				Current: "waiting",

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -272,6 +272,7 @@ type UnitInfo struct {
 	MachineId      string      `json:"machine-id"`
 	Ports          []Port      `json:"ports"`
 	PortRanges     []PortRange `json:"port-ranges"`
+	Principal      string      `json:"principal"`
 	Subordinate    bool        `json:"subordinate"`
 	// Workload and agent state are modelled separately.
 	WorkloadStatus StatusInfo `json:"workload-status"`

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -273,6 +273,7 @@ func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
 			MachineId:      value.MachineId,
 			Ports:          coreNetworkPorts(value.Ports),
 			PortRanges:     coreNetworkPortRanges(value.PortRanges),
+			Principal:      value.Principal,
 			Subordinate:    value.Subordinate,
 			WorkloadStatus: coreStatus(value.WorkloadStatus),
 			AgentStatus:    coreStatus(value.AgentStatus),


### PR DESCRIPTION
## Description of change

A unit's Principal is needed in the model cache for upcoming working for the InstanceMutater worker.

## QA steps

No direct qa steps at this time.  There should be no impact to current juju use.

