### PR TITLE
Add model.WatchMachines to model cache

### DIFF
--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -110,7 +110,7 @@ func (m *Model) WatchMachines() *ChangeWatcher {
 	}
 
 	w := newAddRemoveWatcher(machines...)
-	unsub := m.hub.Subscribe(m.modelTopic(modelMachineChange), w.changed)
+	unsub := m.hub.Subscribe(m.topic(modelMachineChange), w.changed)
 
 	w.tomb.Go(func() error {
 		<-w.tomb.Dying()
@@ -184,7 +184,7 @@ func (m *Model) updateMachine(ch MachineChange) {
 	if !found {
 		machine = newMachine(m.metrics, m.hub)
 		m.machines[ch.Id] = machine
-		m.hub.Publish(m.modelTopic(modelMachineChange), []string{ch.Id})
+		m.hub.Publish(m.topic(modelMachineChange), []string{ch.Id})
 	}
 	machine.setDetails(ch)
 
@@ -195,7 +195,7 @@ func (m *Model) updateMachine(ch MachineChange) {
 func (m *Model) removeMachine(ch RemoveMachine) {
 	m.mu.Lock()
 	delete(m.machines, ch.Id)
-	m.hub.Publish(m.modelTopic(modelMachineChange), []string{ch.Id})
+	m.hub.Publish(m.topic(modelMachineChange), []string{ch.Id})
 	m.mu.Unlock()
 }
 

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -11,6 +11,7 @@ import (
 )
 
 const modelConfigChange = "model-config-change"
+const modelMachineChange = "model-machine-change"
 
 func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Model {
 	m := &Model{
@@ -97,6 +98,29 @@ func (m *Model) Machine(machineId string) (*Machine, error) {
 	return machine, nil
 }
 
+// WatchMachines creates a ChangeWatcher (strings watcher) to notify about
+// added and removed machines in the model.  The initial event contains
+// a slice of the current machine ids.
+func (m *Model) WatchMachines() *ChangeWatcher {
+	machines := make([]string, len(m.machines))
+	i := 0
+	for k := range m.machines {
+		machines[i] = k
+		i += 1
+	}
+
+	w := newAddRemoveWatcher(machines...)
+	unsub := m.hub.Subscribe(m.modelTopic(modelMachineChange), w.changed)
+
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
+		unsub()
+		return nil
+	})
+
+	return w
+}
+
 // Unit returns the unit with the input name.
 // If the unit is not found, a NotFoundError is returned.
 func (m *Model) Unit(unitName string) (*Unit, error) {
@@ -160,6 +184,7 @@ func (m *Model) updateMachine(ch MachineChange) {
 	if !found {
 		machine = newMachine(m.metrics, m.hub)
 		m.machines[ch.Id] = machine
+		m.hub.Publish(m.modelTopic(modelMachineChange), []string{ch.Id})
 	}
 	machine.setDetails(ch)
 
@@ -170,6 +195,7 @@ func (m *Model) updateMachine(ch MachineChange) {
 func (m *Model) removeMachine(ch RemoveMachine) {
 	m.mu.Lock()
 	delete(m.machines, ch.Id)
+	m.hub.Publish(m.modelTopic(modelMachineChange), []string{ch.Id})
 	m.mu.Unlock()
 }
 

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -220,6 +220,24 @@ func (s *ControllerSuite) TestWatchMachineChangeMachine(c *gc.C) {
 	wc.AssertNoChange()
 }
 
+func (s *ControllerSuite) TestWatchMachineGatherMachines(c *gc.C) {
+	w, events := s.setupWithWatchMachine(c)
+	defer workertest.CleanKill(c, w)
+	wc := NewStringsWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange([]string{machineChange.Id})
+
+	change := cache.MachineChange{
+		ModelUUID: modelChange.ModelUUID,
+		Id:        "2",
+	}
+	s.processChange(c, change, events)
+	change2 := change
+	change2.Id = "3"
+	s.processChange(c, change2, events)
+	wc.AssertOneChange([]string{change.Id, change2.Id})
+}
+
 func (s *ControllerSuite) newWithMachine(c *gc.C) (*cache.Controller, <-chan interface{}) {
 	events := s.captureEvents(c)
 	controller, err := cache.NewController(s.config)

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -235,7 +235,7 @@ func (s *ControllerSuite) TestWatchMachineGatherMachines(c *gc.C) {
 	change2 := change
 	change2.Id = "3"
 	s.processChange(c, change2, events)
-	wc.AssertOneChange([]string{change.Id, change2.Id})
+	wc.AssertMaybeCombinedChanges([]string{change.Id, change2.Id})
 }
 
 func (s *ControllerSuite) newWithMachine(c *gc.C) (*cache.Controller, <-chan interface{}) {

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -163,6 +163,82 @@ func (s *ModelSuite) TestMachineNotFoundError(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
+func (s *ControllerSuite) TestWatchMachineStops(c *gc.C) {
+	controller, _ := s.newWithMachine(c)
+	m, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	w := m.WatchMachines()
+	wc := NewStringsWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange([]string{machineChange.Id})
+	wc.AssertStops()
+}
+
+func (s *ControllerSuite) TestWatchMachineAddMachine(c *gc.C) {
+	w, events := s.setupWithWatchMachine(c)
+	defer workertest.CleanKill(c, w)
+	wc := NewStringsWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange([]string{machineChange.Id})
+
+	change := cache.MachineChange{
+		ModelUUID: modelChange.ModelUUID,
+		Id:        "2",
+	}
+	s.processChange(c, change, events)
+	wc.AssertOneChange([]string{change.Id})
+}
+
+func (s *ControllerSuite) TestWatchMachineRemoveMachine(c *gc.C) {
+	w, events := s.setupWithWatchMachine(c)
+	defer workertest.CleanKill(c, w)
+	wc := NewStringsWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange([]string{machineChange.Id})
+
+	change := cache.RemoveMachine{
+		ModelUUID: modelChange.ModelUUID,
+		Id:        machineChange.Id,
+	}
+	s.processChange(c, change, events)
+	wc.AssertOneChange([]string{change.Id})
+}
+
+func (s *ControllerSuite) TestWatchMachineChangeMachine(c *gc.C) {
+	w, events := s.setupWithWatchMachine(c)
+	defer workertest.CleanKill(c, w)
+	wc := NewStringsWatcherC(c, w)
+	// Sends initial event.
+	wc.AssertOneChange([]string{machineChange.Id})
+
+	change := cache.MachineChange{
+		ModelUUID: modelChange.ModelUUID,
+		Id:        "0",
+	}
+	s.processChange(c, change, events)
+	wc.AssertNoChange()
+}
+
+func (s *ControllerSuite) newWithMachine(c *gc.C) (*cache.Controller, <-chan interface{}) {
+	events := s.captureEvents(c)
+	controller, err := cache.NewController(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
+	s.processChange(c, modelChange, events)
+	s.processChange(c, machineChange, events)
+	return controller, events
+}
+
+func (s *ControllerSuite) setupWithWatchMachine(c *gc.C) (*cache.ChangeWatcher, <-chan interface{}) {
+	controller, events := s.newWithMachine(c)
+	m, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	w := m.WatchMachines()
+	return w, events
+}
+
 var modelChange = cache.ModelChange{
 	ModelUUID: "model-uuid",
 	Name:      "test-model",
@@ -172,6 +248,7 @@ var modelChange = cache.ModelChange{
 		"key":     "value",
 		"another": "foo",
 	},
+
 	Status: status.StatusInfo{
 		Status: status.Active,
 	},

--- a/core/cache/stringswatcher_test.go
+++ b/core/cache/stringswatcher_test.go
@@ -28,10 +28,11 @@ type StringsWatcherC struct {
 // AssertOneChange fails if no change is sent before a long time has passed; or
 // if, subsequent to that, any further change is sent before a short time has
 // passed.
-func (c StringsWatcherC) AssertOneChange() {
+func (c StringsWatcherC) AssertOneChange(expected []string) {
 	select {
-	case _, ok := <-c.Watcher.Changes():
+	case obtained, ok := <-c.Watcher.Changes():
 		c.Assert(ok, jc.IsTrue)
+		c.Assert(obtained, jc.SameContents, expected)
 	case <-time.After(testing.LongWait):
 		c.Fatalf("watcher did not send change")
 	}

--- a/core/cache/stringswatcher_test.go
+++ b/core/cache/stringswatcher_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/testing"
+)
+
+func NewStringsWatcherC(c *gc.C, watcher cache.StringsWatcher) StringsWatcherC {
+	return StringsWatcherC{
+		C:       c,
+		Watcher: watcher,
+	}
+}
+
+type StringsWatcherC struct {
+	*gc.C
+	Watcher cache.StringsWatcher
+}
+
+// AssertOneChange fails if no change is sent before a long time has passed; or
+// if, subsequent to that, any further change is sent before a short time has
+// passed.
+func (c StringsWatcherC) AssertOneChange() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher did not send change")
+	}
+	c.AssertNoChange()
+}
+
+// AssertNoChange fails if it manages to read a value from Changes before a
+// short time has passed.
+func (c StringsWatcherC) AssertNoChange() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		if ok {
+			c.Fatalf("watcher sent unexpected change")
+		}
+		c.Fatalf("watcher changes channel closed")
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertStops Kills the watcher and asserts (1) that Wait completes without
+// error before a long time has passed; and (2) that Changes channel is closed.
+func (c StringsWatcherC) AssertStops() {
+	c.Watcher.Kill()
+	wait := make(chan error)
+	go func() {
+		wait <- c.Watcher.Wait()
+	}()
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher never stopped")
+	case err := <-wait:
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		if ok {
+			c.Fatalf("watcher sent unexpected change")
+		}
+	default:
+		c.Fatalf("channel not closed")
+	}
+}

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -144,3 +144,76 @@ func (w *ConfigWatcher) configChanged(topic string, value interface{}) {
 	}
 	w.notify()
 }
+
+// StringsWatcher will return what has changed.
+type StringsWatcher interface {
+	Watcher
+	Changes() <-chan struct{}
+}
+
+type stringsWatcherBase struct {
+	tomb    tomb.Tomb
+	changes chan []string
+	// We can't send down a closed channel, so protect the sending
+	// with a mutex and bool. Since you can't really even ask a channel
+	// if it is closed.
+	closed bool
+	mu     sync.Mutex
+}
+
+func newStringsWatcherBase() *stringsWatcherBase {
+	// We use a single entry buffered channel for the changes.
+	// This allows the config changed handler to send a value when there
+	// is a change, but if that value hasn't been consumed before the
+	// next change, the second change is discarded.
+	ch := make(chan []string, 1)
+
+	// Send initial event down the channel. We know that this will
+	// execute immediately because it is a buffered channel.
+	ch <- []string{}
+
+	return &stringsWatcherBase{changes: ch}
+}
+
+// Changes is part of the core watcher definition.
+// The changes channel is never closed.
+func (w *stringsWatcherBase) Changes() <-chan []string {
+	return w.changes
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *stringsWatcherBase) Kill() {
+	w.mu.Lock()
+	w.closed = true
+	close(w.changes)
+	w.mu.Unlock()
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *stringsWatcherBase) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Stop is currently required by the Resources wrapper in the apiserver.
+func (w *stringsWatcherBase) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *stringsWatcherBase) notify(values []string) {
+	w.mu.Lock()
+
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+
+	select {
+	case w.changes <- values:
+	default:
+		// Already a pending change, so do nothing.
+	}
+
+	w.mu.Unlock()
+}


### PR DESCRIPTION
## Description of change

Add a model.WatchMachines to model cache to be notified of new and removed machines in the model.  Functionality for the Instance Mutater.

## QA steps

Functionality not used by packages outside of model cache yet. Unit tests should pass.  No change to existing juju functionality.
