### PR TITLE
Force option for remove-application and remove-unit commands.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -450,6 +450,10 @@ type DestroyUnitsParams struct {
 	// DestroyStorage controls whether or not storage attached
 	// to the units will be destroyed.
 	DestroyStorage bool
+
+	// Force controls whether or not the removal of applications
+	// will be forced, i.e. ignore removal errors.
+	Force bool
 }
 
 // DestroyUnits decreases the number of units dedicated to one or more
@@ -471,6 +475,7 @@ func (c *Client) DestroyUnits(in DestroyUnitsParams) ([]params.DestroyUnitResult
 		argsV5.Units = append(argsV5.Units, params.DestroyUnitParams{
 			UnitTag:        names.NewUnitTag(name).String(),
 			DestroyStorage: in.DestroyStorage,
+			Force:          in.Force,
 		})
 	}
 	if len(argsV5.Units) == 0 {
@@ -528,6 +533,10 @@ type DestroyApplicationsParams struct {
 	// DestroyStorage controls whether or not storage attached
 	// to units of the applications will be destroyed.
 	DestroyStorage bool
+
+	// Force controls whether or not the removal of applications
+	// will be forced, i.e. ignore removal errors.
+	Force bool
 }
 
 // DestroyApplications destroys the given applications.
@@ -548,6 +557,7 @@ func (c *Client) DestroyApplications(in DestroyApplicationsParams) ([]params.Des
 		argsV5.Applications = append(argsV5.Applications, params.DestroyApplicationParams{
 			ApplicationTag: names.NewApplicationTag(name).String(),
 			DestroyStorage: in.DestroyStorage,
+			Force:          in.Force,
 		})
 	}
 	if len(argsV5.Applications) == 0 {
@@ -624,6 +634,10 @@ type ScaleApplicationParams struct {
 
 	// ScaleChange is the amount of change to the target number of existing units.
 	ScaleChange int
+
+	// Force controls whether or not the removal of applications
+	// will be forced, i.e. ignore removal errors.
+	Force bool
 }
 
 // ScaleApplication sets the desired unit count for one or more applications.
@@ -641,6 +655,7 @@ func (c *Client) ScaleApplication(in ScaleApplicationParams) (params.ScaleApplic
 			ApplicationTag: names.NewApplicationTag(in.ApplicationName).String(),
 			Scale:          in.Scale,
 			ScaleChange:    in.ScaleChange,
+			Force:          in.Force,
 		}},
 	}
 	var results params.ScaleApplicationResults

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -346,8 +346,8 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 		c.Assert(request, gc.Equals, "DestroyApplication")
 		c.Assert(a, jc.DeepEquals, params.DestroyApplicationsParams{
 			Applications: []params.DestroyApplicationParams{
-				{ApplicationTag: "application-foo"},
-				{ApplicationTag: "application-bar"},
+				{ApplicationTag: "application-foo", Force: true},
+				{ApplicationTag: "application-bar", Force: true},
 			},
 		})
 		c.Assert(response, gc.FitsTypeOf, &params.DestroyApplicationResults{})
@@ -357,6 +357,7 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 	})
 	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
 		Applications: []string{"foo", "bar"},
+		Force:        true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
@@ -463,8 +464,8 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 		c.Assert(request, gc.Equals, "DestroyUnit")
 		c.Assert(a, jc.DeepEquals, params.DestroyUnitsParams{
 			Units: []params.DestroyUnitParams{
-				{UnitTag: "unit-foo-0"},
-				{UnitTag: "unit-bar-1"},
+				{UnitTag: "unit-foo-0", Force: true},
+				{UnitTag: "unit-bar-1", Force: true},
 			},
 		})
 		c.Assert(response, gc.FitsTypeOf, &params.DestroyUnitResults{})
@@ -474,6 +475,7 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 	})
 	results, err := client.DestroyUnits(application.DestroyUnitsParams{
 		Units: []string{"foo/0", "bar/1"},
+		Force: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
@@ -1144,7 +1146,7 @@ func (s *applicationSuite) TestScaleApplication(c *gc.C) {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args, jc.DeepEquals, params.ScaleApplicationsParams{
 				Applications: []params.ScaleApplicationParams{
-					{ApplicationTag: "application-foo", Scale: 5},
+					{ApplicationTag: "application-foo", Scale: 5, Force: true},
 				}})
 
 			result, ok := response.(*params.ScaleApplicationResults)
@@ -1159,6 +1161,7 @@ func (s *applicationSuite) TestScaleApplication(c *gc.C) {
 	results, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
+		Force:           true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ScaleApplicationResult{

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -146,7 +146,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 6, application.NewFacadeV6)
 	reg("Application", 7, application.NewFacadeV7)
 	reg("Application", 8, application.NewFacadeV8)
-	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo, generational config.
+	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo, generational config, Force on App and Unit Removal.
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -292,6 +292,10 @@ type DestroyApplicationParams struct {
 	// DestroyStorage controls whether or not storage attached to
 	// units of the application should be destroyed.
 	DestroyStorage bool `json:"destroy-storage,omitempty"`
+
+	// Force controls whether or not the destruction of an application
+	// will be forced, i.e. ignore operational errors.
+	Force bool
 }
 
 // DestroyConsumedApplicationsParams holds bulk parameters for the
@@ -368,6 +372,10 @@ type ScaleApplicationParams struct {
 
 	// Scale is the number of units which should be added/removed from the existing count.
 	ScaleChange int `json:"scale-change,omitempty"`
+
+	// Force controls whether or not scaling of an application
+	// will be forced, i.e. ignore operational errors.
+	Force bool
 }
 
 // ScaleApplicationResults contains the results of a ScaleApplication

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -410,6 +410,10 @@ type DestroyUnitParams struct {
 	// DestroyStorage controls whether or not storage
 	// attached to the unit should be destroyed.
 	DestroyStorage bool `json:"destroy-storage,omitempty"`
+
+	// Force controls whether or not the destruction of an application
+	// will be forced, i.e. ignore operational errors.
+	Force bool
 }
 
 // Creds holds credentials for identifying an entity.

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/juju/juju/resource/resourceadapters"
 )
 
-type RemoveApplicationAPI removeApplicationAPI
-
 func NewUpgradeCharmCommandForTest(
 	store jujuclient.ClientStore,
 	apiOpen api.OpenFunc,
@@ -65,10 +63,20 @@ func NewAddUnitCommandForTestWithRefresh(api applicationAddUnitAPI, store jujucl
 }
 
 // NewRemoveUnitCommandForTest returns a RemoveUnitCommand with the api provided as specified.
-func NewRemoveUnitCommandForTest(api removeApplicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+func NewRemoveUnitCommandForTest(api RemoveApplicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &removeUnitCommand{api: api}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
+}
+
+type removeAPIFunc func() (RemoveApplicationAPI, int, error)
+
+// NewRemoveApplicationCommandForTest returns a RemoveApplicationCommand.
+func NewRemoveApplicationCommandForTest(f removeAPIFunc, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	c := &removeApplicationCommand{}
+	c.newAPIFunc = f
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c)
 }
 
 // NewAddRelationCommandForTest returns an AddRelationCommand with the api provided as specified.

--- a/cmd/juju/application/remove_application_test.go
+++ b/cmd/juju/application/remove_application_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apiapplication "github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&RemoveApplicationCmdSuite{})
+
+type RemoveApplicationCmdSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	api *testApplicationRemoveUnitAPI
+
+	apiFunc func() (application.RemoveApplicationAPI, int, error)
+	store   *jujuclient.MemStore
+}
+
+func (s *RemoveApplicationCmdSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.api = &testApplicationRemoveUnitAPI{
+		Stub: &jujutesting.Stub{},
+	}
+	s.store = jujuclienttesting.MinimalStore()
+	s.apiFunc = func() (application.RemoveApplicationAPI, int, error) {
+		return s.api, 5, nil
+	}
+}
+
+func (s *RemoveApplicationCmdSuite) TestForceFlagUnset(c *gc.C) {
+	s.assertAPIForceFlag(c, []string{"real-app"}, false)
+}
+
+func (s *RemoveApplicationCmdSuite) TestForceFlagSet(c *gc.C) {
+	s.assertAPIForceFlag(c, []string{"real-app", "--force"}, true)
+}
+
+func (s *RemoveApplicationCmdSuite) runRemoveApplication(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, application.NewRemoveApplicationCommandForTest(s.apiFunc, s.store), args...)
+}
+
+func (s *RemoveApplicationCmdSuite) assertAPIForceFlag(c *gc.C, args []string, expectedValue bool) {
+	s.api.destroyApplications = func(args apiapplication.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error) {
+		c.Assert(args.Force, gc.Equals, expectedValue)
+		return []params.DestroyApplicationResult{
+			{Info: &params.DestroyApplicationInfo{}},
+		}, nil
+	}
+	ctx, err := s.runRemoveApplication(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application real-app\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	s.api.CheckCallNames(c, "DestroyApplications", "Close")
+}
+
+type testApplicationRemoveUnitAPI struct {
+	*jujutesting.Stub
+
+	destroyApplications func(args apiapplication.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error)
+
+	destroyUnits func(args apiapplication.DestroyUnitsParams) ([]params.DestroyUnitResult, error)
+}
+
+func (a *testApplicationRemoveUnitAPI) DestroyApplications(args apiapplication.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error) {
+	a.AddCall("DestroyApplications", args)
+	return a.destroyApplications(args)
+}
+
+func (a *testApplicationRemoveUnitAPI) DestroyUnits(args apiapplication.DestroyUnitsParams) ([]params.DestroyUnitResult, error) {
+	a.AddCall("DestroyUnits", args)
+	return a.destroyUnits(args)
+}
+
+func (a *testApplicationRemoveUnitAPI) Close() error {
+	a.AddCall("Close")
+	return a.NextErr()
+}
+
+func (a *testApplicationRemoveUnitAPI) BestAPIVersion() int {
+	panic("BestAPIVersion not implemented here")
+}
+
+func (a *testApplicationRemoveUnitAPI) ModelUUID() string {
+	panic("ModelUUID not implemented here")
+}
+
+func (a *testApplicationRemoveUnitAPI) ScaleApplication(ps apiapplication.ScaleApplicationParams) (params.ScaleApplicationResult, error) {
+	panic("ScaleApplication not implemented here")
+}
+
+func (a *testApplicationRemoveUnitAPI) DestroyDeprecated(appName string) error {
+	panic("DestroyDeprecated not implemented here")
+}
+
+func (a *testApplicationRemoveUnitAPI) DestroyUnitsDeprecated(unitNames ...string) error {
+	panic("DestroyUnitsDeprecated not implemented here")
+}


### PR DESCRIPTION
## Description of change

Juju is introducing --force option for remove-application and remove-unit commands.
This is the first PR in the series. It simply adds the option to the commands and ensure that it is passed in to the api and "Application" client facade.

