### PR TITLE
Allow cloud changes to be watched for openstack

### DIFF
--- a/api/common/cloudspec/cloudspec_test.go
+++ b/api/common/cloudspec/cloudspec_test.go
@@ -75,6 +75,36 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 	})
 }
 
+func (s *CloudSpecSuite) TestWatchCloudSpecChanges(c *gc.C) {
+	called := false
+	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}
+	facadeCaller.ReturnRawAPICaller = apitesting.BestVersionCaller{
+		APICallerFunc: apitesting.APICallerFunc(
+			func(objType string, version int, id, request string, a, response interface{}) error {
+				c.Assert(request, gc.Equals, "Next")
+				return nil
+			}),
+		BestVersion: 1}
+	facadeCaller.FacadeCallFn = func(name string, args, response interface{}) error {
+		c.Assert(name, gc.Equals, "WatchCloudSpecsChanges")
+		c.Assert(args, jc.DeepEquals, params.Entities{Entities: []params.Entity{
+			{Tag: coretesting.ModelTag.String()},
+		}})
+		*(response.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{{
+				NotifyWatcherId: "1",
+			}},
+		}
+		called = true
+		return nil
+	}
+	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
+	w, err := api.WatchCloudSpecChanges()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.NotNil)
+	c.Assert(called, jc.IsTrue)
+}
+
 func (s *CloudSpecSuite) TestCloudSpecOverallError(c *gc.C) {
 	expect := errors.New("bewm")
 	facadeCaller := apitesting.StubFacadeCaller{Stub: &testing.Stub{}}

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -59,3 +59,20 @@ func MakeCloudSpecGetterForModel(st *state.State) func(names.ModelTag) (environs
 		return configGetter.CloudSpec()
 	}
 }
+
+// MakeCloudSpecWatcherForModel returns a function which returns a
+// NotifyWatcher for cloud spec changes for a single model.
+// Attempts to request a watcher for any other model other than the
+// one associated with the given state.State results in an error.
+func MakeCloudSpecWatcherForModel(st *state.State) func(names.ModelTag) (state.NotifyWatcher, error) {
+	return func(tag names.ModelTag) (state.NotifyWatcher, error) {
+		m, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if tag.Id() != st.ModelUUID() {
+			return nil, errors.New("cannot get cloud spec for this model")
+		}
+		return m.WatchCloudSpecChanges(), nil
+	}
+}

--- a/apiserver/common/testing/modelwatcher.go
+++ b/apiserver/common/testing/modelwatcher.go
@@ -21,7 +21,9 @@ type ModelWatcher interface {
 type ModelWatcherTest struct {
 	modelWatcher ModelWatcher
 	st           *state.State
-	resources    *common.Resources
+	// We can't call this "resources" as it conflicts
+	// when embedded in other test suites.
+	res *common.Resources
 }
 
 func NewModelWatcherTest(
@@ -54,7 +56,7 @@ func (s *ModelWatcherTest) TestModelConfig(c *gc.C) {
 }
 
 func (s *ModelWatcherTest) TestWatchForModelConfigChanges(c *gc.C) {
-	c.Assert(s.resources.Count(), gc.Equals, 0)
+	c.Assert(s.res.Count(), gc.Equals, 0)
 
 	result, err := s.modelWatcher.WatchForModelConfigChanges()
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,8 +65,8 @@ func (s *ModelWatcherTest) TestWatchForModelConfigChanges(c *gc.C) {
 	})
 
 	// Verify the resources were registered and stop them when done.
-	c.Assert(s.resources.Count(), gc.Equals, 1)
-	resource := s.resources.Get("1")
+	c.Assert(s.res.Count(), gc.Equals, 1)
+	resource := s.res.Get("1")
 	defer statetesting.AssertStop(c, resource)
 
 	// Check that the Watch has consumed the initial event ("returned"

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -54,7 +54,9 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 		ModelWatcher:        common.NewModelWatcher(model, resources, auth),
 		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		CloudSpecAPI: cloudspec.NewCloudSpec(
+			resources,
 			cloudspec.MakeCloudSpecGetterForModel(st),
+			cloudspec.MakeCloudSpecWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		st:        st,

--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -31,7 +31,9 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		return nil, errors.Trace(err)
 	}
 	cloudSpecAPI := cloudspec.NewCloudSpec(
+		resources,
 		cloudspec.MakeCloudSpecGetterForModel(ctx.State()),
+		cloudspec.MakeCloudSpecWatcherForModel(ctx.State()),
 		common.AuthFuncForTag(model.ModelTag()),
 	)
 	return &Facade{

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -244,7 +244,9 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	accessUnitOrApplication := common.AuthAny(accessUnit, accessApplication)
 
 	cloudSpec := cloudspec.NewCloudSpec(
+		resources,
 		cloudspec.MakeCloudSpecGetterForModel(st),
+		cloudspec.MakeCloudSpecWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
 

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -139,7 +139,9 @@ func NewControllerAPI(
 			apiUser,
 		),
 		CloudSpecAPI: cloudspec.NewCloudSpec(
+			resources,
 			cloudspec.MakeCloudSpecGetter(pool),
+			cloudspec.MakeCloudSpecWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		state:      st,

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -61,7 +61,9 @@ func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 	}
 
 	cloudSpecAPI := cloudspec.NewCloudSpec(
+		context.Resources(),
 		cloudspec.MakeCloudSpecGetterForModel(st),
+		cloudspec.MakeCloudSpecWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
 	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st, m)}, context.Resources(), context.Auth(), cloudSpecAPI)

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -38,7 +38,9 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cloudSpecAPI := cloudspec.NewCloudSpec(
+		s.resources,
 		cloudspec.MakeCloudSpecGetterForModel(s.State),
+		cloudspec.MakeCloudSpecWatcherForModel(s.State),
 		common.AuthFuncForTag(s.Model.ModelTag()),
 	)
 	// Create a firewaller API for the machine.

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -294,8 +294,6 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	controllerTag := agentConfig.Controller()
 	modelTag := agentConfig.Model()
 	manifolds := dependency.Manifolds{
-		// The environ tracker could/should be used by several other
-		// workers (firewaller, provisioners, address-cleaner?).
 		environTrackerName: ifCredentialValid(ifResponsible(environ.Manifold(environ.ManifoldConfig{
 			APICallerName:  apiCallerName,
 			NewEnvironFunc: config.NewEnvironFunc,

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -22,20 +22,27 @@ type NewEnvironFunc func(OpenParams) (Environ, error)
 // GetEnviron returns the environs.Environ ("provider") associated
 // with the model.
 func GetEnviron(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, error) {
+	env, _, err := GetEnvironAndCloud(st, newEnviron)
+	return env, err
+}
+
+// GetEnvironAndCloud returns the environs.Environ ("provider") and cloud associated
+// with the model.
+func GetEnvironAndCloud(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, *CloudSpec, error) {
 	modelConfig, err := st.ModelConfig()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 	cloudSpec, err := st.CloudSpec()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 	env, err := newEnviron(OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
-	return env, nil
+	return env, &cloudSpec, nil
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -265,6 +265,12 @@ type ConfigSetter interface {
 	SetConfig(cfg *config.Config) error
 }
 
+// CloudSpecSetter implements access to an environment's cloud spec.
+type CloudSpecSetter interface {
+	// SetConfig updates the Environ's configuration.
+	SetCloudSpec(spec CloudSpec) error
+}
+
 // Bootstraper provides the way for bootstrapping controller.
 type Bootstraper interface {
 	// This will be called very early in the bootstrap procedure, to

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -106,7 +106,7 @@ var newOpenstackStorage = func(env *Environ) (OpenstackStorage, error) {
 
 	client := env.clientUnlocked
 	if env.volumeURL == nil {
-		url, err := getVolumeEndpointURL(client, env.cloud.Region)
+		url, err := getVolumeEndpointURL(client, env.cloudUnlocked.Region)
 		if errors.IsNotFound(err) {
 			// No volume endpoint found; Cinder is not supported.
 			return nil, errors.NotSupportedf("volumes")
@@ -119,7 +119,7 @@ var newOpenstackStorage = func(env *Environ) (OpenstackStorage, error) {
 
 	cinderCl := cinderClient{cinder.Basic(env.volumeURL, client.TenantId(), client.Token)}
 
-	cloudSpec := env.cloud
+	cloudSpec := env.cloudUnlocked
 	if len(cloudSpec.CACertificates) > 0 {
 		cinderCl = cinderClient{cinder.BasicTLSConfig(
 			env.volumeURL,

--- a/provider/openstack/cinder_internal_test.go
+++ b/provider/openstack/cinder_internal_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&cinderInternalSuite{})
 
 func (s *cinderInternalSuite) TestStorageProviderTypes(c *gc.C) {
 	env := &Environ{
-		cloud: environs.CloudSpec{
+		cloudUnlocked: environs.CloudSpec{
 			Region: "foo",
 		},
 		clientUnlocked: &testAuthClient{

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -896,6 +896,12 @@ func (e *Environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
+// SetCloudSpec is specified in the environs.Environ interface.
+func (e *Environ) SetCloudSpec(spec environs.CloudSpec) error {
+	// TODO - not supported
+	return nil
+}
+
 func identityClientVersion(authURL string) (int, error) {
 	url, err := url.Parse(authURL)
 	if err != nil {

--- a/provider/openstack/series_test.go
+++ b/provider/openstack/series_test.go
@@ -29,7 +29,7 @@ func MetadataStorage(e environs.Environ) envstorage.Storage {
 	env := e.(*Environ)
 	ecfg := env.ecfg()
 	container := "juju-dist-test"
-	client, err := authClient(env.cloud, ecfg)
+	client, err := authClient(env.cloud(), ecfg)
 	if err != nil {
 		panic(fmt.Errorf("cannot create %s container: %v", container, err))
 	}
@@ -495,7 +495,7 @@ func FindInstanceSpec(
 	return findInstanceSpec(env, &instances.InstanceConstraint{
 		Series:      series,
 		Arches:      []string{arch},
-		Region:      env.cloud.Region,
+		Region:      env.cloud().Region,
 		Constraints: constraints.MustParse(cons),
 	}, imageMetadata)
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3061,6 +3061,27 @@ func (s *StateSuite) TestWatchForModelConfigControllerChanges(c *gc.C) {
 	wc.AssertOneChange()
 }
 
+func (s *StateSuite) TestWatchCloudSpecChanges(c *gc.C) {
+	w := s.model.WatchCloudSpecChanges()
+	defer statetesting.AssertStop(c, w)
+
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+	// Initially we get one change notification
+	wc.AssertOneChange()
+
+	cloud, err := s.State.Cloud(s.Model.Cloud())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Multiple changes will only result in a single change notification
+	cloud.StorageEndpoint = "https://storage"
+	err = s.State.UpdateCloud(cloud)
+	c.Assert(err, jc.ErrorIsNil)
+	cloud.StorageEndpoint = "https://storage1"
+	err = s.State.UpdateCloud(cloud)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+}
+
 func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 	// The equivalence tested here isn't necessarily correct, and
 	// comparing private details is discouraged in the project.

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1909,6 +1909,12 @@ func (model *Model) WatchForModelConfigChanges() NotifyWatcher {
 	return newEntityWatcher(model.st, settingsC, model.st.docID(modelGlobalKey))
 }
 
+// WatchCloudSpecChanges returns a NotifyWatcher waiting for the cloud
+// to change for the model.
+func (model *Model) WatchCloudSpecChanges() NotifyWatcher {
+	return newEntityWatcher(model.st, cloudsC, model.Cloud())
+}
+
 // WatchModelEntityReferences returns a NotifyWatcher waiting for the Model
 // Entity references to change for specified model.
 func (st *State) WatchModelEntityReferences(mUUID string) NotifyWatcher {


### PR DESCRIPTION
## Description of change

The environ tracker for each model worker watches for changes to the model's cloud and updates the environ instance with the new cloud spec. Currently, only openstack has the capability to react to cloud changes.

There are 2 commits.

1. boiler plate

The changes are largely mechanical and add to the existing common cloud spec api facade plugin, using the existing coding conventions. The key components are:
- state watcher
- apiserver, api facade implementation
- environ tracker worker

2. openstack provider

Add support for reacting to cloud changes. Really just a simple re-org of the Open() logic.

## QA steps

bootstrap lxd
run juju update-cloud
observe via logging that the SetCloudSpec api is called on the lxd provider
todo: test on openstack

## Bug reference

https://bugs.launchpad.net/juju/+bug/1819456
