### PR TITLE
2.5 Pass a Working Directory to KVM Commands Instead of Switching Process Directory

### DIFF
--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -53,8 +53,8 @@ type runStub struct {
 }
 
 // Run fakes running commands, instead recording calls made for use in testing.
-func (s *runStub) Run(cmd string, args ...string) (string, error) {
-	call := []string{cmd}
+func (s *runStub) Run(dir, cmd string, args ...string) (string, error) {
+	call := []string{dir, cmd}
 	call = append(call, args...)
 	s.calls = append(s.calls, strings.Join(call, " "))
 	if s.err != nil {

--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -129,10 +129,10 @@ func createPool(pathfinder func(string) (string, error), runCmd runFunc, chownFu
 	return nil
 }
 
-// definePool creates the required directories and changes ownershipt of the
+// definePool creates the required directories and changes ownership of the
 // guest directory so that libvirt-qemu can read, write, and execute its
 // guest volumes.
-func definePool(dir string, runCmd runFunc, chownFunc func(string) error) error {
+func definePool(dir string, runCmd runFunc, _ func(string) error) error {
 	// Permissions gleaned from https://goo.gl/SZIw14
 	// The command itself would change the permissions to match anyhow.
 	err := os.MkdirAll(dir, 0755)
@@ -144,7 +144,8 @@ func definePool(dir string, runCmd runFunc, chownFunc func(string) error) error 
 	// e.g. file, lvm, scsi, disk, NFS. Newer versions support using only named
 	// args (--type, --target) but this is backwards compatible for trusty.
 	output, err := runCmd(
-		"virsh",
+		"",
+		virsh,
 		"pool-define-as",
 		poolName,
 		"dir",
@@ -179,7 +180,7 @@ func chownToLibvirt(dir string) error {
 // buildPool sets up libvirt internals for the guest pool.
 func buildPool(runCmd runFunc) error {
 	// This can run without error if the pool isn't active.
-	output, err := runCmd("virsh", "pool-build", poolName)
+	output, err := runCmd("", virsh, "pool-build", poolName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -189,7 +190,7 @@ func buildPool(runCmd runFunc) error {
 
 // startPool makes the pool available for use in libvirt.
 func startPool(runCmd runFunc) error {
-	output, err := runCmd("virsh", "pool-start", poolName)
+	output, err := runCmd("", virsh, "pool-start", poolName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -200,7 +201,7 @@ func startPool(runCmd runFunc) error {
 
 // autostartPool sets up the pool to run automatically when libvirt starts.
 func autostartPool(runCmd runFunc) error {
-	output, err := runCmd("virsh", "pool-autostart", poolName)
+	output, err := runCmd("", virsh, "pool-autostart", poolName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -13,7 +13,6 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-// gocheck boilerplate.
 type initialisationInternalSuite struct {
 	testing.IsolationSuite
 }
@@ -37,10 +36,10 @@ func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
 	err = createPool(pathfinder, stub.Run, chown)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(stub.Calls(), jc.DeepEquals, []string{
-		fmt.Sprintf("virsh pool-define-as juju-pool dir - - - - %s/kvm/guests", tmpDir),
-		"virsh pool-build juju-pool",
-		"virsh pool-start juju-pool",
-		"virsh pool-autostart juju-pool",
+		fmt.Sprintf(" virsh pool-define-as juju-pool dir - - - - %s/kvm/guests", tmpDir),
+		" virsh pool-build juju-pool",
+		" virsh pool-start juju-pool",
+		" virsh pool-autostart juju-pool",
 	})
 }
 

--- a/container/kvm/run.go
+++ b/container/kvm/run.go
@@ -3,21 +3,33 @@
 
 package kvm
 
-import "github.com/juju/utils"
+import (
+	"os/exec"
+)
 
 // This is the user on ubuntu. I don't know what the user would be on other
 // linux distros. At the time of this writing we are only supporting ubuntu on
 // ubuntu for kvm containers in Juju.
 const libvirtUser = "libvirt-qemu"
 
-// runFunc provides the signature for running an external command and returning
-// the combined output.
-type runFunc func(string, ...string) (string, error)
+// runFunc provides the signature for running an external
+// command and returning the combined output.
+// The first parameter, if non-empty will use the input
+// path as the working directory for the command.
+type runFunc func(string, string, ...string) (string, error)
 
 // run the command and return the combined output.
-func run(command string, args ...string) (output string, err error) {
-	logger.Debugf("%s %v", command, args)
-	output, err = utils.RunCommand(command, args...)
+func run(dir, command string, args ...string) (string, error) {
+	logger.Debugf("(%s) %s %v", dir, command, args)
+
+	cmd := exec.Command(command, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+
 	logger.Debugf("output: %v", output)
 	return output, err
 }

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -237,7 +237,7 @@ func (i *Image) write(r io.Reader, md *imagedownloads.Metadata) error {
 	// TODO(jam): 2017-03-19 If this is slow, maybe we want to add a progress step for it, rather than only
 	// indicating download progress.
 	output, err := i.runCmd(
-		"qemu-img", "convert", "-f", "qcow2", tmpPath, i.FilePath)
+		"", "qemu-img", "convert", "-f", "qcow2", tmpPath, i.FilePath)
 	logger.Debugf("qemu-image convert output: %s", output)
 	if err != nil {
 		i.cleanupAll()

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -66,7 +66,7 @@ func (syncInternalSuite) TestFetcher(c *gc.C) {
 
 	// Check that our call was made as expected.
 	c.Assert(stub.Calls(), gc.HasLen, 1)
-	c.Assert(stub.Calls()[0], gc.Matches, "qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/spammy-archless-backing-file.qcow")
+	c.Assert(stub.Calls()[0], gc.Matches, " qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/spammy-archless-backing-file.qcow")
 
 }
 
@@ -102,7 +102,7 @@ func (syncInternalSuite) TestFetcherWriteFails(c *gc.C) {
 
 	// Check that our call was made as expected.
 	c.Assert(stub.Calls(), gc.HasLen, 1)
-	c.Assert(stub.Calls()[0], gc.Matches, "qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/spammy-archless-backing-file.qcow")
+	c.Assert(stub.Calls()[0], gc.Matches, " qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/spammy-archless-backing-file.qcow")
 
 }
 

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -145,14 +145,14 @@ func (commandWrapperSuite) TestCreateMachineSuccess(c *gc.C) {
 
 	c.Check(len(stub.Calls()), gc.Equals, 4)
 	want := []string{
-		`genisoimage -output \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00-ds\.iso -volid cidata -joliet -rock user-data meta-data network-config`,
-		`qemu-img create -b \/tmp/juju-libvirtSuite-\d+\/kvm\/guests\/precise-arm64-backing-file.qcow -f qcow2 \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00.qcow 8G`,
-		`virsh define \/tmp\/juju-libvirtSuite-\d+\/host00.xml`,
-		"virsh start host00",
+		tmpDir + ` genisoimage -output \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00-ds\.iso -volid cidata -joliet -rock user-data meta-data network-config`,
+		` qemu-img create -b \/tmp/juju-libvirtSuite-\d+\/kvm\/guests\/precise-arm64-backing-file.qcow -f qcow2 \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00.qcow 8G`,
+		` virsh define \/tmp\/juju-libvirtSuite-\d+\/host00.xml`,
+		" virsh start host00",
 	}
 
 	for i, cmd := range stub.Calls() {
-		c.Assert(cmd, gc.Matches, want[i])
+		c.Check(cmd, gc.Matches, want[i])
 	}
 }
 
@@ -177,8 +177,8 @@ func (commandWrapperSuite) TestDestroyMachineSuccess(c *gc.C) {
 	err = DestroyMachine(container)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stub.Calls(), jc.DeepEquals, []string{
-		"virsh destroy aname",
-		"virsh undefine --nvram aname",
+		" virsh destroy aname",
+		" virsh undefine --nvram aname",
 	})
 }
 
@@ -187,8 +187,8 @@ func (commandWrapperSuite) TestDestroyMachineFails(c *gc.C) {
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := DestroyMachine(container)
 	c.Check(stub.Calls(), jc.DeepEquals, []string{
-		"virsh destroy aname",
-		"virsh undefine --nvram aname",
+		" virsh destroy aname",
+		" virsh undefine --nvram aname",
 	})
 	log := c.GetTestLog()
 	c.Check(log, jc.Contains, "`virsh destroy aname` failed")
@@ -201,7 +201,7 @@ func (commandWrapperSuite) TestAutostartMachineSuccess(c *gc.C) {
 	stub := NewRunStub("success", nil)
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := AutostartMachine(container)
-	c.Assert(stub.Calls(), jc.DeepEquals, []string{"virsh autostart aname"})
+	c.Assert(stub.Calls(), jc.DeepEquals, []string{" virsh autostart aname"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -209,7 +209,7 @@ func (commandWrapperSuite) TestAutostartMachineFails(c *gc.C) {
 	stub := NewRunStub("", errors.Errorf("Boom"))
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := AutostartMachine(container)
-	c.Assert(stub.Calls(), jc.DeepEquals, []string{"virsh autostart aname"})
+	c.Assert(stub.Calls(), jc.DeepEquals, []string{" virsh autostart aname"})
 	c.Check(err, gc.ErrorMatches, `failed to autostart domain "aname": Boom`)
 }
 
@@ -224,7 +224,7 @@ func (commandWrapperSuite) TestListMachinesSuccess(c *gc.C) {
 	got, err := ListMachines(stub.Run)
 
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(stub.Calls(), jc.DeepEquals, []string{"virsh -q list --all"})
+	c.Check(stub.Calls(), jc.DeepEquals, []string{" virsh -q list --all"})
 	c.Assert(got, jc.DeepEquals, map[string]string{
 		"Domain-0": "running",
 		"ubuntu":   "paused",
@@ -236,6 +236,6 @@ func (commandWrapperSuite) TestListMachinesFails(c *gc.C) {
 	stub := NewRunStub("", errors.Errorf("Boom"))
 	got, err := ListMachines(stub.Run)
 	c.Check(err, gc.ErrorMatches, "Boom")
-	c.Check(stub.Calls(), jc.DeepEquals, []string{"virsh -q list --all"})
+	c.Check(stub.Calls(), jc.DeepEquals, []string{" virsh -q list --all"})
 	c.Assert(got, gc.IsNil)
 }


### PR DESCRIPTION
## Description of change

For generating KVM meta-data ISOs, the `genisoimage` command needs be run from the exact directory where `meta-data` and `user-data` reside so that these names can be passed in verbatim, with no path prefix.

This was being done by calling `os.Chdir` to switch the process working directory. This command is not re-entrant, so obviously not Goroutine safe.

Instead, implementations of `params.runCmd` accept a working directory, which is used by `exec.Command` if not empty.

## QA steps

- Bootstrap to a substrate supporting KVMs.
- `juju add-machine`
- `juju deploy redis -n 9 --to kvm:0,kvm:0,kvm:0,kvm:0,kvm:0,kvm:0,kvm:0,kvm:0,kvm:0`
- Wait for quiescence, then `juju ssh 0`
- Check that the SHAs of generated ISOs in `/var/lib/juju/kvm/guests` are unique.

Example:
```bash
root@nuc5:/var/lib/juju/kvm/guests# ls
juju-34a79d-0-kvm-0-ds.iso  juju-34a79d-0-kvm-2.qcow    juju-34a79d-0-kvm-5-ds.iso  juju-34a79d-0-kvm-7.qcow
juju-34a79d-0-kvm-0.qcow    juju-34a79d-0-kvm-3-ds.iso  juju-34a79d-0-kvm-5.qcow    juju-34a79d-0-kvm-8-ds.iso
juju-34a79d-0-kvm-1-ds.iso  juju-34a79d-0-kvm-3.qcow    juju-34a79d-0-kvm-6-ds.iso  juju-34a79d-0-kvm-8.qcow
juju-34a79d-0-kvm-1.qcow    juju-34a79d-0-kvm-4-ds.iso  juju-34a79d-0-kvm-6.qcow    trusty-amd64-backing-file.qcow
juju-34a79d-0-kvm-2-ds.iso  juju-34a79d-0-kvm-4.qcow    juju-34a79d-0-kvm-7-ds.iso
root@nuc5:/var/lib/juju/kvm/guests# shasum *.iso
62b89d1e5191b897cfe4e77cef81e0738ed512ec  juju-34a79d-0-kvm-0-ds.iso
67105017010721b2ada54890096019363938a655  juju-34a79d-0-kvm-1-ds.iso
ba0e15b9602c062b629cf4063dc073737d0d2f25  juju-34a79d-0-kvm-2-ds.iso
65aa793284613e940d673519ba6160fda77aa3cd  juju-34a79d-0-kvm-3-ds.iso
68d0a1d2a51bb57997a35a6fc23c2a313c7c06fe  juju-34a79d-0-kvm-4-ds.iso
b39e051e5be4ecfccdad371bf66e60785d881351  juju-34a79d-0-kvm-5-ds.iso
2f44312f12f9c7aec1d056cd40b87928178edded  juju-34a79d-0-kvm-6-ds.iso
022620793e6bb7b68d6ab24311cb2c6f75e83900  juju-34a79d-0-kvm-7-ds.iso
ded9e587a33f8850415b37c381794e171ac9d415  juju-34a79d-0-kvm-8-ds.iso
```
## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1820901
