### PR TITLE
Fixes logging line for KVM runAsLibvirt.

### DIFF
--- a/container/kvm/run_linux.go
+++ b/container/kvm/run_linux.go
@@ -31,7 +31,7 @@ func runAsLibvirt(dir, command string, args ...string) (string, error) {
 	if dir == "" {
 		dir, _ = os.Getwd()
 	}
-	logger.Debugf("running: %s %v from %s", command, args)
+	logger.Debugf("running: %s %v from %s", command, args, dir)
 	logger.Debugf("running as uid: %d, gid: %d\n", uid, gid)
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{}


### PR DESCRIPTION
Trivial fix for missing format argument in KVM logging.
