### PR TITLE
InstanceMutator Machine API for SetModificationStatus

### DIFF
--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -43,7 +43,7 @@ type MutaterMachine interface {
 	WatchUnits() (watcher.StringsWatcher, error)
 
 	// SetModificationStatus sets the provider specific modification status
-	// for a machine. Allowing the propergation of status messages to the
+	// for a machine. Allowing the propagation of status messages to the
 	// operator.
 	SetModificationStatus(status status.Status, info string, data map[string]interface{}) error
 }

--- a/api/instancemutater/mocks/caller_mock.go
+++ b/api/instancemutater/mocks/caller_mock.go
@@ -5,15 +5,14 @@
 package mocks
 
 import (
-	http "net/http"
-	url "net/url"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	httprequest "github.com/juju/httprequest"
 	base "github.com/juju/juju/api/base"
 	names_v2 "gopkg.in/juju/names.v2"
 	httpbakery "gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	http "net/http"
+	url "net/url"
+	reflect "reflect"
 )
 
 // MockAPICaller is a mock of APICaller interface

--- a/api/instancemutater/mocks/machinemutater_mock.go
+++ b/api/instancemutater/mocks/machinemutater_mock.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
+	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v2 "gopkg.in/juju/names.v2"
 	reflect "reflect"
@@ -70,6 +71,18 @@ func (m *MockMutaterMachine) SetCharmProfiles(arg0 []string) error {
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0)
+}
+
+// SetModificationStatus mocks base method
+func (m *MockMutaterMachine) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetModificationStatus indicates an expected call of SetModificationStatus
+func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // SetUpgradeCharmProfileComplete mocks base method

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -4,7 +4,10 @@
 package instancemutater
 
 import (
+	"time"
+
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
 
@@ -14,6 +17,7 @@ type InstanceMutaterState interface {
 	WatchModelMachines() state.StringsWatcher
 	Unit(string) (Unit, error)
 	Model() (Model, error)
+	ControllerTimestamp() (*time.Time, error)
 }
 
 // State represents point of use methods from the state object
@@ -32,6 +36,7 @@ type Machine interface {
 	InstanceId() (instance.Id, error)
 	SetCharmProfiles([]string) error
 	SetUpgradeCharmProfileComplete(unitName, msg string) error
+	SetModificationStatus(status.StatusInfo) error
 }
 
 // Unit represents point of use methods from the state unit object

--- a/apiserver/facades/agent/instancemutater/mocks/facade_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/facade_mock.go
@@ -136,6 +136,19 @@ func (mr *MockContextMockRecorder) LeadershipPinner(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeadershipPinner", reflect.TypeOf((*MockContext)(nil).LeadershipPinner), arg0)
 }
 
+// LeadershipReader mocks base method
+func (m *MockContext) LeadershipReader(arg0 string) (leadership.Reader, error) {
+	ret := m.ctrl.Call(m, "LeadershipReader", arg0)
+	ret0, _ := ret[0].(leadership.Reader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LeadershipReader indicates an expected call of LeadershipReader
+func (mr *MockContextMockRecorder) LeadershipReader(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeadershipReader", reflect.TypeOf((*MockContext)(nil).LeadershipReader), arg0)
+}
+
 // Presence mocks base method
 func (m *MockContext) Presence() facade.Presence {
 	ret := m.ctrl.Call(m, "Presence")

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -8,9 +8,11 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/apiserver/facades/agent/instancemutater"
 	instance "github.com/juju/juju/core/instance"
+	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	names_v2 "gopkg.in/juju/names.v2"
 	reflect "reflect"
+	time "time"
 )
 
 // MockInstanceMutaterState is a mock of InstanceMutaterState interface
@@ -34,6 +36,19 @@ func NewMockInstanceMutaterState(ctrl *gomock.Controller) *MockInstanceMutaterSt
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInstanceMutaterState) EXPECT() *MockInstanceMutaterStateMockRecorder {
 	return m.recorder
+}
+
+// ControllerTimestamp mocks base method
+func (m *MockInstanceMutaterState) ControllerTimestamp() (*time.Time, error) {
+	ret := m.ctrl.Call(m, "ControllerTimestamp")
+	ret0, _ := ret[0].(*time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerTimestamp indicates an expected call of ControllerTimestamp
+func (mr *MockInstanceMutaterStateMockRecorder) ControllerTimestamp() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerTimestamp", reflect.TypeOf((*MockInstanceMutaterState)(nil).ControllerTimestamp))
 }
 
 // FindEntity mocks base method
@@ -181,6 +196,18 @@ func (m *MockMachine) SetCharmProfiles(arg0 []string) error {
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMachineMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachine)(nil).SetCharmProfiles), arg0)
+}
+
+// SetModificationStatus mocks base method
+func (m *MockMachine) SetModificationStatus(arg0 status.StatusInfo) error {
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetModificationStatus indicates an expected call of SetModificationStatus
+func (mr *MockMachineMockRecorder) SetModificationStatus(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachine)(nil).SetModificationStatus), arg0)
 }
 
 // SetUpgradeCharmProfileComplete mocks base method

--- a/state/machine.go
+++ b/state/machine.go
@@ -1234,8 +1234,9 @@ func (m *Machine) ModificationStatus() (status.StatusInfo, error) {
 	return machineStatus, nil
 }
 
-// SetModificationStatus sets the provider specific modification status for a
-// machine.
+// SetModificationStatus sets the provider specific modification status
+// for a machine. Allowing the propergation of status messages to the
+// operator.
 func (m *Machine) SetModificationStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st.db(), setStatusParams{
 		badge:     "modification",

--- a/state/machine.go
+++ b/state/machine.go
@@ -1235,7 +1235,7 @@ func (m *Machine) ModificationStatus() (status.StatusInfo, error) {
 }
 
 // SetModificationStatus sets the provider specific modification status
-// for a machine. Allowing the propergation of status messages to the
+// for a machine. Allowing the propagation of status messages to the
 // operator.
 func (m *Machine) SetModificationStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st.db(), setStatusParams{

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
+	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v2 "gopkg.in/juju/names.v2"
 	reflect "reflect"
@@ -70,6 +71,18 @@ func (m *MockMutaterMachine) SetCharmProfiles(arg0 []string) error {
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0)
+}
+
+// SetModificationStatus mocks base method
+func (m *MockMutaterMachine) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetModificationStatus indicates an expected call of SetModificationStatus
+func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // SetUpgradeCharmProfileComplete mocks base method

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -94,6 +94,7 @@ func (m *mutater) startMachines(tags []names.MachineTag) error {
 				}
 				return errors.Trace(err)
 			}
+
 			m.logger.Tracef("startMachines added machine %s", machine.Tag().Id())
 			c = make(chan struct{})
 			m.machines[tag] = c


### PR DESCRIPTION
## Description of change

The following exposes SetModificationStatus on the instance mutator
machine api.

## QA steps

Note to actually see the changes, edit the `worker/instancemutater/mutater.go`
file and add a call to the `machine.SetModificationStatus`

Then perform the following:

```
juju bootstrap lxd test
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
```