### PR TITLE
Rename db name used for capturing webscale metrics

### DIFF
--- a/acceptancetests/reporting.py
+++ b/acceptancetests/reporting.py
@@ -9,7 +9,7 @@ from influxdb import InfluxDBClient
 
 __metaclass__ = type
 
-DBNAME = 'txn_metrics'
+DBNAME = 'juju'
 POLICYNAME = 'txn_metric'
 
 


### PR DESCRIPTION
## Description of change

This PR renames the database used for capturing webscale test metrics to the one provisioned by IS for us.