### PR TITLE
update runAsLibvirt to match recent change to type runFunc

### DIFF
--- a/container/kvm/run.go
+++ b/container/kvm/run.go
@@ -16,6 +16,9 @@ const libvirtUser = "libvirt-qemu"
 // command and returning the combined output.
 // The first parameter, if non-empty will use the input
 // path as the working directory for the command.
+// NOTE: if changing runFunc, remember to edit BOTH copies of
+// runAsLibvirt() in run_other.go and run_linux.go.  One doesn't
+// compile on linux, thus easily missed.
 type runFunc func(string, string, ...string) (string, error)
 
 // run the command and return the combined output.

--- a/container/kvm/run_other.go
+++ b/container/kvm/run_other.go
@@ -7,7 +7,7 @@ package kvm
 
 import "github.com/juju/errors"
 
-func runAsLibvirt(commands string, args ...string) (string, error) {
+func runAsLibvirt(_, _ string, _ ...string) (string, error) {
 	return "", errors.New("kvm is only supported on linux amd64, arm64, and ppc64el")
 }
 


### PR DESCRIPTION
## Description of change

Update runAsLibvirt to match a recent change in type runFunc in container/kvm/run.go.  The file isn't built on linux boxes, so passed the merge checks.