### PR TITLE
Add syslog user to jujud-operator

### DIFF
--- a/caas/jujud-operator-dockerfile
+++ b/caas/jujud-operator-dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
 
+# Add the syslog user for audit logging.
+RUN useradd --system -M syslog
+RUN usermod -s /usr/sbin/nologin syslog
+
 # Some Python dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Description of change

So audit logging can work on juju k8s, add the syslog user to the jujud-operator

## QA steps

bootstrap k8s
check log for errors
check audit.log file