### PR TITLE
Change SetSSHHostKeys to use buildTxn.

### DIFF
--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
 	"gopkg.in/juju/names.v2"
@@ -52,6 +54,10 @@ func keysEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
+	a = a[:]
+	b = b[:]
+	sort.Strings(a)
+	sort.Strings(b)
 	for i := range a {
 		if a[i] != b[i] {
 			return false

--- a/state/sshhostkeys_test.go
+++ b/state/sshhostkeys_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -31,7 +33,7 @@ func (s *SSHHostKeysSuite) TestGetWithNoKeys(c *gc.C) {
 
 func (s *SSHHostKeysSuite) TestSetGet(c *gc.C) {
 	for i := 0; i < 3; i++ {
-		keys := state.SSHHostKeys{"rsa foo", "dsa bar"}
+		keys := state.SSHHostKeys{fmt.Sprintf("rsa foo %d", i), "dsa bar"}
 		err := s.State.SetSSHHostKeys(s.machineTag, keys)
 		c.Assert(err, jc.ErrorIsNil)
 		checkGet(c, s.State, s.machineTag, keys)


### PR DESCRIPTION
## Description of change

Rather than having it always Insert+Update, now it reads to see which
one it needs to do. The old code worked with client-side transactions,
but doesn't feel great. So switch to something that will work with
server-side transactions, and still feels a bit better. (No need to
create Txns that don't do anything.)

## QA steps

The change should cause us to not write to the database on every startup of a machine agent. The easiest way to check this would be to look at the txns log, and restart various machine agents to see that there aren't transactions trying to update the host keys.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1821147