### PR TITLE
Fix mongo 4 support for k8s

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -673,11 +673,11 @@
   revision = "5b9ff866471762aa2ab2dced63c9fb6f53921342"
 
 [[projects]]
-  digest = "1:0919e1397c5d494538f8f6a5bf18ab9546d104565d2a2214ec6973f4fbdb00f3"
+  digest = "1:592b7bbe9d2e0e76c45217ccc69938c5b61a607a5c7a1dd4de88be6c98f44ee5"
   name = "github.com/juju/replicaset"
   packages = ["."]
   pruneopts = ""
-  revision = "86037679224858cd82666e4877a8ac4c42cbda8b"
+  revision = "501ab59799b199dc2a129e60a771a51fef99cd51"
 
 [[projects]]
   digest = "1:2876394b554fd2ea3a68d6585c529817b76a7e3c3c5e0f23e7bf93b6f9956bb8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -102,7 +102,7 @@
   name = "github.com/juju/proxy"
 
 [[constraint]]
-  revision = "86037679224858cd82666e4877a8ac4c42cbda8b"
+  revision = "501ab59799b199dc2a129e60a771a51fef99cd51"
   name = "github.com/juju/replicaset"
 
 [[constraint]]

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -510,6 +510,10 @@ func (c controllerStack) buildStorageSpecForController(statefulset *apps.Statefu
 }
 
 func (c controllerStack) buildContainerSpecForController(statefulset *apps.StatefulSet) error {
+	wiredTigerCacheSize := float32(mongo.LowCacheSize)
+	if c.pcfg.Controller.Config.MongoMemoryProfile() == string(mongo.MemoryProfileLow) {
+		wiredTigerCacheSize = 0.25
+	}
 	generateContainerSpecs := func(jujudCmd string) []core.Container {
 		var containerSpec []core.Container
 		// add container mongoDB.
@@ -548,7 +552,7 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 				"--auth",
 				fmt.Sprintf("--keyFile=%s/%s", c.pcfg.DataDir, c.fileNameSharedSecret),
 				"--storageEngine=wiredTiger",
-				"--wiredTigerCacheSizeGB=0.25",
+				fmt.Sprintf("--wiredTigerCacheSizeGB=%v", wiredTigerCacheSize),
 				"--bind_ip_all",
 			},
 			Ports: []core.ContainerPort{

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -305,7 +305,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "jujusolutions/juju-db:4.1.9",
+			Image:           "jujusolutions/juju-db:4.0.6",
 			Command: []string{
 				"mongod",
 			},
@@ -323,7 +323,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 				"--auth",
 				"--keyFile=/var/lib/juju/shared-secret",
 				"--storageEngine=wiredTiger",
-				"--wiredTigerCacheSizeGB=0.25",
+				"--wiredTigerCacheSizeGB=1",
 				"--bind_ip_all",
 			},
 			Ports: []core.ContainerPort{

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -36,6 +36,9 @@ const (
 	jujudbOCIName     = "juju-db"
 )
 
+// jujudbVersion is the version of juju-db to use.
+var jujudbVersion = mongo.Mongo406wt
+
 // ControllerPodConfig represents initialization information for a new juju caas controller pod.
 type ControllerPodConfig struct {
 	// Tags is a set of tags/labels to set on the Pod, if supported. This
@@ -118,20 +121,18 @@ func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWr
 			LogDir:          cfg.LogDir,
 			MetricsSpoolDir: cfg.MetricsSpoolDir,
 		},
-		Jobs:              cfg.Jobs,
-		Tag:               tag,
-		UpgradedToVersion: cfg.JujuVersion,
-		Password:          password,
-		Nonce:             cfg.PodNonce,
-		APIAddresses:      cfg.APIHostAddrs(),
-		CACert:            cacert,
-		Values:            cfg.AgentEnvironment,
-		Controller:        cfg.ControllerTag,
-		Model:             cfg.APIInfo.ModelTag,
-		// TODO(bootstrap): IAAS updates version after mongo installed, but for CAAS, it's predefined.
-		// make mongo version and profile more flexible to modifiable.
-		MongoVersion:       mongo.Mongo36wt,
-		MongoMemoryProfile: mongo.MemoryProfileDefault,
+		Jobs:               cfg.Jobs,
+		Tag:                tag,
+		UpgradedToVersion:  cfg.JujuVersion,
+		Password:           password,
+		Nonce:              cfg.PodNonce,
+		APIAddresses:       cfg.APIHostAddrs(),
+		CACert:             cacert,
+		Values:             cfg.AgentEnvironment,
+		Controller:         cfg.ControllerTag,
+		Model:              cfg.APIInfo.ModelTag,
+		MongoVersion:       jujudbVersion,
+		MongoMemoryProfile: mongo.MemoryProfile(cfg.Controller.Config.MongoMemoryProfile()),
 	}
 	return agent.NewStateMachineConfig(configParams, cfg.Bootstrap.StateServingInfo)
 }
@@ -233,7 +234,7 @@ func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
 	if imageRepo == "" {
 		imageRepo = jujudOCINamespace
 	}
-	v := mongo.Mongo419wt
+	v := jujudbVersion
 	return fmt.Sprintf("%s/%s:%d.%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor, v.Point)
 }
 

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -63,7 +63,7 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "jujusolutions/jujud-operator:6.6.6")
-	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "jujusolutions/juju-db:4.1.9")
+	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "jujusolutions/juju-db:4.0.6")
 }
 
 func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
@@ -76,5 +76,5 @@ func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "path/to/my/repo/jujud-operator:6.6.6")
-	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "path/to/my/repo/juju-db:4.1.9")
+	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "path/to/my/repo/juju-db:4.0.6")
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -232,22 +232,16 @@ var (
 		Patch:         "",
 		StorageEngine: WiredTiger,
 	}
-	// Mongo34wt represents 'mongodb-server-core' at version 3.4.x with WiredTiger
-	Mongo34wt = Version{Major: 3,
-		Minor:         4,
-		Patch:         "",
-		StorageEngine: WiredTiger,
-	}
 	// Mongo36wt represents 'mongodb-server-core' at version 3.6.x with WiredTiger
 	Mongo36wt = Version{Major: 3,
 		Minor:         6,
 		Patch:         "",
 		StorageEngine: WiredTiger,
 	}
-	// Mongo419wt represents 'mongodb-server-core' at version 4.1.9 with WiredTiger
-	Mongo419wt = Version{Major: 4,
-		Minor:         1,
-		Point:         9,
+	// Mongo406wt represents 'mongodb-server-core' at version 4.0.6 with WiredTiger
+	Mongo406wt = Version{Major: 4,
+		Minor:         0,
+		Point:         6,
 		StorageEngine: WiredTiger,
 	}
 	// MongoUpgrade represents a sepacial case where an upgrade is in

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -44,9 +44,6 @@ const (
 	// Mongo34LowCacheSize changed to being a float, and allows you to specify down to 256MB
 	Mongo34LowCacheSize = 0.25
 
-	// defaultStorageEngine is the storage engine used by juju.
-	defaultStorageEngine = WiredTiger
-
 	// flagMarker is an in-line comment for bash. If it somehow makes its way onto
 	// the command line, it will be ignored. See https://stackoverflow.com/a/1456019/395287
 	flagMarker = "`#flag: true` \\"


### PR DESCRIPTION
## Description of change

Tweak the mongo 4 setup for bootstrapping on k8s. Main fix is to use an updated juju/replicaset.

## QA steps

bootstrap on k8s
deploy kubeflow
