### PR TITLE
Fixes lp#1793147: Clarify how a file can be passed in to 'add-cloud'.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -66,7 +66,7 @@ A cloud definition can be provided in a file either as an option --f or as a
 positional argument:
 
     juju add-cloud mycloud ~/mycloud.yaml
-    juju add-cloud mycloud --f ~/mycloud.yaml
+    juju add-cloud mycloud -f ~/mycloud.yaml
 
 Juju will validate the contents of the supplied file and
 store that cloud definition in its internal cache.

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -62,9 +62,14 @@ When invoked without arguments, add-cloud begins an interactive session
 designed for working with private clouds.  The session will enable you 
 to instruct Juju how to connect to your private cloud.
 
-When <cloud definition file> is provided with <cloud name>, 
-Juju stores that definition its internal cache directly after 
-validating the contents.
+A cloud definition can be provided in a file either as an option --f or as a 
+positional argument:
+
+    juju add-cloud mycloud ~/mycloud.yaml
+    juju add-cloud mycloud --f ~/mycloud.yaml
+
+Juju will validate the contents of the supplied file and
+store that cloud definition in its internal cache.
 
 If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
 option is required.


### PR DESCRIPTION
## Description of change

'add-cloud' command accepts cloud definition in a file which can be passed in as an option and as a positional argument. This PR re-phrases command help to clarify that either is acceptable.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1793147
