### PR TITLE
Fixes lp#1800056: Remove redundant --credential option - it was never operational.

### DIFF
--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -81,7 +81,6 @@ func (c *updateCredentialCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	f.StringVar(&c.credential, "credential", "", "Name of credential to update")
 }
 
 type credentialAPI interface {


### PR DESCRIPTION
## Description of change

'update-credential' command advertises a --credential option but it never catered for it. The command takes credential name from a positional argument and due to the logic that handles positional arguments, this command never worked with the option. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1800056
