### PR TITLE
Tighted pod security and adjust annotations

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -510,9 +510,9 @@ func (c controllerStack) buildStorageSpecForController(statefulset *apps.Statefu
 }
 
 func (c controllerStack) buildContainerSpecForController(statefulset *apps.StatefulSet) error {
-	wiredTigerCacheSize := float32(mongo.LowCacheSize)
+	var wiredTigerCacheSize float32
 	if c.pcfg.Controller.Config.MongoMemoryProfile() == string(mongo.MemoryProfileLow) {
-		wiredTigerCacheSize = 0.25
+		wiredTigerCacheSize = mongo.Mongo34LowCacheSize
 	}
 	generateContainerSpecs := func(jujudCmd string) []core.Container {
 		var containerSpec []core.Container
@@ -531,6 +531,25 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 				"db.adminCommand('ping')",
 			},
 		}
+		args := []string{
+			fmt.Sprintf("--dbpath=%s/db", c.pcfg.DataDir),
+			fmt.Sprintf("--sslPEMKeyFile=%s/%s", c.pcfg.DataDir, c.fileNameSSLKey),
+			"--sslPEMKeyPassword=ignored",
+			"--sslMode=requireSSL",
+			fmt.Sprintf("--port=%d", c.portMongoDB),
+			"--journal",
+			fmt.Sprintf("--replSet=%s", mongo.ReplicaSetName),
+			"--quiet",
+			"--oplogSize=1024",
+			"--ipv6",
+			"--auth",
+			fmt.Sprintf("--keyFile=%s/%s", c.pcfg.DataDir, c.fileNameSharedSecret),
+			"--storageEngine=wiredTiger",
+			"--bind_ip_all",
+		}
+		if wiredTigerCacheSize > 0 {
+			args = append(args, fmt.Sprintf("--wiredTigerCacheSizeGB=%v", wiredTigerCacheSize))
+		}
 		containerSpec = append(containerSpec, core.Container{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
@@ -538,23 +557,7 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 			Command: []string{
 				"mongod",
 			},
-			Args: []string{
-				fmt.Sprintf("--dbpath=%s/db", c.pcfg.DataDir),
-				fmt.Sprintf("--sslPEMKeyFile=%s/%s", c.pcfg.DataDir, c.fileNameSSLKey),
-				"--sslPEMKeyPassword=ignored",
-				"--sslMode=requireSSL",
-				fmt.Sprintf("--port=%d", c.portMongoDB),
-				"--journal",
-				fmt.Sprintf("--replSet=%s", mongo.ReplicaSetName),
-				"--quiet",
-				"--oplogSize=1024",
-				"--ipv6",
-				"--auth",
-				fmt.Sprintf("--keyFile=%s/%s", c.pcfg.DataDir, c.fileNameSharedSecret),
-				"--storageEngine=wiredTiger",
-				fmt.Sprintf("--wiredTigerCacheSizeGB=%v", wiredTigerCacheSize),
-				"--bind_ip_all",
-			},
+			Args: args,
 			Ports: []core.ContainerPort{
 				{
 					Name:          "mongodb",

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -96,11 +96,11 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	svc := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-service",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Spec: core.ServiceSpec{
-			Selector: map[string]string{"juju-application": "juju-controller-test"},
+			Selector: map[string]string{"juju-app": "juju-controller-test"},
 			Type:     core.ServiceType("ClusterIP"),
 			Ports: []core.ServicePort{
 				{
@@ -121,7 +121,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	emptySecret := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-secret",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Type: core.SecretTypeOpaque,
@@ -129,7 +129,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	secretWithSharedSecretAdded := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-secret",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Type: core.SecretTypeOpaque,
@@ -140,7 +140,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	secretWithServerPEMAdded := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-secret",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Type: core.SecretTypeOpaque,
@@ -153,7 +153,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	emptyConfigMap := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-configmap",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 	}
@@ -162,7 +162,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	configMapWithBootstrapParamsAdded := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-configmap",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Data: map[string]string{
@@ -172,7 +172,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	configMapWithAgentConfAdded := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test-configmap",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Data: map[string]string{
@@ -186,20 +186,20 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	statefulSetSpec := &apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "juju-controller-test",
-			Labels:    map[string]string{"juju-application": "juju-controller-test"},
+			Labels:    map[string]string{"juju-app": "juju-controller-test"},
 			Namespace: s.namespace,
 		},
 		Spec: apps.StatefulSetSpec{
 			ServiceName: "juju-controller-test-service",
 			Replicas:    &numberOfPods,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-application": "juju-controller-test"},
+				MatchLabels: map[string]string{"juju-app": "juju-controller-test"},
 			},
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{
 				{
 					ObjectMeta: v1.ObjectMeta{
 						Name:   "storage",
-						Labels: map[string]string{"juju-application": "juju-controller-test"},
+						Labels: map[string]string{"juju-app": "juju-controller-test"},
 					},
 					Spec: core.PersistentVolumeClaimSpec{
 						StorageClassName: &scName,
@@ -214,7 +214,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels:    map[string]string{"juju-application": "juju-controller-test"},
+					Labels:    map[string]string{"juju-app": "juju-controller-test"},
 					Namespace: s.namespace,
 				},
 				Spec: core.PodSpec{
@@ -323,7 +323,6 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 				"--auth",
 				"--keyFile=/var/lib/juju/shared-secret",
 				"--storageEngine=wiredTiger",
-				"--wiredTigerCacheSizeGB=1",
 				"--bind_ip_all",
 			},
 			Ports: []core.ContainerPort{

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -305,7 +305,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "jujusolutions/juju-db:4.0.6",
+			Image:           "jujusolutions/juju-db:4.0",
 			Command: []string{
 				"mongod",
 			},

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -66,7 +66,8 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 				Nameservers: []string{"ns1", "n2"},
 			},
 			SecurityContext: &core.PodSecurityContext{
-				RunAsNonRoot: boolPtr(true),
+				RunAsNonRoot:       boolPtr(true),
+				SupplementalGroups: []int64{1, 2},
 			},
 			ReadinessGates: []core.PodReadinessGate{
 				{ConditionType: core.PodInitialized},
@@ -85,6 +86,10 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 				LivenessProbe: &core.Probe{
 					SuccessThreshold: 20,
 					Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
+				},
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					Privileged:   boolPtr(true),
 				},
 			},
 		}, {
@@ -110,7 +115,8 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 			Nameservers: []string{"ns1", "n2"},
 		},
 		SecurityContext: &core.PodSecurityContext{
-			RunAsNonRoot: boolPtr(true),
+			RunAsNonRoot:       boolPtr(true),
+			SupplementalGroups: []int64{1, 2},
 		},
 		ReadinessGates: []core.PodReadinessGate{
 			{ConditionType: core.PodInitialized},
@@ -121,6 +127,10 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 				Image:           "juju/image",
 				Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 				ImagePullPolicy: core.PullAlways,
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					Privileged:   boolPtr(true),
+				},
 				ReadinessProbe: &core.Probe{
 					InitialDelaySeconds: 10,
 					Handler:             core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/ready"}},
@@ -153,6 +163,10 @@ func (s *K8sSuite) TestMakeUnitSpecWithInitContainers(c *gc.C) {
 				LivenessProbe: &core.Probe{
 					SuccessThreshold: 20,
 					Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
+				},
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					Privileged:   boolPtr(true),
 				},
 			},
 		}, {
@@ -188,6 +202,10 @@ func (s *K8sSuite) TestMakeUnitSpecWithInitContainers(c *gc.C) {
 					SuccessThreshold: 20,
 					Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
 				},
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					Privileged:   boolPtr(true),
+				},
 			}, {
 				Name:  "test2",
 				Image: "juju/image2",
@@ -202,6 +220,12 @@ func (s *K8sSuite) TestMakeUnitSpecWithInitContainers(c *gc.C) {
 				WorkingDir:      "/path/to/here",
 				Command:         []string{"sh", "ls"},
 				ImagePullPolicy: core.PullAlways,
+				// Defaults since not specified.
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot:             boolPtr(true),
+					ReadOnlyRootFilesystem:   boolPtr(true),
+					AllowPrivilegeEscalation: boolPtr(false),
+				},
 			},
 		},
 	})
@@ -274,10 +298,11 @@ test -e ./jujud || cp /opt/jujud $(pwd)/jujud
 
 var basicServiceArg = &core.Service{
 	ObjectMeta: v1.ObjectMeta{
-		Name:   "app-name",
-		Labels: map[string]string{"juju-application": "app-name"}},
+		Name:        "app-name",
+		Labels:      map[string]string{"juju-app": "app-name"},
+		Annotations: map[string]string{}},
 	Spec: core.ServiceSpec{
-		Selector: map[string]string{"juju-application": "app-name"},
+		Selector: map[string]string{"juju-app": "app-name"},
 		Type:     "nodeIP",
 		Ports: []core.ServicePort{
 			{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
@@ -288,22 +313,23 @@ var basicServiceArg = &core.Service{
 	},
 }
 
-func (s *K8sBrokerSuite) secretArg(c *gc.C, labels map[string]string) *core.Secret {
+func (s *K8sBrokerSuite) secretArg(c *gc.C, annotations map[string]string) *core.Secret {
 	secretData, err := provider.CreateDockerConfigJSON(&basicPodspec.Containers[0].ImageDetails)
 	c.Assert(err, jc.ErrorIsNil)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
 	secret := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name-test-secret",
-			Namespace: "test",
-			Labels:    labels,
+			Name:        "app-name-test-secret",
+			Namespace:   "test",
+			Labels:      map[string]string{"juju-app": "app-name"},
+			Annotations: annotations,
 		},
 		Type: "kubernetes.io/dockerconfigjson",
 		Data: map[string][]byte{".dockerconfigjson": secretData},
 	}
-	if secret.Labels == nil {
-		secret.Labels = make(map[string]string)
-	}
-	secret.Labels["juju-application"] = "app-name"
 	return secret
 }
 
@@ -337,13 +363,18 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 
 func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
-		"juju-operator": "gitlab",
+		"fred": "mary",
 	}
 	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", tags)
 	c.Assert(pod.Name, gc.Equals, "gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
 		"juju-operator": "gitlab",
-		"juju-version":  "2.99.0",
+	})
+	c.Assert(pod.Annotations, jc.DeepEquals, map[string]string{
+		"fred":         "mary",
+		"juju-version": "2.99.0",
+		"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+		"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 	})
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
 	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "jujusolutions/jujud-operator")
@@ -631,8 +662,10 @@ func operatorStatefulSetArg(numUnits int32, scName string) *appsv1.StatefulSet {
 			Name: "test-operator",
 			Labels: map[string]string{
 				"juju-operator": "test",
-				"juju-version":  "2.99.0",
-				"fred":          "mary",
+			},
+			Annotations: map[string]string{
+				"juju-version": "2.99.0",
+				"fred":         "mary",
 			}},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
@@ -643,8 +676,12 @@ func operatorStatefulSetArg(numUnits int32, scName string) *appsv1.StatefulSet {
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{
 						"juju-operator": "test",
-						"fred":          "mary",
-						"juju-version":  "2.99.0",
+					},
+					Annotations: map[string]string{
+						"fred":         "mary",
+						"juju-version": "2.99.0",
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 					},
 				},
 				Spec: operatorPodspec,
@@ -652,9 +689,8 @@ func operatorStatefulSetArg(numUnits int32, scName string) *appsv1.StatefulSet {
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "charm",
-					Labels: map[string]string{
-						"juju-operator": "test",
-						"foo":           "bar",
+					Annotations: map[string]string{
+						"foo": "bar",
 					}},
 				Spec: core.PersistentVolumeClaimSpec{
 					StorageClassName: &scName,
@@ -675,31 +711,32 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 	return &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "app-name",
-			Labels: map[string]string{
-				"juju-application": "app-name",
-			},
 			Annotations: map[string]string{
-				"juju-application-uuid": "appuuid",
+				"juju-app-uuid": "appuuid",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-application": "app-name"},
+				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-application": "app-name"},
+					Labels: map[string]string{"juju-app": "app-name"},
+					Annotations: map[string]string{
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+					},
 				},
 				Spec: podSpec,
 			},
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "database-appuuid",
-					Labels: map[string]string{
-						"juju-application": "app-name",
-						"foo":              "bar",
-						"juju-storage":     "database",
+					Annotations: map[string]string{
+						"juju-app":     "app-name",
+						"foo":          "bar",
+						"juju-storage": "database",
 					}},
 				Spec: core.PersistentVolumeClaimSpec{
 					StorageClassName: &scName,
@@ -828,7 +865,7 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 			Return(s.k8sNotFoundError()),
 		s.mockDeployments.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground)).Times(1).
 			Return(s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().List(v1.ListOptions{LabelSelector: "juju-application==test"}).Times(1).
+		s.mockSecrets.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==test"}).Times(1).
 			Return(&core.SecretList{Items: []core.Secret{{
 				ObjectMeta: v1.ObjectMeta{Name: "secret"},
 			}}}, nil),
@@ -876,22 +913,26 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 
 	deploymentArg := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "app-name",
-			Labels: map[string]string{
-				"juju-application": "app-name",
-				"fred":             "mary",
+			Name:   "app-name",
+			Labels: map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred": "mary",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-application": "app-name"},
+				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
 					Labels: map[string]string{
-						"juju-application": "app-name",
-						"fred":             "mary",
+						"juju-app": "app-name",
+					},
+					Annotations: map[string]string{
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+						"fred": "mary",
 					},
 				},
 				Spec: podSpec,
@@ -900,14 +941,14 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	}
 	serviceArg := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "app-name",
-			Annotations: map[string]string{"a": "b"},
-			Labels: map[string]string{
-				"juju-application": "app-name",
-				"fred":             "mary",
+			Name:   "app-name",
+			Labels: map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred": "mary",
+				"a":    "b",
 			}},
 		Spec: core.ServiceSpec{
-			Selector: map[string]string{"juju-application": "app-name"},
+			Selector: map[string]string{"juju-app": "app-name"},
 			Type:     "nodeIP",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
@@ -1191,7 +1232,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-application-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1259,17 +1300,22 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 
 	deploymentArg := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-application": "app-name"}},
+			Name:        "app-name",
+			Labels:      map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-application": "app-name"},
+				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
-					Labels:       map[string]string{"juju-application": "app-name"},
+					Labels:       map[string]string{"juju-app": "app-name"},
+					Annotations: map[string]string{
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+					},
 				},
 				Spec: podSpec,
 			},
@@ -1343,7 +1389,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-application-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1415,7 +1461,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-application-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1494,7 +1540,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-application-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1565,7 +1611,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-application-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
@@ -1651,11 +1697,11 @@ func (s *K8sBrokerSuite) TestWatchService(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Watch(v1.ListOptions{
-			LabelSelector: "juju-application==test",
+			LabelSelector: "juju-app==test",
 			Watch:         true,
 		}).Return(ssWatcher, nil),
 		s.mockDeployments.EXPECT().Watch(v1.ListOptions{
-			LabelSelector: "juju-application==test",
+			LabelSelector: "juju-app==test",
 			Watch:         true,
 		}).Return(deployWatcher, nil),
 	)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -143,6 +143,12 @@ func (s *K8sSuite) TestMakeUnitSpecNoConfigConfig(c *gc.C) {
 				Name:  "test2",
 				Image: "juju/image2",
 				Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
+				// Defaults since not specified.
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot:             boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(false),
+					AllowPrivilegeEscalation: boolPtr(false),
+				},
 			},
 		},
 	})
@@ -210,6 +216,12 @@ func (s *K8sSuite) TestMakeUnitSpecWithInitContainers(c *gc.C) {
 				Name:  "test2",
 				Image: "juju/image2",
 				Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
+				// Defaults since not specified.
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot:             boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(false),
+					AllowPrivilegeEscalation: boolPtr(false),
+				},
 			},
 		},
 		InitContainers: []core.Container{
@@ -222,8 +234,8 @@ func (s *K8sSuite) TestMakeUnitSpecWithInitContainers(c *gc.C) {
 				ImagePullPolicy: core.PullAlways,
 				// Defaults since not specified.
 				SecurityContext: &core.SecurityContext{
-					RunAsNonRoot:             boolPtr(true),
-					ReadOnlyRootFilesystem:   boolPtr(true),
+					RunAsNonRoot:             boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(false),
 					AllowPrivilegeEscalation: boolPtr(false),
 				},
 			},
@@ -352,10 +364,22 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 					{Name: "restricted", Value: "yes"},
 					{Name: "switch", Value: "true"},
 				},
+				// Defaults since not specified.
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot:             boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(false),
+					AllowPrivilegeEscalation: boolPtr(false),
+				},
 			}, {
 				Name:  "test2",
 				Image: "juju/image2",
 				Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP, Name: "fred"}},
+				// Defaults since not specified.
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot:             boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(false),
+					AllowPrivilegeEscalation: boolPtr(false),
+				},
 			},
 		},
 	})
@@ -734,7 +758,6 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 				ObjectMeta: v1.ObjectMeta{
 					Name: "database-appuuid",
 					Annotations: map[string]string{
-						"juju-app":     "app-name",
 						"foo":          "bar",
 						"juju-storage": "database",
 					}},

--- a/caas/kubernetes/provider/k8stypes.go
+++ b/caas/kubernetes/provider/k8stypes.go
@@ -31,9 +31,10 @@ type k8sContainers struct {
 // K8sContainerSpec is a subset of v1.Container which defines
 // attributes we expose for charms to set.
 type K8sContainerSpec struct {
-	LivenessProbe   *core.Probe     `json:"livenessProbe,omitempty"`
-	ReadinessProbe  *core.Probe     `json:"readinessProbe,omitempty"`
-	ImagePullPolicy core.PullPolicy `json:"imagePullPolicy,omitempty"`
+	LivenessProbe   *core.Probe           `json:"livenessProbe,omitempty"`
+	ReadinessProbe  *core.Probe           `json:"readinessProbe,omitempty"`
+	SecurityContext *core.SecurityContext `json:"securityContext,omitempty"`
+	ImagePullPolicy core.PullPolicy       `json:"imagePullPolicy,omitempty"`
 }
 
 // Validate is defined on ProviderContainer.

--- a/caas/kubernetes/provider/k8stypes_test.go
+++ b/caas/kubernetes/provider/k8stypes_test.go
@@ -32,6 +32,7 @@ terminationGracePeriodSeconds: 20
 automountServiceAccountToken: true
 securityContext:
   runAsNonRoot: true
+  supplementalGroups: [1,2]
 hostname: host
 subdomain: sub
 priorityClassName: top
@@ -54,6 +55,9 @@ containers:
       protocol: TCP
     - containerPort: 443
       name: mary
+    securityContext:
+      runAsNonRoot: true
+      privileged: true
     livenessProbe:
       initialDelaySeconds: 10
       httpGet:
@@ -152,7 +156,8 @@ foo: bar
 			TerminationGracePeriodSeconds: int64Ptr(20),
 			AutomountServiceAccountToken:  boolPtr(true),
 			SecurityContext: &core.PodSecurityContext{
-				RunAsNonRoot: boolPtr(true),
+				RunAsNonRoot:       boolPtr(true),
+				SupplementalGroups: []int64{1, 2},
 			},
 			Hostname:          "host",
 			Subdomain:         "sub",
@@ -196,6 +201,10 @@ foo: bar
 			},
 			ProviderContainer: &provider.K8sContainerSpec{
 				ImagePullPolicy: "Always",
+				SecurityContext: &core.SecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					Privileged:   boolPtr(true),
+				},
 				LivenessProbe: &core.Probe{
 					InitialDelaySeconds: 10,
 					Handler: core.Handler{

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -37,7 +37,7 @@ const (
 )
 
 // jujudbVersion is the version of juju-db to use.
-var jujudbVersion = mongo.Mongo406wt
+var jujudbVersion = mongo.Mongo40wt
 
 // ControllerPodConfig represents initialization information for a new juju caas controller pod.
 type ControllerPodConfig struct {
@@ -235,7 +235,7 @@ func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
 		imageRepo = jujudOCINamespace
 	}
 	v := jujudbVersion
-	return fmt.Sprintf("%s/%s:%d.%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor, v.Point)
+	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor)
 }
 
 // GetJujuOCIImagePath returns the jujud oci image path.

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -63,7 +63,7 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "jujusolutions/jujud-operator:6.6.6")
-	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "jujusolutions/juju-db:4.0.6")
+	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "jujusolutions/juju-db:4.0")
 }
 
 func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
@@ -76,5 +76,5 @@ func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "path/to/my/repo/jujud-operator:6.6.6")
-	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "path/to/my/repo/juju-db:4.0.6")
+	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "path/to/my/repo/juju-db:4.0")
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -238,10 +238,10 @@ var (
 		Patch:         "",
 		StorageEngine: WiredTiger,
 	}
-	// Mongo406wt represents 'mongodb-server-core' at version 4.0.6 with WiredTiger
-	Mongo406wt = Version{Major: 4,
+	// Mongo40wt represents 'mongodb' at version 4.0.x with WiredTiger
+	Mongo40wt = Version{Major: 4,
 		Minor:         0,
-		Point:         6,
+		Patch:         "",
 		StorageEngine: WiredTiger,
 	}
 	// MongoUpgrade represents a sepacial case where an upgrade is in

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -123,12 +123,11 @@ func (s *serviceSuite) TestNewConf32(c *gc.C) {
 			c.Check(confFields[i+1], gc.Equals, "10")
 		} else if field == "--wiredTigerCacheSizeGB" {
 			hasCacheSize = true
-			c.Check(confFields[i+1], gc.Equals, "1")
 		}
 	}
 	c.Check(hasStorageEngine, gc.Equals, true)
 	c.Check(hasOplogSize, gc.Equals, true)
-	c.Check(hasCacheSize, gc.Equals, true)
+	c.Check(hasCacheSize, gc.Equals, false)
 }
 
 func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
@@ -145,7 +144,7 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 		oplogSizeMB,
 		false,
 		mongodVersion,
-		mongo.MemoryProfileDefault,
+		mongo.MemoryProfileLow,
 	)
 	conf := mongo.NewConf(confArgs)
 
@@ -197,7 +196,7 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 			c.Assert(expectedVal, gc.Equals, actualVal)
 		}
 	}
-	logger.Debugf("expectedArgs contents %v", expectedArgs)
+	logger.Debugf("expectedArgs contents %v", expectedArgs.Values())
 	c.Assert(expectedArgs.IsEmpty(), gc.Equals, true)
 }
 


### PR DESCRIPTION
## Description of change

Several changes to how k8s pods are created:
- security is locked down by default (eg allow privilege escalation = false, run as root = false etc)
- container level security context supported
- set seccomp and apparmour profiles
- move model and controller uuid and resource tags to annotations
- rename juju-application to juju-app

Also drivebt fix for wired tiger cache size.

## QA steps

bootstrap k8s
deploy kubeflow

