### PR TITLE
Fixes lp#1628211: simplify Examples in commands help.

### DIFF
--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -76,68 +76,15 @@ explicit arguments will override the parameter file.
 
 Examples:
 
-$ juju run-action mysql/3 backup --wait
-action-id: <ID>
-result:
-  status: success
-  file:
-    size: 873.2
-    units: GB
-    name: foo.sql
-
-
-$ juju run-action mysql/3 backup
-action: <ID>
-
-$ juju run-action mysql/leader backup
-resolved leader: mysql/0
-action: <ID>
-
-$ juju show-action-output <ID>
-result:
-  status: success
-  file:
-    size: 873.2
-    units: GB
-    name: foo.sql
-
-$ juju run-action mysql/3 backup --params parameters.yml
-...
-Params sent will be the contents of parameters.yml.
-...
-
-$ juju run-action mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
-...
-Params sent will be:
-
-out: out.tar.bz2
-file:
-  kind: xz
-  quality: high
-...
-
-$ juju run-action mysql/3 backup --params p.yml file.kind=xz file.quality=high
-...
-If p.yml contains:
-
-file:
-  location: /var/backups/mysql/
-  kind: gzip
-
-then the merged args passed will be:
-
-file:
-  location: /var/backups/mysql/
-  kind: xz
-  quality: high
-...
-
-$ juju run-action sleeper/0 pause time=1000
-...
-
-$ juju run-action sleeper/0 pause --string-args time=1000
-...
-The value for the "time" param will be the string literal "1000".
+    juju run-action mysql/3 backup --wait
+    juju run-action mysql/3 backup
+    juju run-action mysql/leader backup
+    juju show-action-output <ID>
+    juju run-action mysql/3 backup --params parameters.yml
+    juju run-action mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
+    juju run-action mysql/3 backup --params p.yml file.kind=xz file.quality=high
+    juju run-action sleeper/0 pause time=1000
+    juju run-action sleeper/0 pause --string-args time=1000
 `
 
 // SetFlags offers an option for YAML output.

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -58,13 +58,8 @@ The online store will, of course, need to be contacted at some point to get
 the software.
 
 Examples:
-    # Download the software (version auto-selected) to the model:
     juju sync-agent-binaries --debug
-
-    # Download a specific version of the software locally:
     juju sync-agent-binaries --debug --version 2.0 --local-dir=/home/ubuntu/sync-agent-binaries
-
-    # Get locally available software to the model:
     juju sync-agent-binaries --debug --source=/home/ubuntu/sync-agent-binaries
 
 See also:

--- a/cmd/juju/machine/show.go
+++ b/cmd/juju/machine/show.go
@@ -16,10 +16,7 @@ other formats can be specified with the "--format" option.
 Available formats are yaml, tabular, and json
 
 Examples:
-    # Display status for machine 0
     juju show-machine 0
-
-    # Display status for machines 1, 2 & 3
     juju show-machine 1 2 3
 
 `

--- a/cmd/juju/setmeterstatus/setmeterstatus.go
+++ b/cmd/juju/setmeterstatus/setmeterstatus.go
@@ -21,10 +21,7 @@ Set meter status on the given application or unit. This command is used
 to test the meter-status-changed hook for charms in development.
 
 Examples:
-    # Set Red meter status on all units of myapp
     juju set-meter-status myapp RED
-
-    # Set AMBER meter status with "my message" as info on unit myapp/0
     juju set-meter-status myapp/0 AMBER --info "my message"
 `
 


### PR DESCRIPTION
## Description of change

We provide comprehensive details in commands' help for different options and positional arguments.
The examples are added for a demonstrative purposes only. Providing explanation on examples make the whole help difficult to read as per linked bug.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1628211
