### PR TITLE
Fix MemoryProfile!='low' to properly handle WiredTigerCacheSize.

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -238,13 +238,20 @@ var (
 		Patch:         "",
 		StorageEngine: WiredTiger,
 	}
-	// Mongo406wt represents 'mongodb-server-core' at version 4.0.6 with WiredTiger
+	// Mongo406wt represents snap 'juju-db' at version 4.0.x with WiredTiger
+	// XXX: (jam) This is the only Mongo declaration that declares a Point
+	//  release. It doesn't seem the right place to do so. We currently have to,
+	//  because the K8s pod spec requires it but
+	//  a) It doesn't match the current snap version
+	//  b) It prevents our normal "update the package to get an updated mongo without
+	//     rebuilding Juju".
+	//  c) It will get *real* messy if we support a range of 4.0.* releases.
 	Mongo406wt = Version{Major: 4,
 		Minor:         0,
 		Point:         6,
 		StorageEngine: WiredTiger,
 	}
-	// MongoUpgrade represents a sepacial case where an upgrade is in
+	// MongoUpgrade represents a special case where an upgrade is in
 	// progress.
 	MongoUpgrade = Version{Major: 0,
 		Minor:         0,
@@ -535,6 +542,12 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 	// Disable the default mongodb installed by the mongodb-server package.
 	// Only do this if the file doesn't exist already, so users can run
 	// their own mongodb server if they wish to.
+	// Note (jam): 2019-03-22 This shouldn't be needed anymore. It was used
+	//  on Precise where we installed mongodb-server from the archive. On
+	//   Trusty:  we install juju-mongodb
+	//   Xenial:  we install juju-mongodb3.2
+	//   Bionic:  we install mongodb-server-core (which doesn't run the service)
+	//        or  snap install juju-db
 	if _, err := os.Stat(mongoConfigPath); os.IsNotExist(err) {
 		err = utils.AtomicWriteFile(
 			mongoConfigPath,

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -483,13 +483,11 @@ func generateConfig(mongoPath string, dataDir string, statePort int, oplogSizeMB
 	}
 
 	if featureflag.Enabled(feature.MongoDbSnap) {
-		// TODO (jam): 2019-03-22 Do we have to set Syslog = false, it has
-		//  been very useful in debugging production systems. Maybe we
-		//  can put the syslog 'long running queries' to another file
+		// Switch from syslog to appending to dataDir, because snaps don't
+		// have the same permissions
 		mongoArgs.Syslog = false
 		mongoArgs.LogAppend = true
 		mongoArgs.LogPath = logPath(dataDir)
-		mongoArgs.BindToAllIP = true // TODO(tsm): disable when not needed
 	}
 
 	return mongoArgs

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -128,7 +128,7 @@ func (s *serviceSuite) TestNewConf32(c *gc.C) {
 	}
 	c.Check(hasStorageEngine, gc.Equals, true)
 	c.Check(hasOplogSize, gc.Equals, true)
-	c.Check(hasCacheSize, gc.Equals, true)
+	c.Check(hasCacheSize, gc.Equals, false)
 }
 
 func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
@@ -145,7 +145,7 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 		oplogSizeMB,
 		false,
 		mongodVersion,
-		mongo.MemoryProfileDefault,
+		mongo.MemoryProfileLow,
 	)
 	conf := mongo.NewConf(confArgs)
 


### PR DESCRIPTION
## Description of change

Using 1GB or 0.25GB memory are both considered "low" memory. We want
Mongo to decide how much memory to use rather than passing it in if you
use default memory profile.

When the code was refactored to support snaps, it accidentally broke how we handled low mem vs default mem with 3.4+.

## QA steps

Test suite passes, ``juju bootstrap`` should default to configure mongo without '--wiredTigerCacheSizeGB', and bootstrap with mongo-memory-profile=low should set it to 0.25GB on new mongo.

## Documentation changes

None.

## Bug reference

None.
