### PR TITLE
Remove set_application_series from assess_upgrade_series

### DIFF
--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -39,7 +39,6 @@ def assess_juju_upgrade_series(client, args):
     reboot_machine(client, target_machine)
     upgrade_series_complete(client, target_machine)
     assert_correct_series(client, target_machine, args.to_series)
-    set_application_series(client, "dummy-subordinate", args.to_series)
 
 
 def upgrade_series_prepare(client, machine, series, **flags):
@@ -71,10 +70,6 @@ def reboot_machine(client, machine):
 
     log.info("wait_for_started()")
     client.wait_for_started()
-
-def set_application_series(client, application, series):
-    args = (application, series)
-    client.juju('set-series', args)
 
 
 def assert_correct_series(client, machine, expected):


### PR DESCRIPTION
This patch modifies the _develop_ test for congruence with the 2.5 version.

Setting application series on subordinates is not supported.