### PR TITLE
k8s CLI fixes

### DIFF
--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -31,6 +31,7 @@ type Backend interface {
 	MongoSession() *mgo.Session
 	MongoVersion() (string, error)
 	ModelTag() names.ModelTag
+	ModelType() state.ModelType
 	ControllerTag() names.ControllerTag
 	ModelConfig() (*config.Config, error)
 	ControllerConfig() (controller.Config, error)
@@ -74,6 +75,10 @@ func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Autho
 	// For now, backup operations are only permitted on the controller model.
 	if !backend.IsController() {
 		return nil, errors.New("backups are only supported from the controller model\nUse juju switch to select the controller model")
+	}
+
+	if backend.ModelType() == state.ModelTypeCAAS {
+		return nil, errors.NotSupportedf("backups on kubernetes controllers")
 	}
 
 	// Get the backup paths.

--- a/apiserver/facades/client/backups/mock_test.go
+++ b/apiserver/facades/client/backups/mock_test.go
@@ -14,6 +14,15 @@ import (
 type stateShim struct {
 	*state.State
 	*state.Model
+
+	isController *bool
+}
+
+func (s *stateShim) IsController() bool {
+	if s.isController == nil {
+		return s.State.IsController()
+	}
+	return *s.isController
 }
 
 func (s *stateShim) MachineSeries(id string) (string, error) {
@@ -22,4 +31,8 @@ func (s *stateShim) MachineSeries(id string) (string, error) {
 
 func (s *stateShim) ControllerTag() names.ControllerTag {
 	return s.State.ControllerTag()
+}
+
+func (s *stateShim) ModelType() state.ModelType {
+	return s.Model.Type()
 }

--- a/apiserver/facades/client/backups/shim.go
+++ b/apiserver/facades/client/backups/shim.go
@@ -61,3 +61,7 @@ func (s *stateShim) ControllerTag() names.ControllerTag {
 func (s *stateShim) ModelTag() names.ModelTag {
 	return s.Model.ModelTag()
 }
+
+func (s *stateShim) ModelType() state.ModelType {
+	return s.Model.Type()
+}

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -48,6 +48,15 @@ func NewHighAvailabilityAPI(st *state.State, resources facade.Resources, authori
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() == state.ModelTypeCAAS {
+		return nil, errors.NotSupportedf("high availability on kubernetes controllers")
+	}
+
 	return &HighAvailabilityAPI{
 		state:      st,
 		resources:  resources,

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -599,3 +599,11 @@ func (s *clientSuite) TestEnableHABootstrap(c *gc.C) {
 	c.Assert(enableHAResult.Converted, gc.HasLen, 0)
 	c.Assert(enableHAResult.Demoted, gc.HasLen, 0)
 }
+
+func (s *clientSuite) TestHighAvailabilityCAASFails(c *gc.C) {
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer st.Close()
+
+	_, err := highavailability.NewHighAvailabilityAPI(st, s.resources, s.authoriser)
+	c.Assert(err, gc.ErrorMatches, "high availability on kubernetes controllers not supported")
+}

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -72,6 +72,14 @@ func (st *mockState) Model() (caasunitprovisioner.Model, error) {
 	return &st.model, nil
 }
 
+func (st *mockState) ResolveConstraints(cons constraints.Value) (constraints.Value, error) {
+	st.MethodCall(st, "ResolveConstraints", cons)
+	if err := st.NextErr(); err != nil {
+		return constraints.Value{}, err
+	}
+	return cons, nil
+}
+
 type mockModel struct {
 	testing.Stub
 	podSpecWatcher *statetesting.MockNotifyWatcher

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -304,6 +304,10 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	mergedCons, err := f.state.ResolveConstraints(cons)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	resourceTags := tags.ResourceTags(
 		names.NewModelTag(modelConfig.UUID()),
 		names.NewControllerTag(controllerCfg.ControllerUUID()),
@@ -314,7 +318,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		PodSpec:     podSpec,
 		Filesystems: filesystemParams,
 		Devices:     devices,
-		Constraints: cons,
+		Constraints: mergedCons,
 		Tags:        resourceTags,
 	}, nil
 }

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -211,7 +211,8 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 			},
 		}},
 	})
-	s.st.CheckCallNames(c, "Model", "Application", "ControllerConfig")
+	s.st.CheckCallNames(c, "Model", "Application", "ControllerConfig", "ResolveConstraints")
+	s.st.CheckCall(c, 3, "ResolveConstraints", constraints.MustParse("mem=64G"))
 	s.storage.CheckCallNames(c, "UnitStorageAttachments", "StorageInstance", "FilesystemAttachment")
 	s.storagePoolManager.CheckCallNames(c, "Get")
 }

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -24,6 +24,7 @@ type CAASUnitProvisionerState interface {
 	FindEntity(names.Tag) (state.Entity, error)
 	Model() (Model, error)
 	WatchApplications() state.StringsWatcher
+	ResolveConstraints(cons constraints.Value) (constraints.Value, error)
 }
 
 // StorageBackend provides the subset of backend storage

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/backups"
 	apiserverbackups "github.com/juju/juju/apiserver/facades/client/backups"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	statebackups "github.com/juju/juju/state/backups"
 )
@@ -68,6 +69,14 @@ func (c *CommandBase) SetFlags(f *gnuflag.FlagSet) {
 	if c.Log != nil {
 		c.Log.AddFlags(f)
 	}
+}
+
+func (c *CommandBase) validateIaasController(cmdName string) error {
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return common.ValidateIaasController(c.CommandBase, cmdName, controllerName, c.ClientStore())
 }
 
 var newAPIClient = func(c *CommandBase) (APIClient, error) {

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -125,6 +124,9 @@ func (c *createCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *createCommand) Run(ctx *cmd.Context) error {
+	if err := c.validateIaasController(c.Info().Name); err != nil {
+		return errors.Trace(err)
+	}
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -17,7 +17,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type createSuite struct {
@@ -31,7 +30,7 @@ var _ = gc.Suite(&createSuite{})
 
 func (s *createSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.wrappedCommand, s.command = backups.NewCreateCommandForTest(jujuclienttesting.MinimalStore())
+	s.wrappedCommand, s.command = backups.NewCreateCommandForTest(s.store)
 	s.defaultFilename = "juju-backup-<date>-<time>.tar.gz"
 }
 

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -69,6 +69,9 @@ func (c *downloadCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *downloadCommand) Run(ctx *cmd.Context) error {
+	if err := c.validateIaasController(c.Info().Name); err != nil {
+		return errors.Trace(err)
+	}
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err

--- a/cmd/juju/backups/download_test.go
+++ b/cmd/juju/backups/download_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type downloadSuite struct {
@@ -24,7 +23,7 @@ var _ = gc.Suite(&downloadSuite{})
 
 func (s *downloadSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.wrappedCommand, s.command = backups.NewDownloadCommandForTest(jujuclienttesting.MinimalStore())
+	s.wrappedCommand, s.command = backups.NewDownloadCommandForTest(s.store)
 }
 
 func (s *downloadSuite) TearDownTest(c *gc.C) {

--- a/cmd/juju/backups/list.go
+++ b/cmd/juju/backups/list.go
@@ -54,6 +54,9 @@ func (c *listCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *listCommand) Run(ctx *cmd.Context) error {
+	if err := c.validateIaasController(c.Info().Name); err != nil {
+		return errors.Trace(err)
+	}
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err

--- a/cmd/juju/backups/list_test.go
+++ b/cmd/juju/backups/list_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type listSuite struct {
@@ -23,7 +22,7 @@ var _ = gc.Suite(&listSuite{})
 
 func (s *listSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = backups.NewListCommandForTest(jujuclienttesting.MinimalStore())
+	s.subcommand = backups.NewListCommandForTest(s.store)
 }
 
 func (s *listSuite) TestOkay(c *gc.C) {

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -14,11 +14,15 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	apibackups "github.com/juju/juju/api/backups"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -52,6 +56,8 @@ type BaseBackupsSuite struct {
 	apiVersion int
 
 	filename string
+
+	store *jujuclient.MemStore
 }
 
 func (s *BaseBackupsSuite) SetUpTest(c *gc.C) {
@@ -64,6 +70,14 @@ func (s *BaseBackupsSuite) SetUpTest(c *gc.C) {
 	s.data = "<compressed archive data>"
 
 	s.apiVersion = 2
+
+	s.store = jujuclienttesting.MinimalStore()
+	models := s.store.Models["arthur"]
+	models.Models["admin/controller"] = jujuclient.ModelDetails{
+		ModelUUID: utils.MustNewUUID().String(),
+		ModelType: model.IAAS,
+	}
+	s.store.Models["arthur"] = models
 }
 
 func (s *BaseBackupsSuite) TearDownTest(c *gc.C) {

--- a/cmd/juju/backups/remove.go
+++ b/cmd/juju/backups/remove.go
@@ -70,6 +70,9 @@ func (c *removeCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *removeCommand) Run(ctx *cmd.Context) error {
+	if err := c.validateIaasController(c.Info().Name); err != nil {
+		return errors.Trace(err)
+	}
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err

--- a/cmd/juju/backups/remove_test.go
+++ b/cmd/juju/backups/remove_test.go
@@ -17,12 +17,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/testing"
 )
 
 type removeSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
+	BaseBackupsSuite
 
 	command cmd.Command
 }
@@ -30,9 +28,9 @@ type removeSuite struct {
 var _ = gc.Suite(&removeSuite{})
 
 func (s *removeSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.BaseBackupsSuite.SetUpTest(c)
 
-	s.command = backups.NewRemoveCommandForTest(jujuclienttesting.MinimalStore())
+	s.command = backups.NewRemoveCommandForTest(s.store)
 }
 
 func (s *removeSuite) patch(c *gc.C) (*gomock.Controller, *MockAPIClient) {

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -30,8 +30,6 @@ type restoreSuite struct {
 	BaseBackupsSuite
 	wrappedCommand cmd.Command
 	command        *backups.RestoreCommand
-
-	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&restoreSuite{})
@@ -46,7 +44,6 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
 
 	controllerName := "test-master"
-	s.store = jujuclient.NewMemStore()
 	s.store.Controllers[controllerName] = jujuclient.ControllerDetails{
 		ControllerUUID: controllerUUID,
 		CACert:         testing.CACert,
@@ -60,8 +57,8 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 	}
 	s.store.Models[controllerName] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
-			"bob/test1":      {ModelUUID: test1ModelUUID, ModelType: model.IAAS},
-			"bob/controller": {ModelUUID: controllerModelUUID, ModelType: model.IAAS},
+			"bob/test1":        {ModelUUID: test1ModelUUID, ModelType: model.IAAS},
+			"admin/controller": {ModelUUID: controllerModelUUID, ModelType: model.IAAS},
 		},
 		CurrentModel: "controller",
 	}

--- a/cmd/juju/backups/show.go
+++ b/cmd/juju/backups/show.go
@@ -52,6 +52,9 @@ func (c *showCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *showCommand) Run(ctx *cmd.Context) error {
+	if err := c.validateIaasController(c.Info().Name); err != nil {
+		return errors.Trace(err)
+	}
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err

--- a/cmd/juju/backups/show_test.go
+++ b/cmd/juju/backups/show_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type showSuite struct {
@@ -23,7 +22,7 @@ var _ = gc.Suite(&showSuite{})
 
 func (s *showSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = backups.NewShowCommandForTest(jujuclienttesting.MinimalStore())
+	s.subcommand = backups.NewShowCommandForTest(s.store)
 }
 
 func (s *showSuite) TestOkay(c *gc.C) {

--- a/cmd/juju/backups/upload.go
+++ b/cmd/juju/backups/upload.go
@@ -56,6 +56,9 @@ func (c *uploadCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *uploadCommand) Run(ctx *cmd.Context) error {
+	if err := c.validateIaasController(c.Info().Name); err != nil {
+		return errors.Trace(err)
+	}
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err

--- a/cmd/juju/backups/upload_test.go
+++ b/cmd/juju/backups/upload_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 )
 
 type uploadSuite struct {
@@ -29,7 +28,7 @@ var _ = gc.Suite(&uploadSuite{})
 func (s *uploadSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
 
-	s.command = backups.NewUploadCommandForTest(jujuclienttesting.MinimalStore())
+	s.command = backups.NewUploadCommandForTest(s.store)
 	s.filename = "juju-backup-20140912-130755.abcd-spam-deadbeef-eggs.tar.gz"
 }
 

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -210,7 +210,14 @@ type MakeHAClient interface {
 // Run connects to the environment specified on the command line
 // and calls EnableHA.
 func (c *enableHACommand) Run(ctx *cmd.Context) error {
-	var err error
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := common.ValidateIaasController(c.CommandBase, c.Info().Name, controllerName, c.ClientStore()); err != nil {
+		return errors.Trace(err)
+	}
+
 	c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr)
 	if err != nil {
 		return err

--- a/cmd/juju/model/constraints.go
+++ b/cmd/juju/model/constraints.go
@@ -19,12 +19,12 @@ import (
 // getConstraintsDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 const getConstraintsDoc = "" +
-	"Shows machine constraints that have been set on the model with\n" +
+	"Shows constraints that have been set on the model with\n" +
 	"`juju set-model-constraints.`\n" +
 	"By default, the model is the current model.\n" +
 	"Model constraints are combined with constraints set on an application\n" +
 	"with `juju set-constraints` for commands (such as 'deploy') that provision\n" +
-	"machines for applications. Where model and application constraints overlap, the\n" +
+	"machines/containers for applications. Where model and application constraints overlap, the\n" +
 	"application constraints take precedence.\n" +
 	"Constraints for a specific application can be viewed with `juju get-constraints`.\n" + getConstraintsDocExamples
 
@@ -44,11 +44,11 @@ See also:
 // setConstraintsDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 const setConstraintsDoc = "" +
-	"Sets machine constraints on the model that can be viewed with\n" +
+	"Sets constraints on the model that can be viewed with\n" +
 	"`juju get-model-constraints`.  By default, the model is the current model.\n" +
 	"Model constraints are combined with constraints set for an application with\n" +
 	"`juju set-constraints` for commands (such as 'deploy') that provision\n" +
-	"machines for applications. Where model and application constraints overlap, the\n" +
+	"machines/containers for applications. Where model and application constraints overlap, the\n" +
 	"application constraints take precedence.\n" +
 	"Constraints for a specific application can be viewed with `juju get-constraints`.\n" + setConstraintsDocExamples
 
@@ -81,7 +81,6 @@ func NewModelGetConstraintsCommand() cmd.Command {
 // modelGetConstraintsCommand shows the constraints for a model.
 type modelGetConstraintsCommand struct {
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
 	out cmd.Output
 	api ConstraintsAPI
 }
@@ -141,7 +140,6 @@ func NewModelSetConstraintsCommand() cmd.Command {
 // modelSetConstraintsCommand sets the constraints for a model.
 type modelSetConstraintsCommand struct {
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
 	api         ConstraintsAPI
 	Constraints constraints.Value
 }

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -199,7 +199,7 @@ func (st *State) addMachine(mdoc *machineDoc, ops []txn.Op) (*Machine, error) {
 }
 
 func (st *State) resolveMachineConstraints(cons constraints.Value) (constraints.Value, error) {
-	mcons, err := st.resolveConstraints(cons)
+	mcons, err := st.ResolveConstraints(cons)
 	if err != nil {
 		return constraints.Value{}, err
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -1496,7 +1496,7 @@ func (a *Application) addUnitOps(
 		if err != nil {
 			return "", nil, err
 		}
-		cons, err = a.st.resolveConstraints(scons)
+		cons, err = a.st.ResolveConstraints(scons)
 		if err != nil {
 			return "", nil, err
 		}

--- a/state/policy.go
+++ b/state/policy.go
@@ -128,9 +128,9 @@ func (st *State) constraintsValidator() (constraints.Validator, error) {
 	return validator, nil
 }
 
-// resolveConstraints combines the given constraints with the environ constraints to get
+// ResolveConstraints combines the given constraints with the environ constraints to get
 // a constraints which will be used to create a new instance.
-func (st *State) resolveConstraints(cons constraints.Value) (constraints.Value, error) {
+func (st *State) ResolveConstraints(cons constraints.Value) (constraints.Value, error) {
 	validator, err := st.constraintsValidator()
 	if err != nil {
 		return constraints.Value{}, err

--- a/state/state.go
+++ b/state/state.go
@@ -1426,7 +1426,7 @@ func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) err
 	// Ignore constraints that result from this call as
 	// these would be accumulation of model and application constraints
 	// but we only want application constraints to be persisted here.
-	cons, err := st.resolveConstraints(args.Constraints)
+	cons, err := st.ResolveConstraints(args.Constraints)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

backup/restore and enable-ha are disable on k8s models
Also add support for model level constraints

## QA steps

deploy k8s controller on microk8s
enable-ha, backup etc should fail with warning

add model constraint
deploy k8s app and check pod limits

