### PR TITLE
vsphere: Fix root disk resizing

### DIFF
--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -73,6 +73,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([
 		for _, cr := range computeResources {
 			if cr.Summary.GetComputeResourceSummary().EffectiveCpu == 0 {
 				logger.Debugf("skipping empty compute resource %q", cr.Name)
+				continue
 			}
 			pools, err := env.client.ResourcePools(env.ctx, cr.Name+"/...")
 			if err != nil {

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -22,7 +22,10 @@ type environAvailzonesSuite struct {
 var _ = gc.Suite(&environAvailzonesSuite{})
 
 func (s *environAvailzonesSuite) TestAvailabilityZones(c *gc.C) {
+	emptyResource := newComputeResource("empty")
+	emptyResource.Summary.(*mockSummary).EffectiveCpu = 0
 	s.client.computeResources = []*mo.ComputeResource{
+		emptyResource,
 		newComputeResource("z1"),
 		newComputeResource("z2"),
 	}
@@ -42,6 +45,7 @@ func (s *environAvailzonesSuite) TestAvailabilityZones(c *gc.C) {
 	zones, err := zonedEnviron.AvailabilityZones(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(zones), gc.Equals, 5)
+	// No zones for the empty resource.
 	c.Assert(zones[0].Name(), gc.Equals, "z1")
 	c.Assert(zones[1].Name(), gc.Equals, "z2")
 	c.Assert(zones[2].Name(), gc.Equals, "z2/child")

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -241,6 +241,11 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs.ResourcePool = availZone.pool.Reference()
 
 	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
+	if vsphereclient.IsExtendDiskError(err) {
+		// Ensure we don't try to make the same extension across
+		// different resource groups.
+		err = common.ZoneIndependentError(err)
+	}
 	if err != nil {
 		HandleCredentialError(err, ctx)
 		return nil, nil, errors.Trace(err)

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -397,14 +397,98 @@ func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {
 	args.Constraints.RootDisk = &rootDisk
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	errCh := make(chan error)
+	go func() {
+		_, err := client.CreateVirtualMachine(context.Background(), args)
+		select {
+		case errCh <- err:
+		case <-time.After(coretesting.ShortWait):
+			c.Fatalf("timed out sending error back")
+		}
+	}()
+
+	select {
+	case <-errCh:
+		c.Fatalf("creating virtual machine finished too soon")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	err := s.clock.WaitAdvance(50*time.Millisecond, coretesting.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Report that the disk is big now.
+	s.roundTripper.updateContents("FakeVm1", []types.ObjectContent{{
+		Obj: types.ManagedObjectReference{
+			Type:  "VirtualMachine",
+			Value: "FakeVm1",
+		},
+		PropSet: []types.DynamicProperty{
+			{Name: "name", Val: "vm-1"},
+			{Name: "runtime.powerState", Val: "poweredOn"},
+			{
+				Name: "config.hardware.device",
+				Val: []types.BaseVirtualDevice{
+					&types.VirtualDisk{
+						VirtualDevice: types.VirtualDevice{
+							Backing: &types.VirtualDiskFlatVer2BackingInfo{
+								VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+									FileName: "disk.vmdk",
+								},
+							},
+						},
+						CapacityInKB: 1024 * 1024 * 20, // 20 GiB
+					},
+				},
+			},
+		},
+	}})
+
+	select {
+	case err := <-errCh:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for CreateVirtualMachine")
+	}
 
 	call := findStubCall(c, s.roundTripper.Calls(), "ExtendVirtualDisk")
 	c.Assert(call.Args, jc.DeepEquals, []interface{}{
 		"disk.vmdk",
 		int64(rootDisk) * 1024, // in KiB
 	})
+}
+
+func (s *clientSuite) TestCreateVirtualMachineTimesOut(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	rootDisk := uint64(1024 * 20) // 20 GiB
+	args.Constraints.RootDisk = &rootDisk
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	errCh := make(chan error)
+	go func() {
+		_, err := client.CreateVirtualMachine(context.Background(), args)
+		select {
+		case errCh <- err:
+		case <-time.After(coretesting.ShortWait):
+			c.Fatalf("timed out sending error back")
+		}
+	}()
+
+	select {
+	case <-errCh:
+		c.Fatalf("creating virtual machine finished too soon")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	err := s.clock.WaitAdvance(35*time.Second, coretesting.LongWait, 1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case err := <-errCh:
+		c.Assert(err, gc.ErrorMatches, "extending disk failed")
+		c.Assert(err, jc.Satisfies, IsExtendDiskError)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for CreateVirtualMachine")
+	}
 }
 
 func (s *clientSuite) TestVerifyMAC(c *gc.C) {


### PR DESCRIPTION
## Description of change

Creating a new VM with a non-default disk size would hang because after the extend disk task is successfully started, the API call to get the task status fails with a permission error (you can see the error in the commit message). This means the task waiter never returns. I haven't been able to work out the cause of the error requesting the task status - it seems like a bug in the VSphere API. The extend disk task itself succeeds, we just can't request the status.

To work around this, poll the size of the VM's disk to detect when it's been extended and return then.
If we timeout waiting for the disk to be the right size we return a ZoneIndependentError to make sure the provisioner doesn't retry in different resource groups.

## QA steps
* Bootstrap a vsphere controller 
* Deploy an application using a root-disk constraint `--constraints="root-disk=20G"`
* The machine should be created with a 20Gb root disk

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1790183