### PR TITLE
Fix serialization of errors in status fields.

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1390,7 +1390,7 @@ func (c *statusContext) processUnitAndAgentStatus(unit *state.Unit) (agentStatus
 // of a status getter.
 // TODO: make this a function that just returns a type.
 func populateStatusFromStatusInfoAndErr(agent *params.DetailedStatus, statusInfo status.StatusInfo, err error) {
-	agent.Err = err
+	agent.Err = common.ServerError(err)
 	agent.Status = statusInfo.Status.String()
 	agent.Info = statusInfo.Message
 	agent.Data = filterStatusData(statusInfo.Data)

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -237,7 +237,7 @@ type DetailedStatus struct {
 	Kind    string                 `json:"kind"`
 	Version string                 `json:"version"`
 	Life    string                 `json:"life"`
-	Err     error                  `json:"err,omitempty"`
+	Err     *Error                 `json:"err,omitempty"`
 }
 
 // History holds many DetailedStatus.

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -96,6 +96,7 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"            type: unix-char\n",
 	)
 }
+
 func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, newMachineShowCommand(), "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -315,10 +315,19 @@ func (sf *statusFormatter) formatRelation(rel params.RelationStatus) relationSta
 	return out
 }
 
+func typedNilCheck(err *params.Error) error {
+	// When the api comes back over the wire, the error is a typed-nil.
+	// Maning that when we check against nil, we see nil, but it isn't nil.
+	if err == nil {
+		return nil
+	}
+	return err
+}
+
 func (sf *statusFormatter) getApplicationStatusInfo(application params.ApplicationStatus) statusInfoContents {
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
-		Err:     application.Status.Err,
+		Err:     typedNilCheck(application.Status.Err),
 		Current: status.Status(application.Status.Status),
 		Message: application.Status.Info,
 		Version: application.Status.Version,
@@ -332,7 +341,7 @@ func (sf *statusFormatter) getApplicationStatusInfo(application params.Applicati
 func (sf *statusFormatter) getRemoteApplicationStatusInfo(application params.RemoteApplicationStatus) statusInfoContents {
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
-		Err:     application.Status.Err,
+		Err:     typedNilCheck(application.Status.Err),
 		Current: status.Status(application.Status.Status),
 		Message: application.Status.Info,
 		Version: application.Status.Version,
@@ -407,7 +416,7 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) statusInfoContents {
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
-		Err:     inst.Err,
+		Err:     typedNilCheck(inst.Err),
 		Current: status.Status(inst.Status),
 		Message: inst.Info,
 		Version: inst.Version,
@@ -425,7 +434,7 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusI
 	}
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
-		Err:     unit.WorkloadStatus.Err,
+		Err:     typedNilCheck(unit.WorkloadStatus.Err),
 		Current: status.Status(unit.WorkloadStatus.Status),
 		Message: unit.WorkloadStatus.Info,
 		Version: unit.WorkloadStatus.Version,
@@ -439,7 +448,7 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusI
 func (sf *statusFormatter) getAgentStatusInfo(unit params.UnitStatus) statusInfoContents {
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
-		Err:     unit.AgentStatus.Err,
+		Err:     typedNilCheck(unit.AgentStatus.Err),
 		Current: status.Status(unit.AgentStatus.Status),
 		Message: unit.AgentStatus.Info,
 		Version: unit.AgentStatus.Version,


### PR DESCRIPTION
Found during debugging of deploying a bundle problem in bug listed below.

The missing status for machine modifications was getting an error added to the DetailedStatus response. This should never have had 'error' as the type.

## QA steps

Reproduction steps listed in bug

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1821418