### PR TITLE
Use native k8s crd yaml in charm pod spec

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -887,47 +887,33 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 
 // EnsureCustomResourceDefinition creates or updates a custom resource definition resource.
 func (k *kubernetesClient) EnsureCustomResourceDefinition(appName string, podSpec *caas.PodSpec) error {
-	for _, t := range podSpec.CustomResourceDefinitions {
-		crd, err := k.ensureCustomResourceDefinitionTemplate(&t)
+	for name, crd := range podSpec.CustomResourceDefinitions {
+		crd, err := k.ensureCustomResourceDefinitionTemplate(name, crd)
 		if err != nil {
-			return errors.Annotate(err, fmt.Sprintf("ensure custom resource definition %q", t.Kind))
+			return errors.Annotate(err, fmt.Sprintf("ensure custom resource definition %q", name))
 		}
 		logger.Debugf("ensured custom resource definition %q", crd.ObjectMeta.Name)
 	}
 	return nil
 }
 
-func (k *kubernetesClient) ensureCustomResourceDefinitionTemplate(t *caas.CustomResourceDefinition) (
+func (k *kubernetesClient) ensureCustomResourceDefinitionTemplate(name string, spec apiextensionsv1beta1.CustomResourceDefinitionSpec) (
 	crd *apiextensionsv1beta1.CustomResourceDefinition, err error) {
-	singularName := strings.ToLower(t.Kind)
-	pluralName := fmt.Sprintf("%ss", singularName)
-	crdFullName := fmt.Sprintf("%s.%s", pluralName, t.Group)
 	crdIn := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      crdFullName,
+			Name:      name,
 			Namespace: k.namespace,
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   t.Group,
-			Version: t.Version,
-			Scope:   apiextensionsv1beta1.ResourceScope(t.Scope),
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   pluralName,
-				Kind:     t.Kind,
-				Singular: singularName,
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: t.Validation.Properties,
-				},
-			},
-		},
+		Spec: spec,
 	}
 	apiextensionsV1beta1 := k.apiextensionsClient.ApiextensionsV1beta1()
 	logger.Debugf("creating crd %#v", crdIn)
 	crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Create(crdIn)
 	if k8serrors.IsAlreadyExists(err) {
-		crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Get(crdFullName, v1.GetOptions{})
+		crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Get(name, v1.GetOptions{})
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		resourceVersion := crd.ObjectMeta.GetResourceVersion()
 		crdIn.ObjectMeta.SetResourceVersion(resourceVersion)
 		logger.Debugf("existing crd with resource version %q found, so update it %#v", resourceVersion, crdIn)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -849,37 +849,43 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionCreate(c *gc.C) {
 	defer ctrl.Finish()
 
 	podSpec := basicPodspec
-	podSpec.CustomResourceDefinitions = []caas.CustomResourceDefinition{
-		{
-			Kind:    "TFJob",
-			Group:   "kubeflow.org",
+	podSpec.CustomResourceDefinitions = map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		"tfjobs.kubeflow.org": {
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:     "TFJob",
+				Singular: "tfjob",
+				Plural:   "tfjobs",
+			},
 			Version: "v1alpha2",
+			Group:   "kubeflow.org",
 			Scope:   "Namespaced",
-			Validation: caas.CustomResourceDefinitionValidation{
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-					"tfReplicaSpecs": {
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-							"Worker": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"replicas": {
-										Type:    "integer",
-										Minimum: float64Ptr(1),
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"tfReplicaSpecs": {
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"Worker": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+										},
 									},
 								},
-							},
-							"PS": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"replicas": {
-										Type: "integer", Minimum: float64Ptr(1),
+								"PS": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer", Minimum: float64Ptr(1),
+										},
 									},
 								},
-							},
-							"Chief": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"replicas": {
-										Type:    "integer",
-										Minimum: float64Ptr(1),
-										Maximum: float64Ptr(1),
+								"Chief": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+											Maximum: float64Ptr(1),
+										},
 									},
 								},
 							},
@@ -953,37 +959,43 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionUpdate(c *gc.C) {
 	defer ctrl.Finish()
 
 	podSpec := basicPodspec
-	podSpec.CustomResourceDefinitions = []caas.CustomResourceDefinition{
-		{
-			Kind:    "TFJob",
-			Group:   "kubeflow.org",
+	podSpec.CustomResourceDefinitions = map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		"tfjobs.kubeflow.org": {
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:     "TFJob",
+				Singular: "tfjob",
+				Plural:   "tfjobs",
+			},
 			Version: "v1alpha2",
+			Group:   "kubeflow.org",
 			Scope:   "Namespaced",
-			Validation: caas.CustomResourceDefinitionValidation{
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-					"tfReplicaSpecs": {
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-							"Worker": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"replicas": {
-										Type:    "integer",
-										Minimum: float64Ptr(1),
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"tfReplicaSpecs": {
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"Worker": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+										},
 									},
 								},
-							},
-							"PS": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"replicas": {
-										Type: "integer", Minimum: float64Ptr(1),
+								"PS": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer", Minimum: float64Ptr(1),
+										},
 									},
 								},
-							},
-							"Chief": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"replicas": {
-										Type:    "integer",
-										Minimum: float64Ptr(1),
-										Maximum: float64Ptr(1),
+								"Chief": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+											Maximum: float64Ptr(1),
+										},
 									},
 								},
 							},

--- a/caas/kubernetes/provider/k8stypes.go
+++ b/caas/kubernetes/provider/k8stypes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 	core "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/juju/juju/caas"
@@ -24,8 +25,9 @@ type k8sContainer struct {
 }
 
 type k8sContainers struct {
-	Containers     []k8sContainer `json:"containers"`
-	InitContainers []k8sContainer `json:"initContainers"`
+	Containers                []k8sContainer                                               `json:"containers"`
+	InitContainers            []k8sContainer                                               `json:"initContainers"`
+	CustomResourceDefinitions map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec `yaml:"customResourceDefinitions,omitempty"`
 }
 
 // K8sContainerSpec is a subset of v1.Container which defines
@@ -129,6 +131,7 @@ func parseK8sPodSpec(in string) (*caas.PodSpec, error) {
 		}
 		spec.InitContainers[i] = containerFromK8sSpec(c)
 	}
+	spec.CustomResourceDefinitions = containers.CustomResourceDefinitions
 	return &spec, nil
 }
 

--- a/caas/kubernetes/provider/k8stypes_test.go
+++ b/caas/kubernetes/provider/k8stypes_test.go
@@ -109,31 +109,36 @@ initContainers:
 service:
   annotations:
     foo: bar
-customResourceDefinition:
-  - group: kubeflow.org
+customResourceDefinitions:
+  tfjobs.kubeflow.org:
+    group: kubeflow.org
     version: v1alpha2
     scope: Namespaced
-    kind: TFJob
+    names:
+      plural: "tfjobs"
+      singular: "tfjob"
+      kind: TFJob
     validation:
-      properties:
-        tfReplicaSpecs:
-          properties:
-            Worker:
-              properties:
-                replicas:
-                  type: integer
-                  minimum: 1
-            PS:
-              properties:
-                replicas:
-                  type: integer
-                  minimum: 1
-            Chief:
-              properties:
-                replicas:
-                  type: integer
-                  minimum: 1
-                  maximum: 1
+      openAPIV3Schema:
+        properties:
+          tfReplicaSpecs:
+            properties:
+              Worker:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
+              PS:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
+              Chief:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
+                    maximum: 1
 `[1:]
 
 	expectedFileContent := `
@@ -253,37 +258,43 @@ foo: bar
 				ImagePullPolicy: "Always",
 			},
 		}},
-		CustomResourceDefinitions: []caas.CustomResourceDefinition{
-			{
-				Kind:    "TFJob",
+		CustomResourceDefinitions: map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			"tfjobs.kubeflow.org": {
 				Group:   "kubeflow.org",
 				Version: "v1alpha2",
 				Scope:   "Namespaced",
-				Validation: caas.CustomResourceDefinitionValidation{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+					Kind:     "TFJob",
+					Plural:   "tfjobs",
+					Singular: "tfjob",
+				},
+				Validation: &apiextensionsv1beta1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+							"tfReplicaSpecs": {
+								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+									"PS": {
+										Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+											"replicas": {
+												Type: "integer", Minimum: float64Ptr(1),
+											},
 										},
 									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+									"Chief": {
+										Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+											"replicas": {
+												Type:    "integer",
+												Minimum: float64Ptr(1),
+												Maximum: float64Ptr(1),
+											},
 										},
 									},
-								},
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+									"Worker": {
+										Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+											"replicas": {
+												Type:    "integer",
+												Minimum: float64Ptr(1),
+											},
 										},
 									},
 								},

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -443,38 +443,49 @@ func (s *WorkerSuite) TestNewPodSpecChangeCrd(c *gc.C) {
 
 	var (
 		anotherSpec = `
-crd:
-  - group: kubeflow.org
+customResourceDefinitions:
+  tfjobs.kubeflow.org:
+    group: kubeflow.org
     version: v1alpha2
     scope: Namespaced
-    kind: TFJob
+    names:
+      plural: "tfjobs"
+      singular: "tfjob"
+      kind: TFJob
     validation:
-      properties:
-        tfReplicaSpecs:
-          properties:
-            Worker:
-              properties:
-                replicas:
-                  type: integer
-                  minimum: 1
+      openAPIV3Schema:
+        properties:
+          tfReplicaSpecs:
+            properties:
+              Worker:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
 `[1:]
 
 		anotherParsedSpec = caas.PodSpec{
-			CustomResourceDefinitions: []caas.CustomResourceDefinition{
-				{
-					Kind:    "TFJob",
+			CustomResourceDefinitions: map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec{
+				"tfjobs.kubeflow.org": {
 					Group:   "kubeflow.org",
 					Version: "v1alpha2",
 					Scope:   "Namespaced",
-					Validation: caas.CustomResourceDefinitionValidation{
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-							"tfReplicaSpecs": {
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-									"Worker": {
-										Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-											"replicas": {
-												Type:    "integer",
-												Minimum: float64Ptr(1),
+					Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+						Kind:     "TFJob",
+						Plural:   "tfjobs",
+						Singular: "tfjob",
+					},
+					Validation: &apiextensionsv1beta1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
 											},
 										},
 									},


### PR DESCRIPTION
## Description of change

k8s charm could define CRDs but didn't use native k8s yaml.
The charms now specify native k8s yaml, keyed on the name of the CRD.

## QA steps

Deploy a modified pytorchjobs charm

## Bug reference

https://bugs.launchpad.net/juju/+bug/1821069
