### PR TITLE
Enhance/bootstrap messages

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -93,7 +93,8 @@ func controllerCorelation(broker *kubernetesClient) (*kubernetesClient, error) {
 	return broker, nil
 }
 
-func decideControllerNamespace(controllerName string) string {
+// DecideControllerNamespace decides the namespace name to use for a new controller.
+func DecideControllerNamespace(controllerName string) string {
 	return "controller-" + controllerName
 }
 

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -93,6 +93,10 @@ func controllerCorelation(broker *kubernetesClient) (*kubernetesClient, error) {
 	return broker, nil
 }
 
+func decideControllerNamespace(controllerName string) string {
+	return "controller-" + controllerName
+}
+
 func newcontrollerStack(
 	ctx environs.BootstrapContext,
 	stackName string,

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -130,6 +130,7 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 			"juju.io/is-controller": "true",
 		},
 	)
+	// controller namespace linked back(changed from 'controller' to 'controller-1')
 	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller-1")
 }
 

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
+	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -86,7 +87,9 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	}
 	s.pcfg = pcfg
 	s.controllerStackerGetter = func() provider.ControllerStackerForTest {
-		controllerStacker, err := provider.NewcontrollerStackForTest("juju-controller-test", "some-storage", s.broker, s.pcfg)
+		controllerStacker, err := provider.NewcontrollerStackForTest(
+			envtesting.BootstrapContext(c), "juju-controller-test", "some-storage", s.broker, s.pcfg,
+		)
 		c.Assert(err, jc.ErrorIsNil)
 		return controllerStacker
 	}

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloudconfig/podcfg"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/storage"
 )
@@ -57,8 +58,8 @@ func (cs controllerStack) GetStorageSize() resource.Quantity {
 	return cs.storageSize
 }
 
-func NewcontrollerStackForTest(stackName, storageClass string, broker *kubernetesClient, pcfg *podcfg.ControllerPodConfig) (ControllerStackerForTest, error) {
-	cs, err := newcontrollerStack(stackName, storageClass, broker, pcfg)
+func NewcontrollerStackForTest(ctx environs.BootstrapContext, stackName, storageClass string, broker *kubernetesClient, pcfg *podcfg.ControllerPodConfig) (ControllerStackerForTest, error) {
+	cs, err := newcontrollerStack(ctx, stackName, storageClass, broker, pcfg)
 	return cs.(controllerStack), err
 }
 

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -202,11 +202,13 @@ func (k *kubernetesClient) validateOperatorStorage() (string, error) {
 
 // PrepareForBootstrap prepares for bootstraping a controller.
 func (k *kubernetesClient) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
-	k.namespace = controllerName
 	alreadyExistErr := errors.NewAlreadyExists(nil,
 		fmt.Sprintf(`a controller called %q already exists on this k8s cluster.
 Please bootstrap again and choose a different controller name.`, k.namespace),
 	)
+
+	k.namespace = decideControllerNamespace(controllerName)
+
 	// ensure no existing namespace has the same name.
 	_, err := k.GetNamespace(k.namespace)
 	if err == nil {
@@ -218,6 +220,7 @@ Please bootstrap again and choose a different controller name.`, k.namespace),
 	// Good, no existing namespace has the same name.
 	// Now, try to find if there is any existing controller running in this cluster.
 	// Note: we have to do this check before we are confident to support multi controllers running in same k8s cluster.
+
 	_, err = k.listNamespacesByAnnotations(k.annotations)
 	if err == nil {
 		return alreadyExistErr
@@ -267,11 +270,13 @@ func (k *kubernetesClient) Bootstrap(
 		logger.Debugf("controller pod config: \n%+v", pcfg)
 
 		// we use controller name to name controller namespace in bootstrap time.
-		setControllerNamespace := func(name string, broker *kubernetesClient) error {
-			_, err := broker.GetNamespace(name)
+		setControllerNamespace := func(controllerName string, broker *kubernetesClient) error {
+			nsName := decideControllerNamespace(controllerName)
+
+			_, err := broker.GetNamespace(nsName)
 			if errors.IsNotFound(err) {
 				// all good.
-				broker.SetNamespace(name)
+				broker.SetNamespace(nsName)
 				// ensure controller specific annotations.
 				_ = broker.addAnnotations(annotationControllerIsControllerKey, "true")
 				return nil

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -210,7 +210,7 @@ Please bootstrap again and choose a different controller name.`, k.namespace),
 	k.namespace = decideControllerNamespace(controllerName)
 
 	// ensure no existing namespace has the same name.
-	_, err := k.GetNamespace(k.namespace)
+	_, err := k.getNamespaceByName(k.namespace)
 	if err == nil {
 		return alreadyExistErr
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -288,7 +288,7 @@ func (k *kubernetesClient) Bootstrap(
 		}
 
 		// create configmap, secret, volume, statefulset, etc resources for controller stack.
-		controllerStack, err := newcontrollerStack(JujuControllerStackName, storageClass, k, pcfg)
+		controllerStack, err := newcontrollerStack(ctx, JujuControllerStackName, storageClass, k, pcfg)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -207,7 +207,7 @@ func (k *kubernetesClient) PrepareForBootstrap(ctx environs.BootstrapContext, co
 Please bootstrap again and choose a different controller name.`, k.namespace),
 	)
 
-	k.namespace = decideControllerNamespace(controllerName)
+	k.namespace = DecideControllerNamespace(controllerName)
 
 	// ensure no existing namespace has the same name.
 	_, err := k.getNamespaceByName(k.namespace)
@@ -271,7 +271,7 @@ func (k *kubernetesClient) Bootstrap(
 
 		// we use controller name to name controller namespace in bootstrap time.
 		setControllerNamespace := func(controllerName string, broker *kubernetesClient) error {
-			nsName := decideControllerNamespace(controllerName)
+			nsName := DecideControllerNamespace(controllerName)
 
 			_, err := broker.GetNamespace(nsName)
 			if errors.IsNotFound(err) {

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -96,7 +96,7 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 				msg += `
 Now you can run 
 	juju add-model <model-name>
-to create a new model to deploy CAAS workload
+to create a new model to deploy k8s workloads
 `
 			} else {
 				msg += fmt.Sprintf("\nController machines are in the %q model", bootstrap.ControllerModelName)

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/api/block"
 	"github.com/juju/juju/apiserver/params"
+	caasprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -92,7 +93,7 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 		if err == nil {
 			msg := fmt.Sprintf("\nBootstrap complete, controller %q now is available", controllerName)
 			if isCAAS {
-				msg += fmt.Sprintf(" in namespace %q", controllerName)
+				msg += fmt.Sprintf(" in namespace %q", caasprovider.DecideControllerNamespace(controllerName))
 				msg += `
 Now you can run 
 	juju add-model <model-name>


### PR DESCRIPTION
## Description of change

made bootstrap messages better.

## QA steps
- CAAS

```bash
$ juju bootstrap microk8s-cloud k28
```
```text
Creating Juju controller "k30" on microk8s-new/localhost
Creating k8s resources for controller "controller-k30"
Downloading Juju agent OCI image
Bootstrap agent now started
Contacting Juju controller at 10.152.183.126 to verify accessibility...

Bootstrap complete, controller "k30" now is available in namespace "controller-k30"
Now you can run 
	juju add-model <model-name>
to create a new model to deploy k8s workloads
```

```bash
$ kubectl get ns controller-<controller-name> -o yaml
```

```yaml
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    juju.io/controller: c11e1630-1331-4aca-8aeb-83534b59f0c7
    juju.io/is-controller: "true"
    juju.io/model: dde6e9bf-d962-410c-8f0d-b1764227ae15
  creationTimestamp: 2019-03-27T01:26:48Z
  name: controller-k29
  resourceVersion: "108647"
  selfLink: /api/v1/namespaces/controller-k29
  uid: 63df117a-502f-11e9-af64-9cb6d0fbc7cd
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```


- IAAS

```bash
$ juju bootstrap lxd ctrl1
```

## Documentation changes

None

## Bug reference

None
