### PR TITLE
Make kvm storage pool creation idempotent

### DIFF
--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -33,12 +33,58 @@ func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
 	}
 	stub := runStub{}
 	chown := func(string) error { return nil }
-	err = createPool(pathfinder, stub.Run, chown)
+	err = ensurePool(nil, pathfinder, stub.Run, chown)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(stub.Calls(), jc.DeepEquals, []string{
 		fmt.Sprintf(" virsh pool-define-as juju-pool dir - - - - %s/kvm/guests", tmpDir),
 		" virsh pool-build juju-pool",
 		" virsh pool-start juju-pool",
+		" virsh pool-autostart juju-pool",
+	})
+}
+
+func (initialisationInternalSuite) TestStartPool(c *gc.C) {
+	tmpDir, err := ioutil.TempDir("", "juju-initialisationInternalSuite")
+	defer func() {
+		err = os.RemoveAll(tmpDir)
+		if err != nil {
+			c.Errorf("failed to remove tmpDir: %s\n", err)
+		}
+	}()
+	c.Check(err, jc.ErrorIsNil)
+	pathfinder := func(s string) (string, error) {
+		return tmpDir, nil
+	}
+	poolInfo := &libvirtPool{Name: "juju-pool", Autostart: "no", State: "inactive"}
+	stub := runStub{}
+	chown := func(string) error { return nil }
+	err = ensurePool(poolInfo, pathfinder, stub.Run, chown)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(stub.Calls(), jc.DeepEquals, []string{
+		" virsh pool-build juju-pool",
+		" virsh pool-start juju-pool",
+		" virsh pool-autostart juju-pool",
+	})
+}
+
+func (initialisationInternalSuite) TestAutoStartPool(c *gc.C) {
+	tmpDir, err := ioutil.TempDir("", "juju-initialisationInternalSuite")
+	defer func() {
+		err = os.RemoveAll(tmpDir)
+		if err != nil {
+			c.Errorf("failed to remove tmpDir: %s\n", err)
+		}
+	}()
+	c.Check(err, jc.ErrorIsNil)
+	pathfinder := func(s string) (string, error) {
+		return tmpDir, nil
+	}
+	poolInfo := &libvirtPool{Name: "juju-pool", Autostart: "no", State: "running"}
+	stub := runStub{}
+	chown := func(string) error { return nil }
+	err = ensurePool(poolInfo, pathfinder, stub.Run, chown)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(stub.Calls(), jc.DeepEquals, []string{
 		" virsh pool-autostart juju-pool",
 	})
 }


### PR DESCRIPTION
## Description of change

This change makes libvirt storage pool creation idempotent, allowing handling situations where a pool creation was interrupted. This condition has happened in a case of interrupted provisioning.

There is no performance impact since all the pool information is already available and has to be only used.

## QA steps

QA tests are added to juju test suite.

## Documentation changes

No documentation changes.


