### PR TITLE
Upgrade modification status

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1916,7 +1916,7 @@ func EnsureDefaultModificationStatus(pool *StatePool) error {
 
 		// We only need to migrate machines that don't have a modification
 		// status document. So we need to first check if there is one, before
-		// creating an txn.Op for the missing document.
+		// creating a txn.Op for the missing document.
 		var status statusDoc
 		err := statusCol.Find(bson.D{{"_id", key}}).Select(bson.D{{"_id", 1}}).One(&status)
 		if err == mgo.ErrNotFound {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -59,6 +59,7 @@ type StateBackend interface {
 	LegacyLeases(time.Time) (map[lease.Key]lease.Info, error)
 	SetEnableDiskUUIDOnVsphere() error
 	UpdateInheritedControllerConfig() error
+	EnsureDefaultModificationStatus() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -223,4 +224,8 @@ func (s stateBackend) SetEnableDiskUUIDOnVsphere() error {
 
 func (s stateBackend) UpdateInheritedControllerConfig() error {
 	return state.UpdateInheritedControllerConfig(s.pool)
+}
+
+func (s stateBackend) EnsureDefaultModificationStatus() error {
+	return state.EnsureDefaultModificationStatus(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -34,6 +34,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.4.0"), stateStepsFor24()},
 		upgradeToVersion{version.MustParse("2.5.0"), stateStepsFor25()},
 		upgradeToVersion{version.MustParse("2.5.3"), stateStepsFor253()},
+		upgradeToVersion{version.MustParse("2.5.4"), stateStepsFor254()},
 	}
 	return steps
 }

--- a/upgrades/steps_254.go
+++ b/upgrades/steps_254.go
@@ -1,0 +1,18 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor254 returns the upgrade steps for Juju 2.5.4 that manipulates
+// state directly.
+func stateStepsFor254() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "ensure default modification status is set for machines",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureDefaultModificationStatus()
+			},
+		},
+	}
+}

--- a/upgrades/steps_254_test.go
+++ b/upgrades/steps_254_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v254 = version.MustParse("2.5.4")
+
+type steps254Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps254Suite{})
+
+func (s *steps254Suite) TestUpdateInheritedControllerConfig(c *gc.C) {
+	step := findStateStep(c, v254, `ensure default modification status is set for machines`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -650,6 +650,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.4.0",
 		"2.5.0",
 		"2.5.3",
+		"2.5.4",
 	})
 }
 


### PR DESCRIPTION
Adds the missing status for machine modification. Supercedes #9957.

## QA steps
simple.yaml has the following
```
applications:
  ubuntu:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 2
```

```
snap refresh juju --channel 2.4
/snap/bin/juju bootstrap lxd test
vi ~/sandbox/simple.yaml 
juju deploy ~/sandbox/simple.yaml
juju deploy --dry-run ~/sandbox/simple.yaml
watch -c juju status --color
```
Wait for the units to be deployed.
```
snap refresh juju --channel 2.5
/snap/bin/juju upgrade-model -m controller
/snap/bin/juju deploy --dry-run ~/sandbox/simple.yaml
# errors as expected
juju status --format yaml
```
Shows 
```yaml
    modification-status:
      status-error: ""
```
in the machine status section
```
juju upgrade-juju -m controller --build-agent
juju status --format yaml
```
now shows modification status as:
```
    modification-status:
      current: idle
      since: 27 Mar 2019 11:12:08+13:00
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1821418