### PR TITLE
upgrade step to add device constraints

### DIFF
--- a/state/devices.go
+++ b/state/devices.go
@@ -5,9 +5,8 @@ package state
 
 import (
 	"github.com/juju/errors"
-	charm "gopkg.in/juju/charm.v6"
-	mgo "gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/environs/config"
@@ -75,15 +74,6 @@ func createDeviceConstraintsOp(id string, cons map[string]DeviceConstraints) txn
 		Insert: &deviceConstraintsDoc{
 			Constraints: cons,
 		},
-	}
-}
-
-func replaceDeviceConstraintsOp(id string, cons map[string]DeviceConstraints) txn.Op {
-	return txn.Op{
-		C:      deviceConstraintsC,
-		Id:     id,
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"constraints", cons}}}},
 	}
 }
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -60,6 +60,7 @@ type StateBackend interface {
 	SetEnableDiskUUIDOnVsphere() error
 	UpdateInheritedControllerConfig() error
 	EnsureDefaultModificationStatus() error
+	EnsureApplicationDeviceConstraints() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -228,4 +229,8 @@ func (s stateBackend) UpdateInheritedControllerConfig() error {
 
 func (s stateBackend) EnsureDefaultModificationStatus() error {
 	return state.EnsureDefaultModificationStatus(s.pool)
+}
+
+func (s stateBackend) EnsureApplicationDeviceConstraints() error {
+	return state.EnsureApplicationDeviceConstraints(s.pool)
 }

--- a/upgrades/steps_254.go
+++ b/upgrades/steps_254.go
@@ -14,5 +14,12 @@ func stateStepsFor254() []Step {
 				return context.State().EnsureDefaultModificationStatus()
 			},
 		},
+		&upgradeStep{
+			description: "ensure device constraints exists for applications",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureApplicationDeviceConstraints()
+			},
+		},
 	}
 }

--- a/upgrades/steps_254_test.go
+++ b/upgrades/steps_254_test.go
@@ -20,8 +20,14 @@ type steps254Suite struct {
 
 var _ = gc.Suite(&steps254Suite{})
 
-func (s *steps254Suite) TestUpdateInheritedControllerConfig(c *gc.C) {
+func (s *steps254Suite) TestEnsureDefaultModificationStatus(c *gc.C) {
 	step := findStateStep(c, v254, `ensure default modification status is set for machines`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
+func (s *steps254Suite) TestEnsureApplicationDeviceConstraints(c *gc.C) {
+	step := findStateStep(c, v254, `ensure device constraints exists for applications`)
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }


### PR DESCRIPTION
## Description of change

An upgrade step to add empty device constraint docs for applications created prior to 2.5

## QA steps

bootstrap juju 2.4
add an application
upgrade to 2.5
use mongo client to confirm deviceconstraints collection has a doc for each application

