### PR TITLE
lxd and maas providers react to cloud updates

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -33,23 +33,23 @@ type environ struct {
 	cloud    environs.CloudSpec
 	provider *environProvider
 
-	name   string
-	uuid   string
-	server Server
-	base   baseProvider
+	name string
+	uuid string
+	base baseProvider
 
 	// namespace is used to create the machine and device hostnames.
 	namespace instance.Namespace
 
-	lock sync.Mutex
-	ecfg *environConfig
+	// lock protects the *Unlocked fields below.
+	lock           sync.Mutex
+	ecfgUnlocked   *environConfig
+	serverUnlocked Server
 }
 
 func newEnviron(
-	_ *environProvider,
+	p *environProvider,
 	spec environs.CloudSpec,
 	cfg *config.Config,
-	serverFactory ServerFactory,
 ) (*environ, error) {
 	ecfg, err := newValidConfig(cfg)
 	if err != nil {
@@ -61,22 +61,18 @@ func newEnviron(
 		return nil, errors.Trace(err)
 	}
 
-	server, err := serverFactory.RemoteServer(spec)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	env := &environ{
-		cloud:     spec,
-		name:      ecfg.Name(),
-		uuid:      ecfg.UUID(),
-		server:    server,
-		namespace: namespace,
-		ecfg:      ecfg,
+		provider:     p,
+		cloud:        spec,
+		name:         ecfg.Name(),
+		uuid:         ecfg.UUID(),
+		namespace:    namespace,
+		ecfgUnlocked: ecfg,
 	}
 	env.base = common.DefaultProvider{Env: env}
 
-	if err := env.initProfile(); err != nil {
+	err = env.SetCloudSpec(spec)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -86,7 +82,7 @@ func newEnviron(
 func (env *environ) initProfile() error {
 	pName := env.profileName()
 
-	hasProfile, err := env.server.HasProfile(pName)
+	hasProfile, err := env.serverUnlocked.HasProfile(pName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -98,7 +94,7 @@ func (env *environ) initProfile() error {
 		"boot.autostart":   "true",
 		"security.nesting": "true",
 	}
-	return env.server.CreateProfileWithConfig(pName, cfg)
+	return env.serverUnlocked.CreateProfileWithConfig(pName, cfg)
 }
 
 func (env *environ) profileName() string {
@@ -123,15 +119,37 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	env.ecfg = ecfg
+	env.ecfgUnlocked = ecfg
 	return nil
+}
+
+// SetCloudSpec is specified in the environs.Environ interface.
+func (env *environ) SetCloudSpec(spec environs.CloudSpec) error {
+	env.lock.Lock()
+	defer env.lock.Unlock()
+
+	serverFactory := env.provider.serverFactory
+	server, err := serverFactory.RemoteServer(spec)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	env.serverUnlocked = server
+	return env.initProfile()
+}
+
+func (env *environ) server() Server {
+	env.lock.Lock()
+	defer env.lock.Unlock()
+
+	return env.serverUnlocked
 }
 
 // Config returns the configuration data with which the env was created.
 func (env *environ) Config() *config.Config {
 	env.lock.Lock()
-	cfg := env.ecfg.Config
-	env.lock.Unlock()
+	defer env.lock.Unlock()
+
+	cfg := env.ecfgUnlocked.Config
 	return cfg
 }
 
@@ -206,7 +224,7 @@ func (env *environ) destroyHostedModelResources(controllerUUID string) error {
 	}
 	logger.Debugf("removing instances: %v", names)
 
-	return errors.Trace(env.server.RemoveContainers(names))
+	return errors.Trace(env.server().RemoveContainers(names))
 }
 
 // lxdAvailabilityZone wraps a LXD cluster member as an availability zone.
@@ -230,18 +248,19 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common
 	// If we are not using a clustered server (which includes those not
 	// supporting the clustering API) just represent the single server as the
 	// only availability zone.
-	if !env.server.IsClustered() {
+	server := env.server()
+	if !server.IsClustered() {
 		return []common.AvailabilityZone{
 			&lxdAvailabilityZone{
 				ClusterMember: api.ClusterMember{
-					ServerName: env.server.Name(),
+					ServerName: server.Name(),
 					Status:     "ONLINE",
 				},
 			},
 		}, nil
 	}
 
-	nodes, err := env.server.GetClusterMembers()
+	nodes, err := server.GetClusterMembers()
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, errors.Annotate(err, "listing cluster members")
@@ -266,9 +285,10 @@ func (env *environ) InstanceAvailabilityZoneNames(
 
 	// If not clustered, just report all input IDs as being in the zone
 	// represented by the single server.
-	if !env.server.IsClustered() {
+	server := env.server()
+	if !server.IsClustered() {
 		zones := make([]string, len(ids))
-		n := env.server.Name()
+		n := server.Name()
 		for i := range zones {
 			zones[i] = n
 		}
@@ -301,7 +321,8 @@ func (env *environ) DeriveAvailabilityZones(
 
 // MaybeWriteLXDProfile implements environs.LXDProfiler.
 func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
-	hasProfile, err := env.server.HasProfile(pName)
+	server := env.server()
+	hasProfile, err := server.HasProfile(pName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -313,7 +334,7 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 		Name:       pName,
 		ProfilePut: api.ProfilePut(*put),
 	}
-	if err = env.server.CreateProfile(post); err != nil {
+	if err = server.CreateProfile(post); err != nil {
 		return errors.Trace(err)
 	}
 	logger.Debugf("wrote lxd profile %q", pName)
@@ -322,7 +343,7 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 
 // LXDProfileNames implements environs.LXDProfiler.
 func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
-	return env.server.GetContainerProfiles(containerName)
+	return env.server().GetContainerProfiles(containerName)
 }
 
 // ReplaceLXDProfile implements environs.LXDProfiler.
@@ -332,11 +353,12 @@ func (env *environ) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile s
 			return []string{}, errors.Trace(err)
 		}
 	}
-	if err := env.server.ReplaceOrAddContainerProfile(instId, oldProfile, newProfile); err != nil {
+	server := env.server()
+	if err := server.ReplaceOrAddContainerProfile(instId, oldProfile, newProfile); err != nil {
 		return []string{}, errors.Trace(err)
 	}
 	if oldProfile != "" {
-		if err := env.server.DeleteProfile(oldProfile); err != nil {
+		if err := server.DeleteProfile(oldProfile); err != nil {
 			// most likely the failure is because the profile is already in use
 			logger.Debugf("failed to delete profile %q: %s", oldProfile, err)
 		}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -61,7 +61,7 @@ func (env *environ) StartInstance(
 }
 
 func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, error) {
-	arch := env.server.HostArch()
+	arch := env.server().HostArch()
 	tools, err := args.Tools.Match(tools.Filter{Arch: arch})
 	if err != nil {
 		return "", errors.Trace(err)
@@ -69,7 +69,7 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (str
 	if err := args.InstanceConfig.SetTools(tools); err != nil {
 		return "", errors.Trace(err)
 	}
-	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.ecfg.Config); err != nil {
+	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {
 		return "", errors.Trace(err)
 	}
 	return arch, nil
@@ -194,7 +194,7 @@ func (env *environ) getContainerSpec(
 	// Check to see if there are any non-eth0 devices in the default profile.
 	// If there are, we need cloud-init to configure them, and we need to
 	// explicitly add them to the container spec.
-	nics, err := env.server.GetNICsFromProfile("default")
+	nics, err := env.server().GetNICsFromProfile("default")
 	if err != nil {
 		return cSpec, errors.Trace(err)
 	}
@@ -253,9 +253,9 @@ func (env *environ) getTargetServer(
 	}
 
 	if p.nodeName == "" {
-		return env.server, nil
+		return env.server(), nil
 	}
-	return env.server.UseTargetServer(p.nodeName)
+	return env.server().UseTargetServer(p.nodeName)
 }
 
 type lxdPlacement struct {
@@ -299,7 +299,7 @@ func (env *environ) getHardwareCharacteristics(
 
 	archStr := container.Arch()
 	if archStr == "unknown" || !arch.IsSupportedArch(archStr) {
-		archStr = env.server.HostArch()
+		archStr = env.server().HostArch()
 	}
 	cores := uint64(container.CPUs())
 	mem := uint64(container.Mem())
@@ -336,7 +336,7 @@ func (env *environ) StopInstances(ctx context.ProviderCallContext, instances ...
 		}
 	}
 
-	err := env.server.RemoveContainers(names)
+	err := env.server().RemoveContainers(names)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 	}

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -78,7 +78,7 @@ func (env *environ) allInstances() ([]*environInstance, error) {
 
 // prefixedInstances returns instances with the specified prefix.
 func (env *environ) prefixedInstances(prefix string) ([]*environInstance, error) {
-	containers, err := env.server.AliveContainers(prefix)
+	containers, err := env.server().AliveContainers(prefix)
 	err = errors.Trace(err)
 
 	// Turn lxd.Container values into *environInstance values,
@@ -95,7 +95,7 @@ func (env *environ) prefixedInstances(prefix string) ([]*environInstance, error)
 // ControllerInstances returns the IDs of the instances corresponding
 // to juju controllers.
 func (env *environ) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
-	containers, err := env.server.AliveContainers("juju-")
+	containers, err := env.server().AliveContainers("juju-")
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
@@ -134,7 +134,7 @@ func (env *environ) AdoptResources(ctx context.ProviderCallContext, controllerUU
 		// If we added a method directly to environInstance to do this, we wouldn't need this
 		// implementation of UpdateContainerConfig at all, and the container representation we are
 		// holding would be consistent with that on the server.
-		err := env.server.UpdateContainerConfig(string(id), map[string]string{qualifiedKey: controllerUUID})
+		err := env.server().UpdateContainerConfig(string(id), map[string]string{qualifiedKey: controllerUUID})
 		if err != nil {
 			logger.Errorf("error setting controller uuid tag for %q: %v", id, err)
 			failed = append(failed, id)

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -31,7 +31,7 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 	validator := constraints.NewValidator()
 
 	validator.RegisterUnsupported(unsupportedConstraints)
-	validator.RegisterVocabulary(constraints.Arch, []string{env.server.HostArch()})
+	validator.RegisterVocabulary(constraints.Arch, []string{env.server().HostArch()})
 
 	return validator, nil
 }

--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -70,11 +70,11 @@ func ExposeInstEnv(inst *environInstance) *environ {
 }
 
 func ExposeEnvConfig(env *environ) *environConfig {
-	return env.ecfg
+	return env.ecfgUnlocked
 }
 
 func ExposeEnvServer(env *environ) Server {
-	return env.server
+	return env.server()
 }
 
 func GetImageSources(env environs.Environ) ([]lxd.ServerSpec, error) {

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -56,6 +56,6 @@ func (i *environInstance) Status(ctx context.ProviderCallContext) instance.Insta
 
 // Addresses implements instance.Instance.
 func (i *environInstance) Addresses(_ context.ProviderCallContext) ([]network.Address, error) {
-	addrs, err := i.env.server.ContainerAddresses(i.container.Name)
+	addrs, err := i.env.server().ContainerAddresses(i.container.Name)
 	return addrs, errors.Trace(err)
 }

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -145,7 +145,6 @@ func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, erro
 		p,
 		args.Cloud,
 		args.Config,
-		p.serverFactory,
 	)
 	return env, errors.Trace(err)
 }

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -42,7 +42,7 @@ const (
 )
 
 func (env *environ) storageSupported() bool {
-	return env.server.StorageSupported()
+	return env.server().StorageSupported()
 }
 
 // StorageProviderTypes implements storage.ProviderRegistry.
@@ -192,7 +192,8 @@ func (e *lxdStorageProvider) FilesystemSource(cfg *storage.Config) (storage.File
 }
 
 func ensureLXDStoragePool(env *environ, cfg *lxdStorageConfig) error {
-	createErr := env.server.CreatePool(cfg.lxdPool, cfg.driver, cfg.attrs)
+	server := env.server()
+	createErr := server.CreatePool(cfg.lxdPool, cfg.driver, cfg.attrs)
 	if createErr == nil {
 		return nil
 	}
@@ -201,7 +202,7 @@ func ensureLXDStoragePool(env *environ, cfg *lxdStorageConfig) error {
 	// verify that. If it doesn't exist, return the original
 	// CreateStoragePool error.
 
-	pool, _, err := env.server.GetStoragePool(cfg.lxdPool)
+	pool, _, err := server.GetStoragePool(cfg.lxdPool)
 	if lxd.IsLXDNotFound(err) {
 		return errors.Annotatef(createErr, "creating LXD storage pool %q", cfg.lxdPool)
 	} else if err != nil {
@@ -280,7 +281,7 @@ func (s *lxdFilesystemSource) createFilesystem(
 		config["size"] = fmt.Sprintf("%dMiB", arg.Size)
 	}
 
-	if err := s.env.server.CreateVolume(cfg.lxdPool, volumeName, config); err != nil {
+	if err := s.env.server().CreateVolume(cfg.lxdPool, volumeName, config); err != nil {
 		return nil, errors.Annotate(err, "creating volume")
 	}
 
@@ -327,12 +328,13 @@ func destroyModelFilesystems(env *environ) error {
 }
 
 func destroyFilesystems(env *environ, match func(api.StorageVolume) bool) error {
-	pools, err := env.server.GetStoragePools()
+	server := env.server()
+	pools, err := server.GetStoragePools()
 	if err != nil {
 		return errors.Annotate(err, "listing LXD storage pools")
 	}
 	for _, pool := range pools {
-		volumes, err := env.server.GetStoragePoolVolumes(pool.Name)
+		volumes, err := server.GetStoragePoolVolumes(pool.Name)
 		if err != nil {
 			return errors.Annotatef(err, "listing volumes in LXD storage pool %q", pool)
 		}
@@ -340,7 +342,7 @@ func destroyFilesystems(env *environ, match func(api.StorageVolume) bool) error 
 			if !match(volume) {
 				continue
 			}
-			if err := env.server.DeleteStoragePoolVolume(pool.Name, storagePoolVolumeType, volume.Name); err != nil {
+			if err := server.DeleteStoragePoolVolume(pool.Name, storagePoolVolumeType, volume.Name); err != nil {
 				return errors.Annotatef(err, "deleting volume %q in LXD storage pool %q", volume.Name, pool)
 			}
 		}
@@ -363,7 +365,7 @@ func (s *lxdFilesystemSource) destroyFilesystem(filesystemId string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = s.env.server.DeleteStoragePoolVolume(poolName, storagePoolVolumeType, volumeName)
+	err = s.env.server().DeleteStoragePoolVolume(poolName, storagePoolVolumeType, volumeName)
 	if err != nil && !lxd.IsLXDNotFound(err) {
 		return errors.Trace(err)
 	}
@@ -385,14 +387,15 @@ func (s *lxdFilesystemSource) releaseFilesystem(filesystemId string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	volume, eTag, err := s.env.server.GetStoragePoolVolume(poolName, storagePoolVolumeType, volumeName)
+	server := s.env.server()
+	volume, eTag, err := server.GetStoragePoolVolume(poolName, storagePoolVolumeType, volumeName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if volume.Config != nil {
 		delete(volume.Config, "user."+tags.JujuModel)
 		delete(volume.Config, "user."+tags.JujuController)
-		if err := s.env.server.UpdateStoragePoolVolume(
+		if err := server.UpdateStoragePoolVolume(
 			poolName, storagePoolVolumeType, volumeName, volume.Writable(), eTag); err != nil {
 			return errors.Annotatef(
 				err, "removing tags from volume %q in pool %q",
@@ -473,7 +476,7 @@ func (s *lxdFilesystemSource) attachFilesystem(
 		return nil, errors.Trace(err)
 	}
 
-	if err := s.env.server.WriteContainer(inst.container); err != nil {
+	if err := s.env.server().WriteContainer(inst.container); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -537,7 +540,7 @@ func (s *lxdFilesystemSource) detachFilesystem(
 ) error {
 	deviceName := arg.Filesystem.String()
 	delete(inst.container.Devices, deviceName)
-	return errors.Trace(s.env.server.WriteContainer(inst.container))
+	return errors.Trace(s.env.server().WriteContainer(inst.container))
 }
 
 // ImportFilesystem is part of the storage.FilesystemImporter interface.
@@ -550,7 +553,7 @@ func (s *lxdFilesystemSource) ImportFilesystem(
 	if err != nil {
 		return storage.FilesystemInfo{}, errors.Trace(err)
 	}
-	volume, eTag, err := s.env.server.GetStoragePoolVolume(lxdPool, storagePoolVolumeType, volumeName)
+	volume, eTag, err := s.env.server().GetStoragePoolVolume(lxdPool, storagePoolVolumeType, volumeName)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
 		return storage.FilesystemInfo{}, errors.Trace(err)
@@ -586,7 +589,7 @@ func (s *lxdFilesystemSource) ImportFilesystem(
 		for k, v := range tags {
 			volume.Config["user."+k] = v
 		}
-		if err := s.env.server.UpdateStoragePoolVolume(
+		if err := s.env.server().UpdateStoragePoolVolume(
 			lxdPool, storagePoolVolumeType, volumeName, volume.Writable(), eTag); err != nil {
 			common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
 			return storage.FilesystemInfo{}, errors.Annotate(err, "tagging volume")

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -246,7 +246,7 @@ func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 	s.EnvConfig = ecfg
 	uuid := cfg.UUID()
 	s.Env.uuid = uuid
-	s.Env.ecfg = s.EnvConfig
+	s.Env.ecfgUnlocked = s.EnvConfig
 	namespace, err := instance.NewNamespace(uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	s.Env.namespace = namespace
@@ -336,7 +336,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Common = &stubCommon{stub: s.Stub}
 
 	// Patch out all expensive external deps.
-	s.Env.server = s.Client
+	s.Env.serverUnlocked = s.Client
 	s.Env.base = s.Common
 }
 
@@ -760,9 +760,9 @@ func (s *EnvironSuite) NewEnviron(c *gc.C, svr Server, cfgEdit map[string]interf
 	c.Assert(err, jc.ErrorIsNil)
 
 	return &environ{
-		server:    svr,
-		ecfg:      eCfg,
-		namespace: namespace,
+		serverUnlocked: svr,
+		ecfgUnlocked:   eCfg,
+		namespace:      namespace,
 	}
 }
 

--- a/provider/maas/storage.go
+++ b/provider/maas/storage.go
@@ -40,7 +40,7 @@ func NewStorage(env *maasEnviron) storage.Storage {
 	} else {
 		return &maas1Storage{
 			environ:    env,
-			maasClient: env.getMAASClient().GetSubObject("files"),
+			maasClient: env.maasClientUnlocked.GetSubObject("files"),
 		}
 	}
 }


### PR DESCRIPTION
## Description of change

Add the optional SetCloudSpec() API to the lxd and maas providers. This means that when a user runs juju update-cloud, these providers now reconfigure accordingly to use the new endpoints etc.

## QA steps

bootstrap lxd and maas and ensure deploys work
It's hard to do a functional test of changing endpoints, but the provider initialisation now calls SetCloudSpec() and the wiring up to react to changes is tested elsewhere.

go test --race

## Bug
https://bugs.launchpad.net/juju/+bug/1821218