### PR TITLE
Add upgrade-controller command

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -282,6 +282,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewModelSetConstraintsCommand())
 	r.Register(newSyncToolsCommand())
 	r.Register(newUpgradeJujuCommand(nil, nil))
+	r.Register(newUpgradeControllerCommand())
 	r.Register(application.NewUpgradeCharmCommand())
 	r.Register(application.NewSetSeriesCommand())
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -595,6 +595,7 @@ var commandNames = []string{
 	"update-credential",
 	"update-storage-pool",
 	"upgrade-charm",
+	"upgrade-controller",
 	"upgrade-gui",
 	"upgrade-juju",
 	"upgrade-model",

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/version"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/bootstrap"
+)
+
+var usageUpgradeControllerSummary = `
+Upgrades Juju on a controller.`[1:]
+
+var usageUpgradeControllerDetails = `
+This command upgrades the Juju agent for a controller.
+
+A controller's agent version can be shown with `[1:] + "`juju model-config -m controller agent-\nversion`" + `.
+A version is denoted by: major.minor.patch
+The upgrade candidate will be auto-selected if '--agent-version' is not
+specified:
+ - If the server major version matches the client major version, the
+ version selected is minor+1. If such a minor version is not available then
+ the next patch version is chosen.
+ - If the server major version does not match the client major version,
+ the version selected is that of the client version.
+The command will abort if an upgrade is in progress. It will also abort if
+a previous upgrade was not fully completed (e.g.: if one of the
+controllers in a high availability model failed to upgrade).
+
+Examples:
+    juju upgrade-controller --dry-run
+    juju upgrade-controller --agent-version 2.0.1
+    
+See also: 
+    upgrade-model`
+
+func newUpgradeControllerCommand(options ...modelcmd.WrapControllerOption) cmd.Command {
+	cmd := &upgradeControllerCommand{}
+	return modelcmd.WrapController(cmd, options...)
+}
+
+// upgradeControllerCommand upgrades the controller agents in a juju installation.
+type upgradeControllerCommand struct {
+	modelcmd.ControllerCommandBase
+	upgradeFlags
+
+	rawArgs []string
+}
+
+func (c *upgradeControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "upgrade-controller",
+		Purpose: usageUpgradeControllerSummary,
+		Doc:     usageUpgradeControllerDetails,
+	})
+}
+
+func (c *upgradeControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ControllerCommandBase.SetFlags(f)
+	c.upgradeFlags.SetFlags(f)
+}
+
+func (c *upgradeControllerCommand) Init(args []string) error {
+	c.rawArgs = args
+	if c.vers != "" {
+		vers, err := version.Parse(c.vers)
+		if err != nil {
+			return err
+		}
+		if c.BuildAgent && vers.Build != 0 {
+			return errors.New("cannot specify build number when building an agent")
+		}
+		c.Version = vers
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *upgradeControllerCommand) Run(ctx *cmd.Context) (err error) {
+	// For now, we only support upgrading IAAS controllers.
+	// This is done by calling upgrade-juju -m controller.
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := common.ValidateIaasController(c.CommandBase, c.Info().Name, controllerName, c.ClientStore()); err != nil {
+		return errors.Trace(err)
+	}
+	return c.upgradeIAASController(ctx)
+}
+
+func (c *upgradeControllerCommand) upgradeIAASController(ctx *cmd.Context) error {
+	jcmd := &upgradeJujuCommand{
+		upgradeMessage: "upgrade to this version by running\n    juju upgrade-controller",
+	}
+	jcmd.SetClientStore(c.ClientStore())
+	wrapped := modelcmd.Wrap(jcmd)
+	args := append(c.rawArgs, "-m", bootstrap.ControllerModelName)
+	if c.vers != "" {
+		args = append(args, "--agent-version", c.vers)
+	}
+	if c.AgentStream != "" {
+		args = append(args, "--agent-stream", c.AgentStream)
+	}
+	if c.BuildAgent {
+		args = append(args, "--build-agent")
+	}
+	if c.DryRun {
+		args = append(args, "--dry-run")
+	}
+	if c.IgnoreAgentVersions {
+		args = append(args, "--ignore-agent-versions")
+	}
+	if c.ResetPrevious {
+		args = append(args, "--reset-previous-upgrade")
+	}
+	if c.AssumeYes {
+		args = append(args, "--yes")
+	}
+	code := cmd.Main(wrapped, ctx, args)
+	if code == 0 {
+		return nil
+	}
+	return cmd.ErrSilent
+}

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/os/series"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/jujuclient"
+	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type UpgradeControllerSuite struct {
+	UpgradeBaseSuite
+}
+
+func (s *UpgradeControllerSuite) SetUpTest(c *gc.C) {
+	s.UpgradeBaseSuite.SetUpTest(c)
+	err := s.ControllerStore.UpdateModel(jujutesting.ControllerName, "admin/dummy-model", jujuclient.ModelDetails{
+		ModelType: model.IAAS,
+		ModelUUID: coretesting.ModelTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.resources = common.NewResources()
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+
+	s.CmdBlockHelper = coretesting.NewCmdBlockHelper(s.APIState)
+	c.Assert(s.CmdBlockHelper, gc.NotNil)
+	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+}
+
+var _ = gc.Suite(&UpgradeControllerSuite{})
+
+var upgradeIAASControllerPassthroughTests = []upgradeTest{{
+	about:          "unwanted extra argument",
+	currentVersion: "1.0.0-quantal-amd64",
+	args:           []string{"foo"},
+	expectInitErr:  "unrecognized args:.*",
+}, {
+	about:          "invalid --agent-version value",
+	currentVersion: "1.0.0-quantal-amd64",
+	args:           []string{"--agent-version", "invalid-version"},
+	expectInitErr:  "invalid version .*",
+}, {
+	about:          "latest supported stable release",
+	tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
+	currentVersion: "2.0.0-quantal-amd64",
+	agentVersion:   "2.0.0",
+	expectVersion:  "2.1.3",
+}, {
+	about:          "latest supported stable, when client is dev, explicit upload",
+	tools:          []string{"2.1-dev1-quantal-amd64", "2.1.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},
+	currentVersion: "2.1-dev0-quantal-amd64",
+	agentVersion:   "2.0.0",
+	args:           []string{"--build-agent"},
+	expectVersion:  "2.1-dev0.1",
+}, {
+	about:          "upload with explicit version",
+	currentVersion: "2.2.0-quantal-amd64",
+	agentVersion:   "2.0.0",
+	args:           []string{"--build-agent", "--agent-version", "2.7.3"},
+	expectVersion:  "2.7.3.1",
+	expectUploaded: []string{"2.7.3.1-quantal-amd64", "2.7.3.1-%LTS%-amd64", "2.7.3.1-raring-amd64"},
+}}
+
+func (s *UpgradeControllerSuite) upgradeControllerCommand(minUpgradeVers map[int]version.Number) cmd.Command {
+	cmd := &upgradeControllerCommand{}
+	cmd.SetClientStore(s.ControllerStore)
+	return modelcmd.WrapController(cmd)
+}
+
+func (s *UpgradeControllerSuite) TestUpgradeIAASController(c *gc.C) {
+	// Run a subset of the upgrade-juju tests ensuring the controller
+	// model is selected.
+	c.Assert(s.Model.Name(), gc.Equals, "controller")
+	err := s.ControllerStore.SetCurrentModel("kontroll", "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertUpgradeTests(c, upgradeIAASControllerPassthroughTests, s.upgradeControllerCommand)
+}
+
+func (s *UpgradeControllerSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
+	s.Reset(c)
+	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
+	cmd := s.upgradeControllerCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
+	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
+	c.Assert(err, jc.ErrorIsNil)
+	vers := version.Binary{
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		Series: series.MustHostSeries(),
+	}
+	vers.Build = 1
+	s.checkToolsUploaded(c, vers, vers.Number)
+}
+
+func (s *UpgradeControllerSuite) TestUpgradeDryRun(c *gc.C) {
+	s.assertUpgradeDryRun(c, "upgrade-controller", s.upgradeControllerCommand)
+}


### PR DESCRIPTION
## Description of change

Add juju upgrade-controller command.

For IAAS models, this is simply a wrapper around `juju upgrade-model -m controller`
For k8s models, it will (eventually) upgrade the controller operator.

## QA steps

bootstrap and iaas controller and unsure that juju upgrade-controller does the same thing as juju upgrade-model -m controller
