### PR TITLE
2.5 - Logging Corrections Regarding "juju-ha-space"

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -197,7 +197,7 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 	if len(badIds) > 0 {
 		return errors.Errorf(
 			"juju-ha-space is not set and a unique usable address was not found for machines: %s"+
-				"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication",
+				"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication",
 			strings.Join(badIds, ", "),
 		)
 	}

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -202,7 +202,7 @@ func (s *clientSuite) TestEnableHAErrorForMultiCloudLocal(c *gc.C) {
 	_, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
 		"juju-ha-space is not set and a unique usable address was not found for machines: 0"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHAErrorForNoCloudLocal(c *gc.C) {
@@ -218,7 +218,7 @@ func (s *clientSuite) TestEnableHAErrorForNoCloudLocal(c *gc.C) {
 	_, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
 		"juju-ha-space is not set and a unique usable address was not found for machines: 0"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHANoErrorForNoAddresses(c *gc.C) {
@@ -260,7 +260,7 @@ func (s *clientSuite) TestEnableHAAddMachinesErrorForMultiCloudLocal(c *gc.C) {
 	_, err = s.enableHA(c, 5, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
 		"juju-ha-space is not set and a unique usable address was not found for machines: 2"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHAConstraints(c *gc.C) {

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -486,7 +486,7 @@ func (p *peerGroupChanges) updateAddresses() error {
 }
 
 const multiAddressMessage = "multiple usable addresses found" +
-	"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication"
+	"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication"
 
 // updateAddressesFromInternal attempts to update each member with a
 // cloud-local address from the machine.
@@ -554,7 +554,7 @@ func (p *peerGroupChanges) updateAddressesFromInternal() error {
 	if len(multipleAddresses) > 0 {
 		ids := strings.Join(multipleAddresses, ", ")
 		return fmt.Errorf("juju-ha-space is not set and these machines have more than one usable address: %s"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication", ids)
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication", ids)
 	}
 	return nil
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -781,7 +781,7 @@ func (s *workerSuite) doTestErrorAndStatusForNewPeersAndNoHASpaceAndMachinesWith
 	err := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}).Wait()
 	errMsg := `computing desired peer group: updating member addresses: ` +
 		`juju-ha-space is not set and these machines have more than one usable address: 1[12], 1[12]` +
-		"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication"
+		"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication"
 	c.Check(err, gc.ErrorMatches, errMsg)
 
 	for _, id := range []string{"11", "12"} {


### PR DESCRIPTION
## Description of change

This patch ensures that:
- Warning messages for multiple usable Mongo peer addresses are not logged when there is only a single controller.
- Messages with instructions for setting a value for `juju-ha-space` refer to the `controller-config` command rather than the `config` command.

## QA steps

A/B Test:
- Bootstrap to a machine with NICs in multiple spaces (I configured a machine on finfolk).
- Observe the periodic warning messages in the controller machine debug log.
- Build this patch and bootstrap to the same machine.
- Observe that the warnings are no longer logged.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1772895
