### PR TITLE
Merge 2.5 to Bring in Patch #9964

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -206,7 +206,7 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 	if len(badIds) > 0 {
 		return errors.Errorf(
 			"juju-ha-space is not set and a unique usable address was not found for machines: %s"+
-				"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication",
+				"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication",
 			strings.Join(badIds, ", "),
 		)
 	}

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -202,7 +202,7 @@ func (s *clientSuite) TestEnableHAErrorForMultiCloudLocal(c *gc.C) {
 	_, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
 		"juju-ha-space is not set and a unique usable address was not found for machines: 0"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHAErrorForNoCloudLocal(c *gc.C) {
@@ -218,7 +218,7 @@ func (s *clientSuite) TestEnableHAErrorForNoCloudLocal(c *gc.C) {
 	_, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
 		"juju-ha-space is not set and a unique usable address was not found for machines: 0"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHANoErrorForNoAddresses(c *gc.C) {
@@ -260,7 +260,7 @@ func (s *clientSuite) TestEnableHAAddMachinesErrorForMultiCloudLocal(c *gc.C) {
 	_, err = s.enableHA(c, 5, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches,
 		"juju-ha-space is not set and a unique usable address was not found for machines: 2"+
-			"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication")
+			"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication")
 }
 
 func (s *clientSuite) TestEnableHAConstraints(c *gc.C) {

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -781,7 +781,7 @@ func (s *workerSuite) doTestErrorAndStatusForNewPeersAndNoHASpaceAndMachinesWith
 	err := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}).Wait()
 	errMsg := `computing desired peer group: updating member addresses: ` +
 		`juju-ha-space is not set and these machines have more than one usable address: 1[12], 1[12]` +
-		"\nrun \"juju config juju-ha-space=<name>\" to set a space for Mongo peer communication"
+		"\nrun \"juju controller-config juju-ha-space=<name>\" to set a space for Mongo peer communication"
 	c.Check(err, gc.ErrorMatches, errMsg)
 
 	for _, id := range []string{"11", "12"} {


### PR DESCRIPTION
Forward port of https://github.com/juju/juju/pull/9964, which fixes logging for setting `juju-ha-space`.
