### PR TITLE
WatchApplications API AssertStop

### DIFF
--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -223,6 +223,7 @@ func (api *InstanceMutaterAPI) watchOneEntityApplication(canAccess common.AuthFu
 		return result, err
 	}
 	watch := machine.WatchApplicationLXDProfiles()
+	// Consume the initial event before sending the result.
 	if _, ok := <-watch.Changes(); ok {
 		result.NotifyWatcherId = api.resources.Register(watch)
 	} else {


### PR DESCRIPTION
## Description of change

The following ensures that we have sent out all the notifies for the
watcher before finishing the test. This way we can be sure that the
first event is consumed by the facade and that we don't pass it
towards.