### PR TITLE
Make default hosted model optional for k8s controller.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -191,6 +191,10 @@ func ensureHostedModel(
 	adminUser names.UserTag,
 	cloudCredentialTag names.CloudCredentialTag,
 ) error {
+	if args.HostedModelConfig == nil || len(args.HostedModelConfig) == 0 {
+		logger.Debugf("no hosted model configured")
+		return nil
+	}
 
 	// Create the initial hosted model, with the model config passed to
 	// bootstrap, which contains the UUID, name for the hosted model,
@@ -240,17 +244,12 @@ func ensureHostedModel(
 		return errors.Annotate(err, "opening hosted model environment")
 	}
 
-	// TODO(bootstrapping): enable creating default hostedmodel after we solve the "default" namespace conflict!
-	if isCAAS {
-		logger.Debugf("default hosted model is disabled for k8s controller due to conflict with the k8s default namespace.")
-	} else {
-		if err := hostedModelEnv.Create(
-			state.CallContext(st),
-			environs.CreateParams{
-				ControllerUUID: controllerUUID,
-			}); err != nil {
-			return errors.Annotate(err, "creating hosted model environment")
-		}
+	if err := hostedModelEnv.Create(
+		state.CallContext(st),
+		environs.CreateParams{
+			ControllerUUID: controllerUUID,
+		}); err != nil {
+		return errors.Annotate(err, "creating hosted model environment")
 	}
 
 	ctrlModel, err := st.Model()

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -191,7 +191,7 @@ func ensureHostedModel(
 	adminUser names.UserTag,
 	cloudCredentialTag names.CloudCredentialTag,
 ) error {
-	if args.HostedModelConfig == nil || len(args.HostedModelConfig) == 0 {
+	if len(args.HostedModelConfig) == 0 {
 		logger.Debugf("no hosted model configured")
 		return nil
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -276,7 +276,7 @@ func (k *kubernetesClient) Bootstrap(
 				return errors.NewAlreadyExists(nil,
 					fmt.Sprintf(`
 namespace %q already exists in the cluster,
-please choose a different hosted model name then try again
+please choose a different hosted model name then try again.
 `, hostedModelName),
 				)
 			}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -269,6 +269,23 @@ func (k *kubernetesClient) Bootstrap(
 
 		logger.Debugf("controller pod config: \n%+v", pcfg)
 
+		// validate hosted model name if we need to create it.
+		if hostedModelName, has := pcfg.GetHostedModel(); has {
+			_, err := k.getNamespaceByName(hostedModelName)
+			if err == nil {
+				return errors.NewAlreadyExists(nil,
+					fmt.Sprintf(`
+namespace %q already exists in the cluster,
+please choose a different hosted model name then try again
+`, hostedModelName),
+				)
+			}
+			if !errors.IsNotFound(err) {
+				return errors.Trace(err)
+			}
+			// hosted model is all good.
+		}
+
 		// we use controller name to name controller namespace in bootstrap time.
 		setControllerNamespace := func(controllerName string, broker *kubernetesClient) error {
 			nsName := DecideControllerNamespace(controllerName)

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -309,9 +309,6 @@ func (cfg *BootstrapConfig) VerifyConfig() (err error) {
 	if cfg.StateServingInfo.APIPort == 0 {
 		return errors.New("missing API port")
 	}
-	if len(cfg.HostedModelConfig) == 0 {
-		return errors.New("missing hosted model config")
-	}
 	return nil
 }
 
@@ -408,7 +405,9 @@ func NewBootstrapControllerPodConfig(config controller.Config, controllerName, s
 	}
 	pcfg.Jobs = []multiwatcher.MachineJob{
 		multiwatcher.JobManageModel,
-		multiwatcher.JobHostUnits,
+	}
+	if pcfg.Bootstrap.HostedModelConfig != nil && len(pcfg.Bootstrap.HostedModelConfig) > 0 {
+		pcfg.Jobs = append(pcfg.Jobs, multiwatcher.JobHostUnits)
 	}
 	return pcfg, nil
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -580,6 +580,7 @@ to create a new model to deploy k8s workloads
 			return nil, nil
 		}
 		initialHostedModelInstructionMsg = fmt.Sprintf("Initial model %q added", c.hostedModelName)
+
 		hostedModelUUID, err := utils.NewUUID()
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -472,7 +472,7 @@ to create a new model to deploy k8s workloads.
 			} else {
 				msg = fmt.Sprintf("Initial model %q added", c.hostedModelName)
 			}
-			defer ctx.Infof(msg)
+			ctx.Infof(msg)
 		}
 	}()
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -116,7 +116,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		panic("tests must call setupAutoUploadTest or otherwise patch envtools.BundleTools")
 	})
 
-	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, string, string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, bool, string, string) error {
 		return nil
 	})
 
@@ -1875,7 +1875,7 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 
 	// Record the controller name seen by ModelCommandBase at the end of bootstrap.
 	var seenControllerName string
-	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, controllerName, _ string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _ bool, controllerName, _ string) error {
 		seenControllerName = controllerName
 		return nil
 	})

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -63,13 +63,7 @@ func tryAPI(c *modelcmd.ModelCommandBase) error {
 // WaitForAgentInitialisation polls the bootstrapped controller with a read-only
 // command which will fail until the controller is fully initialised.
 // TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
-func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName, hostedModelName string) (err error) {
-	modelType, err := c.ModelType()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	isCAAS := modelType == model.CAAS
-
+func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, isCAASController bool, controllerName, hostedModelName string) (err error) {
 	// TODO(katco): 2016-08-09: lp:1611427
 	attempts := utils.AttemptStrategy{
 		Min:   bootstrapReadyPollCount,
@@ -92,7 +86,7 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 		err = tryAPI(c)
 		if err == nil {
 			msg := fmt.Sprintf("\nBootstrap complete, controller %q now is available", controllerName)
-			if isCAAS {
+			if isCAASController {
 				msg += fmt.Sprintf(" in namespace %q", caasprovider.DecideControllerNamespace(controllerName))
 				msg += `
 Now you can run 
@@ -101,7 +95,9 @@ to create a new model to deploy k8s workloads
 `
 			} else {
 				msg += fmt.Sprintf("\nController machines are in the %q model", bootstrap.ControllerModelName)
-				msg += fmt.Sprintf("\nInitial model %q added", hostedModelName)
+				if hostedModelName != "" {
+					msg += fmt.Sprintf("\nInitial model %q added", hostedModelName)
+				}
 			}
 			ctx.Infof(msg)
 			break

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -88,16 +88,8 @@ func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, 
 			msg := fmt.Sprintf("\nBootstrap complete, controller %q now is available", controllerName)
 			if isCAASController {
 				msg += fmt.Sprintf(" in namespace %q", caasprovider.DecideControllerNamespace(controllerName))
-				msg += `
-Now you can run 
-	juju add-model <model-name>
-to create a new model to deploy k8s workloads
-`
 			} else {
 				msg += fmt.Sprintf("\nController machines are in the %q model", bootstrap.ControllerModelName)
-				if hostedModelName != "" {
-					msg += fmt.Sprintf("\nInitial model %q added", hostedModelName)
-				}
 			}
 			ctx.Infof(msg)
 			break

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -97,7 +97,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
 		runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-			err := WaitForAgentInitialisation(ctx, base, "controller", "default")
+			err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
 			c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		})
 		expectedRetries := t.numRetries
@@ -116,7 +116,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C
 	s.mockBlockClient.discoveringSpacesError = 2
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, "controller", "default")
+		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
@@ -128,7 +128,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C)
 	s.mockBlockClient.loginError = io.EOF
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, "controller", "default")
+		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
@@ -139,7 +139,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, "controller", "default")
+		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
 		c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)


### PR DESCRIPTION

## Description of change

Now we do not create the `default hosted model` for `k8s controller`, 
but the user can still request a preferred hosted model created 
during bootstrapping time by specifying option `--default-model`.

## QA steps

- add k8s cloud

```bash
$ microk8s.config | juju add-k8s <k8s-cloud>
```

- juju bootstrap without hosted model created;

```bash
$ juju bootstrap <k8s-cloud> <controller-name> --debug
```

- juju bootstrap with hosted model created (the "default" model name will be valid for k8s controller);

```bash
$ juju bootstrap <k8s-cloud> <controller-name> --debug --default-model <my-default-hosted-model>
```

## Documentation changes

Added instructions in Bootstrapping Infof messages;

## Bug reference

None
