### PR TITLE
add functions to model cache for instance mutater apiserver functionaltiy 

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -33,6 +33,11 @@ type Application struct {
 	hashCache  *hashCache
 }
 
+// CharmURL returns the charm url string for this application.
+func (a *Application) CharmURL() string {
+	return a.details.CharmURL
+}
+
 // Config returns a copy of the current application config.
 func (a *Application) Config() map[string]interface{} {
 	a.mu.Lock()

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"github.com/juju/pubsub"
+
+	"github.com/juju/juju/core/lxdprofile"
 )
 
 func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
@@ -25,6 +27,11 @@ type Charm struct {
 	mu      sync.Mutex
 
 	details CharmChange
+}
+
+// LXDProfile returns the lxd profile of this charm.
+func (c *Charm) LXDProfile() lxdprofile.Profile {
+	return c.details.LXDProfile
 }
 
 func (c *Charm) setDetails(details CharmChange) {

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -18,3 +18,13 @@ func (m *Model) SetDetails(details ModelChange) {
 func (a *Application) SetDetails(details ApplicationChange) {
 	a.setDetails(details)
 }
+
+// Expose Update* for testing.
+
+func (m *Model) UpdateMachine(details MachineChange) {
+	m.updateMachine(details)
+}
+
+func (m *Model) UpdateUnit(details UnitChange) {
+	m.updateUnit(details)
+}

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -4,6 +4,10 @@
 package cache_test
 
 import (
+	"sort"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/cache"
@@ -12,14 +16,102 @@ import (
 	"github.com/juju/juju/core/status"
 )
 
-type MachineSuite struct {
+type machineSuite struct {
 	entitySuite
+
+	model *cache.Model
 }
 
-var _ = gc.Suite(&MachineSuite{})
+var _ = gc.Suite(&machineSuite{})
 
-func (s *MachineSuite) SetUpTest(c *gc.C) {
+func (s *machineSuite) SetUpTest(c *gc.C) {
 	s.entitySuite.SetUpTest(c)
+	s.model = s.newModel(modelChange)
+}
+
+func (s *machineSuite) TestUnits(c *gc.C) {
+	machine, expectedUnits := s.setupMachineWithUnits(c, "0", []string{"test1", "test2"})
+	obtainedUnits, err := machine.Units()
+	c.Assert(err, jc.ErrorIsNil)
+	sort.Sort(orderedUnits(obtainedUnits))
+	sort.Sort(orderedUnits(expectedUnits))
+	c.Assert(obtainedUnits, jc.DeepEquals, expectedUnits)
+}
+
+func (s *machineSuite) TestUnitsSubordinate(c *gc.C) {
+	machine, expectedUnits := s.setupMachineWithUnits(c, "0", []string{"test1", "test2"})
+
+	// add subordinate
+	uc := unitChange
+	uc.MachineId = ""
+	uc.Name = "test5/0"
+	uc.Application = "test5"
+	uc.Principal = "test1/0"
+	uc.Subordinate = true
+	s.model.UpdateUnit(uc)
+	unit, err := s.model.Unit(uc.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedUnits = append(expectedUnits, unit)
+
+	obtainedUnits, err := machine.Units()
+	c.Assert(err, jc.ErrorIsNil)
+	sort.Sort(orderedUnits(obtainedUnits))
+	sort.Sort(orderedUnits(expectedUnits))
+	c.Assert(obtainedUnits, jc.DeepEquals, expectedUnits)
+}
+
+func (s *machineSuite) TestUnitsTwoMachines(c *gc.C) {
+	machine0, expectedUnits0 := s.setupMachineWithUnits(c, "0", []string{"test1", "test2"})
+	machine1, expectedUnits1 := s.setupMachineWithUnits(c, "1", []string{"test3", "test4", "test5"})
+
+	obtainedUnits0, err := machine0.Units()
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedUnits1, err := machine1.Units()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sort.Sort(orderedUnits(obtainedUnits0))
+	sort.Sort(orderedUnits(expectedUnits0))
+	sort.Sort(orderedUnits(obtainedUnits1))
+	sort.Sort(orderedUnits(expectedUnits1))
+
+	c.Assert(obtainedUnits0, jc.DeepEquals, expectedUnits0)
+	c.Assert(obtainedUnits1, jc.DeepEquals, expectedUnits1)
+}
+
+func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (*cache.Machine, []*cache.Unit) {
+	mc := machineChange
+	mc.Id = machineId
+	s.model.UpdateMachine(mc)
+	machine, err := s.model.Machine(machineId)
+	c.Assert(err, jc.ErrorIsNil)
+
+	units := make([]*cache.Unit, len(apps))
+	for i, name := range apps {
+		uc := unitChange
+		uc.MachineId = machineId
+		uc.Name = name + "/" + machineId
+		uc.Application = name
+		s.model.UpdateUnit(uc)
+		unit, err := s.model.Unit(uc.Name)
+		c.Assert(err, jc.ErrorIsNil)
+		units[i] = unit
+	}
+
+	return machine, units
+}
+
+type orderedUnits []*cache.Unit
+
+func (o orderedUnits) Len() int {
+	return len(o)
+}
+
+func (o orderedUnits) Less(i, j int) bool {
+	return strings.Compare(o[i].Application(), o[j].Application()) < 0
+}
+
+func (o orderedUnits) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
 }
 
 var machineChange = cache.MachineChange{

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -55,6 +55,11 @@ func (m *Model) Config() map[string]interface{} {
 	return cfg
 }
 
+// Name returns the current model's name.
+func (m *Model) Name() string {
+	return m.details.Name
+}
+
 // WatchConfig creates a watcher for the model config.
 func (m *Model) WatchConfig(keys ...string) *ConfigWatcher {
 	return newConfigWatcher(keys, m.hashCache, m.hub, m.topic(modelConfigChange))

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -219,7 +219,7 @@ func (m *Model) updateMachine(ch MachineChange) {
 
 	machine, found := m.machines[ch.Id]
 	if !found {
-		machine = newMachine(m.metrics, m.hub)
+		machine = newMachine(m)
 		m.machines[ch.Id] = machine
 		m.hub.Publish(m.topic(modelMachineChange), []string{ch.Id})
 	}

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -25,12 +25,6 @@ func (s *ModelSuite) SetUpTest(c *gc.C) {
 	s.entitySuite.SetUpTest(c)
 }
 
-func (s *ModelSuite) newModel(details cache.ModelChange) *cache.Model {
-	m := cache.NewModel(s.gauges, s.hub)
-	m.SetDetails(details)
-	return m
-}
-
 func (s *ModelSuite) TestReport(c *gc.C) {
 	m := s.newModel(modelChange)
 	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -50,6 +50,12 @@ func (s *entitySuite) SetUpTest(c *gc.C) {
 	})
 }
 
+func (s *entitySuite) newModel(details cache.ModelChange) *cache.Model {
+	m := cache.NewModel(s.gauges, s.hub)
+	m.SetDetails(details)
+	return m
+}
+
 type ImportSuite struct{}
 
 var _ = gc.Suite(&ImportSuite{})

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -27,6 +27,11 @@ func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
 	return u
 }
 
+// Application returns the application name of this unit.
+func (u *Unit) Application() string {
+	return u.details.Application
+}
+
 func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
 	defer u.mu.Unlock()


### PR DESCRIPTION
Based on PR9966 for change to cache.Machine constructer.

## Description of change

Added charm.LXDProfile(), unit.Application(), machine.Units(), and application.CharmURL() to model cache.

## QA steps

No change  to current juju usage. 