### PR TITLE
made destroy-controller kill-controller cmds work for k8s controller

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
 )
@@ -99,9 +98,6 @@ type Broker interface {
 
 	// APIVersion returns the master kubelet API version.
 	APIVersion() (string, error)
-
-	// Destroy terminates all containers and other resources in this broker's namespace.
-	Destroy(context.ProviderCallContext) error
 
 	// EnsureOperator creates or updates an operator pod for running
 	// a charm for the specified application.

--- a/core/annotations/annotations.go
+++ b/core/annotations/annotations.go
@@ -74,6 +74,11 @@ func (a Annotation) ToMap() map[string]string {
 	return out
 }
 
+// Copy returns a copy of current annotation.
+func (a Annotation) Copy() Annotation {
+	return New(nil).Merge(a)
+}
+
 // CheckKeysNonEmpty checks if the provided keys are all set to non empty value.
 func (a Annotation) CheckKeysNonEmpty(keys ...string) error {
 	for _, k := range keys {
@@ -100,7 +105,12 @@ func (a Annotation) setVal(key, val string) {
 	}
 
 	oldVal, existing := a.getVal(key)
-	if existing {
+	if existing && oldVal == val {
+		return
+	}
+	if !existing {
+		logger.Debugf("annotation %q sets to %q", key, val)
+	} else {
 		logger.Debugf("annotation %q changed from %q to %q", key, oldVal, val)
 	}
 	a[key] = val

--- a/core/annotations/annotations_test.go
+++ b/core/annotations/annotations_test.go
@@ -39,6 +39,39 @@ func (s *annotationsSuite) TestExistAndAdd(c *gc.C) {
 	c.Assert(s.annotations.Has(key, "a new value"), jc.IsTrue)
 }
 
+func (s *annotationsSuite) TestCopy(c *gc.C) {
+	annotation1 := map[string]string{
+		"annotation-1-key": "annotation-1-val",
+	}
+	s.annotations.Merge(jujuannotations.New(annotation1))
+	c.Assert(s.annotations.ToMap(), jc.DeepEquals, annotation1)
+
+	newAnnotation1 := s.annotations.Copy()
+	newAnnotation2 := s.annotations
+
+	newAnnotation1.Add("a-new-key", "a-new-value")
+	c.Assert(
+		newAnnotation1.ToMap(), jc.DeepEquals,
+		map[string]string{
+			"annotation-1-key": "annotation-1-val",
+			"a-new-key":        "a-new-value",
+		},
+	)
+	// no change in original one because it was Copy.
+	c.Assert(s.annotations.ToMap(), jc.DeepEquals, annotation1)
+
+	newAnnotation2.Add("aaaa", "bbbbb")
+	c.Assert(newAnnotation2.ToMap(), jc.DeepEquals, map[string]string{
+		"annotation-1-key": "annotation-1-val",
+		"aaaa":             "bbbbb",
+	})
+	// changed in original one because it was NOT Copy.
+	c.Assert(s.annotations.ToMap(), jc.DeepEquals, map[string]string{
+		"annotation-1-key": "annotation-1-val",
+		"aaaa":             "bbbbb",
+	})
+}
+
 func (s *annotationsSuite) TestExistAllExistAnyMergeToMap(c *gc.C) {
 	annotation1 := map[string]string{
 		"annotation-1-key": "annotation-1-val",

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -309,6 +309,8 @@ type BootstrapEnviron interface {
 	Configer
 	Bootstrapper
 	ConstraintsChecker
+
+	CloudDestroyer
 	ControllerDestroyer
 
 	// Environ implements storage.ProviderRegistry for acquiring
@@ -355,9 +357,6 @@ type CloudDestroyer interface {
 // avoid undefined behaviour when the configuration changes.
 type Environ interface {
 	BootstrapEnviron
-
-	// CloudDestroyer provides the API to cleanup cloud resources.
-	CloudDestroyer
 
 	// ResourceAdopter defines methods for adopting resources.
 	ResourceAdopter


### PR DESCRIPTION
## Description of change

made `destroy-controller` & `kill-controller` commands work for `k8s controller`;

## QA steps

- add k8s cloud

```bash
$ microk8s.config | juju add-k8s <k8s-cloud>
```

- juju bootstrap without hosted model created;

```bash
$ juju bootstrap <k8s-cloud> <controller-name> --debug
```

- destroy or kill controller

``` bash
$ juju destroy-controller <controller-name> --destroy-all-models --destroy-storage  --debug -y
# or
$ juju kill-controller -t 0 -y <controller-name> --debug
```

## Documentation changes

None

## Bug reference

None