### PR TITLE
Add CLI front end for upgrade-controller k8s

### DIFF
--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -256,6 +256,9 @@ func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) st
 	if imageRepo == "" {
 		imageRepo = jujudOCINamespace
 	}
+	if ver == version.Zero {
+		return fmt.Sprintf("%s/%s", imageRepo, jujudOCIName)
+	}
 	return fmt.Sprintf("%s/%s:%s", imageRepo, jujudOCIName, ver.String())
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -281,7 +281,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewModelGetConstraintsCommand())
 	r.Register(model.NewModelSetConstraintsCommand())
 	r.Register(newSyncToolsCommand())
-	r.Register(newUpgradeJujuCommand(nil, nil))
+	r.Register(newUpgradeJujuCommand())
 	r.Register(newUpgradeControllerCommand())
 	r.Register(application.NewUpgradeCharmCommand())
 	r.Register(application.NewSetSeriesCommand())

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -4,15 +4,27 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/version"
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/cloudconfig/podcfg"
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/docker"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var usageUpgradeControllerSummary = `
@@ -49,9 +61,10 @@ func newUpgradeControllerCommand(options ...modelcmd.WrapControllerOption) cmd.C
 // upgradeControllerCommand upgrades the controller agents in a juju installation.
 type upgradeControllerCommand struct {
 	modelcmd.ControllerCommandBase
-	upgradeFlags
+	baseUpgradeCommand
 
-	rawArgs []string
+	upgradeJujuAPI upgradeJujuAPI
+	rawArgs        []string
 }
 
 func (c *upgradeControllerCommand) Info() *cmd.Info {
@@ -64,41 +77,195 @@ func (c *upgradeControllerCommand) Info() *cmd.Info {
 
 func (c *upgradeControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	c.upgradeFlags.SetFlags(f)
+	c.baseUpgradeCommand.SetFlags(f)
 }
 
-func (c *upgradeControllerCommand) Init(args []string) error {
-	c.rawArgs = args
-	if c.vers != "" {
-		vers, err := version.Parse(c.vers)
-		if err != nil {
-			return err
-		}
-		if c.BuildAgent && vers.Build != 0 {
-			return errors.New("cannot specify build number when building an agent")
-		}
-		c.Version = vers
+func (c *upgradeControllerCommand) getUpgradeJujuAPI() (upgradeJujuAPI, error) {
+	if c.upgradeJujuAPI != nil {
+		return c.upgradeJujuAPI, nil
 	}
-	return cmd.CheckEmpty(args)
+
+	root, err := c.NewModelAPIRoot(bootstrap.ControllerModelName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return root.Client(), nil
+}
+
+func (c *upgradeControllerCommand) getModelConfigAPI() (modelConfigAPI, error) {
+	if c.modelConfigAPI != nil {
+		return c.modelConfigAPI, nil
+	}
+
+	api, err := c.NewModelAPIRoot(bootstrap.ControllerModelName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return modelconfig.NewClient(api), nil
+}
+
+func (c *upgradeControllerCommand) getControllerAPI() (controllerAPI, error) {
+	if c.controllerAPI != nil {
+		return c.controllerAPI, nil
+	}
+
+	return c.NewControllerAPIClient()
 }
 
 func (c *upgradeControllerCommand) Run(ctx *cmd.Context) (err error) {
-	// For now, we only support upgrading IAAS controllers.
-	// This is done by calling upgrade-juju -m controller.
 	controllerName, err := c.ControllerName()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := common.ValidateIaasController(c.CommandBase, c.Info().Name, controllerName, c.ClientStore()); err != nil {
+	controllerModel := jujuclient.JoinOwnerModelName(
+		names.NewUserTag(environs.AdminUser), bootstrap.ControllerModelName)
+	_, err = c.ModelUUIDs([]string{controllerModel})
+	if err != nil {
+		return errors.Annotatef(err, "cannot get controller model uuid")
+	}
+	details, err := c.ClientStore().ModelByName(controllerName, controllerModel)
+	if err != nil {
 		return errors.Trace(err)
+	}
+	if details.ModelType == model.CAAS {
+		return c.upgradeCAASController(ctx)
 	}
 	return c.upgradeIAASController(ctx)
 }
 
-func (c *upgradeControllerCommand) upgradeIAASController(ctx *cmd.Context) error {
-	jcmd := &upgradeJujuCommand{
-		upgradeMessage: "upgrade to this version by running\n    juju upgrade-controller",
+func (c *upgradeControllerCommand) upgradeCAASController(ctx *cmd.Context) error {
+	if c.BuildAgent {
+		return errors.NotSupportedf("--build-agent for k8s controller upgrades")
 	}
+	client, err := c.getUpgradeJujuAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	modelConfigClient, err := c.getModelConfigAPI()
+	if err != nil {
+		return err
+	}
+	defer modelConfigClient.Close()
+	controllerAPI, err := c.getControllerAPI()
+	if err != nil {
+		return err
+	}
+	defer controllerAPI.Close()
+
+	defer func() {
+		if err == errUpToDate {
+			ctx.Infof(err.Error())
+			err = nil
+		}
+	}()
+
+	// Determine the version to upgrade to.
+	attrs, err := modelConfigClient.ModelGet()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return err
+	}
+
+	currentAgentVersion, ok := cfg.AgentVersion()
+	if !ok {
+		// Can't happen. In theory.
+		return errors.New("incomplete model configuration")
+	}
+
+	warnCompat, err := c.precheck(ctx, currentAgentVersion)
+	if err != nil {
+		return err
+	}
+
+	controllerCfg, err := controllerAPI.ControllerConfig()
+	if err != nil {
+		return err
+	}
+
+	context, err := c.initCAASVersions(controllerCfg, currentAgentVersion, warnCompat)
+	if err != nil {
+		return err
+	}
+
+	if err := context.maybeChoosePackagedAgent(); err != nil {
+		ctx.Verbosef("%v", err)
+		return err
+	}
+
+	if err := context.validate(); err != nil {
+		return err
+	}
+	ctx.Verbosef("available agent images:\n%s", formatVersions(context.packagedAgents))
+	fmt.Fprintf(ctx.Stderr, "best version:\n    %v\n", context.chosen)
+	if warnCompat {
+		fmt.Fprintf(ctx.Stderr, "version %s incompatible with this client (%s)\n", context.chosen, jujuversion.Current)
+	}
+	if c.DryRun {
+		fmt.Fprintf(ctx.Stderr, "%s\n", c.upgradeMessage)
+		return nil
+	}
+	return c.notifyControllerUpgrade(ctx, client, context)
+}
+
+// initCAASVersions collects state relevant to an upgrade decision. The returned
+// agent and client versions, and the list of currently available operator images, will
+// always be accurate; the chosen version, and the flag indicating development
+// mode, may remain blank until uploadTools or validate is called.
+func (c *upgradeControllerCommand) initCAASVersions(
+	controllerCfg controller.Config, agentVersion version.Number, filterOnPrior bool,
+) (*upgradeContext, error) {
+	if c.Version == agentVersion {
+		return nil, errUpToDate
+	}
+	c.upgradeMessage = "upgrade to this version by running\n    juju upgrade-controller"
+
+	filterVersion := jujuversion.Current
+	if c.Version != version.Zero {
+		filterVersion = c.Version
+	} else if filterOnPrior {
+		filterVersion.Major--
+	}
+	logger.Debugf("searching for agent images with major: %d", filterVersion.Major)
+	imagePath := podcfg.GetJujuOCIImagePath(controllerCfg, version.Zero)
+	availableTags, err := docker.ListOperatorImages(imagePath)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debugf("found available tags: %v", availableTags)
+	var matchingTags tools.Versions
+	for _, t := range availableTags {
+		vers := t.AgentVersion()
+		if filterVersion.Major != -1 && vers.Major != filterVersion.Major {
+			continue
+		}
+		matchingTags = append(matchingTags, t)
+	}
+
+	logger.Debugf("found matching tags: %v", matchingTags)
+	if len(matchingTags) == 0 {
+		// No images found, so if we are not asking for a major upgrade,
+		// pretend there is no more recent version available.
+		if c.Version == version.Zero && agentVersion.Major == filterVersion.Major {
+			return nil, errUpToDate
+		}
+		return nil, err
+	}
+	return &upgradeContext{
+		agent:          agentVersion,
+		client:         jujuversion.Current,
+		chosen:         c.Version,
+		packagedAgents: matchingTags,
+	}, nil
+}
+
+func (c *upgradeControllerCommand) upgradeIAASController(ctx *cmd.Context) error {
+	jcmd := &upgradeJujuCommand{baseUpgradeCommand: baseUpgradeCommand{
+		upgradeMessage: "upgrade to this version by running\n    juju upgrade-controller",
+	}}
 	jcmd.SetClientStore(c.ClientStore())
 	wrapped := modelcmd.Wrap(jcmd)
 	args := append(c.rawArgs, "-m", bootstrap.ControllerModelName)

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -4,6 +4,9 @@
 package commands
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/os/series"
@@ -16,17 +19,19 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/docker"
+	"github.com/juju/juju/environs/tools"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
 
-type UpgradeControllerSuite struct {
+type UpgradeIAASControllerSuite struct {
 	UpgradeBaseSuite
 }
 
-func (s *UpgradeControllerSuite) SetUpTest(c *gc.C) {
+func (s *UpgradeIAASControllerSuite) SetUpTest(c *gc.C) {
 	s.UpgradeBaseSuite.SetUpTest(c)
 	err := s.ControllerStore.UpdateModel(jujutesting.ControllerName, "admin/dummy-model", jujuclient.ModelDetails{
 		ModelType: model.IAAS,
@@ -43,7 +48,7 @@ func (s *UpgradeControllerSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
 }
 
-var _ = gc.Suite(&UpgradeControllerSuite{})
+var _ = gc.Suite(&UpgradeIAASControllerSuite{})
 
 var upgradeIAASControllerPassthroughTests = []upgradeTest{{
 	about:          "unwanted extra argument",
@@ -57,13 +62,13 @@ var upgradeIAASControllerPassthroughTests = []upgradeTest{{
 	expectInitErr:  "invalid version .*",
 }, {
 	about:          "latest supported stable release",
-	tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
+	available:      []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
 	currentVersion: "2.0.0-quantal-amd64",
 	agentVersion:   "2.0.0",
 	expectVersion:  "2.1.3",
 }, {
 	about:          "latest supported stable, when client is dev, explicit upload",
-	tools:          []string{"2.1-dev1-quantal-amd64", "2.1.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},
+	available:      []string{"2.1-dev1-quantal-amd64", "2.1.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},
 	currentVersion: "2.1-dev0-quantal-amd64",
 	agentVersion:   "2.0.0",
 	args:           []string{"--build-agent"},
@@ -77,13 +82,15 @@ var upgradeIAASControllerPassthroughTests = []upgradeTest{{
 	expectUploaded: []string{"2.7.3.1-quantal-amd64", "2.7.3.1-%LTS%-amd64", "2.7.3.1-raring-amd64"},
 }}
 
-func (s *UpgradeControllerSuite) upgradeControllerCommand(minUpgradeVers map[int]version.Number) cmd.Command {
-	cmd := &upgradeControllerCommand{}
+func (s *UpgradeIAASControllerSuite) upgradeControllerCommand(minUpgradeVers map[int]version.Number) cmd.Command {
+	cmd := &upgradeControllerCommand{
+		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
+	}
 	cmd.SetClientStore(s.ControllerStore)
 	return modelcmd.WrapController(cmd)
 }
 
-func (s *UpgradeControllerSuite) TestUpgradeIAASController(c *gc.C) {
+func (s *UpgradeIAASControllerSuite) TestUpgrade(c *gc.C) {
 	// Run a subset of the upgrade-juju tests ensuring the controller
 	// model is selected.
 	c.Assert(s.Model.Name(), gc.Equals, "controller")
@@ -93,7 +100,7 @@ func (s *UpgradeControllerSuite) TestUpgradeIAASController(c *gc.C) {
 	s.assertUpgradeTests(c, upgradeIAASControllerPassthroughTests, s.upgradeControllerCommand)
 }
 
-func (s *UpgradeControllerSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
+func (s *UpgradeIAASControllerSuite) TestUpgradeWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
 	cmd := s.upgradeControllerCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
@@ -108,6 +115,141 @@ func (s *UpgradeControllerSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	s.checkToolsUploaded(c, vers, vers.Number)
 }
 
-func (s *UpgradeControllerSuite) TestUpgradeDryRun(c *gc.C) {
+func (s *UpgradeIAASControllerSuite) TestUpgradeDryRun(c *gc.C) {
 	s.assertUpgradeDryRun(c, "upgrade-controller", s.upgradeControllerCommand)
+}
+
+type UpgradeCAASControllerSuite struct {
+	UpgradeBaseSuite
+}
+
+func (s *UpgradeCAASControllerSuite) SetUpTest(c *gc.C) {
+	s.UpgradeBaseSuite.SetUpTest(c)
+	err := s.ControllerStore.RemoveModel(jujutesting.ControllerName, "admin/controller")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.ControllerStore.UpdateModel(jujutesting.ControllerName, "admin/controller", jujuclient.ModelDetails{
+		ModelType: model.CAAS,
+		ModelUUID: coretesting.ModelTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.resources = common.NewResources()
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+
+	s.CmdBlockHelper = coretesting.NewCmdBlockHelper(s.APIState)
+	c.Assert(s.CmdBlockHelper, gc.NotNil)
+	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+}
+
+var _ = gc.Suite(&UpgradeCAASControllerSuite{})
+
+var upgradeCAASControllerTests = []upgradeTest{{
+	about:          "unwanted extra argument",
+	currentVersion: "1.0.0",
+	args:           []string{"foo"},
+	expectInitErr:  "unrecognized args:.*",
+}, {
+	about:          "invalid --agent-version value",
+	currentVersion: "1.0.0",
+	args:           []string{"--agent-version", "invalid-version"},
+	expectInitErr:  "invalid version .*",
+}, {
+	about:          "latest supported stable release",
+	available:      []string{"2.1.0", "2.1.2", "2.1.3", "2.1-dev1"},
+	currentVersion: "2.0.0",
+	agentVersion:   "2.0.0",
+	expectVersion:  "2.1.3",
+}, {
+	about:          "latest supported stable release increments by one minor version number",
+	available:      []string{"1.21.3", "1.22.1"},
+	currentVersion: "1.22.1",
+	agentVersion:   "1.20.14",
+	expectVersion:  "1.21.3",
+}, {
+	about:          "latest supported stable release from custom version",
+	available:      []string{"1.21.3", "1.22.1"},
+	currentVersion: "1.22.1",
+	agentVersion:   "1.20.14.1",
+	expectVersion:  "1.21.3",
+}}
+
+func (s *UpgradeCAASControllerSuite) upgradeControllerCommand(minUpgradeVers map[int]version.Number) cmd.Command {
+	cmd := &upgradeControllerCommand{}
+	cmd.SetClientStore(s.ControllerStore)
+	return modelcmd.WrapController(cmd)
+}
+
+func (s *UpgradeCAASControllerSuite) TestUpgrade(c *gc.C) {
+	c.Assert(s.Model.Name(), gc.Equals, "controller")
+	err := s.ControllerStore.SetCurrentModel("kontroll", "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertUpgradeTests(c, upgradeCAASControllerTests, s.upgradeControllerCommand)
+}
+
+func (s *UpgradeCAASControllerSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgradeJujuCommand upgradeCommandFunc) {
+	type info struct {
+		Tag string `json:"name"`
+	}
+	var tagInfo []info
+
+	s.PatchValue(&docker.HttpGet, func(url string, timeout time.Duration) ([]byte, error) {
+		c.Assert(url, gc.Equals, "https://registry.hub.docker.com/v1/repositories/jujusolutions/jujud-operator/tags")
+		c.Assert(timeout, gc.Equals, 30*time.Second)
+		return json.Marshal(tagInfo)
+	})
+
+	for i, test := range tests {
+		c.Logf("\ntest %d: %s", i, test.about)
+		s.Reset(c)
+		tools.DefaultBaseURL = ""
+		err := s.ControllerStore.RemoveModel(jujutesting.ControllerName, "admin/controller")
+		c.Assert(err, jc.ErrorIsNil)
+		err = s.ControllerStore.UpdateModel(jujutesting.ControllerName, "admin/controller", jujuclient.ModelDetails{
+			ModelType: model.CAAS,
+			ModelUUID: coretesting.ModelTag.Id(),
+		})
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Set up apparent CLI version and initialize the command.
+		current := version.MustParse(test.currentVersion)
+		s.PatchValue(&jujuversion.Current, current)
+		com := upgradeJujuCommand(nil)
+		if err := cmdtesting.InitCommand(com, test.args); err != nil {
+			if test.expectInitErr != "" {
+				c.Check(err, gc.ErrorMatches, test.expectInitErr)
+			} else {
+				c.Check(err, jc.ErrorIsNil)
+			}
+			continue
+		}
+
+		// Set up state and environ, and run the command.
+		updateAttrs := map[string]interface{}{
+			"agent-version": test.agentVersion,
+		}
+		err = s.Model.UpdateModelConfig(updateAttrs, nil)
+		c.Assert(err, jc.ErrorIsNil)
+		tagInfo = make([]info, len(test.available))
+		for i, v := range test.available {
+			tagInfo[i] = info{v}
+		}
+
+		err = com.Run(cmdtesting.Context(c))
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+			continue
+		} else if !c.Check(err, jc.ErrorIsNil) {
+			continue
+		}
+
+		// Check expected changes to environ/state.
+		cfg, err := s.Model.ModelConfig()
+		c.Check(err, jc.ErrorIsNil)
+		agentVersion, ok := cfg.AgentVersion()
+		c.Check(ok, jc.IsTrue)
+		c.Check(agentVersion, gc.Equals, version.MustParse(test.expectVersion))
+	}
 }

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -18,12 +18,13 @@ import (
 	"github.com/juju/os/series"
 	"github.com/juju/version"
 
-	"github.com/juju/juju/api/controller"
+	apicontroller "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tools"
@@ -68,19 +69,38 @@ Examples:
 See also: 
     sync-agent-binaries`
 
-func newUpgradeJujuCommand(store jujuclient.ClientStore, minUpgradeVers map[int]version.Number, options ...modelcmd.WrapOption) cmd.Command {
+func newUpgradeJujuCommand() cmd.Command {
+	cmd := &upgradeJujuCommand{
+		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion}}
+	return modelcmd.Wrap(cmd)
+}
+
+func newUpgradeJujuCommandForTest(
+	store jujuclient.ClientStore,
+	minUpgradeVers map[int]version.Number,
+	jujuClientAPI jujuClientAPI,
+	modelConfigAPI modelConfigAPI,
+	controllerAPI controllerAPI,
+	options ...modelcmd.WrapOption) cmd.Command {
 	if minUpgradeVers == nil {
 		minUpgradeVers = minMajorUpgradeVersion
 	}
-	cmd := &upgradeJujuCommand{minMajorUpgradeVersion: minUpgradeVers}
+	cmd := &upgradeJujuCommand{
+		baseUpgradeCommand: baseUpgradeCommand{
+			minMajorUpgradeVersion: minUpgradeVers,
+			modelConfigAPI:         modelConfigAPI,
+			controllerAPI:          controllerAPI,
+		},
+		jujuClientAPI: jujuClientAPI,
+	}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd, options...)
 }
 
-// upgradeFlags is used by both the
+// baseUpgradeCommand is used by both the
 // upgradeJujuCommand and upgradeControllerCommand
 // to hold flags common to both.
-type upgradeFlags struct {
+type baseUpgradeCommand struct {
 	vers          string
 	Version       version.Number
 	BuildAgent    bool
@@ -92,9 +112,21 @@ type upgradeFlags struct {
 	// IgnoreAgentVersions is used to allow an admin to request an agent version without waiting for all agents to be at the right
 	// version.
 	IgnoreAgentVersions bool
+
+	rawArgs        []string
+	upgradeMessage string
+
+	// minMajorUpgradeVersion maps known major numbers to
+	// the minimum version that can be upgraded to that
+	// major version.  For example, users must be running
+	// 1.25.4 or later in order to upgrade to 2.0.
+	minMajorUpgradeVersion map[int]version.Number
+
+	modelConfigAPI modelConfigAPI
+	controllerAPI  controllerAPI
 }
 
-func (u *upgradeFlags) SetFlags(f *gnuflag.FlagSet) {
+func (u *baseUpgradeCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&u.vers, "agent-version", "", "Upgrade to specific version")
 	f.StringVar(&u.AgentStream, "agent-stream", "", "Check this agent stream for upgrades")
 	f.BoolVar(&u.BuildAgent, "build-agent", false, "Build a local version of the agent binary; for development use only")
@@ -106,35 +138,8 @@ func (u *upgradeFlags) SetFlags(f *gnuflag.FlagSet) {
 		"Don't check if all agents have already reached the current version")
 }
 
-// upgradeJujuCommand upgrades the agents in a juju installation.
-type upgradeJujuCommand struct {
-	modelcmd.ModelCommandBase
-	upgradeFlags
-
-	// minMajorUpgradeVersion maps known major numbers to
-	// the minimum version that can be upgraded to that
-	// major version.  For example, users must be running
-	// 1.25.4 or later in order to upgrade to 2.0.
-	minMajorUpgradeVersion map[int]version.Number
-
-	upgradeMessage string
-}
-
-func (c *upgradeJujuCommand) Info() *cmd.Info {
-	return jujucmd.Info(&cmd.Info{
-		Name:    "upgrade-model",
-		Purpose: usageUpgradeJujuSummary,
-		Doc:     usageUpgradeJujuDetails,
-		Aliases: []string{"upgrade-juju"},
-	})
-}
-
-func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
-	c.upgradeFlags.SetFlags(f)
-}
-
-func (c *upgradeJujuCommand) Init(args []string) error {
+func (c *baseUpgradeCommand) Init(args []string) error {
+	c.rawArgs = args
 	if c.upgradeMessage == "" {
 		c.upgradeMessage = "upgrade to this version by running\n    juju upgrade-model"
 	}
@@ -155,6 +160,96 @@ func (c *upgradeJujuCommand) Init(args []string) error {
 		c.Version = vers
 	}
 	return cmd.CheckEmpty(args)
+}
+
+func (c *baseUpgradeCommand) precheck(ctx *cmd.Context, agentVersion version.Number) (bool, error) {
+	if c.BuildAgent && c.Version == version.Zero {
+		// Currently, uploading tools assumes the version to be
+		// the same as jujuversion.Current if not specified with
+		// --agent-version.
+		c.Version = jujuversion.Current
+	}
+	warnCompat := false
+
+	// TODO (agprado:01/30/2018):
+	// This logic seems to be overly complicated and it checks the same condition multiple times.
+	switch {
+	case !canUpgradeRunningVersion(agentVersion):
+		// This version of upgrade-model cannot upgrade the running
+		// environment version (can't guarantee API compatibility).
+		return false, errors.Errorf("cannot upgrade a %s model with a %s client",
+			agentVersion, jujuversion.Current)
+	case c.Version != version.Zero && compareNoBuild(agentVersion, c.Version) == 1:
+		// The specified version would downgrade the environment.
+		// Don't upgrade and return an error.
+		return false, errors.Errorf(downgradeErrMsg, agentVersion, c.Version)
+	case agentVersion.Major != jujuversion.Current.Major:
+		// Running environment is the previous major version (a higher major
+		// version wouldn't have passed the check in canUpgradeRunningVersion).
+		if c.Version == version.Zero || c.Version.Major == agentVersion.Major {
+			// Not requesting an upgrade across major release boundary.
+			// Warn of incompatible CLI and filter on the prior major version
+			// when searching for available tools.
+			// TODO(cherylj) Add in a suggestion to upgrade to 2.0 if
+			// no matching tools are found (bug 1532670)
+			warnCompat = true
+			break
+		}
+		// User requested an upgrade to the next major version.
+		// Fallthrough to the next case to verify that the upgrade
+		// conditions are met.
+		fallthrough
+	case c.Version.Major > agentVersion.Major:
+		// User is requesting an upgrade to a new major number
+		// Only upgrade to a different major number if:
+		// 1 - Explicitly requested with --agent-version or using --build-agent, and
+		// 2 - The environment is running a valid version to upgrade from, and
+		// 3 - The upgrade is to a minor version of 0.
+		if c.minMajorUpgradeVersion == nil {
+			break
+		}
+		minVer, ok := c.minMajorUpgradeVersion[c.Version.Major]
+		if !ok {
+			return false, errors.Errorf("unknown version %q", c.Version)
+		}
+		retErr := false
+		if c.Version.Minor != 0 {
+			ctx.Infof("upgrades to %s must first go through juju %d.0",
+				c.Version, c.Version.Major)
+			retErr = true
+		}
+		if comp := agentVersion.Compare(minVer); comp < 0 {
+			ctx.Infof("upgrades to a new major version must first go through %s",
+				minVer)
+			retErr = true
+		}
+		if retErr {
+			return false, errors.New("unable to upgrade to requested version")
+		}
+	}
+	return warnCompat, nil
+}
+
+// upgradeJujuCommand upgrades the agents in a juju installation.
+type upgradeJujuCommand struct {
+	modelcmd.ModelCommandBase
+	baseUpgradeCommand
+
+	jujuClientAPI jujuClientAPI
+}
+
+func (c *upgradeJujuCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "upgrade-model",
+		Purpose: usageUpgradeJujuSummary,
+		Doc:     usageUpgradeJujuDetails,
+		Aliases: []string{"upgrade-juju"},
+	})
+}
+
+func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	c.baseUpgradeCommand.SetFlags(f)
 }
 
 var (
@@ -192,20 +287,28 @@ func canUpgradeRunningVersion(runningAgentVer version.Number) bool {
 	return false
 }
 
-func formatTools(tools coretools.List) string {
-	formatted := make([]string, len(tools))
-	for i, tools := range tools {
-		formatted[i] = fmt.Sprintf("    %s", tools.Version.String())
+func formatVersions(agents coretools.Versions) string {
+	formatted := make([]string, len(agents))
+	for i, agent := range agents {
+		formatted[i] = fmt.Sprintf("    %s", agent.AgentVersion().String())
 	}
 	return strings.Join(formatted, "\n")
 }
 
-type upgradeJujuAPI interface {
+type toolsAPI interface {
 	FindTools(majorVersion, minorVersion int, series, arch, agentStream string) (result params.FindToolsResult, err error)
 	UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error)
+}
+
+type upgradeJujuAPI interface {
 	AbortCurrentUpgrade() error
 	SetModelAgentVersion(version version.Number, ignoreAgentVersion bool) error
 	Close() error
+}
+
+type jujuClientAPI interface {
+	toolsAPI
+	upgradeJujuAPI
 }
 
 type modelConfigAPI interface {
@@ -214,15 +317,24 @@ type modelConfigAPI interface {
 }
 
 type controllerAPI interface {
+	ControllerConfig() (controller.Config, error)
 	ModelConfig() (map[string]interface{}, error)
 	Close() error
 }
 
-var getUpgradeJujuAPI = func(c *upgradeJujuCommand) (upgradeJujuAPI, error) {
+func (c *upgradeJujuCommand) getJujuClientAPI() (jujuClientAPI, error) {
+	if c.jujuClientAPI != nil {
+		return c.jujuClientAPI, nil
+	}
+
 	return c.NewAPIClient()
 }
 
-var getModelConfigAPI = func(c *upgradeJujuCommand) (modelConfigAPI, error) {
+func (c *upgradeJujuCommand) getModelConfigAPI() (modelConfigAPI, error) {
+	if c.modelConfigAPI != nil {
+		return c.modelConfigAPI, nil
+	}
+
 	api, err := c.NewAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -230,28 +342,32 @@ var getModelConfigAPI = func(c *upgradeJujuCommand) (modelConfigAPI, error) {
 	return modelconfig.NewClient(api), nil
 }
 
-var getControllerAPI = func(c *upgradeJujuCommand) (controllerAPI, error) {
+func (c *upgradeJujuCommand) getControllerAPI() (controllerAPI, error) {
+	if c.controllerAPI != nil {
+		return c.controllerAPI, nil
+	}
+
 	api, err := c.NewControllerAPIRoot()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return controller.NewClient(api), nil
+	return apicontroller.NewClient(api), nil
 }
 
 // Run changes the version proposed for the juju envtools.
 func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 
-	client, err := getUpgradeJujuAPI(c)
+	client, err := c.getJujuClientAPI()
 	if err != nil {
 		return err
 	}
 	defer client.Close()
-	modelConfigClient, err := getModelConfigAPI(c)
+	modelConfigClient, err := c.getModelConfigAPI()
 	if err != nil {
 		return err
 	}
 	defer modelConfigClient.Close()
-	controllerClient, err := getControllerAPI(c)
+	controllerClient, err := c.getControllerAPI()
 	if err != nil {
 		return err
 	}
@@ -290,66 +406,9 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.New("incomplete model configuration")
 	}
 
-	if c.BuildAgent && c.Version == version.Zero {
-		// Currently, uploading tools assumes the version to be
-		// the same as jujuversion.Current if not specified with
-		// --agent-version.
-		c.Version = jujuversion.Current
-	}
-	warnCompat := false
-
-	// TODO (agprado:01/30/2018):
-	// This logic seems to be overly complicated and it checks the same condition multiple times.
-	switch {
-	case !canUpgradeRunningVersion(agentVersion):
-		// This version of upgrade-model cannot upgrade the running
-		// environment version (can't guarantee API compatibility).
-		return errors.Errorf("cannot upgrade a %s model with a %s client",
-			agentVersion, jujuversion.Current)
-	case c.Version != version.Zero && compareNoBuild(agentVersion, c.Version) == 1:
-		// The specified version would downgrade the environment.
-		// Don't upgrade and return an error.
-		return errors.Errorf(downgradeErrMsg, agentVersion, c.Version)
-	case agentVersion.Major != jujuversion.Current.Major:
-		// Running environment is the previous major version (a higher major
-		// version wouldn't have passed the check in canUpgradeRunningVersion).
-		if c.Version == version.Zero || c.Version.Major == agentVersion.Major {
-			// Not requesting an upgrade across major release boundary.
-			// Warn of incompatible CLI and filter on the prior major version
-			// when searching for available tools.
-			// TODO(cherylj) Add in a suggestion to upgrade to 2.0 if
-			// no matching tools are found (bug 1532670)
-			warnCompat = true
-			break
-		}
-		// User requested an upgrade to the next major version.
-		// Fallthrough to the next case to verify that the upgrade
-		// conditions are met.
-		fallthrough
-	case c.Version.Major > agentVersion.Major:
-		// User is requesting an upgrade to a new major number
-		// Only upgrade to a different major number if:
-		// 1 - Explicitly requested with --agent-version or using --build-agent, and
-		// 2 - The environment is running a valid version to upgrade from, and
-		// 3 - The upgrade is to a minor version of 0.
-		minVer, ok := c.minMajorUpgradeVersion[c.Version.Major]
-		if !ok {
-			return errors.Errorf("unknown version %q", c.Version)
-		}
-		retErr := false
-		if c.Version.Minor != 0 {
-			ctx.Infof("upgrades to %s must first go through juju %d.0",
-				c.Version, c.Version.Major)
-			retErr = true
-		}
-		if comp := agentVersion.Compare(minVer); comp < 0 {
-			ctx.Infof("upgrades to a new major version must first go through %s",
-				minVer)
-			retErr = true
-		}
-		if retErr {
-			return errors.New("unable to upgrade to requested version")
-		}
+	warnCompat, err := c.precheck(ctx, agentVersion)
+	if err != nil {
+		return err
 	}
 
 	context, tryImplicit, err := c.initVersions(client, cfg, agentVersion, warnCompat)
@@ -370,7 +429,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	// jujud binary if possible.
 	uploadLocalBinary := isControllerModel && packagedAgentErr != nil && tryImplicit
 	if !warnCompat && (uploadLocalBinary || c.BuildAgent) {
-		if err := context.uploadTools(c.BuildAgent, agentVersion, c.DryRun); err != nil {
+		if err := context.uploadTools(client, c.BuildAgent, agentVersion, c.DryRun); err != nil {
 			return block.ProcessBlockedError(err, block.BlockChange)
 		}
 		builtMsg := ""
@@ -387,7 +446,7 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	if err := context.validate(); err != nil {
 		return err
 	}
-	ctx.Verbosef("available agent binaries:\n%s", formatTools(context.tools))
+	ctx.Verbosef("available agent binaries:\n%s", formatVersions(context.packagedAgents))
 	fmt.Fprintf(ctx.Stderr, "best version:\n    %v\n", context.chosen)
 	if warnCompat {
 		fmt.Fprintf(ctx.Stderr, "version %s incompatible with this client (%s)\n", context.chosen, jujuversion.Current)
@@ -399,31 +458,36 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 			fmt.Fprintf(ctx.Stderr, "%s\n", c.upgradeMessage)
 		}
 	} else {
-		if c.ResetPrevious {
-			if ok, err := c.confirmResetPreviousUpgrade(ctx); !ok || err != nil {
-				const message = "previous upgrade not reset and no new upgrade triggered"
-				if err != nil {
-					return errors.Annotate(err, message)
-				}
-				return errors.New(message)
-			}
-			if err := client.AbortCurrentUpgrade(); err != nil {
-				return block.ProcessBlockedError(err, block.BlockChange)
-			}
-		}
-		if err := client.SetModelAgentVersion(context.chosen, c.IgnoreAgentVersions); err != nil {
-			if params.IsCodeUpgradeInProgress(err) {
-				return errors.Errorf("%s\n\n"+
-					"Please wait for the upgrade to complete or if there was a problem with\n"+
-					"the last upgrade that has been resolved, consider running the\n"+
-					"upgrade-model command with the --reset-previous-upgrade option.", err,
-				)
-			} else {
-				return block.ProcessBlockedError(err, block.BlockChange)
-			}
-		}
-		fmt.Fprintf(ctx.Stdout, "started upgrade to %s\n", context.chosen)
+		return c.notifyControllerUpgrade(ctx, client, context)
 	}
+	return nil
+}
+
+func (c *baseUpgradeCommand) notifyControllerUpgrade(ctx *cmd.Context, client upgradeJujuAPI, context *upgradeContext) error {
+	if c.ResetPrevious {
+		if ok, err := c.confirmResetPreviousUpgrade(ctx); !ok || err != nil {
+			const message = "previous upgrade not reset and no new upgrade triggered"
+			if err != nil {
+				return errors.Annotate(err, message)
+			}
+			return errors.New(message)
+		}
+		if err := client.AbortCurrentUpgrade(); err != nil {
+			return block.ProcessBlockedError(err, block.BlockChange)
+		}
+	}
+	if err := client.SetModelAgentVersion(context.chosen, c.IgnoreAgentVersions); err != nil {
+		if params.IsCodeUpgradeInProgress(err) {
+			return errors.Errorf("%s\n\n"+
+				"Please wait for the upgrade to complete or if there was a problem with\n"+
+				"the last upgrade that has been resolved, consider running the\n"+
+				"upgrade-model command with the --reset-previous-upgrade option.", err,
+			)
+		} else {
+			return block.ProcessBlockedError(err, block.BlockChange)
+		}
+	}
+	fmt.Fprintf(ctx.Stdout, "started upgrade to %s\n", context.chosen)
 	return nil
 }
 
@@ -452,7 +516,7 @@ incomplete upgrade where the root cause has been resolved.
 
 Continue [y/N]? `
 
-func (c *upgradeJujuCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool, error) {
+func (c *baseUpgradeCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool, error) {
 	if c.AssumeYes {
 		return true, nil
 	}
@@ -472,7 +536,7 @@ func (c *upgradeJujuCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool
 // always be accurate; the chosen version, and the flag indicating development
 // mode, may remain blank until uploadTools or validate is called.
 func (c *upgradeJujuCommand) initVersions(
-	client upgradeJujuAPI, cfg *config.Config, agentVersion version.Number, filterOnPrior bool,
+	client toolsAPI, cfg *config.Config, agentVersion version.Number, filterOnPrior bool,
 ) (*upgradeContext, bool, error) {
 	if c.Version == agentVersion {
 		return nil, false, errUpToDate
@@ -509,24 +573,26 @@ func (c *upgradeJujuCommand) initVersions(
 			return nil, tryImplicitUpload, err
 		}
 	}
+	agents := make(coretools.Versions, len(findResult.List))
+	for i, t := range findResult.List {
+		agents[i] = t
+	}
 	return &upgradeContext{
-		agent:     agentVersion,
-		client:    jujuversion.Current,
-		chosen:    c.Version,
-		tools:     findResult.List,
-		apiClient: client,
-		config:    cfg,
+		agent:          agentVersion,
+		client:         jujuversion.Current,
+		chosen:         c.Version,
+		packagedAgents: agents,
+		config:         cfg,
 	}, tryImplicitUpload, nil
 }
 
 // upgradeContext holds the version information for making upgrade decisions.
 type upgradeContext struct {
-	agent     version.Number
-	client    version.Number
-	chosen    version.Number
-	tools     coretools.List
-	config    *config.Config
-	apiClient upgradeJujuAPI
+	agent          version.Number
+	client         version.Number
+	chosen         version.Number
+	packagedAgents coretools.Versions
+	config         *config.Config
 }
 
 // uploadTools compiles jujud from $GOPATH and uploads it into the supplied
@@ -536,7 +602,7 @@ type upgradeContext struct {
 // than that of any otherwise-matching available envtools.
 // uploadTools resets the chosen version and replaces the available tools
 // with the ones just uploaded.
-func (context *upgradeContext) uploadTools(buildAgent bool, agentVersion version.Number, dryRun bool) (err error) {
+func (context *upgradeContext) uploadTools(client toolsAPI, buildAgent bool, agentVersion version.Number, dryRun bool) (err error) {
 	// TODO(fwereade): this is kinda crack: we should not assume that
 	// jujuversion.Current matches whatever source happens to be built. The
 	// ideal would be:
@@ -566,7 +632,7 @@ func (context *upgradeContext) uploadTools(buildAgent bool, agentVersion version
 	if agentVersionCopy.Compare(uploadBaseVersionCopy) == 0 {
 		uploadBaseVersion = agentVersion
 	}
-	context.chosen = makeUploadVersion(uploadBaseVersion, context.tools)
+	context.chosen = makeUploadVersion(uploadBaseVersion, context.packagedAgents)
 
 	if dryRun {
 		return nil
@@ -596,11 +662,15 @@ func (context *upgradeContext) uploadTools(buildAgent bool, agentVersion version
 		return errors.Trace(err)
 	}
 	additionalSeries := series.OSSupportedSeries(os)
-	uploaded, err := context.apiClient.UploadTools(f, uploadToolsVersion, additionalSeries...)
+	uploaded, err := client.UploadTools(f, uploadToolsVersion, additionalSeries...)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	context.tools = uploaded
+	agents := make(coretools.Versions, len(uploaded))
+	for i, t := range uploaded {
+		agents[i] = t
+	}
+	context.packagedAgents = agents
 	return nil
 }
 
@@ -620,12 +690,12 @@ func (context *upgradeContext) maybeChoosePackagedAgent() (err error) {
 		// than any tagged version.
 		nextVersion.Tag = " "
 
-		newestNextStable, found := context.tools.NewestCompatible(nextVersion)
+		newestNextStable, found := context.packagedAgents.NewestCompatible(nextVersion)
 		if found {
 			logger.Debugf("found a more recent stable version %s", newestNextStable)
 			context.chosen = newestNextStable
 		} else {
-			newestCurrent, found := context.tools.NewestCompatible(context.agent)
+			newestCurrent, found := context.packagedAgents.NewestCompatible(context.agent)
 			if found {
 				logger.Debugf("found more recent current version %s", newestCurrent)
 				context.chosen = newestCurrent
@@ -640,10 +710,10 @@ func (context *upgradeContext) maybeChoosePackagedAgent() (err error) {
 	} else {
 		// If not completely specified already, pick a single tools version.
 		filter := coretools.Filter{Number: context.chosen}
-		if context.tools, err = context.tools.Match(filter); err != nil {
+		if context.packagedAgents, err = context.packagedAgents.Match(filter); err != nil {
 			return err
 		}
-		context.chosen, context.tools = context.tools.Newest()
+		context.chosen, context.packagedAgents = context.packagedAgents.Newest()
 	}
 	return nil
 }
@@ -673,14 +743,14 @@ func (context *upgradeContext) validate() (err error) {
 
 // makeUploadVersion returns a copy of the supplied version with a build number
 // higher than any of the supplied tools that share its major, minor and patch.
-func makeUploadVersion(vers version.Number, existing coretools.List) version.Number {
+func makeUploadVersion(vers version.Number, existing coretools.Versions) version.Number {
 	vers.Build++
 	for _, t := range existing {
-		if t.Version.Major != vers.Major || t.Version.Minor != vers.Minor || t.Version.Patch != vers.Patch {
+		if t.AgentVersion().Major != vers.Major || t.AgentVersion().Minor != vers.Minor || t.AgentVersion().Patch != vers.Patch {
 			continue
 		}
-		if t.Version.Build >= vers.Build {
-			vers.Build = t.Version.Build + 1
+		if t.AgentVersion().Build >= vers.Build {
+			vers.Build = t.AgentVersion().Build + 1
 		}
 	}
 	return vers

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/tools"
+)
+
+const (
+	baseRegistryURL = "https://registry.hub.docker.com/v1/repositories"
+)
+
+type imageInfo struct {
+	version version.Number
+}
+
+func (info imageInfo) AgentVersion() version.Number {
+	return info.version
+}
+
+var logger = loggo.GetLogger("juju.docker")
+
+// ListOperatorImages queries the standard docker registry and
+// returns the version tags for images matching imagePath.
+// The results are used when upgrading Juju to see what's available.
+func ListOperatorImages(imagePath string) (tools.Versions, error) {
+	tagsURL := fmt.Sprintf("%s/%s/tags", baseRegistryURL, imagePath)
+	logger.Debugf("operater image tags URL: %v", tagsURL)
+	data, err := HttpGet(tagsURL, 30*time.Second)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	type info struct {
+		Tag string `json:"name"`
+	}
+	var tagInfo []info
+
+	err = json.Unmarshal(data, &tagInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var images tools.Versions
+	for _, t := range tagInfo {
+		v, err := version.Parse(t.Tag)
+		if err != nil {
+			logger.Debugf("ignoring unexpected image tag %q", t.Tag)
+			continue
+		}
+		images = append(images, imageInfo{v})
+	}
+	return images, nil
+}
+
+// Override for testing.
+var HttpGet = doHttpGet
+
+func doHttpGet(url string, timeout time.Duration) ([]byte, error) {
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+	defer cancelFunc()
+	request = request.WithContext(ctx)
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("invalid response code from registry: %v", response.StatusCode)
+	}
+
+	return ioutil.ReadAll(response.Body)
+}

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker
+
+import (
+	"time"
+
+	"github.com/juju/juju/tools"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+type DockerSuiteSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&DockerSuiteSuite{})
+
+func (s *DockerSuiteSuite) TestListImages(c *gc.C) {
+	s.PatchValue(&HttpGet, func(url string, timeout time.Duration) ([]byte, error) {
+		c.Assert(url, gc.Equals, "https://registry.hub.docker.com/v1/repositories/path/tags")
+		c.Assert(timeout, gc.Equals, 30*time.Second)
+		return []byte(`[{"name": "2.6.0"}, {"name": "2.6-beta1"}, {"name": "bad"}]`), nil
+	})
+	v, err := ListOperatorImages("path")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(v, jc.DeepEquals, tools.Versions{
+		imageInfo{version: version.MustParse("2.6.0")},
+		imageInfo{version: version.MustParse("2.6-beta1")},
+	})
+}

--- a/docker/package_test.go
+++ b/docker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/tools/list_test.go
+++ b/tools/list_test.go
@@ -160,6 +160,24 @@ func (s *ListSuite) TestNewest(c *gc.C) {
 	}
 }
 
+func (s *ListSuite) TestNewestVersions(c *gc.C) {
+	for i, test := range newestTests {
+		c.Logf("test %d", i)
+		versions := make(tools.Versions, len(test.src))
+		for i, v := range test.src {
+			versions[i] = v
+		}
+		number, actual := versions.Newest()
+		c.Check(number, gc.DeepEquals, test.number)
+
+		var expectVersions tools.Versions
+		for _, v := range test.expect {
+			expectVersions = append(expectVersions, v)
+		}
+		c.Check(actual, gc.DeepEquals, expectVersions)
+	}
+}
+
 var newestCompatibleTests = []struct {
 	src    tools.List
 	base   version.Number
@@ -200,7 +218,11 @@ var newestCompatibleTests = []struct {
 func (s *ListSuite) TestNewestCompatible(c *gc.C) {
 	for i, test := range newestCompatibleTests {
 		c.Logf("test %d", i)
-		actual, found := test.src.NewestCompatible(test.base)
+		versions := make(tools.Versions, len(test.src))
+		for i, v := range test.src {
+			versions[i] = v
+		}
+		actual, found := versions.NewestCompatible(test.base)
 		c.Check(actual, gc.DeepEquals, test.expect)
 		c.Check(found, gc.Equals, test.found)
 	}
@@ -303,5 +325,27 @@ func (s *ListSuite) TestMatch(c *gc.C) {
 		} else {
 			c.Check(err, gc.Equals, tools.ErrNoMatches)
 		}
+	}
+}
+
+func (s *ListSuite) TestMatchVersions(c *gc.C) {
+	for i, test := range matchTests {
+		c.Logf("test %d", i)
+		versions := make(tools.Versions, len(test.src))
+		for i, v := range test.src {
+			versions[i] = v
+		}
+		actual, err := versions.Match(test.filter)
+		if len(test.expect) > 0 {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.Equals, tools.ErrNoMatches)
+		}
+
+		var expectVersions tools.Versions
+		for _, v := range test.expect {
+			expectVersions = append(expectVersions, v)
+		}
+		c.Check(actual, gc.DeepEquals, expectVersions)
 	}
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -15,6 +15,11 @@ type Tools struct {
 	Size    int64          `json:"size"`
 }
 
+// AgentVersion
+func (t *Tools) AgentVersion() version.Number {
+	return t.Version.Number
+}
+
 // GUI represents the location and version of a GUI release archive.
 type GUIArchive struct {
 	Version version.Number `json:"version"`


### PR DESCRIPTION
## Description of change

Implement the CLI front end for upgrade-controller for k8s.
Instead of getting available agent versions using FindTools(), we instead query the docker repo hosting the operator images to see what tagged versions are available.

A fair chunk of the PR is refactoring to extract common logic used by both IAAS and CAAS. Also the existing upgrade tests are cleaned up to remove the patching of the API funcs and instead pass in stubs.

The next PR will wire up the backend changes, ie upgrade worker.

## QA steps

Ensure IAAS upgrade controller and model still works.