### PR TITLE
Fixes intermittent failure in IsolatedWorkerSuite.TestTriggering.

### DIFF
--- a/worker/meterstatus/isolated_test.go
+++ b/worker/meterstatus/isolated_test.go
@@ -128,8 +128,12 @@ func (s *IsolatedWorkerSuite) TearDownTest(c *gc.C) {
 
 func (s *IsolatedWorkerSuite) TestTriggering(c *gc.C) {
 	assertSignal(c, s.triggersCreated)
-	s.clk.Advance(AmberGracePeriod + time.Second)
+
+	// Wait on the red and amber timers.
+	c.Assert(s.clk.WaitAdvance(AmberGracePeriod+time.Second, testing.ShortWait, 2), jc.ErrorIsNil)
 	assertSignal(c, s.hookRan)
+
+	// Don't need to ensure the timers here, we did it for both above.
 	s.clk.Advance(RedGracePeriod + time.Second)
 	assertSignal(c, s.hookRan)
 


### PR DESCRIPTION
## Description of change

Fixes an intermittent failure in `IsolatedWorkerSuite.TestTriggering` observed in CI:
```
10:02:28 FAIL: isolated_test.go:129: IsolatedWorkerSuite.TestTriggering
10:02:28 
10:02:28 [LOG] 0:00.001 DEBUG juju.clock advancing a clock that has nothing waiting: cf. https://github.com/juju/juju/wiki/Intermittent-failures
10:02:28 isolated_test.go:132:
10:02:28     assertSignal(c, s.hookRan)
10:02:28 connected_test.go:44:
10:02:28     c.Fatal("timed out waiting for signal")
10:02:28 ... Error: timed out waiting for signal
```

## QA steps

Test now passes consistently.
