### PR TITLE
Bump timeout for LXD bundle deploys

### DIFF
--- a/acceptancetests/assess_deploy_lxd_profile_bundle.py
+++ b/acceptancetests/assess_deploy_lxd_profile_bundle.py
@@ -47,7 +47,9 @@ def deploy_bundle(client, charm_bundle):
         )
     else:
         bundle = charm_bundle
-    _, primary = client.deploy(bundle)
+    # bump the timeout of the wait_timeout to ensure that we can give more time
+    # for complex deploys.
+    _, primary = client.deploy(bundle, wait_timeout=1800)
     client.wait_for(primary)
 
 def assess_profile_machines(client):

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -103,6 +103,7 @@ KVM_MACHINE = 'kvm'
 LXC_MACHINE = 'lxc'
 LXD_MACHINE = 'lxd'
 
+_DEFAULT_POLL_TIMEOUT = 2
 _DEFAULT_BUNDLE_TIMEOUT = 3600
 
 log = logging.getLogger("jujupy")
@@ -1439,7 +1440,7 @@ class ModelClient:
                             break
                         status.raise_highest_error(ignore_recoverable=True)
                         reporter.update(states)
-                        time.sleep(1)
+                        time.sleep(_DEFAULT_POLL_TIMEOUT)
                     else:
                         if status is not None:
                             log.error(status.status_text)
@@ -1656,7 +1657,7 @@ class ModelClient:
                     status = self.get_status()
                     if status.get_service_count() >= service_count:
                         return
-                    time.sleep(1)
+                    time.sleep(_DEFAULT_POLL_TIMEOUT)
                 else:
                     raise ApplicationsNotStarted(self.env.environment, status)
 
@@ -1701,7 +1702,7 @@ class ModelClient:
                     return
                 if not quiet:
                     reporter.update(states)
-                time.sleep(1)
+                time.sleep(_DEFAULT_POLL_TIMEOUT)
             else:
                 status.raise_highest_error(ignore_recoverable=False)
         except StatusTimeout:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -103,7 +103,7 @@ KVM_MACHINE = 'kvm'
 LXC_MACHINE = 'lxc'
 LXD_MACHINE = 'lxd'
 
-_DEFAULT_POLL_TIMEOUT = 2
+_DEFAULT_POLL_TIMEOUT = 5
 _DEFAULT_BUNDLE_TIMEOUT = 3600
 
 log = logging.getLogger("jujupy")

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1271,7 +1271,7 @@ class ModelClient:
 
     def deploy(self, charm, repository=None, to=None, series=None,
                service=None, force=False, resource=None, num=None,
-               constraints=None, alias=None, bind=None, **kwargs):
+               constraints=None, alias=None, bind=None, wait_timeout=None, **kwargs):
         args = [charm]
         if service is not None:
             args.extend([service])
@@ -1298,7 +1298,9 @@ class ModelClient:
             else:
                 args.extend(['--{}'.format(key), value])
         retvar, ct = self.juju('deploy', tuple(args))
-        return retvar, CommandComplete(WaitAgentsStarted(), ct)
+        # Unfortunately some times we need to up the wait condition timeout if
+        # we're deploying a complex set of machines/containers.
+        return retvar, CommandComplete(WaitAgentsStarted(wait_timeout), ct)
 
     def attach(self, service, resource):
         args = (service, resource)

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -319,8 +319,8 @@ class WaitModelVersion(BaseCondition):
 class WaitAgentsStarted(BaseCondition):
     """Wait until all agents are idle or started."""
 
-    def __init__(self, timeout=1200):
-        super(WaitAgentsStarted, self).__init__(timeout)
+    def __init__(self, timeout=None):
+        super(WaitAgentsStarted, self).__init__(1200 if timeout is None else timeout)
 
     def iter_blocking_state(self, status):
         states = Status.check_agents_started(status)


### PR DESCRIPTION
## Description of change

The following bumps the deployment timeout to ensure we give enough
timeout for complex deploys.

## QA steps

It expects you to setup the following acceptance tests as [follows](https://github.com/juju/juju/tree/develop/acceptancetests#quick-run-using-lxd)

```
mkdir /tmp/test-run
mkdir /tmp/artifacts
export JUJU_HOME=/tmp/test-run
export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository
vim $JUJU_HOME/environments.yaml
```

Local LXD environments.yaml
```yaml
environments:
    lxd:
        type: lxd
        test-mode: true
        default-series: bionic
```

Run the following (substitute the right arg):
```
cd acceptancetests
./assess_deploy_lxd_profile_bundle.py
```