### PR TITLE
Bump the charm version

### DIFF
--- a/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile-upgrade.yaml
@@ -1,7 +1,7 @@
 series: bionic
 applications:
   lxd-profile:
-    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-2
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-4
     num_units: 4
     to:
       - "0"

--- a/acceptancetests/repository/bundles-lxd-profile.yaml
+++ b/acceptancetests/repository/bundles-lxd-profile.yaml
@@ -6,7 +6,7 @@ machines:
   '3': {}
 applications:
   lxd-profile:
-    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-2
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-4
     num_units: 8
     to:
       - lxd:0


### PR DESCRIPTION
## Description of change

Bump the charm version for the lxd-profiles so we work on more different
types of infrastructure.

## QA steps

It expects you to setup the following acceptance tests as [follows](https://github.com/juju/juju/tree/develop/acceptancetests#quick-run-using-lxd)

```
mkdir /tmp/test-run
mkdir /tmp/artifacts
export JUJU_HOME=/tmp/test-run
export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository
vim $JUJU_HOME/environments.yaml
```

Local LXD environments.yaml
```yaml
environments:
    lxd:
        type: lxd
        test-mode: true
        default-series: bionic
```

Run the following (substitute the right arg):
```
cd acceptancetests
./assess_deploy_lxd_profile_bundle.py
```
