### PR TITLE
add machine.WatchContainers to model cache

### DIFF
--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -112,7 +112,7 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 }
 
 // modelCacheShim is used as a shim between the
-// cache.ChangeWatcher and cache.StringsWatcher to enable better mock testing.
+// cache.PredicateStringsWatcher and cache.StringsWatcher to enable better mock testing.
 type modelCacheShim struct {
 	*cache.Model
 }

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -9,6 +9,12 @@ var (
 	NewModel               = newModel
 )
 
+// Expose Remove* for testing.
+
+func (m *Model) RemoveMachine(details RemoveMachine) {
+	m.removeMachine(details)
+}
+
 // Expose SetDetails for testing.
 
 func (a *Application) SetDetails(details ApplicationChange) {

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -58,10 +58,10 @@ func (m *Machine) Units() ([]*Unit, error) {
 	return result, nil
 }
 
-// WatchContainers creates a RegexpChangeWatcher (strings watcher) to notify
+// WatchContainers creates a PredicateStringsWatcher (strings watcher) to notify
 // about added and removed containers on this machine.  The initial event
 // contains a slice of the current container machine ids.
-func (m *Machine) WatchContainers() (*RegexpChangeWatcher, error) {
+func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 	m.model.mu.Lock()
 
 	// Create a compiled regexp to match containers on this machine.
@@ -78,7 +78,7 @@ func (m *Machine) WatchContainers() (*RegexpChangeWatcher, error) {
 		}
 	}
 
-	w := newRegexpAddRemoveWatcher(compiled, machines...)
+	w := newPredicateStringsWatcher(regexpPredicate(compiled), machines...)
 	unsub := m.model.hub.Subscribe(m.modelTopic(modelAddRemoveMachine), w.changed)
 
 	w.tomb.Go(func() error {

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -141,7 +141,7 @@ func (s *machineSuite) setupMachine0(c *gc.C) {
 	s.machine0 = machine
 }
 
-func (s *machineSuite) setupMachine0WithContainerWatcher(c *gc.C, addContainer bool) *cache.RegexpChangeWatcher {
+func (s *machineSuite) setupMachine0WithContainerWatcher(c *gc.C, addContainer bool) *cache.PredicateStringsWatcher {
 	s.setupMachine0(c)
 
 	if addContainer {

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -9,6 +9,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/instance"
@@ -19,7 +20,9 @@ import (
 type machineSuite struct {
 	entitySuite
 
-	model *cache.Model
+	model    *cache.Model
+	machine0 *cache.Machine
+	wc0      StringsWatcherC
 }
 
 var _ = gc.Suite(&machineSuite{})
@@ -76,6 +79,94 @@ func (s *machineSuite) TestUnitsTwoMachines(c *gc.C) {
 
 	c.Assert(obtainedUnits0, jc.DeepEquals, expectedUnits0)
 	c.Assert(obtainedUnits1, jc.DeepEquals, expectedUnits1)
+}
+
+func (s *machineSuite) TestWatchContainersStops(c *gc.C) {
+	s.setupMachine0WithContainerWatcher(c, false)
+	s.wc0.AssertStops()
+}
+
+func (s *machineSuite) TestWatchContainersStartWithContainer(c *gc.C) {
+	defer workertest.CleanKill(c, s.setupMachine0WithContainerWatcher(c, true))
+}
+
+func (s *machineSuite) TestWatchContainersAddContainer(c *gc.C) {
+	defer workertest.CleanKill(c, s.setupMachine0WithContainerWatcher(c, false))
+
+	// Add a container to the machine
+	mc := machineChange
+	mc.Id = "0/lxd/0"
+	s.model.UpdateMachine(mc)
+	s.wc0.AssertOneChange([]string{mc.Id})
+}
+
+func (s *machineSuite) TestWatchContainersOnlyThisMachinesAddContainers(c *gc.C) {
+	defer workertest.CleanKill(c, s.setupMachine0WithContainerWatcher(c, false))
+
+	// Add a container to a different machine
+	mc := machineChange
+	mc.Id = "1/lxd/0"
+	s.model.UpdateMachine(mc)
+	s.wc0.AssertNoChange()
+}
+
+func (s *machineSuite) TestWatchContainersOnlyThisMachinesRemoveContainers(c *gc.C) {
+	defer workertest.CleanKill(c, s.setupMachine0WithContainerWatcher(c, false))
+
+	// Remove a container from a different machine
+	rm := cache.RemoveMachine{
+		ModelUUID: modelChange.ModelUUID,
+		Id:        "1/lxd/0",
+	}
+	s.model.RemoveMachine(rm)
+	s.wc0.AssertNoChange()
+}
+
+func (s *machineSuite) TestWatchContainersRemoveContainer(c *gc.C) {
+	defer workertest.CleanKill(c, s.setupMachine0WithContainerWatcher(c, true))
+
+	// Remove a container from this machine
+	rm := cache.RemoveMachine{
+		ModelUUID: modelChange.ModelUUID,
+		Id:        "0/lxd/0",
+	}
+	s.model.RemoveMachine(rm)
+	s.wc0.AssertOneChange([]string{rm.Id})
+}
+
+func (s *machineSuite) setupMachine0(c *gc.C) {
+	s.model.UpdateMachine(machineChange)
+	machine, err := s.model.Machine(machineChange.Id)
+	c.Assert(err, jc.ErrorIsNil)
+	s.machine0 = machine
+}
+
+func (s *machineSuite) setupMachine0WithContainerWatcher(c *gc.C, addContainer bool) *cache.RegexpChangeWatcher {
+	s.setupMachine0(c)
+
+	if addContainer {
+		s.setupMachine0Container(c)
+	}
+
+	w, err := s.machine0.WatchContainers()
+	c.Assert(err, jc.ErrorIsNil)
+	wc := NewStringsWatcherC(c, w)
+	// Sends initial event.
+	if addContainer {
+		wc.AssertOneChange([]string{"0/lxd/0"})
+	} else {
+		wc.AssertOneChange([]string{})
+	}
+
+	s.wc0 = wc
+	return w
+}
+
+func (s *machineSuite) setupMachine0Container(c *gc.C) {
+	// Add a container to the machine
+	mc := machineChange
+	mc.Id = "0/lxd/0"
+	s.model.UpdateMachine(mc)
 }
 
 func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (*cache.Machine, []*cache.Unit) {

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -130,6 +130,9 @@ func (m *Model) Machine(machineId string) (*Machine, error) {
 // added and removed machines in the model.  The initial event contains
 // a slice of the current machine ids.
 func (m *Model) WatchMachines() *ChangeWatcher {
+	m.mu.Lock()
+
+	// Gather initial slice of machines in this model.
 	machines := make([]string, len(m.machines))
 	i := 0
 	for k := range m.machines {
@@ -146,6 +149,7 @@ func (m *Model) WatchMachines() *ChangeWatcher {
 		return nil
 	})
 
+	m.mu.Unlock()
 	return w
 }
 
@@ -256,6 +260,10 @@ func (m *Model) removeMachine(ch RemoveMachine) {
 // topic prefixes the input string with the model UUID.
 func (m *Model) topic(suffix string) string {
 	return modelTopic(m.details.ModelUUID, suffix)
+}
+
+func modelTopic(modeluuid, suffix string) string {
+	return modeluuid + ":" + suffix
 }
 
 func modelTopic(modeluuid, suffix string) string {

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -126,10 +126,10 @@ func (m *Model) Machine(machineId string) (*Machine, error) {
 	return machine, nil
 }
 
-// WatchMachines creates a ChangeWatcher (strings watcher) to notify about
+// WatchMachines returns a PredicateStringsWatcher to notify about
 // added and removed machines in the model.  The initial event contains
 // a slice of the current machine ids.
-func (m *Model) WatchMachines() *ChangeWatcher {
+func (m *Model) WatchMachines() *PredicateStringsWatcher {
 	m.mu.Lock()
 
 	// Gather initial slice of machines in this model.
@@ -140,7 +140,7 @@ func (m *Model) WatchMachines() *ChangeWatcher {
 		i += 1
 	}
 
-	w := newAddRemoveWatcher(machines...)
+	w := newChangeWatcher(machines...)
 	unsub := m.hub.Subscribe(m.topic(modelAddRemoveMachine), w.changed)
 
 	w.tomb.Go(func() error {
@@ -260,10 +260,6 @@ func (m *Model) removeMachine(ch RemoveMachine) {
 // topic prefixes the input string with the model UUID.
 func (m *Model) topic(suffix string) string {
 	return modelTopic(m.details.ModelUUID, suffix)
-}
-
-func modelTopic(modeluuid, suffix string) string {
-	return modeluuid + ":" + suffix
 }
 
 func modelTopic(modeluuid, suffix string) string {

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -255,7 +255,7 @@ func (s *ControllerSuite) newWithMachine(c *gc.C) (*cache.Controller, <-chan int
 	return controller, events
 }
 
-func (s *ControllerSuite) setupWithWatchMachine(c *gc.C) (*cache.ChangeWatcher, <-chan interface{}) {
+func (s *ControllerSuite) setupWithWatchMachine(c *gc.C) (*cache.PredicateStringsWatcher, <-chan interface{}) {
 	controller, events := s.newWithMachine(c)
 	m, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -238,45 +238,41 @@ func (w *stringsWatcherBase) amendBufferedChange(values []string) {
 	}
 }
 
-// ChangeWatcher notifies that something changed, with
-// the given slice of strings.  An initial event is sent
-// with the input given at creation.
-type ChangeWatcher struct {
-	*stringsWatcherBase
-}
-
-func newAddRemoveWatcher(values ...string) *ChangeWatcher {
-	return &ChangeWatcher{
-		stringsWatcherBase: newStringsWatcherBase(values...),
-	}
-}
-
-func (w *ChangeWatcher) changed(topic string, value interface{}) {
-	strings, ok := value.([]string)
-	if !ok {
-		logger.Errorf("programming error, value not of type []string")
-	}
-
-	w.notify(strings)
-}
-
-// RegexpChangeWatcher notifies when individual pieces of a subscribed topic
-// match the given compiled regular expression.  An initial event is sent
-// with the input given at creation.
-type RegexpChangeWatcher struct {
+// PredicateStringsWatcher notifies that something changed, with
+// a slice of strings.  The predicateFunc will test the values
+// before notification. An initial event is sent with the input
+// given at creation.
+type PredicateStringsWatcher struct {
 	*stringsWatcherBase
 
-	compiled *regexp.Regexp
+	fn predicateFunc
 }
 
-func newRegexpAddRemoveWatcher(compiled *regexp.Regexp, values ...string) *RegexpChangeWatcher {
-	return &RegexpChangeWatcher{
+// newChangeWatcher provides a PredicateStringsWatcher which notifies
+// with all strings passed to it.
+func newChangeWatcher(values ...string) *PredicateStringsWatcher {
+	return &PredicateStringsWatcher{
 		stringsWatcherBase: newStringsWatcherBase(values...),
-		compiled:           compiled,
+		fn:                 func(string) bool { return true },
 	}
 }
 
-func (w *RegexpChangeWatcher) changed(topic string, value interface{}) {
+func regexpPredicate(compiled *regexp.Regexp) func(string) bool {
+	return func(value string) bool { return compiled.MatchString(value) }
+}
+
+type predicateFunc func(string) bool
+
+// newPredicateStringsWatcher provides a PredicateStringsWatcher which notifies
+// with any string which passes the predicateFunc.
+func newPredicateStringsWatcher(fn predicateFunc, values ...string) *PredicateStringsWatcher {
+	return &PredicateStringsWatcher{
+		stringsWatcherBase: newStringsWatcherBase(values...),
+		fn:                 fn,
+	}
+}
+
+func (w *PredicateStringsWatcher) changed(topic string, value interface{}) {
 	strings, ok := value.([]string)
 	if !ok {
 		logger.Errorf("programming error, value not of type []string")
@@ -284,7 +280,7 @@ func (w *RegexpChangeWatcher) changed(topic string, value interface{}) {
 
 	matches := set.NewStrings()
 	for _, s := range strings {
-		if w.compiled.MatchString(s) {
+		if w.fn(s) {
 			matches.Add(s)
 		}
 	}


### PR DESCRIPTION
## Description of change

Add  machine.WatchContainers() to model cache for use by the Instance Mutater worker.  The underlying watcher type is also new: RegexpChangeWatcher.

## QA steps

This watcher is not in use as of this PR.  No impact to current juju operations should be seen.  Unit tests for the watcher should pass.

