### PR TITLE
increase go linter deadline value

### DIFF
--- a/scripts/golinters.bash
+++ b/scripts/golinters.bash
@@ -24,7 +24,7 @@ $GOPATH/bin/golangci-lint run \
     --enable=goimports \
     --enable=misspell \
     --enable=unconvert \
-    --deadline=240s \
+    --deadline=10m \
     &> $OUTPUT_FILE
 
 # go through each golangci-lint error and check to see if it's related 


### PR DESCRIPTION
## Description of change

Execution times for the golinters.bash on macOS for juju vary from 1h48 to 5m+.  Increase golinter deadline to reduce unfound issues when pushing juju git hub juju branches from macOS.