### PR TITLE
Add metrics to model cache for lxd profile change watcher

### DIFF
--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -21,6 +21,10 @@ func (m *Model) SetDetails(details ModelChange) {
 
 // Expose Remove* for testing
 
+func (m *Model) RemoveCharm(ch RemoveCharm) {
+	m.removeCharm(ch)
+}
+
 func (m *Model) RemoveUnit(ch RemoveUnit) {
 	m.removeUnit(ch)
 }

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -103,6 +103,7 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 				return nil, errors.Errorf("programming error, unit %s has machineId but not application", unitName)
 			}
 			logger.Errorf("unit %s has no application, nor machine id, start watching when machine id assigned.", unitName)
+			m.model.metrics.LXDProfileChangeError.Inc()
 			continue
 		}
 		info := appInfo{
@@ -117,14 +118,15 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 		}
 		applications[appName] = info
 	}
-	w := newMachineAppLXDProfileWatcher(
-		m.model.topic(applicationCharmURLChange),
-		m.model.topic(modelUnitLXDProfileChange),
-		m.details.Id,
-		applications,
-		m.model,
-		m.model.hub,
-	)
+	w := newMachineAppLXDProfileWatcher(MachineAppLXDProfileConfig{
+		appTopic:     m.model.topic(applicationCharmURLChange),
+		unitTopic:    m.model.topic(modelUnitLXDProfileChange),
+		machineId:    m.details.Id,
+		applications: applications,
+		modeler:      m.model,
+		metrics:      m.model.metrics,
+		hub:          m.model.hub,
+	})
 	m.model.mu.Unlock()
 	return w, nil
 }

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -53,6 +53,10 @@ type ControllerGauges struct {
 	ApplicationConfigReads   prometheus.Gauge
 	ApplicationHashCacheHit  prometheus.Gauge
 	ApplicationHashCacheMiss prometheus.Gauge
+
+	LXDProfileChangeError prometheus.Gauge
+	LXDProfileChangeHit   prometheus.Gauge
+	LXDProfileChangeMiss  prometheus.Gauge
 }
 
 func createControllerGauges() *ControllerGauges {
@@ -99,6 +103,27 @@ func createControllerGauges() *ControllerGauges {
 				Help:      "The number of times the application config change hash was generated.",
 			},
 		),
+		LXDProfileChangeError: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "lxdprofile_change_error",
+				Help:      "The number of times there was an error calculating LXD profile changes.",
+			},
+		),
+		LXDProfileChangeHit: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "lxdprofile_change_hit",
+				Help:      "The number of times an LXD Profile change was found.",
+			},
+		),
+		LXDProfileChangeMiss: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "lxdprofile_change_miss",
+				Help:      "The number of times an LXD Profile change was not found.",
+			},
+		),
 	}
 }
 
@@ -111,6 +136,10 @@ func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.ApplicationConfigReads.Collect(ch)
 	c.ApplicationHashCacheHit.Collect(ch)
 	c.ApplicationHashCacheMiss.Collect(ch)
+
+	c.LXDProfileChangeError.Collect(ch)
+	c.LXDProfileChangeHit.Collect(ch)
+	c.LXDProfileChangeMiss.Collect(ch)
 }
 
 // Collector is a prometheus.Collector that collects metrics about


### PR DESCRIPTION
## Description of change

Add metrics to model cache for lxd profile change watcher.  Count Errors logged, LXDProfile change needed notifications and LXDProfile change investigations with no notification.  Errors are a subset of investigations with no notificaiton.

## QA steps

1. `export JUJU_DEV_FEATURE_FLAGS=instance-mutater`
2. juju bootstrap
3. juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd"    <-- all should be 0
2. juju deploy ./testcharms/charm-repo/quantal/lxd-profile
3. juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd"      <-- all should be 0
4. juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
3. juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd"      <-- hit increases to 1
2. juju deploy ~/charms/ubuntu
2. juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd"      <-- miss increases to 2, 1 for each machine.
2. juju upgrade-charm ubuntu --path ~/charms/ubuntu
2. juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd"      <-- miss increases to 4, 1 for each machine.