### PR TITLE
2.5 raft recovery 1822454

### DIFF
--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -116,6 +116,7 @@ func (a *API) Restore(p params.RestoreArgs) error {
 	// And passing os.Exit in wouldn't make this any better either,
 	// just using it subverts the expectations of *everything* else
 	// running in the process.
+	// XXX: We have ErrRestartAgent which should be capable of replacing this
 	os.Exit(1)
 	return nil
 }

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -137,7 +137,7 @@ var getArchive = func(filename string) (rc ArchiveReader, metaResult *params.Bac
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	_, err = archive.Seek(0, os.SEEK_SET)
+	_, err = archive.Seek(0, io.SeekStart)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -170,7 +170,7 @@ var getArchive = func(filename string) (rc ArchiveReader, metaResult *params.Bac
 	if meta.Finished == nil || meta.Finished.IsZero() {
 		meta.Finished = fileMeta.Finished
 	}
-	_, err = archive.Seek(0, os.SEEK_SET)
+	_, err = archive.Seek(0, io.SeekStart)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/engine/flag.go
+++ b/cmd/jujud/agent/engine/flag.go
@@ -14,7 +14,7 @@ import (
 type Flag interface {
 
 	// Check returns the flag's value. Check calls must *always* return
-	// the same value for a given instatiation of the type implementing
+	// the same value for a given instantiation of the type implementing
 	// Flag.
 	Check() bool
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1222,6 +1222,8 @@ func (a *MachineAgent) uninstallAgent() error {
 		return nil
 	}
 	logger.Infof("uninstalling agent")
+	logger.Warningf("Refusing to actually uninstall the agent. Stopping instead")
+	return nil
 
 	agentConfig := a.CurrentConfig()
 	var errs []error

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1222,8 +1222,6 @@ func (a *MachineAgent) uninstallAgent() error {
 		return nil
 	}
 	logger.Infof("uninstalling agent")
-	logger.Warningf("Refusing to actually uninstall the agent. Stopping instead")
-	return nil
 
 	agentConfig := a.CurrentConfig()
 	var errs []error

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -340,14 +340,14 @@ var mongoInstalledVersion = func() mongo.Version {
 func NewDBRestorer(args RestorerArgs) (DBRestorer, error) {
 	mongorestorePath, err := getMongorestorePath()
 	if err != nil {
-		return nil, errors.Annotate(err, "mongorestrore not available")
+		return nil, errors.Annotate(err, "mongorestore not available")
 	}
 
 	installedMongo := mongoInstalledVersion()
 	logger.Debugf("args: is %#v", args)
 	logger.Infof("installed mongo is %s", installedMongo)
 	// NewerThan will check Major and Minor so migration between micro versions
-	// will work, before changing this bewar, Mongo has been known to break
+	// will work, before changing this beware, Mongo has been known to break
 	// compatibility between minors.
 	if args.Version.NewerThan(installedMongo) != 0 {
 		return nil, errors.NotSupportedf("restore mongo version %s into version %s", args.Version.String(), installedMongo.String())

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -72,7 +72,7 @@ type Metadata struct {
 	// These are only used by the restore CLI when re-bootstrapping.
 	// We will use a better solution but the way restore currently
 	// works, we need them and they are no longer available via
-	// bootstrap config. We will need to ifx how re-bootstrap deals
+	// bootstrap config. We will need to fix how re-bootstrap deals
 	// with these keys to address the issue.
 
 	// CACert is the controller CA certificate.

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -201,6 +201,7 @@ func ScaryConnect(a agent.Agent, apiOpen api.OpenFunc) (_ api.Connection, err er
 		default:
 			return
 		}
+		logger.Errorf("Failed to connect to controller: %v", err)
 		err = ErrConnectImpossible
 	}()
 

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -80,7 +80,6 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := context.Get(config.AgentName, &agent); err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	var transport raft.Transport
 	if err := context.Get(config.TransportName, &transport); err != nil {
 		return nil, errors.Trace(err)

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -111,7 +111,7 @@ func (w *forwarder) loop() error {
 func (w *forwarder) handleRequest(_ string, req raftlease.ForwardRequest, err error) {
 	w.id++
 	reqID := w.id
-	w.config.Logger.Tracef("%d: received %#v, err: %s", reqID, req, err)
+	w.config.Logger.Tracef("%d: received %#v, err: %v", reqID, req, err)
 	if err != nil {
 		// This should never happen, so treat it as fatal.
 		w.catacomb.Kill(errors.Annotate(err, "requests callback failed"))


### PR DESCRIPTION
## Description of change

Change RaftBackstop so it handles 'no servers'.

If you wipe out the "raft/" directory, then this server is no longer
present in the list of available servers, and raft just never gets
going.

This changes it so that when we detect that case, we BootstrapCluster
with ourselves as the leader.

This was done so that restore-backup would be able to recover the HA cluster. (Where the newly bootstrapped controller's identity is replaced by the identity of an old machine.) However, it makes sense for other places as well, as we do need a way to recover if 'raft/' ever gets wiped.

## QA steps

```
$ juju bootstrap lxd lxd --model-default "logging-config=<root>=INFO;juju.worker.raft=DEBUG"
$ juju ssh -m controller 0
$$ sudo -i
# systemctl stop jujud-machine-0
# cd /var/lib/juju
# rm -rf raft
# mkdir raft
# systemctl start jujud-machine-0
# tail -f /var/log/juju/machine-0.log
2019-03-31 12:15:35 INFO juju.worker.apicaller connect.go:158 [122fa7] "machine-0" successfully connected to "localhost:17070"
2019-03-31 12:15:36 DEBUG juju.worker.raft log.go:172 [WARN] raft: no known peers, aborting election
2019-03-31 12:15:40 INFO juju.core.raftlease store.go:248 timeout
```

Without this patch, the machine's raft engine will be stuck looping, With this patch, there should end up with a line about "rebootstrapping raft configuration". And from then Raft should be happy.
```
2019-03-31 12:21:38 INFO juju.worker.raft.raftbackstop worker.go:246 rebootstrapping raft configuration: raft.Configuration{Servers:[]raft.Server{raft.Server{Suffrage:0, ID:"0", Address:"10.210.24.119:17070"}}}
```


## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1822454