### PR TITLE
Part 1 of 3: force remove app / unit.

### DIFF
--- a/apiserver/common/remove.go
+++ b/apiserver/common/remove.go
@@ -54,6 +54,7 @@ func (r *Remover) removeEntity(tag names.Tag) error {
 			return err
 		}
 	}
+	// TODO (anastasiamac) this needs to work with force if needed
 	return remover.Remove()
 }
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1370,9 +1370,13 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 		}
 		op := unit.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
+		op.Force = arg.Force
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, errors.Trace(err)
 		}
+		// TODO (anastasiamac 2019-03-29) we want to return errors and info when forced..
+		//  maybe always, so that we can report how many errors we are getting/got.
+		// At the moment, this only returns the intent not the actual result.
 		return &info, nil
 	}
 	results := make([]params.DestroyUnitResult, len(args.Units))
@@ -1495,9 +1499,13 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 		}
 		op := app.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
+		op.Force = arg.Force
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, err
 		}
+		// TODO (anastasiamac 2019-03-29) we want to return errors and info when forced..
+		//  maybe always, so that we can report how many errors we are getting/got.
+		// At the moment, this only returns the intent not the actual result.
 		return &info, nil
 	}
 	results := make([]params.DestroyApplicationResult, len(args.Applications))
@@ -1532,6 +1540,8 @@ func (api *APIBase) DestroyConsumedApplications(args params.DestroyConsumedAppli
 			results[i].Error = common.ServerError(err)
 			continue
 		}
+		// TODO (anastasiamac 2019-03-29) This may need to be forced too.
+		// see https://bugs.launchpad.net/juju/+bug/1822050
 		err = app.Destroy()
 		if err != nil {
 			results[i].Error = common.ServerError(err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1377,6 +1377,8 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 		// TODO (anastasiamac 2019-03-29) we want to return errors and info when forced..
 		//  maybe always, so that we can report how many errors we are getting/got.
 		// At the moment, this only returns the intent not the actual result.
+		// However, there is a provision for this functionality for the near-future: destroy operation itself
+		// contains Errors that have been encountered during its application.
 		return &info, nil
 	}
 	results := make([]params.DestroyUnitResult, len(args.Units))
@@ -1506,6 +1508,8 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 		// TODO (anastasiamac 2019-03-29) we want to return errors and info when forced..
 		//  maybe always, so that we can report how many errors we are getting/got.
 		// At the moment, this only returns the intent not the actual result.
+		// However, there is a provision for this functionality for the near-future: destroy operation itself
+		// contains Errors that have been encountered during its application.
 		return &info, nil
 	}
 	results := make([]params.DestroyApplicationResult, len(args.Applications))

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -466,9 +466,18 @@ func (s *ApplicationSuite) TestDestroyRelationIdRelationNotFound(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
+	s.assertDestroyApplication(c, false)
+}
+
+func (s *ApplicationSuite) TestForceDestroyApplication(c *gc.C) {
+	s.assertDestroyApplication(c, true)
+}
+
+func (s *ApplicationSuite) assertDestroyApplication(c *gc.C, force bool) {
 	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
+			Force:          force,
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -498,7 +507,7 @@ func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
 		"UnitStorageAttachments",
 		"ApplyOperation",
 	)
-	s.backend.CheckCall(c, 7, "ApplyOperation", &state.DestroyApplicationOperation{})
+	s.backend.CheckCall(c, 7, "ApplyOperation", &state.DestroyApplicationOperation{Force: force})
 }
 
 func (s *ApplicationSuite) TestDestroyApplicationDestroyStorage(c *gc.C) {
@@ -582,10 +591,20 @@ func (s *ApplicationSuite) TestDestroyConsumedApplicationNotFound(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
+	s.assertDestroyUnit(c, false)
+}
+
+func (s *ApplicationSuite) TestForceDestroyUnit(c *gc.C) {
+	s.assertDestroyUnit(c, true)
+}
+
+func (s *ApplicationSuite) assertDestroyUnit(c *gc.C, force bool) {
 	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{
-			{UnitTag: "unit-postgresql-0"},
 			{
+				UnitTag: "unit-postgresql-0",
+				Force:   force,
+			}, {
 				UnitTag:        "unit-postgresql-1",
 				DestroyStorage: true,
 			},
@@ -619,7 +638,7 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 		"UnitStorageAttachments",
 		"ApplyOperation",
 	)
-	s.backend.CheckCall(c, 6, "ApplyOperation", &state.DestroyUnitOperation{})
+	s.backend.CheckCall(c, 6, "ApplyOperation", &state.DestroyUnitOperation{Force: force})
 	s.backend.CheckCall(c, 9, "ApplyOperation", &state.DestroyUnitOperation{
 		DestroyStorage: true,
 	})

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -414,6 +414,12 @@ type DestroyUnitParams struct {
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
 	Force bool
+
+	// Errors contains errors encountered while applying this operation.
+	// Generally, these are non-fatal errors that have been encountered
+	// during, say, force. They may not have prevented the operation from being
+	// aborted but the user might still want to know about them.
+	Errors []error
 }
 
 // Creds holds credentials for identifying an entity.

--- a/state/application.go
+++ b/state/application.go
@@ -870,8 +870,7 @@ func (a *Application) changeCharmOps(
 		var opErrs []error
 		decOps, opErrs, err = appCharmDecRefOps(a.st, a.doc.Name, a.doc.CharmURL, true, true) // current charm
 		if err != nil {
-			// No need to stop further processing if the old key could not be removed.
-			logger.Errorf("could not remove old charm references for %v:%v", oldKey, err)
+			return nil, errors.Annotatef(err, "could not remove old charm references for %v", oldKey)
 		}
 		if len(opErrs) != 0 {
 			logger.Errorf("could not remove old charm references for %v:%v", oldKey, opErrs)

--- a/state/application.go
+++ b/state/application.go
@@ -335,9 +335,7 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	failedRels := false
 	for _, rel := range rels {
 		relOps, isRemove, opErrs, err := rel.destroyOps(op.app.doc.Name, op.Force)
-		if len(opErrs) != 0 {
-			op.AddError(opErrs...)
-		}
+		op.AddError(opErrs...)
 		if err == errAlreadyDying {
 			relOps = []txn.Op{{
 				C:      relationsC,
@@ -364,9 +362,7 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 		}
 		op.AddError(err)
 	}
-	if len(resOps) != 0 {
-		ops = append(ops, resOps...)
-	}
+	ops = append(ops, resOps...)
 
 	// We can't delete an application if it is being offered.
 	// TODO (anastasiamac 2019-03-29) Should we force remove applications with offers now?
@@ -395,9 +391,7 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	if op.app.doc.UnitCount == 0 && op.app.doc.RelationCount == removeCount {
 		hasLastRefs := bson.D{{"life", Alive}, {"unitcount", 0}, {"relationcount", removeCount}}
 		removeOps, opErrs, err := op.app.removeOps(hasLastRefs, op.Force)
-		if len(opErrs) != 0 {
-			op.AddError(opErrs...)
-		}
+		op.AddError(opErrs...)
 		if err != nil {
 			if !op.Force {
 				return nil, errors.Trace(err)
@@ -486,10 +480,7 @@ func (a *Application) removeOps(asserts bson.D, force bool) ([]txn.Op, []error, 
 		}
 		errs = append(errs, err)
 	}
-
-	if len(removeOfferOps) != 0 {
-		ops = append(ops, removeOfferOps...)
-	}
+	ops = append(ops, removeOfferOps...)
 
 	// Note that appCharmDecRefOps might not catch the final decref
 	// when run in a transaction that decrefs more than once. So we
@@ -498,18 +489,14 @@ func (a *Application) removeOps(asserts bson.D, force bool) ([]txn.Op, []error, 
 	name := a.doc.Name
 	curl := a.doc.CharmURL
 	charmOps, opErrs, err := appCharmDecRefOps(a.st, name, curl, false, force)
-	if len(opErrs) != 0 {
-		errs = append(errs, opErrs...)
-	}
+	errs = append(errs, opErrs...)
 	if err != nil {
 		if !force {
 			return nil, errs, errors.Trace(err)
 		}
 		errs = append(errs, err)
 	}
-	if len(charmOps) != 0 {
-		ops = append(ops, charmOps...)
-	}
+	ops = append(ops, charmOps...)
 	// By the time we get to here, all units and charm refs have been removed,
 	// so it's safe to do this additional cleanup.
 	ops = append(ops, finalAppCharmRemoveOps(name, curl)...)
@@ -1741,9 +1728,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		if err != nil && err != jujutxn.ErrNoOperations {
 			return "", nil, errors.Trace(err)
 		}
-		if len(subCharmProfileOps) > 0 {
-			ops = append(ops, subCharmProfileOps...)
-		}
+		ops = append(ops, subCharmProfileOps...)
 	} else {
 		ops = append(ops, createConstraintsOp(agentGlobalKey, args.cons))
 	}
@@ -1977,9 +1962,7 @@ func (a *Application) AddUnit(args AddUnitParams) (unit *Unit, err error) {
 func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.Op, []error, error) {
 	errs := []error{}
 	hostOps, opErrs, err := u.destroyHostOps(a, force)
-	if len(opErrs) != 0 {
-		errs = append(errs, opErrs...)
-	}
+	errs = append(errs, opErrs...)
 	if err != nil {
 		if !force {
 			return nil, errs, errors.Trace(err)
@@ -2020,15 +2003,9 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 		annotationRemoveOp(a.st, u.globalKey()),
 		newCleanupOp(cleanupRemovedUnit, u.doc.Name, force),
 	}
-	if len(portsOps) != 0 {
-		ops = append(ops, portsOps...)
-	}
-	if len(resOps) != 0 {
-		ops = append(ops, resOps...)
-	}
-	if len(hostOps) != 0 {
-		ops = append(ops, hostOps...)
-	}
+	ops = append(ops, portsOps...)
+	ops = append(ops, resOps...)
+	ops = append(ops, hostOps...)
 
 	model, err := a.st.Model()
 	if err != nil {
@@ -2058,9 +2035,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 			}
 			errs = append(errs, err)
 		}
-		if len(storageInstanceOps) != 0 {
-			ops = append(ops, storageInstanceOps...)
-		}
+		ops = append(ops, storageInstanceOps...)
 	}
 
 	if u.doc.CharmURL != nil {
@@ -2068,9 +2043,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 		// cleanup to happen; otherwise we just do it when the app itself is removed.
 		maybeDoFinal := u.doc.CharmURL != a.doc.CharmURL
 		decOps, opErrs, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL, maybeDoFinal, force)
-		if len(opErrs) != 0 {
-			errs = append(errs, opErrs...)
-		}
+		errs = append(errs, opErrs...)
 		if errors.IsNotFound(err) {
 			return nil, errs, errRefresh
 		} else if err != nil {
@@ -2079,25 +2052,19 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 			}
 			errs = append(errs, err)
 		}
-		if len(decOps) != 0 {
-			ops = append(ops, decOps...)
-		}
+		ops = append(ops, decOps...)
 	}
 	if a.doc.Life == Dying && a.doc.RelationCount == 0 && a.doc.UnitCount == 1 {
 		hasLastRef := bson.D{{"life", Dying}, {"relationcount", 0}, {"unitcount", 1}}
 		removeOps, opErrs, err := a.removeOps(hasLastRef, force)
-		if len(opErrs) != 0 {
-			errs = append(errs, opErrs...)
-		}
+		errs = append(errs, opErrs...)
 		if err != nil {
 			if !force {
 				return nil, errs, errors.Trace(err)
 			}
 			errs = append(errs, err)
 		}
-		if len(removeOps) != 0 {
-			return append(ops, removeOps...), errs, nil
-		}
+		return append(ops, removeOps...), errs, nil
 	}
 	appOp := txn.Op{
 		C:      applicationsC,

--- a/state/application.go
+++ b/state/application.go
@@ -867,11 +867,14 @@ func (a *Application) changeCharmOps(
 	if oldKey != nil {
 		// Since we can force this now, let's.. There is no point hanging on
 		// to the old key.
-		decOps, _, err = appCharmDecRefOps(a.st, a.doc.Name, a.doc.CharmURL, true, true) // current charm
+		var opErrs []error
+		decOps, opErrs, err = appCharmDecRefOps(a.st, a.doc.Name, a.doc.CharmURL, true, true) // current charm
 		if err != nil {
-			// TODO (anastasiamac) The question is do we really need to stop further processing
-			// if the old key could not be removed?
-			return nil, errors.Trace(err)
+			// No need to stop further processing if the old key could not be removed.
+			logger.Errorf("could not remove old charm references for %v:%v", oldKey, err)
+		}
+		if len(opErrs) != 0 {
+			logger.Errorf("could not remove old charm references for %v:%v", oldKey, opErrs)
 		}
 	}
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -225,7 +225,10 @@ func (s *applicationOffers) Remove(offerName string, force bool) (err error) {
 					}
 				}
 
-				relOps, _, err := rel.destroyOps("", force)
+				relOps, _, opErrs, err := rel.destroyOps("", force)
+				if len(opErrs) != 0 {
+					logger.Warningf("errors while getting operations to destroy remote application relation %v: %v", remoteApp.Name(), opErrs)
+				}
 				if err == errAlreadyDying {
 					continue
 				} else if err != nil {

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -225,7 +225,7 @@ func (s *applicationOffers) Remove(offerName string, force bool) (err error) {
 					}
 				}
 
-				relOps, _, err := rel.destroyOps("")
+				relOps, _, err := rel.destroyOps("", force)
 				if err == errAlreadyDying {
 					continue
 				} else if err != nil {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -377,6 +377,7 @@ func (st *State) removeRemoteApplicationsForDyingModel() (err error) {
 // application is destroyed.
 func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanupArgs []bson.Raw) (err error) {
 	var destroyStorage bool
+	var force bool
 	switch n := len(cleanupArgs); n {
 	case 0:
 		// Old cleanups have no args, so follow the old behaviour.
@@ -384,8 +385,15 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
 			return errors.Annotate(err, "unmarshalling cleanup args")
 		}
+	case 2:
+		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'destroyStorage'")
+		}
+		if err := cleanupArgs[1].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		}
 	default:
-		return errors.Errorf("expected 0-1 arguments, got %d", n)
+		return errors.Errorf("expected 0-2 arguments, got %d", n)
 	}
 
 	// This won't miss units, because a Dying application cannot have units
@@ -445,6 +453,7 @@ func (st *State) cleanupCharm(charmURL string) error {
 // they are cleaned up as well.
 func (st *State) cleanupDyingUnit(name string, cleanupArgs []bson.Raw) error {
 	var destroyStorage bool
+	var force bool
 	switch n := len(cleanupArgs); n {
 	case 0:
 		// Old cleanups have no args, so follow the old behaviour.
@@ -452,8 +461,15 @@ func (st *State) cleanupDyingUnit(name string, cleanupArgs []bson.Raw) error {
 		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
 			return errors.Annotate(err, "unmarshalling cleanup args")
 		}
+	case 2:
+		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'destroyStorage'")
+		}
+		if err := cleanupArgs[1].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		}
 	default:
-		return errors.Errorf("expected 0-1 arguments, got %d", n)
+		return errors.Errorf("expected 0-2 arguments, got %d", n)
 	}
 
 	unit, err := st.Unit(name)
@@ -888,6 +904,7 @@ func (st *State) obliterateUnit(unitName string) error {
 	if err := unit.EnsureDead(); err != nil {
 		return err
 	}
+	// TODO (anastasiamac) This needs to work with force
 	return unit.Remove()
 }
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -799,8 +799,8 @@ func AppDeviceConstraints(app *Application) (map[string]DeviceConstraints, error
 	return readDeviceConstraints(app.st, app.deviceConstraintsKey())
 }
 
-func RemoveRelation(c *gc.C, rel *Relation) {
-	ops, err := rel.removeOps("", "")
+func RemoveRelation(c *gc.C, rel *Relation, force bool) {
+	ops, err := rel.removeOps("", "", force)
 	c.Assert(err, jc.ErrorIsNil)
 	err = rel.st.db().RunTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -800,8 +800,9 @@ func AppDeviceConstraints(app *Application) (map[string]DeviceConstraints, error
 }
 
 func RemoveRelation(c *gc.C, rel *Relation, force bool) {
-	ops, err := rel.removeOps("", "", force)
+	ops, opErrs, err := rel.removeOps("", "", force)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("operational errors %v", opErrs)
 	err = rel.st.db().RunTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/relation.go
+++ b/state/relation.go
@@ -334,9 +334,7 @@ func (r *Relation) internalDestroy(force bool) (errs []error, err error) {
 			}
 		}
 		ops, _, opErrs, err := rel.destroyOps("", force)
-		if len(opErrs) != 0 {
-			errs = append(errs, opErrs...)
-		}
+		errs = append(errs, opErrs...)
 		if err == errAlreadyDying {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -417,20 +415,14 @@ func (r *Relation) removeOps(ignoreApplication string, departingUnitName string,
 				if err != nil {
 					errs = append(errs, err)
 				}
-				if len(epOps) != 0 {
-					ops = append(ops, epOps...)
-				}
+				ops = append(ops, epOps...)
 			} else {
 				epOps, opErrs, err := r.removeLocalEndpointOps(ep, departingUnitName, force)
-				if len(opErrs) != 0 {
-					errs = append(errs, opErrs...)
-				}
+				errs = append(errs, opErrs...)
 				if err != nil {
 					errs = append(errs, err)
 				}
-				if len(epOps) != 0 {
-					ops = append(ops, epOps...)
-				}
+				ops = append(ops, epOps...)
 			}
 		}
 	}

--- a/state/relation.go
+++ b/state/relation.go
@@ -249,11 +249,21 @@ func (r *Relation) checkConsumePermission(offerUUID, userId string) (bool, error
 	return true, nil
 }
 
+// DestroyWithForce may force the destruction of the relation.
+func (r *Relation) DestroyWithForce(force bool) (err error) {
+	return r.internalDestroy(force)
+}
+
 // Destroy ensures that the relation will be removed at some point; if no units
 // are currently in scope, it will be removed immediately.
 func (r *Relation) Destroy() (err error) {
+	return r.internalDestroy(false)
+}
+
+func (r *Relation) internalDestroy(force bool) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot destroy relation %q", r)
 	if len(r.doc.Endpoints) == 1 && r.doc.Endpoints[0].Role == charm.RolePeer {
+		// TODO (anastasiamac) what does it do when forcing ??
 		return errors.Errorf("is a peer relation")
 	}
 	defer func() {
@@ -264,27 +274,42 @@ func (r *Relation) Destroy() (err error) {
 	}()
 	rel := &Relation{r.st, r.doc}
 
+	errs := []string{}
 	remoteApp, isCrossModel, err := r.RemoteApplication()
 	if err != nil {
-		return errors.Trace(err)
-	}
-	// If the status of the consumed app is terminated, we will never
-	// get an orderly exit of units from scope so force the issue.
-	if isCrossModel {
-		statusInfo, err := remoteApp.Status()
-		if err != nil && !errors.IsNotFound(err) {
+		if !force {
 			return errors.Trace(err)
 		}
-		if err == nil && statusInfo.Status == status.Terminated {
-			logger.Debugf("forcing cleanup of units for %v", remoteApp.Name())
-			remoteUnits, err := rel.AllRemoteUnits(remoteApp.Name())
-			if err != nil {
-				return errors.Trace(err)
-			}
-			logger.Debugf("got %v relation units to clean", len(remoteUnits))
-			for _, ru := range remoteUnits {
-				if err := ru.LeaveScope(); err != nil {
+		errs = append(errs, err.Error())
+	} else {
+		// If the status of the consumed app is terminated, we will never
+		// get an orderly exit of units from scope so force the issue.
+		if isCrossModel {
+			statusInfo, err := remoteApp.Status()
+			if err != nil && !errors.IsNotFound(err) {
+				if !force {
 					return errors.Trace(err)
+				}
+				errs = append(errs, err.Error())
+			}
+			if err == nil && statusInfo.Status == status.Terminated {
+				logger.Debugf("forcing cleanup of units for %v", remoteApp.Name())
+				remoteUnits, err := rel.AllRemoteUnits(remoteApp.Name())
+				if err != nil {
+					if !force {
+						return errors.Trace(err)
+					}
+					errs = append(errs, err.Error())
+				}
+				logger.Debugf("got %v relation units to clean", len(remoteUnits))
+				for _, ru := range remoteUnits {
+					if err := ru.LeaveScope(); err != nil {
+						if !force {
+							// TODO (anastasiamac) should not we 'continue' here rather than get out?
+							return errors.Trace(err)
+						}
+						errs = append(errs, err.Error())
+					}
 				}
 			}
 		}
@@ -302,15 +327,29 @@ func (r *Relation) Destroy() (err error) {
 				return nil, err
 			}
 		}
-		ops, _, err := rel.destroyOps("")
+		ops, _, err := rel.destroyOps("", force)
 		if err == errAlreadyDying {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
-			return nil, err
+			if !force {
+				return nil, err
+			}
+			errs = append(errs, err.Error())
 		}
-		return ops, nil
+		return ops, err
 	}
-	return rel.st.db().Run(buildTxn)
+	err = rel.st.db().Run(buildTxn)
+	if !force {
+		return err
+	}
+	if err != nil {
+		errs = append(errs, err.Error())
+	}
+	if len(errs) != 0 {
+		return errors.Errorf("%v", strings.Join(errs, "\n"))
+	}
+	return nil
+
 }
 
 // destroyOps returns the operations necessary to destroy the relation, and
@@ -318,14 +357,18 @@ func (r *Relation) Destroy() (err error) {
 // operations may include changes to the relation's applications; however, if
 // ignoreApplication is not empty, no operations modifying that application will
 // be generated.
-func (r *Relation) destroyOps(ignoreApplication string) (ops []txn.Op, isRemove bool, err error) {
+func (r *Relation) destroyOps(ignoreApplication string, force bool) (ops []txn.Op, isRemove bool, err error) {
 	if r.doc.Life != Alive {
+		// TODO (anastasiamac) Should not we ignore this with 'force' to enable stuck removal to proceed?
 		return nil, false, errAlreadyDying
 	}
 	if r.doc.UnitCount == 0 {
-		removeOps, err := r.removeOps(ignoreApplication, "")
+		removeOps, err := r.removeOps(ignoreApplication, "", force)
 		if err != nil {
-			return nil, false, err
+			if !force {
+				return nil, false, err
+			}
+			logger.Warningf("ignoring error (%v) while constructing relation %v destroy operations since force is used", err, r)
 		}
 		return removeOps, true, nil
 	}
@@ -342,7 +385,7 @@ func (r *Relation) destroyOps(ignoreApplication string) (ops []txn.Op, isRemove 
 // included; if departingUnitName is non-empty, this implies that the
 // relation's applications may be Dying and otherwise unreferenced, and may thus
 // require removal themselves.
-func (r *Relation) removeOps(ignoreApplication string, departingUnitName string) ([]txn.Op, error) {
+func (r *Relation) removeOps(ignoreApplication string, departingUnitName string, force bool) ([]txn.Op, error) {
 	relOp := txn.Op{
 		C:      relationsC,
 		Id:     r.doc.DocID,
@@ -354,26 +397,44 @@ func (r *Relation) removeOps(ignoreApplication string, departingUnitName string)
 		relOp.Assert = bson.D{{"life", Alive}, {"unitcount", 0}}
 	}
 	ops := []txn.Op{relOp}
+	errs := []string{}
 	for _, ep := range r.doc.Endpoints {
 		if ep.ApplicationName == ignoreApplication {
 			continue
 		}
 		app, err := applicationByName(r.st, ep.ApplicationName)
 		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if app.IsRemote() {
-			epOps, err := r.removeRemoteEndpointOps(ep, departingUnitName != "")
-			if err != nil {
+			if !force {
+				// TODO (anastasiamac) This should be 'continue'
 				return nil, errors.Trace(err)
 			}
-			ops = append(ops, epOps...)
+			errs = append(errs, err.Error())
 		} else {
-			epOps, err := r.removeLocalEndpointOps(ep, departingUnitName)
-			if err != nil {
-				return nil, errors.Trace(err)
+			if app.IsRemote() {
+				epOps, err := r.removeRemoteEndpointOps(ep, departingUnitName != "")
+				if err != nil {
+					if !force {
+						// TODO (anastasiamac) This should be 'continue'
+						return nil, errors.Trace(err)
+					}
+					errs = append(errs, err.Error())
+				}
+				if len(epOps) != 0 {
+					ops = append(ops, epOps...)
+				}
+			} else {
+				epOps, err := r.removeLocalEndpointOps(ep, departingUnitName, force)
+				if err != nil {
+					if !force {
+						// TODO (anastasiamac) This should be 'continue'
+						return nil, errors.Trace(err)
+					}
+					errs = append(errs, err.Error())
+				}
+				if len(epOps) != 0 {
+					ops = append(ops, epOps...)
+				}
 			}
-			ops = append(ops, epOps...)
 		}
 	}
 	ops = append(ops, removeStatusOp(r.st, r.globalScope()))
@@ -383,11 +444,15 @@ func (r *Relation) removeOps(ignoreApplication string, departingUnitName string)
 	ops = append(ops, tokenOps...)
 	offerOps := removeOfferConnectionsForRelationOps(r.Id())
 	ops = append(ops, offerOps...)
-	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
-	return append(ops, cleanupOp), nil
+	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()), force)
+	ops = append(ops, cleanupOp)
+	if !force || len(errs) == 0 {
+		return ops, nil
+	}
+	return ops, errors.Errorf("%v", strings.Join(errs, "\n"))
 }
 
-func (r *Relation) removeLocalEndpointOps(ep Endpoint, departingUnitName string) ([]txn.Op, error) {
+func (r *Relation) removeLocalEndpointOps(ep Endpoint, departingUnitName string, force bool) ([]txn.Op, error) {
 	var asserts bson.D
 	hasRelation := bson.D{{"relationcount", bson.D{{"$gt", 0}}}}
 	departingUnitApplicationMatchesEndpoint := func() bool {
@@ -413,9 +478,11 @@ func (r *Relation) removeLocalEndpointOps(ep Endpoint, departingUnitName string)
 		hasLastRef := bson.D{{"life", Dying}, {"unitcount", 0}, {"relationcount", 1}}
 		removable := append(bson.D{{"_id", ep.ApplicationName}}, hasLastRef...)
 		if err := applications.Find(removable).One(&app.doc); err == nil {
-			return app.removeOps(hasLastRef)
+			return app.removeOps(hasLastRef, force)
 		} else if err != mgo.ErrNotFound {
-			return nil, err
+			if !force {
+				return nil, err
+			}
 		}
 		// If not, we must check that this is still the case when the
 		// transaction is applied.

--- a/state/relation.go
+++ b/state/relation.go
@@ -250,18 +250,17 @@ func (r *Relation) checkConsumePermission(offerUUID, userId string) (bool, error
 }
 
 // DestroyWithForce may force the destruction of the relation.
-func (r *Relation) DestroyWithForce(force bool) error {
-	// TODO (anastasiamac 2019-04-2) First return here is operational errors.
-	// We might want to consider to pass them up to notify users of non-fatal
-	// errors we have encountered.
-	_, err := r.internalDestroy(force)
-	return err
+// In addition, this function also returns all non-fatal operational errors
+// encountered.
+func (r *Relation) DestroyWithForce(force bool) ([]error, error) {
+	return r.internalDestroy(force)
 }
 
 // Destroy ensures that the relation will be removed at some point; if no units
 // are currently in scope, it will be removed immediately.
 func (r *Relation) Destroy() error {
-	return r.DestroyWithForce(false)
+	_, err := r.DestroyWithForce(false)
+	return err
 }
 
 func (r *Relation) internalDestroy(force bool) (errs []error, err error) {

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -532,7 +532,7 @@ func (s *RelationSuite) TestRemoveAlsoDeletesNetworks(c *gc.C) {
 	_, err = relEgress.Save(relation.Tag().Id(), true, []string{"1.2.3.4/32", "4.3.2.1/16"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.RemoveRelation(c, relation)
+	state.RemoveRelation(c, relation, false)
 	_, err = relIngress.Networks(relation.Tag().Id())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	_, err = relEgress.Networks(relation.Tag().Id())
@@ -554,7 +554,7 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteTokens(c *gc.C) {
 	relToken, err := re.ExportLocalEntity(relation.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.RemoveRelation(c, relation)
+	state.RemoveRelation(c, relation, false)
 	_, err = re.GetToken(relation.Tag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	_, err = re.GetRemoteEntity(relToken)
@@ -597,7 +597,7 @@ func (s *RelationSuite) TestRemoveAlsoDeletesRemoteOfferConnections(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.TotalConnectionCount(), gc.Equals, 1)
 
-	state.RemoveRelation(c, relation)
+	state.RemoveRelation(c, relation, false)
 	rc, err = s.State.RemoteConnectionStatus("offer-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc.TotalConnectionCount(), gc.Equals, 0)
@@ -614,7 +614,7 @@ func (s *RelationSuite) TestRemoveNoFeatureFlag(c *gc.C) {
 	relation, err := s.State.AddRelation(wordpressEP, mysqlEP)
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.RemoveRelation(c, relation)
+	state.RemoveRelation(c, relation, false)
 	_, err = s.State.KeyRelation(relation.Tag().Id())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -361,18 +361,14 @@ func (ru *RelationUnit) internalLeaveScope(force bool) ([]error, error) {
 			})
 		} else {
 			relOps, opErrs, err := ru.relation.removeOps("", ru.unitName, force)
-			if len(opErrs) != 0 {
-				errs = append(errs, opErrs...)
-			}
+			errs = append(errs, opErrs...)
 			if err != nil {
 				if !force {
 					return nil, err
 				}
 				errs = append(errs, err)
 			}
-			if len(relOps) != 0 {
-				ops = append(ops, relOps...)
-			}
+			ops = append(ops, relOps...)
 		}
 		return ops, nil
 	}

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -283,9 +283,7 @@ func (s *RemoteApplication) internalDestroy(force bool) (errs []error, err error
 			}
 		}
 		ops, opErrs, err := app.destroyOps(force)
-		if len(opErrs) != 0 {
-			errs = append(errs, opErrs...)
-		}
+		errs = append(errs, opErrs...)
 		switch err {
 		case errRefresh:
 		case errAlreadyDying:
@@ -370,9 +368,7 @@ func (s *RemoteApplication) destroyOps(force bool) ([]txn.Op, []error, error) {
 			}
 
 			relOps, isRemove, opErrs, err := rel.destroyOps(s.doc.Name, force)
-			if len(opErrs) != 0 {
-				errs = append(errs, opErrs...)
-			}
+			errs = append(errs, opErrs...)
 			if err == errAlreadyDying {
 				relOps = []txn.Op{{
 					C:      relationsC,
@@ -387,9 +383,7 @@ func (s *RemoteApplication) destroyOps(force bool) ([]txn.Op, []error, error) {
 			if isRemove {
 				removeCount++
 			}
-			if len(relOps) != 0 {
-				ops = append(ops, relOps...)
-			}
+			ops = append(ops, relOps...)
 		}
 		if !force && failRels != nil {
 			return nil, errs, errors.Trace(failRels)
@@ -406,9 +400,7 @@ func (s *RemoteApplication) destroyOps(force bool) ([]txn.Op, []error, error) {
 			}
 			errs = append(errs, err)
 		}
-		if len(removeOps) != 0 {
-			ops = append(ops, removeOps...)
-		}
+		ops = append(ops, removeOps...)
 		return ops, errs, nil
 	}
 	// In all other cases, application removal will be handled as a consequence

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4623,7 +4623,7 @@ func (s *StateSuite) TestWatchRelationIngressNetworks(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Delete relation.
-	state.RemoveRelation(c, rel)
+	state.RemoveRelation(c, rel, false)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange()
 	wc.AssertNoChange()
@@ -4686,7 +4686,7 @@ func (s *StateSuite) TestWatchRelationEgressNetworks(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Delete relation.
-	state.RemoveRelation(c, rel)
+	state.RemoveRelation(c, rel, false)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange()
 	wc.AssertNoChange()

--- a/state/unit.go
+++ b/state/unit.go
@@ -1638,9 +1638,13 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 		if u.doc.CharmURL != nil {
 			// Drop the reference to the old charm.
 			// Since we can force this now, let's.. There is no point hanging on to the old charm.
-			decOps, _, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL, true, true)
+			decOps, opErrs, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL, true, true)
 			if err != nil {
-				return nil, errors.Trace(err)
+				// No need to stop further processing if the old key could not be removed.
+				logger.Errorf("could not remove old charm references for %v:%v", u.doc.CharmURL, err)
+			}
+			if len(opErrs) != 0 {
+				logger.Errorf("could not remove old charm references for %v:%v", u.doc.CharmURL, opErrs)
 			}
 			ops = append(ops, decOps...)
 		}

--- a/state/unit.go
+++ b/state/unit.go
@@ -964,18 +964,17 @@ func (u *Unit) EnsureDead() (err error) {
 // Remove removes the unit from state, and may remove its application as well, if
 // the application is Dying and no other references to it exist. It will fail if
 // the unit is not Dead.
-func (u *Unit) Remove() (err error) {
-	return u.RemoveWithForce(false)
+func (u *Unit) Remove() error {
+	_, err := u.RemoveWithForce(false)
+	return err
 }
 
-// ForceRemove removes the unit from state similar to the unit.Remove() but
+// RemoveWithForce removes the unit from state similar to the unit.Remove() but
 // it ignores errors.
-func (u *Unit) RemoveWithForce(force bool) error {
-	// TODO (anastasiamac 2019-04-2) First return here is operational errors.
-	// We might want to consider to pass them up to notify users of non-fatal
-	// errors we have encountered.
-	_, err := u.internalRemove(force)
-	return err
+// In addition, this function also returns all non-fatal operational errors
+// encountered.
+func (u *Unit) RemoveWithForce(force bool) ([]error, error) {
+	return u.internalRemove(force)
 }
 
 func (u *Unit) internalRemove(force bool) (errs []error, err error) {
@@ -1006,7 +1005,6 @@ func (u *Unit) internalRemove(force bool) (errs []error, err error) {
 			if err := ru.LeaveScope(); err != nil {
 				errs = append(errs, err)
 				failRelations = err
-				continue
 			}
 		}
 		if !force && failRelations != nil {

--- a/state/unit.go
+++ b/state/unit.go
@@ -685,9 +685,7 @@ func (op *DestroyUnitOperation) destroyOps() ([]txn.Op, error) {
 	}
 
 	removeOps, opErrs, err := op.unit.removeOps(removeAsserts, op.Force)
-	if len(opErrs) != 0 {
-		op.AddError(opErrs...)
-	}
+	op.AddError(opErrs...)
 	if err == errAlreadyRemoved {
 		return nil, errAlreadyDying
 	} else if err != nil {
@@ -697,9 +695,7 @@ func (op *DestroyUnitOperation) destroyOps() ([]txn.Op, error) {
 		op.AddError(err)
 	}
 	ops := []txn.Op{statusOp, minUnitsOp}
-	if len(removeOps) != 0 {
-		ops = append(ops, removeOps...)
-	}
+	ops = append(ops, removeOps...)
 	return ops, nil
 }
 
@@ -801,9 +797,7 @@ func (u *Unit) destroyHostOps(a *Application, force bool) (ops []txn.Op, errs []
 			}
 			errs = append(errs, err)
 		}
-		if len(profileOps) > 0 {
-			ops = append(ops, profileOps...)
-		}
+		ops = append(ops, profileOps...)
 	}
 
 	// If removal conditions satisfied by machine & container docs, we can
@@ -1032,9 +1026,7 @@ func (u *Unit) internalRemove(force bool) (errs []error, err error) {
 			}
 		}
 		ops, opErrs, err := unit.removeOps(isDeadDoc, force)
-		if len(opErrs) != 0 {
-			errs = append(errs, opErrs...)
-		}
+		errs = append(errs, opErrs...)
 		switch err {
 		case errRefresh:
 		case errAlreadyDying:
@@ -1650,9 +1642,7 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			if len(decOps) != 0 {
-				ops = append(ops, decOps...)
-			}
+			ops = append(ops, decOps...)
 		}
 		return ops, nil
 	}


### PR DESCRIPTION
## Description of change

Providing functionality to force remove application or unit is a bit involved, so I am breaking the change into 3 separate proposals.
This PR, part 1, only contains weaving of 'force' into direct state calls and the logic persevering despite encountered errors. 
Part 2 contains changes to cleanup operations to react to 'force' with potential Part 3 containing errors propagating up to users despite removal proceeding as well as some common scenario tests.
