### PR TITLE
Mark, sweep model cache

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -4,8 +4,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/juju/pubsub"
 )
 
@@ -18,6 +16,7 @@ const (
 
 func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Application {
 	a := &Application{
+		Entity:  &Entity{},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -26,10 +25,11 @@ func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Applicati
 
 // Application represents an application in a model.
 type Application struct {
+	*Entity
+
 	// Link to model?
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
-	mu      sync.Mutex
 
 	details    ApplicationChange
 	configHash string
@@ -72,6 +72,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 		a.hub.Publish(a.modelTopic(applicationCharmURLChange), appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})
 	}
 
+	a.state = Active
 	a.details = details
 	hashCache, configHash := newHashCache(
 		details.Config, a.metrics.ApplicationHashCacheHit, a.metrics.ApplicationHashCacheMiss)

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -72,6 +72,11 @@ func (a *Application) removalDelta() interface{} {
 	}
 }
 
+// remove cleans up any associated data with the application
+func (a *Application) remove() {
+	// TODO (stickupkid): clean watchers
+}
+
 // appCharmUrlChange contains an appName and it's charm URL.  To be used
 // when publishing for applicationCharmURLChange.
 type appCharmUrlChange struct {

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -19,6 +19,7 @@ func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Applicati
 		metrics: metrics,
 		hub:     hub,
 	}
+	a.Entity.removalDelta = a.removalDelta
 	return a
 }
 
@@ -59,7 +60,7 @@ func (a *Application) WatchConfig(keys ...string) *ConfigWatcher {
 	return w
 }
 
-func (a *Application) RemovalDelta() interface{} {
+func (a *Application) removalDelta() interface{} {
 	return RemoveApplication{
 		ModelUUID: a.details.ModelUUID,
 		Name:      a.details.Name,

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -54,7 +54,16 @@ func (a *Application) Config() map[string]interface{} {
 
 // WatchConfig creates a watcher for the application config.
 func (a *Application) WatchConfig(keys ...string) *ConfigWatcher {
-	return newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange))
+	w := newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange))
+	a.registerWatcher(w)
+	return w
+}
+
+func (a *Application) RemovalDelta() interface{} {
+	return RemoveApplication{
+		ModelUUID: a.details.ModelUUID,
+		Name:      a.details.Name,
+	}
 }
 
 // appCharmUrlChange contains an appName and it's charm URL.  To be used

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -16,7 +16,6 @@ const (
 
 func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Application {
 	a := &Application{
-		Entity:  &Entity{},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -25,7 +24,7 @@ func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Applicati
 
 // Application represents an application in a model.
 type Application struct {
-	*Entity
+	Entity
 
 	// Link to model?
 	metrics *ControllerGauges

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -77,3 +77,8 @@ var appChange = cache.ApplicationChange{
 	Status:          status.StatusInfo{Status: status.Active},
 	WorkloadVersion: "666",
 }
+
+var removeApp = cache.RemoveApplication{
+	ModelUUID: "model-uuid",
+	Name:      "application-name",
+}

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -14,6 +14,7 @@ func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
 		metrics: metrics,
 		hub:     hub,
 	}
+	c.Entity.removalDelta = c.removalDelta
 	return c
 }
 
@@ -33,7 +34,7 @@ func (c *Charm) LXDProfile() lxdprofile.Profile {
 	return c.details.LXDProfile
 }
 
-func (c *Charm) RemovalDelta() interface{} {
+func (c *Charm) removalDelta() interface{} {
 	return RemoveCharm{
 		ModelUUID: c.details.ModelUUID,
 		CharmURL:  c.details.CharmURL,

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -47,6 +47,11 @@ func (c *Charm) removalDelta() interface{} {
 	}
 }
 
+// remove cleans up any associated data with the charm
+func (c *Charm) remove() {
+	// TODO (stickupkid): clean watchers
+}
+
 func (c *Charm) setDetails(details CharmChange) {
 	c.mu.Lock()
 	c.freshness = fresh

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -4,8 +4,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/juju/pubsub"
 
 	"github.com/juju/juju/core/lxdprofile"
@@ -13,6 +11,7 @@ import (
 
 func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
 	c := &Charm{
+		Entity:  &Entity{},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -21,10 +20,11 @@ func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
 
 // Charm represents an charm in a model.
 type Charm struct {
+	*Entity
+
 	// Link to model?
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
-	mu      sync.Mutex
 
 	details CharmChange
 }
@@ -36,6 +36,7 @@ func (c *Charm) LXDProfile() lxdprofile.Profile {
 
 func (c *Charm) setDetails(details CharmChange) {
 	c.mu.Lock()
+	c.state = Active
 	c.details = details
 	c.mu.Unlock()
 }

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -33,6 +33,13 @@ func (c *Charm) LXDProfile() lxdprofile.Profile {
 	return c.details.LXDProfile
 }
 
+func (c *Charm) RemovalDelta() interface{} {
+	return RemoveCharm{
+		ModelUUID: c.details.ModelUUID,
+		CharmURL:  c.details.CharmURL,
+	}
+}
+
 func (c *Charm) setDetails(details CharmChange) {
 	c.mu.Lock()
 	c.state = Active

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -11,7 +11,6 @@ import (
 
 func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
 	c := &Charm{
-		Entity:  &Entity{},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -20,7 +19,7 @@ func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
 
 // Charm represents an charm in a model.
 type Charm struct {
-	*Entity
+	Entity
 
 	// Link to model?
 	metrics *ControllerGauges

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -120,16 +120,12 @@ func (c *Controller) Mark() map[string]int {
 	return result
 }
 
-type SweepPhaseResult struct {
-	Active, Stale int
-}
-
 // Sweep goes through all the items within a model that have been marked as
 // stale and if the item hasn't been updated in between Mark and Sweep, then
 // the item will be removed.
 // The result from the sweep is how many items are removed per model.
-func (c *Controller) Sweep() map[string]SweepPhaseResult {
-	result := make(map[string]SweepPhaseResult)
+func (c *Controller) Sweep() map[string]*SweepChecker {
+	result := make(map[string]*SweepChecker)
 	c.mu.Lock()
 	for uuid, model := range c.models {
 		result[uuid] = model.sweep()

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -222,9 +222,8 @@ func (c *Controller) updateModel(ch ModelChange) {
 // removeModel removes the model from the cache.
 func (c *Controller) removeModel(ch RemoveModel) {
 	c.mu.Lock()
-	if _, ok := c.models[ch.ModelUUID]; ok {
-		// TODO (stickupkid): ensure we clean up the model, so that it
-		// also cleans up the watchers
+	if model, ok := c.models[ch.ModelUUID]; ok {
+		model.remove()
 		delete(c.models, ch.ModelUUID)
 	}
 	c.mu.Unlock()

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -77,6 +77,8 @@ func (c *Controller) loop() error {
 	}
 }
 
+// dispatch will take a change event and depending on the type, trigger a update
+// to the controller.
 func (c *Controller) dispatch(change interface{}) {
 	switch ch := change.(type) {
 	case ModelChange:
@@ -211,7 +213,10 @@ func (c *Controller) updateModel(ch ModelChange) {
 // removeModel removes the model from the cache.
 func (c *Controller) removeModel(ch RemoveModel) {
 	c.mu.Lock()
-	delete(c.models, ch.ModelUUID)
+	if entity, ok := c.models[ch.ModelUUID]; ok {
+		entity.remove()
+		delete(c.models, ch.ModelUUID)
+	}
 	c.mu.Unlock()
 }
 

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -121,7 +121,6 @@ func (c *Controller) Mark() map[string]int {
 	for uuid, model := range c.models {
 		result[uuid] = model.mark()
 	}
-	c.metrics.GCMark.Inc()
 	c.mu.Unlock()
 	return result
 }
@@ -149,7 +148,6 @@ func (c *Controller) Sweep() (map[string]SweepInfo, error) {
 			StaleCount: len(deltas.Deltas),
 		}
 	}
-	c.metrics.GCSweep.Inc()
 	c.mu.Unlock()
 
 	// Go through all the deltas and dispatch the removal deltas we
@@ -159,6 +157,8 @@ func (c *Controller) Sweep() (map[string]SweepInfo, error) {
 	for _, delta := range removalOps {
 		c.dispatch(delta)
 	}
+	// Ensure we fire off the collection metric
+	c.metrics.GCCollection.Inc()
 	return result, nil
 }
 

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -81,6 +81,21 @@ func (s *ControllerSuite) TestRemoveModel(c *gc.C) {
 	c.Check(controller.Report(), gc.HasLen, 0)
 }
 
+func (s *ControllerSuite) TestRemoveModelDeletesCascades(c *gc.C) {
+	controller, events := s.new(c)
+	s.processChange(c, modelChange, events)
+	s.processChange(c, appChange, events)
+	s.processChange(c, charmChange, events)
+	s.processChange(c, machineChange, events)
+	s.processChange(c, unitChange, events)
+
+	remove := cache.RemoveModel{ModelUUID: modelChange.ModelUUID}
+	s.processChange(c, remove, events)
+
+	c.Check(controller.ModelUUIDs(), gc.HasLen, 0)
+	c.Check(controller.Report(), gc.HasLen, 0)
+}
+
 func (s *ControllerSuite) TestAddApplication(c *gc.C) {
 	controller, events := s.new(c)
 	s.processChange(c, appChange, events)

--- a/core/cache/entity.go
+++ b/core/cache/entity.go
@@ -1,11 +1,19 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package cache
 
 import "sync"
 
+// State represents the current entity lifecycle.
 type State uint8
 
 const (
+	// Stale represents a lifecycle state that defines if an entity is stale
+	// and isn't currently active.
 	Stale State = iota
+	// Active lifecycle state defines a entity state that represents a the
+	// entity is currently active.
 	Active
 )
 
@@ -25,4 +33,28 @@ func (e *Entity) isStale() bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.state == Stale
+}
+
+// staler represents a way to call isStale on any entity model item, without
+// casting between the item and the base entity item.
+type staler interface {
+	isStale() bool
+}
+
+// SweepChecker represents a checker to walk over all entities in a cache
+// to see which are active and stale.
+type SweepChecker struct {
+	Active, Stale int
+}
+
+// Check takes an Entity and works out if an entity is stale or active.
+// Returns true if additional work when it's stale is required.
+func (s *SweepChecker) Check(e staler) bool {
+	res := e.isStale()
+	if res {
+		s.Stale++
+	} else {
+		s.Active++
+	}
+	return res
 }

--- a/core/cache/entity.go
+++ b/core/cache/entity.go
@@ -24,12 +24,16 @@ type Entity struct {
 	watchers []Watcher
 }
 
+// mark updates the state to be classified as stale.
 func (e *Entity) mark() {
 	e.mu.Lock()
 	e.state = Stale
 	e.mu.Unlock()
 }
 
+// sweep goes through and creates a set of deltas for the entity. That way
+// we can feed that back into the controller so it cleans up the entities in
+// one code path.
 func (e *Entity) sweep() *SweepDeltas {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -49,12 +53,16 @@ func (e *Entity) sweep() *SweepDeltas {
 	}
 }
 
+// registerWatcher allows the tracking of a watcher, so when removing we can
+// kill the watcher.
 func (e *Entity) registerWatcher(w Watcher) {
 	e.mu.Lock()
 	e.watchers = append(e.watchers, w)
 	e.mu.Unlock()
 }
 
+// remove is called when the entity is being cleaned up, so it can kill the
+// watchers.
 func (e *Entity) remove() {
 	for _, watcher := range e.watchers {
 		watcher.Kill()

--- a/core/cache/entity.go
+++ b/core/cache/entity.go
@@ -1,0 +1,28 @@
+package cache
+
+import "sync"
+
+type State uint8
+
+const (
+	Stale State = iota
+	Active
+)
+
+// Entity represents a base entity within the model cache
+type Entity struct {
+	state State
+	mu    sync.Mutex
+}
+
+func (e *Entity) mark() {
+	e.mu.Lock()
+	e.state = Stale
+	e.mu.Unlock()
+}
+
+func (e *Entity) isStale() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.state == Stale
+}

--- a/core/cache/entity_test.go
+++ b/core/cache/entity_test.go
@@ -1,0 +1,11 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package cache_test
+
+import gc "gopkg.in/check.v1"
+
+type EntitySuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&EntitySuite{})

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -110,6 +110,7 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 	})
 
 	m.model.mu.Unlock()
+	m.registerWatcher(w)
 	return w, nil
 }
 
@@ -170,7 +171,15 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 		hub:          m.model.hub,
 	})
 	m.model.mu.Unlock()
+	m.registerWatcher(w)
 	return w, nil
+}
+
+func (m *Machine) RemovalDelta() interface{} {
+	return RemoveMachine{
+		ModelUUID: m.details.ModelUUID,
+		Id:        m.details.Id,
+	}
 }
 
 func (m *Machine) containerRegexp() (*regexp.Regexp, error) {

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -18,6 +18,7 @@ func newMachine(model *Model) *Machine {
 	m := &Machine{
 		model: model,
 	}
+	m.Entity.removalDelta = m.removalDelta
 	return m
 }
 
@@ -175,7 +176,7 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 	return w, nil
 }
 
-func (m *Machine) RemovalDelta() interface{} {
+func (m *Machine) removalDelta() interface{} {
 	return RemoveMachine{
 		ModelUUID: m.details.ModelUUID,
 		Id:        m.details.Id,

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -6,7 +6,6 @@ package cache
 import (
 	"fmt"
 	"regexp"
-	"sync"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -17,15 +16,17 @@ import (
 
 func newMachine(model *Model) *Machine {
 	m := &Machine{
-		model: model,
+		Entity: &Entity{},
+		model:  model,
 	}
 	return m
 }
 
 // Machine represents a machine in a model.
 type Machine struct {
+	*Entity
+
 	model *Model
-	mu    sync.Mutex
 
 	modelUUID  string
 	details    MachineChange
@@ -184,7 +185,8 @@ func (m *Machine) modelTopic(suffix string) string {
 
 func (m *Machine) setDetails(details MachineChange) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+
+	m.state = Active
 	m.details = details
 
 	configHash, err := hash(details.Config)
@@ -196,4 +198,5 @@ func (m *Machine) setDetails(details MachineChange) {
 		m.configHash = configHash
 		// TODO: publish config change...
 	}
+	m.mu.Unlock()
 }

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -187,6 +187,11 @@ func (m *Machine) removalDelta() interface{} {
 	}
 }
 
+// remove cleans up any associated data with the machine
+func (m *Machine) remove() {
+	// TODO (stickupkid): clean watchers
+}
+
 func (m *Machine) containerRegexp() (*regexp.Regexp, error) {
 	regExp := fmt.Sprintf("^%s%s", m.details.Id, names.ContainerSnippet)
 	return regexp.Compile(regExp)

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -16,15 +16,14 @@ import (
 
 func newMachine(model *Model) *Machine {
 	m := &Machine{
-		Entity: &Entity{},
-		model:  model,
+		model: model,
 	}
 	return m
 }
 
 // Machine represents a machine in a model.
 type Machine struct {
-	*Entity
+	Entity
 
 	model *Model
 

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -257,3 +257,8 @@ var machineChange = cache.MachineChange{
 	HasVote:                  true,
 	WantsVote:                true,
 }
+
+var removeMachine = cache.RemoveMachine{
+	ModelUUID: "model-uuid",
+	Id:        "0",
+}

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -58,8 +58,7 @@ type ControllerGauges struct {
 	LXDProfileChangeHit   prometheus.Gauge
 	LXDProfileChangeMiss  prometheus.Gauge
 
-	GCMark  prometheus.Gauge
-	GCSweep prometheus.Gauge
+	GCCollection prometheus.Gauge
 }
 
 func createControllerGauges() *ControllerGauges {
@@ -127,18 +126,11 @@ func createControllerGauges() *ControllerGauges {
 				Help:      "The number of times an LXD Profile change was not found.",
 			},
 		),
-		GCMark: prometheus.NewGauge(
+		GCCollection: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: metricsNamespace,
-				Name:      "cache_gc_mark",
-				Help:      "The number of marks the garbage collector on the cache has performed.",
-			},
-		),
-		GCSweep: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: metricsNamespace,
-				Name:      "cache_gc_sweep",
-				Help:      "The number of sweeps the garbage collector on the cache has performed.",
+				Name:      "cache_gc_collection",
+				Help:      "The number of collections the garbage collector on the cache has performed.",
 			},
 		),
 	}
@@ -158,8 +150,7 @@ func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.LXDProfileChangeHit.Collect(ch)
 	c.LXDProfileChangeMiss.Collect(ch)
 
-	c.GCMark.Collect(ch)
-	c.GCSweep.Collect(ch)
+	c.GCCollection.Collect(ch)
 }
 
 // Collector is a prometheus.Collector that collects metrics about

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -8,6 +8,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var logger = loggo.GetLogger("juju.core.cache")
+
 const (
 	metricsNamespace = "juju_cache"
 
@@ -39,8 +41,6 @@ var (
 		disabledLabel,
 		domainLabel,
 	}
-
-	logger = loggo.GetLogger("juju.core.cache")
 )
 
 // ControllerGauges holds the prometheus gauges for ever increasing
@@ -57,6 +57,9 @@ type ControllerGauges struct {
 	LXDProfileChangeError prometheus.Gauge
 	LXDProfileChangeHit   prometheus.Gauge
 	LXDProfileChangeMiss  prometheus.Gauge
+
+	GCMark  prometheus.Gauge
+	GCSweep prometheus.Gauge
 }
 
 func createControllerGauges() *ControllerGauges {
@@ -124,6 +127,20 @@ func createControllerGauges() *ControllerGauges {
 				Help:      "The number of times an LXD Profile change was not found.",
 			},
 		),
+		GCMark: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "cache_gc_mark",
+				Help:      "The number of marks the garbage collector on the cache has performed.",
+			},
+		),
+		GCSweep: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "cache_gc_sweep",
+				Help:      "The number of sweeps the garbage collector on the cache has performed.",
+			},
+		),
 	}
 }
 
@@ -140,6 +157,9 @@ func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.LXDProfileChangeError.Collect(ch)
 	c.LXDProfileChangeHit.Collect(ch)
 	c.LXDProfileChangeMiss.Collect(ch)
+
+	c.GCMark.Collect(ch)
+	c.GCSweep.Collect(ch)
 }
 
 // Collector is a prometheus.Collector that collects metrics about

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -83,43 +83,31 @@ func (m *Model) mark() int {
 	return result
 }
 
-func (m *Model) sweep() SweepPhaseResult {
-	var result SweepPhaseResult
+func (m *Model) sweep() *SweepChecker {
+	checker := &SweepChecker{}
 	m.mu.Lock()
 	for key, app := range m.applications {
-		if app.isStale() {
+		if checker.Check(app) {
 			delete(m.applications, key)
-			result.Stale++
-		} else {
-			result.Active++
 		}
 	}
 	for key, charm := range m.charms {
-		if charm.isStale() {
+		if checker.Check(charm) {
 			delete(m.charms, key)
-			result.Stale++
-		} else {
-			result.Active++
 		}
 	}
 	for key, machine := range m.machines {
-		if machine.isStale() {
+		if checker.Check(machine) {
 			delete(m.machines, key)
-			result.Stale++
-		} else {
-			result.Active++
 		}
 	}
 	for key, unit := range m.units {
-		if unit.isStale() {
+		if checker.Check(unit) {
 			delete(m.units, key)
-			result.Stale++
-		} else {
-			result.Active++
 		}
 	}
 	m.mu.Unlock()
-	return result
+	return checker
 }
 
 // Report returns information that is used in the dependency engine report.

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -137,11 +137,9 @@ func (m *Model) WatchMachines() *PredicateStringsWatcher {
 	m.mu.Lock()
 
 	// Gather initial slice of machines in this model.
-	machines := make([]string, len(m.machines))
-	i := 0
-	for k := range m.machines {
-		machines[i] = k
-		i++
+	machines := make([]string, 0, len(m.machines))
+	for id := range m.machines {
+		machines = append(machines, id)
 	}
 
 	w := newChangeWatcher(machines...)

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -252,6 +252,29 @@ func (m *Model) removalDelta() interface{} {
 	}
 }
 
+// remove the other entities associated with the model, so everything is cleanly
+// cleaned up
+func (m *Model) remove() {
+	m.mu.Lock()
+	for key, app := range m.applications {
+		app.remove()
+		delete(m.applications, key)
+	}
+	for key, charm := range m.charms {
+		charm.remove()
+		delete(m.charms, key)
+	}
+	for key, machine := range m.machines {
+		machine.remove()
+		delete(m.machines, key)
+	}
+	for key, unit := range m.units {
+		unit.remove()
+		delete(m.units, key)
+	}
+	m.mu.Unlock()
+}
+
 // updateApplication adds or updates the application in the model.
 func (m *Model) updateApplication(ch ApplicationChange) {
 	m.mu.Lock()

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -278,3 +278,7 @@ var modelChange = cache.ModelChange{
 		Status: status.Active,
 	},
 }
+
+var removeModel = cache.RemoveModel{
+	ModelUUID: "model-uuid",
+}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -23,6 +23,7 @@ func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
 		metrics: metrics,
 		hub:     hub,
 	}
+	u.Entity.removalDelta = u.removalDelta
 	return u
 }
 
@@ -31,7 +32,7 @@ func (u *Unit) Application() string {
 	return u.details.Application
 }
 
-func (u *Unit) RemovalDelta() interface{} {
+func (u *Unit) removalDelta() interface{} {
 	return RemoveUnit{
 		ModelUUID: u.details.ModelUUID,
 		Name:      u.details.Name,

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -9,7 +9,7 @@ import (
 
 // Unit represents an unit in a cached model.
 type Unit struct {
-	*Entity
+	Entity
 
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
@@ -20,7 +20,6 @@ type Unit struct {
 
 func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
 	u := &Unit{
-		Entity:  &Entity{},
 		metrics: metrics,
 		hub:     hub,
 	}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -31,6 +31,13 @@ func (u *Unit) Application() string {
 	return u.details.Application
 }
 
+func (u *Unit) RemovalDelta() interface{} {
+	return RemoveUnit{
+		ModelUUID: u.details.ModelUUID,
+		Name:      u.details.Name,
+	}
+}
+
 func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
 	if u.details.MachineId != details.MachineId {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -45,6 +45,11 @@ func (u *Unit) removalDelta() interface{} {
 	}
 }
 
+// remove cleans up any associated data with the unit
+func (u *Unit) remove() {
+	// TODO (stickupkid): clean watchers
+}
+
 func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
 	if u.details.MachineId != details.MachineId {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -4,16 +4,15 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/juju/pubsub"
 )
 
 // Unit represents an unit in a cached model.
 type Unit struct {
+	*Entity
+
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
-	mu      sync.Mutex
 
 	details    UnitChange
 	configHash string
@@ -21,6 +20,7 @@ type Unit struct {
 
 func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
 	u := &Unit{
+		Entity:  &Entity{},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -37,6 +37,7 @@ func (u *Unit) setDetails(details UnitChange) {
 	if u.details.MachineId != details.MachineId {
 		u.hub.Publish(u.modelTopic(modelUnitLXDProfileChange), u)
 	}
+	u.state = Active
 	u.details = details
 
 	// TODO (manadart 2019-02-11): Maintain hash and publish changes.

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -34,3 +34,8 @@ var unitChange = cache.UnitChange{
 	WorkloadStatus: status.StatusInfo{Status: status.Active},
 	AgentStatus:    status.StatusInfo{Status: status.Active},
 }
+
+var removeUnit = cache.RemoveUnit{
+	ModelUUID: "model-uuid",
+	Name:      "application-name/0",
+}

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -66,6 +66,11 @@ func (w *notifyWatcherBase) Changes() <-chan struct{} {
 // Kill is part of the worker.Worker interface.
 func (w *notifyWatcherBase) Kill() {
 	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+
 	w.closed = true
 	close(w.changes)
 	w.mu.Unlock()

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -191,7 +191,7 @@ func (c *cacheWorker) loop() error {
 					}
 				}
 			}
-			c.mu.Lock()
+
 			if c.sweepRequired {
 				c.sweepRequired = false
 
@@ -202,7 +202,6 @@ func (c *cacheWorker) loop() error {
 				}
 				c.config.Logger.Tracef("sweeped %d stale entities", stale)
 			}
-			c.mu.Unlock()
 		}
 	}
 }

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -155,7 +155,7 @@ func (c *cacheWorker) loop() error {
 				stale += result
 			}
 			c.sweepRequired = stale > 0
-			c.config.Logger.Tracef("watcher marked %d stale entities", stale)
+			c.config.Logger.Tracef("marked %d stale entities", stale)
 
 			watcher := pool.SystemState().WatchAllModels(pool)
 			c.watcher = watcher
@@ -191,10 +191,6 @@ func (c *cacheWorker) loop() error {
 					}
 				}
 			}
-
-			// In theory we could just create a new controller and just apply
-			// the new delta's to that. We can track if a new controller is
-			// required in the same vein as sweepRequired.
 			c.mu.Lock()
 			if c.sweepRequired {
 				c.sweepRequired = false
@@ -204,7 +200,7 @@ func (c *cacheWorker) loop() error {
 				for _, sweepResult := range result {
 					stale += sweepResult.Stale
 				}
-				c.config.Logger.Tracef("watcher released %d stale entities", stale)
+				c.config.Logger.Tracef("sweeped %d stale entities", stale)
 			}
 			c.mu.Unlock()
 		}

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -195,10 +195,14 @@ func (c *cacheWorker) loop() error {
 			if c.sweepRequired {
 				c.sweepRequired = false
 
-				result := c.controller.Sweep()
+				result, err := c.controller.Sweep()
+				if err != nil {
+					c.config.Logger.Errorf("sweep error %v", err)
+					continue
+				}
 				var stale int
 				for _, sweepResult := range result {
-					stale += sweepResult.Stale
+					stale += sweepResult.FreshCount
 				}
 				c.config.Logger.Tracef("sweeped %d stale entities", stale)
 			}


### PR DESCRIPTION
## Description of change

The following commit is just a very rough idea around marking and
sweeping values in the model cache in the case that the cache
can have old stale items in it.

The problem this fixes is when the watcher restarts, but we have
old stale content in the cache. So we should clean up anything
that hasn't been updated.

*Note* this is very rough and I'm awaiting feedback before I can
continue on wards.

## QA steps

*Please replace with how we can verify that the change works?*

