### PR TITLE
Change so that a delay=0 doesn't use a timer.

### DIFF
--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -188,9 +188,10 @@ func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, err
 	// to prevent the test hanging.  If the given wait is up, then return
 	// the results; otherwise, return a pending status.
 
-	// First, sync.
-	_ = <-time.NewTimer(0 * time.Second).C
-
+	if c.delay == nil {
+		// No delay requested, just return immediately.
+		return params.ActionResults{Results: c.actionResults}, c.apiErr
+	}
 	select {
 	case _ = <-c.delay.C:
 		// The API delay timer is up.  Pass pre-canned results back.

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -314,8 +314,12 @@ func makeFakeClient(
 	actionsByNames params.ActionsByNames,
 	errStr string,
 ) *fakeAPIClient {
+	var delayTimer *time.Timer
+	if delay != 0 {
+		delayTimer = time.NewTimer(delay)
+	}
 	client := &fakeAPIClient{
-		delay:            time.NewTimer(delay),
+		delay:            delayTimer,
 		timeout:          time.NewTimer(timeout),
 		actionTagMatches: tags,
 		actionResults:    response,


### PR DESCRIPTION
## Description of change

We don't really want to use real clock time.NewTimer anyway, so get rid
of synchronization via 'time.NewTimer(0)' and just treat delay=0 as
being no delay at all.

## QA steps

```
$ go test -failfast -count=1000 -race -check.v -check.f StatusSuite.TestRun
```

Without this patch, I got a failure from time to time with running count=100, with the patch, 1000 runs complete in 23s and have no failures.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1780766