### PR TITLE
Make golinters optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ release-install: dep go-install
 
 pre-check:
 	@echo running pre-test checks
-	@$(PROJECT_DIR)/scripts/verify.bash
+	@IGNORE_GOLINTERS=1 $(PROJECT_DIR)/scripts/verify.bash
 
 check: dep pre-check
 	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ release-install: dep go-install
 
 pre-check:
 	@echo running pre-test checks
-	@IGNORE_GOLINTERS=1 $(PROJECT_DIR)/scripts/verify.bash
+	@INCLUDE_GOLINTERS=1 $(PROJECT_DIR)/scripts/verify.bash
 
 check: dep pre-check
 	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -72,7 +72,7 @@ go vet \
     $DIRNAMES || [ -n "$IGNORE_VET_WARNINGS" ]
 
 # Allow the ignoring of the golinters
-if [ -n "$IGNORE_GOLINTERS" ]; then
+if [ -n "$INCLUDE_GOLINTERS" ]; then
     echo "checking: golinters ..."
     ./scripts/golinters.bash
 else

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -72,7 +72,7 @@ go vet \
     $DIRNAMES || [ -n "$IGNORE_VET_WARNINGS" ]
 
 # Allow the ignoring of the golinters
-if [ -z "$IGNORE_GOLINTERS" ]; then
+if [ -n "$IGNORE_GOLINTERS" ]; then
     echo "checking: golinters ..."
     ./scripts/golinters.bash
 else


### PR DESCRIPTION
## Description of change

The following PR changes the golinters to be optional, to prevent
timeouts from certain setups. Also people can turn them on easily
by setting the IGNORE_GOLINTERS=1.

## QA steps

If you've set up the git pre-push, this just runs `./scripts/verify.bash`
So to test it, you can run `./scripts/verify.bash` and it will ignore the
golinters, otherwise setting `IGNORE_GOLINTERS=1` and running
the command again, should run the golinters.
