### PR TITLE
Expose ca cert fingerprint in show controller output

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -67,7 +67,7 @@ func NewServer(caCertPEM, caKeyPEM string, expiry time.Time, hostnames []string)
 	})
 }
 
-var hexAlphabet = [16]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}
+var hexAlphabet = []byte("0123456789ABCDEF")
 
 // Fingerprint returns a human-readable SHA-256 fingerprint for a certificate
 // stored in the PEM format. The returned fingerprint matches the output of:

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -252,6 +252,31 @@ func (certSuite) TestNewServerHostnames(c *gc.C) {
 	}
 }
 
+func (certSuite) TestFingerprint(c *gc.C) {
+	tests := []struct {
+		input     string
+		exp       string
+		expErrStr string
+	}{
+		{"not in pem format", "", "input does not contain a valid certificate in PEM format"},
+		{"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----", "", "cannot calculate certificate fingerprint: asn1: syntax error: sequence truncated"},
+		{caCertPEM, "93:D9:8E:B8:99:36:E8:8E:23:D5:95:5E:81:29:80:B2:D2:89:A7:38:20:7B:1B:BD:96:C8:D9:C1:03:88:55:70", ""},
+	}
+
+	for i, t := range tests {
+		c.Logf("test %d: ", i)
+
+		fp, err := cert.Fingerprint(t.input)
+		if t.expErrStr == "" {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(fp, gc.Equals, t.exp)
+		} else {
+			c.Assert(err.Error(), gc.Equals, t.expErrStr)
+		}
+	}
+
+}
+
 // roundTime returns t rounded to the previous whole second.
 func roundTime(t time.Time) time.Time {
 	return t.Add(time.Duration(-t.Nanosecond()))

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -254,24 +254,37 @@ func (certSuite) TestNewServerHostnames(c *gc.C) {
 
 func (certSuite) TestFingerprint(c *gc.C) {
 	tests := []struct {
-		input     string
-		exp       string
-		expErrStr string
+		descr string
+		input string
+		exp   string
+		err   string
 	}{
-		{"not in pem format", "", "input does not contain a valid certificate in PEM format"},
-		{"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----", "", "cannot calculate certificate fingerprint: asn1: syntax error: sequence truncated"},
-		{caCertPEM, "93:D9:8E:B8:99:36:E8:8E:23:D5:95:5E:81:29:80:B2:D2:89:A7:38:20:7B:1B:BD:96:C8:D9:C1:03:88:55:70", ""},
+		{
+			descr: "certificate not in PEM format",
+			input: "not in pem format",
+			err:   "input does not contain a valid certificate in PEM format",
+		},
+		{
+			descr: "PEM envelope without a valid certificate",
+			input: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----",
+			err:   "cannot calculate certificate fingerprint: asn1: syntax error: sequence truncated",
+		},
+		{
+			descr: "valid certificate in PEM format",
+			input: caCertPEM,
+			exp:   "93:D9:8E:B8:99:36:E8:8E:23:D5:95:5E:81:29:80:B2:D2:89:A7:38:20:7B:1B:BD:96:C8:D9:C1:03:88:55:70",
+		},
 	}
 
 	for i, t := range tests {
-		c.Logf("test %d: ", i)
+		c.Logf("test %d: %s", i, t.descr)
 
 		fp, err := cert.Fingerprint(t.input)
-		if t.expErrStr == "" {
+		if t.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(fp, gc.Equals, t.exp)
 		} else {
-			c.Assert(err.Error(), gc.Equals, t.expErrStr)
+			c.Assert(err.Error(), gc.Equals, t.err)
 		}
 	}
 

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -57,23 +57,23 @@ controllers:
   aws-test:
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
-    ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
     model-count: 2
     machine-count: 5
     agent-version: 2.0.1
+    ca-cert: this-is-aws-test-ca-cert
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
+    ca-cert: this-is-another-ca-cert
   mark-test-prodstack:
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
-    ca-cert: this-is-a-ca-cert
     cloud: prodstack
+    ca-cert: this-is-a-ca-cert
 current-controller: mallards
 `
 

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -286,12 +286,6 @@ type ControllerDetails struct {
 	// APIEndpoints is the collection of API endpoints running in this controller.
 	APIEndpoints []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
 
-	// CACert is a security certificate for this controller.
-	CACert string `yaml:"ca-cert" json:"ca-cert"`
-
-	// SHA-256 fingerprint of the CA cert
-	CAFingerprint string `yaml:"ca-fingerprint,omitempty" json:"ca-fingerprint,omitempty"`
-
 	// Cloud is the name of the cloud that this controller runs in.
 	Cloud string `yaml:"cloud" json:"cloud"`
 
@@ -311,6 +305,12 @@ type ControllerDetails struct {
 	// IdentityURL contails the address of an external identity provider
 	// if one has been configured for this controller.
 	IdentityURL string `yaml:"identity-url,omitempty" json:"identity-url,omitempty"`
+
+	// SHA-256 fingerprint of the CA cert
+	CAFingerprint string `yaml:"ca-fingerprint,omitempty" json:"ca-fingerprint,omitempty"`
+
+	// CACert is a security certificate for this controller.
+	CACert string `yaml:"ca-cert" json:"ca-cert"`
 }
 
 // ModelDetails holds details of a model to show.

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cert"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/status"
@@ -288,6 +289,9 @@ type ControllerDetails struct {
 	// CACert is a security certificate for this controller.
 	CACert string `yaml:"ca-cert" json:"ca-cert"`
 
+	// SHA-256 fingerprint of the CA cert
+	CAFingerprint string `yaml:"ca-fingerprint,omitempty" json:"ca-fingerprint,omitempty"`
+
 	// Cloud is the name of the cloud that this controller runs in.
 	Cloud string `yaml:"cloud" json:"cloud"`
 
@@ -359,12 +363,15 @@ func (c *showControllerCommand) convertControllerForShow(
 	mongoVersion string,
 	identityURL string,
 ) {
+	// CA cert will always be valid so no need to check for errors here
+	caFingerprint, _ := cert.Fingerprint(details.CACert)
 
 	controller.Details = ControllerDetails{
 		ControllerUUID:    details.ControllerUUID,
 		OldControllerUUID: details.ControllerUUID,
 		APIEndpoints:      details.APIEndpoints,
 		CACert:            details.CACert,
+		CAFingerprint:     caFingerprint,
 		Cloud:             details.Cloud,
 		CloudRegion:       details.CloudRegion,
 		AgentVersion:      details.AgentVersion,

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -58,10 +58,10 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-another-ca-cert
 `
 	s.createTestClientStore(c)
 
@@ -71,10 +71,10 @@ mallards:
     uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-another-ca-cert
   models:
     controller:
       uuid: abc
@@ -100,10 +100,10 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-another-ca-cert
 `
 	s.createTestClientStore(c)
 
@@ -113,10 +113,10 @@ mallards:
     uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-another-ca-cert
   models:
     controller:
       uuid: abc
@@ -143,11 +143,11 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-another-ca-cert
 `
 	store := s.createTestClientStore(c)
 	store.BootstrapConfig["mallards"] = jujuclient.BootstrapConfig{
@@ -169,11 +169,11 @@ mallards:
     uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     region: mallards1
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-another-ca-cert
   models:
     controller:
       uuid: abc
@@ -203,11 +203,11 @@ aws-test:
     uuid: this-is-the-aws-test-uuid
     controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
-    ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-aws-test-ca-cert
   controller-machines:
     "0":
       instance-id: id-0
@@ -240,11 +240,11 @@ aws-test:
     uuid: this-is-the-aws-test-uuid
     controller-uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
-    ca-cert: this-is-aws-test-ca-cert
     cloud: aws
     region: us-east-1
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-aws-test-ca-cert
   controller-machines:
     "0":
       instance-id: id-0
@@ -270,10 +270,10 @@ mark-test-prodstack:
     uuid: this-is-a-uuid
     controller-uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
-    ca-cert: this-is-a-ca-cert
     cloud: prodstack
     agent-version: 999.99.99
     mongo-version: 3.5.12
+    ca-cert: this-is-a-ca-cert
   account:
     user: admin
     access: superuser
@@ -293,9 +293,9 @@ func (s *ShowControllerSuite) TestShowOneControllerWithAPIVersionTooLow(c *gc.C)
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    ca-cert: this-is-another-ca-cert
 `
 	s.createTestClientStore(c)
 
@@ -305,9 +305,9 @@ mallards:
     uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    ca-cert: this-is-another-ca-cert
   models:
     controller:
       uuid: abc
@@ -332,7 +332,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12","ca-cert":"this-is-aws-test-ca-cert"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "aws-test")
@@ -341,7 +341,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert","cloud":"prodstack","agent-version":"999.99.99","mongo-version":"3.5.12"},"account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12","ca-cert":"this-is-aws-test-ca-cert"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}},"mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"cloud":"prodstack","agent-version":"999.99.99","mongo-version":"3.5.12","ca-cert":"this-is-a-ca-cert"},"account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "aws-test", "mark-test-prodstack")
 }
@@ -364,7 +364,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	store.CurrentControllerName = "aws-test"
 
 	s.expectedOutput = `
-{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert","cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
+{"aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"cloud":"aws","region":"us-east-1","agent-version":"999.99.99","mongo-version":"3.5.12","ca-cert":"this-is-aws-test-ca-cert"},"controller-machines":{"0":{"instance-id":"id-0","ha-status":"ha-pending"},"1":{"instance-id":"id-1","ha-status":"down, lost connection"},"2":{"instance-id":"id-2","ha-status":"ha-enabled"}},"models":{"controller":{"uuid":"ghi","machine-count":2,"core-count":4}},"current-model":"admin/controller","account":{"user":"admin","access":"superuser"}}}
 `[1:]
 	s.assertShowController(c, "--format", "json")
 }
@@ -430,9 +430,9 @@ func (s *ShowControllerSuite) TestShowControllerForUserWithLoginAccess(c *gc.C) 
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    ca-cert: this-is-another-ca-cert
 `
 	s.expectedOutput = `
 mallards:
@@ -440,9 +440,9 @@ mallards:
     uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
-    ca-cert: this-is-another-ca-cert
     cloud: mallards
     agent-version: 999.99.99
+    ca-cert: this-is-another-ca-cert
   current-model: admin/my-model
   account:
     user: admin
@@ -473,6 +473,9 @@ func (s *ShowControllerSuite) TestShowControllerWithCAFingerprint(c *gc.C) {
   mallards:
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    cloud: mallards
+    agent-version: 999.99.99
+    mongo-version: 3.5.12
     ca-cert: |-
       -----BEGIN CERTIFICATE-----
       MIICHDCCAcagAwIBAgIUfzWn5ktGMxD6OiTgfiZyvKdM+ZYwDQYJKoZIhvcNAQEL
@@ -488,9 +491,6 @@ func (s *ShowControllerSuite) TestShowControllerWithCAFingerprint(c *gc.C) {
       ovZN0RbUHrO8q9Eazh0qPO4mwW9jbGTDz126uNrLoz1g3TyWxIas1wRJ8IbCgxLy
       XUrBZO5UPZab66lJWXyseA==
       -----END CERTIFICATE-----
-    cloud: mallards
-    agent-version: 999.99.99
-    mongo-version: 3.5.12
 `
 	s.createTestClientStore(c)
 
@@ -500,6 +500,10 @@ mallards:
     uuid: this-is-another-uuid
     controller-uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    cloud: mallards
+    agent-version: 999.99.99
+    mongo-version: 3.5.12
+    ca-fingerprint: 93:D9:8E:B8:99:36:E8:8E:23:D5:95:5E:81:29:80:B2:D2:89:A7:38:20:7B:1B:BD:96:C8:D9:C1:03:88:55:70
     ca-cert: |-
       -----BEGIN CERTIFICATE-----
       MIICHDCCAcagAwIBAgIUfzWn5ktGMxD6OiTgfiZyvKdM+ZYwDQYJKoZIhvcNAQEL
@@ -515,10 +519,6 @@ mallards:
       ovZN0RbUHrO8q9Eazh0qPO4mwW9jbGTDz126uNrLoz1g3TyWxIas1wRJ8IbCgxLy
       XUrBZO5UPZab66lJWXyseA==
       -----END CERTIFICATE-----
-    ca-fingerprint: 93:D9:8E:B8:99:36:E8:8E:23:D5:95:5E:81:29:80:B2:D2:89:A7:38:20:7B:1B:BD:96:C8:D9:C1:03:88:55:70
-    cloud: mallards
-    agent-version: 999.99.99
-    mongo-version: 3.5.12
   models:
     controller:
       uuid: abc

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -468,6 +468,77 @@ func (s *ShowControllerSuite) TestShowControllerWithIdentityProvider(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, "identity-url: "+expURL)
 }
 
+func (s *ShowControllerSuite) TestShowControllerWithCAFingerprint(c *gc.C) {
+	s.controllersYaml = `controllers:
+  mallards:
+    uuid: this-is-another-uuid
+    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    ca-cert: |-
+      -----BEGIN CERTIFICATE-----
+      MIICHDCCAcagAwIBAgIUfzWn5ktGMxD6OiTgfiZyvKdM+ZYwDQYJKoZIhvcNAQEL
+      BQAwazENMAsGA1UEChMEanVqdTEzMDEGA1UEAwwqanVqdS1nZW5lcmF0ZWQgQ0Eg
+      Zm9yIG1vZGVsICJqdWp1IHRlc3RpbmciMSUwIwYDVQQFExwxMjM0LUFCQ0QtSVMt
+      Tk9ULUEtUkVBTC1VVUlEMB4XDTE2MDkyMTEwNDgyN1oXDTI2MDkyODEwNDgyN1ow
+      azENMAsGA1UEChMEanVqdTEzMDEGA1UEAwwqanVqdS1nZW5lcmF0ZWQgQ0EgZm9y
+      IG1vZGVsICJqdWp1IHRlc3RpbmciMSUwIwYDVQQFExwxMjM0LUFCQ0QtSVMtTk9U
+      LUEtUkVBTC1VVUlEMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAL+0X+1zl2vt1wI4
+      1Q+RnlltJyaJmtwCbHRhREXVGU7t0kTMMNERxqLnuNUyWRz90Rg8s9XvOtCqNYW7
+      mypGrFECAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8w
+      HQYDVR0OBBYEFHueMLZ1QJ/2sKiPIJ28TzjIMRENMA0GCSqGSIb3DQEBCwUAA0EA
+      ovZN0RbUHrO8q9Eazh0qPO4mwW9jbGTDz126uNrLoz1g3TyWxIas1wRJ8IbCgxLy
+      XUrBZO5UPZab66lJWXyseA==
+      -----END CERTIFICATE-----
+    cloud: mallards
+    agent-version: 999.99.99
+    mongo-version: 3.5.12
+`
+	s.createTestClientStore(c)
+
+	s.expectedOutput = `
+mallards:
+  details:
+    uuid: this-is-another-uuid
+    controller-uuid: this-is-another-uuid
+    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    ca-cert: |-
+      -----BEGIN CERTIFICATE-----
+      MIICHDCCAcagAwIBAgIUfzWn5ktGMxD6OiTgfiZyvKdM+ZYwDQYJKoZIhvcNAQEL
+      BQAwazENMAsGA1UEChMEanVqdTEzMDEGA1UEAwwqanVqdS1nZW5lcmF0ZWQgQ0Eg
+      Zm9yIG1vZGVsICJqdWp1IHRlc3RpbmciMSUwIwYDVQQFExwxMjM0LUFCQ0QtSVMt
+      Tk9ULUEtUkVBTC1VVUlEMB4XDTE2MDkyMTEwNDgyN1oXDTI2MDkyODEwNDgyN1ow
+      azENMAsGA1UEChMEanVqdTEzMDEGA1UEAwwqanVqdS1nZW5lcmF0ZWQgQ0EgZm9y
+      IG1vZGVsICJqdWp1IHRlc3RpbmciMSUwIwYDVQQFExwxMjM0LUFCQ0QtSVMtTk9U
+      LUEtUkVBTC1VVUlEMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAL+0X+1zl2vt1wI4
+      1Q+RnlltJyaJmtwCbHRhREXVGU7t0kTMMNERxqLnuNUyWRz90Rg8s9XvOtCqNYW7
+      mypGrFECAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8w
+      HQYDVR0OBBYEFHueMLZ1QJ/2sKiPIJ28TzjIMRENMA0GCSqGSIb3DQEBCwUAA0EA
+      ovZN0RbUHrO8q9Eazh0qPO4mwW9jbGTDz126uNrLoz1g3TyWxIas1wRJ8IbCgxLy
+      XUrBZO5UPZab66lJWXyseA==
+      -----END CERTIFICATE-----
+    ca-fingerprint: 93:D9:8E:B8:99:36:E8:8E:23:D5:95:5E:81:29:80:B2:D2:89:A7:38:20:7B:1B:BD:96:C8:D9:C1:03:88:55:70
+    cloud: mallards
+    agent-version: 999.99.99
+    mongo-version: 3.5.12
+  models:
+    controller:
+      uuid: abc
+      model-uuid: abc
+      machine-count: 2
+      core-count: 4
+    my-model:
+      uuid: def
+      model-uuid: def
+      machine-count: 2
+      core-count: 4
+  current-model: admin/my-model
+  account:
+    user: admin
+    access: superuser
+    password: hunter2
+`[1:]
+
+	s.assertShowController(c, "mallards", "--show-password")
+}
 func (s *ShowControllerSuite) runShowController(c *gc.C, args ...string) (*cmd.Context, error) {
 	return cmdtesting.RunCommand(c, controller.NewShowControllerCommandForTest(s.store, s.api), args...)
 }


### PR DESCRIPTION
## Description of change

This PR updates the show-controller command to include a SHA-256 fingerprint for the controller's CA cert. It is part of the work required for implementing redirects for migrated models. The fingerprint format matches the output of `openssl x509 -noout -fingerprint -sha256 -inform pem -in CA.pem` 

## QA steps

```console
$ juju bootstrap lxd lxd-test
$ juju show-controller | grep ca-
 ca-cert: |
    ca-fingerprint: XX:YY:....:ZZ

# As an extra check verify that openssl output matches fingerprint
$ juju show-controller \
    | sed -n -e '/ca-cert:/,/  -----END/p; / -----END/q' \
    | sed -e 's/^[ ]*//' \
    | tail -n+2 \
    | openssl x509 -noout -fingerprint -sha256 -inform PEM
SHA256 Fingerprint=XX:YY:...:ZZ
```

## Documentation changes

@pmatulis Do we need to update the man pages to include the new attribute in the `show-controller` output?