### PR TITLE
Use Existing Mongo Util for Escaping Keys

### DIFF
--- a/state/annotations.go
+++ b/state/annotations.go
@@ -159,14 +159,13 @@ func annotationRemoveOp(mb modelBackend, id string) txn.Op {
 // are non-empty.
 func setUnsetUpdateAnnotations(set, unset bson.M) bson.D {
 	var update bson.D
-	replace := inSubdocReplacer("annotations")
 	if len(set) > 0 {
-		set = bson.M(copyMap(map[string]interface{}(set), replace))
-		update = append(update, bson.DocElem{"$set", set})
+		set = bson.M(subDocKeys(map[string]interface{}(set), "annotations"))
+		update = append(update, bson.DocElem{Name: "$set", Value: set})
 	}
 	if len(unset) > 0 {
-		unset = bson.M(copyMap(map[string]interface{}(unset), replace))
-		update = append(update, bson.DocElem{"$unset", unset})
+		unset = bson.M(subDocKeys(map[string]interface{}(unset), "annotations"))
+		update = append(update, bson.DocElem{Name: "$unset", Value: unset})
 	}
 	return update
 }

--- a/state/application.go
+++ b/state/application.go
@@ -2175,7 +2175,7 @@ func (a *Application) LeaderSettings() (map[string]string, error) {
 	}
 	result := make(map[string]string)
 	for escapedKey, interfaceValue := range doc.Settings {
-		key := unescapeReplacer.Replace(escapedKey)
+		key := mgoutils.UnescapeKey(escapedKey)
 		if value, _ := interfaceValue.(string); value != "" {
 			// Empty strings are technically bad data -- when set, they clear.
 			result[key] = value
@@ -2202,7 +2202,7 @@ func (a *Application) UpdateLeaderSettings(token leadership.Token, updates map[s
 	sets := bson.M{}
 	unsets := bson.M{}
 	for unescapedKey, value := range updates {
-		key := escapeReplacer.Replace(unescapedKey)
+		key := mgoutils.EscapeKey(unescapedKey)
 		if value == "" {
 			unsets[key] = 1
 		} else {

--- a/state/charm.go
+++ b/state/charm.go
@@ -323,7 +323,7 @@ func safeConfig(ch charm.Charm) *charm.Config {
 	cfg := ch.Config()
 	escapedConfig := charm.NewConfig()
 	for optionName, option := range cfg.Options {
-		escapedName := escapeReplacer.Replace(optionName)
+		escapedName := mongoutils.EscapeKey(optionName)
 		escapedConfig.Options[escapedName] = option
 	}
 	return escapedConfig
@@ -371,7 +371,7 @@ func newCharm(st *State, cdoc *charmDoc) *Charm {
 	if cdoc != nil && cdoc.Config != nil {
 		unescapedConfig := charm.NewConfig()
 		for optionName, option := range cdoc.Config.Options {
-			unescapedName := unescapeReplacer.Replace(optionName)
+			unescapedName := mongoutils.UnescapeKey(optionName)
 			unescapedConfig.Options[unescapedName] = option
 		}
 		cdoc.Config = unescapedConfig


### PR DESCRIPTION
## Description of change

This is a small tidy-up patch to remove logic from `state/settings.go` for escaping MongoDB document keys, that duplicates logic in _mongo/utils_.

Two minor changes accompany:
- Transforming keys for sub-documents has a nicer abstraction.
- Upgrade tests use the correct escape functions, with some redundant calls removed.

## QA steps

All unit tests continue to pass.

## Documentation changes

None.

## Bug reference

N/A
