### PR TITLE
adding AssignProfiles to LXDProfileManager interface for instance mutater worker

### DIFF
--- a/container/interface.go
+++ b/container/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/instances"
 )
@@ -82,10 +83,19 @@ func (m ManagerConfig) WarnAboutUnused() {
 // LXDProfileManager defines an interface for dealing with lxd profiles used to
 // deploy juju containers.
 type LXDProfileManager interface {
+	// AssignProfiles assigns the given profile names to the lxd instance
+	// provided.  The slice of ProfilePosts provides details for adding to
+	// and removing profiles from the lxd server.
+	AssignProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
+
 	// MaybeWriteLXDProfile, write given LXDProfile to machine if not already
 	// there.
 	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
 
+	// TODO: HML 2-apr-2019
+	// remove when provisioner_task processProfileChanges() is
+	// removed.
+	//
 	// ReplaceOrAddInstanceProfile replaces, adds, a charm profile to
 	// the given instance and returns a slice of LXD profiles applied
 	// to the instance. Replace happens inplace in the current order of

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -290,6 +291,10 @@ func (m *containerManager) networkDevicesFromConfig(netConfig *container.Network
 	return nics, nil, errors.Trace(err)
 }
 
+// TODO: HML 2-apr-2019
+// When provisioner_task processProfileChanges() is
+// removed, maybe change to take an lxdprofile.ProfilePost as
+// an arg.
 // MaybeWriteLXDProfile implements container.LXDProfileManager.
 func (m *containerManager) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
 	m.profileMutex.Lock()
@@ -318,6 +323,9 @@ func (m *containerManager) LXDProfileNames(containerName string) ([]string, erro
 	return m.server.GetContainerProfiles(containerName)
 }
 
+// TODO: HML 2-apr-2019
+// remove when provisioner_task processProfileChanges() is
+// removed.
 // ReplaceOrAddLXDProfile implements environs.LXDProfiler.
 func (m *containerManager) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
 	if put != nil {
@@ -332,6 +340,47 @@ func (m *containerManager) ReplaceOrAddInstanceProfile(instId, oldProfile, newPr
 		if err := m.server.DeleteProfile(oldProfile); err != nil {
 			// most likely the failure is because the profile is already in use
 			logger.Debugf("failed to delete profile %q: %s", oldProfile, err)
+		}
+	}
+	return m.LXDProfileNames(instId)
+}
+
+// AssignProfiles implements environs.LXDProfiler.
+func (m *containerManager) AssignProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
+	defer func() ([]string, error) {
+		if err != nil {
+			var err2 error
+			current, err2 = m.LXDProfileNames(instId)
+			if err2 != nil {
+				logger.Errorf("secondary error, retrieving profile names: %s", err2)
+			}
+		}
+		return current, err
+	}()
+
+	deleteProfiles := []string{}
+
+	// Write any new profilePosts and gather a slice of profile
+	// names to be deleted, after removal.
+	for _, p := range profilePosts {
+		if p.Profile != nil {
+			pr := charm.LXDProfile(*p.Profile)
+			if err := m.MaybeWriteLXDProfile(p.Name, &pr); err != nil {
+				return nil, err
+			}
+		} else {
+			deleteProfiles = append(deleteProfiles, p.Name)
+		}
+	}
+
+	if err := m.server.UpdateContainerProfiles(instId, profilesNames); err != nil {
+		return []string{}, errors.Trace(err)
+	}
+
+	for _, name := range deleteProfiles {
+		if err := m.server.DeleteProfile(name); err != nil {
+			// Most likely the failure is because the profile is already in use.
+			logger.Debugf("failed to delete profile %q: %s", name, err)
 		}
 	}
 	return m.LXDProfileNames(instId)

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -37,28 +37,34 @@ func Test(t *stdtesting.T) {
 
 type managerSuite struct {
 	lxdtesting.BaseSuite
+
+	cSvr           *lxdtesting.MockContainerServer
+	createRemoteOp *lxdtesting.MockRemoteOperation
+	deleteOp       *lxdtesting.MockOperation
+	startOp        *lxdtesting.MockOperation
+	stopOp         *lxdtesting.MockOperation
+	updateOp       *lxdtesting.MockOperation
+	manager        container.Manager
 }
 
 var _ = gc.Suite(&managerSuite{})
 
-func (s *managerSuite) patch(svr lxdclient.ImageServer) {
-	lxd.PatchConnectRemote(s, map[string]lxdclient.ImageServer{"cloud-images.ubuntu.com": svr})
+func (s *managerSuite) patch() {
+	lxd.PatchConnectRemote(s, map[string]lxdclient.ImageServer{"cloud-images.ubuntu.com": s.cSvr})
 	lxd.PatchGenerateVirtualMACAddress(s)
 }
 
-func (s *managerSuite) makeManager(c *gc.C, svr lxdclient.ContainerServer) container.Manager {
-	return s.makeManagerForConfig(c, getBaseConfig(), svr)
+func (s *managerSuite) makeManager(c *gc.C) {
+	s.makeManagerForConfig(c, getBaseConfig())
 }
 
-func (s *managerSuite) makeManagerForConfig(
-	c *gc.C, cfg container.ManagerConfig, cSvr lxdclient.ContainerServer,
-) container.Manager {
-	svr, err := lxd.NewServer(cSvr)
+func (s *managerSuite) makeManagerForConfig(c *gc.C, cfg container.ManagerConfig) {
+	svr, err := lxd.NewServer(s.cSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
 	manager, err := lxd.NewContainerManager(cfg, svr)
 	c.Assert(err, jc.ErrorIsNil)
-	return manager
+	s.manager = manager
 }
 
 func getBaseConfig() container.ManagerConfig {
@@ -119,31 +125,25 @@ func prepNetworkConfig() *container.NetworkConfig {
 }
 
 func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setup(c)
 	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
-	s.patch(cSvr)
+	s.patch()
+	s.makeManager(c)
 
-	manager := s.makeManager(c, cSvr)
 	iCfg := prepInstanceConfig(c)
-	hostName, err := manager.Namespace().Hostname(iCfg.MachineId)
+	hostName, err := s.manager.Namespace().Hostname(iCfg.MachineId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Operation arrangements.
-	startOp := lxdtesting.NewMockOperation(ctrl)
-	startOp.EXPECT().Wait().Return(nil)
+	s.expectStartOp(ctrl)
+	s.expectStopOp(ctrl)
+	s.expectDeleteOp(ctrl)
 
-	stopOp := lxdtesting.NewMockOperation(ctrl)
-	stopOp.EXPECT().Wait().Return(nil)
-
-	deleteOp := lxdtesting.NewMockOperation(ctrl)
-	deleteOp.EXPECT().Wait().Return(nil)
-
-	exp := cSvr.EXPECT()
+	exp := s.cSvr.EXPECT()
 
 	// Arrangements for the container creation.
-	expectCreateContainer(ctrl, cSvr, "juju/xenial/"+s.Arch(), "foo-target")
-	exp.UpdateContainerState(hostName, lxdapi.ContainerStatePut{Action: "start", Timeout: -1}, "").Return(startOp, nil)
+	s.expectCreateContainer(ctrl)
+	exp.UpdateContainerState(hostName, lxdapi.ContainerStatePut{Action: "start", Timeout: -1}, "").Return(s.startOp, nil)
 
 	exp.GetContainerState(hostName).Return(
 		&lxdapi.ContainerState{StatusCode: lxdapi.Running}, lxdtesting.ETag, nil).Times(2)
@@ -158,11 +158,11 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 		Force:    true,
 	}
 	gomock.InOrder(
-		exp.UpdateContainerState(hostName, stopReq, lxdtesting.ETag).Return(stopOp, nil),
-		exp.DeleteContainer(hostName).Return(deleteOp, nil),
+		exp.UpdateContainerState(hostName, stopReq, lxdtesting.ETag).Return(s.stopOp, nil),
+		exp.DeleteContainer(hostName).Return(s.deleteOp, nil),
 	)
 
-	instance, hc, err := manager.CreateContainer(
+	instance, hc, err := s.manager.CreateContainer(
 		iCfg, constraints.Value{}, "xenial", prepNetworkConfig(), &container.StorageConfig{}, lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -174,22 +174,22 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 	c.Check(instanceStatus.Status, gc.Equals, status.Running)
 	c.Check(*hc.AvailabilityZone, gc.Equals, "test-availability-zone")
 
-	err = manager.DestroyContainer(instanceId)
+	err = s.manager.DestroyContainer(instanceId)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupWithExtensions(c, "network")
 	defer ctrl.Finish()
-	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
-	s.patch(cSvr)
 
-	manager := s.makeManager(c, cSvr)
+	s.patch()
+
+	s.makeManager(c)
 	iCfg := prepInstanceConfig(c)
-	hostName, err := manager.Namespace().Hostname(iCfg.MachineId)
+	hostName, err := s.manager.Namespace().Hostname(iCfg.MachineId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	exp := cSvr.EXPECT()
+	exp := s.cSvr.EXPECT()
 
 	req := lxdapi.NetworkPut{
 		Config: map[string]string{
@@ -202,12 +202,10 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 		exp.UpdateNetwork(network.DefaultLXDBridge, req, lxdtesting.ETag).Return(nil),
 	)
 
-	expectCreateContainer(ctrl, cSvr, "juju/xenial/"+s.Arch(), "foo-target")
+	s.expectCreateContainer(ctrl)
+	s.expectStartOp(ctrl)
 
-	startOp := lxdtesting.NewMockOperation(ctrl)
-	startOp.EXPECT().Wait().Return(nil)
-
-	exp.UpdateContainerState(hostName, lxdapi.ContainerStatePut{Action: "start", Timeout: -1}, "").Return(startOp, nil)
+	exp.UpdateContainerState(hostName, lxdapi.ContainerStatePut{Action: "start", Timeout: -1}, "").Return(s.startOp, nil)
 	exp.GetContainer(hostName).Return(&lxdapi.Container{Name: hostName}, lxdtesting.ETag, nil)
 
 	// Supplying config for a single device with default bridge and without a
@@ -218,32 +216,26 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 		ConfigType:          network.ConfigDHCP,
 		ParentInterfaceName: network.DefaultLXDBridge,
 	}})
-	_, _, err = manager.CreateContainer(
+	_, _, err = s.manager.CreateContainer(
 		iCfg, constraints.Value{}, "xenial", netConfig, &container.StorageConfig{}, lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *managerSuite) TestCreateContainerCreateFailed(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setup(c)
 	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
 
-	createRemoteOp := lxdtesting.NewMockRemoteOperation(ctrl)
-	createRemoteOp.EXPECT().Wait().Return(nil).AnyTimes()
-	createRemoteOp.EXPECT().GetTarget().Return(&lxdapi.Operation{StatusCode: lxdapi.Failure, Err: "create failed"}, nil)
+	s.expectCreateRemoteOp(ctrl, &lxdapi.Operation{StatusCode: lxdapi.Failure, Err: "create failed"})
 
-	exp := cSvr.EXPECT()
-
-	alias := &lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-target"}}
 	image := lxdapi.Image{Filename: "this-is-our-image"}
-	gomock.InOrder(
-		exp.GetImageAlias("juju/xenial/"+s.Arch()).Return(alias, lxdtesting.ETag, nil),
-		exp.GetImage("foo-target").Return(&image, lxdtesting.ETag, nil),
-		exp.CreateContainerFromImage(cSvr, image, gomock.Any()).Return(createRemoteOp, nil),
-	)
+	s.expectGetImage(image, nil)
 
-	_, _, err := s.makeManager(c, cSvr).CreateContainer(
+	exp := s.cSvr.EXPECT()
+	exp.CreateContainerFromImage(s.cSvr, image, gomock.Any()).Return(s.createRemoteOp, nil)
+
+	s.makeManager(c)
+	_, _, err := s.manager.CreateContainer(
 		prepInstanceConfig(c),
 		constraints.Value{},
 		"xenial",
@@ -255,25 +247,18 @@ func (s *managerSuite) TestCreateContainerCreateFailed(c *gc.C) {
 }
 
 func (s *managerSuite) TestCreateContainerSpecCreationError(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	// When the local image acquisition fails, this will cause the remote
 	// connection attempt to fail.
 	// This is our error condition exit from manager.getContainerSpec.
 	lxd.PatchConnectRemote(s, map[string]lxdclient.ImageServer{})
 
-	exp := cSvr.EXPECT()
-
-	alias := &lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-target"}}
 	image := lxdapi.Image{Filename: "this-is-our-image"}
-	gomock.InOrder(
-		exp.GetImageAlias("juju/xenial/"+s.Arch()).Return(alias, lxdtesting.ETag, nil),
-		exp.GetImage("foo-target").Return(&image, lxdtesting.ETag, errors.New("not here")),
-	)
+	s.expectGetImage(image, errors.New("not here"))
 
-	_, _, err := s.makeManager(c, cSvr).CreateContainer(
+	s.makeManager(c)
+	_, _, err := s.manager.CreateContainer(
 		prepInstanceConfig(c),
 		constraints.Value{},
 		"xenial",
@@ -285,33 +270,28 @@ func (s *managerSuite) TestCreateContainerSpecCreationError(c *gc.C) {
 }
 
 func (s *managerSuite) TestCreateContainerStartFailed(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setup(c)
 	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
-	s.patch(cSvr)
+	s.patch()
+	s.makeManager(c)
 
-	manager := s.makeManager(c, cSvr)
 	iCfg := prepInstanceConfig(c)
-	hostName, err := manager.Namespace().Hostname(iCfg.MachineId)
+	hostName, err := s.manager.Namespace().Hostname(iCfg.MachineId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	updateOp := lxdtesting.NewMockOperation(ctrl)
-	updateOp.EXPECT().Wait().Return(errors.New("start failed"))
+	s.expectUpdateOp(ctrl, "", errors.New("start failed"))
+	s.expectDeleteOp(ctrl)
+	s.expectCreateContainer(ctrl)
 
-	deleteOp := lxdtesting.NewMockOperation(ctrl)
-	deleteOp.EXPECT().Wait().Return(nil).AnyTimes()
-
-	exp := cSvr.EXPECT()
-
-	expectCreateContainer(ctrl, cSvr, "juju/xenial/"+s.Arch(), "foo-target")
+	exp := s.cSvr.EXPECT()
 	gomock.InOrder(
 		exp.UpdateContainerState(
-			hostName, lxdapi.ContainerStatePut{Action: "start", Timeout: -1}, "").Return(updateOp, nil),
+			hostName, lxdapi.ContainerStatePut{Action: "start", Timeout: -1}, "").Return(s.updateOp, nil),
 		exp.GetContainerState(hostName).Return(&lxdapi.ContainerState{StatusCode: lxdapi.Stopped}, lxdtesting.ETag, nil),
-		exp.DeleteContainer(hostName).Return(deleteOp, nil),
+		exp.DeleteContainer(hostName).Return(s.deleteOp, nil),
 	)
 
-	_, _, err = manager.CreateContainer(
+	_, _, err = s.manager.CreateContainer(
 		iCfg,
 		constraints.Value{},
 		"xenial",
@@ -322,31 +302,11 @@ func (s *managerSuite) TestCreateContainerStartFailed(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ".*start failed")
 }
 
-// expectCreateContainer is a convenience function for the expectations
-// concerning a successful container creation based on a cached local
-// image.
-func expectCreateContainer(ctrl *gomock.Controller, svr *lxdtesting.MockContainerServer, aliasName, target string) {
-	createRemoteOp := lxdtesting.NewMockRemoteOperation(ctrl)
-	createRemoteOp.EXPECT().Wait().Return(nil).AnyTimes()
-	createRemoteOp.EXPECT().GetTarget().Return(&lxdapi.Operation{StatusCode: lxdapi.Success}, nil)
-
-	exp := svr.EXPECT()
-
-	alias := &lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: target}}
-	exp.GetImageAlias(aliasName).Return(alias, lxdtesting.ETag, nil)
-
-	image := lxdapi.Image{Filename: "this-is-our-image"}
-	exp.GetImage("foo-target").Return(&image, lxdtesting.ETag, nil)
-	exp.CreateContainerFromImage(svr, image, gomock.Any()).Return(createRemoteOp, nil)
-}
-
 func (s *managerSuite) TestListContainers(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
-	manager := s.makeManager(c, cSvr)
+	defer s.setup(c).Finish()
+	s.makeManager(c)
 
-	prefix := manager.Namespace().Prefix()
+	prefix := s.manager.Namespace().Prefix()
 	wrongPrefix := prefix[:len(prefix)-1] + "j"
 
 	containers := []lxdapi.Container{
@@ -359,9 +319,9 @@ func (s *managerSuite) TestListContainers(c *gc.C) {
 		{Name: "nothing-to-see-here-please"},
 	}
 
-	cSvr.EXPECT().GetContainers().Return(containers, nil)
+	s.cSvr.EXPECT().GetContainers().Return(containers, nil)
 
-	result, err := manager.ListContainers()
+	result, err := s.manager.ListContainers()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, gc.HasLen, 2)
 	c.Check(string(result[0].Id()), gc.Equals, prefix+"-0")
@@ -369,18 +329,14 @@ func (s *managerSuite) TestListContainers(c *gc.C) {
 }
 
 func (s *managerSuite) TestIsInitialized(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
-	manager := s.makeManager(c, cSvr)
-	c.Check(manager.IsInitialized(), gc.Equals, true)
+	s.makeManager(c)
+	c.Check(s.manager.IsInitialized(), gc.Equals, true)
 }
 
 func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	interfaces := []network.InterfaceInfo{{
 		InterfaceName: "eth1",
@@ -388,8 +344,8 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C
 		MACAddress:    "aa:bb:cc:dd:ee:f1",
 		MTU:           9000,
 	}}
-
-	result, _, err := lxd.NetworkDevicesFromConfig(s.makeManager(c, cSvr), &container.NetworkConfig{
+	s.makeManager(c)
+	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Interfaces: interfaces,
 	})
 
@@ -398,9 +354,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C
 }
 
 func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	interfaces := []network.InterfaceInfo{{
 		ParentInterfaceName: "br-eth0",
@@ -420,7 +374,8 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 		},
 	}
 
-	result, unknown, err := lxd.NetworkDevicesFromConfig(s.makeManager(c, cSvr), &container.NetworkConfig{
+	s.makeManager(c)
+	result, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device:     "lxdbr0",
 		Interfaces: interfaces,
 	})
@@ -431,9 +386,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 }
 
 func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	interfaces := []network.InterfaceInfo{{
 		ParentInterfaceName: "br-eth0",
@@ -442,7 +395,8 @@ func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
 		MACAddress:          "aa:bb:cc:dd:ee:f0",
 	}}
 
-	_, unknown, err := lxd.NetworkDevicesFromConfig(s.makeManager(c, cSvr), &container.NetworkConfig{
+	s.makeManager(c)
+	_, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device:     "lxdbr0",
 		Interfaces: interfaces,
 	})
@@ -452,14 +406,13 @@ func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
 }
 
 func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
-	s.patch(cSvr)
+	defer s.setup(c).Finish()
+	s.patch()
 
-	cSvr.EXPECT().GetProfile("default").Return(defaultProfileWithNIC(), lxdtesting.ETag, nil)
+	s.cSvr.EXPECT().GetProfile("default").Return(defaultProfileWithNIC(), lxdtesting.ETag, nil)
 
-	result, _, err := lxd.NetworkDevicesFromConfig(s.makeManager(c, cSvr), &container.NetworkConfig{})
+	s.makeManager(c)
+	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := map[string]map[string]string{
@@ -475,55 +428,46 @@ func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.
 }
 
 func (s *managerSuite) TestGetImageSourcesDefaultConfig(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
-	mgr := s.makeManager(c, cSvr)
+	s.makeManager(c)
 
-	sources, err := lxd.GetImageSources(mgr)
+	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesRemote, lxd.CloudImagesDailyRemote})
 }
 
 func (s *managerSuite) TestGetImageSourcesNonStandardStreamDefaultConfig(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	cfg := getBaseConfig()
 	cfg[config.ContainerImageStreamKey] = "nope"
-	mgr := s.makeManagerForConfig(c, cfg, cSvr)
+	s.makeManagerForConfig(c, cfg)
 
-	sources, err := lxd.GetImageSources(mgr)
+	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesRemote, lxd.CloudImagesDailyRemote})
 }
 
 func (s *managerSuite) TestGetImageSourcesDailyOnly(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	cfg := getBaseConfig()
 	cfg[config.ContainerImageStreamKey] = "daily"
-	mgr := s.makeManagerForConfig(c, cfg, cSvr)
-
-	sources, err := lxd.GetImageSources(mgr)
+	s.makeManagerForConfig(c, cfg)
+	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesDailyRemote})
 }
 
 func (s *managerSuite) TestGetImageSourcesImageMetadataURLExpectedHTTPSSources(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	cfg := getBaseConfig()
 	cfg[config.ContainerImageMetadataURLKey] = "http://special.container.sauce"
-	mgr := s.makeManagerForConfig(c, cfg, cSvr)
+	s.makeManagerForConfig(c, cfg)
 
-	sources, err := lxd.GetImageSources(mgr)
+	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedSources := []lxd.ServerSpec{
@@ -539,16 +483,14 @@ func (s *managerSuite) TestGetImageSourcesImageMetadataURLExpectedHTTPSSources(c
 }
 
 func (s *managerSuite) TestGetImageSourcesImageMetadataURLDailyStream(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
 	cfg := getBaseConfig()
 	cfg[config.ContainerImageMetadataURLKey] = "http://special.container.sauce"
 	cfg[config.ContainerImageStreamKey] = "daily"
-	mgr := s.makeManagerForConfig(c, cfg, cSvr)
+	s.makeManagerForConfig(c, cfg)
 
-	sources, err := lxd.GetImageSources(mgr)
+	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedSources := []lxd.ServerSpec{
@@ -563,12 +505,10 @@ func (s *managerSuite) TestGetImageSourcesImageMetadataURLDailyStream(c *gc.C) {
 }
 
 func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
+	defer s.setup(c).Finish()
 
-	mgr := s.makeManager(c, cSvr)
-	proMgr, ok := mgr.(container.LXDProfileManager)
+	s.makeManager(c)
+	proMgr, ok := s.manager.(container.LXDProfileManager)
 	c.Assert(ok, jc.IsTrue)
 
 	put := charm.LXDProfile{
@@ -588,21 +528,18 @@ func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 		ProfilePut: lxdapi.ProfilePut(put),
 		Name:       "juju-default-lxd-0",
 	}
-	cSvr.EXPECT().CreateProfile(post).Return(nil).Times(1)
-	cSvr.EXPECT().GetProfileNames().Return([]string{"default", "custom"}, nil).Times(1)
+	s.cSvr.EXPECT().CreateProfile(post).Return(nil)
+	s.cSvr.EXPECT().GetProfileNames().Return([]string{"default", "custom"}, nil)
 
 	err := proMgr.MaybeWriteLXDProfile("juju-default-lxd-0", &put)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setup(c)
 	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
 	// Operation arrangements.
-	updateOp := lxdtesting.NewMockOperation(ctrl)
-	updateOp.EXPECT().Wait().Return(nil)
-	updateOp.EXPECT().Get().Return(lxdapi.Operation{Description: "Updating container"})
+	s.expectUpdateOp(ctrl, "Updating container", nil)
 
 	instId := "testme"
 	old := "old-profile"
@@ -619,7 +556,7 @@ func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
 		ProfilePut: lxdapi.ProfilePut(put),
 		Name:       new,
 	}
-	cExp := cSvr.EXPECT()
+	cExp := s.cSvr.EXPECT()
 	gomock.InOrder(
 		cExp.GetProfileNames().Return(oldProfiles, nil),
 		cExp.CreateProfile(post).Return(nil),
@@ -629,7 +566,7 @@ func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
 					Profiles: oldProfiles,
 				},
 			}, "", nil),
-		cExp.UpdateContainer(instId, gomock.Any(), gomock.Any()).Return(updateOp, nil),
+		cExp.UpdateContainer(instId, gomock.Any(), gomock.Any()).Return(s.updateOp, nil),
 		cExp.DeleteProfile(old).Return(nil),
 		cExp.GetContainer(instId).Return(
 			&lxdapi.Container{
@@ -639,8 +576,8 @@ func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
 			}, "", nil),
 	)
 
-	mgr := s.makeManager(c, cSvr)
-	proMgr, ok := mgr.(container.LXDProfileManager)
+	s.makeManager(c)
+	proMgr, ok := s.manager.(container.LXDProfileManager)
 	c.Assert(ok, jc.IsTrue)
 
 	obtained, err := proMgr.ReplaceOrAddInstanceProfile(instId, old, new, &put)
@@ -648,55 +585,80 @@ func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, newProfiles)
 }
 
-func (s *managerSuite) TestAssignProfiles(c *gc.C) {
+func (s *managerSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cSvr := s.NewMockServer(ctrl)
-	// Operation arrangements.
-	updateOp := lxdtesting.NewMockOperation(ctrl)
-	updateOp.EXPECT().Wait().Return(nil)
-	updateOp.EXPECT().Get().Return(lxdapi.Operation{Description: "Updating ontainer"})
+	s.cSvr = s.NewMockServer(ctrl)
+	return ctrl
+}
 
-	instId := "testme"
-	old := "old-profile"
-	oldProfiles := []string{"default", "juju-default", old}
-	new := "new-profile"
-	newProfiles := []string{"default", "juju-default", new}
-	put := charm.LXDProfile{
-		Config: map[string]string{
-			"security.nesting": "true",
-		},
-		Description: "test profile",
-	}
-	post := lxdapi.ProfilesPost{
-		ProfilePut: lxdapi.ProfilePut(put),
-		Name:       new,
-	}
-	cExp := cSvr.EXPECT()
+func (s *managerSuite) setupWithExtensions(c *gc.C, extensions ...string) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.cSvr = s.NewMockServerWithExtensions(ctrl, extensions...)
+	return ctrl
+}
+
+// expectCreateContainer is a convenience function for the expectations
+// concerning a successful container creation based on a cached local
+// image.
+func (s *managerSuite) expectCreateContainer(ctrl *gomock.Controller) {
+	s.expectCreateRemoteOp(ctrl, &lxdapi.Operation{StatusCode: lxdapi.Success})
+
+	image := lxdapi.Image{Filename: "this-is-our-image"}
+	s.expectGetImage(image, nil)
+
+	exp := s.cSvr.EXPECT()
+	exp.CreateContainerFromImage(s.cSvr, image, gomock.Any()).Return(s.createRemoteOp, nil)
+}
+
+// expectCreateRemoteOp is a convenience function for the expectations
+// concerning successful remote operations.
+func (s *managerSuite) expectCreateRemoteOp(ctrl *gomock.Controller, op *lxdapi.Operation) {
+	s.createRemoteOp = lxdtesting.NewMockRemoteOperation(ctrl)
+	s.createRemoteOp.EXPECT().Wait().Return(nil).AnyTimes()
+	s.createRemoteOp.EXPECT().GetTarget().Return(op, nil)
+}
+
+// expectDeleteOp is a convenience function for the expectations
+// concerning successful delete operations.
+func (s *managerSuite) expectDeleteOp(ctrl *gomock.Controller) {
+	s.deleteOp = lxdtesting.NewMockOperation(ctrl)
+	s.deleteOp.EXPECT().Wait().Return(nil).AnyTimes()
+}
+
+// expectDeleteOp is a convenience function for the expectations
+// concerning GetImage operations.
+func (s *managerSuite) expectGetImage(image lxdapi.Image, getImageErr error) {
+	target := "foo-target"
+	alias := &lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: target}}
+
+	exp := s.cSvr.EXPECT()
 	gomock.InOrder(
-		cExp.GetProfileNames().Return(oldProfiles, nil),
-		cExp.CreateProfile(post).Return(nil),
-		cExp.GetContainer(instId).Return(
-			&lxdapi.Container{
-				ContainerPut: lxdapi.ContainerPut{
-					Profiles: oldProfiles,
-				},
-			}, "", nil),
-		cExp.UpdateContainer(instId, gomock.Any(), gomock.Any()).Return(updateOp, nil),
-		cExp.DeleteProfile(old).Return(nil),
-		cExp.GetContainer(instId).Return(
-			&lxdapi.Container{
-				ContainerPut: lxdapi.ContainerPut{
-					Profiles: newProfiles,
-				},
-			}, "", nil),
+		exp.GetImageAlias("juju/xenial/"+s.Arch()).Return(alias, lxdtesting.ETag, nil),
+		exp.GetImage(target).Return(&image, lxdtesting.ETag, getImageErr),
 	)
+}
 
-	mgr := s.makeManager(c, cSvr)
-	proMgr, ok := mgr.(container.LXDProfileManager)
-	c.Assert(ok, jc.IsTrue)
+// expectStartOp is a convenience function for the expectations
+// concerning a successful start operation.
+func (s *managerSuite) expectStartOp(ctrl *gomock.Controller) {
+	s.startOp = lxdtesting.NewMockOperation(ctrl)
+	s.startOp.EXPECT().Wait().Return(nil)
+}
 
-	obtained, err := proMgr.ReplaceOrAddInstanceProfile(instId, old, new, &put)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtained, gc.DeepEquals, newProfiles)
+// expectStopOp is a convenience function for the expectations
+// concerning successful stop operation.
+func (s *managerSuite) expectStopOp(ctrl *gomock.Controller) {
+	s.stopOp = lxdtesting.NewMockOperation(ctrl)
+	s.stopOp.EXPECT().Wait().Return(nil)
+}
+
+// expectStopOp is a convenience function for the expectations
+// concerning an update operation.
+func (s *managerSuite) expectUpdateOp(ctrl *gomock.Controller, description string, waitErr error) {
+	s.updateOp = lxdtesting.NewMockOperation(ctrl)
+	s.updateOp.EXPECT().Wait().Return(waitErr)
+	if waitErr != nil {
+		return
+	}
+	s.updateOp.EXPECT().Get().Return(lxdapi.Operation{Description: description})
 }

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -244,11 +244,8 @@ func (s *Server) UpdateContainerProfiles(name string, profiles []string) error {
 	}
 
 	op := resp.Get()
-	logger.Debugf("updated %q, waiting on %s", name, op.Description)
+	logger.Debugf("updated %q profiles, waiting on %s", name, op.Description)
 	err = resp.Wait()
-	if err != nil {
-		logger.Tracef("updating %q failed on %q", name, err)
-	}
 	return errors.Trace(err)
 }
 

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
-	"github.com/lxc/lxd/client"
+	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
-	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -180,6 +180,9 @@ func (s *Server) GetContainerProfiles(name string) ([]string, error) {
 	return container.Profiles, nil
 }
 
+// TODO: HML 2-apr-2019
+// remove when provisioner_task processProfileChanges() is
+// removed.
 // ReplaceOrAddContainerProfile updates the profiles for the container with the
 // input name, using the input values.
 func (s *Server) ReplaceOrAddContainerProfile(name, oldProfile, newProfile string) error {
@@ -223,6 +226,30 @@ func addRemoveReplaceProfileName(profiles []string, oldProfile, newProfile strin
 		}
 	}
 	return profiles
+}
+
+// UpdateContainerProfiles applies the given profiles (by name) to the
+// named container.  It is assumed the profiles have all been added to
+// the server before hand.
+func (s *Server) UpdateContainerProfiles(name string, profiles []string) error {
+	container, eTag, err := s.GetContainer(name)
+	if err != nil {
+		return errors.Trace(errors.Annotatef(err, "failed to get %q", name))
+	}
+
+	container.Profiles = profiles
+	resp, err := s.UpdateContainer(name, container.Writable(), eTag)
+	if err != nil {
+		return errors.Trace(errors.Annotatef(err, "failed to update %q with profiles", name))
+	}
+
+	op := resp.Get()
+	logger.Debugf("updated %q, waiting on %s", name, op.Description)
+	err = resp.Wait()
+	if err != nil {
+		logger.Tracef("updating %q failed on %q", name, err)
+	}
+	return errors.Trace(err)
 }
 
 // CreateClientCertificate adds the input certificate to the server,

--- a/container/testing/interface_mock.go
+++ b/container/testing/interface_mock.go
@@ -5,16 +5,16 @@
 package testing
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	instancecfg "github.com/juju/juju/cloudconfig/instancecfg"
 	container "github.com/juju/juju/container"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
+	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/instances"
+	instances "github.com/juju/juju/environs/instances"
 	charm_v6 "gopkg.in/juju/charm.v6"
+	reflect "reflect"
 )
 
 // MockTestLXDManager is a mock of TestLXDManager interface
@@ -38,6 +38,19 @@ func NewMockTestLXDManager(ctrl *gomock.Controller) *MockTestLXDManager {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockTestLXDManager) EXPECT() *MockTestLXDManagerMockRecorder {
 	return m.recorder
+}
+
+// AssignProfiles mocks base method
+func (m *MockTestLXDManager) AssignProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	ret := m.ctrl.Call(m, "AssignProfiles", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssignProfiles indicates an expected call of AssignProfiles
+func (mr *MockTestLXDManagerMockRecorder) AssignProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignProfiles", reflect.TypeOf((*MockTestLXDManager)(nil).AssignProfiles), arg0, arg1, arg2)
 }
 
 // CreateContainer mocks base method

--- a/core/lxdprofile/profile.go
+++ b/core/lxdprofile/profile.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/utils/set"
+	"github.com/juju/collections/set"
 )
 
 func NewLXDCharmProfiler(profile Profile) LXDProfiler {
@@ -21,6 +21,13 @@ type LXDProfiles struct {
 // Implements LXDProfiler interface.
 func (p LXDProfiles) LXDProfile() LXDProfile {
 	return p.Profile
+}
+
+// ProfilePost is a close representation of lxd api
+// ProfilesPost
+type ProfilePost struct {
+	Name    string
+	Profile *Profile
 }
 
 // Profile is a representation of charm.v6 LXDProfile

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -170,12 +171,20 @@ type InstanceBroker interface {
 // LXDProfiler defines an interface for dealing with lxd profiles used to
 // deploy juju machines and containers.
 type LXDProfiler interface {
+	// AssignProfiles assigns the given profile names to the lxd instance
+	// provided.  The slice of ProfilePosts provides details for adding to
+	// and removing profiles from the lxd server.
+	AssignProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
+
 	// MaybeWriteLXDProfile, write given LXDProfile to if not already there.
 	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
 
 	// LXDProfileNames returns all the profiles associated to a container name
 	LXDProfileNames(containerName string) ([]string, error)
 
+	// TODO: HML 2-apr-2019
+	// remove when provisioner_task processProfileChanges() is
+	// removed.
 	// ReplaceOrAddInstanceProfile replaces, adds, a charm profile to
 	// the given instance and returns a slice of LXD profiles applied
 	// to the instance. Replace happens inplace in the current order of

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -62,6 +62,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -1908,6 +1909,11 @@ func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
 // ReplaceOrAddInstanceProfile implements environs.LXDProfiler.
 func (env *environ) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
 	return []string{newProfile}, nil
+}
+
+// AssignProfiles implements environs.LXDProfiler.
+func (env *environ) AssignProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
+	return profilesNames, nil
 }
 
 // SSHAddresses implements environs.SSHAddresses.

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -57,6 +57,7 @@ type Server interface {
 	CreateProfile(post lxdapi.ProfilesPost) (err error)
 	DeleteProfile(string) (err error)
 	ReplaceOrAddContainerProfile(string, string, string) error
+	UpdateContainerProfiles(name string, profiles []string) error
 	VerifyNetworkDevice(*lxdapi.Profile, string) error
 	EnsureDefaultStorage(*lxdapi.Profile, string) error
 	StorageSupported() bool

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -5,14 +5,13 @@
 package lxd
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	lxd "github.com/juju/juju/container/lxd"
 	environs "github.com/juju/juju/environs"
 	network "github.com/juju/juju/network"
 	client "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
+	reflect "reflect"
 )
 
 // MockServer is a mock of Server interface
@@ -531,6 +530,18 @@ func (m *MockServer) UpdateContainerConfig(arg0 string, arg1 map[string]string) 
 // UpdateContainerConfig indicates an expected call of UpdateContainerConfig
 func (mr *MockServerMockRecorder) UpdateContainerConfig(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerConfig", reflect.TypeOf((*MockServer)(nil).UpdateContainerConfig), arg0, arg1)
+}
+
+// UpdateContainerProfiles mocks base method
+func (m *MockServer) UpdateContainerProfiles(arg0 string, arg1 []string) error {
+	ret := m.ctrl.Call(m, "UpdateContainerProfiles", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateContainerProfiles indicates an expected call of UpdateContainerProfiles
+func (mr *MockServerMockRecorder) UpdateContainerProfiles(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerProfiles", reflect.TypeOf((*MockServer)(nil).UpdateContainerProfiles), arg0, arg1)
 }
 
 // UpdateServerConfig mocks base method

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -555,6 +555,11 @@ func (conn *StubClient) ReplaceOrAddContainerProfile(name, oldProfile, newProfil
 	return conn.NextErr()
 }
 
+func (conn *StubClient) UpdateContainerProfiles(name string, profiles []string) error {
+	conn.AddCall("UpdateContainerProfiles", name, profiles)
+	return conn.NextErr()
+}
+
 func (conn *StubClient) VerifyNetworkDevice(profile *api.Profile, ETag string) error {
 	conn.AddCall("VerifyNetworkDevice", profile, ETag)
 	return conn.NextErr()

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
+	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	context "github.com/juju/juju/environs/context"
@@ -316,6 +317,19 @@ func NewMockLXDProfiler(ctrl *gomock.Controller) *MockLXDProfiler {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfiler) EXPECT() *MockLXDProfilerMockRecorder {
 	return m.recorder
+}
+
+// AssignProfiles mocks base method
+func (m *MockLXDProfiler) AssignProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	ret := m.ctrl.Call(m, "AssignProfiles", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssignProfiles indicates an expected call of AssignProfiles
+func (mr *MockLXDProfilerMockRecorder) AssignProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignProfiles", reflect.TypeOf((*MockLXDProfiler)(nil).AssignProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method

--- a/worker/provisioner/mocks/lxdprofileinstancebroker_mock.go
+++ b/worker/provisioner/mocks/lxdprofileinstancebroker_mock.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	instance "github.com/juju/juju/core/instance"
+	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
@@ -48,6 +49,19 @@ func (m *MockLXDProfileInstanceBroker) AllInstances(arg0 context.ProviderCallCon
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AllInstances), arg0)
+}
+
+// AssignProfiles mocks base method
+func (m *MockLXDProfileInstanceBroker) AssignProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	ret := m.ctrl.Call(m, "AssignProfiles", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssignProfiles indicates an expected call of AssignProfiles
+func (mr *MockLXDProfileInstanceBrokerMockRecorder) AssignProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignProfiles", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AssignProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method


### PR DESCRIPTION
## Description of change

Adding AssignProfiles to LXDProfileManager and LXDProfiler interfaces.  Also added lxd server UpdateContainerProfiles() for use by the implementations of AssignProfiles.  These are needed by the Instance Mutater worker.

## QA steps

Not hooked up for use yet.  No change  to juju functionality should currently be seen.

