### PR TITLE
Microk8s is now a built-in cloud.

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"bytes"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/exec"
+
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+)
+
+const (
+	builtinMicroK8sClusterName = "microk8s-cluster"
+	builtinMicroK8sName        = "microk8s"
+	builtinMicroK8sRegion      = "localhost"
+)
+
+func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error) {
+	var newCloud cloud.Cloud
+	configContent, err := getLocalMicroK8sConfig(cmdRunner)
+	if err != nil {
+		return newCloud, jujucloud.Credential{}, "", err
+	}
+
+	rdr := bytes.NewReader(configContent)
+
+	cloudParams := KubeCloudParams{
+		ClusterName: builtinMicroK8sClusterName,
+		CaasName:    builtinMicroK8sName,
+		CaasType:    CAASProviderType,
+
+		ClientConfigGetter: func(caasType string) (clientconfig.ClientConfigFunc, error) {
+			return clientconfig.NewClientConfigReader(caasType)
+		},
+	}
+	return CloudFromKubeConfig(rdr, cloudParams)
+}
+
+func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
+	execParams := exec.RunParams{
+		Commands: "microk8s.config",
+	}
+	result, err := cmdRunner.RunCommands(execParams)
+	if err != nil {
+		return []byte{}, err
+	}
+	if result.Code != 0 {
+		return []byte{}, errors.New(string(result.Stderr))
+	}
+	return result.Stdout, nil
+}

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -26,7 +26,7 @@ func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, jujucloud.Crede
 
 	cloudParams := KubeCloudParams{
 		ClusterName: caas.MicroK8sClusterName,
-		CaasName:    caas.Microk8s,
+		CaasName:    caas.K8sCloudMicrok8s,
 		CaasType:    CAASProviderType,
 		ClientConfigGetter: func(caasType string) (clientconfig.ClientConfigFunc, error) {
 			return clientconfig.NewClientConfigReader(caasType)

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/cloud"
+)
+
+var (
+	_ = gc.Suite(&builtinSuite{})
+)
+
+var microk8sConfig = `
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://1.1.1.1:8080
+  name: microk8s-cluster
+contexts:
+- context:
+    cluster: microk8s-cluster
+    user: admin
+  name: microk8s
+current-context: microk8s
+kind: Config
+preferences: {}
+users:
+- name: admin
+  user:
+    username: admin
+
+`
+
+type builtinSuite struct {
+	runner dummyRunner
+}
+
+func (s *builtinSuite) SetUpTest(c *gc.C) {
+	var logger loggo.Logger
+	s.runner = dummyRunner{CallMocker: testing.NewCallMocker(logger)}
+}
+
+func (s *builtinSuite) TestGetLocalMicroK8sConfigNotInstalled(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "which microk8s.config"}).Returns(&exec.ExecResponse{Code: 1}, nil)
+
+	result, err := provider.GetLocalMicroK8sConfig(s.runner)
+	c.Assert(err, gc.ErrorMatches, `microk8s not found`)
+	c.Assert(result, gc.HasLen, 0)
+}
+
+func (s *builtinSuite) TestGetLocalMicroK8sConfigCallFails(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "which microk8s.config"}).Returns(&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.config"}).Returns(&exec.ExecResponse{Code: 1, Stderr: []byte("cannot find config")}, nil)
+	result, err := provider.GetLocalMicroK8sConfig(s.runner)
+	c.Assert(err, gc.ErrorMatches, `cannot find config`)
+	c.Assert(result, gc.HasLen, 0)
+}
+
+func (s *builtinSuite) TestGetLocalMicroK8sConfig(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "which microk8s.config"}).Returns(&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.config"}).Returns(&exec.ExecResponse{Code: 0, Stdout: []byte("a bunch of config")}, nil)
+
+	result, err := provider.GetLocalMicroK8sConfig(s.runner)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(result), gc.Equals, "a bunch of config")
+}
+
+func (s *builtinSuite) TestAttemptMicroK8sCloud(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "which microk8s.config"}).Returns(&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.config"}).Returns(&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sConfig)}, nil)
+
+	k8sCloud, credential, credentialName, err := provider.AttemptMicroK8sCloud(s.runner)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(k8sCloud, gc.DeepEquals, defaultK8sCloud)
+	c.Assert(credential, gc.DeepEquals, getDefaultCredential())
+	c.Assert(credentialName, gc.Equals, "admin")
+}
+
+func (s *builtinSuite) TestAttemptMicroK8sCloudErrors(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "which microk8s.config"}).Returns(&exec.ExecResponse{Code: 1}, nil)
+	k8sCloud, credential, credentialName, err := provider.AttemptMicroK8sCloud(s.runner)
+	c.Assert(err, gc.ErrorMatches, `microk8s not found`)
+	c.Assert(k8sCloud, gc.DeepEquals, cloud.Cloud{})
+	c.Assert(credential, gc.DeepEquals, cloud.Credential{})
+	c.Assert(credentialName, gc.Equals, "")
+}

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -4,6 +4,7 @@
 package provider_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -55,6 +56,7 @@ func (s *builtinSuite) TestGetLocalMicroK8sConfigNotInstalled(c *gc.C) {
 
 	result, err := provider.GetLocalMicroK8sConfig(s.runner)
 	c.Assert(err, gc.ErrorMatches, `microk8s not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(result, gc.HasLen, 0)
 }
 

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -180,6 +181,9 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, credential jujucloud.Cred
 	if _, ok := k8sCloud.Config[OperatorStorageKey]; !ok {
 		k8sCloud.Config[OperatorStorageKey] = operatorStorageName
 	}
+	if _, ok := k8sCloud.Config[bootstrap.ControllerServiceTypeKey]; !ok {
+		k8sCloud.Config[bootstrap.ControllerServiceTypeKey] = clusterMetadata.PreferredServiceType
+	}
 
 	return storageMsg, nil
 }
@@ -224,7 +228,7 @@ func BaseKubeCloudOpenParams(cloud jujucloud.Cloud, credential jujucloud.Credent
 // FinalizeCloud is part of the environs.CloudFinalizer interface.
 func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
 	cloudName := cld.Name
-	if cloudName != caas.Microk8s {
+	if cloudName != caas.K8sCloudMicrok8s {
 		return cld, nil
 	}
 	// Need the credentials, need to query for those details

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -1,0 +1,236 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+)
+
+// ClientConfigFuncGetter returns a function that will provide the client reader
+type ClientConfigFuncGetter func(string) (clientconfig.ClientConfigFunc, error)
+
+// GetClusterMetadataFunc returns the ClusterMetadata using the provided ClusterMetadataChecker
+type GetClusterMetadataFunc func(caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error)
+
+// ClusterMetadataCheckerGetter returns a ClusterMetadataChecker that will generally be used by a GetClusterMetadataFunc
+type ClusterMetadataCheckerGetter func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error)
+
+// KubeCloudParams provides the needed information to extract a Cloud from available cluster information.
+type KubeCloudParams struct {
+	ClusterName        string
+	ContextName        string
+	CaasName           string
+	HostCloudRegion    string
+	CaasType           string
+	ClientConfigGetter ClientConfigFuncGetter
+}
+
+// KubeCloudStorageParams allows storage details to be determined for a K8s cloud.
+type KubeCloudStorageParams struct {
+	WorkloadStorage              string
+	HostCloudRegion              string
+	Errors                       KubeCloudParamErrors
+	ClusterMetadataCheckerGetter ClusterMetadataCheckerGetter
+	GetClusterMetadataFunc       GetClusterMetadataFunc
+}
+
+//KubeCloudParamErrors allows errors to be customised based on need (e.g. interactive CLI command or behind the scenes query).
+type KubeCloudParamErrors struct {
+	ClusterQuery         string
+	UnknownCluster       string
+	NoRecommendedStorage string
+}
+
+// CloudFromKubeConfig attempts to extract a cloud and credential details from the provided Kubeconfig.
+func CloudFromKubeConfig(reader io.Reader, cloudParams KubeCloudParams) (cloud.Cloud, jujucloud.Credential, string, error) {
+	return newCloudCredentialFromKubeConfig(reader, cloudParams)
+}
+
+func newCloudCredentialFromKubeConfig(reader io.Reader, cloudParams KubeCloudParams) (jujucloud.Cloud, jujucloud.Credential, string, error) {
+	// Get Cloud (incl. endpoint) and credential details from the kubeconfig details.
+	var credential jujucloud.Credential
+	var context clientconfig.Context
+	fail := func(e error) (jujucloud.Cloud, jujucloud.Credential, string, error) {
+		return jujucloud.Cloud{}, credential, "", e
+	}
+	newCloud := jujucloud.Cloud{
+		Name:            cloudParams.CaasName,
+		Type:            cloudParams.CaasType,
+		HostCloudRegion: cloudParams.HostCloudRegion,
+	}
+	clientConfigFunc, err := cloudParams.ClientConfigGetter(cloudParams.CaasType)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	caasConfig, err := clientConfigFunc(reader, cloudParams.ContextName, cloudParams.ClusterName, clientconfig.EnsureK8sCredential)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+	logger.Debugf("caasConfig: %+v", caasConfig)
+
+	if len(caasConfig.Contexts) == 0 {
+		return fail(errors.Errorf("No k8s cluster definitions found in config"))
+	}
+
+	context = caasConfig.Contexts[reflect.ValueOf(caasConfig.Contexts).MapKeys()[0].Interface().(string)]
+
+	credential = caasConfig.Credentials[context.CredentialName]
+	newCloud.AuthTypes = []jujucloud.AuthType{credential.AuthType()}
+	currentCloud := caasConfig.Clouds[context.CloudName]
+	newCloud.Endpoint = currentCloud.Endpoint
+
+	cloudCAData, ok := currentCloud.Attributes["CAData"].(string)
+	if !ok {
+		return fail(errors.Errorf("CAData attribute should be a string"))
+	}
+	newCloud.CACertificates = []string{cloudCAData}
+	return newCloud, credential, context.CredentialName, nil
+}
+
+// UpdateKubeCloudWithStorage updates the passed Cloud with storage details retrieved from the clouds' cluster.
+func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, credential jujucloud.Credential, storageParams KubeCloudStorageParams) (string, error) {
+	fail := func(e error) (string, error) {
+		return "", e
+	}
+	broker, err := storageParams.ClusterMetadataCheckerGetter(*k8sCloud, credential)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+
+	// Get the cluster metadata so we can see if there's suitable storage available.
+	clusterMetadata, err := storageParams.GetClusterMetadataFunc(broker)
+	if err != nil || clusterMetadata == nil {
+		return fail(errors.Annotate(err, storageParams.Errors.ClusterQuery))
+	}
+
+	if storageParams.HostCloudRegion == "" && clusterMetadata.Regions != nil && clusterMetadata.Regions.Size() > 0 {
+		storageParams.HostCloudRegion = clusterMetadata.Cloud + "/" + clusterMetadata.Regions.SortedValues()[0]
+	}
+	if storageParams.HostCloudRegion == "" {
+		return fail(errors.New(storageParams.Errors.ClusterQuery))
+	}
+	_, region, err := ParseCloudRegion(storageParams.HostCloudRegion)
+	if err != nil {
+		return fail(errors.Annotatef(err, "validating cloud region %q", storageParams.HostCloudRegion))
+	}
+	k8sCloud.HostCloudRegion = storageParams.HostCloudRegion
+	k8sCloud.Regions = []jujucloud.Region{{
+		Name: region,
+	}}
+
+	// If the user has not specified storage, check that the cluster has Juju's opinionated defaults.
+	cloudType := strings.Split(storageParams.HostCloudRegion, "/")[0]
+	err = broker.CheckDefaultWorkloadStorage(cloudType, clusterMetadata.NominatedStorageClass)
+	if errors.IsNotFound(err) {
+		return fail(errors.Errorf(storageParams.Errors.UnknownCluster, cloudType))
+	}
+	if storageParams.WorkloadStorage == "" && caas.IsNonPreferredStorageError(err) {
+		npse := err.(*caas.NonPreferredStorageError)
+		return fail(errors.Errorf(storageParams.Errors.NoRecommendedStorage, npse.Name))
+	}
+	if err != nil && !caas.IsNonPreferredStorageError(err) {
+		return fail(errors.Trace(err))
+	}
+
+	// If no storage class exists, we need to create one with the opinionated defaults.
+	var storageMsg string
+	if storageParams.WorkloadStorage != "" && caas.IsNonPreferredStorageError(err) {
+		preferredStorage := errors.Cause(err).(*caas.NonPreferredStorageError).PreferredStorage
+		sp, err := broker.EnsureStorageProvisioner(caas.StorageProvisioner{
+			Name:        storageParams.WorkloadStorage,
+			Provisioner: preferredStorage.Provisioner,
+			Parameters:  preferredStorage.Parameters,
+		})
+		if err != nil {
+			return fail(errors.Annotatef(err, "creating storage class %q", storageParams.WorkloadStorage))
+		}
+		if sp.Provisioner == preferredStorage.Provisioner {
+			storageMsg = fmt.Sprintf(" with %s default storage", preferredStorage.Name)
+			if storageParams.WorkloadStorage != "" {
+				storageMsg = fmt.Sprintf("%s provisioned\nby the existing %q storage class", storageMsg, storageParams.WorkloadStorage)
+			}
+		} else {
+			storageMsg = fmt.Sprintf(" with storage provisioned\nby the existing %q storage class", storageParams.WorkloadStorage)
+		}
+	}
+	if storageParams.WorkloadStorage == "" && clusterMetadata.NominatedStorageClass != nil {
+		storageParams.WorkloadStorage = clusterMetadata.NominatedStorageClass.Name
+	}
+
+	// Record the operator storage to use.
+	var operatorStorageName string
+	if clusterMetadata.OperatorStorageClass != nil {
+		operatorStorageName = clusterMetadata.OperatorStorageClass.Name
+	} else {
+		operatorStorageName = storageParams.WorkloadStorage
+		if storageMsg == "" {
+			storageMsg += "\nwith "
+		} else {
+			storageMsg += "\n"
+		}
+		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class")
+	}
+
+	if k8sCloud.Config == nil {
+		k8sCloud.Config = make(map[string]interface{})
+	}
+	if _, ok := k8sCloud.Config[WorkloadStorageKey]; !ok {
+		k8sCloud.Config[WorkloadStorageKey] = storageParams.WorkloadStorage
+	}
+	if _, ok := k8sCloud.Config[OperatorStorageKey]; !ok {
+		k8sCloud.Config[OperatorStorageKey] = operatorStorageName
+	}
+
+	return storageMsg, nil
+}
+
+// ParseCloudRegion breaks apart a clusters cloud region.
+func ParseCloudRegion(cloudRegion string) (string, string, error) {
+	fields := strings.SplitN(cloudRegion, "/", 2)
+	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
+		return "", "", errors.NotValidf("cloud region %q", cloudRegion)
+	}
+	return fields[0], fields[1], nil
+}
+
+// BaseKubeCloudOpenParams provides a basic OpenParams for a cluster
+func BaseKubeCloudOpenParams(cloud jujucloud.Cloud, credential jujucloud.Credential) (environs.OpenParams, error) {
+	// To get a k8s client, we need a config with minimal information.
+	// It's not used unless operating on a real model but we need to supply it.
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+	attrs := map[string]interface{}{
+		config.NameKey: "add-cloud",
+		config.TypeKey: "kubernetes",
+		config.UUIDKey: uuid.String(),
+	}
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+
+	cloudSpec, err := environs.MakeCloudSpec(cloud, "", &credential)
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+	openParams := environs.OpenParams{
+		Cloud: cloudSpec, Config: cfg,
+	}
+	return openParams, nil
+}

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -98,8 +98,9 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, credential jujucloud.Cred
 
 	// Get the cluster metadata so we can see if there's suitable storage available.
 	clusterMetadata, err := storageParams.GetClusterMetadataFunc(storageParams.MetadataChecker)
+
 	if err != nil || clusterMetadata == nil {
-		return fail(errors.Wrap(err, ClusterQueryError{}))
+		return fail(ClusterQueryError{Message: err.Error()})
 	}
 
 	if storageParams.HostCloudRegion == "" && clusterMetadata.Regions != nil && clusterMetadata.Regions.Size() > 0 {
@@ -121,7 +122,7 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, credential jujucloud.Cred
 	cloudType := strings.Split(storageParams.HostCloudRegion, "/")[0]
 	err = storageParams.MetadataChecker.CheckDefaultWorkloadStorage(cloudType, clusterMetadata.NominatedStorageClass)
 	if errors.IsNotFound(err) {
-		return fail(UnknownClusterError{cloudType})
+		return fail(UnknownClusterError{CloudName: cloudType})
 	}
 	if storageParams.WorkloadStorage == "" && caas.IsNonPreferredStorageError(err) {
 		npse := err.(*caas.NonPreferredStorageError)

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -21,13 +21,13 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-// ClientConfigFuncGetter returns a function that will provide the client reader
+// ClientConfigFuncGetter returns a function returning az reader that will read a k8s cluster config for a given cluster type
 type ClientConfigFuncGetter func(string) (clientconfig.ClientConfigFunc, error)
 
 // GetClusterMetadataFunc returns the ClusterMetadata using the provided ClusterMetadataChecker
 type GetClusterMetadataFunc func(caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error)
 
-// KubeCloudParams provides the needed information to extract a Cloud from available cluster information.
+// KubeCloudParams defines the parameters used to extract a k8s cluster definition from kubeconfig data.
 type KubeCloudParams struct {
 	ClusterName        string
 	ContextName        string
@@ -37,7 +37,7 @@ type KubeCloudParams struct {
 	ClientConfigGetter ClientConfigFuncGetter
 }
 
-// KubeCloudStorageParams allows storage details to be determined for a K8s cloud.
+// KubeCloudStorageParams defines the parameters used to determine storage details for a k8s cluster.
 type KubeCloudStorageParams struct {
 	WorkloadStorage        string
 	HostCloudRegion        string

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -1,0 +1,124 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"fmt"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
+
+var (
+	_ = gc.Suite(&cloudSuite{})
+)
+
+type cloudSuite struct {
+	fakeBroker fakeK8sClusterMetadataChecker
+}
+
+var defaultK8sCloud = jujucloud.Cloud{
+	Name:           caas.Microk8s,
+	Endpoint:       "http://1.1.1.1:8080",
+	Type:           cloud.CloudTypeCAAS,
+	AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
+	CACertificates: []string{""},
+}
+
+var defaultClusterMetadata = &caas.ClusterMetadata{
+	Cloud:                caas.Microk8s,
+	Regions:              set.NewStrings(caas.Microk8sRegion),
+	OperatorStorageClass: &caas.StorageProvisioner{Name: "operator-sc"},
+}
+
+func getDefaultCredential() cloud.Credential {
+	defaultCredential := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "admin", "password": ""})
+	defaultCredential.Label = "kubernetes credential \"admin\""
+	return defaultCredential
+}
+
+func (s *cloudSuite) SetUpTest(c *gc.C) {
+	var logger loggo.Logger
+	s.fakeBroker = fakeK8sClusterMetadataChecker{CallMocker: testing.NewCallMocker(logger)}
+}
+
+func (s *cloudSuite) TestFinalizeCloudNotMicrok8s(c *gc.C) {
+	notK8sCloud := jujucloud.Cloud{}
+	p := provider.NewProviderWithFakes(
+		dummyRunner{},
+		getterFunc(builtinCloudRet{}),
+		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil })
+	cloudFinalizer := p.(environs.CloudFinalizer)
+
+	var ctx mockContext
+	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, notK8sCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, notK8sCloud)
+}
+
+func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
+	p := s.getProvider()
+	cloudFinalizer := p.(environs.CloudFinalizer)
+
+	var ctx mockContext
+	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, defaultK8sCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{
+		Name:            caas.Microk8s,
+		Type:            jujucloud.CloudTypeCAAS,
+		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
+		CACertificates:  []string{""},
+		Endpoint:        "http://1.1.1.1:8080",
+		HostCloudRegion: fmt.Sprintf("%s/%s", caas.Microk8s, caas.Microk8sRegion),
+		Config:          map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": ""},
+		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
+	})
+}
+
+func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
+	s.fakeBroker.Call("GetClusterMetadata").Returns(defaultClusterMetadata, nil)
+	s.fakeBroker.Call("CheckDefaultWorkloadStorage").Returns(nil)
+	return provider.NewProviderWithFakes(
+		dummyRunner{},
+		getterFunc(builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}),
+		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
+	)
+}
+
+type mockContext struct {
+	testing.Stub
+}
+
+func (c *mockContext) Verbosef(f string, args ...interface{}) {
+	c.MethodCall(c, "Verbosef", f, args)
+}
+
+type fakeK8sClusterMetadataChecker struct {
+	*testing.CallMocker
+	caas.ClusterMetadataChecker
+}
+
+func (api *fakeK8sClusterMetadataChecker) GetClusterMetadata(storageClass string) (result *caas.ClusterMetadata, err error) {
+	results := api.MethodCall(api, "GetClusterMetadata")
+	return results[0].(*caas.ClusterMetadata), testing.TypeAssertError(results[1])
+}
+
+func (api *fakeK8sClusterMetadataChecker) CheckDefaultWorkloadStorage(cluster string, storageProvisioner *caas.StorageProvisioner) error {
+	results := api.MethodCall(api, "CheckDefaultWorkloadStorage")
+	return testing.TypeAssertError(results[0])
+}
+
+func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, error) {
+	results := api.MethodCall(api, "EnsureStorageProvisioner")
+	return results[0].(*caas.StorageProvisioner), testing.TypeAssertError(results[1])
+}

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -28,7 +28,7 @@ type cloudSuite struct {
 }
 
 var defaultK8sCloud = jujucloud.Cloud{
-	Name:           caas.Microk8s,
+	Name:           caas.K8sCloudMicrok8s,
 	Endpoint:       "http://1.1.1.1:8080",
 	Type:           cloud.CloudTypeCAAS,
 	AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
@@ -36,7 +36,7 @@ var defaultK8sCloud = jujucloud.Cloud{
 }
 
 var defaultClusterMetadata = &caas.ClusterMetadata{
-	Cloud:                caas.Microk8s,
+	Cloud:                caas.K8sCloudMicrok8s,
 	Regions:              set.NewStrings(caas.Microk8sRegion),
 	OperatorStorageClass: &caas.StorageProvisioner{Name: "operator-sc"},
 }
@@ -74,13 +74,13 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{
-		Name:            caas.Microk8s,
+		Name:            caas.K8sCloudMicrok8s,
 		Type:            jujucloud.CloudTypeCAAS,
 		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
 		CACertificates:  []string{""},
 		Endpoint:        "http://1.1.1.1:8080",
-		HostCloudRegion: fmt.Sprintf("%s/%s", caas.Microk8s, caas.Microk8sRegion),
-		Config:          map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": ""},
+		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
+		Config:          map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": "", "controller-service-type": ""},
 		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
 	})
 }

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -113,3 +113,25 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
 	return &args.Credential, nil
 }
+
+// RegisterCredentials is part of the environs.ProviderCredentialsRegister interface.
+func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
+	cloudName := cld.Name
+	if cloudName != builtinMicroK8sName {
+		return make(map[string]*cloud.CloudCredential), nil
+	}
+	_, cred, _, err := attemptMicroK8sCloud(defaultRunner{})
+
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return map[string]*cloud.CloudCredential{
+		cloudName: {
+			DefaultCredential: cloudName,
+			AuthCredentials: map[string]cloud.Credential{
+				cloudName: cred,
+			},
+		},
+	}, nil
+}

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -121,7 +121,7 @@ func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredenti
 // RegisterCredentials is part of the environs.ProviderCredentialsRegister interface.
 func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	cloudName := cld.Name
-	if cloudName != caas.Microk8s {
+	if cloudName != caas.K8sCloudMicrok8s {
 		return make(map[string]*cloud.CloudCredential), nil
 	}
 	_, cred, _, err := p.builtinCloudGetter(p.cmdRunner)

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -104,10 +104,10 @@ func (s *credentialsSuite) TestRegisterCredentialsMicrok8s(c *gc.C) {
 	credentials, err := p.RegisterCredentials(defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[caas.Microk8s], gc.DeepEquals, &cloud.CloudCredential{
-		DefaultCredential: caas.Microk8s,
+	c.Assert(credentials[caas.K8sCloudMicrok8s], gc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: caas.K8sCloudMicrok8s,
 		AuthCredentials: map[string]cloud.Credential{
-			caas.Microk8s: getDefaultCredential(),
+			caas.K8sCloudMicrok8s: getDefaultCredential(),
 		},
 	})
 }

--- a/caas/kubernetes/provider/detectcloud.go
+++ b/caas/kubernetes/provider/detectcloud.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
+
+// DetectClouds implements environs.CloudDetector.
+func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
+	clouds := []cloud.Cloud{}
+	mk8sCloud, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
+	if err != nil {
+		logger.Debugf("failed to query local microk8s: %s", err)
+	} else {
+		clouds = append(clouds, mk8sCloud)
+	}
+	return clouds, nil
+}
+
+// DetectCloud implements environs.CloudDetector.
+func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
+	if name != builtinMicroK8sName {
+		return cloud.Cloud{}, nil
+	}
+
+	mk8sCloud, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
+	if err == nil {
+		return mk8sCloud, nil
+	}
+	logger.Debugf("failed to query local microk8s: %s", err)
+	return cloud.Cloud{}, nil
+}
+
+// FinalizeCloud is part of the environs.CloudFinalizer interface.
+func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
+	cloudName := cld.Name
+	if cloudName != builtinMicroK8sName {
+		return cld, nil
+	}
+	// Need the credentials, need to query for those details
+	mk8sCloud, credential, _, err := attemptMicroK8sCloud(p.cmdRunner)
+	if err != nil {
+		return cloud.Cloud{}, errors.Trace(err)
+	}
+
+	storageUpdateParams := KubeCloudStorageParams{
+		ClusterMetadataCheckerGetter: func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
+			openParams, err := BaseKubeCloudOpenParams(cloud, credential)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return caas.New(openParams)
+		},
+		GetClusterMetadataFunc: func(broker caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error) {
+			clusterMetadata, err := broker.GetClusterMetadata("")
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return clusterMetadata, nil
+		},
+		Errors: KubeCloudParamErrors{
+			ClusterQuery:         "Unable to query cluster. Ensure storage has been enabled with 'microk8s.enable storage'.",
+			UnknownCluster:       "Unable to determine cluster details from microk8s.config",
+			NoRecommendedStorage: "No recommended storage configuration is defined for microk8s.",
+		},
+	}
+	_, err = UpdateKubeCloudWithStorage(&mk8sCloud, credential, storageUpdateParams)
+	for i := range mk8sCloud.Regions {
+		if mk8sCloud.Regions[i].Endpoint == "" {
+			mk8sCloud.Regions[i].Endpoint = mk8sCloud.Endpoint
+		}
+	}
+	if err != nil {
+		return cloud.Cloud{}, errors.Trace(err)
+	}
+	return mk8sCloud, nil
+}

--- a/caas/kubernetes/provider/detectcloud.go
+++ b/caas/kubernetes/provider/detectcloud.go
@@ -27,7 +27,7 @@ func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
 
 // DetectCloud implements environs.CloudDetector.
 func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
-	if name != caas.Microk8s {
+	if name != caas.K8sCloudMicrok8s {
 		return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
 	}
 

--- a/caas/kubernetes/provider/detectcloud.go
+++ b/caas/kubernetes/provider/detectcloud.go
@@ -8,77 +8,36 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
-	jujucloud "github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 // DetectClouds implements environs.CloudDetector.
 func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
 	clouds := []cloud.Cloud{}
-	mk8sCloud, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
-	if err != nil {
-		logger.Debugf("failed to query local microk8s: %s", err)
-	} else {
+	mk8sCloud, _, _, err := p.builtinCloudGetter(p.cmdRunner)
+	if err == nil {
 		clouds = append(clouds, mk8sCloud)
+		return clouds, nil
 	}
+	if errors.IsNotFound(err) {
+		err = errors.Annotatef(err, "microk8s is not installed")
+	}
+	logger.Debugf("failed to query local microk8s: %s", err.Error())
 	return clouds, nil
 }
 
 // DetectCloud implements environs.CloudDetector.
 func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
-	if name != builtinMicroK8sName {
-		return cloud.Cloud{}, nil
+	if name != caas.Microk8s {
+		return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
 	}
 
-	mk8sCloud, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
+	mk8sCloud, _, _, err := p.builtinCloudGetter(p.cmdRunner)
 	if err == nil {
 		return mk8sCloud, nil
 	}
-	logger.Debugf("failed to query local microk8s: %s", err)
-	return cloud.Cloud{}, nil
-}
-
-// FinalizeCloud is part of the environs.CloudFinalizer interface.
-func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
-	cloudName := cld.Name
-	if cloudName != builtinMicroK8sName {
-		return cld, nil
+	if errors.IsNotFound(err) {
+		err = errors.Annotatef(err, "microk8s is not installed")
 	}
-	// Need the credentials, need to query for those details
-	mk8sCloud, credential, _, err := attemptMicroK8sCloud(p.cmdRunner)
-	if err != nil {
-		return cloud.Cloud{}, errors.Trace(err)
-	}
-
-	storageUpdateParams := KubeCloudStorageParams{
-		ClusterMetadataCheckerGetter: func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
-			openParams, err := BaseKubeCloudOpenParams(cloud, credential)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return caas.New(openParams)
-		},
-		GetClusterMetadataFunc: func(broker caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error) {
-			clusterMetadata, err := broker.GetClusterMetadata("")
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return clusterMetadata, nil
-		},
-		Errors: KubeCloudParamErrors{
-			ClusterQuery:         "Unable to query cluster. Ensure storage has been enabled with 'microk8s.enable storage'.",
-			UnknownCluster:       "Unable to determine cluster details from microk8s.config",
-			NoRecommendedStorage: "No recommended storage configuration is defined for microk8s.",
-		},
-	}
-	_, err = UpdateKubeCloudWithStorage(&mk8sCloud, credential, storageUpdateParams)
-	for i := range mk8sCloud.Regions {
-		if mk8sCloud.Regions[i].Endpoint == "" {
-			mk8sCloud.Regions[i].Endpoint = mk8sCloud.Endpoint
-		}
-	}
-	if err != nil {
-		return cloud.Cloud{}, errors.Trace(err)
-	}
-	return mk8sCloud, nil
+	logger.Debugf("failed to query local microk8s: %s", err.Error())
+	return cloud.Cloud{}, err
 }

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -1,0 +1,108 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
+
+var (
+	_ = gc.Suite(&detectCloudSuite{})
+)
+
+type detectCloudSuite struct{}
+
+type builtinCloudRet struct {
+	cloud          cloud.Cloud
+	credential     jujucloud.Credential
+	credentialName string
+	err            error
+}
+
+type dummyRunner struct {
+	*testing.CallMocker
+}
+
+func (d dummyRunner) RunCommands(run exec.RunParams) (*exec.ExecResponse, error) {
+	results := d.MethodCall(d, "RunCommands", run)
+	return results[0].(*exec.ExecResponse), testing.TypeAssertError(results[1])
+}
+
+func getterFunc(args builtinCloudRet) func(provider.CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error) {
+	return func(provider.CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error) {
+		return args.cloud, args.credential, args.credentialName, args.err
+	}
+}
+
+func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEnvironProvider {
+	return provider.NewProviderWithFakes(
+		dummyRunner{},
+		getterFunc(builtin),
+		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) {
+			return &fakeK8sClusterMetadataChecker{}, nil
+		},
+	)
+}
+
+func (s *detectCloudSuite) TestDetectClouds(c *gc.C) {
+	k8sCloud := jujucloud.Cloud{
+		Name: "testingMicrok8s",
+	}
+	p := s.getProvider(builtinCloudRet{cloud: k8sCloud, err: nil})
+	cloudDetector := p.(environs.CloudDetector)
+
+	clouds, err := cloudDetector.DetectClouds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(clouds, gc.HasLen, 1)
+	c.Assert(clouds[0], jc.DeepEquals, k8sCloud)
+}
+
+func (s *detectCloudSuite) TestDetectCloudsMicroK8sNotFound(c *gc.C) {
+	p := s.getProvider(builtinCloudRet{err: errors.NotFoundf("")})
+	cloudDetector := p.(environs.CloudDetector)
+
+	clouds, err := cloudDetector.DetectClouds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(clouds, gc.HasLen, 0)
+}
+
+func (s *detectCloudSuite) TestDetectCloudMicrok8s(c *gc.C) {
+	k8sCloud := jujucloud.Cloud{
+		Name: "testingMicrok8s",
+	}
+	p := s.getProvider(builtinCloudRet{cloud: k8sCloud, err: nil})
+	cloudDetector := p.(environs.CloudDetector)
+
+	cloud, err := cloudDetector.DetectCloud("microk8s")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, k8sCloud)
+}
+
+func (s *detectCloudSuite) TestDetectCloudNotMicroK8s(c *gc.C) {
+	p := s.getProvider(builtinCloudRet{})
+	cloudDetector := p.(environs.CloudDetector)
+
+	cloud, err := cloudDetector.DetectCloud("notmicrok8s")
+	c.Assert(err, gc.ErrorMatches, `cloud notmicrok8s not found`)
+	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{})
+}
+
+func (s *detectCloudSuite) TestDetectCloudMicroK8sErrorsNotFound(c *gc.C) {
+	p := s.getProvider(builtinCloudRet{err: errors.NotFoundf("")})
+	cloudDetector := p.(environs.CloudDetector)
+
+	cloud, err := cloudDetector.DetectCloud("notmicrok8s")
+	c.Assert(err, gc.ErrorMatches, `cloud notmicrok8s not found`)
+	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{})
+}

--- a/caas/kubernetes/provider/errors.go
+++ b/caas/kubernetes/provider/errors.go
@@ -20,7 +20,8 @@ func IsClusterQueryError(err error) bool {
 
 // UnknownClusterError occurs when the provided cluster is not known to Juju.
 type UnknownClusterError struct {
-	Message string
+	Message   string
+	CloudName string
 }
 
 func (e UnknownClusterError) Error() string {

--- a/caas/kubernetes/provider/errors.go
+++ b/caas/kubernetes/provider/errors.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+// ClusterQueryError represents an issue when querying a cluster.
+type ClusterQueryError struct {
+	Message string
+}
+
+func (e ClusterQueryError) Error() string {
+	return e.Message
+}
+
+// IsClusterQueryError returns true if err is a ClusterQueryError.
+func IsClusterQueryError(err error) bool {
+	_, ok := err.(ClusterQueryError)
+	return ok
+}
+
+// UnknownClusterError occurs when the provided cluster is not known to Juju.
+type UnknownClusterError struct {
+	Message string
+}
+
+func (e UnknownClusterError) Error() string {
+	return e.Message
+}
+
+// IsUnknownClusterError returns true if err is a UnknownClusterError
+func IsUnknownClusterError(err error) bool {
+	_, ok := err.(UnknownClusterError)
+	return ok
+}
+
+// NoRecommendedStorageError represents when Juju is unable to determine which storage a cluster uses (or should use)
+type NoRecommendedStorageError struct {
+	Message      string
+	ProviderName string
+}
+
+func (e NoRecommendedStorageError) Error() string {
+	return e.Message
+}
+
+func (e NoRecommendedStorageError) StorageProvider() string {
+	return e.ProviderName
+}
+
+// IsNoRecommendedStorageError returns true if err is a NoRecommendedStorageError
+func IsNoRecommendedStorageError(err error) bool {
+	_, ok := err.(NoRecommendedStorageError)
+	return ok
+}

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/mongo"
@@ -28,6 +30,8 @@ var (
 	CompileK8sCloudCheckers  = compileK8sCloudCheckers
 	CloudSpecToK8sRestConfig = cloudSpecToK8sRestConfig
 	ControllerCorelation     = controllerCorelation
+	GetLocalMicroK8sConfig   = getLocalMicroK8sConfig
+	AttemptMicroK8sCloud     = attemptMicroK8sCloud
 )
 
 type (
@@ -69,6 +73,23 @@ func PodSpec(u *unitSpec) core.PodSpec {
 
 func NewProvider() caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{}
+}
+
+func NewProviderWithFakes(
+	runner CommandRunner,
+	getter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error),
+	brokerGetter func(environs.OpenParams) (caas.ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
+	return kubernetesEnvironProvider{
+		cmdRunner:          runner,
+		builtinCloudGetter: getter,
+		brokerGetter:       brokerGetter,
+	}
+}
+
+func NewProviderCredentials(getter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error)) environProviderCredentials {
+	return environProviderCredentials{
+		builtinCloudGetter: getter,
+	}
 }
 
 func StorageProvider(k8sClient kubernetes.Interface, namespace string) storage.Provider {

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 )

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -4,35 +4,26 @@
 package provider
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"net/url"
-	"reflect"
-	"strings"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
-	"github.com/juju/utils"
 	"github.com/juju/utils/exec"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas"
-	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
-	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 )
 
-var builtinMicroK8sClusterName = "microk8s-cluster"
-var builtinMicroK8sName = "microk8s"
-
+// need to pass environProviderCredentials a cmdRunner too?
+// I think that would be possible
 type kubernetesEnvironProvider struct {
 	environProviderCredentials
 	cmdRunner CommandRunner
@@ -170,277 +161,4 @@ func (p kubernetesEnvironProvider) validateCloudSpec(spec environs.CloudSpec) er
 		return errors.NotSupportedf("%q auth-type", authType)
 	}
 	return nil
-}
-
-// DetectClouds implements environs.CloudDetector.
-func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
-	clouds := []cloud.Cloud{}
-	mk8sCloud, _, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
-	if err != nil {
-		logger.Debugf("failed to query local microk8s: %s", err)
-	} else {
-		clouds = append(clouds, mk8sCloud)
-	}
-	return clouds, nil
-}
-
-// DetectCloud implements environs.CloudDetector.
-func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
-	if name == builtinMicroK8sName {
-		mk8sCloud, _, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
-		return mk8sCloud, err
-	}
-	return cloud.Cloud{}, nil
-}
-
-func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, jujucloud.Credential, string, string, error) {
-	var newCloud cloud.Cloud
-	fail := func(err error) (cloud.Cloud, jujucloud.Credential, string, string, error) {
-		return newCloud, jujucloud.Credential{}, "", "", err
-	}
-	execParams := exec.RunParams{
-		Commands: "microk8s.config",
-	}
-	result, err := cmdRunner.RunCommands(execParams)
-	if err != nil {
-		return fail(err)
-	}
-	if result.Code != 0 {
-		return fail(errors.New(string(result.Stderr)))
-	}
-
-	rdr := bytes.NewReader(result.Stdout)
-
-	cloudParams := KubeCloudParams{
-		ClusterName: builtinMicroK8sClusterName,
-		CaasName:    builtinMicroK8sName,
-		CaasType:    CAASProviderType,
-		Errors: KubeCloudParamErrors{
-			ClusterQuery:         "Unable to query cluster. Ensure storage has been enabled with 'microk8s.enable storage'.",
-			UnknownCluster:       "Unable to determine cluster details from microk8s.config",
-			NoRecommendedStorage: "No recommended storage configuration is defined for microk8s.",
-		},
-		ClusterMetadataCheckerGetter: func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
-			openParams, err := BaseKubeCloudOpenParams(cloud, credential)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return caas.New(openParams)
-		},
-		ClientConfigGetter: func(caasType string) (clientconfig.ClientConfigFunc, error) {
-			return clientconfig.NewClientConfigReader(caasType)
-		},
-		ClusterMetadataCheckerFunc: func(broker caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error) {
-			clusterMetadata, err := broker.GetClusterMetadata("")
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return clusterMetadata, nil
-		},
-	}
-	return CloudFromKubeConfig(rdr, cloudParams)
-}
-
-type ClusterMetadataCheckerGetter func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error)
-type ClientConfigFuncGetter func(string) (clientconfig.ClientConfigFunc, error)
-type ClusterMetadataCheckerFunc func(caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error)
-
-// KubeCloudParams provides the needed information to extract a Cloud from available cluster information.
-type KubeCloudParams struct {
-	ClusterName                  string
-	ContextName                  string
-	CaasName                     string
-	HostCloudRegion              string
-	WorkloadStorage              string
-	CaasType                     string
-	Errors                       KubeCloudParamErrors
-	ClusterMetadataCheckerGetter ClusterMetadataCheckerGetter
-	ClientConfigGetter           ClientConfigFuncGetter
-	ClusterMetadataCheckerFunc   ClusterMetadataCheckerFunc
-}
-
-//KubeCloudParamErrors allows errors to be customised based on need (e.g. interactive CLI command or behind the scenes query).
-type KubeCloudParamErrors struct {
-	ClusterQuery         string
-	UnknownCluster       string
-	NoRecommendedStorage string
-}
-
-// BaseKubeCloudOpenParams provides a basic OpenParams for a cluster
-func BaseKubeCloudOpenParams(cloud jujucloud.Cloud, credential jujucloud.Credential) (environs.OpenParams, error) {
-	// To get a k8s client, we need a config with minimal information.
-	// It's not used unless operating on a real model but we need to supply it.
-	uuid, err := utils.NewUUID()
-	if err != nil {
-		return environs.OpenParams{}, errors.Trace(err)
-	}
-	attrs := map[string]interface{}{
-		config.NameKey: "add-cloud",
-		config.TypeKey: "kubernetes",
-		config.UUIDKey: uuid.String(),
-	}
-	cfg, err := config.New(config.NoDefaults, attrs)
-	if err != nil {
-		return environs.OpenParams{}, errors.Trace(err)
-	}
-
-	cloudSpec, err := environs.MakeCloudSpec(cloud, "", &credential)
-	if err != nil {
-		return environs.OpenParams{}, errors.Trace(err)
-	}
-	openParams := environs.OpenParams{
-		Cloud: cloudSpec, Config: cfg,
-	}
-	return openParams, nil
-}
-
-// CloudFromKubeConfig attempts to extract a cloud and credential details from the provided Kubeconfig.
-func CloudFromKubeConfig(reader io.Reader, betterName KubeCloudParams) (cloud.Cloud, jujucloud.Credential, string, string, error) {
-	fail := func(e error) (cloud.Cloud, jujucloud.Credential, string, string, error) {
-		return cloud.Cloud{}, jujucloud.Credential{}, "", "", e
-	}
-	newCloud, credential, context, err := newCloudCredentialFromKubeConfig(reader, betterName)
-	if err != nil {
-		return fail(errors.Trace(err))
-	}
-
-	broker, err := betterName.ClusterMetadataCheckerGetter(newCloud, credential)
-	if err != nil {
-		return fail(errors.Trace(err))
-	}
-
-	// Get the cluster metadata so we can see if there's suitable storage available.
-	clusterMetadata, err := betterName.ClusterMetadataCheckerFunc(broker)
-	if err != nil || clusterMetadata == nil {
-		return fail(errors.Annotate(err, betterName.Errors.ClusterQuery))
-	}
-
-	if betterName.HostCloudRegion == "" && clusterMetadata.Regions != nil && clusterMetadata.Regions.Size() > 0 {
-		betterName.HostCloudRegion = clusterMetadata.Cloud + "/" + clusterMetadata.Regions.SortedValues()[0]
-	}
-	if betterName.HostCloudRegion == "" {
-		return fail(errors.New(betterName.Errors.ClusterQuery))
-	}
-	_, region, err := ParseCloudRegion(betterName.HostCloudRegion)
-	if err != nil {
-		return fail(errors.Annotatef(err, "validating cloud region %q", betterName.HostCloudRegion))
-	}
-	newCloud.HostCloudRegion = betterName.HostCloudRegion
-	newCloud.Regions = []jujucloud.Region{{
-		Name: region,
-	}}
-
-	// If the user has not specified storage, check that the cluster has Juju's opinionated defaults.
-	cloudType := strings.Split(betterName.HostCloudRegion, "/")[0]
-	err = broker.CheckDefaultWorkloadStorage(cloudType, clusterMetadata.NominatedStorageClass)
-	if errors.IsNotFound(err) {
-		return fail(errors.Errorf(betterName.Errors.UnknownCluster, cloudType))
-	}
-	if betterName.WorkloadStorage == "" && caas.IsNonPreferredStorageError(err) {
-		npse := err.(*caas.NonPreferredStorageError)
-		return fail(errors.Errorf(betterName.Errors.NoRecommendedStorage, npse.Name))
-	}
-	if err != nil && !caas.IsNonPreferredStorageError(err) {
-		return fail(errors.Trace(err))
-	}
-
-	// If no storage class exists, we need to create one with the opinionated defaults.
-	var storageMsg string
-	if betterName.WorkloadStorage != "" && caas.IsNonPreferredStorageError(err) {
-		preferredStorage := errors.Cause(err).(*caas.NonPreferredStorageError).PreferredStorage
-		sp, err := broker.EnsureStorageProvisioner(caas.StorageProvisioner{
-			Name:        betterName.WorkloadStorage,
-			Provisioner: preferredStorage.Provisioner,
-			Parameters:  preferredStorage.Parameters,
-		})
-		if err != nil {
-			return fail(errors.Annotatef(err, "creating storage class %q", betterName.WorkloadStorage))
-		}
-		if sp.Provisioner == preferredStorage.Provisioner {
-			storageMsg = fmt.Sprintf(" with %s default storage", preferredStorage.Name)
-			if betterName.WorkloadStorage != "" {
-				storageMsg = fmt.Sprintf("%s provisioned\nby the existing %q storage class", storageMsg, betterName.WorkloadStorage)
-			}
-		} else {
-			storageMsg = fmt.Sprintf(" with storage provisioned\nby the existing %q storage class", betterName.WorkloadStorage)
-		}
-	}
-	if betterName.WorkloadStorage == "" && clusterMetadata.NominatedStorageClass != nil {
-		betterName.WorkloadStorage = clusterMetadata.NominatedStorageClass.Name
-	}
-
-	// Record the operator storage to use.
-	var operatorStorageName string
-	if clusterMetadata.OperatorStorageClass != nil {
-		operatorStorageName = clusterMetadata.OperatorStorageClass.Name
-	} else {
-		operatorStorageName = betterName.WorkloadStorage
-		if storageMsg == "" {
-			storageMsg += "\nwith "
-		} else {
-			storageMsg += "\n"
-		}
-		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class")
-	}
-
-	if newCloud.Config == nil {
-		newCloud.Config = make(map[string]interface{})
-	}
-	if _, ok := newCloud.Config[WorkloadStorageKey]; !ok {
-		newCloud.Config[WorkloadStorageKey] = betterName.WorkloadStorage
-	}
-	if _, ok := newCloud.Config[OperatorStorageKey]; !ok {
-		newCloud.Config[OperatorStorageKey] = operatorStorageName
-	}
-	if _, ok := newCloud.Config[bootstrap.ControllerServiceTypeKey]; !ok {
-		newCloud.Config[bootstrap.ControllerServiceTypeKey] = clusterMetadata.PreferredServiceType
-	}
-
-	return newCloud, credential, context.CredentialName, storageMsg, nil
-}
-
-func newCloudCredentialFromKubeConfig(reader io.Reader, betterName KubeCloudParams) (jujucloud.Cloud, jujucloud.Credential, clientconfig.Context, error) {
-	var credential jujucloud.Credential
-	var context clientconfig.Context
-	newCloud := jujucloud.Cloud{
-		Name:            betterName.CaasName,
-		Type:            betterName.CaasType,
-		HostCloudRegion: betterName.HostCloudRegion,
-	}
-	clientConfigFunc, err := betterName.ClientConfigGetter(betterName.CaasType)
-	if err != nil {
-		return newCloud, credential, context, errors.Trace(err)
-	}
-	caasConfig, err := clientConfigFunc(reader, betterName.ContextName, betterName.ClusterName, clientconfig.EnsureK8sCredential)
-	if err != nil {
-		return newCloud, credential, context, errors.Trace(err)
-	}
-	logger.Debugf("caasConfig: %+v", caasConfig)
-
-	if len(caasConfig.Contexts) == 0 {
-		return newCloud, credential, context, errors.Errorf("No k8s cluster definitions found in config")
-	}
-
-	context = caasConfig.Contexts[reflect.ValueOf(caasConfig.Contexts).MapKeys()[0].Interface().(string)]
-
-	credential = caasConfig.Credentials[context.CredentialName]
-	newCloud.AuthTypes = []jujucloud.AuthType{credential.AuthType()}
-	currentCloud := caasConfig.Clouds[context.CloudName]
-	newCloud.Endpoint = currentCloud.Endpoint
-
-	cloudCAData, ok := currentCloud.Attributes["CAData"].(string)
-	if !ok {
-		return newCloud, credential, context, errors.Errorf("CAData attribute should be a string")
-	}
-	newCloud.CACertificates = []string{cloudCAData}
-	return newCloud, credential, context, nil
-}
-
-// ParseCloudRegion breaks apart a clusters cloud region.
-func ParseCloudRegion(cloudRegion string) (string, string, error) {
-	fields := strings.SplitN(cloudRegion, "/", 2)
-	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
-		return "", "", errors.NotValidf("cloud region %q", cloudRegion)
-	}
-	return fields[0], fields[1], nil
 }

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -22,8 +22,6 @@ import (
 	"github.com/juju/juju/environs/context"
 )
 
-// need to pass environProviderCredentials a cmdRunner too?
-// I think that would be possible
 type kubernetesEnvironProvider struct {
 	environProviderCredentials
 	cmdRunner          CommandRunner

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -4,32 +4,59 @@
 package provider
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/url"
+	"reflect"
+	"strings"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
+	"github.com/juju/utils"
+	"github.com/juju/utils/exec"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 )
 
+var builtinMicroK8sClusterName = "microk8s-cluster"
+var builtinMicroK8sName = "microk8s"
+
 type kubernetesEnvironProvider struct {
 	environProviderCredentials
+	cmdRunner CommandRunner
 }
 
 var _ environs.EnvironProvider = (*kubernetesEnvironProvider)(nil)
-var providerInstance = kubernetesEnvironProvider{}
+var providerInstance = kubernetesEnvironProvider{
+	cmdRunner: defaultRunner{},
+}
 
 // Version is part of the EnvironProvider interface.
 func (kubernetesEnvironProvider) Version() int {
 	return 0
+}
+
+// CommandRunner allows to run commands on the underlying system
+type CommandRunner interface {
+	RunCommands(run exec.RunParams) (*exec.ExecResponse, error)
+}
+
+type defaultRunner struct{}
+
+func (defaultRunner) RunCommands(run exec.RunParams) (*exec.ExecResponse, error) {
+	return exec.RunCommands(run)
 }
 
 func newK8sClient(c *rest.Config) (kubernetes.Interface, apiextensionsclientset.Interface, error) {
@@ -143,4 +170,277 @@ func (p kubernetesEnvironProvider) validateCloudSpec(spec environs.CloudSpec) er
 		return errors.NotSupportedf("%q auth-type", authType)
 	}
 	return nil
+}
+
+// DetectClouds implements environs.CloudDetector.
+func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
+	clouds := []cloud.Cloud{}
+	mk8sCloud, _, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
+	if err != nil {
+		logger.Debugf("failed to query local microk8s: %s", err)
+	} else {
+		clouds = append(clouds, mk8sCloud)
+	}
+	return clouds, nil
+}
+
+// DetectCloud implements environs.CloudDetector.
+func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
+	if name == builtinMicroK8sName {
+		mk8sCloud, _, _, _, err := attemptMicroK8sCloud(p.cmdRunner)
+		return mk8sCloud, err
+	}
+	return cloud.Cloud{}, nil
+}
+
+func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, jujucloud.Credential, string, string, error) {
+	var newCloud cloud.Cloud
+	fail := func(err error) (cloud.Cloud, jujucloud.Credential, string, string, error) {
+		return newCloud, jujucloud.Credential{}, "", "", err
+	}
+	execParams := exec.RunParams{
+		Commands: "microk8s.config",
+	}
+	result, err := cmdRunner.RunCommands(execParams)
+	if err != nil {
+		return fail(err)
+	}
+	if result.Code != 0 {
+		return fail(errors.New(string(result.Stderr)))
+	}
+
+	rdr := bytes.NewReader(result.Stdout)
+
+	cloudParams := KubeCloudParams{
+		ClusterName: builtinMicroK8sClusterName,
+		CaasName:    builtinMicroK8sName,
+		CaasType:    CAASProviderType,
+		Errors: KubeCloudParamErrors{
+			ClusterQuery:         "Unable to query cluster. Ensure storage has been enabled with 'microk8s.enable storage'.",
+			UnknownCluster:       "Unable to determine cluster details from microk8s.config",
+			NoRecommendedStorage: "No recommended storage configuration is defined for microk8s.",
+		},
+		ClusterMetadataCheckerGetter: func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
+			openParams, err := BaseKubeCloudOpenParams(cloud, credential)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return caas.New(openParams)
+		},
+		ClientConfigGetter: func(caasType string) (clientconfig.ClientConfigFunc, error) {
+			return clientconfig.NewClientConfigReader(caasType)
+		},
+		ClusterMetadataCheckerFunc: func(broker caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error) {
+			clusterMetadata, err := broker.GetClusterMetadata("")
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return clusterMetadata, nil
+		},
+	}
+	return CloudFromKubeConfig(rdr, cloudParams)
+}
+
+type ClusterMetadataCheckerGetter func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error)
+type ClientConfigFuncGetter func(string) (clientconfig.ClientConfigFunc, error)
+type ClusterMetadataCheckerFunc func(caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error)
+
+// KubeCloudParams provides the needed information to extract a Cloud from available cluster information.
+type KubeCloudParams struct {
+	ClusterName                  string
+	ContextName                  string
+	CaasName                     string
+	HostCloudRegion              string
+	WorkloadStorage              string
+	CaasType                     string
+	Errors                       KubeCloudParamErrors
+	ClusterMetadataCheckerGetter ClusterMetadataCheckerGetter
+	ClientConfigGetter           ClientConfigFuncGetter
+	ClusterMetadataCheckerFunc   ClusterMetadataCheckerFunc
+}
+
+//KubeCloudParamErrors allows errors to be customised based on need (e.g. interactive CLI command or behind the scenes query).
+type KubeCloudParamErrors struct {
+	ClusterQuery         string
+	UnknownCluster       string
+	NoRecommendedStorage string
+}
+
+// BaseKubeCloudOpenParams provides a basic OpenParams for a cluster
+func BaseKubeCloudOpenParams(cloud jujucloud.Cloud, credential jujucloud.Credential) (environs.OpenParams, error) {
+	// To get a k8s client, we need a config with minimal information.
+	// It's not used unless operating on a real model but we need to supply it.
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+	attrs := map[string]interface{}{
+		config.NameKey: "add-cloud",
+		config.TypeKey: "kubernetes",
+		config.UUIDKey: uuid.String(),
+	}
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+
+	cloudSpec, err := environs.MakeCloudSpec(cloud, "", &credential)
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+	openParams := environs.OpenParams{
+		Cloud: cloudSpec, Config: cfg,
+	}
+	return openParams, nil
+}
+
+// CloudFromKubeConfig attempts to extract a cloud and credential details from the provided Kubeconfig.
+func CloudFromKubeConfig(reader io.Reader, betterName KubeCloudParams) (cloud.Cloud, jujucloud.Credential, string, string, error) {
+	fail := func(e error) (cloud.Cloud, jujucloud.Credential, string, string, error) {
+		return cloud.Cloud{}, jujucloud.Credential{}, "", "", e
+	}
+	newCloud, credential, context, err := newCloudCredentialFromKubeConfig(reader, betterName)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+
+	broker, err := betterName.ClusterMetadataCheckerGetter(newCloud, credential)
+	if err != nil {
+		return fail(errors.Trace(err))
+	}
+
+	// Get the cluster metadata so we can see if there's suitable storage available.
+	clusterMetadata, err := betterName.ClusterMetadataCheckerFunc(broker)
+	if err != nil || clusterMetadata == nil {
+		return fail(errors.Annotate(err, betterName.Errors.ClusterQuery))
+	}
+
+	if betterName.HostCloudRegion == "" && clusterMetadata.Regions != nil && clusterMetadata.Regions.Size() > 0 {
+		betterName.HostCloudRegion = clusterMetadata.Cloud + "/" + clusterMetadata.Regions.SortedValues()[0]
+	}
+	if betterName.HostCloudRegion == "" {
+		return fail(errors.New(betterName.Errors.ClusterQuery))
+	}
+	_, region, err := ParseCloudRegion(betterName.HostCloudRegion)
+	if err != nil {
+		return fail(errors.Annotatef(err, "validating cloud region %q", betterName.HostCloudRegion))
+	}
+	newCloud.HostCloudRegion = betterName.HostCloudRegion
+	newCloud.Regions = []jujucloud.Region{{
+		Name: region,
+	}}
+
+	// If the user has not specified storage, check that the cluster has Juju's opinionated defaults.
+	cloudType := strings.Split(betterName.HostCloudRegion, "/")[0]
+	err = broker.CheckDefaultWorkloadStorage(cloudType, clusterMetadata.NominatedStorageClass)
+	if errors.IsNotFound(err) {
+		return fail(errors.Errorf(betterName.Errors.UnknownCluster, cloudType))
+	}
+	if betterName.WorkloadStorage == "" && caas.IsNonPreferredStorageError(err) {
+		npse := err.(*caas.NonPreferredStorageError)
+		return fail(errors.Errorf(betterName.Errors.NoRecommendedStorage, npse.Name))
+	}
+	if err != nil && !caas.IsNonPreferredStorageError(err) {
+		return fail(errors.Trace(err))
+	}
+
+	// If no storage class exists, we need to create one with the opinionated defaults.
+	var storageMsg string
+	if betterName.WorkloadStorage != "" && caas.IsNonPreferredStorageError(err) {
+		preferredStorage := errors.Cause(err).(*caas.NonPreferredStorageError).PreferredStorage
+		sp, err := broker.EnsureStorageProvisioner(caas.StorageProvisioner{
+			Name:        betterName.WorkloadStorage,
+			Provisioner: preferredStorage.Provisioner,
+			Parameters:  preferredStorage.Parameters,
+		})
+		if err != nil {
+			return fail(errors.Annotatef(err, "creating storage class %q", betterName.WorkloadStorage))
+		}
+		if sp.Provisioner == preferredStorage.Provisioner {
+			storageMsg = fmt.Sprintf(" with %s default storage", preferredStorage.Name)
+			if betterName.WorkloadStorage != "" {
+				storageMsg = fmt.Sprintf("%s provisioned\nby the existing %q storage class", storageMsg, betterName.WorkloadStorage)
+			}
+		} else {
+			storageMsg = fmt.Sprintf(" with storage provisioned\nby the existing %q storage class", betterName.WorkloadStorage)
+		}
+	}
+	if betterName.WorkloadStorage == "" && clusterMetadata.NominatedStorageClass != nil {
+		betterName.WorkloadStorage = clusterMetadata.NominatedStorageClass.Name
+	}
+
+	// Record the operator storage to use.
+	var operatorStorageName string
+	if clusterMetadata.OperatorStorageClass != nil {
+		operatorStorageName = clusterMetadata.OperatorStorageClass.Name
+	} else {
+		operatorStorageName = betterName.WorkloadStorage
+		if storageMsg == "" {
+			storageMsg += "\nwith "
+		} else {
+			storageMsg += "\n"
+		}
+		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class")
+	}
+
+	if newCloud.Config == nil {
+		newCloud.Config = make(map[string]interface{})
+	}
+	if _, ok := newCloud.Config[WorkloadStorageKey]; !ok {
+		newCloud.Config[WorkloadStorageKey] = betterName.WorkloadStorage
+	}
+	if _, ok := newCloud.Config[OperatorStorageKey]; !ok {
+		newCloud.Config[OperatorStorageKey] = operatorStorageName
+	}
+	if _, ok := newCloud.Config[bootstrap.ControllerServiceTypeKey]; !ok {
+		newCloud.Config[bootstrap.ControllerServiceTypeKey] = clusterMetadata.PreferredServiceType
+	}
+
+	return newCloud, credential, context.CredentialName, storageMsg, nil
+}
+
+func newCloudCredentialFromKubeConfig(reader io.Reader, betterName KubeCloudParams) (jujucloud.Cloud, jujucloud.Credential, clientconfig.Context, error) {
+	var credential jujucloud.Credential
+	var context clientconfig.Context
+	newCloud := jujucloud.Cloud{
+		Name:            betterName.CaasName,
+		Type:            betterName.CaasType,
+		HostCloudRegion: betterName.HostCloudRegion,
+	}
+	clientConfigFunc, err := betterName.ClientConfigGetter(betterName.CaasType)
+	if err != nil {
+		return newCloud, credential, context, errors.Trace(err)
+	}
+	caasConfig, err := clientConfigFunc(reader, betterName.ContextName, betterName.ClusterName, clientconfig.EnsureK8sCredential)
+	if err != nil {
+		return newCloud, credential, context, errors.Trace(err)
+	}
+	logger.Debugf("caasConfig: %+v", caasConfig)
+
+	if len(caasConfig.Contexts) == 0 {
+		return newCloud, credential, context, errors.Errorf("No k8s cluster definitions found in config")
+	}
+
+	context = caasConfig.Contexts[reflect.ValueOf(caasConfig.Contexts).MapKeys()[0].Interface().(string)]
+
+	credential = caasConfig.Credentials[context.CredentialName]
+	newCloud.AuthTypes = []jujucloud.AuthType{credential.AuthType()}
+	currentCloud := caasConfig.Clouds[context.CloudName]
+	newCloud.Endpoint = currentCloud.Endpoint
+
+	cloudCAData, ok := currentCloud.Attributes["CAData"].(string)
+	if !ok {
+		return newCloud, credential, context, errors.Errorf("CAData attribute should be a string")
+	}
+	newCloud.CACertificates = []string{cloudCAData}
+	return newCloud, credential, context, nil
+}
+
+// ParseCloudRegion breaks apart a clusters cloud region.
+func ParseCloudRegion(cloudRegion string) (string, string, error) {
+	fields := strings.SplitN(cloudRegion, "/", 2)
+	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
+		return "", "", errors.NotValidf("cloud region %q", cloudRegion)
+	}
+	return fields[0], fields[1], nil
 }

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -20,9 +20,10 @@ const (
 	K8sCloudEC2 = "ec2"
 	// K8sCloudCDK is the name used for CDK k8s clouds.
 	K8sCloudCDK = "cdk"
-
 	// Microk8sRegion is the single microk8s cloud region.
 	Microk8sRegion = "localhost"
+	// MicroK8sClusterName is the cluster named used by microk8s.
+	MicroK8sClusterName = "microk8s-cluster"
 )
 
 // PreferredStorage defines preferred storage

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -371,6 +371,7 @@ var defaultCloudDescription = map[string]string{
 	"maas":        "Metal As A Service",
 	"openstack":   "Openstack Cloud",
 	"oracle":      "Oracle Compute Cloud Service",
+	"kubernetes":  "Kubernetes",
 }
 
 // WritePublicCloudMetadata marshals to YAML and writes the cloud metadata

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -371,7 +371,7 @@ var defaultCloudDescription = map[string]string{
 	"maas":        "Metal As A Service",
 	"openstack":   "Openstack Cloud",
 	"oracle":      "Oracle Compute Cloud Service",
-	"kubernetes":  "Kubernetes",
+	"kubernetes":  "A Kubernetes Cluster",
 }
 
 // WritePublicCloudMetadata marshals to YAML and writes the cloud metadata

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -386,13 +386,16 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) error {
 	storageMsg, err := provider.UpdateKubeCloudWithStorage(&newCloud, credential, storageParams)
 	if err != nil {
 		if provider.IsClusterQueryError(err) {
+			if err.Error() == "" {
+				return errors.New(clusterQueryErrMsg)
+			}
 			return errors.Annotate(err, clusterQueryErrMsg)
 		}
 		if provider.IsNoRecommendedStorageError(err) {
 			return errors.Errorf(noRecommendedStorageErrMsg, err.(provider.NoRecommendedStorageError).StorageProvider())
 		}
 		if provider.IsUnknownClusterError(err) {
-			return errors.Annotate(err, unknownClusterErrMsg)
+			return errors.Errorf(unknownClusterErrMsg, err.(provider.UnknownClusterError).CloudName)
 		}
 		return errors.Trace(err)
 	}

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -19,7 +20,7 @@ func NewAddCAASCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
 	store jujuclient.ClientStore,
 	addCloudAPIFunc func() (AddCloudAPI, error),
-	brokerGetter BrokerGetter,
+	brokerGetter provider.ClusterMetadataCheckerGetter,
 	k8sCluster k8sCluster,
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),
 	getAllCloudDetails func() (map[string]*jujucmdcloud.CloudDetails, error),

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
-	"github.com/juju/juju/caas/kubernetes/provider"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -20,7 +19,7 @@ func NewAddCAASCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
 	store jujuclient.ClientStore,
 	addCloudAPIFunc func() (AddCloudAPI, error),
-	brokerGetter provider.ClusterMetadataCheckerGetter,
+	brokerGetter BrokerGetter,
 	k8sCluster k8sCluster,
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),
 	getAllCloudDetails func() (map[string]*jujucmdcloud.CloudDetails, error),


### PR DESCRIPTION
## Description of change

Make MicroK8s a built-in cloud. So if you have microk8s snap installed it will show in ```juju clouds``` and you can ```juju bootstrap microk8s <controller name>``` much like how LXD currently is.

## QA steps

Without microk8s installed run ```juju clouds``` it must not show in the output.
Install microk8s and re-run the above command, microk8s will be visible in the output.

## Documentation changes

n/a
## Bug reference

n/a