### PR TITLE
Remove github.com/juju/charmstore.v5 from application.DeploySuite

### DIFF
--- a/apiserver/testing/fakecharmstore.go
+++ b/apiserver/testing/fakecharmstore.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charmrepo.v3"
 	"gopkg.in/juju/charmrepo.v3/csclient"
+	"gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/charmstore.v5"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakerytest"
@@ -21,6 +22,15 @@ import (
 
 	"github.com/juju/juju/testcharms"
 )
+
+type charmstoreClientShim struct {
+	*csclient.Client
+}
+
+func (c charmstoreClientShim) WithChannel(channel params.Channel) testcharms.CharmstoreClient {
+	client := c.Client.WithChannel(channel)
+	return charmstoreClientShim{client}
+}
 
 type CharmStoreSuite struct {
 	testing.CleanupSuite
@@ -77,9 +87,11 @@ func (s *CharmStoreSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *CharmStoreSuite) UploadCharm(c *gc.C, url, name string) (*charm.URL, charm.Charm) {
-	return testcharms.UploadCharm(c, s.Client, url, name)
+	client := &charmstoreClientShim{s.Client}
+	return testcharms.UploadCharm(c, client, url, name)
 }
 
 func (s *CharmStoreSuite) UploadCharmMultiSeries(c *gc.C, url, name string) (*charm.URL, charm.Charm) {
-	return testcharms.UploadCharmMultiSeries(c, s.Client, url, name)
+	client := &charmstoreClientShim{s.Client}
+	return testcharms.UploadCharmMultiSeries(c, client, url, name)
 }

--- a/charmstore/fakeclient.go
+++ b/charmstore/fakeclient.go
@@ -24,11 +24,19 @@
 package charmstore
 
 import (
+	"bytes"
+	"crypto/sha512"
+	"fmt"
 	"io"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/charmrepo.v3/csclient"
 	"gopkg.in/juju/charmrepo.v3/csclient/params"
+	"gopkg.in/macaroon.v2-unstable"
+
+	"github.com/juju/juju/api/charms"
 )
 
 // datastore is a small, in-memory key/value store. Its primary use case is to
@@ -89,7 +97,8 @@ type FakeClient struct {
 //var _ csWrapper = (*FakeClient)(nil)
 
 // NewFakeClient returns a FakeClient that is initialised
-// with repo.
+// with repo. If repo is nil, a blank Repository will be
+// created.
 func NewFakeClient(repo *Repository) *FakeClient {
 	if repo == nil {
 		repo = NewRepository()
@@ -97,13 +106,92 @@ func NewFakeClient(repo *Repository) *FakeClient {
 	return &FakeClient{repo}
 }
 
-// Get retrieves data from path
+// Get retrieves data from path. If nothing has been Put to
+// path, an error satisfying errors.IsNotFound is returned.
 func (c FakeClient) Get(path string, value interface{}) error {
 	return c.repo.resourcesData.Get(path, value)
 }
 
+// WithChannel returns a ChannelAwareFakeClient with its channel
+// set to channel and its other values originating from this client.
 func (c FakeClient) WithChannel(channel params.Channel) *ChannelAwareFakeClient {
 	return &ChannelAwareFakeClient{channel, c}
+}
+
+// Put uploads data to path, overwriting any data that is already present
+func (c FakeClient) Put(path string, value interface{}) error {
+	return c.repo.resourcesData.Put(path, value)
+}
+
+// AddDockerResource adds a docker resource against id.
+func (c FakeClient) AddDockerResource(id *charm.URL, resourceName string, imageName, digest string) (revision int, err error) {
+	return -1, nil
+}
+
+// UploadCharm takes a charm's formal identifier (its URL)
+// and its contents, then uploads it into the store for other clients
+// to download.
+//
+// Returns another charm identifier, which has had its revision set to
+// the new revision, which will be 0 for the first revision or
+// current revision in the store, plus 1.
+func (c FakeClient) UploadCharm(id *charm.URL, charmData charm.Charm) (*charm.URL, error) {
+	return c.repo.UploadCharm(id, charmData)
+}
+
+// UploadCharmWithRevision takes a charm's formal identifier (its URL)
+// and its contents and a revision number, then uploads it into the
+// store for other clients to download.
+func (c FakeClient) UploadCharmWithRevision(id *charm.URL, charmData charm.Charm, promulgatedRevision int) error {
+	return c.repo.UploadCharmWithRevision(id, charmData, promulgatedRevision)
+}
+
+// UploadBundle takes a bundle's formal identifier (its URL)
+// and its contents, then uploads it into the store for other clients
+// to download.
+//
+// Returns another charm identifier, which has had its revision set to
+// the new revision, which will be 0 for the first revision or
+// current revision in the store, plus 1.
+func (c FakeClient) UploadBundle(id *charm.URL, bundleData charm.Bundle) (*charm.URL, error) {
+	return c.repo.UploadBundle(id, bundleData)
+}
+
+// UploadBundleWithRevision takes a bundle's formal identifier (its URL)
+// and its contents and a revision number, then uploads it into the
+// store for other clients to download.
+func (c FakeClient) UploadBundleWithRevision(id *charm.URL, bundleData charm.Bundle, promulgatedRevision int) error {
+	return c.repo.UploadBundleWithRevision(id, bundleData, promulgatedRevision)
+}
+
+// UploadResource uploads a resource (an archive) into the store,
+// tags it to a charm/bundle represented by id for other clients
+// to download when they download the charm/bundle.
+//
+// In this implementation, the progress parameter is ignored.
+func (c FakeClient) UploadResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, progress csclient.Progress) (revision int, err error) {
+	return c.repo.UploadResource(id, name, path, file, size, progress)
+}
+
+// ListResources returns Resource metadata for resources that have been
+// uploaded to the repository for id. To upload a resource, use UploadResource.
+// Although id is type *charm.URL, resources are not restricted to charms. That
+// type is also used for other entities in the charmstore, such as bundles.
+//
+// Returns an error that satisfies errors.IsNotFound when no resources
+// are present for id.
+func (c FakeClient) ListResources(channel params.Channel, id *charm.URL) ([]params.Resource, error) {
+	originalChannel := c.repo.channel
+	defer func() { c.repo.channel = originalChannel }()
+	c.repo.channel = channel
+	return c.repo.ListResources(id)
+}
+
+// Publish marks id as published against channels within the charm store.
+//
+// In this implementation, the resources parameter is ignored.
+func (c FakeClient) Publish(id *charm.URL, channels []params.Channel, resources map[string]int) error {
+	return c.repo.Publish(id, channels, resources)
 }
 
 // ChannelAwareFakeClient is a charmstore client that stores the channel that its methods
@@ -124,10 +212,86 @@ type ChannelAwareFakeClient struct {
 	charmstore FakeClient
 }
 
+// Get retrieves data from path. If nothing has been Put to
+// path, an error satisfying errors.IsNotFound is returned.
 func (c ChannelAwareFakeClient) Get(path string, value interface{}) error {
 	return c.charmstore.Get(path, value)
 }
 
+// Put uploads data to path, overwriting any data that is already present
+func (c ChannelAwareFakeClient) Put(path string, value interface{}) error {
+	return c.charmstore.Put(path, value)
+}
+
+// AddDockerResource adds a docker resource against id.
+func (c ChannelAwareFakeClient) AddDockerResource(id *charm.URL, resourceName string, imageName, digest string) (revision int, err error) {
+	return c.charmstore.AddDockerResource(id, resourceName, imageName, digest)
+}
+
+// UploadCharm takes a charm's formal identifier (its URL)
+// and its contents, then uploads it into the store for other clients
+// to download.
+//
+// Returns another charm identifier, which has had its revision set to
+// the new revision, which will be 0 for the first revision or
+// current revision in the store, plus 1.
+func (c ChannelAwareFakeClient) UploadCharm(id *charm.URL, ch charm.Charm) (*charm.URL, error) {
+	return c.charmstore.UploadCharm(id, ch)
+}
+
+// UploadCharmWithRevision takes a charm's formal identifier (its URL)
+// and its contents and a revision number, then uploads it into the
+// store for other clients to download.
+func (c ChannelAwareFakeClient) UploadCharmWithRevision(id *charm.URL, ch charm.Charm, promulgatedRevision int) error {
+	return c.charmstore.UploadCharmWithRevision(id, ch, promulgatedRevision)
+}
+
+// UploadBundle takes a bundle's formal identifier (its URL)
+// and its contents, then uploads it into the store for other clients
+// to download.
+//
+// Returns another charm identifier, which has had its revision set to
+// the new revision, which will be 0 for the first revision or
+// current revision in the store, plus 1.
+func (c ChannelAwareFakeClient) UploadBundle(id *charm.URL, bundle charm.Bundle) (*charm.URL, error) {
+	return c.charmstore.UploadBundle(id, bundle)
+}
+
+// UploadBundleWithRevision takes a bundle's formal identifier (its URL)
+// and its contents and a revision number, then uploads it into the
+// store for other clients to download.
+func (c ChannelAwareFakeClient) UploadBundleWithRevision(id *charm.URL, bundle charm.Bundle, promulgatedRevision int) error {
+	return c.charmstore.UploadBundleWithRevision(id, bundle, promulgatedRevision)
+}
+
+// UploadResource uploads a resource (an archive) into the store,
+// tags it to a charm/bundle represented by id for other clients
+// to download when they download the charm/bundle.
+//
+// In this implementation, the progress parameter is ignored.
+func (c ChannelAwareFakeClient) UploadResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, progress csclient.Progress) (revision int, err error) {
+	return c.charmstore.UploadResource(id, name, path, file, size, progress)
+}
+
+// ListResources returns Resource metadata for resources that have been
+// uploaded to the repository for id. To upload a resource, use UploadResource.
+// Although id is type *charm.URL, resources are not restricted to charms. That
+// type is also used for other entities in the charmstore, such as bundles.
+//
+// Returns an error that satisfies errors.IsNotFound when no resources
+// are present for id.
+func (c ChannelAwareFakeClient) ListResources(id *charm.URL) ([]params.Resource, error) {
+	return c.charmstore.ListResources(c.channel, id)
+}
+
+// Publish marks id as published against channels within the charm store.
+//
+// In this implementation, the resources parameter is ignored.
+func (c ChannelAwareFakeClient) Publish(id *charm.URL, channels []params.Channel, resources map[string]int) error {
+	return c.charmstore.Publish(id, channels, resources)
+}
+
+// WithChannel returns a ChannelAwareFakeClient with its channel set to channel.
 func (c ChannelAwareFakeClient) WithChannel(channel params.Channel) *ChannelAwareFakeClient {
 	c.channel = channel
 	return &c
@@ -157,6 +321,7 @@ type Repository struct {
 	added         map[string][]charm.URL
 	resourcesData datastore
 	generations   map[string]string
+	published     map[params.Channel]set.Strings
 }
 
 // NewRepository returns an empty Repository. To populate it with charms, bundles and resources
@@ -170,12 +335,14 @@ func NewRepository() *Repository {
 		revisions:     make(map[params.Channel]map[charm.URL]int),
 		added:         make(map[string][]charm.URL),
 		resourcesData: make(datastore),
+		published:     make(map[params.Channel]set.Strings),
 	}
 	for _, channel := range params.OrderedChannels {
 		repo.charms[channel] = make(map[charm.URL]charm.Charm)
 		repo.bundles[channel] = make(map[charm.URL]charm.Bundle)
 		repo.resources[channel] = make(map[charm.URL][]params.Resource)
 		repo.revisions[channel] = make(map[charm.URL]int)
+		repo.published[channel] = set.NewStrings()
 	}
 	return &repo
 }
@@ -183,6 +350,71 @@ func NewRepository() *Repository {
 func (r *Repository) addRevision(ref *charm.URL) *charm.URL {
 	revision := r.revisions[r.channel][*ref]
 	return ref.WithRevision(revision)
+}
+
+// AddCharm registers a charm's availability on a particular channel,
+// but does not upload its contents. This is part of a two stage process
+// for storing charms in the repository.
+//
+// In this implementation, the force parameter is ignored.
+func (r Repository) AddCharm(id *charm.URL, channel params.Channel, force bool) error {
+	withRevision := r.addRevision(id)
+	alreadyAdded := r.added[string(channel)]
+
+	for _, charm := range alreadyAdded {
+		if *withRevision == charm {
+			return nil
+			// TODO(tsm) check expected behaviour
+			//
+			// if force {
+			// 	return nil
+			// } else {
+			// 	return errors.NewAlreadyExists(errors.NewErr("%v already added in channel %v", id, channel))
+			// }
+		}
+	}
+	r.added[string(channel)] = append(alreadyAdded, *withRevision)
+	return nil
+}
+
+// AddCharmWithAuthorization is equivalent to AddCharm.
+// The macaroon parameter is ignored.
+func (r Repository) AddCharmWithAuthorization(id *charm.URL, channel params.Channel, macaroon *macaroon.Macaroon, force bool) error {
+	return r.AddCharm(id, channel, force)
+}
+
+// AddLocalCharm allows you to register a charm that is not associated with a particular release channel.
+// Its purpose is to facilitate registering charms that have been built locally.
+func (r Repository) AddLocalCharm(id *charm.URL, details charm.Charm, force bool) (*charm.URL, error) {
+	return id, r.AddCharm(id, params.NoChannel, force)
+}
+
+// AuthorizeCharmstoreEntity returns (nil,nil) as Repository
+// has no authorisation to manage
+func (r Repository) AuthorizeCharmstoreEntity(id *charm.URL) (*macaroon.Macaroon, error) {
+	return nil, nil
+}
+
+// CharmInfo returns information about charms that are currently in the charm store.
+func (r Repository) CharmInfo(charmURL string) (*charms.CharmInfo, error) {
+	charmId, err := charm.ParseURL(charmURL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	charmDetails, err := r.Get(charmId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	info := charms.CharmInfo{
+		Revision: charmDetails.Revision(),
+		URL:      charmId.String(),
+		Config:   charmDetails.Config(),
+		Meta:     charmDetails.Meta(),
+		Actions:  charmDetails.Actions(),
+		Metrics:  charmDetails.Metrics(),
+	}
+	return &info, nil
 }
 
 // Resolve disambiguates a charm to a specific revision.
@@ -218,7 +450,140 @@ func (r Repository) Get(id *charm.URL) (charm.Charm, error) {
 func (r Repository) GetBundle(id *charm.URL) (charm.Bundle, error) {
 	bundleData := r.bundles[r.channel][*id]
 	if bundleData == nil {
-		return bundleData, errors.NotFoundf(id.String())
+		return nil, errors.NotFoundf(id.String())
 	}
 	return bundleData, nil
+}
+
+// ListResources returns Resource metadata for resources that have been
+// uploaded to the repository for id. To upload a resource, use UploadResource.
+// Although id is type *charm.URL, resources are not restricted to charms. That
+// type is also used for other entities in the charmstore, such as bundles.
+//
+// Returns an error that satisfies errors.IsNotFound when no resources
+// are present for id.
+func (r Repository) ListResources(id *charm.URL) ([]params.Resource, error) {
+	resources := r.resources[r.channel][*id]
+	if len(resources) == 0 {
+		return resources, errors.NotFoundf("no resources for %v", id)
+	}
+	return resources, nil
+}
+
+// UploadCharm takes a charm's formal identifier (its URL)
+// and its contents, then uploads it into the store for clients
+// to download.
+//
+// Returns another charm identifier, which has had its revision set to
+// the new revision, which will be 0 for the first revision or
+// current revision in the store, plus 1.
+func (r Repository) UploadCharm(id *charm.URL, charmData charm.Charm) (*charm.URL, error) {
+	if len(r.charms[r.channel]) == 0 {
+		r.charms[r.channel] = make(map[charm.URL]charm.Charm)
+	}
+	withRevision := r.addRevision(id)
+	r.charms[r.channel][*withRevision] = charmData
+	return withRevision, nil
+}
+
+// UploadCharmWithRevision takes a charm's formal identifier (its URL)
+// and its contents and a revision number, then uploads it into the
+// store for clients to download.
+func (r Repository) UploadCharmWithRevision(id *charm.URL, charmData charm.Charm, promulgatedRevision int) error {
+	if len(r.revisions[r.channel]) == 0 {
+		r.revisions[r.channel] = make(map[charm.URL]int)
+	}
+	r.revisions[r.channel][*id] = promulgatedRevision
+	_, err := r.UploadCharm(id, charmData)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// UploadBundle takes a bundle's formal identifier (its URL)
+// and its contents, then uploads it into the store for other clients
+// to download.
+//
+// Returns another charm identifier, which has had its revision set to
+// the new revision, which will be 0 for the first revision or
+// current revision in the store, plus 1.
+func (r Repository) UploadBundle(id *charm.URL, bundleData charm.Bundle) (*charm.URL, error) {
+	r.bundles[r.channel][*id] = bundleData
+	return id, nil
+}
+
+// UploadBundleWithRevision takes a bundle's formal identifier (its URL)
+// and its contents and a revision number, then uploads it into the
+// store for other clients to download.
+func (r Repository) UploadBundleWithRevision(id *charm.URL, bundleData charm.Bundle, promulgatedRevision int) error {
+	_, err := r.UploadBundle(id, bundleData)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	r.revisions[r.channel][*id] = promulgatedRevision
+	return nil
+}
+
+// UploadResource uploads a resource (an archive) into the store,
+// tags it to a charm/bundle represented by id for other clients
+// to download when they download the charm/bundle.
+//
+// In this implementation, the progress parameter is ignored.
+func (r Repository) UploadResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, progress csclient.Progress) (revision int, err error) {
+	if len(r.resources[r.channel]) == 0 {
+		r.resources[r.channel] = make(map[charm.URL][]params.Resource)
+	}
+	resources, err := r.ListResources(id)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	revision = len(resources)
+	data := []byte{}
+	_, err = file.ReadAt(data, 0)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	hash, err := signature(bytes.NewBuffer(data))
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	r.resources[r.channel][*id] = append(resources, params.Resource{
+		Name:        name,
+		Path:        path,
+		Revision:    revision,
+		Size:        size,
+		Fingerprint: hash,
+	})
+
+	err = r.resourcesData.Put(path, data)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	return revision, nil
+}
+
+// Publish marks a charm or bundle as published within channels.
+//
+// In this implementation, the resources parameter is ignored.
+func (r Repository) Publish(id *charm.URL, channels []params.Channel, resources map[string]int) error {
+	for _, channel := range channels {
+		published := r.published[channel]
+		published.Add(id.String())
+		r.published[channel] = published
+	}
+	return nil
+}
+
+// signature creates a SHA384 digest from r
+func signature(r io.Reader) (hash []byte, err error) {
+	h := sha512.New384()
+	_, err = io.Copy(h, r)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	hash = []byte(fmt.Sprintf("%x", h.Sum(nil)))
+	return hash, nil
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -26,7 +26,6 @@ import (
 	"gopkg.in/juju/charm.v6"
 	charmresource "gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/juju/charmrepo.v3"
-	"gopkg.in/juju/charmrepo.v3/csclient"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -539,7 +538,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleGatedCharmUnauthorized(c *
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleResources(c *gc.C) {
-	testcharms.UploadCharm(c, s.Client(), "trusty/starsay-42", "starsay")
+	testcharms.UploadCharm(c, s.client, "trusty/starsay-42", "starsay")
 	bundleMeta := `
         applications:
             starsay:
@@ -635,7 +634,7 @@ func (s *BundleDeployCharmStoreSuite) checkResources(c *gc.C, serviceapplication
 }
 
 type BundleDeployCharmStoreSuite struct {
-	charmStoreSuite
+	legacyCharmStoreSuite
 
 	stub   *testing.Stub
 	server *httptest.Server
@@ -644,7 +643,7 @@ type BundleDeployCharmStoreSuite struct {
 var _ = gc.Suite(&BundleDeployCharmStoreSuite{})
 
 func (s *BundleDeployCharmStoreSuite) SetUpSuite(c *gc.C) {
-	s.charmStoreSuite.SetUpSuite(c)
+	s.legacyCharmStoreSuite.SetUpSuite(c)
 	s.PatchValue(&watcher.Period, 10*time.Millisecond)
 }
 
@@ -658,7 +657,7 @@ func (s *BundleDeployCharmStoreSuite) SetUpTest(c *gc.C) {
 	}
 	s.ControllerConfigAttrs[controller.MeteringURL] = s.server.URL
 
-	s.charmStoreSuite.SetUpTest(c)
+	s.legacyCharmStoreSuite.SetUpTest(c)
 	logger.SetLogLevel(loggo.TRACE)
 }
 
@@ -666,11 +665,7 @@ func (s *BundleDeployCharmStoreSuite) TearDownTest(c *gc.C) {
 	if s.server != nil {
 		s.server.Close()
 	}
-	s.charmStoreSuite.TearDownTest(c)
-}
-
-func (s *BundleDeployCharmStoreSuite) Client() *csclient.Client {
-	return s.client
+	s.legacyCharmStoreSuite.TearDownTest(c)
 }
 
 // DeployBundleYAML uses the given bundle content to create a bundle in the

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apicharms "github.com/juju/juju/api/charms"
 	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/resource/resourceadapters"
@@ -68,7 +69,7 @@ func NewDeployCommandForTest(newAPIRoot func() (DeployAPI, error), steps []Deplo
 
 // NewDeployCommandForTest2 returns a command to deploy applications intended to be used only in tests
 // that do not use gomock.
-func NewDeployCommandForTest2(charmstore charmstoreForDeploy, charmrepo charmrepoForDeploy) modelcmd.ModelCommand {
+func NewDeployCommandForTest2(charmstore charmstoreForDeploy, charmrepo *charmstore.Repository) modelcmd.ModelCommand {
 	deployCmd := &DeployCommand{
 		Steps: []DeployStep{
 			&RegisterMeteredCharm{

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -142,14 +142,14 @@ func (s *RemoveApplicationSuite) TestInvalidArgs(c *gc.C) {
 }
 
 type RemoveCharmStoreCharmsSuite struct {
-	charmStoreSuite
+	legacyCharmStoreSuite
 	ctx *cmd.Context
 }
 
 var _ = gc.Suite(&RemoveCharmStoreCharmsSuite{})
 
 func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
-	s.charmStoreSuite.SetUpTest(c)
+	s.legacyCharmStoreSuite.SetUpTest(c)
 
 	s.ctx = cmdtesting.Context(c)
 

--- a/cmd/juju/application/shim.go
+++ b/cmd/juju/application/shim.go
@@ -6,12 +6,24 @@ package application
 import (
 	"gopkg.in/juju/charmrepo.v3/csclient"
 	"gopkg.in/juju/charmrepo.v3/csclient/params"
+
+	"github.com/juju/juju/testcharms"
 )
 
 type charmstoreClientShim struct {
 	*csclient.Client
 }
 
-func (c *charmstoreClientShim) WithChannel(channel params.Channel) charmstoreForDeploy {
-	return c.WithChannel(channel)
+func (c charmstoreClientShim) WithChannel(channel params.Channel) charmstoreForDeploy {
+	client := c.Client.WithChannel(channel)
+	return charmstoreClientShim{client}
+}
+
+type charmstoreClientToTestcharmsClientShim struct {
+	*csclient.Client
+}
+
+func (c charmstoreClientToTestcharmsClientShim) WithChannel(channel params.Channel) testcharms.CharmstoreClient {
+	client := c.Client.WithChannel(channel)
+	return charmstoreClientToTestcharmsClientShim{client}
 }

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -621,7 +621,7 @@ func (s *UpgradeCharmSuccessStateSuite) TestCharmPathDifferentNameFails(c *gc.C)
 
 type UpgradeCharmCharmStoreStateSuite struct {
 	BaseUpgradeCharmStateSuite
-	charmStoreSuite
+	legacyCharmStoreSuite
 }
 
 var _ = gc.Suite(&UpgradeCharmCharmStoreStateSuite{})

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -39,10 +39,10 @@ func RepoForSeries(series string) *testing.Repo {
 	return testing.NewRepo("charm-repo", series)
 }
 
-// charmstoreClient bridges a charmstore and Juju
+// CharmstoreClient bridges a charmstore and Juju
 //
 // Only methods that are relied upon by the testcharms package are exposed here.
-type charmstoreClient interface {
+type CharmstoreClient interface {
 	// Put enables "raw HTTP" calls
 	Put(path string, value interface{}) error
 	// Publish publishes an object representable by `id`, which could be a bundle, charm or resource
@@ -54,7 +54,7 @@ type charmstoreClient interface {
 	UploadResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, progress csclient.Progress) (revision int, err error)
 	ListResources(id *charm.URL) ([]params.Resource, error)
 	AddDockerResource(id *charm.URL, resourceName string, imageName, digest string) (revision int, err error)
-	WithChannel(channel params.Channel) *csclient.Client // TODO(tsm) make generic
+	WithChannel(channel params.Channel) CharmstoreClient
 }
 
 // UploadCharmWithMeta pushes a new charm to the charmstore.
@@ -64,7 +64,7 @@ type charmstoreClient interface {
 // here for us in tests.
 //
 // For convenience the charm is also made public
-func UploadCharmWithMeta(c *gc.C, client charmstoreClient, charmURL, meta, metrics string, revision int) (*charm.URL, charm.Charm) {
+func UploadCharmWithMeta(c *gc.C, client CharmstoreClient, charmURL, meta, metrics string, revision int) (*charm.URL, charm.Charm) {
 	ch := testing.NewCharm(c, testing.CharmSpec{
 		Meta:     meta,
 		Metrics:  metrics,
@@ -77,7 +77,7 @@ func UploadCharmWithMeta(c *gc.C, client charmstoreClient, charmURL, meta, metri
 }
 
 // UploadCharm sets default series to quantal
-func UploadCharm(c *gc.C, client charmstoreClient, url, name string) (*charm.URL, charm.Charm) {
+func UploadCharm(c *gc.C, client CharmstoreClient, url, name string) (*charm.URL, charm.Charm) {
 	return UploadCharmWithSeries(c, client, url, name, defaultSeries)
 }
 
@@ -86,7 +86,7 @@ func UploadCharm(c *gc.C, client charmstoreClient, url, name string) (*charm.URL
 //
 // It also adds any required resources that haven't already been uploaded
 // with the content "<resourcename> content".
-func UploadCharmWithSeries(c *gc.C, client charmstoreClient, url, name, series string) (*charm.URL, charm.Charm) {
+func UploadCharmWithSeries(c *gc.C, client CharmstoreClient, url, name, series string) (*charm.URL, charm.Charm) {
 	id := charm.MustParseURL(url)
 	promulgatedRevision := -1
 	if id.User == "" {
@@ -134,7 +134,7 @@ func UploadCharmWithSeries(c *gc.C, client charmstoreClient, url, name, series s
 // UploadCharmMultiSeries uploads a charm with revision using the given charm store client,
 // and returns the resulting charm URL and charm. This API caters for new multi-series charms
 // which do not specify a series in the URL.
-func UploadCharmMultiSeries(c *gc.C, client charmstoreClient, url, name string) (*charm.URL, charm.Charm) {
+func UploadCharmMultiSeries(c *gc.C, client CharmstoreClient, url, name string) (*charm.URL, charm.Charm) {
 	id := charm.MustParseURL(url)
 	if id.User == "" {
 		// We still need a user even if we are uploading a promulgated charm.
@@ -154,7 +154,7 @@ func UploadCharmMultiSeries(c *gc.C, client charmstoreClient, url, name string) 
 
 // UploadBundle uploads a bundle using the given charm store client, and
 // returns the resulting bundle URL and bundle.
-func UploadBundle(c *gc.C, client charmstoreClient, url, name string) (*charm.URL, charm.Bundle) {
+func UploadBundle(c *gc.C, client CharmstoreClient, url, name string) (*charm.URL, charm.Bundle) {
 	id := charm.MustParseURL(url)
 	promulgatedRevision := -1
 	if id.User == "" {
@@ -179,7 +179,7 @@ func UploadBundle(c *gc.C, client charmstoreClient, url, name string) (*charm.UR
 //
 // The named resources with their associated revision
 // numbers are also published.
-func SetPublicWithResources(c *gc.C, client charmstoreClient, id *charm.URL, resources map[string]int) {
+func SetPublicWithResources(c *gc.C, client CharmstoreClient, id *charm.URL, resources map[string]int) {
 	// Publish to the stable channel.
 	err := client.Publish(id, []params.Channel{params.StableChannel}, resources)
 	c.Assert(err, jc.ErrorIsNil)
@@ -191,7 +191,7 @@ func SetPublicWithResources(c *gc.C, client charmstoreClient, id *charm.URL, res
 
 // SetPublic sets the charm or bundle with the given id to be
 // published with global read permissions to the stable channel.
-func SetPublic(c *gc.C, client charmstoreClient, id *charm.URL) {
+func SetPublic(c *gc.C, client CharmstoreClient, id *charm.URL) {
 	SetPublicWithResources(c, client, id, nil)
 }
 


### PR DESCRIPTION
## Description of change

This pull request removes the `github.com/juju/charmstore.v5` dependency from the DeploySuite within `cmd/juju/application/deploy_test.go`. Tests relying on `charmstore` have been moved into a new suite `legacyCharmStoreSuite`. This is intended as a temporary name until all suites are ported to the new behaviour.

Note: This use of the term "legacy charm store" should not be confused with other uses of the term that refer to the pre-2014 charm store.

## QA steps

Run unit tests. All tests should pass.

## Documentation changes

N/A

## Bug reference

*Please add a link to any bugs that this change is related to.*
