### PR TITLE
Support variable payloads in rpc request errors

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -53,7 +53,12 @@ func (c *Client) handleError(apiErr error) (macaroon.Slice, error) {
 		return nil, errors.Annotatef(apiErr, "no error info found in discharge-required response error")
 	}
 	logger.Debugf("attempting to discharge macaroon due to error: %v", apiErr)
-	ms, err := c.facade.RawAPICaller().BakeryClient().DischargeAll(errResp.Info.Macaroon)
+	var info params.DischargeRequiredErrorInfo
+	if errUnmarshal := errResp.UnmarshalInfo(&info); errUnmarshal != nil {
+		return nil, errors.Annotatef(apiErr, "unable to extract macaroon details from discharge-required response error")
+	}
+
+	ms, err := c.facade.RawAPICaller().BakeryClient().DischargeAll(info.Macaroon)
 	if err == nil && logger.IsTraceEnabled() {
 		logger.Tracef("discharge macaroon ids:")
 		for _, m := range ms {

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -120,9 +120,9 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChangeDischargeRequired(c 
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		}
 		argParam := arg.(params.RemoteRelationsChanges)
@@ -228,9 +228,9 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationDischargeRequired(c
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		}
 		argParam := arg.(params.RegisterRemoteRelationArgs)
@@ -317,9 +317,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationUnitsDischargeRequired(c *gc
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		case 1:
 			argParam := arg.(params.RemoteEntityArgs)
@@ -401,9 +401,9 @@ func (s *CrossModelRelationsSuite) TestRelationUnitSettingsDischargeRequired(c *
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		}
 		argParam := arg.(params.RemoteRelationUnits)
@@ -489,9 +489,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatusDischargeRequired(c *g
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		case 1:
 			argParam := arg.(params.RemoteEntityArgs)
@@ -572,9 +572,9 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChangeDischargeRequi
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		}
 		argParam := arg.(params.IngressNetworksChanges)
@@ -657,9 +657,9 @@ func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelationDischargeR
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		case 1:
 			argParam := arg.(params.RemoteEntityArgs)
@@ -743,9 +743,9 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatusDischargeRequired(c *gc.C
 			mac = s.newDischargeMacaroon(c)
 			resultErr = &params.Error{
 				Code: params.CodeDischargeRequired,
-				Info: &params.ErrorInfo{
+				Info: params.DischargeRequiredErrorInfo{
 					Macaroon: mac,
-				},
+				}.AsMap(),
 			}
 		case 1:
 			argParam := arg.(params.OfferArgs)

--- a/api/http.go
+++ b/api/http.go
@@ -201,12 +201,17 @@ func bakeryError(err error) error {
 	}
 	// It's a discharge-required error, so make an appropriate httpbakery
 	// error from it.
+	var info params.DischargeRequiredErrorInfo
+	if errUnmarshal := errResp.UnmarshalInfo(&info); errUnmarshal != nil {
+		return errors.Annotatef(err, "unable to extract macaroon details from discharge-required response error")
+	}
+
 	return &httpbakery.Error{
 		Message: err.Error(),
 		Code:    httpbakery.ErrDischargeRequired,
 		Info: &httpbakery.ErrorInfo{
-			Macaroon:     errResp.Info.Macaroon,
-			MacaroonPath: errResp.Info.MacaroonPath,
+			Macaroon:     info.Macaroon,
+			MacaroonPath: info.MacaroonPath,
 		},
 	}
 }

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -46,7 +46,7 @@ var httpClientTests = []struct {
 	expectResponse  interface{}
 	expectError     string
 	expectErrorCode string
-	expectErrorInfo *params.ErrorInfo
+	expectErrorInfo map[string]interface{}
 }{{
 	about: "success",
 	handler: func(w http.ResponseWriter, req *http.Request) {
@@ -109,18 +109,18 @@ var httpClientTests = []struct {
 		httprequest.WriteJSON(w, http.StatusBadRequest, params.CharmsResponse{
 			Error:     "some error",
 			ErrorCode: params.CodeBadRequest,
-			ErrorInfo: &params.ErrorInfo{
+			ErrorInfo: params.DischargeRequiredErrorInfo{
 				MacaroonPath: "foo",
-			},
+			}.AsMap(),
 		})
 	},
 	expectError:     `.*some error$`,
 	expectErrorCode: params.CodeBadRequest,
-	expectErrorInfo: &params.ErrorInfo{
+	expectErrorInfo: params.DischargeRequiredErrorInfo{
 		MacaroonPath: "foo",
-	},
+	}.AsMap(),
 }, {
-	about: "discharge-required response with no error info",
+	about: "discharge-required response with no attached info",
 	handler: func(w http.ResponseWriter, req *http.Request) {
 		httprequest.WriteJSON(w, http.StatusUnauthorized, params.Error{
 			Message: "some error",
@@ -135,7 +135,9 @@ var httpClientTests = []struct {
 		httprequest.WriteJSON(w, http.StatusUnauthorized, params.Error{
 			Message: "some error",
 			Code:    params.CodeDischargeRequired,
-			Info:    &params.ErrorInfo{},
+			Info: params.DischargeRequiredErrorInfo{
+				MacaroonPath: "/",
+			}.AsMap(),
 		})
 	},
 	expectError: `GET http://.*/: no macaroon found in discharge-required response`,

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -4,8 +4,10 @@
 package common_test
 
 import (
+	"encoding/json"
 	stderrors "errors"
 	"net/http"
+	"reflect"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -176,7 +178,8 @@ var errorTransformTests = []struct {
 	code:   params.CodeDischargeRequired,
 	helperFunc: func(err error) bool {
 		err1, ok := err.(*params.Error)
-		if !ok || err1.Info == nil || err1.Info["macaroon"] != sampleMacaroon {
+		exp := asMap(sampleMacaroon)
+		if !ok || err1.Info == nil || !reflect.DeepEqual(err1.Info["macaroon"], exp) {
 			return false
 		}
 		return true
@@ -203,6 +206,14 @@ var sampleMacaroon = func() *macaroon.Macaroon {
 	}
 	return m
 }()
+
+func asMap(v interface{}) map[string]interface{} {
+	var m map[string]interface{}
+	d, _ := json.Marshal(v)
+	_ = json.Unmarshal(d, &m)
+
+	return m
+}
 
 type unhashableError []string
 

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -176,7 +176,7 @@ var errorTransformTests = []struct {
 	code:   params.CodeDischargeRequired,
 	helperFunc: func(err error) bool {
 		err1, ok := err.(*params.Error)
-		if !ok || err1.Info == nil || err1.Info.Macaroon != sampleMacaroon {
+		if !ok || err1.Info == nil || err1.Info["macaroon"] != sampleMacaroon {
 			return false
 		}
 		return true

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1828,14 +1828,14 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 	results := res.Results
 	c.Assert(results, gc.HasLen, 6)
 	c.Check(results[0].Error, gc.IsNil)
-	c.Check(*results[1].Error, gc.Equals,
+	c.Check(*results[1].Error, gc.DeepEquals,
 		*common.ServerError(errors.NotFoundf("machine 100")))
 	c.Check(*results[1].Error, jc.Satisfies, params.IsCodeNotFound)
 	c.Check(results[2].Error, gc.IsNil)
-	c.Check(*results[3].Error, gc.Equals,
+	c.Check(*results[3].Error, gc.DeepEquals,
 		*common.ServerError(errors.New("cannot remove machine 1: machine is not dead")))
-	c.Check(*results[4].Error, gc.Equals, *apiservertesting.ErrUnauthorized)
-	c.Check(*results[5].Error, gc.Equals,
+	c.Check(*results[4].Error, gc.DeepEquals, *apiservertesting.ErrUnauthorized)
+	c.Check(*results[5].Error, gc.DeepEquals,
 		*common.ServerError(errors.New(`"application-thing" is not a valid machine tag`)))
 
 	removals, err := s.State.AllMachineRemovals()

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1828,14 +1828,14 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 	results := res.Results
 	c.Assert(results, gc.HasLen, 6)
 	c.Check(results[0].Error, gc.IsNil)
-	c.Check(*results[1].Error, gc.DeepEquals,
+	c.Check(*results[1].Error, jc.DeepEquals,
 		*common.ServerError(errors.NotFoundf("machine 100")))
 	c.Check(*results[1].Error, jc.Satisfies, params.IsCodeNotFound)
 	c.Check(results[2].Error, gc.IsNil)
-	c.Check(*results[3].Error, gc.DeepEquals,
+	c.Check(*results[3].Error, jc.DeepEquals,
 		*common.ServerError(errors.New("cannot remove machine 1: machine is not dead")))
-	c.Check(*results[4].Error, gc.DeepEquals, *apiservertesting.ErrUnauthorized)
-	c.Check(*results[5].Error, gc.DeepEquals,
+	c.Check(*results[4].Error, jc.DeepEquals, *apiservertesting.ErrUnauthorized)
+	c.Check(*results[5].Error, jc.DeepEquals,
 		*common.ServerError(errors.New(`"application-thing" is not a valid machine tag`)))
 
 	removals, err := s.State.AllMachineRemovals()

--- a/apiserver/observer/recorder_test.go
+++ b/apiserver/observer/recorder_test.go
@@ -188,7 +188,9 @@ func (s *recorderSuite) TestReplyResultSlice(c *gc.C) {
 				Error: &params.Error{
 					Message: "something bad",
 					Code:    "fall-down-go-boom",
-					Info:    &params.ErrorInfo{MacaroonPath: "somewhere"},
+					Info: params.DischargeRequiredErrorInfo{
+						MacaroonPath: "somewhere",
+					}.AsMap(),
 				},
 			}},
 		},

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -643,8 +643,7 @@ type CharmsResponse struct {
 	ErrorCode string `json:"error-code,omitempty"`
 
 	// ErrorInfo holds extra information associated with the error.
-	// Like ErrorCode, this should really be in an Error object.
-	ErrorInfo *ErrorInfo `json:"error-info,omitempty"`
+	ErrorInfo map[string]interface{} `json:"error-info,omitempty"`
 
 	CharmURL string   `json:"charm-url,omitempty"`
 	Files    []string `json:"files,omitempty"`

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -44,6 +44,10 @@ func (e *RequestError) ErrorCode() string {
 	return e.Code
 }
 
+func (e *RequestError) ErrorInfo() map[string]interface{} {
+	return e.Info
+}
+
 // UnmarshalInfo attempts to unmarshal the information contained in the Info
 // field of a RequestError into an object instance a pointer to which is passed
 // via the to argument. The method will return an error if a non-pointer arg

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -28,6 +28,7 @@ type Call struct {
 type RequestError struct {
 	Message string
 	Code    string
+	Info    map[string]interface{}
 }
 
 func (e *RequestError) Error() string {
@@ -111,6 +112,7 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 		call.Error = &RequestError{
 			Message: hdr.Error,
 			Code:    hdr.ErrorCode,
+			Info:    hdr.ErrorInfo,
 		}
 		err = conn.readBody(nil, false)
 		call.done()

--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -63,15 +63,16 @@ type inMsgV0 struct {
 }
 
 type inMsgV1 struct {
-	RequestId uint64          `json:"request-id"`
-	Type      string          `json:"type"`
-	Version   int             `json:"version"`
-	Id        string          `json:"id"`
-	Request   string          `json:"request"`
-	Params    json.RawMessage `json:"params"`
-	Error     string          `json:"error"`
-	ErrorCode string          `json:"error-code"`
-	Response  json.RawMessage `json:"response"`
+	RequestId uint64                 `json:"request-id"`
+	Type      string                 `json:"type"`
+	Version   int                    `json:"version"`
+	Id        string                 `json:"id"`
+	Request   string                 `json:"request"`
+	Params    json.RawMessage        `json:"params"`
+	Error     string                 `json:"error"`
+	ErrorCode string                 `json:"error-code"`
+	ErrorInfo map[string]interface{} `json:"error-info"`
+	Response  json.RawMessage        `json:"response"`
 }
 
 // outMsg holds an outgoing message.
@@ -88,15 +89,16 @@ type outMsgV0 struct {
 }
 
 type outMsgV1 struct {
-	RequestId uint64      `json:"request-id,omitempty"`
-	Type      string      `json:"type,omitempty"`
-	Version   int         `json:"version,omitempty"`
-	Id        string      `json:"id,omitempty"`
-	Request   string      `json:"request,omitempty"`
-	Params    interface{} `json:"params,omitempty"`
-	Error     string      `json:"error,omitempty"`
-	ErrorCode string      `json:"error-code,omitempty"`
-	Response  interface{} `json:"response,omitempty"`
+	RequestId uint64                 `json:"request-id,omitempty"`
+	Type      string                 `json:"type,omitempty"`
+	Version   int                    `json:"version,omitempty"`
+	Id        string                 `json:"id,omitempty"`
+	Request   string                 `json:"request,omitempty"`
+	Params    interface{}            `json:"params,omitempty"`
+	Error     string                 `json:"error,omitempty"`
+	ErrorCode string                 `json:"error-code,omitempty"`
+	ErrorInfo map[string]interface{} `json:"error-info,omitempty"`
+	Response  interface{}            `json:"response,omitempty"`
 }
 
 func (c *Codec) Close() error {
@@ -139,6 +141,7 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 	}
 	hdr.Error = c.msg.Error
 	hdr.ErrorCode = c.msg.ErrorCode
+	hdr.ErrorInfo = c.msg.ErrorInfo
 	hdr.Version = version
 	return nil
 }
@@ -272,6 +275,7 @@ func newOutMsgV1(hdr *rpc.Header, body interface{}) outMsgV1 {
 		Request:   hdr.Request.Action,
 		Error:     hdr.Error,
 		ErrorCode: hdr.ErrorCode,
+		ErrorInfo: hdr.ErrorInfo,
 	}
 	if hdr.IsRequest() {
 		result.Params = body

--- a/rpc/jsoncodec/codec_test.go
+++ b/rpc/jsoncodec/codec_test.go
@@ -96,6 +96,19 @@ func (*suite) TestRead(c *gc.C) {
 		},
 		expectBody: new(map[string]interface{}),
 	}, {
+		msg: `{"request-id": 2, "error": "an error", "error-code": "a code", "error-info": {"foo": "bar", "baz": true}}`,
+		expectHdr: rpc.Header{
+			RequestId: 2,
+			Error:     "an error",
+			ErrorCode: "a code",
+			ErrorInfo: map[string]interface{}{
+				"foo": "bar",
+				"baz": true,
+			},
+			Version: 1,
+		},
+		expectBody: new(map[string]interface{}),
+	}, {
 		msg: `{"request-id": 3, "response": {"X": "result"}}`,
 		expectHdr: rpc.Header{
 			RequestId: 3,
@@ -180,6 +193,16 @@ func (*suite) TestWrite(c *gc.C) {
 		expect: `{"RequestId": 2, "Error": "an error", "ErrorCode": "a code"}`,
 	}, {
 		hdr: &rpc.Header{
+			RequestId: 2,
+			Error:     "an error",
+			ErrorCode: "a code",
+			ErrorInfo: map[string]interface{}{
+				"ignored": "for version0",
+			},
+		},
+		expect: `{"RequestId": 2, "Error": "an error", "ErrorCode": "a code"}`,
+	}, {
+		hdr: &rpc.Header{
 			RequestId: 3,
 		},
 		body:   &value{X: "result"},
@@ -216,6 +239,18 @@ func (*suite) TestWrite(c *gc.C) {
 			Version:   1,
 		},
 		expect: `{"request-id": 2, "error": "an error", "error-code": "a code"}`,
+	}, {
+		hdr: &rpc.Header{
+			RequestId: 2,
+			Error:     "an error",
+			ErrorCode: "a code",
+			ErrorInfo: map[string]interface{}{
+				"foo": "bar",
+				"baz": true,
+			},
+			Version: 1,
+		},
+		expect: `{"request-id": 2, "error": "an error", "error-code": "a code", "error-info": {"foo": "bar", "baz": true}}`,
 	}, {
 		hdr: &rpc.Header{
 			RequestId: 3,

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -572,13 +572,13 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 		c.Assert(serverReply.body, gc.Equals, stringVal{p.request().Action + " ret"})
 	}
 	if p.retErr && p.testErr {
-		c.Assert(serverReply.hdr, gc.Equals, rpc.Header{
+		c.Assert(serverReply.hdr, gc.DeepEquals, rpc.Header{
 			RequestId: requestId,
 			Error:     p.errorMessage(),
 			Version:   1,
 		})
 	} else {
-		c.Assert(serverReply.hdr, gc.Equals, rpc.Header{
+		c.Assert(serverReply.hdr, gc.DeepEquals, rpc.Header{
 			RequestId: requestId,
 			Version:   1,
 		})

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -572,13 +572,13 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 		c.Assert(serverReply.body, gc.Equals, stringVal{p.request().Action + " ret"})
 	}
 	if p.retErr && p.testErr {
-		c.Assert(serverReply.hdr, gc.DeepEquals, rpc.Header{
+		c.Assert(serverReply.hdr, jc.DeepEquals, rpc.Header{
 			RequestId: requestId,
 			Error:     p.errorMessage(),
 			Version:   1,
 		})
 	} else {
-		c.Assert(serverReply.hdr, gc.DeepEquals, rpc.Header{
+		c.Assert(serverReply.hdr, jc.DeepEquals, rpc.Header{
 			RequestId: requestId,
 			Version:   1,
 		})
@@ -792,7 +792,7 @@ func (*rpcSuite) TestErrorInfo(c *gc.C) {
 	defer closeClient(c, client, srvDone)
 	err := client.Call(rpc.Request{"ErrorMethods", 0, "", "Call"}, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `message`)
-	c.Assert(errors.Cause(err).(rpc.ErrorInfoProvider).ErrorInfo(), gc.DeepEquals, info)
+	c.Assert(errors.Cause(err).(rpc.ErrorInfoProvider).ErrorInfo(), jc.DeepEquals, info)
 }
 
 func (*rpcSuite) TestTransformErrors(c *gc.C) {
@@ -1287,7 +1287,7 @@ func (s *rpcSuite) TestRequestErrorInfoUnmarshaling(c *gc.C) {
 		err := re.UnmarshalInfo(spec.to)
 		if spec.err == "" {
 			c.Assert(err, gc.IsNil)
-			c.Assert(spec.to, gc.DeepEquals, spec.exp)
+			c.Assert(spec.to, jc.DeepEquals, spec.exp)
 		} else {
 			c.Assert(err, gc.ErrorMatches, spec.err)
 		}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -65,6 +65,10 @@ type Header struct {
 	// ErrorCode holds the code of the error, if any.
 	ErrorCode string
 
+	// ErrorInfo holds an optional set of additional information for an
+	// error, if any.
+	ErrorInfo map[string]interface{}
+
 	// Version defines the wire format of the request and response structure.
 	Version int
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -333,11 +333,16 @@ func (conn *Conn) Close() error {
 	return conn.inputLoopError
 }
 
-// ErrorCoder represents an any error that has an associated
-// error code. An error code is a short string that represents the
-// kind of an error.
+// ErrorCoder represents any error that has an associated error code. An error
+// code is a short string that represents the kind of an error.
 type ErrorCoder interface {
 	ErrorCode() string
+}
+
+// ErrorInfoProvider represents any error that can provide additional error
+// information as a map.
+type ErrorInfoProvider interface {
+	ErrorInfo() map[string]interface{}
 }
 
 // Root represents a type that can be used to lookup a Method and place
@@ -491,6 +496,9 @@ func (conn *Conn) writeErrorResponse(reqHdr *Header, err error, recorder Recorde
 		hdr.ErrorCode = ""
 	}
 	hdr.Error = err.Error()
+	if err, ok := err.(ErrorInfoProvider); ok {
+		hdr.ErrorInfo = err.ErrorInfo()
+	}
 	if err := recorder.HandleReply(reqHdr.Request, hdr, struct{}{}); err != nil {
 		logger.Errorf("error recording reply %+v: %T %+v", hdr, err, err)
 	}


### PR DESCRIPTION
## Description of change

This PR is part of the work for supporting redirects for migrated models. I have split this work into a standalone PR to make reviewing easier. 

The main idea behind this PR is to make `params.Error` support variable `Info` payloads and to make it possible for them to be returned as part of an RPC `ResponseError` object. This change will allow us to support all those use-cases where we need to attach structured information to errors returned by the apiserver. 

One example of this (and relevant to the redirect work) is to be able to intercept calls to `Login` that attempt to login to a model that has been migrated return a `Redirect` error that includes the addresses/CA cert of the controller to connect to.

Half of the work in the PR updates the rpc/jsoncodec packages to support marshaling/unmarshaling of additional error information. As the new `ErrorInfo` field is entirely optional, I opted not to create V2 in/out messages and instead just add it to the existing V1 version. This shouldn't cause any problems with older juju clients/servers as this field will just be ignored.

The remainder of the work focuses around cleaning up `params.Errors` and the `ServerError` implementation in the apiserver/common packages.
