### PR TITLE
InstanceMutater worker enhancements 

### DIFF
--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -217,14 +217,18 @@ func (m *Machine) CharmProfilingInfo() (*UnitProfileInfo, error) {
 	}
 	profileChanges := make([]UnitProfileChanges, len(result.ProfileChanges))
 	for i, change := range result.ProfileChanges {
-		profileChanges[i] = UnitProfileChanges{
-			ApplicationName: change.ApplicationName,
-			Revision:        change.Revision,
-			Profile: lxdprofile.Profile{
+		var profile lxdprofile.Profile
+		if change.Profile != nil {
+			profile = lxdprofile.Profile{
 				Config:      change.Profile.Config,
 				Description: change.Profile.Description,
 				Devices:     change.Profile.Devices,
-			},
+			}
+		}
+		profileChanges[i] = UnitProfileChanges{
+			ApplicationName: change.ApplicationName,
+			Revision:        change.Revision,
+			Profile:         profile,
 		}
 		if change.Error != nil {
 			return nil, change.Error

--- a/api/instancemutater/machine_test.go
+++ b/api/instancemutater/machine_test.go
@@ -186,6 +186,31 @@ func (s *instanceMutaterMachineSuite) TestCharmProfilingInfoSuccessChanges(c *gc
 	c.Assert(info.ProfileChanges[0].Profile.Description, gc.Equals, "Test Profile")
 }
 
+func (s *instanceMutaterMachineSuite) TestCharmProfilingInfoSuccessChangesWithNoProfile(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	args := params.Entity{Tag: s.tag.String()}
+	results := params.CharmProfilingInfoResult{
+		InstanceId:      instance.Id("juju-gd4c23-0"),
+		ModelName:       "default",
+		CurrentProfiles: []string{"juju-default-neutron-ovswitch-255"},
+		Error:           nil,
+		ProfileChanges: []params.ProfileInfoResult{{
+			Profile: nil,
+		}},
+	}
+
+	fExp := s.fCaller.EXPECT()
+	fExp.FacadeCall("CharmProfilingInfo", args, gomock.Any()).SetArg(2, results).Return(nil)
+
+	info, err := s.setupMachine().CharmProfilingInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.InstanceId, gc.Equals, results.InstanceId)
+	c.Assert(info.ModelName, gc.Equals, results.ModelName)
+	c.Assert(info.CurrentProfiles, gc.DeepEquals, results.CurrentProfiles)
+	c.Assert(info.ProfileChanges[0].Profile.Description, gc.Equals, "")
+}
+
 func (s *instanceMutaterMachineSuite) TestSetModificationStatus(c *gc.C) {
 	defer s.setup(c).Finish()
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -590,10 +590,11 @@ func (ch *backingCharm) mongoId() string {
 }
 
 func toMulitwatcherProfile(profile *charm.LXDProfile) *multiwatcher.Profile {
+	unescapedProfile := unescapeLXDProfile(profile)
 	return &multiwatcher.Profile{
-		Config:      profile.Config,
-		Description: profile.Description,
-		Devices:     profile.Devices,
+		Config:      unescapedProfile.Config,
+		Description: unescapedProfile.Description,
+		Devices:     unescapedProfile.Devices,
 	}
 }
 

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -4,13 +4,17 @@
 package instancemutater
 
 import (
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs"
+	"github.com/lxc/lxd/shared/logger"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/instancemutater"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/environs"
 )
 
 // lifetimeContext was extracted to allow the various context clients to get
@@ -25,13 +29,23 @@ type lifetimeContext interface {
 
 type machineContext interface {
 	lifetimeContext
+	//Logger
+	getBroker() environs.LXDProfiler
+}
+
+type mutaterMachine struct {
+	context    machineContext
+	logger     Logger
+	machineApi instancemutater.MutaterMachine
+	id         string
 }
 
 type mutaterContext interface {
-	lifetimeContext
+	//lifetimeContext
+	machineContext
 	newMachineContext() machineContext
 	getMachine(tag names.MachineTag) (instancemutater.MutaterMachine, error)
-	getBroker() environs.LXDProfiler
+	//getBroker() environs.LXDProfiler
 }
 
 type mutater struct {
@@ -41,63 +55,35 @@ type mutater struct {
 	machineDead chan instancemutater.MutaterMachine
 }
 
-func watchMachinesLoop(context mutaterContext, logger Logger, machinesWatcher watcher.StringsWatcher) (err error) {
-	m := &mutater{
-		context:     context,
-		logger:      logger,
-		machines:    make(map[names.MachineTag]chan struct{}),
-		machineDead: make(chan instancemutater.MutaterMachine),
-	}
-	defer func() {
-		// TODO(fwereade): is this a home-grown sync.WaitGroup or something?
-		// strongly suspect these machine goroutines could be managed rather
-		// less opaquely if we made them all workers.
-		for len(m.machines) > 0 {
-			delete(m.machines, (<-m.machineDead).Tag())
-		}
-	}()
-	for {
-		select {
-		case <-m.context.dying():
-			return m.context.errDying()
-		case ids, ok := <-machinesWatcher.Changes():
-			if !ok {
-				return errors.New("machines watcher closed")
-			}
-			tags := make([]names.MachineTag, len(ids))
-			for i := range ids {
-				tags[i] = names.NewMachineTag(ids[i])
-			}
-			if err := m.startMachines(tags); err != nil {
-				return err
-			}
-		case d := <-m.machineDead:
-			delete(m.machines, d.Tag())
-		}
-	}
-}
-
 func (m *mutater) startMachines(tags []names.MachineTag) error {
 	for _, tag := range tags {
 		if c := m.machines[tag]; c == nil {
 			m.logger.Warningf("received tag %q", tag.String())
 
-			machine, err := m.context.getMachine(tag)
+			api, err := m.context.getMachine(tag)
 			if err != nil {
 				// If the machine is not found, don't fail in hard way and
-				// continue onwards until a machine is found for a subsequent
+				// continue onwards until a mach is found for a subsequent
 				// tag.
-				if errors.IsNotFound(err) {
-					continue
-				}
+				//if errors.IsNotFound(err) {
+				//	continue
+				//}
 				return errors.Trace(err)
 			}
 
-			m.logger.Tracef("startMachines added machine %s", machine.Tag().Id())
+			id := api.Tag().Id()
+			m.logger.Tracef("startMachines added machine %s", id)
 			c = make(chan struct{})
 			m.machines[tag] = c
 
-			go runMachine(m.context.newMachineContext(), m.logger, machine, c, m.machineDead)
+			machine := mutaterMachine{
+				context:    m.context.newMachineContext(),
+				logger:     m.logger,
+				machineApi: api,
+				id:         id,
+			}
+
+			go runMachine(machine, c, m.machineDead)
 		} else {
 			select {
 			case <-m.context.dying():
@@ -109,42 +95,131 @@ func (m *mutater) startMachines(tags []names.MachineTag) error {
 	return nil
 }
 
-func runMachine(context machineContext, logger Logger, m instancemutater.MutaterMachine, changed <-chan struct{}, died chan<- instancemutater.MutaterMachine) {
+func runMachine(machine mutaterMachine, changed <-chan struct{}, died chan<- instancemutater.MutaterMachine) {
 	defer func() {
 		// We can't just send on the dead channel because the
 		// central loop might be trying to write to us on the
 		// changed channel.
 		for {
 			select {
-			case died <- m:
+			case died <- machine.machineApi:
 				return
 			case <-changed:
 			}
 		}
 	}()
 
-	profileChangeWatcher, err := m.WatchApplicationLXDProfiles()
+	profileChangeWatcher, err := machine.machineApi.WatchApplicationLXDProfiles()
 	if err != nil {
-		logger.Errorf(err.Error())
+		machine.logger.Errorf(errors.Annotatef(err, "failed to start watching application lxd profiles for machine-%s", machine.id).Error())
+		machine.context.kill(err)
 		return
 	}
-	if err := context.add(profileChangeWatcher); err != nil {
+	if err := machine.context.add(profileChangeWatcher); err != nil {
 		return
 	}
 
-	if err := watchUnitLoop(context, logger, m, profileChangeWatcher); err != nil {
-		context.kill(err)
+	if err := machine.watchProfileChangesLoop(profileChangeWatcher); err != nil {
+		machine.context.kill(err)
 	}
 }
 
-func watchUnitLoop(context machineContext, logger Logger, m instancemutater.MutaterMachine, profileChangeWatcher watcher.NotifyWatcher) error {
-	logger.Tracef("watching change on  machine %s", m.Tag().Id())
+func (m mutaterMachine) watchProfileChangesLoop(profileChangeWatcher watcher.NotifyWatcher) error {
+	m.logger.Tracef("watching change on mutaterMachine %s", m.id)
 	for {
 		select {
-		case <-context.dying():
-			return context.errDying()
+		case <-m.context.dying():
+			return m.context.errDying()
 		case <-profileChangeWatcher.Changes():
-			logger.Debugf("machine-%s Received notification profile verification and change needed", m.Tag().Id())
+			logger.Debugf("mutaterMachine-%s Received notification profile verification and change needed", m.id)
+
+			info, err := m.machineApi.CharmProfilingInfo()
+			if err != nil && !params.IsCodeNotProvisioned(err) {
+				logger.Errorf("")
+				continue
+			}
+			if err = m.processMachineProfileChanges(info); err != nil {
+				return errors.Annotatef(err, "trigger worker restart, mutaterMachine-%s", m.id)
+			}
 		}
 	}
+}
+
+func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitProfileInfo) error {
+	m.logger.Tracef("%s.processMachineProfileChanges(%#v)", m.id, info)
+	if len(info.CurrentProfiles) == 0 && len(info.ProfileChanges) == 0 {
+		// no changes to be made, return now.
+		return nil
+	}
+
+	expectedProfiles, post, err := m.gatherProfileData(info)
+	if err != nil {
+		return errors.Annotatef(err, "processMachineProfileChanges %s.gatherProfileData(info):", m.id)
+	}
+	for _, p := range post {
+		if p.Profile != nil {
+			expectedProfiles = append(expectedProfiles, p.Name)
+		}
+	}
+
+	verified, err := m.verifyCurrentProfiles(string(info.InstanceId), expectedProfiles)
+	if err != nil {
+		return errors.Annotatef(err, "processMachineProfileChanges %s.verifyCurrentProfiles():", m.id)
+	}
+	if verified {
+		m.logger.Tracef("no changes necessary to machine-%s lxd profiles", m.id)
+		return nil
+	}
+
+	m.logger.Tracef("machine-%s (%s) assign profiles %q", m.id, string(info.InstanceId), expectedProfiles)
+	broker := m.context.getBroker()
+	currentProfiles, err := broker.AssignProfiles(string(info.InstanceId), expectedProfiles, post)
+	if err != nil {
+		return errors.Annotatef(err, "processMachineProfileChanges %s broker.AssignProfiles():", m.id)
+	}
+
+	return m.machineApi.SetCharmProfiles(currentProfiles)
+}
+
+func (m mutaterMachine) gatherProfileData(info *instancemutater.UnitProfileInfo) ([]string, []lxdprofile.ProfilePost, error) {
+	expectedProfiles := []string{"default", "juju-" + info.ModelName}
+	result := make([]lxdprofile.ProfilePost, len(info.ProfileChanges))
+	for i, pu := range info.ProfileChanges {
+		oldName, err := lxdprofile.MatchProfileNameByAppName(info.CurrentProfiles, pu.ApplicationName)
+		if err != nil {
+			return nil, nil, err
+		}
+		if pu.Profile.Empty() && oldName != "" {
+			// There is no new Profile and no Profile for this application applied
+			// already, move on.
+			continue
+		}
+		name := lxdprofile.Name(info.ModelName, pu.ApplicationName, pu.Revision)
+		result[i] = lxdprofile.ProfilePost{Name: name}
+		if !pu.Profile.Empty() {
+			result[i].Profile = &pu.Profile
+			expectedProfiles = append(expectedProfiles, name)
+		}
+	}
+	return expectedProfiles, result, nil
+}
+
+func (m mutaterMachine) verifyCurrentProfiles(instId string, expectedProfiles []string) (bool, error) {
+	broker := m.context.getBroker()
+	obtainedProfiles, err := broker.LXDProfileNames(instId)
+	if err != nil {
+		return false, nil
+	}
+	obtainedSet := set.NewStrings(obtainedProfiles...)
+
+	if obtainedSet.Union(set.NewStrings(expectedProfiles...)).Size() > obtainedSet.Size() {
+		return false, nil
+	}
+
+	for _, expected := range expectedProfiles {
+		if !obtainedSet.Contains(expected) {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
@@ -36,6 +37,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
@@ -213,8 +215,10 @@ func (task *provisionerTask) loop() error {
 			if !ok {
 				return errors.New("profile watcher closed channel")
 			}
-			if err := task.processProfileChanges(ids); err != nil {
-				return errors.Annotate(err, "failed to process updated charm profiles")
+			if !featureflag.Enabled(feature.InstanceMutater) {
+				if err := task.processProfileChanges(ids); err != nil {
+					return errors.Annotate(err, "failed to process updated charm profiles")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description of change

Added mutaterMachine.processMachineProfileChanges() to handle
verification of profiles and applying profiles when expected profiles
are not in use by the machine.

Disables processProfileChanges in the provisioner for InstanceMutater
feature flag.

## QA steps

export JUJU_DEV_FEATURE_FLAGS=instance-mutater
juju bootstrap
juju deploy the lxd-profile charm
juju deploy the ubuntu charm
upgrade both
check the lxd profiles assigned
juju deploy a bundle
