### PR TITLE
Disable replicaset config on k8s

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -547,28 +547,6 @@ func (a *MachineAgent) makeEngineCreator(agentName string, previousAgentVersion 
 			}, handle)
 		}
 
-		// We need to pass this in for the peergrouper, which wants to
-		// know whether the controller model supports spaces.
-		//
-		// TODO(axw) this seems unnecessary, and perhaps even wrong.
-		// Even if the provider supports spaces, you could have manual
-		// machines in the mix, in which case they won't necessarily
-		// be in the same space. I think the peergrouper should just
-		// check what spaces the machines are in, rather than trying
-		// to short cut anything.
-		controllerSupportsSpaces := func(st *state.State) (bool, error) {
-			env, err := stateenvirons.GetNewEnvironFunc(environs.New)(st)
-			if err != nil {
-				return false, errors.Annotate(err, "getting environ from state")
-			}
-			return environs.SupportsSpaces(state.CallContext(st), env), nil
-		}
-		if a.isCaasMachineAgent {
-			controllerSupportsSpaces = func(st *state.State) (bool, error) {
-				return false, nil
-			}
-		}
-
 		manifoldsCfg := machine.ManifoldsConfig{
 			PreviousAgentVersion:    previousAgentVersion,
 			AgentName:               agentName,
@@ -602,7 +580,6 @@ func (a *MachineAgent) makeEngineCreator(agentName string, previousAgentVersion 
 			SetStatePool:                      statePoolReporter.set,
 			RegisterIntrospectionHTTPHandlers: registerIntrospectionHandlers,
 			NewModelWorker:                    a.startModelWorkers,
-			ControllerSupportsSpaces:          controllerSupportsSpaces,
 			MuxShutdownWait:                   1 * time.Minute,
 			NewContainerBrokerFunc:            newCAASBroker,
 		}

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -241,11 +241,6 @@ type ManifoldsConfig struct {
 	// the specified UUID and type.
 	NewModelWorker func(modelUUID string, modelType state.ModelType) (worker.Worker, error)
 
-	// ControllerSupportsSpaces is a function that reports whether or
-	// not the controller model, represented by the given *state.State,
-	// supports network spaces.
-	ControllerSupportsSpaces func(*state.State) (bool, error)
-
 	// MachineLock is a central source for acquiring the machine lock.
 	// This is used by a number of workers to ensure serialisation of actions
 	// across the machine.
@@ -724,13 +719,12 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{
-			AgentName:                agentName,
-			ClockName:                clockName,
-			ControllerPortName:       controllerPortName,
-			StateName:                stateName,
-			Hub:                      config.CentralHub,
-			NewWorker:                peergrouper.New,
-			ControllerSupportsSpaces: config.ControllerSupportsSpaces,
+			AgentName:          agentName,
+			ClockName:          clockName,
+			ControllerPortName: controllerPortName,
+			StateName:          stateName,
+			Hub:                config.CentralHub,
+			NewWorker:          peergrouper.New,
 		})),
 
 		restoreWatcherName: restorewatcher.Manifold(restorewatcher.ManifoldConfig{

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -60,12 +60,6 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		StateName:          "state",
 		Hub:                s.hub,
 		NewWorker:          s.newWorker,
-		ControllerSupportsSpaces: func(st *state.State) (bool, error) {
-			if st != s.State {
-				return false, errors.New("invalid state")
-			}
-			return true, nil
-		},
 	})
 }
 
@@ -124,11 +118,11 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		APIHostPortsSetter: &peergrouper.CachingAPIHostPortsSetter{
 			APIHostPortsSetter: s.State,
 		},
-		Clock:          s.clock,
-		Hub:            s.hub,
-		SupportsSpaces: true,
-		MongoPort:      1234,
-		APIPort:        5678,
+		Clock:      s.clock,
+		Hub:        s.hub,
+		MongoPort:  1234,
+		APIPort:    5678,
+		SupportsHA: true,
 	})
 }
 


### PR DESCRIPTION
## Description of change

When a k8s controller pod restarts, it gets a new IP address. This breaks mongo replicaset config.
For now we disable mongo replicasets on k8s controllers, as HA is not yet supported anyway.

As a driveby remove an unused SupportsSpaces config item from the peergrouper worker.

## QA steps

bootstrap k8s controller
upgrade

bootstrap lxd
enable-ha