### PR TITLE
Add user messaging to cloud commands run locally

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -250,7 +250,7 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 	}
 
 	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil {
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
 	return cmd.CheckEmpty(args[1:])

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -97,8 +97,8 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 // Run is defined on the Command interface.
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 	if c.controllerName == "" && !c.Local {
-		ctxt.Stdout.Write(
-			[]byte("There are no controllers running.\nRemoving cluster from local cache. You will no longer be able to bootstrap on this cluster.\n"))
+		return errors.Errorf(
+			"There are no controllers running.\nTo remove cloud %q from the local cache, use the --local option.", c.cloudName)
 	}
 	if err := removeCloudFromLocal(c.cloudMetadataStore, c.cloudName); err != nil {
 		return errors.Annotatef(err, "cannot remove cloud from local cache")

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -88,7 +88,7 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 	}
 	c.cloudName = args[0]
 	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil {
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
 	return cmd.CheckEmpty(args[1:])
@@ -96,6 +96,10 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 
 // Run is defined on the Command interface.
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
+	if c.controllerName == "" && !c.Local {
+		ctxt.Stdout.Write(
+			[]byte("There are no controllers running.\nRemoving cluster from local cache. You will no longer be able to bootstrap on this cluster.\n"))
+	}
 	if err := removeCloudFromLocal(c.cloudMetadataStore, c.cloudName); err != nil {
 		return errors.Annotatef(err, "cannot remove cloud from local cache")
 	}

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -221,7 +221,7 @@ func (c *AddCloudCommand) Init(args []string) (err error) {
 		return cmd.CheckEmpty(args[2:])
 	}
 	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil {
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
 	return nil
@@ -297,6 +297,10 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	if c.controllerName == "" {
+		if !c.Local {
+			ctxt.Stdout.Write(
+				[]byte("There are no controllers running.\nAdding cloud to local cache so you can use it to bootstrap a controller.\n"))
+		}
 		return addLocalCloud(c.cloudMetadataStore, *newCloud)
 	}
 

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -298,8 +298,8 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 
 	if c.controllerName == "" {
 		if !c.Local {
-			ctxt.Stdout.Write(
-				[]byte("There are no controllers running.\nAdding cloud to local cache so you can use it to bootstrap a controller.\n"))
+			ctxt.Infof(
+				"There are no controllers running.\nAdding cloud to local cache so you can use it to bootstrap a controller.\n")
 		}
 		return addLocalCloud(c.cloudMetadataStore, *newCloud)
 	}
@@ -316,7 +316,12 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	// Add a credential for the newly added cloud.
-	return c.addCredentialToController(ctxt, *newCloud, api)
+	err = c.addCredentialToController(ctxt, *newCloud, api)
+	if err != nil {
+		return err
+	}
+	ctxt.Infof("Cloud %q added to controller %q.", c.Cloud, c.controllerName)
+	return nil
 }
 
 func cloudFromLocal(cloudName string) (*jujucloud.Cloud, error) {

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -32,7 +32,7 @@ import (
 type addSuite struct {
 	jujutesting.IsolationSuite
 
-	store jujuclient.ClientStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&addSuite{})
@@ -292,6 +292,29 @@ func (s *addSuite) TestAddNew(c *gc.C) {
 	_, err = s.runCommand(c, fake, "garage-maas", cloudFile.Name(), "--local")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
+}
+
+func (s *addSuite) TestAddLocalDefault(c *gc.C) {
+	s.store.Controllers = nil
+	cloudFile := prepareTestCloudYaml(c, garageMaasYamlFile)
+	defer cloudFile.Close()
+	defer os.Remove(cloudFile.Name())
+
+	mockCloud, err := jujucloud.ParseCloudMetadataFile(cloudFile.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	fake := newFakeCloudMetadataStore()
+	fake.Call("ParseCloudMetadataFile", cloudFile.Name()).Returns(mockCloud, nil)
+	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
+	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
+
+	ctx, err := s.runCommand(c, fake, "garage-maas", cloudFile.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(numCallsToWrite(), gc.Equals, 1)
+	out := cmdtesting.Stdout(ctx)
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Matches, `There are no controllers running.Adding cloud to local cache so you can use it to bootstrap a controller.*`)
 }
 
 func (s *addSuite) TestAddNewInvalidAuthType(c *gc.C) {

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -312,7 +312,7 @@ func (s *addSuite) TestAddLocalDefault(c *gc.C) {
 	ctx, err := s.runCommand(c, fake, "garage-maas", cloudFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
-	out := cmdtesting.Stdout(ctx)
+	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	c.Assert(out, gc.Matches, `There are no controllers running.Adding cloud to local cache so you can use it to bootstrap a controller.*`)
 }
@@ -396,7 +396,7 @@ func (s *addSuite) setupControllerCloudScenario(c *gc.C) (
 
 func (s *addSuite) TestAddToController(c *gc.C) {
 	cloudFileName, cmd, _, api, cred, _ := s.setupControllerCloudScenario(c)
-	_, err := cmdtesting.RunCommand(
+	ctx, err := cmdtesting.RunCommand(
 		c, cmd, "garage-maas", cloudFileName)
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckCallNames(c, "AddCloud", "AddCredential", "Close")
@@ -408,6 +408,9 @@ func (s *addSuite) TestAddToController(c *gc.C) {
 		Endpoint:    "http://garagemaas",
 	})
 	api.CheckCall(c, 1, "AddCredential", "cloudcred-garage-maas_fred_default", cred)
+	out := cmdtesting.Stderr(ctx)
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Matches, `Cloud "garage-maas" added to controller "mycontroller".`)
 }
 
 func (s *addSuite) TestAddLocal(c *gc.C) {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -163,8 +163,12 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 		output = details.all()
 	default:
 		if c.controllerName == "" && !c.Local {
-			ctxt.Stdout.Write(
-				[]byte("There are no controllers running.\nYou can bootstrap a new controller using one of these clouds:\n"))
+			ctxt.Infof(
+				"There are no controllers running.\nYou can bootstrap a new controller using one of these clouds:\n")
+		}
+		if c.controllerName != "" {
+			ctxt.Infof(
+				"Clouds on controller %q:\n\n", c.controllerName)
 		}
 		output = details
 	}

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -118,7 +118,7 @@ func (c *listCloudsCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init populates the command with the args from the command line.
 func (c *listCloudsCommand) Init(args []string) (err error) {
 	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil {
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
 	return nil
@@ -162,6 +162,10 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	case "yaml", "json":
 		output = details.all()
 	default:
+		if c.controllerName == "" && !c.Local {
+			ctxt.Stdout.Write(
+				[]byte("There are no controllers running.\nYou can bootstrap a new controller using one of these clouds:\n"))
+		}
 		output = details
 	}
 

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -24,7 +24,7 @@ import (
 type listSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api   *fakeListCloudsAPI
-	store jujuclient.ClientStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&listSuite{})
@@ -46,6 +46,23 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 
 	// Check that we are producing the expected fields
 	c.Assert(out, gc.Matches, `Cloud +Regions +Default +Type +Description.*`)
+	// // Just check couple of snippets of the output to make sure it looks ok.
+	c.Assert(out, gc.Matches, `.*aws +[0-9]+ +[a-z0-9-]+ +ec2 +Amazon Web Services.*`)
+	c.Assert(out, gc.Matches, `.*azure +[0-9]+ +[a-z0-9-]+ +azure +Microsoft Azure.*`)
+	// LXD should be there too.
+	c.Assert(out, gc.Matches, `.*localhost[ ]*1[ ]*localhost[ ]*lxd.*`)
+}
+
+func (s *listSuite) TestListPublicLocalDefault(c *gc.C) {
+	s.store.Controllers = nil
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil))
+	c.Assert(err, jc.ErrorIsNil)
+	out := cmdtesting.Stdout(ctx)
+	out = strings.Replace(out, "\n", "", -1)
+
+	c.Assert(out, gc.Matches, `There are no controllers running.You can bootstrap a new controller using one of these clouds:.*`)
+	// Check that we are producing the expected fields
+	c.Assert(out, gc.Matches, `.*Cloud +Regions +Default +Type +Description.*`)
 	// // Just check couple of snippets of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws +[0-9]+ +[a-z0-9-]+ +ec2 +Amazon Web Services.*`)
 	c.Assert(out, gc.Matches, `.*azure +[0-9]+ +[a-z0-9-]+ +azure +Microsoft Azure.*`)

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -57,11 +57,13 @@ func (s *listSuite) TestListPublicLocalDefault(c *gc.C) {
 	s.store.Controllers = nil
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil))
 	c.Assert(err, jc.ErrorIsNil)
-	out := cmdtesting.Stdout(ctx)
+	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-
 	c.Assert(out, gc.Matches, `There are no controllers running.You can bootstrap a new controller using one of these clouds:.*`)
+
 	// Check that we are producing the expected fields
+	out = cmdtesting.Stdout(ctx)
+	out = strings.Replace(out, "\n", "", -1)
 	c.Assert(out, gc.Matches, `.*Cloud +Regions +Default +Type +Description.*`)
 	// // Just check couple of snippets of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws +[0-9]+ +[a-z0-9-]+ +ec2 +Amazon Web Services.*`)
@@ -174,7 +176,12 @@ func (s *listSuite) TestListTabular(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(controllerAPICalled, gc.Equals, "mycontroller")
-	out := cmdtesting.Stdout(ctx)
+
+	out := cmdtesting.Stderr(ctx)
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Matches, `Clouds on controller "mycontroller":.*`)
+
+	out = cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
 Cloud    Regions  Default  Type       Description
 antnest        1  default  openstack  

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -92,8 +92,8 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.controllerName == "" {
 		if c.controllerName == "" && !c.Local {
-			ctxt.Stdout.Write(
-				[]byte("There are no controllers running.\nRemoving cloud from local cache. You will no longer be able to bootstrap on this cloud.\n"))
+			return errors.Errorf(
+				"There are no controllers running.\nTo remove cloud %q from the local cache, use the --local option.", c.Cloud)
 		}
 		return c.removeLocalCloud(ctxt)
 	}

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -83,7 +83,7 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 	}
 	c.Cloud = args[0]
 	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil {
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
 	return cmd.CheckEmpty(args[1:])
@@ -91,6 +91,10 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.controllerName == "" {
+		if c.controllerName == "" && !c.Local {
+			ctxt.Stdout.Write(
+				[]byte("There are no controllers running.\nRemoving cloud from local cache. You will no longer be able to bootstrap on this cloud.\n"))
+		}
 		return c.removeLocalCloud(ctxt)
 	}
 	return c.removeControllerCloud(ctxt)

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -90,7 +90,7 @@ func (s *removeSuite) TestRemoveCloudLocal(c *gc.C) {
 	assertPersonalClouds(c, "homestack2")
 }
 
-func (s *removeSuite) TestRemoveCloudDefaultLocal(c *gc.C) {
+func (s *removeSuite) TestRemoveCloudNoControllers(c *gc.C) {
 	s.store.Controllers = nil
 	cmd := cloud.NewRemoveCloudCommandForTest(
 		s.store,
@@ -100,13 +100,11 @@ func (s *removeSuite) TestRemoveCloudDefaultLocal(c *gc.C) {
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of personal cloud \"homestack\"\n")
-	assertPersonalClouds(c, "homestack2")
-	out := cmdtesting.Stdout(ctx)
-	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `There are no controllers running.Removing cloud from local cache. You will no longer be able to bootstrap on this cloud.*`)
+	_, err := cmdtesting.RunCommand(c, cmd, "homestack")
+	c.Assert(err, gc.NotNil)
+	msg := err.Error()
+	msg = strings.Replace(msg, "\n", "", -1)
+	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the local cache, use the --local option.*`)
 }
 
 func (s *removeSuite) TestRemoveCloudController(c *gc.C) {

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -101,7 +101,7 @@ func (c *showCloudCommand) Init(args []string) error {
 	var err error
 	c.controllerName, err = c.ControllerNameFromArg()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Wrap(err, errors.New(err.Error()+"\nUse --local to query the local cache."))
 	}
 	return cmd.CheckEmpty(args[1:])
 }

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -149,8 +149,8 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 
 func (c *updateCloudCommand) updateLocalCacheFromFile(ctxt *cmd.Context) error {
 	if !c.Local {
-		ctxt.Stdout.Write(
-			[]byte("There are no controllers running.\nUpdating cloud in local cache so you can use it to bootstrap a controller.\n"))
+		ctxt.Infof(
+			"There are no controllers running.\nUpdating cloud in local cache so you can use it to bootstrap a controller.\n")
 	}
 	r := cloudFileReader{
 		cloudMetadataStore: c.cloudMetadataStore,
@@ -170,7 +170,7 @@ func (c *updateCloudCommand) updateControllerFromFile(ctxt *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return c.updateController(newCloud)
+	return c.updateController(ctxt, newCloud)
 }
 
 func (c *updateCloudCommand) updateControllerCacheFromLocalCache(ctxt *cmd.Context) error {
@@ -178,14 +178,19 @@ func (c *updateCloudCommand) updateControllerCacheFromLocalCache(ctxt *cmd.Conte
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return c.updateController(newCloud)
+	return c.updateController(ctxt, newCloud)
 }
 
-func (c updateCloudCommand) updateController(cloud *jujucloud.Cloud) error {
+func (c updateCloudCommand) updateController(ctxt *cmd.Context, cloud *jujucloud.Cloud) error {
 	api, err := c.updateCloudAPIFunc(c.controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer api.Close()
-	return api.UpdateCloud(*cloud)
+	err = api.UpdateCloud(*cloud)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ctxt.Infof("Cloud %q updated on controller %q.", c.Cloud, c.controllerName)
+	return nil
 }

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -109,7 +109,7 @@ func (c *updateCloudCommand) Init(args []string) error {
 
 	var err error
 	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil {
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
 
@@ -148,6 +148,10 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *updateCloudCommand) updateLocalCacheFromFile(ctxt *cmd.Context) error {
+	if !c.Local {
+		ctxt.Stdout.Write(
+			[]byte("There are no controllers running.\nUpdating cloud in local cache so you can use it to bootstrap a controller.\n"))
+	}
 	r := cloudFileReader{
 		cloudMetadataStore: c.cloudMetadataStore,
 	}

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -99,7 +99,7 @@ func (s *updateCloudSuite) TestUpdateFromFileDefaultLocal(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
-	out := cmdtesting.Stdout(ctx)
+	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	c.Assert(out, gc.Matches, `There are no controllers running.Updating cloud in local cache so you can use it to bootstrap a controller.*`)
 }
@@ -120,7 +120,7 @@ func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
 		controllerNameCalled = controllerName
 		return s.api, nil
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "UpdateCloud", "Close")
 	c.Assert(controllerNameCalled, gc.Equals, "mycontroller")
@@ -131,6 +131,9 @@ func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
 		AuthTypes:   jujucloud.AuthTypes{"oauth1"},
 		Endpoint:    "http://garagemaas",
 	})
+	out := cmdtesting.Stderr(ctx)
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Matches, `Cloud "garage-maas" updated on controller "mycontroller".`)
 }
 
 func (s *updateCloudSuite) TestUpdateControllerLocalCacheBadFile(c *gc.C) {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -389,14 +389,14 @@ type OptionalControllerCommand struct {
 	CommandBase
 	Store jujuclient.ClientStore
 
-	noContoller    bool
+	Local          bool
 	controllerName string
 }
 
 // SetFlags initializes the flags supported by the command.
 func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.noContoller, "local", false, "Local operation only; controller not affected")
+	f.BoolVar(&c.Local, "local", false, "Local operation only; controller not affected")
 	f.StringVar(&c.controllerName, "c", "", "Controller to operate in")
 	f.StringVar(&c.controllerName, "controller", "", "")
 }
@@ -405,7 +405,7 @@ func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 // A non default controller can be chosen using the --controller option.
 // Use the --local arg to return an empty string, meaning no controller is selected.
 func (c *OptionalControllerCommand) ControllerNameFromArg() (string, error) {
-	if c.noContoller {
+	if c.Local {
 		return "", nil
 	}
 	controllerName := c.controllerName
@@ -415,7 +415,7 @@ func (c *OptionalControllerCommand) ControllerNameFromArg() (string, error) {
 			return "", errors.Trace(err)
 		}
 		if len(all) == 0 {
-			return "", errors.New(ErrNoControllersDefined.Error() + "\nUse --local to update the local cache.")
+			return "", errors.Trace(ErrNoControllersDefined)
 		}
 		controllerName, err = DetermineCurrentController(c.Store)
 		if err != nil {
@@ -423,7 +423,7 @@ func (c *OptionalControllerCommand) ControllerNameFromArg() (string, error) {
 		}
 	}
 	if controllerName == "" {
-		return "", errors.New(ErrNoCurrentController.Error() + "\nUse --local to update the local cache.")
+		return "", errors.Trace(ErrNoCurrentController)
 	}
 	return controllerName, nil
 }

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -158,8 +158,7 @@ No controllers registered.
 
 Please either create a new controller using "juju bootstrap" or connect to
 another controller that you have been given access to using "juju register".
-
-Use --local to update the local cache.`[1:])
+`[1:])
 }
 
 func (s *OptionalControllerCommandSuite) TestControllerCommandCurrent(c *gc.C) {


### PR DESCRIPTION
## Description of change

When running commands like list-clouds, if there are no controllers at all that have been set up, operate on the local cache with suitable user facing messages. This allows for example a user to install juju and run list-clouds to see what they can bootstrap to.

## QA steps

Run the various cloud commands with/without controllers running.