### PR TITLE
WIP: Part 2 of force remove application/unit - cleanup operations.

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -83,8 +83,8 @@ type StorageBackend interface {
 	AllStorageInstances() ([]state.StorageInstance, error)
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
-	ReleaseStorageInstance(names.StorageTag, bool) error
-	DetachStorage(names.StorageTag, names.UnitTag) error
+	ReleaseStorageInstance(names.StorageTag, bool, bool) error
+	DetachStorage(names.StorageTag, names.UnitTag, bool) error
 
 	Filesystem(names.FilesystemTag) (state.Filesystem, error)
 	FilesystemAttachment(names.Tag, names.FilesystemTag) (state.FilesystemAttachment, error)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -578,9 +578,9 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 	// Make the "data" storage volume Dead, releasing.
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storage[0].StorageTag(), true)
+	err = s.storageBackend.ReleaseStorageInstance(storage[0].StorageTag(), true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storage[0].StorageTag(), unit.UnitTag())
+	err = s.storageBackend.DetachStorage(storage[0].StorageTag(), unit.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 	unitMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -701,9 +701,9 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 	// Make the "data" storage filesystem Dead, releasing.
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storage[0].StorageTag(), true)
+	err = s.storageBackend.ReleaseStorageInstance(storage[0].StorageTag(), true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storage[0].StorageTag(), unit.UnitTag())
+	err = s.storageBackend.DetachStorage(storage[0].StorageTag(), unit.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 	unitMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -19,7 +19,7 @@ type storageAccess interface {
 type storageInterface interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
-	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
+	RemoveStorageAttachment(names.StorageTag, names.UnitTag, bool) error
 	DestroyUnitStorageAttachments(names.UnitTag) error
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)

--- a/apiserver/facades/agent/uniter/storage.go
+++ b/apiserver/facades/agent/uniter/storage.go
@@ -338,7 +338,9 @@ func (s *StorageAPI) removeOneStorageAttachment(id params.StorageAttachmentId, c
 	if err != nil {
 		return err
 	}
-	err = s.storage.RemoveStorageAttachment(storageTag, unitTag)
+	// TODO (anastasiamac 2019-04-04) We can now force storage removal
+	// but for now, while we have not an arg passed in, just hardcode.
+	err = s.storage.RemoveStorageAttachment(storageTag, unitTag, false)
 	if errors.IsNotFound(err) {
 		err = nil
 	}

--- a/apiserver/facades/agent/uniter/storage_test.go
+++ b/apiserver/facades/agent/uniter/storage_test.go
@@ -254,7 +254,7 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 }
 
 func (s *storageSuite) TestRemoveStorageAttachments(c *gc.C) {
-	setMock := func(st *mockStorageState, f func(s names.StorageTag, u names.UnitTag) error) {
+	setMock := func(st *mockStorageState, f func(s names.StorageTag, u names.UnitTag, force bool) error) {
 		st.remove = f
 	}
 
@@ -271,7 +271,7 @@ func (s *storageSuite) TestRemoveStorageAttachments(c *gc.C) {
 	}
 
 	st := &mockStorageState{}
-	setMock(st, func(s names.StorageTag, u names.UnitTag) error {
+	setMock(st, func(s names.StorageTag, u names.UnitTag, force bool) error {
 		c.Assert(u, gc.DeepEquals, unitTag0)
 		if s == storageTag1 {
 			return errors.New("badness")
@@ -482,7 +482,7 @@ type mockStorageState struct {
 	uniter.StorageVolumeInterface
 	uniter.StorageFilesystemInterface
 	destroyUnitStorageAttachments func(names.UnitTag) error
-	remove                        func(names.StorageTag, names.UnitTag) error
+	remove                        func(names.StorageTag, names.UnitTag, bool) error
 	storageInstance               func(names.StorageTag) (state.StorageInstance, error)
 	storageInstanceFilesystem     func(names.StorageTag) (state.Filesystem, error)
 	storageInstanceVolume         func(names.StorageTag) (state.Volume, error)
@@ -512,8 +512,8 @@ func (m *mockStorageState) DestroyUnitStorageAttachments(u names.UnitTag) error 
 	return m.destroyUnitStorageAttachments(u)
 }
 
-func (m *mockStorageState) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {
-	return m.remove(s, u)
+func (m *mockStorageState) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag, force bool) error {
+	return m.remove(s, u, force)
 }
 
 func (m *mockStorageState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1379,6 +1379,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 		// At the moment, this only returns the intent not the actual result.
 		// However, there is a provision for this functionality for the near-future: destroy operation itself
 		// contains Errors that have been encountered during its application.
+		logger.Warningf("aoperational errors destroying unit %v: %v", unit.Name(), op.Errors)
 		return &info, nil
 	}
 	results := make([]params.DestroyUnitResult, len(args.Units))
@@ -1510,6 +1511,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 		// At the moment, this only returns the intent not the actual result.
 		// However, there is a provision for this functionality for the near-future: destroy operation itself
 		// contains Errors that have been encountered during its application.
+		logger.Warningf("operational errors destroying application %v: %v", tag.Id(), op.Errors)
 		return &info, nil
 	}
 	results := make([]params.DestroyApplicationResult, len(args.Applications))

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1379,7 +1379,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 		// At the moment, this only returns the intent not the actual result.
 		// However, there is a provision for this functionality for the near-future: destroy operation itself
 		// contains Errors that have been encountered during its application.
-		logger.Warningf("aoperational errors destroying unit %v: %v", unit.Name(), op.Errors)
+		logger.Warningf("operational errors destroying unit %v: %v", unit.Name(), op.Errors)
 		return &info, nil
 	}
 	results := make([]params.DestroyUnitResult, len(args.Units))

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -284,8 +284,8 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 			s.stub.AddCall(addStorageForUnitCall)
 			return nil, nil
 		},
-		detachStorage: func(storage names.StorageTag, unit names.UnitTag) error {
-			s.stub.AddCall(detachStorageCall, storage, unit)
+		detachStorage: func(storage names.StorageTag, unit names.UnitTag, force bool) error {
+			s.stub.AddCall(detachStorageCall, storage, unit, force)
 			if storage == s.storageTag && unit == s.unitTag {
 				return nil
 			}
@@ -306,12 +306,12 @@ func (s *baseStorageSuite) constructStorageAccessor() *mockStorageAccessor {
 				names.ReadableString(unit),
 			)
 		},
-		destroyStorageInstance: func(tag names.StorageTag, destroyAttached bool) error {
-			s.stub.AddCall(destroyStorageInstanceCall, tag, destroyAttached)
+		destroyStorageInstance: func(tag names.StorageTag, destroyAttached bool, force bool) error {
+			s.stub.AddCall(destroyStorageInstanceCall, tag, destroyAttached, force)
 			return errors.New("cannae do it")
 		},
-		releaseStorageInstance: func(tag names.StorageTag, destroyAttached bool) error {
-			s.stub.AddCall(releaseStorageInstanceCall, tag, destroyAttached)
+		releaseStorageInstance: func(tag names.StorageTag, destroyAttached bool, force bool) error {
+			s.stub.AddCall(releaseStorageInstanceCall, tag, destroyAttached, force)
 			return errors.New("cannae do it")
 		},
 		addExistingFilesystem: func(f state.FilesystemInfo, v *state.VolumeInfo, storageName string) (names.StorageTag, error) {

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -64,10 +64,10 @@ type mockStorageAccessor struct {
 	allFilesystems                      func() ([]state.Filesystem, error)
 	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
 	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
-	destroyStorageInstance              func(names.StorageTag, bool) error
-	releaseStorageInstance              func(names.StorageTag, bool) error
+	destroyStorageInstance              func(names.StorageTag, bool, bool) error
+	releaseStorageInstance              func(names.StorageTag, bool, bool) error
 	attachStorage                       func(names.StorageTag, names.UnitTag) error
-	detachStorage                       func(names.StorageTag, names.UnitTag) error
+	detachStorage                       func(names.StorageTag, names.UnitTag, bool) error
 	addExistingFilesystem               func(state.FilesystemInfo, *state.VolumeInfo, string) (names.StorageTag, error)
 }
 
@@ -167,16 +167,16 @@ func (st *mockStorageAccessor) AttachStorage(storage names.StorageTag, unit name
 	return st.attachStorage(storage, unit)
 }
 
-func (st *mockStorageAccessor) DetachStorage(storage names.StorageTag, unit names.UnitTag) error {
-	return st.detachStorage(storage, unit)
+func (st *mockStorageAccessor) DetachStorage(storage names.StorageTag, unit names.UnitTag, force bool) error {
+	return st.detachStorage(storage, unit, force)
 }
 
-func (st *mockStorageAccessor) DestroyStorageInstance(tag names.StorageTag, destroyAttached bool) error {
-	return st.destroyStorageInstance(tag, destroyAttached)
+func (st *mockStorageAccessor) DestroyStorageInstance(tag names.StorageTag, destroyAttached bool, force bool) error {
+	return st.destroyStorageInstance(tag, destroyAttached, force)
 }
 
-func (st *mockStorageAccessor) ReleaseStorageInstance(tag names.StorageTag, destroyAttached bool) error {
-	return st.releaseStorageInstance(tag, destroyAttached)
+func (st *mockStorageAccessor) ReleaseStorageInstance(tag names.StorageTag, destroyAttached bool, force bool) error {
+	return st.releaseStorageInstance(tag, destroyAttached, force)
 }
 
 func (st *mockStorageAccessor) UnitStorageAttachments(tag names.UnitTag) ([]state.StorageAttachment, error) {

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -52,13 +52,13 @@ type storageInterface interface {
 
 	// DetachStorage detaches the storage instance with the
 	// specified tag from the unit with the specified tag.
-	DetachStorage(names.StorageTag, names.UnitTag) error
+	DetachStorage(names.StorageTag, names.UnitTag, bool) error
 
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
-	DestroyStorageInstance(names.StorageTag, bool) error
+	DestroyStorageInstance(names.StorageTag, bool, bool) error
 
 	// ReleaseStorageInstance releases the storage instance with the specified tag.
-	ReleaseStorageInstance(names.StorageTag, bool) error
+	ReleaseStorageInstance(names.StorageTag, bool, bool) error
 }
 
 type storageVolume interface {

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -917,7 +917,9 @@ func (a *StorageAPI) remove(args params.RemoveStorage) (params.ErrorResults, err
 			remove = a.storageAccess.ReleaseStorageInstance
 		}
 		result[i].Error = common.ServerError(
-			remove(tag, arg.DestroyAttachments),
+			// TODO (anastasiamac 2019-04-04) We can now force storage removal
+			// but for now, while we have not an arg passed in, just hardcode.
+			remove(tag, arg.DestroyAttachments, false),
 		)
 	}
 	return params.ErrorResults{result}, nil
@@ -963,7 +965,9 @@ func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.Un
 	if unitTag != (names.UnitTag{}) {
 		// The caller has specified a unit explicitly. Do
 		// not filter out "not found" errors in this case.
-		return a.storageAccess.DetachStorage(storageTag, unitTag)
+		// TODO (anastasiamac 2019-04-04) We can now force storage removal
+		// but for now, while we have not an arg passed in, just hardcode.
+		return a.storageAccess.DetachStorage(storageTag, unitTag, false)
 	}
 	attachments, err := a.storageAccess.StorageAttachments(storageTag)
 	if err != nil {
@@ -979,7 +983,9 @@ func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.Un
 		if att.Life() != state.Alive {
 			continue
 		}
-		err := a.storageAccess.DetachStorage(storageTag, att.Unit())
+		// TODO (anastasiamac 2019-04-04) We can now force storage removal
+		// but for now, while we have not an arg passed in, just hardcode.
+		err := a.storageAccess.DetachStorage(storageTag, att.Unit(), false)
 		if err != nil && !errors.IsNotFound(err) {
 			// We only care about NotFound errors if
 			// the user specified a unit explicitly.

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -342,9 +342,9 @@ func (s *storageSuite) TestRemove(c *gc.C) {
 		destroyStorageInstanceCall,
 		releaseStorageInstanceCall,
 	)
-	s.stub.CheckCall(c, 2, destroyStorageInstanceCall, names.NewStorageTag("foo/0"), false)
-	s.stub.CheckCall(c, 3, destroyStorageInstanceCall, names.NewStorageTag("foo/1"), true)
-	s.stub.CheckCall(c, 4, releaseStorageInstanceCall, names.NewStorageTag("foo/1"), true)
+	s.stub.CheckCall(c, 2, destroyStorageInstanceCall, names.NewStorageTag("foo/0"), false, false)
+	s.stub.CheckCall(c, 3, destroyStorageInstanceCall, names.NewStorageTag("foo/1"), true, false)
+	s.stub.CheckCall(c, 4, releaseStorageInstanceCall, names.NewStorageTag("foo/1"), true, false)
 }
 
 func (s *storageSuite) TestDestroyV3(c *gc.C) {
@@ -366,7 +366,7 @@ func (s *storageSuite) TestDestroyV3(c *gc.C) {
 		getBlockForTypeCall, // Change
 		destroyStorageInstanceCall,
 	)
-	s.stub.CheckCall(c, 2, destroyStorageInstanceCall, names.NewStorageTag("foo/0"), true)
+	s.stub.CheckCall(c, 2, destroyStorageInstanceCall, names.NewStorageTag("foo/0"), true, false)
 }
 
 func (s *storageSuite) TestDetach(c *gc.C) {
@@ -396,9 +396,9 @@ func (s *storageSuite) TestDetach(c *gc.C) {
 	})
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
-		{detachStorageCall, []interface{}{s.storageTag, s.unitTag}},
+		{detachStorageCall, []interface{}{s.storageTag, s.unitTag, false}},
 		{storageInstanceAttachmentsCall, []interface{}{s.storageTag}},
-		{detachStorageCall, []interface{}{s.storageTag, s.unitTag}},
+		{detachStorageCall, []interface{}{s.storageTag, s.unitTag, false}},
 	})
 }
 
@@ -423,6 +423,7 @@ func (s *storageSuite) TestDetachSpecifiedNotFound(c *gc.C) {
 		{detachStorageCall, []interface{}{
 			s.storageTag,
 			names.NewUnitTag("foo/42"),
+			false,
 		}},
 	})
 }
@@ -433,8 +434,8 @@ func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
 	//     a list of alive attachments
 	//  2. attachment is concurrently destroyed
 	//     and removed by another process
-	s.storageAccessor.detachStorage = func(sTag names.StorageTag, uTag names.UnitTag) error {
-		s.stub.AddCall(detachStorageCall, sTag, uTag)
+	s.storageAccessor.detachStorage = func(sTag names.StorageTag, uTag names.UnitTag, force bool) error {
+		s.stub.AddCall(detachStorageCall, sTag, uTag, force)
 		return errors.NotFoundf(
 			"attachment of %s to %s",
 			names.ReadableString(sTag),
@@ -455,7 +456,7 @@ func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
 	s.stub.CheckCalls(c, []testing.StubCall{
 		{getBlockForTypeCall, []interface{}{state.ChangeBlock}},
 		{storageInstanceAttachmentsCall, []interface{}{s.storageTag}},
-		{detachStorageCall, []interface{}{s.storageTag, s.unitTag}},
+		{detachStorageCall, []interface{}{s.storageTag, s.unitTag, false}},
 	})
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -295,8 +295,8 @@ func (m *mockStorage) AllFilesystems() ([]state.Filesystem, error) {
 	return result, nil
 }
 
-func (m *mockStorage) DestroyStorageInstance(tag names.StorageTag, destroyAttachments bool) (err error) {
-	m.MethodCall(m, "DestroyStorageInstance", tag, destroyAttachments)
+func (m *mockStorage) DestroyStorageInstance(tag names.StorageTag, destroyAttachments bool, force bool) (err error) {
+	m.MethodCall(m, "DestroyStorageInstance", tag, destroyAttachments, force)
 	return nil
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -1041,7 +1041,9 @@ func (a *Facade) cleaupOrphanedFilesystems(processedFilesystemIds set.Strings) e
 		}
 
 		logger.Debugf("found orphaned filesystem %v", fs.FilesystemTag())
-		err = a.storage.DestroyStorageInstance(storageTag, false)
+		// TODO (anastasiamac 2019-04-04) We can now force storage removal
+		// but for now, while we have not an arg passed in, just hardcode.
+		err = a.storage.DestroyStorageInstance(storageTag, false, false)
 		if err != nil && !errors.IsNotFound(err) {
 			return errors.Trace(err)
 		}

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -45,7 +45,7 @@ type StorageBackend interface {
 	// These are for cleanup up orphaned filesystems when pods are recreated.
 	// TODO(caas) - record unit id on the filesystem so we can query by unit
 	AllFilesystems() ([]state.Filesystem, error)
-	DestroyStorageInstance(tag names.StorageTag, destroyAttachments bool) (err error)
+	DestroyStorageInstance(tag names.StorageTag, destroyAttachments bool, force bool) (err error)
 	DestroyFilesystem(tag names.FilesystemTag) (err error)
 }
 

--- a/state/application.go
+++ b/state/application.go
@@ -2028,9 +2028,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 		}
 		errs = append(errs, err)
 	} else {
-		// TODO (anastasiamac 2019-03-29) There is a lot of logic in here...
-		// Should this also accept a force flag?
-		storageInstanceOps, err := removeStorageInstancesOps(sb, u.Tag())
+		storageInstanceOps, err := removeStorageInstancesOps(sb, u.Tag(), force)
 		if err != nil {
 			if !force {
 				return nil, errs, errors.Trace(err)

--- a/state/application.go
+++ b/state/application.go
@@ -285,6 +285,11 @@ func (op *DestroyApplicationOperation) Build(attempt int) ([]txn.Op, error) {
 			return nil, err
 		}
 	}
+	// This call returns needed operations to destroy an application.
+	// All operational errors are added to 'op' struct
+	// and may be of interest to the user. Without 'force', these errors are considered fatal.
+	// If 'force' is specified, they are treated as non-fatal - they will not prevent further
+	// processing: we'll still try to remove application.
 	ops, err := op.destroyOps()
 	switch err {
 	case errRefresh:
@@ -309,6 +314,13 @@ func (op *DestroyApplicationOperation) Done(err error) error {
 // destroyOps returns the operations required to destroy the application. If it
 // returns errRefresh, the application should be refreshed and the destruction
 // operations recalculated.
+//
+// When this operation has 'force' set, all operational errors are considered non-fatal
+// and are accumulated on the operation.
+// This method will return all operations we can construct despite errors.
+//
+// When the 'force' is not set, any operational errors will be considered fatal. All operations
+// constructed up until the error will be discarded and the error will be returned.
 func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	if op.app.doc.Life == Dying {
 		if !op.Force {
@@ -334,6 +346,10 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	removeCount := 0
 	failedRels := false
 	for _, rel := range rels {
+		// When forced, this call will return both operations to remove this
+		// relation as well as all operational errors encountered.
+		// If the 'force' is not set and the call came across some errors,
+		// these errors will be fatal and no operations will be returned.
 		relOps, isRemove, opErrs, err := rel.destroyOps(op.app.doc.Name, op.Force)
 		op.AddError(opErrs...)
 		if err == errAlreadyDying {
@@ -390,6 +406,10 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	// removed, the application can also be removed.
 	if op.app.doc.UnitCount == 0 && op.app.doc.RelationCount == removeCount {
 		hasLastRefs := bson.D{{"life", Alive}, {"unitcount", 0}, {"relationcount", removeCount}}
+		// When forced, this call will return both operations to remove this
+		// application as well as all operational errors encountered.
+		// If the 'force' is not set and the call came across some errors,
+		// these errors will be fatal and no operations will be returned.
 		removeOps, opErrs, err := op.app.removeOps(hasLastRefs, op.Force)
 		op.AddError(opErrs...)
 		if err != nil {
@@ -463,6 +483,9 @@ func removeResourcesOps(st *State, applicationID string) ([]txn.Op, error) {
 // When force is set, the operation will proceed regardless of the errors,
 // and if any errors are encountered, all possible accumulated operations
 // as well as all encountered errors will be returned.
+// When 'force' is set, this call will return both operations to remove this
+// application as well as all operational errors encountered.
+// If the 'force' is not set, any error will be fatal and no operations will be returned.
 func (a *Application) removeOps(asserts bson.D, force bool) ([]txn.Op, []error, error) {
 	ops := []txn.Op{{
 		C:      applicationsC,
@@ -488,6 +511,9 @@ func (a *Application) removeOps(asserts bson.D, force bool) ([]txn.Op, []error, 
 	// do it explicitly below.
 	name := a.doc.Name
 	curl := a.doc.CharmURL
+	// When 'force' is set, this call will return both operations to delete application references
+	// to this charm as well as all operational errors encountered.
+	// If the 'force' is not set, any error will be fatal and no operations will be returned.
 	charmOps, opErrs, err := appCharmDecRefOps(a.st, name, curl, false, force)
 	errs = append(errs, opErrs...)
 	if err != nil {
@@ -1961,6 +1987,9 @@ func (a *Application) AddUnit(args AddUnitParams) (unit *Unit, err error) {
 
 // removeUnitOps returns the operations necessary to remove the supplied unit,
 // assuming the supplied asserts apply to the unit document.
+// When 'force' is set, this call will return both needed operations
+// as well as all operational errors encountered.
+// If the 'force' is not set, any error will be fatal and no operations will be returned.
 func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.Op, []error, error) {
 	errs := []error{}
 	hostOps, opErrs, err := u.destroyHostOps(a, force)
@@ -2042,6 +2071,9 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 		// If the unit has a different URL to the application, allow any final
 		// cleanup to happen; otherwise we just do it when the app itself is removed.
 		maybeDoFinal := u.doc.CharmURL != a.doc.CharmURL
+		// When 'force' is set, this call will return both needed operations
+		// as well as all operational errors encountered.
+		// If the 'force' is not set, any error will be fatal and no operations will be returned.
 		decOps, opErrs, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL, maybeDoFinal, force)
 		errs = append(errs, opErrs...)
 		if errors.IsNotFound(err) {
@@ -2056,6 +2088,9 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, force bool) ([]txn.
 	}
 	if a.doc.Life == Dying && a.doc.RelationCount == 0 && a.doc.UnitCount == 1 {
 		hasLastRef := bson.D{{"life", Dying}, {"relationcount", 0}, {"unitcount", 1}}
+		// When 'force' is set, this call will return both needed operations
+		// as well as all operational errors encountered.
+		// If the 'force' is not set, any error will be fatal and no operations will be returned.
 		removeOps, opErrs, err := a.removeOps(hasLastRef, force)
 		errs = append(errs, opErrs...)
 		if err != nil {

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -225,6 +225,9 @@ func (s *applicationOffers) Remove(offerName string, force bool) (err error) {
 					}
 				}
 
+				// When 'force' is set, this call will return both needed operations
+				// as well as all operational errors encountered.
+				// If the 'force' is not set, any error will be fatal and no operations will be returned.
 				relOps, _, opErrs, err := rel.destroyOps("", force)
 				if len(opErrs) != 0 {
 					logger.Warningf("errors while getting operations to destroy remote application relation %v: %v", remoteApp.Name(), opErrs)

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -66,6 +66,9 @@ func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCrea
 // storage constraints documents for that pair, and schedule a cleanup
 // to see if the charm itself is now unreferenced and can be tidied
 // away itself.
+// When 'force' is set, this call will return both needed operations
+// as well as all operational errors encountered.
+// If the 'force' is not set, any error will be fatal and no operations will be returned.
 func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL, maybeDoFinal, force bool) ([]txn.Op, []error, error) {
 	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -304,23 +304,21 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 	}
 
 	var force bool
-	switch n := len(cleanupArgs); n {
-	case 0:
-		// Old cleanups have no args, so follow the old
-		// behaviour: destroy the storage.
-	case 1:
-		if err := destroyStorageFromArg(); err != nil {
-			return err
+	// It's valid to have no args: old cleanups have no args, so follow the old behaviour.
+	if n := len(cleanupArgs); n > 0 {
+		if n > 2 {
+			return errors.Errorf("expected 0-2 arguments, got %d", n)
 		}
-	case 2:
-		if err := destroyStorageFromArg(); err != nil {
-			return err
+		if n >= 1 {
+			if err := destroyStorageFromArg(); err != nil {
+				return err
+			}
 		}
-		if err := cleanupArgs[1].Unmarshal(&force); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		if n >= 2 {
+			if err := cleanupArgs[1].Unmarshal(&force); err != nil {
+				return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+			}
 		}
-	default:
-		return errors.Errorf("expected 0-2 arguments, got %d", n)
 	}
 	storage, err := sb.AllStorageInstances()
 	if err != nil {
@@ -393,22 +391,21 @@ func (st *State) removeRemoteApplicationsForDyingModel() (err error) {
 func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanupArgs []bson.Raw) (err error) {
 	var destroyStorage bool
 	var force bool
-	switch n := len(cleanupArgs); n {
-	case 0:
-		// Old cleanups have no args, so follow the old behaviour.
-	case 1:
-		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup args")
+	// It's valid to have no args: old cleanups have no args, so follow the old behaviour.
+	if n := len(cleanupArgs); n > 0 {
+		if n > 2 {
+			return errors.Errorf("expected 0-2 arguments, got %d", n)
 		}
-	case 2:
-		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup arg 'destroyStorage'")
+		if n >= 1 {
+			if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
+				return errors.Annotate(err, "unmarshalling cleanup args")
+			}
 		}
-		if err := cleanupArgs[1].Unmarshal(&force); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		if n >= 2 {
+			if err := cleanupArgs[1].Unmarshal(&force); err != nil {
+				return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+			}
 		}
-	default:
-		return errors.Errorf("expected 0-2 arguments, got %d", n)
 	}
 
 	// This won't miss units, because a Dying application cannot have units
@@ -470,22 +467,21 @@ func (st *State) cleanupCharm(charmURL string) error {
 func (st *State) cleanupDyingUnit(name string, cleanupArgs []bson.Raw) error {
 	var destroyStorage bool
 	var force bool
-	switch n := len(cleanupArgs); n {
-	case 0:
-		// Old cleanups have no args, so follow the old behaviour.
-	case 1:
-		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup args")
+	// It's valid to have no args: old cleanups have no args, so follow the old behaviour.
+	if n := len(cleanupArgs); n > 0 {
+		if n > 2 {
+			return errors.Errorf("expected 0-2 arguments, got %d", n)
 		}
-	case 2:
-		if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup arg 'destroyStorage'")
+		if n >= 1 {
+			if err := cleanupArgs[0].Unmarshal(&destroyStorage); err != nil {
+				return errors.Annotate(err, "unmarshalling cleanup args")
+			}
 		}
-		if err := cleanupArgs[1].Unmarshal(&force); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		if n >= 2 {
+			if err := cleanupArgs[1].Unmarshal(&force); err != nil {
+				return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+			}
 		}
-	default:
-		return errors.Errorf("expected 0-2 arguments, got %d", n)
 	}
 
 	unit, err := st.Unit(name)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -131,17 +131,17 @@ func (st *State) Cleanup() (err error) {
 		case cleanupDyingUnit:
 			err = st.cleanupDyingUnit(doc.Prefix, args)
 		case cleanupDyingUnitResources:
-			err = st.cleanupDyingUnitResources(doc.Prefix)
+			err = st.cleanupDyingUnitResources(doc.Prefix, args)
 		case cleanupRemovedUnit:
-			err = st.cleanupRemovedUnit(doc.Prefix)
+			err = st.cleanupRemovedUnit(doc.Prefix, args)
 		case cleanupApplicationsForDyingModel:
 			err = st.cleanupApplicationsForDyingModel()
 		case cleanupDyingMachine:
-			err = st.cleanupDyingMachine(doc.Prefix)
+			err = st.cleanupDyingMachine(doc.Prefix, args)
 		case cleanupForceDestroyedMachine:
 			err = st.cleanupForceDestroyedMachine(doc.Prefix)
 		case cleanupAttachmentsForDyingStorage:
-			err = st.cleanupAttachmentsForDyingStorage(doc.Prefix)
+			err = st.cleanupAttachmentsForDyingStorage(doc.Prefix, args)
 		case cleanupAttachmentsForDyingVolume:
 			err = st.cleanupAttachmentsForDyingVolume(doc.Prefix)
 		case cleanupAttachmentsForDyingFilesystem:
@@ -292,20 +292,35 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 		return errors.Trace(err)
 	}
 	destroyStorage := sb.DestroyStorageInstance
+	destroyStorageFromArg := func() error {
+		var destroyStorageFlag bool
+		if err := cleanupArgs[0].Unmarshal(&destroyStorageFlag); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'destroyStorage'")
+		}
+		if !destroyStorageFlag {
+			destroyStorage = sb.ReleaseStorageInstance
+		}
+		return nil
+	}
+
+	var force bool
 	switch n := len(cleanupArgs); n {
 	case 0:
 		// Old cleanups have no args, so follow the old
 		// behaviour: destroy the storage.
 	case 1:
-		var destroyStorageFlag bool
-		if err := cleanupArgs[0].Unmarshal(&destroyStorageFlag); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup args")
+		if err := destroyStorageFromArg(); err != nil {
+			return err
 		}
-		if !destroyStorageFlag {
-			destroyStorage = sb.ReleaseStorageInstance
+	case 2:
+		if err := destroyStorageFromArg(); err != nil {
+			return err
+		}
+		if err := cleanupArgs[1].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
 		}
 	default:
-		return errors.Errorf("expected 0-1 arguments, got %d", n)
+		return errors.Errorf("expected 0-2 arguments, got %d", n)
 	}
 	storage, err := sb.AllStorageInstances()
 	if err != nil {
@@ -313,7 +328,7 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 	}
 	for _, s := range storage {
 		const destroyAttached = true
-		err := destroyStorage(s.StorageTag(), destroyAttached)
+		err := destroyStorage(s.StorageTag(), destroyAttached, force)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
@@ -409,6 +424,7 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 	for iter.Next(&unit.doc) {
 		op := unit.DestroyOperation()
 		op.DestroyStorage = destroyStorage
+		op.Force = force
 		if err := st.ApplyOperation(op); err != nil {
 			return errors.Trace(err)
 		}
@@ -484,32 +500,53 @@ func (st *State) cleanupDyingUnit(name string, cleanupArgs []bson.Raw) error {
 	// is gone as quickly as possible.
 	relations, err := unit.RelationsJoined()
 	if err != nil {
-		return err
+		if !force {
+			return err
+		}
+		logger.Warningf("could not get joined relations for unit %v during dying unit cleanup: %v", unit.Name(), err)
 	}
 	for _, relation := range relations {
 		relationUnit, err := relation.Unit(unit)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
-			return err
-		}
-		if err := relationUnit.PrepareLeaveScope(); err != nil {
-			return err
+			if !force {
+				return err
+			}
+			logger.Warningf("could not get unit relation for unit %v during dying unit cleanup: %v", unit.Name(), err)
+		} else {
+			if err := relationUnit.PrepareLeaveScope(); err != nil {
+				if !force {
+					return err
+				}
+				logger.Warningf("could not prepare to leave scope for relation %v for unit %v during dying unit cleanup: %v", relation, unit.Name(), err)
+			}
 		}
 	}
 
 	if destroyStorage {
 		// Detach and mark storage instances as dying, allowing the
 		// unit to terminate.
-		return st.cleanupUnitStorageInstances(unit.UnitTag())
+		return st.cleanupUnitStorageInstances(unit.UnitTag(), force)
 	} else {
 		// Mark storage attachments as dying, so that they are detached
 		// and removed from state, allowing the unit to terminate.
-		return st.cleanupUnitStorageAttachments(unit.UnitTag(), false)
+		return st.cleanupUnitStorageAttachments(unit.UnitTag(), false, force)
 	}
 }
 
-func (st *State) cleanupDyingUnitResources(unitId string) error {
+func (st *State) cleanupDyingUnitResources(unitId string, cleanupArgs []bson.Raw) error {
+	var force bool
+	switch n := len(cleanupArgs); n {
+	case 0:
+		// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		}
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
+	}
 	unitTag := names.NewUnitTag(unitId)
 	sb, err := NewStorageBackend(st)
 	if err != nil {
@@ -517,17 +554,25 @@ func (st *State) cleanupDyingUnitResources(unitId string) error {
 	}
 	filesystemAttachments, err := sb.UnitFilesystemAttachments(unitTag)
 	if err != nil {
-		return errors.Annotate(err, "getting unit filesystem attachments")
+		err := errors.Annotate(err, "getting unit filesystem attachments")
+		if !force {
+			return err
+		}
+		logger.Warningf("%v", err)
 	}
 	volumeAttachments, err := sb.UnitVolumeAttachments(unitTag)
 	if err != nil {
-		return errors.Annotate(err, "getting unit volume attachments")
+		err := errors.Annotate(err, "getting unit volume attachments")
+		if !force {
+			return err
+		}
+		logger.Warningf("%v", err)
 	}
 
-	return cleanupDyingEntityStorage(sb, unitTag, false, filesystemAttachments, volumeAttachments)
+	return cleanupDyingEntityStorage(sb, unitTag, false, filesystemAttachments, volumeAttachments, force)
 }
 
-func (st *State) cleanupUnitStorageAttachments(unitTag names.UnitTag, remove bool) error {
+func (st *State) cleanupUnitStorageAttachments(unitTag names.UnitTag, remove bool, force bool) error {
 	sb, err := NewStorageBackend(st)
 	if err != nil {
 		return err
@@ -538,26 +583,32 @@ func (st *State) cleanupUnitStorageAttachments(unitTag names.UnitTag, remove boo
 	}
 	for _, storageAttachment := range storageAttachments {
 		storageTag := storageAttachment.StorageInstance()
-		err := sb.DetachStorage(storageTag, unitTag)
+		err := sb.DetachStorage(storageTag, unitTag, force)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
-			return err
+			if !force {
+				return err
+			}
+			logger.Warningf("could not detach storage %v for unit %v: %v", storageTag.Id(), unitTag.Id(), err)
 		}
 		if !remove {
 			continue
 		}
-		err = sb.RemoveStorageAttachment(storageTag, unitTag)
+		err = sb.RemoveStorageAttachment(storageTag, unitTag, force)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
-			return err
+			if !force {
+				return err
+			}
+			logger.Warningf("could not remove storage attachment for storage %v for unit %v: %v", storageTag.Id(), unitTag.Id(), err)
 		}
 	}
 	return nil
 }
 
-func (st *State) cleanupUnitStorageInstances(unitTag names.UnitTag) error {
+func (st *State) cleanupUnitStorageInstances(unitTag names.UnitTag, force bool) error {
 	sb, err := NewStorageBackend(st)
 	if err != nil {
 		return err
@@ -568,7 +619,7 @@ func (st *State) cleanupUnitStorageInstances(unitTag names.UnitTag) error {
 	}
 	for _, storageAttachment := range storageAttachments {
 		storageTag := storageAttachment.StorageInstance()
-		err := sb.DestroyStorageInstance(storageTag, true)
+		err := sb.DestroyStorageInstance(storageTag, true, force)
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
@@ -580,10 +631,25 @@ func (st *State) cleanupUnitStorageInstances(unitTag names.UnitTag) error {
 
 // cleanupRemovedUnit takes care of all the final cleanup required when
 // a unit is removed.
-func (st *State) cleanupRemovedUnit(unitId string) error {
+func (st *State) cleanupRemovedUnit(unitId string, cleanupArgs []bson.Raw) error {
+	var force bool
+	switch n := len(cleanupArgs); n {
+	case 0:
+		// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		}
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
+	}
+
 	actions, err := st.matchingActionsByReceiverId(unitId)
 	if err != nil {
-		return errors.Trace(err)
+		if !force {
+			return errors.Trace(err)
+		}
+		logger.Warningf("could not get unit actions for unit %v during cleanup of removed unit: %v", unitId, err)
 	}
 	cancelled := ActionResults{
 		Status:  ActionCancelled,
@@ -595,7 +661,10 @@ func (st *State) cleanupRemovedUnit(unitId string) error {
 			// nothing to do here
 		default:
 			if _, err = action.Finish(cancelled); err != nil {
-				return errors.Trace(err)
+				if !force {
+					return errors.Trace(err)
+				}
+				logger.Warningf("could not finish action %v for unit %v during cleanup of removed unit: %v", action.Name(), unitId, err)
 			}
 		}
 	}
@@ -604,21 +673,35 @@ func (st *State) cleanupRemovedUnit(unitId string) error {
 		Unit: unitId,
 	}
 	if err := Apply(st.database, change); err != nil {
-		return errors.Trace(err)
+		if !force {
+			return errors.Trace(err)
+		}
+		logger.Warningf("could not cleanup payload for unit %v during cleanup of removed unit: %v", unitId, err)
 	}
 	return nil
 }
 
 // cleanupDyingMachine marks resources owned by the machine as dying, to ensure
 // they are cleaned up as well.
-func (st *State) cleanupDyingMachine(machineId string) error {
+func (st *State) cleanupDyingMachine(machineId string, cleanupArgs []bson.Raw) error {
+	var force bool
+	switch n := len(cleanupArgs); n {
+	case 0:
+		// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		}
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
+	}
 	machine, err := st.Machine(machineId)
 	if errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return err
 	}
-	return cleanupDyingMachineResources(machine)
+	return cleanupDyingMachineResources(machine, force)
 }
 
 // cleanupForceDestroyedMachine systematically destroys and removes all entities
@@ -647,11 +730,15 @@ func (st *State) cleanupForceDestroyedMachine(machineId string) error {
 		return errors.Trace(err)
 	}
 	for _, unitName := range machine.doc.Principals {
-		if err := st.obliterateUnit(unitName); err != nil {
+		opErrs, err := st.obliterateUnit(unitName, true)
+		if len(opErrs) != 0 {
+			logger.Warningf("while obliterating unit %v: %v", unitName, opErrs)
+		}
+		if err != nil {
 			return errors.Trace(err)
 		}
 	}
-	if err := cleanupDyingMachineResources(machine); err != nil {
+	if err := cleanupDyingMachineResources(machine, true); err != nil {
 		return errors.Trace(err)
 	}
 	if machine.IsManager() {
@@ -739,7 +826,7 @@ func (st *State) cleanupContainers(machine *Machine) error {
 	return nil
 }
 
-func cleanupDyingMachineResources(m *Machine) error {
+func cleanupDyingMachineResources(m *Machine, force bool) error {
 	sb, err := NewStorageBackend(m.st)
 	if err != nil {
 		return errors.Trace(err)
@@ -747,43 +834,66 @@ func cleanupDyingMachineResources(m *Machine) error {
 
 	filesystemAttachments, err := sb.MachineFilesystemAttachments(m.MachineTag())
 	if err != nil {
-		return errors.Annotate(err, "getting machine filesystem attachments")
+		err = errors.Annotate(err, "getting machine filesystem attachments")
+		if !force {
+			return err
+		}
+		logger.Warningf("%v", err)
 	}
 	volumeAttachments, err := sb.MachineVolumeAttachments(m.MachineTag())
 	if err != nil {
-		return errors.Annotate(err, "getting machine volume attachments")
+		err = errors.Annotate(err, "getting machine volume attachments")
+		if !force {
+			return err
+		}
+		logger.Warningf("%v", err)
 	}
 
 	// Check if the machine is manual, to decide whether or not to
 	// short circuit the removal of non-detachable filesystems.
 	manual, err := m.IsManual()
 	if err != nil {
-		return errors.Trace(err)
+		if !force {
+			return errors.Trace(err)
+		}
+		logger.Warningf("could not determine if machine %v is manual: %v", m.MachineTag().Id(), err)
 	}
-	return cleanupDyingEntityStorage(sb, m.Tag(), manual, filesystemAttachments, volumeAttachments)
+	return cleanupDyingEntityStorage(sb, m.Tag(), manual, filesystemAttachments, volumeAttachments, force)
 }
 
-func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual bool, filesystemAttachments []FilesystemAttachment, volumeAttachments []VolumeAttachment) error {
+func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual bool, filesystemAttachments []FilesystemAttachment, volumeAttachments []VolumeAttachment, force bool) error {
 	// Destroy non-detachable machine/unit filesystems first.
 	filesystems, err := sb.filesystems(bson.D{{"hostid", hostTag.Id()}})
-	if err != nil {
-		return errors.Annotate(err, "getting host filesystems")
+	if err != nil && !errors.IsNotFound(err) {
+		err = errors.Annotate(err, "getting host filesystems")
+		if !force {
+			logger.Warningf("%v", err)
+		}
 	}
 	for _, f := range filesystems {
-		if err := sb.DestroyFilesystem(f.FilesystemTag()); err != nil {
-			return errors.Trace(err)
+		if err := sb.DestroyFilesystem(f.FilesystemTag()); err != nil && !errors.IsNotFound(err) {
+			if !force {
+				return errors.Trace(err)
+			}
+			logger.Warningf("could not destroy filesystem %v for %v: %v", f.FilesystemTag().Id(), hostTag, err)
 		}
 	}
 
 	// Detach all filesystems from the machine/unit.
 	for _, fsa := range filesystemAttachments {
 		detachable, err := isDetachableFilesystemTag(sb.mb.db(), fsa.Filesystem())
-		if err != nil {
-			return errors.Trace(err)
+		if err != nil && !errors.IsNotFound(err) {
+			if !force {
+				return errors.Trace(err)
+			}
+			logger.Warningf("could not determine if filesystem %v for %v is detachable: %v", fsa.Filesystem().Id(), hostTag, err)
 		}
 		if detachable {
-			if err := sb.DetachFilesystem(fsa.Host(), fsa.Filesystem()); err != nil {
-				return errors.Trace(err)
+			if err := sb.DetachFilesystem(fsa.Host(), fsa.Filesystem()); err != nil && !errors.IsNotFound(err) {
+				if !force {
+					return errors.Trace(err)
+				}
+				logger.Warningf("could not detach filesystem %v for %v: %v", fsa.Filesystem().Id(), hostTag, err)
 			}
 		}
 		if !manual {
@@ -800,35 +910,45 @@ func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual boo
 				updateStatus = func() error { return nil }
 			} else {
 				f, err := sb.Filesystem(fsa.Filesystem())
-				if err != nil {
-					return errors.Trace(err)
+				if err != nil && !errors.IsNotFound(err) {
+					if !force {
+						return errors.Trace(err)
+					}
+					logger.Warningf("could not get filesystem %v for %v: %v", fsa.Filesystem().Id(), hostTag, err)
 				}
-				if v, err := f.Volume(); err == nil {
-					// Filesystem is volume-backed.
-					volumeTag = v
-					remove = true
-				}
-				updateStatus = func() error {
-					return f.SetStatus(status.StatusInfo{
-						Status: status.Detached,
-					})
+				if err == nil {
+					if v, err := f.Volume(); err == nil && !errors.IsNotFound(err) {
+						// Filesystem is volume-backed.
+						volumeTag = v
+						remove = true
+					}
+					updateStatus = func() error {
+						return f.SetStatus(status.StatusInfo{
+							Status: status.Detached,
+						})
+					}
 				}
 			}
 			if remove {
-				if err := sb.RemoveFilesystemAttachment(
-					fsa.Host(), fsa.Filesystem(),
-				); err != nil {
-					return errors.Trace(err)
+				if err := sb.RemoveFilesystemAttachment(fsa.Host(), fsa.Filesystem()); err != nil && !errors.IsNotFound(err) {
+					if !force {
+						return errors.Trace(err)
+					}
+					logger.Warningf("could not remove attachment for filesystem %v for %v: %v", fsa.Filesystem().Id(), hostTag, err)
 				}
 				if volumeTag != (names.VolumeTag{}) {
-					if err := sb.RemoveVolumeAttachmentPlan(
-						machineTag, volumeTag,
-					); err != nil {
-						return errors.Trace(err)
+					if err := sb.RemoveVolumeAttachmentPlan(machineTag, volumeTag); err != nil && !errors.IsNotFound(err) {
+						if !force {
+							return errors.Trace(err)
+						}
+						logger.Warningf("could not remove attachment plan for volume %v for %v: %v", volumeTag.Id(), hostTag, err)
 					}
 				}
 				if err := updateStatus(); err != nil && !errors.IsNotFound(err) {
-					return errors.Trace(err)
+					if !force {
+						return errors.Trace(err)
+					}
+					logger.Warningf("could not update status while cleaning up storage for dying %v: %v", hostTag, err)
 				}
 			}
 		}
@@ -843,28 +963,37 @@ func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual boo
 	// filesystems will have to be fixed manually.
 	if !manual {
 		for _, f := range filesystems {
-			if err := sb.RemoveFilesystem(f.FilesystemTag()); err != nil {
-				return errors.Trace(err)
+			if err := sb.RemoveFilesystem(f.FilesystemTag()); err != nil && !errors.IsNotFound(err) {
+				if !force {
+					return errors.Trace(err)
+				}
+				logger.Warningf("could not remove filesystem %v for dying %v: %v", f.FilesystemTag().Id(), hostTag, err)
 			}
 		}
 	}
 
 	// Detach all remaining volumes from the machine.
 	for _, va := range volumeAttachments {
-		if detachable, err := isDetachableVolumeTag(sb.mb.db(), va.Volume()); err != nil {
-			return errors.Trace(err)
+		if detachable, err := isDetachableVolumeTag(sb.mb.db(), va.Volume()); err != nil && !errors.IsNotFound(err) {
+			if !force {
+				return errors.Trace(err)
+			}
+			logger.Warningf("could not determine if volume %v for dying %v is detachable: %v", va.Volume().Id(), hostTag, err)
 		} else if !detachable {
 			// Non-detachable volumes will be removed along with the machine.
 			continue
 		}
-		if err := sb.DetachVolume(va.Host(), va.Volume()); err != nil {
+		if err := sb.DetachVolume(va.Host(), va.Volume()); err != nil && !errors.IsNotFound(err) {
 			if IsContainsFilesystem(err) {
 				// The volume will be destroyed when the
 				// contained filesystem is removed, whose
 				// destruction is initiated below.
 				continue
 			}
-			return errors.Trace(err)
+			if !force {
+				return errors.Trace(err)
+			}
+			logger.Warningf("could not detach volume %v for dying %v: %v", va.Volume().Id(), hostTag, err)
 		}
 	}
 	return nil
@@ -874,44 +1003,78 @@ func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual boo
 // sane to obliterate any unit in isolation; its only reasonable use is in
 // the context of machine obliteration, in which we can be sure that unclean
 // shutdown of units is not going to leave a machine in a difficult state.
-func (st *State) obliterateUnit(unitName string) error {
+func (st *State) obliterateUnit(unitName string, force bool) ([]error, error) {
+	var opErrs []error
 	unit, err := st.Unit(unitName)
 	if errors.IsNotFound(err) {
-		return nil
+		return opErrs, nil
 	} else if err != nil {
-		return err
+		return opErrs, err
 	}
 	// Unlike the machine, we *can* always destroy the unit, and (at least)
 	// prevent further dependencies being added. If we're really lucky, the
 	// unit will be removed immediately.
-	if err := unit.Destroy(); err != nil {
-		return errors.Annotatef(err, "cannot destroy unit %q", unitName)
+	errs, err := unit.DestroyWithForce(force)
+	opErrs = append(opErrs, errs...)
+	if err != nil {
+		if !force {
+			return opErrs, errors.Annotatef(err, "cannot destroy unit %q", unitName)
+		}
+		opErrs = append(opErrs, err)
 	}
 	if err := unit.Refresh(); errors.IsNotFound(err) {
-		return nil
+		return opErrs, nil
 	} else if err != nil {
-		return err
+		if !force {
+			return opErrs, err
+		}
+		opErrs = append(opErrs, err)
 	}
 	// Destroy and remove all storage attachments for the unit.
-	if err := st.cleanupUnitStorageAttachments(unit.UnitTag(), true); err != nil {
-		return errors.Annotatef(err, "cannot destroy storage for unit %q", unitName)
+	if err := st.cleanupUnitStorageAttachments(unit.UnitTag(), true, force); err != nil {
+		err := errors.Annotatef(err, "cannot destroy storage for unit %q", unitName)
+		if !force {
+			return opErrs, err
+		}
+		opErrs = append(opErrs, err)
 	}
 	for _, subName := range unit.SubordinateNames() {
-		if err := st.obliterateUnit(subName); err != nil {
-			return err
+		errs, err := st.obliterateUnit(subName, force)
+		opErrs = append(opErrs, errs...)
+		if err != nil {
+			if !force {
+				return opErrs, err
+			}
+			opErrs = append(opErrs, err)
 		}
 	}
 	if err := unit.EnsureDead(); err != nil {
-		return err
+		if !force {
+			return opErrs, err
+		}
+		opErrs = append(opErrs, err)
 	}
-	// TODO (anastasiamac) This needs to work with force
-	return unit.Remove()
+	errs, err = unit.RemoveWithForce(force)
+	opErrs = append(opErrs, errs...)
+	return opErrs, err
 }
 
 // cleanupAttachmentsForDyingStorage sets all storage attachments related
 // to the specified storage instance to Dying, if they are not already Dying
 // or Dead. It's expected to be used when a storage instance is destroyed.
-func (st *State) cleanupAttachmentsForDyingStorage(storageId string) (err error) {
+func (st *State) cleanupAttachmentsForDyingStorage(storageId string, cleanupArgs []bson.Raw) (err error) {
+	var force bool
+	switch n := len(cleanupArgs); n {
+	case 0:
+		// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&force); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
+		}
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
+	}
+
 	sb, err := NewStorageBackend(st)
 	if err != nil {
 		return errors.Trace(err)
@@ -929,11 +1092,16 @@ func (st *State) cleanupAttachmentsForDyingStorage(storageId string) (err error)
 	fields := bson.D{{"unitid", 1}}
 	iter := coll.Find(bson.D{{"storageid", storageId}}).Select(fields).Iter()
 	defer closeIter(iter, &err, "reading storage attachment document")
+	var detachErr error
 	for iter.Next(&doc) {
 		unitTag := names.NewUnitTag(doc.Unit)
-		if err := sb.DetachStorage(storageTag, unitTag); err != nil {
-			return errors.Annotate(err, "destroying storage attachment")
+		if err := sb.DetachStorage(storageTag, unitTag, force); err != nil {
+			detachErr = errors.Annotate(err, "destroying storage attachment")
+			logger.Warningf("%v", detachErr)
 		}
+	}
+	if !force && detachErr != nil {
+		return detachErr
 	}
 	return nil
 }

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -703,7 +703,7 @@ func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 	c.Assert(si.Life(), gc.Equals, state.Alive)
 
 	// destroy storage instance and run cleanups
-	err = s.storageBackend.DestroyStorageInstance(storageTag, true)
+	err = s.storageBackend.DestroyStorageInstance(storageTag, true, false)
 	c.Assert(err, jc.ErrorIsNil)
 	si, err = s.storageBackend.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -743,9 +743,9 @@ func (s *FilesystemIAASModelSuite) TestRemoveStorageInstanceDestroysAndUnassigns
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DestroyStorageInstance(storageTag, true)
+	err = s.storageBackend.DestroyStorageInstance(storageTag, true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storageTag, unitTag)
+	err = s.storageBackend.DetachStorage(storageTag, unitTag, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance and attachment are dying, but not yet
@@ -753,7 +753,7 @@ func (s *FilesystemIAASModelSuite) TestRemoveStorageInstanceDestroysAndUnassigns
 	s.storageInstanceFilesystem(c, storageTag)
 	s.storageInstanceVolume(c, storageTag)
 
-	err = s.storageBackend.RemoveStorageAttachment(storageTag, unitTag)
+	err = s.storageBackend.RemoveStorageAttachment(storageTag, unitTag, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance is now gone; the filesystem should no longer
@@ -782,9 +782,9 @@ func (s *FilesystemIAASModelSuite) TestReleaseStorageInstanceFilesystemReleasing
 
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storageTag, true)
+	err = s.storageBackend.ReleaseStorageInstance(storageTag, true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag())
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The filesystem should should be dying, and releasing.
@@ -803,10 +803,10 @@ func (s *FilesystemIAASModelSuite) TestReleaseStorageInstanceFilesystemUnreleasa
 
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storageTag, true)
+	err = s.storageBackend.ReleaseStorageInstance(storageTag, true, false)
 	c.Assert(err, gc.ErrorMatches,
 		`cannot release storage "data/0": storage provider "modelscoped-unreleasable" does not support releasing storage`)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag())
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The filesystem should should be dying, and releasing.

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1629,7 +1629,7 @@ func (s *MigrationImportSuite) TestStorageDetached(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sb, err := state.NewStorageBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
-	err = sb.DetachStorage(storageTag, u.UnitTag())
+	err = sb.DetachStorage(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/model.go
+++ b/state/model.go
@@ -1304,6 +1304,10 @@ func (m *Model) destroyOps(
 				// cleanup, so the storage can be destroyed/released
 				// according to the parameters.
 				*args.DestroyStorage,
+				// TODO (anastasiamac 2019-04-04) Once we implement
+				// 'destroy-model --force' this will be passed in from the user.
+				// For now, hardcode.
+				false,
 			))
 		}
 	}

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -209,7 +209,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	for _, storageTag := range storageTags {
-		err = sb.DetachStorage(storageTag, unit.UnitTag())
+		err = sb.DetachStorage(storageTag, unit.UnitTag(), false)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	for _, volumeTag := range volumeTags {

--- a/state/relation.go
+++ b/state/relation.go
@@ -432,7 +432,8 @@ func (r *Relation) removeOps(ignoreApplication string, departingUnitName string,
 	ops = append(ops, tokenOps...)
 	offerOps := removeOfferConnectionsForRelationOps(r.Id())
 	ops = append(ops, offerOps...)
-	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()), force)
+	// This cleanup does not need to be forced.
+	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
 	return append(ops, cleanupOp), errs, nil
 }
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -274,12 +274,8 @@ func (ru *RelationUnit) PrepareLeaveScope() error {
 // LeaveScopeWithForce in addition to doing what LeaveScope() does,
 // when force is passed in as 'true', forces relation unit to leave scope,
 // ignoring errors.
-func (ru *RelationUnit) LeaveScopeWithForce(force bool) error {
-	// TODO (anastasiamac 2019-04-2) First return here is operational errors.
-	// We might want to consider to pass them up to notify users of non-fatal
-	// errors we have encountered.
-	_, err := ru.internalLeaveScope(force)
-	return err
+func (ru *RelationUnit) LeaveScopeWithForce(force bool) ([]error, error) {
+	return ru.internalLeaveScope(force)
 }
 
 // LeaveScope signals that the unit has left its scope in the relation.
@@ -288,7 +284,8 @@ func (ru *RelationUnit) LeaveScopeWithForce(force bool) error {
 // leaves, it is removed immediately. It is not an error to leave a scope
 // that the unit is not, or never was, a member of.
 func (ru *RelationUnit) LeaveScope() error {
-	return ru.LeaveScopeWithForce(false)
+	_, err := ru.LeaveScopeWithForce(false)
+	return err
 }
 
 func (ru *RelationUnit) internalLeaveScope(force bool) ([]error, error) {

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -274,6 +274,9 @@ func (ru *RelationUnit) PrepareLeaveScope() error {
 // LeaveScopeWithForce in addition to doing what LeaveScope() does,
 // when force is passed in as 'true', forces relation unit to leave scope,
 // ignoring errors.
+// TODO (anastasiamac) Need to consider to do this an Operation,
+// similar to Unit and Apllication DestroyOperation to better differentiate between
+// business logic and opeational errors and database errors.
 func (ru *RelationUnit) LeaveScopeWithForce(force bool) ([]error, error) {
 	return ru.internalLeaveScope(force)
 }
@@ -288,6 +291,9 @@ func (ru *RelationUnit) LeaveScope() error {
 	return err
 }
 
+// When 'force' is set, this call will construct and apply needed operations
+// and return all operational errors encountered.
+// If the 'force' is not set, any error will be fatal and no operations will be applied.
 func (ru *RelationUnit) internalLeaveScope(force bool) ([]error, error) {
 	relationScopes, closer := ru.st.db().GetCollection(relationScopesC)
 	defer closer()
@@ -357,6 +363,9 @@ func (ru *RelationUnit) internalLeaveScope(force bool) ([]error, error) {
 				Update: bson.D{{"$inc", bson.D{{"unitcount", -1}}}},
 			})
 		} else {
+			// When 'force' is set, this call will return both needed operations
+			// as well as all operational errors encountered.
+			// If the 'force' is not set, any error will be fatal and no operations will be returned.
 			relOps, opErrs, err := ru.relation.removeOps("", ru.unitName, force)
 			errs = append(errs, opErrs...)
 			if err != nil {

--- a/state/unit.go
+++ b/state/unit.go
@@ -467,14 +467,24 @@ func (op *UpdateUnitOperation) Done(err error) error {
 // life is just set to Dying; but if a principal unit that is not assigned
 // to a provisioned machine is Destroyed, it will be removed from state
 // directly.
-func (u *Unit) Destroy() (err error) {
+func (u *Unit) Destroy() error {
+	_, err := u.DestroyWithForce(false)
+	return err
+}
+
+// DestroyWithForce does the same thing as Destroy() but
+// ignores errors.
+func (u *Unit) DestroyWithForce(force bool) (errs []error, err error) {
 	defer func() {
 		if err == nil {
 			// This is a white lie; the document might actually be removed.
 			u.doc.Life = Dying
 		}
 	}()
-	return u.st.ApplyOperation(u.DestroyOperation())
+	op := u.DestroyOperation()
+	op.Force = force
+	err = u.st.ApplyOperation(op)
+	return op.Errors, err
 }
 
 // DestroyOperation returns a model operation that will destroy the unit.

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -538,16 +538,16 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceDestroysAndUnassignsVolume(c
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
-	err = s.storageBackend.DestroyStorageInstance(storageTag, true)
+	err = s.storageBackend.DestroyStorageInstance(storageTag, true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag())
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance and attachment are dying, but not yet
 	// removed from state. The volume should still be assigned.
 	s.storageInstanceVolume(c, storageTag)
 
-	err = s.storageBackend.RemoveStorageAttachment(storageTag, u.UnitTag())
+	err = s.storageBackend.RemoveStorageAttachment(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance is now gone; the volume should no longer
@@ -572,9 +572,9 @@ func (s *VolumeStateSuite) TestReleaseStorageInstanceVolumeReleasing(c *gc.C) {
 
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storageTag, true)
+	err = s.storageBackend.ReleaseStorageInstance(storageTag, true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag())
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The volume should should be dying, and releasing.
@@ -595,11 +595,11 @@ func (s *VolumeStateSuite) TestReleaseStorageInstanceVolumeUnreleasable(c *gc.C)
 
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storageTag, true)
+	err = s.storageBackend.ReleaseStorageInstance(storageTag, true, false)
 	c.Assert(err, gc.ErrorMatches,
 		`cannot release storage "data/0": storage provider "modelscoped-unreleasable" does not support releasing storage`,
 	)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag())
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The volume should should still be alive.
@@ -990,12 +990,12 @@ func removeVolumeStorageInstance(c *gc.C, sb *state.StorageBackend, volumeTag na
 }
 
 func removeStorageInstance(c *gc.C, sb *state.StorageBackend, storageTag names.StorageTag) {
-	err := sb.DestroyStorageInstance(storageTag, true)
+	err := sb.DestroyStorageInstance(storageTag, true, false)
 	c.Assert(err, jc.ErrorIsNil)
 	attachments, err := sb.StorageAttachments(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, a := range attachments {
-		err = sb.DetachStorage(storageTag, a.Unit())
+		err = sb.DetachStorage(storageTag, a.Unit(), false)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	_, err = sb.StorageInstance(storageTag)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1765,6 +1765,7 @@ func (s destroyStorageAttachment) step(c *gc.C, ctx *context) {
 	err = sb.DetachStorage(
 		storageAttachments[0].StorageInstance(),
 		ctx.unit.UnitTag(),
+		false,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
## Description of change

This is part 2 part of the implementation to allow users to force remove application or unit.

This caters for all asynchronous calls that are started up as part of the removal.

This is a WIP at the moment as it needs more comments. 
