### PR TITLE
Write Branch Config Deltas to Generation Document

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1098,8 +1098,7 @@ func (api *APIBase) Set(p params.ApplicationSet) error {
 		return err
 	}
 
-	return app.UpdateCharmConfig(p.Generation, changes)
-
+	return app.UpdateCharmConfig(model.GenerationMaster, changes)
 }
 
 // Unset implements the server side of Client.Unset.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1831,6 +1831,8 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsStrings(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetSettingsStringsBranch(c *gc.C) {
+	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
+
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1880,7 +1880,9 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
 }
 
-func (s *applicationSuite) TestApplicationUpdateSetSettingsYAMLNextGen(c *gc.C) {
+func (s *applicationSuite) TestApplicationUpdateSetSettingsYAMLBranch(c *gc.C) {
+	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
+
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
 

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -4,7 +4,9 @@
 package model
 
 import (
-	errors "github.com/juju/errors"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/settings"
 )
 
 // TODO (manadart 2019-04-21) Change the nomenclature here to indicate "branch"
@@ -35,6 +37,11 @@ func ValidateBranchName(name string) error {
 func NextGenerationKey(key string) string {
 	return key + generationKeySuffix
 }
+
+// BranchCharmConfig is a type alias for representing charm configuration
+// changes made under a branch.
+// It is collections of settings changes keyed on application name.
+type BranchCharmConfig = map[string]settings.ItemChanges
 
 // GenerationApplication represents changes to an application
 // made under a generation.

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -5,8 +5,6 @@ package model
 
 import (
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/core/settings"
 )
 
 // TODO (manadart 2019-04-21) Change the nomenclature here to indicate "branch"
@@ -37,11 +35,6 @@ func ValidateBranchName(name string) error {
 func NextGenerationKey(key string) string {
 	return key + generationKeySuffix
 }
-
-// BranchCharmConfig is a type alias for representing charm configuration
-// changes made under a branch.
-// It is collections of settings changes keyed on application name.
-type BranchCharmConfig = map[string]settings.ItemChanges
 
 // GenerationApplication represents changes to an application
 // made under a generation.

--- a/core/settings/package_test.go
+++ b/core/settings/package_test.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package settings_test
+
+import (
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+
+	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type importSuite struct{}
+
+var _ = gc.Suite(&importSuite{})
+
+func (*importSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/settings")
+
+	// This package only brings in other core packages.
+	c.Assert(found, jc.SameContents, []string{})
+}

--- a/core/settings/settings.go
+++ b/core/settings/settings.go
@@ -23,14 +23,20 @@ type ItemChange struct {
 	NewValue interface{} `bson:"new,omitempty"`
 }
 
+// IsAddition returns true if this change indicates a settings value
+// not previously defines.
 func (c *ItemChange) IsAddition() bool {
 	return c.Type == added
 }
 
+// IsModification returns true if this change is an update of a previously
+// operator-defined setting.
 func (c *ItemChange) IsModification() bool {
 	return c.Type == modified
 }
 
+// Is deletion returns true if this change indicates the removal of a
+// previously operator-defined setting.
 func (c *ItemChange) IsDeletion() bool {
 	return c.Type == deleted
 }

--- a/core/settings/settings.go
+++ b/core/settings/settings.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package settings
+
+import "fmt"
+
+const (
+	added = iota
+	modified
+	deleted
+)
+
+// ItemChange represents the change of an item in a settings.
+type ItemChange struct {
+	Type     int         `bson:"type"`
+	Key      string      `bson:"key"`
+	OldValue interface{} `bson:"old,omitempty"`
+	NewValue interface{} `bson:"new,omitempty"`
+}
+
+// String returns the item change in a readable format.
+func (ic *ItemChange) String() string {
+	switch ic.Type {
+	case added:
+		return fmt.Sprintf("setting added: %v = %v", ic.Key, ic.NewValue)
+	case modified:
+		return fmt.Sprintf("setting modified: %v = %v (was %v)",
+			ic.Key, ic.NewValue, ic.OldValue)
+	case deleted:
+		return fmt.Sprintf("setting deleted: %v (was %v)", ic.Key, ic.OldValue)
+	}
+	return fmt.Sprintf("unknown setting change type %d: %v = %v (was %v)", ic.Type, ic.Key, ic.NewValue, ic.OldValue)
+}
+
+// MakeAddition returns an itemChange indicating a modification of the input
+// key, with its new value.
+func MakeAddition(key string, newVal interface{}) ItemChange {
+	return ItemChange{
+		Type:     added,
+		Key:      key,
+		NewValue: newVal,
+	}
+}
+
+// MakeModification returns an ItemChange indicating a modification of the
+// input key, with its old and new values.
+func MakeModification(key string, oldVal, newVal interface{}) ItemChange {
+	return ItemChange{
+		Type:     modified,
+		Key:      key,
+		OldValue: oldVal,
+		NewValue: newVal,
+	}
+}
+
+// MakeDeletion returns an ItemChange indicating a deletion of the input key,
+// with its old value.
+func MakeDeletion(key string, oldVal interface{}) ItemChange {
+	return ItemChange{
+		Type:     deleted,
+		Key:      key,
+		OldValue: oldVal,
+	}
+}
+
+// ItemChanges contains a slice of item changes in a config node.
+// It implements the sort interface to sort the items changes by key.
+type ItemChanges []ItemChange
+
+func (ics ItemChanges) Len() int           { return len(ics) }
+func (ics ItemChanges) Less(i, j int) bool { return ics[i].Key < ics[j].Key }
+func (ics ItemChanges) Swap(i, j int)      { ics[i], ics[j] = ics[j], ics[i] }

--- a/core/settings/settings.go
+++ b/core/settings/settings.go
@@ -84,6 +84,23 @@ func MakeDeletion(key string, oldVal interface{}) ItemChange {
 // It implements the sort interface to sort the items changes by key.
 type ItemChanges []ItemChange
 
+// ApplyDeltaSource turns this second-order delta into a first-older delta
+// by replacing the OldValue for any key present in the input ItemChange
+// collection.
+func (c ItemChanges) ApplyDeltaSource(oldChanges ItemChanges) error {
+	m, err := oldChanges.Map()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for i, ch := range c {
+		if old, ok := m[ch.Key]; ok {
+			c[i].OldValue = old.OldValue
+		}
+	}
+	return nil
+}
+
 // Map is a convenience method for working with collections of changes.
 // It returns a map representation of the change collection,
 // indexed with the change key.

--- a/core/settings/settings_test.go
+++ b/core/settings/settings_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package settings
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type settingsSuite struct{}
+
+var _ = gc.Suite(&settingsSuite{})
+
+func (*settingsSuite) TestItemChangeType(c *gc.C) {
+	a := MakeAddition("key", "new-val")
+	m := MakeModification("key", "old-val", "new-val")
+	d := MakeDeletion("key", "old-val")
+
+	c.Check(a.IsAddition(), jc.IsTrue)
+	c.Check(m.IsModification(), jc.IsTrue)
+	c.Check(d.IsDeletion(), jc.IsTrue)
+}
+
+func (*settingsSuite) TestItemChangesMapNonUniqueError(c *gc.C) {
+	_, err := ItemChanges{
+		MakeAddition("key", "new-val"),
+		MakeAddition("key", "other-val"),
+	}.Map()
+
+	c.Assert(err, gc.ErrorMatches, `duplicated key in settings collection: "key"`)
+}
+
+func (*settingsSuite) TestItemChangesMapSuccess(c *gc.C) {
+	mapped, err := ItemChanges{
+		MakeAddition("key1", "new-val"),
+		MakeModification("key2", "old-val", "other-val"),
+		MakeDeletion("key3", "gone-val"),
+	}.Map()
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(mapped, gc.DeepEquals, map[string]ItemChange{
+		"key1": MakeAddition("key1", "new-val"),
+		"key2": MakeModification("key2", "old-val", "other-val"),
+		"key3": MakeDeletion("key3", "gone-val"),
+	})
+}
+
+func (*settingsSuite) TestItemTypeString(c *gc.C) {
+	a := MakeAddition("key1", "new-val")
+	m := MakeModification("key2", "old-val", "other-val")
+	d := MakeDeletion("key3", "gone-val")
+	e := ItemChange{Type: 4, Key: "key4", OldValue: "old-val", NewValue: "new-val"}
+
+	c.Check(a.String(), gc.Equals, "setting added: key1 = new-val")
+	c.Check(m.String(), gc.Equals, "setting modified: key2 = other-val (was old-val)")
+	c.Check(d.String(), gc.Equals, "setting deleted: key3 (was gone-val)")
+	c.Check(e.String(), gc.Equals, "unknown setting change type 4: key4 = new-val (was old-val)")
+}

--- a/state/application.go
+++ b/state/application.go
@@ -2078,7 +2078,7 @@ func (a *Application) CharmConfig(gen string) (charm.Settings, error) {
 
 // UpdateCharmConfig changes a application's charm config settings. Values set
 // to nil will be deleted; unknown and invalid values will return an error.
-func (a *Application) UpdateCharmConfig(gen string, changes charm.Settings) error {
+func (a *Application) UpdateCharmConfig(branchName string, changes charm.Settings) error {
 	ch, _, err := a.Charm()
 	if err != nil {
 		return errors.Trace(err)
@@ -2092,21 +2092,41 @@ func (a *Application) UpdateCharmConfig(gen string, changes charm.Settings) erro
 	// about every use case. This needs to be resolved some time; but at
 	// least the settings docs are keyed by charm url as well as application
 	// name, so the actual impact of a race is non-threatening.
-
-	k1, k2 := a.charmConfigKeyGeneration(gen)
-	node, err := readSettingsOrCreateFromFallback(a.st.db(), settingsC, k1, k2)
+	current, err := readSettings(a.st.db(), settingsC, a.charmConfigKey())
 	if err != nil {
 		return errors.Annotatef(err, "charm config for application %q", a.doc.Name)
 	}
-	for name, value := range changes {
+
+	if branchName == model.GenerationMaster {
+		return errors.Trace(a.updateMasterConfig(current, changes))
+	}
+	return errors.Trace(a.updateBranchConfig(branchName, current, changes))
+}
+
+// TODO (manadart 2019-04-03): Implement master config changes as
+// instantly committed branches.
+func (a *Application) updateMasterConfig(current *Settings, validChanges charm.Settings) error {
+	for name, value := range validChanges {
 		if value == nil {
-			node.Delete(name)
+			current.Delete(name)
 		} else {
-			node.Set(name, value)
+			current.Set(name, value)
 		}
 	}
-	_, err = node.Write()
+	_, err := current.Write()
 	return errors.Trace(err)
+}
+
+// updateBranchConfig compares the incoming charm settings to the current
+// settings to generate a collection of changes, which is used to update the
+// branch with the input name.
+func (a *Application) updateBranchConfig(branchName string, current *Settings, validChanges charm.Settings) error {
+	branch, err := a.st.Branch(branchName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return errors.Trace(branch.UpdateCharmConfig(a.Name(), current, validChanges))
 }
 
 // ApplicationConfig returns the configuration for the application itself.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -253,7 +253,7 @@ func (s *ApplicationSuite) TestSetCharmCharmSettings(c *gc.C) {
 	}))
 }
 
-func (s *ApplicationSuite) TestGenerationCharmCharmSettings(c *gc.C) {
+func (s *ApplicationSuite) TestSetCharmCharmSettingsForBranch(c *gc.C) {
 	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
 
 	newCh := s.AddConfigCharm(c, "mysql", stringConfig, 2)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -254,6 +254,8 @@ func (s *ApplicationSuite) TestSetCharmCharmSettings(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestGenerationCharmCharmSettings(c *gc.C) {
+	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
+
 	newCh := s.AddConfigCharm(c, "mysql", stringConfig, 2)
 	err := s.mysql.SetCharm(state.SetCharmConfig{
 		Charm:          newCh,

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -786,6 +786,15 @@ func GetControllerSettings(st *State) *Settings {
 	return newSettings(st.db(), controllersC, controllerSettingsGlobalKey)
 }
 
+// GetPopulatedSettings returns a reference to settings with the input values
+// populated. Attempting to read/write will cause nil-reference panics.
+func GetPopulatedSettings(cfg map[string]interface{}) *Settings {
+	return &Settings{
+		disk: copyMap(cfg, nil),
+		core: copyMap(cfg, nil),
+	}
+}
+
 // NewSLALevel returns a new SLA level.
 func NewSLALevel(level string) (slaLevel, error) {
 	return newSLALevel(level)

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/model"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
@@ -17,6 +16,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/model"
 )
 
 // generationDoc represents the state of a model generation in MongoDB.

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 
+	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
 )
 
 const (
@@ -208,9 +210,60 @@ func (s *generationSuite) TestCommitNoChangesEffectivelyAborted(c *gc.C) {
 
 // TODO (manadart 2019-03-21): Tests for abort.
 
+func (s *generationSuite) TestBranchCharmConfigDeltas(c *gc.C) {
+	gen := s.setupAssignAllUnits(c)
+	c.Assert(gen.Config(), gc.HasLen, 0)
+
+	current := state.GetPopulatedSettings(map[string]interface{}{
+		"http_port":    8098,
+		"handoff_port": 8099,
+		"riak_version": "1.1.4-1",
+	})
+
+	// Process a modification, deletion, and addition.
+	changes := charm.Settings{
+		"http_port":    8100,
+		"handoff_port": nil,
+		"node_name":    "nodey-node",
+	}
+	c.Assert(gen.UpdateCharmConfig("riak", current, changes), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.Config(), gc.DeepEquals, map[string]settings.ItemChanges{"riak": {
+		settings.MakeDeletion("handoff_port", 8099),
+		settings.MakeModification("http_port", 8098, 8100),
+		settings.MakeAddition("node_name", "nodey-node"),
+	}})
+
+	// Now simulate node_name being set on master in the meantime,
+	// along with changes to http_port and handoff_port.
+	current = state.GetPopulatedSettings(map[string]interface{}{
+		"http_port":    100,
+		"handoff_port": 100,
+		"riak_version": "1.1.4-1",
+		"node_name":    "come-lately",
+	})
+
+	// Re-set previously deleted handoff_port, update node_name.
+	changes = charm.Settings{
+		"handoff_port": 9000,
+		"node_name":    "latest-nodey-node",
+	}
+	c.Assert(gen.UpdateCharmConfig("riak", current, changes), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+
+	// handoff_port old value is the original.
+	// http_port unchanged.
+	// node_name remains as an addition.
+	c.Check(gen.Config(), gc.DeepEquals, map[string]settings.ItemChanges{"riak": {
+		settings.MakeModification("handoff_port", 8099, 9000),
+		settings.MakeModification("http_port", 8098, 8100),
+		settings.MakeAddition("node_name", "latest-nodey-node"),
+	}})
+}
+
 func (s *generationSuite) setupAssignAllUnits(c *gc.C) *state.Generation {
-	charm := s.AddTestingCharm(c, "riak")
-	riak := s.AddTestingApplication(c, "riak", charm)
+	ch := s.AddTestingCharm(c, "riak")
+	riak := s.AddTestingApplication(c, "riak", ch)
 	for i := 0; i < 4; i++ {
 		_, err := riak.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/settings.go
+++ b/state/settings.go
@@ -253,7 +253,8 @@ func readSettingsDocInto(db Database, collection, key string, out interface{}) e
 	return err
 }
 
-// applyChanges
+// applyChanges modifies the live settings
+// based on the input collection of changes.
 func (s *Settings) applyChanges(changes settings.ItemChanges) {
 	for _, ch := range changes {
 		switch {

--- a/state/settings.go
+++ b/state/settings.go
@@ -159,6 +159,7 @@ func (s *Settings) changes() settings.ItemChanges {
 		if reflect.DeepEqual(live, old) {
 			continue
 		}
+
 		var change settings.ItemChange
 		switch {
 		case inCore && onDisk:
@@ -172,7 +173,6 @@ func (s *Settings) changes() settings.ItemChanges {
 		}
 		changes = append(changes, change)
 	}
-
 	sort.Sort(changes)
 	return changes
 }

--- a/state/settings.go
+++ b/state/settings.go
@@ -151,7 +151,7 @@ func (s *Settings) settingsUpdateOps() (settings.ItemChanges, []txn.Op) {
 // changes compares the live settings with those that were retrieved from the
 // database in order to generate a set of changes.
 func (s *Settings) changes() settings.ItemChanges {
-	var changes []settings.ItemChange
+	var changes settings.ItemChanges
 
 	for key := range cacheKeys(s.disk, s.core) {
 		old, onDisk := s.disk[key]
@@ -173,9 +173,8 @@ func (s *Settings) changes() settings.ItemChanges {
 		changes = append(changes, change)
 	}
 
-	res := settings.ItemChanges(changes)
-	sort.Sort(res)
-	return res
+	sort.Sort(changes)
+	return changes
 }
 
 // cacheKeys returns the keys of all caches as a key=>true map.

--- a/state/settings.go
+++ b/state/settings.go
@@ -271,6 +271,8 @@ func (st *State) ReadSettings(collection, key string) (*Settings, error) {
 	return readSettings(st.db(), collection, key)
 }
 
+// TODO (manadart 2019-04-05): Remove this method when logic to apply deltas
+// from branches is implemented.
 // readSettingsOrCreateFromFallback attempts to retrieve settings first for the
 // requested key, then if not found, a non-empty fallback key.
 // If the fallback is used, the settings are created for the requested key.

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/core/model"
+	coresettings "github.com/juju/juju/core/settings"
 )
 
 type SettingsSuite struct {
@@ -74,9 +74,9 @@ func (s *SettingsSuite) TestUpdateWithWrite(c *gc.C) {
 	node.Update(options)
 	changes, err := node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "alpha", nil, "beta"},
-		{ItemAdded, "one", nil, 1},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("alpha", "beta"),
+		coresettings.MakeAddition("one", 1),
 	})
 
 	// Check local state.
@@ -108,9 +108,9 @@ func (s *SettingsSuite) TestConflictOnSet(c *gc.C) {
 	nodeTwo.Update(optionsOld)
 	changes, err := nodeTwo.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "alpha", nil, "beta"},
-		{ItemAdded, "one", nil, 1},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("alpha", "beta"),
+		coresettings.MakeAddition("one", 1),
 	})
 
 	// First test node one.
@@ -121,9 +121,9 @@ func (s *SettingsSuite) TestConflictOnSet(c *gc.C) {
 	nodeOne.Update(optionsNew)
 	changes, err = nodeOne.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemModified, "alpha", "beta", "gamma"},
-		{ItemModified, "one", 1, "two"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeModification("alpha", "beta", "gamma"),
+		coresettings.MakeModification("one", 1, "two"),
 	})
 
 	// Verify that node one reports as expected.
@@ -142,10 +142,10 @@ func (s *SettingsSuite) TestConflictOnSet(c *gc.C) {
 	expected := map[string]interface{}{"alpha": "cappa", "new": "next"}
 	changes, err = nodeTwo.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemModified, "alpha", "beta", "cappa"},
-		{ItemAdded, "new", nil, "next"},
-		{ItemDeleted, "one", 1, nil},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeModification("alpha", "beta", "cappa"),
+		coresettings.MakeAddition("new", "next"),
+		coresettings.MakeDeletion("one", 1),
 	})
 	c.Assert(expected, gc.DeepEquals, nodeTwo.Map())
 
@@ -162,9 +162,9 @@ func (s *SettingsSuite) TestSetItem(c *gc.C) {
 	node.Set("one", 1)
 	changes, err := node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "alpha", nil, "beta"},
-		{ItemAdded, "one", nil, 1},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("alpha", "beta"),
+		coresettings.MakeAddition("one", 1),
 	})
 	// Check local state.
 	c.Assert(node.Map(), gc.DeepEquals, options)
@@ -188,9 +188,9 @@ func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
 	node.Set("$bar", 1)
 	changes, err := node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "$bar", nil, 1},
-		{ItemAdded, "foo.alpha", nil, "beta"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("$bar", 1),
+		coresettings.MakeAddition("foo.alpha", "beta"),
 	})
 	// Check local state.
 	c.Assert(node.Map(), gc.DeepEquals, options)
@@ -315,9 +315,9 @@ func (s *SettingsSuite) TestMultipleReads(c *gc.C) {
 	nodeOne.Update(map[string]interface{}{"alpha": "beta", "foo": "bar"})
 	changes, err := nodeOne.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "alpha", nil, "beta"},
-		{ItemAdded, "foo", nil, "bar"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("alpha", "beta"),
+		coresettings.MakeAddition("foo", "bar"),
 	})
 
 	// A write retains the newly set values.
@@ -334,8 +334,8 @@ func (s *SettingsSuite) TestMultipleReads(c *gc.C) {
 	nodeTwo.Update(map[string]interface{}{"foo": "different"})
 	changes, err = nodeTwo.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemModified, "foo", "bar", "different"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeModification("foo", "bar", "different"),
 	})
 
 	// This should pull in the new state into node one.
@@ -355,14 +355,14 @@ func (s *SettingsSuite) TestDeleteEmptiesState(c *gc.C) {
 	node.Set("a", "foo")
 	changes, err := node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "a", nil, "foo"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("a", "foo"),
 	})
 	node.Delete("a")
 	changes, err = node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemDeleted, "a", "foo", nil},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeDeletion("a", "foo"),
 	})
 	c.Assert(node.Map(), gc.DeepEquals, map[string]interface{}{})
 }
@@ -374,22 +374,22 @@ func (s *SettingsSuite) TestReadResync(c *gc.C) {
 	nodeOne.Set("a", "foo")
 	changes, err := nodeOne.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "a", nil, "foo"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("a", "foo"),
 	})
 	nodeTwo, err := s.readSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	nodeTwo.Delete("a")
 	changes, err = nodeTwo.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemDeleted, "a", "foo", nil},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeDeletion("a", "foo"),
 	})
 	nodeTwo.Set("a", "bar")
 	changes, err = nodeTwo.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "a", nil, "bar"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("a", "bar"),
 	})
 	// Read of node one should pick up the new value.
 	err = nodeOne.Read()
@@ -406,17 +406,17 @@ func (s *SettingsSuite) TestMultipleWrites(c *gc.C) {
 	node.Update(map[string]interface{}{"foo": "bar", "this": "that"})
 	changes, err := node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "foo", nil, "bar"},
-		{ItemAdded, "this", nil, "that"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("foo", "bar"),
+		coresettings.MakeAddition("this", "that"),
 	})
 	node.Delete("this")
 	node.Set("another", "value")
 	changes, err = node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "another", nil, "value"},
-		{ItemDeleted, "this", "that", nil},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("another", "value"),
+		coresettings.MakeDeletion("this", "that"),
 	})
 
 	expected := map[string]interface{}{"foo": "bar", "another": "value"}
@@ -424,7 +424,7 @@ func (s *SettingsSuite) TestMultipleWrites(c *gc.C) {
 
 	changes, err = node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{})
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{})
 
 	err = node.Read()
 	c.Assert(err, jc.ErrorIsNil)
@@ -432,7 +432,7 @@ func (s *SettingsSuite) TestMultipleWrites(c *gc.C) {
 
 	changes, err = node.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{})
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{})
 }
 
 func (s *SettingsSuite) TestMultipleWritesAreStable(c *gc.C) {
@@ -472,8 +472,8 @@ func (s *SettingsSuite) TestWriteTwice(c *gc.C) {
 	nodeOne.Set("a", "foo")
 	changes, err := nodeOne.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemAdded, "a", nil, "foo"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeAddition("a", "foo"),
 	})
 
 	nodeTwo, err := s.readSettings()
@@ -481,15 +481,15 @@ func (s *SettingsSuite) TestWriteTwice(c *gc.C) {
 	nodeTwo.Set("a", "bar")
 	changes, err = nodeTwo.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{
-		{ItemModified, "a", "foo", "bar"},
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{
+		coresettings.MakeModification("a", "foo", "bar"),
 	})
 
 	// Shouldn't write again. Changes were already
 	// flushed and acted upon by other parties.
 	changes, err = nodeOne.Write()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes, gc.DeepEquals, []ItemChange{})
+	c.Assert(changes, gc.DeepEquals, []coresettings.ItemChange{})
 
 	err = nodeOne.Read()
 	c.Assert(err, jc.ErrorIsNil)
@@ -541,34 +541,6 @@ func (s *SettingsSuite) TestReplaceSettingsNotFound(c *gc.C) {
 	options := map[string]interface{}{"alpha": "beta", "foo2": "zap100"}
 	err := replaceSettings(s.state.db(), s.collection, s.key, options)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *SettingsSuite) TestReadSettingsWithFallback(c *gc.C) {
-	s1, err := s.createSettings(s.key, map[string]interface{}{"foo1": []interface{}{"bar1"}})
-	c.Assert(err, jc.ErrorIsNil)
-
-	nextGenKey := model.NextGenerationKey(s.key)
-
-	// Without a fallback, we get a not found error.
-	_, err = readSettingsOrCreateFromFallback(s.state.db(), s.collection, nextGenKey, "")
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
-
-	// Next generation settings do not exist; fallback should create them.
-	s2, err := readSettingsOrCreateFromFallback(s.state.db(), s.collection, nextGenKey, s.key)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(s2.key, gc.DeepEquals, nextGenKey)
-	c.Check(s2.Map(), gc.DeepEquals, s1.Map())
-
-	// If they exist, writing is successful.
-	s2.Set("new", "value")
-	_, err = s2.Write()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Original settings are unchanged.
-	s1, err = s.readSettings()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(s1.Map(), gc.DeepEquals, map[string]interface{}{"foo1": []interface{}{"bar1"}})
-
 }
 
 func (s *SettingsSuite) TestUpdatingInterfaceSliceValue(c *gc.C) {

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -571,9 +571,9 @@ func (s *SettingsSuite) TestUpdatingInterfaceSliceValue(c *gc.C) {
 
 func (s *SettingsSuite) TestApplyAndRetrieveChanges(c *gc.C) {
 	s1, err := s.createSettings(s.key, map[string]interface{}{
-		"foo":    "bar",
-		"alpha":  "beta",
-		"number": 1,
+		"foo.dot":      "bar",
+		"alpha$dollar": "beta",
+		"number":       1,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s1.Write()
@@ -585,18 +585,18 @@ func (s *SettingsSuite) TestApplyAndRetrieveChanges(c *gc.C) {
 	// Add, update, update one not present, delete, delete one not present,
 	// leave one alone.
 	s2.applyChanges(coresettings.ItemChanges{
-		coresettings.MakeModification("foo", "no-matter", "new-bar"),
+		coresettings.MakeModification("foo.dot", "no-matter", "new-bar"),
 		coresettings.MakeModification("make", "no-matter", "new"),
-		coresettings.MakeDeletion("alpha", "no-matter"),
+		coresettings.MakeDeletion("alpha$dollar", "no-matter"),
 		coresettings.MakeDeletion("what", "the"),
 		coresettings.MakeAddition("new", "noob"),
 	})
 
 	// Updating one not present = addition, deleting one not present = no-op.
 	exp := coresettings.ItemChanges{
-		coresettings.MakeModification("foo", "bar", "new-bar"),
+		coresettings.MakeModification("foo.dot", "bar", "new-bar"),
 		coresettings.MakeAddition("make", "new"),
-		coresettings.MakeDeletion("alpha", "beta"),
+		coresettings.MakeDeletion("alpha$dollar", "beta"),
 		coresettings.MakeAddition("new", "noob"),
 	}
 	sort.Sort(exp)


### PR DESCRIPTION
## Description of change

This patch:
- Pulls some logic from _state/settings_ into a new _core/settings_ package.
- Charm config updated under a branch is written as a delta into the generation document.

## QA steps

There is currently no branch configuration retrieval to CLI; it is forthcoming. These tests rely on interrogation of the branch's _generation_ document directly. Note also that there are warnings when setting values to be the same as the those existing in master - this will be addressed in another future patch.

Setup:
- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- Bootstrap.
- `juju deploy redis`.
- `juju branch test-branch`.
- `juju config redis databases=4 --branch master`.
- `juju config redis --reset databases --branch test-branch`. Document indicates deletion:
```
        "charm-config" : {
                "redis" : [
                        {
                                "type" : 2,
                                "key" : "databases",
                                "old" : NumberLong(4)
                        }
                ]
        },
```
- `juju config redis databases=4 --branch test-branch`. Document has no-op delta preserving the first value we observed for the setting:
```
        "charm-config" : {
                "redis" : [
                        {
                                "type" : 1,
                                "key" : "databases",
                                "old" : NumberLong(4),
                                "new" : NumberLong(4)
                        }
                ]
        },
```
- `juju config redis databases=8 --branch master`.
- `juju config redis databases=2 --branch test-branch`. Document indicates modification with original master value as old:
```
        "charm-config" : {
                "redis" : [
                        {
                                "type" : 1,
                                "key" : "databases",
                                "old" : NumberLong(4),
                                "new" : NumberLong(2)
                        }
                ]
        },
```
- `juju config redis password=new-pass --branch test-branch`. Document indicates last _databases_ entry, plus the addition:
```
        "charm-config" : {
                "redis" : [
                        {
                                "type" : 1,
                                "key" : "databases",
                                "old" : NumberLong(4),
                                "new" : NumberLong(2)
                        },
                        {
                                "type" : 0,
                                "key" : "password",
                                "new" : "new-pass"
                        }
                ]
        },
```

## Documentation changes

None.

## Bug reference

N/A
