### PR TITLE
2 small bugs in writing profiles with instancemutater

### DIFF
--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -114,7 +114,7 @@ func (api *InstanceMutaterAPI) CharmProfilingInfo(arg params.Entity) (params.Cha
 	}
 	lxdProfileInfo, err := api.machineLXDProfileInfo(m)
 	if err != nil {
-		result.Error = common.ServerError(err)
+		result.Error = common.ServerError(errors.Annotatef(err, "%s", tag))
 	}
 
 	// use the results from the machineLXDProfileInfo and apply them to the
@@ -285,11 +285,8 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m ModelCacheMachine) (lxdPr
 	var empty lxdProfileInfo
 
 	instId, err := m.InstanceId()
-	if err != nil && params.IsCodeNotProvisioned(err) {
-		// There is nothing we can do with this machine at this point. The
-		// profiles will be applied when the machine is provisioned.
-		logger.Tracef("Attempting to apply a profile to a machine that isn't provisioned %q", instId)
-		return empty, nil
+	if err != nil {
+		return empty, errors.Trace(errors.Annotate(err, "attempting to get instanceId"))
 	}
 
 	units, err := m.Units()

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -362,7 +362,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithMa
 
 	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
-	c.Assert(results.Error, gc.IsNil)
+	c.Assert(results.Error, gc.ErrorMatches, "machine-0: attempting to get instanceId: ")
 	c.Assert(results.InstanceId, gc.Equals, instance.Id(""))
 	c.Assert(results.ModelName, gc.Equals, "")
 	c.Assert(results.ProfileChanges, gc.HasLen, 0)

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -246,7 +246,7 @@ func (s *Server) UpdateContainerProfiles(name string, profiles []string) error {
 	op := resp.Get()
 	logger.Debugf("updated %q profiles, waiting on %s", name, op.Description)
 	err = resp.Wait()
-	return errors.Trace(err)
+	return errors.Trace(errors.Annotatef(err, "update failed"))
 }
 
 // CreateClientCertificate adds the input certificate to the server,

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -45,6 +45,9 @@ type environ struct {
 	lock           sync.Mutex
 	ecfgUnlocked   *environConfig
 	serverUnlocked Server
+
+	// profileMutex is used when writing profiles via the server.
+	profileMutex sync.Mutex
 }
 
 func newEnviron(
@@ -326,6 +329,8 @@ func (env *environ) DeriveAvailabilityZones(
 // an arg.
 // MaybeWriteLXDProfile implements environs.LXDProfiler.
 func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+	env.profileMutex.Lock()
+	defer env.profileMutex.Unlock()
 	server := env.server()
 	hasProfile, err := server.HasProfile(pName)
 	if err != nil {
@@ -380,7 +385,7 @@ func (env *environ) AssignProfiles(instId string, profilesNames []string, profil
 		// Always return the current profiles assigned to the instance.
 		currentProfiles, err2 := env.LXDProfileNames(instId)
 		if err != nil && err2 != nil {
-			logger.Errorf("secondary error, retrieving profile names: %s", err2)
+			logger.Errorf("retrieving profile names for %q: %s", instId, err2)
 		}
 		return currentProfiles, err
 	}

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -125,10 +125,10 @@ func (m mutaterMachine) watchProfileChangesLoop(profileChangeWatcher watcher.Not
 		case <-profileChangeWatcher.Changes():
 			info, err := m.machineApi.CharmProfilingInfo()
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			if err = m.processMachineProfileChanges(info); err != nil {
-				return err
+				return errors.Trace(err)
 			}
 		}
 	}

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -125,7 +125,7 @@ func (m mutaterMachine) watchProfileChangesLoop(profileChangeWatcher watcher.Not
 		case <-profileChangeWatcher.Changes():
 			info, err := m.machineApi.CharmProfilingInfo()
 			if err != nil {
-				return errors.Annotatef(err, "machine-%s", m.id)
+				return err
 			}
 			if err = m.processMachineProfileChanges(info); err != nil {
 				return err
@@ -159,8 +159,9 @@ func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 	// of expected profiles.
 	post, err := m.gatherProfileData(info)
 	if err != nil {
-		return report(errors.Annotatef(err, "processMachineProfileChanges %s.gatherProfileData(info):", m.id))
+		return report(errors.Annotatef(err, "%s", m.id))
 	}
+
 	// All juju lxd machines use these 2 profiles, independent of charm
 	// profiles.
 	expectedProfiles := []string{"default", "juju-" + info.ModelName}
@@ -172,7 +173,7 @@ func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 
 	verified, err := m.verifyCurrentProfiles(string(info.InstanceId), expectedProfiles)
 	if err != nil {
-		return report(errors.Annotatef(err, "processMachineProfileChanges %s.verifyCurrentProfiles():", m.id))
+		return report(errors.Annotatef(err, "%s", m.id))
 	}
 	if verified {
 		m.logger.Tracef("no changes necessary to machine-%s lxd profiles", m.id)
@@ -183,7 +184,8 @@ func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 	broker := m.context.getBroker()
 	currentProfiles, err := broker.AssignProfiles(string(info.InstanceId), expectedProfiles, post)
 	if err != nil {
-		return report(errors.Annotatef(err, "processMachineProfileChanges %s broker.AssignProfiles():", m.id))
+		m.logger.Errorf("failure to assign profiles %s to machine-%s: %s", expectedProfiles, m.id, err)
+		return report(err)
 	}
 
 	return report(m.machineApi.SetCharmProfiles(currentProfiles))


### PR DESCRIPTION
## Description of change

Add lock to lxd provider MaybeWriteLXDProfile, fixes race in writing lxd profiles to the server.  

Let the user handle the IsNotProvisioned from CharmProfileInfo(), helps with restarting the worker and getting a profile written to all machines needed.

## QA steps

export JUJU_DEV_FEATURE_FLAGS=instance-mutater
juju bootstrap
juju deploy the lxd-profile-alt charm -n 4
juju deploy the lxd-profile-subordinate and relate to above.
juju deploy the ubuntu charm -n 4 to same machines
upgrade all three
check the lxd profiles assigned
juju deploy a bundle

