### PR TITLE
Add support for upgrading k8s operators

### DIFF
--- a/api/caasoperatorupgrader/client.go
+++ b/api/caasoperatorupgrader/client.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorupgrader
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Client allows access to the CAAS operator upgrader API endpoint.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient returns a client used to access the CAAS Operator Upgrader API.
+func NewClient(caller base.APICaller) *Client {
+	facadeCaller := base.NewFacadeCaller(caller, "CAASOperatorUpgrader")
+	return &Client{
+		facade: facadeCaller,
+	}
+}
+
+// Upgrade upgrades the operator for the specified agent tag to v.
+func (c *Client) Upgrade(agentTag string, v version.Number) error {
+	var result params.ErrorResult
+	arg := params.KubernetesUpgradeArg{
+		AgentTag: agentTag,
+		Version:  v,
+	}
+	if err := c.facade.FacadeCall("UpgradeOperator", arg, &result); err != nil {
+		return errors.Trace(err)
+	}
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}

--- a/api/caasoperatorupgrader/client_test.go
+++ b/api/caasoperatorupgrader/client_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorupgrader_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/caasoperatorupgrader"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type provisionerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&provisionerSuite{})
+
+func newClient(f basetesting.APICallerFunc) *caasoperatorupgrader.Client {
+	return caasoperatorupgrader.NewClient(basetesting.BestVersionCaller{f, 5})
+}
+
+func (s *provisionerSuite) TestUpgrader(c *gc.C) {
+	var called bool
+	client := newClient(func(objType string, v int, id, request string, a, result interface{}) error {
+		called = true
+		c.Check(objType, gc.Equals, "CAASOperatorUpgrader")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "UpgradeOperator")
+		c.Assert(a, jc.DeepEquals, params.KubernetesUpgradeArg{
+			AgentTag: "application-foo",
+			Version:  version.MustParse("6.6.6"),
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResult{})
+		*(result.(*params.ErrorResult)) = params.ErrorResult{
+			Error: &params.Error{Message: "FAIL"},
+		}
+		return nil
+	})
+	err := client.Upgrade("application-foo", version.MustParse("6.6.6"))
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(called, jc.IsTrue)
+}

--- a/api/caasoperatorupgrader/package_test.go
+++ b/api/caasoperatorupgrader/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorupgrader_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -28,6 +28,7 @@ var facadeVersions = map[string]int{
 	"CAASFirewaller":               1,
 	"CAASOperator":                 1,
 	"CAASOperatorProvisioner":      1,
+	"CAASOperatorUpgrader":         1,
 	"CAASUnitProvisioner":          1,
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -75,6 +75,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/applicationscaler"
 	"github.com/juju/juju/apiserver/facades/controller/caasfirewaller"
 	"github.com/juju/juju/apiserver/facades/controller/caasoperatorprovisioner"
+	"github.com/juju/juju/apiserver/facades/controller/caasoperatorupgrader"
 	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
 	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater"
 	"github.com/juju/juju/apiserver/facades/controller/cleaner"
@@ -173,6 +174,7 @@ func AllFacades() *facade.Registry {
 	reg("CAASOperator", 1, caasoperator.NewStateFacade)
 	reg("CAASAgent", 1, caasagent.NewStateFacade)
 	reg("CAASOperatorProvisioner", 1, caasoperatorprovisioner.NewStateCAASOperatorProvisionerAPI)
+	reg("CAASOperatorUpgrader", 1, caasoperatorupgrader.NewStateCAASOperatorUpgraderAPI)
 	reg("CAASUnitProvisioner", 1, caasunitprovisioner.NewStateFacade)
 
 	reg("Controller", 3, controller.NewControllerAPIv3)

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -39,7 +39,7 @@ func NewUpgraderFacade(st *state.State, resources facade.Resources, auth facade.
 		return nil, common.ErrPerm
 	}
 	switch tag.(type) {
-	case names.MachineTag:
+	case names.MachineTag, names.ApplicationTag:
 		return NewUpgraderAPI(st, resources, auth)
 	case names.UnitTag:
 		return NewUnitUpgraderAPI(st, resources, auth)
@@ -72,7 +72,7 @@ func NewUpgraderAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*UpgraderAPI, error) {
-	if !authorizer.AuthMachineAgent() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthApplicationAgent() {
 		return nil, common.ErrPerm
 	}
 	getCanReadWrite := func() (common.AuthFunc, error) {

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -99,7 +99,36 @@ func (s *upgraderSuite) TestWatchAPIVersion(c *gc.C) {
 	wc.AssertClosed()
 }
 
-func (s *upgraderSuite) TestUpgraderAPIRefusesNonMachineAgent(c *gc.C) {
+func (s *upgraderSuite) TestWatchAPIVersionApplication(c *gc.C) {
+	app := s.Factory.MakeApplication(c, nil)
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag: app.Tag(),
+	}
+	upgrader, err := upgrader.NewUpgraderAPI(s.State, s.resources, authorizer)
+
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: app.Tag().String()}},
+	}
+	results, err := upgrader.WatchAPIVersion(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(results.Results, gc.HasLen, 1)
+	c.Check(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
+	c.Check(results.Results[0].Error, gc.IsNil)
+	resource := s.resources.Get(results.Results[0].NotifyWatcherId)
+	c.Check(resource, gc.NotNil)
+
+	w := resource.(state.NotifyWatcher)
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+	wc.AssertNoChange()
+
+	err = statetesting.SetAgentVersion(s.State, version.MustParse("3.4.567.8"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+
+func (s *upgraderSuite) TestUpgraderAPIRefusesNonMachineOrApplicationAgent(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewUnitTag("ubuntu/1")
 	anUpgrader, err := upgrader.NewUpgraderAPI(s.State, s.resources, anAuthorizer)

--- a/apiserver/facades/controller/caasoperatorupgrader/package_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorupgrader_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorupgrader
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/state/stateenvirons"
+)
+
+var logger = loggo.GetLogger("juju.controller.caasoperatorupgrader")
+
+type API struct {
+	auth facade.Authorizer
+
+	broker caas.Upgrader
+}
+
+// NewStateCAASOperatorUpgraderAPI provides the signature required for facade registration.
+func NewStateCAASOperatorUpgraderAPI(ctx facade.Context) (*API, error) {
+	authorizer := ctx.Auth()
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	if err != nil {
+		return nil, errors.Annotate(err, "getting caas client")
+	}
+	return NewCAASOperatorUpgraderAPI(authorizer, broker)
+}
+
+// NewCAASOperatorUpgraderAPI returns a new CAAS operator upgrader API facade.
+func NewCAASOperatorUpgraderAPI(
+	authorizer facade.Authorizer,
+	broker caas.Upgrader,
+) (*API, error) {
+	if !authorizer.AuthController() && !authorizer.AuthApplicationAgent() {
+		return nil, common.ErrPerm
+	}
+	return &API{
+		auth:   authorizer,
+		broker: broker,
+	}, nil
+}
+
+// UpgradeOperator upgrades the operator for the specified agents.
+func (api *API) UpgradeOperator(arg params.KubernetesUpgradeArg) (params.ErrorResult, error) {
+	serverErr := func(err error) params.ErrorResult {
+		return params.ErrorResult{common.ServerError(err)}
+	}
+	tag, err := names.ParseTag(arg.AgentTag)
+	if err != nil {
+		return serverErr(err), nil
+	}
+	if !api.auth.AuthOwner(tag) {
+		return serverErr(common.ErrPerm), nil
+	}
+	appName := tag.Id()
+
+	// Machines representing controllers really mean the controller operator.
+	if tag.Kind() == names.MachineTagKind {
+		appName = bootstrap.ControllerModelName
+	}
+	logger.Debugf("upgrading caas app %v", appName)
+	err = api.broker.Upgrade(appName, arg.Version)
+	if err != nil {
+		return serverErr(err), nil
+	}
+	return params.ErrorResult{}, nil
+}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperatorupgrader_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/facades/controller/caasoperatorupgrader"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&CAASProvisionerSuite{})
+
+type CAASProvisionerSuite struct {
+	coretesting.BaseSuite
+
+	authorizer *apiservertesting.FakeAuthorizer
+	api        *caasoperatorupgrader.API
+	broker     *mockBroker
+}
+
+func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.broker = &mockBroker{}
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag: names.NewApplicationTag("app"),
+	}
+
+	api, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("0"),
+	}
+	_, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *CAASProvisionerSuite) TestUpgradeOperator(c *gc.C) {
+	vers := version.MustParse("6.6.6")
+	result, err := s.api.UpgradeOperator(params.KubernetesUpgradeArg{
+		AgentTag: s.authorizer.Tag.String(),
+		Version:  vers,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	s.broker.CheckCall(c, 0, "Upgrade", "app", vers)
+}
+
+func (s *CAASProvisionerSuite) TestUpgradeController(c *gc.C) {
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	api, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	vers := version.MustParse("6.6.6")
+	result, err := api.UpgradeOperator(params.KubernetesUpgradeArg{
+		AgentTag: s.authorizer.Tag.String(),
+		Version:  vers,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	s.broker.CheckCall(c, 0, "Upgrade", "controller", vers)
+}
+
+type mockBroker struct {
+	testing.Stub
+}
+
+func (m *mockBroker) Upgrade(app string, vers version.Number) error {
+	m.AddCall("Upgrade", app, vers)
+	return nil
+}

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -4,6 +4,8 @@
 package params
 
 import (
+	"github.com/juju/version"
+
 	"github.com/juju/juju/core/constraints"
 )
 
@@ -98,4 +100,10 @@ type KubernetesDeviceParams struct {
 	Type       DeviceType        `bson:"type"`
 	Count      int64             `bson:"count"`
 	Attributes map[string]string `bson:"attributes,omitempty"`
+}
+
+// KubernetesUpgradeArg holds args used to upgrade an operator.
+type KubernetesUpgradeArg struct {
+	AgentTag string         `json:"agent-tag"`
+	Version  version.Number `json:"version"`
 }

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -78,6 +78,7 @@ var caasModelFacadeNames = set.NewStrings(
 	"CAASFirewaller",
 	"CAASOperator",
 	"CAASOperatorProvisioner",
+	"CAASOperatorUpgrader",
 	"CAASUnitProvisioner",
 )
 

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -474,7 +474,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Args: []string{
 				"-c",
 				`
-test -e ./jujud || cp /opt/jujud $(pwd)/jujud
+cp /opt/jujud $(pwd)/jujud
 
 test -e /var/lib/juju/agents/machine-0/agent.conf || ./jujud bootstrap-state /var/lib/juju/bootstrap-params --data-dir /var/lib/juju --debug --timeout 0s
 ./jujud machine --data-dir /var/lib/juju --machine-id 0 --debug

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -275,7 +275,7 @@ var operatorPodspec = core.PodSpec{
 		Args: []string{
 			"-c",
 			`
-test -e ./jujud || cp /opt/jujud $(pwd)/jujud
+cp /opt/jujud $(pwd)/jujud
 ./jujud caasoperator --application-name=test --debug
 `[1:],
 		},

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -6,7 +6,7 @@ package caas
 var (
 	// JujudStartUpSh is the exec script for CAAS controller.
 	JujudStartUpSh = `
-test -e ./jujud || cp /opt/jujud $(pwd)/jujud
+cp /opt/jujud $(pwd)/jujud
 %s
 `[1:]
 )

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -205,6 +205,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		})
 	}
 
+	agentConfig := op.AgentConf.CurrentConfig()
 	manifolds := CaasOperatorManifolds(caasoperator.ManifoldsConfig{
 		Agent:                agent.APIHostPortsSetter{op},
 		AgentConfigChanged:   op.configChangedVal,
@@ -216,6 +217,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		UpgradeStepsLock:     op.upgradeComplete,
 		ValidateMigration:    op.validateMigration,
 		MachineLock:          op.machineLock,
+		PreviousAgentVersion: agentConfig.UpgradedToVersion(),
 	})
 
 	engine, err := dependency.NewEngine(dependencyEngineConfig())

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -50,6 +50,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"migration-inactive-flag",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate",
+		"upgrader",
 		// TODO(caas)
 		//"metric-spool",
 		//"meter-status",
@@ -180,6 +181,11 @@ var expectedOperatorManifoldsWithDependencies = map[string][]string{
 	"upgrade-steps-flag": {"upgrade-steps-gate"},
 
 	"upgrade-steps-gate": {},
+
+	"upgrader": {
+		"agent",
+		"api-caller",
+		"api-config-watcher"},
 
 	"clock": {},
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -44,8 +44,7 @@ import (
 	"github.com/juju/juju/worker/apiservercertwatcher"
 	"github.com/juju/juju/worker/auditconfigupdater"
 	"github.com/juju/juju/worker/authenticationworker"
-	"github.com/juju/juju/worker/caasbroker"
-	"github.com/juju/juju/worker/caascontrollerupgrader"
+	"github.com/juju/juju/worker/caasupgrader"
 	"github.com/juju/juju/worker/centralhub"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/common"
@@ -935,18 +934,12 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 // various responsibilities of a CAAS machine agent.
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
-		caasBrokerTrackerName: caasbroker.Manifold(caasbroker.ManifoldConfig{
-			APICallerName:          apiCallerName,
-			NewContainerBrokerFunc: config.NewContainerBrokerFunc,
-		}),
-
 		// TODO(caas) - when we support HA, only want this on primary
-		upgraderName: caascontrollerupgrader.Manifold(caascontrollerupgrader.ManifoldConfig{
+		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
 			AgentName:            agentName,
 			APICallerName:        apiCallerName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
-			BrokerName:           caasBrokerTrackerName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 		}),
 	})
@@ -1086,6 +1079,4 @@ const (
 	raftForwarderName = "raft-forwarder"
 
 	validCredentialFlagName = "valid-credential-flag"
-
-	caasBrokerTrackerName = "caas-broker-tracker"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -138,7 +138,6 @@ func (ms *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
 			"api-config-watcher",
 			"api-server",
 			"audit-config-updater",
-			"caas-broker-tracker",
 			"central-hub",
 			"certificate-updater",
 			"certificate-watcher",

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -134,6 +134,7 @@ var (
 		"migration-minion",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate",
+		"upgrader",
 	}
 	notMigratingCAASWorkers = []string{
 		"charm-dir",

--- a/worker/caasupgrader/manifold.go
+++ b/worker/caasupgrader/manifold.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package caascontrollerupgrader
+package caasupgrader
 
 import (
 	"github.com/juju/errors"
@@ -11,8 +11,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/caasoperatorupgrader"
 	"github.com/juju/juju/api/upgrader"
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/worker/gate"
 )
 
@@ -24,8 +24,6 @@ type ManifoldConfig struct {
 	UpgradeStepsGateName string
 	UpgradeCheckGateName string
 	PreviousAgentVersion version.Number
-
-	BrokerName string
 }
 
 // Manifold returns a dependency manifold that runs an upgrader
@@ -34,9 +32,14 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	inputs := []string{
 		config.AgentName,
 		config.APICallerName,
-		config.BrokerName,
-		config.UpgradeStepsGateName,
-		config.UpgradeCheckGateName,
+	}
+
+	// The machine agent uses these but the application agent doesn't.
+	if config.UpgradeStepsGateName != "" {
+		inputs = append(inputs, config.UpgradeStepsGateName)
+	}
+	if config.UpgradeCheckGateName != "" {
+		inputs = append(inputs, config.UpgradeCheckGateName)
 	}
 
 	return dependency.Manifold{
@@ -57,30 +60,37 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, err
 			}
 
-			var broker caas.Broker
-			if err := context.Get(config.BrokerName, &broker); err != nil {
-				return nil, errors.Trace(err)
-			}
-
 			upgraderFacade := upgrader.NewState(apiCaller)
+			operatorUpgraderFacade := caasoperatorupgrader.NewClient(apiCaller)
 
 			var upgradeStepsWaiter gate.Waiter
-			if err := context.Get(config.UpgradeStepsGateName, &upgradeStepsWaiter); err != nil {
-				return nil, err
+			if config.UpgradeStepsGateName == "" {
+				upgradeStepsWaiter = gate.NewLock()
+			} else {
+				if config.PreviousAgentVersion == version.Zero {
+					return nil, errors.New("previous agent version not specified")
+				}
+				if err := context.Get(config.UpgradeStepsGateName, &upgradeStepsWaiter); err != nil {
+					return nil, err
+				}
 			}
 
 			var initialCheckUnlocker gate.Unlocker
-			if err := context.Get(config.UpgradeCheckGateName, &initialCheckUnlocker); err != nil {
-				return nil, err
+			if config.UpgradeCheckGateName == "" {
+				initialCheckUnlocker = gate.NewLock()
+			} else {
+				if err := context.Get(config.UpgradeCheckGateName, &initialCheckUnlocker); err != nil {
+					return nil, err
+				}
 			}
 
-			return NewControllerUpgrader(Config{
-				Client:                      upgraderFacade,
+			return NewUpgrader(Config{
+				UpgraderClient:              upgraderFacade,
+				CAASOperatorUpgrader:        operatorUpgraderFacade,
 				AgentTag:                    currentConfig.Tag(),
 				OrigAgentVersion:            config.PreviousAgentVersion,
 				UpgradeStepsWaiter:          upgradeStepsWaiter,
 				InitialUpgradeCheckComplete: initialCheckUnlocker,
-				Broker:                      broker,
 			})
 		},
 	}

--- a/worker/caasupgrader/mock_test.go
+++ b/worker/caasupgrader/mock_test.go
@@ -1,17 +1,16 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package caascontrollerupgrader_test
+package caasupgrader_test
 
 import (
 	"github.com/juju/testing"
 	"github.com/juju/version"
 
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/watcher"
 )
 
-type mockUpgrader struct {
+type mockUpgraderClient struct {
 	testing.Stub
 
 	desired version.Number
@@ -19,27 +18,26 @@ type mockUpgrader struct {
 	watcher watcher.NotifyWatcher
 }
 
-func (m *mockUpgrader) DesiredVersion(tag string) (version.Number, error) {
+func (m *mockUpgraderClient) DesiredVersion(tag string) (version.Number, error) {
 	m.Stub.AddCall("DesiredVersion", tag)
 	return m.desired, nil
 }
 
-func (m *mockUpgrader) SetVersion(tag string, v version.Binary) error {
+func (m *mockUpgraderClient) SetVersion(tag string, v version.Binary) error {
 	m.Stub.AddCall("SetVersion", tag, v)
 	m.actual = v
 	return nil
 }
 
-func (m *mockUpgrader) WatchAPIVersion(agentTag string) (watcher.NotifyWatcher, error) {
+func (m *mockUpgraderClient) WatchAPIVersion(agentTag string) (watcher.NotifyWatcher, error) {
 	return m.watcher, nil
 }
 
-type mockBroker struct {
+type mockOperatorUpgrader struct {
 	testing.Stub
-	caas.Broker
 }
 
-func (m *mockBroker) Upgrade(appName string, vers version.Number) error {
+func (m *mockOperatorUpgrader) Upgrade(appName string, vers version.Number) error {
 	m.AddCall("Upgrade", appName, vers)
 	return nil
 }

--- a/worker/caasupgrader/package_test.go
+++ b/worker/caasupgrader/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENSE file for details.
 
-package caascontrollerupgrader_test
+package caasupgrader_test
 
 import (
 	stdtesting "testing"


### PR DESCRIPTION
## Description of change

k8s application operators watch for agent version changes in their model and react. The existing k8s upgrader worker was changed to support this. A new API facade is introduced for the worker to call to request an upgrade instead of doing the upgrade inside the worker. This allows the upgrader worker to run in both the controller and the operator - the upgrade request to the controller then means that only the controller talks to the cluster.

## QA steps

This can't work properly until the controller API address which is published is changed.
For now, ensure that controller upgrades work as before and that operator agents log that the new worker is started and running and watcher for agent upgrades.

