### PR TITLE
Generation CLI Command Docs Only Refer to Charm Config

### DIFF
--- a/cmd/juju/model/branch.go
+++ b/cmd/juju/model/branch.go
@@ -21,10 +21,10 @@ const (
 	branchSummary = "Adds a new branch to the model."
 	branchDoc     = `
 A branch is a mechanism by which changes can be applied to units gradually at 
-the operator's discretion. When changes are made to charm configuration, charm
-URL or resources against a branch, only units set to track the branch will realise 
-such changes. Once the changes are assessed and deemed acceptable, the branch 
-can be committed, applying the changes to the model and affecting all units.
+the operator's discretion. When changes are made to charm configuration under 
+a branch, only units set to track the branch will realise such changes. 
+Once the changes are assessed and deemed acceptable, the branch can be 
+committed, applying the changes to the model and affecting all units.
 The branch name "master" is reserved for primary model-based settings and is
 not valid for new branches.
 

--- a/cmd/juju/model/checkout.go
+++ b/cmd/juju/model/checkout.go
@@ -22,7 +22,8 @@ const (
 	checkoutDoc     = `
 Switch to the supplied branch, causing changes to charm configuration to apply 
 only to units tracking the branch. Changing the branch to "master" causes 
-changes to be applied to all units as usual.
+subsequent changes to be applied to all units that are not tracking an active
+branch.
 
 Examples:
     juju checkout test-branch

--- a/cmd/juju/model/checkout.go
+++ b/cmd/juju/model/checkout.go
@@ -20,10 +20,9 @@ import (
 const (
 	checkoutSummary = "Work on the supplied branch."
 	checkoutDoc     = `
-Switch to the supplied branch, causing changes to charm configuration,
-charm URL or resources to apply only to units tracking the branch.
-Changing the branch to "master" causes changes to be applied to all units
-as usual.
+Switch to the supplied branch, causing changes to charm configuration to apply 
+only to units tracking the branch. Changing the branch to "master" causes 
+changes to be applied to all units as usual.
 
 Examples:
     juju checkout test-branch

--- a/cmd/juju/model/commit.go
+++ b/cmd/juju/model/commit.go
@@ -19,9 +19,9 @@ import (
 const (
 	commitSummary = "Commits a branch to the model."
 	commitDoc     = `
-Committing a branch writes changes to charm configuration, charm URL and
-resources made under the branch, to the model. All units who's applications
-were changed under the branch realise those changes, as will any new units.
+Committing a branch writes changes to charm configuration made under the 
+branch, to the model. All units who's applications were changed under the 
+branch realise those changes, as will any new units.
 
 Examples:
     juju commit upgrade-postgresql


### PR DESCRIPTION
## Description of change

Model generations will see a release targeting charm config, before later covering charm URL and resources. Until fully featured, help docs only refer to the charm config aspect.

## QA steps

None. No functional changes.

## Documentation changes

Possibly something for @pmatulis to be aware of.

## Bug reference

N/A
