### PR TITLE
Remove Juju specific sysctl tweaks for LXD

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -7,12 +7,3 @@ fi
 
 # copy bash completions to host system
 cp -a $SNAP/bash_completions/* /usr/share/bash-completion/completions/. || true
-
-# setup sysctl defaults for lxd
-mkdir -p /usr/lib/sysctl.d
-cat <<EOF>/usr/lib/sysctl.d/juju-2.conf
-fs.inotify.max_user_watches = 524288
-fs.inotify.max_user_instances = 256
-EOF
-
-sysctl -p /usr/lib/sysctl.d/juju-2.conf


### PR DESCRIPTION
Fixes #1817774

It was noted that we set a couple of sysctl values for LXD and since then LXD
has started providing their own default values. This pulls that from our
config.
