### PR TITLE
Accomodate Branch Deltas in Charm Config

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -165,7 +165,7 @@ func (c *Client) GetCharmURL(branchName, applicationName string) (*charm.URL, er
 	result := new(params.StringResult)
 	args := params.ApplicationGet{
 		ApplicationName: applicationName,
-		Generation:      branchName,
+		BranchName:      branchName,
 	}
 	err := c.facade.FacadeCall("GetCharmURL", args, result)
 	if err != nil {
@@ -204,7 +204,7 @@ func (c *Client) GetConfig(branchName string, appNames ...string) ([]map[string]
 		// Version 9 of the API introduces generational config.
 		arg := params.ApplicationGetArgs{Args: make([]params.ApplicationGet, len(appNames))}
 		for i, appName := range appNames {
-			arg.Args[i] = params.ApplicationGet{ApplicationName: appName, Generation: branchName}
+			arg.Args[i] = params.ApplicationGet{ApplicationName: appName, BranchName: branchName}
 		}
 		callArg = arg
 	}
@@ -735,7 +735,7 @@ func (c *Client) Get(branchName, application string) (*params.ApplicationGetResu
 	var results params.ApplicationGetResults
 	args := params.ApplicationGet{
 		ApplicationName: application,
-		Generation:      branchName,
+		BranchName:      branchName,
 	}
 	err := c.facade.FacadeCall("Get", args, &results)
 	return &results, err
@@ -934,7 +934,7 @@ func (c *Client) ApplicationsInfo(applications []names.ApplicationTag) ([]params
 	for i, one := range applications {
 		all[i] = params.Entity{Tag: one.String()}
 	}
-	in := params.Entities{all}
+	in := params.Entities{Entities: all}
 	var out params.ApplicationInfoResults
 	err := c.facade.FacadeCall("ApplicationsInfo", in, &out)
 	if err != nil {

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -870,7 +870,7 @@ func (c *Client) UnsetApplicationConfig(branchName, application string, options 
 	args := params.ApplicationConfigUnsetArgs{
 		Args: []params.ApplicationUnset{{
 			ApplicationName: application,
-			Generation:      branchName,
+			BranchName:      branchName,
 			Options:         options,
 		}},
 	}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1015,7 +1015,7 @@ func (s *applicationSuite) TestUnsetApplicationConfig(c *gc.C) {
 					Args: []params.ApplicationUnset{{
 						ApplicationName: "foo",
 						Options:         []string{"option"},
-						Generation:      newBranchName,
+						BranchName:      newBranchName,
 					}}})
 				result, ok := response.(*params.ErrorResults)
 				c.Assert(ok, jc.IsTrue)

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -34,11 +34,11 @@ type applicationSuite struct {
 var _ = gc.Suite(&applicationSuite{})
 
 func newClient(f basetesting.APICallerFunc) *application.Client {
-	return application.NewClient(basetesting.BestVersionCaller{f, 8})
+	return application.NewClient(basetesting.BestVersionCaller{APICallerFunc: f, BestVersion: 8})
 }
 
 func newClientV4(f basetesting.APICallerFunc) *application.Client {
-	return application.NewClient(basetesting.BestVersionCaller{f, 4})
+	return application.NewClient(basetesting.BestVersionCaller{APICallerFunc: f, BestVersion: 4})
 }
 
 func (s *applicationSuite) TestSetApplicationMetricCredentials(c *gc.C) {
@@ -239,7 +239,7 @@ func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
 		args, ok := a.(params.ApplicationGet)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(args.ApplicationName, gc.Equals, "application")
-		c.Assert(args.Generation, gc.Equals, newBranchName)
+		c.Assert(args.BranchName, gc.Equals, newBranchName)
 
 		result := response.(*params.StringResult)
 		result.Result = "curl"
@@ -725,8 +725,8 @@ func (s *applicationSuite) TestGetConfigV6(c *gc.C) {
 
 func (s *applicationSuite) TestGetConfigV9(c *gc.C) {
 	args := params.ApplicationGetArgs{Args: []params.ApplicationGet{
-		{ApplicationName: "foo", Generation: newBranchName},
-		{ApplicationName: "bar", Generation: newBranchName},
+		{ApplicationName: "foo", BranchName: newBranchName},
+		{ApplicationName: "bar", BranchName: newBranchName},
 	}}
 	s.assertGetConfig(c, 9, "CharmConfig", args)
 }
@@ -817,7 +817,7 @@ func (s *applicationSuite) TestGetConfigAPIv4(c *gc.C) {
 				c.Assert(request, gc.Equals, "Get")
 				args, ok := a.(params.ApplicationGet)
 				c.Assert(ok, jc.IsTrue)
-				c.Assert(args.Generation, gc.Equals, newBranchName)
+				c.Assert(args.BranchName, gc.Equals, newBranchName)
 
 				result, ok := response.(*params.ApplicationGetResults)
 				c.Assert(ok, jc.IsTrue)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2025,7 +2025,7 @@ func (api *APIBase) CharmConfig(args params.ApplicationGetArgs) (params.Applicat
 		Results: make([]params.ConfigResult, len(args.Args)),
 	}
 	for i, arg := range args.Args {
-		config, err := api.getCharmConfig(arg.Generation, arg.ApplicationName)
+		config, err := api.getCharmConfig(arg.BranchName, arg.ApplicationName)
 		results.Results[i].Config = config
 		results.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1117,7 +1117,13 @@ func (api *APIBase) Unset(p params.ApplicationUnset) error {
 	for _, option := range p.Options {
 		settings[option] = nil
 	}
-	return app.UpdateCharmConfig(p.Generation, settings)
+
+	// We need a guard on the API server-side for direct API callers such as
+	// python-libjuju. Always default to the master branch.
+	if p.BranchName == "" {
+		p.BranchName = model.GenerationMaster
+	}
+	return app.UpdateCharmConfig(p.BranchName, settings)
 }
 
 // CharmRelations implements the server side of Application.CharmRelations.
@@ -1127,11 +1133,11 @@ func (api *APIBase) CharmRelations(p params.ApplicationCharmRelations) (params.A
 		return results, errors.Trace(err)
 	}
 
-	application, err := api.backend.Application(p.ApplicationName)
+	app, err := api.backend.Application(p.ApplicationName)
 	if err != nil {
 		return results, errors.Trace(err)
 	}
-	endpoints, err := application.Endpoints()
+	endpoints, err := app.Endpoints()
 	if err != nil {
 		return results, errors.Trace(err)
 	}
@@ -2052,6 +2058,7 @@ func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfig
 			continue
 		}
 
+		// Always deal with the master branch version of config.
 		config, err := api.getCharmConfig(model.GenerationMaster, tag.Id())
 		results.Results[i].Config = config
 		results.Results[i].Error = common.ServerError(err)
@@ -2195,8 +2202,14 @@ func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 			return errors.Annotate(err, "updating application config values")
 		}
 	}
+
 	if len(charmSettings) > 0 {
-		if err := app.UpdateCharmConfig(arg.Generation, charmSettings); err != nil {
+		// We need a guard on the API server-side for direct API callers such as
+		// python-libjuju. Always default to the master branch.
+		if arg.BranchName == "" {
+			arg.BranchName = model.GenerationMaster
+		}
+		if err := app.UpdateCharmConfig(arg.BranchName, charmSettings); err != nil {
 			return errors.Annotate(err, "updating application charm settings")
 		}
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -116,13 +116,14 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {
 	s.setUpConfigTest(c)
 
-	// TODO (manadart 2019-02-04): When upstream methods receive a generation,
-	// refactor these tests to account for it.
+	branchName := "test-branch"
+	c.Assert(s.State.AddBranch(branchName, "test-user"), jc.ErrorIsNil)
+
 	results, err := s.applicationAPI.CharmConfig(params.ApplicationGetArgs{
 		Args: []params.ApplicationGet{
-			{ApplicationName: "foo", BranchName: model.GenerationMaster},
-			{ApplicationName: "bar", BranchName: model.GenerationMaster},
-			{ApplicationName: "wat", BranchName: model.GenerationMaster},
+			{ApplicationName: "foo", BranchName: branchName},
+			{ApplicationName: "bar", BranchName: branchName},
+			{ApplicationName: "wat", BranchName: branchName},
 		},
 	})
 	assertConfigTest(c, results, err, []params.ConfigResult{})
@@ -2030,7 +2031,6 @@ func (s *applicationSuite) TestApplicationSet(c *gc.C) {
 			"title":    "foobar",
 			"username": validSetTestValue,
 		},
-		Generation: model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := dummy.CharmConfig(model.GenerationMaster)
@@ -2045,7 +2045,6 @@ func (s *applicationSuite) TestApplicationSet(c *gc.C) {
 			"title":    "barfoo",
 			"username": "",
 		},
-		Generation: model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err = dummy.CharmConfig(model.GenerationMaster)
@@ -2072,7 +2071,6 @@ func (s *applicationSuite) assertApplicationSet(c *gc.C, dummy *state.Applicatio
 			"title":    "foobar",
 			"username": validSetTestValue,
 		},
-		Generation: model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := dummy.CharmConfig(model.GenerationMaster)
@@ -2113,7 +2111,6 @@ func (s *applicationSuite) TestServerUnset(c *gc.C) {
 			"title":    "foobar",
 			"username": "user name",
 		},
-		Generation: model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := dummy.CharmConfig(model.GenerationMaster)
@@ -2126,7 +2123,6 @@ func (s *applicationSuite) TestServerUnset(c *gc.C) {
 	err = s.applicationAPI.Unset(params.ApplicationUnset{
 		ApplicationName: "dummy",
 		Options:         []string{"username"},
-		Generation:      model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err = dummy.CharmConfig(model.GenerationMaster)
@@ -2145,7 +2141,6 @@ func (s *applicationSuite) setupServerUnsetBlocked(c *gc.C) *state.Application {
 			"title":    "foobar",
 			"username": "user name",
 		},
-		Generation: model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := dummy.CharmConfig(model.GenerationMaster)
@@ -2163,7 +2158,6 @@ func (s *applicationSuite) assertServerUnset(c *gc.C, dummy *state.Application) 
 	err := s.applicationAPI.Unset(params.ApplicationUnset{
 		ApplicationName: "dummy",
 		Options:         []string{"username"},
-		Generation:      model.GenerationMaster,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := dummy.CharmConfig(model.GenerationMaster)

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -120,9 +120,9 @@ func (s *applicationSuite) TestCharmConfig(c *gc.C) {
 	// refactor these tests to account for it.
 	results, err := s.applicationAPI.CharmConfig(params.ApplicationGetArgs{
 		Args: []params.ApplicationGet{
-			{ApplicationName: "foo", Generation: model.GenerationMaster},
-			{ApplicationName: "bar", Generation: model.GenerationMaster},
-			{ApplicationName: "wat", Generation: model.GenerationMaster},
+			{ApplicationName: "foo", BranchName: model.GenerationMaster},
+			{ApplicationName: "bar", BranchName: model.GenerationMaster},
+			{ApplicationName: "wat", BranchName: model.GenerationMaster},
 		},
 	})
 	assertConfigTest(c, results, err, []params.ConfigResult{})
@@ -1831,8 +1831,6 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsStrings(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetSettingsStringsBranch(c *gc.C) {
-	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
-
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
 
@@ -1881,8 +1879,6 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsYAML(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationUpdateSetSettingsYAMLBranch(c *gc.C) {
-	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
-
 	ch := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy", ch)
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1513,7 +1513,7 @@ func (s *ApplicationSuite) TestUnsetApplicationConfig(c *gc.C) {
 		Args: []params.ApplicationUnset{{
 			ApplicationName: "postgresql",
 			Options:         []string{"juju-external-hostname", "stringVal"},
-			Generation:      "new-branch",
+			BranchName:      "new-branch",
 		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -18,6 +18,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -462,7 +463,7 @@ func (s *DeployLocalSuite) assertCharm(c *gc.C, app application.Application, exp
 }
 
 func (s *DeployLocalSuite) assertSettings(c *gc.C, app application.Application, settings charm.Settings) {
-	settings, err := app.CharmConfig("new-branch")
+	settings, err := app.CharmConfig(model.GenerationMaster)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := s.charm.Config().DefaultSettings()
 	for name, value := range settings {

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -54,7 +54,7 @@ func (api *APIBase) getConfig(
 	if err != nil {
 		return params.ApplicationGetResults{}, err
 	}
-	settings, err := app.CharmConfig(args.Generation)
+	settings, err := app.CharmConfig(args.BranchName)
 	if err != nil {
 		return params.ApplicationGetResults{}, err
 	}

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -52,21 +52,21 @@ func (api *APIBase) getConfig(
 		return params.ApplicationGetResults{}, err
 	}
 
-	// We need a guard on the API server-side for direct API callers such as
-	// python-libjuju. Always default to the master branch.
-	branchName := args.BranchName
-	if branchName == "" {
-		branchName = model.GenerationMaster
-	}
-
 	app, err := api.backend.Application(args.ApplicationName)
 	if err != nil {
 		return params.ApplicationGetResults{}, err
 	}
-	settings, err := app.CharmConfig(branchName)
+
+	// We need a guard on the API server-side for direct API callers such as
+	// python-libjuju. Always default to the master branch.
+	if args.BranchName == "" {
+		args.BranchName = model.GenerationMaster
+	}
+	settings, err := app.CharmConfig(args.BranchName)
 	if err != nil {
 		return params.ApplicationGetResults{}, err
 	}
+
 	ch, _, err := app.Charm()
 	if err != nil {
 		return params.ApplicationGetResults{}, err

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -61,13 +61,10 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	s.applicationAPI = &application.APIv9{api}
 }
 
-func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}}
-	results, err := v4.Get(params.ApplicationGet{
-		ApplicationName: "wordpress",
-		BranchName:      model.GenerationMaster,
-	})
+	results, err := v4.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -84,13 +81,10 @@ func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	})
 }
 
-func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}
-	results, err := v5.Get(params.ApplicationGet{
-		ApplicationName: "wordpress",
-		BranchName:      model.GenerationMaster,
-	})
+	results, err := v5.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -111,10 +105,7 @@ func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	results, err := s.applicationAPI.Get(params.ApplicationGet{
-		ApplicationName: "wordpress",
-		BranchName:      model.GenerationMaster,
-	})
+	results, err := s.applicationAPI.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -140,7 +131,7 @@ func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 	})
 }
 
-func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 	st := s.Factory.MakeCAASModel(c, nil)
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -210,10 +201,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{&application.APIv9{api}}
 
-	results, err := apiV8.Get(params.ApplicationGet{
-		ApplicationName: "dashboard4miner",
-		BranchName:      model.GenerationMaster,
-	})
+	results, err := apiV8.Get(params.ApplicationGet{ApplicationName: "dashboard4miner"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "dashboard4miner",

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -64,7 +64,10 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}}
-	results, err := v4.Get(params.ApplicationGet{ApplicationName: "wordpress"})
+	results, err := v4.Get(params.ApplicationGet{
+		ApplicationName: "wordpress",
+		BranchName:      model.GenerationMaster,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -84,7 +87,10 @@ func (s *getSuite) TestClientApplicationGetSmoketestV4(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}
-	results, err := v5.Get(params.ApplicationGet{ApplicationName: "wordpress"})
+	results, err := v5.Get(params.ApplicationGet{
+		ApplicationName: "wordpress",
+		BranchName:      model.GenerationMaster,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -102,10 +108,13 @@ func (s *getSuite) TestClientApplicationGetSmoketestV5(c *gc.C) {
 	})
 }
 
-func (s *getSuite) TestClientApplicationGetIAASModelSmoketest(c *gc.C) {
+func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	results, err := s.applicationAPI.Get(params.ApplicationGet{ApplicationName: "wordpress"})
+	results, err := s.applicationAPI.Get(params.ApplicationGet{
+		ApplicationName: "wordpress",
+		BranchName:      model.GenerationMaster,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
@@ -184,14 +193,14 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 	storageAccess, err := application.GetStorageState(st)
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(st)
-	model, err := st.Model()
+	mod, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := application.NewAPIBase(
 		application.GetState(st),
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		model,
+		mod,
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
@@ -201,7 +210,10 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmoketest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiV8 := &application.APIv8{&application.APIv9{api}}
 
-	results, err := apiV8.Get(params.ApplicationGet{ApplicationName: "dashboard4miner"})
+	results, err := apiV8.Get(params.ApplicationGet{
+		ApplicationName: "dashboard4miner",
+		BranchName:      model.GenerationMaster,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "dashboard4miner",

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -185,9 +185,9 @@ type ApplicationGetArgs struct {
 type ApplicationGet struct {
 	ApplicationName string `json:"application"`
 
-	// Generation is the generation version that this
+	// BranchName identifies the "in-flight" branch that this
 	// request will retrieve application data for.
-	Generation string `json:"generation"`
+	BranchName string `json:"branch"`
 }
 
 // ApplicationGetResults holds results of the application Get call.

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -154,9 +154,9 @@ type ApplicationExpose struct {
 type ApplicationSet struct {
 	ApplicationName string `json:"application"`
 
-	// Generation is the generation version that this request
-	// will set application configuration options for.
-	Generation string `json:"generation"`
+	// BranchName identifies the "in-flight" branch that this
+	// request will set configuration for.
+	BranchName string `json:"branch"`
 
 	Options map[string]string `json:"options"`
 }
@@ -167,9 +167,9 @@ type ApplicationSet struct {
 type ApplicationUnset struct {
 	ApplicationName string `json:"application"`
 
-	// Generation is the generation version that this request
-	// will unset application configuration options for.
-	Generation string `json:"generation"`
+	// BranchName identifies the "in-flight" branch that this
+	// request will unset configuration for.
+	BranchName string `json:"branch"`
 
 	Options []string `json:"options"`
 }

--- a/core/model/generation.go
+++ b/core/model/generation.go
@@ -10,13 +10,9 @@ import (
 // TODO (manadart 2019-04-21) Change the nomenclature here to indicate "branch"
 // instead of "generation", and remove Current/Next.
 
-const (
-	// GenerationMaster is used to indicate the main model configuration,
-	// i.e. that not dealing with in-flight branches.
-	GenerationMaster = "master"
-
-	generationKeySuffix = "#next"
-)
+// GenerationMaster is used to indicate the main model configuration,
+// i.e. that not dealing with in-flight branches.
+const GenerationMaster = "master"
 
 // ValidateBranchName returns an error if the input name is not suitable for
 // identifying a new in-flight branch.
@@ -28,12 +24,6 @@ func ValidateBranchName(name string) error {
 		return errors.NotValidf("branch name %q", GenerationMaster)
 	}
 	return nil
-}
-
-// NextGenerationKey adds a suffix to the input key that designates it as being
-// for "next" generation config, and returns the result.
-func NextGenerationKey(key string) string {
-	return key + generationKeySuffix
 }
 
 // GenerationApplication represents changes to an application

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -259,7 +259,7 @@ settings:
 	modelDetails := jujuclient.ModelDetails{
 		ModelUUID:    st.ModelUUID(),
 		ModelType:    "caas",
-		ActiveBranch: "current",
+		ActiveBranch: coremodel.GenerationMaster,
 	}
 	c.Assert(s.ControllerStore.UpdateModel("kontroll", "admin/caas-model", modelDetails), jc.ErrorIsNil)
 

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -254,7 +254,7 @@ func (s *ApplicationSuite) TestSetCharmCharmSettings(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestSetCharmCharmSettingsForBranch(c *gc.C) {
-	c.Skip("To be rewritten when branch-based configuration reads are implemented.")
+	c.Assert(s.State.AddBranch("new-branch", "branch-user"), jc.ErrorIsNil)
 
 	newCh := s.AddConfigCharm(c, "mysql", stringConfig, 2)
 	err := s.mysql.SetCharm(state.SetCharmConfig{

--- a/state/settings.go
+++ b/state/settings.go
@@ -271,29 +271,6 @@ func (st *State) ReadSettings(collection, key string) (*Settings, error) {
 	return readSettings(st.db(), collection, key)
 }
 
-// TODO (manadart 2019-04-05): Remove this method when logic to apply deltas
-// from branches is implemented.
-// readSettingsOrCreateFromFallback attempts to retrieve settings first for the
-// requested key, then if not found, a non-empty fallback key.
-// If the fallback is used, the settings are created for the requested key.
-func readSettingsOrCreateFromFallback(db Database, collection, requestKey, fallbackKey string) (*Settings, error) {
-	s, err := readSettings(db, collection, requestKey)
-	if err == nil {
-		return s, nil
-	}
-	if fallbackKey == "" {
-		return nil, errors.Trace(err)
-	}
-
-	if errors.IsNotFound(err) {
-		s, err = readSettings(db, collection, fallbackKey)
-	}
-	if err == nil {
-		s, err = createSettings(db, collection, requestKey, s.Map())
-	}
-	return s, errors.Trace(err)
-}
-
 // readSettings returns the Settings for key.
 func readSettings(db Database, collection, key string) (*Settings, error) {
 	s := newSettings(db, collection, key)

--- a/state/unit.go
+++ b/state/unit.go
@@ -149,8 +149,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	}
 
 	// TODO (manadart 2019-02-21) Factor the current generation into this call.
-	s, err := charmSettingsWithDefaults(
-		u.st, u.doc.CharmURL, applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL), "")
+	s, err := charmSettingsWithDefaults(u.st, u.doc.CharmURL, u.doc.Application, model.GenerationMaster)
 	if err != nil {
 		return nil, errors.Annotatef(err, "charm config for unit %q", u.Name())
 	}


### PR DESCRIPTION
## Description of change

This patch:
- Removes old code based around the current/next generation idea.
- Merges stored branch deltas with settings when charm configuration is retrieved for a branch.
- Renames more generation variables to indicate branch names.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- Bootstrap.
- `juju deploy redis`.
- `juju branch test-branch`.
- `juju config redis databases=4 --branch master`.
- `juju config redis databases=8 --branch test-branch`.
- `juju config redis databases --branch master` shows 4.
- `juju config redis databases --branch test-branch` shows 8.

## Documentation changes

None.

## Bug reference

N/A
