### PR TITLE
Add machine.WatchContainers to the api and apiserver for

### DIFF
--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -54,6 +54,10 @@ type MutaterMachine interface {
 	//  - unit is add or removed and there is a lxd profile
 	WatchApplicationLXDProfiles() (watcher.NotifyWatcher, error)
 
+	// WatchContainers returns a watcher.StringsWatcher for watching
+	// containers of a given machine.
+	WatchContainers() (watcher.StringsWatcher, error)
+
 	// SetModificationStatus sets the provider specific modification status
 	// for a machine. Allowing the propagation of status messages to the
 	// operator.
@@ -184,6 +188,20 @@ func (m *Machine) WatchApplicationLXDProfiles() (watcher.NotifyWatcher, error) {
 		return nil, result.Error
 	}
 	return apiwatcher.NewNotifyWatcher(m.facade.RawAPICaller(), result), nil
+}
+
+// WatchContainers returns a StringsWatcher reporting changes to containers.
+func (m *Machine) WatchContainers() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	arg := params.Entity{Tag: m.tag.String()}
+	err := m.facade.FacadeCall("WatchContainers", arg, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return apiwatcher.NewStringsWatcher(m.facade.RawAPICaller(), result), nil
 }
 
 type UnitProfileInfo struct {

--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -198,6 +198,35 @@ func (api *InstanceMutaterAPI) WatchMachines() (params.StringsWatchResult, error
 	return result, nil
 }
 
+// WatchContainers starts a watcher to track Containers on a given
+// machine.
+func (api *InstanceMutaterAPI) WatchContainers(arg params.Entity) (params.StringsWatchResult, error) {
+	result := params.StringsWatchResult{}
+	canAccess, err := api.getAuthFunc()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	tag, err := names.ParseMachineTag(arg.Tag)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	machine, err := api.getCacheMachine(canAccess, tag)
+	if err != nil {
+		return result, err
+	}
+	watch, err := machine.WatchContainers()
+	if err != nil {
+		return result, err
+	}
+	if changes, ok := <-watch.Changes(); ok {
+		result.StringsWatcherId = api.resources.Register(watch)
+		result.Changes = changes
+	} else {
+		return result, errors.Errorf("cannot obtain initial machine containers")
+	}
+	return result, nil
+}
+
 // WatchApplicationLXDProfiles starts a watcher to track Applications with
 // LXD Profiles.
 func (api *InstanceMutaterAPI) WatchApplicationLXDProfiles(args params.Entities) (params.NotifyWatchResults, error) {

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -85,6 +85,7 @@ type ModelCacheMachine interface {
 	InstanceId() (instance.Id, error)
 	CharmProfiles() []string
 	WatchApplicationLXDProfiles() (cache.NotifyWatcher, error)
+	WatchContainers() (cache.StringsWatcher, error)
 	Units() ([]ModelCacheUnit, error)
 }
 

--- a/apiserver/facades/agent/instancemutater/mocks/modelcache_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/modelcache_mock.go
@@ -173,6 +173,19 @@ func (mr *MockModelCacheMachineMockRecorder) WatchApplicationLXDProfiles() *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationLXDProfiles", reflect.TypeOf((*MockModelCacheMachine)(nil).WatchApplicationLXDProfiles))
 }
 
+// WatchContainers mocks base method
+func (m *MockModelCacheMachine) WatchContainers() (cache.StringsWatcher, error) {
+	ret := m.ctrl.Call(m, "WatchContainers")
+	ret0, _ := ret[0].(cache.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchContainers indicates an expected call of WatchContainers
+func (mr *MockModelCacheMachineMockRecorder) WatchContainers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockModelCacheMachine)(nil).WatchContainers))
+}
+
 // MockModelCacheApplication is a mock of ModelCacheApplication interface
 type MockModelCacheApplication struct {
 	ctrl     *gomock.Controller

--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -159,6 +159,10 @@ func (m *modelCacheMachine) WatchApplicationLXDProfiles() (cache.NotifyWatcher, 
 	return m.Machine.WatchApplicationLXDProfiles()
 }
 
+func (m *modelCacheMachine) WatchContainers() (cache.StringsWatcher, error) {
+	return m.Machine.WatchContainers()
+}
+
 func (m *modelCacheMachine) Units() ([]ModelCacheUnit, error) {
 	units, err := m.Machine.Units()
 	if err != nil {

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -135,6 +135,19 @@ func (mr *MockMutaterMachineMockRecorder) WatchApplicationLXDProfiles() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationLXDProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).WatchApplicationLXDProfiles))
 }
 
+// WatchContainers mocks base method
+func (m *MockMutaterMachine) WatchContainers() (watcher.StringsWatcher, error) {
+	ret := m.ctrl.Call(m, "WatchContainers")
+	ret0, _ := ret[0].(watcher.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchContainers indicates an expected call of WatchContainers
+func (mr *MockMutaterMachineMockRecorder) WatchContainers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers))
+}
+
 // WatchUnits mocks base method
 func (m *MockMutaterMachine) WatchUnits() (watcher.StringsWatcher, error) {
 	ret := m.ctrl.Call(m, "WatchUnits")


### PR DESCRIPTION
## Description of change

Add machine.WatchContainers to the api and apiserver for InstanceMutater worker.

## QA steps

all unit tests should pass, no change to current juju functionality.