### PR TITLE
split NewWorker in Instance Mutater into environ and container

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -406,7 +406,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			EnvironName:   environTrackerName,
 			Logger:        loggo.GetLogger("juju.worker.instancemutater"),
 			NewClient:     instancemutater.NewClient,
-			NewWorker:     instancemutater.NewWorker,
+			NewWorker:     instancemutater.NewEnvironWorker,
 		}))
 	}
 


### PR DESCRIPTION
## Description of change

Add NewEnvironWorker() and NewContainerWorker() to specialize for starting from different manifolds.

## QA steps

export JUJU_DEV_FEATURE_FLAGS=instance-mutater
juju bootstrap
juju deploy the lxd-profile-alt charm -n 4
juju deploy the lxd-profile-subordinate and relate to above.
juju deploy the ubuntu charm -n 4 to same machines
upgrade all three
check the lxd profiles assigned
juju deploy a bundle


