### PR TITLE
Use WatchMachines instead of WatchModelMachines in Instance Mutater

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -152,7 +152,7 @@ func (w *srvNotifyWatcher) Next() error {
 // sending the changes as a list of strings.
 type srvStringsWatcher struct {
 	watcherCommon
-	watcher state.StringsWatcher
+	watcher cache.StringsWatcher
 }
 
 func newStringsWatcher(context facade.Context) (facade.Facade, error) {
@@ -165,7 +165,7 @@ func newStringsWatcher(context facade.Context) (facade.Facade, error) {
 	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
-	watcher, ok := resources.Get(id).(state.StringsWatcher)
+	watcher, ok := resources.Get(id).(cache.StringsWatcher)
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}
@@ -184,7 +184,10 @@ func (w *srvStringsWatcher) Next() (params.StringsWatchResult, error) {
 			Changes: changes,
 		}, nil
 	}
-	err := w.watcher.Err()
+	var err error
+	if e, ok := w.watcher.(hasErr); ok {
+		err = e.Err()
+	}
 	if err == nil {
 		err = common.ErrStoppedWatcher
 	}

--- a/worker/instancemutater/mocks/instancebroker_mock.go
+++ b/worker/instancemutater/mocks/instancebroker_mock.go
@@ -48,15 +48,15 @@ func (mr *MockInstanceMutaterAPIMockRecorder) Machine(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).Machine), arg0)
 }
 
-// WatchModelMachines mocks base method
-func (m *MockInstanceMutaterAPI) WatchModelMachines() (watcher.StringsWatcher, error) {
-	ret := m.ctrl.Call(m, "WatchModelMachines")
+// WatchMachines mocks base method
+func (m *MockInstanceMutaterAPI) WatchMachines() (watcher.StringsWatcher, error) {
+	ret := m.ctrl.Call(m, "WatchMachines")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchModelMachines indicates an expected call of WatchModelMachines
-func (mr *MockInstanceMutaterAPIMockRecorder) WatchModelMachines() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchModelMachines))
+// WatchMachines indicates an expected call of WatchMachines
+func (mr *MockInstanceMutaterAPIMockRecorder) WatchMachines() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchMachines))
 }

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -22,7 +22,7 @@ import (
 //go:generate mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
 
 type InstanceMutaterAPI interface {
-	WatchModelMachines() (watcher.StringsWatcher, error)
+	WatchMachines() (watcher.StringsWatcher, error)
 	Machine(tag names.MachineTag) (instancemutater.MutaterMachine, error)
 }
 
@@ -83,7 +83,7 @@ func (config Config) Validate() error {
 // the machines in the state and polls their instance
 // for addition or removal changes.
 func NewEnvironWorker(config Config) (worker.Worker, error) {
-	config.GetMachineWatcher = config.Facade.WatchModelMachines
+	config.GetMachineWatcher = config.Facade.WatchMachines
 	return newWorker(config)
 }
 

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -403,7 +403,7 @@ func (s *workerSuite) notifyMachines(values [][]string, doneFn func()) func() {
 		s.machinesWorker.EXPECT().Kill().AnyTimes()
 		s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-		s.facade.EXPECT().WatchModelMachines().Return(
+		s.facade.EXPECT().WatchMachines().Return(
 			&fakeStringsWatcher{
 				Worker: s.machinesWorker,
 				ch:     ch,


### PR DESCRIPTION
## Description of change

Use WatchMachines instead of WatchModelMachines in Instance Mutater.  StringsWatcher changes like previous NotifyWatcher changes to use the model cache watcher in apiserver.

## QA steps

export JUJU_DEV_FEATURE_FLAGS=instance-mutater
juju bootstrap
juju deploy the lxd-profile-alt charm -n 4
juju deploy the lxd-profile-subordinate and relate to above.
juju deploy the ubuntu charm -n 4 to same machines
upgrade all three
check the lxd profiles assigned
juju deploy a bundle

