### PR TITLE
Surface pod provisioning errors

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -923,6 +923,10 @@ func (api *APIBase) setCharmWithAgentValidation(
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if api.modelType == state.ModelTypeCAAS {
+		return api.applicationSetCharm(params, newCharm)
+	}
+
 	application := params.Application
 	// Check if the controller agent tools version is greater than the
 	// version we support for the new LXD profiles.

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -207,6 +207,11 @@ func (m *mockApplication) SetOperatorStatus(sInfo status.StatusInfo) error {
 	return nil
 }
 
+func (m *mockApplication) SetStatus(sInfo status.StatusInfo) error {
+	m.MethodCall(m, "SetStatus", sInfo)
+	return nil
+}
+
 type mockContainerInfo struct {
 	state.CloudContainer
 	providerId string

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -489,6 +489,20 @@ func (a *Facade) UpdateApplicationsUnits(args params.UpdateApplicationUnitArgs) 
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
+		appStatus := appUpdate.Status
+		if appStatus.Status != "" && appStatus.Status != status.Unknown {
+			now := a.clock.Now()
+			err = app.SetStatus(status.StatusInfo{
+				Status:  appStatus.Status,
+				Message: appStatus.Info,
+				Data:    appStatus.Data,
+				Since:   &now,
+			})
+			if err != nil {
+				result.Results[i].Error = common.ServerError(err)
+				continue
+			}
+		}
 		err = a.updateUnitsFromCloud(app, appUpdate.Scale, appUpdate.Units)
 		if err != nil {
 			// Mask any not found errors as the worker (caller) treats them specially

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -386,7 +386,9 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsScaleChange(c *gc.C) {
 	}
 	args := params.UpdateApplicationUnitArgs{
 		Args: []params.UpdateApplicationUnits{
-			{ApplicationTag: "application-gitlab", Units: units, Scale: intPtr(2)},
+			{ApplicationTag: "application-gitlab",
+				Units: units, Scale: intPtr(2),
+				Status: params.EntityStatus{Status: status.Active, Info: "working"}},
 		},
 	}
 	results, err := s.facade.UpdateApplicationsUnits(args)
@@ -396,8 +398,11 @@ func (s *CAASProvisionerSuite) TestUpdateApplicationsScaleChange(c *gc.C) {
 			{nil},
 		},
 	})
-	s.st.application.CheckCallNames(c, "Life", "Name", "GetScale", "SetScale")
-	s.st.application.CheckCall(c, 3, "SetScale", 2)
+	s.st.application.CheckCallNames(c, "SetStatus", "Life", "Name", "GetScale", "SetScale")
+	now := s.clock.Now()
+	s.st.application.CheckCall(c, 0, "SetStatus",
+		status.StatusInfo{Status: status.Active, Message: "working", Since: &now})
+	s.st.application.CheckCall(c, 4, "SetScale", 2)
 
 	s.st.application.units[0].(*mockUnit).CheckCallNames(c, "Life", "UpdateOperation")
 	// CloudContainer message is not overwritten based on agent status

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -81,6 +81,7 @@ type Application interface {
 	Constraints() (constraints.Value, error)
 	GetPlacement() string
 	SetOperatorStatus(sInfo status.StatusInfo) error
+	SetStatus(statusInfo status.StatusInfo) error
 }
 
 type stateShim struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -375,6 +375,7 @@ type UpdateApplicationUnitArgs struct {
 type UpdateApplicationUnits struct {
 	ApplicationTag string                  `json:"application-tag"`
 	Scale          *int                    `json:"scale,omitempty"`
+	Status         EntityStatus            `json:"status,omitempty"`
 	Units          []ApplicationUnitParams `json:"units"`
 }
 

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -229,6 +229,7 @@ type Service struct {
 	Id        string
 	Addresses []network.Address
 	Scale     *int
+	Status    status.StatusInfo
 }
 
 // FilesystemInfo represents information about a filesystem

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
@@ -154,11 +155,12 @@ func (aw *applicationWorker) loop() error {
 				brokerUnitsWatcher = nil
 				continue
 			}
-			scale, err := aw.getScale()
-			if err != nil {
+			service, err := aw.serviceBroker.GetService(aw.application)
+			if err != nil && !errors.IsNotFound(err) {
 				return errors.Trace(err)
 			}
-			if err := aw.clusterChanged(scale, lastReportedStatus); err != nil {
+			logger.Debugf("service for %v: %+v", aw.application, service)
+			if err := aw.clusterChanged(service, lastReportedStatus); err != nil {
 				return errors.Trace(err)
 			}
 		case _, ok := <-appDeploymentWatcher.Changes():
@@ -169,15 +171,32 @@ func (aw *applicationWorker) loop() error {
 				appDeploymentWatcher = nil
 				continue
 			}
-			scale, err := aw.getScale()
-			if err != nil {
+			service, err := aw.serviceBroker.GetService(aw.application)
+			if err != nil && !errors.IsNotFound(err) {
 				return errors.Trace(err)
 			}
-			if scale == nil || *scale == lastReportedScale {
-				continue
+			haveNewStatus := true
+			if service.Id != "" {
+				lastStatus, ok := lastReportedStatus[service.Id]
+				lastReportedStatus[service.Id] = service.Status
+				if ok {
+					// If we've seen the same status value previously,
+					// report as unknown as this value is ignored.
+					if reflect.DeepEqual(lastStatus, service.Status) {
+						service.Status = status.StatusInfo{
+							Status: status.Unknown,
+						}
+						haveNewStatus = false
+					}
+				}
 			}
-			lastReportedScale = *scale
-			if err := aw.clusterChanged(scale, lastReportedStatus); err != nil {
+			if service != nil && service.Scale != nil {
+				if *service.Scale == lastReportedScale && !haveNewStatus {
+					continue
+				}
+				lastReportedScale = *service.Scale
+			}
+			if err := aw.clusterChanged(service, lastReportedStatus); err != nil {
 				return errors.Trace(err)
 			}
 		case _, ok := <-appOperatorWatcher.Changes():
@@ -206,27 +225,25 @@ func (aw *applicationWorker) loop() error {
 	}
 }
 
-func (aw *applicationWorker) getScale() (*int, error) {
-	service, err := aw.serviceBroker.GetService(aw.application)
-	if errors.IsNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("service for %v: %+v", aw.application, service)
-	return service.Scale, nil
-}
-
-func (aw *applicationWorker) clusterChanged(scale *int, lastReportedStatus map[string]status.StatusInfo) error {
+func (aw *applicationWorker) clusterChanged(service *caas.Service, lastReportedStatus map[string]status.StatusInfo) error {
 	units, err := aw.containerBroker.Units(aw.application)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	logger.Debugf("units for %v: %+v", aw.application, units)
+	serviceStatus := service.Status
+	var scale *int
+	if service != nil {
+		scale = service.Scale
+	}
 	args := params.UpdateApplicationUnits{
 		ApplicationTag: names.NewApplicationTag(aw.application).String(),
 		Scale:          scale,
+		Status: params.EntityStatus{
+			Status: serviceStatus.Status,
+			Info:   serviceStatus.Message,
+			Data:   serviceStatus.Data,
+		},
 	}
 	for _, u := range units {
 		// For pods managed by the substrate, any marked as dying

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -42,6 +42,7 @@ type mockServiceBroker struct {
 	ensured        chan<- struct{}
 	deleted        chan<- struct{}
 	podSpec        *caas.PodSpec
+	serviceStatus  status.StatusInfo
 	serviceWatcher *watchertest.MockNotifyWatcher
 }
 
@@ -68,7 +69,10 @@ func (m *mockServiceBroker) EnsureCustomResourceDefinition(appName string, podSp
 func (m *mockServiceBroker) GetService(appName string) (*caas.Service, error) {
 	m.MethodCall(m, "Service", appName)
 	scale := 4
-	return &caas.Service{Id: "id", Scale: &scale, Addresses: []network.Address{{Value: "10.0.0.1"}}}, m.NextErr()
+	return &caas.Service{
+		Id: "id", Scale: &scale, Addresses: []network.Address{{Value: "10.0.0.1"}},
+		Status: m.serviceStatus,
+	}, m.NextErr()
 }
 
 func (m *mockServiceBroker) WatchService(appName string) (watcher.NotifyWatcher, error) {

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -321,6 +321,10 @@ func (s *WorkerSuite) TestScaleChangedInCluster(c *gc.C) {
 
 	s.containerBroker.ResetCalls()
 	s.serviceBroker.ResetCalls()
+	s.serviceBroker.serviceStatus = status.StatusInfo{
+		Status:  status.Active,
+		Message: "working",
+	}
 
 	select {
 	case s.caasServiceChanges <- struct{}{}:
@@ -355,6 +359,10 @@ func (s *WorkerSuite) TestScaleChangedInCluster(c *gc.C) {
 		params.UpdateApplicationUnits{
 			ApplicationTag: names.NewApplicationTag("gitlab").String(),
 			Scale:          &scale,
+			Status: params.EntityStatus{
+				Status: status.Active,
+				Info:   "working",
+			},
 			Units: []params.ApplicationUnitParams{
 				{ProviderId: "u1", Address: "10.0.0.1", Ports: []string(nil),
 					Stateful: true,
@@ -785,7 +793,7 @@ func (s *WorkerSuite) TestOperatorChange(c *gc.C) {
 	})
 }
 
-func (s *WorkerSuite) assertUnitChange(c *gc.C, reported, expected status.Status) {
+func (s *WorkerSuite) assertUnitChange(c *gc.C, reported, expectedUnitStatus status.Status) {
 	s.containerBroker.ResetCalls()
 	s.unitUpdater.ResetCalls()
 	s.containerBroker.reportedUnitStatus = reported
@@ -816,7 +824,7 @@ func (s *WorkerSuite) assertUnitChange(c *gc.C, reported, expected status.Status
 			ApplicationTag: names.NewApplicationTag("gitlab").String(),
 			Scale:          &scale,
 			Units: []params.ApplicationUnitParams{
-				{ProviderId: "u1", Address: "10.0.0.1", Ports: []string(nil), Status: expected.String(),
+				{ProviderId: "u1", Address: "10.0.0.1", Ports: []string(nil), Status: expectedUnitStatus.String(),
 					Stateful: true,
 					FilesystemInfo: []params.KubernetesFilesystemInfo{
 						{StorageName: "database", MountPoint: "/path-to-here", ReadOnly: true,


### PR DESCRIPTION
## Description of change

The pod spec and/or config such as securityContext may not allow any workload pods to be provisioned by the statefulset or deployment controller. These errors are now surfaced in juju status.

## QA steps

bootstrap k8s and deploy a charm with a bad pod spec
check juju status shows the error

## Bug reference

https://bugs.launchpad.net/juju/+bug/1814055