### PR TITLE
Extra checks for built-in MicroK8s

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -32,7 +32,15 @@ func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, jujucloud.Crede
 			return clientconfig.NewClientConfigReader(caasType)
 		},
 	}
-	return CloudFromKubeConfig(rdr, cloudParams)
+	newCloud, credential, credentialName, err := CloudFromKubeConfig(rdr, cloudParams)
+	if err != nil {
+		return newCloud, jujucloud.Credential{}, "", err
+	}
+	newCloud.Regions = []jujucloud.Region{{
+		Name: caas.Microk8sRegion,
+	}}
+	newCloud.Description = cloud.DefaultCloudDescription(cloud.CloudTypeCAAS)
+	return newCloud, credential, credentialName, nil
 }
 
 func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloud"
 )
@@ -95,7 +96,17 @@ func (s *builtinSuite) TestAttemptMicroK8sCloud(c *gc.C) {
 
 	k8sCloud, credential, credentialName, err := provider.AttemptMicroK8sCloud(s.runner)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(k8sCloud, gc.DeepEquals, defaultK8sCloud)
+	c.Assert(k8sCloud, gc.DeepEquals, cloud.Cloud{
+		Name:           caas.K8sCloudMicrok8s,
+		Endpoint:       "http://1.1.1.1:8080",
+		Type:           cloud.CloudTypeCAAS,
+		AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
+		CACertificates: []string{""},
+		Description:    cloud.DefaultCloudDescription(cloud.CloudTypeCAAS),
+		Regions: []cloud.Region{{
+			Name: "localhost",
+		}},
+	})
 	c.Assert(credential, gc.DeepEquals, getDefaultCredential())
 	c.Assert(credentialName, gc.Equals, "admin")
 }

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -240,10 +240,8 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	}
 
 	// if storage is already defined there is no need to query the cluster
-	if opStorage, ok := cld.Config[OperatorStorageKey]; ok {
-		if opStorage != nil && opStorage != "" {
-			return cld, nil
-		}
+	if opStorage, ok := cld.Config[OperatorStorageKey]; ok && opStorage != "" {
+		return cld, nil
 	}
 
 	// Need the credentials, need to query for those details
@@ -321,6 +319,5 @@ func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 }
 
 type microk8sStatus struct {
-	Microk8s map[string]string `yaml:"microk8s"`
-	Addons   map[string]string `yaml:"addons"`
+	Addons map[string]string `yaml:"addons"`
 }

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -229,6 +229,8 @@ func BaseKubeCloudOpenParams(cloud jujucloud.Cloud, credential jujucloud.Credent
 
 // FinalizeCloud is part of the environs.CloudFinalizer interface.
 func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
+	// We special case Microk8s here as we need to query the cluster for the
+	// storage details with no input from the user
 	if cld.Name != caas.K8sCloudMicrok8s {
 		return cld, nil
 	}
@@ -239,12 +241,7 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 
 	// if storage is already defined there is no need to query the cluster
 	if opStorage, ok := cld.Config[OperatorStorageKey]; ok {
-		if opStorage == nil || opStorage == "" {
-			return cld, nil
-		}
-	}
-	if workStorage, ok := cld.Config[WorkloadStorageKey]; ok {
-		if workStorage == nil || workStorage == "" {
+		if opStorage != nil && opStorage != "" {
 			return cld, nil
 		}
 	}

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -227,10 +227,14 @@ func BaseKubeCloudOpenParams(cloud jujucloud.Cloud, credential jujucloud.Credent
 
 // FinalizeCloud is part of the environs.CloudFinalizer interface.
 func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
-	cloudName := cld.Name
-	if cloudName != caas.K8sCloudMicrok8s {
+	if cld.Name != caas.K8sCloudMicrok8s {
 		return cld, nil
 	}
+
+	if cld.Config["operator-storage"] != nil && cld.Config["workload-storage"] != nil {
+		return cld, nil
+	}
+
 	// Need the credentials, need to query for those details
 	mk8sCloud, credential, _, err := p.builtinCloudGetter(p.cmdRunner)
 	if err != nil {

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas"
@@ -23,8 +24,43 @@ var (
 	_ = gc.Suite(&cloudSuite{})
 )
 
+var microk8sStatusEnabled = `
+microk8s:
+  running: true
+addons:
+  jaeger: disabled
+  fluentd: disabled
+  gpu: disabled
+  storage: enabled
+  registry: disabled
+  ingress: disabled
+  dns: enabled
+  metrics-server: disabled
+  prometheus: disabled
+  istio: disabled
+  dashboard: disabled
+`
+
+var microk8sStatusDisabled = `
+microk8s:
+  running: true
+addons:
+  jaeger: disabled
+  fluentd: disabled
+  gpu: disabled
+  storage: disabled
+  registry: disabled
+  ingress: disabled
+  dns: enabled
+  metrics-server: disabled
+  prometheus: disabled
+  istio: disabled
+  dashboard: disabled
+`
+
 type cloudSuite struct {
 	fakeBroker fakeK8sClusterMetadataChecker
+	runner     dummyRunner
 }
 
 var defaultK8sCloud = jujucloud.Cloud{
@@ -50,6 +86,7 @@ func getDefaultCredential() cloud.Credential {
 func (s *cloudSuite) SetUpTest(c *gc.C) {
 	var logger loggo.Logger
 	s.fakeBroker = fakeK8sClusterMetadataChecker{CallMocker: testing.NewCallMocker(logger)}
+	s.runner = dummyRunner{CallMocker: testing.NewCallMocker(logger)}
 }
 
 func (s *cloudSuite) TestFinalizeCloudNotMicrok8s(c *gc.C) {
@@ -70,6 +107,11 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
 
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
+
 	var ctx mockContext
 	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
@@ -85,14 +127,73 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	})
 }
 
+func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
+	preparedCloud := jujucloud.Cloud{
+		Name:            caas.K8sCloudMicrok8s,
+		Type:            jujucloud.CloudTypeCAAS,
+		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
+		CACertificates:  []string{""},
+		Endpoint:        "http://1.1.1.1:8080",
+		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
+		Config:          map[string]interface{}{"operator-storage": "something-else", "workload-storage": "", "controller-service-type": ""},
+		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
+	}
+
+	p := s.getProvider()
+	cloudFinalizer := p.(environs.CloudFinalizer)
+
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
+
+	var ctx mockContext
+	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, preparedCloud)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{
+		Name:            caas.K8sCloudMicrok8s,
+		Type:            jujucloud.CloudTypeCAAS,
+		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
+		CACertificates:  []string{""},
+		Endpoint:        "http://1.1.1.1:8080",
+		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
+		Config:          map[string]interface{}{"operator-storage": "something-else", "workload-storage": "", "controller-service-type": ""},
+		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
+	})
+}
+
 func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 	s.fakeBroker.Call("GetClusterMetadata").Returns(defaultClusterMetadata, nil)
 	s.fakeBroker.Call("CheckDefaultWorkloadStorage").Returns(nil)
 	return provider.NewProviderWithFakes(
-		dummyRunner{},
+		s.runner,
 		getterFunc(builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}),
 		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
 	)
+}
+
+func (s *cloudSuite) TestMicroK8sStorageEnabledSuccessEnabled(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
+	c.Assert(provider.MicroK8sStorageEnabled(s.runner), gc.Equals, true)
+}
+
+func (s *cloudSuite) TestMicroK8sStorageEnabledSuccessDisabled(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDisabled)}, nil)
+	c.Assert(provider.MicroK8sStorageEnabled(s.runner), gc.Equals, false)
+}
+
+func (s *cloudSuite) TestMicroK8sStorageEnabledError(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		&exec.ExecResponse{Code: 1}, nil)
+	c.Assert(provider.MicroK8sStorageEnabled(s.runner), gc.Equals, false)
 }
 
 type mockContext struct {

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -32,6 +32,7 @@ var (
 	ControllerCorelation     = controllerCorelation
 	GetLocalMicroK8sConfig   = getLocalMicroK8sConfig
 	AttemptMicroK8sCloud     = attemptMicroK8sCloud
+	MicroK8sStorageEnabled   = microK8sStorageEnabled
 )
 
 type (

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -32,7 +32,7 @@ var (
 	ControllerCorelation     = controllerCorelation
 	GetLocalMicroK8sConfig   = getLocalMicroK8sConfig
 	AttemptMicroK8sCloud     = attemptMicroK8sCloud
-	MicroK8sStorageEnabled   = microK8sStorageEnabled
+	EnsureMicroK8sSuitable   = ensureMicroK8sSuitable
 )
 
 type (


### PR DESCRIPTION
## Description of change

For builtin MicroK8s at bootstrap check that storage is enabled and fail if not (with message).
Also make sure we don't re-query for storage details if it is already defined for the cloud.
## QA steps

unit tests cover the changes.

## Documentation changes

n/a
## Bug reference

n/a