### PR TITLE
Juju login to controller IP with (optional) CA verification

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"net/url"
 	"time"
@@ -174,6 +175,12 @@ type DialOpts struct {
 	// Clock is used as a time source for retries.
 	// If it is nil, clock.WallClock will be used.
 	Clock clock.Clock
+
+	// VerifyCA is an optional callback that is invoked by the dialer when
+	// the remote server presents a CA certificate that cannot be
+	// automatically verified. If the callback returns a non-nil error then
+	// the connection attempt will be aborted.
+	VerifyCA func(host, endpoint string, caCert *x509.Certificate) error
 }
 
 // IPAddrResolver implements a resolved from host name to the

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -193,7 +194,11 @@ func IsCodeUnauthorized(err error) bool {
 }
 
 func IsCodeNoCreds(err error) bool {
-	return ErrCode(err) == CodeNoCreds
+	// When we receive this error from an rpc call, rpc.RequestError
+	// is populated with a CodeUnauthorized code and a message that
+	// is formatted as "$CodeNoCreds ($CodeUnauthorized)".
+	ec := ErrCode(err)
+	return ec == CodeNoCreds || (ec == CodeUnauthorized && strings.HasPrefix(errors.Cause(err).Error(), CodeNoCreds))
 }
 
 func IsCodeLoginExpired(err error) bool {

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -618,12 +618,10 @@ func ensureNotKnownEndpoint(store jujuclient.ClientStore, endpoint string) error
 	}
 
 	if accountDetails != nil {
-		logger.Warningf(`This controller has already been registered on this client as %q
-To login user %q run 'juju login -u %s -c %s'.`, existingName, accountDetails.User, accountDetails.User, existingName)
-	} else {
-		logger.Warningf(`This controller has already been registered on this client as %q
-To login run 'juju login -c %s'.`, existingName, existingName)
+		return errors.Errorf(`This controller has already been registered on this client as %q
+To login as user %q run 'juju login -u %s -c %s'.`, existingName, accountDetails.User, accountDetails.User, existingName)
 	}
 
-	return errors.Errorf("controller is already registered as %q", existingName)
+	return errors.Errorf(`This controller has already been registered on this client as %q
+To login run 'juju login -c %s'.`, existingName, existingName)
 }

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/juju/juju/api"
 	apibase "github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
 )
 
 type LoginCommandSuite struct {
@@ -258,6 +260,82 @@ Welcome, new-user. You are now logged into "testing".
 
 There are no models available(.|\n)*`[1:])
 	c.Assert(code, gc.Equals, 0)
+}
+
+func (s *LoginCommandSuite) TestLoginWithCAVerification(c *gc.C) {
+	caCert := testing.CACertX509
+	fingerprint, err := cert.Fingerprint(testing.CACert)
+	c.Assert(err, jc.ErrorIsNil)
+
+	specs := []struct {
+		descr    string
+		input    string
+		host     string
+		endpoint string
+		expRegex string
+		expCode  int
+	}{
+		{
+			descr:    "user trusts CA cert",
+			input:    "y\n",
+			host:     "myprivatecontroller:443",
+			endpoint: "127.0.0.1:443",
+			expRegex: `
+Controller "myprivatecontroller:443" (127.0.0.1:443) presented a CA cert that could not be verified.
+CA fingerprint: [` + fingerprint + `]
+Trust remote controller? (y/N): 
+Welcome, new-user. You are now logged into "foo".
+
+There are no models available. You can add models with
+"juju add-model", or you can ask an administrator or owner
+of a model to grant access to that model with "juju grant".
+`,
+		},
+		{
+			descr:    "user does not trust CA cert",
+			input:    "n\n",
+			host:     "myprivatecontroller:443",
+			endpoint: "127.0.0.1:443",
+			expRegex: `
+Controller "myprivatecontroller:443" (127.0.0.1:443) presented a CA cert that could not be verified.
+CA fingerprint: [` + fingerprint + `]
+Trust remote controller? (y/N): 
+ERROR cannot log into "myprivatecontroller:443": controller CA not trusted
+`,
+			expCode: 1,
+		},
+		{
+			descr:    "user does not trust CA cert when logging to a controller IP",
+			input:    "n\n",
+			host:     "127.0.0.1:443",
+			endpoint: "127.0.0.1:443",
+			expRegex: `
+Controller "127.0.0.1:443" presented a CA cert that could not be verified.
+CA fingerprint: [` + fingerprint + `]
+Trust remote controller? (y/N): 
+ERROR cannot log into "127.0.0.1:443": controller CA not trusted
+`,
+			expCode: 1,
+		},
+	}
+
+	for specIndex, spec := range specs {
+		c.Logf("test %d: %s", specIndex, spec.descr)
+		_ = s.store.RemoveAccount("foo")
+		_ = s.store.RemoveController("foo")
+
+		*user.APIOpen = func(c *modelcmd.CommandBase, info *api.Info, opts api.DialOpts) (api.Connection, error) {
+			if err := opts.VerifyCA(spec.host, spec.endpoint, caCert); err != nil {
+				return nil, err
+			}
+			return s.apiConnection, nil
+		}
+
+		stdout, stderr, code := runLogin(c, spec.input, spec.host, "-c", "foo", "-u", "new-user")
+		c.Check(stdout, gc.Equals, ``)
+		c.Check(stderr, gc.Equals, spec.expRegex[1:])
+		c.Assert(code, gc.Equals, spec.expCode)
+	}
 }
 
 func runLogin(c *gc.C, stdin string, args ...string) (stdout, stderr string, errCode int) {

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -335,6 +335,14 @@ ERROR cannot log into "127.0.0.1:443": controller CA not trusted
 		c.Check(stdout, gc.Equals, ``)
 		c.Check(stderr, gc.Equals, spec.expRegex[1:])
 		c.Assert(code, gc.Equals, spec.expCode)
+
+		// For successful login make sure that the controller CA cert
+		// gets persisted in the controller store
+		if code == 0 {
+			ctrl, err := s.store.ControllerByName("foo")
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(ctrl.CACert, gc.Equals, testing.CACert)
+		}
 	}
 }
 

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -370,21 +370,24 @@ func (s *LoginCommandSuite) TestLoginUsingKnownControllerEndpoint(c *gc.C) {
 			descr: "user provides an endpoint as the controller name and has a local account for the controller",
 			cmd:   []string{details.APIEndpoints[0]},
 			expErr: `
-ERROR controller is already registered as "` + existingName + `"
+ERROR This controller has already been registered on this client as "` + existingName + `"
+To login as user "current-user" run 'juju login -u current-user -c ` + existingName + `'.
 `,
 		},
 		{
 			descr: "user provides an endpoint as the controller name and does not have a local account for the controller",
 			cmd:   []string{"1.1.1.1:12345"},
 			expErr: `
-ERROR controller is already registered as "controller-with-no-account"
+ERROR This controller has already been registered on this client as "controller-with-no-account"
+To login run 'juju login -c controller-with-no-account'.
 `,
 		},
 		{
 			descr: "user provides an endpoint and overrides the controller name",
 			cmd:   []string{details.APIEndpoints[0], "-c", "some-controller-name"},
 			expErr: `
-ERROR controller is already registered as "` + existingName + `"
+ERROR This controller has already been registered on this client as "` + existingName + `"
+To login as user "current-user" run 'juju login -u current-user -c ` + existingName + `'.
 `,
 		},
 	}

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -220,7 +220,8 @@ func (s *LoginCommandSuite) TestLoginWithExistingInvalidPassword(c *gc.C) {
 	stdout, stderr, code := runLogin(c, "other-user\n")
 	c.Check(code, gc.Equals, 0)
 	c.Check(stdout, gc.Equals, "")
-	c.Check(stderr, gc.Matches, `username: Welcome, other-user. (.|\n)+`)
+	c.Check(stderr, gc.Matches, `Enter username: 
+Welcome, other-user. (.|\n)+`)
 }
 
 func (s *LoginCommandSuite) TestLoginWithMacaroons(c *gc.C) {
@@ -252,7 +253,8 @@ func (s *LoginCommandSuite) TestLoginWithMacaroonsNotSupported(c *gc.C) {
 	stdout, stderr, code := runLogin(c, "new-user\n")
 	c.Check(stdout, gc.Equals, ``)
 	c.Check(stderr, gc.Matches, `
-username: Welcome, new-user. You are now logged into "testing".
+Enter username: 
+Welcome, new-user. You are now logged into "testing".
 
 There are no models available(.|\n)*`[1:])
 	c.Assert(code, gc.Equals, 0)

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -62,6 +62,23 @@ func (s *ControllersSuite) TestControllerByName(c *gc.C) {
 	c.Assert(found, jc.DeepEquals, &expected)
 }
 
+func (s *ControllersSuite) TestControllerByAPIEndpoints(c *gc.C) {
+	name := firstTestControllerName(c)
+	expected := s.getControllers(c)[name]
+	found, foundName, err := s.store.ControllerByAPIEndpoints(expected.APIEndpoints...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, jc.DeepEquals, &expected)
+	c.Assert(foundName, gc.Equals, name)
+}
+
+func (s *ControllersSuite) TestControllerByAPIEndpointsNoneExists(c *gc.C) {
+	writeTestControllersFile(c)
+	found, foundName, err := s.store.ControllerByAPIEndpoints("1.1.1.1:17070")
+	c.Assert(err, gc.ErrorMatches, "controller with API endpoints .* not found")
+	c.Assert(found, gc.IsNil)
+	c.Assert(foundName, gc.Equals, "")
+}
+
 func (s *ControllersSuite) TestAddController(c *gc.C) {
 	err := s.store.AddController(s.controllerName, s.controller)
 	c.Assert(err, jc.ErrorIsNil)

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -183,6 +183,12 @@ type ControllerGetter interface {
 	// satisfying errors.IsNotFound will be returned.
 	ControllerByName(controllerName string) (*ControllerDetails, error)
 
+	// ControllerByAPIEndpoints returns the details and name of the
+	// controller where the set of API endpoints contains any of the
+	// provided endpoints. If no controller can be located, an error
+	// satisfying errors.IsNotFound will be returned.
+	ControllerByAPIEndpoints(endpoints ...string) (*ControllerDetails, string, error)
+
 	// CurrentController returns the name of the current controller.
 	// If there is no current controller, an error satisfying
 	// errors.IsNotFound will be returned.

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -13,13 +13,14 @@ import (
 type StubStore struct {
 	*testing.Stub
 
-	AllControllersFunc       func() (map[string]jujuclient.ControllerDetails, error)
-	ControllerByNameFunc     func(name string) (*jujuclient.ControllerDetails, error)
-	AddControllerFunc        func(name string, one jujuclient.ControllerDetails) error
-	UpdateControllerFunc     func(name string, one jujuclient.ControllerDetails) error
-	RemoveControllerFunc     func(name string) error
-	SetCurrentControllerFunc func(name string) error
-	CurrentControllerFunc    func() (string, error)
+	AllControllersFunc           func() (map[string]jujuclient.ControllerDetails, error)
+	ControllerByNameFunc         func(name string) (*jujuclient.ControllerDetails, error)
+	ControllerByAPIEndpointsFunc func(endpoints ...string) (*jujuclient.ControllerDetails, string, error)
+	AddControllerFunc            func(name string, one jujuclient.ControllerDetails) error
+	UpdateControllerFunc         func(name string, one jujuclient.ControllerDetails) error
+	RemoveControllerFunc         func(name string) error
+	SetCurrentControllerFunc     func(name string) error
+	CurrentControllerFunc        func() (string, error)
 
 	UpdateModelFunc     func(controller, model string, details jujuclient.ModelDetails) error
 	SetCurrentModelFunc func(controller, model string) error
@@ -52,6 +53,9 @@ func NewStubStore() *StubStore {
 	}
 	result.ControllerByNameFunc = func(name string) (*jujuclient.ControllerDetails, error) {
 		return nil, result.Stub.NextErr()
+	}
+	result.ControllerByAPIEndpointsFunc = func(endpoints ...string) (*jujuclient.ControllerDetails, string, error) {
+		return nil, "", result.Stub.NextErr()
 	}
 	result.AddControllerFunc = func(name string, one jujuclient.ControllerDetails) error {
 		return result.Stub.NextErr()
@@ -130,6 +134,7 @@ func WrapClientStore(underlying jujuclient.ClientStore) *StubStore {
 	stub := NewStubStore()
 	stub.AllControllersFunc = underlying.AllControllers
 	stub.ControllerByNameFunc = underlying.ControllerByName
+	stub.ControllerByAPIEndpointsFunc = underlying.ControllerByAPIEndpoints
 	stub.AddControllerFunc = underlying.AddController
 	stub.UpdateControllerFunc = underlying.UpdateController
 	stub.RemoveControllerFunc = underlying.RemoveController
@@ -161,6 +166,12 @@ func (c *StubStore) AllControllers() (map[string]jujuclient.ControllerDetails, e
 func (c *StubStore) ControllerByName(name string) (*jujuclient.ControllerDetails, error) {
 	c.MethodCall(c, "ControllerByName", name)
 	return c.ControllerByNameFunc(name)
+}
+
+// ControllerByAPIEndpoints implements ControllersGetter.ControllerByAPIEndpoints
+func (c *StubStore) ControllerByAPIEndpoints(endpoints ...string) (*jujuclient.ControllerDetails, string, error) {
+	c.MethodCall(c, "ControllerByAPIEndpoints", endpoints)
+	return c.ControllerByAPIEndpointsFunc(endpoints...)
 }
 
 // AddController implements ControllerUpdater.AddController

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -63,6 +63,22 @@ func (c *MemStore) ControllerByName(name string) (*ControllerDetails, error) {
 	return nil, errors.NotFoundf("controller %s", name)
 }
 
+// ControllerByAPIEndpoints implements ControllersGetter.ControllerByAPIEndpoints
+func (c *MemStore) ControllerByAPIEndpoints(endpoints ...string) (*ControllerDetails, string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	matchEps := set.NewStrings(endpoints...)
+	for name, ctrl := range c.Controllers {
+		if matchEps.Intersection(set.NewStrings(ctrl.APIEndpoints...)).IsEmpty() {
+			continue
+		}
+
+		return &ctrl, name, nil
+	}
+	return nil, "", errors.NotFoundf("controller with API endpoints %v", endpoints)
+}
+
 // CurrentController implements ControllerGetter.CurrentController
 func (c *MemStore) CurrentController() (string, error) {
 	c.mu.Lock()

--- a/testing/cert.go
+++ b/testing/cert.go
@@ -37,7 +37,8 @@ var (
 	Certs = serverCerts()
 
 	// Other valid test certs different from the default.
-	OtherCACert, OtherCAKey = mustNewCA()
+	OtherCACert, OtherCAKey        = mustNewCA()
+	OtherCACertX509, OtherCAKeyRSA = mustParseCertAndKey(OtherCACert, OtherCAKey)
 )
 
 func verifyCertificates() error {


### PR DESCRIPTION
## Description of change

This PR updates the apiserver so it exposes full certificate chain (up to and including the CA cert) as part of the regular TLS handshake. This is achieved by modifying `apiservercertwatcher` to append the CA cert to the new certs that it observes making the full chain available to the worker that serves the API.

Having access to the CA allows us to display its fingerprint to users trying to login to **unknown** controllers and prompting them to trust it or not. To make this work, a new field called `VerifyCA` has been added to the `DialOpts` struct. If that is provided AND the remote server (e.g one bootstrapped with the changes from this PR) presents a self-signed CA cert, the dial code will delegate the trust check for the CA to the `VerifyCA` implementation and abort the connection if the verifier returns an error, before any data is transmitted to the remote server. If the remote server does not present a CA (e.g one bootstrapped without the changes from this PR) OR presents a CA that can be verified using the system CA roots then the connection proceeds normally without requiring a CA verification check.

The same PR also modifies the client-side login code so that users can now login to a controller if they know one of their endpoints. To maintain consistency with `juju register` output, the login code has been made a bit smarter: it now checks whether the local controller cache contains an entry with an endpoint matching the one the user tries to connect to (via the new `ControllerByAPIEndpoints` method added to `jujuclient.Store`). If that is the case then it will return an error back to the user and provide additional info guiding the user to properly connect to the controller using its local name.

## QA steps

### Check logins against new controllers (CA cert being exposed)
```console
# bootstrap controller and set password for admin
$ juju bootstrap lxd ca-presenting-controller
$ juju change-user-password

# grab endpoints and unregister controller
$ juju show-controller | grep endpoints
 api-endpoints: ['10.65.47.180:17070']
$ juju unregister ca-presenting-controller

# try to login to the endpoint without user and answer y to the prompt
$ juju login 10.65.47.180:17070 -c ca-presenting-controller
Controller "10.65.47.180:17070" presented a CA cert that could not be verified.
CA fingerprint: [05:79:98:89:FB:91:D8:39:15:BC:6B:0C:39:BE:45:11:0E:AA:C2:5B:44:5F:35:9A:3A:81:F2:A6:97:3E:6D:1E]
Trust remote controller? (y/N): y

Enter username: admin

Enter password: *****

Welcome, admin. You are now logged into "ca-presenting-controller".

There are 2 models available. Use "juju switch" to select
one of them:
  - juju switch controller
  - juju switch default

```

Repeat the unregister/login flow but this time login via ` juju login 10.65.47.180:17070 -c ca-presenting-controller -u admin` (juju should NOT prompt you for the user name this time)

### Check logins against old controllers (no CA cert being exposed)

Repeat the previous steps but:
- bootstrap an older controller
- use the juju binary from this PR to run the login commands

Attempts to login should fail with an error like: `unable to connect to API: x509: certificate signed by unknown authority`.

### Check login by endpoint IP against known controllers

```console
# bootstrap controller
$ juju bootstrap lxd ca-presenting-controller

# grab endpoints
$ juju show-controller | grep endpoints
 api-endpoints: ['10.65.47.180:17070']

$ juju login 10.65.47.180:17070
WARNING This controller has already been registered on this client as "ca-presenting-controller"
To login as user "admin" run 'juju login -u admin -c ca-presenting-controller'.
ERROR controller is already registered as "ca-presenting-controller"

$ juju login 10.65.47.180:17070 -c alias
ERROR This controller has already been registered on this client as "ca-presenting-controller"
To login as user "admin" run 'juju login -u admin -c ca-presenting-controller'.

# Edit ~/.local/share/juju/accounts.yaml and rename the account name for "ca-presenting-controller"
# Then try login one more time (error message is slightly different this time as the user is not known)
$ juju login 10.65.47.180:17070
ERROR This controller has already been registered on this client as "ca-presenting-controller"
To login run 'juju login -c ca-presenting-controller'.
```

### Make sure JAAS logins are not broken 

`juju login jaas` should work as before

## Documentation changes

@pmatulis I think we may need to update our login command docs to include the "trust-this-ca" flow.
