### PR TITLE
move charmstoreClientToTestcharmsClientShim to export_test

### DIFF
--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/romulus"
 	"gopkg.in/juju/charmrepo.v3"
+	"gopkg.in/juju/charmrepo.v3/csclient"
+	"gopkg.in/juju/charmrepo.v3/csclient/params"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/annotations"
@@ -19,6 +21,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/resource/resourceadapters"
+	"github.com/juju/juju/testcharms"
 )
 
 // NewDeployCommandForTest returns a command to deploy applications intended to be used only in tests.
@@ -275,4 +278,13 @@ func NewShowCommandForTest(api ApplicationsInfoAPI, store jujuclient.ClientStore
 	}}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)
+}
+
+type charmstoreClientToTestcharmsClientShim struct {
+	*csclient.Client
+}
+
+func (c charmstoreClientToTestcharmsClientShim) WithChannel(channel params.Channel) testcharms.CharmstoreClient {
+	client := c.Client.WithChannel(channel)
+	return charmstoreClientToTestcharmsClientShim{client}
 }

--- a/cmd/juju/application/shim.go
+++ b/cmd/juju/application/shim.go
@@ -6,8 +6,6 @@ package application
 import (
 	"gopkg.in/juju/charmrepo.v3/csclient"
 	"gopkg.in/juju/charmrepo.v3/csclient/params"
-
-	"github.com/juju/juju/testcharms"
 )
 
 type charmstoreClientShim struct {
@@ -17,13 +15,4 @@ type charmstoreClientShim struct {
 func (c charmstoreClientShim) WithChannel(channel params.Channel) charmstoreForDeploy {
 	client := c.Client.WithChannel(channel)
 	return charmstoreClientShim{client}
-}
-
-type charmstoreClientToTestcharmsClientShim struct {
-	*csclient.Client
-}
-
-func (c charmstoreClientToTestcharmsClientShim) WithChannel(channel params.Channel) testcharms.CharmstoreClient {
-	client := c.Client.WithChannel(channel)
-	return charmstoreClientToTestcharmsClientShim{client}
 }


### PR DESCRIPTION
## Description of change

Move charmstoreClientToTestcharmsClientShim from shim.go to export_test.go to prevent panic on bootstrap.  Global variable in testcharms pkg led to os.stat of directory which doesn't exist on a juju machine which panics on error.

## QA steps

bootstrap.