### PR TITLE
don't check charm profiles upgrading a caas charm

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -823,8 +823,11 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := application.SetCharmProfile(args.CharmURL); err != nil {
-		return errors.Annotatef(err, "unable to set charm profile")
+	// Only look at a charm's lxd profile data for non CAAS models.
+	if api.modelType == state.ModelTypeIAAS {
+		if err := application.SetCharmProfile(args.CharmURL); err != nil {
+			return errors.Annotatef(err, "unable to set charm profile")
+		}
 	}
 
 	channel := csparams.Channel(args.Channel)


### PR DESCRIPTION
## Description of change

Don't check charm profiles upgrading a caas charm.  They don't exist and it breaks looking for a unit's machine.

## QA steps

bootstrap
setup a microk8s model
deploy a local k8s charm
upgrade a local k8s charm
in the default model
deploy testcharms/charm-repo/quantal/lxd-profile-alt
upgrade the charm

## Bug reference

https://bugs.launchpad.net/juju/+bug/1818510