### PR TITLE
Improve duplicate namespace message

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -544,6 +544,16 @@ func (m *ModelManagerAPI) newCAASModel(cloudSpec environs.CloudSpec,
 		m.callContext,
 		environs.CreateParams{ControllerUUID: controllerConfig.ControllerUUID()},
 	); err != nil {
+		if errors.IsAlreadyExists(err) {
+			// Retain the error stack but with a better message.
+			return nil, errors.Wrap(err, errors.NewAlreadyExists(nil,
+				`
+the model cannot be created because a namespace with the proposed
+model name already exists in the k8s cluster.
+Please choose a different model name.
+`[1:],
+			))
+		}
 		return nil, errors.Annotatef(err, "creating namespace %q", createArgs.Name)
 	}
 


### PR DESCRIPTION
## Description of change

When adding a k8s model and the namespace already exists, improve the user facing error message.

## QA steps

bootstrap k8s
add same model twice

