### PR TITLE
Fix race in featuretests/api_meterstatus_test.go

### DIFF
--- a/featuretests/api_meterstatus_test.go
+++ b/featuretests/api_meterstatus_test.go
@@ -75,6 +75,12 @@ func (s *meterStatusIntegrationSuite) TestWatchMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = mm.SetLastSuccessfulSend(time.Now())
 	c.Assert(err, jc.ErrorIsNil)
+	// While in theory it is only one event, when the metrics manager is first
+	// asked for, if it doesn't exist it adds a document. Then the set last
+	// successful send changes that document, so there are actually two changes
+	// from the database perspective. Here we wait for the model to be idle
+	// before checking for one change.
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	wc.AssertOneChange()
 
 	// meter status does not change on every failed


### PR DESCRIPTION
There is a subtle small race condition that we tend to hit on the arm64 machines, and very hard to reproduce locally. When the `MetricsManager` is created for the first time it adds the initial document in. Then the `SetLastSuccessfulSend` call updates that document. This causes the potential for two events.

The fix is to sync with the internal watchers before asking for the next one.
