### PR TITLE
MAAS display name falls back to FQDN when hostname unavailable.

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1050,6 +1050,7 @@ func (env *maasEnviron) StartInstance(
 	}
 	logger.Debugf("maas user data; %d bytes", len(userdata))
 
+	var displayName string
 	var interfaces []network.InterfaceInfo
 	if !env.usingMAAS2() {
 		inst1 := inst.(*maas1Instance)
@@ -1068,6 +1069,10 @@ func (env *maasEnviron) StartInstance(
 			return nil, common.ZoneIndependentError(err)
 		}
 		env.tagInstance1(inst1, args.InstanceConfig)
+		displayName, err = inst1.displayName()
+		if err != nil {
+			return nil, common.ZoneIndependentError(err)
+		}
 	} else {
 		inst2 := inst.(*maas2Instance)
 		startedInst, err := env.startNode2(*inst2, series, userdata)
@@ -1083,6 +1088,11 @@ func (env *maasEnviron) StartInstance(
 			return nil, common.ZoneIndependentError(err)
 		}
 		env.tagInstance2(inst2, args.InstanceConfig)
+
+		displayName, err = inst2.displayName()
+		if err != nil {
+			return nil, common.ZoneIndependentError(err)
+		}
 	}
 	logger.Debugf("started instance %q", inst.Id())
 
@@ -1105,7 +1115,7 @@ func (env *maasEnviron) StartInstance(
 	}
 
 	return &environs.StartInstanceResult{
-		DisplayName:       hostname,
+		DisplayName:       displayName,
 		Instance:          inst,
 		Hardware:          hc,
 		NetworkInfo:       interfaces,

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -23,6 +23,7 @@ import (
 type maasInstance interface {
 	instances.Instance
 	zone() (string, error)
+	displayName() (string, error)
 	hostname() (string, error)
 	hardwareCharacteristics() (*instance.HardwareCharacteristics, error)
 	volumes(names.MachineTag, []names.VolumeTag) ([]storage.Volume, []storage.VolumeAttachment, error)
@@ -261,4 +262,12 @@ func (mi *maas1Instance) hardwareCharacteristics() (*instance.HardwareCharacteri
 func (mi *maas1Instance) hostname() (string, error) {
 	// A MAAS instance has its DNS name immediately.
 	return mi.maasObject.GetField("hostname")
+}
+
+func (mi *maas1Instance) displayName() (string, error) {
+	displayName, err := mi.hostname()
+	if err != nil {
+		logger.Infof("error detecting hostname for %s", mi)
+	}
+	return displayName, err
 }

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -264,10 +264,20 @@ func (mi *maas1Instance) hostname() (string, error) {
 	return mi.maasObject.GetField("hostname")
 }
 
+func (mi *maas1Instance) fqdn() (string, error) {
+	return mi.maasObject.GetField("fqdn")
+}
+
 func (mi *maas1Instance) displayName() (string, error) {
 	displayName, err := mi.hostname()
 	if err != nil {
 		logger.Infof("error detecting hostname for %s", mi)
+	}
+	if displayName == "" {
+		displayName, err = mi.fqdn()
+	}
+	if err != nil {
+		logger.Infof("error detecting fqdn for %s", mi)
 	}
 	return displayName, err
 }

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -103,6 +103,19 @@ func (s *instanceTest) TestStringWithoutHostname(c *gc.C) {
 	c.Assert(fmt.Sprint(instance), gc.Equals, expected)
 }
 
+func (s *instanceTest) TestDisplayNameIsHostname(c *gc.C) {
+	jsonValue := `{"system_id": "system_id", "test": "test", "hostname": "abc.internal"}`
+	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
+
+	instance := &maas1Instance{&obj, nil, nil}
+	displayName, err := instance.displayName()
+	c.Assert(err, gc.IsNil)
+	c.Assert(displayName, gc.Equals, "abc.internal")
+}
+
+// Note: no need to test displayName() without hostname, as Juju defaults to presenting the
+// instance.Id() when a display name is unavailable
+
 func (s *instanceTest) TestAddressesViaInterfaces(c *gc.C) {
 	server := s.testMAASObject.TestServer
 	server.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -348,7 +348,7 @@ func (suite *maas2EnvironSuite) TestStartInstance(c *gc.C) {
 	result, err := jujutesting.StartInstanceWithParams(env, suite.callCtx, "1", params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Instance.Id(), gc.Equals, instance.Id("Bruce Sterling"))
-	c.Assert(result.DisplayName, gc.Equals, "")
+	c.Assert(result.DisplayName, gc.Equals, "example.com.")
 }
 
 func (suite *maas2EnvironSuite) TestStartInstanceReturnsHostnameAsDisplayName(c *gc.C) {
@@ -365,6 +365,22 @@ func (suite *maas2EnvironSuite) TestStartInstanceReturnsHostnameAsDisplayName(c 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Instance.Id(), gc.Equals, instance.Id("Bruce Sterling"))
 	c.Assert(result.DisplayName, gc.Equals, machine.Hostname())
+}
+
+func (suite *maas2EnvironSuite) TestStartInstanceReturnsFQDNAsDisplayNameWhenHostnameUnavailable(c *gc.C) {
+	machine := &fakeMachine{
+		systemID:     "Bruce Sterling",
+		architecture: arch.HostArch(),
+		hostname:     "",
+		Stub:         &testing.Stub{},
+		statusName:   "",
+	}
+	env, _ := suite.injectControllerWithMachine(c, machine, nil, gomaasapi.AllocateMachineArgs{})
+	params := environs.StartInstanceParams{ControllerUUID: suite.controllerUUID}
+	result, err := jujutesting.StartInstanceWithParams(env, suite.callCtx, "0", params)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Instance.Id(), gc.Equals, instance.Id("Bruce Sterling"))
+	c.Assert(result.DisplayName, gc.Equals, machine.FQDN())
 }
 
 func (suite *maas2EnvironSuite) TestStartInstanceAppliesResourceTags(c *gc.C) {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -289,7 +289,12 @@ func (m *fakeMachine) Hostname() string {
 }
 
 func (m *fakeMachine) FQDN() string {
-	return m.Hostname() + "."
+	domain := "example.com."
+	host := m.Hostname()
+	if host == "" {
+		return domain
+	}
+	return host + "." + domain
 }
 
 func (m *fakeMachine) IPAddresses() []string {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -288,6 +288,10 @@ func (m *fakeMachine) Hostname() string {
 	return m.hostname
 }
 
+func (m *fakeMachine) FQDN() string {
+	return m.Hostname() + "."
+}
+
 func (m *fakeMachine) IPAddresses() []string {
 	return m.ipAddresses
 }

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -48,10 +48,7 @@ func (mi *maas2Instance) hardwareCharacteristics() (*instance.HardwareCharacteri
 }
 
 func (mi *maas2Instance) displayName() (string, error) {
-	hostname, err := mi.hostname()
-	if err != nil {
-		return "", err
-	}
+	hostname := mi.machine.Hostname()
 	if hostname != "" {
 		return hostname, nil
 	}
@@ -59,8 +56,7 @@ func (mi *maas2Instance) displayName() (string, error) {
 }
 
 func (mi *maas2Instance) String() string {
-	hostname, _ := mi.hostname()
-	return fmt.Sprintf("%s:%s", hostname, mi.machine.SystemID())
+	return fmt.Sprintf("%s:%s", mi.machine.Hostname(), mi.machine.SystemID())
 }
 
 func (mi *maas2Instance) Id() instance.Id {

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -47,8 +47,20 @@ func (mi *maas2Instance) hardwareCharacteristics() (*instance.HardwareCharacteri
 	return hc, nil
 }
 
+func (mi *maas2Instance) displayName() (string, error) {
+	hostname, err := mi.hostname()
+	if err != nil {
+		return "", err
+	}
+	if hostname != "" {
+		return hostname, nil
+	}
+	return mi.machine.FQDN(), nil
+}
+
 func (mi *maas2Instance) String() string {
-	return fmt.Sprintf("%s:%s", mi.machine.Hostname(), mi.machine.SystemID())
+	hostname, _ := mi.hostname()
+	return fmt.Sprintf("%s:%s", hostname, mi.machine.SystemID())
 }
 
 func (mi *maas2Instance) Id() instance.Id {

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -113,6 +113,22 @@ func (s *maas2InstanceSuite) TestHostname(c *gc.C) {
 	c.Assert(result, gc.Equals, "saul-goodman")
 }
 
+func (s *maas2InstanceSuite) TestHostnameIsDisplayName(c *gc.C) {
+	machine := &fakeMachine{hostname: "saul-goodman"}
+	thing := &maas2Instance{machine: machine}
+	result, err := thing.displayName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, "saul-goodman")
+}
+
+func (s *maas2InstanceSuite) TestDisplayNameFallsBackToFQDN(c *gc.C) {
+	machine := newFakeMachine("abc123", "amd64", "ok")
+	thing := &maas2Instance{machine: machine}
+	result, err := thing.displayName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, thing.machine.FQDN()) //TODO(tsm) fix to use non-empty string
+}
+
 func (s *maas2InstanceSuite) TestHardwareCharacteristics(c *gc.C) {
 	machine := &fakeMachine{
 		cpuCount:     3,

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -126,7 +126,7 @@ func (s *maas2InstanceSuite) TestDisplayNameFallsBackToFQDN(c *gc.C) {
 	thing := &maas2Instance{machine: machine}
 	result, err := thing.displayName()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.Equals, thing.machine.FQDN()) //TODO(tsm) fix to use non-empty string
+	c.Assert(result, gc.Equals, thing.machine.FQDN())
 }
 
 func (s *maas2InstanceSuite) TestHardwareCharacteristics(c *gc.C) {


### PR DESCRIPTION
## Description of change

MAAS nodes sometimes can sometimes fail to return a hostname. This leads to their instance names being rendered with their (ugly) instance ID. The suggestion is that we fall back to the fully-qualified domain name first, before relying on the instance ID. This commit implements that suggestion.

## QA steps

TODO 

## Documentation changes

Perhaps add a note on how MAAS machines may change their display names in status. 

## Bug reference

- [lp#1825068](https://bugs.launchpad.net/juju/+bug/1825068)
- indirectly related to [lp#1792210](https://bugs.launchpad.net/juju/+bug/1792210)