### PR TITLE
Fix juju models --exact-time

### DIFF
--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -252,6 +252,12 @@ type ModelSummary struct {
 }
 
 func (c *modelsCommand) modelSummaryFromParams(apiSummary base.UserModelSummary, now time.Time) (ModelSummary, error) {
+	var statusSince string
+	if c.exactTime {
+		statusSince = apiSummary.Status.Since.String()
+	} else {
+		statusSince = common.FriendlyDuration(apiSummary.Status.Since, now)
+	}
 	summary := ModelSummary{
 		ShortName:      apiSummary.Name,
 		Name:           jujuclient.JoinOwnerModelName(names.NewUserTag(apiSummary.Owner), apiSummary.Name),
@@ -267,7 +273,7 @@ func (c *modelsCommand) modelSummaryFromParams(apiSummary base.UserModelSummary,
 		Status: &common.ModelStatus{
 			Current: apiSummary.Status.Status,
 			Message: apiSummary.Status.Info,
-			Since:   common.FriendlyDuration(apiSummary.Status.Since, now),
+			Since:   statusSince,
 		},
 	}
 	if apiSummary.AgentVersion != nil {
@@ -300,7 +306,11 @@ func (c *modelsCommand) modelSummaryFromParams(apiSummary base.UserModelSummary,
 		}
 	}
 	if apiSummary.UserLastConnection != nil {
-		summary.UserLastConnection = common.UserFriendlyDuration(*apiSummary.UserLastConnection, now)
+		if c.exactTime {
+			summary.UserLastConnection = apiSummary.UserLastConnection.String()
+		} else {
+			summary.UserLastConnection = common.UserFriendlyDuration(*apiSummary.UserLastConnection, now)
+		}
 	} else {
 		summary.UserLastConnection = "never connected"
 	}


### PR DESCRIPTION
----

## Description of change

Running `juju list-models --exact-time` still returns a "friendly time stamp", rather than an exact time.

## QA steps

* `juju switch <controller>`
* `juju list-models --exact-time`, you will see a full ISO 8601 timestamp rather than "just now", "a few seconds ago", etc

## Documentation changes

None.

## Bug reference

[lp#1782282](https://bugs.launchpad.net/juju/+bug/1782282)
