### PR TITLE
Fix intermittent test failure in TestUnitRelations.

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -24,6 +24,7 @@ import (
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	jujunames "github.com/juju/juju/juju/names"
 	jujuversion "github.com/juju/juju/version"
@@ -418,6 +419,7 @@ func (op *caasOperator) loop() (err error) {
 				}
 
 				params := op.config.UniterParams
+				params.ModelType = model.CAAS
 				params.UnitTag = unitTag
 				params.UniterFacade = op.config.UniterFacadeFunc(unitTag)
 				params.LeadershipTracker = op.config.LeadershipTrackerFunc(unitTag)

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/resolver"
@@ -93,6 +94,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			uniter, err := NewUniter(&UniterParams{
 				UniterFacade:         uniterFacade,
 				UnitTag:              unitTag,
+				ModelType:            model.IAAS,
 				LeadershipTracker:    leadershipTracker,
 				DataDir:              agentConfig.DataDir(),
 				Downloader:           downloader,

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -46,7 +46,13 @@ import (
 	"github.com/juju/juju/worker/uniter/upgradeseries"
 )
 
-var logger = loggo.GetLogger("juju.worker.uniter")
+var (
+	logger = loggo.GetLogger("juju.worker.uniter")
+
+	// ErrCAASUnitDead is the error returned from terminate or init
+	// if the unit is Dead.
+	ErrCAASUnitDead = errors.New("unit dead")
+)
 
 // A UniterExecutionObserver gets the appropriate methods called when a hook
 // is executed and either succeeds or fails.  Missing hooks don't get reported
@@ -117,6 +123,7 @@ type Uniter struct {
 type UniterParams struct {
 	UniterFacade         *uniter.State
 	UnitTag              names.UnitTag
+	ModelType            model.ModelType
 	LeadershipTracker    leadership.Tracker
 	DataDir              string
 	Downloader           charm.Downloader
@@ -159,10 +166,10 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 	if translateResolverErr == nil {
 		translateResolverErr = func(err error) error { return err }
 	}
-
 	u := &Uniter{
 		st:                   uniterParams.UniterFacade,
 		paths:                NewPaths(uniterParams.DataDir, uniterParams.UnitTag),
+		modelType:            uniterParams.ModelType,
 		hookLock:             uniterParams.MachineLock,
 		leadershipTracker:    uniterParams.LeadershipTracker,
 		charmDirGuard:        uniterParams.CharmDirGuard,
@@ -191,10 +198,17 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 
 func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	if err := u.init(unitTag); err != nil {
-		if err == jworker.ErrTerminateAgent {
+		switch cause := errors.Cause(err); cause {
+		case resolver.ErrLoopAborted:
+			return u.catacomb.ErrDying()
+		case ErrCAASUnitDead:
+			// Normal exit from the loop as we don't want it restarted.
+			return nil
+		case jworker.ErrTerminateAgent:
 			return err
+		default:
+			return errors.Annotatef(err, "failed to initialize uniter for %q", unitTag)
 		}
-		return errors.Annotatef(err, "failed to initialize uniter for %q", unitTag)
 	}
 	logger.Infof("unit %q started", u.unit)
 
@@ -397,6 +411,11 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		}
 	}
 
+	// If this is a CAAS unit, then dead errors are fairly normal ways to exit
+	// the uniter main loop, but the actual agent needs to keep running.
+	if errors.Cause(err) == ErrCAASUnitDead {
+		err = nil
+	}
 	logger.Infof("unit %q shutting down: %s", u.unit, err)
 	return err
 }
@@ -439,13 +458,20 @@ func (u *Uniter) terminate() error {
 // For IAAS models, we want to terminate the agent, as each unit is run by
 // an individual agent for that unit.
 func (u *Uniter) stopUnitError() error {
-	if u.modelType == model.IAAS {
-		return jworker.ErrTerminateAgent
+	logger.Debugf("u.modelType: %s", u.modelType)
+	if u.modelType == model.CAAS {
+		return ErrCAASUnitDead
 	}
-	return nil
+	return jworker.ErrTerminateAgent
 }
 
 func (u *Uniter) init(unitTag names.UnitTag) (err error) {
+	switch u.modelType {
+	case model.IAAS, model.CAAS:
+		// known types, all good
+	default:
+		return errors.Errorf("unknown model type %q", u.modelType)
+	}
 	u.unit, err = u.st.Unit(unitTag)
 	if err != nil {
 		return err
@@ -495,11 +521,6 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	u.commands = runcommands.NewCommands()
 	u.commandChannel = make(chan string)
 
-	m, err := u.st.Model()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	u.modelType = m.ModelType
 	storageAttachments, err := storage.NewAttachments(
 		u.st, unitTag, u.paths.State.StorageDir, u.catacomb.Dying(),
 	)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/juju/testing"
@@ -480,6 +481,7 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 	uniterParams := uniter.UniterParams{
 		UniterFacade:         ctx.api,
 		UnitTag:              tag,
+		ModelType:            model.IAAS,
 		LeadershipTracker:    ctx.leaderTracker,
 		CharmDirGuard:        ctx.charmDirGuard,
 		DataDir:              ctx.dataDir,


### PR DESCRIPTION
On slow substrate machines like the arm64 or s390x build machines we'd intermittently see a test failure.
This was due to the uniter being killed before the init function was finished.

The error returns from init were not sufficiently handled for the various error types. During the discovery of this, I found another issue with CAAS uniter instances where the intent is to have a nil error return from the main loop if the unit becomes dead or is dead. However this was also returned from `init`, which the caller took as all good, and would cause a panic when a method on the operatorExecutor was called.
To address this we introduce a particular error type for the CAAS unit being dead, and handle that error type explicitly in the response places.

This lead to yet another issue where we were checking the model type before it had been initialized in the init function. To resolve this we pass the model type into the uniter as one of the UniterParams as when we start the uniter, we know what the model type is, so don't bother asking the model.

