### PR TITLE
Feature/gke support

### DIFF
--- a/caas/jujud-operator-dockerfile
+++ b/caas/jujud-operator-dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     python3-pip \
     python3-distutils \
     # below apt dependencies are required by controller pod.
-    iproute2 \ 
+    iproute2 \
     && pip3 install --upgrade pip setuptools \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /root/.cache
@@ -24,9 +24,8 @@ ENV PIP_FIND_LINKS=/tmp/wheelhouse
 COPY jujud-operator-requirements.txt /tmp/wheelhouse/jujud-operator-requirements.txt
 RUN pip3 install -r /tmp/wheelhouse/jujud-operator-requirements.txt
 
-# Finally jujud
-ARG JUJUD_DIR=/var/lib/juju/tools
-WORKDIR $JUJUD_DIR
+# copy jujud
+WORKDIR /var/lib/juju
 COPY jujud /opt/
 
 ENTRYPOINT ["sh", "-c"]

--- a/caas/jujud-operator-dockerfile
+++ b/caas/jujud-operator-dockerfile
@@ -24,8 +24,8 @@ ENV PIP_FIND_LINKS=/tmp/wheelhouse
 COPY jujud-operator-requirements.txt /tmp/wheelhouse/jujud-operator-requirements.txt
 RUN pip3 install -r /tmp/wheelhouse/jujud-operator-requirements.txt
 
-# copy jujud
 WORKDIR /var/lib/juju
+# copy jujud
 COPY jujud /opt/
 
 ENTRYPOINT ["sh", "-c"]

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -700,7 +700,7 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 				fmt.Sprintf(
 					caas.JujudStartUpSh,
 					c.pcfg.DataDir,
-					fmt.Sprintf("%s/tools", c.pcfg.DataDir),
+					"tools",
 					jujudCmd,
 				),
 			},
@@ -750,12 +750,16 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 		loggingOption = "--debug"
 	}
 
-	agentConfigRelativePath := fmt.Sprintf("agents/machine-%s/%s", c.pcfg.MachineId, c.fileNameAgentConf)
+	agentConfigRelativePath := filepath.Join(
+		"agents",
+		fmt.Sprintf("machine-%s", c.pcfg.MachineId),
+		c.fileNameAgentConf,
+	)
 	var jujudCmd string
 	if c.pcfg.MachineId == "0" {
 		// only do bootstrap-state on the bootstrap machine - machine-0.
 		jujudCmd += "\n" + fmt.Sprintf(
-			"test -e $JUJU_HOME/%s || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_HOME/%s --data-dir $JUJU_HOME %s --timeout %s",
+			"test -e $JUJU_DATA_DIR/%s || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/%s --data-dir $JUJU_DATA_DIR %s --timeout %s",
 			agentConfigRelativePath,
 			c.fileNameBootstrapParams,
 			loggingOption,
@@ -763,7 +767,7 @@ func (c controllerStack) buildContainerSpecForController(statefulset *apps.State
 		)
 	}
 	jujudCmd += "\n" + fmt.Sprintf(
-		"$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_HOME --machine-id %s %s",
+		"$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --machine-id %s %s",
 		c.pcfg.MachineId,
 		loggingOption,
 	)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -501,8 +501,7 @@ export JUJU_TOOLS_DIR=/var/lib/juju/tools
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
 
-
-test -e /var/lib/juju/agents/machine-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_HOME/bootstrap-params --data-dir $JUJU_HOME --debug --timeout 0s
+test -e $JUJU_HOME/agents/machine-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_HOME/bootstrap-params --data-dir $JUJU_HOME --debug --timeout 0s
 $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_HOME --machine-id 0 --debug
 `[1:],
 			},

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -495,14 +495,14 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Args: []string{
 				"-c",
 				`
-export JUJU_HOME=/var/lib/juju
-export JUJU_TOOLS_DIR=/var/lib/juju/tools
+export JUJU_DATA_DIR=/var/lib/juju
+export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
 
-test -e $JUJU_HOME/agents/machine-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_HOME/bootstrap-params --data-dir $JUJU_HOME --debug --timeout 0s
-$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_HOME --machine-id 0 --debug
+test -e $JUJU_DATA_DIR/agents/machine-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/bootstrap-params --data-dir $JUJU_DATA_DIR --debug --timeout 0s
+$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --machine-id 0 --debug
 `[1:],
 			},
 			WorkingDir: "/var/lib/juju",

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -495,13 +495,18 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Args: []string{
 				"-c",
 				`
-cp /opt/jujud $(pwd)/jujud
+export JUJU_HOME=/var/lib/juju
+export JUJU_TOOLS_DIR=/var/lib/juju/tools
 
-test -e /var/lib/juju/agents/machine-0/agent.conf || ./jujud bootstrap-state /var/lib/juju/bootstrap-params --data-dir /var/lib/juju --debug --timeout 0s
-./jujud machine --data-dir /var/lib/juju --machine-id 0 --debug
+mkdir -p $JUJU_TOOLS_DIR
+cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
+
+test -e /var/lib/juju/agents/machine-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_HOME/bootstrap-params --data-dir $JUJU_HOME --debug --timeout 0s
+$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_HOME --machine-id 0 --debug
 `[1:],
 			},
-			WorkingDir: "/var/lib/juju/tools",
+			WorkingDir: "/var/lib/juju",
 			VolumeMounts: []core.VolumeMount{
 				{
 					Name:      "storage",

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -65,6 +65,5 @@ func compileK8sCloudCheckers() map[string]k8slabels.Selector {
 			requirementParams{"kubernetes.azure.com/cluster", selection.Exists, nil},
 		),
 		// format - cloudType: requirements.
-		// TODO(caas): add support for cdk, etc.
 	}
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -72,8 +72,7 @@ const (
 
 	gpuAffinityNodeSelectorKey = "gpu"
 
-	jujuHome     = "/var/lib/juju"
-	jujudToolDir = jujuHome + "/tools"
+	jujuDataDir = "/var/lib/juju"
 
 	annotationPrefix = "juju.io"
 )
@@ -2297,7 +2296,7 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 	}
 
 	appTag := names.NewApplicationTag(appName)
-	jujudCmd := fmt.Sprintf("%s/jujud caasoperator --application-name=%s --debug", jujudToolDir, appName)
+	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud caasoperator --application-name=%s --debug", appName)
 
 	return &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
@@ -2311,13 +2310,18 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 				Name:            "juju-operator",
 				ImagePullPolicy: core.PullIfNotPresent,
 				Image:           operatorImagePath,
-				WorkingDir:      jujuHome,
+				WorkingDir:      jujuDataDir,
 				Command: []string{
 					"/bin/sh",
 				},
 				Args: []string{
 					"-c",
-					fmt.Sprintf(caas.JujudStartUpSh, jujuHome, jujudToolDir, jujudCmd),
+					fmt.Sprintf(
+						caas.JujudStartUpSh,
+						jujuDataDir,
+						"tools",
+						jujudCmd,
+					),
 				},
 				Env: []core.EnvVar{
 					{Name: "JUJU_APPLICATION", Value: appName},

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -72,7 +72,8 @@ const (
 
 	gpuAffinityNodeSelectorKey = "gpu"
 
-	jujudToolDir = "/var/lib/juju/tools"
+	jujuHome     = "/var/lib/juju"
+	jujudToolDir = jujuHome + "/tools"
 
 	annotationPrefix = "juju.io"
 )
@@ -2296,7 +2297,7 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 	}
 
 	appTag := names.NewApplicationTag(appName)
-	jujudCmd := fmt.Sprintf("./jujud caasoperator --application-name=%s --debug", appName)
+	jujudCmd := fmt.Sprintf("%s/jujud caasoperator --application-name=%s --debug", jujudToolDir, appName)
 
 	return &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
@@ -2310,13 +2311,13 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 				Name:            "juju-operator",
 				ImagePullPolicy: core.PullIfNotPresent,
 				Image:           operatorImagePath,
-				WorkingDir:      jujudToolDir,
+				WorkingDir:      jujuHome,
 				Command: []string{
 					"/bin/sh",
 				},
 				Args: []string{
 					"-c",
-					fmt.Sprintf(caas.JujudStartUpSh, jujudCmd),
+					fmt.Sprintf(caas.JujudStartUpSh, jujuHome, jujudToolDir, jujudCmd),
 				},
 				Env: []core.EnvVar{
 					{Name: "JUJU_APPLICATION", Value: appName},

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -72,8 +72,6 @@ const (
 
 	gpuAffinityNodeSelectorKey = "gpu"
 
-	jujuDataDir = "/var/lib/juju"
-
 	annotationPrefix = "juju.io"
 )
 
@@ -553,7 +551,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 			Annotations: resourceTagsToAnnotations(config.CharmStorage.ResourceTags).ToMap()},
 		Spec: *pvcSpec,
 	}
-	pod := operatorPod(
+	pod, err := operatorPod(
 		operatorName,
 		appName,
 		agentPath,
@@ -561,6 +559,9 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		config.Version.String(),
 		annotations.Copy(),
 	)
+	if err != nil {
+		return errors.Annotate(err, "generating operator podspec")
+	}
 	// Take a copy for use with statefulset.
 	podWithoutStorage := pod
 
@@ -2287,7 +2288,7 @@ func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) 
 
 // operatorPod returns a *core.Pod for the operator pod
 // of the specified application.
-func operatorPod(podName, appName, agentPath, operatorImagePath, version string, annotations k8sannotations.Annotation) *core.Pod {
+func operatorPod(podName, appName, agentPath, operatorImagePath, version string, annotations k8sannotations.Annotation) (*core.Pod, error) {
 	configMapName := operatorConfigMapName(podName)
 	configVolName := configMapName
 
@@ -2297,7 +2298,10 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 
 	appTag := names.NewApplicationTag(appName)
 	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud caasoperator --application-name=%s --debug", appName)
-
+	jujuDataDir, err := paths.DataDir("kubernetes")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name: podName,
@@ -2347,7 +2351,7 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 				},
 			}},
 		},
-	}
+	}, nil
 }
 
 // operatorConfigMap returns a *core.ConfigMap for the operator pod

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -280,7 +280,6 @@ export JUJU_TOOLS_DIR=/var/lib/juju/tools
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
-
 /var/lib/juju/tools/jujud caasoperator --application-name=test --debug
 `[1:],
 		},

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -268,15 +268,20 @@ var operatorPodspec = core.PodSpec{
 		Name:            "juju-operator",
 		ImagePullPolicy: core.PullIfNotPresent,
 		Image:           "/path/to/image",
-		WorkingDir:      "/var/lib/juju/tools",
+		WorkingDir:      "/var/lib/juju",
 		Command: []string{
 			"/bin/sh",
 		},
 		Args: []string{
 			"-c",
 			`
-cp /opt/jujud $(pwd)/jujud
-./jujud caasoperator --application-name=test --debug
+export JUJU_HOME=/var/lib/juju
+export JUJU_TOOLS_DIR=/var/lib/juju/tools
+
+mkdir -p $JUJU_TOOLS_DIR
+cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
+/var/lib/juju/tools/jujud caasoperator --application-name=test --debug
 `[1:],
 		},
 		Env: []core.EnvVar{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -392,7 +392,8 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
 		"fred": "mary",
 	}
-	pod := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", tags)
+	pod, err := provider.OperatorPod("gitlab", "gitlab", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", tags)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pod.Name, gc.Equals, "gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, map[string]string{
 		"juju-operator": "gitlab",

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -275,12 +275,12 @@ var operatorPodspec = core.PodSpec{
 		Args: []string{
 			"-c",
 			`
-export JUJU_HOME=/var/lib/juju
-export JUJU_TOOLS_DIR=/var/lib/juju/tools
+export JUJU_DATA_DIR=/var/lib/juju
+export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
-/var/lib/juju/tools/jujud caasoperator --application-name=test --debug
+$JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 `[1:],
 		},
 		Env: []core.EnvVar{

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -6,8 +6,8 @@ package caas
 var (
 	// JujudStartUpSh is the exec script for CAAS controller.
 	JujudStartUpSh = `
-export JUJU_HOME=%[1]s
-export JUJU_TOOLS_DIR=%[2]s
+export JUJU_DATA_DIR=%[1]s
+export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/%[2]s
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -6,7 +6,13 @@ package caas
 var (
 	// JujudStartUpSh is the exec script for CAAS controller.
 	JujudStartUpSh = `
-cp /opt/jujud $(pwd)/jujud
-%s
+
+export JUJU_HOME=%[1]s
+export JUJU_TOOLS_DIR=%[2]s
+
+mkdir -p $JUJU_TOOLS_DIR
+cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
+%[3]s
 `[1:]
 )

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -6,13 +6,11 @@ package caas
 var (
 	// JujudStartUpSh is the exec script for CAAS controller.
 	JujudStartUpSh = `
-
 export JUJU_HOME=%[1]s
 export JUJU_TOOLS_DIR=%[2]s
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
-
 %[3]s
 `[1:]
 )


### PR DESCRIPTION
## Description of change

enhanced container start scripts to fix `gke` bootstrap; 

Note: tested on `gke`, `microk8s`, 
`aks` - TODO

## QA steps

1. import gke cloud to local;

```bash
$ juju add-k8s <cloud-name> --local --cluster-name <gke-cluster-name> --debug
```

2. bootstrap controller;

```bash
$ juju bootstrap <cloud-name> <controller-name> --debug --config caas-image-repo=<ur-docker-ns>
```

3. deploy caas workload into the k8s controller;


## Documentation changes

Not fully released yet.

## Bug reference

Not fully released yet.