### PR TITLE
Smallchanges

### DIFF
--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -6,15 +6,15 @@ package instancemutater
 import (
 	"fmt"
 
-	"github.com/juju/juju/core/lxdprofile"
-
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -38,6 +38,12 @@ type MutaterMachine interface {
 
 	// Tag returns the current machine tag
 	Tag() names.MachineTag
+
+	// Life returns the machine's lifecycle value.
+	Life() params.Life
+
+	// Refresh updates the cached local copy of the machine's data.
+	Refresh() error
 
 	// RemoveUpgradeCharmProfileData completely removes the instance charm
 	// profile data for a machine and the given unit, even if the machine
@@ -147,6 +153,21 @@ func (m *Machine) SetUpgradeCharmProfileComplete(unitName string, message string
 // Tag implements MutaterMachine.Tag.
 func (m *Machine) Tag() names.MachineTag {
 	return m.tag
+}
+
+// Life implements MutaterMachine.Life.
+func (m *Machine) Life() params.Life {
+	return m.life
+}
+
+// Refresh implements MutaterMachine.Refresh.
+func (m *Machine) Refresh() error {
+	life, err := common.OneLife(m.facade, m.tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.life = life
+	return nil
 }
 
 // WatchUnits implements MutaterMachine.WatchUnits.

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
+	params "github.com/juju/juju/apiserver/params"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v2 "gopkg.in/juju/names.v2"
@@ -60,6 +61,30 @@ func (m *MockMutaterMachine) InstanceId() (string, error) {
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId))
+}
+
+// Life mocks base method
+func (m *MockMutaterMachine) Life() params.Life {
+	ret := m.ctrl.Call(m, "Life")
+	ret0, _ := ret[0].(params.Life)
+	return ret0
+}
+
+// Life indicates an expected call of Life
+func (mr *MockMutaterMachineMockRecorder) Life() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMutaterMachine)(nil).Life))
+}
+
+// Refresh mocks base method
+func (m *MockMutaterMachine) Refresh() error {
+	ret := m.ctrl.Call(m, "Refresh")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Refresh indicates an expected call of Refresh
+func (mr *MockMutaterMachineMockRecorder) Refresh() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh))
 }
 
 // RemoveUpgradeCharmProfileData mocks base method

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/instancemutater"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -56,9 +57,14 @@ type mutater struct {
 
 func (m *mutater) startMachines(tags []names.MachineTag) error {
 	for _, tag := range tags {
+		select {
+		case <-m.context.dying():
+			return m.context.errDying()
+		default:
+		}
+		m.logger.Debugf("received tag %q", tag.String())
 		if c := m.machines[tag]; c == nil {
-			m.logger.Warningf("received tag %q", tag.String())
-
+			// First time we recieve the tag, setup watchers.
 			api, err := m.context.getMachine(tag)
 			if err != nil {
 				return errors.Trace(err)
@@ -77,26 +83,25 @@ func (m *mutater) startMachines(tags []names.MachineTag) error {
 
 			go runMachine(machine, c, m.machineDead)
 		} else {
-			select {
-			case <-m.context.dying():
-				return m.context.errDying()
-			case c <- struct{}{}:
-			}
+			// We've received this tag before, therefore
+			// the machine has been removed from the model
+			// cache and no longer needed
+			c <- struct{}{}
 		}
 	}
 	return nil
 }
 
-func runMachine(machine mutaterMachine, changed <-chan struct{}, died chan<- instancemutater.MutaterMachine) {
+func runMachine(machine mutaterMachine, removed <-chan struct{}, died chan<- instancemutater.MutaterMachine) {
 	defer func() {
 		// We can't just send on the dead channel because the
 		// central loop might be trying to write to us on the
-		// changed channel.
+		// removed channel.
 		for {
 			select {
 			case died <- machine.machineApi:
 				return
-			case <-changed:
+			case <-removed:
 			}
 		}
 	}()
@@ -108,16 +113,16 @@ func runMachine(machine mutaterMachine, changed <-chan struct{}, died chan<- ins
 		return
 	}
 	if err := machine.context.add(profileChangeWatcher); err != nil {
+		machine.context.kill(err)
 		return
 	}
-
-	if err := machine.watchProfileChangesLoop(profileChangeWatcher); err != nil {
+	if err := machine.watchProfileChangesLoop(removed, profileChangeWatcher); err != nil {
 		machine.context.kill(err)
 	}
 }
 
 // watchProfileChanges, any error returned will cause the worker to restart.
-func (m mutaterMachine) watchProfileChangesLoop(profileChangeWatcher watcher.NotifyWatcher) error {
+func (m mutaterMachine) watchProfileChangesLoop(removed <-chan struct{}, profileChangeWatcher watcher.NotifyWatcher) error {
 	m.logger.Tracef("watching change on mutaterMachine %s", m.id)
 	for {
 		select {
@@ -128,18 +133,32 @@ func (m mutaterMachine) watchProfileChangesLoop(profileChangeWatcher watcher.Not
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if err = m.processMachineProfileChanges(info); err != nil {
+			if err = m.processMachineProfileChanges(info); err != nil && errors.IsNotValid(err) {
+				// Return to stop mutating the machine, but no need to restart
+				// the worker.
+				return nil
+			} else if err != nil {
 				return errors.Trace(err)
 			}
+		case <-removed:
+			return nil
 		}
 	}
 }
 
 func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitProfileInfo) error {
-	m.logger.Tracef("%s.processMachineProfileChanges(%#v)", m.id, info)
 	if len(info.CurrentProfiles) == 0 && len(info.ProfileChanges) == 0 {
 		// no changes to be made, return now.
 		return nil
+	}
+
+	if err := m.machineApi.Refresh(); err != nil {
+		return err
+	}
+	if m.machineApi.Life() == params.Dead {
+		// Machine is dead, continue onwards as we can't do anything in this
+		// position.
+		return errors.NotValidf("machine %q", m.id)
 	}
 
 	// Set the modification status to idle, that way we have a baseline for
@@ -150,7 +169,7 @@ func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 
 	report := func(retErr error) error {
 		if retErr != nil {
-			m.logger.Errorf("cannot upgrade machine-%s lxd profile: %s", m.id, retErr.Error())
+			m.logger.Errorf("cannot upgrade machine-%s lxd profiles: %s", m.id, retErr.Error())
 			if err := m.machineApi.SetModificationStatus(status.Error, fmt.Sprintf("cannot upgrade machine's lxd profile: %s", retErr.Error()), nil); err != nil {
 				m.logger.Errorf("cannot set modification status of machine %q error: %v", m.id, err)
 			}
@@ -186,11 +205,11 @@ func (m mutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 		return report(nil)
 	}
 
-	m.logger.Tracef("machine-%s (%s) assign profiles %q, %#v", m.id, string(info.InstanceId), expectedProfiles, post)
+	m.logger.Tracef("machine-%s (%s) assign lxd profiles %q, %#v", m.id, string(info.InstanceId), expectedProfiles, post)
 	broker := m.context.getBroker()
 	currentProfiles, err := broker.AssignLXDProfiles(string(info.InstanceId), expectedProfiles, post)
 	if err != nil {
-		m.logger.Errorf("failure to assign profiles %s to machine-%s: %s", expectedProfiles, m.id, err)
+		m.logger.Errorf("failure to assign lxd profiles %s to machine-%s: %s", expectedProfiles, m.id, err)
 		return report(err)
 	}
 
@@ -222,7 +241,6 @@ func (m mutaterMachine) gatherProfileData(info *instancemutater.UnitProfileInfo)
 		}
 		result = append(result, add)
 	}
-	m.logger.Tracef("%s.data gathered %#v", m.id, result)
 	return result, nil
 }
 
@@ -230,7 +248,7 @@ func (m mutaterMachine) verifyCurrentProfiles(instId string, expectedProfiles []
 	broker := m.context.getBroker()
 	obtainedProfiles, err := broker.LXDProfileNames(instId)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	obtainedSet := set.NewStrings(obtainedProfiles...)
 

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -162,14 +162,6 @@ func (w *mutaterWorker) loop() error {
 		machines:    make(map[names.MachineTag]chan struct{}),
 		machineDead: make(chan instancemutater.MutaterMachine),
 	}
-	defer func() {
-		// TODO(fwereade): is this a home-grown sync.WaitGroup or something?
-		// strongly suspect these mutaterMachine goroutines could be managed rather
-		// less opaquely if we made them all workers.
-		for len(m.machines) > 0 {
-			delete(m.machines, (<-m.machineDead).Tag())
-		}
-	}()
 	for {
 		select {
 		case <-m.context.dying():
@@ -201,14 +193,14 @@ func (w *mutaterWorker) Wait() error {
 	return w.catacomb.Wait()
 }
 
-// Stop stops the upgradeseriesworker and returns any
+// Stop stops the instancemutaterworker and returns any
 // error it encountered when running.
 func (w *mutaterWorker) Stop() error {
 	w.Kill()
 	return w.Wait()
 }
 
-// newMachineContext is part of the updaterContext interface.
+// newMachineContext is part of the mutaterContext interface.
 func (w *mutaterWorker) newMachineContext() machineContext {
 	return w
 }

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -156,12 +156,9 @@ type workerSuite struct {
 	appLXDProfileWorker    map[int]*workermocks.MockWorker
 	getRequiredLXDProfiles instancemutater.RequiredLXDProfilesFunc
 
-	// The done channel is used by tests to indicate that
-	// the worker has accomplished the scenario and can be stopped.
-	done chan struct{}
-	mu   sync.Mutex
-
-	closedCount int
+	// doneWG is a collection of things each test needs to wait to
+	// be completed within the test.
+	doneWG sync.WaitGroup
 
 	newWorkerFunc func(instancemutater.Config) (worker.Worker, error)
 }
@@ -171,9 +168,6 @@ var _ = gc.Suite(&workerSuite{})
 func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
-	s.mu.Lock()
-	s.done = make(chan struct{})
-	s.mu.Unlock()
 	s.newWorkerFunc = instancemutater.NewEnvironWorker
 	s.machineTag = names.NewMachineTag("0")
 	s.getRequiredLXDProfiles = func(modelName string) []string {
@@ -195,18 +189,15 @@ func (s *workerEnvironSuite) TestFullWorkflow(c *gc.C) {
 
 	w := s.workerForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyMachines([][]string{
-			{"0"},
-		}, s.noopDone),
+		s.notifyMachines([][]string{{"0"}}),
 		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1, s.noopDone),
-		s.expectMachineTag(0),
+		s.notifyMachineAppLXDProfile(0, 1),
 		s.expectMachineCharmProfilingInfo(0, 3),
 		s.expectLXDProfileNamesTrue,
 		s.expectSetCharmProfiles(0),
 		s.expectAssignLXDProfiles,
 		s.expectAliveAndSetModificationStatusIdle(0),
-		s.expectModificationStatusAppliedDoCloseDone(0, s.closeDone),
+		s.expectModificationStatusApplied(0),
 	)
 	s.cleanKill(c, w)
 }
@@ -216,16 +207,13 @@ func (s *workerEnvironSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 
 	w := s.workerForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyMachines([][]string{
-			{"0"},
-		}, s.noopDone),
+		s.notifyMachines([][]string{{"0"}}),
 		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1, s.noopDone),
-		s.expectMachineTag(0),
+		s.notifyMachineAppLXDProfile(0, 1),
 		s.expectAliveAndSetModificationStatusIdle(0),
 		s.expectMachineCharmProfilingInfo(0, 2),
 		s.expectLXDProfileNamesTrue,
-		s.expectModificationStatusAppliedDoCloseDone(0, s.closeDone),
+		s.expectModificationStatusApplied(0),
 	)
 	s.cleanKill(c, w)
 }
@@ -233,26 +221,23 @@ func (s *workerEnvironSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 func (s *workerEnvironSuite) TestMachineNotifyTwice(c *gc.C) {
 	defer s.setup(c, 2).Finish()
 
+	// A WaitGroup for this test to synchronize when the
+	// machine notifications are sent.  The 2nd group must
+	// be after machine 0 gets Life() == Alive.
+	var group sync.WaitGroup
 	w := s.workerForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyMachines([][]string{
-			{"0", "1", "0"},
-		}, s.noopDone),
+		s.notifyMachinesWaitGroup([][]string{{"0", "1"}, {"0"}}, &group),
 		s.expectFacadeMachineTag(0),
 		s.expectFacadeMachineTag(1),
-		s.notifyMachineAppLXDProfile(0, 1, s.noopDone),
-		s.notifyMachineAppLXDProfile(1, 1, s.noopDone),
-		s.expectMachineTag(0),
-		s.expectMachineTag(1),
-		s.expectAliveAndSetModificationStatusIdle(0),
+		s.notifyMachineAppLXDProfile(0, 1),
+		s.notifyMachineAppLXDProfile(1, 1),
 		s.expectAliveAndSetModificationStatusIdle(1),
 		s.expectMachineCharmProfilingInfo(0, 2),
 		s.expectMachineCharmProfilingInfo(1, 2),
 		s.expectLXDProfileNamesTrue,
 		s.expectLXDProfileNamesTrue,
-		s.expectModificationStatusAppliedDoCloseDone(0, s.noopDone),
-		s.expectModificationStatusAppliedDoCloseDone(1, s.noopDone),
-		s.expectMachineDead(0, s.closeDone),
+		s.expectMachineAliveStatusIdleMachineDead(0, &group),
 	)
 	s.cleanKill(c, w)
 }
@@ -262,12 +247,9 @@ func (s *workerEnvironSuite) TestNoChangeFoundOne(c *gc.C) {
 
 	w := s.workerForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyMachines([][]string{
-			{"0"},
-		}, s.noopDone),
+		s.notifyMachines([][]string{{"0"}}),
 		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1, s.closeDone),
-		s.expectMachineTag(0),
+		s.notifyMachineAppLXDProfile(0, 1),
 		s.expectCharmProfilingInfoSimpleNoChange(0),
 	)
 	s.cleanKill(c, w)
@@ -278,11 +260,13 @@ func (s *workerEnvironSuite) TestNoMachineFound(c *gc.C) {
 
 	w, err := s.workerErrorForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyMachines([][]string{
-			{"0"},
-		}, s.closeDone),
+		s.notifyMachines([][]string{{"0"}}),
 		s.expectFacadeReturnsNoMachine,
 	)
+
+	// Since we don't use cleanKill() nor errorKill()
+	// here, but do waitDone() before checking errors.
+	s.waitDone(c)
 
 	// This test had intermittent failures, one of the
 	// two following would occur.  The 2nd is what we're
@@ -301,12 +285,9 @@ func (s *workerEnvironSuite) TestCharmProfilingInfoNotProvisioned(c *gc.C) {
 
 	w := s.workerForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyMachines([][]string{
-			{"0"},
-		}, s.noopDone),
+		s.notifyMachines([][]string{{"0"}}),
 		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1, s.closeDone),
-		s.expectMachineTag(0),
+		s.notifyMachineAppLXDProfile(0, 1),
 		s.expectCharmProfileInfoNotProvisioned(0),
 	)
 
@@ -332,16 +313,6 @@ func (s *workerSuite) setup(c *gc.C, machineCount int) *gomock.Controller {
 	}
 
 	return ctrl
-}
-
-func (s *workerSuite) noopDone() {
-	// do nothing with the done channel
-}
-
-func (s *workerSuite) closeDone() {
-	s.mu.Lock()
-	close(s.done)
-	s.mu.Unlock()
 }
 
 // workerForScenario creates worker config based on the suite's mocks.
@@ -394,20 +365,20 @@ func (s *workerSuite) expectFacadeMachineTag(machine int) func() {
 }
 
 func (s *workerSuite) expectFacadeReturnsNoMachine() {
-	s.facade.EXPECT().Machine(s.machineTag).Return(nil, errors.NewNotFound(nil, "machine"))
-}
-
-func (s *workerSuite) expectMachineTag(machine int) func() {
-	return func() {
-		tag := names.NewMachineTag(strconv.Itoa(machine))
-		s.machine[machine].EXPECT().Tag().Return(tag).AnyTimes()
-	}
+	do := s.workGroupAddGetDoneFunc()
+	s.facade.EXPECT().Machine(s.machineTag).Return(nil, errors.NewNotFound(nil, "machine")).Do(do)
 }
 
 func (s *workerSuite) expectCharmProfilingInfoSimpleNoChange(machine int) func() {
 	return func() {
-		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, nil)
+		do := s.workGroupAddGetDoneFunc()
+		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, nil).Do(do)
 	}
+}
+
+func (s *workerSuite) workGroupAddGetDoneFunc() func(_ ...interface{}) {
+	s.doneWG.Add(1)
+	return func(_ ...interface{}) { s.doneWG.Done() }
 }
 
 func (s *workerSuite) expectLXDProfileNamesTrue() {
@@ -439,7 +410,8 @@ func (s *workerSuite) expectCharmProfilingInfo(mock *mocks.MockMutaterMachine, r
 
 func (s *workerSuite) expectCharmProfileInfoNotProvisioned(machine int) func() {
 	return func() {
-		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, errors.NotProvisionedf("machine 0"))
+		do := s.workGroupAddGetDoneFunc()
+		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, errors.NotProvisionedf("machine 0")).Do(do)
 	}
 }
 
@@ -452,24 +424,30 @@ func (s *workerSuite) expectAliveAndSetModificationStatusIdle(machine int) func(
 	}
 }
 
-func (s *workerSuite) expectMachineDead(machine int, fn func()) func() {
+func (s *workerSuite) expectMachineAliveStatusIdleMachineDead(machine int, group *sync.WaitGroup) func() {
 	return func() {
 		mExp := s.machine[machine].EXPECT()
-		mExp.Refresh().Return(nil)
-		do := func(_ status.Status, _ string, _ map[string]interface{}) { fn() }
-		mExp.Life().Return(params.Dead).Do(do)
+
+		group.Add(1)
+		notificationSync := func(_ ...interface{}) { group.Done() }
+
+		mExp.Refresh().Return(nil).Times(2)
+		o1 := mExp.Life().Return(params.Alive).Do(notificationSync)
+
+		mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
+
+		do := s.workGroupAddGetDoneFunc()
+		s.machine[0].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
+		s.machine[1].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
+
+		s.doneWG.Add(1)
+		mExp.Life().Return(params.Dead).After(o1).Do(do)
 	}
 }
 
 func (s *workerSuite) expectModificationStatusApplied(machine int) func() {
 	return func() {
-		s.machine[machine].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
-	}
-}
-
-func (s *workerSuite) expectModificationStatusAppliedDoCloseDone(machine int, fn func()) func() {
-	return func() {
-		do := func(_ status.Status, _ string, _ map[string]interface{}) { fn() }
+		do := s.workGroupAddGetDoneFunc()
 		s.machine[machine].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
 	}
 }
@@ -488,15 +466,40 @@ func (s *workerSuite) expectSetCharmProfiles(machine int) func() {
 // notifyMachines returns a suite behaviour that will cause the instance mutator
 // watcher to send a number of notifications equal to the supplied argument.
 // Once notifications have been consumed, we notify via the suite's channel.
-func (s *workerSuite) notifyMachines(values [][]string, doneFn func()) func() {
+func (s *workerSuite) notifyMachines(values [][]string) func() {
 	ch := make(chan []string)
 
 	return func() {
+		s.doneWG.Add(1)
 		go func() {
 			for _, v := range values {
 				ch <- v
 			}
-			doneFn()
+			s.doneWG.Done()
+		}()
+
+		s.machinesWorker.EXPECT().Kill().AnyTimes()
+		s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
+
+		s.facade.EXPECT().WatchMachines().Return(
+			&fakeStringsWatcher{
+				Worker: s.machinesWorker,
+				ch:     ch,
+			}, nil)
+	}
+}
+
+func (s *workerSuite) notifyMachinesWaitGroup(values [][]string, group *sync.WaitGroup) func() {
+	ch := make(chan []string)
+
+	return func() {
+		s.doneWG.Add(1)
+		go func() {
+			for _, v := range values {
+				ch <- v
+				group.Wait()
+			}
+			s.doneWG.Done()
 		}()
 
 		s.machinesWorker.EXPECT().Kill().AnyTimes()
@@ -513,23 +516,24 @@ func (s *workerSuite) notifyMachines(values [][]string, doneFn func()) func() {
 // notifyAppLXDProfile returns a suite behaviour that will cause the instance mutator
 // watcher to send a number of notifications equal to the supplied argument.
 // Once notifications have been consumed, we notify via the suite's channel.
-func (s *workerSuite) notifyMachineAppLXDProfile(machine, times int, doneFn func()) func() {
-	return s.notifyAppLXDProfile(s.machine[machine], machine, times, doneFn)
+func (s *workerSuite) notifyMachineAppLXDProfile(machine, times int) func() {
+	return s.notifyAppLXDProfile(s.machine[machine], machine, times)
 }
 
-func (s *workerContainerSuite) notifyContainerAppLXDProfile(times int, doneFn func()) func() {
-	return s.notifyAppLXDProfile(s.container, 0, times, doneFn)
+func (s *workerContainerSuite) notifyContainerAppLXDProfile(times int) func() {
+	return s.notifyAppLXDProfile(s.container, 0, times)
 }
 
-func (s *workerSuite) notifyAppLXDProfile(mock *mocks.MockMutaterMachine, which, times int, doneFn func()) func() {
+func (s *workerSuite) notifyAppLXDProfile(mock *mocks.MockMutaterMachine, which, times int) func() {
 	ch := make(chan struct{})
 
 	return func() {
+		s.doneWG.Add(1)
 		go func() {
 			for i := 0; i < times; i += 1 {
 				ch <- struct{}{}
 			}
-			doneFn()
+			s.doneWG.Done()
 		}()
 
 		w := s.appLXDProfileWorker[which]
@@ -547,11 +551,7 @@ func (s *workerSuite) notifyAppLXDProfile(mock *mocks.MockMutaterMachine, which,
 // cleanKill waits for notifications to be processed, then waits for the input
 // worker to be killed cleanly. If either ops time out, the test fails.
 func (s *workerSuite) cleanKill(c *gc.C, w worker.Worker) {
-	select {
-	case <-s.done:
-	case <-time.After(testing.LongWait * 20):
-		c.Errorf("timed out waiting for notifications to be consumed")
-	}
+	s.waitDone(c)
 	workertest.CleanKill(c, w)
 }
 
@@ -559,12 +559,22 @@ func (s *workerSuite) cleanKill(c *gc.C, w worker.Worker) {
 // worker to be killed.  Any error is returned to the caller. If either ops
 // time out, the test fails.
 func (s *workerSuite) errorKill(c *gc.C, w worker.Worker) error {
+	s.waitDone(c)
+	return workertest.CheckKill(c, w)
+}
+
+func (s *workerSuite) waitDone(c *gc.C) {
+	ch := make(chan struct{})
+	go func() {
+		s.doneWG.Wait()
+		ch <- struct{}{}
+	}()
+
 	select {
-	case <-s.done:
+	case <-ch:
 	case <-time.After(testing.LongWait):
 		c.Errorf("timed out waiting for notifications to be consumed")
 	}
-	return workertest.CheckKill(c, w)
 }
 
 // ignoreLogging turns the suite's mock logger into a sink, with no validation.
@@ -624,19 +634,17 @@ func (s *workerContainerSuite) TestFullWorkflow(c *gc.C) {
 
 	w := s.workerForScenario(c,
 		s.ignoreLogging(c),
-		s.notifyContainers(0, [][]string{
-			{"0/lxd/0"},
-		}, s.noopDone),
+		s.notifyContainers(0, [][]string{{"0/lxd/0"}}),
 		s.expectFacadeMachineTag(0),
 		s.expectFacadeContainerTag,
-		s.notifyContainerAppLXDProfile(1, s.noopDone),
+		s.notifyContainerAppLXDProfile(1),
 		s.expectContainerTag,
 		s.expectContainerCharmProfilingInfo(3),
 		s.expectLXDProfileNamesTrue,
 		s.expectContainerSetCharmProfiles,
 		s.expectAssignLXDProfiles,
 		s.expectContainerAliveAndSetModificationStatusIdle,
-		s.expectContainerModificationStatusAppliedDoCloseDone,
+		s.expectContainerModificationStatusApplied,
 	)
 	s.cleanKill(c, w)
 }
@@ -668,11 +676,7 @@ func (s *workerContainerSuite) expectContainerAliveAndSetModificationStatusIdle(
 }
 
 func (s *workerContainerSuite) expectContainerModificationStatusApplied() {
-	s.container.EXPECT().SetModificationStatus(status.Applied, gomock.Any(), gomock.Any()).Return(nil)
-}
-
-func (s *workerContainerSuite) expectContainerModificationStatusAppliedDoCloseDone() {
-	do := func(_ status.Status, _ string, _ map[string]interface{}) { s.closeDone() }
+	do := s.workGroupAddGetDoneFunc()
 	s.container.EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
 }
 
@@ -688,15 +692,16 @@ func (s *workerContainerSuite) expectContainerSetCharmProfiles() {
 // notifyContainers returns a suite behaviour that will cause the instance mutator
 // watcher to send a number of notifications equal to the supplied argument.
 // Once notifications have been consumed, we notify via the suite's channel.
-func (s *workerContainerSuite) notifyContainers(machine int, values [][]string, doneFn func()) func() {
+func (s *workerContainerSuite) notifyContainers(machine int, values [][]string) func() {
 	ch := make(chan []string)
 
 	return func() {
+		s.doneWG.Add(1)
 		go func() {
 			for _, v := range values {
 				ch <- v
 			}
-			doneFn()
+			s.doneWG.Done()
 		}()
 
 		s.machinesWorker.EXPECT().Kill().AnyTimes()


### PR DESCRIPTION
## Description of change

On receiving a machine tag after the first time, check to ensure the machine is alive, or close down the go routine.

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=instance-mutater
2. juju bootstrap localhost
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd -n 2
2. wait for both units to be active
3. juju upgrade-charm lxd-profile-alt  --path ./testcharms/charm-repo/quantal/lxd-profile-alt
4. verify that both are successful and that their profiles have been updated