### PR TITLE
Add base-image-path model config attribute to gce provider

### DIFF
--- a/provider/gce/config.go
+++ b/provider/gce/config.go
@@ -11,17 +11,16 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-// TODO(ericsnow) While not strictly config-related, we could use some
-// mechanism by which we can validate the values we've hard-coded in
-// this provider match up with the external authoritative sources. One
-// example of this is the data stored in instancetypes.go. Similarly
-// we should also ensure the cloud-images metadata is correct and
-// up-to-date, though that is more the responsibility of that team.
-// Regardless, it may be useful to include a tool somewhere in juju
-// that we can use to validate this provider's potentially out-of-date
-// data.
+const (
+	cfgBaseImagePath = "base-image-path"
+)
 
-var configSchema = environschema.Fields{}
+var configSchema = environschema.Fields{
+	cfgBaseImagePath: {
+		Description: "Base path to look for machine disk images.",
+		Type:        environschema.Tstring,
+	},
+}
 
 // configFields is the spec for each GCE config value's type.
 var configFields = func() schema.Fields {
@@ -34,7 +33,9 @@ var configFields = func() schema.Fields {
 
 var configImmutableFields = []string{}
 
-var configDefaults = schema.Defaults{}
+var configDefaults = schema.Defaults{
+	cfgBaseImagePath: schema.Omit,
+}
 
 type environConfig struct {
 	config *config.Config
@@ -78,4 +79,9 @@ func newConfig(cfg, old *config.Config) (*environConfig, error) {
 		attrs:  attrs,
 	}
 	return ecfg, nil
+}
+
+func (c *environConfig) baseImagePath() (string, bool) {
+	path, ok := c.attrs[cfgBaseImagePath].(string)
+	return path, ok
 }


### PR DESCRIPTION
## Description of change

This functionality has been requested to facilitate nested virtualisation capabilities of Google Compute Engine (GCE).

> Juju can target GCP[sic] to stand up services, however, the images don't allow nested virtualisation.
>
> Google offers this by creating a copy of the disk image and applying a Google license tag to it: https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances
>
> [...]
>> If you did go and create your own images, I do not know if said images would still be available from the base path "projects/ubuntu-os-cloud/global/images/"? I suspect we'd also need to **introduce a model config item** to allow the base image path to be specified.

## QA steps

Default behaviour:

* Bootstrap to GCE
* Running `juju model-config base-image-path` prints out an empty line

Invalid Path

* `juju bootstrap --config base-image-path=/tmp/ google g1`
```
Creating Juju controller "g1" on google/us-east1
Looking for packaged Juju agent version 2.6-beta2 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on google/us-east1...
ERROR failed to bootstrap model: cannot start bootstrap instance in any availability zone (us-east1-b, us-east1-c, us-east1-d)
```

**Future improvement**: verify that `relative-image-path` exists at the start of the bootstrap command.

## Documentation changes

End-user documentation is required.

We need to explain that the `base-image-path` is used in conjunction with `default-image-id`.

Additionally, please note that when `base-image-path` and `image-stream` are specified `image-stream` is ignored.

## Bug reference

* [lp#1814633](https://bugs.launchpad.net/juju/+bug/1814633)
