### PR TITLE
'model-destroy' gains --force and max-wait options.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -76,7 +76,7 @@ var facadeVersions = map[string]int{
 	"MigrationTarget":              1,
 	"ModelConfig":                  2,
 	"ModelGeneration":              1,
-	"ModelManager":                 6,
+	"ModelManager":                 7,
 	"ModelUpgrader":                1,
 	"NotifyWatcher":                1,
 	"OfferStatusWatcher":           1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -246,6 +246,7 @@ func AllFacades() *facade.Registry {
 	reg("ModelManager", 4, modelmanager.NewFacadeV4)
 	reg("ModelManager", 5, modelmanager.NewFacadeV5) // adds ChangeModelCredential
 	reg("ModelManager", 6, modelmanager.NewFacadeV6) // adds cloud specific default config
+	reg("ModelManager", 7, modelmanager.NewFacadeV7) // DestroyModels gains 'force' and max-wait' parameters.
 	reg("ModelUpgrader", 1, modelupgrader.NewStateFacade)
 
 	reg("Payloads", 1, payloads.NewFacade)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -673,7 +673,9 @@ func (s *modelManagerSuite) TestDumpModelV2(c *gc.C) {
 		&modelmanager.ModelManagerAPIV3{
 			&modelmanager.ModelManagerAPIV4{
 				&modelmanager.ModelManagerAPIV5{
-					s.api,
+					&modelmanager.ModelManagerAPIV6{
+						s.api,
+					},
 				},
 			},
 		},
@@ -837,7 +839,9 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	api := &modelmanager.ModelManagerAPIV3{
 		&modelmanager.ModelManagerAPIV4{
 			&modelmanager.ModelManagerAPIV5{
-				s.api,
+				&modelmanager.ModelManagerAPIV6{
+					s.api,
+				},
 			},
 		},
 	}
@@ -1605,7 +1609,9 @@ func (s *modelManagerSuite) TestModelStatusV2(c *gc.C) {
 		&modelmanager.ModelManagerAPIV3{
 			&modelmanager.ModelManagerAPIV4{
 				&modelmanager.ModelManagerAPIV5{
-					s.api,
+					&modelmanager.ModelManagerAPIV6{
+						s.api,
+					},
 				},
 			},
 		},
@@ -1640,7 +1646,9 @@ func (s *modelManagerSuite) TestModelStatusV3(c *gc.C) {
 	api := &modelmanager.ModelManagerAPIV3{
 		&modelmanager.ModelManagerAPIV4{
 			&modelmanager.ModelManagerAPIV5{
-				s.api,
+				&modelmanager.ModelManagerAPIV6{
+					s.api,
+				},
 			},
 		},
 	}

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -398,6 +398,15 @@ type DestroyModelParams struct {
 	// storage in the model, an error with the code
 	// params.CodeHasPersistentStorage will be returned.
 	DestroyStorage *bool `json:"destroy-storage,omitempty"`
+
+	// Force specifies whether model destruction will be forced, i.e.
+	// keep going despite operational errors.
+	Force *bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in model destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // ModelCredential stores information about cloud credential that a model uses:

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -92,7 +92,7 @@ Model destruction is a multi-step process and when forcing this process, users c
 specify for how long each step will wait to complete cleanly before forcing the next step to start.
 When --max-wait is not explicitly specified, a default wait of 1 minute will be used.
 --max-wait is a duration and can be specified with suffixes such as 'h' for 'hours',
-'m' for 'minutes' and 's' for 'seconds'. For example, '--max-wait 1h20ms45s' is painfully
+'m' for 'minutes' and 's' for 'seconds'. For example, '--max-wait 1h20m45s' is painfully
 long but completely valid.
 
 Examples:

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -65,6 +65,9 @@ type destroyCommand struct {
 	api            DestroyModelAPI
 	configAPI      ModelConfigAPI
 	storageAPI     StorageAPI
+
+	Force   bool
+	MaxWait time.Duration
 }
 
 var destroyDoc = `
@@ -77,6 +80,20 @@ action.
 If there is persistent storage in any of the models managed by the
 controller, then you must choose to either destroy or release the
 storage, using --destroy-storage or --release-storage respectively.
+
+Sometimes, the destruction of the model may fail as Juju encounters errors
+and failures that need to be dealt with before a model can be destroyed.
+However, at times, there is a need to destroy a model ignoring
+all operational errors. In these rare cases, use --force option but note 
+that --force will also remove all units of the application, its subordinates
+and, potentially, machines without given them the opportunity to shutdown cleanly.
+
+Model destruction is a multi-step process and when forcing this process, users can also 
+specify for how long each step will wait to complete cleanly before forcing the next step to start.
+When --max-wait is not explicitly specified, a default wait of 1 minute will be used.
+--max-wait is a duration and can be specified with suffixes such as 'h' for 'hours',
+'m' for 'minutes' and 's' for 'seconds'. For example, '--max-wait 1h20ms45s' is painfully
+long but completely valid.
 
 Examples:
 
@@ -105,7 +122,7 @@ Continue [y/N]? `[1:]
 type DestroyModelAPI interface {
 	Close() error
 	BestAPIVersion() int
-	DestroyModel(tag names.ModelTag, destroyStorage *bool) error
+	DestroyModel(tag names.ModelTag, destroyStorage, force *bool, maxWait *time.Duration) error
 	ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, error)
 }
 
@@ -135,12 +152,18 @@ func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.DurationVar(&c.timeout, "timeout", 30*time.Minute, "")
 	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage instances in the model")
 	f.BoolVar(&c.releaseStorage, "release-storage", false, "Release all storage instances from the model, and management of the controller, without destroying them")
+	f.BoolVar(&c.Force, "force", false, "Force destroy model ignoring any errors")
+	f.DurationVar(&c.MaxWait, "max-wait", 1*time.Minute, "Time interval to wait for each step to complete")
 }
 
 // Init implements Command.Init.
 func (c *destroyCommand) Init(args []string) error {
 	if c.destroyStorage && c.releaseStorage {
 		return errors.New("--destroy-storage and --release-storage cannot both be specified")
+	}
+
+	if !c.Force && c.MaxWait != 1*time.Minute {
+		return errors.NotValidf("--max-wait duration without --force")
 	}
 	switch len(args) {
 	case 0:
@@ -287,8 +310,15 @@ upgrade the controller to version 2.3 or greater.
 	if c.destroyStorage || c.releaseStorage {
 		destroyStorage = &c.destroyStorage
 	}
+	var force *bool
+	var maxWait *time.Duration
+	if c.Force {
+		force = &c.Force
+		// max wait only makes sense if c.force is set.
+		maxWait = &c.MaxWait
+	}
 	modelTag := names.NewModelTag(modelDetails.ModelUUID)
-	if err := api.DestroyModel(modelTag, destroyStorage); err != nil {
+	if err := api.DestroyModel(modelTag, destroyStorage, force, maxWait); err != nil {
 		return c.handleError(
 			modelTag, modelName, api,
 			errors.Annotate(err, "cannot destroy model"),


### PR DESCRIPTION
## Description of change

Model destroy can very soon be forced.
This PR adds --force option to the command and passes it through to api and apiserver. 
As most destructions and removals are a multi-step process, all these operations when forced will support user's ability to specify for how long each step will wait to execute cleanly. If a step waited for --max-wait duration and its following step did not kick off, Juju will force the next step.

This PR also adds --max-wait option from CLI and transports through to api and apiserver.
This required a facade version bump, since additional values were added to an existing api call parameter.