### PR TITLE
Unittests for mutater in the InstanceMutater worker

### DIFF
--- a/api/instancemutater/mocks/machinemutater_mock.go
+++ b/api/instancemutater/mocks/machinemutater_mock.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
+	params "github.com/juju/juju/apiserver/params"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v2 "gopkg.in/juju/names.v2"
@@ -60,6 +61,30 @@ func (m *MockMutaterMachine) InstanceId() (string, error) {
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId))
+}
+
+// Life mocks base method
+func (m *MockMutaterMachine) Life() params.Life {
+	ret := m.ctrl.Call(m, "Life")
+	ret0, _ := ret[0].(params.Life)
+	return ret0
+}
+
+// Life indicates an expected call of Life
+func (mr *MockMutaterMachineMockRecorder) Life() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMutaterMachine)(nil).Life))
+}
+
+// Refresh mocks base method
+func (m *MockMutaterMachine) Refresh() error {
+	ret := m.ctrl.Call(m, "Refresh")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Refresh indicates an expected call of Refresh
+func (mr *MockMutaterMachineMockRecorder) Refresh() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh))
 }
 
 // RemoveUpgradeCharmProfileData mocks base method
@@ -133,6 +158,19 @@ func (m *MockMutaterMachine) WatchApplicationLXDProfiles() (watcher.NotifyWatche
 // WatchApplicationLXDProfiles indicates an expected call of WatchApplicationLXDProfiles
 func (mr *MockMutaterMachineMockRecorder) WatchApplicationLXDProfiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationLXDProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).WatchApplicationLXDProfiles))
+}
+
+// WatchContainers mocks base method
+func (m *MockMutaterMachine) WatchContainers() (watcher.StringsWatcher, error) {
+	ret := m.ctrl.Call(m, "WatchContainers")
+	ret0, _ := ret[0].(watcher.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchContainers indicates an expected call of WatchContainers
+func (mr *MockMutaterMachineMockRecorder) WatchContainers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers))
 }
 
 // WatchUnits mocks base method

--- a/worker/instancemutater/export_test.go
+++ b/worker/instancemutater/export_test.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancemutater
+
+import (
+	"github.com/juju/juju/api/instancemutater"
+	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/environs"
+)
+
+func NewMachineContext(
+	logger Logger,
+	broker environs.LXDProfiler,
+	machine instancemutater.MutaterMachine,
+	fn RequiredLXDProfilesFunc,
+	id string,
+) *MutaterMachine {
+	w := mutaterWorker{
+		broker:                     broker,
+		getRequiredLXDProfilesFunc: fn,
+	}
+	return &MutaterMachine{
+		context:    w.newMachineContext(),
+		logger:     logger,
+		machineApi: machine,
+		id:         id,
+	}
+}
+
+func ProcessMachineProfileChanges(m *MutaterMachine, info *instancemutater.UnitProfileInfo) error {
+	return m.processMachineProfileChanges(info)
+}
+
+func GatherProfileData(m *MutaterMachine, info *instancemutater.UnitProfileInfo) ([]lxdprofile.ProfilePost, error) {
+	return m.gatherProfileData(info)
+}
+
+func VerifyCurrentProfiles(m *MutaterMachine, instId string, expectedProfiles []string) (bool, error) {
+	return m.verifyCurrentProfiles(instId, expectedProfiles)
+}

--- a/worker/instancemutater/manifold_test.go
+++ b/worker/instancemutater/manifold_test.go
@@ -39,7 +39,7 @@ func (s *modelManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			err:         "nil Logger not valid",
 		},
 		{
-			description: "Test no logger",
+			description: "Test no Logger",
 			config:      instancemutater.ModelManifoldConfig{},
 			err:         "nil Logger not valid",
 		},
@@ -378,7 +378,7 @@ func (s *machineManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			err:         "nil Logger not valid",
 		},
 		{
-			description: "Test no logger",
+			description: "Test no Logger",
 			config:      instancemutater.MachineManifoldConfig{},
 			err:         "nil Logger not valid",
 		},

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -5,39 +5,268 @@ package instancemutater_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	apimocks "github.com/juju/juju/api/instancemutater/mocks"
-	jujutesting "github.com/juju/juju/testing"
+	apiinstancemutater "github.com/juju/juju/api/instancemutater"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/worker/instancemutater"
 	"github.com/juju/juju/worker/instancemutater/mocks"
 )
 
 type mutaterSuite struct {
-	jujutesting.BaseSuite
+	loggerSuite
 
-	tag names.MachineTag
+	tag    names.MachineTag
+	instId string
 
-	logger  *mocks.MockLogger
-	machine *apimocks.MockMutaterMachine
+	facade  *mocks.MockInstanceMutaterAPI
+	machine *mocks.MockMutaterMachine
+	broker  *mocks.MockLXDProfiler
+
+	mutaterMachine *instancemutater.MutaterMachine
 }
 
 var _ = gc.Suite(&mutaterSuite{})
 
 func (s *mutaterSuite) SetUpTest(c *gc.C) {
 	s.tag = names.NewMachineTag("2")
-	s.BaseSuite.SetUpTest(c)
+	s.instId = "juju-23413-2"
+	s.IsolationSuite.SetUpTest(c)
+}
+
+func (s *mutaterSuite) TestProcessMachineProfileChanges(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	startingProfiles := []string{"default", "juju-testme"}
+	finishingProfiles := append(startingProfiles, "juju-testme-lxd-profile-1")
+
+	s.ignoreLogging(c)()
+	s.expectRefreshLifeAliveStatusIdle()
+	s.expectLXDProfileNames(startingProfiles, nil)
+	s.expectAssignLXDProfiles(finishingProfiles, nil)
+	s.expectSetCharmProfiles(finishingProfiles)
+	s.expectModificationStatusApplied()
+
+	info := s.info(startingProfiles, 1, true)
+	err := instancemutater.ProcessMachineProfileChanges(s.mutaterMachine, info)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *mutaterSuite) TestProcessMachineProfileChangesMachineDead(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	startingProfiles := []string{"default", "juju-testme"}
+
+	s.ignoreLogging(c)()
+	s.expectRefreshLifeDead()
+
+	info := s.info(startingProfiles, 1, false)
+	err := instancemutater.ProcessMachineProfileChanges(s.mutaterMachine, info)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *mutaterSuite) TestProcessMachineProfileChangesError(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	startingProfiles := []string{"default", "juju-testme"}
+	finishingProfiles := append(startingProfiles, "juju-testme-lxd-profile-1")
+
+	s.ignoreLogging(c)()
+	s.expectRefreshLifeAliveStatusIdle()
+	s.expectLXDProfileNames(startingProfiles, nil)
+	s.expectAssignLXDProfiles(finishingProfiles, errors.New("fail me"))
+	s.expectModificationStatusError()
+
+	info := s.info(startingProfiles, 1, true)
+	err := instancemutater.ProcessMachineProfileChanges(s.mutaterMachine, info)
+	c.Assert(err, gc.ErrorMatches, "fail me")
+}
+
+func (s *mutaterSuite) TestProcessMachineProfileChangesNilInfo(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	err := instancemutater.ProcessMachineProfileChanges(s.mutaterMachine, &apiinstancemutater.UnitProfileInfo{})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *mutaterSuite) TestGatherProfileDataReplace(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	post, err := instancemutater.GatherProfileData(
+		s.mutaterMachine,
+		s.info([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, 1, true),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(post, gc.DeepEquals, []lxdprofile.ProfilePost{
+		{Name: "juju-testme-lxd-profile-0", Profile: nil},
+		{Name: "juju-testme-lxd-profile-1", Profile: &testProfile},
+	})
+}
+
+func (s *mutaterSuite) TestGatherProfileDataRemove(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	post, err := instancemutater.GatherProfileData(
+		s.mutaterMachine,
+		s.info([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, 0, false),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(post, gc.DeepEquals, []lxdprofile.ProfilePost{
+		{Name: "juju-testme-lxd-profile-0", Profile: nil},
+	})
+}
+
+func (s *mutaterSuite) TestGatherProfileDataAdd(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	post, err := instancemutater.GatherProfileData(
+		s.mutaterMachine,
+		s.info([]string{"default", "juju-testme"}, 1, true),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(post, gc.DeepEquals, []lxdprofile.ProfilePost{
+		{Name: "juju-testme-lxd-profile-1", Profile: &testProfile},
+	})
+}
+
+func (s *mutaterSuite) TestGatherProfileDataNoChange(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	post, err := instancemutater.GatherProfileData(
+		s.mutaterMachine,
+		s.info([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, 0, true),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(post, gc.DeepEquals, []lxdprofile.ProfilePost{
+		{Name: "juju-testme-lxd-profile-0", Profile: &testProfile},
+	})
+}
+
+func (s *mutaterSuite) info(profiles []string, rev int, add bool) *apiinstancemutater.UnitProfileInfo {
+	info := &apiinstancemutater.UnitProfileInfo{
+		ModelName:       "testme",
+		InstanceId:      instance.Id(s.instId),
+		CurrentProfiles: profiles,
+		ProfileChanges: []apiinstancemutater.UnitProfileChanges{
+			{ApplicationName: "lxd-profile",
+				Revision: rev,
+			},
+		},
+	}
+	if add {
+		info.ProfileChanges[0].Profile = testProfile
+	}
+	return info
+}
+
+func (s *mutaterSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	profiles := []string{"default", "juju-testme", "juju-testme-lxd-profile-0"}
+	s.expectLXDProfileNames(profiles, nil)
+
+	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, profiles)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *mutaterSuite) TestVerifyCurrentProfilesFalseLength(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	profiles := []string{"default", "juju-testme", "juju-testme-lxd-profile-0"}
+	s.expectLXDProfileNames(profiles, nil)
+
+	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, append(profiles, "juju-testme-next-1"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContents(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.expectLXDProfileNames([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, nil)
+
+	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme", "juju-testme-lxd-profile-1"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *mutaterSuite) TestVerifyCurrentProfilesError(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.expectLXDProfileNames([]string{}, errors.NotFoundf("instId"))
+
+	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default"})
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *mutaterSuite) setUpMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.logger = mocks.NewMockLogger(ctrl)
-	lExp := s.logger.EXPECT()
-	lExp.Tracef(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	s.machine = apimocks.NewMockMutaterMachine(ctrl)
+	s.machine = mocks.NewMockMutaterMachine(ctrl)
 	s.machine.EXPECT().Tag().Return(s.tag).AnyTimes()
 
+	s.broker = mocks.NewMockLXDProfiler(ctrl)
+	s.facade = mocks.NewMockInstanceMutaterAPI(ctrl)
+
+	s.mutaterMachine = instancemutater.NewMachineContext(s.logger, s.broker, s.machine, s.getRequiredLXDProfiles, s.tag.Id())
 	return ctrl
+}
+
+func (s *mutaterSuite) expectLXDProfileNames(profiles []string, err error) {
+	s.broker.EXPECT().LXDProfileNames(s.instId).Return(profiles, err)
+}
+
+func (s *mutaterSuite) expectRefreshLifeAliveStatusIdle() {
+	mExp := s.machine.EXPECT()
+	mExp.Refresh().Return(nil)
+	mExp.Life().Return(params.Alive)
+	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
+}
+
+func (s *mutaterSuite) expectRefreshLifeDead() {
+	mExp := s.machine.EXPECT()
+	mExp.Refresh().Return(nil)
+	mExp.Life().Return(params.Dead)
+}
+
+func (s *mutaterSuite) expectModificationStatusApplied() {
+	s.machine.EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
+}
+
+func (s *mutaterSuite) expectModificationStatusError() {
+	s.machine.EXPECT().SetModificationStatus(status.Error, gomock.Any(), gomock.Any()).Return(nil)
+}
+
+func (s *mutaterSuite) expectAssignLXDProfiles(profiles []string, err error) {
+	s.broker.EXPECT().AssignLXDProfiles(s.instId, profiles, gomock.Any()).Return(profiles, err)
+}
+
+func (s *mutaterSuite) expectSetCharmProfiles(profiles []string) {
+	s.machine.EXPECT().SetCharmProfiles(profiles)
+}
+
+func (s *mutaterSuite) getRequiredLXDProfiles(modelName string) []string {
+	return []string{"default", "juju-" + modelName}
+}
+
+var testProfile = lxdprofile.Profile{
+	Config: map[string]string{
+		"security.nesting": "true",
+	},
+	Description: "dummy profile description",
+	Devices: map[string]map[string]string{
+		"tun": {
+			"path": "/dev/net/tun",
+		},
+	},
 }

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -38,14 +38,14 @@ type Logger interface {
 type Config struct {
 	Facade InstanceMutaterAPI
 
-	// Logger is the logger for this worker.
+	// Logger is the Logger for this worker.
 	Logger Logger
 
 	Broker environs.LXDProfiler
 
 	AgentConfig agent.Config
 
-	// Tag is the current mutaterMachine tag
+	// Tag is the current MutaterMachine tag
 	Tag names.Tag
 
 	// GetMachineWatcher allows the worker to watch different "machines"
@@ -201,22 +201,22 @@ func (w *mutaterWorker) Stop() error {
 }
 
 // newMachineContext is part of the mutaterContext interface.
-func (w *mutaterWorker) newMachineContext() machineContext {
+func (w *mutaterWorker) newMachineContext() MachineContext {
 	return w
 }
 
-// getMachine is part of the machineContext interface.
+// getMachine is part of the MachineContext interface.
 func (w *mutaterWorker) getMachine(tag names.MachineTag) (instancemutater.MutaterMachine, error) {
 	m, err := w.facade.Machine(tag)
 	return m, err
 }
 
-// getBroker is part of the machineContext interface.
+// getBroker is part of the MachineContext interface.
 func (w *mutaterWorker) getBroker() environs.LXDProfiler {
 	return w.broker
 }
 
-// getRequiredLXDProfiles part of the machineContext interface.
+// getRequiredLXDProfiles part of the MachineContext interface.
 func (w *mutaterWorker) getRequiredLXDProfiles(modelName string) []string {
 	return w.getRequiredLXDProfilesFunc(modelName)
 }

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -53,7 +53,7 @@ func (s *workerConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			err:         "nil Logger not valid",
 		},
 		{
-			description: "Test no logger",
+			description: "Test no Logger",
 			config:      instancemutater.Config{},
 			err:         "nil Logger not valid",
 		},
@@ -144,9 +144,8 @@ func (s *workerConfigSuite) TestValidConfigValidate(c *gc.C) {
 }
 
 type workerSuite struct {
-	testing.IsolationSuite
+	loggerSuite
 
-	logger                 *mocks.MockLogger
 	facade                 *mocks.MockInstanceMutaterAPI
 	broker                 *mocks.MockLXDProfiler
 	agentConfig            *mocks.MockConfig
@@ -307,7 +306,6 @@ func (s *workerSuite) setup(c *gc.C, machineCount int) *gomock.Controller {
 	s.machine = make(map[int]*mocks.MockMutaterMachine, machineCount)
 	s.appLXDProfileWorker = make(map[int]*workermocks.MockWorker)
 	for i := 0; i < machineCount; i += 1 {
-		c.Logf("new machine %d", i)
 		s.machine[i] = mocks.NewMockMutaterMachine(ctrl)
 		s.appLXDProfileWorker[i] = workermocks.NewMockWorker(ctrl)
 	}
@@ -577,9 +575,17 @@ func (s *workerSuite) waitDone(c *gc.C) {
 	}
 }
 
-// ignoreLogging turns the suite's mock logger into a sink, with no validation.
-// Logs are still emitted via the test logger.
-func (s *workerSuite) ignoreLogging(c *gc.C) func() {
+type loggerSuite struct {
+	testing.IsolationSuite
+
+	logger *mocks.MockLogger
+}
+
+var _ = gc.Suite(&loggerSuite{})
+
+// ignoreLogging turns the suite's mock Logger into a sink, with no validation.
+// Logs are still emitted via the test Logger.
+func (s *loggerSuite) ignoreLogging(c *gc.C) func() {
 	warnIt := func(message string, args ...interface{}) { logIt(c, loggo.WARNING, message, args) }
 	debugIt := func(message string, args ...interface{}) { logIt(c, loggo.DEBUG, message, args) }
 	errorIt := func(message string, args ...interface{}) { logIt(c, loggo.ERROR, message, args) }


### PR DESCRIPTION
## Description of change

Unittests for mutater in the InstanceMutater worker

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=instance-mutater
2. juju bootstrap localhost
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd -n 2
2. wait for both units to be active
3. juju upgrade-charm lxd-profile-alt  --path ./testcharms/charm-repo/quantal/lxd-profile-alt
4. verify that both are successful and that their profiles have been updated