### PR TITLE
Be careful when initializing slices.

### DIFF
--- a/mongo/service.go
+++ b/mongo/service.go
@@ -224,7 +224,7 @@ type ConfigArgs struct {
 type configArgsConverter map[string]string
 
 func (conf configArgsConverter) asCommandLineArguments() string {
-	command := make([]string, len(conf)*2)
+	command := make([]string, 0, len(conf)*2)
 	for key, value := range conf {
 		if len(key) >= 2 {
 			key = "--" + key
@@ -246,7 +246,7 @@ func (conf configArgsConverter) asCommandLineArguments() string {
 
 func (conf configArgsConverter) asMongoDbConfigurationFileFormat() string {
 	pathArgs := set.NewStrings("dbpath", "logpath", "sslPEMKeyFile", "keyFile")
-	command := make([]string, len(conf))
+	command := make([]string, 0, len(conf))
 	for key, value := range conf {
 		if len(key) == 0 {
 			continue


### PR DESCRIPTION
## Description of change

If the loop just does 'append' we need to make sure to set the capacity
and not the slice length.

## QA steps

```
$ JUJU_DEV_FEATURE_FLAGS="mongodb-snap" juju bootstrap lxd
$ juju ssh -m controller 0
$$ sudo cat /var/snap/juju-db/common/juju-db.config
```

Notice that with the change, you don't end up with a header, then 16 blank lines followed by 16 lines of content.

## Documentation changes

None.

## Bug reference

None.
