### PR TITLE
Make Cached Entity Detail Access Goroutine-Safe

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -38,6 +38,8 @@ type Application struct {
 
 // CharmURL returns the charm url string for this application.
 func (a *Application) CharmURL() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.details.CharmURL
 }
 

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -31,6 +31,8 @@ type Charm struct {
 
 // LXDProfile returns the lxd profile of this charm.
 func (c *Charm) LXDProfile() lxdprofile.Profile {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.details.LXDProfile
 }
 

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -33,7 +33,7 @@ type MachineAppModeler interface {
 
 type appInfo struct {
 	charmURL     string
-	charmProfile *lxdprofile.Profile
+	charmProfile lxdprofile.Profile
 	units        set.Strings
 }
 
@@ -98,20 +98,21 @@ func (w *MachineAppLXDProfileWatcher) applicationCharmURLChange(topic string, va
 			w.logError(fmt.Sprintf("error getting charm %s to evaluate for lxd profile notification: %s", chURL, err))
 			return
 		}
+
 		// notify if:
 		// 1. the prior charm had a profile and the new one does not.
 		// 2. the new profile is not empty.
-		if (info.charmProfile != nil && ch.details.LXDProfile.Empty()) ||
-			!ch.details.LXDProfile.Empty() {
+		lxdProfile := ch.LXDProfile()
+		if (!info.charmProfile.Empty() && lxdProfile.Empty()) || !lxdProfile.Empty() {
 			logger.Tracef("notifying due to change of charm lxd profile for %s, machine-%s", appName, w.machineId)
 			notify = true
 		} else {
 			logger.Tracef("no notification of charm lxd profile needed for %s, machine-%s", appName, w.machineId)
 		}
-		if ch.details.LXDProfile.Empty() {
-			info.charmProfile = nil
+		if lxdProfile.Empty() {
+			info.charmProfile = lxdprofile.Profile{}
 		} else {
-			info.charmProfile = &ch.details.LXDProfile
+			info.charmProfile = lxdProfile
 		}
 		info.charmURL = chURL
 		w.applications[appName] = info
@@ -148,24 +149,24 @@ func (w *MachineAppLXDProfileWatcher) unitChange(topic string, value interface{}
 		notify = w.removeUnit(names)
 	case okUnit:
 		switch {
-		case unit.details.MachineId == "" && !unit.details.Subordinate:
-			logger.Tracef("%s has no machineId and not a sub", unit.details.Name)
+		case unit.MachineId() == "" && !unit.Subordinate():
+			logger.Tracef("%s has no machineId and not a sub", unit.Name())
 			return
-		case unit.details.Subordinate:
-			principal, err := w.modeler.Unit(unit.details.Principal)
+		case unit.Subordinate():
+			principal, err := w.modeler.Unit(unit.Principal())
 			if err != nil {
-				logger.Tracef("unit %s is subordinate, principal %s not found", unit.details.Name, unit.details.Principal)
+				logger.Tracef("unit %s is subordinate, principal %s not found", unit.Name(), principal)
 				return
 			}
-			if w.machineId != principal.details.MachineId {
-				logger.Tracef("watching unit changes on machine-%s not machine-%s", w.machineId, unit.details.MachineId)
+			if w.machineId != principal.MachineId() {
+				logger.Tracef("watching unit changes on machine-%s not machine-%s", w.machineId, unit.MachineId())
 				return
 			}
-		case w.machineId != unit.details.MachineId:
-			logger.Tracef("watching unit changes on machine-%s not machine-%s", w.machineId, unit.details.MachineId)
+		case w.machineId != unit.MachineId():
+			logger.Tracef("watching unit changes on machine-%s not machine-%s", w.machineId, unit.MachineId())
 			return
 		}
-		logger.Tracef("start watching %q on machine-%s", unit.details.Name, w.machineId)
+		logger.Tracef("start watching %q on machine-%s", unit.Name(), w.machineId)
 		notify = w.addUnit(unit)
 	default:
 		w.logError("programming error, value not of type *Unit or []string")
@@ -174,35 +175,40 @@ func (w *MachineAppLXDProfileWatcher) unitChange(topic string, value interface{}
 }
 
 func (w *MachineAppLXDProfileWatcher) addUnit(unit *Unit) bool {
-	_, ok := w.applications[unit.details.Application]
+	unitName := unit.Name()
+	appName := unit.Application()
+
+	_, ok := w.applications[appName]
 	if !ok {
-		curl := unit.details.CharmURL
+		curl := unit.CharmURL()
 		if curl == "" {
 			// this happens for new units to existing machines.
-			app, err := w.modeler.Application(unit.details.Application)
+			app, err := w.modeler.Application(appName)
 			if err != nil {
-				w.logError(fmt.Sprintf("failed to get application %s for machine-%s", unit.details.Application, w.machineId))
+				w.logError(fmt.Sprintf("failed to get application %s for machine-%s", appName, w.machineId))
 				return false
 			}
-			curl = app.details.CharmURL
+			curl = app.CharmURL()
 		}
 		ch, err := w.modeler.Charm(curl)
 		if err != nil {
-			w.logError(fmt.Sprintf("failed to get charm %q for %s on machine-%s", curl, unit.details.Name, w.machineId))
+			w.logError(fmt.Sprintf("failed to get charm %q for %s on machine-%s", curl, appName, w.machineId))
 			return false
 		}
 		info := appInfo{
 			charmURL: curl,
-			units:    set.NewStrings(unit.details.Name),
+			units:    set.NewStrings(unitName),
 		}
-		if !ch.details.LXDProfile.Empty() {
-			info.charmProfile = &ch.details.LXDProfile
+
+		lxdProfile := ch.LXDProfile()
+		if !lxdProfile.Empty() {
+			info.charmProfile = lxdProfile
 		}
-		w.applications[unit.details.Application] = info
+		w.applications[appName] = info
 	} else {
-		w.applications[unit.details.Application].units.Add(unit.details.Name)
+		w.applications[appName].units.Add(unitName)
 	}
-	if w.applications[unit.details.Application].charmProfile != nil {
+	if !w.applications[appName].charmProfile.Empty() {
 		return true
 	}
 	return false
@@ -233,7 +239,7 @@ func (w *MachineAppLXDProfileWatcher) removeUnit(names []string) bool {
 	// If there are additional units on the machine and the current
 	// application has an lxd profile, notify so it can be removed
 	// from the machine.
-	if len(w.applications) > 0 && profile != nil && !profile.Empty() {
+	if len(w.applications) > 0 && !profile.Empty() {
 		return true
 	}
 	return false

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -76,7 +76,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAddUnit(c *gc.C)
 			Application: "application-name",
 			Series:      "bionic",
 		})
-	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 1)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 0)
 
 	// Add the machine id, this time we should get a notification.
 	s.model.UpdateUnit(cache.UnitChange{
@@ -86,7 +86,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAddUnit(c *gc.C)
 		Series:      "bionic",
 		MachineId:   "0",
 	})
-	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 1)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 0)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAddUnitWrongMachine(c *gc.C) {

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -46,7 +46,7 @@ func (m *Machine) InstanceId() (instance.Id, error) {
 	defer m.mu.Unlock()
 
 	if m.details.InstanceId == "" {
-		return "", errors.NotProvisionedf("machine %v", m.Id())
+		return "", errors.NotProvisionedf("machine %v", m.details.Id)
 	}
 	return instance.Id(m.details.InstanceId), nil
 }

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -116,6 +116,19 @@ func (m *Model) Charm(charmURL string) (*Charm, error) {
 	return charm, nil
 }
 
+// Machines makes a copy of the model's machine collection and returns it.
+func (m *Model) Machines() map[string]*Machine {
+	machines := make(map[string]*Machine)
+
+	m.mu.Lock()
+	for k, v := range m.machines {
+		machines[k] = v
+	}
+	m.mu.Unlock()
+
+	return machines
+}
+
 // Machine returns the machine with the input id.
 // If the machine is not found, a NotFoundError is returned.
 func (m *Model) Machine(machineId string) (*Machine, error) {
@@ -134,6 +147,7 @@ func (m *Model) Machine(machineId string) (*Machine, error) {
 // a slice of the current machine ids.  Containers are excluded.
 func (m *Model) WatchMachines() (*PredicateStringsWatcher, error) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	// Create a compiled regexp to match machines not containers.
 	compiled, err := m.machineRegexp()
@@ -159,7 +173,6 @@ func (m *Model) WatchMachines() (*PredicateStringsWatcher, error) {
 		return nil
 	})
 
-	m.mu.Unlock()
 	return w, nil
 }
 

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -239,7 +239,6 @@ func (m *Model) updateUnit(ch UnitChange) {
 	if !found {
 		unit = newUnit(m.metrics, m.hub)
 		m.units[ch.Name] = unit
-		m.hub.Publish(m.topic(modelUnitLXDProfileChange), unit)
 	}
 	unit.setDetails(ch)
 

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -27,9 +27,46 @@ func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
 	return u
 }
 
+// Name returns the name of this unit.
+func (u *Unit) Name() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.details.Name
+}
+
 // Application returns the application name of this unit.
 func (u *Unit) Application() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	return u.details.Application
+}
+
+// MachineId returns the ID of the machine hosting this unit.
+func (u *Unit) MachineId() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.details.MachineId
+}
+
+// Subordinate returns a bool indicating whether this unit is a subordinate.
+func (u *Unit) Subordinate() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.details.Subordinate
+}
+
+// Principal returns the name of the principal unit for the same application.
+func (u *Unit) Principal() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.details.Principal
+}
+
+// CharmURL returns the charm URL for this unit's application.
+func (u *Unit) CharmURL() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.details.CharmURL
 }
 
 func (u *Unit) setDetails(details UnitChange) {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/pubsub"
 )
 
-// Unit represents an unit in a cached model.
+// Unit represents a unit in a cached model.
 type Unit struct {
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
@@ -71,10 +71,12 @@ func (u *Unit) CharmURL() string {
 
 func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
-	if u.details.MachineId != details.MachineId {
+
+	machineChange := u.details.MachineId != details.MachineId
+	u.details = details
+	if machineChange {
 		u.hub.Publish(u.modelTopic(modelUnitLXDProfileChange), u)
 	}
-	u.details = details
 
 	// TODO (manadart 2019-02-11): Maintain hash and publish changes.
 	u.mu.Unlock()

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -248,6 +248,15 @@ type PredicateStringsWatcher struct {
 	fn predicateFunc
 }
 
+// newChangeWatcher provides a PredicateStringsWatcher which notifies
+// with all strings passed to it.
+func newChangeWatcher(values ...string) *PredicateStringsWatcher {
+	return &PredicateStringsWatcher{
+		stringsWatcherBase: newStringsWatcherBase(values...),
+		fn:                 func(string) bool { return true },
+	}
+}
+
 func regexpPredicate(compiled *regexp.Regexp) func(string) bool {
 	return func(value string) bool { return compiled.MatchString(value) }
 }

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -248,15 +248,6 @@ type PredicateStringsWatcher struct {
 	fn predicateFunc
 }
 
-// newChangeWatcher provides a PredicateStringsWatcher which notifies
-// with all strings passed to it.
-func newChangeWatcher(values ...string) *PredicateStringsWatcher {
-	return &PredicateStringsWatcher{
-		stringsWatcherBase: newStringsWatcherBase(values...),
-		fn:                 func(string) bool { return true },
-	}
-}
-
 func regexpPredicate(compiled *regexp.Regexp) func(string) bool {
 	return func(value string) bool { return compiled.MatchString(value) }
 }

--- a/core/lxdprofile/profile.go
+++ b/core/lxdprofile/profile.go
@@ -10,10 +10,6 @@ import (
 	"github.com/juju/collections/set"
 )
 
-func NewLXDCharmProfiler(profile Profile) LXDProfiler {
-	return LXDProfiles{Profile: profile}
-}
-
 type LXDProfiles struct {
 	Profile Profile
 }


### PR DESCRIPTION
## Description of change

This patch aims to appease the race-checker, and fix intermittent failures in the the core cache's `lxdProfileWatcherSuite`.

It involves guarding access to the inner `details` members of cached entities with locks, and ensuring appropriate synchronisation.

## QA steps

Tests will pass consistently with the `-race` flag.

## Documentation changes

None.

## Bug reference

N/A
