### PR TITLE
show/list k8s controllers display relevant info

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -28,11 +28,13 @@ type UserModel struct {
 type ModelStatus struct {
 	UUID               string
 	Life               string
+	ModelType          model.ModelType
 	Owner              string
 	TotalMachineCount  int
 	CoreCount          int
 	HostedMachineCount int
 	ApplicationCount   int
+	UnitCount          int
 	Machines           []Machine
 	Volumes            []Volume
 	Filesystems        []Filesystem

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
 )
 
 // ModelStatusAPI provides common client-side API functions
@@ -63,7 +64,7 @@ func (c *ModelStatusAPI) processModelStatusResults(rs []params.ModelStatus) ([]b
 	return results, nil
 }
 
-func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.ModelStatus) base.ModelStatus {
+func constructModelStatus(m names.ModelTag, owner names.UserTag, r params.ModelStatus) base.ModelStatus {
 	volumes := make([]base.Volume, len(r.Volumes))
 	for i, in := range r.Volumes {
 		volumes[i] = base.Volume{
@@ -87,11 +88,13 @@ func constructModelStatus(model names.ModelTag, owner names.UserTag, r params.Mo
 	}
 
 	result := base.ModelStatus{
-		UUID:               model.Id(),
+		UUID:               m.Id(),
 		Life:               string(r.Life),
 		Owner:              owner.Id(),
+		ModelType:          model.ModelType(r.Type),
 		HostedMachineCount: r.HostedMachineCount,
 		ApplicationCount:   r.ApplicationCount,
+		UnitCount:          r.UnitCount,
 		TotalMachineCount:  len(r.Machines),
 		Volumes:            volumes,
 		Filesystems:        filesystems,

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -216,7 +216,9 @@ func (st modelManagerStateShim) AllMachines() ([]Machine, error) {
 }
 
 // Application defines methods provided by a state.Application instance.
-type Application interface{}
+type Application interface {
+	UnitCount() int
+}
 
 type applicationShim struct {
 	*state.Application

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -87,6 +87,10 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 	if err != nil {
 		return status, errors.Trace(err)
 	}
+	var unitCount int
+	for _, app := range applications {
+		unitCount += app.UnitCount()
+	}
 
 	modelMachines, err := ModelMachineInfo(st)
 	if err != nil {
@@ -97,8 +101,10 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 		ModelTag:           tag,
 		OwnerTag:           model.Owner().String(),
 		Life:               params.Life(model.Life().String()),
+		Type:               string(model.Type()),
 		HostedMachineCount: len(hostedMachines),
 		ApplicationCount:   len(applications),
+		UnitCount:          unitCount,
 		Machines:           modelMachines,
 	}
 

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -193,6 +193,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			ApplicationCount:   1,
 			OwnerTag:           s.Owner.String(),
 			Life:               params.Alive,
+			Type:               string(state.ModelTypeIAAS),
 			Machines: []params.ModelMachineInfo{
 				{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", DisplayName: "snowflake", Status: "pending", WantsVote: true},
 				{Id: "1", Hardware: stdHw, InstanceId: "id-5", Status: "pending"},
@@ -212,6 +213,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			ApplicationCount:   1,
 			OwnerTag:           otherModelOwner.UserTag.String(),
 			Life:               params.Alive,
+			Type:               string(state.ModelTypeIAAS),
 			Machines: []params.ModelMachineInfo{
 				{Id: "0", Hardware: stdHw, InstanceId: "id-8", Status: "pending"},
 				{Id: "1", Hardware: stdHw, InstanceId: "id-9", Status: "pending"},
@@ -231,8 +233,11 @@ func (s *modelStatusSuite) TestModelStatusCAAS(c *gc.C) {
 	defer otherSt.Close()
 
 	otherFactory := factory.NewFactory(otherSt, s.StatePool)
-	otherFactory.MakeApplication(c, &factory.ApplicationParams{
+	app := otherFactory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: otherFactory.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"}),
+	})
+	otherFactory.MakeUnit(c, &factory.UnitParams{
+		Application: app,
 	})
 
 	otherModel, err := otherSt.Model()
@@ -254,13 +259,16 @@ func (s *modelStatusSuite) TestModelStatusCAAS(c *gc.C) {
 			ApplicationCount:   0,
 			OwnerTag:           s.Owner.String(),
 			Life:               params.Alive,
+			Type:               string(state.ModelTypeIAAS),
 		},
 		{
 			ModelTag:           hostedModelTag,
 			HostedMachineCount: 0,
 			ApplicationCount:   1,
+			UnitCount:          1,
 			OwnerTag:           otherModelOwner.UserTag.String(),
 			Life:               params.Alive,
+			Type:               string(state.ModelTypeCAAS),
 		},
 	})
 }
@@ -280,6 +288,7 @@ func (s *modelStatusSuite) TestModelStatusRunsForAllModels(c *gc.C) {
 				ModelTag: s.Model.ModelTag().String(),
 				Life:     params.Life(s.Model.Life().String()),
 				OwnerTag: s.Model.Owner().String(),
+				Type:     string(state.ModelTypeIAAS),
 			},
 		},
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -884,6 +884,10 @@ func (m *ModelManagerAPI) ListModelSummaries(req params.ModelSummariesRequest) (
 			summary.Counts = append(summary.Counts, params.ModelEntityCount{params.Cores, mi.CoreCount})
 		}
 
+		if mi.UnitCount > 0 {
+			summary.Counts = append(summary.Counts, params.ModelEntityCount{params.Units, mi.UnitCount})
+		}
+
 		access, err := common.StateToParamsUserAccessPermission(mi.Access)
 		if err == nil {
 			summary.UserAccess = access

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -45,8 +45,10 @@ type RemoveBlocksArgs struct {
 type ModelStatus struct {
 	ModelTag           string                `json:"model-tag"`
 	Life               Life                  `json:"life"`
+	Type               string                `json:"type"`
 	HostedMachineCount int                   `json:"hosted-machine-count"`
 	ApplicationCount   int                   `json:"application-count"`
+	UnitCount          int                   `json:"unit-count"`
 	OwnerTag           string                `json:"owner-tag"`
 	Machines           []ModelMachineInfo    `json:"machines,omitempty"`
 	Volumes            []ModelVolumeInfo     `json:"volumes,omitempty"`

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -234,6 +234,7 @@ type CountedEntity string
 const (
 	Machines CountedEntity = "machines"
 	Cores    CountedEntity = "cores"
+	Units    CountedEntity = "units"
 )
 
 // ModelSLAInfo describes the SLA info for a model.

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -38,7 +38,7 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 		fmt.Fprintln(writer, "Use --refresh option with this command to see the latest information.")
 		fmt.Fprintln(writer)
 	}
-	w.Println("Controller", "Model", "User", "Access", "Cloud/Region", "Models", "Machines", "HA", "Version")
+	w.Println("Controller", "Model", "User", "Access", "Cloud/Region", "Models", "Nodes", "HA", "Version")
 	tw.SetColumnAlignRight(5)
 	tw.SetColumnAlignRight(6)
 	tw.SetColumnAlignRight(7)
@@ -85,6 +85,9 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 		machineCount := noValueDisplay
 		if c.MachineCount != nil && *c.MachineCount > 0 {
 			machineCount = fmt.Sprintf("%d", *c.MachineCount)
+		}
+		if c.NodeCount != nil && *c.NodeCount > 0 {
+			machineCount = fmt.Sprintf("%d", *c.NodeCount)
 		}
 		modelCount := noValueDisplay
 		if c.ModelCount != nil && *c.ModelCount > 0 {

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -74,6 +74,15 @@ controllers:
     api-endpoints: [this-is-one-of-many-api-endpoints]
     cloud: prodstack
     ca-cert: this-is-a-ca-cert
+  k8s-controller:
+    uuid: this-is-a-k8s-uuid
+    api-endpoints: [this-is-one-of-many-k8s-api-endpoints]
+    cloud: microk8s
+    region: localhost
+    type: kubernetes
+    ca-cert: this-is-a-k8s-ca-cert
+    machine-count: 3
+    agent-version: 6.6.6
 current-controller: mallards
 `
 
@@ -94,6 +103,15 @@ controllers:
         uuid: def
         type: iaas
     current-model: admin/my-model
+  k8s-controller:
+    models:
+      controller:
+        uuid: xyz
+        type: caas
+      my-k8s-model:
+        uuid: def
+        type: caas
+    current-model: admin/my-k8s-model
 `
 
 const testAccountsYaml = `
@@ -105,6 +123,10 @@ controllers:
     user: admin
     password: hunter2
   mallards:
+    user: admin
+    password: hunter2
+    last-known-access: superuser
+  k8s-controller:
     user: admin
     password: hunter2
     last-known-access: superuser

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -230,6 +230,7 @@ func prepare(
 	}
 	details.ControllerDetails.Cloud = args.Cloud.Name
 	details.ControllerDetails.CloudRegion = args.Cloud.Region
+	details.ControllerDetails.CloudType = args.Cloud.Type
 	details.BootstrapConfig.CloudType = args.Cloud.Type
 	details.BootstrapConfig.Cloud = args.Cloud.Name
 	details.BootstrapConfig.CloudRegion = args.Cloud.Region

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -74,6 +74,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foundController.ControllerUUID, gc.DeepEquals, controllerCfg.ControllerUUID())
 	c.Assert(foundController.Cloud, gc.Equals, "dummy")
+	c.Assert(foundController.CloudType, gc.Equals, "dummy")
 
 	// Check that bootstrap config was written
 	bootstrapCfg, err := controllerStore.BootstrapConfigForController(cfg.Name())

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -77,8 +77,8 @@ func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	expectedOutput := `
 Use --refresh option with this command to see the latest information.
 
-Controller  Model       User   Access     Cloud/Region        Models  Machines  HA  Version
-kontroll*   controller  admin  superuser  dummy/dummy-region       1         -   -  (unknown)  
+Controller  Model       User   Access     Cloud/Region        Models  Nodes  HA  Version
+kontroll*   controller  admin  superuser  dummy/dummy-region       1      -   -  (unknown)  
 
 `[1:]
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)

--- a/featuretests/cmd_juju_current_controller_test.go
+++ b/featuretests/cmd_juju_current_controller_test.go
@@ -69,11 +69,11 @@ func (s *cmdCurrentControllerSuite) TestControllerListCommand(c *gc.C) {
 	expectedOutput := `
 Use --refresh option with this command to see the latest information.
 
-Controller  Model       User   Access     Cloud/Region        Models  Machines  HA  Version
-ctrlOne     -           -      -                                   -         -   -  (unknown)  
-ctrlThree*  -           -      -                                   -         -   -  (unknown)  
-ctrlTwo     -           -      -                                   -         -   -  (unknown)  
-kontroll    controller  admin  superuser  dummy/dummy-region       1         -   -  (unknown)  
+Controller  Model       User   Access     Cloud/Region        Models  Nodes  HA  Version
+ctrlOne     -           -      -                                   -      -   -  (unknown)  
+ctrlThree*  -           -      -                                   -      -   -  (unknown)  
+ctrlTwo     -           -      -                                   -      -   -  (unknown)  
+kontroll    controller  admin  superuser  dummy/dummy-region       1      -   -  (unknown)  
 
 `[1:]
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -43,6 +43,9 @@ type ControllerDetails struct {
 	// runs in. This will be empty for clouds without regions.
 	CloudRegion string `yaml:"region,omitempty"`
 
+	// CloudType is the type of the cloud that this controller runs in.
+	CloudType string `yaml:"type,omitempty"`
+
 	// AgentVersion is the version of the agent running on this controller.
 	// While this isn't strictly needed to connect to a controller, it is used
 	// in formatting show-controller output where this struct is also used.

--- a/state/application.go
+++ b/state/application.go
@@ -3038,6 +3038,11 @@ func (a *Application) ServiceInfo() (CloudService, error) {
 	return *svc, nil
 }
 
+// UnitCount returns the of numbr of units for this application.
+func (a *Application) UnitCount() int {
+	return a.doc.UnitCount
+}
+
 // UnitNames returns the of this application's units.
 func (a *Application) UnitNames() ([]string, error) {
 	u, err := appUnitNames(a.st, a.Name())

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1983,8 +1983,12 @@ func (s *ApplicationSuite) TestApplicationExposed(c *gc.C) {
 
 func (s *ApplicationSuite) TestAddUnit(c *gc.C) {
 	// Check that principal units can be added on their own.
+	c.Assert(s.mysql.UnitCount(), gc.Equals, 0)
 	unitZero, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
+	err = s.mysql.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mysql.UnitCount(), gc.Equals, 1)
 	c.Assert(unitZero.Name(), gc.Equals, "mysql/0")
 	c.Assert(unitZero.IsPrincipal(), jc.IsTrue)
 	c.Assert(unitZero.SubordinateNames(), gc.HasLen, 0)

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -47,8 +47,11 @@ func (s *ModelSummariesSuite) Setup4Models(c *gc.C) map[string]string {
 	st2 := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name:  "user2model",
 		Owner: user2.Tag(),
+		Type:  state.ModelTypeCAAS,
 	})
 	modelUUIDs["user2model"] = st2.ModelUUID()
+	f2 := factory.NewFactory(st2, s.StatePool)
+	f2.MakeUnit(c, nil)
 	st2.Close()
 	user3 := s.Factory.MakeUser(c, &factory.UserParams{
 		Name:        "user3admin",
@@ -447,4 +450,16 @@ func (s *ModelSummariesSuite) TestModelsWithNoSettings(c *gc.C) {
 	userSummary = summaryMap["user2model"]
 	c.Assert(userSummary, gc.NotNil)
 	c.Check(userSummary.Status.Message, gc.Equals, "stopping")
+}
+
+func (s *ModelSummariesSuite) TestCAASModel(c *gc.C) {
+	s.Setup4Models(c)
+
+	summaryMap := s.namedSummariesForUser(c, "user2read")
+	c.Check(summaryMap, gc.HasLen, 2)
+	userSummary := summaryMap["user2model"]
+	c.Assert(userSummary, gc.NotNil)
+	c.Assert(userSummary.MachineCount, gc.Equals, int64(0))
+	c.Assert(userSummary.CoreCount, gc.Equals, int64(0))
+	c.Assert(userSummary.UnitCount, gc.Equals, int64(1))
 }

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -220,6 +220,9 @@ func (st *State) ModelSummariesForUser(user names.UserTag, all bool) ([]ModelSum
 	if err := p.fillInMachineSummary(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := p.fillInApplicationSummary(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if err := p.fillInMigration(); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Modify show/list controllers/models to correctly display k8s info. ie k8s models have no machines. Instead we display nodes and unit count.

## QA steps

bootstrap lxd and l8s controllers
add iaas and caas models
run various CLI commands to check output