### PR TITLE
Model Cache Resource Cleanup

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -62,7 +62,8 @@ func (a *Application) Config() map[string]interface{} {
 
 // WatchConfig creates a watcher for the application config.
 func (a *Application) WatchConfig(keys ...string) *ConfigWatcher {
-	return newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange))
+	w := newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange), a.resident)
+	return w
 }
 
 // appCharmUrlChange contains an appName and it's charm URL.  To be used

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -16,9 +16,9 @@ const (
 	applicationConfigChange = "application-config-change"
 )
 
-func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *Application {
+func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Application {
 	a := &Application{
-		resident: res,
+		Resident: res,
 		metrics:  metrics,
 		hub:      hub,
 	}
@@ -27,9 +27,9 @@ func newApplication(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resid
 
 // Application represents an application in a model.
 type Application struct {
-	// resident identifies the application as a type-agnostic cached entity
+	// Resident identifies the application as a type-agnostic cached entity
 	// and tracks resources that it is responsible for cleaning up.
-	*resident
+	*Resident
 
 	// Link to model?
 	metrics *ControllerGauges
@@ -62,7 +62,7 @@ func (a *Application) Config() map[string]interface{} {
 
 // WatchConfig creates a watcher for the application config.
 func (a *Application) WatchConfig(keys ...string) *ConfigWatcher {
-	w := newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange), a.resident)
+	w := newConfigWatcher(keys, a.hashCache, a.hub, a.topic(applicationConfigChange), a.Resident)
 	return w
 }
 

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -1,5 +1,6 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 package cache_test
 
 import (
@@ -56,7 +57,7 @@ func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
 }
 
 func (s *ApplicationSuite) newApplication(details cache.ApplicationChange) *cache.Application {
-	a := cache.NewApplication(s.Gauges, s.Hub)
+	a := cache.NewApplication(s.Gauges, s.Hub, s.NewResident())
 	a.SetDetails(details)
 	return a
 }

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -14,22 +14,22 @@ import (
 )
 
 type ApplicationSuite struct {
-	entitySuite
+	cache.EntitySuite
 }
 
 var _ = gc.Suite(&ApplicationSuite{})
 
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
-	s.entitySuite.SetUpTest(c)
+	s.EntitySuite.SetUpTest(c)
 }
 
 func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
 	m := s.newApplication(appChange)
-	c.Check(testutil.ToFloat64(s.gauges.ApplicationConfigReads), gc.Equals, float64(0))
+	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(0))
 	m.Config()
-	c.Check(testutil.ToFloat64(s.gauges.ApplicationConfigReads), gc.Equals, float64(1))
+	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(1))
 	m.Config()
-	c.Check(testutil.ToFloat64(s.gauges.ApplicationConfigReads), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(2))
 }
 
 // See model_test.go for other config watcher tests.
@@ -49,14 +49,14 @@ func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
 	wc.AssertOneChange()
 
 	// The hash is generated each time we set the details.
-	c.Check(testutil.ToFloat64(s.gauges.ApplicationHashCacheMiss), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ApplicationHashCacheMiss), gc.Equals, float64(2))
 
 	// The value is retrieved from the cache when the watcher is created and notified.
-	c.Check(testutil.ToFloat64(s.gauges.ApplicationHashCacheHit), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ApplicationHashCacheHit), gc.Equals, float64(2))
 }
 
 func (s *ApplicationSuite) newApplication(details cache.ApplicationChange) *cache.Application {
-	a := cache.NewApplication(s.gauges, s.hub)
+	a := cache.NewApplication(s.Gauges, s.Hub)
 	a.SetDetails(details)
 	return a
 }

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 )
 
-func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *Charm {
+func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Charm {
 	c := &Charm{
-		resident: res,
+		Resident: res,
 		metrics:  metrics,
 		hub:      hub,
 	}
@@ -22,9 +22,9 @@ func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *
 
 // Charm represents an charm in a model.
 type Charm struct {
-	// resident identifies the charm as a type-agnostic cached entity
+	// Resident identifies the charm as a type-agnostic cached entity
 	// and tracks resources that it is responsible for cleaning up.
-	*resident
+	*Resident
 
 	// Link to model?
 	metrics *ControllerGauges

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -11,16 +11,21 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 )
 
-func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
+func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *Charm {
 	c := &Charm{
-		metrics: metrics,
-		hub:     hub,
+		resident: res,
+		metrics:  metrics,
+		hub:      hub,
 	}
 	return c
 }
 
 // Charm represents an charm in a model.
 type Charm struct {
+	// resident identifies the charm as a type-agnostic cached entity
+	// and tracks resources that it is responsible for cleaning up.
+	*resident
+
 	// Link to model?
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub

--- a/core/cache/charm_test.go
+++ b/core/cache/charm_test.go
@@ -11,14 +11,10 @@ import (
 )
 
 type CharmSuite struct {
-	entitySuite
+	cache.EntitySuite
 }
 
 var _ = gc.Suite(&CharmSuite{})
-
-func (s *CharmSuite) SetUpTest(c *gc.C) {
-	s.entitySuite.SetUpTest(c)
-}
 
 var charmChange = cache.CharmChange{
 	ModelUUID: "model-uuid",

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -229,12 +229,12 @@ func (c *Controller) removeMachine(ch RemoveMachine) error {
 	return errors.Trace(c.removeResident(ch.ModelUUID, func(m *Model) error { return m.removeMachine(ch) }))
 }
 
-func (c *Controller) removeResident(modelUUID string, delete func(m *Model) error) error {
+func (c *Controller) removeResident(modelUUID string, removeFrom func(m *Model) error) error {
 	c.mu.Lock()
 
 	var err error
 	if model, ok := c.models[modelUUID]; ok {
-		err = delete(model)
+		err = removeFrom(model)
 	}
 
 	c.mu.Unlock()

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -55,11 +55,17 @@ type Controller struct {
 // The changes channel is what is used to supply the cache with the changes
 // in order for the cache to be kept up to date.
 func NewController(config ControllerConfig) (*Controller, error) {
+	c, err := newController(config, newResidentManager())
+	return c, errors.Trace(err)
+}
+
+// newController is the internal constructor that allows supply of a manager.
+func newController(config ControllerConfig, manager *residentManager) (*Controller, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	c := &Controller{
-		manager: newResidentManager(),
+		manager: manager,
 		config:  config,
 		models:  make(map[string]*Model),
 		hub: pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -107,7 +107,7 @@ func (c *Controller) loop() error {
 			}
 
 			if err != nil {
-				return errors.Trace(err)
+				logger.Errorf("processing cache change: %s", err.Error())
 			}
 		}
 	}

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -68,17 +68,26 @@ func (s *ControllerSuite) TestAddModel(c *gc.C) {
 			"machine-count":     0,
 			"unit-count":        0,
 		}})
+
+	// The model has the first ID and is registered.
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertResident(c, mod.CacheId(), true)
 }
 
 func (s *ControllerSuite) TestRemoveModel(c *gc.C) {
 	controller, events := s.new(c)
 	s.processChange(c, modelChange, events)
 
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
 	remove := cache.RemoveModel{ModelUUID: modelChange.ModelUUID}
 	s.processChange(c, remove, events)
 
 	c.Check(controller.ModelUUIDs(), gc.HasLen, 0)
 	c.Check(controller.Report(), gc.HasLen, 0)
+	s.AssertResident(c, mod.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddApplication(c *gc.C) {
@@ -92,11 +101,18 @@ func (s *ControllerSuite) TestAddApplication(c *gc.C) {
 	app, err := mod.Application(appChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(app, gc.NotNil)
+
+	s.AssertResident(c, app.CacheId(), true)
 }
 
 func (s *ControllerSuite) TestRemoveApplication(c *gc.C) {
 	controller, events := s.new(c)
 	s.processChange(c, appChange, events)
+
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	app, err := mod.Application(appChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
 
 	remove := cache.RemoveApplication{
 		ModelUUID: modelChange.ModelUUID,
@@ -104,9 +120,9 @@ func (s *ControllerSuite) TestRemoveApplication(c *gc.C) {
 	}
 	s.processChange(c, remove, events)
 
-	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["application-count"], gc.Equals, 0)
+	s.AssertResident(c, app.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddCharm(c *gc.C) {
@@ -117,14 +133,20 @@ func (s *ControllerSuite) TestAddCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["charm-count"], gc.Equals, 1)
 
-	app, err := mod.Charm(charmChange.CharmURL)
+	ch, err := mod.Charm(charmChange.CharmURL)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(app, gc.NotNil)
+	c.Check(ch, gc.NotNil)
+	s.AssertResident(c, ch.CacheId(), true)
 }
 
 func (s *ControllerSuite) TestRemoveCharm(c *gc.C) {
 	controller, events := s.new(c)
 	s.processChange(c, charmChange, events)
+
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	ch, err := mod.Charm(charmChange.CharmURL)
+	c.Assert(err, jc.ErrorIsNil)
 
 	remove := cache.RemoveCharm{
 		ModelUUID: modelChange.ModelUUID,
@@ -132,9 +154,8 @@ func (s *ControllerSuite) TestRemoveCharm(c *gc.C) {
 	}
 	s.processChange(c, remove, events)
 
-	mod, err := controller.Model(modelChange.ModelUUID)
-	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["charm-count"], gc.Equals, 0)
+	s.AssertResident(c, ch.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddMachine(c *gc.C) {
@@ -145,14 +166,20 @@ func (s *ControllerSuite) TestAddMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["machine-count"], gc.Equals, 1)
 
-	app, err := mod.Machine(machineChange.Id)
+	machine, err := mod.Machine(machineChange.Id)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(app, gc.NotNil)
+	c.Check(machine, gc.NotNil)
+	s.AssertResident(c, machine.CacheId(), true)
 }
 
 func (s *ControllerSuite) TestRemoveMachine(c *gc.C) {
 	controller, events := s.new(c)
 	s.processChange(c, machineChange, events)
+
+	mod, err := controller.Model(machineChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := mod.Machine(machineChange.Id)
+	c.Assert(err, jc.ErrorIsNil)
 
 	remove := cache.RemoveMachine{
 		ModelUUID: machineChange.ModelUUID,
@@ -160,9 +187,8 @@ func (s *ControllerSuite) TestRemoveMachine(c *gc.C) {
 	}
 	s.processChange(c, remove, events)
 
-	mod, err := controller.Model(machineChange.ModelUUID)
-	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["machine-count"], gc.Equals, 0)
+	s.AssertResident(c, machine.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddUnit(c *gc.C) {
@@ -173,14 +199,20 @@ func (s *ControllerSuite) TestAddUnit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["unit-count"], gc.Equals, 1)
 
-	app, err := mod.Unit(unitChange.Name)
+	unit, err := mod.Unit(unitChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(app, gc.NotNil)
+	c.Check(unit, gc.NotNil)
+	s.AssertResident(c, unit.CacheId(), true)
 }
 
 func (s *ControllerSuite) TestRemoveUnit(c *gc.C) {
 	controller, events := s.new(c)
 	s.processChange(c, unitChange, events)
+
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	unit, err := mod.Unit(unitChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
 
 	remove := cache.RemoveUnit{
 		ModelUUID: modelChange.ModelUUID,
@@ -188,14 +220,13 @@ func (s *ControllerSuite) TestRemoveUnit(c *gc.C) {
 	}
 	s.processChange(c, remove, events)
 
-	mod, err := controller.Model(modelChange.ModelUUID)
-	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["unit-count"], gc.Equals, 0)
+	s.AssertResident(c, unit.CacheId(), false)
 }
 
 func (s *ControllerSuite) new(c *gc.C) (*cache.Controller, <-chan interface{}) {
 	events := s.captureEvents(c)
-	controller, err := cache.NewController(s.config)
+	controller, err := s.NewController(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
 	return controller, events

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ControllerSuite struct {
-	baseSuite
+	cache.BaseSuite
 
 	changes chan interface{}
 	config  cache.ControllerConfig
@@ -25,7 +25,7 @@ type ControllerSuite struct {
 var _ = gc.Suite(&ControllerSuite{})
 
 func (s *ControllerSuite) SetUpTest(c *gc.C) {
-	s.baseSuite.SetUpTest(c)
+	s.BaseSuite.SetUpTest(c)
 	s.changes = make(chan interface{})
 	s.config = cache.ControllerConfig{
 		Changes: s.changes,

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -7,12 +7,6 @@ var (
 	NewApplication = newApplication
 )
 
-// Expose Remove* for testing.
-
-func (m *Model) RemoveMachine(details RemoveMachine) {
-	m.removeMachine(details)
-}
-
 // Expose SetDetails for testing.
 
 func (a *Application) SetDetails(details ApplicationChange) {
@@ -25,12 +19,16 @@ func (m *Model) SetDetails(details ModelChange) {
 
 // Expose Remove* for testing
 
-func (m *Model) RemoveCharm(ch RemoveCharm) {
-	m.removeCharm(ch)
+func (m *Model) RemoveCharm(ch RemoveCharm) error {
+	return m.removeCharm(ch)
 }
 
-func (m *Model) RemoveUnit(ch RemoveUnit) {
-	m.removeUnit(ch)
+func (m *Model) RemoveUnit(ch RemoveUnit) error {
+	return m.removeUnit(ch)
+}
+
+func (m *Model) RemoveMachine(details RemoveMachine) error {
+	return m.removeMachine(details)
 }
 
 // Expose Update* for testing.

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -35,18 +35,18 @@ func (m *Model) RemoveUnit(ch RemoveUnit) {
 
 // Expose Update* for testing.
 
-func (m *Model) UpdateMachine(details MachineChange) {
-	m.updateMachine(details)
+func (m *Model) UpdateMachine(details MachineChange, manager *residentManager) {
+	m.updateMachine(details, manager)
 }
 
-func (m *Model) UpdateUnit(details UnitChange) {
-	m.updateUnit(details)
+func (m *Model) UpdateUnit(details UnitChange, manager *residentManager) {
+	m.updateUnit(details, manager)
 }
 
-func (m *Model) UpdateApplication(details ApplicationChange) {
-	m.updateApplication(details)
+func (m *Model) UpdateApplication(details ApplicationChange, manager *residentManager) {
+	m.updateApplication(details, manager)
 }
 
-func (m *Model) UpdateCharm(details CharmChange) {
-	m.updateCharm(details)
+func (m *Model) UpdateCharm(details CharmChange, manager *residentManager) {
+	m.updateCharm(details, manager)
 }

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -4,9 +4,7 @@
 package cache
 
 var (
-	CreateControllerGauges = createControllerGauges
-	NewApplication         = newApplication
-	NewModel               = newModel
+	NewApplication = newApplication
 )
 
 // Expose Remove* for testing.

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -3,10 +3,6 @@
 
 package cache
 
-var (
-	NewApplication = newApplication
-)
-
 // Expose SetDetails for testing.
 
 func (a *Application) SetDetails(details ApplicationChange) {

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -45,6 +45,7 @@ type MachineAppLXDProfileConfig struct {
 	modeler      MachineAppModeler
 	metrics      *ControllerGauges
 	hub          *pubsub.SimpleHub
+	resident     *resident
 }
 
 func newMachineAppLXDProfileWatcher(config MachineAppLXDProfileConfig) *MachineAppLXDProfileWatcher {
@@ -56,12 +57,14 @@ func newMachineAppLXDProfileWatcher(config MachineAppLXDProfileConfig) *MachineA
 		metrics:           config.metrics,
 	}
 
+	deregister := config.resident.registerWorker(w)
 	unsubApp := config.hub.Subscribe(config.appTopic, w.applicationCharmURLChange)
 	unsubUnit := config.hub.Subscribe(config.unitTopic, w.unitChange)
 	w.tomb.Go(func() error {
 		<-w.tomb.Dying()
 		unsubApp()
 		unsubUnit()
+		deregister()
 		return nil
 	})
 

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -45,7 +45,7 @@ type MachineAppLXDProfileConfig struct {
 	modeler      MachineAppModeler
 	metrics      *ControllerGauges
 	hub          *pubsub.SimpleHub
-	resident     *resident
+	resident     *Resident
 }
 
 func newMachineAppLXDProfileWatcher(config MachineAppLXDProfileConfig) *MachineAppLXDProfileWatcher {

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type lxdProfileWatcherSuite struct {
-	entitySuite
+	cache.EntitySuite
 
 	model    *cache.Model
 	machine0 *cache.Machine
@@ -25,7 +25,7 @@ type lxdProfileWatcherSuite struct {
 var _ = gc.Suite(&lxdProfileWatcherSuite{})
 
 func (s *lxdProfileWatcherSuite) SetUpTest(c *gc.C) {
-	s.entitySuite.SetUpTest(c)
+	s.EntitySuite.SetUpTest(c)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcher(c *gc.C) {
@@ -188,7 +188,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAppChangeCharmUR
 		ModelUUID: "model-uuid",
 		Name:      "application-name",
 		CharmURL:  "charm-url-does-not-exist",
-	})
+	}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 1, 0, 1)
 }
 
@@ -209,7 +209,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherUnitChangeCharmU
 		ModelUUID: "model-uuid",
 		Name:      "new-application-name",
 		CharmURL:  "charm-url-does-not-exist",
-	})
+	}, s.Manager)
 	s.model.UpdateUnit(cache.UnitChange{
 		ModelUUID:   "model-uuid",
 		Name:        "testme/0",
@@ -250,7 +250,7 @@ func (s *lxdProfileWatcherSuite) updateCharmForMachineAppLXDProfileWatcher(rev s
 		ModelUUID: "model-uuid",
 		Name:      "application-name",
 		CharmURL:  curl,
-	})
+	}, s.Manager)
 }
 
 func (s *lxdProfileWatcherSuite) newUnitForMachineAppLXDProfileWatcherNoProfile(c *gc.C, machineId, principal string) {
@@ -278,7 +278,7 @@ func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, c
 	ac := appChange
 	ac.CharmURL = cc.CharmURL
 	ac.Name = "name-me"
-	s.model.UpdateApplication(ac)
+	s.model.UpdateApplication(ac, s.Manager)
 	_, err = s.model.Application(ac.Name)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -298,7 +298,7 @@ func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, c
 }
 
 func (s *lxdProfileWatcherSuite) setupOneMachineAppLXDProfileWatcherScenario(c *gc.C) {
-	s.model = s.newModel(modelChange)
+	s.model = s.NewModel(modelChange)
 
 	s.model.UpdateMachine(machineChange)
 	machine, err := s.model.Machine(machineChange.Id)
@@ -306,7 +306,7 @@ func (s *lxdProfileWatcherSuite) setupOneMachineAppLXDProfileWatcherScenario(c *
 	c.Assert(machine.Id(), gc.Equals, machineChange.Id)
 	s.machine0 = machine
 
-	s.model.UpdateApplication(appChange)
+	s.model.UpdateApplication(appChange, s.Manager)
 	s.model.UpdateUnit(unitChange)
 	s.model.UpdateCharm(charmChange)
 }
@@ -347,7 +347,7 @@ func (s *lxdProfileWatcherSuite) assertStartOneMachineWatcher(c *gc.C) *cache.Ma
 
 func (s *lxdProfileWatcherSuite) assertChangeValidateMetrics(c *gc.C, assert func(), err, hit, miss int) {
 	assert()
-	c.Check(testutil.ToFloat64(s.gauges.LXDProfileChangeError), gc.Equals, float64(err))
-	c.Check(testutil.ToFloat64(s.gauges.LXDProfileChangeHit), gc.Equals, float64(hit))
-	c.Check(testutil.ToFloat64(s.gauges.LXDProfileChangeMiss), gc.Equals, float64(miss))
+	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeError), gc.Equals, float64(err))
+	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeHit), gc.Equals, float64(hit))
+	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeMiss), gc.Equals, float64(miss))
 }

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -39,7 +39,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherError(c *gc.C) {
 	uc.Name = "subordinate/0"
 	uc.Subordinate = true
 	uc.Principal = "principal/0"
-	s.model.UpdateUnit(uc)
+	s.model.UpdateUnit(uc, s.Manager)
 	_, err := s.machine0.WatchApplicationLXDProfiles()
 	c.Assert(err, gc.ErrorMatches, "failed to get units to start MachineAppLXDProfileWatcher: principal unit \"principal/0\" for subordinate subordinate/0 not found")
 }
@@ -75,7 +75,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAddUnit(c *gc.C)
 			Name:        "application-name/1",
 			Application: "application-name",
 			Series:      "bionic",
-		})
+		}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 0)
 
 	// Add the machine id, this time we should get a notification.
@@ -85,7 +85,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAddUnit(c *gc.C)
 		Application: "application-name",
 		Series:      "bionic",
 		MachineId:   "0",
-	})
+	}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 0)
 }
 
@@ -99,7 +99,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherAddUnitWrongMach
 			Series:      "bionic",
 			CharmURL:    "www.no-charm-url.com-1",
 			MachineId:   "42",
-		})
+		}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 1)
 }
 
@@ -124,7 +124,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherTwoMachines(c *g
 	uc := unitChange
 	uc.Name = "application-name/2"
 	uc.MachineId = s.machine0.Id()
-	s.model.UpdateUnit(uc)
+	s.model.UpdateUnit(uc, s.Manager)
 
 	// Assert machine 0 watcher gets the notification,
 	// not machine 1.
@@ -199,7 +199,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherUnitChangeAppNot
 		Name:        "testme/0",
 		Application: "application-name-does-not-exist",
 		MachineId:   s.machine0.Id(),
-	})
+	}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 1, 0, 1)
 }
 
@@ -215,7 +215,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherUnitChangeCharmU
 		Name:        "testme/0",
 		Application: "new-application-name",
 		MachineId:   s.machine0.Id(),
-	})
+	}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 1, 0, 1)
 }
 
@@ -227,7 +227,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherUnitChangeUnitCh
 		Application: "application-name",
 		CharmURL:    "charm-url-does-not-exist",
 		MachineId:   s.machine0.Id(),
-	})
+	}, s.Manager)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 0)
 }
 
@@ -244,7 +244,7 @@ func (s *lxdProfileWatcherSuite) updateCharmForMachineAppLXDProfileWatcher(rev s
 	} else {
 		ch.LXDProfile = lxdprofile.Profile{}
 	}
-	s.model.UpdateCharm(ch)
+	s.model.UpdateCharm(ch, s.Manager)
 
 	s.model.UpdateApplication(cache.ApplicationChange{
 		ModelUUID: "model-uuid",
@@ -271,7 +271,7 @@ func (s *lxdProfileWatcherSuite) newUnitForMachineAppLXDProfileWatcherSubProfile
 }
 
 func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, cc cache.CharmChange) {
-	s.model.UpdateCharm(cc)
+	s.model.UpdateCharm(cc, s.Manager)
 	_, err := s.model.Charm(cc.CharmURL)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -292,7 +292,7 @@ func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, c
 	} else {
 		uc.MachineId = machineId
 	}
-	s.model.UpdateUnit(uc)
+	s.model.UpdateUnit(uc, s.Manager)
 	_, err = s.model.Unit(uc.Name)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -300,15 +300,15 @@ func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, c
 func (s *lxdProfileWatcherSuite) setupOneMachineAppLXDProfileWatcherScenario(c *gc.C) {
 	s.model = s.NewModel(modelChange)
 
-	s.model.UpdateMachine(machineChange)
+	s.model.UpdateMachine(machineChange, s.Manager)
 	machine, err := s.model.Machine(machineChange.Id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Id(), gc.Equals, machineChange.Id)
 	s.machine0 = machine
 
 	s.model.UpdateApplication(appChange, s.Manager)
-	s.model.UpdateUnit(unitChange)
-	s.model.UpdateCharm(charmChange)
+	s.model.UpdateUnit(unitChange, s.Manager)
+	s.model.UpdateCharm(charmChange, s.Manager)
 }
 
 func (s *lxdProfileWatcherSuite) setupTwoMachineAppLXDProfileWatcherScenario(c *gc.C) {
@@ -317,7 +317,7 @@ func (s *lxdProfileWatcherSuite) setupTwoMachineAppLXDProfileWatcherScenario(c *
 	mc := machineChange
 	mc.Id = "1"
 
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 	machine, err := s.model.Machine(mc.Id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Id(), gc.Equals, mc.Id)
@@ -326,11 +326,11 @@ func (s *lxdProfileWatcherSuite) setupTwoMachineAppLXDProfileWatcherScenario(c *
 	uc := unitChange
 	uc.Name = "application-name/1"
 	uc.MachineId = "1"
-	s.model.UpdateUnit(uc)
+	s.model.UpdateUnit(uc, s.Manager)
 	_, err = s.model.Unit(uc.Name)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.model.UpdateCharm(charmChange)
+	s.model.UpdateCharm(charmChange, s.Manager)
 }
 
 func (s *lxdProfileWatcherSuite) assertStartOneMachineWatcher(c *gc.C) *cache.MachineAppLXDProfileWatcher {

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -29,7 +29,13 @@ func (s *lxdProfileWatcherSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcher(c *gc.C) {
-	defer workertest.CleanKill(c, s.assertStartOneMachineWatcher(c))
+	w := s.assertStartOneMachineWatcher(c)
+
+	// The worker is the first and only resource (1).
+	resourceId := uint64(1)
+	s.AssertWorkerResource(c, s.machine0.Resident, resourceId, true)
+	workertest.CleanKill(c, w)
+	s.AssertWorkerResource(c, s.machine0.Resident, resourceId, false)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherError(c *gc.C) {
@@ -154,11 +160,11 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherRemoveUnitWithPr
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 1)
 
 	// Remove the original unit which has a profile.
-	s.model.RemoveUnit(
+	c.Assert(s.model.RemoveUnit(
 		cache.RemoveUnit{
 			ModelUUID: "model-uuid",
 			Name:      "application-name/0",
-		})
+		}), jc.ErrorIsNil)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 1)
 }
 
@@ -168,7 +174,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherRemoveOnlyUnit(c
 		ModelUUID: "model-uuid",
 		Name:      "application-name/0",
 	}
-	s.model.RemoveUnit(ru)
+	c.Assert(s.model.RemoveUnit(ru), jc.ErrorIsNil)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 1)
 }
 
@@ -178,7 +184,7 @@ func (s *lxdProfileWatcherSuite) TestMachineAppLXDProfileWatcherRemoveUnitWrongM
 		ModelUUID: "model-uuid",
 		Name:      "do-not-watch/2",
 	}
-	s.model.RemoveUnit(ru)
+	c.Assert(s.model.RemoveUnit(ru), jc.ErrorIsNil)
 	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 0)
 }
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -15,9 +15,9 @@ import (
 	"github.com/juju/juju/core/instance"
 )
 
-func newMachine(model *Model, res *resident) *Machine {
+func newMachine(model *Model, res *Resident) *Machine {
 	m := &Machine{
-		resident: res,
+		Resident: res,
 		model:    model,
 	}
 	return m
@@ -25,9 +25,9 @@ func newMachine(model *Model, res *resident) *Machine {
 
 // Machine represents a machine in a model.
 type Machine struct {
-	// resident identifies the machine as a type-agnostic cached entity
+	// Resident identifies the machine as a type-agnostic cached entity
 	// and tracks resources that it is responsible for cleaning up.
-	*resident
+	*Resident
 
 	model *Model
 	mu    sync.Mutex
@@ -182,7 +182,7 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 		modeler:      m.model,
 		metrics:      m.model.metrics,
 		hub:          m.model.hub,
-		resident:     m.resident,
+		resident:     m.Resident,
 	})
 	return w, nil
 }

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -106,11 +106,13 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 	}
 
 	w := newPredicateStringsWatcher(regexpPredicate(compiled), machines...)
+	deregister := m.registerWorker(w)
 	unsub := m.model.hub.Subscribe(m.modelTopic(modelAddRemoveMachine), w.changed)
 
 	w.tomb.Go(func() error {
 		<-w.tomb.Dying()
 		unsub()
+		deregister()
 		return nil
 	})
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -15,15 +15,20 @@ import (
 	"github.com/juju/juju/core/instance"
 )
 
-func newMachine(model *Model) *Machine {
+func newMachine(model *Model, res *resident) *Machine {
 	m := &Machine{
-		model: model,
+		resident: res,
+		model:    model,
 	}
 	return m
 }
 
 // Machine represents a machine in a model.
 type Machine struct {
+	// resident identifies the machine as a type-agnostic cached entity
+	// and tracks resources that it is responsible for cleaning up.
+	*resident
+
 	model *Model
 	mu    sync.Mutex
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -114,6 +114,7 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 		return nil
 	})
 
+	m.registerWorker(w)
 	return w, nil
 }
 
@@ -172,6 +173,7 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 		}
 		applications[appName] = info
 	}
+
 	w := newMachineAppLXDProfileWatcher(MachineAppLXDProfileConfig{
 		appTopic:     m.model.topic(applicationCharmURLChange),
 		unitTopic:    m.model.topic(modelUnitLXDProfileChange),
@@ -180,6 +182,7 @@ func (m *Machine) WatchApplicationLXDProfiles() (*MachineAppLXDProfileWatcher, e
 		modeler:      m.model,
 		metrics:      m.model.metrics,
 		hub:          m.model.hub,
+		resident:     m.resident,
 	})
 	return w, nil
 }

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -44,7 +44,7 @@ func (s *machineSuite) TestEmptyInstanceId(c *gc.C) {
 	mc := cache.MachineChange{
 		Id: "0",
 	}
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 
 	machine, err := s.model.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -58,7 +58,7 @@ func (s *machineSuite) TestCharmProfiles(c *gc.C) {
 		Id:            "0",
 		CharmProfiles: []string{"charm-profile-1"},
 	}
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 
 	machine, err := s.model.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -86,7 +86,7 @@ func (s *machineSuite) TestUnitsSubordinate(c *gc.C) {
 	uc.Application = "test5"
 	uc.Principal = "test1/0"
 	uc.Subordinate = true
-	s.model.UpdateUnit(uc)
+	s.model.UpdateUnit(uc, s.Manager)
 	unit, err := s.model.Unit(uc.Name)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedUnits = append(expectedUnits, unit)
@@ -131,7 +131,7 @@ func (s *machineSuite) TestWatchContainersAddContainer(c *gc.C) {
 	// Add a container to the machine
 	mc := machineChange
 	mc.Id = "0/lxd/0"
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 	s.wc0.AssertOneChange([]string{mc.Id})
 }
 
@@ -141,7 +141,7 @@ func (s *machineSuite) TestWatchContainersOnlyThisMachinesAddContainers(c *gc.C)
 	// Add a container to a different machine
 	mc := machineChange
 	mc.Id = "1/lxd/0"
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 	s.wc0.AssertNoChange()
 }
 
@@ -170,7 +170,7 @@ func (s *machineSuite) TestWatchContainersRemoveContainer(c *gc.C) {
 }
 
 func (s *machineSuite) setupMachine0(c *gc.C) {
-	s.model.UpdateMachine(machineChange)
+	s.model.UpdateMachine(machineChange, s.Manager)
 	machine, err := s.model.Machine(machineChange.Id)
 	c.Assert(err, jc.ErrorIsNil)
 	s.machine0 = machine
@@ -201,13 +201,13 @@ func (s *machineSuite) setupMachine0Container(c *gc.C) {
 	// Add a container to the machine
 	mc := machineChange
 	mc.Id = "0/lxd/0"
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 }
 
 func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (*cache.Machine, []*cache.Unit) {
 	mc := machineChange
 	mc.Id = machineId
-	s.model.UpdateMachine(mc)
+	s.model.UpdateMachine(mc, s.Manager)
 	machine, err := s.model.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -217,7 +217,7 @@ func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []s
 		uc.MachineId = machineId
 		uc.Name = name + "/" + machineId
 		uc.Application = name
-		s.model.UpdateUnit(uc)
+		s.model.UpdateUnit(uc, s.Manager)
 		unit, err := s.model.Unit(uc.Name)
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 type machineSuite struct {
-	entitySuite
+	cache.EntitySuite
 
 	model    *cache.Model
 	machine0 *cache.Machine
@@ -28,8 +28,8 @@ type machineSuite struct {
 var _ = gc.Suite(&machineSuite{})
 
 func (s *machineSuite) SetUpTest(c *gc.C) {
-	s.entitySuite.SetUpTest(c)
-	s.model = s.newModel(modelChange)
+	s.EntitySuite.SetUpTest(c)
+	s.model = s.NewModel(modelChange)
 }
 
 func (s *machineSuite) TestInstanceId(c *gc.C) {

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -118,7 +118,12 @@ func (s *machineSuite) TestUnitsTwoMachines(c *gc.C) {
 
 func (s *machineSuite) TestWatchContainersStops(c *gc.C) {
 	s.setupMachine0WithContainerWatcher(c, false)
+
+	// The worker is the first and only resource (1).
+	resourceId := uint64(1)
+	s.AssertWorkerResource(c, s.machine0.Resident, resourceId, true)
 	s.wc0.AssertStops()
+	s.AssertWorkerResource(c, s.machine0.Resident, resourceId, false)
 }
 
 func (s *machineSuite) TestWatchContainersStartWithContainer(c *gc.C) {
@@ -153,7 +158,7 @@ func (s *machineSuite) TestWatchContainersOnlyThisMachinesRemoveContainers(c *gc
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "1/lxd/0",
 	}
-	s.model.RemoveMachine(rm)
+	c.Assert(s.model.RemoveMachine(rm), jc.ErrorIsNil)
 	s.wc0.AssertNoChange()
 }
 
@@ -165,7 +170,7 @@ func (s *machineSuite) TestWatchContainersRemoveContainer(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "0/lxd/0",
 	}
-	s.model.RemoveMachine(rm)
+	c.Assert(s.model.RemoveMachine(rm), jc.ErrorIsNil)
 	s.wc0.AssertOneChange([]string{rm.Id})
 }
 

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -23,9 +23,9 @@ const (
 	modelUnitLXDProfileChange = "model-unit-lxd-profile-change"
 )
 
-func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *Model {
+func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Model {
 	m := &Model{
-		resident: res,
+		Resident: res,
 		metrics:  metrics,
 		// TODO: consider a separate hub per model for better scalability
 		// when many models.
@@ -41,9 +41,9 @@ func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *
 // Model is a cached model in the controller. The model is kept up to
 // date with changes flowing into the cached controller.
 type Model struct {
-	// resident identifies the model as a type-agnostic cached entity
+	// Resident identifies the model as a type-agnostic cached entity
 	// and tracks resources that it is responsible for cleaning up.
-	*resident
+	*Resident
 
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
@@ -77,7 +77,7 @@ func (m *Model) Name() string {
 
 // WatchConfig creates a watcher for the model config.
 func (m *Model) WatchConfig(keys ...string) *ConfigWatcher {
-	return newConfigWatcher(keys, m.hashCache, m.hub, m.topic(modelConfigChange), m.resident)
+	return newConfigWatcher(keys, m.hashCache, m.hub, m.topic(modelConfigChange), m.Resident)
 }
 
 // Report returns information that is used in the dependency engine report.

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -115,7 +115,15 @@ func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
 func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
 	m := s.NewModel(modelChange)
 	w := m.WatchConfig("key")
-	defer workertest.CleanKill(c, w)
+
+	// The worker is the first and only resource (1).
+	resourceId := uint64(1)
+	s.AssertWorkerResource(c, m.Resident, resourceId, true)
+	defer func() {
+		workertest.CleanKill(c, w)
+		s.AssertWorkerResource(c, m.Resident, resourceId, false)
+	}()
+
 	wc := NewNotifyWatcherC(c, w)
 	// Sends initial event.
 	wc.AssertOneChange()
@@ -180,7 +188,12 @@ func (s *ControllerSuite) TestWatchMachineStops(c *gc.C) {
 	wc := NewStringsWatcherC(c, w)
 	// Sends initial event.
 	wc.AssertOneChange([]string{machineChange.Id})
+
+	// The worker is the first and only resource (1).
+	resourceId := uint64(1)
+	s.AssertWorkerResource(c, m.Resident, resourceId, true)
 	wc.AssertStops()
+	s.AssertWorkerResource(c, m.Resident, resourceId, false)
 }
 
 func (s *ControllerSuite) TestWatchMachineAddMachine(c *gc.C) {

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -16,17 +16,17 @@ import (
 )
 
 type ModelSuite struct {
-	entitySuite
+	cache.EntitySuite
 }
 
 var _ = gc.Suite(&ModelSuite{})
 
 func (s *ModelSuite) SetUpTest(c *gc.C) {
-	s.entitySuite.SetUpTest(c)
+	s.EntitySuite.SetUpTest(c)
 }
 
 func (s *ModelSuite) TestReport(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
 		"name":              "model-owner/test-model",
 		"life":              life.Value("alive"),
@@ -38,7 +38,7 @@ func (s *ModelSuite) TestReport(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfig(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	c.Assert(m.Config(), jc.DeepEquals, map[string]interface{}{
 		"key":     "value",
 		"another": "foo",
@@ -46,24 +46,24 @@ func (s *ModelSuite) TestConfig(c *gc.C) {
 }
 
 func (s *ModelSuite) TestNewModelGeneratesHash(c *gc.C) {
-	s.newModel(modelChange)
-	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(1))
+	s.NewModel(modelChange)
+	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheMiss), gc.Equals, float64(1))
 }
 
 func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
-	m := s.newModel(modelChange)
-	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(0))
+	m := s.NewModel(modelChange)
+	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(0))
 	m.Config()
-	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(1))
+	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(1))
 	m.Config()
-	c.Check(testutil.ToFloat64(s.gauges.ModelConfigReads), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(2))
 }
 
 // Some of the tested behaviour in the following methods is specific to the
 // watcher, but using a cached model avoids the need to put scaffolding code in
 // export_test.go to create a watcher in isolation.
 func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	w := m.WatchConfig()
 	wc := NewNotifyWatcherC(c, w)
 	// Sends initial event.
@@ -72,7 +72,7 @@ func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	w := m.WatchConfig()
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -88,14 +88,14 @@ func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
 	wc.AssertOneChange()
 
 	// The hash is generated each time we set the details.
-	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheMiss), gc.Equals, float64(2))
 
 	// The value is retrieved from the cache when the watcher is created and notified.
-	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheHit), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheHit), gc.Equals, float64(2))
 }
 
 func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	w := m.WatchConfig("key")
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -113,7 +113,7 @@ func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	w := m.WatchConfig("key")
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -131,7 +131,7 @@ func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 
 	w := m.WatchConfig("key", "another")
 	defer workertest.CleanKill(c, w)
@@ -140,32 +140,32 @@ func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
 	defer workertest.CleanKill(c, w2)
 
 	// One cache miss for the "all" hash, and one for the specific fields.
-	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheMiss), gc.Equals, float64(2))
+	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheMiss), gc.Equals, float64(2))
 
 	// Specific field hash should get a hit despite the field ordering.
-	c.Check(testutil.ToFloat64(s.gauges.ModelHashCacheHit), gc.Equals, float64(1))
+	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheHit), gc.Equals, float64(1))
 }
 
 func (s *ModelSuite) TestApplicationNotFoundError(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	_, err := m.Application("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestCharmNotFoundError(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	_, err := m.Charm("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestMachineNotFoundError(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	_, err := m.Machine("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestUnitNotFoundError(c *gc.C) {
-	m := s.newModel(modelChange)
+	m := s.NewModel(modelChange)
 	_, err := m.Unit("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -32,8 +32,17 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Manager = newResidentManager()
 }
 
-func (s *BaseSuite) NewResident() *resident {
+func (s *BaseSuite) NewController(config ControllerConfig) (*Controller, error) {
+	return newController(config, s.Manager)
+}
+
+func (s *BaseSuite) NewResident() *Resident {
 	return s.Manager.new()
+}
+
+func (s *BaseSuite) AssertResident(c *gc.C, id uint64, expectPresent bool) {
+	_, present := s.Manager.residents[id]
+	c.Assert(present, gc.Equals, expectPresent)
 }
 
 // entitySuite is the base suite for testing cached entities

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -72,6 +72,17 @@ func (s *EntitySuite) NewModel(details ModelChange) *Model {
 	return m
 }
 
+func (s *EntitySuite) NewApplication(details ApplicationChange) *Application {
+	a := newApplication(s.Gauges, s.Hub, s.NewResident())
+	a.SetDetails(details)
+	return a
+}
+
+func (s *BaseSuite) AssertWorkerResource(c *gc.C, resident *Resident, id uint64, expectPresent bool) {
+	_, present := resident.workers[id]
+	c.Assert(present, gc.Equals, expectPresent)
+}
+
 type ImportSuite struct{}
 
 var _ = gc.Suite(&ImportSuite{})

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -1,0 +1,168 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+)
+
+// The cached controller includes a "residentManager", which supplies new
+// cache "resident" instances, monitors their life cycles and is the source
+// of unique identifiers for residents and resources.
+// All cached entities aside from the parent controller should include
+// the "resident" type as a base.
+// Each resident monitors resources that it creates and is responsible for
+// cleanup up when it is to be evicted from the cache.
+// This design meets resource management requirements multi-directionally:
+//   1. Resources (such as watchers) that are stopped or otherwise destroyed
+//      by their upstream owners need to be deregistered from their residents.
+//   2. Residents removed from a model in the normal course of events need to
+//      release resources that they created and deregister from the controller.
+//   3. If the multi-watcher supplying deltas to the cache is restarted,
+//      The controller itself must mark and sweep, evicting stale residents and
+//      cleaning up their resources.
+// Where possible the manager and residents eschew responsibility for Goroutine
+// safety. The types into which they are embedded should handle this.
+
+// counter supplies monotonically increasing unique identifiers.
+type counter uint64
+
+func (c *counter) next() uint64 {
+	return atomic.AddUint64((*uint64)(c), 1)
+}
+
+func (c *counter) last() uint64 {
+	return atomic.LoadUint64((*uint64)(c))
+}
+
+// residentManager creates and tracks cache residents.
+// It is also the source for resource identifiers in the cache.
+type residentManager struct {
+	residentCount *counter
+	resourceCount *counter
+
+	residents map[uint64]*resident
+}
+
+func newResidentManager() *residentManager {
+	residentC := counter(0)
+	resourceC := counter(0)
+
+	return &residentManager{
+		residentCount: &residentC,
+		resourceCount: &resourceC,
+		residents:     make(map[uint64]*resident),
+	}
+}
+
+// new creates a uniquely identified type-agnostic cache resident,
+// registers it in the internal map, then returns it.
+func (m *residentManager) new() *resident {
+	r := &resident{
+		id:      m.residentCount.next(),
+		manager: m,
+		workers: make(map[uint64]worker.Worker),
+	}
+	m.residents[r.id] = r
+	return r
+}
+
+func (m *residentManager) evict(id uint64) {
+	// TODO (manadart 2019-04-17): TBC when the mark/sweep logic is added.
+}
+
+func (m *residentManager) deregister(id uint64) {
+	delete(m.residents, id)
+}
+
+// resident is the base class for entities managed in the cache.
+type resident struct {
+	// id uniquely identifies this resident among all
+	// that were supplied by the same resident manager.
+	id uint64
+
+	// stale indicates that this cache resident is stale
+	// and is a candidate for removal.
+	stale bool
+
+	// manager is the resident manager that is responsible for this resource.
+	// If the resident is being evicted, it deregisters from the manager.
+	// TODO (manadart 2019-04-16): Maybe?
+	manager *residentManager
+
+	// workers are resources that must be cleaned up when a resident is to be
+	// evicted from the cache.
+	// Obvious examples are watchers created by the resident.
+	// Access to this map should be Goroutine-safe.
+	workers map[uint64]worker.Worker
+	mu      sync.Mutex
+}
+
+// registerWorker is used to indicate that the input worker needs to be stopped
+// when this resident is evicted from the cache.
+// The unique ID assigned to the worker resource is returned.
+// TODO (manadart 2019-04-16): Handle case where registration is called
+// on a stale resident.
+func (r *resident) registerWorker(w worker.Worker) uint64 {
+	id := r.manager.resourceCount.next()
+	r.mu.Lock()
+	r.workers[id] = w
+	r.mu.Unlock()
+	return id
+}
+
+// evict cleans up
+func (r *resident) evict() error {
+	if err := r.cleanup(); err != nil {
+		return errors.Trace(err)
+	}
+	r.manager.deregister(r.id)
+	return nil
+}
+
+// cleanup performs all resource maintenance associated with a resident
+// being evicted from the cache.
+// Note that this method does not deregister the resident from the manager.
+func (r *resident) cleanup() error {
+	return errors.Trace(r.cleanupWorkers())
+}
+
+// cleanupWorkers calls "Stop" on all registered workers
+// and removes them from the internal map.
+func (r *resident) cleanupWorkers() error {
+	for id := range r.workers {
+		if err := r.cleanupWorker(id); err != nil {
+			return errors.Annotatef(err, "cleaning up worker %d for cache resident %d", id, r.id)
+		}
+	}
+	return nil
+}
+
+// cleanupWorker stops and deregisters the worker with the input ID.
+// If no such worker is found, an error is returned.
+func (r *resident) cleanupWorker(id uint64) error {
+	w, ok := r.workers[id]
+	if !ok {
+		return errors.Errorf("worker %d not found", id)
+	}
+
+	if err := worker.Stop(w); err != nil {
+		return errors.Trace(err)
+	}
+	r.deregisterWorker(id)
+	return nil
+}
+
+// deregisterWorker informs the resident that we no longer care about this
+// worker. We expect this call to come from workers stopped by other actors
+// other than the resident, so we ensure Goroutine safety.
+func (r *resident) deregisterWorker(id uint64) {
+	r.mu.Lock()
+	delete(r.workers, id)
+	r.mu.Unlock()
+}

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -17,7 +17,7 @@ import (
 // All cached entities aside from the parent controller should include
 // the "resident" type as a base.
 // Each resident monitors resources that it creates and is responsible for
-// cleanup up when it is to be evicted from the cache.
+// cleaning up when it is to be evicted from the cache.
 // This design meets resource management requirements multi-directionally:
 //   1. Resources (such as watchers) that are stopped or otherwise destroyed
 //      by their upstream owners need to be deregistered from their residents.
@@ -145,6 +145,8 @@ func (r *resident) cleanupWorkers() error {
 
 // cleanupWorker stops and deregisters the worker with the input ID.
 // If no such worker is found, an error is returned.
+// Note that the deregistration method should have been added the the worker's
+// tomb cleanup method - stopping the worker cleanly is enough to deregister.
 func (r *resident) cleanupWorker(id uint64) error {
 	w, ok := r.workers[id]
 	if !ok {
@@ -154,7 +156,6 @@ func (r *resident) cleanupWorker(id uint64) error {
 	if err := worker.Stop(w); err != nil {
 		return errors.Trace(err)
 	}
-	r.deregisterWorker(id)
 	return nil
 }
 

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -105,15 +105,15 @@ type resident struct {
 
 // registerWorker is used to indicate that the input worker needs to be stopped
 // when this resident is evicted from the cache.
-// The unique ID assigned to the worker resource is returned.
+// The deregistration method is returned.
 // TODO (manadart 2019-04-16): Handle case where registration is called
 // on a stale resident.
-func (r *resident) registerWorker(w worker.Worker) uint64 {
+func (r *resident) registerWorker(w worker.Worker) func() {
 	id := r.manager.resourceCount.next()
 	r.mu.Lock()
 	r.workers[id] = w
 	r.mu.Unlock()
-	return id
+	return func() { r.deregisterWorker(id) }
 }
 
 // evict cleans up

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -43,7 +43,7 @@ func (s *residentSuite) TestManagerNewIdentifiedResources(c *gc.C) {
 	// and that they are registered with the manager.
 	c.Check(r1.id, gc.Equals, uint64(1))
 	c.Check(r2.id, gc.Equals, uint64(2))
-	c.Check(s.manager.residents, gc.DeepEquals, map[uint64]*resident{1: r1, 2: r2})
+	c.Check(s.manager.residents, gc.DeepEquals, map[uint64]*Resident{1: r1, 2: r2})
 }
 
 func (s *residentSuite) TestManagerDeregister(c *gc.C) {

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -89,8 +89,11 @@ func (s *residentSuite) TestResidentWorkerConcurrentRegisterCleanup(c *gc.C) {
 		c.Errorf("expected correctly registered workers, got %v", r.workers)
 	}
 
-	// Call cleanup, which should stop and deregister the workers.
+	// Call cleanup, which should stop the workers.
 	c.Assert(r.cleanup(), jc.ErrorIsNil)
+
+	r.deregisterWorker(1)
+	r.deregisterWorker(2)
 	c.Check(r.workers, gc.HasLen, 0)
 }
 

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -122,7 +122,7 @@ func (s *residentSuite) TestResidentWorkerCleanupErrors(c *gc.C) {
 	_ = r.registerWorker(w3)
 
 	err := r.cleanup()
-	c.Assert(err, gc.ErrorMatches, "(.|\n|\t)*biff(.|\n|\t)*thwack")
+	c.Assert(err, gc.ErrorMatches, "(.|\n|\t)*(biff|thwack)(.|\n|\t)*(biff|thwack)")
 	c.Assert(err, gc.Not(gc.ErrorMatches), "worker 3")
 }
 

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/golang/mock/gomock"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/mocks"
+)
+
+type residentSuite struct {
+	testing.BaseSuite
+
+	manager *residentManager
+}
+
+var _ = gc.Suite(&residentSuite{})
+
+func (s *residentSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.manager = newResidentManager()
+}
+
+func (s *residentSuite) TestManagerNewIdentifiedResources(c *gc.C) {
+	r1 := s.manager.new()
+	r2 := s.manager.new()
+
+	// Check that the count is what we expect.
+	c.Check(s.manager.residentCount.last(), gc.Equals, uint64(2))
+
+	// Check that the residents have IDs,
+	// and that they are registered with the manager.
+	c.Check(r1.id, gc.Equals, uint64(1))
+	c.Check(r2.id, gc.Equals, uint64(2))
+	c.Check(s.manager.residents, gc.DeepEquals, map[uint64]*resident{1: r1, 2: r2})
+}
+
+func (s *residentSuite) TestManagerDeregister(c *gc.C) {
+	r1 := s.manager.new()
+	c.Assert(r1.evict(), jc.ErrorIsNil)
+	c.Check(s.manager.residents, gc.HasLen, 0)
+}
+
+func (s *residentSuite) TestResidentWorkerConcurrentRegisterCleanup(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w1 := mocks.NewMockWorker(ctrl)
+	w1.EXPECT().Kill()
+	w1.EXPECT().Wait().Return(nil)
+
+	w2 := mocks.NewMockWorker(ctrl)
+	w2.EXPECT().Kill()
+	w2.EXPECT().Wait().Return(nil)
+
+	r := s.manager.new()
+
+	var id1, id2 uint64
+
+	// Register some workers concurrently.
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		id1 = r.registerWorker(w1)
+		wg.Done()
+	}()
+	go func() {
+		id2 = r.registerWorker(w2)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// Check that the count is what we expect.
+	c.Check(s.manager.resourceCount.last(), gc.Equals, uint64(2))
+
+	// Check that the workers have IDs,
+	// and that they are registered with the resident.
+	switch id1 {
+	case 1:
+		c.Check(id2, gc.Equals, uint64(2))
+		c.Check(r.workers, gc.DeepEquals, map[uint64]worker.Worker{1: w1, 2: w2})
+	case 2:
+		c.Check(id2, gc.Equals, uint64(1))
+		c.Check(r.workers, gc.DeepEquals, map[uint64]worker.Worker{1: w2, 2: w1})
+	default:
+		c.Errorf("expected id1 to be either 1 or 2, got %d", id1)
+	}
+
+	// Call cleanup, which should stop and deregister the workers.
+	c.Assert(r.cleanup(), jc.ErrorIsNil)
+	c.Check(r.workers, gc.HasLen, 0)
+}
+
+func (s *residentSuite) TestResidentWorkerConcurrentDeregister(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	r := s.manager.new()
+
+	// Note that we do not expect deregister to stop the worker.
+	id1 := r.registerWorker(mocks.NewMockWorker(ctrl))
+	id2 := r.registerWorker(mocks.NewMockWorker(ctrl))
+
+	// Unregister concurrently.
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		r.deregisterWorker(id1)
+		wg.Done()
+	}()
+	go func() {
+		r.deregisterWorker(id2)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	c.Check(r.workers, gc.HasLen, 0)
+}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -11,9 +11,9 @@ import (
 
 // Unit represents a unit in a cached model.
 type Unit struct {
-	// resident identifies the unit as a type-agnostic cached entity
+	// Resident identifies the unit as a type-agnostic cached entity
 	// and tracks resources that it is responsible for cleaning up.
-	*resident
+	*Resident
 
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
@@ -23,9 +23,9 @@ type Unit struct {
 	configHash string
 }
 
-func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *Unit {
+func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Unit {
 	u := &Unit{
-		resident: res,
+		Resident: res,
 		metrics:  metrics,
 		hub:      hub,
 	}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -11,6 +11,10 @@ import (
 
 // Unit represents a unit in a cached model.
 type Unit struct {
+	// resident identifies the unit as a type-agnostic cached entity
+	// and tracks resources that it is responsible for cleaning up.
+	*resident
+
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
 	mu      sync.Mutex
@@ -19,10 +23,11 @@ type Unit struct {
 	configHash string
 }
 
-func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
+func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *resident) *Unit {
 	u := &Unit{
-		metrics: metrics,
-		hub:     hub,
+		resident: res,
+		metrics:  metrics,
+		hub:      hub,
 	}
 	return u
 }

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 type UnitSuite struct {
-	entitySuite
+	cache.EntitySuite
 }
 
 var _ = gc.Suite(&UnitSuite{})
 
 func (s *UnitSuite) SetUpTest(c *gc.C) {
-	s.entitySuite.SetUpTest(c)
+	s.EntitySuite.SetUpTest(c)
 }
 
 var unitChange = cache.UnitChange{

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -115,7 +115,7 @@ type ConfigWatcher struct {
 // with a baseline hash of their config values from the input hash cache.
 // As per the cache requirements, hashes are only generated from sorted keys.
 func newConfigWatcher(
-	keys []string, cache *hashCache, hub *pubsub.SimpleHub, topic string, res *resident,
+	keys []string, cache *hashCache, hub *pubsub.SimpleHub, topic string, res *Resident,
 ) *ConfigWatcher {
 	sort.Strings(keys)
 

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -114,7 +114,9 @@ type ConfigWatcher struct {
 // newConfigWatcher returns a new watcher for the input config keys
 // with a baseline hash of their config values from the input hash cache.
 // As per the cache requirements, hashes are only generated from sorted keys.
-func newConfigWatcher(keys []string, cache *hashCache, hub *pubsub.SimpleHub, topic string) *ConfigWatcher {
+func newConfigWatcher(
+	keys []string, cache *hashCache, hub *pubsub.SimpleHub, topic string, res *resident,
+) *ConfigWatcher {
 	sort.Strings(keys)
 
 	w := &ConfigWatcher{
@@ -124,10 +126,12 @@ func newConfigWatcher(keys []string, cache *hashCache, hub *pubsub.SimpleHub, to
 		hash: cache.getHash(keys),
 	}
 
+	deregister := res.registerWorker(w)
 	unsub := hub.Subscribe(topic, w.configChanged)
 	w.tomb.Go(func() error {
 		<-w.tomb.Dying()
 		unsub()
+		deregister()
 		return nil
 	})
 


### PR DESCRIPTION
## Description of change

Patch adds a type agnostic overlay to the model cache so that:
- The controller administers unique IDs for cache residents and their resources.
- The controller tracks all residents in the cache.
- Residents track resources that they create (currently watchers).
- Evicted residents clean up their resources and evict themselves from the cache.
- Externally stopped watchers deregister themselves the residents.

I wanted to do more unit style testing of the new resident logic, which is all internal to the cache, so I have moved some test infrastructure into the `cache` package.

A future patch will add the mark/sweep logic. It will probably change some patterns here, but I wanted to get acceptance before going that far

## QA steps

TBD - All `core/cache` tests are passing.

## Documentation changes

None.

## Bug reference

N/A
