### PR TITLE
add backingInstanceData to all watcher

### DIFF
--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2363,7 +2363,9 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "", "fake_nonce", nil)
+
+			hc := &instance.HardwareCharacteristics{}
+			err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "", "fake_nonce", hc)
 			c.Assert(err, jc.ErrorIsNil)
 
 			profiles := []string{"default, juju-default"}
@@ -2382,9 +2384,10 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.MachineInfo{
-						ModelUUID:     st.ModelUUID(),
-						Id:            "0",
-						CharmProfiles: profiles,
+						ModelUUID:               st.ModelUUID(),
+						Id:                      "0",
+						CharmProfiles:           profiles,
+						HardwareCharacteristics: hc,
 					}}}
 		},
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1025,9 +1025,55 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	wpTime := s.state.clock().Now()
 
 	// Look for the state changes from the allwatcher.
-	deltas = tw.All(6)
+	deltas = tw.All(7)
+
+	expectedRemoveMachineEntity := &multiwatcher.MachineInfo{
+		ModelUUID: s.state.ModelUUID(),
+		Id:        "1",
+	}
+
+	// checkDeltasEqual sets removals to nil before comparing the deltas.
+	// Perhaps because, the multiwatcher.*Info{} is very different once it's
+	// converted to multiwatcher.Remove*{} and contains only the modelUUID,
+	// and an "Id" depending on the thing being removed.  For the model
+	// cache, we do want to ensure the correct removals are being seen,
+	// so check here.
+	for _, d := range deltas {
+		if d.Removed {
+			// This is a very specific check for the recent call to
+			// m1.Remove()
+			obtainedMachine, ok := d.Entity.(*multiwatcher.MachineInfo)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(obtainedMachine.ModelUUID, gc.Equals, expectedRemoveMachineEntity.ModelUUID)
+			c.Assert(obtainedMachine.Id, gc.Equals, expectedRemoveMachineEntity.Id)
+		}
+	}
 
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
+		Entity: &multiwatcher.MachineInfo{
+			ModelUUID:  s.state.ModelUUID(),
+			Id:         "0",
+			InstanceId: "",
+			AgentStatus: multiwatcher.StatusInfo{
+				Current: status.Pending,
+				Data:    map[string]interface{}{},
+				Since:   &now,
+			},
+			InstanceStatus: multiwatcher.StatusInfo{
+				Current: status.Pending,
+				Data:    map[string]interface{}{},
+				Since:   &now,
+			},
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "trusty",
+			Jobs:                    []multiwatcher.MachineJob{JobManageModel.ToParams()},
+			Addresses:               []multiwatcher.Address{},
+			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			CharmProfiles:           []string{},
+			HasVote:                 false,
+			WantsVote:               true,
+		},
+	}, {
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID:  s.state.ModelUUID(),
 			Id:         "0",
@@ -1053,10 +1099,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		},
 	}, {
 		Removed: true,
-		Entity: &multiwatcher.MachineInfo{
-			ModelUUID: s.state.ModelUUID(),
-			Id:        "1",
-		},
+		Entity:  expectedRemoveMachineEntity,
 	}, {
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID: s.state.ModelUUID(),
@@ -1920,9 +1963,55 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 
 	// Look for the state changes from the allwatcher.
 	later := st2.clock().Now()
-	deltas = tw.All(8)
+	deltas = tw.All(9)
 
-	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
+	expectedRemoveMachineEntity := &multiwatcher.MachineInfo{
+		ModelUUID: st1.ModelUUID(),
+		Id:        "0",
+	}
+
+	// checkDeltasEqual sets removals to nil before comparing the deltas.
+	// Perhaps because, the multiwatcher.*Info{} is very different once it's
+	// converted to multiwatcher.Remove*{} and contains only the modelUUID,
+	// and an "Id" depending on the thing being removed.  For the model
+	// cache, we do want to ensure the correct removals are being seen,
+	// so check here.
+	for _, d := range deltas {
+		if d.Removed {
+			// This is a very specific check for the recent call to
+			// m10.Remove()
+			obtainedMachine, ok := d.Entity.(*multiwatcher.MachineInfo)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(obtainedMachine.ModelUUID, gc.Equals, expectedRemoveMachineEntity.ModelUUID)
+			c.Assert(obtainedMachine.Id, gc.Equals, expectedRemoveMachineEntity.Id)
+		}
+	}
+
+	expectedDeltas := []multiwatcher.Delta{{
+		Entity: &multiwatcher.MachineInfo{
+			ModelUUID:  st0.ModelUUID(),
+			Id:         "0",
+			InstanceId: "",
+			AgentStatus: multiwatcher.StatusInfo{
+				Current: status.Pending,
+				Data:    map[string]interface{}{},
+				Since:   &now,
+			},
+			InstanceStatus: multiwatcher.StatusInfo{
+				Current: status.Pending,
+				Data:    map[string]interface{}{},
+				Since:   &now,
+			},
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "trusty",
+			Jobs:                    []multiwatcher.MachineJob{JobManageModel.ToParams()},
+			Addresses:               []multiwatcher.Address{},
+			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			CharmProfiles:           []string{},
+			HasVote:                 false,
+			WantsVote:               true,
+		},
+	}, {
 		Entity: &multiwatcher.MachineInfo{
 			ModelUUID:  st0.ModelUUID(),
 			Id:         "0",
@@ -1945,12 +2034,6 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			CharmProfiles:           []string{},
 			HasVote:                 false,
 			WantsVote:               true,
-		},
-	}, {
-		Removed: true,
-		Entity: &multiwatcher.MachineInfo{
-			ModelUUID: st1.ModelUUID(),
-			Id:        "0",
 		},
 	}, {
 		Entity: &multiwatcher.MachineInfo{
@@ -1979,6 +2062,9 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			CharmURL:  "local:quantal/quantal-wordpress-3",
 			Life:      multiwatcher.Life("alive"),
 		},
+	}, {
+		Removed: true,
+		Entity:  expectedRemoveMachineEntity,
 	}, {
 		Entity: &multiwatcher.ApplicationInfo{
 			ModelUUID: st1.ModelUUID(),
@@ -2053,7 +2139,9 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			HasVote:   false,
 			WantsVote: false,
 		},
-	}})
+	}}
+
+	checkDeltasEqual(c, deltas, expectedDeltas)
 }
 
 // The testChange* funcs are extracted so the test cases can be used


### PR DESCRIPTION
## Description of change

Add backingInstanceData as a subsidiary of backingMachine to ensure CharmProfiles are updated in the model cache.  This resolves an issue where profiles were not being removing from machines, such as removing a subordinate charm with a profile while not destroying the principal unit as well; or a profile not being deleted from the lxd server after charm upgrade.

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=instance-mutater
2. juju bootstrap localhost
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd -n 2 ; juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate ; juju add-relation lxd-profile-alt lxd-profile-subordinate
2. wait for both units to be active
3. juju upgrade-charm lxd-profile-alt  --path ./testcharms/charm-repo/quantal/lxd-profile-alt ; juju upgrade-charm lxd-profile-subordinate --path ./testcharms/charm-repo/quantal/lxd-profile-subordinate ;
4. verify that both are successful and that their profiles have been updated
2. ensure that the older rev profiles were deleted by checking lxd profile list.

