### PR TITLE
Improvements to MachineAppLXDProfileWatcher

### DIFF
--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -79,8 +79,8 @@ func (u *Unit) setDetails(details UnitChange) {
 
 	machineChange := u.details.MachineId != details.MachineId
 	u.details = details
-	if machineChange {
-		u.hub.Publish(u.modelTopic(modelUnitLXDProfileChange), u)
+	if machineChange || u.details.Subordinate {
+		u.hub.Publish(u.modelTopic(modelUnitLXDProfileAdd), u)
 	}
 
 	// TODO (manadart 2019-02-11): Maintain hash and publish changes.


### PR DESCRIPTION
## Description of change

Improvements to MachineAppLXDProfileWatcher after PR 10057.  
Move watcher's init state setup to newMachineAppLXDProfileWatcher()
Break MachineAppLXDProfileWatcher.unitChange() into addUnit() and removeUnit().

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=instance-mutater
2. juju bootstrap localhost
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to lxd -n 2 ; juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate ; juju add-relation lxd-profile-alt lxd-profile-subordinate
2. wait for both units to be active
3. juju upgrade-charm lxd-profile-alt  --path ./testcharms/charm-repo/quantal/lxd-profile-alt ; juju upgrade-charm lxd-profile-subordinate --path ./testcharms/charm-repo/quantal/lxd-profile-subordinate ;
4. verify that both are successful and that their profiles have been updated
3. juju add-unit lxd-profile-alt
3. make sure other functionality is not broken.


