### PR TITLE
Fix verifyCurrentProfiles when all charm profiles should be removed from the machine.

### DIFF
--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -254,15 +254,15 @@ func (m MutaterMachine) verifyCurrentProfiles(instId string, expectedProfiles []
 		return false, err
 	}
 	obtainedSet := set.NewStrings(obtainedProfiles...)
+	expectedSet := set.NewStrings(expectedProfiles...)
 
-	if obtainedSet.Union(set.NewStrings(expectedProfiles...)).Size() > obtainedSet.Size() {
+	if obtainedSet.Union(expectedSet).Size() > obtainedSet.Size() {
 		return false, nil
 	}
 
-	for _, expected := range expectedProfiles {
-		if !obtainedSet.Contains(expected) {
-			return false, nil
-		}
+	if expectedSet.Union(obtainedSet).Size() > expectedSet.Size() {
+		return false, nil
 	}
+
 	return true, nil
 }


### PR DESCRIPTION
## Description of change

Fix verifyCurrentProfiles when all charm profiles should be removed from the machine.

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=instance-mutater
2. juju bootstrap localhost
3. juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt  ; juju deploy ./testcharms/charm-repo/quantal/lxd-profile-subordinate  ; juju add-relation lxd-profile-alt lxd-profile-subordinate 
3. juju deploy ubuntu --to 0
4. once all the units are installed on machine 0, check that 2 charm profiles have been applied.
4. juju remove-unit lxd-profile-alt/0
3. once removed, check that there are no charm profiles applied to machine 0.
